### PR TITLE
docs(aqua): document local custom registries

### DIFF
--- a/docs/dev-tools/backends/aqua.md
+++ b/docs/dev-tools/backends/aqua.md
@@ -25,7 +25,7 @@ The code for this is inside the mise repository at [`./src/backend/aqua.rs`](htt
 ## Custom Registry
 
 Set [`aqua.registries`](/configuration/settings.html#aqua-registries) to check custom aqua
-registry repositories before the baked-in registry:
+registry sources before the baked-in registry:
 
 ```toml
 [settings]
@@ -42,10 +42,24 @@ aqua.registries = [
 ]
 ```
 
-mise downloads `registry.yaml` from each repository root, falling back to `registry.yml` if needed.
-Downloaded registry sources are cached under `MISE_CACHE_DIR` for
+Each source can be a repository URL, a direct URL to a `registry.yaml` or `registry.yml` file, or a
+local directory or registry file specified with an absolute `file://` URL:
+
+```toml
+[settings]
+aqua.registries = [
+  "file:///absolute/path/to/aqua-registry",
+  "file:///absolute/path/to/registry.yaml",
+  "https://example.com/registry.yaml",
+]
+```
+
+For repository and directory sources, mise loads `registry.yaml` from the source root, falling back
+to `registry.yml` if needed. Remote registry sources are cached under `MISE_CACHE_DIR` for
 [`aqua.registry_cache_ttl`](/configuration/settings.html#aqua-registry_cache_ttl), which defaults
-to one week. In `MISE_AQUA_REGISTRIES`, separate multiple registry URLs with commas.
+to one week. Local `file://` sources bypass the downloaded source cache, so changes are read the
+next time the registry is loaded. In `MISE_AQUA_REGISTRIES`, separate multiple registry URLs with
+commas.
 
 After a refreshed registry source is downloaded, mise hashes the source and uses that hash in the
 compiled registry cache path. When a new compiled cache is successfully loaded or written, older

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -586,7 +586,7 @@
               "type": "boolean"
             },
             "registries": {
-              "description": "Aqua registry repositories to fetch before the baked-in registry.",
+              "description": "Aqua registry sources to load before the baked-in registry.",
               "type": "array",
               "items": {
                 "type": "string"

--- a/settings.toml
+++ b/settings.toml
@@ -126,14 +126,17 @@ env = "MISE_AQUA_MINISIGN"
 type = "Bool"
 
 [aqua.registries]
-description = "Aqua registry repositories to fetch before the baked-in registry."
+description = "Aqua registry sources to load before the baked-in registry."
 docs = """
-Aqua registry repositories to fetch before the baked-in registry. mise downloads `registry.yaml`
-from each repository root and falls back to `registry.yml` if needed.
+Aqua registry sources to load before the baked-in registry. Each source can be a repository URL, a
+direct URL to a `registry.yaml` or `registry.yml` file, or an absolute `file://` URL to a local
+registry directory or file. For repository and directory sources, mise loads `registry.yaml` from
+the source root and falls back to `registry.yml` if needed.
 
 Downloaded registries are cached according to `aqua.registry_cache_ttl`, which defaults to one
 week. To refresh sooner, run `mise cache clear`, set `aqua.registry_cache_ttl = "0s"`, or change
-`MISE_CACHE_DIR` to use a different cache location.
+`MISE_CACHE_DIR` to use a different cache location. Local `file://` sources bypass the downloaded
+source cache, so changes are read the next time the registry is loaded.
 
 If this is set, mise checks the configured registries in order. When `aqua.baked_registry` is
 enabled, the baked-in aqua registry remains a fallback for packages missing from all configured


### PR DESCRIPTION
## Summary

- document `file://` aqua registry directories and direct YAML files
- document direct remote registry YAML URLs
- clarify that local registry sources bypass the downloaded source cache
- update the generated settings schema description

## Why

The custom registry documentation described only repository URLs even though mise also supports local directory sources, direct local registry files, and direct remote registry files.

## Validation

- `mise run lint-fix`
- `mise run render:schema`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Aqua custom registry configuration and supported source formats, including repository URLs, direct registry file URLs, and local `file://` paths.
  * Documented registry file resolution, remote caching, cache refresh controls, and local-source behavior.
  * Updated configuration references to consistently describe Aqua registry sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->