### PR TITLE
feat(oci): add reproducible host path copy layers

### DIFF
--- a/docs/cli/oci/build.md
+++ b/docs/cli/oci/build.md
@@ -16,6 +16,10 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 
 ## Flags
 
+### `--copy… <HOST_PATH:IMAGE_PATH>`
+
+Copy a host file or directory into the image (repeatable, HOST:IMAGE)
+
 ### `-o --output <OUTPUT>`
 
 Output directory for the OCI image layout

--- a/docs/cli/oci/build.md
+++ b/docs/cli/oci/build.md
@@ -18,7 +18,7 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 
 ### `--copy… <HOST_PATH:IMAGE_PATH>`
 
-Copy a host file or directory into the image (repeatable, HOST:IMAGE)
+Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)
 
 ### `-o --output <OUTPUT>`
 

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -84,6 +84,7 @@ the previous build (or from the registry, on pull).
 
 ```sh
 mise oci build [-o PATH] [--from REF] [--tag REF] [--mount-point PATH]
+               [--copy HOST_PATH:IMAGE_PATH]...
                [--no-mise] [--owner UID[:GID]]
 ```
 
@@ -94,6 +95,10 @@ mise oci build [-o PATH] [--from REF] [--tag REF] [--mount-point PATH]
   `org.opencontainers.image.ref.name` annotation
 - `--mount-point PATH` — where mise installs live inside the image
   (default `/mise`). Must be absolute.
+- `--copy HOST_PATH:IMAGE_PATH` — copy a host file or directory to an
+  absolute path in the image. Repeat the flag for multiple payloads. Each
+  payload is emitted as an independent, content-addressed layer after the
+  tool layers.
 - `--no-mise` — don't embed the running mise binary at
   `/usr/local/bin/mise`
 - `--owner UID[:GID]` — numeric owner for every generated layer entry.
@@ -188,6 +193,14 @@ user_id     = 1000                      # tar layer entry UID (file ownership)
 group_id    = 1000                      # tar layer entry GID (defaults to user_id)
 mount_point = "/mise"                  # where tools install in the image
 
+[[oci.copy]]
+host  = "dist/my-app"
+image = "/usr/local/bin/my-app"
+
+[[oci.copy]]
+host  = "assets"
+image = "/srv/app/assets"
+
 # Extra env baked into the image config (image-only — won't shadow MISE_*).
 [oci.env]
 NODE_ENV = "production"
@@ -206,6 +219,13 @@ CLI flags override the `[oci]` section. The `[oci]` section overrides the
 
 When `mise.toml` files are layered (global + project), sections are merged
 field-by-field with the more specific file winning per field.
+
+Copy sources may be files, directories, or symlinks. Directory contents land
+at `image`; the source directory name is not added. Image paths must be
+absolute and may not contain `.` or `..` components. Parent directories are
+created automatically, executable bits are preserved, and ownership follows
+`--owner` or `[oci].user_id` / `[oci].group_id`. Copy layers are annotated
+with `dev.mise.copy=<image path>` so they can be identified during inspection.
 
 ### `[bootstrap]` and `[dotfiles]` in OCI images
 

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -226,6 +226,9 @@ absolute and may not contain `.` or `..` components. Parent directories are
 created automatically, executable bits are preserved, and ownership follows
 `--owner` or `[oci].user_id` / `[oci].group_id`. Copy layers are annotated
 with `dev.mise.copy=<image path>` so they can be identified during inspection.
+Relative `host` paths in `[[oci.copy]]` resolve from the directory containing
+the config file that declares them; relative CLI paths resolve from the current
+working directory.
 When layered configs copy to the same image path, less-specific entries are
 emitted first so the most-specific config wins. CLI copies are emitted last.
 

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -226,6 +226,8 @@ absolute and may not contain `.` or `..` components. Parent directories are
 created automatically, executable bits are preserved, and ownership follows
 `--owner` or `[oci].user_id` / `[oci].group_id`. Copy layers are annotated
 with `dev.mise.copy=<image path>` so they can be identified during inspection.
