### PR TITLE
fix(task): respect configured directory when editing tasks

### DIFF
--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -91,3 +91,12 @@ EOF
 TASK_PATH4=$(mise tasks edit configured --path 2>&1)
 assert "printf '%s' \"$TASK_PATH4\"" "$PWD/tasks/configured"
 assert "test -f \"$TASK_PATH4\""
+
+# Explicit includes replace the default directories; do not fall back to mise-tasks.
+cat <<'EOF' >mise.toml
+[task_config]
+includes = ["tasks.toml"]
+EOF
+
+assert_fail_contains "mise tasks edit no-directory --path" "does not contain a directory"
+assert_fail "test -e mise-tasks/no-directory"

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -98,5 +98,5 @@ cat <<'EOF' >mise.toml
 includes = ["tasks.toml"]
 EOF
 
-assert_fail_contains "mise tasks edit no-directory --path" "does not contain a directory"
+assert_fail_contains "mise tasks edit no-directory --path" "do not contain a directory"
 assert_fail "test -e mise-tasks/no-directory"

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -82,17 +82,23 @@ assert_contains "mise run deploy:prod:backend:api" "deeply nested task executed"
 # Verify it shows up in the task list
 assert_contains "mise tasks ls" "deploy:prod:backend:api"
 
-# A single configured directory is the destination even when it does not exist yet.
+# Default includes select the first directory that already exists.
+mkdir -p default-project/.mise-tasks
+cd default-project
+DEFAULT_PATH=$(mise tasks edit default-choice --path 2>&1)
+assert "printf '%s' \"$DEFAULT_PATH\"" "$PWD/.mise-tasks/default-choice"
+cd ..
+
+# Explicit includes never fall back to a default directory.
 cat <<'EOF' >mise.toml
 [task_config]
 includes = ["tasks"]
 EOF
 
-TASK_PATH4=$(mise tasks edit configured --path 2>&1)
-assert "printf '%s' \"$TASK_PATH4\"" "$PWD/tasks/configured"
-assert "test -f \"$TASK_PATH4\""
+assert_fail_contains "mise tasks edit configured --path" "do not contain an existing directory"
+assert_fail "test -e mise-tasks/configured"
 
-# Preserve include order and allow dots in a configured directory name.
+# Select the first existing directory in include order.
 mkdir existing-tasks
 cat <<'EOF' >mise.toml
 [task_config]
@@ -100,7 +106,7 @@ includes = ["tasks.d", "existing-tasks"]
 EOF
 
 TASK_PATH5=$(mise tasks edit dotted --path 2>&1)
-assert "printf '%s' \"$TASK_PATH5\"" "$PWD/tasks.d/dotted"
+assert "printf '%s' \"$TASK_PATH5\"" "$PWD/existing-tasks/dotted"
 assert "test -f \"$TASK_PATH5\""
 
 # Explicit includes replace the default directories; do not fall back to mise-tasks.
@@ -114,7 +120,7 @@ includes = ["tasks.toml"]
 EOF
 
 assert "mise tasks edit existing --path" "$PWD/tasks.toml"
-assert_fail_contains "mise tasks edit no-directory --path" "do not contain a directory"
+assert_fail_contains "mise tasks edit no-directory --path" "do not contain an existing directory"
 assert_fail "test -e mise-tasks/no-directory"
 
 # Existing inline tasks also remain editable without a file-task directory.

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -81,3 +81,13 @@ assert_contains "mise run deploy:prod:backend:api" "deeply nested task executed"
 
 # Verify it shows up in the task list
 assert_contains "mise tasks ls" "deploy:prod:backend:api"
+
+# A single configured directory is the destination even when it does not exist yet.
+cat <<'EOF' >mise.toml
+[task_config]
+includes = ["tasks"]
+EOF
+
+TASK_PATH4=$(mise tasks edit configured --path 2>&1)
+assert "printf '%s' \"$TASK_PATH4\"" "$PWD/tasks/configured"
+assert "test -f \"$TASK_PATH4\""

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -84,10 +84,11 @@ assert_contains "mise tasks ls" "deploy:prod:backend:api"
 
 # Default includes select the first directory that already exists.
 mkdir -p default-project/.mise-tasks
