### PR TITLE
perf(aqua): skip public probes for private releases

### DIFF
--- a/crates/aqua-registry/src/cache.rs
+++ b/crates/aqua-registry/src/cache.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-const COMPILED_REGISTRY_CACHE_VERSION: &str = "v5";
+const COMPILED_REGISTRY_CACHE_VERSION: &str = "v6";
 
 #[derive(Debug, Clone)]
 pub struct RegistryCache {

--- a/crates/aqua-registry/src/codec.rs
+++ b/crates/aqua-registry/src/codec.rs
@@ -30,6 +30,7 @@ mod tests {
         let mut package = AquaPackage::default();
         package.repo_owner = "owner".into();
         package.repo_name = "repo".into();
+        package.private = true;
         package.vars = vec![AquaVar {
             name: "channel".into(),
             default: Some("beta".into()),
@@ -41,6 +42,7 @@ mod tests {
 
         assert_eq!(decoded.repo_owner, "owner");
         assert_eq!(decoded.repo_name, "repo");
+        assert!(decoded.private);
         assert_eq!(decoded.vars[0].default.as_deref(), Some("beta"));
     }
 }

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -1505,6 +1505,24 @@ packages:
     }
 
     #[test]
+    fn test_registry_package_private_survives_version_override() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - type: github_release
+    private: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tool.tar.gz
+"#,
+        )
+        .with_version(&["1.0.0"], "linux", "amd64");
+
+        assert!(pkg.private);
+    }
+
+    #[test]
     fn test_github_artifact_attestations_predicate_type() {
         let pkg = first_registry_package(
             r#"

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -88,6 +88,7 @@ pub struct AquaPackage {
     #[rkyv(omit_bounds)]
     pub version_overrides: Vec<AquaPackage>,
     pub no_asset: bool,
+    pub private: bool,
     pub error_message: Option<String>,
     pub path: Option<String>,
     #[serde(skip)]
@@ -404,6 +405,7 @@ impl Default for AquaPackage {
             version_constraint: String::new(),
             version_overrides: Vec::new(),
             no_asset: false,
+            private: false,
             error_message: None,
             path: None,
             var_values: HashMap::new(),
@@ -1485,6 +1487,21 @@ packages:
 
         assert_eq!(pkg.replacements.get("386"), Some(&"i686".to_string()));
         assert_eq!(pkg.vars[0].default.as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn test_registry_package_private_defaults_to_false() {
+        let pkg = first_registry_package("packages:\n  - type: github_release\n");
+
+        assert!(!pkg.private);
+    }
+
+    #[test]
+    fn test_registry_package_preserves_private() {
+        let pkg =
+            first_registry_package("packages:\n  - type: github_release\n    private: true\n");
+
+        assert!(pkg.private);
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -570,10 +570,8 @@ impl Backend for AquaBackend {
 
         // Public repos download from the browser URL; private repos return 404/HTML there
         // and must be fetched from the API asset endpoint instead.
-        let download_url = match url_api.as_deref() {
-            Some(url_api) => github::pick_reachable_asset_url(&url, url_api).await,
-            None => url.clone(),
-        };
+        let download_url =
+            select_github_release_download_url(pkg.private, &url, url_api.as_deref()).await;
         self.download(ctx, &tv, &download_url, &filename).await?;
 
         if validated_url.is_none() {
@@ -1427,10 +1425,9 @@ impl AquaBackend {
         pr: Option<&dyn SingleReport>,
     ) -> Result<String> {
         let (provenance_url, url_api) = self.resolve_slsa_url(pkg, v, os(), arch()).await?;
-        let download_url = match url_api.as_deref() {
-            Some(url_api) => github::pick_reachable_asset_url(&provenance_url, url_api).await,
-            None => provenance_url.clone(),
-        };
+        let download_url =
+            select_github_release_download_url(pkg.private, &provenance_url, url_api.as_deref())
+                .await;
         let provenance_path = download_dir.join(get_filename_from_url(&provenance_url));
         HTTP.download_file(&download_url, &provenance_path, pr)
             .await?;
@@ -1965,10 +1962,8 @@ impl AquaBackend {
         asset_strs: IndexSet<String>,
     ) -> Result<(String, String)> {
         let (url, url_api, _) = self.github_release_asset(pkg, v, asset_strs).await?;
-        let transport = match url_api.as_deref() {
-            Some(url_api) => github::pick_reachable_asset_url(&url, url_api).await,
-            None => url.clone(),
-        };
+        let transport =
+            select_github_release_download_url(pkg.private, &url, url_api.as_deref()).await;
         Ok((url, transport))
     }
 
@@ -3089,6 +3084,18 @@ fn cosign_opt_value<'a>(opts: &'a [String], flag: &str) -> Option<&'a str> {
         .map(|pair| pair[1].as_str())
 }
 
+async fn select_github_release_download_url(
+    private: bool,
+    browser_url: &str,
+    api_url: Option<&str>,
+) -> String {
+    match api_url {
+        Some(api_url) if private => api_url.to_string(),
+        Some(api_url) => github::pick_reachable_asset_url(browser_url, api_url).await,
+        None => browser_url.to_string(),
+    }
+}
+
 fn version_with_prefix<'a>(version: &'a str, version_prefix: Option<&str>) -> Cow<'a, str> {
     if let Some(prefix) = version_prefix
         && !version.starts_with(prefix)
@@ -3249,6 +3256,27 @@ mod tests {
         assert_eq!(
             version_with_prefix("tool-1.0.0", Some("tool-")),
             "tool-1.0.0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_private_github_release_uses_api_url_without_probe() {
+        let browser_url = "not a valid URL";
+        let api_url = "https://api.github.com/repos/owner/repo/releases/assets/1";
+
+        assert_eq!(
+            select_github_release_download_url(true, browser_url, Some(api_url)).await,
+            api_url
+        );
+    }
+
+    #[tokio::test]
+    async fn test_github_release_without_api_url_uses_browser_url() {
+        let browser_url = "https://example.com/tool.tar.gz";
+
+        assert_eq!(
+            select_github_release_download_url(true, browser_url, None).await,
+            browser_url
         );
     }
 


### PR DESCRIPTION
## Summary

- preserve aqua's `private` package field in YAML and compiled registry data
- use the authenticated GitHub API asset URL immediately for declared-private release assets
- retain browser-URL probing and API fallback when `private` is absent or false
- bump the compiled aqua registry cache version from v5 to v6

## Why

Aqua registries can mark GitHub-hosted packages as private. Mise previously discarded that field, so private release downloads always made a browser-URL probe that is known to fail before selecting the authenticated API asset endpoint.

This keeps the fallback behavior for registries with missing or incorrect metadata while avoiding the unnecessary request for correctly declared private packages. The same selection applies to auxiliary release assets such as checksums, signatures, and provenance.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p aqua-registry private`
- `cargo test -p aqua-registry test_rkyv_package_roundtrip_preserves_var_default`
- `cargo test test_private_github_release_uses_api_url_without_probe`
- `cargo test test_github_release_without_api_url_uses_browser_url`

The full `cargo test -p aqua-registry` run passed 107 tests and hit one pre-existing platform-dependent failure in `test_override_envs_all_matches_any_platform` (`.exe` expectation). The repository-wide `mise run format` task could not complete because `ajv` is unavailable on PATH.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry packages can now be marked as private (with a default of public when omitted).
  * Private GitHub-hosted releases use direct authenticated API download URLs for package artifacts and related verification assets.
* **Bug Fixes**
  * Improved GitHub release asset URL resolution for private packages, avoiding reachability probing when an API URL is available.
  * Preserved package privacy settings during serialization/deserialization and version overrides.
  * Updated compiled registry cache version to refresh stored cache data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->