### PR TITLE
fix(release): smoke test workspace package

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -74,6 +74,52 @@ use_published_aqua_registry() {
 	cargo add --build "aqua-registry@$version"
 }
 
+set_path_dependency_version() {
+	local manifest="$1"
+	local dep="$2"
+	local version="$3"
+
+	if ! grep -qE "^$dep = \\{.*path = " "$manifest"; then
+		echo "Error: $manifest does not have a path dependency for $dep"
+		exit 1
+	fi
+	if grep -qE "^$dep = \\{.*path = .*version = " "$manifest"; then
+		sed -i.bak -E "/^$dep = \\{.*path = / s/version = \"[^\"]*\"/version = \"$version\"/" "$manifest"
+	else
+		sed -i.bak -E "/^$dep = \\{.*path = / s/[[:space:]]*}$/, version = \"$version\" }/" "$manifest"
+	fi
+	rm -f "$manifest.bak"
+}
+
+package_workspace_smoke_test() {
+	local cargo_toml_backup
+	local vfox_cargo_toml_backup
+	cargo_toml_backup="$(mktemp)"
+	vfox_cargo_toml_backup="$(mktemp)"
+
+	cp Cargo.toml "$cargo_toml_backup"
+	cp crates/vfox/Cargo.toml "$vfox_cargo_toml_backup"
+
+	set +e
+	(
+		set -e
+		set_path_dependency_version Cargo.toml "mise-sigstore" "$(cargo pkgid -p mise-sigstore | cut -d# -f2)"
+		set_path_dependency_version crates/vfox/Cargo.toml "mise-sigstore" "$(cargo pkgid -p mise-sigstore | cut -d# -f2)"
+		set_path_dependency_version Cargo.toml "vfox" "$(cargo pkgid -p vfox | cut -d# -f2)"
+		set_path_dependency_version Cargo.toml "aqua-registry" "$(cargo pkgid -p aqua-registry | cut -d# -f2)"
+		set_path_dependency_version Cargo.toml "mise-interactive-config" "$(cargo pkgid -p mise-interactive-config | cut -d# -f2)"
+		cp schema/mise.json crates/mise-interactive-config/mise.json
+		cargo package --allow-dirty --workspace
+	)
+	local smoke_status=$?
+	set -e
+
+	cp "$cargo_toml_backup" Cargo.toml
+	cp "$vfox_cargo_toml_backup" crates/vfox/Cargo.toml
+	rm -f "$cargo_toml_backup" "$vfox_cargo_toml_backup" crates/mise-interactive-config/mise.json
+	return "$smoke_status"
+}
+
 # Check if a directory has uncommitted changes (staged or unstaged)
 has_uncommitted_changes() {
 	local dir="$1"
@@ -193,6 +239,8 @@ if [[ $cur_version != "$latest_version" ]]; then
 	AQUA_REGISTRY_VERSION=""
 	INTERACTIVE_CONFIG_VERSION=""
 	MISE_SIGSTORE_VERSION=""
+
+	package_workspace_smoke_test
 
 	bump_and_publish_subcrate "mise-sigstore" "crates/mise-sigstore" "MISE_SIGSTORE_VERSION"
 	cargo add -p mise "mise-sigstore@$MISE_SIGSTORE_VERSION" --no-default-features


### PR DESCRIPTION
## Summary
- add a pre-publish `cargo package --allow-dirty --workspace` smoke test
- temporarily add local path dependency versions only so Cargo can verify the workspace package set
- restore those manifest edits before the existing publish flow runs
- leave subcrate publish order and `cargo publish` behavior unchanged

## Tests
- `bash -n xtasks/release-plz`
- `mise x -- shellcheck xtasks/release-plz`
- `git diff --check`
- `cargo package --allow-dirty --workspace` completed successfully during smoke-test validation

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the GitHub Actions release shell script; no runtime app logic, with manifest edits rolled back after the smoke test.
> 
> **Overview**
> Adds a **release preflight** in `xtasks/release-plz` that runs **`cargo package --allow-dirty --workspace`** before any subcrate is published.
> 
> New helper **`set_path_dependency_version`** temporarily adds or updates **`version`** on path dependencies in the root and `crates/vfox` manifests (via `cargo pkgid`), and **`package_workspace_smoke_test`** copies `schema/mise.json` into `mise-interactive-config`, runs the workspace package, then restores the touched files so the tree is unchanged if packaging fails.
> 
> The smoke test is invoked at the start of the mise release block, **before** the existing `bump_and_publish_subcrate` sequence and registry `cargo add` rewrites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f4104c27e463b4453d04bf210caa47d614e9dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a release-time smoke test that validates workspace packaging by temporarily rewriting path dependency versions and running a workspace package step.
* **Bug Fixes**
  * Improved release reliability by verifying packaging behavior after version initialization, helping prevent release failures caused by mismatched workspace manifest versions.
* **Chores / Tests**
  * Added Bash tooling to safely update dependency version fields in manifests and clean up temporary artifacts used during the packaging check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->