### PR TITLE
fix(http): validate locked artifacts before replacement

### DIFF
--- a/e2e/backend/test_http_lock_install_verify
+++ b/e2e/backend/test_http_lock_install_verify
@@ -55,9 +55,20 @@ assert_contains "cat mise.lock" "sha256:${REAL_SHA}"
 mise install --locked
 assert_contains "mise x -- mytool" "mytool ok"
 
+# A changed config URL must not replace the artifact selected by the lockfile.
+printf '#!/bin/sh\necho wrong artifact\n' >"$SRV/mytool-new"
+sed 's#/mytool"#/mytool-new"#' mise.toml >mise.toml.tmp && mv mise.toml.tmp mise.toml
+mise uninstall --all
+mise install --locked
+assert_contains "mise x -- mytool" "mytool ok"
+
 # Tamper with the locked checksum: install must now fail on mismatch.
 sed "s/${REAL_SHA}/${BAD_SHA}/" mise.lock >mise.lock.tmp && mv mise.lock.tmp mise.lock
-assert_fail "mise install --locked -f"
+cp mise.lock mise.lock.before-failed-install
+mise uninstall --all
+assert_fail "mise install --locked"
+assert "cmp -s mise.lock.before-failed-install mise.lock"
+assert "test ! -e '$HOME/.local/share/mise/installs/http-mytool-lock-verify/1.0.0'"
 
 # === Same loop, but the checksum comes from a JSON manifest via checksum_expr ===
 # sha256 of the exprtool artifact bytes, published under the host's platform key
@@ -94,4 +105,48 @@ assert_contains "mise x -- exprtool" "exprtool ok"
 
 # A tampered manifest-resolved checksum must also fail the install.
 sed "s/${EXPR_SHA}/${BAD_SHA}/" mise.lock >mise.lock.tmp && mv mise.lock.tmp mise.lock
-assert_fail "mise install --locked -f"
+cp mise.lock mise.lock.before-failed-expr-install
+mise uninstall --all
+assert_fail "mise install --locked"
+assert "cmp -s mise.lock.before-failed-expr-install mise.lock"
+assert "test ! -e '$HOME/.local/share/mise/installs/http-exprtool-lock-verify/1.0.0'"
+
+# Validation must happen before persistent cache/install side effects, including
+# the content-derived install path used by `latest`.
+cp "$SRV/mytool" "$SRV/latesttool"
+printf '%s  latesttool\n' "$REAL_SHA" >"$SRV/latesttool_SHASUMS"
+printf '1.0.0\n' >"$SRV/latesttool_versions.txt"
+
+rm -f mise.lock
+cat >mise.toml <<EOF
+[tools."http:latest-lock-failure"]
+version = "latest"
+bin = "latesttool"
+url = "http://127.0.0.1:${PORT}/latesttool"
+checksum_url = "http://127.0.0.1:${PORT}/latesttool_SHASUMS"
+version_list_url = "http://127.0.0.1:${PORT}/latesttool_versions.txt"
+EOF
+
+mise lock --platform "$PLATFORM"
+printf '#!/bin/sh\necho tampered latest artifact\n' >"$SRV/latesttool"
+
+HTTP_CACHE_DIR="$HOME/.local/share/mise/http-tarballs"
+find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.before-failed-latest
+cp mise.lock mise.lock.before-failed-latest
+assert_fail "mise install --locked"
+find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.after-failed-latest
+assert "cmp -s http-cache.before-failed-latest http-cache.after-failed-latest"
+assert "cmp -s mise.lock.before-failed-latest mise.lock"
+assert "test ! -e '$HOME/.local/share/mise/installs/http-latest-lock-failure'"
+
+# A locked size mismatch has the same fail-before-cache guarantee.
+cp "$SRV/mytool" "$SRV/latesttool"
+awk '{ print; if ($1 == "checksum" && $2 == "=") print "size = 999999" }' mise.lock >mise.lock.tmp
+mv mise.lock.tmp mise.lock
+cp mise.lock mise.lock.before-failed-size
+find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.before-failed-size
+assert_fail "mise install --locked"
+find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.after-failed-size
+assert "cmp -s http-cache.before-failed-size http-cache.after-failed-size"
+assert "cmp -s mise.lock.before-failed-size mise.lock"
+assert "test ! -e '$HOME/.local/share/mise/installs/http-latest-lock-failure'"

--- a/e2e/backend/test_http_lock_install_verify
+++ b/e2e/backend/test_http_lock_install_verify
@@ -55,20 +55,9 @@ assert_contains "cat mise.lock" "sha256:${REAL_SHA}"
 mise install --locked
 assert_contains "mise x -- mytool" "mytool ok"
 
-# A changed config URL must not replace the artifact selected by the lockfile.
-printf '#!/bin/sh\necho wrong artifact\n' >"$SRV/mytool-new"
-sed 's#/mytool"#/mytool-new"#' mise.toml >mise.toml.tmp && mv mise.toml.tmp mise.toml
-mise uninstall --all
-mise install --locked
-assert_contains "mise x -- mytool" "mytool ok"
-
 # Tamper with the locked checksum: install must now fail on mismatch.
 sed "s/${REAL_SHA}/${BAD_SHA}/" mise.lock >mise.lock.tmp && mv mise.lock.tmp mise.lock
-cp mise.lock mise.lock.before-failed-install
-mise uninstall --all
-assert_fail "mise install --locked"
-assert "cmp -s mise.lock.before-failed-install mise.lock"
-assert "test ! -e '$HOME/.local/share/mise/installs/http-mytool-lock-verify/1.0.0'"
+assert_fail "mise install --locked -f"
 
 # === Same loop, but the checksum comes from a JSON manifest via checksum_expr ===
 # sha256 of the exprtool artifact bytes, published under the host's platform key
@@ -105,48 +94,4 @@ assert_contains "mise x -- exprtool" "exprtool ok"
 
 # A tampered manifest-resolved checksum must also fail the install.
 sed "s/${EXPR_SHA}/${BAD_SHA}/" mise.lock >mise.lock.tmp && mv mise.lock.tmp mise.lock
-cp mise.lock mise.lock.before-failed-expr-install
-mise uninstall --all
-assert_fail "mise install --locked"
-assert "cmp -s mise.lock.before-failed-expr-install mise.lock"
-assert "test ! -e '$HOME/.local/share/mise/installs/http-exprtool-lock-verify/1.0.0'"
-
-# Validation must happen before persistent cache/install side effects, including
-# the content-derived install path used by `latest`.
-cp "$SRV/mytool" "$SRV/latesttool"
-printf '%s  latesttool\n' "$REAL_SHA" >"$SRV/latesttool_SHASUMS"
-printf '1.0.0\n' >"$SRV/latesttool_versions.txt"
-
-rm -f mise.lock
-cat >mise.toml <<EOF
-[tools."http:latest-lock-failure"]
-version = "latest"
-bin = "latesttool"
-url = "http://127.0.0.1:${PORT}/latesttool"
-checksum_url = "http://127.0.0.1:${PORT}/latesttool_SHASUMS"
-version_list_url = "http://127.0.0.1:${PORT}/latesttool_versions.txt"
-EOF
-
-mise lock --platform "$PLATFORM"
-printf '#!/bin/sh\necho tampered latest artifact\n' >"$SRV/latesttool"
-
-HTTP_CACHE_DIR="$HOME/.local/share/mise/http-tarballs"
-find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.before-failed-latest
-cp mise.lock mise.lock.before-failed-latest
-assert_fail "mise install --locked"
-find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.after-failed-latest
-assert "cmp -s http-cache.before-failed-latest http-cache.after-failed-latest"
-assert "cmp -s mise.lock.before-failed-latest mise.lock"
-assert "test ! -e '$HOME/.local/share/mise/installs/http-latest-lock-failure'"
-
-# A locked size mismatch has the same fail-before-cache guarantee.
-cp "$SRV/mytool" "$SRV/latesttool"
-awk '{ print; if ($1 == "checksum" && $2 == "=") print "size = 999999" }' mise.lock >mise.lock.tmp
-mv mise.lock.tmp mise.lock
-cp mise.lock mise.lock.before-failed-size
-find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.before-failed-size
-assert_fail "mise install --locked"
-find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.after-failed-size
-assert "cmp -s http-cache.before-failed-size http-cache.after-failed-size"
-assert "cmp -s mise.lock.before-failed-size mise.lock"
-assert "test ! -e '$HOME/.local/share/mise/installs/http-latest-lock-failure'"
+assert_fail "mise install --locked -f"

--- a/e2e/backend/test_http_locked_install_transaction
+++ b/e2e/backend/test_http_locked_install_transaction
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# A locked HTTP install is one transaction: it consumes the artifact URL from
+# the lockfile and validates the locked integrity contract before exposing any
+# shared extraction cache or install path.
+
+export MISE_LOCKFILE=1
+
+detect_platform
+PLATFORM="$MISE_PLATFORM"
+
+SRV="$PWD/srv"
+mkdir -p "$SRV"
+
+REAL_SHA="34a3c3a03073287eea9375cd9838e60a3b875715005eb2cc854a4461cf2c428d"
+printf '#!/bin/sh\necho mytool ok\n' >"$SRV/locked-tool"
+printf '#!/bin/sh\necho configured artifact\n' >"$SRV/configured-tool"
+printf '%s  locked-tool\n' "$REAL_SHA" >"$SRV/locked-tool_SHASUMS"
+printf '1.0.0\n' >"$SRV/locked-tool_versions.txt"
+
+PORT_FILE="$TMPDIR/mise_locked_install_transaction_port"
+python3 - "$SRV" "$PORT_FILE" <<'PY' &
+import http.server, socketserver, sys, os
+srv, port_file = sys.argv[1], sys.argv[2]
+os.chdir(srv)
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler) as httpd:
+    with open(port_file, "w") as f:
+        f.write(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+wait_for_file "$PORT_FILE" "locked install transaction port file" 30 "$SERVER_PID"
+PORT=$(cat "$PORT_FILE")
+
+cat >mise.toml <<EOF
+[tools."http:locked-install-transaction"]
+version = "latest"
+bin = "locked-tool"
+url = "http://127.0.0.1:${PORT}/locked-tool"
+checksum_url = "http://127.0.0.1:${PORT}/locked-tool_SHASUMS"
+version_list_url = "http://127.0.0.1:${PORT}/locked-tool_versions.txt"
+EOF
+
+mise lock --platform "$PLATFORM"
+cp mise.lock mise.lock.initial
+cp mise.toml mise.toml.initial
+
+# Configuration changes after locking must not replace the selected artifact.
+sed 's#/locked-tool"#/configured-tool"#' mise.toml.initial >mise.toml
+mise install --locked
+assert_contains "mise x -- locked-tool" "mytool ok"
+
+# A locked checksum mismatch must fail before persistent install side effects.
+mise uninstall --all
+cp mise.toml.initial mise.toml
+cp mise.lock.initial mise.lock
+printf '#!/bin/sh\necho tampered artifact\n' >"$SRV/locked-tool"
+
+HTTP_CACHE_DIR="$HOME/.local/share/mise/http-tarballs"
+mkdir -p "$HTTP_CACHE_DIR"
+find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.before-checksum-failure
+assert_fail "mise install --locked"
+find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.after-checksum-failure
+assert "cmp -s http-cache.before-checksum-failure http-cache.after-checksum-failure"
+assert "test ! -e '$HOME/.local/share/mise/installs/http-locked-install-transaction'"
+
+# A locked size mismatch must fail at the same pre-commit boundary.
+printf '#!/bin/sh\necho mytool ok\n' >"$SRV/locked-tool"
+cp mise.lock.initial mise.lock
+awk '{ print; if ($1 == "checksum" && $2 == "=") print "size = 999999" }' mise.lock >mise.lock.tmp
+mv mise.lock.tmp mise.lock
+
+find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.before-size-failure
+assert_fail "mise install --locked"
+find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.after-size-failure
+assert "cmp -s http-cache.before-size-failure http-cache.after-size-failure"
+assert "test ! -e '$HOME/.local/share/mise/installs/http-locked-install-transaction'"

--- a/e2e/backend/test_http_locked_install_transaction
+++ b/e2e/backend/test_http_locked_install_transaction
@@ -54,28 +54,62 @@ sed 's#/locked-tool"#/configured-tool"#' mise.toml.initial >mise.toml
 mise install --locked
 assert_contains "mise x -- locked-tool" "mytool ok"
 
-# A locked checksum mismatch must fail before persistent install side effects.
-mise uninstall --all
+# A forced replacement must stage and verify the artifact before removing the
+# working install.
 cp mise.toml.initial mise.toml
 cp mise.lock.initial mise.lock
 printf '#!/bin/sh\necho tampered artifact\n' >"$SRV/locked-tool"
 
-HTTP_CACHE_DIR="$HOME/.local/share/mise/http-tarballs"
+HTTP_CACHE_DIR="$MISE_DATA_DIR/http-tarballs"
 mkdir -p "$HTTP_CACHE_DIR"
-find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.before-checksum-failure
-assert_fail "mise install --locked"
-find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.after-checksum-failure
-assert "cmp -s http-cache.before-checksum-failure http-cache.after-checksum-failure"
-assert "test ! -e '$HOME/.local/share/mise/installs/http-locked-install-transaction'"
+fingerprint_cache() {
+  {
+    find "$HTTP_CACHE_DIR" -type d -print
+    find "$HTTP_CACHE_DIR" -type f -exec cksum {} \;
+  } | LC_ALL=C sort
+}
 
-# A locked size mismatch must fail at the same pre-commit boundary.
-printf '#!/bin/sh\necho mytool ok\n' >"$SRV/locked-tool"
+fingerprint_cache >http-cache.before-checksum-failure
+assert_fail \
+  "mise install --locked --force http:locked-install-transaction@1.0.0" \
+  "Checksum mismatch"
+fingerprint_cache >http-cache.after-checksum-failure
+assert "cmp -s http-cache.before-checksum-failure http-cache.after-checksum-failure"
+assert_contains "mise x -- locked-tool" "mytool ok"
+
+# A correctly checksummed malformed archive must also fail during preparation,
+# before the working install or shared cache is changed.
+MALFORMED_SHA="9bf1d02c36d95a04d8ed7049b33afd0bde6b094d3092aff3677b9b5b89e1610a"
+printf 'not a gzip archive\n' >"$SRV/locked-tool"
+printf '%s  locked-tool\n' "$MALFORMED_SHA" >"$SRV/locked-tool_SHASUMS"
+printf '\nformat = "tar.gz"\n' >>mise.toml
+mise lock --platform "$PLATFORM"
+assert_contains "grep 'checksum = ' mise.lock" "$MALFORMED_SHA"
+
+fingerprint_cache >http-cache.before-extraction-failure
+assert_fail \
+  "mise install --locked --force http:locked-install-transaction@1.0.0" \
+  "gzip"
+fingerprint_cache >http-cache.after-extraction-failure
+assert "cmp -s http-cache.before-extraction-failure http-cache.after-extraction-failure"
+assert_contains "mise x -- locked-tool" "mytool ok"
+
+# A distinct artifact with a matching checksum but bad locked size must fail
+# before creating a new cache entry or install path.
+mise uninstall --all
+SIZE_SHA="c851d3773651c13cee2ed09733aa3ff68dceef7445406c58efa57be5c375d67e"
+printf '#!/bin/sh\necho size mismatch fixture\n' >"$SRV/locked-tool"
+cp mise.toml.initial mise.toml
 cp mise.lock.initial mise.lock
+sed "s/$REAL_SHA/$SIZE_SHA/" mise.lock >mise.lock.tmp
+mv mise.lock.tmp mise.lock
 awk '{ print; if ($1 == "checksum" && $2 == "=") print "size = 999999" }' mise.lock >mise.lock.tmp
 mv mise.lock.tmp mise.lock
+assert_contains "grep 'checksum = ' mise.lock" "$SIZE_SHA"
+assert_contains "grep 'size = ' mise.lock" "999999"
 
-find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.before-size-failure
-assert_fail "mise install --locked"
-find "$HTTP_CACHE_DIR" -maxdepth 2 -print | sort >http-cache.after-size-failure
+fingerprint_cache >http-cache.before-size-failure
+assert_fail "mise install --locked" "Size mismatch"
+fingerprint_cache >http-cache.after-size-failure
 assert "cmp -s http-cache.before-size-failure http-cache.after-size-failure"
-assert "test ! -e '$HOME/.local/share/mise/installs/http-locked-install-transaction'"
+assert "test ! -e '$MISE_DATA_DIR/installs/http-locked-install-transaction'"

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -3,15 +3,13 @@ use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::prepared_install::{
-    PreparedInstall, PreparedInstallEvidencePayload, PreparedInstallPlan,
-};
+use crate::backend::prepared_install::{PreparedInstall, PreparedInstallPlan};
 use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
     apply_rename_exe, clean_binary_name, ensure_plain_bin_name, ensure_safe_relative_bin_path,
     eval_checksum_expr, fetch_checksum_from_file, fetch_checksum_from_shasums,
-    get_filename_from_url, lookup_value_with_fallback, rename_binary_name, shasums_has_entries,
-    template_string, template_string_for_target, verify_checksum_str,
+    get_filename_from_url, rename_binary_name, shasums_has_entries, template_string,
+    template_string_for_target,
 };
 use crate::backend::version_list;
 use crate::cli::args::BackendArg;
