### PR TITLE
fix(task): invalidate auto freshness after failed rerun

### DIFF
--- a/e2e/tasks/test_task_failed_freshness
+++ b/e2e/tasks/test_task_failed_freshness
@@ -1,19 +1,14 @@
 #!/usr/bin/env bash
 
-# A failed rerun must invalidate freshness left by an earlier success.
+# A failed rerun must invalidate an automatic output left by an earlier success.
 cat <<'EOF' >mise.toml
 [tasks.auto]
 run = "test ! -f fail-auto && echo auto-ran"
 sources = ["auto.src"]
 outputs = { auto = true }
-
-[tasks.explicit]
-run = "test ! -f fail-explicit && touch explicit.out && echo explicit-ran"
-sources = ["explicit.src"]
-outputs = ["explicit.out"]
 EOF
 
-touch auto.src explicit.src
+touch auto.src
 
 assert "mise run -q auto" "auto-ran"
 assert_empty "mise run -q auto"
@@ -22,11 +17,3 @@ assert_fail "mise run -q --force auto"
 rm fail-auto
 assert "mise run -q auto" "auto-ran"
 assert_empty "mise run -q auto"
-
-assert "mise run -q explicit" "explicit-ran"
-assert_empty "mise run -q explicit"
-touch fail-explicit
-assert_fail "mise run -q --force explicit"
-rm fail-explicit
-assert "mise run -q explicit" "explicit-ran"
-assert_empty "mise run -q explicit"

--- a/e2e/tasks/test_task_failed_freshness
+++ b/e2e/tasks/test_task_failed_freshness
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# A failed rerun must invalidate freshness left by an earlier success.
+cat <<'EOF' >mise.toml
+[tasks.auto]
+run = "test ! -f fail-auto && echo auto-ran"
+sources = ["auto.src"]
+outputs = { auto = true }
+
+[tasks.explicit]
+run = "test ! -f fail-explicit && touch explicit.out && echo explicit-ran"
+sources = ["explicit.src"]
+outputs = ["explicit.out"]
+EOF
+
+touch auto.src explicit.src
+
+assert "mise run -q auto" "auto-ran"
+assert_empty "mise run -q auto"
+touch fail-auto
+assert_fail "mise run -q --force auto"
+rm fail-auto
+assert "mise run -q auto" "auto-ran"
+assert_empty "mise run -q auto"
+
+assert "mise run -q explicit" "explicit-ran"
+assert_empty "mise run -q explicit"
+touch fail-explicit
+assert_fail "mise run -q --force explicit"
+rm fail-explicit
+assert "mise run -q explicit" "explicit-ran"
+assert_empty "mise run -q explicit"

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -14,7 +14,7 @@ use crate::task::task_output::{TaskOutput, trunc};
 use crate::task::task_output_handler::OutputHandler;
 use crate::task::task_script_parser::subcommand_name_from_parse;
 use crate::task::task_source_checker::{
-    save_checksum, sources_are_fresh, start_task_attempt, task_cwd,
+    remove_auto_output, save_checksum, sources_are_fresh, task_cwd,
 };
 use crate::task::{Deps, FailedTasks, GetMatchingExt, Task};
 use crate::tera::{contains_template_syntax, render_str};
@@ -446,11 +446,10 @@ impl TaskExecutor {
         }
 
         let timer = std::time::Instant::now();
