### PR TITLE
docs: fix broken source-code links in generated CLI reference

### DIFF
--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -2,7 +2,7 @@
 # `mise bootstrap`
 
 - **Usage**: `mise bootstrap [FLAGS] [SUBCOMMAND]`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Set up a machine for the current config in one command
 

--- a/docs/cli/bootstrap/dotfiles.md
+++ b/docs/cli/bootstrap/dotfiles.md
@@ -2,7 +2,7 @@
 # `mise bootstrap dotfiles`
 
 - **Usage**: `mise bootstrap dotfiles <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage dotfiles from `[dotfiles]`
 

--- a/docs/cli/bootstrap/dotfiles/apply.md
+++ b/docs/cli/bootstrap/dotfiles/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap dotfiles apply`
 
 - **Usage**: `mise bootstrap dotfiles apply [FLAGS] [TARGET]…`
-- **Source code**: [`src/cli/bootstrap/dotfiles/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/dotfiles/apply.rs)
+- **Source code**: [`src/cli/dotfiles/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/dotfiles/apply.rs)
 
 Apply dotfiles from `[dotfiles]`
 

--- a/docs/cli/bootstrap/dotfiles/status.md
+++ b/docs/cli/bootstrap/dotfiles/status.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `mise bootstrap dotfiles status [-J --json] [--missing] [TARGET]…`
 - **Aliases**: `ls`
-- **Source code**: [`src/cli/bootstrap/dotfiles/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/dotfiles/status.rs)
+- **Source code**: [`src/cli/dotfiles/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/dotfiles/status.rs)
 
 Show the status of dotfiles from `[dotfiles]`
 

--- a/docs/cli/bootstrap/launchd/apply.md
+++ b/docs/cli/bootstrap/launchd/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap launchd apply`
 
 - **Usage**: `mise bootstrap launchd apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/launchd/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/launchd/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/launchd/status.md
+++ b/docs/cli/bootstrap/launchd/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap launchd status`
 
 - **Usage**: `mise bootstrap launchd status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/launchd/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/launchd/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/linux.md
+++ b/docs/cli/bootstrap/linux.md
@@ -2,7 +2,7 @@
 # `mise bootstrap linux`
 
 - **Usage**: `mise bootstrap linux <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage Linux bootstrap config from `[bootstrap.linux]`
 

--- a/docs/cli/bootstrap/linux/systemd-units.md
+++ b/docs/cli/bootstrap/linux/systemd-units.md
@@ -2,7 +2,7 @@
 # `mise bootstrap linux systemd-units`
 
 - **Usage**: `mise bootstrap linux systemd-units <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage systemd user services from `[bootstrap.linux.systemd.units]`
 

--- a/docs/cli/bootstrap/linux/systemd-units/apply.md
+++ b/docs/cli/bootstrap/linux/systemd-units/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap linux systemd-units apply`
 
 - **Usage**: `mise bootstrap linux systemd-units apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/linux/systemd_units/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/linux/systemd_units/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/linux/systemd-units/status.md
+++ b/docs/cli/bootstrap/linux/systemd-units/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap linux systemd-units status`
 
 - **Usage**: `mise bootstrap linux systemd-units status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/linux/systemd_units/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/linux/systemd_units/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/macos-defaults/apply.md
+++ b/docs/cli/bootstrap/macos-defaults/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos-defaults apply`
 
 - **Usage**: `mise bootstrap macos-defaults apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/macos_defaults/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/macos_defaults/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/macos-defaults/status.md
+++ b/docs/cli/bootstrap/macos-defaults/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos-defaults status`
 
 - **Usage**: `mise bootstrap macos-defaults status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/macos_defaults/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/macos_defaults/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/macos.md
+++ b/docs/cli/bootstrap/macos.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos`
 
 - **Usage**: `mise bootstrap macos <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage macOS bootstrap config from `[bootstrap.macos]`
 

--- a/docs/cli/bootstrap/macos/defaults.md
+++ b/docs/cli/bootstrap/macos/defaults.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos defaults`
 
 - **Usage**: `mise bootstrap macos defaults <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage macOS defaults from `[bootstrap.macos.defaults]`
 

--- a/docs/cli/bootstrap/macos/defaults/apply.md
+++ b/docs/cli/bootstrap/macos/defaults/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos defaults apply`
 
 - **Usage**: `mise bootstrap macos defaults apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/macos/defaults/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/macos/defaults/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/macos/defaults/status.md
+++ b/docs/cli/bootstrap/macos/defaults/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos defaults status`
 
 - **Usage**: `mise bootstrap macos defaults status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/macos/defaults/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/macos/defaults/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/macos/launchd-agents.md
