### PR TITLE
fix(build): restore linux arm64 glibc compatibility

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -15,9 +15,9 @@ passthrough = [
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 
 [target.aarch64-unknown-linux-gnu]
-# Use newer image for aarch64 to get assembler that supports ARMv8.2-A crypto instructions
-# This is based on Ubuntu 20.04 (glibc 2.31) but should still be compatible with Amazon Linux 2
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
+# Keep this pinned so the release binary does not inherit a newer glibc
+# floor when cross-rs updates its floating main image.
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5"
 pre-build = [
   "apt-get update && apt-get install --assume-yes --no-install-recommends libclang-dev clang curl",
   "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable",

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -81,33 +81,23 @@ else
 	cargo build --profile=serious --target "$RUST_TRIPLE" --no-default-features --features "$features"
 fi
 
-# Check glibc compatibility for x86_64-unknown-linux-gnu (Amazon Linux 2 requirement: glibc <= 2.26)
-if [[ $RUST_TRIPLE == "x86_64-unknown-linux-gnu" ]]; then
-	echo "Checking glibc compatibility for Amazon Linux 2..."
-	# Use CARGO_TARGET_DIR if set, otherwise default to target
-	target_dir="${CARGO_TARGET_DIR:-target}"
-	binary_path="$target_dir/$RUST_TRIPLE/serious/mise"
-	if [[ -f $binary_path ]]; then
-		max_glibc=$(objdump -p "$binary_path" | grep 'GLIBC_' | sed 's/.*GLIBC_//' | sort -V | tail -1)
-		echo "Maximum glibc version required: $max_glibc"
+# Use CARGO_TARGET_DIR if set, otherwise default to target
+target_dir="${CARGO_TARGET_DIR:-target}"
+binary_path="$target_dir/$RUST_TRIPLE/serious/mise"
 
-		# Amazon Linux 2 has glibc 2.26, so we check if our binary requires <= 2.26
-		if printf '%s\n' "$max_glibc" "2.26" | sort -V -C; then
-			echo "✅ Binary is compatible with Amazon Linux 2 (glibc $max_glibc <= 2.26)"
-		else
-			echo "❌ Binary requires glibc $max_glibc, which is newer than Amazon Linux 2's glibc 2.26"
-			echo "This binary will NOT work on Amazon Linux 2"
-			exit 1
-		fi
-	else
-		echo "Warning: Binary not found at $binary_path, skipping glibc check"
-	fi
-fi
+case "$RUST_TRIPLE" in
+x86_64-unknown-linux-gnu)
+	echo "Checking glibc compatibility for Amazon Linux 2..."
+	scripts/check-glibc.sh "$binary_path" "2.26" "Amazon Linux 2"
+	;;
+aarch64-unknown-linux-gnu)
+	echo "Checking glibc compatibility for Amazon Linux 2023..."
+	scripts/check-glibc.sh "$binary_path" "2.34" "Amazon Linux 2023"
+	;;
+esac
 mkdir -p dist/mise/bin
 mkdir -p dist/mise/man/man1
 mkdir -p dist/mise/share/fish/vendor_conf.d
-# Use CARGO_TARGET_DIR if set, otherwise default to target
-target_dir="${CARGO_TARGET_DIR:-target}"
 cp "$target_dir/$RUST_TRIPLE/serious/mise"* dist/mise/bin
 cp README.md dist/mise/README.md
 cp LICENSE dist/mise/LICENSE

--- a/scripts/check-glibc.sh
+++ b/scripts/check-glibc.sh
@@ -6,7 +6,7 @@ max_allowed=${2:?"usage: check-glibc.sh <binary> <max-glibc> <target-name>"}
 target_name=${3:-$binary_path}
 
 if [[ ! -f $binary_path ]]; then
-	echo "Warning: binary not found at $binary_path, skipping glibc check"
+	echo "Error: binary not found at $binary_path; aborting glibc check" >&2
 	exit 1
 fi
 

