### PR TITLE
docs(bootstrap): style and consistency pass across bootstrap pages

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -124,13 +124,13 @@ python = "3.12"
 run = "gh auth status || gh auth login"
 ```
 
-Then run:
+Then converge the whole machine (`--yes` skips the confirmation prompts):
 
 ```sh
 mise bootstrap --yes
 ```
 
-For a dry run:
+To preview what would change without touching anything:
 
 ```sh
 mise bootstrap --dry-run
@@ -147,7 +147,7 @@ By default, bootstrap refuses dotfile conflicts rather than replacing local
 files. Use `mise bootstrap --force-dotfiles` when you explicitly want the
 dotfiles phase to replace conflicting whole-file dotfile targets.
 
-## Inspecting State
+## Inspecting state
 
 Use `mise bootstrap status` to inspect the declarative bootstrap state in one
 place. It reports every declarative part — packages, repos, dotfiles, shell
@@ -175,7 +175,7 @@ surface in one command. The narrower `mise bootstrap packages status
 --missing` and `mise bootstrap dotfiles status --missing` commands are useful when you
 only want to check one part without installing anything.
 
-## What Goes Where
+## What goes where
 
 | Config                                                         | Use for                                                       |
 | -------------------------------------------------------------- | ------------------------------------------------------------- |
@@ -231,16 +231,16 @@ post-defaults = "killall Dock || true"
 Hooks merge across the config hierarchy from global to local, so shared config
 can define broad machine setup while a project adds its own phase commands.
 
-## Common Workflows
+## Common workflows
 
-### New Machine
+### New machine
 
 ```sh
 mise trust
 mise bootstrap --yes
 ```
 
-### Add A Package
+### Add a package
 
 ```sh
 mise bootstrap packages use apk:zlib-dev apt:libssl-dev
@@ -248,7 +248,7 @@ mise bootstrap packages use apk:zlib-dev apt:libssl-dev
 
 This writes `[bootstrap.packages]` and installs what is missing.
 
-### Capture An Edited Dotfile
+### Capture an edited dotfile
 
 ```sh
 $EDITOR ~/.zshrc
@@ -258,7 +258,7 @@ mise dotfiles add ~/.zshrc
 `mise dotfiles add` stores the live file under `dotfiles.root` and writes an
 explicit `[dotfiles]` entry with `mode`.
 
-### Edit A Managed Dotfile
+### Edit a managed dotfile
 
 ```sh
 mise dotfiles edit ~/.zshrc
@@ -268,7 +268,7 @@ mise dotfiles apply ~/.zshrc
 For symlinked dotfiles, `edit` opens the managed source, so it works with the
 default `symlink` mode.
 
-## Advanced: Self-Managing Config
+## Advanced: self-managing config
 
 You can manage the dotfiles repository and the mise global config as
 dotfiles:

--- a/docs/bootstrap/launchd.md
+++ b/docs/bootstrap/launchd.md
@@ -2,7 +2,8 @@
 
 mise can declare macOS user LaunchAgents in
 `[bootstrap.macos.launchd.agents]` and apply them with
-`mise bootstrap macos launchd-agents apply`:
+`mise bootstrap macos launchd-agents apply` or as part of
+[`mise bootstrap`](/bootstrap.html):
 
 ```toml
 [bootstrap.macos.launchd.agents.my-sync]

--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -2,7 +2,8 @@
 
 mise can declare macOS user defaults (preferences) in the
 `[bootstrap.macos.defaults]` section of `mise.toml` and apply them with
-`mise bootstrap macos defaults apply`:
+`mise bootstrap macos defaults apply` or as part of
+[`mise bootstrap`](/bootstrap.html):
 
 ```toml
 [bootstrap.macos.dock]

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -1,7 +1,9 @@
 # Bootstrap Packages
 
 mise can ensure machine-global system packages are installed via the
-`[bootstrap.packages]` section of `mise.toml`:
+`[bootstrap.packages]` section of `mise.toml`, applied by
+`mise bootstrap packages apply` or as part of
+[`mise bootstrap`](/bootstrap.html):
 
 ```toml
 [bootstrap.packages]
@@ -19,9 +21,6 @@ and the value is a version: `"latest"` for whatever the manager installs, or
 a pin in the manager's native format where supported (see the per-manager
 pages).
 
