### PR TITLE
feat(task): render timeout templates

### DIFF
--- a/e2e/tasks/test_task_timeout
+++ b/e2e/tasks/test_task_timeout
@@ -92,6 +92,24 @@ echo "Testing duration format parsing..."
 mise run duration_test 2>&1
 echo "✓ Duration format works"
 
+# Test task timeout Tera rendering with the ordinary task-load context
+cat <<'EOF' >mise.toml
+[tasks.template_timeout]
+run = "sleep 5 && echo 'Should not appear'"
+timeout = "{{ vars.timeout }}"
+
+[tasks.template_timeout.vars]
+timeout = "1s"
+EOF
+
+echo "Testing task timeout Tera rendering..."
+output="$(mise run template_timeout 2>&1 || true)"
+if [[ $output != *"timed out"* ]]; then
+  echo "ERROR: Expected rendered task timeout to fire, got: $output"
+  exit 1
+fi
+echo "✓ Task timeout Tera rendering works"
+
 # Test global timeout + per-task timeout serve distinct purposes
 cat <<EOF >mise.toml
 [settings]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1749,6 +1749,10 @@ impl Task {
                 .shell
                 .as_ref()
                 .is_some_and(|s| contains_template_syntax(s))
+            || self
+                .timeout
+                .as_ref()
+                .is_some_and(|s| contains_template_syntax(s))
             || self.allow_read.iter().any(|p| path_contains_template(p))
             || self.allow_write.iter().any(|p| path_contains_template(p))
             || tools_have_template
@@ -1831,6 +1835,11 @@ impl Task {
             && contains_template_syntax(shell)
         {
             *shell = render_str(&mut tera, shell, &tera_ctx)?;
+        }
+        if let Some(timeout) = &mut self.timeout
+            && contains_template_syntax(timeout)
+        {
+            *timeout = render_str(&mut tera, timeout, &tera_ctx)?;
         }
         let mut render_sandbox_paths = |paths: &mut Vec<PathBuf>| -> Result<()> {
             let mut rendered = Vec::with_capacity(paths.len());


### PR DESCRIPTION
## Summary

- render Tera templates in task-level `timeout` values
- use the same load-time task context as `dir`, `shell`, sources, and other task fields
- add E2E coverage proving a timeout sourced from task vars is enforced

## Context and scope

`timeout` now has access to the ordinary task-load template context, including config and task vars, the resolved config/toolset environment, tool metadata, `config_root`, and the standard mise Tera functions.

This PR deliberately does **not** defer timeout rendering. Invocation-time `usage.*` values and task-local runtime environment values are therefore out of scope. Supporting those would require preserving the raw timeout and adding a separate post-argument/environment rendering phase.

## Why

`timeout` is a string-valued task control parsed immediately before execution, but unlike adjacent string fields it was omitted from task template detection and rendering. This makes the small, predictable load-time form work without changing timeout precedence or execution behavior.

## Validation

- `mise run test:e2e e2e/tasks/test_task_timeout`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task timeout values can now use Tera templates.
  * Timeout templates are rendered using the standard task context before execution.

* **Bug Fixes**
  * Fixed templated timeout settings not being recognized or applied correctly.
  * Added coverage to verify tasks time out according to rendered timeout values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->