### PR TITLE
feat(bootstrap): stabilize bootstrap commands

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,4 +1,4 @@
-# Bootstrap <Badge type="warning" text="experimental" />
+# Bootstrap
 
 packages, git repos, dotfiles, mise shell activation, macOS defaults, macOS
 LaunchAgents, Linux systemd user services, the user's login shell, tools, and

--- a/docs/bootstrap/launchd.md
+++ b/docs/bootstrap/launchd.md
@@ -1,4 +1,4 @@
-# launchd <Badge type="warning" text="experimental" />
+# launchd
 
 mise can declare macOS user LaunchAgents in
 `[bootstrap.macos.launchd.agents]` and apply them with

--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -1,4 +1,4 @@
-# macOS Defaults <Badge type="warning" text="experimental" />
+# macOS Defaults
 
 mise can declare macOS user defaults (preferences) in the
 `[bootstrap.macos.defaults]` section of `mise.toml` and apply them with

--- a/docs/bootstrap/packages/apk.md
+++ b/docs/bootstrap/packages/apk.md
@@ -1,4 +1,4 @@
-# apk <Badge type="warning" text="experimental" />
+# apk
 
 System packages for Alpine Linux.
 

--- a/docs/bootstrap/packages/apt.md
+++ b/docs/bootstrap/packages/apt.md
@@ -1,4 +1,4 @@
-# apt <Badge type="warning" text="experimental" />
+# apt
 
 System packages for Debian-family Linux (Debian, Ubuntu, Mint, ...).
 

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -1,4 +1,4 @@
-# brew <Badge type="warning" text="experimental" />
+# brew
 
 Homebrew formulae and casks — **without requiring Homebrew to be installed**.
 

--- a/docs/bootstrap/packages/dnf.md
+++ b/docs/bootstrap/packages/dnf.md
@@ -1,4 +1,4 @@
-# dnf <Badge type="warning" text="experimental" />
+# dnf
 
 System packages for RedHat-family Linux (Fedora, RHEL, CentOS Stream, Rocky,
 Alma, ...).

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -1,4 +1,4 @@
-# Bootstrap Packages <Badge type="warning" text="experimental" />
+# Bootstrap Packages
 
 mise can ensure machine-global system packages are installed via the
 `[bootstrap.packages]` section of `mise.toml`:

