### PR TITLE
fix(erlang): lock source install outcomes

### DIFF
--- a/docs/lang/erlang.md
+++ b/docs/lang/erlang.md
@@ -25,8 +25,9 @@ See kerl's docs for information on configuring kerl.
 
 On GitHub Actions Linux runners, `ImageOS=ubuntu24`, `ImageOS=ubuntu22`, and `ImageOS=ubuntu20`
 map to the precompiled Erlang build targets `ubuntu-24.04`, `ubuntu-22.04`, and
-`ubuntu-20.04`. Unsupported values disable precompiled lockfile URL resolution in the
-default `erlang.compile` mode, so locked installs can fall back to kerl.
+`ubuntu-20.04`. In the default `erlang.compile` mode, unsupported values record the
+Erlang/OTP source archive as the platform's locked input so installs can reproduce the
+kerl fallback.
 
 ## Tool Options
 

--- a/e2e/core/test_erlang_lockfile
+++ b/e2e/core/test_erlang_lockfile
@@ -33,8 +33,8 @@ mise lock --platform "$CURRENT_PLATFORM"
 assert_contains "cat mise.lock" '[[tools.erlang]]'
 assert_contains "cat mise.lock" 'version = "28.3"'
 assert_contains "cat mise.lock" '[tools.erlang.options]'
-assert_contains "cat mise.lock" 'precompiled = "if_available"'
 assert_contains "cat mise.lock" 'precompiled_os = "ubuntu-24.04"'
+assert_not_contains "cat mise.lock" 'precompiled = '
 assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
 assert_matches "cat mise.lock" 'url = "https://builds\.hex\.pm/builds/otp/(amd64|arm64)/ubuntu-24\.04/OTP-28\.3\.tar\.gz"'
 assert_not_contains "cat mise.lock" 'install = "source"'
@@ -48,8 +48,8 @@ mise lock --platform "$CURRENT_PLATFORM"
 
 assert_contains "cat mise.lock" '[[tools.erlang]]'
 assert_contains "cat mise.lock" 'version = "28.3"'
-assert_contains "cat mise.lock" '[tools.erlang.options]'
-assert_contains "cat mise.lock" 'precompiled = "if_available"'
+assert_not_contains "cat mise.lock" '[tools.erlang.options]'
+assert_not_contains "cat mise.lock" 'precompiled = '
 assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
 assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'install = "source"'
 assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
@@ -74,6 +74,7 @@ assert_contains "cat mise.lock" '[tools.erlang.options]'
 assert_contains "cat mise.lock" 'compile = "true"'
 assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
 assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'install = "source"'
+assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
 assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'url = "https://github.com/erlang/otp/releases/download/OTP-28.3/otp_src_28.3.tar.gz"'
 
 assert "mise install --locked --dry-run"

--- a/e2e/core/test_erlang_lockfile
+++ b/e2e/core/test_erlang_lockfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Test that core:erlang resolves lockfile URLs and records kerl fallback mode.
+# Test that core:erlang locks precompiled and source install outcomes.
 export MISE_LOCKFILE=1
 
 if [[ "$(uname -s)" != "Linux" ]]; then
@@ -37,9 +37,11 @@ assert_contains "cat mise.lock" 'precompiled = "if_available"'
 assert_contains "cat mise.lock" 'precompiled_os = "ubuntu-24.04"'
 assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
 assert_matches "cat mise.lock" 'url = "https://builds\.hex\.pm/builds/otp/(amd64|arm64)/ubuntu-24\.04/OTP-28\.3\.tar\.gz"'
+assert_not_contains "cat mise.lock" 'install = "source"'
 
 assert "mise install --locked --dry-run"
 
+echo "=== default fallback records the source artifact ==="
 rm -f mise.lock
 export ImageOS=nobara-43
 mise lock --platform "$CURRENT_PLATFORM"
