### PR TITLE
fix(cargo): own cargo-binstall compile fallback

### DIFF
--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -66,9 +66,13 @@ Some Cargo settings are only meaningful when mise runs `cargo install`. If `carg
 installs a prebuilt binary, Cargo build settings and `cargo install` behavior do not affect that
 artifact. Set `cargo.binstall = false` when you need Cargo settings to control the install.
 
-When mise uses `cargo-binstall`, mise runs `cargo-binstall` once and lets `cargo-binstall` handle
-its own fallback order, including its final fallback to compiling with `cargo install`. mise does
-not retry with a separate `cargo install` command if `cargo-binstall` exits with an error.
+When mise uses external `cargo-binstall`, it disables cargo-binstall's `compile` strategy. If
+cargo-binstall reports that no prebuilt artifact is available (exit code 94), mise runs
+`cargo install` itself. Other cargo-binstall errors do not trigger this fallback. When
+`cargo.binstall_only = true`, Cargo tools without an explicit Git source must be installed by cargo-binstall:
+mise does not fall back to `cargo install`, and options that require `cargo install` produce an
+error. Explicit Git sources are unaffected because they always use `cargo install --git` and are
+never eligible for cargo-binstall.
 
 By default, mise disables external `cargo-binstall`'s use of the third-party
 [cargo-quickinstall](https://github.com/cargo-bins/cargo-quickinstall) artifact host. This is
@@ -90,9 +94,9 @@ go in `[tools]` in `mise.toml`.
 When `cargo-binstall` is available, mise uses it for registry installs unless a tool option needs
 `cargo install` to build from source.
 
-For options that do not skip `cargo-binstall`, any source-build fallback is handled by
-`cargo-binstall` itself. mise does not perform an additional compile fallback after
-`cargo-binstall` fails.
+For options that do not skip `cargo-binstall`, mise disables cargo-binstall's compile strategy and
+runs `cargo install` itself only when cargo-binstall exits with code 94 to report that no prebuilt
+artifact is available.
 
 | Option                     | `cargo-binstall` behavior                                                                |
 | -------------------------- | ---------------------------------------------------------------------------------------- |
@@ -168,5 +172,5 @@ pass `false` to disable:
 "cargo:https://github.com/username/demo" = { version = "latest", locked = false }
 ```
 
-This option does not cause mise to skip `cargo-binstall`; it only affects the install if
-`cargo-binstall` itself falls back to compiling with `cargo install`.
+This option does not cause mise to skip `cargo-binstall`; it affects mise's `cargo install`
+fallback when cargo-binstall reports that no prebuilt artifact is available.