@@ -27,13 +25,15 @@ use crate::toolset::ToolVersionOptions;
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, file, hash};
 use async_trait::async_trait;
-use eyre::{Result, bail};
+use eyre::{Result, WrapErr, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
 
 // Constants
 const HTTP_TARBALLS_DIR: &str = "http-tarballs";
@@ -59,6 +59,7 @@ enum ExtractionType {
 }
 
 /// Information about a downloaded file's format
+#[derive(Debug)]
 struct FileInfo {
     /// Path with effective extension (after applying format option)
     effective_path: PathBuf,
@@ -70,6 +71,7 @@ struct FileInfo {
     is_compressed_binary: bool,
 }
 
+#[derive(Debug)]
 struct CachePlan {
     key: String,
     file_info: FileInfo,
@@ -142,46 +144,106 @@ struct HttpOptions<'a> {
     values: BackendOptions<'a>,
 }
 
-/// The HTTP inputs that installation is allowed to consume.
-///
-/// Configured verification inputs apply to fresh resolution. Once a lock URL
-/// is replayed, its checksum and size are the sole artifact contract.
 #[derive(Debug)]
 struct PreparedHttpInstall {
-    raw_options: ToolVersionOptions,
     target: String,
-    url: String,
-    lock_checksum: Option<String>,
+    url: reqwest::Url,
+    filename: String,
+    lock_checksum: Option<PreparedChecksum>,
     lock_size: Option<u64>,
-    configured_checksum: Option<String>,
+    configured_checksum: Option<PreparedChecksum>,
     configured_size: Option<u64>,
+    lockfile_enabled: bool,
     format: Option<String>,
-    strip_components: Option<String>,
+    strip_components: Option<usize>,
     bin: Option<String>,
-    rename_exe: Option<String>,
+    rename_exe: Option<toml::Value>,
     bin_path: Option<String>,
 }
 
 #[derive(Debug)]
 struct PreparedHttpInstallPlan {
     backend: HttpBackend,
-    spec: Arc<PreparedHttpInstall>,
+    spec: PreparedHttpInstall,
+    staged_dir: TempDir,
+    staged_file: PathBuf,
+    staged_cache: PathBuf,
+    cache_plan: CachePlan,
+    extraction_type: ExtractionType,
+    lock_checksum: Option<String>,
+    lock_size: Option<u64>,
 }
 
 #[async_trait]
 impl PreparedInstallPlan for PreparedHttpInstallPlan {
-    fn evidence(&self) -> Arc<dyn PreparedInstallEvidencePayload> {
-        self.spec.clone()
-    }
-
     async fn execute(
         self: Box<Self>,
         ctx: &InstallContext,
         tv: ToolVersion,
     ) -> Result<ToolVersion> {
-        self.backend
-            .install_prepared_http(ctx, tv, self.spec.as_ref())
-            .await
+        let Self {
+            backend,
+            spec,
+            staged_dir,
+            staged_file,
+            staged_cache,
+            cache_plan,
+            extraction_type,
+            lock_checksum,
+            lock_size,
+        } = *self;
+        let tv = backend.install_prepared_http(
+            ctx,
+            tv,
+            &spec,
+            &staged_file,
+            &staged_cache,
+            &cache_plan,
+            extraction_type,
+            lock_checksum,
+            lock_size,
+        )?;
+        drop(staged_dir);
+        Ok(tv)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PreparedChecksum {
+    algorithm: &'static str,
+    digest: String,
+}
+
+impl PreparedChecksum {
+    fn parse(value: &str) -> Result<Self> {
+        let (algorithm, digest) = value
+            .split_once(':')
+            .ok_or_else(|| eyre::eyre!("Invalid checksum format: {value}"))?;
+        let (algorithm, expected_len): (&'static str, usize) = match algorithm {
+            "md5" => ("md5", 32),
+            "sha1" => ("sha1", 40),
+            "sha256" => ("sha256", 64),
+            "blake3" => ("blake3", 64),
+            "sha512" => ("sha512", 128),
+            _ => bail!("Unknown checksum algorithm: {algorithm}"),
+        };
+        if digest.len() != expected_len || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            bail!("Invalid {algorithm} checksum: expected {expected_len} hexadecimal characters");
+        }
+        Ok(Self {
+            algorithm,
+            digest: digest.to_ascii_lowercase(),
+        })
+    }
+
+    fn verify(&self, file: &Path, pr: Option<&dyn SingleReport>) -> Result<()> {
+        hash::ensure_checksum(file, &self.digest, pr, self.algorithm)
+    }
+}
+
+impl fmt::Display for PreparedChecksum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.algorithm, self.digest)
     }
 }
 
@@ -232,6 +294,10 @@ impl<'a> HttpOptions<'a> {
         self.values.platform_string_for_target("rename_exe", target)
     }
 
+    fn rename_exe_value_for_target(&self, target: &PlatformTarget) -> Option<&'a toml::Value> {
+        self.values.platform_value_for_target("rename_exe", target)
+    }
+
     fn bin_for_target(&self, target: &PlatformTarget) -> Option<String> {
         self.values.platform_string_for_target("bin", target)
     }
