### PR TITLE
fix(upgrade): suppress release-age warning for installed versions

### DIFF
--- a/e2e/cli/test_install_before
+++ b/e2e/cli/test_install_before
@@ -50,6 +50,14 @@ assert_contains "echo '$output'" "newer jq release"
 # The warning includes the effective minimum_release_age value
 assert_contains "echo '$output'" "ignored by minimum_release_age (2019-01-01)"
 
+# Test: upgrade --minimum-release-age should not warn about a hidden release
+# when that release is already installed.
+latest_jq=$(mise latest jq --minimum-release-age 0s)
+mise uninstall jq --all 2>/dev/null || true
+mise install "jq@$latest_jq"
+output=$(mise upgrade jq --minimum-release-age 2019-01-01 --dry-run 2>&1)
+assert_not_contains "echo '$output'" "newer jq release"
+
 # Test: install --minimum-release-age with relative duration "90d"
 mise uninstall tiny --all 2>/dev/null || true
 output=$(mise install tiny@latest --minimum-release-age 90d --dry-run 2>&1)

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -625,6 +625,9 @@ impl Upgrade {
             };
             match (eligible_latest, baseline_latest) {
                 (Some(eligible), Some(baseline)) if is_outdated_version(&eligible, &baseline) => {
+                    if current_satisfies_hidden_release(config, &tv, &baseline) {
+                        continue;
+                    }
                     let suffix = format!("latest eligible release is {eligible}");
                     warn_hidden_release_ignored_by_minimum_release_age(
                         config,
@@ -636,6 +639,9 @@ impl Upgrade {
                     .await;
                 }
                 (None, Some(baseline)) => {
+                    if current_satisfies_hidden_release(config, &tv, &baseline) {
+                        continue;
+                    }
                     warn_hidden_release_ignored_by_minimum_release_age(
                         config,
                         &tv,
@@ -686,6 +692,22 @@ impl Upgrade {
         };
         backend.latest_version_unfiltered(config, query).await
     }
+}
+
+fn current_satisfies_hidden_release(
+    config: &Arc<Config>,
+    tv: &ToolVersion,
+    hidden_version: &str,
+) -> bool {
+    OutdatedInfo::new(config, tv.clone(), hidden_version.to_string())
+        .ok()
+        .and_then(|info| info.current)
+        .as_deref()
+        .is_some_and(|current| current_version_satisfies_hidden_release(current, hidden_version))
+}
+
+fn current_version_satisfies_hidden_release(current: &str, hidden_version: &str) -> bool {
+    !is_outdated_version(current, hidden_version)
 }
 
 fn backend_matches(backends: &HashSet<String>, ba: &BackendArg) -> bool {
@@ -835,8 +857,18 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::{format_hidden_release_details, release_is_eligible_at};
+    use super::{
+        current_version_satisfies_hidden_release, format_hidden_release_details,
+        release_is_eligible_at,
+    };
     use jiff::tz::TimeZone;
+
+    #[test]
+    fn test_current_version_satisfies_hidden_release() {
+        assert!(!current_version_satisfies_hidden_release("1.0.0", "1.1.0"));
+        assert!(current_version_satisfies_hidden_release("1.1.0", "1.1.0"));
+        assert!(current_version_satisfies_hidden_release("1.2.0", "1.1.0"));
+    }
 
     #[test]
     fn test_format_hidden_release_details_with_duration_age() {


### PR DESCRIPTION
## Summary
- suppress `minimum_release_age` hidden-release warnings when the current/installed version already satisfies the hidden release
- add a focused helper test for the warning decision
- add an e2e regression for `mise upgrade jq --minimum-release-age` after the hidden latest is installed

## Tests
- `cargo fmt --check`
- `cargo test --bin mise cli::upgrade::tests`
- `mise run test:e2e e2e/cli/test_install_before`
- `mise run lint-fix`

Refs #10872

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to optional warning output during upgrade dry-run/resolution; no install or version-resolution behavior changed beyond suppressing false-positive warnings.
> 
> **Overview**
> **`mise upgrade --minimum-release-age`** no longer prints the “newer … release ignored by minimum_release_age” warning when the **installed** version already meets or exceeds the unfiltered “hidden” latest.
> 
> The upgrade path now checks **`current_satisfies_hidden_release`** (via **`OutdatedInfo`** and semver **`is_outdated_version`**) before emitting that warning in both branches (eligible latest behind baseline, or no eligible release). Unit tests cover the version comparison helper; an e2e case installs jq at the unfiltered latest and asserts **`--dry-run`** does not mention “newer jq release”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3633efaa68544a40e8fe92dde64f140a4c37acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mise upgrade` warnings so already-installed eligible releases no longer trigger misleading “hidden release” messages.
  * Fixed `--minimum-release-age` dry-run output to avoid warning about newer releases that are already present on the system.

* **Tests**
  * Added end-to-end coverage for upgrade behavior with `--minimum-release-age` when the relevant release is already installed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->