-mise can also place config files (dotfiles) — see
-[Dotfiles](/dotfiles.html), which uses `mise dotfiles` commands.
-
 System packages are intentionally separate from [`[tools]`](/configuration.html):
 they are not version-pinned per-project, do not get shims, and are installed
 machine-globally by the platform's package manager — or, for `brew` and
@@ -30,19 +29,16 @@ Homebrew itself. Use them for shared libraries, build dependencies, and
 machine-global GUI apps (`libssl-dev`, `postgresql`, `ffmpeg`, `firefox`),
 not for project dev tools — those belong in `[tools]`.
 
-The `[bootstrap]` section can also declare
-[repos](/bootstrap/repos.html) (`[bootstrap.repos]`), applied by
-`mise bootstrap repos apply`, [macOS defaults](/bootstrap/macos-defaults.html)
-(`[bootstrap.macos.defaults]`), applied by
-`mise bootstrap macos defaults apply`, and macOS
-[LaunchAgents](/bootstrap/launchd.html) (`[bootstrap.macos.launchd.agents]`),
-applied by `mise bootstrap macos launchd-agents apply`. Linux user services live in
-[systemd](/bootstrap/systemd.html) (`[bootstrap.linux.systemd.units]`),
-applied by `mise bootstrap linux systemd-units apply`. Shell activation snippets live in
-[Shell Activation](/bootstrap/shell.html) (`[bootstrap.mise_shell_activate]`).
-Current-user
-[login shells](/bootstrap/user.html) (`[bootstrap.user].login_shell`) are
-applied by `mise bootstrap user apply` or [`mise bootstrap`](/cli/bootstrap.html).
+Packages are one part of [mise bootstrap](/bootstrap.html). The other
+declarative sections work the same way:
+
+- [Repos](/bootstrap/repos.html) — `[bootstrap.repos]`
+- [Dotfiles](/dotfiles.html) — `[dotfiles]`
+- [Shell Activation](/bootstrap/shell.html) — `[bootstrap.mise_shell_activate]`
+- [macOS Defaults](/bootstrap/macos-defaults.html) — `[bootstrap.macos.defaults]`
+- [launchd](/bootstrap/launchd.html) — `[bootstrap.macos.launchd.agents]`
+- [systemd](/bootstrap/systemd.html) — `[bootstrap.linux.systemd.units]`
+- [User Login Shell](/bootstrap/user.html) — `[bootstrap.user].login_shell`
 
 ## Supported package managers
 
@@ -101,9 +97,9 @@ mise bootstrap packages apply --manager apt
 mise bootstrap packages apply --update  # refresh package manager metadata first
 
 mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox mas:497799835
-mise bootstrap packages use -g brew:ffmpeg                      # write globally
-mise bootstrap packages use apt:curl@8.5.0-2   # pin a version (brew pins via the
-                                   # formula name: brew:postgresql@17)
+mise bootstrap packages use -g brew:ffmpeg     # write globally
+mise bootstrap packages use apt:curl@8.5.0-2   # pin a version
+    # (brew pins via the formula name instead: brew:postgresql@17)
 
 mise bootstrap packages import --manager brew   # add installed requested brew formulae
 mise bootstrap packages import --manager brew --all
@@ -202,7 +198,7 @@ mise bootstrap packages apply --yes
 mise install
 ```
 
-[`mise bootstrap --yes`](/cli/bootstrap.html) combines both (and runs a task
+[`mise bootstrap --yes`](/bootstrap.html) combines both (and runs a task
 named `bootstrap` afterwards, if one is defined) — one command to set up a
 fresh machine or container.
 

--- a/docs/bootstrap/packages/mas.md
+++ b/docs/bootstrap/packages/mas.md
@@ -12,16 +12,10 @@ Mac App Store apps via the [`mas`](https://github.com/mas-cli/mas) CLI.
 Homebrew formulae, and casks. The package name is the App Store app ID:
 a numeric ADAM ID accepted by `mas install` and `mas upgrade`.
 
-mise does not install `mas` implicitly. Install it yourself first, for
-example with the built-in brew manager:
-
-```toml
-[bootstrap.packages]
-"brew:mas" = "latest"
-"mas:497799835" = "latest"
-```
-
-or with a normal mise tool if you have one configured globally:
+mise does not install `mas` implicitly. Install it yourself first — the
+`"brew:mas"` entry in the example above does this with the built-in
+[brew manager](/bootstrap/packages/brew.html) — or install it as a normal
+mise tool:
 
 ```sh
 mise use -g mas

