### PR TITLE
fix(bootstrap): support localized brew casks

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1,5 +1,6 @@
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+use std::process::Command;
 
 use async_trait::async_trait;
 use eyre::{WrapErr, bail, eyre};
@@ -384,7 +385,7 @@ async fn execute_lifecycle_hook(
     if !has_lifecycle_hook(cask, hook) {
         return Ok(());
     }
-    let ruby = source::ruby_bin().await?;
+    let ruby = cask_ruby_bin().await?;
     let cask_rb = fetch_cask_rb(cask, pr).await?;
     let shim_path = crate::dirs::CACHE
         .join("system-brew")
@@ -414,6 +415,25 @@ async fn execute_lifecycle_hook(
         .execute_async()
         .await
         .wrap_err_with(|| format!("brew-cask:{}: failed to run {hook}", cask.token))
+}
+
+async fn cask_ruby_bin() -> Result<PathBuf> {
+    if let Some(brew) = file::which("brew")
+        && let Ok(output) = Command::new(brew)
+            .args(["ruby", "-e", "print RbConfig.ruby"])
+            .output()
+        && output.status.success()
+        && let Ok(path) = String::from_utf8(output.stdout)
+    {
+        let path = PathBuf::from(path.trim());
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+    if let Some(ruby) = file::which("ruby") {
+        return Ok(ruby);
+    }
+    source::ruby_bin().await
 }
 
 fn ensure_cask_shim(path: &Path) -> Result<()> {
@@ -1409,6 +1429,60 @@ mod tests {
         ensure_cask_shim(&shim_path)?;
 
         assert_eq!(file::read_to_string(&shim_path)?, CASK_SHIM_RB);
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cask_shim_supports_language_and_system_conditionals() -> Result<()> {
+        let Some(ruby) = file::which("ruby") else {
+            return Ok(());
+        };
+        let tmp = tempfile::tempdir()?;
+        let shim = tmp.path().join("cask_shim.rb");
+        let cask = tmp.path().join("example.rb");
+        let result = tmp.path().join("result");
+        file::write(&shim, CASK_SHIM_RB)?;
+        file::write(
+            &cask,
+            r##"cask "example" do
+  version "1.0.0"
+  language "fr" do
+    "fr"
+  end
+  language "en", default: true do
+    "en-US"
+  end
+  suffix = on_system_conditional linux: "-linux", macos: "-macos"
+  preflight do
+    File.write staged_path/"result", "#{language}#{suffix}"
+  end
+end
+"##,
+        )?;
+
+        let output = Command::new(ruby)
+            .arg(shim)
+            .env("LANG", "zz_ZZ.UTF-8")
+            .env("MISE_BREW_CASK_FILE", cask)
+            .env("MISE_BREW_CASK_TOKEN", "example")
+            .env("MISE_BREW_CASK_VERSION", "1.0.0")
+            .env("MISE_BREW_CASK_STAGED_PATH", tmp.path())
+            .env("MISE_BREW_CASK_APPDIR", tmp.path())
+            .env("MISE_BREW_PREFIX", tmp.path())
+            .env("MISE_BREW_CASK_HOOK", "preflight")
+            .output()?;
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let suffix = if cfg!(target_os = "macos") {
+            "-macos"
+        } else {
+            "-linux"
+        };
+        assert_eq!(file::read_to_string(result)?, format!("en-US{suffix}"));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1,6 +1,5 @@
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
 
 use async_trait::async_trait;
 use eyre::{WrapErr, bail, eyre};
@@ -419,9 +418,10 @@ async fn execute_lifecycle_hook(
 
 async fn cask_ruby_bin() -> Result<PathBuf> {
     if let Some(brew) = file::which("brew")
-        && let Ok(output) = Command::new(brew)
+        && let Ok(output) = tokio::process::Command::new(brew)
             .args(["ruby", "-e", "print RbConfig.ruby"])
             .output()
+            .await
         && output.status.success()
         && let Ok(path) = String::from_utf8(output.stdout)
     {
@@ -1407,6 +1407,25 @@ mod tests {
         }
     }
 
+    fn run_cask_shim(
+        ruby: &Path,
+        shim: &Path,
+        cask: &Path,
+        staged_path: &Path,
+    ) -> std::io::Result<std::process::Output> {
+        std::process::Command::new(ruby)
+            .arg(shim)
+            .env("LANG", "zz_ZZ.UTF-8")
+            .env("MISE_BREW_CASK_FILE", cask)
+            .env("MISE_BREW_CASK_TOKEN", "example")
+            .env("MISE_BREW_CASK_VERSION", "1.0.0")
+            .env("MISE_BREW_CASK_STAGED_PATH", staged_path)
+            .env("MISE_BREW_CASK_APPDIR", staged_path)
+            .env("MISE_BREW_PREFIX", staged_path)
+            .env("MISE_BREW_CASK_HOOK", "preflight")
+            .output()
+    }
+
     fn test_cask(token: &str, version: &str) -> Cask {
         Cask {
             token: token.to_string(),
@@ -1461,17 +1480,7 @@ end
 "##,
         )?;
 
-        let output = Command::new(ruby)
-            .arg(shim)
-            .env("LANG", "zz_ZZ.UTF-8")
-            .env("MISE_BREW_CASK_FILE", cask)
-            .env("MISE_BREW_CASK_TOKEN", "example")
-            .env("MISE_BREW_CASK_VERSION", "1.0.0")
-            .env("MISE_BREW_CASK_STAGED_PATH", tmp.path())
-            .env("MISE_BREW_CASK_APPDIR", tmp.path())
-            .env("MISE_BREW_PREFIX", tmp.path())
-            .env("MISE_BREW_CASK_HOOK", "preflight")
-            .output()?;
+        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path())?;
         assert!(
             output.status.success(),
             "{}",
@@ -1483,6 +1492,34 @@ end
             "-linux"
         };
         assert_eq!(file::read_to_string(result)?, format!("en-US{suffix}"));
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cask_shim_reports_missing_system_conditional() -> Result<()> {
+        let Some(ruby) = file::which("ruby") else {
+            return Ok(());
+        };
+        let tmp = tempfile::tempdir()?;
+        let shim = tmp.path().join("cask_shim.rb");
+        let cask = tmp.path().join("example.rb");
+        let (conditional, platform) = if cfg!(target_os = "macos") {
+            ("linux: \"-linux\"", "macos")
+        } else {
+            ("macos: \"-macos\"", "linux")
+        };
+        file::write(&shim, CASK_SHIM_RB)?;
+        file::write(
+            &cask,
+            format!("cask \"example\" do\n  on_system_conditional {conditional}\nend\n"),
+        )?;
+
+        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path())?;
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains(&format!(
+            "Error: cask uses `on_system_conditional without {platform}`"
+        )));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -227,7 +227,10 @@ class CaskContext
 
   def on_system_conditional(values)
     key = OS.mac? ? :macos : :linux
-    values.fetch(key) { values.fetch(key.to_s) }
+    return values[key] if values.key?(key)
+    return values[key.to_s] if values.key?(key.to_s)
+
+    shim_unsupported!("on_system_conditional without #{key}")
   end
 
   def sha256(*) nil end

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -187,6 +187,8 @@ class CaskContext
     @version = Version.new(MISE_BREW_CASK_VERSION)
     @hooks = {}
     @arch = Hardware::CPU.arch.to_s
+    @languages = {}
+    @default_language = nil
   end
 
   def run_hook(name)
@@ -209,6 +211,23 @@ class CaskContext
   def version(value = nil)
     @version = Version.new(value) unless value.nil?
     @version
+  end
+
+  def language(code = nil, default: false, &block)
+    if code
+      @languages[code.to_s] = instance_eval(&block)
+      @default_language = code.to_s if default
+      return
+    end
+
+    # The API metadata and downloaded artifact use the cask's default language,
+    # so lifecycle evaluation must select the same variant.
+    @languages[@default_language] || @languages.values.first
+  end
+
+  def on_system_conditional(values)
+    key = OS.mac? ? :macos : :linux
+    values.fetch(key) { values.fetch(key.to_s) }
   end
 
   def sha256(*) nil end


### PR DESCRIPTION
## Summary
- support the Homebrew cask `language` DSL and select the default language used by API metadata
- support `on_system_conditional` for platform-specific cask source evaluation
- reuse Homebrew's portable Ruby or an existing Ruby on `PATH` before provisioning a mise-managed Ruby
- add a focused shim test covering language selection, system conditionals, and lifecycle execution

## Root cause
The brew-cask backend uses API metadata for downloads but evaluates verified cask Ruby source when lifecycle hooks are present. The lifecycle shim rejected top-level metadata selectors such as `language` and `on_system_conditional` before reaching the hook. It also always called the mise Ruby provisioning path, even when Homebrew or the system already provided a usable interpreter.

## Impact
Localized casks such as Firefox can reach their lifecycle hooks, casks such as kitty can evaluate platform-specific source, and machines with Homebrew or Ruby installed avoid an unexpected mise-managed Ruby installation.

Addresses https://github.com/jdx/mise/discussions/10917

## Validation
- `mise run lint-fix`
- `cargo test --all-features system::packages::brew::cask::tests::cask_shim_supports_language_and_system_conditionals`
- ran the current upstream kitty cask through the shim with Homebrew portable Ruby and verified both preflight wrapper scripts were generated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS cask install lifecycle execution and Ruby interpreter selection; scoped to brew-cask shim behavior with new regression tests.
> 
> **Overview**
> Fixes Homebrew cask **lifecycle hook** evaluation when cask Ruby source uses **`language`** blocks or **`on_system_conditional`**, which previously failed in mise’s cask shim before hooks could run.
> 
> The Ruby shim now implements **`language`** (default variant matches API metadata) and **`on_system_conditional`** (macOS vs Linux), with clear errors when the current platform has no branch. **`execute_lifecycle_hook`** resolves Ruby via **`cask_ruby_bin`**: Homebrew’s portable Ruby (`brew ruby`), then **`ruby` on PATH**, then mise-provisioned Ruby—avoiding unnecessary Ruby installs when Brew or the system already provides one.
> 
> Adds unix tests that exercise the shim for language selection, platform suffixes, and missing conditional keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e20f69d899a14f60436c759d97507cdeda5bc5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew Cask lifecycle processing by selecting the most appropriate Ruby interpreter and falling back safely when unavailable.
  * Added support for cask language variants, including default language selection.
  * Added macOS/Linux conditional handling to pick the correct value (and fail with a clear error when the expected platform key is missing).
* **Tests**
  * Added Unix-only coverage for the cask shim’s language and platform-conditional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->