### PR TITLE
registry: add nika (github:supernovae-st/nika)

### DIFF
--- a/registry/nika.toml
+++ b/registry/nika.toml
@@ -1,0 +1,3 @@
+backends = ["github:supernovae-st/nika"]
+description = "Workflow language for AI - one YAML file, 4 verbs, one Rust binary; statically checked before any token is spent"
+test = { cmd = "nika --version", expected = "nika {{version}}" }


### PR DESCRIPTION
Workflow runner for AI jobs: the job lives in one `.nika.yaml` file (DAG of tasks), statically checked before anything runs (`nika check`: plan, types, secret flows, honest cost floor), with hash-chained run traces (`nika trace verify`). Works fully offline (mock + Ollama paths need zero keys); cloud providers are opt-in.

https://github.com/supernovae-st/nika
https://docs.nika.sh

Single static Rust binary per platform, released as GitHub tarballs with SHA256SUMS (macos-arm64/x64, linux-arm64/x64) — the `github:` backend resolves them directly (verified locally: `mise install github:supernovae-st/nika` → `nika --version` OK, and `ubi --project supernovae-st/nika` resolves the latest release). Also distributed via a Homebrew tap.

Full disclosure: I'm the author. Latest release 0.99.0 (2026-07-10), released weekly, actively developed. Engine AGPL-3.0-or-later, spec + SDK Apache-2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added registry metadata describing the workflow language and tooling.
  * Added backend source configuration.
  * Added a version verification test for the command-line tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->