### PR TITLE
feat(rust): support the extensionless rust-toolchain version file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -410,7 +410,7 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | pnpm       | `package.json`                            |
 | python     | `.python-version`, `.python-versions`     |
 | ruby       | `.ruby-version`, `Gemfile`                |
-| rust       | `rust-toolchain.toml`                     |
+| rust       | `rust-toolchain.toml`, `rust-toolchain`   |
 | terraform  | `.terraform-version`                      |
 | terragrunt | `.terragrunt-version`                     |
 | terramate  | `.terramate-version`                      |

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -33,6 +33,22 @@ mise use -g rust@1.82
 cargo build
 ```
 
+## Toolchain files
+
+With [idiomatic version files](/configuration.html#idiomatic-version-files) enabled for rust
+(`mise settings add idiomatic_version_file_enable_tools rust`), mise reads the same toolchain
+files rustup does: `rust-toolchain.toml` and the extensionless `rust-toolchain`. Both must
+contain the TOML format:
+
+```toml
+[toolchain]
+channel = "1.84.0"
+```
+
+rustup's legacy format—a bare channel name on a single line—is not supported; such files are
+ignored. If both files exist in the same directory, `rust-toolchain` takes precedence over
+`rust-toolchain.toml`, matching rustup's behavior.
+
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `rust` backend—these

--- a/e2e/core/test_rust_toolchain_file
+++ b/e2e/core/test_rust_toolchain_file
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Test that the extensionless rust-toolchain file works like rust-toolchain.toml
+
+mise settings set idiomatic_version_file_enable_tools rust
+
+# extensionless rust-toolchain in TOML format
+cat <<EOF >rust-toolchain
+[toolchain]
+channel = "1.84.0"
+EOF
+assert "mise current rust" "1.84.0"
+
+# when both files exist, rust-toolchain takes precedence, matching rustup
+cat <<EOF >rust-toolchain.toml
+[toolchain]
+channel = "1.85.0"
+EOF
+assert "mise current rust" "1.84.0"
+
+rm rust-toolchain
+assert "mise current rust" "1.85.0"
+
+# rustup's legacy format (a bare channel name) is not supported; the file is ignored
+rm rust-toolchain.toml
+echo "nightly-2025-01-01" >rust-toolchain
+assert "mise current rust" ""

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -672,6 +672,10 @@ mod tests {
             detect_config_file_type(Path::new("/foo/bar/rust-toolchain.toml")).await,
             Some(ConfigFileType::IdiomaticVersion(_))
         ));
+        assert!(matches!(
+            detect_config_file_type(Path::new("/foo/bar/rust-toolchain")).await,
+            Some(ConfigFileType::IdiomaticVersion(_))
+        ));
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -322,7 +322,7 @@ impl Backend for RustPlugin {
     }
 
     async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec!["rust-toolchain.toml".into()])
+        Ok(vec!["rust-toolchain.toml".into(), "rust-toolchain".into()])
     }
 
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
@@ -338,6 +338,18 @@ impl Backend for RustPlugin {
         &self,
         path: &Path,
     ) -> Result<Vec<IdiomaticVersion>> {
+        // rustup reads the extensionless `rust-toolchain` file when both it and
+        // `rust-toolchain.toml` exist in the same directory
+        let extensionless = path.with_extension("");
+        if path.extension().is_some() && extensionless.is_file() {
+            warn_once!(
+                "both {} and {} exist; using {}",
+                file::display_path(&extensionless),
+                file::display_path(path),
+                file::display_path(&extensionless),
+            );
+            return Ok(vec![]);
+        }
         let rt = parse_idiomatic_file(path)?;
         if rt.channel.is_empty() {
             return Ok(vec![]);
@@ -498,6 +510,9 @@ fn string_array(values: &[String]) -> toml::Value {
 
 fn parse_idiomatic_file(path: &Path) -> Result<RustToolchain> {
     let content = file::read_to_string(path)?;
+    // only the TOML format is supported; extensionless `rust-toolchain` files
+    // in rustup's legacy format (a bare channel name) fail to parse and are
+    // skipped like any other unparseable idiomatic version file
     let toml: toml::Value = toml::de::from_str(&content)?;
     let mut rt = RustToolchain::default();
     if let Some(toolchain) = toml.get("toolchain") {
@@ -821,6 +836,51 @@ targets = ["wasm32-wasip1", " wasm32-wasip1 "]
                 ("targets".to_string(), "wasm32-wasip1".to_string()),
             ])
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rust_idiomatic_file_supports_toml_without_extension() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("rust-toolchain");
+        std::fs::write(&path, "[toolchain]\nchannel = \"nightly-2026-04-11\"\n")?;
+
+        let plugin = RustPlugin::new();
+        let versions = plugin.parse_idiomatic_file_with_options(&path).await?;
+        assert_eq!(versions.into_iter().next().unwrap().0, "nightly-2026-04-11");
+        Ok(())
+    }
+
+    #[test]
+    fn rust_legacy_format_is_not_supported() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("rust-toolchain");
+        // rustup's legacy format: a bare channel name on a single line
+        std::fs::write(&path, "nightly-2026-04-11\n")?;
+
+        assert!(parse_idiomatic_file(&path).is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rust_toolchain_file_takes_precedence_over_toml() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("rust-toolchain"),
+            "[toolchain]\nchannel = \"1.84.0\"\n",
+        )?;
+        let toml_path = dir.path().join("rust-toolchain.toml");
+        std::fs::write(&toml_path, "[toolchain]\nchannel = \"1.85.0\"\n")?;
+
+        // like rustup, the extensionless file wins when both exist
+        let plugin = RustPlugin::new();
+        let versions = plugin.parse_idiomatic_file_with_options(&toml_path).await?;
+        assert!(versions.is_empty());
+
+        let versions = plugin
+            .parse_idiomatic_file_with_options(&dir.path().join("rust-toolchain"))
+            .await?;
+        assert_eq!(versions.into_iter().next().unwrap().0, "1.84.0");
         Ok(())
     }
 


### PR DESCRIPTION
rustup accepts two spellings of its toolchain file: rust-toolchain.toml and the extensionless rust-toolchain. mise only recognized rust-toolchain.toml, and because mise exports RUSTUP_TOOLCHAIN (which outranks toolchain files in rustup's own precedence), a global rust version would silently override a project's extensionless pin.

Register rust-toolchain as an idiomatic version file for rust. Only the TOML format is accepted; rustup's legacy format (a bare channel name on a single line) fails to parse and is ignored like any other unparseable idiomatic version file. When both files exist in the same directory, the extensionless file wins with a warning, matching rustup's precedence.

@jdx This is a more minimal version of #10824 hopefully this one can go in. It just supports the old name with the new format, not the old format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Rust toolchain configuration through both `rust-toolchain` and `rust-toolchain.toml` files.
  * When both files exist, `rust-toolchain` takes precedence, matching rustup behavior.
  * Added documentation covering supported formats, precedence, and legacy format limitations.

* **Bug Fixes**
  * Legacy single-line Rust toolchain files are now rejected instead of being interpreted incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->