### PR TITLE
fix(toolset): preserve ref selector install identity

### DIFF
--- a/e2e/backend/test_cargo_compile_git_slow
+++ b/e2e/backend/test_cargo_compile_git_slow
@@ -7,3 +7,4 @@ https://github.com/eza-community/eza"
 assert "mise where cargo:eza-community/eza@tag:v0.18.24" \
   "$MISE_DATA_DIR/installs/cargo-eza-community-eza/tag-v0.18.24"
 assert_fail "test -d $MISE_DATA_DIR/installs/cargo-eza-community-eza/ref-v0.18.24"
+assert "mise outdated cargo:eza-community/eza@tag:v0.18.24" ""

--- a/e2e/backend/test_cargo_compile_git_slow
+++ b/e2e/backend/test_cargo_compile_git_slow
@@ -4,3 +4,6 @@ require_cmd cargo
 assert "mise x cargo:eza-community/eza@tag:v0.18.24 -- eza --version" "eza - A modern, maintained replacement for ls
 v0.18.24 [+git]
 https://github.com/eza-community/eza"
+assert "mise where cargo:eza-community/eza@tag:v0.18.24" \
+  "$MISE_DATA_DIR/installs/cargo-eza-community-eza/tag-v0.18.24"
+assert_fail "test -d $MISE_DATA_DIR/installs/cargo-eza-community-eza/ref-v0.18.24"

--- a/e2e/lockfile/test_lockfile_cargo_git_selector
+++ b/e2e/lockfile/test_lockfile_cargo_git_selector
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+REV=1f8f13e3ab97e475193886b897b0af95c7b6ed6d
+TOOL=cargo:https://github.com/eza-community/eza
+
+cat >mise.toml <<EOF
+[tools]
+"$TOOL" = "rev:$REV"
+EOF
+
+output=$(mise lock --dry-run --platform linux-x64 2>&1)
+assert_contains_text "$output" "Processing 1 tool(s)"
+assert_contains_text "$output" "$TOOL@rev:$REV for linux-x64"
+assert_not_contains_text "$output" "$TOOL@ref:$REV"
+
+mise lock --platform linux-x64
+count=$(grep -c '^\[\[tools\.' mise.lock)
+assert "test $count -eq 1"
+assert_contains_text "$(cat mise.lock)" "version = \"rev:$REV\""
+assert_not_contains_text "$(cat mise.lock)" "version = \"ref:$REV\""
+
+cp mise.lock mise.lock.before
+mise lock --platform linux-x64
+assert "cmp mise.lock.before mise.lock"

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -18,6 +18,7 @@ use tokio::task::JoinSet;
 
 /// A tool to lock for a specific lockfile target.
 type LockTool = (crate::cli::args::BackendArg, crate::toolset::ToolVersion);