+When layered configs copy to the same image path, less-specific entries are
+emitted first so the most-specific config wins. CLI copies are emitted last.
 
 ### `[bootstrap]` and `[dotfiles]` in OCI images
 

--- a/e2e/oci/test_oci_build_slow
+++ b/e2e/oci/test_oci_build_slow
@@ -125,7 +125,27 @@ assert_contains "tar -tzf ./out-files/blobs/sha256/$files_layer" "root/.config/a
 assert_contains "tar -xOzf ./out-files/blobs/sha256/$files_layer etc/profile.d/project.sh" "PROJECT_READY=1"
 assert_contains "tar -xOzf ./out-files/blobs/sha256/$files_layer root/.config/app/config.toml" "tool=dev"
 
-# --- 10. [bootstrap.packages] participates in OCI builds ---
+# --- 10. --copy and [[oci.copy]] each produce an annotated layer ---
+mkdir -p assets
+echo "from-cli" >cli-copy.txt
+echo "from-config" >assets/config-copy.txt
+cat >mise.toml <<EOF
+[tools]
+jq = "1.8.1"
+
+[[oci.copy]]
+host = "assets"
+image = "/srv/assets"
+EOF
+assert_succeed "mise oci build -o ./out-copy --from scratch --copy cli-copy.txt:/etc/cli-copy.txt"
+mf_copy="$(jq -r '.manifests[0].digest | ltrimstr("sha256:")' ./out-copy/index.json)"
+assert "jq -r '[.layers[] | select(.annotations.\"dev.mise.copy\") | .annotations.\"dev.mise.copy\"] | join(\",\")' ./out-copy/blobs/sha256/$mf_copy" "/srv/assets,/etc/cli-copy.txt"
+config_copy_layer="$(jq -r '.layers[] | select(.annotations."dev.mise.copy" == "/srv/assets") | .digest | ltrimstr("sha256:")' ./out-copy/blobs/sha256/"$mf_copy")"
+cli_copy_layer="$(jq -r '.layers[] | select(.annotations."dev.mise.copy" == "/etc/cli-copy.txt") | .digest | ltrimstr("sha256:")' ./out-copy/blobs/sha256/"$mf_copy")"
+assert_contains "tar -tzf ./out-copy/blobs/sha256/$config_copy_layer" "srv/assets/config-copy.txt"
+assert "tar -xOzf ./out-copy/blobs/sha256/$cli_copy_layer etc/cli-copy.txt" "from-cli"
+
+# --- 11. [bootstrap.packages] participates in OCI builds ---
 # scratch has no apt metadata, so this exercises the OCI package path without
 # requiring network access in the e2e test environment.
 cat >mise.toml <<EOF
@@ -134,7 +154,7 @@ cat >mise.toml <<EOF
 EOF
 assert_fail "mise oci build -o ./out-system-packages --from scratch" "requires an apt-based base image"
 
-# --- 11. No project config + no --include-global → clear error ---
+# --- 12. No project config + no --include-global → clear error ---
 # Error message is shared between build/run/push, so it must NOT name a
 # specific subcommand (just "mise oci").
 rm -f mise.toml

--- a/e2e/oci/test_oci_build_slow
+++ b/e2e/oci/test_oci_build_slow
@@ -143,6 +143,7 @@ assert "jq -r '[.layers[] | select(.annotations.\"dev.mise.copy\") | .annotation
 config_copy_layer="$(jq -r '.layers[] | select(.annotations."dev.mise.copy" == "/srv/assets") | .digest | ltrimstr("sha256:")' ./out-copy/blobs/sha256/"$mf_copy")"
 cli_copy_layer="$(jq -r '.layers[] | select(.annotations."dev.mise.copy" == "/etc/cli-copy.txt") | .digest | ltrimstr("sha256:")' ./out-copy/blobs/sha256/"$mf_copy")"
 assert_contains "tar -tzf ./out-copy/blobs/sha256/$config_copy_layer" "srv/assets/config-copy.txt"
