### PR TITLE
fix(release): clone node release keys

### DIFF
--- a/xtasks/fetch-gpg-keys
+++ b/xtasks/fetch-gpg-keys
@@ -8,26 +8,31 @@ set -euxo pipefail
 rm -rf src/assets/gpg
 mkdir -p src/assets/gpg
 
-# Download each key file from nodejs/release-keys repository
-NODE_KEYS_URL="https://raw.githubusercontent.com/nodejs/release-keys/main/keys"
-NODE_KEYS_LIST_URL="https://raw.githubusercontent.com/nodejs/release-keys/main/keys.list"
+# Clone nodejs/release-keys once instead of making many raw.githubusercontent.com
+# requests. The raw host is prone to 429 throttling on shared CI egress.
+NODE_KEYS_REPO="https://github.com/nodejs/release-keys.git"
+NODE_KEYS_CHECKOUT="$(mktemp -d)"
+trap 'rm -rf "$NODE_KEYS_CHECKOUT"' EXIT
 
-echo "Fetching Node.js release keys list..."
-if ! keys_list=$(curl -fsSL "$NODE_KEYS_LIST_URL"); then
-	echo "ERROR: Failed to download keys.list from nodejs/release-keys" >&2
+echo "Cloning Node.js release keys..."
+if ! git clone --depth 1 --single-branch --branch main "$NODE_KEYS_REPO" "$NODE_KEYS_CHECKOUT"; then
+	echo "ERROR: Failed to clone nodejs/release-keys" >&2
 	exit 1
 fi
 
 key_count=0
-for fingerprint in $keys_list; do
-	echo "Fetching key: $fingerprint"
-	if ! curl -fLSs "${NODE_KEYS_URL}/${fingerprint}.asc" >>"src/assets/gpg/node.asc"; then
-		echo "ERROR: Failed to download key $fingerprint" >&2
+while IFS= read -r fingerprint || [[ -n $fingerprint ]]; do
+	[[ -z $fingerprint ]] && continue
+	key_file="$NODE_KEYS_CHECKOUT/keys/$fingerprint.asc"
+	echo "Adding key: $fingerprint"
+	if [[ ! -f $key_file ]]; then
+		echo "ERROR: Missing key $key_file" >&2
 		exit 1
 	fi
+	cat "$key_file" >>"src/assets/gpg/node.asc"
 	echo "" >>"src/assets/gpg/node.asc"
 	key_count=$((key_count + 1))
-done
+done <"$NODE_KEYS_CHECKOUT/keys.list"
 echo "Successfully fetched $key_count Node.js release keys"
 
 # Swift release keys


### PR DESCRIPTION
## Summary
- replace per-key raw.githubusercontent.com downloads with a single shallow clone of nodejs/release-keys
- keep node.asc generation ordered by keys.list and fail if a listed key is missing
- avoid the release-plz 429 failures seen on shared CI egress

## Testing
- bash -n xtasks/fetch-gpg-keys
- bash xtasks/fetch-gpg-keys
- git diff --check
- mise run lint-fix

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-time tooling only; output format and ordering stay tied to keys.list with the same failure modes for missing keys.
> 
> **Overview**
> **Node.js GPG key fetch** in `xtasks/fetch-gpg-keys` no longer downloads `keys.list` and each `.asc` from `raw.githubusercontent.com`. It performs one shallow `git clone` of `nodejs/release-keys`, then builds `src/assets/gpg/node.asc` by walking `keys.list` and concatenating local `keys/<fingerprint>.asc` files (still failing if a listed key is missing).
> 
> This targets **429 rate limiting** on shared CI egress during release-plz runs. Swift key fetching is unchanged (still `curl` from swift.org).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6de62600ff34549a37191c25bd1855e2c1b974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node.js release key fetching to be more reliable and consistent.
  * Added cleanup for temporary files and validation to ensure all required keys are found before use.
  * Reduced the number of external downloads by gathering keys from a single repository checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->