### PR TITLE
feat(vfox): plugin-declared system dependencies with capability detection

### DIFF
--- a/crates/vfox/src/lib.rs
+++ b/crates/vfox/src/lib.rs
@@ -9,6 +9,7 @@ extern crate mlua;
 pub use error::Result as VfoxResult;
 pub use error::VfoxError;
 pub use hooks::pre_install::VerifiedAttestation;
+pub use metadata::{Metadata, SystemDependency};
 pub use plugin::Plugin;
 pub use vfox::InstallResult;
 pub use vfox::Vfox;

--- a/crates/vfox/src/metadata.rs
+++ b/crates/vfox/src/metadata.rs
@@ -43,7 +43,11 @@ impl FromLua for SystemDependency {
                 to: "SystemDependency".to_string(),
                 message: Some("each systemDependencies entry must be a table".to_string()),
             })?;
-        let dep = SystemDependency {
+        // Parse fields only. Validation (exactly one of bin/pkgconfig/
+        // sharedlib/command) is left to the consumer so that a single bad
+        // entry never fails the whole metadata parse — mise warns and skips
+        // invalid entries while keeping the rest of the plugin usable.
+        Ok(SystemDependency {
             bin: table.get("bin")?,
             pkgconfig: table.get("pkgconfig")?,
             sharedlib: table.get("sharedlib")?,
@@ -53,22 +57,7 @@ impl FromLua for SystemDependency {
             packages: table
                 .get::<Option<BTreeMap<String, String>>>("packages")?
                 .unwrap_or_default(),
-        };
-        let checks = [&dep.bin, &dep.pkgconfig, &dep.sharedlib, &dep.command]
-            .iter()
-            .filter(|c| c.is_some())
-            .count();
-        if checks != 1 {
-            return Err(mlua::Error::FromLuaConversionError {
-                from: "table",
-                to: "SystemDependency".to_string(),
-                message: Some(format!(
-                    "each systemDependencies entry must set exactly one of \
-                     bin/pkgconfig/sharedlib/command (found {checks})"
-                )),
-            });
-        }
-        Ok(dep)
+        })
     }
 }
 
