### PR TITLE
chore: release 2026.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,132 @@
 # Changelog
 
+## [2026.7.6](https://github.com/jdx/mise/compare/v2026.7.5..v2026.7.6) - 2026-07-14
+
+### 🚀 Features
+
+- **(aqua)** support private content and archives by @risu729 in [#10915](https://github.com/jdx/mise/pull/10915)
+- **(bootstrap)** add flatpak package support by @jdx in [#10951](https://github.com/jdx/mise/pull/10951)
+- **(cargo)** disable cargo-quickinstall by default by @risu729 in [#10923](https://github.com/jdx/mise/pull/10923)
+- **(doctor)** report shadowed shims by @risu729 in [#10919](https://github.com/jdx/mise/pull/10919)
+- **(oci)** add reproducible host path copy layers by @jdx in [#10952](https://github.com/jdx/mise/pull/10952)
+- **(sandbox)** add default deny settings by @risu729 in [#10940](https://github.com/jdx/mise/pull/10940)
+- **(task)** **breaking** decouple task output style from verbosity by @JamBalaya56562 in [#10885](https://github.com/jdx/mise/pull/10885)
+- **(task)** render timeout templates by @risu729 in [#10959](https://github.com/jdx/mise/pull/10959)
+
+### 🐛 Bug Fixes
+
+- **(backend)** reinstall rolling versions when outdated by @zelch in [#10827](https://github.com/jdx/mise/pull/10827)
+- **(backend)** align migrated backend resolution by @jdx in [#10969](https://github.com/jdx/mise/pull/10969)
+- **(bootstrap)** preserve symlinks when extracting dmgs by @jdx in [#10949](https://github.com/jdx/mise/pull/10949)
+- **(bootstrap)** support localized brew casks by @jdx in [#10950](https://github.com/jdx/mise/pull/10950)
+- **(cargo)** own cargo-binstall compile fallback by @risu729 in [#10926](https://github.com/jdx/mise/pull/10926)
+- **(config)** warn about unsupported semver ranges by @risu729 in [#10916](https://github.com/jdx/mise/pull/10916)
+- **(config)** let user tool options override registry defaults by @risu729 in [#10924](https://github.com/jdx/mise/pull/10924)
+- **(config)** reload settings with config by @risu729 in [#10945](https://github.com/jdx/mise/pull/10945)
+- **(config)** add tera contrib helpers by @jdx in [#10970](https://github.com/jdx/mise/pull/10970)
+- **(config)** keep installed versions eligible with release age by @jdx in [#10973](https://github.com/jdx/mise/pull/10973)
+- **(copr)** fix x86_64 builds with add nasm/cmake for Fedora and PREBUILT_NASM for RHEL/EPEL by @bestagi in [#10947](https://github.com/jdx/mise/pull/10947)
+- **(copr)** add PIE flag for aws-lc probe by @jdx in [#10974](https://github.com/jdx/mise/pull/10974)
+- **(erlang)** lock source install outcomes by @risu729 in [#10937](https://github.com/jdx/mise/pull/10937)
+- **(file)** ignore malformed pax metadata during sparse detection by @risu729 in [#10978](https://github.com/jdx/mise/pull/10978)
+- **(github)** align SLSA provenance with selected asset by @risu729 in [#10928](https://github.com/jdx/mise/pull/10928)
+- **(github)** treat bin/rename_exe as install-time options by @risu729 in [#10925](https://github.com/jdx/mise/pull/10925)
+- **(http)** bound total download time by @risu729 in [#10920](https://github.com/jdx/mise/pull/10920)
+- **(npm)** isolate version queries from project cwd by @risu729 in [#10927](https://github.com/jdx/mise/pull/10927)
+- **(registry)** normalize backend platform selectors by @risu729 in [#10938](https://github.com/jdx/mise/pull/10938)
+- **(registry)** rename podman banary to podman-remote by @tony-sol in [#10826](https://github.com/jdx/mise/pull/10826)
+- **(s3)** resolve cross-platform lockfile URLs for locked mode by @icholy in [#10873](https://github.com/jdx/mise/pull/10873)
+- **(task)** invalidate auto freshness after failed rerun by @risu729 in [#10953](https://github.com/jdx/mise/pull/10953)
+- **(task)** isolate usage variables per invocation by @risu729 in [#10963](https://github.com/jdx/mise/pull/10963)
+- **(task)** preserve task tool options by @risu729 in [#10958](https://github.com/jdx/mise/pull/10958)
+- **(task)** respect configured directory when editing tasks by @risu729 in [#10955](https://github.com/jdx/mise/pull/10955)
+- **(toolset)** preserve ref selector install identity by @risu729 in [#10942](https://github.com/jdx/mise/pull/10942)
+
+### 📚 Documentation
+
+- **(aqua)** document local custom registries by @risu729 in [#10966](https://github.com/jdx/mise/pull/10966)
+- **(config)** clarify sub version arithmetic by @risu729 in [#10943](https://github.com/jdx/mise/pull/10943)
+
+### ⚡ Performance
+
+- **(aqua)** skip public probes for private releases by @risu729 in [#10914](https://github.com/jdx/mise/pull/10914)
+
+### 🧪 Testing
+
+- **(cargo)** align binstall fallback coverage by @risu729 in [#10980](https://github.com/jdx/mise/pull/10980)
+
+### ◀️ Revert
+
+- prefer aqua for codex by @risu729 in [#10922](https://github.com/jdx/mise/pull/10922)
+
+### 📦️ Dependency Updates
+
+- update rust docker digest to 44637ff by @renovate[bot] in [#10901](https://github.com/jdx/mise/pull/10901)
+- update ghcr.io/jdx/mise:deb docker digest to c5e848b by @renovate[bot] in [#10899](https://github.com/jdx/mise/pull/10899)
+- update ghcr.io/jdx/mise:alpine docker digest to 94d8801 by @renovate[bot] in [#10898](https://github.com/jdx/mise/pull/10898)
+- update rust crate demand to v2.0.3 by @renovate[bot] in [#10903](https://github.com/jdx/mise/pull/10903)
+- update phf to 0.14 by @renovate[bot] in [#10906](https://github.com/jdx/mise/pull/10906)
+- update ubuntu docker tag to resolute-20260627 by @renovate[bot] in [#10905](https://github.com/jdx/mise/pull/10905)
+- update ghcr.io/jdx/mise:rpm docker digest to 4363aec by @renovate[bot] in [#10900](https://github.com/jdx/mise/pull/10900)
+- update rust crate usage-lib to v3.5.4 by @renovate[bot] in [#10904](https://github.com/jdx/mise/pull/10904)
+- update rust crate chacha20poly1305 to 0.11 by @renovate[bot] in [#10907](https://github.com/jdx/mise/pull/10907)
+- update actions/github-script action to v9 by @renovate[bot] in [#10908](https://github.com/jdx/mise/pull/10908)
+- update rust crate rmcp to v2 by @renovate[bot] in [#10909](https://github.com/jdx/mise/pull/10909)
+- update dependency prettier to v3.9.4 by @renovate[bot] in [#10902](https://github.com/jdx/mise/pull/10902)
+
+### 📦 Registry
+
+- add git-town ([aqua:git-town/git-town](https://github.com/git-town/git-town)) by @joealden in [#10935](https://github.com/jdx/mise/pull/10935)
+- add bundler (gem:bundler) by @risu729 in [#10939](https://github.com/jdx/mise/pull/10939)
+
+### Chore
+
+- **(release)** skip ai reviews for release prs by @jdx in [#10891](https://github.com/jdx/mise/pull/10891)
+- **(release)** publish registry artifact by @jdx in [#10972](https://github.com/jdx/mise/pull/10972)
+
+### New Contributors
+
+- @zelch made their first contribution in [#10827](https://github.com/jdx/mise/pull/10827)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (10)
+
+- [`GitTools/GitVersion`](https://github.com/GitTools/GitVersion)
+- [`StanMarek/ghost-complete`](https://github.com/StanMarek/ghost-complete)
+- [`cachix/secretspec`](https://github.com/cachix/secretspec)
+- [`ctxrs/ctx`](https://github.com/ctxrs/ctx)
+- [`nao1215/atago`](https://github.com/nao1215/atago)
+- [`sters/diffnest`](https://github.com/sters/diffnest)
+- [`supernovae-st/nika`](https://github.com/supernovae-st/nika)
+- [`suzuki-shunsuke/langcheck`](https://github.com/suzuki-shunsuke/langcheck)
+- [`tedilabs/tfvault`](https://github.com/tedilabs/tfvault)
+- [`vcsjones/AzureSignTool`](https://github.com/vcsjones/AzureSignTool)
+
+#### Updated Packages (21)
+
+- [`FairwindsOps/polaris`](https://github.com/FairwindsOps/polaris)
+- [`charmbracelet/glow`](https://github.com/charmbracelet/glow)
+- [`charmbracelet/vhs`](https://github.com/charmbracelet/vhs)
+- [`docker/buildx`](https://github.com/docker/buildx)
+- [`docker/compose`](https://github.com/docker/compose)
+- [`gleam-lang/gleam`](https://github.com/gleam-lang/gleam)
+- [`kubernetes-sigs/cri-tools/crictl`](https://github.com/kubernetes-sigs/cri-tools)
+- [`lintnet/lintnet`](https://github.com/lintnet/lintnet)
+- [`moby/buildkit`](https://github.com/moby/buildkit)
+- [`mpyw/suve`](https://github.com/mpyw/suve)
+- [`openziti/zrok`](https://github.com/openziti/zrok)
+- [`ouch-org/ouch`](https://github.com/ouch-org/ouch)
+- [`sharkdp/vivid`](https://github.com/sharkdp/vivid)
+- [`superradcompany/microsandbox`](https://github.com/superradcompany/microsandbox)
+- [`suzuki-shunsuke/asciinema-trim`](https://github.com/suzuki-shunsuke/asciinema-trim)
+- [`suzuki-shunsuke/nllint`](https://github.com/suzuki-shunsuke/nllint)
+- [`taiki-e/cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov)
+- [`thomasschafer/scooter`](https://github.com/thomasschafer/scooter)
+- [`wasilibs/go-yamllint`](https://github.com/wasilibs/go-yamllint)
+- [`watchexec/cargo-watch`](https://github.com/watchexec/cargo-watch)
+- [`watchexec/watchexec`](https://github.com/watchexec/watchexec)
+
 ## [2026.7.5](https://github.com/jdx/mise/compare/v2026.7.4..v2026.7.5) - 2026-07-09
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.5"
+version = "2026.7.6"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.5"
+version = "2026.7.6"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.5 macos-arm64 (2026-07-09)
+2026.7.6 macos-arm64 (2026-07-14)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_5.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_6.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_5.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_6.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_5.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_6.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_5.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_6.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.5";
+  version = "2026.7.6";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "30.6k",
+      stars: "30.7k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.5
+Version: 2026.7.6
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.5"
+version: "2026.7.6"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "be9482e91ec7b37144d5464e4ebab14052ca82b5"
+  "tag": "c69bf57e87e9609e23087d3b40fd02de70bf2d87"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -3388,12 +3388,34 @@ packages:
   - type: github_release
     repo_owner: FairwindsOps
     repo_name: polaris
-    asset: polaris_{{.OS}}_{{.Arch}}.tar.gz
     description: Validation of best practices in your Kubernetes clusters
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 10.2.0")
+        asset: polaris_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: polaris_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --key
+              - https://artifacts.fairwinds.com/cosign-p256.pub
   - type: github_release
     repo_owner: FairwindsOps
     repo_name: rbac-lookup
@@ -3910,6 +3932,50 @@ packages:
           - linux/amd64
         github_artifact_attestations:
           signer_workflow: GitGuardian/ggshield/\.github/workflows/tag\.yml
+  - type: github_release
+    repo_owner: GitTools
+    repo_name: GitVersion
+    aliases:
+      - name: gittools/gitversion
+    description: From git log to SemVer in no time
+    files:
+      - name: gitversion
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 6.0.3")
+        asset: gitversion-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+          - windows
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          enabled: false
+      - version_constraint: "true"
+        asset: gitversion-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+          - windows
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          enabled: false
+        github_artifact_attestations:
+          signer_workflow: GitTools/GitVersion/\.github/workflows/ci\.yml
   - type: github_release
     repo_owner: GoTestTools
     repo_name: gotestfmt
@@ -7897,6 +7963,46 @@ packages:
         supported_envs:
           - linux
           - darwin
+  - type: github_release
+    repo_owner: StanMarek
+    repo_name: ghost-complete
+    description: Terminal autocomplete engine with a PTY proxy and shell specifications for Ghostty
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.1")
+        asset: ghost-complete-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        files:
+          - name: ghost-complete
+            src: ghost-complete-{{.Arch}}-{{.OS}}/ghost-complete
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: ghost-complete-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        files:
+          - name: ghost-complete
+            src: ghost-complete-{{.Arch}}-{{.OS}}/ghost-complete
+        supported_envs:
+          - darwin
+        github_artifact_attestations:
+          signer_workflow: StanMarek/ghost-complete/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: Stranger6667
     repo_name: jsonschema
@@ -22511,6 +22617,62 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: cachix
+    repo_name: secretspec
+    description: Declare secrets once. Store them anywhere
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: secretspec-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        files:
+          - name: secretspec
+            src: secretspec-{{.Arch}}-{{.OS}}/secretspec
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: secretspec
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: secretspec-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        files:
+          - name: secretspec
+            src: secretspec-{{.Arch}}-{{.OS}}/secretspec
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: secretspec
+  - type: github_release
     repo_owner: caddyserver
     repo_name: caddy
     description: Fast, multi-platform web server with automatic HTTPS
@@ -24430,6 +24592,25 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 2.1.1")
+        asset: glow_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: glow
+            src: "{{.AssetWithoutExt}}/glow"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: glow_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -24446,6 +24627,15 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/charmbracelet/meta/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -24676,6 +24866,26 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 0.10.0")
+        asset: vhs_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: vhs
+            src: "{{.AssetWithoutExt}}/vhs"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: vhs_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -24693,6 +24903,15 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/charmbracelet/meta/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -29986,6 +30205,44 @@ packages:
         github_artifact_attestations:
           signer_workflow: ctron/oidc-cli/.github/workflows/release.yaml
   - type: github_release
+    repo_owner: ctxrs
+    repo_name: ctx
+    description: Search the coding agent history already on your machine
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.20.0"
+        asset: ctx-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.19.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: ctx-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+  - type: github_release
     repo_owner: cubefs
     repo_name: cubefs
     description: cloud-native distributed storage
@@ -33418,7 +33675,7 @@ packages:
           - goos: darwin
             checksum:
               enabled: false # https://github.com/docker/buildx/issues/945
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.31.0")
         asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
         format: raw
         checksum:
@@ -33429,6 +33686,28 @@ packages:
           - goos: darwin
             checksum:
               enabled: false # https://github.com/docker/buildx/issues/945
+      - version_constraint: "true"
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "buildx-{{.Version}}.{{.OS}}-{{.Arch}}.sigstore.json"
+          opts:
+            - --certificate-identity-regexp
+            - "^https://github\\.com/docker/github-builder/\\.github/workflows/bake\\.yml@.+$"
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: darwin
+            checksum:
+              enabled: false # https://github.com/docker/buildx/issues/945
+            cosign:
+              enabled: false
   - type: github_release
     repo_owner: docker
     repo_name: cagent
@@ -33646,6 +33925,16 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+      - version_constraint: semver("<= 5.0.2")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
       - version_constraint: "true"
         asset: docker-compose-{{.OS}}-{{.Arch}}
         format: raw
@@ -33656,6 +33945,15 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "docker-compose-{{.OS}}-{{.Arch}}.sigstore.json"
+          opts:
+            - --certificate-identity-regexp
+            - "^https://github\\.com/docker/github-builder/\\.github/workflows/bake\\.yml@"
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
   - type: github_release
     repo_owner: docker
     repo_name: hub-tool
@@ -41411,28 +41709,6 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
-    repo_owner: gittools
-    repo_name: gitversion
-    description: From git log to SemVer in no time
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        asset: gitversion-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
-        format: tar.gz
-        supported_envs:
-          - linux
-          - darwin
-          - windows
-        replacements:
-          amd64: x64
-          darwin: osx
-          windows: win
-        overrides:
-          - goos: windows
-            format: zip
-        checksum:
-          enabled: false
-  - type: github_release
     repo_owner: gittower
     repo_name: git-flow-next
     description: A modern reimplementation of git-flow in Go that offers greater flexibility while maintaining backward compatibility with the original git-flow and git-flow-avh
@@ -41836,8 +42112,8 @@ packages:
           darwin: macos
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: darwin
             goarch: amd64
@@ -41862,11 +42138,31 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 1.9.1")
+        asset: gleam-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          predicate_type: https://spdx.dev/Document/v2.3
+          signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
       - version_constraint: semver("<= 1.10.0")
         asset: gleam-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -41879,11 +42175,20 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.sigstore"
+          opts:
+            - --certificate-identity
+            - https://github.com/gleam-lang/gleam/.github/workflows/release.yaml@refs/tags/{{.Version}}
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
           signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
@@ -41898,11 +42203,20 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.sigstore"
+          opts:
+            - --certificate-identity
+            - https://github.com/gleam-lang/gleam/.github/workflows/release.yaml@refs/tags/{{.Version}}
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
           signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
@@ -57519,10 +57833,18 @@ packages:
       - linux
       - amd64
     rosetta2: true
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.sha256"
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.23.0")
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
   - type: github_release
     repo_owner: kubernetes-sigs
     repo_name: gwctl
@@ -61100,7 +61422,7 @@ packages:
     description: General Linter powered by Jsonnet
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.11")
         asset: lintnet_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         overrides:
@@ -61115,14 +61437,36 @@ packages:
           algorithm: sha256
           cosign:
             opts:
-              - --certificate-identity-regexp
-              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
-              - --certificate-oidc-issuer
-              - "https://token.actions.githubusercontent.com"
               - --signature
               - https://github.com/lintnet/lintnet/releases/download/{{.Version}}/lintnet_{{trimV .Version}}_checksums.txt.sig
               - --certificate
               - https://github.com/lintnet/lintnet/releases/download/{{.Version}}/lintnet_{{trimV .Version}}_checksums.txt.pem
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+      - version_constraint: "true"
+        asset: lintnet_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        checksum:
+          type: github_release
+          asset: lintnet_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: lintnet_{{trimV .Version}}_checksums.txt.bundle
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
   - type: github_release
     repo_owner: linuxkit
     repo_name: linuxkit
@@ -65170,9 +65514,86 @@ packages:
                 src: bin/{{.FileName}}
               - name: buildkitd
                 src: bin/{{.FileName}}
+      - version_constraint: semver("< 0.27.0")
+        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-bridge
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-firewall
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-host-local
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-loopback
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-aarch64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
+          - goos: linux
+            goarch: arm64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-bridge
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-firewall
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-host-local
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-loopback
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-x86_64
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
+          - goos: windows
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.AssetWithoutExt}}.sigstore.json"
+          opts:
+            - --certificate-identity-regexp
+            - "^https://github\\.com/docker/github-builder/\\.github/workflows/bake\\.yml@"
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
         overrides:
           - goos: linux
             goarch: amd64
@@ -65997,13 +66418,13 @@ packages:
   - type: github_release
     repo_owner: mpyw
     repo_name: suve
-    description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
+    description: Git-like CLI/TUI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 1.3.0")
+      - version_constraint: semver("< 1.6.1")
         error_message: |
-          suve versions before v1.3.0 are not supported by the aqua registry.
-          The project changed significantly in earlier releases; please use v1.3.0 or later.
+          suve versions before v1.6.1 are not supported by the aqua registry.
+          The project changed significantly in earlier releases; please use v1.6.1 or later.
       - version_constraint: "true"
         asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -67377,6 +67798,33 @@ packages:
           type: github_release
           asset: golangci-lint-langserver_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: nao1215
+    repo_name: atago
+    description: "Tests CLI behavior from plain YAML: exit codes, output, files, snapshots, and interactive terminals (PTY/TUI)"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: atago_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          github_artifact_attestations:
+            signer_workflow: nao1215/atago/.github/workflows/release.yml
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/nao1215/atago/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: nao1215
     repo_name: gup
@@ -71088,11 +71536,6 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha1
-      # TODO support GitHub Artifact Attestation
-      # https://github.com/openziti/zrok/releases/tag/v0.4.49
-      # > CHANGE: Release binary and text artifacts are now accompanied by provenance attestations
-      # github_artifact_attestations:
-      #   signer_workflow:
       - version_constraint: "true"
         asset: zrok_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -71101,6 +71544,8 @@ packages:
           type: github_release
           asset: checksums.sha256.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: openziti/zrok/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: operator-framework
     repo_name: operator-registry
@@ -71983,6 +72428,22 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+      - version_constraint: semver("< 0.8.0")
+        asset: ouch-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: ouch
+            src: "{{.AssetWithoutExt}}/ouch"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: ouch-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -71999,6 +72460,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: ouch-org/ouch/\.github/workflows/draft-release-automatic-trigger\.yml
   - type: github_release
     repo_owner: out-of-cheese-error
     repo_name: the-way
@@ -81926,7 +82389,6 @@ packages:
       - darwin
       - linux
       - amd64
-    rosetta2: true
     files:
       - name: vivid
         src: vivid-{{.Version}}-{{.Arch}}-{{.OS}}/vivid
@@ -81942,6 +82404,13 @@ packages:
           - linux/amd64
           - darwin
         rosetta2: true
+      - version_constraint: semver(">= 0.8.0, < 0.11.0")
+        rosetta2: true
+      - version_constraint: semver("= 0.11.0")
+        asset: vivid-v0.10.1-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: vivid
+            src: vivid-v0.10.1-{{.Arch}}-{{.OS}}/vivid
       - version_constraint: "true"
   - type: github_release
     repo_owner: sheepla
@@ -86350,6 +86819,30 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: sters
+    repo_name: diffnest
+    description: A diff tool for structured data files like YAML, JSON
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.4.0")
+        asset: diffnest_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: diffnest_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: diffnest_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: diffnest_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: stoplightio
     repo_name: spectral
     description: A flexible JSON/YAML linter for creating automated style guides, with baked in support for OpenAPI (v3.1, v3.0, and v2.0), Arazzo v1.0, as well as AsyncAPI v2.x
@@ -87436,6 +87929,27 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: supernovae-st
+    repo_name: nika
+    description: Workflow language and runner for AI jobs - one .nika.yaml file, statically checked before any token is spent, hash-chained run traces
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.80.0-alpha.4")
+        no_asset: true
+      - version_constraint: "true"
+        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: superradcompany
     repo_name: microsandbox
     aliases:
@@ -87444,10 +87958,10 @@ packages:
     description: Self-Hosted Platform for Secure Execution of Untrusted User/AI Code
     files:
       - name: msb
-    version_prefix: microsandbox-v
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.2.6")
+        version_prefix: microsandbox-v
         asset: microsandbox-{{.SemVer}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -87475,6 +87989,40 @@ packages:
         supported_envs:
           - linux
           - darwin/arm64
+      - version_constraint: semver("<= 0.5.10")
+        asset: microsandbox-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: checksums.sha256
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: microsandbox-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: checksums.sha256
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
   - type: github_release
     repo_owner: suzuki-shunsuke
     repo_name: akoi
@@ -87525,6 +88073,13 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("< 0.1.4")
+        asset: asciinema-trim_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: asciinema-trim_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: asciinema-trim_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -87532,6 +88087,9 @@ packages:
           type: github_release
           asset: asciinema-trim_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
   - type: github_content
     repo_owner: suzuki-shunsuke
     repo_name: checkout-merged-branch-with-ci-info
@@ -88499,6 +89057,36 @@ packages:
               - https://github.com/suzuki-shunsuke/github-comment/releases/download/{{.Version}}/github-comment_{{trimV .Version}}_checksums.txt.pem
   - type: github_release
     repo_owner: suzuki-shunsuke
+    repo_name: langcheck
+    description: langcheck is a CLI for checking if disallowed characters are included in files and texts. This is useful to prevent coding agents from using disallowed characters in code, commit messages, issues, pull requests, and so on
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: langcheck_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: langcheck_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
+            bundle:
+              type: github_release
+              asset: langcheck_checksums.txt.sigstore.json
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: suzuki-shunsuke
     repo_name: matchfile
     description: CLI tool to check file paths are matched to the condition
     version_constraint: "false"
@@ -88605,7 +89193,7 @@ packages:
     description: Linter to check newlines at the end of files
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.1.2")
         asset: nllint_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         overrides:
@@ -88628,6 +89216,50 @@ packages:
               - https://github.com/suzuki-shunsuke/nllint/releases/download/{{.Version}}/nllint_{{trimV .Version}}_checksums.txt.sig
               - --certificate
               - https://github.com/suzuki-shunsuke/nllint/releases/download/{{.Version}}/nllint_{{trimV .Version}}_checksums.txt.pem
+      - version_constraint: semver("<= 1.1.0")
+        asset: nllint_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        checksum:
+          type: github_release
+          asset: nllint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: nllint_{{trimV .Version}}_checksums.txt.bundle
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+      - version_constraint: "true"
+        asset: nllint_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        checksum:
+          type: github_release
+          asset: nllint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: nllint_{{trimV .Version}}_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
   - type: github_release
     repo_owner: suzuki-shunsuke
     repo_name: pinact
@@ -89791,6 +90423,16 @@ packages:
           - goos: linux
             replacements:
               arm64: aarch64
+      - version_constraint: semver("<= 0.8.4")
+        asset: cargo-llvm-cov-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
       - version_constraint: "true"
         asset: cargo-llvm-cov-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -89801,6 +90443,8 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        github_artifact_attestations:
+          signer-workflow: taiki-e/github-actions/\.github/workflows/rust-release\.yml
   - type: github_release
     repo_owner: tailor-platform
     repo_name: patterner
@@ -90588,6 +91232,22 @@ packages:
         overrides:
           - goos: darwin
             asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: tedilabs
+    repo_name: tfvault
+    description: A Terraform credentials helper to fetch secrets from several secret backends (OS keyring, environment variables, pass)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tfvault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
         supported_envs:
           - linux
           - darwin
@@ -91985,8 +92645,8 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip
@@ -92002,8 +92662,8 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip
@@ -96033,6 +96693,21 @@ packages:
             checksum:
               enabled: false
   - type: github_release
+    repo_owner: vcsjones
+    repo_name: AzureSignTool
+    description: SignTool Library with Azure Key Vault Support
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 6.0.0")
+        error_message: Please use v6.0.0 or later
+      - version_constraint: "true"
+        asset: AzureSignTool-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        supported_envs:
+          - windows
+  - type: github_release
     repo_owner: vectordotdev
     repo_name: vector
     description: A high-performance observability data pipeline
@@ -97619,6 +98294,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer-workflow: wasilibs/actions/\.github/workflows/release\.yaml
   - type: github_release
     repo_owner: wasm-bindgen
     repo_name: wasm-pack
@@ -98024,6 +98701,10 @@ packages:
           type: github_release
           asset: SHA512SUMS
           algorithm: sha512
+          minisign:
+            type: github_release
+            asset: SHA512SUMS.auto.minisig
+            public_key: RWRxgTERVHnagvTTKlALKHIBLnPb5hHU2BcX6fe/MDXLSXvKu70Lft0b
         overrides:
           - goos: linux
             goarch: amd64
@@ -98050,6 +98731,10 @@ packages:
           type: github_release
           asset: SHA512SUMS
           algorithm: sha512
+          minisign:
+            type: github_release
+            asset: SHA512SUMS.auto.minisig
+            public_key: RWRxgTERVHnagvTTKlALKHIBLnPb5hHU2BcX6fe/MDXLSXvKu70Lft0b
         overrides:
           - goos: linux
             goarch: amd64
@@ -98077,6 +98762,10 @@ packages:
           type: github_release
           asset: SHA512SUMS
           algorithm: sha512
+          minisign:
+            type: github_release
+            asset: SHA512SUMS.auto.minisig
+            public_key: RWRxgTERVHnagvTTKlALKHIBLnPb5hHU2BcX6fe/MDXLSXvKu70Lft0b
         overrides:
           - goos: linux
             goarch: amd64
@@ -98103,6 +98792,10 @@ packages:
           type: github_release
           asset: SHA512SUMS
           algorithm: sha512
+          minisign:
+            type: github_release
+            asset: SHA512SUMS.auto.minisig
+            public_key: RWRxgTERVHnagvTTKlALKHIBLnPb5hHU2BcX6fe/MDXLSXvKu70Lft0b
         overrides:
           - goos: linux
             goarch: amd64
@@ -98291,8 +98984,8 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip
@@ -98310,8 +99003,8 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
### 🚀 Features

- **(aqua)** support private content and archives by @risu729 in [#10915](https://github.com/jdx/mise/pull/10915)
- **(bootstrap)** add flatpak package support by @jdx in [#10951](https://github.com/jdx/mise/pull/10951)
- **(cargo)** disable cargo-quickinstall by default by @risu729 in [#10923](https://github.com/jdx/mise/pull/10923)
- **(doctor)** report shadowed shims by @risu729 in [#10919](https://github.com/jdx/mise/pull/10919)
- **(oci)** add reproducible host path copy layers by @jdx in [#10952](https://github.com/jdx/mise/pull/10952)
- **(sandbox)** add default deny settings by @risu729 in [#10940](https://github.com/jdx/mise/pull/10940)
- **(task)** **breaking** decouple task output style from verbosity by @JamBalaya56562 in [#10885](https://github.com/jdx/mise/pull/10885)
- **(task)** render timeout templates by @risu729 in [#10959](https://github.com/jdx/mise/pull/10959)

### 🐛 Bug Fixes

- **(backend)** reinstall rolling versions when outdated by @zelch in [#10827](https://github.com/jdx/mise/pull/10827)
- **(backend)** align migrated backend resolution by @jdx in [#10969](https://github.com/jdx/mise/pull/10969)
- **(bootstrap)** preserve symlinks when extracting dmgs by @jdx in [#10949](https://github.com/jdx/mise/pull/10949)
- **(bootstrap)** support localized brew casks by @jdx in [#10950](https://github.com/jdx/mise/pull/10950)
- **(cargo)** own cargo-binstall compile fallback by @risu729 in [#10926](https://github.com/jdx/mise/pull/10926)
- **(config)** warn about unsupported semver ranges by @risu729 in [#10916](https://github.com/jdx/mise/pull/10916)
- **(config)** let user tool options override registry defaults by @risu729 in [#10924](https://github.com/jdx/mise/pull/10924)
- **(config)** reload settings with config by @risu729 in [#10945](https://github.com/jdx/mise/pull/10945)
- **(config)** add tera contrib helpers by @jdx in [#10970](https://github.com/jdx/mise/pull/10970)
- **(config)** keep installed versions eligible with release age by @jdx in [#10973](https://github.com/jdx/mise/pull/10973)
- **(copr)** fix x86_64 builds with add nasm/cmake for Fedora and PREBUILT_NASM for RHEL/EPEL by @bestagi in [#10947](https://github.com/jdx/mise/pull/10947)
- **(copr)** add PIE flag for aws-lc probe by @jdx in [#10974](https://github.com/jdx/mise/pull/10974)
- **(erlang)** lock source install outcomes by @risu729 in [#10937](https://github.com/jdx/mise/pull/10937)
- **(file)** ignore malformed pax metadata during sparse detection by @risu729 in [#10978](https://github.com/jdx/mise/pull/10978)
- **(github)** align SLSA provenance with selected asset by @risu729 in [#10928](https://github.com/jdx/mise/pull/10928)
- **(github)** treat bin/rename_exe as install-time options by @risu729 in [#10925](https://github.com/jdx/mise/pull/10925)
- **(http)** bound total download time by @risu729 in [#10920](https://github.com/jdx/mise/pull/10920)
- **(npm)** isolate version queries from project cwd by @risu729 in [#10927](https://github.com/jdx/mise/pull/10927)
- **(registry)** normalize backend platform selectors by @risu729 in [#10938](https://github.com/jdx/mise/pull/10938)
- **(registry)** rename podman banary to podman-remote by @tony-sol in [#10826](https://github.com/jdx/mise/pull/10826)
- **(s3)** resolve cross-platform lockfile URLs for locked mode by @icholy in [#10873](https://github.com/jdx/mise/pull/10873)
- **(task)** invalidate auto freshness after failed rerun by @risu729 in [#10953](https://github.com/jdx/mise/pull/10953)
- **(task)** isolate usage variables per invocation by @risu729 in [#10963](https://github.com/jdx/mise/pull/10963)
- **(task)** preserve task tool options by @risu729 in [#10958](https://github.com/jdx/mise/pull/10958)
- **(task)** respect configured directory when editing tasks by @risu729 in [#10955](https://github.com/jdx/mise/pull/10955)
- **(toolset)** preserve ref selector install identity by @risu729 in [#10942](https://github.com/jdx/mise/pull/10942)

### 📚 Documentation

- **(aqua)** document local custom registries by @risu729 in [#10966](https://github.com/jdx/mise/pull/10966)
- **(config)** clarify sub version arithmetic by @risu729 in [#10943](https://github.com/jdx/mise/pull/10943)

### ⚡ Performance

- **(aqua)** skip public probes for private releases by @risu729 in [#10914](https://github.com/jdx/mise/pull/10914)

### 🧪 Testing

- **(cargo)** align binstall fallback coverage by @risu729 in [#10980](https://github.com/jdx/mise/pull/10980)

### ◀️ Revert

- prefer aqua for codex by @risu729 in [#10922](https://github.com/jdx/mise/pull/10922)

### 📦️ Dependency Updates

- update rust docker digest to 44637ff by @renovate[bot] in [#10901](https://github.com/jdx/mise/pull/10901)
- update ghcr.io/jdx/mise:deb docker digest to c5e848b by @renovate[bot] in [#10899](https://github.com/jdx/mise/pull/10899)
- update ghcr.io/jdx/mise:alpine docker digest to 94d8801 by @renovate[bot] in [#10898](https://github.com/jdx/mise/pull/10898)
- update rust crate demand to v2.0.3 by @renovate[bot] in [#10903](https://github.com/jdx/mise/pull/10903)
- update phf to 0.14 by @renovate[bot] in [#10906](https://github.com/jdx/mise/pull/10906)
- update ubuntu docker tag to resolute-20260627 by @renovate[bot] in [#10905](https://github.com/jdx/mise/pull/10905)
- update ghcr.io/jdx/mise:rpm docker digest to 4363aec by @renovate[bot] in [#10900](https://github.com/jdx/mise/pull/10900)
- update rust crate usage-lib to v3.5.4 by @renovate[bot] in [#10904](https://github.com/jdx/mise/pull/10904)
- update rust crate chacha20poly1305 to 0.11 by @renovate[bot] in [#10907](https://github.com/jdx/mise/pull/10907)
- update actions/github-script action to v9 by @renovate[bot] in [#10908](https://github.com/jdx/mise/pull/10908)
- update rust crate rmcp to v2 by @renovate[bot] in [#10909](https://github.com/jdx/mise/pull/10909)
- update dependency prettier to v3.9.4 by @renovate[bot] in [#10902](https://github.com/jdx/mise/pull/10902)

### 📦 Registry

- add git-town ([aqua:git-town/git-town](https://github.com/git-town/git-town)) by @joealden in [#10935](https://github.com/jdx/mise/pull/10935)
- add bundler (gem:bundler) by @risu729 in [#10939](https://github.com/jdx/mise/pull/10939)

### Chore

- **(release)** skip ai reviews for release prs by @jdx in [#10891](https://github.com/jdx/mise/pull/10891)
- **(release)** publish registry artifact by @jdx in [#10972](https://github.com/jdx/mise/pull/10972)

### New Contributors

- @zelch made their first contribution in [#10827](https://github.com/jdx/mise/pull/10827)

## 📦 Aqua Registry Updates

### New Packages (10)

- [`GitTools/GitVersion`](https://github.com/GitTools/GitVersion)
- [`StanMarek/ghost-complete`](https://github.com/StanMarek/ghost-complete)
- [`cachix/secretspec`](https://github.com/cachix/secretspec)
- [`ctxrs/ctx`](https://github.com/ctxrs/ctx)
- [`nao1215/atago`](https://github.com/nao1215/atago)
- [`sters/diffnest`](https://github.com/sters/diffnest)
- [`supernovae-st/nika`](https://github.com/supernovae-st/nika)
- [`suzuki-shunsuke/langcheck`](https://github.com/suzuki-shunsuke/langcheck)
- [`tedilabs/tfvault`](https://github.com/tedilabs/tfvault)
- [`vcsjones/AzureSignTool`](https://github.com/vcsjones/AzureSignTool)

### Updated Packages (21)

- [`FairwindsOps/polaris`](https://github.com/FairwindsOps/polaris)
- [`charmbracelet/glow`](https://github.com/charmbracelet/glow)
- [`charmbracelet/vhs`](https://github.com/charmbracelet/vhs)
- [`docker/buildx`](https://github.com/docker/buildx)
- [`docker/compose`](https://github.com/docker/compose)
- [`gleam-lang/gleam`](https://github.com/gleam-lang/gleam)
- [`kubernetes-sigs/cri-tools/crictl`](https://github.com/kubernetes-sigs/cri-tools)
- [`lintnet/lintnet`](https://github.com/lintnet/lintnet)
- [`moby/buildkit`](https://github.com/moby/buildkit)
- [`mpyw/suve`](https://github.com/mpyw/suve)
- [`openziti/zrok`](https://github.com/openziti/zrok)
- [`ouch-org/ouch`](https://github.com/ouch-org/ouch)
- [`sharkdp/vivid`](https://github.com/sharkdp/vivid)
- [`superradcompany/microsandbox`](https://github.com/superradcompany/microsandbox)
- [`suzuki-shunsuke/asciinema-trim`](https://github.com/suzuki-shunsuke/asciinema-trim)
- [`suzuki-shunsuke/nllint`](https://github.com/suzuki-shunsuke/nllint)
- [`taiki-e/cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov)
- [`thomasschafer/scooter`](https://github.com/thomasschafer/scooter)
- [`wasilibs/go-yamllint`](https://github.com/wasilibs/go-yamllint)
- [`watchexec/cargo-watch`](https://github.com/watchexec/cargo-watch)
- [`watchexec/watchexec`](https://github.com/watchexec/watchexec)