+++ b/docs/cli/bootstrap/macos/launchd-agents.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos launchd-agents`
 
 - **Usage**: `mise bootstrap macos launchd-agents <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
 

--- a/docs/cli/bootstrap/macos/launchd-agents/apply.md
+++ b/docs/cli/bootstrap/macos/launchd-agents/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos launchd-agents apply`
 
 - **Usage**: `mise bootstrap macos launchd-agents apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/macos/launchd_agents/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/macos/launchd_agents/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/macos/launchd-agents/status.md
+++ b/docs/cli/bootstrap/macos/launchd-agents/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap macos launchd-agents status`
 
 - **Usage**: `mise bootstrap macos launchd-agents status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/macos/launchd_agents/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/macos/launchd_agents/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/mise-shell-activate.md
+++ b/docs/cli/bootstrap/mise-shell-activate.md
@@ -2,7 +2,7 @@
 # `mise bootstrap mise-shell-activate`
 
 - **Usage**: `mise bootstrap mise-shell-activate <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage mise shell activation from `[bootstrap.mise_shell_activate]`
 

--- a/docs/cli/bootstrap/mise-shell-activate/apply.md
+++ b/docs/cli/bootstrap/mise-shell-activate/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap mise-shell-activate apply`
 
 - **Usage**: `mise bootstrap mise-shell-activate apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/mise_shell_activate/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mise_shell_activate/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/mise-shell-activate/status.md
+++ b/docs/cli/bootstrap/mise-shell-activate/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap mise-shell-activate status`
 
 - **Usage**: `mise bootstrap mise-shell-activate status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/mise_shell_activate/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mise_shell_activate/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/packages.md
+++ b/docs/cli/bootstrap/packages.md
@@ -2,7 +2,7 @@
 # `mise bootstrap packages`
 
 - **Usage**: `mise bootstrap packages <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage bootstrap system packages from `[bootstrap.packages]`
 

--- a/docs/cli/bootstrap/packages/apply.md
+++ b/docs/cli/bootstrap/packages/apply.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `mise bootstrap packages apply [FLAGS] [PACKAGE]…`
 - **Aliases**: `i`
-- **Source code**: [`src/cli/bootstrap/packages/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/packages/apply.rs)
+- **Source code**: [`src/cli/system/install.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/install.rs)
 
 Apply system packages from `[bootstrap.packages]`
 