+type LockToolIndex = BTreeMap<(String, String), Vec<usize>>;
 
 fn request_matches(a: &ToolRequest, b: &ToolRequest) -> bool {
     a.version() == b.version() && a.options() == b.options()
@@ -41,21 +42,27 @@ fn lock_target_version(
 
 fn insert_lock_tool(
     tools: &mut Vec<LockTool>,
+    index: &mut LockToolIndex,
     ba: crate::cli::args::BackendArg,
     tv: crate::toolset::ToolVersion,
 ) {
     let version = lock_target_version(&ba, &tv);
-    if let Some((_, existing)) = tools.iter_mut().find(|(existing_ba, existing)| {
-        existing_ba.short == ba.short
-            && lock_target_version(existing_ba, existing) == version
-            && existing.request.options() == tv.request.options()
-    }) {
+    let key = (ba.short.clone(), version);
+    let matching_index = index.get(&key).and_then(|indices| {
+        indices
+            .iter()
+            .copied()
+            .find(|&i| tools[i].1.request.options() == tv.request.options())
+    });
+    if let Some(i) = matching_index {
+        let existing = &mut tools[i].1;
         // list_current_versions uses ref:<value> for Cargo's install-path identity.
         // Prefer the configured selector because ref: is not a Cargo install selector.
         if existing.version.starts_with("ref:") && !tv.version.starts_with("ref:") {
             *existing = tv;
         }
     } else {
+        index.entry(key).or_default().push(tools.len());
         tools.push((ba, tv));
     }
 }
@@ -592,6 +599,7 @@ impl Lock {
         let config_paths_set: BTreeSet<&PathBuf> = config_paths.iter().collect();
 
         let mut all_tools: Vec<LockTool> = Vec::new();
+        let mut tool_index = LockToolIndex::new();
         // First pass: tools from the resolved toolset whose source maps to this lockfile
         for (backend, tv) in ts.list_current_versions() {
             if let Some((source_lockfile, _)) =
@@ -620,7 +628,12 @@ impl Lock {
             if tv.version == "latest" {
                 continue;
             }
-            insert_lock_tool(&mut all_tools, backend.ba().as_ref().clone(), tv);
+            insert_lock_tool(
+                &mut all_tools,
+                &mut tool_index,
+                backend.ba().as_ref().clone(),
+                tv,
+            );
         }
 
         // Second pass: iterate config files matching this lockfile to catch
@@ -648,6 +661,7 @@ impl Lock {
                                         matched_resolved = true;
                                         insert_lock_tool(
                                             &mut all_tools,
+                                            &mut tool_index,
                                             ba.as_ref().clone(),
                                             tv.clone(),
                                         );
@@ -694,7 +708,12 @@ impl Lock {
                                 }
                                 match request.resolve(config, &resolve_options).await {
                                     Ok(tv) => {
-                                        insert_lock_tool(&mut all_tools, ba.as_ref().clone(), tv);
+                                        insert_lock_tool(
+                                            &mut all_tools,
+                                            &mut tool_index,
+                                            ba.as_ref().clone(),
+                                            tv,
+                                        );
                                     }
                                     Err(err) => {
                                         if active_unresolved {
@@ -770,8 +789,9 @@ impl Lock {
             }
             // Deduplicate after potential "latest" -> concrete-version resolution.
             let mut deduplicated = Vec::new();
+            let mut deduplicated_index = LockToolIndex::new();
             for (ba, tv) in tools {
-                insert_lock_tool(&mut deduplicated, ba, tv);
+                insert_lock_tool(&mut deduplicated, &mut deduplicated_index, ba, tv);
             }
             Ok(deduplicated)
         }
@@ -904,7 +924,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::{Lock, LockTool, insert_lock_tool};
+    use super::{Lock, LockTool, LockToolIndex, insert_lock_tool};
     use crate::cli::args::ToolArg;
     use crate::lockfile::{Lockfile, PlatformInfo};
     use crate::toolset::{ToolRequest, ToolSource, ToolVersion};
@@ -993,13 +1013,14 @@ mod tests {
         for selector in ["rev:abc123", "tag:v1.0.0", "branch:main"] {
             let ref_version = format!("ref:{}", selector.split_once(':').unwrap().1);
             let mut tools = Vec::new();
+            let mut index = LockToolIndex::new();
 
             let (ba, tv) = cargo_git_tool(selector, &ref_version, "git");
-            insert_lock_tool(&mut tools, ba, tv);
+            insert_lock_tool(&mut tools, &mut index, ba, tv);
             let (ba, tv) = cargo_git_tool(selector, selector, "git");
-            insert_lock_tool(&mut tools, ba, tv);
+            insert_lock_tool(&mut tools, &mut index, ba, tv);
             let (ba, tv) = cargo_git_tool(selector, selector, "vendored-openssl");
-            insert_lock_tool(&mut tools, ba, tv);
+            insert_lock_tool(&mut tools, &mut index, ba, tv);
 
             assert_eq!(tools.len(), 2, "selector: {selector}");
             assert_eq!(tools[0].1.version, selector);

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -18,28 +18,9 @@ use tokio::task::JoinSet;
 
 /// A tool to lock for a specific lockfile target.
 type LockTool = (crate::cli::args::BackendArg, crate::toolset::ToolVersion);
-type LockToolIndex = BTreeMap<(String, String), Vec<usize>>;
 
 fn request_matches(a: &ToolRequest, b: &ToolRequest) -> bool {
     a.version() == b.version() && a.options() == b.options()
-}
-
-fn insert_lock_tool(
-    tools: &mut Vec<LockTool>,
-    index: &mut LockToolIndex,
-    ba: crate::cli::args::BackendArg,
-    tv: crate::toolset::ToolVersion,
-) {
-    let key = (ba.short.clone(), tv.version.clone());
-    let already_present = index.get(&key).is_some_and(|indices| {
-        indices
-            .iter()
-            .any(|&i| tools[i].1.request.options() == tv.request.options())
-    });
-    if !already_present {
-        index.entry(key).or_default().push(tools.len());
-        tools.push((ba, tv));
-    }
 }
 
 /// Update lockfile checksums and URLs for all specified platforms
@@ -574,7 +555,7 @@ impl Lock {
         let config_paths_set: BTreeSet<&PathBuf> = config_paths.iter().collect();
 
         let mut all_tools: Vec<LockTool> = Vec::new();
-        let mut tool_index = LockToolIndex::new();
+        let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
 
         // First pass: tools from the resolved toolset whose source maps to this lockfile
         for (backend, tv) in ts.list_current_versions() {
@@ -604,12 +585,10 @@ impl Lock {
             if tv.version == "latest" {
                 continue;
             }
-            insert_lock_tool(
-                &mut all_tools,
-                &mut tool_index,
-                backend.ba().as_ref().clone(),
-                tv,
-            );
+            let key = (backend.ba().short.clone(), tv.version.clone());
+            if seen.insert(key) {
+                all_tools.push((backend.ba().as_ref().clone(), tv));
+            }
         }
 
         // Second pass: iterate config files matching this lockfile to catch
@@ -635,12 +614,10 @@ impl Lock {
                                         && tv.version != "latest"
                                     {
                                         matched_resolved = true;
-                                        insert_lock_tool(
-                                            &mut all_tools,
-                                            &mut tool_index,
-                                            ba.as_ref().clone(),
-                                            tv.clone(),
-                                        );
+                                        let key = (ba.short.clone(), tv.version.clone());
+                                        if seen.insert(key) {
+                                            all_tools.push((ba.as_ref().clone(), tv.clone()));
+                                        }
                                     }
                                 }
                             }
@@ -684,12 +661,10 @@ impl Lock {
                                 }
                                 match request.resolve(config, &resolve_options).await {
                                     Ok(tv) => {
-                                        insert_lock_tool(
-                                            &mut all_tools,
-                                            &mut tool_index,
-                                            ba.as_ref().clone(),
-                                            tv,
-                                        );
+                                        let key = (ba.short.clone(), tv.version.clone());
+                                        if seen.insert(key) {
+                                            all_tools.push((ba.as_ref().clone(), tv));
+                                        }
                                     }
                                     Err(err) => {
                                         if active_unresolved {
@@ -764,12 +739,9 @@ impl Lock {
                 tools.push((ba, tv));
             }
             // Deduplicate after potential "latest" -> concrete-version resolution.
-            let mut deduplicated = Vec::new();
-            let mut deduplicated_index = LockToolIndex::new();
-            for (ba, tv) in tools {
-                insert_lock_tool(&mut deduplicated, &mut deduplicated_index, ba, tv);
-            }
-            Ok(deduplicated)
+            let mut seen_after: BTreeSet<(String, String)> = BTreeSet::new();
+            tools.retain(|(ba, tv)| seen_after.insert((ba.short.clone(), tv.version.clone())));
+            Ok(tools)
         }
     }
 
@@ -900,10 +872,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::{Lock, LockToolIndex, insert_lock_tool};
+    use super::Lock;
     use crate::cli::args::ToolArg;
     use crate::lockfile::{Lockfile, PlatformInfo};
-    use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions};
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersion};
     use std::collections::BTreeMap;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -964,26 +936,6 @@ mod tests {
             ToolRequest::new(Arc::new(ba.clone()), version, ToolSource::Argument).unwrap();
         let tv = ToolVersion::new(request, version.to_string());
         (ba, tv)
-    }
-
-    #[test]
-    fn test_lock_tool_identity_includes_options() {
-        let mut tools = Vec::new();
-        let mut index = LockToolIndex::new();
-
-        for features in ["git", "git", "vendored-openssl"] {
-            let (ba, mut tv) = configured_tool("dummy", "1.0.0");
-            let mut options = ToolVersionOptions::default();
-            options.opts.insert(
-                "features".to_string(),
-                toml::Value::String(features.to_string()),
-            );
-            tv.request.set_options(options);
-            insert_lock_tool(&mut tools, &mut index, ba, tv);
-        }
-
-        assert_eq!(tools.len(), 2);
-        assert_ne!(tools[0].1.request.options(), tools[1].1.request.options());
     }
 
     #[test]

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -24,44 +24,19 @@ fn request_matches(a: &ToolRequest, b: &ToolRequest) -> bool {
     a.version() == b.version() && a.options() == b.options()
 }
 
-fn lock_target_version(
-    ba: &crate::cli::args::BackendArg,
-    tv: &crate::toolset::ToolVersion,
-) -> String {
-    if ba.short.starts_with("cargo:") && tv.version.starts_with("ref:") {
-        let request_version = tv.request.version();
-        if matches!(
-            request_version.split_once(':'),
-            Some(("rev" | "tag" | "branch", _))
-        ) {
-            return request_version;
-        }
-    }
-    tv.version.clone()
-}
-
 fn insert_lock_tool(
     tools: &mut Vec<LockTool>,
     index: &mut LockToolIndex,
     ba: crate::cli::args::BackendArg,
     tv: crate::toolset::ToolVersion,
 ) {
-    let version = lock_target_version(&ba, &tv);
-    let key = (ba.short.clone(), version);
-    let matching_index = index.get(&key).and_then(|indices| {
+    let key = (ba.short.clone(), tv.version.clone());
+    let already_present = index.get(&key).is_some_and(|indices| {
         indices
             .iter()
-            .copied()
-            .find(|&i| tools[i].1.request.options() == tv.request.options())
+            .any(|&i| tools[i].1.request.options() == tv.request.options())
     });
-    if let Some(i) = matching_index {
-        let existing = &mut tools[i].1;
-        // list_current_versions uses ref:<value> for Cargo's install-path identity.
-        // Prefer the configured selector because ref: is not a Cargo install selector.
-        if existing.version.starts_with("ref:") && !tv.version.starts_with("ref:") {
-            *existing = tv;
-        }
-    } else {
+    if !already_present {
         index.entry(key).or_default().push(tools.len());
         tools.push((ba, tv));
     }
@@ -600,6 +575,7 @@ impl Lock {
 
         let mut all_tools: Vec<LockTool> = Vec::new();
         let mut tool_index = LockToolIndex::new();
+
         // First pass: tools from the resolved toolset whose source maps to this lockfile
         for (backend, tv) in ts.list_current_versions() {
             if let Some((source_lockfile, _)) =
@@ -924,10 +900,10 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::{Lock, LockTool, LockToolIndex, insert_lock_tool};
+    use super::{Lock, LockToolIndex, insert_lock_tool};
     use crate::cli::args::ToolArg;
     use crate::lockfile::{Lockfile, PlatformInfo};
-    use crate::toolset::{ToolRequest, ToolSource, ToolVersion};
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions};
     use std::collections::BTreeMap;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -990,43 +966,24 @@ mod tests {
         (ba, tv)
     }
 
-    fn cargo_git_tool(selector: &str, stored_version: &str, features: &str) -> LockTool {
-        let backend = "cargo:https://github.com/eza-community/eza";
-        let ba = crate::cli::args::BackendArg::new(backend.to_string(), Some(backend.to_string()));
-        let mut options = crate::toolset::ToolVersionOptions::default();
-        options.opts.insert(
-            "features".to_string(),
-            toml::Value::String(features.to_string()),
-        );
-        let request = ToolRequest::new_opts(
-            Arc::new(ba.clone()),
-            selector,
-            options,
-            ToolSource::Argument,
-        )
-        .unwrap();
-        (ba, ToolVersion::new(request, stored_version.to_string()))
-    }
-
     #[test]
-    fn test_collect_cargo_git_selectors_deduplicates_internal_refs_with_options() {
-        for selector in ["rev:abc123", "tag:v1.0.0", "branch:main"] {
-            let ref_version = format!("ref:{}", selector.split_once(':').unwrap().1);
-            let mut tools = Vec::new();
-            let mut index = LockToolIndex::new();
+    fn test_lock_tool_identity_includes_options() {
+        let mut tools = Vec::new();
+        let mut index = LockToolIndex::new();
 
-            let (ba, tv) = cargo_git_tool(selector, &ref_version, "git");
+        for features in ["git", "git", "vendored-openssl"] {
+            let (ba, mut tv) = configured_tool("dummy", "1.0.0");
+            let mut options = ToolVersionOptions::default();
+            options.opts.insert(
+                "features".to_string(),
+                toml::Value::String(features.to_string()),
+            );
+            tv.request.set_options(options);
             insert_lock_tool(&mut tools, &mut index, ba, tv);
-            let (ba, tv) = cargo_git_tool(selector, selector, "git");
-            insert_lock_tool(&mut tools, &mut index, ba, tv);
-            let (ba, tv) = cargo_git_tool(selector, selector, "vendored-openssl");
-            insert_lock_tool(&mut tools, &mut index, ba, tv);
-
-            assert_eq!(tools.len(), 2, "selector: {selector}");
-            assert_eq!(tools[0].1.version, selector);
-            assert_eq!(tools[1].1.version, selector);
-            assert_ne!(tools[0].1.request.options(), tools[1].1.request.options());
         }
+
+        assert_eq!(tools.len(), 2);
+        assert_ne!(tools[0].1.request.options(), tools[1].1.request.options());
     }
 
     #[test]

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -23,6 +23,43 @@ fn request_matches(a: &ToolRequest, b: &ToolRequest) -> bool {
     a.version() == b.version() && a.options() == b.options()
 }
 
+fn lock_target_version(
+    ba: &crate::cli::args::BackendArg,
+    tv: &crate::toolset::ToolVersion,
+) -> String {
+    if ba.short.starts_with("cargo:") && tv.version.starts_with("ref:") {
+        let request_version = tv.request.version();
+        if matches!(
+            request_version.split_once(':'),
+            Some(("rev" | "tag" | "branch", _))
+        ) {
+            return request_version;
+        }
+    }
+    tv.version.clone()
+}
+
+fn insert_lock_tool(
+    tools: &mut Vec<LockTool>,
+    ba: crate::cli::args::BackendArg,
+    tv: crate::toolset::ToolVersion,
+) {
+    let version = lock_target_version(&ba, &tv);
+    if let Some((_, existing)) = tools.iter_mut().find(|(existing_ba, existing)| {
+        existing_ba.short == ba.short
+            && lock_target_version(existing_ba, existing) == version
+            && existing.request.options() == tv.request.options()
+    }) {
+        // list_current_versions uses ref:<value> for Cargo's install-path identity.
+        // Prefer the configured selector because ref: is not a Cargo install selector.
+        if existing.version.starts_with("ref:") && !tv.version.starts_with("ref:") {
+            *existing = tv;
+        }
+    } else {
+        tools.push((ba, tv));
+    }
+}
+
 /// Update lockfile checksums and URLs for all specified platforms
 ///
 /// Updates checksums and download URLs for all platforms already specified in the lockfile.
@@ -555,8 +592,6 @@ impl Lock {
         let config_paths_set: BTreeSet<&PathBuf> = config_paths.iter().collect();
 
         let mut all_tools: Vec<LockTool> = Vec::new();
-        let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
-
         // First pass: tools from the resolved toolset whose source maps to this lockfile
         for (backend, tv) in ts.list_current_versions() {
             if let Some((source_lockfile, _)) =
@@ -585,10 +620,7 @@ impl Lock {
             if tv.version == "latest" {
                 continue;
             }
-            let key = (backend.ba().short.clone(), tv.version.clone());
-            if seen.insert(key) {
-                all_tools.push((backend.ba().as_ref().clone(), tv));
-            }
+            insert_lock_tool(&mut all_tools, backend.ba().as_ref().clone(), tv);
         }
 
         // Second pass: iterate config files matching this lockfile to catch
@@ -614,10 +646,11 @@ impl Lock {
                                         && tv.version != "latest"
                                     {
                                         matched_resolved = true;
-                                        let key = (ba.short.clone(), tv.version.clone());
-                                        if seen.insert(key) {
-                                            all_tools.push((ba.as_ref().clone(), tv.clone()));
-                                        }
+                                        insert_lock_tool(
+                                            &mut all_tools,
+                                            ba.as_ref().clone(),
+                                            tv.clone(),
+                                        );
                                     }
                                 }
                             }
@@ -661,10 +694,7 @@ impl Lock {
                                 }
                                 match request.resolve(config, &resolve_options).await {
                                     Ok(tv) => {
-                                        let key = (ba.short.clone(), tv.version.clone());
-                                        if seen.insert(key) {
-                                            all_tools.push((ba.as_ref().clone(), tv));
-                                        }
+                                        insert_lock_tool(&mut all_tools, ba.as_ref().clone(), tv);
                                     }
                                     Err(err) => {
                                         if active_unresolved {
@@ -739,9 +769,11 @@ impl Lock {
                 tools.push((ba, tv));
             }
             // Deduplicate after potential "latest" -> concrete-version resolution.
-            let mut seen_after: BTreeSet<(String, String)> = BTreeSet::new();
-            tools.retain(|(ba, tv)| seen_after.insert((ba.short.clone(), tv.version.clone())));
-            Ok(tools)
+            let mut deduplicated = Vec::new();
+            for (ba, tv) in tools {
+                insert_lock_tool(&mut deduplicated, ba, tv);
+            }
+            Ok(deduplicated)
         }
     }
 
@@ -872,7 +904,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[cfg(test)]
 mod tests {
-    use super::Lock;
+    use super::{Lock, LockTool, insert_lock_tool};
     use crate::cli::args::ToolArg;
     use crate::lockfile::{Lockfile, PlatformInfo};
     use crate::toolset::{ToolRequest, ToolSource, ToolVersion};
@@ -936,6 +968,44 @@ mod tests {
             ToolRequest::new(Arc::new(ba.clone()), version, ToolSource::Argument).unwrap();
         let tv = ToolVersion::new(request, version.to_string());
         (ba, tv)
+    }
+
+    fn cargo_git_tool(selector: &str, stored_version: &str, features: &str) -> LockTool {
+        let backend = "cargo:https://github.com/eza-community/eza";
+        let ba = crate::cli::args::BackendArg::new(backend.to_string(), Some(backend.to_string()));
+        let mut options = crate::toolset::ToolVersionOptions::default();
+        options.opts.insert(
+            "features".to_string(),
+            toml::Value::String(features.to_string()),
+        );
+        let request = ToolRequest::new_opts(
+            Arc::new(ba.clone()),
+            selector,
+            options,
+            ToolSource::Argument,
+        )
+        .unwrap();
+        (ba, ToolVersion::new(request, stored_version.to_string()))
+    }
+
+    #[test]
+    fn test_collect_cargo_git_selectors_deduplicates_internal_refs_with_options() {
+        for selector in ["rev:abc123", "tag:v1.0.0", "branch:main"] {
+            let ref_version = format!("ref:{}", selector.split_once(':').unwrap().1);
+            let mut tools = Vec::new();
+
+            let (ba, tv) = cargo_git_tool(selector, &ref_version, "git");
+            insert_lock_tool(&mut tools, ba, tv);
+            let (ba, tv) = cargo_git_tool(selector, selector, "git");
+            insert_lock_tool(&mut tools, ba, tv);
+            let (ba, tv) = cargo_git_tool(selector, selector, "vendored-openssl");
+            insert_lock_tool(&mut tools, ba, tv);
+
+            assert_eq!(tools.len(), 2, "selector: {selector}");
+            assert_eq!(tools[0].1.version, selector);
+            assert_eq!(tools[1].1.version, selector);
+            assert_ne!(tools[0].1.request.options(), tools[1].1.request.options());
+        }
     }
 
     #[test]

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -203,7 +203,7 @@ impl Toolset {
             .into_iter()
             .map(|(p, tv)| {
                 (
-                    (p.ba().installs_path.clone(), tv.version.clone()),
+                    (p.ba().installs_path.clone(), tv.tv_pathname()),
                     (p.clone(), tv),
                 )
             })

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -284,24 +284,9 @@ impl Toolset {
         self.list_versions_by_plugin()
             .iter()
             .flat_map(|(p, v)| {
-                v.iter().filter(|v| v.request.is_os_supported()).map(|v| {
-                    // map cargo backend specific prefixes to ref
-                    let tv = match v.version.split_once(':') {
-                        Some((ref_type @ ("tag" | "branch" | "rev"), r)) => {
-                            let request = ToolRequest::Ref {
-                                backend: p.ba().clone(),
-                                ref_: r.to_string(),
-                                ref_type: ref_type.to_string(),
-                                options: v.request.options().clone(),
-                                source: v.request.source().clone(),
-                            };
-                            let version = format!("ref:{r}");
-                            ToolVersion::new(request, version)
-                        }
-                        _ => v.clone(),
-                    };
-                    (p.clone(), tv)
-                })
+                v.iter()
+                    .filter(|v| v.request.is_os_supported())
+                    .map(|v| (p.clone(), v.clone()))
             })
             .collect()
     }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -277,14 +277,7 @@ impl ToolVersion {
             inactive: base_opts.inactive,
         };
         let tv = self.request.resolve(config, &opts).await?;
-        // map cargo backend specific prefixes to ref
-        let version = match tv.request.version().split_once(':') {
-            Some((_ref_type @ ("tag" | "branch" | "rev"), r)) => {
-                format!("ref:{r}")
-            }
-            _ => tv.version,
-        };
-        Ok(version)
+        Ok(tv.version)
     }
     pub fn style(&self) -> String {
         format!(

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -298,7 +298,9 @@ impl ToolVersion {
             ToolRequest::Version { .. } => self.version.to_string(),
             ToolRequest::Prefix { .. } => self.version.to_string(),
             ToolRequest::Sub { .. } => self.version.to_string(),
-            ToolRequest::Ref { ref_: r, .. } => format!("ref-{r}"),
+            ToolRequest::Ref {
+                ref_: r, ref_type, ..
+            } => format!("{ref_type}-{r}"),
             ToolRequest::Path { path: p, .. } => format!("path-{}", hash_to_str(p)),
             ToolRequest::System { .. } => {
                 // Only show deprecation warning if not from .tool-versions file
@@ -914,6 +916,30 @@ mod tests {
         );
         backend.installs_path = installs_path;
         backend
+    }
+
+    #[test]
+    fn ref_pathname_preserves_selector_type() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backend = Arc::new(test_backend(temp_dir.path().join("installs")));
+
+        for (version, pathname) in [
+            ("ref:main", "ref-main"),
+            ("rev:abc123", "rev-abc123"),
+            ("tag:v1.0.0", "tag-v1.0.0"),
+            ("branch:main", "branch-main"),
+        ] {
+            let (ref_type, ref_) = version.split_once(':').unwrap();
+            let request = ToolRequest::Ref {
+                backend: backend.clone(),
+                ref_: ref_.to_string(),
+                ref_type: ref_type.to_string(),
+                options: ToolVersionOptions::default(),
+                source: ToolSource::Argument,
+            };
+            let tv = ToolVersion::new(request, version.to_string());
+            assert_eq!(tv.tv_pathname(), pathname);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve `ref_type` when deriving install pathnames, so `ref:`, `rev:`, `tag:`, and `branch:` no longer collapse to the same `ref-*` directory
- remove the `list_current_versions()` rewrite from Cargo Git selectors to the internal `ref:` form
- retain configured Cargo Git selectors in lock targets and lockfile entries without adding Cargo-specific behavior to `lock.rs`
- add focused pathname, Cargo Git install, and lock round-trip coverage

## Root cause
`ToolRequest::Ref` retains both the selector value and its type, but `ToolVersion::tv_pathname()` discarded the type and mapped every ref-like request to `ref-<value>`. `list_current_versions()` then rewrote `rev:`, `tag:`, and `branch:` versions to `ref:` to match that install path. During lock collection, the resolved pass saw the rewritten value while the config pass saw the configured selector, producing duplicate lock targets.

The fix keeps selector identity intact at the install-path boundary:

- `ref:main` -> `ref-main`
- `rev:<sha>` -> `rev-<sha>`
- `tag:v1` -> `tag-v1`
- `branch:main` -> `branch-main`

Both lock collection passes now naturally see the configured selector, so the existing generic lock deduplication remains unchanged.

## Compatibility
Existing Cargo Git installs stored under the old shared `ref-*` pathname are not migrated or treated as the new typed path. The next use of the corresponding `rev:`, `tag:`, or `branch:` request will install it once into the new typed directory. The old `ref-*` install is then unused and can be removed by normal pruning. Generic `ref:` requests keep the same `ref-*` pathname.

## Validation
- `mise run lint-fix`
- `mise run test:unit -- ref_pathname_preserves_selector_type`
- `mise run test:e2e e2e/lockfile/test_lockfile_cargo_git_selector`
- `mise run test:e2e e2e/cli/test_ls`
- `mise run test:e2e e2e/backend/test_cargo_compile_git_slow`

Addresses the repro discussed in https://github.com/jdx/mise/discussions/8755.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Cargo git tool selectors so revisions, tags, and branches retain their original selector type.
  - Fixed installation paths and version reporting for selector-based Cargo tools.
  - Ensured lockfiles record revision-pinned tools accurately without converting them to `ref` selectors.
  - Improved lockfile consistency and repeatability across platforms.
- **Tests**
  - Added coverage for Cargo git selector locking, installation paths, outdated checks, and idempotent lockfile generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->