### PR TITLE
fix(python): lock python-build outcomes

### DIFF
--- a/e2e/core/test_python_lockfile_outcomes
+++ b/e2e/core/test_python_lockfile_outcomes
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Test that core:python locks precompiled and python-build source outcomes.
+export MISE_LOCKFILE=1
+export MISE_PYTHON_GITHUB_ATTESTATIONS=0
+
+if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* || "$(uname -s)" == CYGWIN* ]]; then
+  echo "Skipping python-build source lockfile test on Windows"
+  exit 0
+fi
+
+detect_platform
+CURRENT_PLATFORM="$MISE_PLATFORM"
+
+cat <<'EOF' >mise.toml
+[tools]
+python = "3.13.5"
+EOF
+
+mise lock --platform "$CURRENT_PLATFORM"
+assert_not_contains "cat mise.lock" 'compile = '
+assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
+assert_contains "cat mise.lock" 'github.com/astral-sh/python-build-standalone/releases/download'
+assert_not_contains "cat mise.lock" 'install = "source"'
+assert "mise install --locked --dry-run"
+
+echo "=== default fallback records the python-build source artifact ==="
+cat <<'EOF' >mise.toml
+[tools]
+python = "3.5.10"
+EOF
+
+rm -f mise.lock
+mise lock --platform "$CURRENT_PLATFORM"
+assert_not_contains "cat mise.lock" '[tools.python.options]'
+assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
+assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'install = "source"'
+assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
+assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'url = "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tar.xz"'
+assert "mise install --locked --dry-run"
+
+echo "=== compile=true records a source outcome ==="
+cat <<'EOF' >mise.toml
+[tools]
+python = "3.13.0"
+
+[settings.python]
+compile = true
+EOF
+
+rm -f mise.lock
+mise lock --platform "$CURRENT_PLATFORM"
+assert_contains "cat mise.lock" '[tools.python.options]'
+assert_contains "cat mise.lock" 'compile = "true"'
+assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'install = "source"'
+assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
+assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'url = "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz"'
+assert "mise install --locked --dry-run"
+
+echo "=== compile=false does not record unavailable source fallback ==="
+cat <<'EOF' >mise.toml
+[tools]
+python = "3.5.10"
+
+[settings.python]
+compile = false
+EOF
+
+rm -f mise.lock
+mise lock --platform "$CURRENT_PLATFORM"
+assert_contains "cat mise.lock" 'compile = "false"'
+assert_not_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
+
+echo "=== locked source outcome without a URL fails ==="
+cat <<'EOF' >mise.toml
+[tools]
+python = "3.13.0"
+
+[settings.python]
+compile = true
+EOF
+
+cat <<EOF >mise.lock
+$LOCKFILE_HEADER
+
+[[tools.python]]
+version = "3.13.0"
+backend = "core:python"
+
+[tools.python.options]
+compile = "true"
+
+[tools.python."platforms.$CURRENT_PLATFORM"]
+install = "source"
+EOF
+
+assert_fail "mise install --locked --dry-run" "No lockfile URL found"

--- a/e2e/core/test_python_lockfile_outcomes
+++ b/e2e/core/test_python_lockfile_outcomes
@@ -112,3 +112,28 @@ compile = "true"
 EOF
 
 assert_fail "mise install --locked --dry-run" "No lockfile URL found"
+
+echo "=== compile=false rejects a manually authored source outcome ==="
+cat <<'EOF' >mise.toml
+[tools]
+python = "3.13.0"
+
+[settings.python]
+compile = false
+EOF
+
+cat <<EOF >mise.lock
+$LOCKFILE_HEADER
+
+[[tools.python]]
+version = "3.13.0"
+backend = "core:python"
+
+[tools.python.options]
+compile = "false"
+
+[tools.python."platforms.$CURRENT_PLATFORM"]
+install = "source"
+EOF
+
+assert_fail "mise install --locked --dry-run" 'install = "source" conflicts with python.compile=false'

--- a/e2e/core/test_python_lockfile_outcomes
+++ b/e2e/core/test_python_lockfile_outcomes
@@ -11,6 +11,7 @@ fi
 
 detect_platform
 CURRENT_PLATFORM="$MISE_PLATFORM"
+PLATFORM_SECTION="awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock"
 
 cat <<'EOF' >mise.toml
 [tools]
@@ -34,9 +35,9 @@ rm -f mise.lock
 mise lock --platform "$CURRENT_PLATFORM"
 assert_not_contains "cat mise.lock" '[tools.python.options]'
 assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
-assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'install = "source"'
-assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
-assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'url = "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tar.xz"'
+assert_contains "$PLATFORM_SECTION" 'install = "source"'
+assert_contains "$PLATFORM_SECTION" 'checksum = "sha256:'
+assert_contains "$PLATFORM_SECTION" 'url = "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tar.xz"'
 assert "mise install --locked --dry-run"
 
 echo "=== compile=true records a source outcome ==="
@@ -52,9 +53,9 @@ rm -f mise.lock
 mise lock --platform "$CURRENT_PLATFORM"
 assert_contains "cat mise.lock" '[tools.python.options]'
 assert_contains "cat mise.lock" 'compile = "true"'
-assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'install = "source"'
-assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
-assert_contains "awk '/\[tools.python.\"platforms.$CURRENT_PLATFORM\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'url = "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz"'
+assert_contains "$PLATFORM_SECTION" 'install = "source"'
+assert_contains "$PLATFORM_SECTION" 'checksum = "sha256:'
+assert_contains "$PLATFORM_SECTION" 'url = "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz"'
 assert "mise install --locked --dry-run"
 
 echo "=== compile=false does not record unavailable source fallback ==="

--- a/e2e/core/test_python_lockfile_outcomes
+++ b/e2e/core/test_python_lockfile_outcomes
@@ -37,7 +37,7 @@ assert_not_contains "cat mise.lock" '[tools.python.options]'
 assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
 assert_contains "$PLATFORM_SECTION" 'install = "source"'
 assert_contains "$PLATFORM_SECTION" 'checksum = "sha256:'
-assert_contains "$PLATFORM_SECTION" 'url = "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tar.xz"'
+assert_contains "$PLATFORM_SECTION" 'url = "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tgz"'
 assert "mise install --locked --dry-run"
 
 echo "=== compile=true records a source outcome ==="
@@ -55,7 +55,7 @@ assert_contains "cat mise.lock" '[tools.python.options]'
 assert_contains "cat mise.lock" 'compile = "true"'
 assert_contains "$PLATFORM_SECTION" 'install = "source"'
 assert_contains "$PLATFORM_SECTION" 'checksum = "sha256:'
-assert_contains "$PLATFORM_SECTION" 'url = "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz"'
+assert_contains "$PLATFORM_SECTION" 'url = "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tgz"'
 assert "mise install --locked --dry-run"
 
 echo "=== compile=false does not record unavailable source fallback ==="

--- a/e2e/core/test_python_lockfile_outcomes
+++ b/e2e/core/test_python_lockfile_outcomes
@@ -25,7 +25,7 @@ assert_contains "cat mise.lock" 'github.com/astral-sh/python-build-standalone/re
 assert_not_contains "cat mise.lock" 'install = "source"'
 assert "mise install --locked --dry-run"
 
-echo "=== default fallback records the python-build source artifact ==="
+echo "=== default fallback records the python-build outcome ==="
 cat <<'EOF' >mise.toml
 [tools]
 python = "3.5.10"
@@ -36,8 +36,8 @@ mise lock --platform "$CURRENT_PLATFORM"
 assert_not_contains "cat mise.lock" '[tools.python.options]'
 assert_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
 assert_contains "$PLATFORM_SECTION" 'install = "source"'
-assert_contains "$PLATFORM_SECTION" 'checksum = "sha256:'
-assert_contains "$PLATFORM_SECTION" 'url = "https://www.python.org/ftp/python/3.5.10/Python-3.5.10.tgz"'
+assert_not_contains "$PLATFORM_SECTION" 'checksum = '
+assert_not_contains "$PLATFORM_SECTION" 'url = '
 assert "mise install --locked --dry-run"
 
 echo "=== compile=true records a source outcome ==="
@@ -54,8 +54,8 @@ mise lock --platform "$CURRENT_PLATFORM"
 assert_contains "cat mise.lock" '[tools.python.options]'
 assert_contains "cat mise.lock" 'compile = "true"'
 assert_contains "$PLATFORM_SECTION" 'install = "source"'
-assert_contains "$PLATFORM_SECTION" 'checksum = "sha256:'
-assert_contains "$PLATFORM_SECTION" 'url = "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tgz"'
+assert_not_contains "$PLATFORM_SECTION" 'checksum = '
+assert_not_contains "$PLATFORM_SECTION" 'url = '
 assert "mise install --locked --dry-run"
 
 echo "=== compile=false does not record unavailable source fallback ==="
@@ -72,7 +72,7 @@ mise lock --platform "$CURRENT_PLATFORM"
 assert_contains "cat mise.lock" 'compile = "false"'
 assert_not_contains "cat mise.lock" "\"platforms.$CURRENT_PLATFORM\""
 
