### PR TITLE
chore: release 2026.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2026.7.5](https://github.com/jdx/mise/compare/v2026.7.4..v2026.7.5) - 2026-07-09
+
+### 🚀 Features
+
+- **(trust)** share config trust across git worktrees by @jdx in [#10890](https://github.com/jdx/mise/pull/10890)
+- **(trust)** trust configs in subdirectories with --all by @jdx in [#10889](https://github.com/jdx/mise/pull/10889)
+
+### 🐛 Bug Fixes
+
+- **(npm)** support npm 12 view json output by @jdx in [#10888](https://github.com/jdx/mise/pull/10888)
+
+### 📦 Registry
+
+- prefer npm for codex by @jdx in [#10893](https://github.com/jdx/mise/pull/10893)
+
 ## [2026.7.4](https://github.com/jdx/mise/compare/v2026.7.3..v2026.7.4) - 2026-07-09
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.4"
+version = "2026.7.5"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.4"
+version = "2026.7.5"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.4 macos-arm64 (2026-07-09)
+2026.7.5 macos-arm64 (2026-07-09)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_4.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_5.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_4.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_5.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_4.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_5.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_4.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_5.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.4";
+  version = "2026.7.5";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.4
+Version: 2026.7.5
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.4"
+version: "2026.7.5"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "5c17607dc64d636017fabb0069f58893d3c7fe3a"
+  "tag": "be9482e91ec7b37144d5464e4ebab14052ca82b5"
 }


### PR DESCRIPTION
### 🚀 Features

- **(trust)** share config trust across git worktrees by @jdx in [#10890](https://github.com/jdx/mise/pull/10890)
- **(trust)** trust configs in subdirectories with --all by @jdx in [#10889](https://github.com/jdx/mise/pull/10889)

### 🐛 Bug Fixes

- **(npm)** support npm 12 view json output by @jdx in [#10888](https://github.com/jdx/mise/pull/10888)

### 📦 Registry

- prefer npm for codex by @jdx in [#10893](https://github.com/jdx/mise/pull/10893)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated release metadata to **2026.7.5** across install, package, and distribution references.
  * Refreshed shell completions to use the latest generated usage data.

* **Bug Fixes**
  * Improved npm output support for newer `view json` results.
  * Added a registry preference update for codex-related workflows.

* **Documentation**
  * Updated the changelog and README install example to match the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->