@@ -79,9 +68,17 @@ impl TryFrom<Table> for Metadata {
             .get::<Option<Vec<String>>>("legacyFilenames")?
             .unwrap_or_default();
         let depends = t.get::<Option<Vec<String>>>("depends")?.unwrap_or_default();
-        let system_dependencies = t
-            .get::<Option<Vec<SystemDependency>>>("systemDependencies")?
-            .unwrap_or_default();
+        // Never let a malformed systemDependencies field break the rest of the
+        // metadata (e.g. `depends`, which install hooks rely on) — warn and
+        // treat it as absent.
+        let system_dependencies = match t.get::<Option<Vec<SystemDependency>>>("systemDependencies")
+        {
+            Ok(deps) => deps.unwrap_or_default(),
+            Err(e) => {
+                warn!("ignoring malformed systemDependencies in plugin metadata: {e}");
+                vec![]
+            }
+        };
         Ok(Metadata {
             name: t.get("name")?,
             legacy_filenames,
@@ -194,30 +191,41 @@ mod tests {
     }
 
     #[test]
-    fn test_system_dependencies_requires_exactly_one_check() {
-        // zero check keys
-        assert!(
-            metadata_result(
-                r#"
-                PLUGIN = {
-                    name = "test", version = "1.0.0",
-                    systemDependencies = { { version = ">=3.0" } },
-                }
-                "#,
-            )
-            .is_err()
+    fn test_system_dependencies_parse_is_lenient() {
+        // Field parsing does not validate "exactly one check key" — that is the
+        // consumer's job (mise warns and skips), so a questionable entry must
+        // not fail the whole metadata parse and drop `depends`.
+        let m = metadata_result(
+            r#"
+            PLUGIN = {
+                name = "test", version = "1.0.0",
+                depends = { "node" },
+                systemDependencies = {
+                    { version = ">=3.0" },                       -- zero check keys
+                    { bin = "bison", pkgconfig = "libxml-2.0" }, -- two check keys
+                },
+            }
+            "#,
+        )
+        .unwrap();
+        assert_eq!(m.depends, vec!["node"]);
+        assert_eq!(m.system_dependencies.len(), 2);
+    }
+
+    #[test]
+    fn test_malformed_system_dependencies_does_not_break_metadata() {
+        // A grossly malformed field (not a list of tables) is ignored, and the
+        // rest of the metadata (e.g. depends) still parses.
+        let m = metadata_from_lua(
+            r#"
+            PLUGIN = {
+                name = "test", version = "1.0.0",
+                depends = { "node" },
+                systemDependencies = "not a table",
+            }
+            "#,
         );
-        // two check keys
-        assert!(
-            metadata_result(
-                r#"
-                PLUGIN = {
-                    name = "test", version = "1.0.0",
-                    systemDependencies = { { bin = "bison", pkgconfig = "libxml-2.0" } },
-                }
-                "#,
-            )
-            .is_err()
-        );
+        assert_eq!(m.depends, vec!["node"]);
+        assert!(m.system_dependencies.is_empty());
     }
 }

--- a/crates/vfox/src/metadata.rs
+++ b/crates/vfox/src/metadata.rs
@@ -1,11 +1,8 @@
-use mlua::Table;
-use std::collections::BTreeSet;
+use mlua::{FromLua, Lua, Table, Value};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::error::Result;
 use crate::error::VfoxError;
-
-#[cfg(test)]
-use mlua::Lua;
 
 #[derive(Debug, Clone)]
 pub struct Metadata {
@@ -17,7 +14,62 @@ pub struct Metadata {
     pub author: Option<String>,
     pub license: Option<String>,
     pub homepage: Option<String>,
+    pub system_dependencies: Vec<SystemDependency>,
     pub hooks: BTreeSet<&'static str>,
+}
+
+/// A single `PLUGIN.systemDependencies` entry — a system prerequisite the
+/// plugin needs before it can install (build tools, libraries, ...). Exactly
+/// one of `bin`/`pkgconfig`/`sharedlib`/`command` must be set; `packages` maps
+/// a package-manager name (brew, apt, dnf, pacman, apk) to the package that
+/// provides the capability, used only as a remediation hint.
+#[derive(Debug, Clone, Default)]
+pub struct SystemDependency {
+    pub bin: Option<String>,
+    pub pkgconfig: Option<String>,
+    pub sharedlib: Option<String>,
+    pub command: Option<String>,
+    pub version: Option<String>,
+    pub optional: Option<String>,
+    pub packages: BTreeMap<String, String>,
+}
+
+impl FromLua for SystemDependency {
+    fn from_lua(value: Value, _lua: &Lua) -> mlua::Result<Self> {
+        let table = value
+            .as_table()
+            .ok_or_else(|| mlua::Error::FromLuaConversionError {
+                from: value.type_name(),
+                to: "SystemDependency".to_string(),
+                message: Some("each systemDependencies entry must be a table".to_string()),
+            })?;
+        let dep = SystemDependency {
+            bin: table.get("bin")?,
+            pkgconfig: table.get("pkgconfig")?,
+            sharedlib: table.get("sharedlib")?,
+            command: table.get("command")?,
+            version: table.get("version")?,
+            optional: table.get("optional")?,
+            packages: table
+                .get::<Option<BTreeMap<String, String>>>("packages")?
+                .unwrap_or_default(),
+        };
+        let checks = [&dep.bin, &dep.pkgconfig, &dep.sharedlib, &dep.command]
+            .iter()
+            .filter(|c| c.is_some())
+            .count();
+        if checks != 1 {
+            return Err(mlua::Error::FromLuaConversionError {
+                from: "table",
+                to: "SystemDependency".to_string(),
+                message: Some(format!(
+                    "each systemDependencies entry must set exactly one of \
+                     bin/pkgconfig/sharedlib/command (found {checks})"
+                )),
+            });
+        }
+        Ok(dep)
+    }
 }
 
 impl TryFrom<Table> for Metadata {
@@ -27,6 +79,9 @@ impl TryFrom<Table> for Metadata {
             .get::<Option<Vec<String>>>("legacyFilenames")?
             .unwrap_or_default();
         let depends = t.get::<Option<Vec<String>>>("depends")?.unwrap_or_default();
+        let system_dependencies = t
+            .get::<Option<Vec<SystemDependency>>>("systemDependencies")?
+            .unwrap_or_default();
         Ok(Metadata {
             name: t.get("name")?,
             legacy_filenames,
@@ -36,6 +91,7 @@ impl TryFrom<Table> for Metadata {
             author: t.get("author")?,
             license: t.get("license")?,
             homepage: t.get("homepage")?,
+            system_dependencies,
             hooks: Default::default(),
         })
     }
@@ -50,6 +106,13 @@ mod tests {
         lua.load(code).exec().unwrap();
         let table: Table = lua.globals().get("PLUGIN").unwrap();
         Metadata::try_from(table).unwrap()
+    }
+
+    fn metadata_result(code: &str) -> Result<Metadata> {
+        let lua = Lua::new();
+        lua.load(code).exec().unwrap();
+        let table: Table = lua.globals().get("PLUGIN").unwrap();
+        Metadata::try_from(table)
     }
 
     #[test]
@@ -77,5 +140,84 @@ mod tests {
             "#,
         );
         assert!(m.depends.is_empty());
+    }
+
+    #[test]
+    fn test_system_dependencies_parsed() {
+        let m = metadata_from_lua(
+            r#"
+            PLUGIN = {
+                name = "test",
+                version = "1.0.0",
+                systemDependencies = {
+                    { bin = "bison", version = ">=3.0",
+                      packages = { brew = "bison", apt = "bison" } },
+                    { pkgconfig = "libxml-2.0",
+                      packages = { brew = "libxml2", apt = "libxml2-dev" } },
+                    { sharedlib = "libaio.so.1" },
+                    { command = "test -d /opt/thing", optional = "extra feature" },
+                },
+            }
+            "#,
+        );
+        assert_eq!(m.system_dependencies.len(), 4);
+        let bison = &m.system_dependencies[0];
+        assert_eq!(bison.bin.as_deref(), Some("bison"));
+        assert_eq!(bison.version.as_deref(), Some(">=3.0"));
+        assert_eq!(
+            bison.packages.get("brew").map(|s| s.as_str()),
+            Some("bison")
+        );
+        assert_eq!(bison.packages.get("apt").map(|s| s.as_str()), Some("bison"));
+        assert_eq!(
+            m.system_dependencies[1].pkgconfig.as_deref(),
+            Some("libxml-2.0")
+        );
+        assert_eq!(
+            m.system_dependencies[2].sharedlib.as_deref(),
+            Some("libaio.so.1")
+        );
+        assert_eq!(
+            m.system_dependencies[3].optional.as_deref(),
+            Some("extra feature")
+        );
+    }
+
+    #[test]
+    fn test_system_dependencies_defaults_to_empty() {
+        let m = metadata_from_lua(
+            r#"
+            PLUGIN = { name = "test", version = "1.0.0" }
+            "#,
+        );
+        assert!(m.system_dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_system_dependencies_requires_exactly_one_check() {
+        // zero check keys
+        assert!(
+            metadata_result(
+                r#"
+                PLUGIN = {
+                    name = "test", version = "1.0.0",
+                    systemDependencies = { { version = ">=3.0" } },
+                }
+                "#,
+            )
+            .is_err()
+        );
+        // two check keys
+        assert!(
+            metadata_result(
+                r#"
+                PLUGIN = {
+                    name = "test", version = "1.0.0",
+                    systemDependencies = { { bin = "bison", pkgconfig = "libxml-2.0" } },
+                }
+                "#,
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/vfox/src/snapshots/vfox__vfox__tests__metadata.snap
+++ b/crates/vfox/src/snapshots/vfox__vfox__tests__metadata.snap
@@ -2,4 +2,4 @@
 source: crates/vfox/src/vfox.rs
 expression: out
 ---
-Metadata { name: "dummy", legacy_filenames: [".dummy-version"], depends: [], version: "0.3.0", description: Some("Dummy plugin for testing."), author: None, license: Some("Apache 2.0"), homepage: Some("https://github.com/version-fox/vfox-nodejs"), hooks: {"available", "env_keys", "parse_legacy_file", "post_install", "pre_install", "pre_uninstall"} }
+Metadata { name: "dummy", legacy_filenames: [".dummy-version"], depends: [], version: "0.3.0", description: Some("Dummy plugin for testing."), author: None, license: Some("Apache 2.0"), homepage: Some("https://github.com/version-fox/vfox-nodejs"), system_dependencies: [], hooks: {"available", "env_keys", "parse_legacy_file", "post_install", "pre_install", "pre_uninstall"} }

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -333,6 +333,57 @@ Add `depends` to the `PLUGIN` table when install hooks need other mise-managed t
 
 This is separate from `depends` in `[tools]`, which only makes one configured tool wait for another configured tool in the install graph. vfox `metadata.lua` `depends` is plugin metadata; when matching tools are configured, mise uses it to order current install jobs and to build the hook environment.
 
+#### System Dependencies
+
+Plugins that compile from source (or otherwise rely on system libraries and build tools) can declare those prerequisites with `systemDependencies`. Before installing the tool, mise checks each one and — depending on the [`system_deps`](/configuration/settings.html#system_deps) setting — reports, offers to install, or auto-installs anything missing.
+
+```lua
+PLUGIN = {
+    name = "php",
+    version = "1.0.0",
+
+    systemDependencies = {
+        -- an executable on PATH, with an optional version constraint
+        { bin = "bison", version = ">=3.0",
+          packages = { brew = "bison", apt = "bison", dnf = "bison" } },
+        { bin = "re2c",
+          packages = { brew = "re2c", apt = "re2c", dnf = "re2c" } },
+
+        -- a library discoverable via pkg-config
+        { pkgconfig = "libxml-2.0",
+          packages = { brew = "libxml2", apt = "libxml2-dev", dnf = "libxml2-devel" } },
+        { pkgconfig = "openssl",
+          packages = { brew = "openssl@3", apt = "libssl-dev", dnf = "openssl-devel" } },
+
+        -- a runtime shared library, by soname (Linux)
+        { sharedlib = "libaio.so.1",
+          packages = { apt = "libaio1", dnf = "libaio" } },
+
+        -- an escape hatch: any shell command whose exit status 0 means "satisfied"
+        { command = "xcode-select -p", optional = "macOS command line tools" },
+    },
+}
+```
+
+Each entry must set **exactly one** check:
+
+| Check       | Detection                                          | Use for                                    |
+| ----------- | -------------------------------------------------- | ------------------------------------------ |
+| `bin`       | executable resolvable on `PATH`                    | compilers, build tools, `*-config` scripts |
+| `pkgconfig` | `pkg-config --exists <name>`                       | C libraries that ship a `.pc` file         |
+| `sharedlib` | dynamic linker can resolve the soname (Linux only) | runtime libraries for prebuilt binaries    |
+| `command`   | the shell command exits `0`                        | anything the above can't express           |
+
+Optional fields:
+
+- **`version`** — a constraint (`>=3.0`, `>3`, `<=1.2`, `=3.0`, or a bare `3.0` meaning `>=3.0`) for `bin` and `pkgconfig`. mise runs `<bin> --version` / `pkg-config --modversion` and compares. If a version can't be extracted, the dependency is treated as satisfied (presence is enough) rather than blocking the install.
+- **`optional`** — a short reason string. Missing optional dependencies never prompt or fail; they surface as a single informational line, letting users build without features they don't need (e.g. Erlang's `wxWidgets` GUI).
+- **`packages`** — a map of package-manager name (`brew`, `brew-cask`, `apt`, `dnf`, `pacman`, `apk`, `mas`) to the package that provides the capability.
+
+**Detection is the source of truth.** A check that passes is satisfied no matter how the capability was installed — Homebrew, apt, nix, MacPorts, or from source all pass without ceremony, and mise never asks _how_ it got there. The `packages` map is only consulted to _offer_ installing the missing subset; it is a remediation hint, not a declaration that the tool must come from that package manager.
+
+These declarations are inert on older mise versions and on upstream vfox (both ignore unknown `PLUGIN` fields), so adding them is backward-compatible.
+
 ### 3. Helper Libraries
 
 Create shared functions in the `lib/` directory:

--- a/e2e/plugins/test_plugin_system_deps
+++ b/e2e/plugins/test_plugin_system_deps
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Plugin-declared system dependencies: detection, reporting, and the
+# system_deps setting. Detection is exercised install-free via `mise doctor`
+# and `mise bootstrap status`; the warn/ignore install behavior is exercised
+# with a plugin whose install fails offline (the pre-flight runs first).
+
+PLUGIN_DIR="$MISE_DATA_DIR/plugins/sysdeptest"
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "sysdeptest"
+PLUGIN.version = "0.1.0"
+PLUGIN.description = "system-deps test plugin"
+PLUGIN.systemDependencies = {
+	-- satisfied: `sh` exists everywhere
+	{ command = "sh -c 'exit 0'" },
+	-- missing required, with remediation hints
+	{ bin = "definitely-missing-binary-xyz",
+	  packages = { brew = "missingpkg", apt = "missingpkg" } },
+	-- missing optional: must never fail or prompt
+	{ bin = "another-missing-binary-xyz", optional = "extra feature",
+	  packages = { brew = "extrapkg", apt = "extrapkg" } },
+}
+LUA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
+function PLUGIN:Available(ctx)
+	return { { version = "1.0.0" } }
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/pre_install.lua" <<'LUA'
+function PLUGIN:PreInstall(ctx)
+	-- a local file:// url that does not exist: the download fails offline and
+	-- deterministically, after the system-deps pre-flight has already run.
+	return { version = ctx.version, url = "file:///nonexistent/sysdeptest.tar.gz" }
+end
+LUA
+
+cat >mise.toml <<'TOML'
+[tools]
+sysdeptest = "1.0.0"
+TOML
+
+# warn mode: the pre-flight reports the missing required capability and a
+# copy-paste install hint, then the (offline) install fails.
+assert_fail_contains "MISE_SYSTEM_DEPS=warn mise install sysdeptest@1.0.0" "definitely-missing-binary-xyz"
+assert_fail_contains "MISE_SYSTEM_DEPS=warn mise install sysdeptest@1.0.0" "install with:"
+
+# ignore mode: no system-deps output at all (install still fails on download).
+out="$(MISE_SYSTEM_DEPS=ignore mise install sysdeptest@1.0.0 2>&1 || true)"
+assert_not_contains_text "$out" "definitely-missing-binary-xyz"
+
+# non-interactive prompt mode must not hang — it degrades to warn.
+assert_fail_contains "MISE_SYSTEM_DEPS=prompt mise install sysdeptest@1.0.0" "definitely-missing-binary-xyz"
+
+# doctor surfaces the missing required dep (but not the optional one).
+# (doctor exits non-zero when it finds any problem, so tolerate the status.)
+doctor_out="$(mise doctor 2>&1 || true)"
+assert_contains_text "$doctor_out" "requires system dependency definitely-missing-binary-xyz"
+assert_not_contains_text "$doctor_out" "another-missing-binary-xyz"
+
+# bootstrap status shows a row per declared dep with its state.
+assert_contains "MISE_EXPERIMENTAL=1 mise bootstrap status 2>&1" "plugin-deps"
+assert_contains "MISE_EXPERIMENTAL=1 mise bootstrap status 2>&1" "missing"
+assert_contains "MISE_EXPERIMENTAL=1 mise bootstrap status 2>&1" "optional missing"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1678,6 +1678,12 @@
           "description": "Path to the system mise config file. Default is `/etc/mise/config.toml`. This must be an env var.",
           "type": "string"
         },
+        "system_deps": {
+          "default": "prompt",
+          "description": "How to handle a plugin's declared system dependencies before installing a tool.",
+          "type": "string",
+          "enum": ["prompt", "auto", "warn", "ignore"]
+        },
         "system_packages": {
           "type": "object",
           "unevaluatedProperties": false,

--- a/settings.toml
+++ b/settings.toml
@@ -2346,6 +2346,35 @@ env = "MISE_SYSTEM_CONFIG_FILE"
 optional = true
 type = "Path"
 
+[system_deps]
+default = "prompt"
+description = "How to handle a plugin's declared system dependencies before installing a tool."
+docs = """
+Controls what mise does when a plugin declares system prerequisites (build tools,
+libraries, ...) via `PLUGIN.systemDependencies` and one or more are missing before
+the tool is compiled/installed.
+
+Detection is always the source of truth: a prerequisite that mise can already find
+on the machine (via any means — Homebrew, apt, nix, MacPorts, from source) is never
+questioned. This setting only governs what happens for the *missing* subset:
+
+- `prompt` (default) — report the missing capabilities and offer to install them
+  via the first available system package manager. Falls back to `warn` when not
+  running interactively.
+- `auto` — install the missing packages without asking (implies the package
+  manager's own non-interactive install; may use sudo per `system_packages.sudo`).
+- `warn` — print the missing capabilities and copy-pasteable install commands, then
+  continue with the install anyway.
+- `ignore` — do nothing; skip the check entirely.
+
+Missing *optional* dependencies never prompt or fail — they surface as a single
+informational line regardless of this setting.
+"""
+enum = ["prompt", "auto", "warn", "ignore"]
+env = "MISE_SYSTEM_DEPS"
+rust_type = "SystemDepsMode"
+type = "String"
+
 [system_packages.managers]
 description = "[experimental] Restrict which system package managers mise will use."
 docs = """

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1193,6 +1193,16 @@ pub trait Backend: Debug + Send + Sync {
         Ok(vec![])
     }
 
+    /// Plugin-declared system prerequisites (build tools, libraries, ...) that
+    /// must be present on the machine before this tool can install. Distinct
+    /// from [`Backend::get_dependencies`], which returns other *mise tools*.
+    /// Detection is the source of truth; the package hints attached to each dep
+    /// only drive optional remediation. Infallible by design — a malformed
+    /// declaration must never block an install, so overrides warn and skip.
+    fn system_dependencies(&self) -> Vec<crate::system::deps::SystemDep> {
+        vec![]
+    }
+
     /// Whether this backend's version source lacks an upstream prerelease flag
     /// and should mark regex-shaped versions as prereleases before caching.
     fn mark_prereleases_from_version_pattern(&self) -> bool {

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -34,6 +34,7 @@ pub struct VfoxBackend {
     pathname: String,
     tool_name: Option<String>,
     metadata_deps: OnceLock<Vec<String>>,
+    system_deps: OnceLock<Vec<crate::system::deps::SystemDep>>,
 }
 
 #[async_trait]
@@ -61,6 +62,20 @@ impl Backend for VfoxBackend {
             })
         });
         Ok(deps.iter().map(|s| s.as_str()).collect())
+    }
+
+    fn system_dependencies(&self) -> Vec<crate::system::deps::SystemDep> {
+        self.system_deps
+            .get_or_init(|| {
+                self.load_system_deps().unwrap_or_else(|e| {
+                    warn!(
+                        "failed to load vfox plugin system dependencies for {}: {e}",
+                        self.pathname
+                    );
+                    vec![]
+                })
+            })
+            .clone()
     }
 
     fn mark_prereleases_from_version_pattern(&self) -> bool {
@@ -466,6 +481,7 @@ impl VfoxBackend {
             pathname,
             tool_name,
             metadata_deps: OnceLock::new(),
+            system_deps: OnceLock::new(),
         }
     }
 
@@ -477,6 +493,26 @@ impl VfoxBackend {
         let plugin = vfox::Plugin::from_dir(&plugin_path)?;
         let metadata = plugin.get_metadata()?;
         Ok(metadata.depends)
+    }
+
+    fn load_system_deps(&self) -> eyre::Result<Vec<crate::system::deps::SystemDep>> {
+        let plugin_path = dirs::PLUGINS.join(&self.pathname);
+        if !plugin_path.exists() {
+            return Ok(vec![]);
+        }
+        let plugin = vfox::Plugin::from_dir(&plugin_path)?;
+        let metadata = plugin.get_metadata()?;
+        let mut deps = vec![];
+        for raw in metadata.system_dependencies {
+            match crate::system::deps::SystemDep::try_from(raw) {
+                Ok(dep) => deps.push(dep),
+                Err(e) => warn!(
+                    "ignoring invalid systemDependencies entry in vfox plugin {}: {e}",
+                    self.pathname
+                ),
+            }
+        }
+        Ok(deps)
     }
 
     async fn _exec_env(

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1101,6 +1101,9 @@ impl BootstrapStatus {
         let mut seen = HashSet::new();
         let mut json_entries = vec![];
         for tr in trs.tools.values().flatten() {
+            if !tr.is_os_supported() {
+                continue;
+            }
             let ba = tr.ba();
             if !seen.insert(ba.short.clone()) {
                 continue;

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -707,7 +707,7 @@ impl Bootstrap {
         } else {
             self.run_hooks(&hooks, BootstrapHookPhase::PreTools).await?;
             info!("bootstrap: tools");
-            Install::new_bare(self.dry_run).run().await?;
+            Install::new_bare(self.dry_run, self.yes).run().await?;
             if !self.dry_run {
                 config = Config::reset().await?;
                 hooks = system::hooks_from_config(&config);
@@ -1088,7 +1088,59 @@ impl BootstrapStatus {
         self.collect_systemd(config, &mut report).await?;
         self.collect_user(config, &mut report)?;
         self.collect_tools(config, &mut report).await?;
+        self.collect_plugin_deps(config, &mut report).await?;
         Ok(report)
+    }
+
+    async fn collect_plugin_deps(
+        &self,
+        config: &Arc<Config>,
+        report: &mut BootstrapStatusReport,
+    ) -> Result<()> {
+        let trs = config.get_tool_request_set().await?;
+        let mut seen = HashSet::new();
+        let mut json_entries = vec![];
+        for tr in trs.tools.values().flatten() {
+            let ba = tr.ba();
+            if !seen.insert(ba.short.clone()) {
+                continue;
+            }
+            let Some(backend) = crate::backend::get(ba) else {
+                continue;
+            };
+            let deps = backend.system_dependencies();
+            if deps.is_empty() {
+                continue;
+            }
+            for status in crate::system::deps::detect(&deps).await {
+                let optional = status.dep.optional.is_some();
+                let (state, missing) = if status.satisfied {
+                    ("satisfied".to_string(), false)
+                } else if optional {
+                    ("optional missing".to_string(), false)
+                } else {
+                    ("missing".to_string(), true)
+                };
+                report.row(
+                    "plugin-deps",
+                    format!("{}: {}", ba.tool_name, status.dep.label()),
+                    status.found.clone().unwrap_or_default(),
+                    state.clone(),
+                    missing,
+                );
+                json_entries.push(json!({
+                    "tool": ba.tool_name,
+                    "dependency": status.dep.label(),
+                    "found": status.found,
+                    "optional": optional,
+                    "state": state.replace(' ', "_"),
+                }));
+            }
+        }
+        report
+            .json
+            .insert("plugin_deps".to_string(), json!(json_entries));
+        Ok(())
     }
 
     async fn collect_packages(

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -353,7 +353,13 @@ impl Doctor {
     /// deps and tools whose plugin isn't installed are silently skipped.
     async fn analyze_system_deps(&mut self, ts: &Toolset) {
         let mut seen = std::collections::HashSet::new();
-        for ba in ts.versions.keys() {
+        for (ba, tvl) in &ts.versions {
+            // Skip tools not supported on this OS, matching bootstrap's
+            // collect_plugin_deps — otherwise we'd warn about prerequisites for
+            // a tool that will never install on this platform.
+            if !tvl.requests.iter().any(|tr| tr.is_os_supported()) {
+                continue;
+            }
             if !seen.insert(ba.short.clone()) {
                 continue;
             }

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -163,6 +163,7 @@ impl Doctor {
         self.analyze_shims(&config, ts).await;
         self.analyze_plugins();
         self.analyze_backend_mismatches();
+        self.analyze_system_deps(ts).await;
         self.check_path_ordering(ts, &config).await;
         data.insert(
             "paths".into(),
@@ -293,6 +294,11 @@ impl Doctor {
 
         self.analyze_plugins();
         self.analyze_backend_mismatches();
+        if let Ok(config) = Config::get().await
+            && let Ok(ts) = config.get_toolset().await
+        {
+            self.analyze_system_deps(ts).await;
+        }
 
         let env_vars = mise_env_vars()
             .into_iter()
@@ -340,6 +346,43 @@ impl Doctor {
         }
 
         Ok(())
+    }
+
+    /// Warn about missing required system prerequisites declared by the
+    /// plugins backing the current toolset (php needs bison, etc.). Optional
+    /// deps and tools whose plugin isn't installed are silently skipped.
+    async fn analyze_system_deps(&mut self, ts: &Toolset) {
+        let mut seen = std::collections::HashSet::new();
+        for ba in ts.versions.keys() {
+            if !seen.insert(ba.short.clone()) {
+                continue;
+            }
+            let Some(backend) = crate::backend::get(ba) else {
+                continue;
+            };
+            let deps = backend.system_dependencies();
+            if deps.is_empty() {
+                continue;
+            }
+            for status in crate::system::deps::detect(&deps).await {
+                if status.satisfied || status.dep.optional.is_some() {
+                    continue;
+                }
+                let msg = match &status.found {
+                    Some(found) => format!(
+                        "{} requires system dependency {} (found {found})",
+                        ba.tool_name,
+                        status.dep.label()
+                    ),
+                    None => format!(
+                        "{} requires system dependency {}",
+                        ba.tool_name,
+                        status.dep.label()
+                    ),
+                };
+                self.warnings.push(msg);
+            }
+        }
     }
 
     fn analyze_settings(&mut self) -> eyre::Result<()> {

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -374,13 +374,18 @@ impl Doctor {
                 if status.satisfied || status.dep.optional.is_some() {
                     continue;
                 }
-                let msg = match &status.found {
-                    Some(found) => format!(
+                let msg = match (&status.found, &status.reason) {
+                    (Some(found), _) => format!(
                         "{} requires system dependency {} (found {found})",
                         ba.tool_name,
                         status.dep.label()
                     ),
-                    None => format!(
+                    (None, Some(reason)) => format!(
+                        "{} requires system dependency {} ({reason})",
+                        ba.tool_name,
+                        status.dep.label()
+                    ),
+                    (None, None) => format!(
                         "{} requires system dependency {}",
                         ba.tool_name,
                         status.dep.label()

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -91,14 +91,20 @@ pub struct Install {
     /// May require elevated permissions (e.g. sudo).
     #[clap(long, verbatim_doc_comment, conflicts_with = "shared")]
     system: bool,
+
+    /// Skip confirmation when installing missing plugin system dependencies.
+    /// Set internally by `mise bootstrap --yes`; not a user-facing flag.
+    #[clap(skip)]
+    yes: bool,
 }
 
 impl Install {
     /// a bare `mise install` (install everything missing from config), as run
     /// by `mise bootstrap`
-    pub(crate) fn new_bare(dry_run: bool) -> Self {
+    pub(crate) fn new_bare(dry_run: bool, yes: bool) -> Self {
         Self {
             dry_run,
+            yes,
             ..Default::default()
         }
     }
@@ -388,6 +394,7 @@ impl Install {
             dry_run: self.is_dry_run(),
             locked: Settings::get().locked,
             install_dir,
+            yes: self.yes || Settings::get().yes,
             ..Default::default()
         })
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -67,7 +67,7 @@ mod shell;
 mod shell_alias;
 mod sponsors;
 mod sync;
-mod system;
+pub(crate) mod system;
 mod tasks;
 mod test_tool;
 mod token;

--- a/src/cli/system/mod.rs
+++ b/src/cli/system/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(unix)]
 pub(super) mod brew;
-pub(super) mod driver;
+pub(crate) mod driver;
 pub(super) mod import;
 pub(super) mod install;
 pub(super) mod prune;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -102,6 +102,32 @@ pub enum NpmPackageManager {
     Pnpm,
 }
 
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Default,
+    strum::EnumString,
+    strum::Display,
+    PartialEq,
+    Eq,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum SystemDepsMode {
+    /// prompt to install missing plugin system dependencies (falls back to `warn` non-interactively)
+    #[default]
+    Prompt,
+    /// install missing plugin system dependencies without prompting
+    Auto,
+    /// print missing plugin system dependencies and continue
+    Warn,
+    /// skip the plugin system dependency check
+    Ignore,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PythonUvVenvAuto {
     #[default]

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -227,7 +227,8 @@ impl TryFrom<vfox::SystemDependency> for SystemDep {
 /// Host-only detection result: `(satisfied, found_version, reason)`.
 type DetectOutcome = (bool, Option<String>, Option<String>);
 
-static CACHE: Lazy<Mutex<HashMap<String, DetectOutcome>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static CACHE: Lazy<Mutex<HashMap<String, DetectOutcome>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Detect all `deps`, memoized. Concurrency-safe; two calls with the same
 /// fingerprint reuse the first result.
@@ -251,15 +252,14 @@ async fn detect_inner(deps: &[SystemDep], use_cache: bool) -> Vec<DepStatus> {
         // reusing the first caller's dep would misclassify a required dep as
         // optional when two tools share the same check.
         let fp = dep.fingerprint();
-        let (satisfied, found, reason) = if use_cache
-            && let Some(cached) = CACHE.lock().unwrap().get(&fp).cloned()
-        {
-            cached
-        } else {
-            let outcome = detect_outcome(dep).await;
-            CACHE.lock().unwrap().insert(fp, outcome.clone());
-            outcome
-        };
+        let (satisfied, found, reason) =
+            if use_cache && let Some(cached) = CACHE.lock().unwrap().get(&fp).cloned() {
+                cached
+            } else {
+                let outcome = detect_outcome(dep).await;
+                CACHE.lock().unwrap().insert(fp, outcome.clone());
+                outcome
+            };
         out.push(DepStatus {
             dep: dep.clone(),
             found,

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -337,12 +337,20 @@ async fn check_pkgconfig(
     }
     match run_capture("pkg-config", &["--exists", name]).await {
         Some((true, _)) => {}
-        _ => {
+        Some((false, _)) => {
             return (
                 false,
                 None,
                 Some(format!("pkg-config module `{name}` not found")),
             );
+        }
+        None => {
+            // Timeout or spawn failure — inconclusive, so don't block (matches
+            // the "presence is enough" fallback in check_bin).
+            debug!(
+                "system dep: `pkg-config --exists {name}` timed out or failed to spawn, treating as satisfied"
+            );
+            return (true, None, None);
         }
     }
     let Some(constraint) = constraint else {

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -1,0 +1,592 @@
+//! Plugin-declared system dependencies with capability detection.
+//!
+//! Source-compiling plugins (php, erlang, postgres, ...) need system
+//! prerequisites — build tools, libraries, headers. Historically these lived
+//! as README prose, so users only discovered them when a build failed halfway
+//! through. A plugin can instead declare them as structured *capability
+//! checks* (see [`SystemDepCheck`]) plus per-package-manager remediation hints.
+//!
+//! Detection is the source of truth: a check that passes is satisfied,
+//! full stop — mise never asks *how* the capability got there, so nix,
+//! MacPorts, and from-source installs all pass without ceremony. The package
+//! hints are consulted only to *offer* installing the missing subset via the
+//! existing [`crate::system::packages`] engine.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use indexmap::IndexMap;
+use once_cell::sync::Lazy;
+use versions::Versioning;
+
+use crate::config::Settings;
+use crate::system::packages::{self, PackageRequest, SystemPackageManager};
+
+/// A single capability a plugin requires before it can install.
+#[derive(Debug, Clone)]
+pub struct SystemDep {
+    pub check: SystemDepCheck,
+    /// Optional version constraint (only meaningful for `Bin`/`PkgConfig`).
+    pub version: Option<VersionConstraint>,
+    /// If set, this dependency is optional and this string is the reason it
+    /// might be wanted (e.g. "observer GUI"). Missing optional deps never
+    /// prompt or fail — they surface as a single informational line.
+    pub optional: Option<String>,
+    /// manager name -> package name, used only for remediation hints.
+    pub packages: IndexMap<String, String>,
+}
+
+/// How to detect whether a [`SystemDep`] is satisfied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SystemDepCheck {
+    /// executable resolvable on `PATH`
+    Bin(String),
+    /// `pkg-config --exists <name>` (a `.pc` module)
+    PkgConfig(String),
+    /// dynamic linker can resolve a soname, e.g. `libaio.so.1` (Linux only)
+    SharedLib(String),
+    /// escape hatch: a shell command whose exit status 0 means satisfied
+    Command(String),
+}
+
+impl SystemDepCheck {
+    fn kind(&self) -> &'static str {
+        match self {
+            SystemDepCheck::Bin(_) => "bin",
+            SystemDepCheck::PkgConfig(_) => "pkgconfig",
+            SystemDepCheck::SharedLib(_) => "sharedlib",
+            SystemDepCheck::Command(_) => "command",
+        }
+    }
+
+    fn value(&self) -> &str {
+        match self {
+            SystemDepCheck::Bin(s)
+            | SystemDepCheck::PkgConfig(s)
+            | SystemDepCheck::SharedLib(s)
+            | SystemDepCheck::Command(s) => s,
+        }
+    }
+}
+
+/// A version comparison operator for [`VersionConstraint`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionOp {
+    AtLeast,
+    Greater,
+    AtMost,
+    Less,
+    Exact,
+}
+
+impl VersionOp {
+    fn symbol(self) -> &'static str {
+        match self {
+            VersionOp::AtLeast => ">=",
+            VersionOp::Greater => ">",
+            VersionOp::AtMost => "<=",
+            VersionOp::Less => "<",
+            VersionOp::Exact => "=",
+        }
+    }
+}
+
+/// A parsed version constraint like `>=3.0`. A bare version (`3.0`) means
+/// `>=3.0` — the common "at least this" case.
+///
+/// Note: this compares versions of *system binaries/libraries* declared by a
+/// plugin author against what is installed on the machine. It is NOT used to
+/// resolve or order mise tool versions (see the semver rules in CLAUDE.md);
+/// it is the same class of comparison as [`crate::config::config_file::min_version`].
+#[derive(Debug, Clone)]
+pub struct VersionConstraint {
+    pub op: VersionOp,
+    pub version: Versioning,
+}
+
+impl VersionConstraint {
+    pub fn parse(s: &str) -> eyre::Result<Self> {
+        let s = s.trim();
+        let (op, rest) = if let Some(r) = s.strip_prefix(">=") {
+            (VersionOp::AtLeast, r)
+        } else if let Some(r) = s.strip_prefix("<=") {
+            (VersionOp::AtMost, r)
+        } else if let Some(r) = s.strip_prefix('>') {
+            (VersionOp::Greater, r)
+        } else if let Some(r) = s.strip_prefix('<') {
+            (VersionOp::Less, r)
+        } else if let Some(r) = s.strip_prefix('=') {
+            (VersionOp::Exact, r)
+        } else {
+            (VersionOp::AtLeast, s)
+        };
+        let version = Versioning::new(rest.trim())
+            .ok_or_else(|| eyre::eyre!("invalid version constraint '{s}'"))?;
+        Ok(Self { op, version })
+    }
+
+    pub fn satisfied_by(&self, current: &Versioning) -> bool {
+        match self.op {
+            VersionOp::AtLeast => current >= &self.version,
+            VersionOp::Greater => current > &self.version,
+            VersionOp::AtMost => current <= &self.version,
+            VersionOp::Less => current < &self.version,
+            VersionOp::Exact => current == &self.version,
+        }
+    }
+}
+
+impl fmt::Display for VersionConstraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.op.symbol(), self.version)
+    }
+}
+
+impl SystemDep {
+    /// Human-readable capability label, e.g. `bison >=3.0`, `pkg-config libxml-2.0`.
+    pub fn label(&self) -> String {
+        let base = match &self.check {
+            SystemDepCheck::Bin(name) => name.clone(),
+            SystemDepCheck::PkgConfig(name) => format!("pkg-config {name}"),
+            SystemDepCheck::SharedLib(name) => format!("shared library {name}"),
+            SystemDepCheck::Command(cmd) => format!("`{cmd}`"),
+        };
+        match &self.version {
+            Some(v) => format!("{base} {v}"),
+            None => base,
+        }
+    }
+
+    /// Stable fingerprint used to memoize detection across tools that declare
+    /// the same dependency (php + postgres both needing bison probe once).
+    fn fingerprint(&self) -> String {
+        match &self.version {
+            Some(v) => format!("{}:{}:{v}", self.check.kind(), self.check.value()),
+            None => format!("{}:{}", self.check.kind(), self.check.value()),
+        }
+    }
+}
+
+impl fmt::Display for SystemDep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.label())
+    }
+}
+
+/// The result of probing one [`SystemDep`] on the host.
+#[derive(Debug, Clone)]
+pub struct DepStatus {
+    pub dep: SystemDep,
+    /// detected version, if a version was extracted
+    pub found: Option<String>,
+    pub satisfied: bool,
+    /// why it is unsatisfied (or a note when satisfied)
+    pub reason: Option<String>,
+}
+
+impl TryFrom<vfox::SystemDependency> for SystemDep {
+    type Error = eyre::Error;
+
+    fn try_from(d: vfox::SystemDependency) -> eyre::Result<Self> {
+        let check = match (&d.bin, &d.pkgconfig, &d.sharedlib, &d.command) {
+            (Some(b), None, None, None) => SystemDepCheck::Bin(b.clone()),
+            (None, Some(p), None, None) => SystemDepCheck::PkgConfig(p.clone()),
+            (None, None, Some(s), None) => SystemDepCheck::SharedLib(s.clone()),
+            (None, None, None, Some(c)) => SystemDepCheck::Command(c.clone()),
+            _ => eyre::bail!(
+                "systemDependencies entry must set exactly one of bin/pkgconfig/sharedlib/command"
+            ),
+        };
+        let version = match &d.version {
+            Some(v) => Some(VersionConstraint::parse(v)?),
+            None => None,
+        };
+        Ok(SystemDep {
+            check,
+            version,
+            optional: d.optional.clone(),
+            packages: d.packages.into_iter().collect(),
+        })
+    }
+}
+
+static CACHE: Lazy<Mutex<HashMap<String, DepStatus>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Detect all `deps`, memoized. Concurrency-safe; two calls with the same
+/// fingerprint reuse the first result.
+pub async fn detect(deps: &[SystemDep]) -> Vec<DepStatus> {
+    detect_inner(deps, true).await
+}
+
+/// Detect all `deps`, bypassing (and refreshing) the memo cache. Used to
+/// re-verify after remediation, since a package we just installed changes the
+/// answer.
+pub async fn detect_fresh(deps: &[SystemDep]) -> Vec<DepStatus> {
+    detect_inner(deps, false).await
+}
+
+async fn detect_inner(deps: &[SystemDep], use_cache: bool) -> Vec<DepStatus> {
+    let mut out = Vec::with_capacity(deps.len());
+    for dep in deps {
+        let fp = dep.fingerprint();
+        if use_cache && let Some(cached) = CACHE.lock().unwrap().get(&fp).cloned() {
+            out.push(cached);
+            continue;
+        }
+        let status = detect_one(dep).await;
+        CACHE.lock().unwrap().insert(fp, status.clone());
+        out.push(status);
+    }
+    out
+}
+
+async fn detect_one(dep: &SystemDep) -> DepStatus {
+    let (satisfied, found, reason) = match &dep.check {
+        SystemDepCheck::Bin(name) => check_bin(name, dep.version.as_ref()).await,
+        SystemDepCheck::PkgConfig(name) => check_pkgconfig(name, dep.version.as_ref()).await,
+        SystemDepCheck::SharedLib(name) => check_sharedlib(name).await,
+        SystemDepCheck::Command(cmd) => check_command(cmd).await,
+    };
+    DepStatus {
+        dep: dep.clone(),
+        found,
+        satisfied,
+        reason,
+    }
+}
+
+async fn check_bin(
+    name: &str,
+    constraint: Option<&VersionConstraint>,
+) -> (bool, Option<String>, Option<String>) {
+    let Some(path) = crate::file::which(name) else {
+        return (false, None, Some(format!("`{name}` not found on PATH")));
+    };
+    let Some(constraint) = constraint else {
+        return (true, None, None);
+    };
+    match run_capture(&path.to_string_lossy(), &["--version"]).await {
+        Some((_, output)) => match extract_version(&output) {
+            Some(v) => {
+                let versioning = Versioning::new(&v);
+                match versioning {
+                    Some(versioning) => {
+                        let ok = constraint.satisfied_by(&versioning);
+                        (ok, Some(v), None)
+                    }
+                    // unparseable — do not block; presence is enough
+                    None => {
+                        debug!(
+                            "system dep: `{name}` version '{v}' unparseable, treating as satisfied"
+                        );
+                        (true, Some(v), None)
+                    }
+                }
+            }
+            None => {
+                debug!(
+                    "system dep: could not extract version from `{name} --version`, treating as satisfied"
+                );
+                (true, None, None)
+            }
+        },
+        None => {
+            debug!("system dep: `{name} --version` failed to run, treating as satisfied");
+            (true, None, None)
+        }
+    }
+}
+
+async fn check_pkgconfig(
+    name: &str,
+    constraint: Option<&VersionConstraint>,
+) -> (bool, Option<String>, Option<String>) {
+    if crate::file::which("pkg-config").is_none() {
+        return (
+            false,
+            None,
+            Some("pkg-config is not installed (needed to detect this library)".to_string()),
+        );
+    }
+    match run_capture("pkg-config", &["--exists", name]).await {
+        Some((true, _)) => {}
+        _ => {
+            return (
+                false,
+                None,
+                Some(format!("pkg-config module `{name}` not found")),
+            );
+        }
+    }
+    let Some(constraint) = constraint else {
+        return (true, None, None);
+    };
+    match run_capture("pkg-config", &["--modversion", name]).await {
+        Some((true, output)) => {
+            let v = output.trim().to_string();
+            match Versioning::new(&v) {
+                Some(versioning) => (constraint.satisfied_by(&versioning), Some(v), None),
+                None => {
+                    debug!(
+                        "system dep: pkg-config modversion '{v}' unparseable, treating as satisfied"
+                    );
+                    (true, Some(v), None)
+                }
+            }
+        }
+        _ => (true, None, None),
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn check_sharedlib(soname: &str) -> (bool, Option<String>, Option<String>) {
+    // Primary: ldconfig's cache lists every soname the dynamic linker knows.
+    for ldconfig in ["ldconfig", "/sbin/ldconfig"] {
+        if let Some((true, output)) = run_capture(ldconfig, &["-p"]).await {
+            if output.lines().any(|l| l.contains(soname)) {
+                return (true, None, None);
+            }
+            // ldconfig ran and did not list it; still check LD_LIBRARY_PATH below
+            break;
+        }
+    }
+    // Fallback: honor LD_LIBRARY_PATH dirs the cache doesn't cover.
+    if let Ok(paths) = std::env::var("LD_LIBRARY_PATH") {
+        for dir in std::env::split_paths(&paths) {
+            if dir.join(soname).exists() {
+                return (true, None, None);
+            }
+        }
+    }
+    (
+        false,
+        None,
+        Some(format!(
+            "shared library `{soname}` not found by the dynamic linker"
+        )),
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn check_sharedlib(soname: &str) -> (bool, Option<String>, Option<String>) {
+    debug!("system dep: sharedlib check for `{soname}` is Linux-only, treating as satisfied");
+    (true, None, None)
+}
+
+async fn check_command(cmd: &str) -> (bool, Option<String>, Option<String>) {
+    let (program, args): (&str, Vec<&str>) = if cfg!(windows) {
+        ("cmd", vec!["/C", cmd])
+    } else {
+        ("sh", vec!["-c", cmd])
+    };
+    match run_capture(program, &args).await {
+        Some((true, _)) => (true, None, None),
+        _ => (
+            false,
+            None,
+            Some(format!("command `{cmd}` did not succeed")),
+        ),
+    }
+}
+
+/// Run a short command, capturing combined stdout+stderr. Returns
+/// `(success, output)` or `None` if it could not be spawned. Silent and
+/// side-effect free — never elevates.
+async fn run_capture(program: &str, args: &[&str]) -> Option<(bool, String)> {
+    let output = tokio::process::Command::new(program)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .await
+        .ok()?;
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    Some((output.status.success(), combined))
+}
+
+/// Extract the first version-like token (`3`, `3.0`, `3.12.1`) from text such
+/// as `bison (GNU Bison) 3.8.2`.
+fn extract_version(text: &str) -> Option<String> {
+    static RE: Lazy<regex::Regex> = Lazy::new(|| regex::Regex::new(r"\d+(?:\.\d+)+").unwrap());
+    RE.find(text).map(|m| m.as_str().to_string())
+}
+
+/// Pick the first available, settings-enabled package manager that has a hint
+/// for `dep`. Mirrors the manager selection [`crate::system`] applies so we
+/// never propose a manager the driver would reject.
+pub fn pick_manager(dep: &SystemDep) -> Option<Arc<dyn SystemPackageManager>> {
+    let enabled = Settings::get().system_packages.managers.clone();
+    for m in packages::all_managers() {
+        let name = m.name();
+        if enabled
+            .as_ref()
+            .is_some_and(|e| !e.iter().any(|x| x == name))
+        {
+            continue;
+        }
+        if !m.is_available() {
+            continue;
+        }
+        if dep.packages.contains_key(name) {
+            return Some(m);
+        }
+    }
+    None
+}
+
+/// Group missing deps into per-manager [`PackageRequest`]s for remediation.
+/// Returns `(by_manager, unremediable)` where `unremediable` are deps with no
+/// available manager hint.
+pub fn build_requests(
+    missing: &[&SystemDep],
+) -> (IndexMap<String, Vec<PackageRequest>>, Vec<SystemDep>) {
+    let mut by_mgr: IndexMap<String, Vec<PackageRequest>> = IndexMap::new();
+    let mut unremediable = vec![];
+    for dep in missing {
+        match pick_manager(dep) {
+            Some(m) => {
+                let pkg = dep.packages.get(m.name()).cloned().unwrap_or_default();
+                let requests = by_mgr.entry(m.name().to_string()).or_default();
+                if !requests.iter().any(|r| r.name == pkg) {
+                    requests.push(PackageRequest {
+                        name: pkg,
+                        version: None,
+                        tap_url: None,
+                    });
+                }
+            }
+            None => unremediable.push((*dep).clone()),
+        }
+    }
+    (by_mgr, unremediable)
+}
+
+/// Copy-pasteable install hint commands for `missing`, grouped by the manager
+/// that would satisfy each. Used by warn mode.
+pub fn hint_commands(missing: &[&SystemDep]) -> Vec<String> {
+    let (by_mgr, _) = build_requests(missing);
+    by_mgr
+        .into_iter()
+        .map(|(mgr, requests)| {
+            let pkgs = requests
+                .iter()
+                .map(|r| r.name.as_str())
+                .collect::<Vec<_>>()
+                .join(" ");
+            format!("{}{pkgs}", install_prefix(&mgr))
+        })
+        .collect()
+}
+
+fn install_prefix(mgr: &str) -> &'static str {
+    match mgr {
+        "brew" => "brew install ",
+        "brew-cask" => "brew install --cask ",
+        "apt" => "sudo apt-get install -y ",
+        "dnf" => "sudo dnf install -y ",
+        "pacman" => "sudo pacman -S ",
+        "apk" => "sudo apk add ",
+        "mas" => "mas install ",
+        _ => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_constraint_parse_and_compare() {
+        let c = VersionConstraint::parse(">=3.0").unwrap();
+        assert_eq!(c.op, VersionOp::AtLeast);
+        assert!(!c.satisfied_by(&Versioning::new("2.3").unwrap()));
+        assert!(c.satisfied_by(&Versioning::new("3.0").unwrap()));
+        assert!(c.satisfied_by(&Versioning::new("3.8.2").unwrap()));
+
+        // bare version means >=
+        let bare = VersionConstraint::parse("3.0").unwrap();
+        assert_eq!(bare.op, VersionOp::AtLeast);
+        assert!(bare.satisfied_by(&Versioning::new("3.1").unwrap()));
+        assert!(!bare.satisfied_by(&Versioning::new("2.9").unwrap()));
+
+        assert!(
+            VersionConstraint::parse(">2")
+                .unwrap()
+                .satisfied_by(&Versioning::new("3").unwrap())
+        );
+        assert!(
+            !VersionConstraint::parse(">3")
+                .unwrap()
+                .satisfied_by(&Versioning::new("3").unwrap())
+        );
+        assert!(
+            VersionConstraint::parse("<=1.2")
+                .unwrap()
+                .satisfied_by(&Versioning::new("1.2").unwrap())
+        );
+        assert!(
+            VersionConstraint::parse("=3.0")
+                .unwrap()
+                .satisfied_by(&Versioning::new("3.0").unwrap())
+        );
+        assert!(
+            !VersionConstraint::parse("=3.0")
+                .unwrap()
+                .satisfied_by(&Versioning::new("3.0.1").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_extract_version() {
+        assert_eq!(
+            extract_version("bison (GNU Bison) 2.3").as_deref(),
+            Some("2.3")
+        );
+        assert_eq!(extract_version("GNU Make 3.81").as_deref(), Some("3.81"));
+        assert_eq!(
+            extract_version("OpenSSL 3.0.13 30 Jan 2024").as_deref(),
+            Some("3.0.13")
+        );
+        assert_eq!(extract_version("no version here").as_deref(), None);
+    }
+
+    #[test]
+    fn test_label() {
+        let dep = SystemDep {
+            check: SystemDepCheck::Bin("bison".into()),
+            version: Some(VersionConstraint::parse(">=3.0").unwrap()),
+            optional: None,
+            packages: Default::default(),
+        };
+        assert_eq!(dep.label(), "bison >=3.0");
+
+        let dep = SystemDep {
+            check: SystemDepCheck::PkgConfig("libxml-2.0".into()),
+            version: None,
+            optional: None,
+            packages: Default::default(),
+        };
+        assert_eq!(dep.label(), "pkg-config libxml-2.0");
+    }
+
+    #[tokio::test]
+    async fn test_check_bin_present_and_missing() {
+        // `sh` is present on every unix CI runner; on windows use `cmd`.
+        let present = if cfg!(windows) { "cmd" } else { "sh" };
+        let (ok, _, _) = check_bin(present, None).await;
+        assert!(ok);
+
+        let (ok, _, reason) = check_bin("definitely-not-a-real-binary-xyz", None).await;
+        assert!(!ok);
+        assert!(reason.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_check_command() {
+        let (ok, _, _) = check_command("true").await;
+        assert!(ok);
+        let (ok, _, _) = check_command("false").await;
+        assert!(!ok);
+    }
+}

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -612,8 +612,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_bin_present_and_missing() {
-        // `sh` is present on every unix CI runner; on windows use `cmd`.
-        let present = if cfg!(windows) { "cmd" } else { "sh" };
+        // `file::which` does no PATHEXT resolution, so on Windows the name must
+        // carry the `.exe` extension (cmd.exe lives in System32, on PATH on CI).
+        let present = if cfg!(windows) { "cmd.exe" } else { "sh" };
         let (ok, _, _) = check_bin(present, None).await;
         assert!(ok);
 

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -211,7 +211,10 @@ impl TryFrom<vfox::SystemDependency> for SystemDep {
     }
 }
 
-static CACHE: Lazy<Mutex<HashMap<String, DepStatus>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+/// Host-only detection result: `(satisfied, found_version, reason)`.
+type DetectOutcome = (bool, Option<String>, Option<String>);
+
+static CACHE: Lazy<Mutex<HashMap<String, DetectOutcome>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Detect all `deps`, memoized. Concurrency-safe; two calls with the same
 /// fingerprint reuse the first result.
@@ -229,30 +232,40 @@ pub async fn detect_fresh(deps: &[SystemDep]) -> Vec<DepStatus> {
 async fn detect_inner(deps: &[SystemDep], use_cache: bool) -> Vec<DepStatus> {
     let mut out = Vec::with_capacity(deps.len());
     for dep in deps {
+        // The cache keys on the check + version only (the fingerprint), so it
+        // must store just the detection *outcome* — not the whole DepStatus.
+        // The `dep` (its `optional`/`packages`) belongs to the current caller;
+        // reusing the first caller's dep would misclassify a required dep as
+        // optional when two tools share the same check.
         let fp = dep.fingerprint();
-        if use_cache && let Some(cached) = CACHE.lock().unwrap().get(&fp).cloned() {
-            out.push(cached);
-            continue;
-        }
-        let status = detect_one(dep).await;
-        CACHE.lock().unwrap().insert(fp, status.clone());
-        out.push(status);
+        let (satisfied, found, reason) = if use_cache
+            && let Some(cached) = CACHE.lock().unwrap().get(&fp).cloned()
+        {
+            cached
+        } else {
+            let outcome = detect_outcome(dep).await;
+            CACHE.lock().unwrap().insert(fp, outcome.clone());
+            outcome
+        };
+        out.push(DepStatus {
+            dep: dep.clone(),
+            found,
+            satisfied,
+            reason,
+        });
     }
     out
 }
 
-async fn detect_one(dep: &SystemDep) -> DepStatus {
-    let (satisfied, found, reason) = match &dep.check {
+/// Probe a single dep, returning `(satisfied, found_version, reason)` — the
+/// part of the result that depends only on the host, not on which tool
+/// declared the dep.
+async fn detect_outcome(dep: &SystemDep) -> DetectOutcome {
+    match &dep.check {
         SystemDepCheck::Bin(name) => check_bin(name, dep.version.as_ref()).await,
         SystemDepCheck::PkgConfig(name) => check_pkgconfig(name, dep.version.as_ref()).await,
         SystemDepCheck::SharedLib(name) => check_sharedlib(name).await,
         SystemDepCheck::Command(cmd) => check_command(cmd).await,
-    };
-    DepStatus {
-        dep: dep.clone(),
-        found,
-        satisfied,
-        reason,
     }
 }
 
@@ -391,15 +404,23 @@ async fn check_command(cmd: &str) -> (bool, Option<String>, Option<String>) {
 }
 
 /// Run a short command, capturing combined stdout+stderr. Returns
-/// `(success, output)` or `None` if it could not be spawned. Silent and
-/// side-effect free — never elevates.
+/// `(success, output)` or `None` if it could not be spawned or timed out.
+/// Silent and side-effect free — never elevates. A 5s wall-clock timeout keeps
+/// a hanging binary (e.g. one that blocks on `--version`) from stalling the
+/// whole install.
 async fn run_capture(program: &str, args: &[&str]) -> Option<(bool, String)> {
-    let output = tokio::process::Command::new(program)
+    let fut = tokio::process::Command::new(program)
         .args(args)
         .stdin(std::process::Stdio::null())
-        .output()
-        .await
-        .ok()?;
+        .output();
+    let output = match tokio::time::timeout(std::time::Duration::from_secs(5), fut).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(_)) => return None,
+        Err(_) => {
+            debug!("system dep: `{program}` timed out, treating check as inconclusive");
+            return None;
+        }
+    };
     let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
     combined.push_str(&String::from_utf8_lossy(&output.stderr));
     Some((output.status.success(), combined))

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -624,9 +624,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_command() {
-        let (ok, _, _) = check_command("true").await;
+        // `true`/`false` aren't cmd built-ins on Windows; use `exit N`, which
+        // works in both `sh -c` and `cmd /C`.
+        let (succeed, fail) = if cfg!(windows) {
+            ("exit 0", "exit 1")
+        } else {
+            ("true", "false")
+        };
+        let (ok, _, _) = check_command(succeed).await;
         assert!(ok);
-        let (ok, _, _) = check_command("false").await;
+        let (ok, _, _) = check_command(fail).await;
         assert!(!ok);
     }
 

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -198,9 +198,22 @@ impl TryFrom<vfox::SystemDependency> for SystemDep {
                 "systemDependencies entry must set exactly one of bin/pkgconfig/sharedlib/command"
             ),
         };
-        let version = match &d.version {
-            Some(v) => Some(VersionConstraint::parse(v)?),
-            None => None,
+        // A version constraint is only meaningful for bin/pkgconfig (we probe
+        // `--version` / `--modversion`). If declared on sharedlib/command,
+        // keep the check but drop the version with a warning rather than
+        // silently honoring a constraint that is never enforced.
+        let version = match (&check, &d.version) {
+            (_, None) => None,
+            (SystemDepCheck::Bin(_) | SystemDepCheck::PkgConfig(_), Some(v)) => {
+                Some(VersionConstraint::parse(v)?)
+            }
+            (check, Some(_)) => {
+                warn!(
+                    "systemDependencies: `version` is only supported for bin/pkgconfig checks, ignoring it for the {} check",
+                    check.kind()
+                );
+                None
+            }
         };
         Ok(SystemDep {
             check,
@@ -355,9 +368,15 @@ async fn check_pkgconfig(
 #[cfg(target_os = "linux")]
 async fn check_sharedlib(soname: &str) -> (bool, Option<String>, Option<String>) {
     // Primary: ldconfig's cache lists every soname the dynamic linker knows.
+    // Each entry looks like `	libaio.so.1 (libc6,x86-64) => /path/libaio.so.1`,
+    // so match the advertised soname as the whole first token — a substring
+    // check would let `libfoo.so.10` satisfy a request for `libfoo.so.1`.
     for ldconfig in ["ldconfig", "/sbin/ldconfig"] {
         if let Some((true, output)) = run_capture(ldconfig, &["-p"]).await {
-            if output.lines().any(|l| l.contains(soname)) {
+            if output
+                .lines()
+                .any(|l| l.split_whitespace().next() == Some(soname))
+            {
                 return (true, None, None);
             }
             // ldconfig ran and did not list it; still check LD_LIBRARY_PATH below
@@ -609,5 +628,29 @@ mod tests {
         assert!(ok);
         let (ok, _, _) = check_command("false").await;
         assert!(!ok);
+    }
+
+    #[test]
+    fn test_version_only_applies_to_bin_and_pkgconfig() {
+        // bin + version is honored
+        let d = vfox::SystemDependency {
+            bin: Some("bison".into()),
+            version: Some(">=3.0".into()),
+            ..Default::default()
+        };
+        let dep = SystemDep::try_from(d).unwrap();
+        assert!(dep.version.is_some());
+
+        // sharedlib + version: the check is kept, the version is dropped
+        let d = vfox::SystemDependency {
+            sharedlib: Some("libaio.so.1".into()),
+            version: Some(">=1.0".into()),
+            ..Default::default()
+        };
+        let dep = SystemDep::try_from(d).unwrap();
+        assert!(matches!(dep.check, SystemDepCheck::SharedLib(_)));
+        assert!(dep.version.is_none());
+        // and label must not render a phantom version
+        assert_eq!(dep.label(), "shared library libaio.so.1");
     }
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -30,6 +30,7 @@ use crate::system::shell_activation::{
 use crate::system::systemd::{SystemdRequest, SystemdTomlConfig};
 
 pub mod defaults;
+pub mod deps;
 pub mod edits;
 pub mod files;
 pub mod hooks;

--- a/src/toolset/helpers.rs
+++ b/src/toolset/helpers.rs
@@ -107,15 +107,6 @@ async fn preflight_system_deps_inner(
 
     report_missing(&missing_required);
 
-    if effective == SystemDepsMode::Warn {
-        let deps: Vec<&SystemDep> = missing_required.iter().map(|(_, s)| &s.dep).collect();
-        for line in deps::hint_commands(&deps) {
-            warn!("install with: {line}");
-        }
-        return Ok(());
-    }
-
-    // Prompt / Auto: remediate via the system-packages driver.
     let missing_deps: Vec<SystemDep> = missing_required
         .iter()
         .map(|(_, s)| s.dep.clone())
@@ -123,15 +114,24 @@ async fn preflight_system_deps_inner(
     let refs: Vec<&SystemDep> = missing_deps.iter().collect();
     let (by_mgr, unremediable) = deps::build_requests(&refs);
 
-    if !unremediable.is_empty() {
-        for dep in &unremediable {
-            warn!(
-                "no available package manager can install {} — install it manually",
-                dep.label()
-            );
-        }
+    // Deps no available package manager can install are surfaced in every mode
+    // (warn and prompt/auto) — otherwise they'd only appear in the generic
+    // missing list with no actionable message.
+    for dep in &unremediable {
+        warn!(
+            "no available package manager can install {} — install it manually",
+            dep.label()
+        );
     }
 
+    if effective == SystemDepsMode::Warn {
+        for line in deps::hint_commands(&refs) {
+            warn!("install with: {line}");
+        }
+        return Ok(());
+    }
+
+    // Prompt / Auto: remediate via the system-packages driver.
     if by_mgr.is_empty() {
         return Ok(());
     }

--- a/src/toolset/helpers.rs
+++ b/src/toolset/helpers.rs
@@ -155,12 +155,20 @@ async fn preflight_system_deps_inner(
         return Ok(());
     }
 
-    // Re-detect the remediated subset (bypassing the memo cache) to catch
-    // packages that installed but still aren't visible (e.g. keg-only brew).
-    for status in deps::detect_fresh(&missing_deps).await {
+    // Re-detect only the deps we actually tried to install (those with a
+    // package-manager hint), bypassing the memo cache. Deps with no hint, or
+    // that the user declined at the driver prompt, are excluded — warning that
+    // they "were installed but not detected" would be wrong.
+    let remediated: Vec<SystemDep> = missing_deps
+        .iter()
+        .filter(|d| deps::pick_manager(d).is_some())
+        .cloned()
+        .collect();
+    for status in deps::detect_fresh(&remediated).await {
         if !status.satisfied {
             warn!(
-                "{} was installed but is still not detected — it may need to be linked or added to PATH \
+                "{} is still not detected after attempting to install it — the package install \
+                 may have been declined or skipped, or it needs to be linked or added to PATH \
                  (e.g. `brew link --force`)",
                 status.dep.label()
             );

--- a/src/toolset/helpers.rs
+++ b/src/toolset/helpers.rs
@@ -1,6 +1,12 @@
 use std::sync::Arc;
 
+use indexmap::IndexSet;
+
 use crate::backend::Backend;
+use crate::config::Settings;
+use crate::config::settings::SystemDepsMode;
+use crate::system::deps::{self, DepStatus, SystemDep};
+use crate::toolset::install_options::InstallOptions;
 use crate::toolset::tool_request::ToolRequest;
 use crate::toolset::tool_version::ToolVersion;
 
@@ -19,4 +25,158 @@ pub(super) fn show_python_install_hint(versions: &[ToolRequest]) {
         "use multiple versions simultaneously with",
         "mise use python@3.12 python@3.11"
     );
+}
+
+/// Check plugin-declared system prerequisites for the tools about to install,
+/// and — depending on the `system_deps` setting — report, prompt to install,
+/// or auto-install the missing subset. Never fails the install: any error is
+/// downgraded to a warning. Runs once for the whole batch, on the main task
+/// (before parallel install tasks spawn), because the system-packages driver
+/// futures are not `Send`.
+pub(super) async fn preflight_system_deps(versions: &[ToolRequest], opts: &InstallOptions) {
+    let mode = Settings::get().system_deps;
+    if mode == SystemDepsMode::Ignore {
+        return;
+    }
+    if let Err(err) = preflight_system_deps_inner(versions, opts, mode).await {
+        warn!("system dependency check failed: {err:#}");
+    }
+}
+
+async fn preflight_system_deps_inner(
+    versions: &[ToolRequest],
+    opts: &InstallOptions,
+    mode: SystemDepsMode,
+) -> eyre::Result<()> {
+    // Collect declared deps per tool, deduping backends (multiple versions of
+    // one tool share a backend and its declarations).
+    let mut seen_backends = IndexSet::new();
+    let mut per_tool: Vec<(String, Vec<SystemDep>)> = vec![];
+    for tr in versions {
+        let Ok(backend) = tr.backend() else { continue };
+        if !seen_backends.insert(backend.ba().short.clone()) {
+            continue;
+        }
+        let deps = backend.system_dependencies();
+        if !deps.is_empty() {
+            per_tool.push((backend.ba().tool_name.clone(), deps));
+        }
+    }
+    if per_tool.is_empty() {
+        return Ok(());
+    }
+
+    // Detect (memoized) and partition into missing required / optional.
+    let mut missing_required: Vec<(String, DepStatus)> = vec![];
+    let mut missing_optional: Vec<(String, DepStatus)> = vec![];
+    for (tool, deps) in &per_tool {
+        for status in deps::detect(deps).await {
+            if status.satisfied {
+                continue;
+            }
+            if status.dep.optional.is_some() {
+                missing_optional.push((tool.clone(), status));
+            } else {
+                missing_required.push((tool.clone(), status));
+            }
+        }
+    }
+
+    for (tool, status) in &missing_optional {
+        let reason = status.dep.optional.as_deref().unwrap_or_default();
+        info!(
+            "{tool}: optional system dependency {} is missing ({reason})",
+            status.dep.label()
+        );
+    }
+
+    if missing_required.is_empty() {
+        return Ok(());
+    }
+
+    // Effective mode: prompt degrades to warn when we cannot ask.
+    let can_prompt = console::user_attended_stderr() && !opts.yes;
+    let effective = match mode {
+        SystemDepsMode::Prompt if !can_prompt => SystemDepsMode::Warn,
+        other => other,
+    };
+
+    report_missing(&missing_required);
+
+    if effective == SystemDepsMode::Warn {
+        let deps: Vec<&SystemDep> = missing_required.iter().map(|(_, s)| &s.dep).collect();
+        for line in deps::hint_commands(&deps) {
+            warn!("install with: {line}");
+        }
+        return Ok(());
+    }
+
+    // Prompt / Auto: remediate via the system-packages driver.
+    let missing_deps: Vec<SystemDep> = missing_required
+        .iter()
+        .map(|(_, s)| s.dep.clone())
+        .collect();
+    let refs: Vec<&SystemDep> = missing_deps.iter().collect();
+    let (by_mgr, unremediable) = deps::build_requests(&refs);
+
+    if !unremediable.is_empty() {
+        for dep in &unremediable {
+            warn!(
+                "no available package manager can install {} — install it manually",
+                dep.label()
+            );
+        }
+    }
+
+    if by_mgr.is_empty() {
+        return Ok(());
+    }
+
+    let mgrs = crate::system::packages_from_requests(by_mgr)?;
+    let driver_opts = crate::cli::system::driver::DriverOpts {
+        manager: None,
+        explicit: false,
+        dry_run: opts.dry_run,
+        update: false,
+        yes: matches!(mode, SystemDepsMode::Auto) || opts.yes,
+    };
+    if let Err(err) = crate::cli::system::driver::run(
+        mgrs,
+        crate::cli::system::driver::Action::Install,
+        &driver_opts,
+    )
+    .await
+    {
+        warn!("failed to install system dependencies: {err:#}");
+        return Ok(());
+    }
+
+    if opts.dry_run {
+        return Ok(());
+    }
+
+    // Re-detect the remediated subset (bypassing the memo cache) to catch
+    // packages that installed but still aren't visible (e.g. keg-only brew).
+    for status in deps::detect_fresh(&missing_deps).await {
+        if !status.satisfied {
+            warn!(
+                "{} was installed but is still not detected — it may need to be linked or added to PATH \
+                 (e.g. `brew link --force`)",
+                status.dep.label()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn report_missing(missing: &[(String, DepStatus)]) {
+    warn!("missing system dependencies for tools about to install:");
+    for (tool, status) in missing {
+        match (&status.found, &status.reason) {
+            (Some(found), _) => warn!("  {tool}: {} required, found {found}", status.dep.label()),
+            (None, Some(reason)) => warn!("  {tool}: {} — {reason}", status.dep.label()),
+            (None, None) => warn!("  {tool}: {}", status.dep.label()),
+        }
+    }
 }

--- a/src/toolset/helpers.rs
+++ b/src/toolset/helpers.rs
@@ -53,6 +53,11 @@ async fn preflight_system_deps_inner(
     let mut seen_backends = IndexSet::new();
     let mut per_tool: Vec<(String, Vec<SystemDep>)> = vec![];
     for tr in versions {
+        // Skip requests not applicable to this OS, matching doctor's
+        // analyze_system_deps and bootstrap's collect_plugin_deps.
+        if !tr.is_os_supported() {
+            continue;
+        }
         let Ok(backend) = tr.backend() else { continue };
         if !seen_backends.insert(backend.ba().short.clone()) {
             continue;

--- a/src/toolset/helpers.rs
+++ b/src/toolset/helpers.rs
@@ -94,10 +94,14 @@ async fn preflight_system_deps_inner(
         return Ok(());
     }
 
-    // Effective mode: prompt degrades to warn when we cannot ask.
-    let can_prompt = console::user_attended_stderr() && !opts.yes;
+    // Effective mode: prompt degrades to warn only when we can neither ask
+    // (non-interactive) nor auto-confirm (`--yes`/MISE_YES). With `opts.yes`
+    // set, Prompt stays Prompt and the remediation below runs non-interactively
+    // (the driver uses `yes` to skip its own confirmation).
     let effective = match mode {
-        SystemDepsMode::Prompt if !can_prompt => SystemDepsMode::Warn,
+        SystemDepsMode::Prompt if !console::user_attended_stderr() && !opts.yes => {
+            SystemDepsMode::Warn
+        }
         other => other,
     };
 

--- a/src/toolset/helpers.rs
+++ b/src/toolset/helpers.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use indexmap::IndexSet;
 
 use crate::backend::Backend;
-use crate::config::Settings;
 use crate::config::settings::SystemDepsMode;
+use crate::config::{Config, Settings};
 use crate::system::deps::{self, DepStatus, SystemDep};
 use crate::toolset::install_options::InstallOptions;
 use crate::toolset::tool_request::ToolRequest;
@@ -33,17 +33,22 @@ pub(super) fn show_python_install_hint(versions: &[ToolRequest]) {
 /// downgraded to a warning. Runs once for the whole batch, on the main task
 /// (before parallel install tasks spawn), because the system-packages driver
 /// futures are not `Send`.
-pub(super) async fn preflight_system_deps(versions: &[ToolRequest], opts: &InstallOptions) {
+pub(super) async fn preflight_system_deps(
+    config: &Arc<Config>,
+    versions: &[ToolRequest],
+    opts: &InstallOptions,
+) {
     let mode = Settings::get().system_deps;
     if mode == SystemDepsMode::Ignore {
         return;
     }
-    if let Err(err) = preflight_system_deps_inner(versions, opts, mode).await {
+    if let Err(err) = preflight_system_deps_inner(config, versions, opts, mode).await {
         warn!("system dependency check failed: {err:#}");
     }
 }
 
 async fn preflight_system_deps_inner(
+    config: &Arc<Config>,
     versions: &[ToolRequest],
     opts: &InstallOptions,
     mode: SystemDepsMode,
@@ -117,7 +122,10 @@ async fn preflight_system_deps_inner(
         .map(|(_, s)| s.dep.clone())
         .collect();
     let refs: Vec<&SystemDep> = missing_deps.iter().collect();
-    let (by_mgr, unremediable) = deps::build_requests(&refs);
+    let (mut by_mgr, unremediable) = deps::build_requests(&refs);
+    // Attach any `[bootstrap.brew.taps]` git URLs so a tapped formula hint can
+    // be installed the same way `mise bootstrap packages use` handles it.
+    crate::system::attach_brew_tap_urls(config, &mut by_mgr);
 
     // Deps no available package manager can install are surfaced in every mode
     // (warn and prompt/auto) — otherwise they'd only appear in the generic

--- a/src/toolset/install_options.rs
+++ b/src/toolset/install_options.rs
@@ -20,6 +20,9 @@ pub struct InstallOptions {
     pub locked: bool,
     /// Override the install directory (e.g. for --system or --shared)
     pub install_dir: Option<PathBuf>,
+    /// skip confirmation prompts (e.g. installing missing plugin system deps).
+    /// Defaults to the global `yes` setting; `mise bootstrap --yes` also sets it.
+    pub yes: bool,
 }
 
 impl Default for InstallOptions {
@@ -36,6 +39,7 @@ impl Default for InstallOptions {
             dry_run: false,
             locked: Settings::get().locked,
             install_dir: None,
+            yes: Settings::get().yes,
         }
     }
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -158,7 +158,7 @@ impl Toolset {
         // Runs here (after plugins are installed, before parallel install tasks
         // spawn) so declarations are readable and the non-Send driver stays on
         // the main task.
-        preflight_system_deps(&versions, opts).await;
+        preflight_system_deps(config, &versions, opts).await;
 
         // Build dependency graph and install using Kahn's algorithm
         let (installed, failed) = self.install_with_deps(config, versions, opts).await;

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -14,7 +14,7 @@ use crate::hooks::{Hooks, InstalledToolInfo};
 use crate::install_context::InstallContext;
 use crate::plugins::PluginType;
 use crate::toolset::Toolset;
-use crate::toolset::helpers::show_python_install_hint;
+use crate::toolset::helpers::{preflight_system_deps, show_python_install_hint};
 use crate::toolset::install_options::InstallOptions;
 use crate::toolset::tool_deps::{ToolDeps, tool_key};
 use crate::toolset::tool_request::ToolRequest;
@@ -153,6 +153,12 @@ impl Toolset {
         let tools_with_plugin_errors: HashSet<_> =
             plugin_errors.iter().map(|(tr, _)| tr.clone()).collect();
         versions.retain(|tr| !tools_with_plugin_errors.contains(tr));
+
+        // Check plugin-declared system prerequisites before compiling anything.
+        // Runs here (after plugins are installed, before parallel install tasks
+        // spawn) so declarations are readable and the non-Send driver stays on
+        // the main task.
+        preflight_system_deps(&versions, opts).await;
 
         // Build dependency graph and install using Kahn's algorithm
         let (installed, failed) = self.install_with_deps(config, versions, opts).await;


### PR DESCRIPTION
## Summary

Source-compiling plugins (php, erlang, postgres, mysql...) need system prerequisites — build tools, libraries — that previously lived only as README prose or `PLUGIN.notes` strings. Users discovered them when `./configure` failed 20 minutes into a build.

This lets vfox plugins declare those prerequisites as structured **capability checks** in `metadata.lua`, and has mise check them before installing a tool:

```lua
PLUGIN.systemDependencies = {
    { bin = "bison", version = ">=3.0", packages = { brew = "bison", apt = "bison", dnf = "bison" } },
    { pkgconfig = "libxml-2.0", packages = { brew = "libxml2", apt = "libxml2-dev" } },
    { sharedlib = "libaio.so.1", packages = { apt = "libaio1" } },
    { command = "xcode-select -p", optional = "macOS command line tools" },
}
```

**Detection is the source of truth.** A satisfied check passes no matter *how* the capability got there — Homebrew, apt, nix, MacPorts, or from source — so mise never questions a working machine. The per-manager `packages` map is used only to *offer* installing the missing subset via the existing `[bootstrap.packages]` system-packages driver; it's a remediation hint, not a requirement to install from that manager.

## Check types

| Check | Detection | For |
| --- | --- | --- |
| `bin` (+`version`) | executable on `PATH`, optional version constraint | compilers, build tools, `*-config` scripts |
| `pkgconfig` (+`version`) | `pkg-config --exists` / `--modversion` | C libraries shipping a `.pc` file |
| `sharedlib` | dynamic linker resolves the soname (Linux) | runtime libs for prebuilt binaries |
| `command` | shell command exits `0` | anything the above can't express |

Any entry can be `optional = "<reason>"` — missing optional deps never prompt or fail, they surface as a single info line.

## Behavior

New `system_deps` setting governs the pre-flight before a tool installs:

- **`prompt`** (default) — report missing deps and offer to install them via the first available package manager; degrades to `warn` when non-interactive
- **`auto`** — install the missing subset without prompting
- **`warn`** — print missing deps + copy-paste install commands and continue
- **`ignore`** — skip the check

The check never fails an install (errors are downgraded to warnings), and after remediation it re-detects to catch packages that installed but still aren't visible (e.g. keg-only Homebrew). Missing required deps also appear in `mise doctor` and in a new `plugin-deps` section of `mise bootstrap status`.

Declarations are inert on older mise versions and on upstream vfox (both ignore unknown `PLUGIN` fields), so plugins can adopt them freely.

## Scope

- vfox plugins only. asdf `mise.plugin.toml` support was intentionally left out (the remaining asdf plugins are being converted to vfox).
- Companion PRs adding `systemDependencies` to the vfox plugin repos (vfox-php as the reference, plus lua/redis/chezscheme/chicken) will follow.

## Tests

- Unit tests for version-constraint parsing/comparison, version extraction, and check evaluation (`src/system/deps.rs`); vfox metadata parsing incl. the "exactly one check key" validation (`crates/vfox/src/metadata.rs`).
- e2e `e2e/plugins/test_plugin_system_deps` covering warn/ignore/prompt install behavior, `mise doctor`, and `mise bootstrap status` rows.
- `cargo build`, `clippy`, unit tests, and the e2e test pass locally.

The root-gated apt auto-install e2e was intentionally omitted — it mutates the host and only runs in a specific docker rootfs. The auto/prompt→install path reuses the existing, already-tested system-packages driver unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install-time preflight can invoke system package managers and runs shell/pkg-config/ldconfig probes; behavior is gated by settings and errors are downgraded, but it touches the install path and host environment for vfox-backed tools.
> 
> **Overview**
> Adds **`PLUGIN.systemDependencies`** in vfox `metadata.lua` so plugins can declare host prerequisites (bin/pkg-config/sharedlib/command checks, optional version constraints, and per-package-manager hints). The vfox crate parses these leniently; mise maps them to **`SystemDep`** and runs capability detection before installs.
> 
> Introduces **`system_deps`** (`prompt` / `auto` / `warn` / `ignore`) and an install **preflight** that reports missing required deps, surfaces optional ones informatively, and can remediate via the existing system-packages driver—without failing the tool install. **`mise doctor`** and **`mise bootstrap status`** gain plugin-deps diagnostics; bootstrap passes **`--yes`** through install for non-interactive auto-remediation.
> 
> Backends expose **`system_dependencies()`** (wired for vfox); malformed declarations are warned and skipped so other metadata like **`depends`** still loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1be9d7598d589927a6c15d5b591eca2ad4d597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `PLUGIN.systemDependencies` support with install-time system prerequisite preflight (required vs optional) and remediation hints.
  * Introduced `system_deps` configuration mode (`prompt`, `auto`, `warn`, `ignore`) to control handling of missing prerequisites.
  * Enhanced `doctor` (`-J` and text) and `bootstrap status` with system-dependency diagnostics.
* **Bug Fixes**
  * Malformed `systemDependencies` no longer prevents other plugin metadata (e.g., `depends`) from parsing.
* **Documentation**
  * Documented `PLUGIN.systemDependencies` and `system_deps`, including backward compatibility.
* **Tests**
  * Added end-to-end coverage across all `system_deps` modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->