### PR TITLE
docs(bootstrap): fix broken intro and link bootstrap sub-pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -138,7 +138,7 @@ export default withMermaid(
           ],
         },
         {
-          text: "Bootstrap (experimental)",
+          text: "Bootstrap",
           items: [
             { text: "Overview", link: "/bootstrap" },
             {
@@ -151,6 +151,7 @@ export default withMermaid(
                 { text: "dnf", link: "/bootstrap/packages/dnf" },
                 { text: "pacman", link: "/bootstrap/packages/pacman" },
                 { text: "brew", link: "/bootstrap/packages/brew" },
+                { text: "mas", link: "/bootstrap/packages/mas" },
               ],
             },
             {
@@ -172,6 +173,10 @@ export default withMermaid(
             {
               text: "launchd",
               link: "/bootstrap/launchd",
+            },
+            {
+              text: "systemd",
+              link: "/bootstrap/systemd",
             },
             {
               text: "User Login Shell",

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,5 +1,6 @@
 # Bootstrap
 
+`mise bootstrap` sets up a machine for the current config in one command: OS
 packages, git repos, dotfiles, mise shell activation, macOS defaults, macOS
 LaunchAgents, Linux systemd user services, the user's login shell, tools, and
 any final project-specific task. You can also add hooks that run at named points
@@ -14,19 +15,22 @@ preferences, user services, and one-time machine setup.
 
 `mise bootstrap` runs these steps in order:
 
-1. `mise bootstrap packages apply` installs missing `[bootstrap.packages]`.
-2. `mise bootstrap repos apply` clones or updates `[bootstrap.repos]`.
-3. `mise bootstrap dotfiles apply` applies `[dotfiles]`.
+1. `mise bootstrap packages apply` installs missing
+   [`[bootstrap.packages]`](/bootstrap/packages/).
+2. `mise bootstrap repos apply` clones or updates
+   [`[bootstrap.repos]`](/bootstrap/repos.html).
+3. `mise bootstrap dotfiles apply` applies [`[dotfiles]`](/dotfiles.html).
 4. `mise bootstrap mise-shell-activate apply` configures shell activation from
-   `[bootstrap.mise_shell_activate]`.
-5. `mise bootstrap macos defaults apply` writes `[bootstrap.macos.defaults]`.
+   [`[bootstrap.mise_shell_activate]`](/bootstrap/shell.html).
+5. `mise bootstrap macos defaults apply` writes
+   [`[bootstrap.macos.defaults]`](/bootstrap/macos-defaults.html).
 6. `mise bootstrap macos launchd-agents apply` writes and loads
-   `[bootstrap.macos.launchd.agents]`.
+   [`[bootstrap.macos.launchd.agents]`](/bootstrap/launchd.html).
 7. `mise bootstrap linux systemd-units apply` converges
-   `[bootstrap.linux.systemd.units]`
+   [`[bootstrap.linux.systemd.units]`](/bootstrap/systemd.html)
    by writing unit files, enabling/disabling them, and starting/stopping them
    as configured.
-8. `mise bootstrap user apply` applies `[bootstrap.user]`.
+8. `mise bootstrap user apply` applies [`[bootstrap.user]`](/bootstrap/user.html).
 9. `mise install` installs missing `[tools]`.
 10. `mise run bootstrap` runs a task named `bootstrap`, if one exists.
 11. `[bootstrap.hooks.final]` runs after the bootstrap task, if configured.
@@ -42,6 +46,9 @@ Use `mise bootstrap --only <part>` to run only specific parts. It supports the
 same part names and can be repeated or comma-separated, for example
 `mise bootstrap --only dotfiles,tools`. `--only` and `--skip` are mutually
 exclusive.
+
+Use `mise bootstrap --update` to refresh system package manager metadata
+before installing packages (apk: `--update-cache`, apt: `apt-get update`).
 
 Hook phases can also run before and after the built-in steps:
 `pre-packages`, `post-packages`, `pre-repos`, `post-repos`, `pre-dotfiles`,
@@ -143,7 +150,9 @@ dotfiles phase to replace conflicting whole-file dotfile targets.
 ## Inspecting State
 
 Use `mise bootstrap status` to inspect the declarative bootstrap state in one
-place:
+place. It reports every declarative part — packages, repos, dotfiles, shell
+activation, macOS defaults, LaunchAgents, systemd units, and login shell —
+plus `[tools]` and any system dependencies that installed tools require:
 
 ```sh
 mise bootstrap status
@@ -168,20 +177,20 @@ only want to check one part without installing anything.
 
 ## What Goes Where
 
-| Config                             | Use for                                                       |
-| ---------------------------------- | ------------------------------------------------------------- |
-| `[bootstrap.packages]`             | OS packages from apk, apt, dnf, pacman, or brew               |
-| `[bootstrap.repos]`                | Git repos cloned before dotfiles are applied                  |
-| `[dotfiles]`                       | Whole-file dotfiles and small managed edits to existing files |
-| `[bootstrap.mise_shell_activate]`  | mise activation snippets in shell startup files               |
-| `[bootstrap.macos.*]`              | Curated macOS preferences for Dock/Finder/keyboard/trackpad   |
-| `[bootstrap.macos.defaults]`       | macOS user preferences written through `defaults write`       |
-| `[bootstrap.macos.launchd.agents]` | macOS user LaunchAgents written and loaded with `launchctl`   |
-| `[bootstrap.linux.systemd.units]`  | Linux systemd user services managed with `systemctl --user`   |
-| `[bootstrap.user]`                 | Current-user settings such as `login_shell`                   |
-| `[bootstrap.hooks]`                | Commands that run at named bootstrap phases                   |
-| `[tools]`                          | Versioned dev tools managed by mise                           |
-| `[tasks.bootstrap]`                | Anything custom that should run after tools are installed     |
+| Config                                                         | Use for                                                       |
+| -------------------------------------------------------------- | ------------------------------------------------------------- |
+| [`[bootstrap.packages]`](/bootstrap/packages/)                 | OS packages from apk, apt, dnf, pacman, brew, or mas          |
+| [`[bootstrap.repos]`](/bootstrap/repos.html)                   | Git repos cloned before dotfiles are applied                  |
+| [`[dotfiles]`](/dotfiles.html)                                 | Whole-file dotfiles and small managed edits to existing files |
+| [`[bootstrap.mise_shell_activate]`](/bootstrap/shell.html)     | mise activation snippets in shell startup files               |
+| [`[bootstrap.macos.*]`](/bootstrap/macos-defaults.html)        | Curated macOS preferences for Dock/Finder/keyboard/trackpad   |
+| [`[bootstrap.macos.defaults]`](/bootstrap/macos-defaults.html) | macOS user preferences written through `defaults write`       |
+| [`[bootstrap.macos.launchd.agents]`](/bootstrap/launchd.html)  | macOS user LaunchAgents written and loaded with `launchctl`   |
+| [`[bootstrap.linux.systemd.units]`](/bootstrap/systemd.html)   | Linux systemd user services managed with `systemctl --user`   |
+| [`[bootstrap.user]`](/bootstrap/user.html)                     | Current-user settings such as `login_shell`                   |
+| `[bootstrap.hooks]`                                            | Commands that run at named bootstrap phases                   |
+| `[tools]`                                                      | Versioned dev tools managed by mise                           |
+| `[tasks.bootstrap]`                                            | Anything custom that should run after tools are installed     |
 
 Use declarative sections when mise can inspect and converge the state. Use
 `[tasks.bootstrap]` for imperative setup that does not fit those sections,


### PR DESCRIPTION
## Summary

- Restore the lead-in sentence of the [Bootstrap overview page](https://mise.en.dev/bootstrap.html), which was accidentally dropped in #10611 — the page has been starting mid-sentence ("packages, git repos, dotfiles, …") ever since.
- Link the "How it runs" steps and the "What Goes Where" table to the per-feature detail pages (packages, repos, dotfiles, shell activation, macOS defaults, launchd, systemd, user).
- Document the `--update` flag and note that `mise bootstrap status` also reports `[tools]` and plugin system dependencies.
- Mention `mas` alongside the other package managers in the What Goes Where table.
- Sidebar: drop the stale "(experimental)" label now that bootstrap is stabilized (#10869), and add the orphaned `mas` and `systemd` pages, which previously weren't reachable from navigation.

Verified with `mise run docs:build` (VitePress validates internal links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime or bootstrap behavior changes.
> 
> **Overview**
> **Bootstrap overview** (`bootstrap.md`) is repaired and expanded: the opening sentence describing `mise bootstrap` is restored, numbered steps and the “What Goes Where” table now link to the per-feature docs, **`--update`** is documented, **`mise bootstrap status`** is clarified to include `[tools]` and tool system deps, and **`mas`** is listed with the other package managers.
> 
> **VitePress sidebar** (`config.ts`) drops the stale **“(experimental)”** label on Bootstrap, and adds nav entries for **`mas`** and **`systemd`** so those pages are reachable from the menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f797b6040d65be390485b82a416ced71bbfb2a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the Bootstrap docs with a clearer overview and step-by-step setup flow.
  * Added documentation for a `--update` option that refreshes package manager metadata before installs, including platform-specific notes.
  * Expanded status and configuration references with clearer descriptions and links, including Linux systemd and macOS-related settings.
  * Updated navigation to include a dedicated Bootstrap Packages entry and a direct systemd page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->