### PR TITLE
fix(github): treat bin/rename_exe as install-time options

### DIFF
--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -245,6 +245,9 @@ pub fn install_time_option_keys() -> Vec<String> {
         "no_app".into(),
         "matching".into(),
         "matching_regex".into(),
+        "bin".into(),
+        "rename_exe".into(),
+        "bin_path".into(),
     ]
 }
 
@@ -2492,6 +2495,22 @@ mod tests {
         let keys = install_time_option_keys();
         assert!(keys.contains(&"matching".to_string()));
         assert!(keys.contains(&"matching_regex".to_string()));
+    }
+
+    #[test]
+    fn test_layout_options_are_install_time_keys() {
+        for backend_type in [
+            BackendType::Github,
+            BackendType::Gitlab,
+            BackendType::Forgejo,
+        ] {
+            for key in ["bin", "rename_exe", "bin_path"] {
+                assert!(
+                    crate::backend::is_install_time_option_key_for_type(&backend_type, key),
+                    "{key} must be an install-time key for {backend_type:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1023,7 +1023,7 @@ impl ConfigFile for MiseToml {
                     // Start with cached options but filter out install-time-only options
                     // when config provides its own options. This allows:
                     // - Changing url/asset_pattern/checksum without reinstall issues
-                    // - Preserving post-install options like bin_path for binary discovery
+                    // - Replacing stale layout options like bin_path with current config values
                     let mut ba_opts = ba.opts().clone();
                     let backend_type = ba.backend_type();
                     ba_opts.opts.retain(|k, _| {


### PR DESCRIPTION
## Summary

- classify `bin`, `rename_exe`, and `bin_path` as install-time options for the unified GitHub backend
- apply the classification to GitHub, GitLab, and Forgejo through the existing backend routing
- add a regression test covering all three backend types

## Root cause

Cached layout-affecting values could survive when current configuration supplied replacement options, allowing stale install layout settings to be re-applied from registry defaults.

## Layout options

- `bin` selects the installed executable name. For raw or compressed artifacts it determines the destination filename; for archives it selects and renames the extracted executable.
- `rename_exe` renames the downloaded or extracted executable, directly changing the filename stored in the install directory.
- `bin_path` selects the destination directory for raw or compressed artifacts. For archives it also affects component stripping and scopes where `bin` or `rename_exe` finds and renames the executable.

Because all three can change the files or directory tree under the install path, current config must replace stale cached values before registry defaults are re-applied.

## Impact

Current config values for these layout options now replace stale cached values consistently with the existing HTTP/S3 classifications.

## Validation

- `mise run format --check`
- `mise x -- cargo test test_layout_options_are_install_time_keys`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git layout settings are now correctly recognized as install-time options across GitHub, GitLab, and Forgejo integrations.
  * Improved consistency when configuring binary paths, executable renaming, and related installation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
