### PR TITLE
fix(npm): support npm 12 view json output

### DIFF
--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -353,7 +353,7 @@ impl Backend for NPMBackend {
                                 .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                                 .read()?;
                         let dist_tags: Value = serde_json::from_str(&raw)?;
-                        Ok(npm_view_latest_dist_tag(&dist_tags))
+                        npm_view_latest_dist_tag(&dist_tags)
                     })
                     .await
             },
@@ -969,30 +969,32 @@ fn is_semver_prerelease(version: &str) -> bool {
     core_and_pre.contains('-')
 }
 
-fn npm_view_json(data: &Value) -> &Value {
+fn npm_view_json(data: &Value) -> eyre::Result<&Value> {
     match data {
         // npm 12 changed `npm view --json` to always return an array. mise only
         // queries one package at a time here, so unwrap that compatibility shell.
-        Value::Array(values) if values.len() == 1 => &values[0],
-        _ => data,
+        Value::Array(values) if values.len() == 1 => Ok(&values[0]),
+        Value::Array(values) => Err(eyre::eyre!(
+            "expected npm view --json to return one result, got {}",
+            values.len()
+        )),
+        _ => Ok(data),
     }
 }
 
 fn npm_view_versions_time(data: &Value) -> eyre::Result<Vec<VersionInfo>> {
-    let data = npm_view_json(data);
+    let data = npm_view_json(data)?;
     let versions = data["versions"]
         .as_array()
         .ok_or_else(|| eyre::eyre!("invalid versions"))?;
-    let time = data["time"]
-        .as_object()
-        .ok_or_else(|| eyre::eyre!("invalid time"))?;
+    let time = data.get("time").and_then(|time| time.as_object());
 
     Ok(versions
         .iter()
         .filter_map(|v| v.as_str())
         .map(|version| {
             let created_at = time
-                .get(version)
+                .and_then(|time| time.get(version))
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
             VersionInfo {
@@ -1005,11 +1007,11 @@ fn npm_view_versions_time(data: &Value) -> eyre::Result<Vec<VersionInfo>> {
         .collect())
 }
 
-fn npm_view_latest_dist_tag(data: &Value) -> Option<String> {
-    match npm_view_json(data)["latest"] {
+fn npm_view_latest_dist_tag(data: &Value) -> eyre::Result<Option<String>> {
+    Ok(match npm_view_json(data)?["latest"] {
         Value::String(ref s) => Some(s.clone()),
         _ => None,
-    }
+    })
 }
 
 fn parse_bool_arg(value: &str) -> Option<bool> {
@@ -1198,12 +1200,49 @@ mod tests {
     }
 
     #[test]
+    fn test_npm_view_versions_time_accepts_missing_time() {
+        let data = serde_json::json!({
+            "versions": ["1.0.0", "1.1.0"]
+        });
+
+        let versions = npm_view_versions_time(&data).unwrap();
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].version, "1.0.0");
+        assert_eq!(versions[0].created_at, None);
+        assert_eq!(versions[1].version, "1.1.0");
+        assert_eq!(versions[1].created_at, None);
+    }
+
+    #[test]
+    fn test_npm_view_versions_time_rejects_multiple_results() {
+        let data = serde_json::json!([
+            {
+                "versions": ["1.0.0"],
+                "time": {}
+            },
+            {
+                "versions": ["2.0.0"],
+                "time": {}
+            }
+        ]);
+
+        let error = npm_view_versions_time(&data).unwrap_err().to_string();
+        assert_eq!(
+            error,
+            "expected npm view --json to return one result, got 2"
+        );
+    }
+
+    #[test]
     fn test_npm_view_latest_dist_tag_accepts_legacy_object() {
         let data = serde_json::json!({
             "latest": "1.0.0"
         });
 
-        assert_eq!(npm_view_latest_dist_tag(&data), Some("1.0.0".into()));
+        assert_eq!(
+            npm_view_latest_dist_tag(&data).unwrap(),
+            Some("1.0.0".into())
+        );
     }
 
     #[test]
@@ -1212,7 +1251,28 @@ mod tests {
             "latest": "1.0.0"
         }]);
 
-        assert_eq!(npm_view_latest_dist_tag(&data), Some("1.0.0".into()));
+        assert_eq!(
+            npm_view_latest_dist_tag(&data).unwrap(),
+            Some("1.0.0".into())
+        );
+    }
+
+    #[test]
+    fn test_npm_view_latest_dist_tag_rejects_multiple_results() {
+        let data = serde_json::json!([
+            {
+                "latest": "1.0.0"
+            },
+            {
+                "latest": "2.0.0"
+            }
+        ]);
+
+        let error = npm_view_latest_dist_tag(&data).unwrap_err().to_string();
+        assert_eq!(
+            error,
+            "expected npm view --json to return one result, got 2"
+        );
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -325,28 +325,7 @@ impl Backend for NPMBackend {
                 .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                 .read()?;
                 let data: Value = serde_json::from_str(&raw)?;
-                let versions = data["versions"]
-                    .as_array()
-                    .ok_or_else(|| eyre::eyre!("invalid versions"))?;
-                let time = data["time"]
-                    .as_object()
-                    .ok_or_else(|| eyre::eyre!("invalid time"))?;
-                let version_info = versions
-                    .iter()
-                    .filter_map(|v| v.as_str())
-                    .map(|version| {
-                        let created_at = time
-                            .get(version)
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-                        VersionInfo {
-                            version: version.to_string(),
-                            created_at,
-                            prerelease: is_semver_prerelease(version),
-                            ..Default::default()
-                        }
-                    })
-                    .collect();
+                let version_info = npm_view_versions_time(&data)?;
 
                 Ok(version_info)
             },
@@ -374,10 +353,7 @@ impl Backend for NPMBackend {
                                 .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                                 .read()?;
                         let dist_tags: Value = serde_json::from_str(&raw)?;
-                        match dist_tags["latest"] {
-                            Value::String(ref s) => Ok(Some(s.clone())),
-                            _ => Ok(None),
-                        }
+                        Ok(npm_view_latest_dist_tag(&dist_tags))
                     })
                     .await
             },
@@ -993,6 +969,49 @@ fn is_semver_prerelease(version: &str) -> bool {
     core_and_pre.contains('-')
 }
 
+fn npm_view_json(data: &Value) -> &Value {
+    match data {
+        // npm 12 changed `npm view --json` to always return an array. mise only
+        // queries one package at a time here, so unwrap that compatibility shell.
+        Value::Array(values) if values.len() == 1 => &values[0],
+        _ => data,
+    }
+}
+
+fn npm_view_versions_time(data: &Value) -> eyre::Result<Vec<VersionInfo>> {
+    let data = npm_view_json(data);
+    let versions = data["versions"]
+        .as_array()
+        .ok_or_else(|| eyre::eyre!("invalid versions"))?;
+    let time = data["time"]
+        .as_object()
+        .ok_or_else(|| eyre::eyre!("invalid time"))?;
+
+    Ok(versions
+        .iter()
+        .filter_map(|v| v.as_str())
+        .map(|version| {
+            let created_at = time
+                .get(version)
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            VersionInfo {
+                version: version.to_string(),
+                created_at,
+                prerelease: is_semver_prerelease(version),
+                ..Default::default()
+            }
+        })
+        .collect())
+}
+
+fn npm_view_latest_dist_tag(data: &Value) -> Option<String> {
+    match npm_view_json(data)["latest"] {
+        Value::String(ref s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
 fn parse_bool_arg(value: &str) -> Option<bool> {
     match value {
         "true" | "1" => Some(true),
@@ -1131,6 +1150,69 @@ mod tests {
         assert_eq!(NPMBackend::build_aube_minimum_release_age(1), 1);
         assert_eq!(NPMBackend::build_aube_minimum_release_age(60), 1);
         assert_eq!(NPMBackend::build_aube_minimum_release_age(61), 2);
+    }
+
+    fn assert_npm_view_versions_time(data: &serde_json::Value) {
+        let versions = npm_view_versions_time(data).unwrap();
+        assert_eq!(versions.len(), 2);
+
+        assert_eq!(versions[0].version, "1.0.0");
+        assert_eq!(
+            versions[0].created_at,
+            Some("2026-01-02T03:04:05.000Z".into())
+        );
+        assert!(!versions[0].prerelease);
+
+        assert_eq!(versions[1].version, "1.1.0-beta.1");
+        assert_eq!(
+            versions[1].created_at,
+            Some("2026-01-03T03:04:05.000Z".into())
+        );
+        assert!(versions[1].prerelease);
+    }
+
+    #[test]
+    fn test_npm_view_versions_time_accepts_legacy_object() {
+        let data = serde_json::json!({
+            "versions": ["1.0.0", "1.1.0-beta.1"],
+            "time": {
+                "1.0.0": "2026-01-02T03:04:05.000Z",
+                "1.1.0-beta.1": "2026-01-03T03:04:05.000Z"
+            }
+        });
+
+        assert_npm_view_versions_time(&data);
+    }
+
+    #[test]
+    fn test_npm_view_versions_time_accepts_npm12_array() {
+        let data = serde_json::json!([{
+            "versions": ["1.0.0", "1.1.0-beta.1"],
+            "time": {
+                "1.0.0": "2026-01-02T03:04:05.000Z",
+                "1.1.0-beta.1": "2026-01-03T03:04:05.000Z"
+            }
+        }]);
+
+        assert_npm_view_versions_time(&data);
+    }
+
+    #[test]
+    fn test_npm_view_latest_dist_tag_accepts_legacy_object() {
+        let data = serde_json::json!({
+            "latest": "1.0.0"
+        });
+
+        assert_eq!(npm_view_latest_dist_tag(&data), Some("1.0.0".into()));
+    }
+
+    #[test]
+    fn test_npm_view_latest_dist_tag_accepts_npm12_array() {
+        let data = serde_json::json!([{
+            "latest": "1.0.0"
+        }]);
+
+        assert_eq!(npm_view_latest_dist_tag(&data), Some("1.0.0".into()));
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1214,6 +1214,51 @@ mod tests {
     }
 
     #[test]
+    fn test_npm_view_versions_time_accepts_non_object_time() {
+        let data = serde_json::json!({
+            "versions": ["1.0.0"],
+            "time": "2026-01-02T03:04:05.000Z"
+        });
+
+        let versions = npm_view_versions_time(&data).unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, "1.0.0");
+        assert_eq!(versions[0].created_at, None);
+    }
+
+    #[test]
+    fn test_npm_view_versions_time_rejects_missing_versions() {
+        let data = serde_json::json!({
+            "time": {}
+        });
+
+        let error = npm_view_versions_time(&data).unwrap_err().to_string();
+        assert_eq!(error, "invalid versions");
+    }
+
+    #[test]
+    fn test_npm_view_versions_time_rejects_non_array_versions() {
+        let data = serde_json::json!({
+            "versions": "1.0.0",
+            "time": {}
+        });
+
+        let error = npm_view_versions_time(&data).unwrap_err().to_string();
+        assert_eq!(error, "invalid versions");
+    }
+
+    #[test]
+    fn test_npm_view_versions_time_rejects_empty_npm12_array() {
+        let data = serde_json::json!([]);
+
+        let error = npm_view_versions_time(&data).unwrap_err().to_string();
+        assert_eq!(
+            error,
+            "expected npm view --json to return one result, got 0"
+        );
+    }
+
+    #[test]
     fn test_npm_view_versions_time_rejects_multiple_results() {
         let data = serde_json::json!([
             {
@@ -1254,6 +1299,26 @@ mod tests {
         assert_eq!(
             npm_view_latest_dist_tag(&data).unwrap(),
             Some("1.0.0".into())
+        );
+    }
+
+    #[test]
+    fn test_npm_view_latest_dist_tag_returns_none_for_missing_tag() {
+        let data = serde_json::json!({
+            "beta": "2.0.0"
+        });
+
+        assert_eq!(npm_view_latest_dist_tag(&data).unwrap(), None);
+    }
+
+    #[test]
+    fn test_npm_view_latest_dist_tag_rejects_empty_npm12_array() {
+        let data = serde_json::json!([]);
+
+        let error = npm_view_latest_dist_tag(&data).unwrap_err().to_string();
+        assert_eq!(
+            error,
+            "expected npm view --json to return one result, got 0"
         );
     }
 


### PR DESCRIPTION
## Summary
- normalize `npm view --json` responses so npm 12's single-item array wrapper works with existing parsers
- share parsing for `versions`/`time` metadata and `dist-tags.latest`
- add unit coverage for legacy npm object output and npm 12 wrapped output

## Tests
- `cargo fmt --check`
- `cargo test backend::npm::tests -- --nocapture`
- `mise run build`
- `target/debug/mise ls-remote npm:@director.run/cli | head -5`

Refs #10887.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing refactor in the npm backend with broad unit tests; no install/auth or data-path changes beyond making version queries tolerant of npm 12 CLI output.
> 
> **Overview**
> Fixes **remote npm version listing** and **latest stable resolution** when `npm view --json` returns npm 12’s single-element array instead of a bare object.
> 
> Parsing is centralized in `npm_view_json`, `npm_view_versions_time`, and `npm_view_latest_dist_tag`, which unwrap the array shell and keep legacy object output working. **`time` metadata is now optional**—missing or non-object `time` yields versions without `created_at` instead of failing.
> 
> Unit tests cover legacy vs npm 12 shapes, malformed `versions`, and empty/multi-result arrays for both version lists and `dist-tags.latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e39406f94a31ee0502a0dbc0b90f89c4490192fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with different `npm` output formats, including newer single-array JSON responses.
  * Made remote version listing and “latest” version detection more reliable across npm versions and payload variations.
  * Kept accurate prerelease handling when deriving version details.
* **Tests**
  * Expanded automated coverage for version/time parsing and “latest” dist-tag extraction across legacy and newer npm response shapes, including missing or malformed fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->