### PR TITLE
registry: use vfox for spring-boot

### DIFF
--- a/registry/spring-boot.toml
+++ b/registry/spring-boot.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-spring-boot"]
+backends = ["vfox:jdx/vfox-spring-boot", "asdf:mise-plugins/mise-spring-boot"]
 description = "Spring Boot CLI"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,7 +89,6 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
-        assert_str_eq!(shorthands["spring-boot"][0], "vfox:jdx/vfox-spring-boot");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,6 +89,7 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
+        assert_str_eq!(shorthands["spring-boot"][0], "vfox:jdx/vfox-spring-boot");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- switch the spring-boot registry shorthand to prefer `vfox:jdx/vfox-spring-boot`
- keep `asdf:mise-plugins/mise-spring-boot` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Created `jdx/vfox-spring-boot`: https://github.com/jdx/vfox-spring-boot
- Uses the same Maven Central Spring Boot CLI tarball URLs as the existing asdf plugin and exposes `bin/spring` on PATH.

## Popularity
- Plugin repo: `jdx/vfox-spring-boot`, 0 GitHub stars, 0 forks, created/pushed 2026-07-08
- Source behavior ported from: `mise-plugins/mise-spring-boot`
- Tool upstream: `spring-projects/spring-boot`, 81.1k GitHub stars, 41.9k forks, last pushed 2026-07-07
- Tool: Spring Boot CLI is already in the registry; this PR only changes the preferred backend for the existing `spring-boot` shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- local linked plugin latest: `./target/debug/mise latest vfox:jdx/vfox-spring-boot` -> `4.1.0`
- GitHub plugin install: `./target/debug/mise plugins install vfox-jdx-vfox-spring-boot https://github.com/jdx/vfox-spring-boot`
- GitHub plugin latest: `./target/debug/mise latest vfox:jdx/vfox-spring-boot` -> `4.1.0`
- GitHub plugin install: `./target/debug/mise install vfox:jdx/vfox-spring-boot@4.1.0`
- smoke test: `which spring` resolves to the vfox install bin

Note: `spring --version` cannot run on this machine because no Java runtime is installed; the existing asdf-installed Spring Boot CLI has the same runtime requirement here.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry backend ordering change with fallback unchanged; no runtime or security impact in this diff.
> 
> **Overview**
> The **`spring-boot`** registry entry now lists **`vfox:jdx/vfox-spring-boot`** first and keeps **`asdf:mise-plugins/mise-spring-boot`** as the fallback, so mise tries the new vfox plugin before the existing asdf plugin for the same shorthand.
> 
> No other registry fields change; users who only have the asdf backend available should still resolve installs via the second entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103b3fb0ef127abb42f4879c488094760a18eb80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional Spring Boot backend, expanding the available setup options.
* **Bug Fixes**
  * Improved backend selection coverage by including an extra compatible provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->