### PR TITLE
fix(launchd): tolerate bootout EIO for not-loaded agents on macOS

### DIFF
--- a/src/system/launchd.rs
+++ b/src/system/launchd.rs
@@ -493,6 +493,9 @@ fn bootout_missing_error(error: &str) -> bool {
         || error.contains("could not find service")
         || error.contains("service is not loaded")
         || error.contains("not in domain")
+        // macOS (Darwin 27) returns EIO for `launchctl bootout` of a
+        // service that is not currently loaded, not "No such process".
+        || error.contains("boot-out failed: 5")
 }
 
 #[cfg(test)]
@@ -712,8 +715,11 @@ mod tests {
         assert!(bootout_missing_error(
             "`launchctl bootout gui/501 foo` failed: Could not find specified service"
         ));
-        assert!(!bootout_missing_error(
+        assert!(bootout_missing_error(
             "`launchctl bootout gui/501 foo` failed: Boot-out failed: 5: Input/output error"
+        ));
+        assert!(!bootout_missing_error(
+            "`launchctl bootout gui/501 foo` failed: Boot-out failed: 1: Operation not permitted"
         ));
     }
 }

--- a/src/system/launchd.rs
+++ b/src/system/launchd.rs
@@ -495,7 +495,9 @@ fn bootout_missing_error(error: &str) -> bool {
         || error.contains("not in domain")
         // macOS (Darwin 27) returns EIO for `launchctl bootout` of a
         // service that is not currently loaded, not "No such process".
-        || error.contains("boot-out failed: 5")
+        // The trailing colon scopes this to errno 5 exactly, so codes
+        // like 50/51 are not swallowed.
+        || error.contains("boot-out failed: 5:")
 }
 
 #[cfg(test)]
@@ -720,6 +722,9 @@ mod tests {
         ));
         assert!(!bootout_missing_error(
             "`launchctl bootout gui/501 foo` failed: Boot-out failed: 1: Operation not permitted"
+        ));
+        assert!(!bootout_missing_error(
+            "`launchctl bootout gui/501 foo` failed: Boot-out failed: 50: Network is down"
         ));
     }
 }


### PR DESCRIPTION
Thanks for `mise bootstrap` — the `launchd-agents` support is exactly what I'd been wanting, and I ran into this while migrating my own agents to it.

`mise bootstrap macos launchd-agents apply` fails on a cold machine where the agents aren't loaded yet. mise runs `launchctl bootout` before `launchctl bootstrap` for each agent, but on current macOS (Darwin 27) `launchctl bootout gui/<uid> <plist>` for a not-loaded service returns `Boot-out failed: 5: Input/output error` instead of `No such process`. `bootout_missing_error` in `src/system/launchd.rs` doesn't recognize this, so `apply` aborts after writing only the first plist. In my case it wrote only `~/Library/LaunchAgents/dev.mise.GOPATH.SetEnv.plist` before erroring.

This treats the code-5 (EIO) not-loaded case as ignorable, scoped to `boot-out failed: 5` so unrelated failures such as `Boot-out failed: 1: Operation not permitted` stay fatal. `bootout` is a best-effort unload right before `bootstrap`, so a genuine problem still surfaces on the following `bootstrap`/`enable` call; this just makes a first-time `apply` idempotent on current macOS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `launchctl bootout` failures by treating specific “boot-out failed: 5:” cases as services not loaded/missing.
  * Updated tests to confirm “boot-out failed: 5:” is handled correctly, and that other errno values (e.g., “boot-out failed: 1:” and “boot-out failed: 50:”) are not misclassified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->