--- a/docs/bootstrap/repos.md
+++ b/docs/bootstrap/repos.md
@@ -1,7 +1,7 @@
 # Repos
 
 mise can declare git repositories in `[bootstrap.repos]` and apply them with
-`mise bootstrap repos apply`:
+`mise bootstrap repos apply` or as part of [`mise bootstrap`](/bootstrap.html):
 
 ```toml
 [bootstrap.repos]

--- a/docs/bootstrap/shell.md
+++ b/docs/bootstrap/shell.md
@@ -1,8 +1,10 @@
 # Shell Activation
 
-mise can declaratively add shell activation snippets for bash, zsh, and fish
-with `[bootstrap.mise_shell_activate]`. Configure startup-file targets directly
-when you want separate shims and normal activation setup:
+mise can declaratively add [shell activation](/getting-started.html#activate-mise)
+snippets for bash, zsh, and fish with `[bootstrap.mise_shell_activate]`,
+applied by `mise bootstrap mise-shell-activate apply` or as part of
+[`mise bootstrap`](/bootstrap.html). Each key names a shell startup file and
+each value picks a mode:
 
 ```toml
 [bootstrap.mise_shell_activate]
@@ -52,16 +54,16 @@ eval "$(mise activate zsh)"
 `[bootstrap.mise_shell_activate]` follows the same manual, idempotent model as
 other bootstrap sections:
 
-- **Per-target override** - a project config can override a global setting for
+- **Per-target override** — a project config can override a global setting for
   one startup file with `zshrc = false` without changing `zprofile`.
-- **Manual application only** - mise never edits shell rc files implicitly.
+- **Manual application only** — mise never edits shell rc files implicitly.
   Only `mise bootstrap mise-shell-activate apply` and `mise bootstrap` apply this section.
-- **Marker-owned edits** - mise only owns the block between its markers. Other
+- **Marker-owned edits** — mise only owns the block between its markers. Other
   content in the rc file is left untouched.
-- **Shims stay out of `zshenv` by default** - `zshenv` is supported when
+- **Shims stay out of `zshenv` by default** — `zshenv` is supported when
   configured explicitly, but shell shortcuts do not write it because zsh reads
   it for every invocation, including scripts.
-- **Explicit dotfiles win** - if `[dotfiles]` already manages the same rc file
+- **Explicit dotfiles win** — if `[dotfiles]` already manages the same rc file
   as a whole file, or defines an edit for the same target/id such as
   `"~/.zshrc/activate"`, mise skips the generated shell activation entry for
   that shell.

--- a/docs/bootstrap/systemd.md
+++ b/docs/bootstrap/systemd.md
@@ -2,7 +2,8 @@
 
 mise can declare Linux systemd user services in
 `[bootstrap.linux.systemd.units]` and apply them with
-`mise bootstrap linux systemd-units apply`:
+`mise bootstrap linux systemd-units apply` or as part of
+[`mise bootstrap`](/bootstrap.html):
 
 ```toml
 [bootstrap.linux.systemd.units.my-sync]

--- a/docs/bootstrap/user.md
+++ b/docs/bootstrap/user.md
@@ -1,8 +1,8 @@
 # User Login Shell
 
 mise can declare the current user's login shell in `[bootstrap.user]` and
-apply it with `mise bootstrap user apply` or
-[`mise bootstrap`](/cli/bootstrap.html):
+apply it with `mise bootstrap user apply` or as part of
+[`mise bootstrap`](/bootstrap.html):
 
 ```toml
 [bootstrap.user]
@@ -25,17 +25,18 @@ new login session when it changes or would change the login shell.
 `[bootstrap.user].login_shell` follows the same manual, idempotent model as
 [bootstrap packages](/bootstrap/packages/):
 
-- **Most local wins** - a project config can override a global
+- **Most local wins** — a project config can override a global
   `login_shell`; unlike package/file lists, there is only one desired value.
