### PR TITLE
fix(task): keep task_source_files available with usage args

### DIFF
--- a/e2e/tasks/test_task_usage_map_tera
+++ b/e2e/tasks/test_task_usage_map_tera
@@ -278,6 +278,25 @@ EOF
 assert "mise run usage-tera-opt-arg" "hello world"
 assert "mise run usage-tera-opt-arg -- Alice" "hello Alice"
 
+# task_source_files() stays available when scripts are re-rendered with usage args
+cat <<'EOF' >mise.toml
+[tasks.usage-tera-source-files]
+usage = '''
+arg "[files]" var=#true
+'''
+sources = ["*.toml"]
+run = '''
+{% if usage.files %}
+echo {{ usage.files | join(sep=' ') }}
+{% else %}
+echo {{ task_source_files() | join(sep=' ') }}
+{% endif %}
+'''
+EOF
+
+assert "mise run --dry-run --force usage-tera-source-files 2>&1" "[usage-tera-source-files] $ echo mise.toml"
+assert "mise run --dry-run --force usage-tera-source-files -- mise.toml 2>&1" "[usage-tera-source-files] $ echo mise.toml"
+
 # Arg choices restrict allowed values
 cat <<'EOF' >mise.toml
 [tasks.usage-tera-arg-choices]

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -1243,9 +1243,10 @@ mod tests {
     #[tokio::test]
     async fn test_task_source_files_with_usage_args() {
         let config = Config::get().await.unwrap();
+        let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
         let task = Task {
             usage: r#"arg "[files]" var=#true"#.to_string(),
-            sources: vec![concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml").to_string()],
+            sources: vec![source.to_string_lossy().to_string()],
             ..Default::default()
         };
         let parser = TaskScriptParser::new(None);
@@ -1261,10 +1262,7 @@ mod tests {
             .parse_run_scripts_with_args(&config, &task, &scripts, &Default::default(), &[], &spec)
             .await
             .unwrap();
-        assert_eq!(
-            parsed,
-            vec![concat!("echo ", env!("CARGO_MANIFEST_DIR"), "/Cargo.toml")]
-        );
+        assert_eq!(parsed, vec![format!("echo {}", source.display())]);
 
         let parsed = parser
             .parse_run_scripts_with_args(

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -124,6 +124,101 @@ impl TaskScriptParser {
         tera::Error::message(format!("failed to lock: {}", e))
     }
 
+    fn register_task_source_files_function(tera: &mut tera::Tera, task: &Task) {
+        tera.register_function("task_source_files", {
+            let glob_patterns = Arc::new(
+                crate::task::task_source_checker::source_glob_patterns(&task.sources),
+            );
+            // Anchor the matcher at the process cwd. `is_source` handles
+            // absolute paths outside this root by trusting the glob result,
+            // so absolute outside-cwd patterns (e.g. workspace-root paths)
+            // still flow through.
+            let cwd = crate::dirs::CWD
+                .clone()
+                .unwrap_or_else(|| std::path::PathBuf::from("."));
+            let matcher = Arc::new(crate::task::task_source_checker::build_source_matcher(
+                &cwd,
+                &task.sources,
+            ));
+
+            move |_: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
+                if glob_patterns.is_empty() {
+                    trace!("tera::render::resolve_task_sources `task_source_files` called in task with empty sources array");
+                    return Ok(tera::Value::from(Vec::<tera::Value>::new()));
+                };
+
+                let mut resolved = Vec::with_capacity(glob_patterns.len());
+
+                for pattern in glob_patterns.iter() {
+                    if contains_template_syntax(pattern) {
+                        trace!(
+                            "tera::render::resolve_task_sources including tera template string in resolved task sources: {pattern}"
+                        );
+                        resolved.push(tera::Value::from(pattern.clone()));
+                        continue;
+                    }
+
+                    match glob::glob_with(
+                        pattern,
+                        glob::MatchOptions {
+                            case_sensitive: false,
+                            require_literal_separator: false,
+                            require_literal_leading_dot: false,
+                        },
+                    ) {
+                        Err(error) => {
+                            warn!(
+                                "tera::render::resolve_task_sources including '{pattern}' in resolved task sources, ignoring glob parsing error: {error:#?}"
+                            );
+                            resolved.push(tera::Value::from(pattern.clone()));
+                        }
+                        Ok(expanded) => {
+                            let mut source_found = false;
+
+                            for path in expanded {
+                                source_found = true;
+
+                                match path {
+                                    Ok(path) => {
+                                        if !crate::task::task_source_checker::is_source(
+                                            &matcher, &path,
+                                        ) {
+                                            trace!(
+                                                "tera::render::resolve_task_sources excluded '{}' due to !-pattern",
+                                                path.display()
+                                            );
+                                            continue;
+                                        }
+                                        let source = path.display();
+                                        trace!(
+                                            "tera::render::resolve_task_sources resolved source from pattern '{pattern}': {source}"
+                                        );
+                                        resolved.push(tera::Value::from(source.to_string()));
+                                    }
+                                    Err(error) => {
+                                        let source = error.path().display();
+                                        warn!(
+                                            "tera::render::resolve_task_sources omitting '{source}' from resolved task sources due to: {:#?}",
+                                            error.error()
+                                        );
+                                    }
+                                }
+                            }
+
+                            if !source_found {
+                                warn!(
+                                    "tera::render::resolve_task_sources no source file(s) resolved for pattern: '{pattern}'"
+                                );
+                            }
+                        }
+                    }
+                }
+
+                Ok(tera::Value::from(resolved))
+            }
+        });
+    }
+
     fn setup_tera_for_spec_parsing(&self, task: &Task) -> TeraSpecParsingResult {
         let mut tera = self.get_tera();
         let arg_order = Arc::new(Mutex::new(HashMap::new()));
@@ -401,98 +496,7 @@ impl TaskScriptParser {
             }
         });
 
-        tera.register_function("task_source_files", {
-            let glob_patterns = Arc::new(
-                crate::task::task_source_checker::source_glob_patterns(&task.sources),
-            );
-            // Anchor the matcher at the process cwd. `is_source` handles
-            // absolute paths outside this root by trusting the glob result,
-            // so absolute outside-cwd patterns (e.g. workspace-root paths)
-            // still flow through.
-            let cwd = crate::dirs::CWD
-                .clone()
-                .unwrap_or_else(|| std::path::PathBuf::from("."));
-            let matcher = Arc::new(crate::task::task_source_checker::build_source_matcher(
-                &cwd,
-                &task.sources,
-            ));
-
-            move |_: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
-               if glob_patterns.is_empty() {
-                   trace!("tera::render::resolve_task_sources `task_source_files` called in task with empty sources array");
-                   return Ok(tera::Value::from(Vec::<tera::Value>::new()));
-               };
-
-                let mut resolved = Vec::with_capacity(glob_patterns.len());
-
-                for pattern in glob_patterns.iter() {
-                    if contains_template_syntax(pattern) {
-                        trace!(
-                            "tera::render::resolve_task_sources including tera template string in resolved task sources: {pattern}"
-                        );
-                        resolved.push(tera::Value::from(pattern.clone()));
-                        continue;
-                    }
-
-                    match glob::glob_with(
-                        pattern,
-                        glob::MatchOptions {
-                            case_sensitive: false,
-                            require_literal_separator: false,
-                            require_literal_leading_dot: false,
-                        },
-                    ) {
-                        Err(error) => {
-                            warn!(
-                                "tera::render::resolve_task_sources including '{pattern}' in resolved task sources, ignoring glob parsing error: {error:#?}"
-                            );
-                            resolved.push(tera::Value::from(pattern.clone()));
-                        }
-                        Ok(expanded) => {
-                            let mut source_found = false;
-
-                            for path in expanded {
-                                source_found = true;
-
-                                match path {
-                                    Ok(path) => {
-                                        if !crate::task::task_source_checker::is_source(
-                                            &matcher, &path,
-                                        ) {
-                                            trace!(
-                                                "tera::render::resolve_task_sources excluded '{}' due to !-pattern",
-                                                path.display()
-                                            );
-                                            continue;
-                                        }
-                                        let source = path.display();
-                                        trace!(
-                                            "tera::render::resolve_task_sources resolved source from pattern '{pattern}': {source}"
-                                        );
-                                        resolved.push(tera::Value::from(source.to_string()));
-                                    }
-                                    Err(error) => {
-                                        let source = error.path().display();
-                                        warn!(
-                                            "tera::render::resolve_task_sources omitting '{source}' from resolved task sources due to: {:#?}",
-                                            error.error()
-                                        );
-                                    }
-                                }
-                            }
-
-                            if !source_found {
-                                warn!(
-                                    "tera::render::resolve_task_sources no source file(s) resolved for pattern: '{pattern}'"
-                                );
-                            }
-                        }
-                    }
-                }
-
-                Ok(tera::Value::from(resolved))
-            }
-        });
+        Self::register_task_source_files_function(&mut tera, task);
 
         (tera, arg_order, input_args, input_flags)
     }
@@ -693,6 +697,7 @@ impl TaskScriptParser {
                 }
             };
             let mut tera = self.get_tera();