@@ -48,7 +50,47 @@ assert_contains "cat mise.lock" '[[tools.erlang]]'
 assert_contains "cat mise.lock" 'version = "28.3"'
 assert_contains "cat mise.lock" '[tools.erlang.options]'
 assert_contains "cat mise.lock" 'precompiled = "if_available"'
-assert_not_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
-assert_not_contains "cat mise.lock" 'url = '
+assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
+assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'install = "source"'
+assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
+assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'url = "https://github.com/erlang/otp/releases/download/OTP-28.3/otp_src_28.3.tar.gz"'
 
 assert "mise install --locked --dry-run"
+
+echo "=== compile=true records a source outcome on supported platforms ==="
+cat <<'EOF' >mise.toml
+[tools]
+erlang = "28.3"
+
+[settings.erlang]
+compile = true
+EOF
+
+rm -f mise.lock
+export ImageOS=ubuntu24
+mise lock --platform "$CURRENT_PLATFORM"
+
+assert_contains "cat mise.lock" '[tools.erlang.options]'
+assert_contains "cat mise.lock" 'compile = "true"'
+assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
+assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'install = "source"'
+assert_contains "awk '/\[tools.erlang.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'url = "https://github.com/erlang/otp/releases/download/OTP-28.3/otp_src_28.3.tar.gz"'
+
+assert "mise install --locked --dry-run"
+
+echo "=== locked source outcome without a URL fails ==="
+cat <<EOF >mise.lock
+$LOCKFILE_HEADER
+
+[[tools.erlang]]
+version = "28.3"
+backend = "core:erlang"
+
+[tools.erlang.options]
+compile = "true"
+
+[tools.erlang."platforms.$CURRENT_PLATFORM"]
+install = "source"
+EOF
+
+assert_fail "mise install --locked --dry-run" "No lockfile URL found"

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -31,7 +31,6 @@ pub struct ErlangPlugin {
 }
 
 const KERL_VERSION: &str = "4.4.0";
