### PR TITLE
feat: allow overriding terminal width via MISE_TERM_WIDTH/COLUMNS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -576,6 +576,21 @@ plugin accepts input or otherwise does not seem to be installing correctly.
 
 Sets `MISE_JOBS=1` because only 1 plugin script can be executed at a time.
 
+### `MISE_TERM_WIDTH`
+
+Override the terminal width mise uses to render tables and lists (e.g. `mise ls`).
+By default mise detects the width from the terminal. This is useful in CI or other
+non-interactive environments where detection returns a bogus value (for example
+CircleCI, where the width is reported as `0`), producing oddly wrapped output.
+
+If `MISE_TERM_WIDTH` is unset, mise falls back to the conventional `COLUMNS`
+environment variable, and finally to auto-detection. The override is honored
+exactly, so you can also force a narrower width:
+
+```sh
+MISE_TERM_WIDTH=120 mise ls
+```
+
 ### `MISE_FISH_AUTO_ACTIVATE=1`
 
 Configures the vendor_conf.d script for fish shell to automatically activate.

--- a/e2e/cli/test_term_width
+++ b/e2e/cli/test_term_width
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# MISE_TERM_WIDTH (and the conventional COLUMNS fallback) override the terminal
+# width used to render tables/lists such as `mise registry`. See discussion #4109.
+
+# The full backends string for `gh` is ~48 chars; it fits on one line only when
+# the table is rendered wide enough.
+full="aqua:cli/cli asdf:bartlomiejdanek/asdf-github-cli"
+
+# A wide width shows the full backends string for the `gh` row.
+assert_contains "MISE_TERM_WIDTH=400 mise registry" "$full"
+
+# A narrow width shrinks the table so the full string no longer fits on the row.
+assert_not_contains "MISE_TERM_WIDTH=40 mise registry" "$full"
+
+# COLUMNS is honored as a fallback when MISE_TERM_WIDTH is unset.
+assert_not_contains "COLUMNS=40 mise registry" "$full"
+
+# MISE_TERM_WIDTH takes precedence over COLUMNS.
+assert_contains "MISE_TERM_WIDTH=400 COLUMNS=40 mise registry" "$full"

--- a/e2e/cli/test_term_width
+++ b/e2e/cli/test_term_width
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 # MISE_TERM_WIDTH (and the conventional COLUMNS fallback) override the terminal
 # width used to render tables/lists such as `mise registry`. See discussion #4109.
+#
+# The assertions are content-independent: they check the width of the rendered
+# lines rather than any specific registry entry, so they don't break when the
+# registry contents change.
 
-# The full backends string for `gh` is ~48 chars; it fits on one line only when
-# the table is rendered wide enough.
-full="aqua:cli/cli asdf:bartlomiejdanek/asdf-github-cli"
+# awk program: emits "narrow" when the widest rendered line is <= 45 chars,
+# otherwise "wide". (A narrow override caps every line; a wide one leaves the
+# naturally long backends rows intact.)
+maxw="awk '{ if (length > m) m = length } END { print (m <= 45 ? \"narrow\" : \"wide\") }'"
 
-# A wide width shows the full backends string for the `gh` row.
-assert_contains "MISE_TERM_WIDTH=400 mise registry" "$full"
+# A narrow override caps the table width.
+assert "MISE_TERM_WIDTH=40 mise registry | $maxw" "narrow"
 
-# A narrow width shrinks the table so the full string no longer fits on the row.
-assert_not_contains "MISE_TERM_WIDTH=40 mise registry" "$full"
+# A wide override leaves long rows un-truncated, proving the override applies.
+assert "MISE_TERM_WIDTH=400 mise registry | $maxw" "wide"
 
 # COLUMNS is honored as a fallback when MISE_TERM_WIDTH is unset.
-assert_not_contains "COLUMNS=40 mise registry" "$full"
+assert "COLUMNS=40 mise registry | $maxw" "narrow"
 
 # MISE_TERM_WIDTH takes precedence over COLUMNS.
-assert_contains "MISE_TERM_WIDTH=400 COLUMNS=40 mise registry" "$full"
+assert "MISE_TERM_WIDTH=400 COLUMNS=40 mise registry | $maxw" "wide"

--- a/src/env.rs
+++ b/src/env.rs
@@ -450,11 +450,25 @@ pub fn is_mise_binary(bin_name: &str) -> bool {
     bin_name == "mise" || bin_name.starts_with("mise.") || bin_name.starts_with("mise-")
 }
 
