### PR TITLE
fix(backend): align migrated backend resolution

### DIFF
--- a/e2e/backend/test_registry_backend_migration
+++ b/e2e/backend/test_registry_backend_migration
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+require_cmd npm
+
+# Simulate npm installed through the old registry default. Non-explicit short
+# names should migrate to the current aqua backend as a single unit: backend
+# type and tool name must both come from aqua:npm/cli.
+mkdir -p "$MISE_DATA_DIR/installs/npm/11.0.0"
+cat <<'EOF' >"$MISE_DATA_DIR/installs/npm/.mise.backend.toml"
+short = "npm"
+full = "npm:npm"
+explicit_backend = false
+EOF
+
+mise cache clear
+assert_succeed "mise latest npm"

--- a/e2e/backend/test_registry_backend_migration
+++ b/e2e/backend/test_registry_backend_migration
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-require_cmd npm
-
 # Simulate npm installed through the old registry default. Non-explicit short
 # names should migrate to the current aqua backend as a single unit: backend
 # type and tool name must both come from aqua:npm/cli.
@@ -13,4 +11,5 @@ explicit_backend = false
 EOF
 
 mise cache clear
+assert "mise tool npm --backend" "aqua:npm/cli"
 assert_succeed "mise latest npm"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -336,16 +336,20 @@ impl BackendArg {
             }
         }
 
-        // Only check install state for non-plugin:tool format entries
-        if !self.short.contains(':')
-            && let Ok(Some(backend_type)) = install_state::backend_type(&self.short)
+        // Derive the backend type from the same resolved identifier used by
+        // `tool_name()`. For non-explicit tools, `full()` may intentionally
+        // prefer the current registry backend over stale install metadata.
+        let full = self.full();
+        if let Some((backend, _)) = full.split_once(':')
+            && let Ok(backend_type) = backend.parse()
         {
             return backend_type;
         }
 
-        let full = self.full();
-        if let Some((backend, _)) = full.split_once(':')
-            && let Ok(backend_type) = backend.parse()
+        // Legacy install state may have a backend type without a full
+        // identifier. Keep it as a fallback when `full()` was inconclusive.
+        if !self.short.contains(':')
+            && let Ok(Some(backend_type)) = install_state::backend_type(&self.short)
         {
             return backend_type;
         }

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -327,15 +327,6 @@ impl BackendArg {
             }
         }
 
-        if self.resolution.explicit {
-            let full = self.full();
-            if let Some((backend, _)) = full.split_once(':')
-                && let Ok(backend_type) = backend.parse()
-            {
-                return backend_type;
-            }
-        }
-
         // Derive the backend type from the same resolved identifier used by
         // `tool_name()`. For non-explicit tools, `full()` may intentionally
         // prefer the current registry backend over stale install metadata.


### PR DESCRIPTION
## Summary

- resolve a non-explicit tool's backend type from the same full identifier used for its tool name
- retain stored backend type metadata only as a fallback for legacy entries without a conclusive full identifier
- add an end-to-end regression test for the stale `npm:npm` to `aqua:npm/cli` migration reported in discussion #10967

## Root cause

When a registry shorthand moved between backend families, `BackendArg::backend_type()` preferred the old install metadata while `BackendArg::full()` preferred the current registry entry. This could construct one backend family with another backend's tool identifier. For npm, mise constructed an npm backend whose tool name resolved to `npm/cli`, resulting in `npm view npm/cli versions time --json` and `invalid versions`.

Resolving the backend type from `full()` keeps the backend implementation and tool identifier consistent while preserving the intended automatic migration behavior for non-explicit shorthand installs.

## Validation

- `mise run test:e2e backend/test_registry_backend_migration`
- `cargo test --all-features cli::args::backend_arg`
- `mise run lint-fix`

Reported in https://github.com/jdx/mise/discussions/10967

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tool resolution used by install and version commands; behavior change is intentional for non-explicit shorthand tools but could affect edge cases that relied on stale install-state backend types.
> 
> **Overview**
> Fixes a mismatch where **`BackendArg::backend_type()`** could follow stale install metadata while **`full()`** already pointed at the current registry backend (e.g. shorthand `npm` moving from `npm:npm` to `aqua:npm/cli`). That mixed an npm backend with an aqua tool id and broke version listing.
> 
> **`backend_type()`** now derives the backend from the same resolved **`full()`** string used for the tool name, and only falls back to **`install_state::backend_type`** when **`full()`** does not yield a parseable backend (legacy entries).
> 
> Adds e2e **`backend/test_registry_backend_migration`** that seeds a non-explicit install with old `npm:npm` metadata and asserts **`mise tool npm --backend`** reports **`aqua:npm/cli`** and **`mise latest npm`** succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 651130568f968751c6cc3a1a298c57d6ca34bfbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backend resolution for tool identifiers, including legacy configurations using non-explicit short names.
  - Ensures migrated installations resolve to the intended backend/tool consistently.

- **Tests**
  - Added an end-to-end regression test covering migration from a legacy default registry scenario (non-explicit `npm` install), including cache reset and verification that `mise latest npm` succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->