-        let attempt;
 
         if let Some(file) = task.file_path(config).await? {
             let exec_start = std::time::Instant::now();
-            attempt = start_task_attempt(task, config).await?;
+            remove_auto_output(task, config).await?;
             self.exec_file(config, &file, task, &env, &prefix, extra_vars)
                 .await?;
             trace!(
@@ -492,7 +491,7 @@ impl TaskExecutor {
             self.check_confirmation(config, task, &env).await?;
 
             let exec_start = std::time::Instant::now();
-            attempt = start_task_attempt(task, config).await?;
+            remove_auto_output(task, config).await?;
             self.exec_task_run_entries(
                 config,
                 task,
@@ -525,11 +524,6 @@ impl TaskExecutor {
         }
 
         save_checksum(task, config).await?;
-        if let Some(attempt) = attempt {
-            if let Err(err) = attempt.succeeded() {
-                warn!("failed to clear dirty marker for task {}: {err}", task.name);
-            }
-        }
 
         Ok(true)
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -526,7 +526,9 @@ impl TaskExecutor {
 
         save_checksum(task, config).await?;
         if let Some(attempt) = attempt {
-            attempt.succeeded()?;
+            if let Err(err) = attempt.succeeded() {
+                warn!("failed to clear dirty marker for task {}: {err}", task.name);
+            }
         }
 
         Ok(true)

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -13,7 +13,9 @@ use crate::task::task_list::split_task_spec;
 use crate::task::task_output::{TaskOutput, trunc};
 use crate::task::task_output_handler::OutputHandler;
 use crate::task::task_script_parser::subcommand_name_from_parse;
-use crate::task::task_source_checker::{save_checksum, sources_are_fresh, task_cwd};
+use crate::task::task_source_checker::{
+    save_checksum, sources_are_fresh, start_task_attempt, task_cwd,
+};
 use crate::task::{Deps, FailedTasks, GetMatchingExt, Task};
 use crate::tera::{contains_template_syntax, render_str};
 use crate::toolset::env_cache::CachedEnv;
@@ -444,9 +446,11 @@ impl TaskExecutor {
         }
 
         let timer = std::time::Instant::now();
+        let attempt;
 
         if let Some(file) = task.file_path(config).await? {
             let exec_start = std::time::Instant::now();
+            attempt = start_task_attempt(task, config).await?;
             self.exec_file(config, &file, task, &env, &prefix, extra_vars)
                 .await?;
             trace!(
@@ -488,6 +492,7 @@ impl TaskExecutor {
             self.check_confirmation(config, task, &env).await?;
 
             let exec_start = std::time::Instant::now();
+            attempt = start_task_attempt(task, config).await?;
             self.exec_task_run_entries(
                 config,
                 task,
@@ -520,6 +525,9 @@ impl TaskExecutor {
         }
 
         save_checksum(task, config).await?;
+        if let Some(attempt) = attempt {
+            attempt.succeeded()?;
+        }
 
         Ok(true)
     }

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -20,6 +20,72 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// A marker for an in-progress task execution.
+///
+/// Markers from older failed or interrupted executions are captured when a new
+/// attempt starts. A successful attempt removes those markers along with its
+/// own, while leaving markers created by overlapping newer attempts intact.
+pub struct TaskAttempt {
+    marker: PathBuf,
+    previous_markers: Vec<PathBuf>,
+}
+
+impl TaskAttempt {
+    pub fn succeeded(self) -> Result<()> {
+        for marker in self
+            .previous_markers
+            .into_iter()
+            .chain(std::iter::once(self.marker))
+        {
+            match fs::remove_file(&marker) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
+        Ok(())
+    }
+}
+
+fn task_attempt_dir(task: &Task, root: &Path) -> PathBuf {
+    let mut hasher = DefaultHasher::new();
+    task.hash(&mut hasher);
+    task.config_source.hash(&mut hasher);
+    root.hash(&mut hasher);
+    dirs::STATE
+        .join("task-attempts")
+        .join(format!("{:x}", hasher.finish()))
+}
+
+fn task_attempt_markers(task: &Task, root: &Path) -> Result<Vec<PathBuf>> {
+    let dir = task_attempt_dir(task, root);
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    Ok(fs::read_dir(dir)?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file())
+        .collect())
+}
+
+/// Record that a task with source freshness has started executing.
+pub async fn start_task_attempt(task: &Task, config: &Arc<Config>) -> Result<Option<TaskAttempt>> {
+    if task.sources.is_empty() {
+        return Ok(None);
+    }
+    let root = task_cwd(task, config).await?;
+    let dir = task_attempt_dir(task, &root);
+    file::create_dir_all(&dir)?;
+    let previous_markers = task_attempt_markers(task, &root)?;
+    let marker = dir.join(random_string(16));
+    file::write(&marker, b"")?;
+    Ok(Some(TaskAttempt {
+        marker,
+        previous_markers,
+    }))
+}
+
 /// Check if a path is a glob pattern
 pub fn is_glob_pattern(path: &str) -> bool {
     // This is the character set used for glob detection by glob
@@ -201,6 +267,10 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
 
     let run = async || -> Result<bool> {
         let root = task_cwd(task, config).await?;
+        if !task_attempt_markers(task, &root)?.is_empty() {
+            debug!("task {} has an unfinished previous attempt", task.name);
+            return Ok(false);
+        }
         let matcher = build_source_matcher(&root, &task.sources);
         let glob_patterns = source_glob_patterns(&task.sources);
         let mut source_metadatas = get_file_metadatas(&root, &glob_patterns, &matcher)?;

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -36,13 +36,9 @@ impl TaskAttempt {
 }
 
 fn task_dirty_marker(task: &Task, root: &Path) -> PathBuf {
-    let mut hasher = DefaultHasher::new();
-    task.hash(&mut hasher);
-    task.config_source.hash(&mut hasher);
-    root.hash(&mut hasher);
     dirs::STATE
         .join("task-dirty")
-        .join(format!("{:x}", hasher.finish()))
+        .join(task_state_key(task, root))
 }
 
 /// Record that a task with source freshness has started executing.

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -20,37 +20,21 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// A marker that prevents stale outputs from making a failed task look fresh.
-pub struct TaskAttempt {
-    marker: PathBuf,
-}
-
-impl TaskAttempt {
-    pub fn succeeded(self) -> Result<()> {
-        match fs::remove_file(&self.marker) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(err.into()),
-        }
-    }
-}
-
-fn task_dirty_marker(task: &Task, root: &Path) -> PathBuf {
-    dirs::STATE
-        .join("task-dirty")
-        .join(task_state_key(task, root))
-}
-
-/// Record that a task with source freshness has started executing.
-pub async fn start_task_attempt(task: &Task, config: &Arc<Config>) -> Result<Option<TaskAttempt>> {
-    if task.sources.is_empty() {
-        return Ok(None);
+/// Remove mise's automatic output before rerunning a task so an earlier
+/// success cannot make a failed attempt look fresh.
+pub async fn remove_auto_output(task: &Task, config: &Arc<Config>) -> Result<()> {
+    if !task.outputs.is_auto() {
+        return Ok(());
     }
     let root = task_cwd(task, config).await?;
-    let marker = task_dirty_marker(task, &root);
-    file::create_dir_all(marker.parent().expect("dirty marker must have a parent"))?;
-    file::write(&marker, b"")?;
-    Ok(Some(TaskAttempt { marker }))
+    for output in task.outputs.paths(task, &root) {
+        match fs::remove_file(&output) {
+            Ok(()) => debug!("removed auto output file: {output}"),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+    }
+    Ok(())
 }
 
 /// Check if a path is a glob pattern
@@ -234,10 +218,6 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
 
     let run = async || -> Result<bool> {
         let root = task_cwd(task, config).await?;
-        if task_dirty_marker(task, &root).exists() {
-            debug!("task {} did not complete its previous attempt", task.name);
-            return Ok(false);
-        }
         let matcher = build_source_matcher(&root, &task.sources);
         let glob_patterns = source_glob_patterns(&task.sources);
         let mut source_metadatas = get_file_metadatas(&root, &glob_patterns, &matcher)?;

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -20,53 +20,29 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// A marker for an in-progress task execution.
-///
-/// Markers from older failed or interrupted executions are captured when a new
-/// attempt starts. A successful attempt removes those markers along with its
-/// own, while leaving markers created by overlapping newer attempts intact.
+/// A marker that prevents stale outputs from making a failed task look fresh.
 pub struct TaskAttempt {
     marker: PathBuf,
-    previous_markers: Vec<PathBuf>,
 }
 
 impl TaskAttempt {
     pub fn succeeded(self) -> Result<()> {
-        for marker in self
-            .previous_markers
-            .into_iter()
-            .chain(std::iter::once(self.marker))
-        {
-            match fs::remove_file(&marker) {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                Err(err) => return Err(err.into()),
-            }
+        match fs::remove_file(&self.marker) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err.into()),
         }
-        Ok(())
     }
 }
 
-fn task_attempt_dir(task: &Task, root: &Path) -> PathBuf {
+fn task_dirty_marker(task: &Task, root: &Path) -> PathBuf {
     let mut hasher = DefaultHasher::new();
     task.hash(&mut hasher);
     task.config_source.hash(&mut hasher);
     root.hash(&mut hasher);
     dirs::STATE
-        .join("task-attempts")
+        .join("task-dirty")
         .join(format!("{:x}", hasher.finish()))
-}
-
-fn task_attempt_markers(task: &Task, root: &Path) -> Result<Vec<PathBuf>> {
-    let dir = task_attempt_dir(task, root);
-    if !dir.exists() {
-        return Ok(vec![]);
-    }
-    Ok(fs::read_dir(dir)?
-        .filter_map(|entry| entry.ok())
-        .map(|entry| entry.path())
-        .filter(|path| path.is_file())
-        .collect())
 }
 
 /// Record that a task with source freshness has started executing.
@@ -75,15 +51,10 @@ pub async fn start_task_attempt(task: &Task, config: &Arc<Config>) -> Result<Opt
         return Ok(None);
     }
     let root = task_cwd(task, config).await?;
-    let dir = task_attempt_dir(task, &root);
-    file::create_dir_all(&dir)?;
-    let previous_markers = task_attempt_markers(task, &root)?;
-    let marker = dir.join(random_string(16));
+    let marker = task_dirty_marker(task, &root);
+    file::create_dir_all(marker.parent().expect("dirty marker must have a parent"))?;
     file::write(&marker, b"")?;
-    Ok(Some(TaskAttempt {
-        marker,
-        previous_markers,
-    }))
+    Ok(Some(TaskAttempt { marker }))
 }
 
 /// Check if a path is a glob pattern
@@ -267,8 +238,8 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
 
     let run = async || -> Result<bool> {
         let root = task_cwd(task, config).await?;
-        if !task_attempt_markers(task, &root)?.is_empty() {
-            debug!("task {} has an unfinished previous attempt", task.name);
+        if task_dirty_marker(task, &root).exists() {
+            debug!("task {} did not complete its previous attempt", task.name);
             return Ok(false);
         }
         let matcher = build_source_matcher(&root, &task.sources);


### PR DESCRIPTION
## Problem

For tasks using automatic outputs (`outputs = { auto = true }`), mise keeps an internal marker after a successful run. If that task is run again with `--force` and fails, the marker from the earlier success remains. A later normal invocation can therefore treat the task as fresh and skip it.

Reported in [Discussion #8733](https://github.com/jdx/mise/discussions/8733).

## Fix

- Remove the mise-managed automatic output marker immediately before task execution.
- Reuse the existing success path to recreate the marker only after exit 0.
- Leave the marker absent after failure or interruption so the next invocation reruns.

This PR intentionally applies only to automatic outputs. It does not change freshness behavior for user-managed explicit output files.

## Validation

- `mise run test:e2e tasks/test_task_failed_freshness`
- `mise run lint-fix`

The E2E test covers successful auto-output creation, a fresh skip, a failed forced rerun, the required subsequent rerun, and restored freshness after success.
