### PR TITLE
feat(trust): trust configs in subdirectories with --all

### DIFF
--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -32,7 +32,7 @@ The config file to trust
 Trust all config files in the current directory, its parents, and its subdirectories
 
 Subdirectories are walked respecting .gitignore, skipping hidden directories
-and common build/dependency directories (node_modules, target, dist, build).
+and common build/dependency directories (node_modules, vendor, target, dist, build).
 
 ### `--ignore`
 

--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -29,7 +29,10 @@ The config file to trust
 
 ### `-a --all`
 
-Trust all config files in the current directory and its parents
+Trust all config files in the current directory, its parents, and its subdirectories
+
+Subdirectories are walked respecting .gitignore, skipping hidden directories
+and common build/dependency directories (node_modules, target, dist, build).
 
 ### `--ignore`
 

--- a/e2e/cli/test_trust_all
+++ b/e2e/cli/test_trust_all
@@ -59,3 +59,13 @@ mise untrust packages/bar/.mise.toml
 assert "cd / && mise -C '$ROOT' trust --all"
 assert_contains "cd packages/foo && mise trust --show" "packages/foo: trusted"
 assert_contains "cd packages/bar && mise trust --show" "packages/bar: trusted"
+
+# an excluded name (build/vendor/...) is only skipped as a subdirectory — when
+# it is itself the walk root, its descendants are still trusted
+mkdir -p build/sub
+cat <<EOF >build/sub/mise.toml
+[env]
+INBUILD = "1"
+EOF
+assert "mise -C build trust --all"
+assert_contains "cd build/sub && mise trust --show" "build/sub: trusted"

--- a/e2e/cli/test_trust_all
+++ b/e2e/cli/test_trust_all
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# `mise trust --all` trusts config files in subdirectories in addition to the
+# current directory and its parents. The walk respects .gitignore and skips
+# common dependency/build directories like node_modules.
+
+# The test harness pre-trusts the test dir via MISE_TRUSTED_CONFIG_PATHS;
+# clear it so configs actually start out untrusted
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+mkdir -p packages/foo packages/bar node_modules/dep ignored-dir
+cat <<EOF >mise.toml
+[env]
+ROOT = "1"
+EOF
+cat <<EOF >packages/foo/mise.toml
+[env]
+FOO = "1"
+EOF
+cat <<EOF >packages/bar/.mise.toml
+[env]
+BAR = "1"
+EOF
+cat <<EOF >node_modules/dep/mise.toml
+[env]
+DEP = "1"
+EOF
+cat <<EOF >ignored-dir/mise.toml
+[env]
+IGNORED = "1"
+EOF
+echo "ignored-dir/" >.gitignore
+
+output="$(mise trust --all 2>&1)"
+assert_contains_text "$output" "trusted"
+assert_contains_text "$output" "packages/foo"
+assert_contains_text "$output" "packages/bar"
+assert_not_contains_text "$output" "node_modules"
+assert_not_contains_text "$output" "ignored-dir"
+
+# nested configs are trusted and load without prompting
+assert_contains "cd packages/bar && mise env 2>&1" "BAR=1"
+assert_contains "cd packages/foo && mise trust --show" "packages/foo: trusted"
+
+# second run is a no-op
+assert_not_contains "mise trust --all 2>&1" "trusted"

--- a/e2e/cli/test_trust_all
+++ b/e2e/cli/test_trust_all
@@ -50,3 +50,12 @@ assert_contains "cd packages/bar && mise trust --show" "packages/bar: trusted"
 
 # second run is a no-op
 assert_not_contains "mise trust --all 2>&1" "trusted"
+
+# -C/--cd is honored: the descendant walk anchors to the same directory as the
+# ancestor pass, so running from a different cwd still reaches nested configs
+ROOT="$PWD"
+mise untrust packages/foo/mise.toml
+mise untrust packages/bar/.mise.toml
+assert "cd / && mise -C '$ROOT' trust --all"
+assert_contains "cd packages/foo && mise trust --show" "packages/foo: trusted"
+assert_contains "cd packages/bar && mise trust --show" "packages/bar: trusted"

