### PR TITLE
fix(registry): normalize backend platform selectors

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -116,7 +116,7 @@ impl RegistryTool {
         let experimental = settings.experimental;
         self.backends
             .iter()
-            .filter(|rb| backend_matches_platform(rb, &settings))
+            .filter(|rb| backend_matches_platform(rb.platforms, &settings))
             .map(|rb| rb.full)
             .filter(|full| {
                 full.split(':')
@@ -174,11 +174,7 @@ impl RegistryTool {
 /// Unlike `backends.options.platforms.*` lookup, this is deliberately not
 /// alias-tolerant: registry selectors use canonical names such as `macos-x64`,
 /// while option lookup accepts release asset aliases such as `darwin-amd64`.
-fn backend_matches_platform(backend: &RegistryBackend, settings: &Settings) -> bool {
-    backend_platforms_match(backend.platforms, settings)
-}
-
-fn backend_platforms_match(platforms: &[&str], settings: &Settings) -> bool {
+fn backend_matches_platform(platforms: &[&str], settings: &Settings) -> bool {
     let os = settings.os();
     let arch = settings.arch();
     let platform = format!("{os}-{arch}");
@@ -353,7 +349,7 @@ mod tests {
             settings.arch = Some(raw_arch.to_string());
 
             assert!(
-                backend_platforms_match(&[selector], &settings),
+                backend_matches_platform(&[selector], &settings),
                 "{raw_os}-{raw_arch} should match normalized selector {selector}"
             );
         }
@@ -391,7 +387,7 @@ mod tests {
 
         let matching = backends
             .iter()
-            .filter(|backend| backend_matches_platform(backend, &settings))
+            .filter(|backend| backend_matches_platform(backend.platforms, &settings))
             .map(|backend| backend.full)
             .collect::<Vec<_>>();
 
@@ -405,7 +401,10 @@ mod tests {
             platforms: &["darwin-amd64"],
             options: &[],
         };
-        assert!(!backend_matches_platform(&alias_selector, &settings));
+        assert!(!backend_matches_platform(
+            alias_selector.platforms,
+            &settings
+        ));
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,7 +6,7 @@ use heck::ToShoutySnakeCase;
 use indexmap::IndexMap;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::env;
-use std::env::consts::{ARCH, OS};
+use std::env::consts::OS;
 use std::fmt::Display;
 use std::iter::Iterator;
 use std::sync::{LazyLock as Lazy, Mutex};
@@ -113,18 +113,10 @@ impl RegistryTool {
             backend_types
         });
         let settings = Settings::get();
-        let os = settings.os.clone().unwrap_or(OS.to_string());
-        let arch = settings.arch.clone().unwrap_or(ARCH.to_string());
-        let platform = format!("{os}-{arch}");
         let experimental = settings.experimental;
         self.backends
             .iter()
-            .filter(|rb| {
-                rb.platforms.is_empty()
-                    || rb.platforms.contains(&&*os)
-                    || rb.platforms.contains(&&*arch)
-                    || rb.platforms.contains(&&*platform)
-            })
+            .filter(|rb| backend_matches_platform(rb, &settings))
             .map(|rb| rb.full)
             .filter(|full| {
                 full.split(':')
@@ -175,6 +167,26 @@ impl RegistryTool {
             ..Default::default()
         }
     }
+}
+
+/// Matches registry backend selectors using the schema's normalized platform names.
+///
+/// Unlike `backends.options.platforms.*` lookup, this is deliberately not
+/// alias-tolerant: registry selectors use canonical names such as `macos-x64`,
+/// while option lookup accepts release asset aliases such as `darwin-amd64`.
+fn backend_matches_platform(backend: &RegistryBackend, settings: &Settings) -> bool {
+    backend_platforms_match(backend.platforms, settings)
+}
+
+fn backend_platforms_match(platforms: &[&str], settings: &Settings) -> bool {
+    let os = settings.os();
+    let arch = settings.arch();
+    let platform = format!("{os}-{arch}");
+
+    platforms.is_empty()
+        || platforms.contains(&os)
+        || platforms.contains(&arch)
+        || platforms.contains(&platform.as_str())
 }
 
 pub fn shorts_for_full(full: &str) -> &'static Vec<&'static str> {
@@ -324,6 +336,76 @@ mod tests {
         let codex = REGISTRY.get("codex").unwrap();
 
         assert_eq!(codex.backends[0].full, "npm:@openai/codex");
+    }
+
+    #[test]
+    fn test_backend_platform_matching_normalizes_settings() {
+        use super::*;
+
+        for (raw_os, raw_arch, selector) in [
+            ("windows", "x86_64", "windows-x64"),
+            ("windows", "amd64", "x64"),
+            ("linux", "aarch64", "linux-arm64"),
+            ("darwin", "x86_64", "macos-x64"),
+        ] {
+            let mut settings = Settings::default();
+            settings.os = Some(raw_os.to_string());
+            settings.arch = Some(raw_arch.to_string());
+
+            assert!(
+                backend_platforms_match(&[selector], &settings),
+                "{raw_os}-{raw_arch} should match normalized selector {selector}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_backend_platform_matching_preserves_os_only_and_order() {
+        use super::*;
+
+        let mut settings = Settings::default();
+        settings.os = Some("darwin".to_string());
+        settings.arch = Some("amd64".to_string());
+        let backends = [
+            RegistryBackend {
+                full: "aqua:first/tool",
+                platforms: &["macos"],
+                options: &[],
+            },
+            RegistryBackend {
+                full: "github:second/tool",
+                platforms: &["macos-x64"],
+                options: &[],
+            },
+            RegistryBackend {
+                full: "cargo:third-tool",
+                platforms: &[],
+                options: &[],
+            },
+            RegistryBackend {
+                full: "npm:excluded-tool",
+                platforms: &["linux"],
+                options: &[],
+            },
+        ];
+
+        let matching = backends
+            .iter()
+            .filter(|backend| backend_matches_platform(backend, &settings))
+            .map(|backend| backend.full)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            matching,
+            ["aqua:first/tool", "github:second/tool", "cargo:third-tool"]
+        );
+
+        let alias_selector = RegistryBackend {
+            full: "github:owner/repo",
+            platforms: &["darwin-amd64"],
+            options: &[],
+        };
+        assert!(!backend_matches_platform(&alias_selector, &settings));
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -344,9 +344,11 @@ mod tests {
             ("linux", "aarch64", "linux-arm64"),
             ("darwin", "x86_64", "macos-x64"),
         ] {
-            let mut settings = Settings::default();
-            settings.os = Some(raw_os.to_string());
-            settings.arch = Some(raw_arch.to_string());
+            let settings = Settings {
+                os: Some(raw_os.to_string()),
+                arch: Some(raw_arch.to_string()),
+                ..Default::default()
+            };
 
             assert!(
                 backend_matches_platform(&[selector], &settings),
@@ -359,9 +361,11 @@ mod tests {
     fn test_backend_platform_matching_preserves_os_only_and_order() {
         use super::*;
 
-        let mut settings = Settings::default();
-        settings.os = Some("darwin".to_string());
-        settings.arch = Some("amd64".to_string());
+        let settings = Settings {
+            os: Some("darwin".to_string()),
+            arch: Some("amd64".to_string()),
+            ..Default::default()
+        };
         let backends = [
             RegistryBackend {
                 full: "aqua:first/tool",


### PR DESCRIPTION
## Summary

- match registry backend platform selectors against `Settings::os()` and `Settings::arch()`
- cover raw `x86_64`, `amd64`, `aarch64`, and `darwin` values mapping to canonical selectors
- preserve OS-only selectors and backend ordering
- document that backend selectors are strict canonical keys while platform option lookup remains alias-tolerant for release assets

## Root cause

`RegistryTool::backends()` read the raw OS and architecture settings directly. That produced keys such as `windows-x86_64`, which could not match schema-valid registry selectors such as `windows-x64`, causing mise to silently fall through to later backends.

## User impact

Registry entries now select the intended backend when host or override values use Rust/common platform aliases. For example, ImageMagick selects its aqua backend for both `MISE_ARCH=x86_64` and `MISE_ARCH=amd64` on Windows.

## Validation

- `mise run format` (includes the repository lint suite and `cargo check --all-features`)
- `mise x -- cargo test --all-features registry::tests::test_backend_platform_matching -- --nocapture`
- `mise run build`
- `MISE_OS=windows MISE_ARCH=x86_64 target/debug/mise registry imagemagick`
- `MISE_OS=windows MISE_ARCH=amd64 target/debug/mise registry imagemagick`
- `MISE_OS=darwin MISE_ARCH=x86_64 target/debug/mise registry npm`
- `MISE_OS=darwin MISE_ARCH=aarch64 target/debug/mise registry npm`

Project item: https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=199522775


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry backend platform detection by matching against normalized OS/architecture selector forms, including `os-arch` (e.g., Windows x64 and macOS x64).
  * Ensured OS-only selectors continue to work, with correct selector precedence/ordering.
  * Prevented non-canonical platform alias selectors from matching incorrectly.
* **Tests**
  * Added/updated unit tests to verify OS/arch normalization and correct matching for canonical and non-canonical inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->