-cd default-project
-DEFAULT_PATH=$(mise tasks edit default-choice --path 2>&1)
-assert "printf '%s' \"$DEFAULT_PATH\"" "$PWD/.mise-tasks/default-choice"
-cd ..
+(
+  cd default-project
+  DEFAULT_PATH=$(mise tasks edit default-choice --path 2>&1)
+  assert "printf '%s' \"$DEFAULT_PATH\"" "$PWD/.mise-tasks/default-choice"
+)
 
 # Explicit includes never fall back to a default directory.
 cat <<'EOF' >mise.toml

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -90,14 +90,19 @@ mkdir -p default-project/.mise-tasks
   assert "printf '%s' \"$DEFAULT_PATH\"" "$PWD/.mise-tasks/default-choice"
 )
 
-# Explicit includes never fall back to a default directory.
+# A sole explicit literal directory is created instead of falling back to a default directory.
 cat <<'EOF' >mise.toml
 [task_config]
 includes = ["tasks"]
 EOF
 
-assert_fail_contains "mise tasks edit configured --path" "do not contain an existing directory"
+TASK_PATH4=$(mise tasks edit configured --path 2>&1)
+assert "printf '%s' \"$TASK_PATH4\"" "$PWD/tasks/configured"
+assert "test -f \"$TASK_PATH4\""
+mise tasks add added --file
+assert "test -f tasks/added"
 assert_fail "test -e mise-tasks/configured"
+assert_fail "test -e mise-tasks/added"
 
 # Select the first existing directory in include order.
 mkdir existing-tasks
@@ -109,6 +114,16 @@ EOF
 TASK_PATH5=$(mise tasks edit dotted --path 2>&1)
 assert "printf '%s' \"$TASK_PATH5\"" "$PWD/existing-tasks/dotted"
 assert "test -f \"$TASK_PATH5\""
+
+# Multiple missing literal directories are ambiguous and must not be guessed.
+cat <<'EOF' >mise.toml
+[task_config]
+includes = ["missing-a", "missing-b"]
+EOF
+
+assert_fail_contains "mise tasks edit ambiguous --path" "do not contain an existing directory"
+assert_fail "test -e missing-a/ambiguous"
+assert_fail "test -e missing-b/ambiguous"
 
 # Explicit includes replace the default directories; do not fall back to mise-tasks.
 cat <<'EOF' >tasks.toml

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -90,17 +90,16 @@ mkdir -p default-project/.mise-tasks
   assert "printf '%s' \"$DEFAULT_PATH\"" "$PWD/.mise-tasks/default-choice"
 )
 
-# A sole explicit literal directory is created instead of falling back to a default directory.
+# A missing explicit path is not assumed to be a directory and never falls back to a default.
 cat <<'EOF' >mise.toml
 [task_config]
 includes = ["tasks"]
 EOF
 
-TASK_PATH4=$(mise tasks edit configured --path 2>&1)
-assert "printf '%s' \"$TASK_PATH4\"" "$PWD/tasks/configured"
-assert "test -f \"$TASK_PATH4\""
-mise tasks add added --file
-assert "test -f tasks/added"
+assert_fail_contains "mise tasks edit configured --path" "do not contain an existing directory"
+assert_fail_contains "mise tasks add added --file" "do not contain an existing directory"
+assert_fail "test -e tasks/configured"
+assert_fail "test -e tasks/added"
 assert_fail "test -e mise-tasks/configured"
 assert_fail "test -e mise-tasks/added"
 

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -92,6 +92,17 @@ TASK_PATH4=$(mise tasks edit configured --path 2>&1)
 assert "printf '%s' \"$TASK_PATH4\"" "$PWD/tasks/configured"
 assert "test -f \"$TASK_PATH4\""
 
