### PR TITLE
feat(trust): share config trust across git worktrees

### DIFF
--- a/docs/cli/trust.md
+++ b/docs/cli/trust.md
@@ -19,6 +19,11 @@ without prompting, since nothing in them executes code at load time —
 tools install and tasks run only on explicit commands like `mise install`
 or `mise run`.
 
+Trust is shared across git worktrees: a config file inside a linked
+worktree is trusted when the equivalent path in the repository's main
+checkout has been trusted. Paranoid mode disables this sharing since
+worktrees can check out branches with different config contents.
+
 ## Arguments
 
 ### `[CONFIG_FILE]`

--- a/e2e/cli/test_trust_worktree
+++ b/e2e/cli/test_trust_worktree
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+mkdir -p repo
+cd repo || exit 1
+git init -q .
+cat <<EOF >mise.toml
+[env]
+TRUSTED_ENV = "1"
+EOF
+git add mise.toml
+git -c user.email=e2e@example.com -c user.name=e2e commit -qm init
+
+# before trusting, neither the main checkout nor a worktree is trusted
+git worktree add -q ../wt
+assert_contains "mise trust --show" ": untrusted"
+cd ../wt || exit 1
+assert_contains "mise trust --show" ": untrusted"
+
+# trusting the main checkout also trusts linked worktrees
+cd ../repo || exit 1
+mise trust
+assert_contains "mise trust --show" ": trusted"
+cd ../wt || exit 1
+assert_contains "mise trust --show" ": trusted"
+assert_contains "mise env" "TRUSTED_ENV=1"
+
+# untrusting inside the worktree warns that the main checkout still trusts it
+assert_contains "mise untrust 2>&1" "git worktree"
+assert_contains "mise trust --show" ": trusted"
+
+# untrusting the main checkout untrusts the worktree too
+cd ../repo || exit 1
+mise untrust
+assert_contains "mise trust --show" ": untrusted"
+cd ../wt || exit 1
+assert_contains "mise trust --show" ": untrusted"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4004,6 +4004,11 @@ of them), and `[tasks]` (no templates and no tool options) are loaded
 without prompting, since nothing in them executes code at load time —
 tools install and tasks run only on explicit commands like `mise install`
 or `mise run`.
+
+Trust is shared across git worktrees: a config file inside a linked
+worktree is trusted when the equivalent path in the repository's main
+checkout has been trusted. Paranoid mode disables this sharing since
+worktrees can check out branches with different config contents.
 .PP
 \fBUsage:\fR mise trust [OPTIONS] [<CONFIG_FILE>]
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3954,6 +3954,11 @@ of them), and `[tasks]` (no templates and no tool options) are loaded
 without prompting, since nothing in them executes code at load time —
 tools install and tasks run only on explicit commands like `mise install`
 or `mise run`.
+
+Trust is shared across git worktrees: a config file inside a linked
+worktree is trusted when the equivalent path in the repository's main
+checkout has been trusted. Paranoid mode disables this sharing since
+worktrees can check out branches with different config contents.
 """#
     after_long_help #"""
 Examples:

--- a/src/cli/trust.rs
+++ b/src/cli/trust.rs
@@ -25,6 +25,11 @@ use itertools::Itertools;
 /// without prompting, since nothing in them executes code at load time —
 /// tools install and tasks run only on explicit commands like `mise install`
 /// or `mise run`.
