### PR TITLE
registry: use vfox for v

### DIFF
--- a/registry/v.toml
+++ b/registry/v.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-v"]
+backends = ["vfox:jdx/vfox-v", "asdf:mise-plugins/mise-v"]
 description = "V - https://vlang.io"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,7 +89,6 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
-        assert_str_eq!(shorthands["v"][0], "vfox:jdx/vfox-v");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,6 +89,7 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
+        assert_str_eq!(shorthands["v"][0], "vfox:jdx/vfox-v");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- prefer the new `vfox:jdx/vfox-v` backend for the `v` registry shorthand
- keep the existing asdf plugin as a fallback backend
- add a shorthand assertion that `v` resolves to the vfox backend first

## Plugin
- Created `jdx/vfox-v`: https://github.com/jdx/vfox-v
- The plugin uses official V release archives for normal tags and keeps a source checkout fallback for `ref:` installs.
- This improves on the asdf plugin's default source-build path; building `0.5.1` from source failed locally, while the official release archive installed and ran successfully.

## Popularity
- V upstream: `vlang/v`, 37,698 stars, 2,254 forks, pushed 2026-07-07
- Latest release: `0.5.1`, published 2026-03-09
- Plugin repo: `jdx/vfox-v`, 0 stars, 0 forks, created/pushed 2026-07-08
- This PR changes the preferred backend for an existing registry tool; it does not add a new registry shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- pre-commit `mise run lint`
- asdf parity:
  - `/tmp/asdf-mise-v/bin/latest-stable` -> `0.5.1`
  - `/tmp/asdf-mise-v/bin/list-all` contains `0.5.1`
  - `mise latest vfox:jdx/vfox-v` -> `0.5.1`
- GitHub plugin smoke:
  - `mise plugins install vfox-jdx-vfox-v https://github.com/jdx/vfox-v`
  - `mise latest vfox:jdx/vfox-v` -> `0.5.1`
  - `mise install vfox:jdx/vfox-v@0.5.1`
  - `mise x vfox:jdx/vfox-v@0.5.1 -- which v`
  - `mise x vfox:jdx/vfox-v@0.5.1 -- v version` -> `V 0.5.1 0c3183c`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry ordering change with asdf fallback retained; affects which installer runs for the `v` shorthand, not auth or core runtime logic.
> 
> **Overview**
> The **`v`** registry entry now tries **`vfox:jdx/vfox-v`** first and keeps **`asdf:mise-plugins/mise-v`** as a fallback, so `mise install` / `mise use v` prefer official release archives via the new vfox plugin instead of the asdf plugin alone.
> 
> This is a **backend preference** change only in `registry/v.toml`; the separate **`vlang`** shorthand is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96053d25d774eaf583fb4760540fd2472775eec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional backend option to the available backend configuration choices.
  * Updated the shorthands to include a new `v` entry corresponding to the newly added backend.
* **Tests**
  * Strengthened unit coverage to verify the presence and value of the new `v` shorthand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->