+# Preserve include order and allow dots in a configured directory name.
+mkdir existing-tasks
+cat <<'EOF' >mise.toml
+[task_config]
+includes = ["tasks.d", "existing-tasks"]
+EOF
+
+TASK_PATH5=$(mise tasks edit dotted --path 2>&1)
+assert "printf '%s' \"$TASK_PATH5\"" "$PWD/tasks.d/dotted"
+assert "test -f \"$TASK_PATH5\""
+
 # Explicit includes replace the default directories; do not fall back to mise-tasks.
 cat <<'EOF' >mise.toml
 [task_config]

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -104,10 +104,26 @@ assert "printf '%s' \"$TASK_PATH5\"" "$PWD/tasks.d/dotted"
 assert "test -f \"$TASK_PATH5\""
 
 # Explicit includes replace the default directories; do not fall back to mise-tasks.
+cat <<'EOF' >tasks.toml
+[existing]
+run = "echo existing"
+EOF
 cat <<'EOF' >mise.toml
 [task_config]
 includes = ["tasks.toml"]
 EOF
 
+assert "mise tasks edit existing --path" "$PWD/tasks.toml"
 assert_fail_contains "mise tasks edit no-directory --path" "do not contain a directory"
 assert_fail "test -e mise-tasks/no-directory"
+
+# Existing inline tasks also remain editable without a file-task directory.
+cat <<'EOF' >mise.toml
+[task_config]
+includes = []
+
+[tasks.inline]
+run = "echo inline"
+EOF
+
+assert "mise tasks edit inline --path" "$PWD/mise.toml"

