### PR TITLE
fix(bootstrap): preserve symlinks when extracting dmgs

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -255,6 +255,25 @@ pub fn copy_dir_all<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()
     })
 }
 
+fn copy_dir_all_preserve_symlinks(from: &Path, to: &Path) -> Result<()> {
+    trace!("cp -a {} {}", from.display(), to.display());
+    for entry in WalkDir::new(from).follow_links(false).min_depth(1) {
+        let entry = entry?;
+        let relative = entry.path().strip_prefix(from)?;
+        let dest = to.join(relative);
+        if entry.file_type().is_dir() {
+            create_dir_all(&dest)?;
+        } else if entry.file_type().is_symlink() {
+            create_dir_all(dest.parent().unwrap())?;
+            make_symlink(&fs::read_link(entry.path())?, &dest)?;
+        } else if entry.file_type().is_file() {
+            create_dir_all(dest.parent().unwrap())?;
+            copy(entry.path(), &dest)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
     let path = path.as_ref();
     trace!("write {}", display_path(path));
@@ -1387,8 +1406,10 @@ pub fn un_dmg(archive: &Path, dest: &Path) -> Result<()> {
         archive.to_path_buf()
     )
     .run()?;
-    copy_dir_all(tmp.path(), dest)?;
-    cmd!("hdiutil", "detach", tmp.path()).run()?;
+    let copy_result = copy_dir_all_preserve_symlinks(tmp.path(), dest);
+    let detach_result = cmd!("hdiutil", "detach", tmp.path()).run();
+    copy_result?;
+    detach_result?;
     Ok(())
 }
 
@@ -1776,6 +1797,28 @@ mod tests {
     use crate::config::Config;
 
     use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn test_copy_dir_all_preserve_symlinks_does_not_follow_loops() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source");
+        let dest = dir.path().join("dest");
+        fs::create_dir_all(source.join("Example.app/Contents")).unwrap();
+        fs::write(source.join("Example.app/Contents/example"), "example").unwrap();
+        std::os::unix::fs::symlink(".", source.join("Applications")).unwrap();
+
+        copy_dir_all_preserve_symlinks(&source, &dest).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dest.join("Example.app/Contents/example")).unwrap(),
+            "example"
+        );
+        assert_eq!(
+            fs::read_link(dest.join("Applications")).unwrap(),
+            Path::new(".")
+        );
+    }
 
     #[test]
     #[cfg(unix)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1408,9 +1408,13 @@ pub fn un_dmg(archive: &Path, dest: &Path) -> Result<()> {
     .run()?;
     let copy_result = copy_dir_all_preserve_symlinks(tmp.path(), dest);
     let detach_result = cmd!("hdiutil", "detach", tmp.path()).run();
-    copy_result?;
-    detach_result?;
-    Ok(())
+    match (copy_result, detach_result) {
+        (Err(copy_err), Err(detach_err)) => Err(copy_err)
+            .wrap_err_with(|| format!("additionally failed to detach DMG: {detach_err}")),
+        (Err(copy_err), _) => Err(copy_err),
+        (Ok(()), Err(detach_err)) => Err(detach_err.into()),
+        (Ok(()), Ok(_)) => Ok(()),
+    }
 }
 
 pub fn un_pkg(archive: &Path, dest: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary
- preserve symlinks while copying mounted DMG contents instead of following them
- always attempt to detach a mounted DMG when copying fails
- add a regression test covering a directory symlink cycle

## Root cause
DMG images commonly contain an `Applications` symlink. The generic recursive copy followed that link into the host `/Applications` directory, eventually encountering a symlink loop in the installed Xcode SDK. Returning from that copy error also skipped `hdiutil detach`, leaving the image mounted.

## Impact
`mise bootstrap packages apply` can extract DMG-backed brew casks without traversing the host filesystem or leaking mounts after copy failures.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --all-features file::tests::test_copy_dir_all_preserve_symlinks_does_not_follow_loops`
- real `brew-cask:kitty` bootstrap reached successful DMG copy and ejection; it then stopped at the separate existing `on_system_conditional` limitation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem behavior on macOS for all `un_dmg` callers (aqua DMG installs and brew cask bootstrap); scope is localized but mistakes could still corrupt installs or leave mounts attached.
> 
> **Overview**
> DMG extraction now copies mounted volume contents with **`copy_dir_all_preserve_symlinks`** instead of the generic recursive copy, so entries like an `Applications` symlink are recreated rather than followed into the host filesystem (avoiding symlink loops and accidental traversal of `/Applications`).
> 
> **`un_dmg`** always runs **`hdiutil detach`** after the copy attempt, surfacing copy failures first and attaching detach errors when both fail.
> 
> Adds a **Unix regression test** for a self-referential directory symlink alongside normal file copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057e15ae7e5a676495bd74b6e79499e65c7d3708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DMG extraction to preserve symbolic links and avoid following symlink loops.
  * Ensured the mounted disk image is detached even if copying its contents fails.
  * Improved reliability when copying directories that contain symbolic links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->