### PR TITLE
fix(npm): isolate version queries from project cwd

### DIFF
--- a/e2e/backend/test_npm_devengines
+++ b/e2e/backend/test_npm_devengines
@@ -17,8 +17,10 @@ cat >package.json <<'EOF'
 }
 EOF
 
-# Sanity: bare npm view in this cwd fails under the project's devEngines.
-assert_fail "npm view cowsay version --json"
+# Sanity: project-cwd npm view fails under the project's devEngines.
+# Use mise-managed npm (from `mise use node`) so this does not depend on a
+# system npm that may predate npm 10.4's onFail:error support.
+assert_fail "mise x -- npm view cowsay version --json"
 
 assert_contains "mise latest npm:cowsay" "1."
 assert_contains "mise x npm:cowsay@1.6.0 -- cowsay hi" "hi"

--- a/e2e/backend/test_npm_devengines
+++ b/e2e/backend/test_npm_devengines
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Regression for https://github.com/jdx/mise/discussions/10492
+# Project package.json with non-npm devEngines must not block npm: resolution.
+
+export NPM_CONFIG_FUND=false
+export MISE_GPG_VERIFY=false
+
+mise use node
+
+cat >package.json <<'EOF'
+{
+  "name": "repro",
+  "private": true,
+  "devEngines": {
+    "packageManager": { "name": "bun", "version": "1", "onFail": "error" }
+  }
+}
+EOF
+
+# Sanity: bare npm view in this cwd fails under the project's devEngines.
+assert_fail "npm view cowsay version --json"
+
+assert_contains "mise latest npm:cowsay" "1."
+assert_contains "mise x npm:cowsay@1.6.0 -- cowsay hi" "hi"

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -21,7 +21,7 @@ use jiff::Timestamp;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{fmt::Debug, sync::Arc};
 use tokio::sync::Mutex as TokioMutex;
 
@@ -307,11 +307,14 @@ impl Backend for NPMBackend {
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
-        // Use npm CLI to respect custom registry configurations
+        // Use npm CLI so user/global .npmrc and NPM_CONFIG_* registry settings apply.
+        // --prefix points at a neutral cache dir so project package.json (e.g. devEngines)
+        // cannot fail the query. Install already uses --prefix the same way.
         self.ensure_npm_for_version_check(config).await;
         timeout::run_with_timeout_async(
             async || {
                 let env = self.dependency_env(config).await?;
+                let prefix = Self::npm_meta_prefix()?;
 
                 let raw = cmd!(
                     NPM_PROGRAM,
@@ -319,7 +322,9 @@ impl Backend for NPMBackend {
                     self.tool_name(),
                     "versions",
                     "time",
-                    "--json"
+                    "--json",
+                    "--prefix",
+                    &prefix
                 )
                 .full_env(&env)
                 .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
@@ -347,11 +352,19 @@ impl Backend for NPMBackend {
                     .get_or_try_init_async(async || {
                         // Always use npm for getting version info since bun info requires package.json
                         // bun is only used for actual package installation
-                        let raw =
-                            cmd!(NPM_PROGRAM, "view", this.tool_name(), "dist-tags", "--json")
-                                .full_env(this.dependency_env(config).await?)
-                                .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-                                .read()?;
+                        let prefix = Self::npm_meta_prefix()?;
+                        let raw = cmd!(
+                            NPM_PROGRAM,
+                            "view",
+                            this.tool_name(),
+                            "dist-tags",
+                            "--json",
+                            "--prefix",
+                            &prefix
+                        )
+                        .full_env(this.dependency_env(config).await?)
+                        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+                        .read()?;
                         let dist_tags: Value = serde_json::from_str(&raw)?;
                         npm_view_latest_dist_tag(&dist_tags)
                     })
@@ -712,6 +725,14 @@ impl NPMBackend {
             }
         };
         semver_is_at_least(&output, min_version).unwrap_or(false)
+    }
+
+    /// Empty prefix used for `npm view` so project `package.json` / `devEngines`
+    /// cannot block mise-owned metadata queries. User and global npm config still apply.
+    fn npm_meta_prefix() -> eyre::Result<PathBuf> {
+        let dir = crate::dirs::CACHE.join("npm-meta");
+        crate::file::create_dir_all(&dir)?;
+        Ok(dir)
     }
 
     /// Check dependencies for version checking (always needs npm)


### PR DESCRIPTION
## Summary

- Run mise-owned `npm view` calls with `--prefix` against a neutral cache dir (`$MISE_CACHE_DIR/npm-meta`) so project-local npm config / `package.json` cannot affect version resolution.
- Aligns metadata queries with install (details below).
- Adds an e2e regression covering the Bun `devEngines` failure mode from the discussion.

Addresses https://github.com/jdx/mise/discussions/10492.

### Aligning `npm view` with install

Before this change, resolve and install disagreed about which project files npm consulted:

| Call | Working context | Project `package.json` | Project `.npmrc` |
| --- | --- | --- | --- |
| `npm view` (latest / ls-remote) | process cwd | applied | applied |
| `npm install -g --prefix <install_path>` | `--prefix` = install dir | ignored | ignored |

So a project could influence version lookup (registry, `devEngines`, etc.) even though the eventual install already ignored that same project config. The reported failure was `EBADDEVENGINES` when `devEngines.packageManager` required Bun with `onFail: "error"`, but any project-local npm policy that runs on `view` could hit the same asymmetry.

This PR gives `npm view` the same kind of isolation install already had: `--prefix` points at an empty cache directory. User/global `.npmrc` and `NPM_CONFIG_*` still apply; only the project tree is skipped. That matches install behavior rather than newly dropping project registry config for installs.

### E2E regression

`e2e/backend/test_npm_devengines` builds a project `package.json` with Bun `devEngines` + `onFail: "error"`, asserts bare `npm view` fails in that cwd, then checks that `mise latest npm:cowsay` and `mise x npm:cowsay@1.6.0` still succeed.

## Test plan
- [x] `mise run test:e2e e2e/backend/test_npm_devengines`
- [ ] Confirm `mise latest npm:cowsay` / `mise use npm:cowsay` still work in a normal project without `devEngines`
- [ ] Optional: project with only a custom `.npmrc` registry — resolve/install both use user/global config (project `.npmrc` was already ignored for install)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed npm package version lookups so they work reliably in projects with restrictive `devEngines` settings.
  * Ensured npm package discovery and execution continue to function independently of project-specific package manager constraints.
* **Tests**
  * Added regression coverage for resolving npm package versions and running npm-installed commands in affected projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->