### PR TITLE
fix(task): preserve task tool options

### DIFF
--- a/e2e/tasks/test_task_tools
+++ b/e2e/tasks/test_task_tools
@@ -12,3 +12,16 @@ EOF
 
 assert "mise run b" "rtx-tiny: v1.1.0 args:
 rtx-tiny: v2.1.0 args:"
+
+# Task tool maps must preserve structured options. The needs-dummy installer
+# fails unless its `depends` entry causes dummy to be installed first.
+cat <<EOF >mise.toml
+[tasks.structured-options]
+tools = { needs-dummy = { version = "1.0.0", depends = ["dummy"] }, dummy = "2.0.0" }
+run = "needs-dummy"
+EOF
+
+rm -rf "$MISE_DATA_DIR/installs/dummy"
+rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
+
+assert "MISE_JOBS=1 mise run structured-options" "needs-dummy v1.0.0"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -103,27 +103,24 @@ impl TaskToolValue {
                 // Preserve the existing behavior until task tools support structured
                 // options: bracket serialization omitted all arrays and tables,
                 // including the core `os` and `depends` fields.
-                let scalar_options = map
-                    .opts
-                    .iter()
-                    .filter(|(_, value)| {
-                        !matches!(value, toml::Value::Array(_) | toml::Value::Table(_))
-                    })
-                    .map(|(key, value)| (key.clone(), value.clone()))
-                    .collect();
-                let task_options: ToolVersionOptions =
-                    toml::Value::Table(scalar_options).try_into()?;
+                let mut task_options = ToolVersionOptions::default();
+                for (key, value) in map.opts.iter().filter(|(_, value)| {
+                    !matches!(value, toml::Value::Array(_) | toml::Value::Table(_))
+                }) {
+                    task_options
+                        .insert_option(key.clone(), value.clone())
+                        .map_err(|err| eyre!(err))?;
+                }
 
-                let backend: BackendArg = tool.parse()?;
-                let mut options = backend.opts();
-                options.apply_overrides(&task_options);
+                let mut backend: BackendArg = tool.parse()?;
+                let mut explicit_options = backend.explicit_opts().cloned().unwrap_or_default();
+                explicit_options.apply_overrides(&task_options);
+                if !explicit_options.is_empty() {
+                    backend.set_opts(Some(explicit_options));
+                }
                 let backend = Arc::new(backend);
-                let request = ToolRequest::new_opts(
-                    backend.clone(),
-                    &map.version,
-                    options,
-                    ToolSource::Argument,
-                )?;
+                let request =
+                    ToolRequest::new(backend.clone(), &map.version, ToolSource::Argument)?;
                 Ok(ToolArg {
                     short: backend.short.clone(),
                     ba: backend,
@@ -3927,17 +3924,19 @@ echo "test"
             "github_attestations".to_string(),
             toml::Value::Boolean(true),
         );
+        opts.insert("allow_builds".to_string(), toml::Value::Boolean(true));
+        opts.insert(
+            "numeric_string".to_string(),
+            toml::Value::String("1e2".to_string()),
+        );
+        opts.insert("os".to_string(), toml::Value::String("linux".to_string()));
+        opts.insert(
+            "depends".to_string(),
+            toml::Value::String("node".to_string()),
+        );
         opts.insert(
             "targets".to_string(),
             toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
-        );
-        opts.insert(
-            "os".to_string(),
-            toml::Value::Array(vec![toml::Value::String("linux".to_string())]),
-        );
-        opts.insert(
-            "depends".to_string(),
-            toml::Value::Array(vec![toml::Value::String("node".to_string())]),
         );
         opts.insert(
             "platforms".to_string(),
@@ -3957,12 +3956,119 @@ echo "test"
         assert_eq!(options.get_string("strip_components"), Some("1".into()));
         assert_eq!(
             options.opts.get("github_attestations"),
+            Some(&toml::Value::String("true".to_string()))
+        );
+        assert_eq!(
+            options.opts.get("allow_builds"),
             Some(&toml::Value::Boolean(true))
         );
+        assert_eq!(options.get("numeric_string"), Some("1e2"));
         assert!(!options.contains_key("targets"));
         assert!(!options.contains_key("platforms"));
+        assert_eq!(options.os, Some(vec!["linux".to_string()]));
+        assert_eq!(options.depends, Some(vec!["node".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn test_to_tool_arg_omits_structured_core_options() {
+        use indexmap::IndexMap;
+
+        use crate::config::Config;
+
+        use super::{TaskToolValue, TaskToolValueMap};
+
+        let _config = Config::get().await.unwrap();
+        let tool = TaskToolValue::Map(TaskToolValueMap {
+            version: "1.0.0".to_string(),
+            opts: IndexMap::from([
+                (
+                    "os".to_string(),
+                    toml::Value::Array(vec![toml::Value::String("linux".to_string())]),
+                ),
+                (
+                    "depends".to_string(),
+                    toml::Value::Array(vec![toml::Value::String("node".to_string())]),
+                ),
+            ]),
+        });
+
+        let options = tool
+            .to_tool_arg("http:task-tool-options")
+            .unwrap()
+            .tvr
+            .unwrap()
+            .options();
+
         assert_eq!(options.os, None);
         assert_eq!(options.depends, None);
+    }
+
+    #[tokio::test]
+    async fn test_task_tool_options_survive_toolset_build() {
+        use indexmap::IndexMap;
+
+        use crate::config::Config;
+        use crate::toolset::ToolsetBuilder;
+
+        use super::{TaskToolValue, TaskToolValueMap};
+
+        let config = Config::get().await.unwrap();
+        let tool = TaskToolValue::Map(TaskToolValueMap {
+            version: "1.0.0".to_string(),
+            opts: IndexMap::from([(
+                "query".to_string(),
+                toml::Value::String("first,second=value".to_string()),
+            )]),
+        });
+        let arg = tool.to_tool_arg("http:task-tool-options").unwrap();
+
+        let toolset = ToolsetBuilder::new()
+            .with_args(&[arg])
+            .build(&config)
+            .await
+            .unwrap();
+        let request = toolset
+            .list_current_requests()
+            .into_iter()
+            .find(|request| request.ba().short == "http:task-tool-options")
+            .unwrap();
+
+        assert_eq!(request.options().get("query"), Some("first,second=value"));
+    }
+
+    #[tokio::test]
+    async fn test_to_tool_arg_preserves_options_for_all_request_types() {
+        use indexmap::IndexMap;
+
+        use crate::config::Config;
+
+        use super::{TaskToolValue, TaskToolValueMap};
+
+        let _config = Config::get().await.unwrap();
+        for version in [
+            "1.0.0",
+            "prefix:1",
+            "ref:main",
+            "path:/tmp/task-tool-options",
+            "sub-foo:1.0.0",
+            "system",
+        ] {
+            let tool = TaskToolValue::Map(TaskToolValueMap {
+                version: version.to_string(),
+                opts: IndexMap::from([(
+                    "query".to_string(),
+                    toml::Value::String("value".to_string()),
+                )]),
+            });
+
+            let request = tool
+                .to_tool_arg("http:task-tool-options")
+                .unwrap()
+                .tvr
+                .unwrap();
+
+            assert_eq!(request.options().get("query"), Some("value"), "{version}");
+        }
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -101,7 +101,8 @@ impl TaskToolValue {
             Self::String(version) => format!("{tool}@{version}").parse(),
             Self::Map(map) => {
                 // Preserve the existing behavior until task tools support structured
-                // options: bracket serialization omitted arrays and tables.
+                // options: bracket serialization omitted all arrays and tables,
+                // including the core `os` and `depends` fields.
                 let scalar_options = map
                     .opts
                     .iter()
@@ -711,6 +712,13 @@ fn normalize_root_mount_node(line: &str) -> String {
 }
 
 impl Task {
+    pub(crate) fn tool_args(&self) -> Result<Vec<ToolArg>> {
+        self.tools
+            .iter()
+            .map(|(tool, value)| value.to_tool_arg(tool))
+            .collect()
+    }
+
     pub fn new(path: &Path, prefix: &Path, config_root: &Path) -> Result<Task> {
         Ok(Self {
             name: name_from_path(prefix, path)?,
@@ -3924,6 +3932,14 @@ echo "test"
             toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
         );
         opts.insert(
+            "os".to_string(),
+            toml::Value::Array(vec![toml::Value::String("linux".to_string())]),
+        );
+        opts.insert(
+            "depends".to_string(),
+            toml::Value::Array(vec![toml::Value::String("node".to_string())]),
+        );
+        opts.insert(
             "platforms".to_string(),
             toml::Value::Table(toml::map::Map::new()),
         );
@@ -3945,6 +3961,8 @@ echo "test"
         );
         assert!(!options.contains_key("targets"));
         assert!(!options.contains_key("platforms"));
+        assert_eq!(options.os, None);
+        assert_eq!(options.depends, None);
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -100,13 +100,8 @@ impl TaskToolValue {
         match self {
             Self::String(version) => format!("{tool}@{version}").parse(),
             Self::Map(map) => {
-                // Preserve the existing behavior until task tools support structured
-                // options: bracket serialization omitted all arrays and tables,
-                // including the core `os` and `depends` fields.
                 let mut task_options = ToolVersionOptions::default();
-                for (key, value) in map.opts.iter().filter(|(_, value)| {
-                    !matches!(value, toml::Value::Array(_) | toml::Value::Table(_))
-                }) {
+                for (key, value) in &map.opts {
                     task_options
                         .insert_option(key.clone(), value.clone())
                         .map_err(|err| eyre!(err))?;
@@ -3963,14 +3958,22 @@ echo "test"
             Some(&toml::Value::Boolean(true))
         );
         assert_eq!(options.get("numeric_string"), Some("1e2"));
-        assert!(!options.contains_key("targets"));
-        assert!(!options.contains_key("platforms"));
+        assert_eq!(
+            options.opts.get("targets"),
+            Some(&toml::Value::Array(vec![toml::Value::String(
+                "x86_64".to_string()
+            )]))
+        );
+        assert_eq!(
+            options.opts.get("platforms"),
+            Some(&toml::Value::Table(toml::map::Map::new()))
+        );
         assert_eq!(options.os, Some(vec!["linux".to_string()]));
         assert_eq!(options.depends, Some(vec!["node".to_string()]));
     }
 
     #[tokio::test]
-    async fn test_to_tool_arg_omits_structured_core_options() {
+    async fn test_to_tool_arg_preserves_structured_core_options() {
         use indexmap::IndexMap;
 
         use crate::config::Config;
@@ -3999,8 +4002,8 @@ echo "test"
             .unwrap()
             .options();
 
-        assert_eq!(options.os, None);
-        assert_eq!(options.depends, None);
+        assert_eq!(options.os, Some(vec!["linux".to_string()]));
+        assert_eq!(options.depends, Some(vec!["node".to_string()]));
     }
 
     #[tokio::test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,3 +1,4 @@
+use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::config_file::mise_toml::EnvList;
 use crate::config::config_file::toml::{TrackingTomlParser, deserialize_arr};
 use crate::config::env_directive::{EnvDirective, EnvResolveOptions, EnvResults, ToolsFilter};
@@ -71,7 +72,7 @@ use crate::config::config_file::ConfigFile;
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
 use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
-use crate::toolset::{Toolset, serialize_tool_options};
+use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, Toolset};
 use crate::ui::style;
 pub use deps::{Deps, TaskKey};
 use task_dep::TaskDep;
@@ -95,18 +96,40 @@ pub struct TaskToolValueMap {
 }
 
 impl TaskToolValue {
-    /// Convert to a tool specification string for ToolArg parsing.
-    /// String values become "{tool}@{version}".
-    /// Map values become "{tool}[{opts}]@{version}" where opts are serialized.
-    pub fn to_tool_spec(&self, tool: &str) -> String {
+    pub fn to_tool_arg(&self, tool: &str) -> Result<ToolArg> {
         match self {
-            TaskToolValue::String(version) => format!("{tool}@{version}"),
-            TaskToolValue::Map(map) => {
-                if let Some(opts_str) = serialize_tool_options(map.opts.iter()) {
-                    format!("{tool}[{opts_str}]@{}", map.version)
-                } else {
-                    format!("{tool}@{}", map.version)
-                }
+            Self::String(version) => format!("{tool}@{version}").parse(),
+            Self::Map(map) => {
+                // Preserve the existing behavior until task tools support structured
+                // options: bracket serialization omitted arrays and tables.
+                let scalar_options = map
+                    .opts
+                    .iter()
+                    .filter(|(_, value)| {
+                        !matches!(value, toml::Value::Array(_) | toml::Value::Table(_))
+                    })
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect();
+                let task_options: ToolVersionOptions =
+                    toml::Value::Table(scalar_options).try_into()?;
+
+                let backend: BackendArg = tool.parse()?;
+                let mut options = backend.opts();
+                options.apply_overrides(&task_options);
+                let backend = Arc::new(backend);
+                let request = ToolRequest::new_opts(
+                    backend.clone(),
+                    &map.version,
+                    options,
+                    ToolSource::Argument,
+                )?;
+                Ok(ToolArg {
+                    short: backend.short.clone(),
+                    ba: backend,
+                    version: Some(map.version.clone()),
+                    version_type: map.version.parse()?,
+                    tvr: Some(request),
+                })
             }
         }
     }
@@ -3869,10 +3892,9 @@ echo "test"
     }
 
     #[tokio::test]
-    async fn test_to_tool_spec_round_trips_string_opts() {
+    async fn test_to_tool_arg_preserves_scalar_options() {
         use indexmap::IndexMap;
 
-        use crate::cli::args::ToolArg;
         use crate::config::Config;
 
         use super::{TaskToolValue, TaskToolValueMap};
@@ -3885,38 +3907,6 @@ echo "test"
             toml::Value::String("first,second=value".to_string()),
         );
         opts.insert(
-            "targets".to_string(),
-            toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
-        );
-
-        let tool = TaskToolValue::Map(TaskToolValueMap {
-            version: "1.0.0".to_string(),
-            opts,
-        });
-
-        let spec = tool.to_tool_spec("http:hello");
-        assert_eq!(spec, r#"http:hello[query="first,second=value"]@1.0.0"#);
-
-        let parsed: ToolArg = spec.parse().unwrap();
-        let parsed_opts = parsed.ba.opts();
-        assert_eq!(parsed_opts.get("query"), Some("first,second=value"));
-        assert!(!parsed_opts.contains_key("targets"));
-        assert!(!parsed_opts.contains_key("second"));
-    }
-
-    #[tokio::test]
-    async fn test_to_tool_spec_round_trips_quoted_string_opts() {
-        use indexmap::IndexMap;
-
-        use crate::cli::args::ToolArg;
-        use crate::config::Config;
-
-        use super::{TaskToolValue, TaskToolValueMap};
-
-        let _config = Config::get().await.unwrap();
-
-        let mut opts = IndexMap::new();
-        opts.insert(
             "pattern".to_string(),
             toml::Value::String(r#"a"b"#.to_string()),
         );
@@ -3924,42 +3914,37 @@ echo "test"
             "bin_path".to_string(),
             toml::Value::String("bin[debug]".to_string()),
         );
-
-        let tool = TaskToolValue::Map(TaskToolValueMap {
-            version: "1.0.0".to_string(),
-            opts,
-        });
-
-        let spec = tool.to_tool_spec("http:hello");
-        assert_eq!(
-            spec,
-            r#"http:hello[pattern='a"b',bin_path="bin[debug]"]@1.0.0"#
+        opts.insert("strip_components".to_string(), toml::Value::Integer(1));
+        opts.insert(
+            "github_attestations".to_string(),
+            toml::Value::Boolean(true),
         );
-
-        let parsed: ToolArg = spec.parse().unwrap();
-        let parsed_opts = parsed.ba.opts();
-        assert_eq!(parsed_opts.get("pattern"), Some(r#"a"b"#));
-        assert_eq!(parsed_opts.get("bin_path"), Some("bin[debug]"));
-    }
-
-    #[test]
-    fn test_to_tool_spec_omits_empty_brackets_for_complex_opts() {
-        use indexmap::IndexMap;
-
-        use super::{TaskToolValue, TaskToolValueMap};
-
-        let mut opts = IndexMap::new();
         opts.insert(
             "targets".to_string(),
             toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
         );
+        opts.insert(
+            "platforms".to_string(),
+            toml::Value::Table(toml::map::Map::new()),
+        );
 
         let tool = TaskToolValue::Map(TaskToolValueMap {
             version: "1.0.0".to_string(),
             opts,
         });
 
-        assert_eq!(tool.to_tool_spec("cross"), "cross@1.0.0");
+        let request = tool.to_tool_arg("http:hello").unwrap().tvr.unwrap();
+        let options = request.options();
+        assert_eq!(options.get("query"), Some("first,second=value"));
+        assert_eq!(options.get("pattern"), Some(r#"a"b"#));
+        assert_eq!(options.get("bin_path"), Some("bin[debug]"));
+        assert_eq!(options.get_string("strip_components"), Some("1".into()));
+        assert_eq!(
+            options.opts.get("github_attestations"),
+            Some(&toml::Value::Boolean(true))
+        );
+        assert!(!options.contains_key("targets"));
+        assert!(!options.contains_key("platforms"));
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -282,9 +282,7 @@ impl TaskExecutor {
         }
 
         let mut tools = self.tool.clone();
-        for (k, v) in &task.tools {
-            tools.push(v.to_tool_arg(k)?);
-        }
+        tools.extend(task.tool_args()?);
         let ts_build_start = std::time::Instant::now();
 
         // Check if we need special handling for monorepo tasks with config file context

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -283,7 +283,7 @@ impl TaskExecutor {
 
         let mut tools = self.tool.clone();
         for (k, v) in &task.tools {
-            tools.push(v.to_tool_spec(k).parse()?);
+            tools.push(v.to_tool_arg(k)?);
         }
         let ts_build_start = std::time::Instant::now();
 

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -33,9 +33,7 @@ impl<'a> TaskToolInstaller<'a> {
         // Collect tools from tasks
         for t in &all_tasks {
             // Collect tools from task.tools (task-level tool overrides)
-            for (k, v) in &t.tools {
-                all_tools.push(v.to_tool_arg(k)?);
-            }
+            all_tools.extend(t.tool_args()?);
 
             // Collect tools from monorepo task config files
             if let Some(task_cf) = t.cf(config) {

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -34,7 +34,7 @@ impl<'a> TaskToolInstaller<'a> {
         for t in &all_tasks {
             // Collect tools from task.tools (task-level tool overrides)
             for (k, v) in &t.tools {
-                all_tools.push(v.to_tool_spec(k).parse()?);
+                all_tools.push(v.to_tool_arg(k)?);
             }
 
             // Collect tools from monorepo task config files

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -39,8 +39,7 @@ pub use tool_version::{ResolveOptions, ToolVersion};
 pub use tool_version_list::ToolVersionList;
 pub use tool_version_options::{
     CoreToolOptions, EPHEMERAL_OPT_KEYS, RawBackendOptions, ResolvedToolOptions, ToolOptionSource,
-    ToolOptions, ToolVersionOptions, parse_tool_options, serialize_tool_options,
-    try_parse_tool_options,
+    ToolOptions, ToolVersionOptions, parse_tool_options, try_parse_tool_options,
 };
 
 mod builder;

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -549,42 +549,6 @@ pub fn try_parse_tool_options(s: &str) -> Result<ToolVersionOptions, String> {
     parse_tool_options_manual(s)
 }
 
-/// Serialize tool options to the bracketed `key=value,key2=value2` form used by
-/// task tool specs and backend args.
-///
-/// Complex values that cannot be round-tripped through that syntax (arrays and
-/// tables) are omitted entirely.
-pub fn serialize_tool_options<'a, I>(opts: I) -> Option<String>
-where
-    I: IntoIterator<Item = (&'a String, &'a toml::Value)>,
-{
-    let serialized = opts
-        .into_iter()
-        .filter_map(|(key, value)| serialize_tool_option(key, value))
-        .collect::<Vec<_>>();
-
-    (!serialized.is_empty()).then(|| serialized.join(","))
-}
-
-fn serialize_tool_option(key: &str, value: &toml::Value) -> Option<String> {
-    match value {
-        toml::Value::Table(_) | toml::Value::Array(_) => None,
-        // Strings that contain delimiters or quotes must be TOML-quoted so they
-        // round-trip through both the TOML parser and the legacy manual parser.
-        // Brackets also need quoting because `split_bracketed_opts()` uses a
-        // regex to peel off the outer `[...]` payload from backend args.
-        toml::Value::String(s) if string_requires_tool_option_quotes(s) => {
-            Some(format!("{key}={}", toml::Value::String(s.clone())))
-        }
-        toml::Value::String(s) => Some(format!("{key}={s}")),
-        _ => Some(format!("{key}={value}")),
-    }
-}
-
-fn string_requires_tool_option_quotes(s: &str) -> bool {
-    s.contains(',') || s.contains('"') || s.contains('\'') || s.contains('[') || s.contains(']')
-}
-
 /// Try parsing an options string as a TOML inline table.
 /// Returns `Some(opts)` if the string is valid TOML, `None` otherwise.
 fn try_parse_as_toml(s: &str) -> Option<Result<ToolVersionOptions, String>> {
@@ -958,90 +922,11 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_tool_options_quotes_comma_strings() {
-        let mut opts = IndexMap::new();
-        opts.insert(
-            "query".to_string(),
-            toml::Value::String("first,second=value".to_string()),
-        );
-        opts.insert(
-            "bin_path".to_string(),
-            toml::Value::String("bin".to_string()),
-        );
-
-        assert_eq!(
-            serialize_tool_options(opts.iter()),
-            Some(r#"query="first,second=value",bin_path=bin"#.to_string())
-        );
-        assert_eq!(
-            parse_tool_options(serialize_tool_options(opts.iter()).unwrap().as_str()).get("query"),
-            Some("first,second=value")
-        );
-    }
-
-    #[test]
-    fn test_serialize_tool_options_quotes_strings_with_quotes_or_brackets() {
-        let mut opts = IndexMap::new();
-        opts.insert(
-            "pattern".to_string(),
-            toml::Value::String(r#"a"b"#.to_string()),
-        );
-        opts.insert(
-            "bin_path".to_string(),
-            toml::Value::String("bin[debug]".to_string()),
-        );
-
-        let serialized = serialize_tool_options(opts.iter()).unwrap();
-        assert_eq!(
-            serialized,
-            r#"pattern='a"b',bin_path="bin[debug]""#.to_string()
-        );
-
-        let reparsed = parse_tool_options(&serialized);
-        assert_eq!(reparsed.get("pattern"), Some(r#"a"b"#));
-        assert_eq!(reparsed.get("bin_path"), Some("bin[debug]"));
-    }
-
-    #[test]
-    fn test_serialize_tool_options_preserves_single_quote_wrapped_strings() {
-        let mut opts = IndexMap::new();
-        opts.insert(
-            "pattern".to_string(),
-            toml::Value::String("'hi'".to_string()),
-        );
-        opts.insert(
-            "bin_path".to_string(),
-            toml::Value::String("bin".to_string()),
-        );
-
-        let serialized = serialize_tool_options(opts.iter()).unwrap();
-        let reparsed = parse_tool_options(&serialized);
-
-        assert_eq!(reparsed.get("pattern"), Some("'hi'"));
-        assert_eq!(reparsed.get("bin_path"), Some("bin"));
-    }
-
-    #[test]
     fn test_parse_tool_options_manual_supports_single_quoted_literals() {
         let reparsed = parse_tool_options(r#"pattern='a"b',bin_path=bin"#);
 
         assert_eq!(reparsed.get("pattern"), Some(r#"a"b"#));
         assert_eq!(reparsed.get("bin_path"), Some("bin"));
-    }
-
-    #[test]
-    fn test_serialize_tool_options_skips_complex_values_and_empty_output() {
-        let mut opts = IndexMap::new();
-        opts.insert(
-            "targets".to_string(),
-            toml::Value::Array(vec![toml::Value::String("x86_64".to_string())]),
-        );
-        opts.insert(
-            "platforms".to_string(),
-            toml::Value::Table(toml::map::Map::new()),
-        );
-
-        assert_eq!(serialize_tool_options(opts.iter()), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve scalar, array, and table values in task-level tool options
- keep task options attached through both task execution and auto-install
- apply options to version, prefix, ref, path, sub, and system requests
- remove the lossy `TaskToolValue -> bracket string -> ToolArg` round trip
- centralize conversion for both task-tool consumers

## Bug

Object-form task tools were parsed as typed TOML and then converted back into bracket syntax before being parsed again. That conversion silently omitted every array and table. Valid task-local options such as `os`, `depends`, `install_env`, and nested backend configuration therefore disappeared even though the equivalent top-level `[tools]` configuration supported them.

The string round trip also introduced quoting and coercion artifacts for scalar strings. After replacing it with a typed request, task options initially lived only on the prebuilt `ToolRequest`; `ToolsetBuilder` later rebuilt options from a bare `BackendArg` and could discard them during task execution.

## Fix

Build typed task `ToolVersionOptions` directly from every TOML option value and attach them to `BackendArg` as explicit options. The existing registry/manifest/alias/config/task precedence then remains intact when the toolset is built, and `ToolRequest::new` applies those options consistently to every request variant.

Both task-tool consumers use the same `Task::tool_args` conversion:

- auto-install/preparation
- task execution

Nested Tera rendering inside the newly preserved arrays/tables remains in the stacked follow-up PR; this PR fixes loss of the structured values themselves.

## Brief history of the string path

- [#9087](https://github.com/jdx/mise/pull/9087) introduced object syntax for task-level tools in April 2026. It converted the new typed TOML map back into a bracketed string because the existing consumers already parsed `ToolArg` strings.
- [#9124](https://github.com/jdx/mise/pull/9124) extracted `serialize_tool_options` the next day to make that round trip safe for commas, quotes, and brackets. Because bracket syntax could not represent structured TOML losslessly, it deliberately omitted arrays and tables.
- [#10238](https://github.com/jdx/mise/pull/10238) later removed `BackendArg::full_with_opts`, leaving task-tool serialization as the helper's only remaining caller.

It is safe to remove the serializer here because task configuration is already typed and both consumers can receive a `ToolArg` containing a prebuilt `ToolRequest`; no text boundary is required. Parsing user-written bracket syntax remains unchanged.

## Validation

- `cargo test --all-features test_to_tool_arg`
- `cargo test --all-features test_task_tool_options_survive_toolset_build`
- `mise run test:e2e -- test_task_tools`
- `cargo check --all-features`
- `mise run lint-fix`

The end-to-end regression declares `depends = ["dummy"]` on a task-local tool whose installer fails unless the dependency is installed first. It proves the array survives task parsing, auto-install collection, dependency ordering, installation, and task execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task-level tool configuration now supports structured options (including nested fields like dependencies) and applies them consistently during both tool installation and task execution.
  * Added end-to-end coverage for structured tool options to confirm correct versioned execution order.

* **Bug Fixes**
  * Improved preservation of task tool options across different tool request “version” variants.
  * More robust handling of non-scalar/complex structured values—unsupported entries are excluded instead of causing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->