### PR TITLE
registry: use vfox for jib

### DIFF
--- a/registry/jib.toml
+++ b/registry/jib.toml
@@ -1,3 +1,3 @@
-backends = ["asdf:mise-plugins/mise-jib"]
+backends = ["vfox:jdx/vfox-jib", "asdf:mise-plugins/mise-jib"]
 description = "jib is a general-purpose command-line utility for building Docker or OCI container images from file system content as well as JAR files"
 test = { cmd = "jib --version", expected = "{{version}}" }

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -64,7 +64,7 @@ mod tests {
     use std::ops::Deref;
 
     #[cfg(unix)]
-    use pretty_assertions::{assert_eq, assert_str_eq};
+    use pretty_assertions::assert_str_eq;
 
     use crate::config::Config;
 
@@ -88,10 +88,6 @@ mod tests {
         assert_str_eq!(
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
-        );
-        assert_eq!(
-            shorthands["jib"],
-            vec!["vfox:jdx/vfox-jib", "asdf:mise-plugins/mise-jib"]
         );
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -64,7 +64,7 @@ mod tests {
     use std::ops::Deref;
 
     #[cfg(unix)]
-    use pretty_assertions::assert_str_eq;
+    use pretty_assertions::{assert_eq, assert_str_eq};
 
     use crate::config::Config;
 
@@ -88,6 +88,10 @@ mod tests {
         assert_str_eq!(
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
+        );
+        assert_eq!(
+            shorthands["jib"],
+            vec!["vfox:jdx/vfox-jib", "asdf:mise-plugins/mise-jib"]
         );
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");


### PR DESCRIPTION
## Summary
- switch the jib registry shorthand to prefer `vfox:jdx/vfox-jib`
- keep `asdf:mise-plugins/mise-jib` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Created `jdx/vfox-jib`: https://github.com/jdx/vfox-jib
- Uses the official `GoogleContainerTools/jib` CLI release assets and exposes `bin/jib` on PATH.

## Popularity
- Plugin repo: `jdx/vfox-jib`, 0 GitHub stars, 0 forks, created/pushed 2026-07-08
- Source behavior ported from: `mise-plugins/mise-jib`
- Tool upstream: `GoogleContainerTools/jib`, 14.4k GitHub stars, 1.5k forks, last pushed 2026-05-19
- Tool: Jib is already in the registry; this PR only changes the preferred backend for the existing `jib` shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- local linked plugin latest: `./target/debug/mise latest vfox:jdx/vfox-jib` -> `0.13.0`
- GitHub plugin install: `./target/debug/mise plugins install vfox-jdx-vfox-jib https://github.com/jdx/vfox-jib`
- GitHub plugin latest: `./target/debug/mise latest vfox:jdx/vfox-jib` -> `0.13.0`
- GitHub plugin install: `./target/debug/mise install vfox:jdx/vfox-jib@0.13.0`
- smoke test: `which jib` resolves to the vfox install bin

Note: `jib --version` cannot run on this machine because no Java runtime is installed; the existing asdf-installed `jib` has the same runtime limitation here.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry backend ordering change for an existing tool; no auth, data, or core runtime logic touched.
> 
> **Overview**
> The **`jib`** registry shorthand now tries **`vfox:jdx/vfox-jib`** first, with **`asdf:mise-plugins/mise-jib`** kept as the fallback so existing installs still resolve.
> 
> This is a backend-preference change only—the tool entry, description, and version smoke test (`jib --version`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef860baaaf4fb9dd2e9ba0e047cb131244b7440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional Jib backend, expanding compatibility when resolving Jib shorthands.
  * Jib shorthand resolution now includes both the newly added backend and the previously supported backend.
* **Tests**
  * Extended the shorthand resolution test to verify the full set of mapped backends for the Jib shorthand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->