+assert_contains "tar -xOzf ./out-copy/blobs/sha256/$config_copy_layer srv/assets/config-copy.txt" "from-config"
 assert "tar -xOzf ./out-copy/blobs/sha256/$cli_copy_layer etc/cli-copy.txt" "from-cli"
 
 # --- 11. [bootstrap.packages] participates in OCI builds ---

--- a/e2e/oci/test_oci_build_slow
+++ b/e2e/oci/test_oci_build_slow
@@ -126,8 +126,8 @@ assert_contains "tar -xOzf ./out-files/blobs/sha256/$files_layer etc/profile.d/p
 assert_contains "tar -xOzf ./out-files/blobs/sha256/$files_layer root/.config/app/config.toml" "tool=dev"
 
 # --- 10. --copy and [[oci.copy]] each produce an annotated layer ---
-mkdir -p assets
-echo "from-cli" >cli-copy.txt
+mkdir -p assets copy-subdir
+echo "from-cli" >copy-subdir/cli-copy.txt
 echo "from-config" >assets/config-copy.txt
 cat >mise.toml <<EOF
 [tools]
@@ -137,7 +137,7 @@ jq = "1.8.1"
 host = "assets"
 image = "/srv/assets"
 EOF
-assert_succeed "mise oci build -o ./out-copy --from scratch --copy cli-copy.txt:/etc/cli-copy.txt"
+assert_succeed "mise --cd copy-subdir oci build -o ../out-copy --from scratch --copy cli-copy.txt:/etc/cli-copy.txt"
 mf_copy="$(jq -r '.manifests[0].digest | ltrimstr("sha256:")' ./out-copy/index.json)"
 assert "jq -r '[.layers[] | select(.annotations.\"dev.mise.copy\") | .annotations.\"dev.mise.copy\"] | join(\",\")' ./out-copy/blobs/sha256/$mf_copy" "/srv/assets,/etc/cli-copy.txt"
 config_copy_layer="$(jq -r '.layers[] | select(.annotations."dev.mise.copy" == "/srv/assets") | .digest | ltrimstr("sha256:")' ./out-copy/blobs/sha256/"$mf_copy")"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2309,6 +2309,9 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 \fBOptions:\fR
 .PP
 .TP
+\fB\-\-copy\fR \fI<HOST_PATH:IMAGE_PATH>\fR
+Copy a host file or directory into the image (repeatable, HOST:IMAGE)
+.TP
 \fB\-o, \-\-output\fR \fI<OUTPUT>\fR
 Output directory for the OCI image layout
 .RS

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2310,7 +2310,7 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 .PP
 .TP
 \fB\-\-copy\fR \fI<HOST_PATH:IMAGE_PATH>\fR
-Copy a host file or directory into the image (repeatable, HOST:IMAGE)
+Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)
 .TP
 \fB\-o, \-\-output\fR \fI<OUTPUT>\fR
 Output directory for the OCI image layout

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2161,6 +2161,9 @@ Notes:
       build on the same OS/arch as your target image (or pass --no-mise).
 
 """#
+        flag --copy help="Copy a host file or directory into the image (repeatable, HOST:IMAGE)" var=#true {
+            arg <HOST_PATH:IMAGE_PATH>
+        }
         flag "-o --output" help="Output directory for the OCI image layout" default="./mise-oci" {
             arg <OUTPUT>
         }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2161,7 +2161,7 @@ Notes:
       build on the same OS/arch as your target image (or pass --no-mise).
 
 """#