-const ERLANG_PRECOMPILED_OPTION: &str = "precompiled";
 const ERLANG_PRECOMPILED_OS_OPTION: &str = "precompiled_os";
 
 impl ErlangPlugin {
@@ -101,10 +100,8 @@ impl ErlangPlugin {
         format!("OTP-{version}")
     }
 
-    fn lockfile_url(&self, tv: &ToolVersion) -> Option<String> {
-        tv.lock_platforms
-            .get(&self.get_platform_key())
-            .and_then(|p| p.url.clone())
+    fn lockfile_url(&self, locked: bool, tv: &ToolVersion) -> Option<String> {
+        locked_platform_url(locked, &tv.lock_platforms, &self.get_platform_key())
     }
 
     fn set_lockfile_info(
@@ -299,7 +296,7 @@ impl ErlangPlugin {
         if !ctx.locked && Settings::get().erlang.compile == Some(true) {
             return Ok(None);
         }
-        let url = if let Some(url) = self.lockfile_url(&tv) {
+        let url = if let Some(url) = self.lockfile_url(ctx.locked, &tv) {
             url
         } else {
             match Self::linux_precompiled_url(&tv.version, &PlatformTarget::from_current()) {
@@ -374,7 +371,7 @@ impl ErlangPlugin {
             return Ok(None);
         }
         let release_tag = Self::release_tag(&tv.version);
-        let (url, checksum) = if let Some(url) = self.lockfile_url(&tv) {
+        let (url, checksum) = if let Some(url) = self.lockfile_url(ctx.locked, &tv) {
             (url, None)
         } else {
             let tarball_name = match Self::macos_asset_name(&PlatformTarget::from_current()) {
@@ -431,7 +428,7 @@ impl ErlangPlugin {
             return Ok(None);
         }
         let release_tag = Self::release_tag(&tv.version);
-        let (url, checksum) = if let Some(url) = self.lockfile_url(&tv) {
+        let (url, checksum) = if let Some(url) = self.lockfile_url(ctx.locked, &tv) {
             (url, None)
         } else {
             let zip_name =
@@ -515,10 +512,12 @@ impl ErlangPlugin {
         );
 
         let source_path = tv.download_path().join(Self::source_cache_name(source_url));
-        ctx.pr.set_message(format!(
-            "Downloading {}",
-            Self::source_asset_name(&tv.version)
-        ));
+        let display_name = source_url
+            .rsplit('/')
+            .next()
+            .filter(|name| !name.is_empty())
+            .unwrap_or("Erlang/OTP source");
+        ctx.pr.set_message(format!("Downloading {display_name}"));
         if !source_path.exists() {
             HTTP.download_file(source_url, &source_path, Some(ctx.pr.as_ref()))
                 .await?;
@@ -645,10 +644,6 @@ impl Backend for ErlangPlugin {
                 }
             }
             None => {
-                opts.insert(
-                    ERLANG_PRECOMPILED_OPTION.to_string(),
-                    "if_available".to_string(),
-                );
                 if let Some(os_version) = Self::lockfile_precompiled_os_option(target) {
                     opts.insert(ERLANG_PRECOMPILED_OS_OPTION.to_string(), os_version);
                 }
@@ -711,6 +706,19 @@ impl Backend for ErlangPlugin {
             _ => self.resolve_source_lock_info(&tv.version).await,
         }
     }
+}
+
+fn locked_platform_url(
+    locked: bool,
+    lock_platforms: &BTreeMap<String, PlatformInfo>,
+    platform_key: &str,
+) -> Option<String> {
+    if !locked {
+        return None;
+    }
+    lock_platforms
+        .get(platform_key)
+        .and_then(|platform_info| platform_info.url.clone())
 }
 
 fn should_install_from_source(
@@ -785,5 +793,27 @@ mod tests {
             "linux-x64",
             None
         ));
+    }
+
+    #[test]
+    fn test_unlocked_erlang_install_ignores_lockfile_url() {
+        let platform_key = Platform::current().to_key();
+        let lock_platforms = BTreeMap::from([(
+            platform_key.clone(),
+            PlatformInfo {
+                install: Some("source".to_string()),
+                url: Some("https://github.com/erlang/otp/source.tar.gz".to_string()),
+                ..Default::default()
+            },
+        )]);
+
+        assert_eq!(
+            locked_platform_url(false, &lock_platforms, &platform_key),
+            None
+        );
+        assert_eq!(
+            locked_platform_url(true, &lock_platforms, &platform_key).as_deref(),
+            Some("https://github.com/erlang/otp/source.tar.gz")
+        );
     }
 }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -625,10 +625,6 @@ impl Backend for ErlangPlugin {
         self.install_via_kerl(ctx, tv).await
     }
 
-    fn supports_lockfile_url(&self) -> bool {
-        true
-    }
-
     fn resolve_lockfile_options(
         &self,
         _request: &ToolRequest,
@@ -780,11 +776,15 @@ mod tests {
                 "--without-javac".to_string(),
             ),
         ]);
-        let env = source_build_kerl_env(install_env, Path::new("/mise/kerl"));
+        let kerl_base_dir = Path::new("/mise/kerl");
+        let env = source_build_kerl_env(install_env, kerl_base_dir);
 
         assert_eq!(env["KERL_BUILD_BACKEND"], "git");
-        assert_eq!(env["KERL_BASE_DIR"], "/mise/kerl");
-        assert_eq!(env["KERL_DOWNLOAD_DIR"], "/mise/kerl/archives");
+        assert_eq!(env["KERL_BASE_DIR"], kerl_base_dir.as_os_str());
+        assert_eq!(
+            env["KERL_DOWNLOAD_DIR"],
+            kerl_base_dir.join("archives").as_os_str()
+        );
         assert_eq!(env["KERL_CONFIGURE_OPTIONS"], "--without-javac");
     }
 

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -107,15 +107,58 @@ impl ErlangPlugin {
             .and_then(|p| p.url.clone())
     }
 
-    fn set_lockfile_info(&self, tv: &mut ToolVersion, url: &str, checksum: Option<String>) {
+    fn set_lockfile_info(
+        &self,
+        tv: &mut ToolVersion,
+        install: Option<&str>,
+        url: &str,
+        checksum: Option<String>,
+        url_api: Option<String>,
+    ) {
         let platform_info = tv
             .lock_platforms
             .entry(self.get_platform_key())
             .or_default();
+        let artifact_changed = platform_info.install.as_deref() != install
+            || platform_info.url.as_deref() != Some(url);
+        if artifact_changed {
+            platform_info.checksum = None;
+            platform_info.size = None;
+            platform_info.url_api = None;
+            platform_info.provenance = None;
+            platform_info.github_attestations = None;
+        }
+        platform_info.install = install.map(str::to_string);
         platform_info.url = Some(url.to_string());
         if let Some(checksum) = checksum {
-            platform_info.checksum.get_or_insert(checksum);
+            platform_info.checksum = Some(checksum);
         }
+        if let Some(url_api) = url_api {
+            platform_info.url_api = Some(url_api);
+        }
+    }
+
+    fn source_asset_name(version: &str) -> String {
+        format!("otp_src_{version}.tar.gz")
+    }
+
+    fn source_asset_url(version: &str) -> String {
+        format!(
+            "https://github.com/erlang/otp/releases/download/{}/{}",
+            Self::release_tag(version),
+            Self::source_asset_name(version)
+        )
+    }
+
+    fn source_archive_url(version: &str) -> String {
+        format!(
+            "https://github.com/erlang/otp/archive/{}.tar.gz",
+            Self::release_tag(version)
+        )
+    }
+
+    fn source_cache_name(url: &str) -> String {
+        format!("otp-source-{}.tar.gz", crate::hash::hash_sha256_to_str(url))
     }
 
     fn linux_precompiled_url(version: &str, target: &PlatformTarget) -> Result<String> {
@@ -211,13 +254,49 @@ impl ErlangPlugin {
         })
     }
 
+    async fn resolve_source_lock_info(&self, version: &str) -> Result<PlatformInfo> {
+        let release_tag = Self::release_tag(version);
+        let asset_name = Self::source_asset_name(version);
+        let info = match Self::github_asset_lock_info("erlang/otp", &release_tag, &asset_name).await
+        {
+            Ok(info) => info,
+            Err(err) => {
+                let asset_url = Self::source_asset_url(version);
+                match HTTP.head(&asset_url).await {
+                    Ok(_) => {
+                        debug!(
+                            "failed to resolve metadata for Erlang/OTP source release asset {asset_name}: {err}; using the reachable release asset without a checksum"
+                        );
+                        PlatformInfo {
+                            url: Some(asset_url),
+                            ..Default::default()
+                        }
+                    }
+                    Err(_) => {
+                        debug!(
+                            "failed to resolve Erlang/OTP source release asset {asset_name}: {err}; using tag archive"
+                        );
+                        PlatformInfo {
+                            url: Some(Self::source_archive_url(version)),
+                            ..Default::default()
+                        }
+                    }
+                }
+            }
+        };
+        Ok(PlatformInfo {
+            install: Some("source".to_string()),
+            ..info
+        })
+    }
+
     #[cfg(linux)]
     async fn install_precompiled(
         &self,
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if Settings::get().erlang.compile == Some(true) {
+        if !ctx.locked && Settings::get().erlang.compile == Some(true) {
             return Ok(None);
         }
         let url = if let Some(url) = self.lockfile_url(&tv) {
@@ -241,7 +320,7 @@ impl ErlangPlugin {
             HTTP.download_file(&url, &tarball_path, Some(ctx.pr.as_ref()))
                 .await?;
         }
-        self.set_lockfile_info(&mut tv, &url, None);
+        self.set_lockfile_info(&mut tv, None, &url, None, None);
         ctx.pr.set_message(format!("Extracting {filename}"));
         file::untar(
             &tarball_path,
@@ -291,7 +370,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if Settings::get().erlang.compile == Some(true) {
+        if !ctx.locked && Settings::get().erlang.compile == Some(true) {
             return Ok(None);
         }
         let release_tag = Self::release_tag(&tv.version);
@@ -327,7 +406,7 @@ impl ErlangPlugin {
             HTTP.download_file(&url, &tarball_path, Some(ctx.pr.as_ref()))
                 .await?;
         }
-        self.set_lockfile_info(&mut tv, &url, checksum);
+        self.set_lockfile_info(&mut tv, None, &url, checksum, None);
         self.verify_checksum(ctx, &mut tv, &tarball_path)?;
         ctx.pr.set_message(format!("Extracting {tarball_name}"));
         file::untar(
@@ -348,7 +427,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if Settings::get().erlang.compile == Some(true) {
+        if !ctx.locked && Settings::get().erlang.compile == Some(true) {
             return Ok(None);
         }
         let release_tag = Self::release_tag(&tv.version);
@@ -385,7 +464,7 @@ impl ErlangPlugin {
             HTTP.download_file(&url, &zip_path, Some(ctx.pr.as_ref()))
                 .await?;
         }
-        self.set_lockfile_info(&mut tv, &url, checksum);
+        self.set_lockfile_info(&mut tv, None, &url, checksum, None);
         self.verify_checksum(ctx, &mut tv, &zip_path)?;
         ctx.pr.set_message(format!("Extracting {}", zip_name));
         file::unzip(&zip_path, &tv.install_path(), &Default::default())?;
@@ -395,10 +474,10 @@ impl ErlangPlugin {
     #[cfg(not(any(linux, macos, windows)))]
     async fn install_precompiled(
         &self,
-        _ctx: &InstallContext,
+        ctx: &InstallContext,
         _tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if Settings::get().erlang.compile == Some(true) {
+        if !ctx.locked && Settings::get().erlang.compile == Some(true) {
             Ok(None)
         } else {
             self.precompiled_unavailable("precompiled erlang is not supported on this platform")
@@ -407,10 +486,51 @@ impl ErlangPlugin {
 
     async fn install_via_kerl(
         &self,
-        _ctx: &InstallContext,
-        tv: ToolVersion,
+        ctx: &InstallContext,
+        mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
         self.update_kerl().await?;
+
+        let platform_key = self.get_platform_key();
+        let source_info = if ctx.locked {
+            tv.lock_platforms
+                .get(&platform_key)
+                .cloned()
+                .ok_or_else(|| {
+                    eyre::eyre!("missing locked Erlang source info for {platform_key}")
+                })?
+        } else {
+            self.resolve_source_lock_info(&tv.version).await?
+        };
+        let source_url = source_info
+            .url
+            .as_deref()
+            .ok_or_else(|| eyre::eyre!("missing Erlang source URL for {platform_key}"))?;
+        self.set_lockfile_info(
+            &mut tv,
+            Some("source"),
+            source_url,
+            source_info.checksum.clone(),
+            source_info.url_api.clone(),
+        );
+
+        let source_path = tv.download_path().join(Self::source_cache_name(source_url));
+        ctx.pr.set_message(format!(
+            "Downloading {}",
+            Self::source_asset_name(&tv.version)
+        ));
+        if !source_path.exists() {
+            HTTP.download_file(source_url, &source_path, Some(ctx.pr.as_ref()))
+                .await?;
+        }
+        self.verify_checksum(ctx, &mut tv, &source_path)?;
+
+        let kerl_source_path = self
+            .kerl_base_dir()
+            .join("archives")
+            .join(format!("{}.tar.gz", Self::release_tag(&tv.version)));
+        file::create_dir_all(kerl_source_path.parent().unwrap())?;
+        file::copy(&source_path, &kerl_source_path)?;
 
         file::remove_all(tv.install_path())?;
         match &tv.request {
@@ -487,6 +607,15 @@ impl Backend for ErlangPlugin {
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
+        let platform_key = self.get_platform_key();
+        if should_install_from_source(
+            ctx.locked,
+            &tv.lock_platforms,
+            &platform_key,
+            Settings::get().erlang.compile,
+        ) {
+            return self.install_via_kerl(ctx, tv).await;
+        }
         if let Some(tv) = self.install_precompiled(ctx, tv.clone()).await? {
             return Ok(tv);
         }
@@ -494,9 +623,7 @@ impl Backend for ErlangPlugin {
     }
 
     fn supports_lockfile_url(&self) -> bool {
-        // In default mode, precompiled Erlang is opportunistic and may fall
-        // back to kerl, so locked installs cannot always require a URL.
-        Settings::get().erlang.compile == Some(false)
+        true
     }
 
     fn resolve_lockfile_options(
@@ -538,7 +665,7 @@ impl Backend for ErlangPlugin {
     ) -> Result<PlatformInfo> {
         let compile = Settings::get().erlang.compile;
         if compile == Some(true) {
-            return Ok(PlatformInfo::default());
+            return self.resolve_source_lock_info(&tv.version).await;
         }
 
         let release_tag = Self::release_tag(&tv.version);
@@ -549,7 +676,7 @@ impl Backend for ErlangPlugin {
                     ..Default::default()
                 }),
                 Err(err) if compile == Some(false) => Err(err),
-                Err(_) => Ok(PlatformInfo::default()),
+                Err(_) => self.resolve_source_lock_info(&tv.version).await,
             },
             "macos" => {
                 let info = match Self::macos_asset_name(target) {
@@ -562,7 +689,7 @@ impl Backend for ErlangPlugin {
                 match info {
                     Ok(info) => Ok(info),
                     Err(err) if compile == Some(false) => Err(err),
-                    Err(_) => Ok(PlatformInfo::default()),
+                    Err(_) => self.resolve_source_lock_info(&tv.version).await,
                 }
             }
             "windows" => {
@@ -575,10 +702,88 @@ impl Backend for ErlangPlugin {
                 match info {
                     Ok(info) => Ok(info),
                     Err(err) if compile == Some(false) => Err(err),
-                    Err(_) => Ok(PlatformInfo::default()),
+                    Err(_) => self.resolve_source_lock_info(&tv.version).await,
                 }
             }
-            _ => Ok(PlatformInfo::default()),
+            os if compile == Some(false) => {
+                bail!("precompiled erlang is not supported on {os}")
+            }
+            _ => self.resolve_source_lock_info(&tv.version).await,
         }
+    }
+}
+
+fn should_install_from_source(
+    locked: bool,
+    lock_platforms: &BTreeMap<String, PlatformInfo>,
+    platform_key: &str,
+    erlang_compile: Option<bool>,
+) -> bool {
+    if locked {
+        lock_platforms
+            .get(platform_key)
+            .is_some_and(|pi| pi.install.as_deref() == Some("source"))
+    } else {
+        erlang_compile == Some(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_locked_erlang_install_uses_source_marker() {
+        let platform_key = Platform::current().to_key();
+        let lock_platforms = BTreeMap::from([(
+            platform_key.clone(),
+            PlatformInfo {
+                install: Some("source".to_string()),
+                url: Some("https://github.com/erlang/otp/source.tar.gz".to_string()),
+                ..Default::default()
+            },
+        )]);
+
+        assert!(should_install_from_source(
+            true,
+            &lock_platforms,
+            &platform_key,
+            Some(false)
+        ));
+    }
+
+    #[test]
+    fn test_locked_erlang_install_ignores_compile_setting_for_precompiled_lock() {
+        let platform_key = Platform::current().to_key();
+        let lock_platforms = BTreeMap::from([(
+            platform_key.clone(),
+            PlatformInfo {
+                url: Some("https://builds.hex.pm/builds/otp/precompiled.tar.gz".to_string()),
+                ..Default::default()
+            },
+        )]);
+
+        assert!(!should_install_from_source(
+            true,
+            &lock_platforms,
+            &platform_key,
+            Some(true)
+        ));
+    }
+
+    #[test]
+    fn test_unlocked_erlang_install_uses_compile_setting() {
+        assert!(should_install_from_source(
+            false,
+            &BTreeMap::new(),
+            "linux-x64",
+            Some(true)
+        ));
+        assert!(!should_install_from_source(
+            false,
+            &BTreeMap::new(),
+            "linux-x64",
+            None
+        ));
     }
 }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -1,5 +1,9 @@
 use std::collections::BTreeMap;
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::backend::Backend;
 use crate::backend::VersionInfo;
@@ -18,6 +22,7 @@ use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{file, github, plugins};
 use async_trait::async_trait;
 use eyre::{Result, bail};
+use indexmap::IndexMap;
 use xx::regex;
 
 #[cfg(linux)]
@@ -524,8 +529,8 @@ impl ErlangPlugin {
         }
         self.verify_checksum(ctx, &mut tv, &source_path)?;
 
-        let kerl_source_path = self
-            .kerl_base_dir()
+        let kerl_base_dir = self.kerl_base_dir();
+        let kerl_source_path = kerl_base_dir
             .join("archives")
             .join(format!("{}.tar.gz", Self::release_tag(&tv.version)));
         file::create_dir_all(kerl_source_path.parent().unwrap())?;
@@ -545,11 +550,10 @@ impl ErlangPlugin {
                     tv.install_path()
                 )
                 .env("MAKEFLAGS", format!("-j{}", num_cpus::get()));
-                for (key, value) in tv.install_env() {
+                for (key, value) in source_build_kerl_env(tv.install_env(), &kerl_base_dir) {
                     cmd = cmd.env(key, value);
                 }
-                cmd.env("KERL_BASE_DIR", self.ba.cache_path.join("kerl"))
-                    .run()?;
+                cmd.run()?;
             }
         }
 
@@ -708,6 +712,29 @@ impl Backend for ErlangPlugin {
     }
 }
 
+fn source_build_kerl_env(
+    install_env: IndexMap<String, String>,
+    kerl_base_dir: &Path,
+) -> IndexMap<String, OsString> {
+    let mut env = install_env
+        .into_iter()
+        .map(|(key, value)| (key, OsString::from(value)))
+        .collect::<IndexMap<_, _>>();
+    // Source lock metadata resolves a GitHub archive and stages it here. Keep
+    // kerl from selecting another backend or download directory and silently
+    // building a different archive instead.
+    env.insert(
+        "KERL_BASE_DIR".to_string(),
+        kerl_base_dir.as_os_str().to_owned(),
+    );
+    env.insert(
+        "KERL_DOWNLOAD_DIR".to_string(),
+        kerl_base_dir.join("archives").into_os_string(),
+    );
+    env.insert("KERL_BUILD_BACKEND".to_string(), OsString::from("git"));
+    env
+}
+
 fn locked_platform_url(
     locked: bool,
     lock_platforms: &BTreeMap<String, PlatformInfo>,
@@ -739,6 +766,27 @@ fn should_install_from_source(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_source_build_kerl_env_pins_staged_archive() {
+        let install_env = IndexMap::from([
+            ("KERL_BUILD_BACKEND".to_string(), "tarball".to_string()),
+            (
+                "KERL_DOWNLOAD_DIR".to_string(),
+                "/custom/downloads".to_string(),
+            ),
+            (
+                "KERL_CONFIGURE_OPTIONS".to_string(),
+                "--without-javac".to_string(),
+            ),
+        ]);
+        let env = source_build_kerl_env(install_env, Path::new("/mise/kerl"));
+
+        assert_eq!(env["KERL_BUILD_BACKEND"], "git");
+        assert_eq!(env["KERL_BASE_DIR"], "/mise/kerl");
+        assert_eq!(env["KERL_DOWNLOAD_DIR"], "/mise/kerl/archives");
+        assert_eq!(env["KERL_CONFIGURE_OPTIONS"], "--without-javac");
+    }
 
     #[test]
     fn test_locked_erlang_install_uses_source_marker() {


### PR DESCRIPTION
## Summary
- record Erlang source fallback inputs in per-platform lock metadata
- keep default fallback mode out of the root lock identity while retaining explicit `compile=true/false`
- make kerl consume the recorded source URL and optional checksum during locked installs
- cover precompiled, automatic fallback, forced source, and incomplete source locks

## Context
Supersedes #10515 after #10547 established the source-outcome lockfile shape. The obsolete Node stack and draft `install_method` changes are not included.

## Diff vs main

### Default fallback without a compatible precompiled build

Main records the default fallback mode at the root but omits the platform outcome. This PR removes the default marker and records the selected source input instead:

```diff
 [[tools.erlang]]
 version = "28.3"
 backend = "core:erlang"
 
-[tools.erlang.options]
-precompiled = "if_available"
+[tools.erlang."platforms.linux-x64"]
+install = "source"
+checksum = "sha256:..."
+url = "https://github.com/erlang/otp/releases/download/OTP-28.3/otp_src_28.3.tar.gz"
+url_api = "https://api.github.com/repos/erlang/otp/releases/assets/..."
```

As with Node, a checksum is optional: it is recorded when release metadata provides one and verified when present. If the release asset is unavailable, the platform entry records the corresponding GitHub tag archive.

### Forced source build

Explicit `erlang.compile = true` remains part of the root lock identity. This PR adds the source outcome for the requested platform:

```diff
 [tools.erlang.options]
 compile = "true"
+
+[tools.erlang."platforms.linux-x64"]
+install = "source"
+checksum = "sha256:..."
+url = "https://github.com/erlang/otp/releases/download/OTP-28.3/otp_src_28.3.tar.gz"
+url_api = "https://api.github.com/repos/erlang/otp/releases/assets/..."
```

### Precompiled outcome

The default marker is also removed when a compatible precompiled build exists. The distro selection remains in the root identity because it changes the Linux artifact URL, while the platform entry keeps the existing precompiled shape:

```diff
 [tools.erlang.options]
-precompiled = "if_available"
 precompiled_os = "ubuntu-24.04"
 
 [tools.erlang."platforms.linux-x64"]
 url = "https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/OTP-28.3.tar.gz"
```

There is no `install = "precompiled"` marker.

### kerl input handling

For a source outcome, mise downloads the recorded URL into a URL-keyed cache, verifies the recorded checksum when present, and copies it to kerl's expected `archives/OTP-<version>.tar.gz` path. It pins kerl's GitHub backend and download directory for this handoff so `KERL_BUILD_BACKEND` or `KERL_DOWNLOAD_DIR` overrides cannot bypass the recorded artifact; other `install_env` build settings remain intact. Unlocked installs ignore lockfile URLs and select their input from current settings, matching Node's locked/unlocked routing.

Tool-level `install_env` remains config-supplied rather than copied into lock options. This matches the general core option policy, including Node: arbitrary installation environment variables are ephemeral, while dedicated backend settings that define artifact identity are recorded separately. Erlang has no additional dedicated source-build settings beyond `compile`.

## Verification
- `mise run lint-fix`
- `mise run test:unit -- plugins::core::erlang::tests`
- `mise run test:e2e e2e/core/test_erlang_lockfile`
- `git diff --check`

A full OTP source compilation was not run locally.