### PR TITLE
registry: use vfox for teleport-community

### DIFF
--- a/registry/teleport-community.toml
+++ b/registry/teleport-community.toml
@@ -1,2 +1,5 @@
-backends = ["asdf:mise-plugins/mise-teleport-community"]
+backends = [
+  "vfox:jdx/vfox-teleport-community",
+  "asdf:mise-plugins/mise-teleport-community",
+]
 description = "Teleport provides connectivity, authentication, access controls and audit for infrastructure (community version)"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -85,6 +85,10 @@ mod tests {
         assert_str_eq!(shorthands["groovy"][0], "vfox:jdx/vfox-groovy");
         assert_str_eq!(shorthands["mongodb"][0], "vfox:jdx/vfox-mongod");
         assert_str_eq!(shorthands["emsdk"][0], "vfox:jdx/vfox-emsdk");
+        assert_str_eq!(
+            shorthands["teleport-community"][0],
+            "vfox:jdx/vfox-teleport-community"
+        );
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- switch the teleport-community registry shorthand to prefer `vfox:jdx/vfox-teleport-community`
- keep `asdf:mise-plugins/mise-teleport-community` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Created `jdx/vfox-teleport-community`: https://github.com/jdx/vfox-teleport-community
- Uses official Teleport community CDN release archives and exposes `tsh`, `tctl`, `tbot`, and `teleport` on PATH.

## Popularity
- Plugin repo: `jdx/vfox-teleport-community`, 0 GitHub stars, 0 forks, created/pushed 2026-07-08
- Source behavior ported from: `mise-plugins/mise-teleport-community`
- Tool upstream: `gravitational/teleport`, 20.6k GitHub stars, 2.1k forks, last pushed 2026-07-08
- Tool: Teleport community is already in the registry; this PR only changes the preferred backend for the existing `teleport-community` shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- local linked plugin latest: `./target/debug/mise latest vfox:jdx/vfox-teleport-community` -> `18.9.2`
- GitHub plugin install: `./target/debug/mise plugins install vfox-jdx-vfox-teleport-community https://github.com/jdx/vfox-teleport-community`
- GitHub plugin latest: `./target/debug/mise latest vfox:jdx/vfox-teleport-community` -> `18.9.2`
- GitHub plugin install: `./target/debug/mise install vfox:jdx/vfox-teleport-community@18.9.2`
- smoke tests: `which tsh`, `which tctl`, `which tbot`, `which teleport`
- smoke tests: `tsh version`, `teleport version`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry backend ordering and test-only change; no runtime logic or security-sensitive paths modified.
> 
> **Overview**
> The **`teleport-community`** registry entry now lists **`vfox:jdx/vfox-teleport-community`** as the **first** backend, with **`asdf:mise-plugins/mise-teleport-community`** kept as fallback. Shorthand resolution therefore defaults installs for that tool name to the vfox plugin instead of asdf-only.
> 
> A unit test in **`shorthands`** asserts the first mapped backend for **`teleport-community`** matches the new vfox default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1fa528ac3861881a282b318f96eee17df0ab1de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional backend option for Teleport Community, expanding the available setup choices.
* **Tests**
  * Updated shorthand coverage to reflect the new backend mapping for Teleport Community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->