--- a/docs/bootstrap/packages/mas.md
+++ b/docs/bootstrap/packages/mas.md
@@ -1,4 +1,4 @@
-# mas <Badge type="warning" text="experimental" />
+# mas
 
 Mac App Store apps via the [`mas`](https://github.com/mas-cli/mas) CLI.
 

--- a/docs/bootstrap/packages/pacman.md
+++ b/docs/bootstrap/packages/pacman.md
@@ -1,4 +1,4 @@
-# pacman <Badge type="warning" text="experimental" />
+# pacman
 
 System packages for Arch-family Linux (Arch, Manjaro, EndeavourOS, ...).
 

--- a/docs/bootstrap/repos.md
+++ b/docs/bootstrap/repos.md
@@ -1,4 +1,4 @@
-# Repos <Badge type="warning" text="experimental" />
+# Repos
 
 mise can declare git repositories in `[bootstrap.repos]` and apply them with
 `mise bootstrap repos apply`:

--- a/docs/bootstrap/shell.md
+++ b/docs/bootstrap/shell.md
@@ -1,4 +1,4 @@
-# Shell Activation <Badge type="warning" text="experimental" />
+# Shell Activation
 
 mise can declaratively add shell activation snippets for bash, zsh, and fish
 with `[bootstrap.mise_shell_activate]`. Configure startup-file targets directly

--- a/docs/bootstrap/systemd.md
+++ b/docs/bootstrap/systemd.md
@@ -1,4 +1,4 @@
-# systemd <Badge type="warning" text="experimental" />
+# systemd
 
 mise can declare Linux systemd user services in
 `[bootstrap.linux.systemd.units]` and apply them with

--- a/docs/bootstrap/user.md
+++ b/docs/bootstrap/user.md
@@ -1,4 +1,4 @@
-# User Login Shell <Badge type="warning" text="experimental" />
+# User Login Shell
 
 mise can declare the current user's login shell in `[bootstrap.user]` and
 apply it with `mise bootstrap user apply` or

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -4,7 +4,7 @@
 - **Usage**: `mise bootstrap [FLAGS] [SUBCOMMAND]`
 - **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
 
-[experimental] Set up a machine for the current config in one command
+Set up a machine for the current config in one command
 
 Runs the bootstrap steps for the current config in order:
 

--- a/docs/cli/dotfiles.md
+++ b/docs/cli/dotfiles.md
@@ -4,7 +4,7 @@
 - **Usage**: `mise dotfiles <SUBCOMMAND>`
 - **Source code**: [`src/cli/dotfiles/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/dotfiles/mod.rs)
 
-[experimental] Manage dotfiles from `[dotfiles]`
+Manage dotfiles from `[dotfiles]`
 
 Dotfiles are config files symlinked, copied, or rendered to target paths,
 plus marker-delimited blocks or single lines in files mise doesn't own.

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -1,4 +1,4 @@
-# Dotfiles <Badge type="warning" text="experimental" />
+# Dotfiles
 
 mise can manage dotfiles from the `[dotfiles]` section of `mise.toml`.
 Entries can either own a whole file or directory, or manage one small piece

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -74,7 +74,7 @@ mise generate task-stubs --mise-bin ./bin/mise
 The generated task stubs behave like small project commands, while `bin/mise`
 downloads and runs the pinned mise binary for the project.
 
-## Machine bootstrapping <Badge type="warning" text="experimental" />
+## Machine bootstrapping
 
 Beyond `[tools]`, mise can declare the rest of the machine setup needed for
 a project or workstation, and [`mise bootstrap`](/cli/bootstrap.html)

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -5,6 +5,8 @@ cat <<EOF >mise.toml
 [tools]
 EOF
 assert_succeed "mise bootstrap --yes"
+assert_succeed "MISE_EXPERIMENTAL=0 mise bootstrap --yes"
+assert_succeed "MISE_EXPERIMENTAL=0 mise bootstrap status"
 assert_not_contains "mise bootstrap --yes" "bootstrap: follow-up"
 
 # bootstrap applies dotfiles, installs tools, and runs the
@@ -34,6 +36,7 @@ assert_contains "mise bootstrap status --json" '"dotfiles"'
 assert_contains "mise bootstrap status --json" '"tools"'
 assert_succeed "mise bootstrap status --missing"
 assert_contains "mise bootstrap dotfiles status" "~/.gitconfig"
+assert_contains "MISE_EXPERIMENTAL=0 mise bootstrap dotfiles status" "~/.gitconfig"
 assert_succeed "mise bootstrap packages apply --dry-run --yes"
 assert_succeed "mise bootstrap packages install --dry-run --yes"
 

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -19,6 +19,7 @@ EOF
 
 # everything is missing before applying
 assert_contains "mise dotfiles status" "missing"
+assert_contains "MISE_EXPERIMENTAL=0 mise dotfiles status" "missing"
 assert_fail "mise dotfiles status --missing"
 
 # system commands do not manage dotfiles

--- a/e2e/cli/test_system_status
+++ b/e2e/cli/test_system_status
@@ -12,6 +12,7 @@ EOF
 
 # status renders on any platform; unavailable managers are skipped, not errors
 assert_succeed "mise bootstrap packages status"
+assert_succeed "MISE_EXPERIMENTAL=0 mise bootstrap packages status"
 assert_contains "mise bootstrap packages status" "bc"
 assert_contains "mise bootstrap packages status" "497799835"
 assert_contains "mise bootstrap packages status --json" '"apt"'

--- a/e2e/cli/test_system_use
+++ b/e2e/cli/test_system_use
@@ -7,6 +7,7 @@
 
 # dry-run prints what would be written without creating the file
 assert_contains "mise bootstrap packages use --dry-run apt:zlib1g-dev" '"apt:zlib1g-dev" = "latest"'
+assert_contains "MISE_EXPERIMENTAL=0 mise bootstrap packages use --dry-run apt:zlib1g-dev" '"apt:zlib1g-dev" = "latest"'
 assert_contains "mise bootstrap packages use --dry-run apk:zlib-dev" '"apk:zlib-dev" = "latest"'
 assert_fail "cat mise.toml"
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -143,7 +143,7 @@ List built\-in backends
 List all the active runtime bin paths
 .TP
 \fBbootstrap\fR
-[experimental] Set up a machine for the current config in one command
+Set up a machine for the current config in one command
 .TP
 \fBbootstrap dotfiles\fR
 Manage dotfiles from `[dotfiles]`
@@ -302,7 +302,7 @@ Set the value of a setting in a mise.toml file
 Disable mise for current shell session
 .TP
 \fBdotfiles\fR
-[experimental] Manage dotfiles from `[dotfiles]`
+Manage dotfiles from `[dotfiles]`
 .TP
 \fBdotfiles add\fR
 Add or update dotfiles in `[dotfiles]`
@@ -840,7 +840,7 @@ Output executable entries in JSON format (implies \-\-bin\-names)
 Tool(s) to look up
 e.g.: ruby@3
 .SH "MISE BOOTSTRAP"
-[experimental] Set up a machine for the current config in one command
+Set up a machine for the current config in one command
 
 Runs the bootstrap steps for the current config in order:
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -280,9 +280,9 @@ Tool(s) to look up
 e.g.: ruby@3
 """# required=#false var=#true
 }
-cmd bootstrap help="[experimental] Set up a machine for the current config in one command" {
+cmd bootstrap help="Set up a machine for the current config in one command" {
     long_help #"""
-[experimental] Set up a machine for the current config in one command
+Set up a machine for the current config in one command
 
 Runs the bootstrap steps for the current config in order:
 
@@ -948,9 +948,9 @@ for direnv to consume.
 for direnv to consume.
 """#
 }
-cmd dotfiles subcommand_required=#true help="[experimental] Manage dotfiles from `[dotfiles]`" {
+cmd dotfiles subcommand_required=#true help="Manage dotfiles from `[dotfiles]`" {
     long_help #"""
-[experimental] Manage dotfiles from `[dotfiles]`
+Manage dotfiles from `[dotfiles]`
 
 Dotfiles are config files symlinked, copied, or rendered to target paths,
 plus marker-delimited blocks or single lines in files mise doesn't own.

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1689,7 +1689,7 @@
           "unevaluatedProperties": false,
           "properties": {
             "managers": {
-              "description": "[experimental] Restrict which system package managers mise will use.",
+              "description": "Restrict which system package managers mise will use.",
               "type": "array",
               "items": {
                 "type": "string"
@@ -1697,7 +1697,7 @@
             },
             "sudo": {
               "default": true,
-              "description": "[experimental] Allow `mise bootstrap packages apply` to elevate with sudo when not running as root.",
+              "description": "Allow `mise bootstrap packages apply` to elevate with sudo when not running as root.",
               "type": "boolean"
             }
           }
@@ -3155,7 +3155,7 @@
     },
     "dotfiles": {
       "type": "object",
-      "description": "[experimental] dotfiles applied with `mise dotfiles apply` or `mise bootstrap`, keyed by target path",
+      "description": "dotfiles applied with `mise dotfiles apply` or `mise bootstrap`, keyed by target path",
       "additionalProperties": {
         "oneOf": [
           {
@@ -3213,7 +3213,7 @@
     },
     "bootstrap": {
       "type": "object",
-      "description": "[experimental] machine-global bootstrapping (system packages, repos, macOS defaults, launchd agents, login shell)",
+      "description": "machine-global bootstrapping (system packages, repos, macOS defaults, launchd agents, login shell)",
       "properties": {
         "packages": {
           "type": "object",

--- a/settings.toml
+++ b/settings.toml
@@ -2376,9 +2376,9 @@ rust_type = "SystemDepsMode"
 type = "String"
 
 [system_packages.managers]
-description = "[experimental] Restrict which system package managers mise will use."
+description = "Restrict which system package managers mise will use."
 docs = """
-[experimental] Restrict which system package managers mise will use.
+Restrict which system package managers mise will use.
 
 By default mise acts on every manager in `[bootstrap.packages]` that is available
 on the current machine. When more than one could apply (e.g. several package
@@ -2401,9 +2401,9 @@ type = "ListString"
 
 [system_packages.sudo]
 default = true
-description = "[experimental] Allow `mise bootstrap packages apply` to elevate with sudo when not running as root."
+description = "Allow `mise bootstrap packages apply` to elevate with sudo when not running as root."
 docs = """
-[experimental] Allow `mise bootstrap packages apply` to elevate with sudo when not running as root.
+Allow `mise bootstrap packages apply` to elevate with sudo when not running as root.
 
 When disabled, mise never runs sudo: if elevation would be required, it errors
 with the exact command to run manually. mise only elevates for explicit

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -9,7 +9,7 @@ use super::install::Install;
 use super::run;
 use super::system::driver::{self, Action, DriverOpts};
 use super::system::{import, install, prune, status, upgrade, r#use};
-use crate::config::{self, Config, Settings};
+use crate::config::{self, Config};
 use crate::dirs;
 use crate::path::PathExt;
 use crate::system;
@@ -25,7 +25,7 @@ use crate::toolset::ResolveOptions;
 use crate::ui::table::MiseTable;
 use clap::{Subcommand, ValueEnum};
 
-/// [experimental] Set up a machine for the current config in one command
+/// Set up a machine for the current config in one command
 ///
 /// Runs the bootstrap steps for the current config in order:
 ///
@@ -496,7 +496,6 @@ struct BootstrapUserStatus {
 
 impl Bootstrap {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         if let Some(command) = self.command {
             return command.run().await;
         }
@@ -1057,7 +1056,6 @@ impl BootstrapStatusReport {
 
 impl BootstrapStatus {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         let config = Config::get().await?;
         let report = self.collect(&config).await?;
         if self.json {
@@ -1719,7 +1717,6 @@ impl BootstrapStatus {
 
 impl BootstrapDotfiles {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapDotfilesCommands::Apply(cmd) => cmd.run().await,
             BootstrapDotfilesCommands::Status(cmd) => cmd.run().await,
@@ -1741,7 +1738,6 @@ impl BootstrapDotfilesStatus {
 
 impl BootstrapPackages {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapPackagesCommands::Apply(cmd) => cmd.run().await,
             #[cfg(unix)]
@@ -1757,7 +1753,6 @@ impl BootstrapPackages {
 
 impl BootstrapRepos {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapReposCommands::Apply(cmd) => cmd.run().await,
             BootstrapReposCommands::Status(cmd) => cmd.run().await,
@@ -1833,7 +1828,6 @@ impl BootstrapReposStatus {
 
 impl BootstrapMacos {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapMacosCommands::Defaults(cmd) => cmd.run().await,
             BootstrapMacosCommands::LaunchdAgents(cmd) => cmd.run().await,
@@ -1843,7 +1837,6 @@ impl BootstrapMacos {
 
 impl BootstrapLinux {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapLinuxCommands::SystemdUnits(cmd) => cmd.run().await,
         }
@@ -1852,7 +1845,6 @@ impl BootstrapLinux {
 
 impl BootstrapMacosDefaults {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapMacosDefaultsCommands::Apply(cmd) => cmd.run().await,
             BootstrapMacosDefaultsCommands::Status(cmd) => cmd.run().await,
@@ -1862,7 +1854,6 @@ impl BootstrapMacosDefaults {
 
 impl BootstrapLaunchd {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapLaunchdCommands::Apply(cmd) => cmd.run().await,
             BootstrapLaunchdCommands::Status(cmd) => cmd.run().await,
@@ -1966,7 +1957,6 @@ impl BootstrapLaunchdStatus {
 
 impl BootstrapSystemd {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapSystemdCommands::Apply(cmd) => cmd.run().await,
             BootstrapSystemdCommands::Status(cmd) => cmd.run().await,
@@ -2170,7 +2160,6 @@ impl BootstrapMacosDefaultsStatus {
 
 impl BootstrapShell {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapShellCommands::Apply(cmd) => cmd.run().await,
             BootstrapShellCommands::Status(cmd) => cmd.run().await,
@@ -2250,7 +2239,6 @@ impl BootstrapShellStatus {
 
 impl BootstrapUser {
     async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             BootstrapUserCommands::Apply(cmd) => cmd.run().await,
             BootstrapUserCommands::Status(cmd) => cmd.run().await,

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -468,9 +468,6 @@ impl Doctor {
 
     /// same diagnostics as [`Self::analyze_system_packages`] for `doctor -J`
     async fn system_packages_json(&mut self, config: &Arc<Config>) -> Option<serde_json::Value> {
-        if !Settings::get().experimental {
-            return None;
-        }
         let mgrs = crate::system::packages_from_config(config);
         if mgrs.is_empty() {
             return None;
@@ -535,9 +532,6 @@ impl Doctor {
         &mut self,
         config: &Arc<Config>,
     ) -> Option<SystemDefaultsDiagnosis> {
-        if !Settings::get().experimental {
-            return None;
-        }
         let defaults = crate::system::defaults_from_config(config);
         if defaults.is_empty() {
             return None;
@@ -627,9 +621,6 @@ impl Doctor {
         &mut self,
         config: &Arc<Config>,
     ) -> Option<SystemLoginShellDiagnosis> {
-        if !Settings::get().experimental {
-            return None;
-        }
         let request = crate::system::login_shell_from_config(config)?;
         if !crate::system::login_shell::is_available() {
             return Some(SystemLoginShellDiagnosis::Unavailable {
@@ -712,9 +703,6 @@ impl Doctor {
     }
 
     async fn analyze_system_packages(&mut self, config: &Arc<Config>) -> eyre::Result<()> {
-        if !Settings::get().experimental {
-            return Ok(());
-        }
         let mgrs = crate::system::packages_from_config(config);
         if mgrs.is_empty() {
             return Ok(());

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -5,7 +5,7 @@ use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
 
 use crate::config::config_file::ConfigFile;
 use crate::config::config_file::mise_toml::MiseToml;
-use crate::config::{Config, ConfigPathOptions, Settings, resolve_target_config_path};
+use crate::config::{Config, ConfigPathOptions, resolve_target_config_path};
 use crate::file;
 use crate::path::PathExt;
 use crate::system;
@@ -59,7 +59,6 @@ pub struct DotfilesAdd {
 
 impl DotfilesAdd {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise dotfiles")?;
         if self.source.is_some() && self.targets.len() != 1 {
             bail!("--source can only be used with one target");
         }

--- a/src/cli/dotfiles/apply.rs
+++ b/src/cli/dotfiles/apply.rs
@@ -31,7 +31,6 @@ pub struct DotfilesApply {
 
 impl DotfilesApply {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise dotfiles")?;
         let config = Config::get().await?;
         let all_files = system::files::files_from_config(&config);
         let files = all_files

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use eyre::{Result, bail};
 
 use super::add::DotfilesAdd;
-use crate::config::{Config, Settings};
+use crate::config::Config;
 use crate::file;
 use crate::system;
 use crate::system::edits::{BlockSource, EditOp};
@@ -36,7 +36,6 @@ pub struct DotfilesEdit {
 
 impl DotfilesEdit {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise dotfiles")?;
         let mut config = Config::get().await?;
         let target = system::files::resolve_target_arg(&self.target);
 

--- a/src/cli/dotfiles/mod.rs
+++ b/src/cli/dotfiles/mod.rs
@@ -10,7 +10,7 @@ mod status;
 pub(crate) use apply::DotfilesApply;
 pub(crate) use status::DotfilesStatus;
 
-/// [experimental] Manage dotfiles from `[dotfiles]`
+/// Manage dotfiles from `[dotfiles]`
 ///
 /// Dotfiles are config files symlinked, copied, or rendered to target paths,
 /// plus marker-delimited blocks or single lines in files mise doesn't own.

--- a/src/cli/dotfiles/status.rs
+++ b/src/cli/dotfiles/status.rs
@@ -1,7 +1,7 @@
 use eyre::Result;
 use serde_json::json;
 
-use crate::config::{Config, Settings};
+use crate::config::Config;
 use crate::path::PathExt;
 use crate::system;
 use crate::system::files::FileState;
@@ -27,7 +27,6 @@ pub struct DotfilesStatus {
 
 impl DotfilesStatus {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise dotfiles")?;
         let config = Config::get().await?;
         let mut any_missing = false;
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -137,9 +137,7 @@ impl Install {
     async fn hint_missing_system_packages(&self) {
         // the status queries spawn package-manager processes; skip them
         // entirely once the hint has been shown (or is disabled)
-        if !Settings::get().experimental
-            || !crate::hint::hint_would_display("system_packages_missing")
-        {
+        if !crate::hint::hint_would_display("system_packages_missing") {
             return;
         }
         let Ok(config) = Config::get().await else {

--- a/src/cli/system/brew/mod.rs
+++ b/src/cli/system/brew/mod.rs
@@ -23,7 +23,6 @@ enum Commands {
 
 impl SystemBrew {
     pub async fn run(self) -> Result<()> {
-        crate::config::Settings::get().ensure_experimental("mise bootstrap")?;
         match self.command {
             Commands::Tap(cmd) => cmd.run(),
             Commands::Untap(cmd) => cmd.run(),

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -59,7 +59,6 @@ pub struct SystemImport {
 
 impl SystemImport {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         if Settings::get()
             .system_packages
             .managers

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -49,7 +49,6 @@ pub struct SystemInstall {
 
 impl SystemInstall {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         let mgrs = if self.packages.is_empty() {
             let config = Config::get().await?;
             system::packages_from_config(&config)

--- a/src/cli/system/prune.rs
+++ b/src/cli/system/prune.rs
@@ -35,7 +35,6 @@ pub struct SystemPrune {
 
 impl SystemPrune {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         if Settings::get()
             .system_packages
             .managers

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -1,7 +1,7 @@
 use eyre::Result;
 use serde_json::json;
 
-use crate::config::{Config, Settings};
+use crate::config::Config;
 use crate::system;
 use crate::system::packages::PackageState;
 use crate::ui::table::MiseTable;
@@ -21,7 +21,6 @@ pub struct SystemStatus {
 
 impl SystemStatus {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         let config = Config::get().await?;
         let mgrs = system::packages_from_config(&config);
         let mut any_missing = false;

--- a/src/cli/system/upgrade.rs
+++ b/src/cli/system/upgrade.rs
@@ -1,7 +1,7 @@
 use eyre::Result;
 
 use super::driver::{self, Action, DriverOpts};
-use crate::config::{Config, Settings};
+use crate::config::Config;
 use crate::system;
 
 /// Upgrade installed bootstrap packages from `[bootstrap.packages]`
@@ -38,7 +38,6 @@ pub struct SystemUpgrade {
 
 impl SystemUpgrade {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         let mgrs = if self.packages.is_empty() {
             let config = Config::get().await?;
             system::packages_from_config(&config)

--- a/src/cli/system/use.rs
+++ b/src/cli/system/use.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 use super::driver::{self, Action, DriverOpts};
 use crate::config::config_file::ConfigFile;
 use crate::config::config_file::mise_toml::MiseToml;
-use crate::config::{ConfigPathOptions, Settings, resolve_target_config_path};
+use crate::config::{ConfigPathOptions, resolve_target_config_path};
 use crate::file::display_path;
 use crate::system;
 use crate::system::packages::PackageRequest;
@@ -53,7 +53,6 @@ pub struct SystemUse {
 
 impl SystemUse {
     pub async fn run(self) -> Result<()> {
-        Settings::get().ensure_experimental("mise bootstrap")?;
         let config = crate::config::Config::get().await?;
         let mut by_mgr: IndexMap<String, Vec<PackageRequest>> = IndexMap::new();
         let mut entries: Vec<(String, String)> = vec![];


### PR DESCRIPTION
## Summary
- remove experimental guards from mise bootstrap, bootstrap package subcommands, and dotfiles commands
- enable bootstrap-related doctor/install diagnostics without requiring experimental mode
- refresh generated CLI docs, manpage, usage data, and schema labels
- add e2e coverage for bootstrap/dotfiles/packages commands with MISE_EXPERIMENTAL=0

## Tests
- mise run render
- mise run format
- mise run render:schema
- mise run test:e2e e2e/cli/test_bootstrap e2e/cli/test_dotfiles_files e2e/cli/test_system_status e2e/cli/test_system_use

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stabilizing machine-wide bootstrap (packages, login shell, launchd/systemd) and dotfiles increases default exposure of privileged operations; behavior is unchanged aside from dropping the experimental gate.
> 
> **Overview**
> **Bootstrap and dotfiles are stable.** `mise bootstrap`, all bootstrap subcommands (packages, repos, macOS/Linux user services, shell activation, user login shell), and `mise dotfiles` no longer call `ensure_experimental`, so they work with `MISE_EXPERIMENTAL=0`.
> 
> **Related behavior is always on.** `mise doctor` reports system packages, macOS defaults, and login-shell drift without checking experimental. `mise install` can show the missing `[bootstrap.packages]` hint whenever the hint system is enabled, not only in experimental mode.
> 
> **Docs and generated artifacts** remove `[experimental]` badges and wording from bootstrap/dotfiles pages, CLI help (`mise.usage.kdl`, man page, `docs/cli/*`), `schema/mise.json`, and `settings.toml` for `dotfiles`, `bootstrap`, and `system_packages.*`.
> 
> **Tests** assert bootstrap, dotfiles status, and `bootstrap packages` commands succeed with `MISE_EXPERIMENTAL=0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b6289152408a8f773354410e8b4c696425ac3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Several bootstrap and dotfiles commands are now available without the experimental label, including related help text, docs, and manual pages.
  * System package and bootstrap-related status/management commands now run normally without requiring an experimental setting.

* **Bug Fixes**
  * Improved consistency in command output and documentation by removing outdated “experimental” warnings.
  * End-to-end checks were updated to validate the new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->