+            Self::register_task_source_files_function(&mut tera, task);
             tera.register_function("arg", {
                 {
                     let usage_args = m.args.clone();
@@ -1233,6 +1238,46 @@ mod tests {
 
             assert_eq!(parsed, vec![expected]);
         }
+    }
+
+    #[tokio::test]
+    async fn test_task_source_files_with_usage_args() {
+        let config = Config::get().await.unwrap();
+        let task = Task {
+            usage: r#"arg "[files]" var=#true"#.to_string(),
+            sources: vec![concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml").to_string()],
+            ..Default::default()
+        };
+        let parser = TaskScriptParser::new(None);
+        let scripts = vec![
+            "{% if usage.files %}echo {{ usage.files | join(sep=' ') }}{% else %}echo {{ task_source_files() | join(sep=' ') }}{% endif %}".to_string(),
+        ];
+        let (_, spec) = parser
+            .parse_run_scripts(&config, &task, &scripts, &Default::default())
+            .await
+            .unwrap();
+
+        let parsed = parser
+            .parse_run_scripts_with_args(&config, &task, &scripts, &Default::default(), &[], &spec)
+            .await
+            .unwrap();
+        assert_eq!(
+            parsed,
+            vec![concat!("echo ", env!("CARGO_MANIFEST_DIR"), "/Cargo.toml")]
+        );
+
+        let parsed = parser
+            .parse_run_scripts_with_args(
+                &config,
+                &task,
+                &scripts,
+                &Default::default(),
+                &["mise.toml".to_string()],
+                &spec,
+            )
+            .await
+            .unwrap();
+        assert_eq!(parsed, vec!["echo mise.toml"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- share `task_source_files()` Tera registration across task script render phases
- preserve `task_source_files()` when scripts are re-rendered with parsed `usage` args
- add unit and e2e regression coverage for discussion #10868

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test test_task_source_files_with_usage_args`
- `cargo test test_task_parse_task_source_files`
- `mise run test:e2e e2e/tasks/test_task_usage_map_tera`

References #10868.

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of existing Tera registration plus tests; behavior change only restores a function that was already available in the other render path.
> 
> **Overview**
> Fixes **`task_source_files()`** missing when a task defines **`usage`** args and the run script is rendered again with parsed CLI values.
> 
> The Tera helper that resolves `sources` globs is extracted into **`register_task_source_files_function`** and registered in both spec-parsing setup and **`parse_run_scripts_with_args`**, which previously built a fresh Tera instance with only `arg` / `option` / `flag`.
> 
> Regression coverage: a unit test for fallback to resolved sources vs `usage.files`, and an e2e task that uses `task_source_files()` when no files are passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b11c361623c691a1b9e58f6765536f0a9b6399f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script re-rendering so task templates can still access detected task source files even when usage arguments are populated.
  * Improved source glob expansion and matching behavior, including clearer fallbacks when patterns can’t be resolved.

* **Tests**
  * Added end-to-end coverage verifying templates render correctly both when file arguments are provided and when they fall back to `task_source_files()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->