### PR TITLE
registry: add muxpilot

### DIFF
--- a/registry/muxpilot.toml
+++ b/registry/muxpilot.toml
@@ -1,0 +1,3 @@
+backends = ["github:muxpilot/muxpilot", "cargo:muxpilot"]
+description = "Fast tmux workspace picker and agent-aware session menu"
+test = { cmd = "muxpilot --version", expected = "muxpilot {{version}}" }


### PR DESCRIPTION
Adds [muxpilot](https://github.com/muxpilot/muxpilot) — a fast tmux workspace picker and agent-aware session menu (Rust).

- **Backends:** `github:muxpilot/muxpilot` (prebuilt release binaries from cargo-dist, for macOS + Linux, x86_64 + aarch64), with `cargo:muxpilot` as a source fallback. Not in aqua-registry yet, so `github` is the primary per the registry backend policy.
- **Smoke test:** `muxpilot --version` → `muxpilot <version>`.

Verified both backends locally against the latest release (0.1.2):

```
$ mise x github:muxpilot/muxpilot@0.1.2 -- muxpilot --version
muxpilot 0.1.2
$ mise x cargo:muxpilot@0.1.2 -- muxpilot --version
muxpilot 0.1.2
```

Homepage: https://muxpilot.n.yatsyk.com · crates.io: https://crates.io/crates/muxpilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a registry entry for **muxpilot**, making it easier to discover and install.
  * Included supported source listings and a version check to verify the published package responds correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->