--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -77,9 +77,11 @@ never eligible for cargo-binstall.
 By default, mise disables external `cargo-binstall`'s use of the third-party
 [cargo-quickinstall](https://github.com/cargo-bins/cargo-quickinstall) artifact host. This is
 separate from crate-author GitHub releases and artifacts declared in `package.metadata.binstall`.
-Set `cargo.binstall_quickinstall = true` to allow that strategy. This setting does not affect
-mise's native `cargo.binstall_native` path, which does not use quickinstall. Set `cargo.binstall =
-false` to disable binstall entirely.
+Together with the always-disabled compile strategy, the default external cargo-binstall flag is
+`--disable-strategies compile,quick-install`. Set `cargo.binstall_quickinstall = true` to allow
+quick-install; mise then passes `--disable-strategies compile`. This setting does not affect mise's
+native `cargo.binstall_native` path, which does not use quickinstall. Set `cargo.binstall = false`
+to disable binstall entirely.
 
 <script setup>
 import Settings from '/components/settings.vue';

--- a/e2e/backend/test_cargo_binstall_token
+++ b/e2e/backend/test_cargo_binstall_token
@@ -7,8 +7,13 @@ cat >~/bin/cargo-binstall <<'EOF'
 #!/usr/bin/env bash
 echo "token=$GITHUB_TOKEN"
 echo "args=$*"
+exit "${BINSTALL_EXIT_CODE:-0}"
 EOF
-chmod u+x ~/bin/cargo-binstall
+cat >~/bin/cargo <<'EOF'
+#!/usr/bin/env bash
+echo "cargo-args=$*"
+EOF
+chmod u+x ~/bin/cargo-binstall ~/bin/cargo
 export PATH="$HOME/bin:$PATH"
 
 # This should reuse the existing GITHUB_TOKEN variable
@@ -23,8 +28,31 @@ assert_contains "GITHUB_API_TOKEN=foobar GITHUB_TOKEN=barquz mise install -f car
 # This should prefer MISE_GITHUB_TOKEN
 assert_contains "MISE_GITHUB_TOKEN=foobar GITHUB_API_TOKEN=barquz GITHUB_TOKEN=barquz mise install -f cargo:eza@0.18.24 2>&1" "token=foobar"
 
-# quick-install should be disabled by default
-assert_contains "mise install -f cargo:eza@0.18.24 2>&1" "args=-y --disable-strategies quick-install eza@0.18.24"
+# compile and quick-install should be disabled by default
+assert_contains "mise install -f cargo:eza@0.18.24 2>&1" "args=-y --disable-strategies compile,quick-install eza@0.18.24"
 
-# The setting should allow cargo-binstall's quick-install strategy
-assert_not_contains "MISE_CARGO_BINSTALL_QUICKINSTALL=1 mise install -f cargo:eza@0.18.24 2>&1" "--disable-strategies"
+# The setting should allow quick-install while compile remains disabled
+assert_contains "MISE_CARGO_BINSTALL_QUICKINSTALL=1 mise install -f cargo:eza@0.18.24 2>&1" "args=-y --disable-strategies compile eza@0.18.24"
+
+# Exit code 94 means no prebuilt artifact, so mise should run cargo install
+assert_contains "BINSTALL_EXIT_CODE=94 mise install -f cargo:eza@0.18.24 2>&1" "cargo-args=install eza@0.18.24 --locked"
+
+# Other cargo-binstall failures must not fall back to cargo install
+output="$(BINSTALL_EXIT_CODE=1 mise install -f cargo:eza@0.18.24 2>&1)" && fail "cargo-binstall exit code 1 unexpectedly succeeded"
+assert_not_contains_text "$output" "cargo-args="
+
+# binstall_only must not allow mise's cargo install fallback
+output="$(MISE_CARGO_BINSTALL_ONLY=1 BINSTALL_EXIT_CODE=94 mise install -f cargo:eza@0.18.24 2>&1)" && fail "cargo-binstall exit code 94 unexpectedly succeeded with binstall_only"
+assert_not_contains_text "$output" "cargo-args="
+
+# Explicit git sources use cargo install even when binstall_only is enabled
+output="$(MISE_CARGO_BINSTALL_ONLY=1 mise install -f cargo:https://github.com/example/example@HEAD 2>&1)"
+assert_contains_text "$output" "cargo-args=install --git=https://github.com/example/example"
+assert_not_contains_text "$output" "example@example@HEAD"
+
+# Cargo-only options on explicit git sources remain unaffected by binstall_only
+cat >mise.toml <<'EOF'
+[tools]
+"cargo:https://github.com/example/features" = { version = "HEAD", features = "extra" }
+EOF
+assert_contains "MISE_CARGO_BINSTALL_ONLY=1 mise install 2>&1" "cargo-args=install --git=https://github.com/example/features --locked --features=extra"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -653,7 +653,7 @@
             },
             "binstall_only": {
               "default": false,
-              "description": "Only use cargo-binstall for installation, fail if not available.",
+              "description": "Require cargo-binstall for Cargo tools without an explicit Git source. Fail if no prebuilt binary is available or if tool options require cargo install.",
               "type": "boolean"
             },
             "binstall_quickinstall": {

--- a/settings.toml
+++ b/settings.toml
@@ -279,9 +279,12 @@ When `cargo-binstall` installs a prebuilt binary, Cargo build settings and `carg
 behavior do not affect the downloaded artifact. Set `cargo.binstall = false` to force
 `cargo install` when you need Cargo settings to control the install.
 
-When mise invokes `cargo-binstall`, `cargo-binstall` handles its own fallback order, including
-its final fallback to compiling with `cargo install`. mise does not retry with a separate
-`cargo install` command if `cargo-binstall` exits with an error.
+When mise invokes external `cargo-binstall`, it disables cargo-binstall's `compile` strategy.
+If cargo-binstall reports that no prebuilt artifact is available (exit code 94), mise runs
+`cargo install` itself. Other cargo-binstall errors do not trigger this fallback. When
+`cargo.binstall_only = true`, Cargo tools without an explicit Git source must be installed by cargo-binstall:
+mise does not fall back to `cargo install`, and options that require `cargo install` produce an
+error. Explicit Git sources are unaffected because they always use `cargo install --git`.
 
 You can install it with mise:
 
@@ -319,7 +322,7 @@ type = "Bool"
 
 [cargo.binstall_only]
 default = false
-description = "Only use cargo-binstall for installation, fail if not available."
+description = "Require cargo-binstall for Cargo tools without an explicit Git source. Fail if no prebuilt binary is available or if tool options require cargo install."
 env = "MISE_CARGO_BINSTALL_ONLY"
 type = "Bool"
 
@@ -332,9 +335,10 @@ the third-party [cargo-quickinstall](https://github.com/cargo-bins/cargo-quickin
 artifacts are separate from crate-author GitHub releases and artifacts declared in
 `package.metadata.binstall`.
 
-By default, mise passes `--disable-strategies quick-install` when invoking the external
-`cargo-binstall` binary. This setting does not affect mise's `cargo.binstall_native` path, which
-does not use quickinstall.
+By default, mise passes `--disable-strategies compile,quick-install` when invoking the external
+`cargo-binstall` binary. The `compile` strategy is always disabled; setting this to `true` changes
+the flag to `--disable-strategies compile`. This setting does not affect mise's
+`cargo.binstall_native` path, which does not use quickinstall.
 
 This only controls external `cargo-binstall`'s quick-install strategy. To disable binstall, set
 `cargo.binstall = false`.

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -21,6 +21,7 @@ use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::env::GITHUB_TOKEN;
+use crate::errors::Error;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
@@ -29,6 +30,9 @@ use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 pub struct CargoBackend {
     ba: Arc<BackendArg>,
 }
+
+const CARGO_BINSTALL_NO_FALLBACK_EXIT_CODE: i32 = 94;
+const CARGO_BINSTALL_DEFAULT_DISABLED_STRATEGIES: &[&str] = &["compile"];
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct CargoOptions<'a> {
@@ -114,7 +118,6 @@ enum BinstallStatus {
     Enabled(PathBuf),
     Disabled,
     Unavailable,
-    UnsupportedOptions(Vec<&'static str>),
 }
 
 #[async_trait]
@@ -190,11 +193,86 @@ impl Backend for CargoBackend {
 
         let config = ctx.config.clone();
         let install_arg = format!("{}@{}", self.tool_name(), tv.version);
-        let registry_name = &Settings::get().cargo.registry_name;
 
-        let cmd = CmdLineRunner::new("cargo").arg("install");
-        let mut cmd = if let Some(url) = self.git_url() {
-            let mut cmd = cmd.arg(format!("--git={url}"));
+        let cargo_install_required_options =
+            Self::cargo_install_required_options(&tv.request.options());
+        if self.git_url().is_none() && cargo_install_required_options.is_empty() {
+            match self.binstall_status(&config, Some(&ctx.ts)).await {
+                BinstallStatus::Enabled(cargo_binstall) => {
+                    let mut cmd = CmdLineRunner::new(cargo_binstall).arg("-y");
+                    let disabled_strategies = CARGO_BINSTALL_DEFAULT_DISABLED_STRATEGIES
+                        .iter()
+                        .copied()
+                        .chain(
+                            (!Settings::get().cargo.binstall_quickinstall)
+                                .then_some("quick-install"),
+                        )
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    cmd = cmd.args(["--disable-strategies", &disabled_strategies]);
+                    if let Some(token) = &*GITHUB_TOKEN {
+                        cmd = cmd.env("GITHUB_TOKEN", token)
+                    }
+                    let result = self
+                        .execute_install_command(ctx, &tv, cmd.arg(&install_arg))
+                        .await;
+                    if result.as_ref().is_ok() {
+                        return Ok(tv.clone());
+                    }
+                    if Settings::get().cargo.binstall_only
+                        || !result.as_ref().is_err_and(|err| {
+                            Error::get_exit_status(err)
+                                == Some(CARGO_BINSTALL_NO_FALLBACK_EXIT_CODE)
+                        })
+                    {
+                        result?;
+                    }
+                    info!("cargo-binstall found no prebuilt binary; falling back to cargo install");
+                }
+                BinstallStatus::Disabled if Settings::get().cargo.binstall_only => {
+                    bail!("cargo-binstall is disabled, but cargo.binstall_only is set");
+                }
+                _ if Settings::get().cargo.binstall_only => {
+                    bail!("cargo-binstall is not available, but cargo.binstall_only is set");
+                }
+                BinstallStatus::Unavailable => match Settings::get().cargo.binstall_native {
+                    Some(true) => {
+                        Settings::get().ensure_experimental("cargo.binstall_native")?;
+                        if self
+                            .native_binstall(ctx, &tv, NativeBinstallAction::Install)
+                            .await?
+                        {
+                            return Ok(tv.clone());
+                        }
+                    }
+                    Some(false) => {}
+                    None if native_binstall::rollout_warning_active() => {
+                        self.native_binstall(ctx, &tv, NativeBinstallAction::WarnOnly)
+                            .await?;
+                    }
+                    None => {}
+                },
+                _ => {}
+            }
+        } else if Settings::get().cargo.binstall_only
+            && self.git_url().is_none()
+            && !cargo_install_required_options.is_empty()
+        {
+            let options = format_tool_options(&cargo_install_required_options);
+            bail!(
+                "cargo-binstall cannot honor cargo install-only tool option(s): {options}\n\
+                hint: Remove the option(s), or disable cargo.binstall_only to allow cargo install"
+            );
+        } else if !cargo_install_required_options.is_empty() {
+            let options = format_tool_options(&cargo_install_required_options);
+            info!(
+                "not using cargo-binstall because cargo install-only tool option(s) are specified: {options}"
+            );
+        }
+
+        let mut cmd = CmdLineRunner::new("cargo").arg("install");
+        if let Some(url) = self.git_url() {
+            cmd = cmd.arg(format!("--git={url}"));
             if let Some(rev) = tv.version.strip_prefix("rev:") {
                 cmd = cmd.arg(format!("--rev={rev}"));
             } else if let Some(branch) = tv.version.strip_prefix("branch:") {
@@ -208,99 +286,10 @@ impl Backend for CargoBackend {
       * mise use cargo:eza-community/eza@branch:main"#,
                 ))?;
             }
-            cmd
         } else {
-            match self.binstall_status(&config, Some(&ctx.ts), &tv).await {
-                BinstallStatus::Enabled(cargo_binstall) => {
-                    let mut cmd = CmdLineRunner::new(cargo_binstall).arg("-y");
-                    if !Settings::get().cargo.binstall_quickinstall {
-                        cmd = cmd.args(["--disable-strategies", "quick-install"]);
-                    }
-                    if let Some(token) = &*GITHUB_TOKEN {
-                        cmd = cmd.env("GITHUB_TOKEN", token)
-                    }
-                    cmd.arg(install_arg)
-                }
-                BinstallStatus::UnsupportedOptions(options)
-                    if Settings::get().cargo.binstall_only =>
-                {
-                    let options = format_tool_options(&options);
-                    bail!(
-                        "cargo-binstall cannot honor cargo install-only tool option(s): {options}\n\
-                        hint: Remove the option(s), or disable cargo.binstall_only to allow cargo install"
-                    );
-                }
-                BinstallStatus::Disabled if Settings::get().cargo.binstall_only => {
-                    bail!("cargo-binstall is disabled, but cargo.binstall_only is set");
-                }
-                _ if Settings::get().cargo.binstall_only => {
-                    bail!("cargo-binstall is not available, but cargo.binstall_only is set");
-                }
-                BinstallStatus::Unavailable => {
-                    match Settings::get().cargo.binstall_native {
-                        Some(true) => {
-                            Settings::get().ensure_experimental("cargo.binstall_native")?;
-                            if self
-                                .native_binstall(ctx, &tv, NativeBinstallAction::Install)
-                                .await?
-                            {
-                                return Ok(tv.clone());
-                            }
-                        }
-                        Some(false) => {}
-                        None if native_binstall::rollout_warning_active() => {
-                            self.native_binstall(ctx, &tv, NativeBinstallAction::WarnOnly)
-                                .await?;
-                        }
-                        None => {}
-                    }
-                    cmd.arg(install_arg)
-                }
-                BinstallStatus::UnsupportedOptions(options) => {
-                    let options = format_tool_options(&options);
-                    info!(
-                        "not using cargo-binstall because cargo install-only tool option(s) are specified: {options}"
-                    );
-                    cmd.arg(install_arg)
-                }
-                _ => cmd.arg(install_arg),
-            }
-        };
-
-        let request_options = tv.request.options();
-        let opts = CargoOptions::new(&request_options);
-        if let Some(bin) = opts.bin() {
-            cmd = cmd.arg(format!("--bin={bin}"));
+            cmd = cmd.arg(&install_arg);
         }
-        if opts.locked() {
-            cmd = cmd.arg("--locked");
-        }
-        if let Some(features) = opts.features() {
-            cmd = cmd.arg(format!("--features={features}"));
-        }
-        if opts.default_features_disabled() {
-            cmd = cmd.arg("--no-default-features");
-        }
-        if let Some(c) = opts.crate_arg() {
-            cmd = cmd.arg(c);
-        }
-        if let Some(registry_name) = registry_name {
-            cmd = cmd.arg(format!("--registry={registry_name}"));
-        }
-
-        cmd.arg("--root")
-            .arg(tv.install_path())
-            .with_pr(ctx.pr.as_ref())
-            .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-            .envs(tv.install_env())
-            .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
-            .prepend_path(
-                self.dependency_toolset(&ctx.config)
-                    .await?
-                    .list_paths(&ctx.config)
-                    .await,
-            )?
-            .execute()?;
+        self.execute_install_command(ctx, &tv, cmd).await?;
 
         Ok(tv.clone())
     }
@@ -331,6 +320,48 @@ impl CargoBackend {
         Self { ba: Arc::new(ba) }
     }
 
+    async fn execute_install_command<'a>(
+        &'a self,
+        ctx: &'a InstallContext,
+        tv: &'a ToolVersion,
+        mut cmd: CmdLineRunner<'a>,
+    ) -> Result<()> {
+        let request_options = tv.request.options();
+        let opts = CargoOptions::new(&request_options);
+        if let Some(bin) = opts.bin() {
+            cmd = cmd.arg(format!("--bin={bin}"));
+        }
+        if opts.locked() {
+            cmd = cmd.arg("--locked");
+        }
+        if let Some(features) = opts.features() {
+            cmd = cmd.arg(format!("--features={features}"));
+        }
+        if opts.default_features_disabled() {
+            cmd = cmd.arg("--no-default-features");
+        }
+        if let Some(c) = opts.crate_arg() {
+            cmd = cmd.arg(c);
+        }
+        if let Some(registry_name) = &Settings::get().cargo.registry_name {
+            cmd = cmd.arg(format!("--registry={registry_name}"));
+        }
+
+        cmd.arg("--root")
+            .arg(tv.install_path())
+            .with_pr(ctx.pr.as_ref())
+            .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+            .envs(tv.install_env())
+            .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
+            .prepend_path(
+                self.dependency_toolset(&ctx.config)
+                    .await?
+                    .list_paths(&ctx.config)
+                    .await,
+            )?
+            .execute()
+    }
+
     fn cargo_install_required_options(opts: &ToolVersionOptions) -> Vec<&'static str> {
         let mut options = vec![];
         if CargoOptions::new(opts)
@@ -348,19 +379,9 @@ impl CargoBackend {
         options
     }
 
-    async fn binstall_status(
-        &self,
-        config: &Arc<Config>,
-        ts: Option<&Toolset>,
-        tv: &ToolVersion,
-    ) -> BinstallStatus {
+    async fn binstall_status(&self, config: &Arc<Config>, ts: Option<&Toolset>) -> BinstallStatus {
         if !Settings::get().cargo.binstall {
             return BinstallStatus::Disabled;
-        }
-        let opts = tv.request.options();
-        let cargo_install_required_options = Self::cargo_install_required_options(&opts);
-        if !cargo_install_required_options.is_empty() {
-            return BinstallStatus::UnsupportedOptions(cargo_install_required_options);
         }
         if let Some(cargo_binstall) = self
             .dependency_path_for_install(config, ts, "cargo-binstall")


### PR DESCRIPTION
## Summary

- always disable the external cargo-binstall `compile` strategy
- when cargo-binstall exits with code 94 (`NoFallbackToCargoInstall`), run `cargo install` through mise
- propagate every other non-zero cargo-binstall exit without a compile fallback
- combine disabled strategies with `join(",")`, including `compile,quick-install` when `cargo.binstall_quickinstall = false`
- inline binstall eligibility checks and keep a single `cargo install` construction path

## `cargo.binstall_only` behavior

This PR makes `cargo.binstall_only` stricter for Cargo tools without an explicit Git source. External cargo-binstall previously handled its own `compile` strategy, so `cargo.binstall_only = true` could still compile from source inside cargo-binstall. mise now disables that strategy and does not run its own `cargo install` fallback when `cargo.binstall_only` is enabled.

The resulting contract is:

- Cargo tool without an explicit Git source and with binstall-compatible options: require cargo-binstall and fail if no compatible prebuilt binary exists
- Cargo tool without an explicit Git source but with Cargo-only options such as `features` or `default-features = false`: fail because those options require `cargo install`
- explicit Git source: continue to use `cargo install --git`; Git sources have never been eligible for cargo-binstall and remain outside `cargo.binstall_only`

The setting description and Cargo backend documentation now state this boundary explicitly.

## Motivation

This makes mise the single owner of the source-install fallback and gives `cargo.binstall_only` its intended binary-only behavior for eligible non-Git Cargo tools. It also aligns external cargo-binstall behavior with the native binstall flow.

This PR does not change the quickinstall default, native binstall behavior or rollout dates, or explicit Git installation behavior.

## Validation

- `cargo check --all-features`
- `mise run render:schema`
- `mise run lint-fix`
- `mise run test:e2e e2e/backend/test_cargo_binstall_token`

The focused E2E covers strategy disablement, exit-code-94 fallback, non-94 propagation, `cargo.binstall_only` fallback suppression, and the explicit Git-source exception.