### PR TITLE
fix(brew): include cask shim in crate package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ include = [
   "/src/**/*.rs",
   "/src/assets/**",
   "/src/plugins/core/assets/**",
+  "/src/system/packages/brew/cask_shim.rb",
   "/src/system/packages/brew/shim.rb",
   "/vendor/aqua-registry/LICENSE",
   "/vendor/aqua-registry/metadata.json",


### PR DESCRIPTION
## Summary
- include `src/system/packages/brew/cask_shim.rb` in the crate package whitelist
- fixes `cargo publish` verification failing because `cask.rs` uses `include_str!("cask_shim.rb")`

## Verification
- `cargo package --allow-dirty -p mise --list | rg 'src/system/packages/brew/(cask_shim|shim)\.rb'`
- `cargo check --all-features`

Fixes the release failure in https://github.com/jdx/mise/actions/runs/28943891068/job/85872673903.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime behavior impact beyond fixing a missing file in the published crate.
> 
> **Overview**
> Adds **`src/system/packages/brew/cask_shim.rb`** to the root `Cargo.toml` **`include`** list so it ships in the published `mise` crate.
> 
> **`cask.rs`** embeds that file via **`include_str!("cask_shim.rb")`**; without an explicit whitelist entry, **`cargo package` / `cargo publish`** verification fails even though the formula **`shim.rb`** was already included the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac87f80a162bfef7d8363c3595b72e76cfc82fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the packaged file list to include an additional resource used in distribution builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->