### PR TITLE
registry: add suve (aqua:mpyw/suve)

### DIFF
--- a/registry/suve.toml
+++ b/registry/suve.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:mpyw/suve"]
+description = "Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration"
+test = { cmd = "suve --version", expected = "suve version {{version}}" }


### PR DESCRIPTION
Adds `suve` to the registry via the aqua backend.

**suve** (Secret Unified Versioning Explorer) is a Git-like CLI/GUI for multi-cloud secret and parameter management — AWS (Parameter Store + Secrets Manager), Google Cloud (Secret Manager), and Azure (Key Vault + App Configuration). It exposes familiar Git-style commands (`show`, `log`, `diff`, `list`, `tag`) with revision syntax (`#VERSION`, `~SHIFT`, `:LABEL`) plus a Git-like staging workflow.

### Entry
```toml
backends = ["aqua:mpyw/suve"]
description = "Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration"
test = { cmd = "suve --version", expected = "suve version {{version}}" }
```

### Backend
- Tier-1 **aqua** backend — already published in the aqua registry at [`pkgs/mpyw/suve`](https://github.com/aquaproj/aqua-registry/tree/main/pkgs/mpyw/suve) (supported since v1.6.1).

### Popularity / maintenance
- Language: Go · License: MIT · actively maintained (latest `v1.8.1`).
- GitHub stars: 9 and growing.
- A Japanese write-up introducing the tool has **21 likes** on Zenn: https://zenn.dev/yumemi_inc/articles/suve-git-like-secret-management
- Prebuilt binaries for all major platforms: darwin (amd64/arm64), linux (amd64/arm64), windows (amd64/arm64) — so no `os` restriction is needed.

### Test
Verified locally against the released binary:
```
$ suve --version
suve version 1.8.1
```