### PR TITLE
registry: add bundler (gem:bundler)

### DIFF
--- a/registry/bundler.toml
+++ b/registry/bundler.toml
@@ -1,0 +1,4 @@
+backends = ["gem:bundler"]
+description = "The best way to manage a Ruby application's gems"
+overrides = ["ruby"]
+test = { cmd = "bundle --version", expected = "Bundler version {{version}}" }

--- a/registry/bundler.toml
+++ b/registry/bundler.toml
@@ -1,4 +1,4 @@
 backends = ["gem:bundler"]
 description = "The best way to manage a Ruby application's gems"
 overrides = ["ruby"]
-test = { cmd = "bundle --version", expected = "Bundler version {{version}}" }
+test = { cmd = "bundle --version", expected = "{{version}}" }

--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -4,7 +4,7 @@ use crate::config::Config;
 use crate::file::display_path;
 use crate::registry::{REGISTRY, RegistryTool};
 use crate::tera::{contains_template_syntax, get_tera, render_str};
-use crate::toolset::{InstallOptions, ToolsetBuilder};
+use crate::toolset::{InstallOptions, ToolRequest, ToolRequestSet, ToolsetBuilder};
 use crate::ui::time;
 use crate::{dirs, env, file};
 use eyre::{Result, bail, eyre};
@@ -375,6 +375,21 @@ impl TestTool {
             .with_default_to_latest(true)
             .build(&config)
             .await?;
+        // Backend dependency environments are resolved from Config. Make the
+        // synthetic toolset used by test-tool visible there so runtime-backed
+        // tools can use dependencies that were added only for the test.
+        let mut test_tools = ToolRequestSet::new();
+        for (_, version) in ts.list_current_versions() {
+            let source = version.request.source().clone();
+            let mut request = ToolRequest::new(
+                version.request.ba().clone(),
+                &version.version,
+                source.clone(),
+            )?;
+            request.set_options(version.request.options());
+            test_tools.add_version(request, &source);
+        }
+        config = config.with_tool_request_set(test_tools);
         let opts = InstallOptions {
             missing_args_only: false,
             jobs: self.jobs,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -153,6 +153,12 @@ impl Config {
         })
     }
 
+    pub(crate) fn with_tool_request_set(&self, tool_request_set: ToolRequestSet) -> Arc<Self> {
+        let config = self.with_config_files(self.config_files.clone());
+        config.tool_request_set.set(tool_request_set).unwrap();
+        config
+    }
+
     #[async_backtrace::framed]
     pub async fn load() -> Result<Arc<Self>> {
         backend::load_tools().await?;


### PR DESCRIPTION
## Summary

- add `bundler` as a registry alias for `gem:bundler`
- ensure the explicitly managed Bundler precedes Ruby's bundled `bundle` executable on `PATH`
- make `test-tool` expose its synthetic resolved toolset to backend dependency environments

## Why a `gem:` registry entry

Runtime-backed registry entries are generally undesirable because they depend on a separately installed runtime. Bundler is an unusual case: Ruby already supplies the required `gem` command, but it also supplies a `bundle` executable that wins on `PATH` when users configure `gem:bundler` directly. This is the problem reported in discussion #10931.

The registry's `overrides` metadata is currently the only declarative way to put the standalone tool before the runtime that bundles the same executable. It is intentionally not exposed in user tool configuration because executable collisions are uncommon and adding another general-purpose ordering option would broaden the configuration surface for a narrow case.

An alternative would be to make `depends` imply both install ordering and reverse runtime `PATH` precedence. That couples two different relationships: needing a tool during installation does not necessarily mean the dependent should override the dependency's executables. Keeping `depends` install-only and recording this exceptional collision in curated registry metadata is more explicit.

The gem backend already declares Ruby as its dependency, so this entry does not duplicate that relationship.

## CI root cause

The initial registry CI run installed Ruby before Bundler, but `test-tool` represented both as synthetic CLI arguments while backend dependency environments were reconstructed from `Config`. As a result, the gem backend could not find the freshly installed `gem` executable.

`test-tool` now places its resolved, concrete tool requests into its cloned config before installation. This keeps backend dependency resolution aligned with the synthetic test toolset and avoids relying on unresolved `latest` runtime symlinks while dependencies are still being installed.

## Popularity

- RubyGems: 3.55 billion total downloads; Bundler 4.0.16 has over 210,000 downloads since its July 10, 2026 release
- GitHub (`rubygems/rubygems`): 3,935 stars, 1,921 forks, active development as of July 10, 2026
- Used by: the Ruby ecosystem as the standard application dependency manager and distributed with Ruby

## Validation

- `mise run render`
- `mise run lint-fix`
- `target/debug/mise test-tool --jobs 1 bundler`
- `target/debug/mise registry bundler`
- `target/debug/mise ls-remote bundler`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bundler backend configuration with Ruby categorization.
  * Added Bundler version detection/validation via the Bundler command.

* **Improvements**
  * Enhanced the CLI test tool flow so it builds and applies a complete request set during tests, improving dependency resolution for backend/runtime-backed tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->