### PR TITLE
registry: use vfox for oci

### DIFF
--- a/registry/oci.toml
+++ b/registry/oci.toml
@@ -1,2 +1,2 @@
-backends = ["asdf:mise-plugins/mise-oci"]
+backends = ["vfox:jdx/vfox-oci", "asdf:mise-plugins/mise-oci"]
 description = "Oracle Cloud Infrastructure CLI"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,7 +89,6 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
-        assert_str_eq!(shorthands["oci"][0], "vfox:jdx/vfox-oci");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,6 +89,7 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
+        assert_str_eq!(shorthands["oci"][0], "vfox:jdx/vfox-oci");
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- prefer the new `vfox:jdx/vfox-oci` backend for the `oci` registry shorthand
- keep the existing asdf plugin as a fallback backend
- add a shorthand assertion that `oci` resolves to the vfox backend first

## Plugin
- Created `jdx/vfox-oci`: https://github.com/jdx/vfox-oci
- The plugin mirrors the asdf plugin's installer flow by running the versioned upstream OCI install script with explicit `lib`, `bin`, and script directories under the mise install root.
- The completion rc file is written inside the install root instead of the user's home directory.

## Popularity
- OCI CLI upstream: `oracle/oci-cli`, 631 stars, 231 forks, pushed 2026-07-07
- Latest release: `v3.89.1`, published 2026-07-07
- Plugin repo: `jdx/vfox-oci`, 0 stars, 0 forks, created/pushed 2026-07-08
- This PR changes the preferred backend for an existing registry tool; it does not add a new registry shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- pre-commit `mise run lint`
- GitHub plugin smoke:
  - `mise plugins install vfox-jdx-vfox-oci https://github.com/jdx/vfox-oci`
  - `mise latest vfox:jdx/vfox-oci` -> `3.89.1`
  - `mise install vfox:jdx/vfox-oci@3.89.1`
  - `mise x vfox:jdx/vfox-oci@3.89.1 -- which oci`
  - `mise x vfox:jdx/vfox-oci@3.89.1 -- oci -v` -> `3.89.1`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry backend ordering change for an existing tool; asdf remains as fallback so install paths are largely unchanged.
> 
> **Overview**
> The **`oci`** registry shorthand now lists **`vfox:jdx/vfox-oci`** as the **first** backend, with **`asdf:mise-plugins/mise-oci`** kept as a **fallback** when the vfox plugin is unavailable or unsuitable.
> 
> Users who install via the shorthand without an explicit backend will get the new vfox-based Oracle Cloud Infrastructure CLI installer by default; behavior should stay familiar because the vfox plugin mirrors the asdf install flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a583e55389f8fba64402d1e5c8bfbaecfa006555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded OCI backend support to include an additional OCI source.
* **Tests**
  * Updated shorthand resolution tests to verify `tinytex` includes the expected first target (`vfox:jdx/vfox-tinytex`) and its ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->