--- a/e2e/cli/test_trust_all
+++ b/e2e/cli/test_trust_all
@@ -2,13 +2,13 @@
 
 # `mise trust --all` trusts config files in subdirectories in addition to the
 # current directory and its parents. The walk respects .gitignore and skips
-# common dependency/build directories like node_modules.
+# common dependency/build directories like node_modules and vendor.
 
 # The test harness pre-trusts the test dir via MISE_TRUSTED_CONFIG_PATHS;
 # clear it so configs actually start out untrusted
 export MISE_TRUSTED_CONFIG_PATHS=""
 
-mkdir -p packages/foo packages/bar node_modules/dep ignored-dir
+mkdir -p packages/foo packages/bar node_modules/dep vendor/dep ignored-dir
 cat <<EOF >mise.toml
 [env]
 ROOT = "1"
@@ -25,6 +25,10 @@ cat <<EOF >node_modules/dep/mise.toml
 [env]
 DEP = "1"
 EOF
+cat <<EOF >vendor/dep/mise.toml
+[env]
+VENDORED = "1"
+EOF
 cat <<EOF >ignored-dir/mise.toml
 [env]
 IGNORED = "1"
@@ -36,11 +40,13 @@ assert_contains_text "$output" "trusted"
 assert_contains_text "$output" "packages/foo"
 assert_contains_text "$output" "packages/bar"
 assert_not_contains_text "$output" "node_modules"
+assert_not_contains_text "$output" "vendor"
 assert_not_contains_text "$output" "ignored-dir"
 
 # nested configs are trusted and load without prompting
 assert_contains "cd packages/bar && mise env 2>&1" "BAR=1"
 assert_contains "cd packages/foo && mise trust --show" "packages/foo: trusted"
+assert_contains "cd packages/bar && mise trust --show" "packages/bar: trusted"
 
 # second run is a no-op
 assert_not_contains "mise trust --all 2>&1" "trusted"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4011,7 +4011,10 @@ or `mise run`.
 .PP
 .TP
 \fB\-a, \-\-all\fR
-Trust all config files in the current directory and its parents
+Trust all config files in the current directory, its parents, and its subdirectories
+
+Subdirectories are walked respecting .gitignore, skipping hidden directories
+and common build/dependency directories (node_modules, vendor, target, dist, build).
 .TP
 \fB\-\-ignore\fR
 Do not trust this config and ignore it in the future

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3970,7 +3970,7 @@ Examples:
 Trust all config files in the current directory, its parents, and its subdirectories
 
 Subdirectories are walked respecting .gitignore, skipping hidden directories
-and common build/dependency directories (node_modules, target, dist, build).
+and common build/dependency directories (node_modules, vendor, target, dist, build).
 """#
     }
     flag --ignore help="Do not trust this config and ignore it in the future"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3965,7 +3965,14 @@ Examples:
     $ mise trust
 
 """#
