### PR TITLE
Add nt

### DIFF
--- a/registry/nt.toml
+++ b/registry/nt.toml
@@ -1,0 +1,3 @@
+backends = ["github:navbytes/nt"]
+description = "Terminal task & note manager — durable memory for AI coding sessions"
+test = { cmd = "nt --version", expected = "nt {{version}}" }


### PR DESCRIPTION
Adds nt (terminal task & note manager) via the github backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry metadata for the terminal task and note manager, making it available for discovery and validation in supported tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->