-echo "=== locked source outcome without a URL fails ==="
+echo "=== locked source outcome does not require a URL ==="
 cat <<'EOF' >mise.toml
 [tools]
 python = "3.13.0"
@@ -93,6 +93,22 @@ compile = "true"
 
 [tools.python."platforms.$CURRENT_PLATFORM"]
 install = "source"
+EOF
+
+assert "mise install --locked --dry-run"
+
+echo "=== locked precompiled outcome still requires a URL ==="
+cat <<EOF >mise.lock
+$LOCKFILE_HEADER
+
+[[tools.python]]
+version = "3.13.0"
+backend = "core:python"
+
+[tools.python.options]
+compile = "true"
+
+[tools.python."platforms.$CURRENT_PLATFORM"]
 EOF
 
 assert_fail "mise install --locked --dry-run" "No lockfile URL found"

--- a/e2e/lockfile/test_lockfile_python
+++ b/e2e/lockfile/test_lockfile_python
@@ -48,7 +48,7 @@ awk '
 assert_contains "cat mise.lock" "fake-tag/fake-python.tar.gz"
 
 rm -rf "$MISE_DATA_DIR/installs/python"
-assert_fail_contains "mise install python -f" "fake-tag/fake-python.tar.gz"
+assert_fail_contains "mise install --locked python -f" "fake-tag/fake-python.tar.gz"
 
 # Regenerate a fresh lockfile for subsequent tests
 rm -f mise.lock
@@ -66,7 +66,7 @@ assert_contains "cat mise.lock" "sha256:0000000000000000000000000000000000000000
 
 # Install with corrupted checksum should fail with a checksum mismatch error
 rm -rf "$MISE_DATA_DIR/installs/python"
