### PR TITLE
registry: add git-town (aqua:git-town/git-town)

### DIFF
--- a/registry/git-town.toml
+++ b/registry/git-town.toml
@@ -1,3 +1,3 @@
 backends = ["aqua:git-town/git-town"]
-description = " Git branches made easy"
+description = "Git branches made easy"
 test = { cmd = "git-town --version", expected = "Git Town {{version}}" }

--- a/registry/git-town.toml
+++ b/registry/git-town.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:git-town/git-town"]
+description = " Git branches made easy"
+test = { cmd = "git-town --version", expected = "Git Town {{version}}" }


### PR DESCRIPTION
https://github.com/git-town/git-town - 3.3k stars - provides addition git commands.

Already some precedent for including git sub command tools in the registry - such as `git-cliff`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added registry support for Git Town.
  * Included a description, installation backend, and version verification for Git Town.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->