### PR TITLE
fix(install): reconcile rust components and targets

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -1,14 +1,14 @@
 # Rust
 
 Rust/cargo can be installed which uses rustup under the hood. mise will install rustup if it is not already
-installed and add the requested targets. By default, mise respects the `RUSTUP_HOME` and `CARGO_HOME` environment
+installed and install the requested toolchain, components, and targets. By default, mise respects the `RUSTUP_HOME` and `CARGO_HOME` environment
 variables for the home directories and falls back to their standard location (`~/.rustup` and `~/.cargo`) if they are
 not set. You can change this by setting the `MISE_RUSTUP_HOME` and `MISE_CARGO_HOME` environment variables if you'd like
 to isolate mise's rustup/cargo from your other rustup/cargo installations.
 
 Unlike most tools, these won't exist inside of `~/.local/share/mise/installs` because they are managed by rustup.
-All mise does is set the `RUSTUP_TOOLCHAIN` environment variable to the requested version and rustup will
-automatically install it if it doesn't exist.
+mise keeps a symlink there for install tracking, sets the `RUSTUP_TOOLCHAIN` environment variable to the requested
+version, and asks rustup to install any configured components or targets when you run `mise install`.
 
 ## Usage
 
@@ -50,13 +50,15 @@ rust = { version = "latest", install_env = { RUSTUP_DIST_SERVER = "https://stati
 ### `components`
 
 The `components` option allows you to specify which components to install. Multiple components can be
-specified by separating them with a comma. The set of available components may vary with different releases and
+specified as an array or by separating them with a comma. The set of available components may vary with different releases and
 toolchains. Please consult the Rust documentation for the most up-to-date list of components.
 
 ```toml
 [tools]
-"rust" = { version = "1.83.0", components = "rust-src,llvm-tools" }
+"rust" = { version = "1.83.0", components = ["rust-src", "llvm-tools"] }
 ```
+
+If the Rust toolchain is already installed, `mise install` will still add any missing configured components.
 
 ### `profile`
 
@@ -77,15 +79,17 @@ If not set, it defaults to the profile configured in `rustup`. You can check you
 ### `targets`
 
 The `targets` option allows you to specify a list of platforms to install for cross-compilation. Multiple targets can
-be specified by separating them with a comma.
+be specified as an array or by separating them with a comma.
 
 ```toml
 [tools]
 "rust" = {
   version = "1.83.0",
-  targets = "wasm32-unknown-unknown,thumbv2-none-eabi",
+  targets = ["wasm32-unknown-unknown", "thumbv2-none-eabi"],
 }
 ```
+
+If the Rust toolchain is already installed, `mise install` will still add any missing configured targets.
 
 ## Settings
 

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export MISE_RUSTUP_HOME="$PWD/rustup"
+export MISE_CARGO_HOME="$PWD/cargo"
+
+mkdir -p "$MISE_RUSTUP_HOME" "$MISE_CARGO_HOME/bin"
+touch "$MISE_RUSTUP_HOME/settings.toml"
+
+cat >"$MISE_CARGO_HOME/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo "cargo"
+EOF
+
+cat >"$MISE_CARGO_HOME/bin/rustc" <<'EOF'
+#!/usr/bin/env bash
+echo "rustc ${RUSTUP_TOOLCHAIN:-unknown}"
+EOF
+
+cat >"$MISE_CARGO_HOME/bin/rustup" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "$*" >>"$MISE_CARGO_HOME/rustup.log"
+
+case "$1 $2" in
+	"component list")
+		cat "$MISE_CARGO_HOME/components" 2>/dev/null || true
+		;;
+	"target list")
+		cat "$MISE_CARGO_HOME/targets" 2>/dev/null || true
+		;;
+	"toolchain install")
+		shift 2
+		toolchain="$1"
+		shift
+		mkdir -p "$MISE_RUSTUP_HOME/toolchains/$toolchain"
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+				--component)
+					echo "$2" >>"$MISE_CARGO_HOME/components"
+					shift 2
+					;;
+				--target)
+					echo "$2" >>"$MISE_CARGO_HOME/targets"
+					shift 2
+					;;
+				--profile)
+					shift 2
+					;;
+				*)
+					shift
+					;;
+			esac
+		done
+		sort -u "$MISE_CARGO_HOME/components" -o "$MISE_CARGO_HOME/components" 2>/dev/null || true
+		sort -u "$MISE_CARGO_HOME/targets" -o "$MISE_CARGO_HOME/targets" 2>/dev/null || true
+		;;
+	"toolchain uninstall")
+		;;
+	*)
+		echo "unexpected rustup args: $*" >&2
+		exit 1
+		;;
+esac
+EOF
+
+chmod +x "$MISE_CARGO_HOME/bin/cargo" "$MISE_CARGO_HOME/bin/rustc" "$MISE_CARGO_HOME/bin/rustup"
+
+cat >mise.toml <<EOF
+[tools]
+rust = "1.81.0"
+EOF
+
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "1"
+
+cat >mise.toml <<EOF
+[tools]
+rust = { version = "1.81.0", components = ["rustfmt", "rust-src"], targets = ["wasm32-unknown-unknown"] }
+EOF
+
+assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
+
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
+assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"
+assert_contains "cat '$MISE_CARGO_HOME/targets'" "wasm32-unknown-unknown"
+
+mise install
+assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
+assert_contains "mise install rust --dry-run-code 2>&1" "already installed"