@@ -266,20 +332,19 @@ impl<'a> HttpOptions<'a> {
 }
 
 impl PreparedHttpInstall {
-    fn raw(&self) -> &ToolVersionOptions {
-        &self.raw_options
-    }
-
-    fn checksum(&self) -> Option<&str> {
-        self.configured_checksum.as_deref()
+    fn checksum(&self) -> Option<String> {
+        self.lock_checksum
+            .as_ref()
+            .or(self.configured_checksum.as_ref())
+            .map(ToString::to_string)
     }
 
     fn format(&self) -> Option<&str> {
         self.format.as_deref()
     }
 
-    fn strip_components(&self) -> Option<&str> {
-        self.strip_components.as_deref()
+    fn strip_components(&self) -> Option<usize> {
+        self.strip_components
     }
 
     fn bin(&self) -> Option<&str> {
@@ -287,7 +352,11 @@ impl PreparedHttpInstall {
     }
 
     fn rename_exe(&self) -> Option<&str> {
-        self.rename_exe.as_deref()
+        self.rename_exe.as_ref().and_then(toml::Value::as_str)
+    }
+
+    fn rename_exe_value(&self) -> Option<&toml::Value> {
+        self.rename_exe.as_ref()
     }
 
     fn bin_path(&self) -> Option<&str> {
@@ -353,7 +422,7 @@ impl HttpBackend {
         // keeps a readable name when it is path-safe and hashes anything else (the
         // table form, or a scalar with path separators / Windows-invalid characters)
         // so nothing unsafe reaches the cache directory name.
-        if let Some(rename) = lookup_value_with_fallback(opts.raw(), "rename_exe") {
+        if let Some(rename) = opts.rename_exe_value() {
             parts.push(format!("rename_{}", rename_cache_token(rename)));
             // When rename_exe is used, bin_path affects where the rename happens,
             // so different bin_path values result in different cached content
@@ -385,13 +454,7 @@ impl HttpBackend {
         file_info: &FileInfo,
         opts: &PreparedHttpInstall,
     ) -> Result<usize> {
-        let mut strip_components: Option<usize> = opts
-            .strip_components()
-            .map(|s| {
-                s.parse::<usize>()
-                    .map_err(|_| eyre::eyre!("Invalid strip_components value: {s}"))
-            })
-            .transpose()?;
+        let mut strip_components = opts.strip_components();
 
         // Auto-detect strip_components=1 for single-directory archives
         if strip_components.is_none()
@@ -479,50 +542,6 @@ impl HttpBackend {
     // Extraction
     // -------------------------------------------------------------------------
 
-    /// Extract artifact to cache with atomic rename
-    fn extract_to_cache(
-        &self,
-        tv: &ToolVersion,
-        file_path: &Path,
-        cache_plan: &CachePlan,
-        url: &str,
-        opts: &PreparedHttpInstall,
-        pr: Option<&dyn SingleReport>,
-    ) -> Result<ExtractionType> {
-        let cache_path = self.cache_path(&cache_plan.key);
-
-        // Ensure parent directory exists
-        file::create_dir_all(Self::tarballs_dir())?;
-
-        // Create unique temp directory for atomic extraction
-        let tmp_path = Self::tarballs_dir().join(format!(
-            "{}.tmp-{}-{}",
-            cache_plan.key,
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis()
-        ));
-
-        // Clean up any stale temp directory
-        if tmp_path.exists() {
-            let _ = file::remove_all(&tmp_path);
-        }
-
-        // Perform extraction
-        let extraction_type =
-            self.extract_artifact(tv, &tmp_path, file_path, cache_plan, opts, pr)?;
-
-        // Atomic replace
-        if cache_path.exists() {
-            file::remove_all(&cache_path)?;
-        }
-        std::fs::rename(&tmp_path, &cache_path)?;
-
-        // Write metadata
-        self.write_metadata(&cache_plan.key, url, file_path, opts)?;
-
-        Ok(extraction_type)
-    }
-
     /// Extract a single artifact to the given directory
     fn extract_artifact(
         &self,
@@ -593,7 +612,7 @@ impl HttpBackend {
     /// Extract an archive (tar, zip, etc.)
     fn extract_archive(
         &self,
-        tv: &ToolVersion,
+        _tv: &ToolVersion,
         dest: &Path,
         file_path: &Path,
         cache_plan: &CachePlan,
@@ -609,11 +628,10 @@ impl HttpBackend {
         file::extract_archive(file_path, dest, cache_plan.file_info.format, &extract_opts)?;
 
         // Handle rename_exe option for archives
-        if let Some(rename_value) = lookup_value_with_fallback(opts.raw(), "rename_exe") {
+        if let Some(rename_value) = opts.rename_exe_value() {
             // When bin_path is not explicitly set, auto-detect bin/ subdirectory to match
             // the same logic used by discover_bin_paths() for PATH construction
-            let search_dir = if let Some(bin_path_template) = opts.bin_path() {
-                let bin_path = template_string(bin_path_template, tv);
+            let search_dir = if let Some(bin_path) = opts.bin_path() {
                 dest.join(&bin_path)
             } else {
                 let bin_dir = dest.join("bin");
@@ -634,21 +652,21 @@ impl HttpBackend {
     /// Write cache metadata file
     fn write_metadata(
         &self,
-        cache_key: &str,
+        cache_path: &Path,
         url: &str,
+        checksum: Option<&str>,
         file_path: &Path,
-        opts: &PreparedHttpInstall,
     ) -> Result<()> {
         let metadata = CacheMetadata {
             url: url.to_string(),
-            checksum: opts.checksum().map(str::to_string),
+            checksum: checksum.map(str::to_string),
             size: file_path.metadata()?.len(),
             extracted_at: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
             platform: self.get_platform_key(),
         };
 
         let json = serde_json::to_string_pretty(&metadata)?;
-        file::write(self.metadata_path(cache_key), json)?;
+        file::write(cache_path.join(METADATA_FILE), json)?;
         Ok(())
     }
 
@@ -736,9 +754,8 @@ impl HttpBackend {
 
         // Handle raw files with bin_path specially for deduplication
         if let ExtractionType::RawFile { filename } = extraction_type
-            && let Some(bin_path_template) = opts.bin_path()
+            && let Some(bin_path) = opts.bin_path()
         {
-            let bin_path = template_string(bin_path_template, tv);
             let dest_dir = install_path.join(&bin_path);
             file::create_dir_all(&dest_dir)?;
 
@@ -778,14 +795,15 @@ impl HttpBackend {
     // Checksum verification
     // -------------------------------------------------------------------------
 
-    fn verify_prepared_artifact(
+    fn verify_staged_artifact(
         &self,
         ctx: &InstallContext,
         file_path: &Path,
         spec: &PreparedHttpInstall,
-    ) -> Result<()> {
+    ) -> Result<(Option<String>, Option<u64>)> {
         if let Some(checksum) = &spec.configured_checksum {
-            verify_checksum_str(file_path, checksum, Some(ctx.pr.as_ref()))?;
+            ctx.pr.next_operation();
+            checksum.verify(file_path, Some(ctx.pr.as_ref()))?;
         }
         if let Some(expected_size) = spec.configured_size {
             let actual_size = file_path.metadata()?.len();
@@ -794,50 +812,54 @@ impl HttpBackend {
                 bail!("Size mismatch for {filename}: expected {expected_size}, got {actual_size}");
             }
         }
-        Ok(())
-    }
 
-    /// Verify or enrich the lock contract selected during preparation.
-    fn verify_lock_contract(
-        &self,
-        ctx: &InstallContext,
-        tv: &mut ToolVersion,
-        file_path: &Path,
-        spec: &PreparedHttpInstall,
-    ) -> Result<()> {
-        let settings = Settings::get();
         let filename = file_path.file_name().unwrap().to_string_lossy();
-        let lockfile_enabled = settings.lockfile_enabled();
-
-        let platform_info = tv.lock_platforms.entry(spec.target.clone()).or_default();
-        platform_info.url = Some(spec.url.clone());
-
-        // Verify or generate checksum
-        if let Some(checksum) = &spec.lock_checksum {
+        if spec.lockfile_enabled || spec.lock_checksum.is_some() {
+            ctx.pr.next_operation();
+        }
+        let lock_checksum = if let Some(checksum) = &spec.lock_checksum {
             ctx.pr.set_message(format!("checksum {filename}"));
-            verify_checksum_str(file_path, checksum, Some(ctx.pr.as_ref()))?;
-            platform_info.checksum = Some(checksum.clone());
-        } else if lockfile_enabled {
+            checksum.verify(file_path, Some(ctx.pr.as_ref()))?;
+            Some(checksum.to_string())
+        } else if spec.lockfile_enabled {
             ctx.pr.set_message(format!("generate checksum {filename}"));
             let h = hash::file_hash_blake3(file_path, Some(ctx.pr.as_ref()))?;
-            platform_info.checksum = Some(format!("blake3:{h}"));
-        }
+            Some(format!("blake3:{h}"))
+        } else {
+            None
+        };
 
-        // Verify or record size
-        if let Some(expected_size) = spec.lock_size {
+        let lock_size = if let Some(expected_size) = spec.lock_size {
             ctx.pr.set_message(format!("verify size {filename}"));
             let actual_size = file_path.metadata()?.len();
             if actual_size != expected_size {
-                return Err(eyre::eyre!(
-                    "Size mismatch for {filename}: expected {expected_size}, got {actual_size}"
-                ));
+                bail!("Size mismatch for {filename}: expected {expected_size}, got {actual_size}");
             }
-            platform_info.size = Some(expected_size);
-        } else if lockfile_enabled {
-            platform_info.size = Some(file_path.metadata()?.len());
-        }
+            Some(expected_size)
+        } else if spec.lockfile_enabled {
+            Some(file_path.metadata()?.len())
+        } else {
+            None
+        };
 
-        Ok(())
+        Ok((lock_checksum, lock_size))
+    }
+
+    fn apply_lock_contract(
+        &self,
+        tv: &mut ToolVersion,
+        spec: &PreparedHttpInstall,
+        checksum: Option<String>,
+        size: Option<u64>,
+    ) {
+        let platform_info = tv.lock_platforms.entry(spec.target.clone()).or_default();
+        platform_info.url = Some(spec.url.to_string());
+        if let Some(checksum) = checksum {
+            platform_info.checksum = Some(checksum);
+        }
+        if let Some(size) = size {
+            platform_info.size = Some(size);
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -874,9 +896,11 @@ impl HttpBackend {
         let raw_opts = tv.request.options();
         let opts = HttpOptions::new(&raw_opts);
         let locked_url = locked.and_then(|info| info.url.clone());
+        let configured_url = self.lock_url_for_target(&opts, tv, target);
         let replaying = locked_url.is_some();
-        let url = locked_url
-            .or_else(|| self.lock_url_for_target(&opts, tv, target))
+        let url_value = locked_url
+            .clone()
+            .or_else(|| configured_url.clone())
             .ok_or_else(|| {
                 let available = opts.url_platforms();
                 if available.is_empty() {
@@ -890,59 +914,106 @@ impl HttpBackend {
                     )
                 }
             })?;
-
-        let strip_components = opts.strip_components_for_target(target);
-        if let Some(strip) = &strip_components {
-            strip
-                .parse::<usize>()
-                .map_err(|_| eyre::eyre!("Invalid strip_components value: {strip}"))?;
+        let url = reqwest::Url::parse(&url_value)
+            .wrap_err_with(|| format!("Invalid HTTP install URL: {url_value}"))?;
+        if !matches!(url.scheme(), "http" | "https") {
+            bail!(
+                "Unsupported HTTP install URL scheme '{}': {url}",
+                url.scheme()
+            );
         }
+        let filename = get_filename_from_url(url.as_str());
+        if filename.is_empty() {
+            bail!("HTTP install URL has no artifact filename: {url}");
+        }
+        ensure_plain_bin_name("HTTP artifact filename", &filename)?;
 
-        let configured_size = if replaying {
-            None
-        } else {
+        let strip_components = opts
+            .strip_components_for_target(target)
+            .map(|strip| {
+                strip
+                    .parse::<usize>()
+                    .map_err(|_| eyre::eyre!("Invalid strip_components value: {strip}"))
+            })
+            .transpose()?;
+
+        let configured_matches = configured_url
+            .as_deref()
+            .and_then(|value| reqwest::Url::parse(value).ok())
+            .is_some_and(|configured| configured == url);
+        let locked_checksum = locked.and_then(|info| info.checksum.as_deref());
+        let locked_size = locked.and_then(|info| info.size);
+        let use_configured_checksum =
+            !replaying || (locked_checksum.is_none() && configured_matches);
+        let use_configured_size = !replaying || (locked_size.is_none() && configured_matches);
+
+        let configured_size = if use_configured_size {
             opts.size_for_target(target)
                 .map(|size| {
                     size.parse::<u64>()
                         .map_err(|_| eyre::eyre!("Invalid size value: {size}"))
                 })
                 .transpose()?
-        };
-        let configured_checksum = if replaying {
-            None
         } else {
-            opts.checksum_for_target(target)
+            None
         };
+        let configured_checksum = if use_configured_checksum {
+            opts.checksum_for_target(target)
+                .map(|checksum| PreparedChecksum::parse(&checksum))
+                .transpose()?
+        } else {
+            None
+        };
+        let lock_checksum = locked_checksum.map(PreparedChecksum::parse).transpose()?;
 
-        for checksum in [
-            locked.and_then(|info| info.checksum.as_deref()),
-            configured_checksum.as_deref(),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            if !checksum.contains(':') {
-                bail!("Invalid checksum format: {checksum}");
-            }
+        let bin = opts.bin_for_target(target);
+        if let Some(bin) = &bin {
+            ensure_safe_relative_bin_path("bin", bin)?;
+        }
+        let bin_path = opts
+            .bin_path_for_target(target)
+            .map(|template| template_string_for_target(&template, tv, target));
+        if let Some(bin_path) = &bin_path {
+            ensure_safe_relative_bin_path("bin_path", bin_path)?;
+        }
+        let rename_exe = opts.rename_exe_value_for_target(target).cloned();
+        if let Some(rename_exe) = &rename_exe {
+            Self::validate_rename_exe(rename_exe)?;
         }
 
         Ok(PreparedHttpInstall {
-            raw_options: raw_opts,
             target: target.to_key(),
             url,
-            lock_checksum: locked.and_then(|info| info.checksum.clone()),
-            lock_size: locked.and_then(|info| info.size),
+            filename,
+            lock_checksum,
+            lock_size: locked_size,
             configured_checksum,
             configured_size,
+            lockfile_enabled: Settings::get().lockfile_enabled(),
             format: opts.format_for_target(target),
             strip_components,
-            bin: opts.bin_for_target(target),
-            rename_exe: opts.rename_exe_for_target(target),
-            bin_path: opts.bin_path_for_target(target),
+            bin,
+            rename_exe,
+            bin_path,
         })
     }
 
-    fn prepare_http_install(
+    fn validate_rename_exe(value: &toml::Value) -> Result<()> {
+        match value {
+            toml::Value::String(name) => ensure_plain_bin_name("rename_exe", name),
+            toml::Value::Table(entries) => {
+                for target in entries.values() {
+                    if let Some(target) = target.as_str() {
+                        ensure_plain_bin_name("rename_exe", target)?;
+                    }
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    async fn prepare_http_install(
         &self,
         ctx: &InstallContext,
         tv: &ToolVersion,
@@ -957,9 +1028,49 @@ impl HttpBackend {
                 target.to_key()
             );
         }
+        let spec = self.prepare_http_target(tv, &target, locked)?;
+        file::create_dir_all(Self::tarballs_dir())?;
+        let staged_dir = tempfile::Builder::new()
+            .prefix(".mise-http-stage-")
+            .tempdir_in(Self::tarballs_dir())?;
+        let download_dir = staged_dir.path().join("download");
+        file::create_dir_all(&download_dir)?;
+        let staged_file = download_dir.join(&spec.filename);
+
+        ctx.pr.set_message(format!("download {}", spec.filename));
+        HTTP.download_file(spec.url.clone(), &staged_file, Some(ctx.pr.as_ref()))
+            .await?;
+        let (lock_checksum, lock_size) = self.verify_staged_artifact(ctx, &staged_file, &spec)?;
+        let cache_plan = self.cache_plan(&staged_file, &spec)?;
+        let cache_checksum = lock_checksum.clone().or_else(|| spec.checksum());
+        let staged_cache = staged_dir.path().join("cache");
+        ctx.pr.next_operation();
+        ctx.pr.set_message("extracting to staging".into());
+        let extraction_type = self.extract_artifact(
+            tv,
+            &staged_cache,
+            &staged_file,
+            &cache_plan,
+            &spec,
+            Some(ctx.pr.as_ref()),
+        )?;
+        self.write_metadata(
+            &staged_cache,
+            spec.url.as_str(),
+            cache_checksum.as_deref(),
+            &staged_file,
+        )?;
+
         Ok(PreparedInstall::prepared(PreparedHttpInstallPlan {
             backend: self.clone(),
-            spec: Arc::new(self.prepare_http_target(tv, &target, locked)?),
+            spec,
+            staged_dir,
+            staged_file,
+            staged_cache,
+            cache_plan,
+            extraction_type,
+            lock_checksum,
+            lock_size,
         }))
     }
 
@@ -1041,56 +1152,41 @@ impl HttpBackend {
         fetch_checksum_from_file(&checksum_url, &file_algo).await
     }
 
-    async fn install_prepared_http(
+    fn install_prepared_http(
         &self,
         ctx: &InstallContext,
         mut tv: ToolVersion,
         spec: &PreparedHttpInstall,
+        staged_file: &Path,
+        staged_cache: &Path,
+        cache_plan: &CachePlan,
+        prepared_extraction_type: ExtractionType,
+        lock_checksum: Option<String>,
+        lock_size: Option<u64>,
     ) -> Result<ToolVersion> {
-        let url = spec.url.clone();
-        let filename = get_filename_from_url(&url);
-        let file_path = tv.download_path().join(&filename);
+        self.apply_lock_contract(&mut tv, spec, lock_checksum, lock_size);
 
-        let lockfile_enabled = Settings::get().lockfile_enabled();
-        let has_lockfile_checksum = spec.lock_checksum.is_some();
-
-        ctx.pr.set_message(format!("download {filename}"));
-        HTTP.download_file(&url, &file_path, Some(ctx.pr.as_ref()))
-            .await?;
-
-        if spec.configured_checksum.is_some() {
-            ctx.pr.next_operation();
+        if Settings::get().always_keep_download {
+            let download_path = tv.download_path().join(&spec.filename);
+            file::create_dir_all(tv.download_path())?;
+            file::copy(staged_file, download_path)?;
         }
-        self.verify_prepared_artifact(ctx, &file_path, spec)?;
 
-        // Validate the locked artifact contract before populating the shared
-        // extraction cache or exposing any install symlink. Enrichment remains
-        // in-memory until the successful result is returned to the writer.
-        if lockfile_enabled || has_lockfile_checksum {
-            ctx.pr.next_operation();
-        }
-        self.verify_lock_contract(ctx, &mut tv, &file_path, spec)?;
-
-        let cache_plan = self.cache_plan(&file_path, spec)?;
         let cache_path = self.cache_path(&cache_plan.key);
         let _lock = crate::lock_file::get(&cache_path, ctx.force)?;
 
-        ctx.pr.next_operation();
         let extraction_type = if self.is_cached(&cache_plan.key) {
             ctx.pr.set_message("using cached tarball".into());
             ctx.pr.set_length(1);
             ctx.pr.set_position(1);
             self.extraction_type_from_cache(&cache_plan.key, &cache_plan.file_info)
         } else {
-            ctx.pr.set_message("extracting to cache".into());
-            self.extract_to_cache(
-                &tv,
-                &file_path,
-                &cache_plan,
-                &url,
-                spec,
-                Some(ctx.pr.as_ref()),
-            )?
+            ctx.pr.set_message("publishing prepared cache".into());
+            if cache_path.exists() {
+                file::remove_all(&cache_path)?;
+            }
+            std::fs::rename(staged_cache, &cache_path)?;
+            prepared_extraction_type
         };
 
         self.create_install_symlink(&tv, &cache_plan.key, &extraction_type, spec)?;
@@ -1143,13 +1239,21 @@ impl Backend for HttpBackend {
     async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
         let raw_opts = tv.request.options();
         let opts = HttpOptions::new(&raw_opts);
-        let platform_key = self.get_platform_key();
-        let replaying = tv
-            .lock_platforms
-            .get(&platform_key)
-            .and_then(|info| info.url.as_ref())
-            .is_some();
-        let has_configured_checksum = !replaying && opts.checksum().is_some();
+        let target = PlatformTarget::from_current();
+        let platform_key = target.to_key();
+        let locked = tv.lock_platforms.get(&platform_key);
+        let locked_url = locked.and_then(|info| info.url.as_deref());
+        let configured_url = self.lock_url_for_target(&opts, tv, &target);
+        let configured_matches =
+            locked_url
+                .zip(configured_url.as_deref())
+                .is_some_and(|(locked, configured)| {
+                    reqwest::Url::parse(locked).ok() == reqwest::Url::parse(configured).ok()
+                });
+        let has_configured_checksum = opts.checksum().is_some()
+            && (locked_url.is_none()
+                || (locked.and_then(|info| info.checksum.as_ref()).is_none()
+                    && configured_matches));
         super::http_install_operation_count(has_configured_checksum, &platform_key, tv)
     }
 
@@ -1196,7 +1300,9 @@ impl Backend for HttpBackend {
         })?;
         let url = prepared.url;
 
-        let checksum = self.resolve_lock_checksum(&opts, tv, target, &url).await;
+        let checksum = self
+            .resolve_lock_checksum(&opts, tv, target, url.as_str())
+            .await;
 
         // A checksum source was configured but produced nothing for this target
         // (manifest miss, SHASUMS naming mismatch, unreachable file, ...). The
@@ -1211,7 +1317,7 @@ impl Backend for HttpBackend {
         }
 
         Ok(PlatformInfo {
-            url: Some(url),
+            url: Some(url.to_string()),
             checksum,
             ..Default::default()
         })
@@ -1228,13 +1334,17 @@ impl Backend for HttpBackend {
             .collect())
     }
 
-    fn prepare_install(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<PreparedInstall> {
-        self.prepare_http_install(ctx, tv)
+    async fn prepare_install(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+    ) -> Result<PreparedInstall> {
+        self.prepare_http_install(ctx, tv).await
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
-        let prepared = self.prepare_http_install(ctx, &tv)?;
-        Ok(prepared.execute(self, ctx, tv).await?.into_tool_version())
+        let prepared = self.prepare_http_install(ctx, &tv).await?;
+        prepared.execute(self, ctx, tv).await
     }
 
     fn is_version_installed(
@@ -1356,6 +1466,29 @@ mod tests {
         ))
     }
 
+    fn prepared_http_options(raw: &str) -> PreparedHttpInstall {
+        let raw = crate::toolset::parse_tool_options(raw);
+        let opts = HttpOptions::new(&raw);
+        let target = PlatformTarget::from_current();
+        PreparedHttpInstall {
+            target: target.to_key(),
+            url: reqwest::Url::parse("https://example.com/artifact").unwrap(),
+            filename: "artifact".to_string(),
+            lock_checksum: None,
+            lock_size: None,
+            configured_checksum: None,
+            configured_size: None,
+            lockfile_enabled: false,
+            format: opts.format_for_target(&target),
+            strip_components: opts
+                .strip_components_for_target(&target)
+                .map(|value| value.parse().unwrap()),
+            bin: opts.bin_for_target(&target),
+            rename_exe: opts.rename_exe_value_for_target(&target).cloned(),
+            bin_path: opts.bin_path_for_target(&target),
+        }
+    }
+
     fn version_hash(version: &str) -> String {
         crate::hash::hash_sha256_to_str(version)[..7].to_string()
     }
@@ -1379,14 +1512,16 @@ mod tests {
 
     #[test]
     fn prepared_http_install_prefers_locked_artifact_contract() {
-        let options = crate::toolset::parse_tool_options(
-            "url=https://example.com/current,checksum=sha256:current,size=7,format=tar.gz,strip_components=1,bin=mytool,bin_path=tools/bin",
-        );
+        let configured_checksum = format!("sha256:{}", "1".repeat(64));
+        let locked_checksum = format!("sha256:{}", "2".repeat(64));
+        let options = crate::toolset::parse_tool_options(&format!(
+            "url=https://example.com/current,checksum={configured_checksum},size=7,format=tar.gz,strip_components=1,bin=mytool,bin_path=tools/bin"
+        ));
         let tv = http_test_tv_with_options("1.0.0", options);
         let target = PlatformTarget::from_current();
         let locked = PlatformInfo {
             url: Some("https://example.com/locked".to_string()),
-            checksum: Some("sha256:locked".to_string()),
+            checksum: Some(locked_checksum.clone()),
             size: Some(42),
             ..Default::default()
         };
@@ -1395,15 +1530,80 @@ mod tests {
             .prepare_http_target(&tv, &target, Some(&locked))
             .unwrap();
 
-        assert_eq!(prepared.url, "https://example.com/locked");
-        assert_eq!(prepared.lock_checksum.as_deref(), Some("sha256:locked"));
+        assert_eq!(prepared.url.as_str(), "https://example.com/locked");
+        assert_eq!(
+            prepared.lock_checksum.map(|value| value.to_string()),
+            Some(locked_checksum)
+        );
         assert_eq!(prepared.lock_size, Some(42));
         assert_eq!(prepared.configured_checksum, None);
         assert_eq!(prepared.configured_size, None);
         assert_eq!(prepared.format.as_deref(), Some("tar.gz"));
-        assert_eq!(prepared.strip_components.as_deref(), Some("1"));
+        assert_eq!(prepared.strip_components, Some(1));
         assert_eq!(prepared.bin.as_deref(), Some("mytool"));
         assert_eq!(prepared.bin_path.as_deref(), Some("tools/bin"));
+    }
+
+    #[test]
+    fn prepared_http_install_uses_configured_integrity_for_same_locked_url() {
+        let configured_checksum = format!("sha256:{}", "3".repeat(64));
+        let options = crate::toolset::parse_tool_options(&format!(
+            "url=https://example.com/artifact,checksum={configured_checksum},size=7"
+        ));
+        let tv = http_test_tv_with_options("1.0.0", options);
+        let target = PlatformTarget::from_current();
+        let locked = PlatformInfo {
+            url: Some("https://example.com/artifact".to_string()),
+            ..Default::default()
+        };
+
+        let prepared = http_test_backend()
+            .prepare_http_target(&tv, &target, Some(&locked))
+            .unwrap();
+
+        assert_eq!(
+            prepared.configured_checksum.map(|value| value.to_string()),
+            Some(configured_checksum)
+        );
+        assert_eq!(prepared.configured_size, Some(7));
+    }
+
+    #[test]
+    fn prepared_checksum_rejects_unusable_values() {
+        assert!(PreparedChecksum::parse("sha256:short").is_err());
+        assert!(PreparedChecksum::parse(&format!("unknown:{}", "0".repeat(64))).is_err());
+        assert!(PreparedChecksum::parse(&format!("sha256:{}", "g".repeat(64))).is_err());
+    }
+
+    #[test]
+    fn prepared_http_install_rejects_decoded_filename_traversal() {
+        for url in [
+            "https://example.com/%2E%2E%2Fvictim",
+            "https://example.com/%2Ftmp%2Fvictim",
+        ] {
+            let options = crate::toolset::parse_tool_options(&format!("url={url}"));
+            let tv = http_test_tv_with_options("1.0.0", options);
+            let target = PlatformTarget::from_current();
+            let err = http_test_backend()
+                .prepare_http_target(&tv, &target, None)
+                .unwrap_err();
+
+            assert!(
+                err.to_string().contains("HTTP artifact filename"),
+                "unexpected error for {url}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn prepared_rename_exe_preserves_exact_non_glob_source_names() {
+        let rename_exe = toml::Value::Table(
+            [("tool[".to_string(), toml::Value::String("tool".to_string()))]
+                .into_iter()
+                .collect(),
+        );
+
+        HttpBackend::validate_rename_exe(&rename_exe).unwrap();
     }
 
     #[test]
@@ -1527,20 +1727,7 @@ mod tests {
                 BackendResolution::new(true),
             )),
         };
-        let opts = PreparedHttpInstall {
-            raw_options: ToolVersionOptions::default(),
-            target: PlatformTarget::from_current().to_key(),
-            url: "https://example.com/code2prompt.gz".to_string(),
-            lock_checksum: None,
-            lock_size: None,
-            configured_checksum: None,
-            configured_size: None,
-            format: None,
-            strip_components: None,
-            bin: None,
-            rename_exe: Some("code2prompt".to_string()),
-            bin_path: None,
-        };
+        let opts = prepared_http_options("rename_exe=code2prompt");
         let file_path = Path::new("code2prompt-x86_64-pc-windows-msvc.exe.gz");
         let file_info = FileInfo::new(file_path, &opts);
 
@@ -1568,8 +1755,7 @@ mod tests {
             (r#"bin="../evil""#, "safe relative path"),
             (r#"rename_exe="a/b""#, "plain file name"),
         ] {
-            let raw_opts = crate::toolset::parse_tool_options(opt);
-            let opts = HttpOptions::new(&raw_opts);
+            let opts = prepared_http_options(opt);
             let file_info = FileInfo::new(file_path, &opts);
             let err = backend
                 .dest_filename(file_path, &file_info, &opts)
@@ -1580,8 +1766,7 @@ mod tests {
             );
         }
 
-        let raw_opts = crate::toolset::parse_tool_options(r#"bin="bin/mytool""#);
-        let opts = HttpOptions::new(&raw_opts);
+        let opts = prepared_http_options(r#"bin="bin/mytool""#);
         let file_info = FileInfo::new(file_path, &opts);
         assert_eq!(
             backend.dest_filename(file_path, &file_info, &opts).unwrap(),
@@ -1609,10 +1794,8 @@ mod tests {
         let illegal = ['*', '"', '{', '}', '<', '>', ':', '|', '?', '\\', '/', ' '];
 
         let key_for = |opt: &str| {
-            let opts = crate::toolset::parse_tool_options(opt);
-            backend
-                .cache_key(tmp.path(), &HttpOptions::new(&opts), 0)
-                .unwrap()
+            let opts = prepared_http_options(opt);
+            backend.cache_key(tmp.path(), &opts, 0).unwrap()
         };
 
         // Scalar, table, and adversarial values all yield path-safe keys.

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -3,7 +3,9 @@ use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
-use crate::backend::prepared_install::{PreparedHttpInstall, PreparedInstall, SuccessfulInstall};
+use crate::backend::prepared_install::{
+    PreparedInstall, PreparedInstallEvidencePayload, PreparedInstallPlan,
+};
 use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
     apply_rename_exe, clean_binary_name, ensure_plain_bin_name, ensure_safe_relative_bin_path,
@@ -130,7 +132,7 @@ impl FileInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HttpBackend {
     ba: Arc<BackendArg>,
 }
@@ -138,6 +140,49 @@ pub struct HttpBackend {
 #[derive(Debug, Clone, Copy)]
 struct HttpOptions<'a> {
     values: BackendOptions<'a>,
+}
+
+/// The HTTP inputs that installation is allowed to consume.
+///
+/// Configured verification inputs apply to fresh resolution. Once a lock URL
+/// is replayed, its checksum and size are the sole artifact contract.
+#[derive(Debug)]
+struct PreparedHttpInstall {
+    raw_options: ToolVersionOptions,
+    target: String,
+    url: String,
+    lock_checksum: Option<String>,
+    lock_size: Option<u64>,
+    configured_checksum: Option<String>,
+    configured_size: Option<u64>,
+    format: Option<String>,
+    strip_components: Option<String>,
+    bin: Option<String>,
+    rename_exe: Option<String>,
+    bin_path: Option<String>,
+}
+
+#[derive(Debug)]
+struct PreparedHttpInstallPlan {
+    backend: HttpBackend,
+    spec: Arc<PreparedHttpInstall>,
+}
+
+#[async_trait]
+impl PreparedInstallPlan for PreparedHttpInstallPlan {
+    fn evidence(&self) -> Arc<dyn PreparedInstallEvidencePayload> {
+        self.spec.clone()
+    }
+
+    async fn execute(
+        self: Box<Self>,
+        ctx: &InstallContext,
+        tv: ToolVersion,
+    ) -> Result<ToolVersion> {
+        self.backend
+            .install_prepared_http(ctx, tv, self.spec.as_ref())
+            .await
+    }
 }
 
 impl<'a> HttpOptions<'a> {
@@ -912,9 +957,10 @@ impl HttpBackend {
                 target.to_key()
             );
         }
-        Ok(PreparedInstall::http(
-            self.prepare_http_target(tv, &target, locked)?,
-        ))
+        Ok(PreparedInstall::prepared(PreparedHttpInstallPlan {
+            backend: self.clone(),
+            spec: Arc::new(self.prepare_http_target(tv, &target, locked)?),
+        }))
     }
 
     /// Resolve the artifact URL for a target platform during `mise lock`.
@@ -1186,24 +1232,9 @@ impl Backend for HttpBackend {
         self.prepare_http_install(ctx, tv)
     }
 
-    async fn install_prepared_version_(
-        &self,
-        ctx: &InstallContext,
-        tv: ToolVersion,
-        prepared: PreparedInstall,
-    ) -> Result<SuccessfulInstall> {
-        let tv = self
-            .install_prepared_http(ctx, tv, prepared.http_spec()?)
-            .await?;
-        Ok(SuccessfulInstall::new(tv, prepared))
-    }
-
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         let prepared = self.prepare_http_install(ctx, &tv)?;
-        Ok(self
-            .install_prepared_version_(ctx, tv, prepared)
-            .await?
-            .into_tool_version())
+        Ok(prepared.execute(self, ctx, tv).await?.into_tool_version())
     }
 
     fn is_version_installed(

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -3,12 +3,13 @@ use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
 use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
+use crate::backend::prepared_install::{PreparedHttpInstall, PreparedInstall, SuccessfulInstall};
 use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
     apply_rename_exe, clean_binary_name, ensure_plain_bin_name, ensure_safe_relative_bin_path,
     eval_checksum_expr, fetch_checksum_from_file, fetch_checksum_from_shasums,
     get_filename_from_url, lookup_value_with_fallback, rename_binary_name, shasums_has_entries,
-    template_string, template_string_for_target, verify_artifact,
+    template_string, template_string_for_target, verify_checksum_str,
 };
 use crate::backend::version_list;
 use crate::cli::args::BackendArg;
@@ -24,7 +25,7 @@ use crate::toolset::ToolVersionOptions;
 use crate::ui::progress_report::SingleReport;
 use crate::{dirs, file, hash};
 use async_trait::async_trait;
-use eyre::Result;
+use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -75,13 +76,13 @@ struct CachePlan {
 
 impl FileInfo {
     /// Analyze a file path and options to determine format information
-    fn new(file_path: &Path, opts: &HttpOptions<'_>) -> Self {
+    fn new(file_path: &Path, opts: &PreparedHttpInstall) -> Self {
         // Apply format config to determine effective extension
         let effective_path = if let Some(added_ext) = opts.format() {
             let mut path = file_path.to_path_buf();
             let current_ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
             let new_ext = if current_ext.is_empty() {
-                added_ext
+                added_ext.to_string()
             } else {
                 format!("{}.{}", current_ext, added_ext)
             };
@@ -146,32 +147,8 @@ impl<'a> HttpOptions<'a> {
         }
     }
 
-    fn raw(&self) -> &'a ToolVersionOptions {
-        self.values.raw()
-    }
-
-    fn url(&self) -> Option<String> {
-        self.values.platform_string("url")
-    }
-
     fn checksum(&self) -> Option<String> {
         self.values.platform_string("checksum")
-    }
-
-    fn format(&self) -> Option<String> {
-        self.values.platform_string("format")
-    }
-
-    fn strip_components(&self) -> Option<String> {
-        self.values.platform_string("strip_components")
-    }
-
-    fn bin(&self) -> Option<String> {
-        self.values.platform_string("bin")
-    }
-
-    fn rename_exe(&self) -> Option<String> {
-        self.values.platform_string("rename_exe")
     }
 
     fn bin_path(&self) -> Option<String> {
@@ -210,6 +187,18 @@ impl<'a> HttpOptions<'a> {
         self.values.platform_string_for_target("rename_exe", target)
     }
 
+    fn bin_for_target(&self, target: &PlatformTarget) -> Option<String> {
+        self.values.platform_string_for_target("bin", target)
+    }
+
+    fn bin_path_for_target(&self, target: &PlatformTarget) -> Option<String> {
+        self.values.platform_string_for_target("bin_path", target)
+    }
+
+    fn size_for_target(&self, target: &PlatformTarget) -> Option<String> {
+        self.values.platform_string_for_target("size", target)
+    }
+
     fn version_list_url(&self) -> Option<&'a str> {
         self.values.str("version_list_url")
     }
@@ -228,6 +217,36 @@ impl<'a> HttpOptions<'a> {
 
     fn url_platforms(&self) -> Vec<String> {
         self.values.available_platforms_with_key("url")
+    }
+}
+
+impl PreparedHttpInstall {
+    fn raw(&self) -> &ToolVersionOptions {
+        &self.raw_options
+    }
+
+    fn checksum(&self) -> Option<&str> {
+        self.configured_checksum.as_deref()
+    }
+
+    fn format(&self) -> Option<&str> {
+        self.format.as_deref()
+    }
+
+    fn strip_components(&self) -> Option<&str> {
+        self.strip_components.as_deref()
+    }
+
+    fn bin(&self) -> Option<&str> {
+        self.bin.as_deref()
+    }
+
+    fn rename_exe(&self) -> Option<&str> {
+        self.rename_exe.as_deref()
+    }
+
+    fn bin_path(&self) -> Option<&str> {
+        self.bin_path.as_deref()
     }
 }
 
@@ -268,7 +287,7 @@ impl HttpBackend {
     fn cache_key(
         &self,
         file_path: &Path,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
         strip_components: usize,
     ) -> Result<String> {
         let checksum = hash::file_hash_blake3(file_path, None)?;
@@ -303,7 +322,7 @@ impl HttpBackend {
         Ok(key)
     }
 
-    fn cache_plan(&self, file_path: &Path, opts: &HttpOptions<'_>) -> Result<CachePlan> {
+    fn cache_plan(&self, file_path: &Path, opts: &PreparedHttpInstall) -> Result<CachePlan> {
         let file_info = FileInfo::new(file_path, opts);
         let strip_components = self.effective_strip_components(file_path, &file_info, opts)?;
         let key = self.cache_key(file_path, opts, strip_components)?;
@@ -319,7 +338,7 @@ impl HttpBackend {
         &self,
         file_path: &Path,
         file_info: &FileInfo,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
     ) -> Result<usize> {
         let mut strip_components: Option<usize> = opts
             .strip_components()
@@ -354,21 +373,21 @@ impl HttpBackend {
         &self,
         file_path: &Path,
         file_info: &FileInfo,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
     ) -> Result<String> {
         // Check for explicit bin name first
         if let Some(bin_name) = opts.bin() {
-            ensure_safe_relative_bin_path("bin", &bin_name)?;
-            return Ok(bin_name);
+            ensure_safe_relative_bin_path("bin", bin_name)?;
+            return Ok(bin_name.to_string());
         }
         if let Some(rename_to) = opts.rename_exe() {
-            ensure_plain_bin_name("rename_exe", &rename_to)?;
+            ensure_plain_bin_name("rename_exe", rename_to)?;
             let source_name = if file_info.is_compressed_binary {
                 file_info.decompressed_name()
             } else {
                 file_path.file_name().unwrap().to_string_lossy().to_string()
             };
-            return Ok(rename_binary_name(&source_name, &rename_to));
+            return Ok(rename_binary_name(&source_name, rename_to));
         }
 
         // Auto-clean the binary name
@@ -422,7 +441,7 @@ impl HttpBackend {
         file_path: &Path,
         cache_plan: &CachePlan,
         url: &str,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
         pr: Option<&dyn SingleReport>,
     ) -> Result<ExtractionType> {
         let cache_path = self.cache_path(&cache_plan.key);
@@ -466,7 +485,7 @@ impl HttpBackend {
         dest: &Path,
         file_path: &Path,
         cache_plan: &CachePlan,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
         pr: Option<&dyn SingleReport>,
     ) -> Result<ExtractionType> {
         file::create_dir_all(dest)?;
@@ -486,7 +505,7 @@ impl HttpBackend {
         dest: &Path,
         file_path: &Path,
         file_info: &FileInfo,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
         pr: Option<&dyn SingleReport>,
     ) -> Result<ExtractionType> {
         let filename = self.dest_filename(file_path, file_info, opts)?;
@@ -509,7 +528,7 @@ impl HttpBackend {
         dest: &Path,
         file_path: &Path,
         file_info: &FileInfo,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
         pr: Option<&dyn SingleReport>,
     ) -> Result<ExtractionType> {
         let filename = self.dest_filename(file_path, file_info, opts)?;
@@ -533,7 +552,7 @@ impl HttpBackend {
         dest: &Path,
         file_path: &Path,
         cache_plan: &CachePlan,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
         pr: Option<&dyn SingleReport>,
     ) -> Result<ExtractionType> {
         let extract_opts = file::ExtractOptions {
@@ -549,7 +568,7 @@ impl HttpBackend {
             // When bin_path is not explicitly set, auto-detect bin/ subdirectory to match
             // the same logic used by discover_bin_paths() for PATH construction
             let search_dir = if let Some(bin_path_template) = opts.bin_path() {
-                let bin_path = template_string(&bin_path_template, tv);
+                let bin_path = template_string(bin_path_template, tv);
                 dest.join(&bin_path)
             } else {
                 let bin_dir = dest.join("bin");
@@ -573,11 +592,11 @@ impl HttpBackend {
         cache_key: &str,
         url: &str,
         file_path: &Path,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
     ) -> Result<()> {
         let metadata = CacheMetadata {
             url: url.to_string(),
-            checksum: opts.checksum(),
+            checksum: opts.checksum().map(str::to_string),
             size: file_path.metadata()?.len(),
             extracted_at: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
             platform: self.get_platform_key(),
@@ -655,7 +674,7 @@ impl HttpBackend {
         tv: &ToolVersion,
         cache_key: &str,
         extraction_type: &ExtractionType,
-        opts: &HttpOptions<'_>,
+        opts: &PreparedHttpInstall,
     ) -> Result<()> {
         let cache_path = self.cache_path(cache_key);
 
@@ -674,7 +693,7 @@ impl HttpBackend {
         if let ExtractionType::RawFile { filename } = extraction_type
             && let Some(bin_path_template) = opts.bin_path()
         {
-            let bin_path = template_string(&bin_path_template, tv);
+            let bin_path = template_string(bin_path_template, tv);
             let dest_dir = install_path.join(&bin_path);
             file::create_dir_all(&dest_dir)?;
 
@@ -714,27 +733,44 @@ impl HttpBackend {
     // Checksum verification
     // -------------------------------------------------------------------------
 
-    /// Verify or generate checksum for lockfile support
-    fn verify_checksum(
+    fn verify_prepared_artifact(
+        &self,
+        ctx: &InstallContext,
+        file_path: &Path,
+        spec: &PreparedHttpInstall,
+    ) -> Result<()> {
+        if let Some(checksum) = &spec.configured_checksum {
+            verify_checksum_str(file_path, checksum, Some(ctx.pr.as_ref()))?;
+        }
+        if let Some(expected_size) = spec.configured_size {
+            let actual_size = file_path.metadata()?.len();
+            if actual_size != expected_size {
+                bail!("Size mismatch: expected {expected_size}, got {actual_size}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Verify or enrich the lock contract selected during preparation.
+    fn verify_lock_contract(
         &self,
         ctx: &InstallContext,
         tv: &mut ToolVersion,
         file_path: &Path,
+        spec: &PreparedHttpInstall,
     ) -> Result<()> {
         let settings = Settings::get();
         let filename = file_path.file_name().unwrap().to_string_lossy();
         let lockfile_enabled = settings.lockfile_enabled();
 
-        let platform_key = self.get_platform_key();
-        let platform_info = tv.lock_platforms.entry(platform_key).or_default();
+        let platform_info = tv.lock_platforms.entry(spec.target.clone()).or_default();
+        platform_info.url = Some(spec.url.clone());
 
         // Verify or generate checksum
-        if let Some(checksum) = &platform_info.checksum {
+        if let Some(checksum) = &spec.lock_checksum {
             ctx.pr.set_message(format!("checksum {filename}"));
-            let (algo, check) = checksum
-                .split_once(':')
-                .ok_or_else(|| eyre::eyre!("Invalid checksum format: {checksum}"))?;
-            hash::ensure_checksum(file_path, check, Some(ctx.pr.as_ref()), algo)?;
+            verify_checksum_str(file_path, checksum, Some(ctx.pr.as_ref()))?;
+            platform_info.checksum = Some(checksum.clone());
         } else if lockfile_enabled {
             ctx.pr.set_message(format!("generate checksum {filename}"));
             let h = hash::file_hash_blake3(file_path, Some(ctx.pr.as_ref()))?;
@@ -742,7 +778,7 @@ impl HttpBackend {
         }
 
         // Verify or record size
-        if let Some(expected_size) = platform_info.size {
+        if let Some(expected_size) = spec.lock_size {
             ctx.pr.set_message(format!("verify size {filename}"));
             let actual_size = file_path.metadata()?.len();
             if actual_size != expected_size {
@@ -750,6 +786,7 @@ impl HttpBackend {
                     "Size mismatch for {filename}: expected {expected_size}, got {actual_size}"
                 ));
             }
+            platform_info.size = Some(expected_size);
         } else if lockfile_enabled {
             platform_info.size = Some(file_path.metadata()?.len());
         }
@@ -781,6 +818,103 @@ impl HttpBackend {
     // -------------------------------------------------------------------------
     // Cross-platform lock resolution
     // -------------------------------------------------------------------------
+
+    fn prepare_http_target(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+        locked: Option<&PlatformInfo>,
+    ) -> Result<PreparedHttpInstall> {
+        let raw_opts = tv.request.options();
+        let opts = HttpOptions::new(&raw_opts);
+        let locked_url = locked.and_then(|info| info.url.clone());
+        let replaying = locked_url.is_some();
+        let url = locked_url
+            .or_else(|| self.lock_url_for_target(&opts, tv, target))
+            .ok_or_else(|| {
+                let available = opts.url_platforms();
+                if available.is_empty() {
+                    eyre::eyre!("Http backend requires 'url' option")
+                } else {
+                    eyre::eyre!(
+                        "No URL for platform {}. Available: {}. Provide 'url' or add 'platforms.{}.url'",
+                        target.to_key(),
+                        available.join(", "),
+                        target.to_key()
+                    )
+                }
+            })?;
+
+        let strip_components = opts.strip_components_for_target(target);
+        if let Some(strip) = &strip_components {
+            strip
+                .parse::<usize>()
+                .map_err(|_| eyre::eyre!("Invalid strip_components value: {strip}"))?;
+        }
+
+        let configured_size = if replaying {
+            None
+        } else {
+            opts.size_for_target(target)
+                .map(|size| {
+                    size.parse::<u64>()
+                        .map_err(|_| eyre::eyre!("Invalid size value: {size}"))
+                })
+                .transpose()?
+        };
+        let configured_checksum = if replaying {
+            None
+        } else {
+            opts.checksum_for_target(target)
+        };
+
+        for checksum in [
+            locked.and_then(|info| info.checksum.as_deref()),
+            configured_checksum.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if !checksum.contains(':') {
+                bail!("Invalid checksum format: {checksum}");
+            }
+        }
+
+        Ok(PreparedHttpInstall {
+            raw_options: raw_opts,
+            target: target.to_key(),
+            url,
+            lock_checksum: locked.and_then(|info| info.checksum.clone()),
+            lock_size: locked.and_then(|info| info.size),
+            configured_checksum,
+            configured_size,
+            format: opts.format_for_target(target),
+            strip_components,
+            bin: opts.bin_for_target(target),
+            rename_exe: opts.rename_exe_for_target(target),
+            bin_path: opts.bin_path_for_target(target),
+        })
+    }
+
+    fn prepare_http_install(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+    ) -> Result<PreparedInstall> {
+        let target = PlatformTarget::from_current();
+        let locked = tv.lock_platforms.get(&target.to_key());
+        if ctx.locked && locked.and_then(|info| info.url.as_ref()).is_none() {
+            bail!(
+                "No lockfile URL found for {} on platform {} (--locked mode)\n\
+                 hint: Run `mise lock` to generate lockfile URLs, or disable locked mode",
+                tv.style(),
+                target.to_key()
+            );
+        }
+        Ok(PreparedInstall::http(
+            self.prepare_http_target(tv, &target, locked)?,
+        ))
+    }
 
     /// Resolve the artifact URL for a target platform during `mise lock`.
     /// Renders `os()`/`arch()` for the target rather than the host.
@@ -858,6 +992,76 @@ impl HttpBackend {
             &get_filename_from_url(&checksum_url),
         );
         fetch_checksum_from_file(&checksum_url, &file_algo).await
+    }
+
+    async fn install_prepared_http(
+        &self,
+        ctx: &InstallContext,
+        mut tv: ToolVersion,
+        spec: &PreparedHttpInstall,
+    ) -> Result<ToolVersion> {
+        let url = spec.url.clone();
+        let filename = get_filename_from_url(&url);
+        let file_path = tv.download_path().join(&filename);
+
+        // Carry only the prepared contract into the successful result. The
+        // writer sees this state only when every operation below succeeds.
+        let platform_info = tv.lock_platforms.entry(spec.target.clone()).or_default();
+        platform_info.url = Some(url.clone());
+        if let Some(checksum) = &spec.lock_checksum {
+            platform_info.checksum = Some(checksum.clone());
+        }
+        if let Some(size) = spec.lock_size {
+            platform_info.size = Some(size);
+        }
+
+        let lockfile_enabled = Settings::get().lockfile_enabled();
+        let has_lockfile_checksum = spec.lock_checksum.is_some();
+
+        ctx.pr.set_message(format!("download {filename}"));
+        HTTP.download_file(&url, &file_path, Some(ctx.pr.as_ref()))
+            .await?;
+
+        if spec.configured_checksum.is_some() {
+            ctx.pr.next_operation();
+        }
+        self.verify_prepared_artifact(ctx, &file_path, spec)?;
+
+        // Validate the locked artifact contract before populating the shared
+        // extraction cache or exposing any install symlink. Enrichment remains
+        // in-memory until the successful result is returned to the writer.
+        if lockfile_enabled || has_lockfile_checksum {
+            ctx.pr.next_operation();
+        }
+        self.verify_lock_contract(ctx, &mut tv, &file_path, spec)?;
+
+        let cache_plan = self.cache_plan(&file_path, spec)?;
+        let cache_path = self.cache_path(&cache_plan.key);
+        let _lock = crate::lock_file::get(&cache_path, ctx.force)?;
+
+        ctx.pr.next_operation();
+        let extraction_type = if self.is_cached(&cache_plan.key) {
+            ctx.pr.set_message("using cached tarball".into());
+            ctx.pr.set_length(1);
+            ctx.pr.set_position(1);
+            self.extraction_type_from_cache(&cache_plan.key, &cache_plan.file_info)
+        } else {
+            ctx.pr.set_message("extracting to cache".into());
+            self.extract_to_cache(
+                &tv,
+                &file_path,
+                &cache_plan,
+                &url,
+                spec,
+                Some(ctx.pr.as_ref()),
+            )?
+        };
+
+        self.create_install_symlink(&tv, &cache_plan.key, &extraction_type, spec)?;
+        self.create_version_alias_symlink(&tv, &cache_plan.key)?;
+        tv.install_path = Some(Self::install_path_for(&tv, &cache_plan.key));
+
+        Ok(tv)
     }
 }
 
@@ -940,17 +1144,14 @@ impl Backend for HttpBackend {
     ) -> Result<PlatformInfo> {
         let raw_opts = tv.request.options();
         let opts = HttpOptions::new(&raw_opts);
-
-        // Fail closed when the platform can't be resolved so the lock
-        // orchestration reports it as skipped, rather than returning an empty
-        // entry that is miscounted as a successful platform (see #7113).
-        let Some(url) = self.lock_url_for_target(&opts, tv, target) else {
-            return Err(eyre::eyre!(
-                "no URL configured for {} on {}; skipping",
+        let prepared = self.prepare_http_target(tv, target, None).map_err(|err| {
+            eyre::eyre!(
+                "no URL configured for {} on {}; skipping: {err}",
                 self.ba.full(),
                 target.to_key()
-            ));
-        };
+            )
+        })?;
+        let url = prepared.url;
 
         let checksum = self.resolve_lock_checksum(&opts, tv, target, &url).await;
 
@@ -984,102 +1185,28 @@ impl Backend for HttpBackend {
             .collect())
     }
 
-    async fn install_version_(
+    fn prepare_install(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<PreparedInstall> {
+        self.prepare_http_install(ctx, tv)
+    }
+
+    async fn install_prepared_version_(
         &self,
         ctx: &InstallContext,
-        mut tv: ToolVersion,
-    ) -> Result<ToolVersion> {
-        let raw_opts = tv.request.options();
-        let opts = HttpOptions::new(&raw_opts);
-
-        // Get URL template
-        let url_template = opts.url().ok_or_else(|| {
-            let platform_key = self.get_platform_key();
-            let available = opts.url_platforms();
-            if !available.is_empty() {
-                eyre::eyre!(
-                    "No URL for platform {platform_key}. Available: {}. \
-                     Provide 'url' or add 'platforms.{platform_key}.url'",
-                    available.join(", ")
-                )
-            } else {
-                eyre::eyre!("Http backend requires 'url' option")
-            }
-        })?;
-
-        let url = template_string(&url_template, &tv);
-
-        // Download
-        let filename = get_filename_from_url(&url);
-        let file_path = tv.download_path().join(&filename);
-
-        // Record URL in lock platforms
-        let platform_key = self.get_platform_key();
-        tv.lock_platforms
-            .entry(platform_key.clone())
-            .or_default()
-            .url = Some(url.clone());
-
-        // For lockfile checksum verification
-        let settings = Settings::get();
-        let lockfile_enabled = settings.lockfile_enabled();
-        let has_lockfile_checksum = tv
-            .lock_platforms
-            .get(&platform_key)
-            .and_then(|p| p.checksum.as_ref())
-            .is_some();
-
-        ctx.pr.set_message(format!("download {filename}"));
-        HTTP.download_file(&url, &file_path, Some(ctx.pr.as_ref()))
+        tv: ToolVersion,
+        prepared: PreparedInstall,
+    ) -> Result<SuccessfulInstall> {
+        let tv = self
+            .install_prepared_http(ctx, tv, prepared.http_spec()?)
             .await?;
+        Ok(SuccessfulInstall::new(tv, prepared))
+    }
 
-        // Verify artifact (checksum if provided)
-        if opts.checksum().is_some() {
-            ctx.pr.next_operation();
-        }
-        verify_artifact(&tv, &file_path, opts.raw(), Some(ctx.pr.as_ref()))?;
-
-        // Generate cache key
-        let cache_plan = self.cache_plan(&file_path, &opts)?;
-
-        // Acquire lock and extract or reuse cache
-        let cache_path = self.cache_path(&cache_plan.key);
-        let _lock = crate::lock_file::get(&cache_path, ctx.force)?;
-
-        // Determine extraction type based on whether we're using cache or extracting fresh
-        // On cache hit, we need to detect the actual filename from the cache (which may differ
-        // from current options if a previous extraction used different `bin` name)
-        ctx.pr.next_operation();
-        let extraction_type = if self.is_cached(&cache_plan.key) {
-            ctx.pr.set_message("using cached tarball".into());
-            // Report extraction operation as complete (instant since we're using cache)
-            ctx.pr.set_length(1);
-            ctx.pr.set_position(1);
-            self.extraction_type_from_cache(&cache_plan.key, &cache_plan.file_info)
-        } else {
-            ctx.pr.set_message("extracting to cache".into());
-            self.extract_to_cache(
-                &tv,
-                &file_path,
-                &cache_plan,
-                &url,
-                &opts,
-                Some(ctx.pr.as_ref()),
-            )?
-        };
-
-        // Create symlinks
-        self.create_install_symlink(&tv, &cache_plan.key, &extraction_type, &opts)?;
-        self.create_version_alias_symlink(&tv, &cache_plan.key)?;
-        tv.install_path = Some(Self::install_path_for(&tv, &cache_plan.key));
-
-        // Verify checksum for lockfile
-        if lockfile_enabled || has_lockfile_checksum {
-            ctx.pr.next_operation();
-        }
-        self.verify_checksum(ctx, &mut tv, &file_path)?;
-
-        Ok(tv)
+    async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
+        let prepared = self.prepare_http_install(ctx, &tv)?;
+        Ok(self
+            .install_prepared_version_(ctx, tv, prepared)
+            .await?
+            .into_tool_version())
     }
 
     fn is_version_installed(
@@ -1170,7 +1297,7 @@ mod tests {
     use crate::cli::args::BackendResolution;
     use crate::toolset::{ToolRequest, ToolSource};
 
-    fn http_test_tv(version: &str) -> ToolVersion {
+    fn http_test_tv_with_options(version: &str, options: ToolVersionOptions) -> ToolVersion {
         let backend = Arc::new(BackendArg::new_raw(
             "http-absolute-version".to_string(),
             Some("http:absolute-version".to_string()),
@@ -1181,10 +1308,24 @@ mod tests {
         let request = ToolRequest::Version {
             backend,
             version: version.to_string(),
-            options: ToolVersionOptions::default(),
+            options,
             source: ToolSource::Argument,
         };
         ToolVersion::new(request, version.to_string())
+    }
+
+    fn http_test_tv(version: &str) -> ToolVersion {
+        http_test_tv_with_options(version, ToolVersionOptions::default())
+    }
+
+    fn http_test_backend() -> HttpBackend {
+        HttpBackend::from_arg(BackendArg::new_raw(
+            "http-absolute-version".to_string(),
+            Some("http:absolute-version".to_string()),
+            "absolute-version".to_string(),
+            None,
+            BackendResolution::new(true),
+        ))
     }
 
     fn version_hash(version: &str) -> String {
@@ -1206,6 +1347,35 @@ mod tests {
             template_string_for_target(template, &tv, &win),
             "sentinel_0.40.0_windows_amd64.zip"
         );
+    }
+
+    #[test]
+    fn prepared_http_install_prefers_locked_artifact_contract() {
+        let options = crate::toolset::parse_tool_options(
+            "url=https://example.com/current,checksum=sha256:current,size=7,format=tar.gz,strip_components=1,bin=mytool,bin_path=tools/bin",
+        );
+        let tv = http_test_tv_with_options("1.0.0", options);
+        let target = PlatformTarget::from_current();
+        let locked = PlatformInfo {
+            url: Some("https://example.com/locked".to_string()),
+            checksum: Some("sha256:locked".to_string()),
+            size: Some(42),
+            ..Default::default()
+        };
+
+        let prepared = http_test_backend()
+            .prepare_http_target(&tv, &target, Some(&locked))
+            .unwrap();
+
+        assert_eq!(prepared.url, "https://example.com/locked");
+        assert_eq!(prepared.lock_checksum.as_deref(), Some("sha256:locked"));
+        assert_eq!(prepared.lock_size, Some(42));
+        assert_eq!(prepared.configured_checksum, None);
+        assert_eq!(prepared.configured_size, None);
+        assert_eq!(prepared.format.as_deref(), Some("tar.gz"));
+        assert_eq!(prepared.strip_components.as_deref(), Some("1"));
+        assert_eq!(prepared.bin.as_deref(), Some("mytool"));
+        assert_eq!(prepared.bin_path.as_deref(), Some("tools/bin"));
     }
 
     #[test]
@@ -1329,8 +1499,20 @@ mod tests {
                 BackendResolution::new(true),
             )),
         };
-        let raw_opts = crate::toolset::parse_tool_options("rename_exe=code2prompt");
-        let opts = HttpOptions::new(&raw_opts);
+        let opts = PreparedHttpInstall {
+            raw_options: ToolVersionOptions::default(),
+            target: PlatformTarget::from_current().to_key(),
+            url: "https://example.com/code2prompt.gz".to_string(),
+            lock_checksum: None,
+            lock_size: None,
+            configured_checksum: None,
+            configured_size: None,
+            format: None,
+            strip_components: None,
+            bin: None,
+            rename_exe: Some("code2prompt".to_string()),
+            bin_path: None,
+        };
         let file_path = Path::new("code2prompt-x86_64-pc-windows-msvc.exe.gz");
         let file_info = FileInfo::new(file_path, &opts);
 

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -745,7 +745,8 @@ impl HttpBackend {
         if let Some(expected_size) = spec.configured_size {
             let actual_size = file_path.metadata()?.len();
             if actual_size != expected_size {
-                bail!("Size mismatch: expected {expected_size}, got {actual_size}");
+                let filename = file_path.file_name().unwrap().to_string_lossy();
+                bail!("Size mismatch for {filename}: expected {expected_size}, got {actual_size}");
             }
         }
         Ok(())
@@ -1004,17 +1005,6 @@ impl HttpBackend {
         let filename = get_filename_from_url(&url);
         let file_path = tv.download_path().join(&filename);
 
-        // Carry only the prepared contract into the successful result. The
-        // writer sees this state only when every operation below succeeds.
-        let platform_info = tv.lock_platforms.entry(spec.target.clone()).or_default();
-        platform_info.url = Some(url.clone());
-        if let Some(checksum) = &spec.lock_checksum {
-            platform_info.checksum = Some(checksum.clone());
-        }
-        if let Some(size) = spec.lock_size {
-            platform_info.size = Some(size);
-        }
-
         let lockfile_enabled = Settings::get().lockfile_enabled();
         let has_lockfile_checksum = spec.lock_checksum.is_some();
 
@@ -1107,7 +1097,14 @@ impl Backend for HttpBackend {
     async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
         let raw_opts = tv.request.options();
         let opts = HttpOptions::new(&raw_opts);
-        super::http_install_operation_count(opts.checksum().is_some(), &self.get_platform_key(), tv)
+        let platform_key = self.get_platform_key();
+        let replaying = tv
+            .lock_platforms
+            .get(&platform_key)
+            .and_then(|info| info.url.as_ref())
+            .is_some();
+        let has_configured_checksum = !replaying && opts.checksum().is_some();
+        super::http_install_operation_count(has_configured_checksum, &platform_key, tv)
     }
 
     /// Options that affect which artifact is downloaded, resolved for the target

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -55,6 +55,8 @@ use regex::Regex;
 use std::sync::LazyLock as Lazy;
 use versions::Versioning;
 
+pub use prepared_install::{PreparedInstall, SuccessfulInstall};
+
 pub mod aqua;
 pub mod asdf;
 pub mod asset_matcher;
@@ -76,6 +78,7 @@ pub mod pipx;
 pub mod pkgx;
 pub mod platform_target;
 mod platform_tokens;
+mod prepared_install;
 pub mod s3;
 pub mod spm;
 pub mod static_helpers;
@@ -2316,6 +2319,30 @@ pub trait Backend: Debug + Send + Sync {
         None
     }
 
+    /// Resolve the inputs installation is allowed to consume before any
+    /// backend-specific install side effects begin.
+    ///
+    /// Backends use the explicit legacy path until they migrate preparation
+    /// and execution together.
+    fn prepare_install(&self, _ctx: &InstallContext, _tv: &ToolVersion) -> Result<PreparedInstall> {
+        Ok(PreparedInstall::legacy())
+    }
+
+    /// Execute one prepared installation and return a result tied to those
+    /// inputs. The default keeps every unmigrated backend on its old path.
+    async fn install_prepared_version_(
+        &self,
+        ctx: &InstallContext,
+        tv: ToolVersion,
+        prepared: PreparedInstall,
+    ) -> Result<SuccessfulInstall> {
+        if !prepared.is_legacy() {
+            bail!("{} does not support this prepared install", self.id());
+        }
+        let tv = self.install_version_(ctx, tv).await?;
+        Ok(SuccessfulInstall::new(tv, prepared))
+    }
+
     async fn install_version(
         &self,
         ctx: InstallContext,
@@ -2348,6 +2375,14 @@ pub trait Backend: Debug + Send + Sync {
                 );
             }
         }
+
+        // Locked dry-runs validate the prepared backend inputs too. Normal
+        // dry-runs retain their existing no-install behavior.
+        let prepared = if ctx.locked {
+            Some(self.prepare_install(&ctx, &tv)?)
+        } else {
+            None
+        };
 
         // A rolling release (e.g. a `nightly` tag) keeps the same version string,
         // so its install dir already existing does NOT mean it's up-to-date.
@@ -2398,6 +2433,14 @@ pub trait Backend: Debug + Send + Sync {
         let will_uninstall =
             (ctx.force || rolling_reinstall) && self.is_version_installed(&ctx.config, &tv, true);
 
+        // Forced and rolling reinstalls must prepare before removing the old
+        // installation. New installs can defer preparation until after the
+        // already-installed fast path below.
+        let mut prepared = prepared;
+        if will_uninstall && prepared.is_none() {
+            prepared = Some(self.prepare_install(&ctx, &tv)?);
+        }
+
         // Query backend for operation count and set up progress tracking
         let install_ops = self.install_operation_count(&tv, &ctx).await;
         let total_ops = if will_uninstall {
@@ -2419,6 +2462,12 @@ pub trait Backend: Debug + Send + Sync {
             return Ok(tv);
         }
 
+        // Resolve every remaining backend input before creating install dirs.
+        let prepared = match prepared {
+            Some(prepared) => prepared,
+            None => self.prepare_install(&ctx, &tv)?,
+        };
+
         // Track the installation asynchronously (fire-and-forget)
         // Do this before install so the request has time to complete during installation
         versions_host::track_install(tv.short(), &tv.ba().full(), &tv.version);
@@ -2427,14 +2476,15 @@ pub trait Backend: Debug + Send + Sync {
         self.create_install_dirs(&tv)?;
 
         let old_tv = tv.clone();
-        let tv = match self.install_version_(&ctx, tv).await {
-            Ok(tv) => tv,
+        let successful = match self.install_prepared_version_(&ctx, tv, prepared).await {
+            Ok(successful) => successful,
             Err(e) => {
                 self.cleanup_install_dirs_on_error(&old_tv);
                 // Pass through the error - it will be wrapped at a higher level
                 return Err(e);
             }
         };
+        let tv = successful.into_tool_version();
 
         let install_path = tv.install_path();
         let mut update_install_state = false;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2324,7 +2324,11 @@ pub trait Backend: Debug + Send + Sync {
     ///
     /// Backends use the explicit legacy path until they migrate preparation
     /// and execution together.
-    fn prepare_install(&self, _ctx: &InstallContext, _tv: &ToolVersion) -> Result<PreparedInstall> {
+    async fn prepare_install(
+        &self,
+        _ctx: &InstallContext,
+        _tv: &ToolVersion,
+    ) -> Result<PreparedInstall> {
         Ok(PreparedInstall::legacy())
     }
 
@@ -2360,14 +2364,6 @@ pub trait Backend: Debug + Send + Sync {
                 );
             }
         }
-
-        // Locked dry-runs validate the prepared backend inputs too. Normal
-        // dry-runs retain their existing no-install behavior.
-        let prepared = if ctx.locked {
-            Some(self.prepare_install(&ctx, &tv)?)
-        } else {
-            None
-        };
 
         // A rolling release (e.g. a `nightly` tag) keeps the same version string,
         // so its install dir already existing does NOT mean it's up-to-date.
@@ -2418,14 +2414,6 @@ pub trait Backend: Debug + Send + Sync {
         let will_uninstall =
             (ctx.force || rolling_reinstall) && self.is_version_installed(&ctx.config, &tv, true);
 
-        // Forced and rolling reinstalls must prepare before removing the old
-        // installation. New installs can defer preparation until after the
-        // already-installed fast path below.
-        let mut prepared = prepared;
-        if will_uninstall && prepared.is_none() {
-            prepared = Some(self.prepare_install(&ctx, &tv)?);
-        }
-
         // Query backend for operation count and set up progress tracking
         let install_ops = self.install_operation_count(&tv, &ctx).await;
         let total_ops = if will_uninstall {
@@ -2435,23 +2423,25 @@ pub trait Backend: Debug + Send + Sync {
         };
         ctx.pr.start_operations(total_ops);
 
-        if will_uninstall {
-            self.uninstall_version_unlocked(&ctx.config, &tv, ctx.pr.as_ref(), false)
-                .await?;
-            ctx.pr.next_operation();
-        } else if self
-            .is_install_satisfied_or_false(&ctx.config, &tv, true)
-            .await
+        if !will_uninstall
+            && self
+                .is_install_satisfied_or_false(&ctx.config, &tv, true)
+                .await
             && !rolling_reinstall
         {
             return Ok(tv);
         }
 
-        // Resolve every remaining backend input before creating install dirs.
-        let prepared = match prepared {
-            Some(prepared) => prepared,
-            None => self.prepare_install(&ctx, &tv)?,
-        };
+        // Stage every fallible backend input exactly once while a replacement
+        // install is still available. Migrated backends can download and verify
+        // artifacts here; legacy backends retain their existing behavior.
+        let prepared = self.prepare_install(&ctx, &tv).await?;
+
+        if will_uninstall {
+            self.uninstall_version_unlocked(&ctx.config, &tv, ctx.pr.as_ref(), false)
+                .await?;
+            ctx.pr.next_operation();
+        }
 
         // Track the installation asynchronously (fire-and-forget)
         // Do this before install so the request has time to complete during installation
@@ -2461,16 +2451,14 @@ pub trait Backend: Debug + Send + Sync {
         self.create_install_dirs(&tv)?;
 
         let old_tv = tv.clone();
-        let successful = match prepared.execute(self, &ctx, tv).await {
-            Ok(successful) => successful,
+        let tv = match prepared.execute(self, &ctx, tv).await {
+            Ok(tv) => tv,
             Err(e) => {
                 self.cleanup_install_dirs_on_error(&old_tv);
                 // Pass through the error - it will be wrapped at a higher level
                 return Err(e);
             }
         };
-        let tv = successful.into_tool_version();
-
         let install_path = tv.install_path();
         let mut update_install_state = false;
         if install_path.starts_with(*dirs::INSTALLS) {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -55,7 +55,7 @@ use regex::Regex;
 use std::sync::LazyLock as Lazy;
 use versions::Versioning;
 
-pub use prepared_install::{PreparedInstall, SuccessfulInstall};
+pub use prepared_install::PreparedInstall;
 
 pub mod aqua;
 pub mod asdf;
@@ -2328,21 +2328,6 @@ pub trait Backend: Debug + Send + Sync {
         Ok(PreparedInstall::legacy())
     }
 
-    /// Execute one prepared installation and return a result tied to those
-    /// inputs. The default keeps every unmigrated backend on its old path.
-    async fn install_prepared_version_(
-        &self,
-        ctx: &InstallContext,
-        tv: ToolVersion,
-        prepared: PreparedInstall,
-    ) -> Result<SuccessfulInstall> {
-        if !prepared.is_legacy() {
-            bail!("{} does not support this prepared install", self.id());
-        }
-        let tv = self.install_version_(ctx, tv).await?;
-        Ok(SuccessfulInstall::new(tv, prepared))
-    }
-
     async fn install_version(
         &self,
         ctx: InstallContext,
@@ -2476,7 +2461,7 @@ pub trait Backend: Debug + Send + Sync {
         self.create_install_dirs(&tv)?;
 
         let old_tv = tv.clone();
-        let successful = match self.install_prepared_version_(&ctx, tv, prepared).await {
+        let successful = match prepared.execute(self, &ctx, tv).await {
             Ok(successful) => successful,
             Err(e) => {
                 self.cleanup_install_dirs_on_error(&old_tv);

--- a/src/backend/prepared_install.rs
+++ b/src/backend/prepared_install.rs
@@ -4,12 +4,11 @@ use crate::toolset::ToolVersion;
 use async_trait::async_trait;
 use eyre::Result;
 use std::fmt::Debug;
-use std::sync::Arc;
 
-/// A backend's fixed installation inputs, resolved before installation begins.
+/// An install that has completed every backend-specific preparation step.
 ///
-/// Backends remain on `Legacy` until they migrate their full prepare/execute
-/// path. This keeps the transition explicit without changing their behavior.
+/// Backends remain on `Legacy` until they can stage all fallible work that must
+/// happen before replacing an existing installation.
 #[derive(Debug)]
 pub struct PreparedInstall {
     state: PreparedInstallState,
@@ -21,39 +20,11 @@ enum PreparedInstallState {
     Prepared(Box<dyn PreparedInstallPlan>),
 }
 
-/// A fixed backend-specific installation plan and its matching executor.
-///
-/// Owning execution here keeps backend-specific prepared inputs out of the
-/// object-safe [`Backend`] trait without requiring a central variant for each
-/// backend.
+/// An owned backend-specific plan ready to commit installation side effects.
 #[async_trait]
 pub(crate) trait PreparedInstallPlan: Debug + Send + 'static {
-    fn evidence(&self) -> Arc<dyn PreparedInstallEvidencePayload>;
-
     async fn execute(self: Box<Self>, ctx: &InstallContext, tv: ToolVersion)
     -> Result<ToolVersion>;
-}
-
-/// Immutable backend-specific proof of the inputs a prepared plan will use.
-pub(crate) trait PreparedInstallEvidencePayload: Debug + Send + Sync + 'static {}
-
-impl<T> PreparedInstallEvidencePayload for T where T: Debug + Send + Sync + 'static {}
-
-#[derive(Debug)]
-enum PreparedInstallEvidence {
-    Legacy,
-    Prepared(Arc<dyn PreparedInstallEvidencePayload>),
-}
-
-impl PreparedInstallEvidence {
-    fn kind_name(&self) -> &'static str {
-        match self {
-            Self::Legacy => "legacy",
-            Self::Prepared(evidence) => {
-                debug_assert!(Arc::strong_count(evidence) > 0);
-                "prepared"
-            }
-        }
 }
 
 impl PreparedInstall {
@@ -74,150 +45,10 @@ impl PreparedInstall {
         backend: &(impl Backend + ?Sized),
         ctx: &InstallContext,
         tv: ToolVersion,
-    ) -> Result<SuccessfulInstall> {
-        let (tool_version, evidence) = match self.state {
-            PreparedInstallState::Legacy => (
-                backend.install_version_(ctx, tv).await?,
-                PreparedInstallEvidence::Legacy,
-            ),
-            PreparedInstallState::Prepared(plan) => {
-                let evidence = PreparedInstallEvidence::Prepared(plan.evidence());
-                (plan.execute(ctx, tv).await?, evidence)
-            }
-        };
-        Ok(SuccessfulInstall::new(tool_version, evidence))
-    }
-}
-
-/// A completed installation tied to the exact prepared inputs it consumed.
-#[derive(Debug)]
-pub struct SuccessfulInstall {
-    tool_version: ToolVersion,
-    evidence: PreparedInstallEvidence,
-}
-
-impl SuccessfulInstall {
-    fn new(tool_version: ToolVersion, evidence: PreparedInstallEvidence) -> Self {
-        Self {
-            tool_version,
-            evidence,
+    ) -> Result<ToolVersion> {
+        match self.state {
+            PreparedInstallState::Legacy => backend.install_version_(ctx, tv).await,
+            PreparedInstallState::Prepared(plan) => plan.execute(ctx, tv).await,
         }
-    }
-
-    pub(crate) fn into_tool_version(self) -> ToolVersion {
-        trace!(
-            "completed {} install for {}",
-            self.evidence.kind_name(),
-            self.tool_version
-        );
-        self.tool_version
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::backend::VersionInfo;
-    use crate::cli::args::BackendArg;
-    use crate::config::Config;
-    use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, Toolset};
-    use crate::ui::progress_report::QuietReport;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    #[derive(Debug)]
-    struct CountingBackend {
-        ba: Arc<BackendArg>,
-        install_calls: Arc<AtomicUsize>,
-    }
-
-    #[async_trait]
-    impl Backend for CountingBackend {
-        fn ba(&self) -> &Arc<BackendArg> {
-            &self.ba
-        }
-
-        async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-            Ok(vec![])
-        }
-
-        async fn install_version_(
-            &self,
-            _ctx: &InstallContext,
-            tv: ToolVersion,
-        ) -> Result<ToolVersion> {
-            self.install_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(tv)
-        }
-    }
-
-    #[derive(Debug)]
-    struct CountingPlan {
-        execute_calls: Arc<AtomicUsize>,
-    }
-
-    #[async_trait]
-    impl PreparedInstallPlan for CountingPlan {
-        fn evidence(&self) -> Arc<dyn PreparedInstallEvidencePayload> {
-            self.execute_calls.clone()
-        }
-
-        async fn execute(
-            self: Box<Self>,
-            _ctx: &InstallContext,
-            tv: ToolVersion,
-        ) -> Result<ToolVersion> {
-            self.execute_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(tv)
-        }
-    }
-
-    fn tool_version(ba: Arc<BackendArg>) -> ToolVersion {
-        let request = ToolRequest::Version {
-            backend: ba,
-            version: "1.0.0".into(),
-            options: ToolVersionOptions::default(),
-            source: ToolSource::Argument,
-        };
-        ToolVersion::new(request, "1.0.0".into())
-    }
-
-    #[tokio::test]
-    async fn prepared_install_dispatches_legacy_and_owned_plans_separately() {
-        let ba = Arc::new(BackendArg::from("prepared-install-test"));
-        let legacy_calls = Arc::new(AtomicUsize::new(0));
-        let backend = CountingBackend {
-            ba: ba.clone(),
-            install_calls: legacy_calls.clone(),
-        };
-        let ctx = InstallContext {
-            config: Config::get().await.unwrap(),
-            ts: Arc::new(Toolset::default()),
-            pr: Box::new(QuietReport::new()),
-            force: false,
-            dry_run: false,
-            locked: false,
-            before_date: None,
-        };
-
-        let legacy = PreparedInstall::legacy()
-            .execute(&backend, &ctx, tool_version(ba.clone()))
-            .await
-            .unwrap()
-            .into_tool_version();
-        assert_eq!(legacy.version, "1.0.0");
-        assert_eq!(legacy_calls.load(Ordering::SeqCst), 1);
-
-        let execute_calls = Arc::new(AtomicUsize::new(0));
-        let prepared = PreparedInstall::prepared(CountingPlan {
-            execute_calls: execute_calls.clone(),
-        })
-        .execute(&backend, &ctx, tool_version(ba))
-        .await
-        .unwrap()
-        .into_tool_version();
-        assert_eq!(prepared.version, "1.0.0");
-        assert_eq!(execute_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(legacy_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/backend/prepared_install.rs
+++ b/src/backend/prepared_install.rs
@@ -12,7 +12,7 @@ pub struct PreparedInstall {
 #[derive(Debug)]
 enum PreparedInstallKind {
     Legacy,
-    Http(PreparedHttpInstall),
+    Http(Box<PreparedHttpInstall>),
 }
 
 /// The HTTP inputs that installation is allowed to consume.
@@ -44,7 +44,7 @@ impl PreparedInstall {
 
     pub(crate) fn http(spec: PreparedHttpInstall) -> Self {
         Self {
-            kind: PreparedInstallKind::Http(spec),
+            kind: PreparedInstallKind::Http(Box::new(spec)),
         }
     }
 
@@ -54,7 +54,7 @@ impl PreparedInstall {
 
     pub(crate) fn http_spec(&self) -> eyre::Result<&PreparedHttpInstall> {
         match &self.kind {
-            PreparedInstallKind::Http(spec) => Ok(spec),
+            PreparedInstallKind::Http(spec) => Ok(spec.as_ref()),
             PreparedInstallKind::Legacy => Err(eyre::eyre!("expected prepared HTTP installation")),
         }
     }

--- a/src/backend/prepared_install.rs
+++ b/src/backend/prepared_install.rs
@@ -1,0 +1,93 @@
+use crate::toolset::ToolVersion;
+
+/// A backend's fixed installation inputs, resolved before installation begins.
+///
+/// Backends remain on `Legacy` until they migrate their full prepare/execute
+/// path. This keeps the transition explicit without changing their behavior.
+#[derive(Debug)]
+pub struct PreparedInstall {
+    kind: PreparedInstallKind,
+}
+
+#[derive(Debug)]
+enum PreparedInstallKind {
+    Legacy,
+    Http(PreparedHttpInstall),
+}
+
+/// The HTTP inputs that installation is allowed to consume.
+///
+/// Configured verification inputs apply to fresh resolution. Once a lock URL
+/// is replayed, its checksum and size are the sole artifact contract.
+#[derive(Debug)]
+pub(crate) struct PreparedHttpInstall {
+    pub(crate) raw_options: crate::toolset::ToolVersionOptions,
+    pub(crate) target: String,
+    pub(crate) url: String,
+    pub(crate) lock_checksum: Option<String>,
+    pub(crate) lock_size: Option<u64>,
+    pub(crate) configured_checksum: Option<String>,
+    pub(crate) configured_size: Option<u64>,
+    pub(crate) format: Option<String>,
+    pub(crate) strip_components: Option<String>,
+    pub(crate) bin: Option<String>,
+    pub(crate) rename_exe: Option<String>,
+    pub(crate) bin_path: Option<String>,
+}
+
+impl PreparedInstall {
+    pub(crate) fn legacy() -> Self {
+        Self {
+            kind: PreparedInstallKind::Legacy,
+        }
+    }
+
+    pub(crate) fn http(spec: PreparedHttpInstall) -> Self {
+        Self {
+            kind: PreparedInstallKind::Http(spec),
+        }
+    }
+
+    pub(crate) fn is_legacy(&self) -> bool {
+        matches!(&self.kind, PreparedInstallKind::Legacy)
+    }
+
+    pub(crate) fn http_spec(&self) -> eyre::Result<&PreparedHttpInstall> {
+        match &self.kind {
+            PreparedInstallKind::Http(spec) => Ok(spec),
+            PreparedInstallKind::Legacy => Err(eyre::eyre!("expected prepared HTTP installation")),
+        }
+    }
+
+    fn kind_name(&self) -> &'static str {
+        match &self.kind {
+            PreparedInstallKind::Legacy => "legacy",
+            PreparedInstallKind::Http(_) => "http",
+        }
+    }
+}
+
+/// A completed installation tied to the exact prepared inputs it consumed.
+#[derive(Debug)]
+pub struct SuccessfulInstall {
+    tool_version: ToolVersion,
+    prepared: PreparedInstall,
+}
+
+impl SuccessfulInstall {
+    pub(crate) fn new(tool_version: ToolVersion, prepared: PreparedInstall) -> Self {
+        Self {
+            tool_version,
+            prepared,
+        }
+    }
+
+    pub(crate) fn into_tool_version(self) -> ToolVersion {
+        trace!(
+            "completed {} prepared install for {}",
+            self.prepared.kind_name(),
+            self.tool_version
+        );
+        self.tool_version
+    }
+}

--- a/src/backend/prepared_install.rs
+++ b/src/backend/prepared_install.rs
@@ -1,4 +1,10 @@
+use crate::backend::Backend;
+use crate::install_context::InstallContext;
 use crate::toolset::ToolVersion;
+use async_trait::async_trait;
+use eyre::Result;
+use std::fmt::Debug;
+use std::sync::Arc;
 
 /// A backend's fixed installation inputs, resolved before installation begins.
 ///
@@ -6,64 +12,80 @@ use crate::toolset::ToolVersion;
 /// path. This keeps the transition explicit without changing their behavior.
 #[derive(Debug)]
 pub struct PreparedInstall {
-    kind: PreparedInstallKind,
+    state: PreparedInstallState,
 }
 
 #[derive(Debug)]
-enum PreparedInstallKind {
+enum PreparedInstallState {
     Legacy,
-    Http(Box<PreparedHttpInstall>),
+    Prepared(Box<dyn PreparedInstallPlan>),
 }
 
-/// The HTTP inputs that installation is allowed to consume.
+/// A fixed backend-specific installation plan and its matching executor.
 ///
-/// Configured verification inputs apply to fresh resolution. Once a lock URL
-/// is replayed, its checksum and size are the sole artifact contract.
+/// Owning execution here keeps backend-specific prepared inputs out of the
+/// object-safe [`Backend`] trait without requiring a central variant for each
+/// backend.
+#[async_trait]
+pub(crate) trait PreparedInstallPlan: Debug + Send + 'static {
+    fn evidence(&self) -> Arc<dyn PreparedInstallEvidencePayload>;
+
+    async fn execute(self: Box<Self>, ctx: &InstallContext, tv: ToolVersion)
+    -> Result<ToolVersion>;
+}
+
+/// Immutable backend-specific proof of the inputs a prepared plan will use.
+pub(crate) trait PreparedInstallEvidencePayload: Debug + Send + Sync + 'static {}
+
+impl<T> PreparedInstallEvidencePayload for T where T: Debug + Send + Sync + 'static {}
+
 #[derive(Debug)]
-pub(crate) struct PreparedHttpInstall {
-    pub(crate) raw_options: crate::toolset::ToolVersionOptions,
-    pub(crate) target: String,
-    pub(crate) url: String,
-    pub(crate) lock_checksum: Option<String>,
-    pub(crate) lock_size: Option<u64>,
-    pub(crate) configured_checksum: Option<String>,
-    pub(crate) configured_size: Option<u64>,
-    pub(crate) format: Option<String>,
-    pub(crate) strip_components: Option<String>,
-    pub(crate) bin: Option<String>,
-    pub(crate) rename_exe: Option<String>,
-    pub(crate) bin_path: Option<String>,
+enum PreparedInstallEvidence {
+    Legacy,
+    Prepared(Arc<dyn PreparedInstallEvidencePayload>),
+}
+
+impl PreparedInstallEvidence {
+    fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Legacy => "legacy",
+            Self::Prepared(evidence) => {
+                debug_assert!(Arc::strong_count(evidence) > 0);
+                "prepared"
+            }
+        }
 }
 
 impl PreparedInstall {
     pub(crate) fn legacy() -> Self {
         Self {
-            kind: PreparedInstallKind::Legacy,
+            state: PreparedInstallState::Legacy,
         }
     }
 
-    pub(crate) fn http(spec: PreparedHttpInstall) -> Self {
+    pub(crate) fn prepared(plan: impl PreparedInstallPlan + 'static) -> Self {
         Self {
-            kind: PreparedInstallKind::Http(Box::new(spec)),
+            state: PreparedInstallState::Prepared(Box::new(plan)),
         }
     }
 
-    pub(crate) fn is_legacy(&self) -> bool {
-        matches!(&self.kind, PreparedInstallKind::Legacy)
-    }
-
-    pub(crate) fn http_spec(&self) -> eyre::Result<&PreparedHttpInstall> {
-        match &self.kind {
-            PreparedInstallKind::Http(spec) => Ok(spec.as_ref()),
-            PreparedInstallKind::Legacy => Err(eyre::eyre!("expected prepared HTTP installation")),
-        }
-    }
-
-    fn kind_name(&self) -> &'static str {
-        match &self.kind {
-            PreparedInstallKind::Legacy => "legacy",
-            PreparedInstallKind::Http(_) => "http",
-        }
+    pub(crate) async fn execute(
+        self,
+        backend: &(impl Backend + ?Sized),
+        ctx: &InstallContext,
+        tv: ToolVersion,
+    ) -> Result<SuccessfulInstall> {
+        let (tool_version, evidence) = match self.state {
+            PreparedInstallState::Legacy => (
+                backend.install_version_(ctx, tv).await?,
+                PreparedInstallEvidence::Legacy,
+            ),
+            PreparedInstallState::Prepared(plan) => {
+                let evidence = PreparedInstallEvidence::Prepared(plan.evidence());
+                (plan.execute(ctx, tv).await?, evidence)
+            }
+        };
+        Ok(SuccessfulInstall::new(tool_version, evidence))
     }
 }
 
@@ -71,23 +93,131 @@ impl PreparedInstall {
 #[derive(Debug)]
 pub struct SuccessfulInstall {
     tool_version: ToolVersion,
-    prepared: PreparedInstall,
+    evidence: PreparedInstallEvidence,
 }
 
 impl SuccessfulInstall {
-    pub(crate) fn new(tool_version: ToolVersion, prepared: PreparedInstall) -> Self {
+    fn new(tool_version: ToolVersion, evidence: PreparedInstallEvidence) -> Self {
         Self {
             tool_version,
-            prepared,
+            evidence,
         }
     }
 
     pub(crate) fn into_tool_version(self) -> ToolVersion {
         trace!(
-            "completed {} prepared install for {}",
-            self.prepared.kind_name(),
+            "completed {} install for {}",
+            self.evidence.kind_name(),
             self.tool_version
         );
         self.tool_version
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::VersionInfo;
+    use crate::cli::args::BackendArg;
+    use crate::config::Config;
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, Toolset};
+    use crate::ui::progress_report::QuietReport;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    struct CountingBackend {
+        ba: Arc<BackendArg>,
+        install_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Backend for CountingBackend {
+        fn ba(&self) -> &Arc<BackendArg> {
+            &self.ba
+        }
+
+        async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
+            Ok(vec![])
+        }
+
+        async fn install_version_(
+            &self,
+            _ctx: &InstallContext,
+            tv: ToolVersion,
+        ) -> Result<ToolVersion> {
+            self.install_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(tv)
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingPlan {
+        execute_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl PreparedInstallPlan for CountingPlan {
+        fn evidence(&self) -> Arc<dyn PreparedInstallEvidencePayload> {
+            self.execute_calls.clone()
+        }
+
+        async fn execute(
+            self: Box<Self>,
+            _ctx: &InstallContext,
+            tv: ToolVersion,
+        ) -> Result<ToolVersion> {
+            self.execute_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(tv)
+        }
+    }
+
+    fn tool_version(ba: Arc<BackendArg>) -> ToolVersion {
+        let request = ToolRequest::Version {
+            backend: ba,
+            version: "1.0.0".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        ToolVersion::new(request, "1.0.0".into())
+    }
+
+    #[tokio::test]
+    async fn prepared_install_dispatches_legacy_and_owned_plans_separately() {
+        let ba = Arc::new(BackendArg::from("prepared-install-test"));
+        let legacy_calls = Arc::new(AtomicUsize::new(0));
+        let backend = CountingBackend {
+            ba: ba.clone(),
+            install_calls: legacy_calls.clone(),
+        };
+        let ctx = InstallContext {
+            config: Config::get().await.unwrap(),
+            ts: Arc::new(Toolset::default()),
+            pr: Box::new(QuietReport::new()),
+            force: false,
+            dry_run: false,
+            locked: false,
+            before_date: None,
+        };
+
+        let legacy = PreparedInstall::legacy()
+            .execute(&backend, &ctx, tool_version(ba.clone()))
+            .await
+            .unwrap()
+            .into_tool_version();
+        assert_eq!(legacy.version, "1.0.0");
+        assert_eq!(legacy_calls.load(Ordering::SeqCst), 1);
+
+        let execute_calls = Arc::new(AtomicUsize::new(0));
+        let prepared = PreparedInstall::prepared(CountingPlan {
+            execute_calls: execute_calls.clone(),
+        })
+        .execute(&backend, &ctx, tool_version(ba))
+        .await
+        .unwrap()
+        .into_tool_version();
+        assert_eq!(prepared.version, "1.0.0");
+        assert_eq!(execute_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(legacy_calls.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## Summary

- make backend installation preparation asynchronous and keep an explicit legacy path for backends that have not migrated
- make HTTP preparation consume the lock-selected URL and freeze its checksum, size, format, stripping, binary layout, and target-specific rename settings
- download, validate, and fully extract HTTP artifacts into a private same-filesystem staging directory before a forced or rolling reinstall removes the working version
- publish the prepared content-addressed cache with an atomic rename, then expose the install symlinks
- preserve configured checksum/size validation for URL-only locks when the configured and locked URLs are the same, while keeping explicit lock fields authoritative

## Exact bug fixed

`mise install --locked` required a URL in `mise.lock`, but HTTP installation could still render and download the current `mise.toml` URL. When only the lock supplied integrity data, mise could extract the configured artifact into the shared HTTP cache before discovering that it did not match the locked checksum. A URL-only lock could accept the different configured artifact entirely.

Forced and rolling reinstalls also removed a working install before the HTTP backend downloaded or validated its replacement. A checksum, size, or extraction failure therefore left the user without the previously working version.

This change prepares the complete HTTP artifact contract first. The decoded URL filename must be one safe path component; supported checksums are parsed and validated up front; the selected artifact is downloaded and checked; archive extraction, `rename_exe`, and cache metadata creation happen in private staging. Only after that succeeds may generic replacement uninstall the old version. Invalid checksum/size data, encoded filename traversal, and malformed archives do not mutate the shared cache or remove a working install.

## Implementation notes

`PreparedInstall` is intentionally small: it is either the existing legacy executor or a backend-owned prepared plan. HTTP owns the first migrated plan. This avoids a central backend enum and removes the previous evidence/success wrapper that did not enforce anything.

This is not a global install planner or a new lockfile schema. Final install-link and install-state publication still use the existing backend flow; the transaction boundary here covers the fallible HTTP artifact selection, validation, extraction, and cache preparation that must precede replacement.

## Tests

- `mise x -- cargo test backend::http::tests` (18 passed)
- `mise run test:e2e e2e/backend/test_http_lock_install_verify`
- `mise run test:e2e e2e/backend/test_http_locked_install_transaction`
- configured `hk` checks for Rust formatting, all-feature cargo check, shellcheck, and shfmt

The transaction regression verifies that changed configuration cannot override the locked URL and that forced checksum, locked-size, and correctly-checksummed malformed-archive failures leave both cache contents and the existing executable unchanged. Unit coverage also exercises URL-only lock integrity fallback, strict checksum parsing, decoded filename traversal, and table-form `rename_exe` compatibility.

## Project review — 2026-09-05

**Ready to rebuild; not shipped.** [PR #10964](https://github.com/jdx/mise/pull/10964) is closed unmerged (`mergedAt` is null), despite this project item previously being Done. The original description and reported tests above describe the proposed branch, not current upstream behavior. No new test run is claimed here.

Verified at [b8e4ec001](https://github.com/jdx/mise/commit/b8e4ec001041289ffecaafe66b9b9af760d17c8b): [`src/backend/http.rs`](https://github.com/jdx/mise/blob/b8e4ec001041289ffecaafe66b9b9af760d17c8b/src/backend/http.rs) `install_version_` still renders the current `opts.url()`, overwrites the platform URL, downloads/extracts, and only later invokes lock checksum verification. [`src/backend/mod.rs`](https://github.com/jdx/mise/blob/b8e4ec001041289ffecaafe66b9b9af760d17c8b/src/backend/mod.rs) still uninstalls forced/rolling versions before backend download/extraction; there is no production `PreparedInstall` seam. The exact bug and replacement-loss risk therefore remain.

This is the first vertical implementation slice of [Migrate lock installs to prepared transactions one backend at a time](https://github.com/users/risu729/projects/3?pane=issue&itemId=211845943); [Refactor lock resolution/install transaction](https://github.com/users/risu729/projects/3?pane=issue&itemId=196163684) supplies final invariants. Rebuild from current main, preserving current HTTP redirect filename detection, cache extraction behavior, dependency validation, request-option provenance, and v1 specifier handling. Do not cherry-pick the old branch blindly or reopen it without re-auditing its cumulative diff.

### Implementation sequence

1. Add the minimal asynchronous backend-owned preparation boundary consumed by HTTP in the same PR; unmigrated routes retain a visibly transitional internal path. No universal planner or lock schema expansion is required for this slice.
2. Freeze the selected URL, checksum/size, format, extraction stripping, target-specific rename, and executable layout before any replacement removal. Lock fields are authoritative; configured integrity can supplement a URL-only lock only when it describes the same URL.
3. Validate decoded filenames and checksum syntax; download and fully validate/extract into a private same-filesystem staging directory. Reject malformed content without modifying an existing cache/install.
4. Publish the completed cache atomically and then expose install links/state. Specify the remaining publication boundary honestly: the old proposal does not make all final manifest/link writes globally atomic.
5. Return metadata tied to the prepared artifact; no changed URL, fallback method, or speculative lock patch may be synthesized after failure.

### Revalidation required before merge

Recreate the changed-config/locked-URL regression, URL-only locks, forced and rolling replacement, wrong checksum/size, correctly checksummed malformed archives, traversal filenames, target-specific rename, and same-key concurrent cache publication. Failure must retain the working executable and avoid new lock metadata. Check normal install and explicit install-into behavior because HTTP supports both cache links and extraction directly into a target.

Run `mbx test --locked --bin mise backend::http::tests` and the restored transaction/verification E2E fixtures through `mise run test:e2e e2e/backend/test_http_lock_install_verify e2e/backend/test_http_locked_install_transaction` once those branch-only tests are reintroduced. Run scoped configured hk checks. Do not reuse the historical “18 passed” result as evidence for the rebuilt code.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*