### PR TITLE
feat: skip re-install in mise.run script when matching version present

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -79,6 +79,7 @@ Options:
 - `MISE_QUIET=1` – disable non-error output
 - `MISE_INSTALL_PATH=/some/path` – change the binary path (default: `~/.local/bin/mise`)
 - `MISE_VERSION=v2025.12.0` – install a specific version
+- `MISE_INSTALL_SKIP_IF_EXISTS=1` – skip the download/install if the mise binary at the install path already matches the requested version
 
 If you want to verify the install script hasn't been tampered with:
 

--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -260,6 +260,17 @@ download_file() {
   echo "$file"
 }
 
+# Prints the version of an installed mise binary (the first field of
+# `mise version`, e.g. "2025.6.0"), with any leading "v" stripped. Prints
+# nothing if the binary is missing or fails to report a version.
+installed_mise_version() {
+  bin="$1"
+  if [ -x "$bin" ]; then
+    installed_version="$("$bin" version 2>/dev/null | head -n1 | cut -d' ' -f1)"
+    echo "${installed_version#v}"
+  fi
+}
+
 install_mise() {
   version="${MISE_VERSION:-$MISE_CURRENT_VERSION}"
   version="${version#v}"
@@ -271,6 +282,20 @@ install_mise() {
   install_path="${MISE_INSTALL_PATH:-$HOME/.local/bin/mise}"
   install_dir="$(dirname "$install_path")"
   install_from_github="${MISE_INSTALL_FROM_GITHUB:-}"
+
+  # Opt-in: skip the download/install if the binary already at the install
+  # path matches the requested version. Only the install path is checked (not
+  # the wider PATH) so that skipping never leaves install_path missing.
+  skip_if_exists="${MISE_INSTALL_SKIP_IF_EXISTS-}"
+  if [ "$skip_if_exists" = "1" ] || [ "$skip_if_exists" = "true" ]; then
+    if [ -x "$install_path" ]; then
+      existing_version="$(installed_mise_version "$install_path")"
+      if [ -n "$existing_version" ] && [ "$existing_version" = "$version" ]; then
+        info "mise: $install_path is already at version $version, skipping install"
+        return 0
+      fi
+    fi
+  fi
   if [ "$version" != "$current_version" ] || [ "$install_from_github" = "1" ] || [ "$install_from_github" = "true" ]; then
     tarball_url="https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-${os}-${arch}.${ext}"
   elif [ -n "${MISE_TARBALL_URL-}" ]; then


### PR DESCRIPTION
## Summary

Resolves #5335.

The `mise.run` (standalone) install script currently always downloads and installs mise, even when the exact requested version is already present. This is wasteful in CI/Docker builds that re-run `curl https://mise.run | sh` on every build.

This adds an **opt-in** env var `MISE_INSTALL_SKIP_IF_EXISTS`. When set to `1` or `true`, the script:

1. Checks the binary at the resolved install path (`MISE_INSTALL_PATH`, default `~/.local/bin/mise`).
2. Reads its version via `mise version` (first field, leading `v` stripped).
3. Skips the download/install entirely if that version matches the requested version (`MISE_VERSION`, or the version the script is pinned to).

Only the install path is checked (not the wider `PATH`), so skipping never leaves the install path missing and downstream `\$install_path activate` calls keep working. Default behavior is unchanged — the skip only happens when the user opts in.

```sh
curl https://mise.run | MISE_INSTALL_SKIP_IF_EXISTS=1 sh
```

## Changes

- `packaging/standalone/install.envsubst`: add `installed_mise_version()` helper and the opt-in skip check in `install_mise()`.
- `docs/installing-mise.md`: document the new option.

## Testing

Verified the skip logic under POSIX `sh`: version match at install path → skip; version mismatch → install; install path missing (even if mise is elsewhere on `PATH`) → install; not opted in → install. `shellcheck -x` passes with no warnings; the markdown doc passes `prettier` and `markdownlint`.

---

*This PR was generated by an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `MISE_INSTALL_SKIP_IF_EXISTS=1`/`true` option to skip installation when an executable already exists at `MISE_INSTALL_PATH` and matches the requested mise version.
* **Documentation**
  * Updated installation docs to describe the new `MISE_INSTALL_SKIP_IF_EXISTS` behavior and when the installer will bypass downloading and installing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->