### PR TITLE
registry: use vfox for elasticsearch

### DIFF
--- a/registry/elasticsearch.toml
+++ b/registry/elasticsearch.toml
@@ -1,2 +1,5 @@
-backends = ["asdf:mise-plugins/mise-elasticsearch"]
+backends = [
+  "vfox:jdx/vfox-elasticsearch",
+  "asdf:mise-plugins/mise-elasticsearch",
+]
 description = "Elasticsearch is an open source, distributed search and analytics engine built for speed, scale, and AI applications"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,10 +89,6 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
-        assert_str_eq!(
-            shorthands["elasticsearch"][0],
-            "vfox:jdx/vfox-elasticsearch"
-        );
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -89,6 +89,10 @@ mod tests {
             shorthands["teleport-community"][0],
             "vfox:jdx/vfox-teleport-community"
         );
+        assert_str_eq!(
+            shorthands["elasticsearch"][0],
+            "vfox:jdx/vfox-elasticsearch"
+        );
         assert_str_eq!(shorthands["node"][0], "https://node");
         assert_str_eq!(shorthands["xxxxxx"][0], "https://xxxxxx");
     }


### PR DESCRIPTION
## Summary
- prefer the new `vfox:jdx/vfox-elasticsearch` backend for the `elasticsearch` registry shorthand
- keep the existing asdf plugin as a fallback backend
- add a shorthand assertion that `elasticsearch` resolves to the vfox backend first

## Plugin
- Created `jdx/vfox-elasticsearch`: https://github.com/jdx/vfox-elasticsearch
- The plugin mirrors the asdf plugin's Elastic artifact download flow and improves platform support by selecting `aarch64` artifacts on arm64 hosts.

## Popularity
- Elasticsearch upstream: `elastic/elasticsearch`, 77,457 stars, 25,984 forks, pushed 2026-07-08
- Latest release: `v9.4.3`, published 2026-06-30
- Plugin repo: `jdx/vfox-elasticsearch`, 0 stars, 0 forks, created/pushed 2026-07-08
- This PR changes the preferred backend for an existing registry tool; it does not add a new registry shorthand.

## Testing
- `cargo test shorthands::tests::test_get_shorthands --all-features`
- pre-commit `mise run lint`
- GitHub plugin smoke:
  - `mise plugins install vfox-jdx-vfox-elasticsearch https://github.com/jdx/vfox-elasticsearch`
  - `mise latest vfox:jdx/vfox-elasticsearch` -> `9.4.3`
  - `mise install vfox:jdx/vfox-elasticsearch@9.4.3`
  - `mise x vfox:jdx/vfox-elasticsearch@9.4.3 -- which elasticsearch`
  - `mise x vfox:jdx/vfox-elasticsearch@9.4.3 -- elasticsearch --version` -> `Version: 9.4.3`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only backend ordering for an existing tool; asdf remains as fallback, so impact is limited to which plugin is tried first on install.
> 
> **Overview**
> The **`elasticsearch`** registry shorthand now lists **`vfox:jdx/vfox-elasticsearch`** as the **first** backend, with **`asdf:mise-plugins/mise-elasticsearch`** kept as a **fallback**—matching the vfox-then-asdf pattern used for tools like `emsdk` and `groovy`.
> 
> This is a **backend preference** change only; the shorthand name and description are unchanged. Install resolution should try the new vfox plugin (including improved **arm64 / aarch64** artifact selection per the plugin) before falling back to the existing asdf plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e32022ea286ae4698110bfedd737f18cca7f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Elasticsearch shorthand support to recognize an additional backend option, improving compatibility when resolving Elasticsearch installs.
* **Tests**
  * Updated shorthand resolution coverage to verify the `tinytex` shorthand resolves correctly, improving confidence in install resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->