+/// Explicit terminal-width override: `MISE_TERM_WIDTH` takes precedence, then the
+/// conventional `COLUMNS`. Lets tables/lists render sanely in CI where terminal
+/// size detection returns 0. Honored exactly (no 80 floor) so a narrow width can
+/// be forced on purpose. See discussion #4109.
+pub static TERM_WIDTH_OVERRIDE: Lazy<Option<usize>> = Lazy::new(|| {
+    ["MISE_TERM_WIDTH", "COLUMNS"]
+        .into_iter()
+        .find_map(|k| var(k).ok().and_then(|v| v.trim().parse::<usize>().ok()))
+        .filter(|w| *w > 0)
+});
+
 #[cfg(test)]
 pub static TERM_WIDTH: Lazy<usize> = Lazy::new(|| 80);
 
 #[cfg(not(test))]
 pub static TERM_WIDTH: Lazy<usize> = Lazy::new(|| {
+    if let Some(w) = *TERM_WIDTH_OVERRIDE {
+        return w;
+    }
     terminal_size::terminal_size()
         .map(|(w, _)| w.0 as usize)
         .unwrap_or(80)

--- a/src/env.rs
+++ b/src/env.rs
@@ -454,11 +454,31 @@ pub fn is_mise_binary(bin_name: &str) -> bool {
 /// conventional `COLUMNS`. Lets tables/lists render sanely in CI where terminal
 /// size detection returns 0. Honored exactly (no 80 floor) so a narrow width can
 /// be forced on purpose. See discussion #4109.
+///
+/// Gated to `None` under `#[cfg(test)]` (like `TERM_WIDTH`) so unit tests that
+/// build a table don't pick up a stray `COLUMNS`/`MISE_TERM_WIDTH` from the env.
+#[cfg(test)]
+pub static TERM_WIDTH_OVERRIDE: Lazy<Option<usize>> = Lazy::new(|| None);
+
+#[cfg(not(test))]
 pub static TERM_WIDTH_OVERRIDE: Lazy<Option<usize>> = Lazy::new(|| {
-    ["MISE_TERM_WIDTH", "COLUMNS"]
-        .into_iter()
-        .find_map(|k| var(k).ok().and_then(|v| v.trim().parse::<usize>().ok()))
-        .filter(|w| *w > 0)
+    for key in ["MISE_TERM_WIDTH", "COLUMNS"] {
+        if let Some(w) = var(key)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|w| *w > 0)
+        {
+            // COLUMNS is maintained by the shell and can leak in unintentionally,
+            // so leave a breadcrumb when it (rather than MISE_TERM_WIDTH) is used.
+            if key == "COLUMNS" {
+                debug!(
+                    "overriding terminal width with COLUMNS={w}; set MISE_TERM_WIDTH to control this explicitly"
+                );
+            }
+            return Some(w);
+        }
+    }
+    None
 });
 
 #[cfg(test)]

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -52,6 +52,12 @@ impl MiseTable {
         table
             .load_preset(comfy_table::presets::NOTHING)
             .set_content_arrangement(ContentArrangement::Dynamic);
+        // Pin the width when the user overrides it (e.g. MISE_TERM_WIDTH in CI).
+        // comfy_table does its own terminal detection, which fails in non-ttys,
+        // so this is what makes the override actually affect `mise ls` et al.
+        if let Some(w) = *crate::env::TERM_WIDTH_OVERRIDE {
+            table.set_width(w.min(u16::MAX as usize) as u16);
+        }
         if !console::colors_enabled() {
             table.force_no_tty();
         }


### PR DESCRIPTION
## Summary

Adds a way to override mise's detected terminal width, as requested in [discussion #4109](https://github.com/jdx/mise/discussions/4109).

mise detects terminal width via the `terminal_size` crate. In some CI environments (the reporter used CircleCI, where `stty size` returns `0 0`) detection yields a bogus value, so table/list output (`mise ls`, `mise registry`, `mise settings`, …) renders oddly and there was **no way to override it**.

Now the width can be overridden via:

- **`MISE_TERM_WIDTH`** — primary, mise-namespaced, highest priority.
- **`COLUMNS`** — the conventional fallback the reporter cited, used when `MISE_TERM_WIDTH` is unset.

When neither is set, behavior is unchanged (auto-detect, floor of 80). An explicit override is honored exactly (no 80 floor), so a narrower width can be forced on purpose.

```sh
MISE_TERM_WIDTH=120 mise ls
```

## Implementation note

Width is consumed through **two independent paths**, and both must honor the override:

1. `env::TERM_WIDTH` (`src/env.rs`) — used by the `tabled`-based `Table` path and several `truncate_str` call sites.
2. `MiseTable` (`src/ui/table.rs`) — the `comfy_table` table used by `mise ls`, `mise registry`, etc. It does its **own** width detection via `ContentArrangement::Dynamic` and never reads `TERM_WIDTH`, so it needs an explicit `set_width()` when an override is present — otherwise `mise ls` (the command named in the request) would ignore the override.

A single `TERM_WIDTH_OVERRIDE` static is the source of truth for both. This is env-var only (no `settings.toml` entry) to match the request and avoid reading `Settings::get()` inside the low-level `env.rs` lazy static.

## Testing

- Added `e2e/cli/test_term_width` asserting that a wide `MISE_TERM_WIDTH` shows a row's full contents while a narrow width truncates it, that `COLUMNS` works as a fallback, and that `MISE_TERM_WIDTH` takes precedence over `COLUMNS`.
- `rustfmt` clean on the changed files; `prettier`/`markdownlint` clean on the docs. Full build + test suite left to CI.

Implements the request in discussion #4109.

---
*This PR was prepared with the help of an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `MISE_TERM_WIDTH` to control table/list rendering width, with auto-detection when unset and fallback to `COLUMNS`.
  * `MISE_TERM_WIDTH` now takes precedence over `COLUMNS`.

* **Documentation**
  * Documented `MISE_TERM_WIDTH` behavior (precedence, default, fallback order) and provided an example for forcing narrower output.

* **Bug Fixes**
  * Terminal width override no longer applies the previous fixed maximum behavior.

* **Tests**
  * Added end-to-end CLI coverage to verify narrow/wide rendering and `MISE_TERM_WIDTH` vs `COLUMNS` precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->