### PR TITLE
registry: consolidate scala vfox plugin

### DIFF
--- a/registry/scala.toml
+++ b/registry/scala.toml
@@ -1,2 +1,2 @@
-backends = ["vfox:jdx/vfox-scala", "asdf:mise-plugins/mise-scala"]
+backends = ["vfox:mise-plugins/vfox-scala", "asdf:mise-plugins/mise-scala"]
 description = "Scala language"

--- a/src/shorthands.rs
+++ b/src/shorthands.rs
@@ -81,7 +81,7 @@ mod tests {
         settings.shorthands_file = Some("../fixtures/shorthands.toml".into());
         let shorthands = get_shorthands(&settings);
         assert_str_eq!(shorthands["aapt2"][0], "vfox:mise-plugins/vfox-aapt2");
-        assert_str_eq!(shorthands["scala"][0], "vfox:jdx/vfox-scala");
+        assert_str_eq!(shorthands["scala"][0], "vfox:mise-plugins/vfox-scala");
         assert_str_eq!(shorthands["groovy"][0], "vfox:jdx/vfox-groovy");
         assert_str_eq!(shorthands["mongodb"][0], "vfox:jdx/vfox-mongod");
         assert_str_eq!(shorthands["emsdk"][0], "vfox:jdx/vfox-emsdk");


### PR DESCRIPTION
## Summary
- update the Scala registry entry to use the canonical `mise-plugins/vfox-scala` fork
- align the shorthand regression test with the consolidated backend

## Popularity
- GitHub: `scala/scala` has 14.5k stars, 3.1k forks, latest release `v2.13.18` published 2025-11-17
- GitHub: `scala/scala3` has 6.3k stars, 1.2k forks, latest release `3.3.8` published 2026-06-11
- Ecosystem: Scala has established related tooling such as `scalameta/scalafmt` and `VirtusLab/scala-cli`

## Testing
- `cargo test shorthands`
- `git diff --check`

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry URL-only change for Scala’s vfox plugin; no auth, data, or core runtime logic touched.
> 
> **Overview**
> **Scala** shorthand installs now resolve the primary vfox backend to **`vfox:mise-plugins/vfox-scala`** instead of **`vfox:jdx/vfox-scala`**, matching the canonical community fork used elsewhere in docs.
> 
> The **`asdf:mise-plugins/mise-scala`** fallback is unchanged. The **`test_get_shorthands`** assertion for `scala` was updated to match the registry entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fcc5d511396338fd9accc5f014b0b463ce05e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Scala backend reference to use the latest supported plugin source.

* **Tests**
  * Adjusted test expectations to match the updated Scala backend value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->