### PR TITLE
registry: use vfox for clojure

### DIFF
--- a/registry/clojure.toml
+++ b/registry/clojure.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-clojure"]
+backends = ["vfox:jdx/vfox-clojure", "asdf:mise-plugins/mise-clojure"]
 description = "The Clojure Programming Language"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -725,7 +725,7 @@ mod tests {
         #[cfg(unix)]
         {
             asdf("asdf:clojure", "asdf:clojure", "clojure");
-            asdf("clojure", "asdf:mise-plugins/mise-clojure", "clojure");
+            vfox("clojure", "vfox:jdx/vfox-clojure", "clojure");
         }
         cargo("cargo:eza", "cargo:eza", "eza");
         t("dotnet-core", "core:dotnet", "dotnet", BackendType::Core);

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,7 +89,6 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
-        assert_str_eq!(shorthands["clojure"][0], "vfox:jdx/vfox-clojure");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,6 +89,7 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
+        assert_str_eq!(shorthands["clojure"][0], "vfox:jdx/vfox-clojure");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- prefer the new `vfox:jdx/vfox-clojure` backend for the `clojure` registry shorthand
- keep the existing asdf plugin as a fallback backend
- add a shorthand assertion that `clojure` resolves to the vfox backend first

## Plugin
- Created `jdx/vfox-clojure`: https://github.com/jdx/vfox-clojure
- The plugin installs official Clojure CLI tarballs from `download.clojure.org` and patches the bundled scripts without relying on Homebrew's installer wrapper.

## Popularity
- Clojure upstream: `clojure/clojure`, 10,986 stars, 1,468 forks, pushed 2026-07-07
- Installer tags source: `clojure/brew-install`, 90 stars, 30 forks, pushed 2026-05-29
- Plugin repo: `jdx/vfox-clojure`, 0 stars, 0 forks, pushed 2026-07-08
- This PR changes the preferred backend for an existing registry tool; it does not add a new registry shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- pre-commit `mise run lint`
- GitHub plugin smoke:
  - `mise plugins install vfox-jdx-vfox-clojure https://github.com/jdx/vfox-clojure`
  - `mise latest vfox:jdx/vfox-clojure` -> `1.12.5.1654`
  - `mise install vfox:jdx/vfox-clojure@1.12.5.1654`
  - `mise x vfox:jdx/vfox-clojure@1.12.5.1654 -- which clojure`
  - `mise x vfox:jdx/vfox-clojure@1.12.5.1654 -- which clj`
  - `mise x vfox:jdx/vfox-clojure@1.12.5.1654 -- clojure --version` -> `Clojure CLI version 1.12.5.1654`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small registry and test-only change; existing asdf installs can still use the fallback backend without touching auth or core install paths.
> 
> **Overview**
> **Clojure** now resolves through **`vfox:jdx/vfox-clojure`** when users reference the registry shorthand `clojure`, with **`asdf:mise-plugins/mise-clojure`** kept as the second backend for fallback.
> 
> The shorthand test in `backend_arg.rs` was updated so `clojure` is expected to map to the vfox backend and type instead of the asdf plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e956a406ea96787365727d7059e00a3b61153ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated backend catalog/config so the `clojure` tool resolves via the `vfox` provider.
  * Shorthand parsing now includes `tinytex` mapped to `vfox:jdx/vfox-tinytex`.
* **Bug Fixes**
  * Adjusted backend selection behavior for `clojure` to use the updated backend type and source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->