### PR TITLE
fix(http): bound total download time

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1083,9 +1083,14 @@
           "description": "Number of retries for transient HTTP failures in mise.",
           "type": "number"
         },
+        "http_download_timeout": {
+          "default": "30m",
+          "description": "Total time allowed for an HTTP download, including retries.",
+          "type": "string"
+        },
         "http_timeout": {
           "default": "30s",
-          "description": "Timeout in seconds for all HTTP requests in mise.",
+          "description": "Timeout for connecting or waiting between reads during HTTP requests.",
           "type": "string"
         },
         "idiomatic_version_file": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1078,15 +1078,15 @@
             }
           }
         },
-        "http_retries": {
-          "default": 3,
-          "description": "Number of retries for transient HTTP failures in mise.",
-          "type": "number"
-        },
         "http_download_timeout": {
           "default": "30m",
           "description": "Total time allowed for an HTTP download, including retries.",
           "type": "string"
+        },
+        "http_retries": {
+          "default": 3,
+          "description": "Number of retries for transient HTTP failures in mise.",
+          "type": "number"
         },
         "http_timeout": {
           "default": "30s",

--- a/settings.toml
+++ b/settings.toml
@@ -1154,6 +1154,20 @@ This setting is useful when:
 env = "MISE_HOOK_ENV_CHPWD_ONLY"
 type = "Bool"
 
+[http_download_timeout]
+default = "30m"
+description = "Total time allowed for an HTTP download, including retries."
+docs = """
+Limits the complete wall-clock time for downloading one artifact, including
+all retry attempts and backoff delays. This is separate from `http_timeout`,
+which detects stalled connections by timing out individual reads.
+
+When this budget is exhausted, mise reports the URL, active attempt, bytes
+received during that attempt, and this setting name.
+"""
+env = "MISE_HTTP_DOWNLOAD_TIMEOUT"
+type = "Duration"
+
 [http_retries]
 default = 3
 description = "Number of retries for transient HTTP failures in mise."
@@ -1171,20 +1185,6 @@ flaky infrastructure doesn't silently mask itself.
 """
 env = "MISE_HTTP_RETRIES"
 type = "Integer"
-
-[http_download_timeout]
-default = "30m"
-description = "Total time allowed for an HTTP download, including retries."
-docs = """
-Limits the complete wall-clock time for downloading one artifact, including
-all retry attempts and backoff delays. This is separate from `http_timeout`,
-which detects stalled connections by timing out individual reads.
-
-When this budget is exhausted, mise reports the URL, active attempt, bytes
-received during that attempt, and this setting name.
-"""
-env = "MISE_HTTP_DOWNLOAD_TIMEOUT"
-type = "Duration"
 
 [http_timeout]
 default = "30s"

--- a/settings.toml
+++ b/settings.toml
@@ -1172,9 +1172,28 @@ flaky infrastructure doesn't silently mask itself.
 env = "MISE_HTTP_RETRIES"
 type = "Integer"
 
+[http_download_timeout]
+default = "30m"
+description = "Total time allowed for an HTTP download, including retries."
+docs = """
+Limits the complete wall-clock time for downloading one artifact, including
+all retry attempts and backoff delays. This is separate from `http_timeout`,
+which detects stalled connections by timing out individual reads.
+
+When this budget is exhausted, mise reports the URL, active attempt, bytes
+received during that attempt, and this setting name.
+"""
+env = "MISE_HTTP_DOWNLOAD_TIMEOUT"
+type = "Duration"
+
 [http_timeout]
 default = "30s"
-description = "Timeout in seconds for all HTTP requests in mise."
+description = "Timeout for connecting or waiting between reads during HTTP requests."
+docs = """
+This timeout applies to the connection phase and to each individual response
+read. The read timer resets whenever data is received, so long-running artifact
+downloads are bounded separately by `http_download_timeout`.
+"""
 env = "MISE_HTTP_TIMEOUT"
 type = "Duration"
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -905,6 +905,10 @@ impl Settings {
         duration::parse_duration(&self.http_timeout).unwrap()
     }
 
+    pub fn http_download_timeout(&self) -> Duration {
+        duration::parse_duration(&self.http_download_timeout).unwrap()
+    }
+
     /// Returns true if offline mode is enabled via setting or CLI flag/env var.
     pub fn offline(&self) -> bool {
         self.offline || *env::OFFLINE

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
@@ -370,40 +371,78 @@ impl Client {
         headers: &HeaderMap,
         pr: Option<&dyn SingleReport>,
     ) -> Result<()> {
+        self.download_file_with_headers_timeout(
+            url,
+            path,
+            headers,
+            pr,
+            Settings::get().http_download_timeout(),
+        )
+        .await
+    }
+
+    async fn download_file_with_headers_timeout<U: IntoUrl>(
+        &self,
+        url: U,
+        path: &Path,
+        headers: &HeaderMap,
+        pr: Option<&dyn SingleReport>,
+        total_timeout: Duration,
+    ) -> Result<()> {
         ensure!(!Settings::get().offline(), "offline mode is enabled");
         let url = url.into_url()?;
         debug!("GET Downloading {} to {}", &url, display_path(path));
         let parent = path.parent().unwrap();
         file::create_dir_all(parent)?;
+        let attempt = Arc::new(AtomicUsize::new(0));
+        let bytes_received = Arc::new(AtomicU64::new(0));
 
         // Retry the whole download so a mid-stream chunk failure restarts from
         // byte 0 instead of failing the install. send_once_with_https_fallback
         // (not send_with_https_fallback) is used inside to avoid retry-on-retry.
-        retry_async("GET", &url, || async {
-            let mut resp = self
-                .send_once_with_https_fallback(Method::GET, url.clone(), headers, "GET")
-                .await?;
-            if let Some(length) = resp.content_length()
-                && let Some(pr) = pr
-            {
-                // Reset progress on each attempt
-                pr.set_length(length);
-                pr.set_position(0);
-            }
-            let mut file = tempfile::NamedTempFile::with_prefix_in(path, parent)?;
-            while let Some(chunk) = resp.chunk().await? {
-                if crate::ui::ctrlc::is_cancelled() {
-                    bail!("download cancelled by user");
+        let download = retry_async("GET", &url, || {
+            let attempt = attempt.clone();
+            let bytes_received = bytes_received.clone();
+            let request_url = url.clone();
+            async move {
+                attempt.fetch_add(1, Ordering::Relaxed);
+                bytes_received.store(0, Ordering::Relaxed);
+                let mut resp = self
+                    .send_once_with_https_fallback(Method::GET, request_url, headers, "GET")
+                    .await?;
+                if let Some(length) = resp.content_length()
+                    && let Some(pr) = pr
+                {
+                    // Reset progress on each attempt
+                    pr.set_length(length);
+                    pr.set_position(0);
                 }
-                file.write_all(&chunk)?;
-                if let Some(pr) = pr {
-                    pr.inc(chunk.len() as u64);
+                let mut file = tempfile::NamedTempFile::with_prefix_in(path, parent)?;
+                while let Some(chunk) = resp.chunk().await? {
+                    if crate::ui::ctrlc::is_cancelled() {
+                        bail!("download cancelled by user");
+                    }
+                    file.write_all(&chunk)?;
+                    bytes_received.fetch_add(chunk.len() as u64, Ordering::Relaxed);
+                    if let Some(pr) = pr {
+                        pr.inc(chunk.len() as u64);
+                    }
                 }
+                file.persist(path)?;
+                Ok(())
             }
-            file.persist(path)?;
-            Ok(())
-        })
-        .await
+        });
+
+        match tokio::time::timeout(total_timeout, download).await {
+            Ok(result) => result,
+            Err(_) => bail!(
+                "HTTP download timed out after {} for {} (attempt {}, {} bytes received; change with `http_download_timeout` or env `MISE_HTTP_DOWNLOAD_TIMEOUT`)",
+                format_duration(total_timeout),
+                url,
+                attempt.load(Ordering::Relaxed),
+                bytes_received.load(Ordering::Relaxed),
+            ),
+        }
     }
 
     async fn send_with_https_fallback(
@@ -1085,6 +1124,7 @@ where
     let mut backoff = default_backoff_strategy(retries);
     let mut attempt: usize = 1;
     loop {
+        let started_at = Instant::now();
         match f().await {
             Ok(value) => return Ok(value),
             Err(err) => {
@@ -1095,8 +1135,13 @@ where
                     return Err(err);
                 };
                 warn!(
-                    "HTTP {} {} attempt {} failed (transient): {}; retrying in {:?}",
-                    verb_label, url, attempt, err, delay
+                    "HTTP {} {} attempt {} failed after {} (transient): {}; retrying in {:?}",
+                    verb_label,
+                    url,
+                    attempt,
+                    format_duration(started_at.elapsed()),
+                    err,
+                    delay
                 );
                 tokio::time::sleep(delay).await;
                 attempt += 1;
@@ -1334,6 +1379,36 @@ mod tests {
         (port, count, requests)
     }
 
+    async fn spawn_trickling_server() -> u16 {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut request = [0u8; 4096];
+            let _ = socket.read(&mut request).await;
+            if socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .is_err()
+            {
+                return;
+            }
+            loop {
+                if socket.write_all(b"x").await.is_err() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        });
+        port
+    }
+
     fn ok_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
     }
@@ -1568,6 +1643,38 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(resp.status().is_success());
         // Should have served 3 connections: two 502s + one 200.
         assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_total_timeout_bounds_trickling_response() {
+        let port = spawn_trickling_server().await;
+        let url = format!("http://127.0.0.1:{port}/artifact.tar.gz");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("artifact.tar.gz");
+        // The server sends a byte every 10ms, so the 100ms idle read timeout
+        // never fires. The separate total budget must still end the download.
+        let client = Client::new(Duration::from_millis(100), ClientKind::Http).unwrap();
+        let started_at = Instant::now();
+        let err = client
+            .download_file_with_headers_timeout(
+                &url,
+                &path,
+                &HeaderMap::new(),
+                None,
+                Duration::from_millis(75),
+            )
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+        assert!(message.contains("HTTP download timed out after 75.0ms"));
+        assert!(message.contains(&url));
+        assert!(message.contains("attempt 1"));
+        assert!(message.contains("bytes received"));
+        assert!(message.contains("http_download_timeout"));
+        assert!(message.contains("MISE_HTTP_DOWNLOAD_TIMEOUT"));
+        assert!(!path.exists());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -13,6 +12,7 @@ use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use reqwest::{ClientBuilder, IntoUrl, Method, Response};
 use std::sync::LazyLock as Lazy;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::OnceCell;
 use url::Url;
 
@@ -410,25 +410,37 @@ impl Client {
                 let mut resp = self
                     .send_once_with_https_fallback(Method::GET, request_url, headers, "GET")
                     .await?;
-                if let Some(length) = resp.content_length()
-                    && let Some(pr) = pr
-                {
-                    // Reset progress on each attempt
-                    pr.set_length(length);
+                if let Some(pr) = pr {
+                    if let Some(length) = resp.content_length() {
+                        pr.set_length(length);
+                    }
                     pr.set_position(0);
                 }
-                let mut file = tempfile::NamedTempFile::with_prefix_in(path, parent)?;
+                let (temp_file, file) = {
+                    let path = path.to_path_buf();
+                    let parent = parent.to_path_buf();
+                    tokio::task::spawn_blocking(move || {
+                        let temp_file = tempfile::NamedTempFile::with_prefix_in(path, parent)?;
+                        let file = temp_file.reopen()?;
+                        Ok::<_, std::io::Error>((temp_file, file))
+                    })
+                    .await??
+                };
+                let mut file = tokio::fs::File::from_std(file);
                 while let Some(chunk) = resp.chunk().await? {
                     if crate::ui::ctrlc::is_cancelled() {
                         bail!("download cancelled by user");
                     }
-                    file.write_all(&chunk)?;
+                    file.write_all(&chunk).await?;
                     bytes_received.fetch_add(chunk.len() as u64, Ordering::Relaxed);
                     if let Some(pr) = pr {
                         pr.inc(chunk.len() as u64);
                     }
                 }
-                file.persist(path)?;
+                file.shutdown().await?;
+                drop(file);
+                let path = path.to_path_buf();
+                tokio::task::spawn_blocking(move || temp_file.persist(path)).await??;
                 Ok(())
             }
         });
@@ -1655,16 +1667,19 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         // never fires. The separate total budget must still end the download.
         let client = Client::new(Duration::from_millis(100), ClientKind::Http).unwrap();
         let started_at = Instant::now();
-        let err = client
-            .download_file_with_headers_timeout(
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            client.download_file_with_headers_timeout(
                 &url,
                 &path,
                 &HeaderMap::new(),
                 None,
                 Duration::from_millis(75),
-            )
-            .await
-            .unwrap_err();
+            ),
+        )
+        .await
+        .expect("download timeout regression test exceeded its independent deadline");
+        let err = result.unwrap_err();
         let message = err.to_string();
 
         assert!(started_at.elapsed() < Duration::from_secs(1));
@@ -1672,6 +1687,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(message.contains(&url));
         assert!(message.contains("attempt 1"));
         assert!(message.contains("bytes received"));
+        assert!(!message.contains("attempt 1, 0 bytes received"));
         assert!(message.contains("http_download_timeout"));
         assert!(message.contains("MISE_HTTP_DOWNLOAD_TIMEOUT"));
         assert!(!path.exists());

--- a/src/http.rs
+++ b/src/http.rs
@@ -439,14 +439,12 @@ impl Client {
                 }
                 file.shutdown().await?;
                 drop(file);
-                let path = path.to_path_buf();
-                tokio::task::spawn_blocking(move || temp_file.persist(path)).await??;
-                Ok(())
+                Ok(temp_file)
             }
         });
 
-        match tokio::time::timeout(total_timeout, download).await {
-            Ok(result) => result,
+        let temp_file = match tokio::time::timeout(total_timeout, download).await {
+            Ok(result) => result?,
             Err(_) => bail!(
                 "HTTP download timed out after {} for {} (attempt {}, {} bytes received; change with `http_download_timeout` or env `MISE_HTTP_DOWNLOAD_TIMEOUT`)",
                 format_duration(total_timeout),
@@ -454,7 +452,15 @@ impl Client {
                 attempt.load(Ordering::Relaxed),
                 bytes_received.load(Ordering::Relaxed),
             ),
-        }
+        };
+
+        // Complete the atomic rename after the cancellable transfer budget. A
+        // blocking task cannot be cancelled once it starts, so keeping it out
+        // of `timeout` prevents us from returning an error while it can still
+        // install the destination in the background.
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || temp_file.persist(path)).await??;
+        Ok(())
     }
 
     async fn send_with_https_fallback(
@@ -1668,13 +1674,13 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let client = Client::new(Duration::from_millis(100), ClientKind::Http).unwrap();
         let started_at = Instant::now();
         let result = tokio::time::timeout(
-            Duration::from_secs(1),
+            Duration::from_secs(5),
             client.download_file_with_headers_timeout(
                 &url,
                 &path,
                 &HeaderMap::new(),
                 None,
-                Duration::from_millis(75),
+                Duration::from_millis(500),
             ),
         )
         .await
@@ -1682,8 +1688,8 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let err = result.unwrap_err();
         let message = err.to_string();
 
-        assert!(started_at.elapsed() < Duration::from_secs(1));
-        assert!(message.contains("HTTP download timed out after 75.0ms"));
+        assert!(started_at.elapsed() < Duration::from_secs(5));
+        assert!(message.contains("HTTP download timed out after 500.0ms"));
         assert!(message.contains(&url));
         assert!(message.contains("attempt 1"));
         assert!(message.contains("bytes received"));


### PR DESCRIPTION
## Summary

- bound each complete artifact download, including retries and backoff, with a new `http_download_timeout` setting
- default the total budget to 30 minutes while retaining `http_timeout` as the per-connect/per-read idle timeout
- include the URL, active attempt, and bytes received in the terminal timeout error
- include elapsed attempt time in transient retry warnings

## Root cause

Reqwest's read timeout resets after every successful read. A response that continues to trickle bytes can therefore keep an artifact download alive indefinitely, and the retry loop cannot advance until that attempt returns. GitHub Actions eventually cancelled affected jobs at its six-hour limit.

Using a separate total download budget preserves support for legitimately large downloads, which motivated switching away from a total request timeout in #2243.

## User impact

Artifact downloads now fail deterministically after 30 minutes by default instead of potentially consuming an entire CI job. Users on unusually slow connections can adjust the budget with `http_download_timeout` or `MISE_HTTP_DOWNLOAD_TIMEOUT`.

## Test plan

- `mise run test:unit http::tests::`
- `mise run lint`
- regression test with a server that sends one byte every 10 ms, keeping the idle read timeout alive while verifying the total budget terminates the download and removes the partial file

## Context

- https://github.com/jdx/mise/discussions/5904#discussioncomment-17404328
- https://github.com/reitzig/espanso-nice-dev-refs/actions/runs/27925022404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `http_download_timeout` to cap total wall-clock time for artifact downloads across retries and backoff.
  * Introduced `MISE_HTTP_DOWNLOAD_TIMEOUT` (Duration) to control this behavior.
  * Improved total-timeout handling with clearer errors including URL, attempt number, budget, and bytes received.
* **Documentation**
  * Clarified that `http_timeout` covers connection and per-read stall waits, separately from long-running download budgeting.
  * Updated retry warning logs to include elapsed time since the start of the attempt.
* **Tests**
  * Added a trickling-server scenario to confirm downloads stop within the total timeout and no output file is produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->