-- **Manual application only** - mise never changes your login shell
-  implicitly. Only [`mise bootstrap`](/cli/bootstrap.html) applies it.
-- **Listed shell** - the shell must appear in `/etc/shells` before `chsh`
+- **Manual application only** — mise never changes your login shell
+  implicitly. Only `mise bootstrap user apply` and
+  [`mise bootstrap`](/bootstrap.html) apply it.
+- **Listed shell** — the shell must appear in `/etc/shells` before `chsh`
   accepts it on many platforms. mise adds the configured path to that file
   when it is missing.
-- **Unix-only** - on non-Unix platforms, or when `chsh` is not available,
+- **Unix-only** — on non-Unix platforms, or when `chsh` is not available,
   `mise bootstrap user status` reports the entry as skipped and bootstrap
   ignores it.
-- **Absolute path required** - relative shell names are skipped with a
+- **Absolute path required** — relative shell names are skipped with a
   warning. Use the full path, such as `/bin/zsh` or `/opt/homebrew/bin/fish`.
 
 `/etc/shells` is usually root-owned. If the file is not writable, mise uses

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -21,8 +21,8 @@ dotfiles.default_mode = "symlink"
 ```
 
 Dotfiles are only applied when explicitly requested with
-`mise dotfiles apply` or [`mise bootstrap`](/cli/bootstrap.html). They are
-never applied implicitly by `mise install` or `mise bootstrap packages`.
+`mise dotfiles apply` or as part of [`mise bootstrap`](/bootstrap.html). They
+are never applied implicitly by `mise install` or `mise bootstrap packages`.
 
 ## Whole-file entries
 
@@ -131,7 +131,7 @@ multi-line content.
   [config hierarchy](/configuration.html) (global → project). Whole-file
   entries merge by target path; edit entries merge by `(path, id)`.
 - **Manual application only** — nothing is written implicitly. Only
-  `mise dotfiles apply` or [`mise bootstrap`](/cli/bootstrap.html) applies
+  `mise dotfiles apply` or [`mise bootstrap`](/bootstrap.html) applies
   dotfiles.
 - **Idempotent** — entries already in their desired state are skipped;
   re-running is always safe.


### PR DESCRIPTION
## Summary

Follow-up to #10878 — a style/consistency pass over all the bootstrap guide pages:

- **Sentence-case headings** on the overview page ("Inspecting state", "What goes where", "Common workflows", …) to match the convention used across the rest of the docs.
- **Em-dashes in semantics bullets** on the Shell Activation and User Login Shell pages, matching the other bootstrap pages.
- **Every sub-page intro now links to the [Bootstrap overview](https://mise.en.dev/bootstrap.html)** ("…or as part of `mise bootstrap`"), so each page places itself in the larger workflow.
- **Packages index**: replaced the run-on cross-reference paragraph (7 links crammed into one sentence) with a scannable list, folded the stray dotfiles aside into it, and fixed a misaligned comment in the commands block.
- **mas page**: removed a duplicated TOML example.
- Guide pages now link to the bootstrap **guide** rather than the CLI reference where the guide is the better target; `mise bootstrap` mentions in Dotfiles follow suit.

No behavioral or factual changes — all content was verified against `src/cli/bootstrap.rs` and `src/system/` in review. Verified with `mise run docs:build` (validates internal links) and `mise run lint-fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation edits only; no code, config schema, or runtime behavior changes.
> 
> **Overview**
> Documentation-only polish across the bootstrap guide and related pages—no behavior or factual changes.
> 
> The **bootstrap overview** (`docs/bootstrap.md`) uses **sentence-case section headings**, clearer wording for `mise bootstrap --yes` / `--dry-run`, and consistent casing on workflow subheadings.
> 
> **Sub-page intros** (packages, repos, shell, macOS defaults, launchd, systemd, user) now state that each area can run via its subcommand **or as part of** [`mise bootstrap`](/bootstrap.html). **Internal links** that pointed at `/cli/bootstrap.html` now target the **bootstrap guide** where that’s the better entry point (including dotfiles and packages CI text).
> 
> The **packages index** replaces a long single-paragraph cross-link list with a **scannable bullet list** of other declarative bootstrap sections, drops redundant dotfiles aside text, and fixes **command-block comment alignment**. **Shell** and **user** semantics bullets use **em dashes** like the other bootstrap pages. The **mas** page removes a **duplicate TOML example** and shortens how to install `mas` first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c48c506f11edbdea4b59e5b0edd8f44b27181b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->