### PR TITLE
fix(config): let user tool options override registry defaults

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1052,7 +1052,9 @@ impl ConfigFile for MiseToml {
                             ba_opts.opts.entry(k).or_insert(v);
                         }
                     }
-                    // Copy os, depends, and install_env from config (not cached)
+                    // Replace config-owned fields rather than merging them with cached values.
+                    // This intentionally supersedes apply_overrides above so omitted values clear
+                    // stale cache and install_env does not retain cached entries.
                     ba_opts.os = options.os.clone();
                     ba_opts.depends = options.depends.clone();
                     ba_opts.install_env = options.install_env.clone();

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1029,7 +1029,7 @@ impl ConfigFile for MiseToml {
                     ba_opts.opts.retain(|k, _| {
                         !crate::backend::is_install_time_option_key_for_type(&backend_type, k)
                     });
-                    ba_opts.merge(&options.opts);
+                    ba_opts.apply_overrides(&options);
                     // Re-apply registry defaults for install-time keys not overridden by user.
                     // The filtering above strips both stale install-state cache AND registry
                     // defaults. We want to keep registry defaults while discarding stale cache.
@@ -3193,6 +3193,28 @@ run = 'echo "template"'
             opts2.get("pipx_args"),
             Some("--include-deps"),
             "non-overridden registry default pipx_args should still be preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_table_syntax_user_opts_override_registry_defaults() {
+        let _config = Config::get().await.unwrap();
+        let cf = parse(formatdoc! {r#"
+            [tools]
+            podman = {{ version = "latest", rename_exe = "podman-remote" }}
+        "#});
+        let trs = cf.to_tool_request_set().unwrap();
+        let podman = trs
+            .tools
+            .iter()
+            .find(|(ba, _)| ba.short == "podman")
+            .map(|(_, reqs)| reqs)
+            .expect("podman should be in tool request set");
+
+        assert_eq!(
+            podman[0].options().get("rename_exe"),
+            Some("podman-remote"),
+            "user-provided rename_exe should override the registry default"
         );
     }
 

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -303,12 +303,6 @@ impl ToolOptions {
             .collect()
     }
 
-    pub fn merge(&mut self, other: &IndexMap<String, toml::Value>) {
-        for (key, value) in other {
-            self.opts.entry(key.to_string()).or_insert(value.clone());
-        }
-    }
-
     pub fn apply_overrides(&mut self, overrides: &ToolVersionOptions) {
         for (key, value) in &overrides.opts {
             self.opts.insert(key.clone(), value.clone());
@@ -1264,36 +1258,6 @@ mod tests {
         );
         assert!(resolved.has_key_from_sources("install_env", &[ToolOptionSource::Config]));
         assert!(resolved.has_key_from_sources("depends", &[ToolOptionSource::InlineBackendArg]));
-    }
-
-    #[test]
-    fn test_merge_functionality() {
-        let mut opts = IndexMap::new();
-        let mut platforms = toml::map::Map::new();
-        let mut macos = toml::map::Map::new();
-        macos.insert(
-            "url".to_string(),
-            toml::Value::String("https://example.com/macos-x64.tar.gz".to_string()),
-        );
-        platforms.insert("macos-x64".to_string(), toml::Value::Table(macos));
-        opts.insert("platforms".to_string(), toml::Value::Table(platforms));
-
-        let mut tool_opts = ToolVersionOptions {
-            opts: opts.into(),
-            ..Default::default()
-        };
-
-        assert!(tool_opts.contains_key("platforms.macos-x64.url"));
-
-        let mut new_opts = IndexMap::new();
-        new_opts.insert(
-            "simple_option".to_string(),
-            toml::Value::String("value".to_string()),
-        );
-        tool_opts.merge(&new_opts);
-
-        assert!(tool_opts.contains_key("platforms.macos-x64.url"));
-        assert!(tool_opts.contains_key("simple_option"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- apply table-syntax user tool options as overrides after stripping install-time cached options
- preserve registry defaults by re-applying them only for keys the user did not set
- cover overriding Podman's non-install-time `rename_exe` registry option

## Root cause
Table-syntax tool options were merged with fill-only semantics, so an existing registry value won over the user's value. Install-time options appeared to work because they were stripped before that merge.

I added `apply_overrides` in #9306 but missed this older table-syntax path. Sorry about that.

## Validation
- `mise run lint-fix`
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `CARGO_TERM_COLOR=always RUST_TEST_THREADS=1 cargo test --all-features test_table_syntax_`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User-provided table-style tool options now correctly override corresponding registry defaults (for example, `rename_exe` for Podman).
  * Tool request preparation now avoids retaining stale cached configuration for install-time behaviors when those fields are omitted, ensuring the latest specified settings are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->