--- a/src/cli/tasks/add.rs
+++ b/src/cli/tasks/add.rs
@@ -74,7 +74,7 @@ impl TasksAdd {
     pub async fn run(self) -> Result<()> {
         if self.file {
             let mut path = Task::task_dir()
-                .await
+                .await?
                 .join(self.task.replace(':', MAIN_SEPARATOR_STR));
             if path.is_dir() {
                 path = path.join("_default");

--- a/src/cli/tasks/edit.rs
+++ b/src/cli/tasks/edit.rs
@@ -26,7 +26,7 @@ impl TasksEdit {
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let project_root = config.project_root.clone().unwrap_or(cwd);
         let path = Task::task_dir()
-            .await
+            .await?
             .join(self.task.replace(':', MAIN_SEPARATOR_STR));
 
         let task = if let Some(task) = config.tasks_with_aliases().await?.get(&self.task).cloned() {

--- a/src/cli/tasks/edit.rs
+++ b/src/cli/tasks/edit.rs
@@ -25,13 +25,12 @@ impl TasksEdit {
         let config = Config::get().await?;
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let project_root = config.project_root.clone().unwrap_or(cwd);
-        let path = Task::task_dir()
-            .await?
-            .join(self.task.replace(':', MAIN_SEPARATOR_STR));
-
         let task = if let Some(task) = config.tasks_with_aliases().await?.get(&self.task).cloned() {
             task
         } else {
+            let path = Task::task_dir()
+                .await?
+                .join(self.task.replace(':', MAIN_SEPARATOR_STR));
             Task::from_path(&config, &path, path.parent().unwrap(), &project_root)
                 .await
                 .or_else(|_| Task::new(&path, path.parent().unwrap(), &project_root))?

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3107,16 +3107,13 @@ pub fn task_creation_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result
     } else {
         None
     };
-    for include in &includes {
-        if include.starts_with("git::") {
-            continue;
-        }
-        if let Some(path) = expand_task_include(&resolve_dir, include)
-            .into_iter()
-            .find(|path| path.is_dir())
-        {
-            return Ok(path);
-        }
+    if let Some(path) = includes
+        .iter()
+        .filter(|include| !include.starts_with("git::"))
+        .flat_map(|include| expand_task_include(&resolve_dir, include))
+        .find(|path| path.is_dir())
+    {
+        return Ok(path);
     }
     if let Some(dir) = default_create_dir {
         return Ok(dir);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3096,7 +3096,8 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
 ///
 /// Existing directories are selected in effective `task_config.includes` order. When the
 /// built-in defaults are in use and none exist yet, the first default path is returned so the
-/// caller can create it. Explicit includes must contain an existing directory.
+/// caller can create it. A sole missing local literal in explicit includes is treated as an
+/// unambiguous directory to create; other explicit include sets must contain an existing directory.
 pub fn task_creation_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<PathBuf> {
     let (includes, resolve_dir, uses_defaults) = task_include_patterns_for_dir(dir, config_files)?;
     let default_create_dir = if uses_defaults {
@@ -3116,6 +3117,15 @@ pub fn task_creation_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result
         {
             return Ok(path);
         }
+    }
+    let missing_literal_dirs = includes
+        .iter()
+        .filter(|include| !include.starts_with("git::") && !is_glob_pattern(include))
+        .map(|include| resolve_dir.join(file::replace_path(include)))
+        .filter(|path| !path.exists() && path.extension().is_none_or(|ext| ext != "toml"))
+        .collect::<Vec<_>>();
+    if !uses_defaults && let [dir] = missing_literal_dirs.as_slice() {
+        return Ok(dir.clone());
     }
     if let Some(dir) = default_create_dir {
         return Ok(dir);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3090,17 +3090,6 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
         .collect::<Vec<_>>())
 }
 
-pub fn has_explicit_task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<bool> {
-    configs_at_root(dir, config_files)
-        .iter()
-        .find_map(|cf| match cf.task_config_includes() {
-            Ok(Some(_)) => Some(Ok(true)),
-            Ok(None) => None,
-            Err(err) => Some(Err(err)),
-        })
-        .unwrap_or(Ok(false))
-}
-
 pub async fn load_tasks_in_dir(
     config: &Arc<Config>,
     dir: &Path,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3096,8 +3096,8 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
 ///
 /// Existing directories are selected in effective `task_config.includes` order. When the
 /// built-in defaults are in use and none exist yet, the first default path is returned so the
-/// caller can create it. A sole missing local literal in explicit includes is treated as an
-/// unambiguous directory to create; other explicit include sets must contain an existing directory.
+/// caller can create it. Explicit includes must contain an existing directory because a missing
+/// path cannot be distinguished from a task file.
 pub fn task_creation_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<PathBuf> {
     let (includes, resolve_dir, uses_defaults) = task_include_patterns_for_dir(dir, config_files)?;
     let default_create_dir = if uses_defaults {
@@ -3117,15 +3117,6 @@ pub fn task_creation_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result
         {
             return Ok(path);
         }
-    }
-    let missing_literal_dirs = includes
-        .iter()
-        .filter(|include| !include.starts_with("git::") && !is_glob_pattern(include))
-        .map(|include| resolve_dir.join(file::replace_path(include)))
-        .filter(|path| !path.exists() && path.extension().is_none_or(|ext| ext != "toml"))
-        .collect::<Vec<_>>();
-    if !uses_defaults && let [dir] = missing_literal_dirs.as_slice() {
-        return Ok(dir.clone());
     }
     if let Some(dir) = default_create_dir {
         return Ok(dir);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3094,19 +3094,26 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
 
 pub fn task_create_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<PathBuf> {
     let (includes, resolve_dir, uses_defaults) = task_include_patterns_for_dir(dir, config_files)?;
-    for include in includes {
+    let default_create_dir = if uses_defaults {
+        includes
+            .first()
+            .map(|include| resolve_dir.join(file::replace_path(include)))
+    } else {
+        None
+    };
+    for include in &includes {
         if include.starts_with("git::") {
             continue;
         }
-        if let Some(path) = expand_task_include(&resolve_dir, &include)
+        if let Some(path) = expand_task_include(&resolve_dir, include)
             .into_iter()
             .find(|path| path.is_dir())
         {
             return Ok(path);
         }
     }
-    if uses_defaults {
-        return Ok(resolve_dir.join("mise-tasks"));
+    if let Some(dir) = default_create_dir {
+        return Ok(dir);
     }
     bail!("task includes do not contain an existing directory where a file task can be created")
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3079,7 +3079,12 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
             if p.starts_with("git::") {
                 return vec![];
             }
-            expand_task_include(&resolve_dir, &p)
+            let paths = expand_task_include(&resolve_dir, &p);
+            if paths.is_empty() && !is_glob_pattern(&p) {
+                vec![resolve_dir.join(file::replace_path(&p))]
+            } else {
+                paths
+            }
         })
         .unique()
         .collect::<Vec<_>>())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3051,21 +3051,20 @@ async fn load_file_tasks(
     Ok(tasks)
 }
 
-fn task_includes_for_dir_with_missing_literals(
+fn task_include_patterns_for_dir(
     dir: &Path,
     config_files: &ConfigMap,
-    include_missing_literals: bool,
-) -> Result<Vec<PathBuf>> {
+) -> Result<(Vec<String>, PathBuf, bool)> {
     let configs = configs_at_root(dir, config_files);
 
     // Find the highest-precedence config that has explicit task_config.includes
     // and resolve paths relative to that config file's directory
-    let (includes, resolve_dir) = configs
+    Ok(configs
         .iter()
         .find_map(|cf| match cf.task_config_includes() {
             Ok(Some(includes)) => Some(Ok({
                 // Resolve relative paths from the config root, not the config file's directory
-                (includes, cf.config_root())
+                (includes, cf.config_root(), false)
             })),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
@@ -3073,8 +3072,12 @@ fn task_includes_for_dir_with_missing_literals(
         .transpose()?
         .unwrap_or_else(|| {
             // Default includes should be resolved relative to the search directory
-            (default_task_includes(), dir.to_path_buf())
-        });
+            (default_task_includes(), dir.to_path_buf(), true)
+        }))
+}
+
+pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec<PathBuf>> {
+    let (includes, resolve_dir, _) = task_include_patterns_for_dir(dir, config_files)?;
 
     Ok(includes
         .into_iter()
@@ -3083,26 +3086,29 @@ fn task_includes_for_dir_with_missing_literals(
             if p.starts_with("git::") {
                 return vec![];
             }
-            let paths = expand_task_include(&resolve_dir, &p);
-            if include_missing_literals && paths.is_empty() && !is_glob_pattern(&p) {
-                vec![resolve_dir.join(file::replace_path(&p))]
-            } else {
-                paths
-            }
+            expand_task_include(&resolve_dir, &p)
         })
         .unique()
         .collect::<Vec<_>>())
 }
 
-pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec<PathBuf>> {
-    task_includes_for_dir_with_missing_literals(dir, config_files, false)
-}
-
-pub fn task_include_candidates_for_dir(
-    dir: &Path,
-    config_files: &ConfigMap,
-) -> Result<Vec<PathBuf>> {
-    task_includes_for_dir_with_missing_literals(dir, config_files, true)
+pub fn task_create_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<PathBuf> {
+    let (includes, resolve_dir, uses_defaults) = task_include_patterns_for_dir(dir, config_files)?;
+    for include in includes {
+        if include.starts_with("git::") {
+            continue;
+        }
+        if let Some(path) = expand_task_include(&resolve_dir, &include)
+            .into_iter()
+            .find(|path| path.is_dir())
+        {
+            return Ok(path);
+        }
+    }
+    if uses_defaults {
+        return Ok(resolve_dir.join("mise-tasks"));
+    }
+    bail!("task includes do not contain an existing directory where a file task can be created")
 }
 
 pub async fn load_tasks_in_dir(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3051,7 +3051,11 @@ async fn load_file_tasks(
     Ok(tasks)
 }
 
-pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec<PathBuf>> {
+fn task_includes_for_dir_with_missing_literals(
+    dir: &Path,
+    config_files: &ConfigMap,
+    include_missing_literals: bool,
+) -> Result<Vec<PathBuf>> {
     let configs = configs_at_root(dir, config_files);
 
     // Find the highest-precedence config that has explicit task_config.includes
@@ -3080,7 +3084,7 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
                 return vec![];
             }
             let paths = expand_task_include(&resolve_dir, &p);
-            if paths.is_empty() && !is_glob_pattern(&p) {
+            if include_missing_literals && paths.is_empty() && !is_glob_pattern(&p) {
                 vec![resolve_dir.join(file::replace_path(&p))]
             } else {
                 paths
@@ -3088,6 +3092,17 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
         })
         .unique()
         .collect::<Vec<_>>())
+}
+
+pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec<PathBuf>> {
+    task_includes_for_dir_with_missing_literals(dir, config_files, false)
+}
+
+pub fn task_include_candidates_for_dir(
+    dir: &Path,
+    config_files: &ConfigMap,
+) -> Result<Vec<PathBuf>> {
+    task_includes_for_dir_with_missing_literals(dir, config_files, true)
 }
 
 pub async fn load_tasks_in_dir(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3090,6 +3090,17 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
         .collect::<Vec<_>>())
 }
 
+pub fn has_explicit_task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<bool> {
+    configs_at_root(dir, config_files)
+        .iter()
+        .find_map(|cf| match cf.task_config_includes() {
+            Ok(Some(_)) => Some(Ok(true)),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .unwrap_or(Ok(false))
+}
+
 pub async fn load_tasks_in_dir(
     config: &Arc<Config>,
     dir: &Path,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3092,7 +3092,12 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
         .collect::<Vec<_>>())
 }
 
-pub fn task_create_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<PathBuf> {
+/// Returns the directory where a new file task should be created.
+///
+/// Existing directories are selected in effective `task_config.includes` order. When the
+/// built-in defaults are in use and none exist yet, the first default path is returned so the
+/// caller can create it. Explicit includes must contain an existing directory.
+pub fn task_creation_dir_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<PathBuf> {
     let (includes, resolve_dir, uses_defaults) = task_include_patterns_for_dir(dir, config_files)?;
     let default_create_dir = if uses_defaults {
         includes

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -942,12 +942,9 @@ impl Task {
             if dir.is_dir() {
                 return Ok(dir.clone());
             }
-        }
-        if let Some(dir) = task_includes
-            .iter()
-            .find(|dir| !dir.exists() && dir.extension().is_none())
-        {
-            return Ok(dir.clone());
+            if !dir.exists() && dir.extension().is_none_or(|ext| ext != "toml") {
+                return Ok(dir.clone());
+            }
         }
         bail!("task includes do not contain a directory where a file task can be created")
     }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -937,7 +937,8 @@ impl Task {
         let config = Config::get().await?;
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let project_root = config.project_root.clone().unwrap_or(cwd);
-        let task_includes = config::task_includes_for_dir(&project_root, &config.config_files)?;
+        let task_includes =
+            config::task_include_candidates_for_dir(&project_root, &config.config_files)?;
         for dir in &task_includes {
             if dir.is_dir() {
                 return Ok(dir.clone());

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -949,12 +949,7 @@ impl Task {
         {
             return Ok(dir.clone());
         }
-        if config::has_explicit_task_includes_for_dir(&project_root, &config.config_files)? {
-            bail!(
-                "task_config.includes does not contain a directory where a file task can be created"
-            );
-        }
-        Ok(project_root.join("mise-tasks"))
+        bail!("task includes do not contain a directory where a file task can be created")
     }
 
     pub fn with_args(mut self, args: Vec<String>) -> Self {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -937,7 +937,7 @@ impl Task {
         let config = Config::get().await?;
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let project_root = config.project_root.clone().unwrap_or(cwd);
-        config::task_create_dir_for_dir(&project_root, &config.config_files)
+        config::task_creation_dir_for_dir(&project_root, &config.config_files)
     }
 
     pub fn with_args(mut self, args: Vec<String>) -> Self {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -937,17 +937,7 @@ impl Task {
         let config = Config::get().await?;
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let project_root = config.project_root.clone().unwrap_or(cwd);
-        let task_includes =
-            config::task_include_candidates_for_dir(&project_root, &config.config_files)?;
-        for dir in &task_includes {
-            if dir.is_dir() {
-                return Ok(dir.clone());
-            }
-            if !dir.exists() && dir.extension().is_none_or(|ext| ext != "toml") {
-                return Ok(dir.clone());
-            }
-        }
-        bail!("task includes do not contain a directory where a file task can be created")
+        config::task_create_dir_for_dir(&project_root, &config.config_files)
     }
 
     pub fn with_args(mut self, args: Vec<String>) -> Self {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -945,10 +945,16 @@ impl Task {
                 Vec::new()
             }
         };
-        for dir in task_includes {
-            if dir.is_dir() && project_root.join(&dir).exists() {
-                return project_root.join(dir);
+        for dir in &task_includes {
+            if dir.is_dir() {
+                return dir.clone();
             }
+        }
+        if let [dir] = task_includes.as_slice()
+            && !dir.exists()
+            && dir.extension().is_none()
+        {
+            return dir.clone();
         }
         project_root.join("mise-tasks")
     }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -933,30 +933,28 @@ impl Task {
         matches || self.aliases.contains(&pat.to_string())
     }
 
-    pub async fn task_dir() -> PathBuf {
-        let config = Config::get().await.unwrap();
+    pub async fn task_dir() -> Result<PathBuf> {
+        let config = Config::get().await?;
         let cwd = dirs::CWD.clone().unwrap_or_default();
         let project_root = config.project_root.clone().unwrap_or(cwd);
-        let task_includes = match config::task_includes_for_dir(&project_root, &config.config_files)
-        {
-            Ok(includes) => includes,
-            Err(err) => {
-                warn!("failed to resolve task include paths: {err:#}");
-                Vec::new()
-            }
-        };
+        let task_includes = config::task_includes_for_dir(&project_root, &config.config_files)?;
         for dir in &task_includes {
             if dir.is_dir() {
-                return dir.clone();
+                return Ok(dir.clone());
             }
         }
-        if let [dir] = task_includes.as_slice()
-            && !dir.exists()
-            && dir.extension().is_none()
+        if let Some(dir) = task_includes
+            .iter()
+            .find(|dir| !dir.exists() && dir.extension().is_none())
         {
-            return dir.clone();
+            return Ok(dir.clone());
         }
-        project_root.join("mise-tasks")
+        if config::has_explicit_task_includes_for_dir(&project_root, &config.config_files)? {
+            bail!(
+                "task_config.includes does not contain a directory where a file task can be created"
+            );
+        }
+        Ok(project_root.join("mise-tasks"))
     }
 
     pub fn with_args(mut self, args: Vec<String>) -> Self {


### PR DESCRIPTION
## Summary

- choose the first existing directory from the effective `task_config.includes` list when creating a file task
- preserve default include behavior, using the first default entry only when no default directory exists
- return an error instead of silently using a default directory when explicit includes contain no existing directory
- edit existing tasks at their known source without requiring a file-task creation directory

## Behavioral decision

Explicit include paths are not auto-created. An entry may represent a task TOML file or a directory, so mise must not infer the type of a path that does not exist. For example, with `includes = ["tasks"]`:

- if `tasks/` exists, a new file task is created there;
- if `tasks` does not exist, the command returns an error and does not create either `tasks/` or `mise-tasks/`;
- the user should create the intended directory before running `mise tasks edit` or `mise tasks add --file`.

This matches the clarification in [Discussion #10954](https://github.com/jdx/mise/discussions/10954#discussioncomment-17613384). Built-in default includes are known directory paths, so when none exist mise may still create the first effective default entry.

## Root cause

`Task::task_dir` fell back to `mise-tasks` whenever no include expanded to an existing directory. That ignored the replacement semantics of an explicit `task_config.includes` value and could create a task outside the configured include paths.

## Validation

- `mise run lint-fix`
- `cargo check --all-features`
- `mise run test:e2e e2e/tasks/test_task_edit_nested_names`
- `shellcheck -x e2e/tasks/test_task_edit_nested_names`

Addresses https://github.com/jdx/mise/discussions/10954