-        flag --copy help="Copy a host file or directory into the image (repeatable, HOST:IMAGE)" var=#true {
+        flag --copy help="Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)" var=#true {
             arg <HOST_PATH:IMAGE_PATH>
         }
         flag "-o --output" help="Output directory for the OCI image layout" default="./mise-oci" {

--- a/src/cli/oci/build.rs
+++ b/src/cli/oci/build.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 use crate::cli::oci::common::{perform_build, short_digest};
 use crate::config::Settings;
 use crate::file::display_path;
-use crate::oci::{BuildOptions, LayerOwner};
+use crate::oci::{BuildOptions, LayerOwner, OciCopy};
 
 /// [experimental] Build an OCI image from the current mise.toml
 ///
@@ -20,6 +20,10 @@ use crate::oci::{BuildOptions, LayerOwner};
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Build {
+    /// Copy a host file or directory into the image (repeatable, HOST:IMAGE)
+    #[clap(long, value_name = "HOST_PATH:IMAGE_PATH")]
+    copy: Vec<OciCopy>,
+
     /// Output directory for the OCI image layout
     #[clap(long, short, default_value = "./mise-oci", value_hint = ValueHint::DirPath)]
     output: PathBuf,
@@ -71,6 +75,7 @@ impl Build {
             mount_point: self.mount_point.clone(),
             owner: self.owner,
             include_mise: !self.no_mise,
+            copy: self.copy.clone(),
         };
         let out = perform_build(opts, self.include_global).await?;
 

--- a/src/cli/oci/build.rs
+++ b/src/cli/oci/build.rs
@@ -20,7 +20,7 @@ use crate::oci::{BuildOptions, LayerOwner, OciCopy};
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Build {
-    /// Copy a host file or directory into the image (repeatable, HOST:IMAGE)
+    /// Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)
     #[clap(long, value_name = "HOST_PATH:IMAGE_PATH")]
     copy: Vec<OciCopy>,
 

--- a/src/cli/oci/common.rs
+++ b/src/cli/oci/common.rs
@@ -1,5 +1,7 @@
 //! Shared helpers for `mise oci` subcommands.
 
+use std::path::Path;
+
 use eyre::{Result, bail};
 
 use crate::config::{Config, ConfigMap};
@@ -22,11 +24,22 @@ pub fn merged_oci_config_from<'a>(
 ) -> OciConfig {
     let mut out = OciConfig::default();
     for cf in config_files {
-        if let Some(oci) = cf.oci_config() {
+        if let Some(mut oci) = cf.oci_config() {
+            resolve_copy_paths(&mut oci, cf.get_path().parent().unwrap_or(Path::new(".")));
             out.fill_defaults_from(oci);
         }
     }
     out
+}
+
+/// Resolve config-provided copy sources relative to the file that declared
+/// them. CLI copy sources remain relative to the process working directory.
+fn resolve_copy_paths(oci: &mut OciConfig, base: &Path) {
+    for copy in &mut oci.copy {
+        if copy.host.is_relative() {
+            copy.host = base.join(&copy.host);
+        }
+    }
 }
 
 /// Convenience wrapper that merges `[oci]` across *all* loaded configs.
@@ -141,5 +154,33 @@ pub fn short_digest(d: &str) -> String {
         format!("sha256:{}", &hex[..12])
     } else {
         d.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oci::OciCopy;
+
+    #[test]
+    fn config_copy_paths_resolve_from_declaring_config_directory() {
+        let mut oci = OciConfig {
+            copy: vec![
+                OciCopy {
+                    host: "assets".into(),
+                    image: "/srv/assets".into(),
+                },
+                OciCopy {
+                    host: "/absolute/tool".into(),
+                    image: "/usr/local/bin/tool".into(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        resolve_copy_paths(&mut oci, Path::new("/project"));
+
+        assert_eq!(oci.copy[0].host, Path::new("/project/assets"));
+        assert_eq!(oci.copy[1].host, Path::new("/absolute/tool"));
     }
 }

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -105,6 +105,7 @@ impl Push {
                     mount_point: self.mount_point.clone(),
                     owner: self.owner,
                     include_mise: !self.no_mise,
+                    copy: vec![],
                 };
                 let built = perform_build(opts, self.include_global).await?;
                 info!("built image: {}", built.manifest_digest);

--- a/src/cli/oci/run.rs
+++ b/src/cli/oci/run.rs
@@ -139,6 +139,7 @@ impl Run {
                     mount_point: self.mount_point.clone(),
                     owner: self.owner,
                     include_mise: !self.no_mise,
+                    copy: vec![],
                 };
                 let built = perform_build(opts, self.include_global).await?;
                 info!("built image: {}", built.manifest_digest);

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -13,12 +13,12 @@ use indexmap::{IndexMap, IndexSet};
 use crate::backend::backend_type::BackendType;
 use crate::config::{Config, Settings};
 use crate::file;
-use crate::oci::OciConfig;
 use crate::oci::layer::{self, LayerBlob, LayerOwner};
 use crate::oci::layout::ImageLayout;
 use crate::oci::manifest::{self, Descriptor, ImageConfig, ImageManifest, Platform, RootFs};
 use crate::oci::packages;
 use crate::oci::registry;
+use crate::oci::{OciConfig, OciCopy};
 use crate::system::ManagerPackages;
 use crate::system::files::{FileMode, FileRequest};
 use crate::toolset::{ToolVersion, Toolset};
@@ -38,6 +38,8 @@ pub struct BuildOptions {
     pub owner: Option<LayerOwner>,
     /// Embed the current mise binary at /usr/local/bin/mise.
     pub include_mise: bool,
+    /// CLI-provided host paths copied after config-provided entries.
+    pub copy: Vec<OciCopy>,
 }
 
 pub struct Builder {
@@ -115,6 +117,7 @@ impl Builder {
         }
 
         let owner = resolve_layer_owner(self.opts.owner, &self.oci);
+        let copies: Vec<&OciCopy> = self.oci.copy.iter().chain(&self.opts.copy).collect();
 
         // --- 1. Base image (optional) ---
         let from_ref = self
@@ -238,7 +241,23 @@ impl Builder {
             tool_layers.push((tv.ba().short.clone(), tv.version.clone(), blob));
         }
 
-        // --- 5. mise binary layer (optional) ---
+        // --- 5. Arbitrary host-path layers ---
+        let mut copy_layers: Vec<(&OciCopy, LayerBlob)> = Vec::new();
+        for copy in copies {
+            copy.validate().map_err(eyre::Report::msg)?;
+            let blob = layer::build_layer_from_path(&copy.host, &copy.image, owner).wrap_err_with(
+                || {
+                    format!(
+                        "copying host path {} to {}",
+                        copy.host.display(),
+                        copy.image
+                    )
+                },
+            )?;
+            copy_layers.push((copy, blob));
+        }
+
+        // --- 6. mise binary layer (optional) ---
         let mut mise_layer: Option<LayerBlob> = None;
         if self.opts.include_mise {
             // OCI images are linux-targeted in v1 (we normalize `os` to
@@ -333,6 +352,20 @@ impl Builder {
                 digest: blob.digest.clone(),
                 size: blob.size,
             });
+        }
+
+        for (copy, blob) in &copy_layers {
+            layout.write_blob_with_digest(&blob.digest, &blob.bytes)?;
+            let mut annotations = IndexMap::new();
+            annotations.insert("dev.mise.copy".to_string(), copy.image.clone());
+            manifest_layers.push(Descriptor {
+                media_type: manifest::MEDIA_TYPE_OCI_LAYER_GZIP.to_string(),
+                size: blob.size,
+                digest: blob.digest.clone(),
+                annotations,
+                platform: None,
+            });
+            all_diff_ids.push(blob.diff_id.clone());
         }
 
         if let Some(blob) = &dotfiles_layer {

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -245,6 +245,12 @@ impl Builder {
         let mut copy_layers: Vec<(&OciCopy, LayerBlob)> = Vec::new();
         for copy in copies {
             copy.validate().map_err(eyre::Report::msg)?;
+            warn!(
+                "mise oci build: copying host path {} into the image at {} — review its \
+                 contents for secrets or credentials before sharing the image",
+                copy.host.display(),
+                copy.image
+            );
             let blob = layer::build_layer_from_path(&copy.host, &copy.image, owner).wrap_err_with(
                 || {
                     format!(

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -120,6 +120,13 @@ pub fn build_layer_from_path(
     if target.is_empty() {
         eyre::bail!("cannot copy a file or symlink to the image root");
     }
+    if image_path.ends_with('/') {
+        eyre::bail!(
+            "copy image path {image_path:?} ends with `/` but {} is not a directory; \
+             specify the exact destination file name",
+            host_path.display()
+        );
+    }
 
     let kind = if metadata.file_type().is_symlink() {
         EntryKind::Symlink(
@@ -146,13 +153,18 @@ pub fn build_layer_from_path(
         .parent()
         .unwrap_or_else(|| Path::new(""))
         .to_string_lossy();
+    let size = if matches!(kind, EntryKind::Symlink(_)) {
+        0
+    } else {
+        metadata.len()
+    };
     let entry = Entry {
         rel,
         abs: host_path.to_path_buf(),
         kind,
         mode,
         owner,
-        size: metadata.len(),
+        size,
     };
     build_layer_from_entries(&[entry], &prefix, owner)
 }
@@ -661,6 +673,16 @@ mod tests {
 
         assert!(paths.contains(&PathBuf::from("opt/app/greeting.txt")));
         assert!(!paths.contains(&PathBuf::from("opt/app/hello.txt")));
+    }
+
+    #[test]
+    fn host_file_rejects_directory_style_image_path() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("hello.txt");
+        fs::write(&source, b"hello\n").unwrap();
+
+        let err = build_layer_from_path(&source, "/opt/app/", LayerOwner::default()).unwrap_err();
+        assert!(err.to_string().contains("exact destination file name"));
     }
 
     #[test]

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -102,6 +102,61 @@ pub fn build_layer_from_dir(
     build_layer_from_entries(&entries, target_prefix, owner)
 }
 
+/// Build a reproducible layer from one host file, symlink, or directory.
+/// Directory contents are placed under `image_path`; a file or symlink is
+/// placed at `image_path` itself.
+pub fn build_layer_from_path(
+    host_path: &Path,
+    image_path: &str,
+    owner: LayerOwner,
+) -> Result<LayerBlob> {
+    let metadata = std::fs::symlink_metadata(host_path)
+        .wrap_err_with(|| format!("reading metadata for {}", host_path.display()))?;
+    let target = image_path.trim_matches('/');
+
+    if metadata.is_dir() {
+        return build_layer_from_dir(host_path, target, owner);
+    }
+    if target.is_empty() {
+        eyre::bail!("cannot copy a file or symlink to the image root");
+    }
+
+    let kind = if metadata.file_type().is_symlink() {
+        EntryKind::Symlink(
+            std::fs::read_link(host_path)
+                .wrap_err_with(|| format!("reading symlink {}", host_path.display()))?,
+        )
+    } else if metadata.is_file() {
+        EntryKind::File
+    } else {
+        eyre::bail!("unsupported host path type: {}", host_path.display());
+    };
+    let mode = match &kind {
+        EntryKind::Symlink(_) => 0o777,
+        EntryKind::File if file_is_executable(host_path, &metadata) => 0o755,
+        EntryKind::File => 0o644,
+        EntryKind::Dir => unreachable!(),
+    };
+    let target_path = Path::new(target);
+    let rel = target_path
+        .file_name()
+        .map(PathBuf::from)
+        .ok_or_else(|| eyre::eyre!("copy image path has no file name: {image_path}"))?;
+    let prefix = target_path
+        .parent()
+        .unwrap_or_else(|| Path::new(""))
+        .to_string_lossy();
+    let entry = Entry {
+        rel,
+        abs: host_path.to_path_buf(),
+        kind,
+        mode,
+        owner,
+        size: metadata.len(),
+    };
+    build_layer_from_entries(&[entry], &prefix, owner)
+}
+
 /// Build a layer from a source directory, preserving uid/gid/mode from disk.
 pub fn build_layer_from_dir_preserve_metadata(
     src_dir: &Path,
@@ -586,6 +641,50 @@ mod tests {
         let a = build_layer_from_dir(dir.path(), "a", LayerOwner::default()).unwrap();
         let b = build_layer_from_dir(dir.path(), "b", LayerOwner::default()).unwrap();
         assert_ne!(a.digest, b.digest);
+    }
+
+    #[test]
+    fn host_file_is_copied_to_exact_image_path() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("hello.txt");
+        fs::write(&source, b"hello\n").unwrap();
+
+        let blob =
+            build_layer_from_path(&source, "/opt/app/greeting.txt", LayerOwner::default()).unwrap();
+        let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
+        let mut archive = tar::Archive::new(decoder);
+        let paths = archive
+            .entries()
+            .unwrap()
+            .map(|entry| entry.unwrap().path().unwrap().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(paths.contains(&PathBuf::from("opt/app/greeting.txt")));
+        assert!(!paths.contains(&PathBuf::from("opt/app/hello.txt")));
+    }
+
+    #[test]
+    fn host_directory_contents_are_copied_beneath_image_path() {
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join("assets")).unwrap();
+        fs::write(dir.path().join("assets/index.html"), b"hello\n").unwrap();
+
+        let blob = build_layer_from_path(
+            &dir.path().join("assets"),
+            "/srv/www",
+            LayerOwner::default(),
+        )
+        .unwrap();
+        let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
+        let mut archive = tar::Archive::new(decoder);
+        let paths = archive
+            .entries()
+            .unwrap()
+            .map(|entry| entry.unwrap().path().unwrap().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(paths.contains(&PathBuf::from("srv/www/index.html")));
+        assert!(!paths.contains(&PathBuf::from("srv/www/assets/index.html")));
     }
 
     #[test]

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -15,9 +15,60 @@ pub mod registry;
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::str::FromStr;
 
 pub use builder::{BuildOptions, BuildOutput, Builder};
 pub use layer::LayerOwner;
+
+/// A host path copied into an OCI image as an independent layer.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OciCopy {
+    pub host: PathBuf,
+    pub image: String,
+}
+
+impl OciCopy {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.host.as_os_str().is_empty() {
+            return Err("copy host path must not be empty".to_string());
+        }
+        validate_image_path(&self.image)
+    }
+}
+
+impl FromStr for OciCopy {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // Split from the right so Windows drive letters in HOST remain intact.
+        let (host, image) = value
+            .rsplit_once(':')
+            .ok_or_else(|| "copy must be HOST_PATH:IMAGE_PATH".to_string())?;
+        if host.is_empty() {
+            return Err("copy host path must not be empty".to_string());
+        }
+        let copy = Self {
+            host: PathBuf::from(host),
+            image: image.to_string(),
+        };
+        copy.validate()?;
+        Ok(copy)
+    }
+}
+
+fn validate_image_path(path: &str) -> Result<(), String> {
+    if !path.starts_with('/') {
+        return Err(format!("copy image path must be absolute (got {path:?})"));
+    }
+    if path.split('/').any(|part| part == "." || part == "..") {
+        return Err(format!(
+            "copy image path must not contain `.` or `..` components (got {path:?})"
+        ));
+    }
+    Ok(())
+}
 
 /// Normalize a Rust-style arch name (`x86_64`, `aarch64`) to the OCI-spec
 /// value (`amd64`, `arm64`).
@@ -74,6 +125,9 @@ pub struct OciConfig {
     /// the `oci.default_mount_point` setting (`/mise`).
     #[serde(default)]
     pub mount_point: Option<String>,
+    /// Host files or directories copied into the image as independent layers.
+    #[serde(default)]
+    pub copy: Vec<OciCopy>,
     /// Extra env vars baked into the image config in addition to those derived
     /// from the mise.toml `[env]` section and per-tool `exec_env()`.
     #[serde(default)]
@@ -122,6 +176,7 @@ impl OciConfig {
         if self.mount_point.is_none() {
             self.mount_point = other.mount_point;
         }
+        self.copy.extend(other.copy);
         for (k, v) in other.env {
             self.env.entry(k).or_insert(v);
         }

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -62,6 +62,11 @@ fn validate_image_path(path: &str) -> Result<(), String> {
     if !path.starts_with('/') {
         return Err(format!("copy image path must be absolute (got {path:?})"));
     }
+    if path.trim_matches('/').is_empty() {
+        return Err(format!(
+            "copy image path must not be the root `/` (got {path:?})"
+        ));
+    }
     if path.split('/').any(|part| part == "." || part == "..") {
         return Err(format!(
             "copy image path must not contain `.` or `..` components (got {path:?})"
@@ -144,7 +149,9 @@ impl OciConfig {
     /// value encountered wins, independent of the map's iteration order.
     ///
     /// For map fields (env, labels), keys already present on `self` win;
-    /// new keys from `other` are added.
+    /// new keys from `other` are added. Copy entries accumulate with less
+    /// specific configs first, so a more specific copy targeting the same
+    /// image path is emitted later and takes precedence.
     pub fn fill_defaults_from(&mut self, other: Self) {
         if self.from.is_none() {
             self.from = other.from;
@@ -176,12 +183,49 @@ impl OciConfig {
         if self.mount_point.is_none() {
             self.mount_point = other.mount_point;
         }
-        self.copy.extend(other.copy);
+        let mut copy = other.copy;
+        copy.append(&mut self.copy);
+        self.copy = copy;
         for (k, v) in other.env {
             self.env.entry(k).or_insert(v);
         }
         for (k, v) in other.labels {
             self.labels.entry(k).or_insert(v);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn copy(host: &str, image: &str) -> OciCopy {
+        OciCopy {
+            host: PathBuf::from(host),
+            image: image.to_string(),
+        }
+    }
+
+    #[test]
+    fn copy_rejects_root_and_relative_image_paths() {
+        assert!("file:/".parse::<OciCopy>().is_err());
+        assert!("file:relative".parse::<OciCopy>().is_err());
+    }
+
+    #[test]
+    fn layered_copies_put_more_specific_entries_last() {
+        let mut merged = OciConfig {
+            copy: vec![copy("project", "/same")],
+            ..Default::default()
+        };
+        merged.fill_defaults_from(OciConfig {
+            copy: vec![copy("parent", "/same")],
+            ..Default::default()
+        });
+
+        assert_eq!(
+            merged.copy,
+            vec![copy("parent", "/same"), copy("project", "/same")]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add repeatable `mise oci build --copy HOST_PATH:IMAGE_PATH` support
- add matching repeated `[[oci.copy]]` configuration entries
- emit each file, directory, or symlink payload as an independent reproducible layer annotated with `dev.mise.copy`
- validate absolute image paths and preserve normalized ownership/executable modes
- document the new primitive and add unit/e2e coverage

Closes the feature request discussed in https://github.com/jdx/mise/discussions/10934.

## Validation
- `cargo test oci::layer::tests`
- `mise run test:e2e e2e/oci/test_oci_build_slow`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New OCI build surface can embed arbitrary host filesystem content into images (with a secrets warning); behavior is well validated but mistakes could leak local files into published images.
> 
> **Overview**
> **`mise oci build`** can now copy arbitrary host paths into the image as **independent, content-addressed layers** (after per-tool layers), via repeatable **`--copy HOST_PATH:IMAGE_PATH`** and **`[[oci.copy]]`** in `mise.toml`.
> 
> Each payload is built with **`build_layer_from_path`** (files, dirs, or symlinks; dirs map contents under the absolute image path without appending the source name). Layers are tagged with **`dev.mise.copy=<image path>`**. Image destinations must be absolute with no `.` / `..`; config-relative `host` paths resolve from the declaring config file, CLI paths from CWD; layered configs append copies so **more-specific targets win**, with CLI copies last. The builder warns about secrets in copied paths. **`oci run` / `oci push`** pass an empty `copy` when they trigger a build.
> 
> Docs, usage/man output, unit tests, and e2e coverage for annotated layers and tar contents are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6824ac208d78549ab30937a8e83a97e0496a147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable `mise oci build --copy HOST_PATH:IMAGE_PATH` option to copy host files, directories, or symlinks into the OCI image as independent layers.
  * Added `[oci]` / `[[oci.copy]]` configuration support for declaring these copy layers.
* **Documentation**
  * Updated the CLI manual and developer docs with `--copy` / `[[oci.copy]]` usage, destination path rules, and copy layer semantics/annotations.
* **Bug Fixes**
  * Relative `[[oci.copy]]` source paths in config files are now resolved relative to the declaring config directory.
* **Tests**
  * Expanded e2e coverage to validate copied contents and emitted OCI layer annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->