--- a/docs/cli/bootstrap/packages/brew.md
+++ b/docs/cli/bootstrap/packages/brew.md
@@ -2,7 +2,7 @@
 # `mise bootstrap packages brew`
 
 - **Usage**: `mise bootstrap packages brew <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/system/brew/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/brew/mod.rs)
 
 Manage Homebrew taps used by bootstrap packages
 

--- a/docs/cli/bootstrap/packages/brew/tap.md
+++ b/docs/cli/bootstrap/packages/brew/tap.md
@@ -2,7 +2,7 @@
 # `mise bootstrap packages brew tap`
 
 - **Usage**: `mise bootstrap packages brew tap [FLAGS] <TAP> [URL]`
-- **Source code**: [`src/cli/bootstrap/packages/brew/tap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/packages/brew/tap.rs)
+- **Source code**: [`src/cli/system/brew/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/brew/mod.rs)
 
 Add a Homebrew tap URL to [bootstrap.brew.taps]
 

--- a/docs/cli/bootstrap/packages/brew/untap.md
+++ b/docs/cli/bootstrap/packages/brew/untap.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `mise bootstrap packages brew untap [FLAGS] <TAPS>…`
 - **Aliases**: `remove`, `rm`
-- **Source code**: [`src/cli/bootstrap/packages/brew/untap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/packages/brew/untap.rs)
+- **Source code**: [`src/cli/system/brew/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/brew/mod.rs)
 
 Remove Homebrew tap URLs from [bootstrap.brew.taps]
 

--- a/docs/cli/bootstrap/packages/status.md
+++ b/docs/cli/bootstrap/packages/status.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `mise bootstrap packages status [-J --json] [--missing]`
 - **Aliases**: `ls`
-- **Source code**: [`src/cli/bootstrap/packages/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/packages/status.rs)
+- **Source code**: [`src/cli/system/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/status.rs)
 
 Show the status of system packages from `[bootstrap.packages]`
 

--- a/docs/cli/bootstrap/packages/upgrade.md
+++ b/docs/cli/bootstrap/packages/upgrade.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `mise bootstrap packages upgrade [FLAGS] [PACKAGE]…`
 - **Aliases**: `up`
-- **Source code**: [`src/cli/bootstrap/packages/upgrade.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/packages/upgrade.rs)
+- **Source code**: [`src/cli/system/upgrade.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/upgrade.rs)
 
 Upgrade installed bootstrap packages from `[bootstrap.packages]`
 

--- a/docs/cli/bootstrap/packages/use.md
+++ b/docs/cli/bootstrap/packages/use.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `mise bootstrap packages use [FLAGS] <PACKAGE>…`
 - **Aliases**: `u`
-- **Source code**: [`src/cli/bootstrap/packages/use.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/packages/use.rs)
+- **Source code**: [`src/cli/system/use.rs`](https://github.com/jdx/mise/blob/main/src/cli/system/use.rs)
 
 Add bootstrap packages to [bootstrap.packages] and install them
 

--- a/docs/cli/bootstrap/repos.md
+++ b/docs/cli/bootstrap/repos.md
@@ -2,7 +2,7 @@
 # `mise bootstrap repos`
 
 - **Usage**: `mise bootstrap repos <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage git repo checkouts from `[bootstrap.repos]`
 

--- a/docs/cli/bootstrap/repos/apply.md
+++ b/docs/cli/bootstrap/repos/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap repos apply`
 
 - **Usage**: `mise bootstrap repos apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/repos/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/repos/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/repos/status.md
+++ b/docs/cli/bootstrap/repos/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap repos status`
 
 - **Usage**: `mise bootstrap repos status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/repos/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/repos/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/systemd/apply.md
+++ b/docs/cli/bootstrap/systemd/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap systemd apply`
 
 - **Usage**: `mise bootstrap systemd apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/systemd/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/systemd/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/systemd/status.md
+++ b/docs/cli/bootstrap/systemd/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap systemd status`
 
 - **Usage**: `mise bootstrap systemd status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/systemd/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/systemd/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/user.md
+++ b/docs/cli/bootstrap/user.md
@@ -2,7 +2,7 @@
 # `mise bootstrap user`
 
 - **Usage**: `mise bootstrap user <SUBCOMMAND>`
-- **Source code**: [`src/cli/bootstrap/mod.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/mod.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 Manage current-user bootstrap settings from `[bootstrap.user]`
 

--- a/docs/cli/bootstrap/user/apply.md
+++ b/docs/cli/bootstrap/user/apply.md
@@ -2,7 +2,7 @@
 # `mise bootstrap user apply`
 
 - **Usage**: `mise bootstrap user apply [-n --dry-run] [-y --yes]`
-- **Source code**: [`src/cli/bootstrap/user/apply.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/user/apply.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/bootstrap/user/status.md
+++ b/docs/cli/bootstrap/user/status.md
@@ -2,7 +2,7 @@
 # `mise bootstrap user status`
 
 - **Usage**: `mise bootstrap user status [-J --json] [--missing]`
-- **Source code**: [`src/cli/bootstrap/user/status.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap/user/status.rs)
+- **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 
 ## Flags
 

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `mise tasks run [FLAGS] [TASK] [ARGS]…`
 - **Aliases**: `r`
-- **Source code**: [`src/cli/tasks/run.rs`](https://github.com/jdx/mise/blob/main/src/cli/tasks/run.rs)
+- **Source code**: [`src/cli/run.rs`](https://github.com/jdx/mise/blob/main/src/cli/run.rs)
 
 Run task(s)
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -5056,12 +5056,28 @@ e.g.: `mise which npm --tool=node@20`
 }
 source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}
-{%- if path == "bootstrap/status" -%}
-{%- set path = "bootstrap.rs" -%}
+{%- if path == "bootstrap/packages/apply" -%}
+{%- set path = "system/install.rs" -%}
 {%- elif path == "bootstrap/packages/import" -%}
 {%- set path = "system/import.rs" -%}
 {%- elif path == "bootstrap/packages/prune" -%}
 {%- set path = "system/prune.rs" -%}
+{%- elif path == "bootstrap/packages/status" -%}
+{%- set path = "system/status.rs" -%}
+{%- elif path == "bootstrap/packages/upgrade" -%}
+{%- set path = "system/upgrade.rs" -%}
+{%- elif path == "bootstrap/packages/use" -%}
+{%- set path = "system/use.rs" -%}
+{%- elif path is starting_with("bootstrap/packages/brew") -%}
+{%- set path = "system/brew/mod.rs" -%}
+{%- elif path == "bootstrap/dotfiles/apply" -%}
+{%- set path = "dotfiles/apply.rs" -%}
+{%- elif path == "bootstrap/dotfiles/status" -%}
+{%- set path = "dotfiles/status.rs" -%}
+{%- elif path is starting_with("bootstrap") -%}
+{%- set path = "bootstrap.rs" -%}
+{%- elif path == "tasks/run" -%}
+{%- set path = "run.rs" -%}
 {%- elif cmd.subcommands | length > 0 -%}
 {%- set parts = path | split(pat="/") -%}
 {%- set path = parts[0] ~ "/mod.rs" -%}

--- a/src/assets/mise-extra.usage.kdl
+++ b/src/assets/mise-extra.usage.kdl
@@ -1,11 +1,27 @@
 source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}
