### PR TITLE
perf(install): parallelize missing version checks

### DIFF
--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -165,16 +165,25 @@ impl Toolset {
     pub async fn list_missing_versions(&self, config: &Arc<Config>) -> Vec<ToolVersion> {
         trace!("list_missing_versions");
         measure!("toolset::list_missing_versions", {
-            let mut missing = vec![];
-            for (backend, tv) in self.list_current_versions() {
-                if !backend
-                    .is_install_satisfied_or_false(config, &tv, true)
-                    .await
-                {
-                    missing.push(tv);
+            let versions = self
+                .list_current_versions()
+                .into_iter()
+                .map(|(backend, tv)| (config.clone(), backend, tv))
+                .collect::<Vec<_>>();
+            match parallel::parallel(versions, |(config, backend, tv)| async move {
+                Ok((!backend
+                    .is_install_satisfied_or_false(&config, &tv, true)
+                    .await)
+                    .then_some(tv))
+            })
+            .await
+            {
+                Ok(missing) => missing.into_iter().flatten().collect(),
+                Err(err) => {
+                    warn!("Error checking missing tool versions: {err:#}");
+                    vec![]
                 }
             }
-            missing
         })
     }
 

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -165,12 +165,13 @@ impl Toolset {
     pub async fn list_missing_versions(&self, config: &Arc<Config>) -> Vec<ToolVersion> {
         trace!("list_missing_versions");
         measure!("toolset::list_missing_versions", {
-            let versions = self
-                .list_current_versions()
+            let versions = self.list_current_versions().into_iter().collect::<Vec<_>>();
+            let parallel_versions = versions
+                .clone()
                 .into_iter()
                 .map(|(backend, tv)| (config.clone(), backend, tv))
                 .collect::<Vec<_>>();
-            match parallel::parallel(versions, |(config, backend, tv)| async move {
+            match parallel::parallel(parallel_versions, |(config, backend, tv)| async move {
                 Ok((!backend
                     .is_install_satisfied_or_false(&config, &tv, true)
                     .await)
@@ -181,7 +182,16 @@ impl Toolset {
                 Ok(missing) => missing.into_iter().flatten().collect(),
                 Err(err) => {
                     warn!("Error checking missing tool versions: {err:#}");
-                    vec![]
+                    let mut missing = vec![];
+                    for (backend, tv) in versions {
+                        if !backend
+                            .is_install_satisfied_or_false(config, &tv, true)
+                            .await
+                        {
+                            missing.push(tv);
+                        }
+                    }
+                    missing
                 }
             }
         })


### PR DESCRIPTION
## Summary
- parallelize `Toolset::list_missing_versions` satisfaction checks
- follow-up to #10876 after CodeRabbit noted the sequential rustup probe overhead

## Tests
- `cargo test rustup_component`
- `cargo test rust_options`
- `mise run test:e2e e2e/core/test_rust_components_reconcile`
- `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor on a hot path; only adds concurrency and error handling around existing satisfaction checks.
> 
> **Overview**
> **Speeds up missing-tool detection** by running each backend’s `is_install_satisfied_or_false` check concurrently (via `parallel::parallel`), instead of awaiting them one-by-one in `Toolset::list_missing_versions`.
> 
> The parallel path mirrors other toolset work (e.g. resolve / outdated checks): each `(backend, ToolVersion)` task returns `Some(tv)` when install is not satisfied, then results are flattened. If the parallel batch fails, the code **logs a warning** and **re-runs the same checks sequentially** so callers (shim resolution, `notify_if_versions_missing`, `install_missing_versions`) still get a correct missing list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411a7daccd3acd7ca88468a9cef2d0c1dc5cc5d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Missing-version detection now evaluates install satisfaction in parallel, improving speed for larger tool sets.
* **Bug Fixes**
  * If the parallel version check fails unexpectedly, the app now logs a warning and continues with a sequential check to produce an accurate missing-versions list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->