-    flag "-a --all" help="Trust all config files in the current directory and its parents"
+    flag "-a --all" help="Trust all config files in the current directory, its parents, and its subdirectories" {
+        long_help #"""
+Trust all config files in the current directory, its parents, and its subdirectories
+
+Subdirectories are walked respecting .gitignore, skipping hidden directories
+and common build/dependency directories (node_modules, target, dist, build).
+"""#
+    }
     flag --ignore help="Do not trust this config and ignore it in the future"
     flag --show help=#"""
 Show the trusted status of config files from the current directory and its parents.

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -199,6 +199,11 @@ impl Trust {
     /// are not trusted.
     fn get_untrusted_descendants(&self) -> Vec<PathBuf> {
         const EXCLUDED_DIRS: &[&str] = &["node_modules", "target", "dist", "build"];
+        // Respect config discovery being disabled, matching load_config_paths
+        // used by the ancestor-walk pass.
+        if Settings::no_config() {
+            return vec![];
+        }
         let Some(cwd) = &*dirs::CWD else {
             return vec![];
         };

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -221,6 +221,11 @@ impl Trust {
             .git_exclude(true) // Respect .git/info/exclude
             .require_git(false) // Don't require a git repo
             .filter_entry(|e| {
+                // Never exclude the walk root itself (depth 0), even if cwd is
+                // named e.g. `build` or `vendor` — otherwise nothing is walked.
+                if e.depth() == 0 {
+                    return true;
+                }
                 let name = e.file_name().to_string_lossy();
                 !EXCLUDED_DIRS.contains(&name.as_ref())
             })

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -206,10 +206,15 @@ impl Trust {
         if Settings::no_config() {
             return vec![];
         }
-        let Some(cwd) = &*dirs::CWD else {
+        // Use the live cwd (not the cached dirs::CWD) so this anchors to the
+        // same directory as the ancestor-walk pass, which uses env::current_dir
+        // via load_config_paths -> all_dirs. A `cd` setting applied during
+        // settings load can move the process directory, and both passes must
+        // agree on where "here" is.
+        let Ok(cwd) = env::current_dir() else {
             return vec![];
         };
-        let walker = ignore::WalkBuilder::new(cwd)
+        let walker = ignore::WalkBuilder::new(&cwd)
             .hidden(true) // Skip hidden files/dirs
             .git_ignore(true) // Respect .gitignore
             .git_global(true) // Respect global .gitignore

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use crate::config::config_file::config_trust_root;
@@ -35,7 +36,7 @@ pub struct Trust {
     /// Trust all config files in the current directory, its parents, and its subdirectories
     ///
     /// Subdirectories are walked respecting .gitignore, skipping hidden directories
-    /// and common build/dependency directories (node_modules, target, dist, build).
+    /// and common build/dependency directories (node_modules, vendor, target, dist, build).
     #[clap(long, short, verbatim_doc_comment, conflicts_with_all = &["ignore", "untrust"])]
     all: bool,
 
@@ -192,13 +193,14 @@ impl Trust {
             .find(|ctr| !config_file::is_trusted(ctr))
     }
 
-    /// Untrusted config roots in subdirectories of the current directory.
+    /// Untrusted config files in subdirectories of the current directory.
     ///
     /// Walks respecting .gitignore, skipping hidden directories and common
     /// build/dependency directories so e.g. vendored configs in node_modules
-    /// are not trusted.
+    /// or vendor are not trusted. Returns one config file per untrusted trust
+    /// root; `trust()` computes the trust root from each.
     fn get_untrusted_descendants(&self) -> Vec<PathBuf> {
-        const EXCLUDED_DIRS: &[&str] = &["node_modules", "target", "dist", "build"];
+        const EXCLUDED_DIRS: &[&str] = &["node_modules", "vendor", "target", "dist", "build"];
         // Respect config discovery being disabled, matching load_config_paths
         // used by the ancestor-walk pass.
         if Settings::no_config() {
@@ -218,7 +220,7 @@ impl Trust {
                 !EXCLUDED_DIRS.contains(&name.as_ref())
             })
             .build();
-        let mut roots = vec![];
+        let mut config_files = vec![];
         for entry in walker {
             let entry = match entry {
                 Ok(e) => e,
@@ -238,14 +240,18 @@ impl Trust {
             }
             for p in config::config_paths_in_dir(dir) {
                 if !is_global_config(&p) {
-                    roots.push(config_trust_root(&p));
+                    config_files.push(p);
                 }
             }
         }
-        roots
+        // Keep one config file per untrusted trust root.
+        let mut seen = HashSet::new();
+        config_files
             .into_iter()
-            .unique()
-            .filter(|ctr| !config_file::is_trusted(ctr))
+            .filter(|p| {
+                let ctr = config_trust_root(p);
+                !config_file::is_trusted(&ctr) && seen.insert(ctr)
+            })
             .collect()
     }
 

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -32,7 +32,10 @@ pub struct Trust {
     #[clap(value_hint = ValueHint::FilePath, verbatim_doc_comment)]
     config_file: Option<PathBuf>,
 
-    /// Trust all config files in the current directory and its parents
+    /// Trust all config files in the current directory, its parents, and its subdirectories
+    ///
+    /// Subdirectories are walked respecting .gitignore, skipping hidden directories
+    /// and common build/dependency directories (node_modules, target, dist, build).
     #[clap(long, short, verbatim_doc_comment, conflicts_with_all = &["ignore", "untrust"])]
     all: bool,
 
@@ -61,6 +64,10 @@ impl Trust {
             self.ignore()
         } else if self.all {
             while let Some(p) = self.get_next_untrusted() {
+                self.config_file = Some(p);
+                self.trust()?;
+            }
+            for p in self.get_untrusted_descendants()? {
                 self.config_file = Some(p);
                 self.trust()?;
             }
@@ -183,6 +190,50 @@ impl Trust {
             .map(|p| config_trust_root(&p))
             .unique()
             .find(|ctr| !config_file::is_trusted(ctr))
+    }
+
+    /// Untrusted config roots in subdirectories of the current directory.
+    ///
+    /// Walks respecting .gitignore, skipping hidden directories and common
+    /// build/dependency directories so e.g. vendored configs in node_modules
+    /// are not trusted.
+    fn get_untrusted_descendants(&self) -> Result<Vec<PathBuf>> {
+        const EXCLUDED_DIRS: &[&str] = &["node_modules", "target", "dist", "build"];
+        let Some(cwd) = &*dirs::CWD else {
+            return Ok(vec![]);
+        };
+        let walker = ignore::WalkBuilder::new(cwd)
+            .hidden(true) // Skip hidden files/dirs
+            .git_ignore(true) // Respect .gitignore
+            .git_global(true) // Respect global .gitignore
+            .git_exclude(true) // Respect .git/info/exclude
+            .require_git(false) // Don't require a git repo
+            .filter_entry(|e| {
+                let name = e.file_name().to_string_lossy();
+                !EXCLUDED_DIRS.contains(&name.as_ref())
+            })
+            .build();
+        let mut roots = vec![];
+        for entry in walker {
+            let entry = entry?;
+            if !entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                continue;
+            }
+            let dir = entry.path();
+            if dir == cwd {
+                continue; // already covered by the parent walk
+            }
+            for p in config::config_paths_in_dir(dir) {
+                if !is_global_config(&p) {
+                    roots.push(config_trust_root(&p));
+                }
+            }
+        }
+        Ok(roots
+            .into_iter()
+            .unique()
+            .filter(|ctr| !config_file::is_trusted(ctr))
+            .collect())
     }
 
     fn show(&self) -> Result<()> {

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -67,7 +67,7 @@ impl Trust {
                 self.config_file = Some(p);
                 self.trust()?;
             }
-            for p in self.get_untrusted_descendants()? {
+            for p in self.get_untrusted_descendants() {
                 self.config_file = Some(p);
                 self.trust()?;
             }
@@ -197,10 +197,10 @@ impl Trust {
     /// Walks respecting .gitignore, skipping hidden directories and common
     /// build/dependency directories so e.g. vendored configs in node_modules
     /// are not trusted.
-    fn get_untrusted_descendants(&self) -> Result<Vec<PathBuf>> {
+    fn get_untrusted_descendants(&self) -> Vec<PathBuf> {
         const EXCLUDED_DIRS: &[&str] = &["node_modules", "target", "dist", "build"];
         let Some(cwd) = &*dirs::CWD else {
-            return Ok(vec![]);
+            return vec![];
         };
         let walker = ignore::WalkBuilder::new(cwd)
             .hidden(true) // Skip hidden files/dirs
@@ -215,7 +215,15 @@ impl Trust {
             .build();
         let mut roots = vec![];
         for entry in walker {
-            let entry = entry?;
+            let entry = match entry {
+                Ok(e) => e,
+                Err(err) => {
+                    // Skip unreadable paths (permission denied, broken symlinks,
+                    // etc.) so one bad directory doesn't abort the whole scan.
+                    warn!("trust --all: skipping unreadable path: {err}");
+                    continue;
+                }
+            };
             if !entry.file_type().is_some_and(|ft| ft.is_dir()) {
                 continue;
             }
@@ -229,11 +237,11 @@ impl Trust {
                 }
             }
         }
-        Ok(roots
+        roots
             .into_iter()
             .unique()
             .filter(|ctr| !config_file::is_trusted(ctr))
-            .collect())
+            .collect()
     }
 
     fn show(&self) -> Result<()> {


### PR DESCRIPTION
## Summary

`mise trust --all` previously only trusted config files in the current directory and its parents. It now also walks subdirectories and trusts any config roots found there, so a monorepo's nested configs can be trusted with one explicit command.

## Behavior

- The existing upward walk (current dir + parents) is unchanged
- New: after the upward walk, subdirectories of the current directory are walked and each untrusted config root found is trusted individually
- The walk respects `.gitignore` (via the `ignore` crate, `require_git(false)`), skips hidden directories, and skips common build/dependency directories (`node_modules`, `target`, `dist`, `build`) — so vendored/third-party configs are not trusted
- Each nested config root gets its own trust record (no `.monorepo` marker), so a config added later in a new subdirectory still prompts
- Each trusted path is printed, and a second run is a no-op

## Design notes

Implicit/automatic trust cascading stays opt-in via `monorepo_root = true` (unchanged); this only extends the explicit `--all` flag, which already expresses bulk-trust intent.

## Test plan

- New e2e test `e2e/cli/test_trust_all` covering: nested `mise.toml`/`.mise.toml` trusted, `node_modules` and gitignored dirs skipped, nested configs load without prompting, idempotent second run
- Regenerated `mise.usage.kdl` and `docs/cli/trust.md`

*This PR was generated by an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends explicit bulk trust into subdirectories (security-sensitive), but limits scope via gitignore, excluded dependency dirs, and per-root trust records rather than monorepo-wide auto-trust.
> 
> **Overview**
> **`mise trust --all`** now trusts nested config roots under the current directory, in addition to the existing upward walk through parents.
> 
> After the ancestor pass finishes, **`get_untrusted_descendants()`** walks subdirectories with the `ignore` crate (`.gitignore`, hidden dirs, no git repo required), skips **`node_modules`**, **`vendor`**, **`target`**, **`dist`**, and **`build`** as child names (but not when that name is the walk root), discovers configs via **`config_paths_in_dir`**, and trusts one file per untrusted trust root. The walk uses **`env::current_dir()`** so it stays aligned with **`mise -C`**. Unreadable paths are warned and skipped; **`Settings::no_config()`** skips the descendant pass.
> 
> CLI help and generated docs (`mise.usage.kdl`, `docs/cli/trust.md`, man page) describe the new behavior. E2e **`test_trust_all`** covers nested trust, skips, idempotency, **`-C`**, and trusting under a **`build`** walk root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c78806b2baf79e6fabff7ff36c3bde270cf1dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise trust --all` now discovers and trusts config files recursively across the current directory, parent directories, and subdirectories.
* **Bug Fixes**
  * Recursive traversal respects `.gitignore`, skips hidden directories, and omits common build/dependency folders (e.g., `node_modules`, `vendor`, `dist`, `build`, `target`).
  * `mise trust --all` is idempotent, including when run from a different working directory via `-C`; trusted nested configs work without extra prompting.
* **Documentation**
  * Updated `mise trust --all` docs and CLI help to describe the recursive behavior and exclusions.
* **Tests**
  * Added an end-to-end test covering recursion, hidden/ignored paths, `-C`, and trust visibility via `mise env` and `mise trust --show`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->