--- a/e2e/core/test_rust_components_reconcile
+++ b/e2e/core/test_rust_components_reconcile
@@ -83,7 +83,7 @@ EOF
 
 assert_fail_contains "mise install rust --dry-run-code 2>&1" "would install"
 
-mise install
+mise exec -- rustc -V
 assert_contains "grep -c '^toolchain install' '$MISE_CARGO_HOME/rustup.log'" "2"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rustfmt"
 assert_contains "cat '$MISE_CARGO_HOME/components'" "rust-src"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1652,6 +1652,23 @@ pub trait Backend: Debug + Send + Sync {
     ) -> Result<bool> {
         Ok(self.is_version_installed(config, tv, check_symlink))
     }
+
+    async fn is_install_satisfied_or_false(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        check_symlink: bool,
+    ) -> bool {
+        self.is_install_satisfied(config, tv, check_symlink)
+            .await
+            .unwrap_or_else(|err| {
+                debug!(
+                    "is_install_satisfied check failed for {}: {err:#}",
+                    tv.style()
+                );
+                false
+            })
+    }
     async fn is_version_outdated(&self, config: &Arc<Config>, tv: &ToolVersion) -> bool {
         let latest = match tv.latest_version(config).await {
             Ok(latest) => latest,
@@ -2122,7 +2139,11 @@ pub trait Backend: Debug + Send + Sync {
         // Handle dry-run mode early to avoid plugin installation
         if ctx.dry_run {
             use crate::ui::progress_report::ProgressIcon;
-            if self.is_install_satisfied(&ctx.config, &tv, true).await? {
+            let satisfied = self
+                .is_install_satisfied_or_false(&ctx.config, &tv, true)
+                .await;
+            tv.install_satisfied = Some(satisfied);
+            if satisfied {
                 ctx.pr
                     .finish_with_icon("already installed".into(), ProgressIcon::Skipped);
             } else {
@@ -2160,7 +2181,10 @@ pub trait Backend: Debug + Send + Sync {
             self.uninstall_version(&ctx.config, &tv, ctx.pr.as_ref(), false)
                 .await?;
             ctx.pr.next_operation();
-        } else if self.is_install_satisfied(&ctx.config, &tv, true).await? {
+        } else if self
+            .is_install_satisfied_or_false(&ctx.config, &tv, true)
+            .await
+        {
             return Ok(tv);
         }
 
@@ -2172,7 +2196,11 @@ pub trait Backend: Debug + Send + Sync {
         let _lock = lock_file::get(&tv.install_path(), ctx.force)?;
 
         // Double-checked (locking) that it wasn't installed while we were waiting for the lock
-        if self.is_install_satisfied(&ctx.config, &tv, true).await? && !ctx.force {
+        if self
+            .is_install_satisfied_or_false(&ctx.config, &tv, true)
+            .await
+            && !ctx.force
+        {
             return Ok(tv);
         }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1638,6 +1638,20 @@ pub trait Backend: Debug + Send + Sync {
             }
         }
     }
+
+    /// Whether an explicit install request is already satisfied.
+    ///
+    /// Most backends are satisfied when the version's install path exists. Some
+    /// backends have extra mutable install state outside mise's install path,
+    /// such as rustup components and targets.
+    async fn is_install_satisfied(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        check_symlink: bool,
+    ) -> Result<bool> {
+        Ok(self.is_version_installed(config, tv, check_symlink))
+    }
     async fn is_version_outdated(&self, config: &Arc<Config>, tv: &ToolVersion) -> bool {
         let latest = match tv.latest_version(config).await {
             Ok(latest) => latest,
@@ -2108,7 +2122,7 @@ pub trait Backend: Debug + Send + Sync {
         // Handle dry-run mode early to avoid plugin installation
         if ctx.dry_run {
             use crate::ui::progress_report::ProgressIcon;
-            if self.is_version_installed(&ctx.config, &tv, true) {
+            if self.is_install_satisfied(&ctx.config, &tv, true).await? {
                 ctx.pr
                     .finish_with_icon("already installed".into(), ProgressIcon::Skipped);
             } else {
@@ -2146,7 +2160,7 @@ pub trait Backend: Debug + Send + Sync {
             self.uninstall_version(&ctx.config, &tv, ctx.pr.as_ref(), false)
                 .await?;
             ctx.pr.next_operation();
-        } else if self.is_version_installed(&ctx.config, &tv, true) {
+        } else if self.is_install_satisfied(&ctx.config, &tv, true).await? {
             return Ok(tv);
         }
 
@@ -2158,7 +2172,7 @@ pub trait Backend: Debug + Send + Sync {
         let _lock = lock_file::get(&tv.install_path(), ctx.force)?;
 
         // Double-checked (locking) that it wasn't installed while we were waiting for the lock
-        if self.is_version_installed(&ctx.config, &tv, true) && !ctx.force {
+        if self.is_install_satisfied(&ctx.config, &tv, true).await? && !ctx.force {
             return Ok(tv);
         }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -307,13 +307,21 @@ impl Install {
         // In dry-run mode, check if any tools would be installed before filtering
         if self.is_dry_run() {
             if self.dry_run_code {
-                let has_work = versions.iter().any(|tv| {
-                    if let Ok(backend) = tv.backend() {
-                        !backend.is_version_installed(&install_config, tv, true)
-                    } else {
-                        true
+                let mut has_work = false;
+                for tv in &versions {
+                    let Ok(backend) = tv.backend() else {
+                        has_work = true;
+                        break;
+                    };
+                    if !backend
+                        .is_install_satisfied(&install_config, tv, true)
+                        .await
+                        .unwrap_or(false)
+                    {
+                        has_work = true;
+                        break;
                     }
-                });
+                }
                 if has_work {
                     exit::exit(1);
                 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -307,21 +307,7 @@ impl Install {
         // In dry-run mode, check if any tools would be installed before filtering
         if self.is_dry_run() {
             if self.dry_run_code {
-                let mut has_work = false;
-                for tv in &versions {
-                    let Ok(backend) = tv.backend() else {
-                        has_work = true;
-                        break;
-                    };
-                    if !backend
-                        .is_install_satisfied(&install_config, tv, true)
-                        .await
-                        .unwrap_or(false)
-                    {
-                        has_work = true;
-                        break;
-                    }
-                }
+                let has_work = versions.iter().any(|tv| tv.install_satisfied != Some(true));
                 if has_work {
                     exit::exit(1);
                 }

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, collections::BTreeSet, ffi::OsString, sync::Arc};
 
 use crate::backend::VersionInfo;
 use crate::backend::options::BackendOptions;
 use crate::backend::{Backend, IdiomaticVersion, platform_target::PlatformTarget};
 use crate::build_time::TARGET;
 use crate::cli::args::BackendArg;
-use crate::cmd::CmdLineRunner;
+use crate::cmd::{CmdLineRunner, cmd};
 use crate::config::{Config, Settings};
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
@@ -40,17 +40,18 @@ impl<'a> RustOptions<'a> {
     }
 
     fn comma_list(&self, name: &str) -> Option<Vec<String>> {
+        let normalize = |value: &str| {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_string())
+        };
         match self.values.raw().opts.get(name) {
-            Some(toml::Value::String(value)) => Some(
-                value
-                    .split(',')
-                    .map(|value| value.trim().to_string())
-                    .collect(),
-            ),
+            Some(toml::Value::String(value)) => {
+                Some(value.split(',').filter_map(normalize).collect())
+            }
             Some(toml::Value::Array(values)) => Some(
                 values
                     .iter()
-                    .filter_map(|value| value.as_str().map(|value| value.trim().to_string()))
+                    .filter_map(|value| value.as_str().and_then(normalize))
                     .collect(),
             ),
             _ => None,
@@ -143,6 +144,74 @@ impl RustPlugin {
     fn target_triple(&self, tv: &ToolVersion) -> String {
         format!("{}-{}", tv.version, TARGET)
     }
+
+    fn rustup_installed_items(
+        &self,
+        tv: &ToolVersion,
+        subcommand: &str,
+    ) -> Result<Option<BTreeSet<String>>> {
+        let args = vec![
+            subcommand.to_string(),
+            "list".to_string(),
+            "--installed".to_string(),
+            "--toolchain".to_string(),
+            tv.version.clone(),
+        ];
+        let mut cmd = cmd(RUSTUP_BIN, args)
+            .env("PATH", rustup_path_env()?)
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked();
+        for (key, value) in rustup_env(&tv.version) {
+            cmd = cmd.env(key, value);
+        }
+        let output = match cmd.run() {
+            Ok(output) => output,
+            Err(err) => {
+                debug!(
+                    "rustup {subcommand} list failed for {}: {err:#}",
+                    tv.style()
+                );
+                return Ok(None);
+            }
+        };
+        if !output.status.success() {
+            debug!(
+                "rustup {subcommand} list failed for {}: {}",
+                tv.style(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+            return Ok(None);
+        }
+        Ok(Some(
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(String::from)
+                .collect(),
+        ))
+    }
+
+    fn missing_components(
+        &self,
+        requested: &[String],
+        installed: &BTreeSet<String>,
+    ) -> Vec<String> {
+        requested
+            .iter()
+            .filter(|component| !rustup_component_installed(installed, component))
+            .cloned()
+            .collect()
+    }
+
+    fn missing_targets(&self, requested: &[String], installed: &BTreeSet<String>) -> Vec<String> {
+        requested
+            .iter()
+            .filter(|target| !installed.contains(*target))
+            .cloned()
+            .collect()
+    }
 }
 
 #[async_trait]
@@ -155,6 +224,59 @@ impl Backend for RustPlugin {
     /// Lockfile URLs are not applicable since we don't download artifacts directly.
     fn supports_lockfile_url(&self) -> bool {
         false
+    }
+
+    /// Rust toolchains can be installed while requested components/targets are
+    /// still absent because rustup owns that mutable state outside mise's
+    /// install directory.
+    async fn is_install_satisfied(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        check_symlink: bool,
+    ) -> Result<bool> {
+        if !self.is_version_installed(config, tv, check_symlink) {
+            return Ok(false);
+        }
+
+        let raw_opts = tv.request.options();
+        let (_, components, targets) = RustOptions::new(&raw_opts).install_args();
+
+        if let Some(components) = components
+            && !components.is_empty()
+        {
+            let Some(installed) = self.rustup_installed_items(tv, "component")? else {
+                return Ok(false);
+            };
+            let missing = self.missing_components(&components, &installed);
+            if !missing.is_empty() {
+                debug!(
+                    "{} missing rustup component(s): {}",
+                    tv.style(),
+                    missing.join(", ")
+                );
+                return Ok(false);
+            }
+        }
+
+        if let Some(targets) = targets
+            && !targets.is_empty()
+        {
+            let Some(installed) = self.rustup_installed_items(tv, "target")? else {
+                return Ok(false);
+            };
+            let missing = self.missing_targets(&targets, &installed);
+            if !missing.is_empty() {
+                debug!(
+                    "{} missing rustup target(s): {}",
+                    tv.style(),
+                    missing.join(", ")
+                );
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
     }
 
     fn resolve_lockfile_options(
@@ -290,19 +412,7 @@ impl Backend for RustPlugin {
         _ts: &Toolset,
         tv: &ToolVersion,
     ) -> Result<BTreeMap<String, String>> {
-        let toolchain = tv.version.to_string();
-        Ok([
-            (
-                "CARGO_HOME".to_string(),
-                cargo_home().to_string_lossy().to_string(),
-            ),
-            (
-                "RUSTUP_HOME".to_string(),
-                rustup_home().to_string_lossy().to_string(),
-            ),
-            ("RUSTUP_TOOLCHAIN".to_string(), toolchain),
-        ]
-        .into())
+        Ok(rustup_env(&tv.version))
     }
 
     async fn outdated_info(
@@ -505,6 +615,33 @@ fn cargo_bindir() -> PathBuf {
     cargo_home().join("bin")
 }
 
+fn rustup_env(toolchain: &str) -> BTreeMap<String, String> {
+    [
+        (
+            "CARGO_HOME".to_string(),
+            cargo_home().to_string_lossy().to_string(),
+        ),
+        (
+            "RUSTUP_HOME".to_string(),
+            rustup_home().to_string_lossy().to_string(),
+        ),
+        ("RUSTUP_TOOLCHAIN".to_string(), toolchain.to_string()),
+    ]
+    .into()
+}
+
+fn rustup_path_env() -> Result<OsString> {
+    Ok(env::join_paths(
+        std::iter::once(cargo_bindir()).chain(env::PATH.clone()),
+    )?)
+}
+
+fn rustup_component_installed(installed: &BTreeSet<String>, component: &str) -> bool {
+    installed
+        .iter()
+        .any(|item| item == component || item.starts_with(&format!("{component}-")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -536,6 +673,49 @@ mod tests {
             Some(vec!["clippy".to_string(), "rustfmt".to_string()])
         );
         assert_eq!(targets, Some(vec!["wasm32-wasip1".to_string()]));
+    }
+
+    #[test]
+    fn rust_options_reads_array_install_args() {
+        let mut opts = opts_with("profile", "minimal");
+        opts.opts.insert(
+            "components".to_string(),
+            string_array(&[" clippy ".to_string(), "rustfmt".to_string(), String::new()]),
+        );
+        opts.opts.insert(
+            "targets".to_string(),
+            string_array(&[
+                "wasm32-wasip1".to_string(),
+                " wasm32-unknown-unknown ".to_string(),
+            ]),
+        );
+
+        let (profile, components, targets) = RustOptions::new(&opts).install_args();
+
+        assert_eq!(profile, Some("minimal".to_string()));
+        assert_eq!(
+            components,
+            Some(vec!["clippy".to_string(), "rustfmt".to_string()])
+        );
+        assert_eq!(
+            targets,
+            Some(vec![
+                "wasm32-wasip1".to_string(),
+                "wasm32-unknown-unknown".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn rustup_component_matching_allows_host_suffixes() {
+        let installed = BTreeSet::from([
+            "rust-src".to_string(),
+            "llvm-tools-x86_64-unknown-linux-gnu".to_string(),
+        ]);
+
+        assert!(rustup_component_installed(&installed, "rust-src"));
+        assert!(rustup_component_installed(&installed, "llvm-tools"));
+        assert!(!rustup_component_installed(&installed, "rustfmt"));
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -637,10 +637,69 @@ fn rustup_path_env() -> Result<OsString> {
 }
 
 fn rustup_component_installed(installed: &BTreeSet<String>, component: &str) -> bool {
-    installed
-        .iter()
-        .any(|item| item == component || item.starts_with(&format!("{component}-")))
+    installed.iter().any(|item| {
+        item == component
+            || item
+                .strip_prefix(component)
+                .and_then(|suffix| suffix.strip_prefix('-'))
+                .is_some_and(rustup_component_suffix_is_host_triple)
+    })
 }
+
+fn rustup_component_suffix_is_host_triple(suffix: &str) -> bool {
+    let Some((arch, rest)) = suffix.split_once('-') else {
+        return false;
+    };
+    !rest.is_empty() && RUST_TARGET_ARCHES.contains(&arch)
+}
+
+const RUST_TARGET_ARCHES: &[&str] = &[
+    "aarch64",
+    "arm",
+    "armeb",
+    "arm64ec",
+    "armv4t",
+    "armv5te",
+    "armv6",
+    "armv7",
+    "armv7a",
+    "armv7r",
+    "armv7s",
+    "avr",
+    "bpfeb",
+    "bpfel",
+    "csky",
+    "hexagon",
+    "i386",
+    "i586",
+    "i686",
+    "loongarch64",
+    "m68k",
+    "mips",
+    "mips64",
+    "mips64el",
+    "mipsel",
+    "msp430",
+    "nvptx64",
+    "powerpc",
+    "powerpc64",
+    "powerpc64le",
+    "riscv32",
+    "riscv64",
+    "s390x",
+    "sparc",
+    "sparc64",
+    "thumbv4t",
+    "thumbv5te",
+    "thumbv6m",
+    "thumbv7a",
+    "thumbv7em",
+    "thumbv7m",
+    "thumbv7neon",
+    "wasm32",
+    "wasm64",
+    "x86_64",
+];
 
 #[cfg(test)]
 mod tests {
@@ -716,6 +775,8 @@ mod tests {
         assert!(rustup_component_installed(&installed, "rust-src"));
         assert!(rustup_component_installed(&installed, "llvm-tools"));
         assert!(!rustup_component_installed(&installed, "rustfmt"));
+        assert!(!rustup_component_installed(&installed, "rust"));
+        assert!(!rustup_component_installed(&installed, "llvm"));
     }
 
     #[test]

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -165,11 +165,16 @@ impl Toolset {
     pub async fn list_missing_versions(&self, config: &Arc<Config>) -> Vec<ToolVersion> {
         trace!("list_missing_versions");
         measure!("toolset::list_missing_versions", {
-            self.list_current_versions()
-                .into_iter()
-                .filter(|(p, tv)| !p.is_version_installed(config, tv, true))
-                .map(|(_, tv)| tv)
-                .collect()
+            let mut missing = vec![];
+            for (backend, tv) in self.list_current_versions() {
+                if !backend
+                    .is_install_satisfied_or_false(config, &tv, true)
+                    .await
+                {
+                    missing.push(tv);
+                }
+            }
+            missing
         })
     }
 

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -227,12 +227,18 @@ impl ToolRequest {
         }
     }
 
-    pub async fn is_installed(&self, config: &Arc<Config>) -> bool {
+    pub async fn is_install_satisfied(&self, config: &Arc<Config>) -> bool {
         if let Some(backend) = backend::get(self.ba()) {
             match self.resolve(config, &Default::default()).await {
-                Ok(tv) => backend.is_version_installed(config, &tv, false),
+                Ok(tv) => match backend.is_install_satisfied(config, &tv, false).await {
+                    Ok(satisfied) => satisfied,
+                    Err(e) => {
+                        debug!("ToolRequest.is_install_satisfied: {e:#}");
+                        false
+                    }
+                },
                 Err(e) => {
-                    debug!("ToolRequest.is_installed: {e:#}");
+                    debug!("ToolRequest.is_install_satisfied: {e:#}");
                     false
                 }
             }

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -48,7 +48,7 @@ impl ToolRequestSet {
     pub async fn missing_tools(&self, config: &Arc<Config>) -> Vec<&ToolRequest> {
         let mut tools = vec![];
         for tr in self.tools.values().flatten() {
-            if tr.is_os_supported() && !tr.is_installed(config).await {
+            if tr.is_os_supported() && !tr.is_install_satisfied(config).await {
                 tools.push(tr);
             }
         }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -46,6 +46,8 @@ pub struct ToolVersion {
     pub conda_packages: BTreeMap<(String, String), CondaPackageInfo>,
     /// pkgx packages resolved during installation: (platform, package@version) -> PkgxPackageInfo
     pub pkgx_packages: BTreeMap<(String, String), PkgxPackageInfo>,
+    /// Install satisfaction computed during dry-run installs.
+    pub install_satisfied: Option<bool>,
 }
 
 impl ToolVersion {
@@ -71,6 +73,7 @@ impl ToolVersion {
             install_path: None,
             conda_packages: Default::default(),
             pkgx_packages: Default::default(),
+            install_satisfied: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- teach install checks to ask backends whether an install request is fully satisfied
- make the Rust backend verify configured rustup components and targets, including array-form values, before skipping install
- document Rust component/target arrays and add a fake-rustup e2e for reconciliation and dry-run-code

## Tests
- cargo test rust_options
- cargo test rustup_component
- mise run test:e2e e2e/core/test_rust_components_reconcile

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install skip/dry-run behavior changes across all backends via the new satisfaction hook; Rust installs may invoke rustup more often when component/target checks fail or return errors (treated as unsatisfied).
> 
> **Overview**
> **Install satisfaction** is now a backend-aware concept: the default is still “install path exists,” but backends can override `is_install_satisfied` when extra state lives outside mise’s install dir. The Rust backend uses this to query rustup for installed **components** and **targets** and treat the toolchain as incomplete if config asks for something rustup does not have yet—so `mise install` is not skipped when only the symlink exists.
> 
> **Rust** parsing for `components` / `targets` now accepts TOML arrays (with trim/empty filtering), matches host-suffixed component names (e.g. `llvm-tools-x86_64-…`), and shares `rustup_env` / `rustup_path_env` for list/install checks. Dry-run records `ToolVersion.install_satisfied` and `mise install --dry-run-code` uses that instead of path-only checks.
> 
> **Docs** describe array config and that `mise install` adds missing components/targets on an already-installed toolchain. An **e2e** script with a fake rustup exercises reconciliation and dry-run exit codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b346ff01f939a68ee71f4c5fe037292f108b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rust installs now evaluate complete readiness (toolchain plus required components/targets) and reconcile what’s missing.
* **Bug Fixes**
  * Dry-run output/exit codes now better reflect whether any installs still need work.
  * Rust installs no longer incorrectly treat existing toolchains as fully satisfied when required components/targets are missing.
  * Improved parsing to ignore extra whitespace and empty component/target entries.
* **Documentation**
  * Updated Rust docs to clarify rustup/cargo home overrides, install behavior, and supported component/target config formats.
* **Tests**
  * Added end-to-end coverage for Rust components/targets reconciliation and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->