-assert_fail "mise install python -f" "Checksum mismatch"
+assert_fail "mise install --locked python -f" "Checksum mismatch"
 
 rm -f mise.lock mise.toml
 

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -254,8 +254,12 @@ impl Backend for AsdfBackend {
 
     /// ASDF plugins handle their own downloads through plugin scripts.
     /// Lockfile URLs are not applicable since installation is delegated to plugin scripts.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &crate::backend::platform_target::PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -137,8 +137,12 @@ impl Backend for CargoBackend {
 
     /// Cargo installs packages from crates.io using version specs (e.g., ripgrep@14.0.0).
     /// It doesn't support installing from direct URLs, so lockfile URLs are not applicable.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn mark_prereleases_from_version_pattern(&self) -> bool {

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -48,8 +48,12 @@ impl Backend for GemBackend {
     /// Gem installs via `gem install`, delegating fetch/resolve to RubyGems rather
     /// than downloading an artifact mise verifies, so a lockfile URL can't be
     /// enforced even though rubygems.org exposes one. Opt out of `--locked`.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &crate::backend::platform_target::PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -69,8 +69,12 @@ impl Backend for GoBackend {
         Ok(vec!["go"])
     }
 
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn mark_prereleases_from_version_pattern(&self) -> bool {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -85,6 +85,14 @@ pub type BackendList = Vec<ABackend>;
 pub type IdiomaticVersion = (String, Option<ToolVersionOptions>);
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockfileTargetPolicy {
+    /// The target is represented by a URL-backed lock entry.
+    Artifact,
+    /// This backend does not currently produce lock information for the target.
+    Unsupported,
+}
+
 pub(crate) const MISE_BINS_DIR: &str = ".mise-bins";
 
 pub(crate) fn backend_arg_matches_registry_backend(ba: &BackendArg) -> bool {
@@ -1171,11 +1179,13 @@ pub trait Backend: Debug + Send + Sync {
         vec![platform.clone()] // Default: just the base platform
     }
 
-    /// Whether this backend supports URL-based locking in locked mode.
-    /// Backends that use external installers (like rustup for Rust) should override
-    /// this to return false, since they don't have downloadable artifacts with lockable URLs.
-    fn supports_lockfile_url(&self) -> bool {
-        true
+    /// Describe the lockfile outcome supported for a specific target.
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<LockfileTargetPolicy> {
+        Ok(LockfileTargetPolicy::Artifact)
     }
 
     async fn description(&self) -> Option<String> {
@@ -2110,7 +2120,7 @@ pub trait Backend: Debug + Send + Sync {
     ) -> eyre::Result<ToolVersion> {
         // Check for --locked mode: if enabled and no lockfile URL exists, fail early
         // Exempt tool stubs from lockfile requirements since they are ephemeral
-        // Also exempt backends that don't support URL locking (e.g., Rust uses rustup)
+        // Also exempt outcomes that don't use URL locking (e.g., Rust uses rustup)
         // This must run before the dry-run check so that --locked --dry-run still validates
         let settings = Settings::get();
         if (ctx.locked || settings.locked) && settings.lockfile == Some(false) {
@@ -2119,7 +2129,11 @@ pub trait Backend: Debug + Send + Sync {
                 hint: Remove `lockfile = false` or set `lockfile = true`, or disable locked mode"
             );
         }
-        if ctx.locked && !tv.request.source().is_tool_stub() && self.supports_lockfile_url() {
+        let lock_target = PlatformTarget::from_current();
+        if ctx.locked
+            && !tv.request.source().is_tool_stub()
+            && self.lockfile_target_policy(&tv, &lock_target)? == LockfileTargetPolicy::Artifact
+        {
             let platform_key = self.get_platform_key();
             let has_lockfile_url = tv
                 .lock_platforms

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -89,6 +89,8 @@ pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 pub enum LockfileTargetPolicy {
     /// The target is represented by a URL-backed lock entry.
     Artifact,
+    /// The target is represented by an installer-owned source outcome.
+    Source,
     /// This backend does not currently produce lock information for the target.
     Unsupported,
 }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -289,8 +289,12 @@ impl Backend for NPMBackend {
 
     /// NPM installs packages from npm registry using version specs (e.g., eslint@8.0.0).
     /// It doesn't support installing from direct URLs, so lockfile URLs are not applicable.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn get_optional_dependencies(&self) -> eyre::Result<Vec<&str>> {

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -127,8 +127,12 @@ impl Backend for PIPXBackend {
 
     /// Pipx installs packages from PyPI or Git using version specs (e.g., black==24.3.0).
     /// It doesn't support installing from direct URLs, so lockfile URLs are not applicable.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {

--- a/src/backend/pkgx.rs
+++ b/src/backend/pkgx.rs
@@ -78,10 +78,6 @@ impl Backend for PkgxBackend {
         &self.ba
     }
 
-    fn supports_lockfile_url(&self) -> bool {
-        true
-    }
-
     fn mark_prereleases_from_version_pattern(&self) -> bool {
         true
     }

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -444,8 +444,12 @@ impl Backend for UbiBackend {
 
     /// UBI is deprecated in favor of the github backend and doesn't resolve download URLs
     /// at lock time. Return false so --locked mode doesn't error for ubi tools.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn resolve_lockfile_options(

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -82,10 +82,18 @@ impl Backend for VfoxBackend {
         true
     }
 
-    fn supports_lockfile_url(&self) -> bool {
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> eyre::Result<crate::backend::LockfileTargetPolicy> {
         // TODO: expose a plugin hook (e.g. BackendLockInfo) so custom Lua backends
         // can surface a download URL + checksum, and flip this back on for them.
-        !self.is_backend_plugin()
+        Ok(if self.is_backend_plugin() {
+            crate::backend::LockfileTargetPolicy::Unsupported
+        } else {
+            crate::backend::LockfileTargetPolicy::Artifact
+        })
     }
 
     fn remote_version_listing_tool_option_keys(&self) -> &'static [&'static str] {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1860,12 +1860,22 @@ fn tool_version_needs_auto_lock(
 
     for platform in target_platforms {
         for variant in backend.platform_variants(platform) {
+            let policy =
+                backend.lockfile_target_policy(tv, &PlatformTarget::new(variant.clone()))?;
+            if policy == crate::backend::LockfileTargetPolicy::Unsupported {
+                continue;
+            }
             let platform_key = variant.to_key();
-            if !tool
+            let complete = tool
                 .platforms
                 .get(&platform_key)
-                .is_some_and(|info| info.checksum.is_some() && info.url.is_some())
-            {
+                .is_some_and(|info| match policy {
+                    crate::backend::LockfileTargetPolicy::Artifact => {
+                        info.checksum.is_some() && info.url.is_some()
+                    }
+                    crate::backend::LockfileTargetPolicy::Unsupported => true,
+                });
+            if !complete {
                 return Ok(true);
             }
         }
@@ -1974,12 +1984,9 @@ pub async fn auto_lock_new_versions(
         .flat_map(|tvl| tvl.versions.iter())
         .chain(new_versions.iter())
     {
-        let Ok(backend) = tv.request.backend() else {
+        let Ok(_backend) = tv.request.backend() else {
             continue;
         };
-        if !backend.supports_lockfile_url() {
-            continue;
-        }
         if let Some((lockfile_path, _)) = lockfile_path_for_tool_source(config, tv.request.source())
         {
             let candidate_key = (
@@ -2056,13 +2063,25 @@ pub async fn auto_lock_new_versions(
 
                 for variant in variants {
                     let platform_key = variant.to_key();
+                    let policy = if let Some(backend) = &backend {
+                        backend.lockfile_target_policy(tv, &PlatformTarget::new(variant.clone()))?
+                    } else {
+                        crate::backend::LockfileTargetPolicy::Unsupported
+                    };
+                    if policy == crate::backend::LockfileTargetPolicy::Unsupported {
+                        continue;
+                    }
 
-                    // Skip if this tool/version/platform already has both checksum and URL
+                    // Skip outcomes already complete for this target.
                     if let Some(tools) = lockfile.tools.get(&ba.short)
                         && let Some(tool) = tools.iter().find(|t| t.version == tv.version)
                         && let Some(info) = tool.platforms.get(&platform_key)
-                        && info.checksum.is_some()
-                        && info.url.is_some()
+                        && match policy {
+                            crate::backend::LockfileTargetPolicy::Artifact => {
+                                info.checksum.is_some() && info.url.is_some()
+                            }
+                            crate::backend::LockfileTargetPolicy::Unsupported => true,
+                        }
                     {
                         continue;
                     }
@@ -3466,6 +3485,18 @@ options = { exe = "rg" }
         let tv = basic_tv("aqua:astral-sh/ruff", "0.15.20");
 
         assert!(tool_version_needs_auto_lock(&lockfile, &tv, &[Platform::current()]).unwrap());
+    }
+
+    #[test]
+    fn test_tool_version_needs_auto_lock_skips_unsupported_target() {
+        let mut lockfile = Lockfile::default();
+        lockfile.tools.insert(
+            "ripgrep".to_string(),
+            vec![basic_tool("14.1.1", "cargo:ripgrep")],
+        );
+        let tv = basic_tv("cargo:ripgrep", "14.1.1");
+
+        assert!(!tool_version_needs_auto_lock(&lockfile, &tv, &[Platform::current()]).unwrap());
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1873,6 +1873,9 @@ fn tool_version_needs_auto_lock(
                     crate::backend::LockfileTargetPolicy::Artifact => {
                         info.checksum.is_some() && info.url.is_some()
                     }
+                    crate::backend::LockfileTargetPolicy::Source => {
+                        info.install.as_deref() == Some("source")
+                    }
                     crate::backend::LockfileTargetPolicy::Unsupported => true,
                 });
             if !complete {
@@ -2079,6 +2082,9 @@ pub async fn auto_lock_new_versions(
                         && match policy {
                             crate::backend::LockfileTargetPolicy::Artifact => {
                                 info.checksum.is_some() && info.url.is_some()
+                            }
+                            crate::backend::LockfileTargetPolicy::Source => {
+                                info.install.as_deref() == Some("source")
                             }
                             crate::backend::LockfileTargetPolicy::Unsupported => true,
                         }
@@ -3516,6 +3522,38 @@ options = { exe = "rg" }
         let tv = basic_tv("aqua:astral-sh/ruff", "0.15.20");
 
         assert!(!tool_version_needs_auto_lock(&lockfile, &tv, &[Platform::current()]).unwrap());
+    }
+
+    #[test]
+    fn test_tool_version_needs_auto_lock_treats_source_as_complete_per_target() {
+        let mut lockfile = Lockfile::default();
+        let mut tool = basic_tool("3.13.0", "core:python");
+        tool.platforms.insert(
+            Platform::current().to_key(),
+            PlatformInfo {
+                install: Some("source".to_string()),
+                ..Default::default()
+            },
+        );
+        lockfile.tools.insert("python".to_string(), vec![tool]);
+        let mut tv = basic_tv("core:python", "3.13.0");
+        tv.lock_platforms.insert(
+            Platform::current().to_key(),
+            PlatformInfo {
+                install: Some("source".to_string()),
+                ..Default::default()
+            },
+        );
+
+        assert!(!tool_version_needs_auto_lock(&lockfile, &tv, &[Platform::current()]).unwrap());
+        assert!(
+            tool_version_needs_auto_lock(
+                &lockfile,
+                &tv,
+                &[Platform::current(), Platform::parse("windows-x64").unwrap()],
+            )
+            .unwrap()
+        );
     }
 
     #[test]

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -103,8 +103,12 @@ impl Backend for DotnetPlugin {
         &self.ba
     }
 
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn resolve_lockfile_options(

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -493,10 +493,18 @@ impl Backend for ErlangPlugin {
         self.install_via_kerl(ctx, tv).await
     }
 
-    fn supports_lockfile_url(&self) -> bool {
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
         // In default mode, precompiled Erlang is opportunistic and may fall
         // back to kerl, so locked installs cannot always require a URL.
-        Settings::get().erlang.compile == Some(false)
+        Ok(if Settings::get().erlang.compile == Some(false) {
+            crate::backend::LockfileTargetPolicy::Artifact
+        } else {
+            crate::backend::LockfileTargetPolicy::Unsupported
+        })
     }
 
     fn resolve_lockfile_options(

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -821,10 +821,21 @@ impl Backend for PythonPlugin {
         &self.ba
     }
 
-    fn requires_lockfile_url(&self, tv: &ToolVersion) -> bool {
-        // core:python cannot build from source on Windows, so a manually
-        // authored source marker must not bypass the precompiled URL check.
-        cfg!(windows) || !is_source_lock(&tv.lock_platforms, &self.get_platform_key())
+    fn lockfile_target_policy(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        let platform_key = target.to_key();
+        if target.os_name() == "windows" || !is_source_lock(&tv.lock_platforms, &platform_key) {
+            return Ok(crate::backend::LockfileTargetPolicy::Artifact);
+        }
+        if Settings::get().python.compile == Some(false) {
+            bail!(
+                "invalid Python lockfile: install = \"source\" conflicts with python.compile=false"
+            );
+        }
+        Ok(crate::backend::LockfileTargetPolicy::Source)
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -32,6 +32,7 @@ use xx::regex;
 
 const ATTESTATION_HELP: &str = "To disable attestation verification, set MISE_PYTHON_GITHUB_ATTESTATIONS=false\n\
     or add `python.github_attestations = false` under [settings] in mise.toml";
+const DEFAULT_PYENV_REPO: &str = "https://github.com/pyenv/pyenv.git";
 
 #[derive(Debug)]
 pub struct PythonPlugin {
@@ -153,7 +154,6 @@ impl PythonPlugin {
             .lock()
     }
     fn install_or_update_python_build(&self, ctx: Option<&InstallContext>) -> eyre::Result<()> {
-        ensure_not_windows()?;
         let _lock = self.lock_pyenv();
         if self.python_build_bin().exists() {
             self.update_python_build()
@@ -511,6 +511,7 @@ impl PythonPlugin {
         ctx: &InstallContext,
         tv: &mut ToolVersion,
     ) -> eyre::Result<()> {
+        ensure_not_windows()?;
         self.install_or_update_python_build(Some(ctx))?;
         if matches!(&tv.request, ToolRequest::Ref { .. }) {
             return Err(eyre!("Ref versions not supported for python"));
@@ -1103,6 +1104,24 @@ impl Backend for PythonPlugin {
             }
         }
 
+        // Source fallback can use these settings even when compile is unset.
+        // Keep them in the shared lock identity so every target platform uses
+        // the same python-build recipe and patches.
+        if compile != Some(false) {
+            if settings.python.pyenv_repo != DEFAULT_PYENV_REPO {
+                opts.insert("pyenv_repo".to_string(), settings.python.pyenv_repo.clone());
+            }
+            if let Some(patch_url) = settings.python.patch_url.clone() {
+                opts.insert("patch_url".to_string(), patch_url);
+            }
+            if let Some(patches_directory) = &settings.python.patches_directory {
+                opts.insert(
+                    "patches_directory".to_string(),
+                    patches_directory.to_string_lossy().to_string(),
+                );
+            }
+        }
+
         let raw_opts = request.options();
         opts.extend(PythonOptions::new(&raw_opts).lockfile_options());
         Ok(opts)
@@ -1166,9 +1185,12 @@ fn parse_python_build_source(definition: &str) -> Result<PythonBuildSource> {
         .ok_or_else(|| eyre!("python-build definition has no source package"))?;
     let source_spec = packages
         .iter()
-        .find(|(name, _)| name == &package_name)
+        .filter(|(name, _)| name == &package_name)
         .map(|(_, source)| source)
-        .expect("package_name was derived from packages.last(); it must be present");
+        .find(|source| python_build_source_is_gzip(source))
+        .ok_or_else(|| {
+            eyre!("python-build definition has no portable gzip source for {package_name:?}")
+        })?;
     let (url, checksum) =
         source_spec
             .split_once('#')
@@ -1217,15 +1239,13 @@ fn rewrite_python_build_source(definition: &str, source: &PythonBuildSource) -> 
 }
 
 fn python_build_archive_name(source: &PythonBuildSource) -> String {
-    let url_path = source.url.split(['?', '#']).next().unwrap_or(&source.url);
-    let extension = if url_path.ends_with("bz2") {
-        "tar.bz2"
-    } else if url_path.ends_with("xz") {
-        "tar.xz"
-    } else {
-        "tar.gz"
-    };
-    format!("{}.{extension}", source.package_name)
+    format!("{}.tar.gz", source.package_name)
+}
+
+fn python_build_source_is_gzip(source: &str) -> bool {
+    let url = source.split_once('#').map_or(source, |(url, _)| url);
+    let path = url.split(['?', '#']).next().unwrap_or(url);
+    path.ends_with(".tgz") || path.ends_with(".tar.gz")
 }
 
 fn should_compile_from_source(
@@ -1421,6 +1441,40 @@ fn filter_freethreaded(v: &str, flavor: &Option<String>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::settings::SettingsPartial;
+    use crate::toolset::ToolSource;
+    use confique::Layer;
+
+    static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct SettingsResetGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for SettingsResetGuard {
+        fn drop(&mut self) {
+            Settings::reset(None);
+        }
+    }
+
+    fn resolve_python_lockfile_options(
+        configure_settings: impl FnOnce(&mut SettingsPartial),
+    ) -> BTreeMap<String, String> {
+        let lock = TEST_SETTINGS_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut settings = SettingsPartial::empty();
+        configure_settings(&mut settings);
+        Settings::reset(Some(settings));
+        let _guard = SettingsResetGuard { _lock: lock };
+
+        let backend = PythonPlugin::new();
+        let request = ToolRequest::new(backend.ba().clone(), "3.13.0", ToolSource::Unknown)
+            .expect("valid Python request");
+        backend
+            .resolve_lockfile_options(&request, &PlatformTarget::from_current())
+            .expect("Python lockfile options")
+    }
 
     const PYTHON_BUILD_DEFINITION: &str = r#"
 install_package "openssl-3.3.2" "https://example.com/openssl.tar.gz#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" mac_openssl
@@ -1437,26 +1491,26 @@ fi
         assert_eq!(source.package_name, "Python-3.13.0");
         assert_eq!(
             source.url,
-            "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz"
+            "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tgz"
         );
         assert_eq!(
             source.checksum.as_deref(),
-            Some("sha256:086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d")
+            Some("sha256:12445c7b3db3126c41190bfdc1c8239c39c719404e844babbd015a1bc3fafcd4")
         );
-        assert_eq!(python_build_archive_name(&source), "Python-3.13.0.tar.xz");
+        assert_eq!(python_build_archive_name(&source), "Python-3.13.0.tar.gz");
         let source_with_query = PythonBuildSource {
             url: format!("{}?download=1#fragment", source.url),
             ..source.clone()
         };
         assert_eq!(
             python_build_archive_name(&source_with_query),
-            "Python-3.13.0.tar.xz"
+            "Python-3.13.0.tar.gz"
         );
 
         let rewritten = rewrite_python_build_source(PYTHON_BUILD_DEFINITION, &source).unwrap();
         assert_eq!(rewritten.matches(&source.url).count(), 2);
         assert!(rewritten.contains("https://example.com/openssl.tar.gz"));
-        assert!(!rewritten.contains("Python-3.13.0.tgz"));
+        assert!(!rewritten.contains("Python-3.13.0.tar.xz"));
     }
 
     #[test]
@@ -1552,6 +1606,48 @@ fi
 
         let opts = opts_with("patch_sysconfig", "true");
         assert!(PythonOptions::new(&opts).lockfile_options().is_empty());
+    }
+
+    #[test]
+    fn python_lockfile_options_include_source_build_settings() {
+        let opts = resolve_python_lockfile_options(|settings| {
+            settings.python.patch_url = Some("https://example.com/python.patch".to_string());
+            settings.python.patches_directory = Some(PathBuf::from("/tmp/python-patches"));
+            settings.python.pyenv_repo = Some("https://example.com/pyenv.git".to_string());
+        });
+
+        assert_eq!(
+            opts,
+            BTreeMap::from([
+                (
+                    "patch_url".to_string(),
+                    "https://example.com/python.patch".to_string()
+                ),
+                (
+                    "patches_directory".to_string(),
+                    "/tmp/python-patches".to_string()
+                ),
+                (
+                    "pyenv_repo".to_string(),
+                    "https://example.com/pyenv.git".to_string()
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn python_lockfile_options_omit_source_settings_when_compile_is_false() {
+        let opts = resolve_python_lockfile_options(|settings| {
+            settings.python.compile = Some(false);
+            settings.python.patch_url = Some("https://example.com/python.patch".to_string());
+            settings.python.patches_directory = Some(PathBuf::from("/tmp/python-patches"));
+            settings.python.pyenv_repo = Some("https://example.com/pyenv.git".to_string());
+        });
+
+        assert_eq!(
+            opts,
+            BTreeMap::from([("compile".to_string(), "false".to_string())])
+        );
     }
 
     #[test]

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -39,13 +39,6 @@ pub struct PythonPlugin {
     ba: Arc<BackendArg>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PythonBuildSource {
-    package_name: String,
-    url: String,
-    checksum: Option<String>,
-}
-
 #[derive(Debug, Clone, Copy)]
 struct PythonOptions<'a> {
     values: BackendOptions<'a>,
@@ -141,11 +134,6 @@ impl PythonPlugin {
         self.python_build_path()
             .join("plugins/python-build/bin/python-build")
     }
-    fn python_build_definition_path(&self, version: &str) -> PathBuf {
-        self.python_build_path()
-            .join("plugins/python-build/share/python-build")
-            .join(version)
-    }
     fn lock_pyenv(&self) -> Result<fslock::LockFile> {
         LockFile::new(&self.python_build_path())
             .with_callback(|l| {
@@ -201,26 +189,11 @@ impl PythonPlugin {
             }
         }
     }
-    fn read_python_build_source(&self, version: &str) -> Result<(String, PythonBuildSource)> {
-        let definition_path = self.python_build_definition_path(version);
-        let definition = file::read_to_string(&definition_path).map_err(|err| {
-            eyre!(
-                "failed to read python-build definition for {version} at {}: {err}",
-                definition_path.display()
-            )
-        })?;
-        let source = parse_python_build_source(&definition)?;
-        Ok((definition, source))
-    }
-    fn resolve_source_lock_info(&self, version: &str) -> Result<PlatformInfo> {
-        self.install_or_update_python_build(None)?;
-        let (_, source) = self.read_python_build_source(version)?;
-        Ok(PlatformInfo {
+    fn source_lock_info() -> PlatformInfo {
+        PlatformInfo {
             install: Some("source".to_string()),
-            checksum: source.checksum,
-            url: Some(source.url),
             ..Default::default()
-        })
+        }
     }
     fn set_lockfile_info(
         &self,
@@ -248,33 +221,18 @@ impl PythonPlugin {
             platform_info.checksum = Some(checksum);
         }
     }
-    fn prepare_locked_python_build_definition(
-        &self,
-        tv: &ToolVersion,
-        definition: &str,
-        source: &PythonBuildSource,
-    ) -> Result<PathBuf> {
-        let definition_path = self.python_build_definition_path(&tv.version);
-        let definition = rewrite_python_build_source(definition, source)?;
-        let locked_dir = tv.download_path().join(format!(
-            "python-build-definition-{}",
-            crate::hash::hash_sha256_to_str(&source.url)
-        ));
-        file::create_dir_all(&locked_dir)?;
-        let locked_definition_path = locked_dir.join(&tv.version);
-        file::write(&locked_definition_path, definition)?;
-
-        let patches = definition_path
-            .parent()
-            .unwrap()
-            .join("patches")
-            .join(&tv.version);
-        if patches.exists() {
-            let locked_patches = locked_dir.join("patches").join(&tv.version);
-            file::remove_all(&locked_patches)?;
-            file::copy_dir_all(patches, locked_patches)?;
-        }
-        Ok(locked_definition_path)
+    fn set_source_lockfile_info(&self, tv: &mut ToolVersion) {
+        let platform_info = tv
+            .lock_platforms
+            .entry(self.get_platform_key())
+            .or_default();
+        platform_info.install = Some("source".to_string());
+        platform_info.checksum = None;
+        platform_info.size = None;
+        platform_info.url = None;
+        platform_info.url_api = None;
+        platform_info.provenance = None;
+        platform_info.github_attestations = None;
     }
     fn python_build_definition_created_at(&self) -> eyre::Result<BTreeMap<String, String>> {
         let output = crate::cmd!(
@@ -516,63 +474,15 @@ impl PythonPlugin {
         if matches!(&tv.request, ToolRequest::Ref { .. }) {
             return Err(eyre!("Ref versions not supported for python"));
         }
-
-        let platform_key = self.get_platform_key();
-        let (definition, mut source) = self.read_python_build_source(&tv.version)?;
-        let source_info = if ctx.locked {
-            tv.lock_platforms
-                .get(&platform_key)
-                .cloned()
-                .ok_or_else(|| eyre!("missing locked Python source info for {platform_key}"))?
-        } else {
-            PlatformInfo {
-                install: Some("source".to_string()),
-                checksum: source.checksum.clone(),
-                url: Some(source.url.clone()),
-                ..Default::default()
-            }
-        };
-        let source_url = source_info
-            .url
-            .as_deref()
-            .ok_or_else(|| eyre!("missing Python source URL for {platform_key}"))?;
-        self.set_lockfile_info(tv, Some("source"), source_url, source_info.checksum.clone());
-
-        source.url = source_url.to_string();
-        source.checksum = source_info.checksum;
-        let source_path = tv.download_path().join(format!(
-            "python-source-{}",
-            crate::hash::hash_sha256_to_str(source_url)
-        ));
-        let display_name = source_url
-            .rsplit('/')
-            .next()
-            .filter(|name| !name.is_empty())
-            .unwrap_or("Python source");
-        ctx.pr.set_message(format!("download {display_name}"));
-        if !source_path.exists() {
-            HTTP.download_file(source_url, &source_path, Some(ctx.pr.as_ref()))
-                .await?;
-        }
-        self.verify_checksum(ctx, tv, &source_path)?;
-
-        let locked_definition =
-            self.prepare_locked_python_build_definition(tv, &definition, &source)?;
-        let python_build_cache = tv.download_path().join("python-build-cache");
-        file::create_dir_all(&python_build_cache)?;
-        file::copy(
-            &source_path,
-            python_build_cache.join(python_build_archive_name(&source)),
-        )?;
+        self.set_source_lockfile_info(tv);
 
         ctx.pr.set_message("python-build".into());
         let mut cmd = CmdLineRunner::new(self.python_build_bin())
             .with_pr(ctx.pr.as_ref())
-            .arg(locked_definition)
+            .arg(tv.version.as_str())
             .arg(tv.install_path())
             .envs(ctx.config.env().await?)
             .envs(tv.install_env())
-            .env("PYTHON_BUILD_CACHE_PATH", python_build_cache)
             .env("PIP_REQUIRE_VIRTUALENV", "false");
         if Settings::get().verbose {
             cmd = cmd.arg("--verbose");
@@ -911,6 +821,12 @@ impl Backend for PythonPlugin {
         &self.ba
     }
 
+    fn requires_lockfile_url(&self, tv: &ToolVersion) -> bool {
+        // core:python cannot build from source on Windows, so a manually
+        // authored source marker must not bypass the precompiled URL check.
+        cfg!(windows) || !is_source_lock(&tv.lock_platforms, &self.get_platform_key())
+    }
+
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         if cfg!(windows) || Settings::get().python.compile == Some(false) {
             Ok(self
@@ -1136,7 +1052,7 @@ impl Backend for PythonPlugin {
         let compile = Settings::get().python.compile;
 
         if compile == Some(true) && target.os_name() != "windows" {
-            return self.resolve_source_lock_info(version);
+            return Ok(Self::source_lock_info());
         }
 
         // Look up the precompiled release for this version and target platform
@@ -1145,7 +1061,7 @@ impl Backend for PythonPlugin {
             if compile == Some(false) || target.os_name() == "windows" {
                 return Ok(PlatformInfo::default());
             }
-            return self.resolve_source_lock_info(version);
+            return Ok(Self::source_lock_info());
         };
 
         let url = format!(
@@ -1170,84 +1086,6 @@ impl Backend for PythonPlugin {
     }
 }
 
-fn python_build_package_specs(definition: &str) -> Vec<(String, String)> {
-    regex!(r#"(?m)^\s*install_package\s+"([^"]+)"\s+"([^"]+)""#)
-        .captures_iter(definition)
-        .map(|captures| (captures[1].to_string(), captures[2].to_string()))
-        .collect()
-}
-
-fn parse_python_build_source(definition: &str) -> Result<PythonBuildSource> {
-    let packages = python_build_package_specs(definition);
-    let package_name = packages
-        .last()
-        .map(|(name, _)| name.clone())
-        .ok_or_else(|| eyre!("python-build definition has no source package"))?;
-    let source_spec = packages
-        .iter()
-        .filter(|(name, _)| name == &package_name)
-        .map(|(_, source)| source)
-        .find(|source| python_build_source_is_gzip(source))
-        .ok_or_else(|| {
-            eyre!("python-build definition has no portable gzip source for {package_name:?}")
-        })?;
-    let (url, checksum) =
-        source_spec
-            .split_once('#')
-            .map_or((source_spec.as_str(), None), |(url, checksum)| {
-                let algorithm = match checksum.len() {
-                    32 => "md5",
-                    64 => "sha256",
-                    _ => return (url, None),
-                };
-                (url, Some(format!("{algorithm}:{checksum}")))
-            });
-    Ok(PythonBuildSource {
-        package_name,
-        url: url.to_string(),
-        checksum,
-    })
-}
-
-fn rewrite_python_build_source(definition: &str, source: &PythonBuildSource) -> Result<String> {
-    let packages = python_build_package_specs(definition);
-    if !packages
-        .iter()
-        .any(|(name, _)| name == &source.package_name)
-    {
-        bail!(
-            "python-build definition has no package named {:?}",
-            source.package_name
-        );
-    }
-    let checksum = source
-        .checksum
-        .as_deref()
-        .and_then(|checksum| checksum.split_once(':'))
-        .filter(|(algorithm, _)| matches!(*algorithm, "md5" | "sha256"))
-        .map(|(_, checksum)| format!("#{checksum}"))
-        .unwrap_or_default();
-    let locked_spec = format!("{}{}", source.url, checksum);
-    let mut rewritten = definition.to_string();
-    for (_, source_spec) in packages
-        .iter()
-        .filter(|(name, _)| name == &source.package_name)
-    {
-        rewritten = rewritten.replace(&format!("\"{source_spec}\""), &format!("\"{locked_spec}\""));
-    }
-    Ok(rewritten)
-}
-
-fn python_build_archive_name(source: &PythonBuildSource) -> String {
-    format!("{}.tar.gz", source.package_name)
-}
-
-fn python_build_source_is_gzip(source: &str) -> bool {
-    let url = source.split_once('#').map_or(source, |(url, _)| url);
-    let path = url.split(['?', '#']).next().unwrap_or(url);
-    path.ends_with(".tgz") || path.ends_with(".tar.gz")
-}
-
 fn should_compile_from_source(
     locked: bool,
     lock_platforms: &BTreeMap<String, PlatformInfo>,
@@ -1255,12 +1093,16 @@ fn should_compile_from_source(
     python_compile: Option<bool>,
 ) -> bool {
     if locked {
-        lock_platforms
-            .get(platform_key)
-            .is_some_and(|info| info.install.as_deref() == Some("source"))
+        is_source_lock(lock_platforms, platform_key)
     } else {
         python_compile == Some(true)
     }
+}
+
+fn is_source_lock(lock_platforms: &BTreeMap<String, PlatformInfo>, platform_key: &str) -> bool {
+    lock_platforms
+        .get(platform_key)
+        .is_some_and(|info| info.install.as_deref() == Some("source"))
 }
 
 fn parse_python_build_definition_created_at(output: &str) -> BTreeMap<String, String> {
@@ -1476,43 +1318,6 @@ mod tests {
             .expect("Python lockfile options")
     }
 
-    const PYTHON_BUILD_DEFINITION: &str = r#"
-install_package "openssl-3.3.2" "https://example.com/openssl.tar.gz#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" mac_openssl
-if has_tar_xz_support; then
-  install_package "Python-3.13.0" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz#086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d" standard
-else
-  install_package "Python-3.13.0" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tgz#12445c7b3db3126c41190bfdc1c8239c39c719404e844babbd015a1bc3fafcd4" standard
-fi
-"#;
-
-    #[test]
-    fn parses_and_rewrites_python_build_source() {
-        let source = parse_python_build_source(PYTHON_BUILD_DEFINITION).unwrap();
-        assert_eq!(source.package_name, "Python-3.13.0");
-        assert_eq!(
-            source.url,
-            "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tgz"
-        );
-        assert_eq!(
-            source.checksum.as_deref(),
-            Some("sha256:12445c7b3db3126c41190bfdc1c8239c39c719404e844babbd015a1bc3fafcd4")
-        );
-        assert_eq!(python_build_archive_name(&source), "Python-3.13.0.tar.gz");
-        let source_with_query = PythonBuildSource {
-            url: format!("{}?download=1#fragment", source.url),
-            ..source.clone()
-        };
-        assert_eq!(
-            python_build_archive_name(&source_with_query),
-            "Python-3.13.0.tar.gz"
-        );
-
-        let rewritten = rewrite_python_build_source(PYTHON_BUILD_DEFINITION, &source).unwrap();
-        assert_eq!(rewritten.matches(&source.url).count(), 2);
-        assert!(rewritten.contains("https://example.com/openssl.tar.gz"));
-        assert!(!rewritten.contains("Python-3.13.0.tar.xz"));
-    }
-
     #[test]
     fn python_install_routing_matches_locked_outcome() {
         let platform_key = Platform::current().to_key();
@@ -1520,10 +1325,10 @@ fi
             platform_key.clone(),
             PlatformInfo {
                 install: Some("source".to_string()),
-                url: Some("https://www.python.org/Python.tar.xz".to_string()),
                 ..Default::default()
             },
         )]);
+        assert!(is_source_lock(&source_lock, &platform_key));
         assert!(should_compile_from_source(
             true,
             &source_lock,

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -38,6 +38,13 @@ pub struct PythonPlugin {
     ba: Arc<BackendArg>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PythonBuildSource {
+    package_name: String,
+    url: String,
+    checksum: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct PythonOptions<'a> {
     values: BackendOptions<'a>,
@@ -133,6 +140,11 @@ impl PythonPlugin {
         self.python_build_path()
             .join("plugins/python-build/bin/python-build")
     }
+    fn python_build_definition_path(&self, version: &str) -> PathBuf {
+        self.python_build_path()
+            .join("plugins/python-build/share/python-build")
+            .join(version)
+    }
     fn lock_pyenv(&self) -> Result<fslock::LockFile> {
         LockFile::new(&self.python_build_path())
             .with_callback(|l| {
@@ -188,6 +200,80 @@ impl PythonPlugin {
                 self.install_python_build(None)
             }
         }
+    }
+    fn read_python_build_source(&self, version: &str) -> Result<PythonBuildSource> {
+        let definition_path = self.python_build_definition_path(version);
+        let definition = file::read_to_string(&definition_path).map_err(|err| {
+            eyre!(
+                "failed to read python-build definition for {version} at {}: {err}",
+                definition_path.display()
+            )
+        })?;
+        parse_python_build_source(&definition)
+    }
+    fn resolve_source_lock_info(&self, version: &str) -> Result<PlatformInfo> {
+        self.install_or_update_python_build(None)?;
+        let source = self.read_python_build_source(version)?;
+        Ok(PlatformInfo {
+            install: Some("source".to_string()),
+            checksum: source.checksum,
+            url: Some(source.url),
+            ..Default::default()
+        })
+    }
+    fn set_lockfile_info(
+        &self,
+        tv: &mut ToolVersion,
+        install: Option<&str>,
+        url: &str,
+        checksum: Option<String>,
+    ) {
+        let platform_info = tv
+            .lock_platforms
+            .entry(self.get_platform_key())
+            .or_default();
+        let artifact_changed = platform_info.install.as_deref() != install
+            || platform_info.url.as_deref() != Some(url);
+        if artifact_changed {
+            platform_info.checksum = None;
+            platform_info.size = None;
+            platform_info.url_api = None;
+            platform_info.provenance = None;
+            platform_info.github_attestations = None;
+        }
+        platform_info.install = install.map(str::to_string);
+        platform_info.url = Some(url.to_string());
+        if let Some(checksum) = checksum {
+            platform_info.checksum = Some(checksum);
+        }
+    }
+    fn prepare_locked_python_build_definition(
+        &self,
+        tv: &ToolVersion,
+        source: &PythonBuildSource,
+    ) -> Result<PathBuf> {
+        let definition_path = self.python_build_definition_path(&tv.version);
+        let definition = file::read_to_string(&definition_path)?;
+        let definition = rewrite_python_build_source(&definition, source)?;
+        let locked_dir = tv.download_path().join(format!(
+            "python-build-definition-{}",
+            crate::hash::hash_sha256_to_str(&source.url)
+        ));
+        file::create_dir_all(&locked_dir)?;
+        let locked_definition_path = locked_dir.join(&tv.version);
+        file::write(&locked_definition_path, definition)?;
+
+        let patches = definition_path
+            .parent()
+            .unwrap()
+            .join("patches")
+            .join(&tv.version);
+        if patches.exists() {
+            let locked_patches = locked_dir.join("patches").join(&tv.version);
+            file::remove_all(&locked_patches)?;
+            file::copy_dir_all(patches, locked_patches)?;
+        }
+        Ok(locked_definition_path)
     }
     fn python_build_definition_created_at(&self) -> eyre::Result<BTreeMap<String, String>> {
         let output = crate::cmd!(
@@ -282,11 +368,14 @@ impl PythonPlugin {
         tv: &mut ToolVersion,
     ) -> eyre::Result<()> {
         let platform_key = self.get_platform_key();
-        let url = if let Some(url) = tv
-            .lock_platforms
-            .get(&platform_key)
-            .and_then(|pi| pi.url.clone())
-        {
+        let locked_url = if ctx.locked {
+            tv.lock_platforms
+                .get(&platform_key)
+                .and_then(|info| info.url.clone())
+        } else {
+            None
+        };
+        let url = if let Some(url) = locked_url {
             debug!("using lockfile URL for platform {platform_key}: {url}");
             url
         } else {
@@ -348,11 +437,7 @@ impl PythonPlugin {
         HTTP.download_file(&url, &tarball_path, Some(ctx.pr.as_ref()))
             .await?;
 
-        // Record the URL in lock_platforms so verify_checksum can find it
-        tv.lock_platforms
-            .entry(platform_key.clone())
-            .or_default()
-            .url = Some(url.to_string());
+        self.set_lockfile_info(tv, None, &url, None);
 
         // Check before verify_checksum, which may generate a new checksum from the
         // downloaded file. We only skip provenance when the lockfile already had
@@ -420,18 +505,72 @@ impl PythonPlugin {
         Ok(())
     }
 
-    async fn install_compiled(&self, ctx: &InstallContext, tv: &ToolVersion) -> eyre::Result<()> {
+    async fn install_compiled(
+        &self,
+        ctx: &InstallContext,
+        tv: &mut ToolVersion,
+    ) -> eyre::Result<()> {
         self.install_or_update_python_build(Some(ctx))?;
         if matches!(&tv.request, ToolRequest::Ref { .. }) {
             return Err(eyre!("Ref versions not supported for python"));
         }
+
+        let platform_key = self.get_platform_key();
+        let source_info = if ctx.locked {
+            tv.lock_platforms
+                .get(&platform_key)
+                .cloned()
+                .ok_or_else(|| eyre!("missing locked Python source info for {platform_key}"))?
+        } else {
+            let source = self.read_python_build_source(&tv.version)?;
+            PlatformInfo {
+                install: Some("source".to_string()),
+                checksum: source.checksum,
+                url: Some(source.url),
+                ..Default::default()
+            }
+        };
+        let source_url = source_info
+            .url
+            .as_deref()
+            .ok_or_else(|| eyre!("missing Python source URL for {platform_key}"))?;
+        self.set_lockfile_info(tv, Some("source"), source_url, source_info.checksum.clone());
+
+        let mut source = self.read_python_build_source(&tv.version)?;
+        source.url = source_url.to_string();
+        source.checksum = source_info.checksum;
+        let source_path = tv.download_path().join(format!(
+            "python-source-{}",
+            crate::hash::hash_sha256_to_str(source_url)
+        ));
+        let display_name = source_url
+            .rsplit('/')
+            .next()
+            .filter(|name| !name.is_empty())
+            .unwrap_or("Python source");
+        ctx.pr.set_message(format!("download {display_name}"));
+        if !source_path.exists() {
+            HTTP.download_file(source_url, &source_path, Some(ctx.pr.as_ref()))
+                .await?;
+        }
+        self.verify_checksum(ctx, tv, &source_path)?;
+
+        let locked_definition = self.prepare_locked_python_build_definition(tv, &source)?;
+        let python_build_cache = tv.download_path().join("python-build-cache");
+        file::create_dir_all(&python_build_cache)?;
+        file::copy(
+            &source_path,
+            python_build_cache.join(python_build_archive_name(&source)),
+        )?;
+
         ctx.pr.set_message("python-build".into());
         let mut cmd = CmdLineRunner::new(self.python_build_bin())
             .with_pr(ctx.pr.as_ref())
-            .arg(tv.version.as_str())
+            .arg(locked_definition)
             .arg(tv.install_path())
             .envs(ctx.config.env().await?)
             .envs(tv.install_env())
+            .env("PYTHON_BUILD_CACHE_PATH", python_build_cache)
             .env("PIP_REQUIRE_VIRTUALENV", "false");
         if Settings::get().verbose {
             cmd = cmd.arg("--verbose");
@@ -857,11 +996,19 @@ impl Backend for PythonPlugin {
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
         let settings = Settings::get();
-        if cfg!(windows) || settings.python.compile != Some(true) {
+        let platform_key = self.get_platform_key();
+        if !cfg!(windows)
+            && should_compile_from_source(
+                ctx.locked,
+                &tv.lock_platforms,
+                &platform_key,
+                settings.python.compile,
+            )
+        {
+            self.install_compiled(ctx, &mut tv).await?;
+        } else {
             validate_python_precompiled_settings(&settings)?;
             self.install_precompiled(ctx, &mut tv).await?;
-        } else {
-            self.install_compiled(ctx, &tv).await?;
         }
         self.test_python(&ctx.config, &tv, ctx.pr.as_ref()).await?;
         if let Err(e) = self.get_virtualenv(&ctx.config, &tv).await {
@@ -926,25 +1073,24 @@ impl Backend for PythonPlugin {
     fn resolve_lockfile_options(
         &self,
         request: &ToolRequest,
-        target: &PlatformTarget,
+        _target: &PlatformTarget,
     ) -> Result<BTreeMap<String, String>> {
         let mut opts = BTreeMap::new();
         let settings = Settings::get();
-        let is_current_platform = target.is_current();
-
-        // Only include compile option if true (non-default)
-        let compile = if is_current_platform {
-            settings.python.compile.unwrap_or(false)
-        } else {
-            false
-        };
-        if compile {
-            opts.insert("compile".to_string(), "true".to_string());
+        let compile = settings.python.compile;
+        match compile {
+            Some(true) => {
+                opts.insert("compile".to_string(), "true".to_string());
+            }
+            Some(false) => {
+                opts.insert("compile".to_string(), "false".to_string());
+            }
+            None => {}
         }
 
         // Include precompiled options for all platforms to avoid splitting
         // lockfile entries between host and non-host platforms (#8390)
-        if !compile {
+        if compile != Some(true) {
             if let Some(arch) = settings.python.precompiled_arch.clone() {
                 opts.insert("precompiled_arch".to_string(), arch);
             }
@@ -967,11 +1113,19 @@ impl Backend for PythonPlugin {
         target: &PlatformTarget,
     ) -> Result<PlatformInfo> {
         let version = &tv.version;
+        let compile = Settings::get().python.compile;
+
+        if compile == Some(true) && target.os_name() != "windows" {
+            return self.resolve_source_lock_info(version);
+        }
 
         // Look up the precompiled release for this version and target platform
         let Some((tag, filename)) = self.fetch_precompiled_for_target(version, target).await?
         else {
-            return Ok(PlatformInfo::default());
+            if compile == Some(false) || target.os_name() == "windows" {
+                return Ok(PlatformInfo::default());
+            }
+            return self.resolve_source_lock_info(version);
         };
 
         let url = format!(
@@ -993,6 +1147,97 @@ impl Backend for PythonPlugin {
             provenance,
             ..Default::default()
         })
+    }
+}
+
+fn python_build_package_specs(definition: &str) -> Vec<(String, String)> {
+    regex!(r#"(?m)^\s*install_package\s+"([^"]+)"\s+"([^"]+)""#)
+        .captures_iter(definition)
+        .map(|captures| (captures[1].to_string(), captures[2].to_string()))
+        .collect()
+}
+
+fn parse_python_build_source(definition: &str) -> Result<PythonBuildSource> {
+    let packages = python_build_package_specs(definition);
+    let package_name = packages
+        .last()
+        .map(|(name, _)| name.clone())
+        .ok_or_else(|| eyre!("python-build definition has no source package"))?;
+    let source_spec = packages
+        .iter()
+        .find(|(name, _)| name == &package_name)
+        .map(|(_, source)| source)
+        .unwrap();
+    let (url, checksum) =
+        source_spec
+            .split_once('#')
+            .map_or((source_spec.as_str(), None), |(url, checksum)| {
+                let algorithm = match checksum.len() {
+                    32 => "md5",
+                    64 => "sha256",
+                    _ => return (url, None),
+                };
+                (url, Some(format!("{algorithm}:{checksum}")))
+            });
+    Ok(PythonBuildSource {
+        package_name,
+        url: url.to_string(),
+        checksum,
+    })
+}
+
+fn rewrite_python_build_source(definition: &str, source: &PythonBuildSource) -> Result<String> {
+    let packages = python_build_package_specs(definition);
+    if !packages
+        .iter()
+        .any(|(name, _)| name == &source.package_name)
+    {
+        bail!(
+            "python-build definition has no package named {:?}",
+            source.package_name
+        );
+    }
+    let checksum = source
+        .checksum
+        .as_deref()
+        .and_then(|checksum| checksum.split_once(':'))
+        .filter(|(algorithm, _)| matches!(*algorithm, "md5" | "sha256"))
+        .map(|(_, checksum)| format!("#{checksum}"))
+        .unwrap_or_default();
+    let locked_spec = format!("{}{}", source.url, checksum);
+    let mut rewritten = definition.to_string();
+    for (_, source_spec) in packages
+        .iter()
+        .filter(|(name, _)| name == &source.package_name)
+    {
+        rewritten = rewritten.replace(&format!("\"{source_spec}\""), &format!("\"{locked_spec}\""));
+    }
+    Ok(rewritten)
+}
+
+fn python_build_archive_name(source: &PythonBuildSource) -> String {
+    let extension = if source.url.ends_with("bz2") {
+        "tar.bz2"
+    } else if source.url.ends_with("xz") {
+        "tar.xz"
+    } else {
+        "tar.gz"
+    };
+    format!("{}.{extension}", source.package_name)
+}
+
+fn should_compile_from_source(
+    locked: bool,
+    lock_platforms: &BTreeMap<String, PlatformInfo>,
+    platform_key: &str,
+    python_compile: Option<bool>,
+) -> bool {
+    if locked {
+        lock_platforms
+            .get(platform_key)
+            .is_some_and(|info| info.install.as_deref() == Some("source"))
+    } else {
+        python_compile == Some(true)
     }
 }
 
@@ -1174,6 +1419,80 @@ fn filter_freethreaded(v: &str, flavor: &Option<String>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const PYTHON_BUILD_DEFINITION: &str = r#"
+install_package "openssl-3.3.2" "https://example.com/openssl.tar.gz#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" mac_openssl
+if has_tar_xz_support; then
+  install_package "Python-3.13.0" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz#086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d" standard
+else
+  install_package "Python-3.13.0" "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tgz#12445c7b3db3126c41190bfdc1c8239c39c719404e844babbd015a1bc3fafcd4" standard
+fi
+"#;
+
+    #[test]
+    fn parses_and_rewrites_python_build_source() {
+        let source = parse_python_build_source(PYTHON_BUILD_DEFINITION).unwrap();
+        assert_eq!(source.package_name, "Python-3.13.0");
+        assert_eq!(
+            source.url,
+            "https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tar.xz"
+        );
+        assert_eq!(
+            source.checksum.as_deref(),
+            Some("sha256:086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d")
+        );
+        assert_eq!(python_build_archive_name(&source), "Python-3.13.0.tar.xz");
+
+        let rewritten = rewrite_python_build_source(PYTHON_BUILD_DEFINITION, &source).unwrap();
+        assert_eq!(rewritten.matches(&source.url).count(), 2);
+        assert!(rewritten.contains("https://example.com/openssl.tar.gz"));
+        assert!(!rewritten.contains("Python-3.13.0.tgz"));
+    }
+
+    #[test]
+    fn python_install_routing_matches_locked_outcome() {
+        let platform_key = Platform::current().to_key();
+        let source_lock = BTreeMap::from([(
+            platform_key.clone(),
+            PlatformInfo {
+                install: Some("source".to_string()),
+                url: Some("https://www.python.org/Python.tar.xz".to_string()),
+                ..Default::default()
+            },
+        )]);
+        assert!(should_compile_from_source(
+            true,
+            &source_lock,
+            &platform_key,
+            Some(false)
+        ));
+
+        let precompiled_lock = BTreeMap::from([(
+            platform_key.clone(),
+            PlatformInfo {
+                url: Some("https://github.com/astral-sh/python.tar.gz".to_string()),
+                ..Default::default()
+            },
+        )]);
+        assert!(!should_compile_from_source(
+            true,
+            &precompiled_lock,
+            &platform_key,
+            Some(true)
+        ));
+        assert!(should_compile_from_source(
+            false,
+            &precompiled_lock,
+            &platform_key,
+            Some(true)
+        ));
+        assert!(!should_compile_from_source(
+            false,
+            &source_lock,
+            &platform_key,
+            None
+        ));
+    }
 
     fn opts_with(key: &str, value: &str) -> ToolVersionOptions {
         opts_with_value(key, toml::Value::String(value.to_string()))

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -201,7 +201,7 @@ impl PythonPlugin {
             }
         }
     }
-    fn read_python_build_source(&self, version: &str) -> Result<PythonBuildSource> {
+    fn read_python_build_source(&self, version: &str) -> Result<(String, PythonBuildSource)> {
         let definition_path = self.python_build_definition_path(version);
         let definition = file::read_to_string(&definition_path).map_err(|err| {
             eyre!(
@@ -209,11 +209,12 @@ impl PythonPlugin {
                 definition_path.display()
             )
         })?;
-        parse_python_build_source(&definition)
+        let source = parse_python_build_source(&definition)?;
+        Ok((definition, source))
     }
     fn resolve_source_lock_info(&self, version: &str) -> Result<PlatformInfo> {
         self.install_or_update_python_build(None)?;
-        let source = self.read_python_build_source(version)?;
+        let (_, source) = self.read_python_build_source(version)?;
         Ok(PlatformInfo {
             install: Some("source".to_string()),
             checksum: source.checksum,
@@ -250,11 +251,11 @@ impl PythonPlugin {
     fn prepare_locked_python_build_definition(
         &self,
         tv: &ToolVersion,
+        definition: &str,
         source: &PythonBuildSource,
     ) -> Result<PathBuf> {
         let definition_path = self.python_build_definition_path(&tv.version);
-        let definition = file::read_to_string(&definition_path)?;
-        let definition = rewrite_python_build_source(&definition, source)?;
+        let definition = rewrite_python_build_source(definition, source)?;
         let locked_dir = tv.download_path().join(format!(
             "python-build-definition-{}",
             crate::hash::hash_sha256_to_str(&source.url)
@@ -516,17 +517,17 @@ impl PythonPlugin {
         }
 
         let platform_key = self.get_platform_key();
+        let (definition, mut source) = self.read_python_build_source(&tv.version)?;
         let source_info = if ctx.locked {
             tv.lock_platforms
                 .get(&platform_key)
                 .cloned()
                 .ok_or_else(|| eyre!("missing locked Python source info for {platform_key}"))?
         } else {
-            let source = self.read_python_build_source(&tv.version)?;
             PlatformInfo {
                 install: Some("source".to_string()),
-                checksum: source.checksum,
-                url: Some(source.url),
+                checksum: source.checksum.clone(),
+                url: Some(source.url.clone()),
                 ..Default::default()
             }
         };
@@ -536,7 +537,6 @@ impl PythonPlugin {
             .ok_or_else(|| eyre!("missing Python source URL for {platform_key}"))?;
         self.set_lockfile_info(tv, Some("source"), source_url, source_info.checksum.clone());
 
-        let mut source = self.read_python_build_source(&tv.version)?;
         source.url = source_url.to_string();
         source.checksum = source_info.checksum;
         let source_path = tv.download_path().join(format!(
@@ -555,7 +555,8 @@ impl PythonPlugin {
         }
         self.verify_checksum(ctx, tv, &source_path)?;
 
-        let locked_definition = self.prepare_locked_python_build_definition(tv, &source)?;
+        let locked_definition =
+            self.prepare_locked_python_build_definition(tv, &definition, &source)?;
         let python_build_cache = tv.download_path().join("python-build-cache");
         file::create_dir_all(&python_build_cache)?;
         file::copy(
@@ -1167,7 +1168,7 @@ fn parse_python_build_source(definition: &str) -> Result<PythonBuildSource> {
         .iter()
         .find(|(name, _)| name == &package_name)
         .map(|(_, source)| source)
-        .unwrap();
+        .expect("package_name was derived from packages.last(); it must be present");
     let (url, checksum) =
         source_spec
             .split_once('#')
@@ -1216,9 +1217,10 @@ fn rewrite_python_build_source(definition: &str, source: &PythonBuildSource) -> 
 }
 
 fn python_build_archive_name(source: &PythonBuildSource) -> String {
-    let extension = if source.url.ends_with("bz2") {
+    let url_path = source.url.split(['?', '#']).next().unwrap_or(&source.url);
+    let extension = if url_path.ends_with("bz2") {
         "tar.bz2"
-    } else if source.url.ends_with("xz") {
+    } else if url_path.ends_with("xz") {
         "tar.xz"
     } else {
         "tar.gz"
@@ -1442,6 +1444,14 @@ fi
             Some("sha256:086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d")
         );
         assert_eq!(python_build_archive_name(&source), "Python-3.13.0.tar.xz");
+        let source_with_query = PythonBuildSource {
+            url: format!("{}?download=1#fragment", source.url),
+            ..source.clone()
+        };
+        assert_eq!(
+            python_build_archive_name(&source_with_query),
+            "Python-3.13.0.tar.xz"
+        );
 
         let rewritten = rewrite_python_build_source(PYTHON_BUILD_DEFINITION, &source).unwrap();
         assert_eq!(rewritten.matches(&source.url).count(), 2);

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -222,8 +222,12 @@ impl Backend for RustPlugin {
 
     /// Rust uses rustup for installation, which handles its own downloads.
     /// Lockfile URLs are not applicable since we don't download artifacts directly.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     /// Rust toolchains can be installed while requested components/targets are

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -216,8 +216,12 @@ impl Backend for SwiftPlugin {
     /// persisted to the lockfile from another host. Opt out of the `--locked`
     /// URL requirement so installs don't hard-fail on platforms missing from
     /// the lockfile; checksums are still verified at install time.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &crate::backend::platform_target::PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     async fn security_info(&self) -> Vec<crate::backend::SecurityFeature> {


### PR DESCRIPTION
## Summary
- record per-platform Python source fallbacks as `install = "source"` python-build outcomes
- keep the default compile mode out of the root lock identity while retaining explicit `compile=true/false`
- include custom python-build repository and patch settings in source-capable lock identities
- make locked installs follow the recorded python-build or precompiled outcome
- keep precompiled URL/checksum/provenance locking unchanged

## Context
Supersedes #10474 after #10547 established the `install = "source"` outcome marker. Python intentionally differs from Node and Erlang by not attaching a source URL to that marker because python-build does not expose a supported primary-archive injection interface.

The obsolete shared `install_method`, Node, backend, and generated `mise.lock` changes from the original draft are not included.

## Lockfile semantics
- platform URL without an install marker: locked python-build-standalone artifact
- `install = "source"` without a URL: run python-build using its current definition
- absent platform entry: no locked outcome for that platform

Precompiled outcomes continue to require a platform URL in locked mode. Only a Python source-marked outcome is exempt from that URL requirement; Node, Erlang, and other URL-locking backends retain their existing validation.

## Diff vs main

### Default fallback without a precompiled build

```diff
 [[tools.python]]
 version = "3.5.10"
 backend = "core:python"
+
+[tools.python."platforms.linux-x64"]
+install = "source"
```

The unset/default compile mode is not recorded in `[tools.python.options]`.

### Forced source build

```diff
 [tools.python.options]
 compile = "true"
+
+[tools.python."platforms.linux-x64"]
+install = "source"
```

### Precompiled and forced-precompiled outcomes
Existing python-build-standalone platform entries keep their URL/checksum/provenance shape and do not gain an `install = "precompiled"` marker. Explicit `compile = false` remains in the root options; unavailable platforms remain omitted rather than becoming source fallbacks.

## Why the source URL is not locked
python-build definitions are executable shell recipes rather than declarative artifact metadata. Depending on the definition and target environment they may:

- choose between xz and gzip CPython archives using a runtime capability check
- select platform-specific Miniconda installers through `install_script`
- expand variables for PyPy source builds
- use zip, Git, Mercurial, nightly, or other fetch mechanisms
- download auxiliary dependencies and apply definition-relative patches

python-build does not provide a supported way for mise to pass one pre-downloaded, verified primary archive while leaving the rest of the recipe intact. Pinning a source URL would require mise to parse and rewrite python-build's shell definitions, reproduce its private cache naming and patch layout, and emulate target-dependent selection. That is fragile and can select a different input than python-build would have chosen.

This PR therefore locks the decision to use python-build, not python-build's downloaded source artifacts. Locked source installs invoke the selected python-build definition unchanged. Source archive selection, checksums, dependencies, and build behavior remain owned by python-build; the lockfile does not claim full source-build reproducibility.

## Source-build identity
When source fallback remains possible, custom `python.pyenv_repo`, `python.patch_url`, and `python.patches_directory` values are part of the shared root lock identity because they can change the build recipe or result. They are omitted when `compile = false`.

Tool-level `install_env` remains config-supplied rather than copied into lock options. This follows the core option policy used by Node and other backends, where arbitrary installation environment variables are ephemeral.

Unlocked installs continue to select precompiled versus python-build behavior from current settings. Locked installs instead follow the recorded platform outcome.

## Verification
- `mise run lint-fix`
- `cargo test plugins::core::python::tests`
- `mise run test:e2e core/test_python_lockfile_outcomes`
- `mise run test:e2e lockfile/test_lockfile_python`
- `git diff --check`
- isolated `mise install --locked python@3.13.0` with a source-marker-only lock entry
## Target outcome policy
Stacked on #10946; the GitHub target remains `main`. That refactor makes lock outcome policy target-specific and preserves existing backend behavior. This PR adds the `Source` outcome and Python’s target-aware selection: existing source markers are complete without a URL, missing targets are still resolved independently, and Windows remains an artifact outcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Python version installation behavior for prebuilt and source-compiled releases.
  * Lockfiles now accurately record platform-specific installation outcomes and Python compile settings.
  * Locked installations can support source-based Python builds when no download URL is applicable.

* **Bug Fixes**
  * Improved validation for missing or invalid lockfile URLs and checksums.
  * Refined locked-install behavior across platforms and backend types.

* **Tests**
  * Added coverage for Python lockfile outcomes, source fallbacks, compilation settings, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->