### PR TITLE
refactor(lockfile): resolve outcomes per target

### DIFF
--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -254,8 +254,12 @@ impl Backend for AsdfBackend {
 
     /// ASDF plugins handle their own downloads through plugin scripts.
     /// Lockfile URLs are not applicable since installation is delegated to plugin scripts.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &crate::backend::platform_target::PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -137,8 +137,12 @@ impl Backend for CargoBackend {
 
     /// Cargo installs packages from crates.io using version specs (e.g., ripgrep@14.0.0).
     /// It doesn't support installing from direct URLs, so lockfile URLs are not applicable.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn mark_prereleases_from_version_pattern(&self) -> bool {

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -48,8 +48,12 @@ impl Backend for GemBackend {
     /// Gem installs via `gem install`, delegating fetch/resolve to RubyGems rather
     /// than downloading an artifact mise verifies, so a lockfile URL can't be
     /// enforced even though rubygems.org exposes one. Opt out of `--locked`.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &crate::backend::platform_target::PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -69,8 +69,12 @@ impl Backend for GoBackend {
         Ok(vec!["go"])
     }
 
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn mark_prereleases_from_version_pattern(&self) -> bool {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -85,6 +85,14 @@ pub type BackendList = Vec<ABackend>;
 pub type IdiomaticVersion = (String, Option<ToolVersionOptions>);
 pub type VersionCacheManager = CacheManager<Vec<VersionInfo>>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockfileTargetPolicy {
+    /// The target is represented by a URL-backed lock entry.
+    Artifact,
+    /// This backend does not currently produce lock information for the target.
+    Unsupported,
+}
+
 pub(crate) const MISE_BINS_DIR: &str = ".mise-bins";
 
 pub(crate) fn backend_arg_matches_registry_backend(ba: &BackendArg) -> bool {
@@ -1171,11 +1179,13 @@ pub trait Backend: Debug + Send + Sync {
         vec![platform.clone()] // Default: just the base platform
     }
 
-    /// Whether this backend supports URL-based locking in locked mode.
-    /// Backends that use external installers (like rustup for Rust) should override
-    /// this to return false, since they don't have downloadable artifacts with lockable URLs.
-    fn supports_lockfile_url(&self) -> bool {
-        true
+    /// Describe the lockfile outcome supported for a specific target.
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<LockfileTargetPolicy> {
+        Ok(LockfileTargetPolicy::Artifact)
     }
 
     async fn description(&self) -> Option<String> {
@@ -2110,7 +2120,7 @@ pub trait Backend: Debug + Send + Sync {
     ) -> eyre::Result<ToolVersion> {
         // Check for --locked mode: if enabled and no lockfile URL exists, fail early
         // Exempt tool stubs from lockfile requirements since they are ephemeral
-        // Also exempt backends that don't support URL locking (e.g., Rust uses rustup)
+        // Also exempt outcomes that don't use URL locking (e.g., Rust uses rustup)
         // This must run before the dry-run check so that --locked --dry-run still validates
         let settings = Settings::get();
         if (ctx.locked || settings.locked) && settings.lockfile == Some(false) {
@@ -2119,7 +2129,11 @@ pub trait Backend: Debug + Send + Sync {
                 hint: Remove `lockfile = false` or set `lockfile = true`, or disable locked mode"
             );
         }
-        if ctx.locked && !tv.request.source().is_tool_stub() && self.supports_lockfile_url() {
+        let lock_target = PlatformTarget::from_current();
+        if ctx.locked
+            && !tv.request.source().is_tool_stub()
+            && self.lockfile_target_policy(&tv, &lock_target)? == LockfileTargetPolicy::Artifact
+        {
             let platform_key = self.get_platform_key();
             let has_lockfile_url = tv
                 .lock_platforms

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -289,8 +289,12 @@ impl Backend for NPMBackend {
 
     /// NPM installs packages from npm registry using version specs (e.g., eslint@8.0.0).
     /// It doesn't support installing from direct URLs, so lockfile URLs are not applicable.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn get_optional_dependencies(&self) -> eyre::Result<Vec<&str>> {

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -127,8 +127,12 @@ impl Backend for PIPXBackend {
 
     /// Pipx installs packages from PyPI or Git using version specs (e.g., black==24.3.0).
     /// It doesn't support installing from direct URLs, so lockfile URLs are not applicable.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {

--- a/src/backend/pkgx.rs
+++ b/src/backend/pkgx.rs
@@ -78,10 +78,6 @@ impl Backend for PkgxBackend {
         &self.ba
     }
 
-    fn supports_lockfile_url(&self) -> bool {
-        true
-    }
-
     fn mark_prereleases_from_version_pattern(&self) -> bool {
         true
     }

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -444,8 +444,12 @@ impl Backend for UbiBackend {
 
     /// UBI is deprecated in favor of the github backend and doesn't resolve download URLs
     /// at lock time. Return false so --locked mode doesn't error for ubi tools.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn resolve_lockfile_options(

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -82,10 +82,18 @@ impl Backend for VfoxBackend {
         true
     }
 
-    fn supports_lockfile_url(&self) -> bool {
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> eyre::Result<crate::backend::LockfileTargetPolicy> {
         // TODO: expose a plugin hook (e.g. BackendLockInfo) so custom Lua backends
         // can surface a download URL + checksum, and flip this back on for them.
-        !self.is_backend_plugin()
+        Ok(if self.is_backend_plugin() {
+            crate::backend::LockfileTargetPolicy::Unsupported
+        } else {
+            crate::backend::LockfileTargetPolicy::Artifact
+        })
     }
 
     fn remote_version_listing_tool_option_keys(&self) -> &'static [&'static str] {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1860,12 +1860,22 @@ fn tool_version_needs_auto_lock(
 
     for platform in target_platforms {
         for variant in backend.platform_variants(platform) {
+            let policy =
+                backend.lockfile_target_policy(tv, &PlatformTarget::new(variant.clone()))?;
+            if policy == crate::backend::LockfileTargetPolicy::Unsupported {
+                continue;
+            }
             let platform_key = variant.to_key();
-            if !tool
+            let complete = tool
                 .platforms
                 .get(&platform_key)
-                .is_some_and(|info| info.checksum.is_some() && info.url.is_some())
-            {
+                .is_some_and(|info| match policy {
+                    crate::backend::LockfileTargetPolicy::Artifact => {
+                        info.checksum.is_some() && info.url.is_some()
+                    }
+                    crate::backend::LockfileTargetPolicy::Unsupported => true,
+                });
+            if !complete {
                 return Ok(true);
             }
         }
@@ -1974,12 +1984,9 @@ pub async fn auto_lock_new_versions(
         .flat_map(|tvl| tvl.versions.iter())
         .chain(new_versions.iter())
     {
-        let Ok(backend) = tv.request.backend() else {
+        let Ok(_backend) = tv.request.backend() else {
             continue;
         };
-        if !backend.supports_lockfile_url() {
-            continue;
-        }
         if let Some((lockfile_path, _)) = lockfile_path_for_tool_source(config, tv.request.source())
         {
             let candidate_key = (
@@ -2056,13 +2063,25 @@ pub async fn auto_lock_new_versions(
 
                 for variant in variants {
                     let platform_key = variant.to_key();
+                    let policy = if let Some(backend) = &backend {
+                        backend.lockfile_target_policy(tv, &PlatformTarget::new(variant.clone()))?
+                    } else {
+                        crate::backend::LockfileTargetPolicy::Unsupported
+                    };
+                    if policy == crate::backend::LockfileTargetPolicy::Unsupported {
+                        continue;
+                    }
 
-                    // Skip if this tool/version/platform already has both checksum and URL
+                    // Skip outcomes already complete for this target.
                     if let Some(tools) = lockfile.tools.get(&ba.short)
                         && let Some(tool) = tools.iter().find(|t| t.version == tv.version)
                         && let Some(info) = tool.platforms.get(&platform_key)
-                        && info.checksum.is_some()
-                        && info.url.is_some()
+                        && match policy {
+                            crate::backend::LockfileTargetPolicy::Artifact => {
+                                info.checksum.is_some() && info.url.is_some()
+                            }
+                            crate::backend::LockfileTargetPolicy::Unsupported => true,
+                        }
                     {
                         continue;
                     }
@@ -3466,6 +3485,18 @@ options = { exe = "rg" }
         let tv = basic_tv("aqua:astral-sh/ruff", "0.15.20");
 
         assert!(tool_version_needs_auto_lock(&lockfile, &tv, &[Platform::current()]).unwrap());
+    }
+
+    #[test]
+    fn test_tool_version_needs_auto_lock_skips_unsupported_target() {
+        let mut lockfile = Lockfile::default();
+        lockfile.tools.insert(
+            "ripgrep".to_string(),
+            vec![basic_tool("14.1.1", "cargo:ripgrep")],
+        );
+        let tv = basic_tv("cargo:ripgrep", "14.1.1");
+
+        assert!(!tool_version_needs_auto_lock(&lockfile, &tv, &[Platform::current()]).unwrap());
     }
 
     #[test]

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -103,8 +103,12 @@ impl Backend for DotnetPlugin {
         &self.ba
     }
 
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     fn resolve_lockfile_options(

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -493,10 +493,18 @@ impl Backend for ErlangPlugin {
         self.install_via_kerl(ctx, tv).await
     }
 
-    fn supports_lockfile_url(&self) -> bool {
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
         // In default mode, precompiled Erlang is opportunistic and may fall
         // back to kerl, so locked installs cannot always require a URL.
-        Settings::get().erlang.compile == Some(false)
+        Ok(if Settings::get().erlang.compile == Some(false) {
+            crate::backend::LockfileTargetPolicy::Artifact
+        } else {
+            crate::backend::LockfileTargetPolicy::Unsupported
+        })
     }
 
     fn resolve_lockfile_options(

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -222,8 +222,12 @@ impl Backend for RustPlugin {
 
     /// Rust uses rustup for installation, which handles its own downloads.
     /// Lockfile URLs are not applicable since we don't download artifacts directly.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     /// Rust toolchains can be installed while requested components/targets are

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -216,8 +216,12 @@ impl Backend for SwiftPlugin {
     /// persisted to the lockfile from another host. Opt out of the `--locked`
     /// URL requirement so installs don't hard-fail on platforms missing from
     /// the lockfile; checksums are still verified at install time.
-    fn supports_lockfile_url(&self) -> bool {
-        false
+    fn lockfile_target_policy(
+        &self,
+        _tv: &ToolVersion,
+        _target: &crate::backend::platform_target::PlatformTarget,
+    ) -> Result<crate::backend::LockfileTargetPolicy> {
+        Ok(crate::backend::LockfileTargetPolicy::Unsupported)
     }
 
     async fn security_info(&self) -> Vec<crate::backend::SecurityFeature> {


### PR DESCRIPTION
## Summary
- replace the backend-wide URL-lock capability switch with a target-aware lock outcome policy
- evaluate lock participation and completeness separately for every target platform
- preserve existing artifact and unsupported-backend behavior

## Why
Auto-lock resolves multiple target platforms, so using one backend-wide answer can incorrectly let the current platform decide whether every other target is processed. The policy now receives both the resolved tool version and the target, allowing follow-up backends to describe different outcomes per platform without adding overlapping capability hooks.

## Behavior
This PR is intentionally behavior-preserving. Existing URL-backed outcomes use `Artifact`; backends that currently opt out of URL locking use `Unsupported`. Swift and delegated installers are not expanded here.

Locked-install validation and auto-lock completeness both evaluate the policy for the relevant target. Auto-lock skips only unsupported targets rather than dropping the whole tool before target expansion.

## Verification
- `mise run lint-fix`
- `cargo test lockfile::tests::test_tool_version_needs_auto_lock`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lockfile handling across supported tools and platforms.
  - Prevented automatic lockfile resolution for targets that do not support artifact-based locking.
  - Ensured locked installations apply lockfile requirements only where appropriate.
  - Improved completion checks by requiring both a checksum and URL for artifact targets.
  - Added coverage for unsupported-target behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->