### PR TITLE
registry: prefer npm for codex

### DIFF
--- a/registry/codex.toml
+++ b/registry/codex.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:openai/codex", "npm:@openai/codex"]
+backends = ["npm:@openai/codex", "aqua:openai/codex"]
 description = "Lightweight coding agent that runs in your terminal"
 test = { cmd = "codex --version", expected = "codex-cli {{version}}" }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -318,6 +318,15 @@ mod tests {
     }
 
     #[test]
+    fn test_codex_prefers_official_npm_package() {
+        use super::*;
+
+        let codex = REGISTRY.get("codex").unwrap();
+
+        assert_eq!(codex.backends[0].full, "npm:@openai/codex");
+    }
+
+    #[test]
     fn test_backend_options_parse_toml_values() {
         use super::*;
 


### PR DESCRIPTION
## Summary
- prefer the official npm package for the `codex` registry shorthand
- keep aqua available as an explicit/fallback backend
- add a generated-registry regression test for the backend order

## Root Cause
Released mise binaries can use baked aqua metadata that resolves `codex@0.144.0` to the plain GitHub `codex-*` asset. That asset installs only the main `codex` executable and omits `codex-code-mode-host`, which breaks tool calling. The official npm package installs the platform vendor bundle that includes `codex-code-mode-host`.

## Validation
- verified `npm:@openai/codex@0.144.0` installs `vendor/.../bin/codex-code-mode-host`
- `cargo test -q registry::tests::test_codex_prefers_official_npm_package`
- pre-commit `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry metadata and test-only change; install behavior for `codex` improves without touching auth or core runtime paths.
> 
> **Overview**
> **`codex` registry shorthand now lists `npm:@openai/codex` before `aqua:openai/codex`**, so mise picks the official npm package as the default backend instead of the aqua GitHub release asset.
> 
> That ordering matters because default installs follow the first backend; the aqua asset for recent releases only shipped the main `codex` binary and omitted `codex-code-mode-host`, which broke tool calling. The npm package installs the vendor bundle that includes that helper. Aqua remains available as an explicit or fallback backend.
> 
> A generated-registry test asserts `codex.backends[0]` is `npm:@openai/codex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8658d9373be02e0f986987687949c864fb503eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the registry ordering so the official npm package is listed first for the Codex tool.
* **Tests**
  * Added coverage to ensure Codex resolves successfully and uses the preferred first backend entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->