-{%- if path == "bootstrap/status" -%}
-{%- set path = "bootstrap.rs" -%}
+{%- if path == "bootstrap/packages/apply" -%}
+{%- set path = "system/install.rs" -%}
 {%- elif path == "bootstrap/packages/import" -%}
 {%- set path = "system/import.rs" -%}
 {%- elif path == "bootstrap/packages/prune" -%}
 {%- set path = "system/prune.rs" -%}
+{%- elif path == "bootstrap/packages/status" -%}
+{%- set path = "system/status.rs" -%}
+{%- elif path == "bootstrap/packages/upgrade" -%}
+{%- set path = "system/upgrade.rs" -%}
+{%- elif path == "bootstrap/packages/use" -%}
+{%- set path = "system/use.rs" -%}
+{%- elif path is starting_with("bootstrap/packages/brew") -%}
+{%- set path = "system/brew/mod.rs" -%}
+{%- elif path == "bootstrap/dotfiles/apply" -%}
+{%- set path = "dotfiles/apply.rs" -%}
+{%- elif path == "bootstrap/dotfiles/status" -%}
+{%- set path = "dotfiles/status.rs" -%}
+{%- elif path is starting_with("bootstrap") -%}
+{%- set path = "bootstrap.rs" -%}
+{%- elif path == "tasks/run" -%}
+{%- set path = "run.rs" -%}
 {%- elif cmd.subcommands | length > 0 -%}
 {%- set parts = path | split(pat="/") -%}
 {%- set path = parts[0] ~ "/mod.rs" -%}


### PR DESCRIPTION
## Summary

Every generated CLI reference page under `docs/cli/bootstrap/` (~39 pages) plus `docs/cli/tasks/run.md` had a **Source code** link pointing at a file that doesn't exist (e.g. `src/cli/bootstrap/mod.rs`, `src/cli/bootstrap/repos/status.rs`, `src/cli/tasks/run.rs`).

The `source_code_link_template` in `src/assets/mise-extra.usage.kdl` guesses a directory-module layout for commands with subcommands, but:

- the entire bootstrap CLI lives in a single file, `src/cli/bootstrap.rs`
- `bootstrap packages` subcommands are implemented in `src/cli/system/` (apply→`install.rs`, status/upgrade/use/import/prune, brew→`brew/mod.rs`)
- `bootstrap dotfiles apply`/`status` flatten `src/cli/dotfiles/apply.rs`/`status.rs`
- `tasks run` is implemented in `src/cli/run.rs`

This PR extends the template's mapping (it already special-cased `bootstrap/status`, `packages/import`, and `packages/prune`) and regenerates the CLI docs. Verified with a scan that every `blob/main/src/cli/...` link in `docs/cli/` now resolves to an existing file; the man page is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and usage template link mapping only; no runtime CLI behavior changes.
> 
> **Overview**
> Generated CLI pages under `docs/cli/bootstrap/` and `docs/cli/tasks/run.md` pointed **Source code** links at paths that do not exist (e.g. `bootstrap/mod.rs`, per-subcommand `bootstrap/.../*.rs`, `tasks/run.rs`).
> 
> The PR expands `source_code_link_template` in `src/assets/mise-extra.usage.kdl` and `mise.usage.kdl` so usage-cli maps commands to real implementations: most bootstrap commands → `bootstrap.rs`, package subcommands → `src/cli/system/*` (apply → `install.rs`, brew → `brew/mod.rs`), dotfiles apply/status → `dotfiles/apply.rs` and `dotfiles/status.rs`, and `tasks run` → `run.rs`. The bootstrap docs are regenerated so GitHub links resolve to existing files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 084ce5a8c9b084a27b7ba52def900743301ee3a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated many CLI docs so “Source code” links point to the correct locations.
  * Broadened source-link coverage for bootstrap-related commands and task runs, improving navigation from docs to code.
* **Bug Fixes**
  * Fixed several outdated source references in command documentation.
  * Corrected source links for bootstrap subcommands across dotfiles, macOS, Linux, systemd, packages, repos, user, and tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->