### PR TITLE
registry: use vfox for teleport-ent

### DIFF
--- a/registry/teleport-ent.toml
+++ b/registry/teleport-ent.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-teleport-ent"]
+backends = ["vfox:jdx/vfox-teleport-ent", "asdf:mise-plugins/mise-teleport-ent"]
 description = "Teleport provides connectivity, authentication, access controls and audit for infrastructure (Enterprise version)"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,7 +89,6 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
-        assert_str_eq!(shorthands["teleport-ent"][0], "vfox:jdx/vfox-teleport-ent");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,6 +89,7 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
+        assert_str_eq!(shorthands["teleport-ent"][0], "vfox:jdx/vfox-teleport-ent");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- switch the teleport-ent registry shorthand to prefer `vfox:jdx/vfox-teleport-ent`
- keep `asdf:mise-plugins/mise-teleport-ent` as the fallback backend
- update the shorthand unit test to pin the new default backend

## Plugin
- Created `jdx/vfox-teleport-ent`: https://github.com/jdx/vfox-teleport-ent
- Uses official Teleport Enterprise CDN release archives and exposes `tsh`, `tctl`, `tbot`, and `teleport` on PATH.

## Popularity
- Plugin repo: `jdx/vfox-teleport-ent`, 0 GitHub stars, 0 forks, created/pushed 2026-07-08
- Source behavior ported from: `mise-plugins/mise-teleport-ent`
- Tool upstream: `gravitational/teleport`, 20.6k GitHub stars, 2.1k forks, last pushed 2026-07-08
- Tool: Teleport Enterprise is already in the registry; this PR only changes the preferred backend for the existing `teleport-ent` shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- `mise run lint` via pre-commit hook
- local linked plugin latest: `./target/debug/mise latest vfox:jdx/vfox-teleport-ent` -> `18.9.2`
- GitHub plugin install: `./target/debug/mise plugins install vfox-jdx-vfox-teleport-ent https://github.com/jdx/vfox-teleport-ent`
- GitHub plugin latest: `./target/debug/mise latest vfox:jdx/vfox-teleport-ent` -> `18.9.2`
- GitHub plugin install: `./target/debug/mise install vfox:jdx/vfox-teleport-ent@18.9.2`
- smoke tests: `which tsh`, `which tctl`, `which tbot`, `which teleport`
- smoke tests: `tsh version`, `teleport version`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only backend ordering change with a retained asdf fallback; no runtime or auth logic is modified.
> 
> **Overview**
> The **`teleport-ent`** registry shorthand now lists **`vfox:jdx/vfox-teleport-ent`** as the **primary** install backend, with **`asdf:mise-plugins/mise-teleport-ent`** kept as the **fallback**—the same ordering pattern already used for **`teleport-community`**.
> 
> Users resolving the shorthand get the new vfox plugin by default; existing asdf-based setups can still work via the secondary backend entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf99aa3e206f76fd6643d36bd9ac4d75fe7564c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional backend option, expanding the available setup choices.
  * Included a new shorthand entry for `tinytex`, making it available in supported configurations.

* **Tests**
  * Updated automated checks to cover the new shorthand entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->