### PR TITLE
registry: use vfox for tinytex

### DIFF
--- a/registry/tinytex.toml
+++ b/registry/tinytex.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-tinytex"]
+backends = ["vfox:jdx/vfox-tinytex", "asdf:mise-plugins/mise-tinytex"]
 description = "A lightweight, cross-platform, portable, and easy-to-maintain LaTeX distribution based on TeX Live"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,6 +89,7 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
+        assert_str_eq!(shorthands["tinytex"][0], "vfox:jdx/vfox-tinytex");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- prefer the new `vfox:jdx/vfox-tinytex` backend for the `tinytex` registry shorthand
- keep the existing asdf plugin as a fallback backend
- add a shorthand assertion that `tinytex` resolves to the vfox backend first

## Plugin
- Created `jdx/vfox-tinytex`: https://github.com/jdx/vfox-tinytex
- The plugin mirrors the asdf plugin's release archive layout and exposes the platform-specific TinyTeX bin directory on PATH.

## Popularity
- TinyTeX package upstream: `rstudio/tinytex`, 1,136 stars, 128 forks, pushed 2026-07-07
- TinyTeX release artifacts: `rstudio/tinytex-releases`, 396 stars, 37 forks, latest release `v2026.07` published 2026-07-01
- Plugin repo: `jdx/vfox-tinytex`, 0 stars, 0 forks, created/pushed 2026-07-08
- This PR changes the preferred backend for an existing registry tool; it does not add a new registry shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- pre-commit `mise run lint`
- GitHub plugin smoke:
  - `mise plugins install vfox-jdx-vfox-tinytex https://github.com/jdx/vfox-tinytex`
  - `mise latest vfox:jdx/vfox-tinytex` -> `2026.07`
  - `mise install vfox:jdx/vfox-tinytex@2026.07`
  - `mise x vfox:jdx/vfox-tinytex@2026.07 -- which tex`
  - `mise x vfox:jdx/vfox-tinytex@2026.07 -- tex --version` -> `TeX 3.141592653 (TeX Live 2026)`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry backend ordering only; existing asdf path remains as fallback with no auth or data changes.
> 
> **Overview**
> **TinyTeX** now uses **`vfox:jdx/vfox-tinytex`** as the primary registry backend, with **`asdf:mise-plugins/mise-tinytex`** kept as a fallback—same pattern as other `jdx/vfox-*` tools (e.g. scala, emsdk).
> 
> A unit test in `shorthands` asserts the `tinytex` shorthand’s first backend is the vfox plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59dcf4ce9cb553becd09ad6be3a10d7bfcc201e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->