--- a/scripts/check-glibc.sh
+++ b/scripts/check-glibc.sh
@@ -7,7 +7,7 @@ target_name=${3:-$binary_path}
 
 if [[ ! -f $binary_path ]]; then
 	echo "Warning: binary not found at $binary_path, skipping glibc check"
-	exit 0
+	exit 1
 fi
 
 max_required=$(

--- a/scripts/check-glibc.sh
+++ b/scripts/check-glibc.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+binary_path=${1:?"usage: check-glibc.sh <binary> <max-glibc> <target-name>"}
+max_allowed=${2:?"usage: check-glibc.sh <binary> <max-glibc> <target-name>"}
+target_name=${3:-$binary_path}
+
+if [[ ! -f $binary_path ]]; then
+	echo "Warning: binary not found at $binary_path, skipping glibc check"
+	exit 0
+fi
+
+max_required=$(
+	objdump -p "$binary_path" |
+		awk '/GLIBC_/ { sub(/.*GLIBC_/, ""); print }' |
+		sort -V |
+		tail -1
+)
+
+if [[ -z $max_required ]]; then
+	echo "No glibc symbols found for $target_name"
+	exit 0
+fi
+
+echo "Maximum glibc version required for $target_name: $max_required"
+
+if printf '%s\n' "$max_required" "$max_allowed" | sort -V -C; then
+	echo "Binary is compatible with $target_name (glibc $max_required <= $max_allowed)"
+else
+	echo "Binary requires glibc $max_required, which is newer than $target_name's glibc $max_allowed"
+	echo "This binary will NOT work on $target_name"
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- pin the `aarch64-unknown-linux-gnu` cross image back to `0.2.5` instead of the floating `main` tag
- add `scripts/check-glibc.sh` for reusable release artifact glibc-floor checks
- keep the existing x86_64 GNU Amazon Linux 2 guard and add an ARM64 GNU Amazon Linux 2023 guard

Refs https://github.com/jdx/mise/discussions/10874.

## Testing
- `mise x shellcheck -- shellcheck scripts/check-glibc.sh scripts/build-tarball.sh`
- `mise x shfmt -- shfmt -d -i 0 scripts/check-glibc.sh scripts/build-tarball.sh`
- `scripts/check-glibc.sh v2026.7.3-linux-arm64 2.34 'Amazon Linux 2023'` fails as expected with max `GLIBC_2.39`
- `scripts/check-glibc.sh v2026.6.14-linux-arm64 2.34 'Amazon Linux 2023'` passes with max `GLIBC_2.30`
- On `bamboo`: `mise x rust@1.93 github:cross-rs/cross -- scripts/build-tarball.sh aarch64-unknown-linux-gnu`
  - build completed and produced linux-arm64 tarballs
  - new glibc check passed with max `GLIBC_2.18 <= 2.34`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to cross build images and release-time glibc validation; they reduce compatibility risk rather than altering runtime application code.
> 
> **Overview**
> Restores predictable **glibc floors** for Linux GNU release builds by pinning the `aarch64-unknown-linux-gnu` cross-rs image to **0.2.5** instead of the floating `main` tag, so ARM64 tarballs no longer pick up a newer toolchain/glibc when the image moves forward.
> 
> Release packaging now runs shared **`scripts/check-glibc.sh`** after the build: **x86_64-gnu** still must satisfy **≤ 2.26** (Amazon Linux 2), and **aarch64-gnu** must satisfy **≤ 2.34** (Amazon Linux 2023). The tarball script no longer inlines the old x86_64-only `objdump` logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ceeb1f4ef7b221421967026046d890b04b2ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux release packaging compatibility checks for both x86_64 and aarch64 builds.
  * Added a dedicated glibc validation step to detect and prevent incompatible binaries from being packaged.
  * Adjusted the compatibility thresholds per platform to match expected environments.
* **Chores**
  * Pinned the aarch64 Cross image to a fixed tag for more consistent, predictable build outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->