+///
+/// Trust is shared across git worktrees: a config file inside a linked
+/// worktree is trusted when the equivalent path in the repository's main
+/// checkout has been trusted. Paranoid mode disables this sharing since
+/// worktrees can check out branches with different config contents.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Trust {
@@ -109,6 +114,17 @@ pub(super) fn untrust_config_file(config_file: Option<PathBuf>) -> Result<()> {
         .any(|p| cfr.starts_with(p));
     if trusted_via_settings {
         warn!("{cfr:?} is trusted via settings so it will still be trusted.");
+    }
+
+    if !Settings::get().paranoid
+        && let Some(main_path) = crate::git::main_checkout_equivalent(&cfr)
+        && config_file::is_trusted(&main_path)
+    {
+        warn!(
+            "{} is a git worktree of {} which is trusted, so it will still be trusted. Untrust that path or use `mise trust --ignore`.",
+            display_path(&cfr),
+            display_path(&main_path)
+        );
     }
 
     Ok(())

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -387,17 +387,6 @@ pub fn is_trusted(path: &Path) -> bool {
             current = dir;
         }
     }
-    // A config inside a linked git worktree shares trust with the equivalent
-    // path in the repo's main checkout. Skipped in paranoid mode, where trust
-    // is tied to file contents that can differ between worktree branches.
-    if !settings.paranoid
-        && let Some(main_path) = crate::git::main_checkout_equivalent(&canonicalized_path)
-        && is_trusted(&main_path)
-    {
-        add_trusted(canonicalized_path.to_path_buf());
-        return true;
-    }
-
     if settings.paranoid {
         let trusted = trust_file_hash(path).unwrap_or_else(|e| {
             warn!("trust_file_hash: {e}");
@@ -410,8 +399,16 @@ pub fn is_trusted(path: &Path) -> bool {
         // in tests/CI we trust everything
         return true;
     } else if !trust_path(path).exists() {
-        // the file isn't trusted, and we're not on a CI system where we generally assume we can
-        // trust config files
+        // No direct trust record. A config inside a linked git worktree
+        // shares trust with the equivalent path in the repo's main checkout.
+        // Not applicable in paranoid mode (excluded above), where trust is
+        // tied to file contents that can differ between worktree branches.
+        if let Some(main_path) = crate::git::main_checkout_equivalent(&canonicalized_path)
+            && is_trusted(&main_path)
+        {
+            add_trusted(canonicalized_path.to_path_buf());
+            return true;
+        }
         return false;
     }
     add_trusted(canonicalized_path.to_path_buf());

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -387,6 +387,17 @@ pub fn is_trusted(path: &Path) -> bool {
             current = dir;
         }
     }
+    // A config inside a linked git worktree shares trust with the equivalent
+    // path in the repo's main checkout. Skipped in paranoid mode, where trust
+    // is tied to file contents that can differ between worktree branches.
+    if !settings.paranoid
+        && let Some(main_path) = crate::git::main_checkout_equivalent(&canonicalized_path)
+        && is_trusted(&main_path)
+    {
+        add_trusted(canonicalized_path.to_path_buf());
+        return true;
+    }
+
     if settings.paranoid {
         let trusted = trust_file_hash(path).unwrap_or_else(|e| {
             warn!("trust_file_hash: {e}");

--- a/src/git.rs
+++ b/src/git.rs
@@ -416,14 +416,20 @@ pub fn main_checkout_equivalent(path: &Path) -> Option<PathBuf> {
             return None; // main checkout
         }
         if dotgit.is_file() {
+            // `.git` files are used by both linked worktrees and submodules.
+            // Only a linked worktree resolves to a main checkout here; for
+            // anything else (submodule, bare-repo worktree) keep walking up —
+            // a submodule may itself live inside a linked worktree.
             let main_root = CACHE
                 .lock()
                 .unwrap()
                 .entry(wt_root.to_path_buf())
                 .or_insert_with(|| main_checkout_root(&dotgit))
-                .clone()?;
-            let equiv = main_root.join(path.strip_prefix(wt_root).ok()?);
-            return (equiv != path).then_some(equiv);
+                .clone();
+            if let Some(main_root) = main_root {
+                let equiv = main_root.join(path.strip_prefix(wt_root).ok()?);
+                return (equiv != path).then_some(equiv);
+            }
         }
     }
     None
@@ -438,14 +444,23 @@ fn main_checkout_root(dotgit_file: &Path) -> Option<PathBuf> {
     } else {
         gitdir
     };
-    // `commondir` inside the worktree's private git dir points to the shared
-    // git dir (usually `../..`, i.e. `<main>/.git`)
-    let common = match std::fs::read_to_string(gitdir.join("commondir")) {
-        Ok(c) => {
-            let c = PathBuf::from(c.trim());
-            if c.is_relative() { gitdir.join(c) } else { c }
-        }
-        Err(_) => gitdir.parent()?.parent()?.to_path_buf(),
+    // Linked worktrees keep their private git dir at
+    // `<common>/worktrees/<name>`, containing a `commondir` file pointing to
+    // the shared git dir (usually `../..`, i.e. `<main>/.git`). Submodule git
+    // dirs live under `modules/` and have neither, which is what
+    // distinguishes them here.
+    if gitdir.parent()?.file_name() != Some(OsStr::new("worktrees")) {
+        return None;
+    }
+    let common = PathBuf::from(
+        std::fs::read_to_string(gitdir.join("commondir"))
+            .ok()?
+            .trim(),
+    );
+    let common = if common.is_relative() {
+        gitdir.join(common)
+    } else {
+        common
     };
     let common = common.canonicalize().ok()?;
     if common.file_name() == Some(OsStr::new(".git")) {
@@ -536,6 +551,36 @@ mod tests {
         )
         .unwrap();
         assert_eq!(super::main_checkout_equivalent(&bare_wt), None);
+
+        // a submodule also uses a `.git` file but is not a linked worktree:
+        // its configs must not inherit the parent checkout's trust
+        let subm = main.join("subm");
+        std::fs::create_dir_all(main.join(".git/modules/subm")).unwrap();
+        std::fs::create_dir_all(&subm).unwrap();
+        std::fs::write(
+            subm.join(".git"),
+            format!("gitdir: {}\n", main.join(".git/modules/subm").display()),
+        )
+        .unwrap();
+        assert_eq!(super::main_checkout_equivalent(&subm), None);
+        assert_eq!(
+            super::main_checkout_equivalent(&subm.join("mise.toml")),
+            None
+        );
+
+        // a submodule checked out inside a linked worktree maps through the
+        // outer worktree to the same submodule path in the main checkout
+        let wt_subm = wt.join("subm");
+        std::fs::create_dir_all(&wt_subm).unwrap();
+        std::fs::write(
+            wt_subm.join(".git"),
+            format!("gitdir: {}\n", main.join(".git/modules/subm").display()),
+        )
+        .unwrap();
+        assert_eq!(
+            super::main_checkout_equivalent(&wt_subm.join("mise.toml")),
+            Some(subm.join("mise.toml"))
+        );
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 
 use duct::Expression;
 use eyre::{Result, WrapErr, eyre};
@@ -397,6 +400,61 @@ fn looks_like_sha(s: &str) -> bool {
     matches!(s.len(), 40 | 64) && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
+/// If `path` is inside a linked git worktree, returns the equivalent path in
+/// the repository's main checkout, e.g. `/repo-wt/sub/mise.toml` →
+/// `/repo/sub/mise.toml`. Returns None for paths in a main checkout, outside
+/// any git repository, or in worktrees of a bare repository.
+///
+/// Detection is filesystem-only (no git subprocess): a linked worktree root
+/// contains a `.git` *file* pointing at `<main>/.git/worktrees/<name>`.
+pub fn main_checkout_equivalent(path: &Path) -> Option<PathBuf> {
+    static CACHE: LazyLock<Mutex<HashMap<PathBuf, Option<PathBuf>>>> =
+        LazyLock::new(Default::default);
+    for wt_root in path.ancestors() {
+        let dotgit = wt_root.join(".git");
+        if dotgit.is_dir() {
+            return None; // main checkout
+        }
+        if dotgit.is_file() {
+            let main_root = CACHE
+                .lock()
+                .unwrap()
+                .entry(wt_root.to_path_buf())
+                .or_insert_with(|| main_checkout_root(&dotgit))
+                .clone()?;
+            let equiv = main_root.join(path.strip_prefix(wt_root).ok()?);
+            return (equiv != path).then_some(equiv);
+        }
+    }
+    None
+}
+
+/// Resolves a linked worktree's `.git` file to the root of the main checkout
+fn main_checkout_root(dotgit_file: &Path) -> Option<PathBuf> {
+    let contents = std::fs::read_to_string(dotgit_file).ok()?;
+    let gitdir = PathBuf::from(contents.strip_prefix("gitdir:")?.trim());
+    let gitdir = if gitdir.is_relative() {
+        dotgit_file.parent()?.join(gitdir)
+    } else {
+        gitdir
+    };
+    // `commondir` inside the worktree's private git dir points to the shared
+    // git dir (usually `../..`, i.e. `<main>/.git`)
+    let common = match std::fs::read_to_string(gitdir.join("commondir")) {
+        Ok(c) => {
+            let c = PathBuf::from(c.trim());
+            if c.is_relative() { gitdir.join(c) } else { c }
+        }
+        Err(_) => gitdir.parent()?.parent()?.to_path_buf(),
+    };
+    let common = common.canonicalize().ok()?;
+    if common.file_name() == Some(OsStr::new(".git")) {
+        common.parent().map(|p| p.to_path_buf())
+    } else {
+        None // bare repository — no main checkout to share trust with
+    }
+}
+
 impl Debug for Git {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Git").field("dir", &self.dir).finish()
@@ -439,6 +497,45 @@ mod tests {
         assert!(!looks_like_sha("abcdef1")); // short SHA not supported
         assert!(!looks_like_sha(""));
         assert!(!looks_like_sha("g123456789abcdef0123456789abcdef01234567")); // non-hex
+    }
+
+    #[test]
+    fn worktree_main_checkout_equivalent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().canonicalize().unwrap();
+        let main = base.join("main");
+        let wt = base.join("wt");
+        std::fs::create_dir_all(main.join(".git/worktrees/wt")).unwrap();
+        std::fs::create_dir_all(wt.join("sub")).unwrap();
+        std::fs::write(main.join(".git/worktrees/wt/commondir"), "../..\n").unwrap();
+        std::fs::write(
+            wt.join(".git"),
+            format!("gitdir: {}\n", main.join(".git/worktrees/wt").display()),
+        )
+        .unwrap();
+
+        // worktree root and nested paths map to the main checkout
+        assert_eq!(super::main_checkout_equivalent(&wt), Some(main.clone()));
+        assert_eq!(
+            super::main_checkout_equivalent(&wt.join("sub/mise.toml")),
+            Some(main.join("sub/mise.toml"))
+        );
+        // main checkout and non-repo paths do not map
+        assert_eq!(super::main_checkout_equivalent(&main), None);
+        assert_eq!(super::main_checkout_equivalent(&base), None);
+
+        // worktree of a bare repo does not map
+        let bare = base.join("bare.git");
+        let bare_wt = base.join("bare-wt");
+        std::fs::create_dir_all(bare.join("worktrees/bare-wt")).unwrap();
+        std::fs::create_dir_all(&bare_wt).unwrap();
+        std::fs::write(bare.join("worktrees/bare-wt/commondir"), "../..\n").unwrap();
+        std::fs::write(
+            bare_wt.join(".git"),
+            format!("gitdir: {}\n", bare.join("worktrees/bare-wt").display()),
+        )
+        .unwrap();
+        assert_eq!(super::main_checkout_equivalent(&bare_wt), None);
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -413,7 +413,12 @@ pub fn main_checkout_equivalent(path: &Path) -> Option<PathBuf> {
     for wt_root in path.ancestors() {
         let dotgit = wt_root.join(".git");
         if dotgit.is_dir() {
-            return None; // main checkout
+            // A `.git` directory is either the main checkout or a nested
+            // independent repository. Either way stop: a nested repo's
+            // contents are not derived from the outer repo's history, so its
+            // configs must keep their own trust records rather than
+            // inheriting the outer main checkout's via path mapping.
+            return None;
         }
         if dotgit.is_file() {
             // `.git` files are used by both linked worktrees and submodules.


### PR DESCRIPTION
## What

A config file inside a linked git worktree is now trusted when the equivalent path in the repository's main checkout has been trusted. Trusting a repo once covers all of its worktrees — no more re-prompting in every `git worktree add` checkout.

## Why

Trust records are keyed by canonicalized absolute path, so every new worktree was a brand-new path that prompted again. This is especially painful for workflows that spin up many short-lived worktrees (e.g. AI-agent worktrees under `.claude/worktrees/`).

## How

- `src/git.rs`: new `main_checkout_equivalent()` maps a path inside a linked worktree to the same relative path in the main checkout. Detection is filesystem-only — a linked worktree root has a `.git` *file* containing `gitdir: <main>/.git/worktrees/<name>`, and `commondir` resolves the shared git dir — so no git subprocess; results are cached per worktree root. Returns `None` for main checkouts, non-repos, and bare-repo worktrees.
- `src/config/config_file/mod.rs`: `is_trusted()` consults the main-checkout equivalent after direct/monorepo checks fail.
- `src/cli/trust.rs`: `mise untrust` inside a worktree warns that the main checkout still trusts the config (mirrors the existing `trusted_config_paths` warning) and suggests untrusting there or using `--ignore`.

## Design notes for review

- **Read-side only**: `mise trust` inside a worktree trusts just that worktree; sharing flows only from main checkout → worktrees.
- **Paranoid mode is excluded**: its trust is tied to per-file content hashes, and a worktree can have a branch checked out with different config contents.
- An explicit `--ignore` on a worktree config still wins over the shared trust, since the ignore check runs first.

## Tests

- Unit: `git::tests::worktree_main_checkout_equivalent` (nested paths, main checkout, non-repo, bare repo; fake `.git` layouts, no git binary needed)
- E2E: `e2e/cli/test_trust_worktree` — untrusted before trust, trusting main trusts the worktree, `mise env` loads config there, untrust-in-worktree warns and stays trusted, untrust-in-main untrusts both
- Existing trust e2e tests pass (`test_untrust`, `test_trusted_config_paths`, `test_hook_env_untrusted_once_per_dir`, `test_bash_duplicate_trust_warning`)

*This PR was generated by an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config trust resolution (security-sensitive) and relies on filesystem heuristics for worktree vs submodule layouts; paranoid mode correctly opts out.
> 
> **Overview**
> **Linked git worktrees can inherit config trust from the main checkout**, so trusting `mise.toml` once in the primary clone avoids re-prompting in every `git worktree add` path.
> 
> `git::main_checkout_equivalent()` maps a worktree path to the same relative path under the main repo root using only `.git` file layout (`gitdir` / `worktrees` / `commondir`), with caching and guards for submodules, nested repos, and bare repos. `is_trusted()` uses that mapping when there is no direct trust record (skipped in **paranoid** mode). `mise untrust` in a worktree now warns if the main-checkout equivalent is still trusted.
> 
> Docs for `mise trust` are updated; coverage adds a unit test for path mapping and an e2e `test_trust_worktree` flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0fa03e550d58feb224fa9cddf9d2a8d8bc0a4d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trust status now carries across linked Git worktrees and the main checkout by equivalent config paths.
  * `mise trust` help and the manual reflect shared trust behavior and note that paranoid mode disables it.
* **Bug Fixes**
  * Improved warnings when untrusting a worktree may still leave it trusted due to the main checkout.
* **Documentation**
  * Expanded CLI documentation on how trust sharing works for Git worktrees.
* **Tests**
  * Added end-to-end coverage for trust/untrust propagation across a worktree setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->