### PR TITLE
fix(config): add tera contrib helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,6 +2815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "formatx"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c40f9ee993b100102723f778c82d3daf1808c494ce2fd6e9a06d58d6e8e59748"
+
+[[package]]
 name = "fs-err"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5440,6 +5446,7 @@ dependencies = [
  "tempfile",
  "tera 1.20.1",
  "tera 2.0.0",
+ "tera-contrib",
  "terminal_size",
  "test-log",
  "thiserror 2.0.18",
@@ -8854,6 +8861,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tera-contrib"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3792553c620406661d510095e5885bfb77b2296db30369bcc8308329a6fe78c"
+dependencies = [
+ "base64 0.22.1",
+ "formatx",
+ "humansize",
+ "jiff",
+ "percent-encoding",
+ "rand 0.10.2",
+ "regex",
+ "serde_json",
+ "slug",
+ "tera 2.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,17 @@ tar = "0.4"
 tempfile = "3"
 tera = "2"
 tera1 = { package = "tera", version = "1.20.1" }
+tera-contrib = { version = "0.2", features = [
+  "base64",
+  "date",
+  "filesize_format",
+  "format",
+  "json",
+  "rand",
+  "regex",
+  "slug",
+  "urlencode",
+] }
 terminal_size = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -141,9 +141,12 @@ MISE_TERA_V1 = true
 ```
 
 The newer `[settings] tera_v1 = true` form also works in mise releases that
-support it, but is less compatible with older releases. This escape hatch is
-scheduled for removal in mise 2027.4.0. Because miserc files are rendered before
-settings are loaded, it does not apply while loading miserc itself.
+support it, but is less compatible with older releases. When enabled, all regular
+config and task templates use the actual Tera v1 engine and its original syntax
+and built-ins. Without it, templates use Tera v2 and the helpers described below.
+This escape hatch is scheduled for removal in mise 2027.4.0. Because miserc files
+are rendered before settings are loaded, it does not apply while loading miserc
+itself.
 
 ### Tera Filters
 
@@ -241,10 +244,13 @@ Some functions:
   - `end: usize`: stop before `end`, mandatory
   - `start: usize`: where to start from, defaults to `0`
   - `step_by: usize`: with what number do we increment, defaults to `1`
-- `now([timezone])` - Returns the current datetime as a string. The timezone
-  defaults to UTC and accepts IANA names such as `America/New_York`.
+- `now([timezone])` - In the default Tera v2 mode, returns the current datetime
+  as a string. The timezone defaults to UTC and accepts IANA names such as
+  `America/New_York`.
   - Tip: use date filter to format date string.
     e.g. <span v-pre>`{{ now() | date(format="%Y") }}`</span> gets the current year.
+  - With `tera_v1 = true`, the original `now([timestamp], [utc])` signature remains
+    available instead.
 - `throw(message)` - Throws with the message.
 - `get_random(start, end, [seed])` - Returns a random integer in a range.
   Providing `seed` makes the result reproducible.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -241,17 +241,18 @@ Some functions:
   - `end: usize`: stop before `end`, mandatory
   - `start: usize`: where to start from, defaults to `0`
   - `step_by: usize`: with what number do we increment, defaults to `1`
-- `now([timestamp], [utc])` - Returns the local datetime as string or
-  the timestamp as integer.
-  - `timestamp: bool`: whether to return the timestamp instead of the datetime
-  - `utc: bool`: whether to return the UTC datetime instead of
-    the local one
+- `now([timezone])` - Returns the current datetime as a string. The timezone
+  defaults to UTC and accepts IANA names such as `America/New_York`.
   - Tip: use date filter to format date string.
     e.g. <span v-pre>`{{ now() | date(format="%Y") }}`</span> gets the current year.
 - `throw(message)` - Throws with the message.
-- `get_random(end, [start])` - Returns a random integer in a range.
-  - `end: usize`: upper end of the range
-  - `start: usize`: defaults to 0
+- `get_random(start, end, [seed])` - Returns a random integer in a range.
+  Providing `seed` makes the result reproducible.
+
+The `before` and `after` tests compare dates and accept `other` and an optional
+`inclusive` argument:
+
+<span v-pre>`{% if release_date is after(other="2026-01-01") %}...{% endif %}`</span>
 
 Tera offers more functions. Read more on [tera documentation](https://keats.github.io/tera/#functions).
 
@@ -336,7 +337,8 @@ Tera offers many [built-in filters](https://keats.github.io/tera/#built-in-filte
 `[]` indicates an optional filter argument.
 Some Tera v1 filters that were removed or renamed in Tera v2 are still supported
 for compatibility until mise 2027.4.0. mise starts emitting deprecation warnings
-for them in mise 2026.10.0.
+for them in mise 2026.10.0. Helpers provided by `tera-contrib` are supported
+without deprecation warnings.
 Some filters:
 
 - `str | lower -> String` – Converts a string to lowercase.
@@ -359,7 +361,7 @@ Some filters:
 - `str | length -> usize` – Returns the length of a string or array.
 - `str | reverse -> String` – Reverses the order of characters in a string or
   elements in an array.
-- `str | urlencode -> String` – Deprecated compatibility filter. Encodes a
+- `str | urlencode -> String` – Encodes a
   string to be safely used in URLs,
   converting special characters to percent-encoded values.
 - `arr | map(attribute) -> Array` – Deprecated compatibility filter. Extracts
@@ -367,13 +369,25 @@ Some filters:
 - `arr | concat(with) -> Array` – Deprecated compatibility filter. Appends
   values to an array. Prefer array literals and spread syntax.
 - `num | abs -> Number` – Returns the absolute value of a number.
-- `num | filesizeformat -> String` – Deprecated compatibility filter. Converts
+- `num | filesize_format -> String` – Converts
   an integer into
-  a human-readable file size (e.g., 110 MB).
-- `str | date(format) -> String` – Deprecated compatibility filter. Converts a timestamp to
+  a human-readable file size. `filesizeformat` is also available as an alias.
+- `str | date(format, [timezone]) -> String` – Converts a timestamp to
   a formatted date string using the provided format,
   such as <span v-pre>`{{ ts | date(format="%Y-%m-%d") }}`</span>.
-  Find a list of time format on [`chrono` documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html).
+  Find a list of time formats in the
+  [`jiff` documentation](https://docs.rs/jiff/latest/jiff/fmt/strtime/index.html).
+- `str | b64_encode([url_safe], [padded]) -> String` – Encodes a string as base64.
+- `str | b64_decode([url_safe]) -> String` – Decodes a base64 string.
+- `value | format(spec) -> String` – Formats a value with Rust-style formatting.
+- `value | json_encode([pretty]) -> String` – Encodes a value as JSON.
+- `array | shuffle([seed]) -> Array` – Randomly shuffles an array.
+- `str | regex_replace(pattern, rep) -> String` – Replaces regex matches.
+- `str | striptags -> String` – Removes HTML tags.
+- `str | spaceless -> String` – Removes whitespace between HTML tags.
+- `str | slug -> String` – Converts a string to a URL-friendly slug.
+  `slugify` is also available as an alias.
+- `str | urlencode_strict -> String` – Percent-encodes all non-alphanumeric characters.
 - `str | split(pat) -> Array` – Splits a string by the given pattern and
   returns an array of substrings.
 - `str | default(value) -> String` – Returns the default value

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -3,22 +3,26 @@ use crate::env_diff::EnvMap;
 use crate::exit::exit;
 use crate::shell::ShellType;
 use crate::task::Task;
-use crate::tera::{contains_template_syntax, get_tera_v2, render_str_v2};
+use crate::tera::{TeraEngine, contains_template_syntax, get_tera, render_str};
 use eyre::{Context, Result};
 use heck::ToSnakeCase;
 use indexmap::IndexMap;
 use itertools::Itertools;
+use serde::de::DeserializeOwned;
+use serde_json::{Value as JsonValue, json};
 use std::collections::{HashMap, HashSet};
 use std::iter::once;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 type TeraSpecParsingResult = (
-    tera::Tera,
+    TeraEngine,
     Arc<Mutex<HashMap<String, usize>>>,
     Arc<Mutex<Vec<usage::SpecArg>>>,
     Arc<Mutex<Vec<usage::SpecFlag>>>,
 );
+
+type TaskTemplateResult = std::result::Result<JsonValue, String>;
 
 pub struct TaskScriptParser {
     dir: Option<PathBuf>,
@@ -39,8 +43,8 @@ impl TaskScriptParser {
         self
     }
 
-    fn get_tera(&self) -> tera::Tera {
-        get_tera_v2(self.dir.as_deref())
+    fn get_tera(&self) -> TeraEngine {
+        get_tera(self.dir.as_deref())
     }
 
     /// Inject extra vars (from monorepo task config hierarchy) into the tera context
@@ -60,11 +64,11 @@ impl TaskScriptParser {
     }
 
     fn render_script_with_context(
-        tera: &mut tera::Tera,
+        tera: &mut TeraEngine,
         script: &str,
         ctx: &tera::Context,
     ) -> Result<String> {
-        render_str_v2(tera, script.trim(), ctx)
+        render_str(tera, script.trim(), ctx)
             .map_err(Self::task_script_tera_error)
             .with_context(|| format!("Failed to render task script: {}", script))
     }
@@ -79,11 +83,11 @@ impl TaskScriptParser {
     }
 
     fn render_usage_with_context(
-        tera: &mut tera::Tera,
+        tera: &mut TeraEngine,
         usage: &str,
         ctx: &tera::Context,
     ) -> Result<String> {
-        render_str_v2(tera, usage.trim(), ctx)
+        render_str(tera, usage.trim(), ctx)
             .with_context(|| format!("Failed to render task usage: {}", usage))
     }
 
@@ -107,28 +111,56 @@ impl TaskScriptParser {
         );
     }
 
-    fn opt_string_kwarg(
-        args: &tera::Kwargs,
-        param_name: &'static str,
-    ) -> tera::TeraResult<Option<String>> {
-        Ok(args.get::<&str>(param_name)?.map(str::to_string))
+    fn template_arg<T: DeserializeOwned>(
+        args: &HashMap<String, JsonValue>,
+        name: &str,
+    ) -> std::result::Result<Option<T>, String> {
+        args.get(name)
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|e| format!("invalid `{name}` argument: {e}"))
     }
 
-    fn string_kwarg(args: &tera::Kwargs, param_name: &'static str) -> tera::TeraResult<String> {
-        Self::opt_string_kwarg(args, param_name)?.ok_or_else(|| {
-            tera::Error::message(format!("missing required '{param_name}' parameter"))
-        })
+    fn string_arg(
+        args: &HashMap<String, JsonValue>,
+        name: &str,
+    ) -> std::result::Result<String, String> {
+        Self::template_arg(args, name)?
+            .ok_or_else(|| format!("missing required '{name}' parameter"))
     }
 
-    fn lock_error(e: impl std::fmt::Display) -> tera::Error {
-        tera::Error::message(format!("failed to lock: {}", e))
+    fn lock_error(e: impl std::fmt::Display) -> String {
+        format!("failed to lock: {e}")
     }
 
-    fn register_task_source_files_function(tera: &mut tera::Tera, task: &Task) {
-        tera.register_function("task_source_files", {
-            let glob_patterns = Arc::new(
-                crate::task::task_source_checker::source_glob_patterns(&task.sources),
-            );
+    fn register_template_function<F>(tera: &mut TeraEngine, name: &'static str, f: F)
+    where
+        F: Fn(&HashMap<String, JsonValue>) -> TaskTemplateResult + Send + Sync + 'static,
+    {
+        let f = Arc::new(f);
+        match tera {
+            TeraEngine::V2(tera) => {
+                let f = f.clone();
+                tera.register_function(name, move |args: tera::Kwargs, _: &tera::State| {
+                    let args = args.deserialize::<HashMap<String, JsonValue>>()?;
+                    let value = f(&args).map_err(tera::Error::message)?;
+                    tera::Value::try_from_serializable(&value)
+                });
+            }
+            TeraEngine::V1(tera) => {
+                tera.register_function(name, move |args: &HashMap<String, JsonValue>| {
+                    f(args).map_err(tera1::Error::msg)
+                });
+            }
+        }
+    }
+
+    fn register_task_source_files_function(tera: &mut TeraEngine, task: &Task) {
+        Self::register_template_function(tera, "task_source_files", {
+            let glob_patterns = Arc::new(crate::task::task_source_checker::source_glob_patterns(
+                &task.sources,
+            ));
             // Anchor the matcher at the process cwd. `is_source` handles
             // absolute paths outside this root by trusting the glob result,
             // so absolute outside-cwd patterns (e.g. workspace-root paths)
@@ -141,10 +173,12 @@ impl TaskScriptParser {
                 &task.sources,
             ));
 
-            move |_: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
+            move |_| -> TaskTemplateResult {
                 if glob_patterns.is_empty() {
-                    trace!("tera::render::resolve_task_sources `task_source_files` called in task with empty sources array");
-                    return Ok(tera::Value::from(Vec::<tera::Value>::new()));
+                    trace!(
+                        "tera::render::resolve_task_sources `task_source_files` called in task with empty sources array"
+                    );
+                    return Ok(json!([]));
                 };
 
                 let mut resolved = Vec::with_capacity(glob_patterns.len());
@@ -154,7 +188,7 @@ impl TaskScriptParser {
                         trace!(
                             "tera::render::resolve_task_sources including tera template string in resolved task sources: {pattern}"
                         );
-                        resolved.push(tera::Value::from(pattern.clone()));
+                        resolved.push(pattern.clone());
                         continue;
                     }
 
@@ -170,7 +204,7 @@ impl TaskScriptParser {
                             warn!(
                                 "tera::render::resolve_task_sources including '{pattern}' in resolved task sources, ignoring glob parsing error: {error:#?}"
                             );
-                            resolved.push(tera::Value::from(pattern.clone()));
+                            resolved.push(pattern.clone());
                         }
                         Ok(expanded) => {
                             let mut source_found = false;
@@ -193,7 +227,7 @@ impl TaskScriptParser {
                                         trace!(
                                             "tera::render::resolve_task_sources resolved source from pattern '{pattern}': {source}"
                                         );
-                                        resolved.push(tera::Value::from(source.to_string()));
+                                        resolved.push(source.to_string());
                                     }
                                     Err(error) => {
                                         let source = error.path().display();
@@ -214,7 +248,7 @@ impl TaskScriptParser {
                     }
                 }
 
-                Ok(tera::Value::from(resolved))
+                Ok(json!(resolved))
             }
         });
     }
@@ -225,53 +259,47 @@ impl TaskScriptParser {
         let input_args = Arc::new(Mutex::new(vec![]));
         let input_flags = Arc::new(Mutex::new(vec![]));
         // override throw function to do nothing
-        tera.register_function("throw", {
-            move |_: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
-                Ok(tera::Value::none())
-            }
-        });
+        Self::register_template_function(&mut tera, "throw", move |_| Ok(JsonValue::Null));
         // render args, options, and flags as null
         // these functions are only used to collect the spec
-        tera.register_function("arg", {
+        Self::register_template_function(&mut tera, "arg", {
             let input_args = input_args.clone();
             let arg_order = arg_order.clone();
-            move |args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
-                let i = args
-                    .get::<i64>("i")?
+            move |args| {
+                let i = Self::template_arg::<i64>(args, "i")?
                     .unwrap_or(input_args.lock().map_err(Self::lock_error)?.len() as i64)
                     as usize;
 
-                let required = args.get::<bool>("required")?.unwrap_or(true);
-                let var = args.get::<bool>("var")?.unwrap_or(false);
-                let name = Self::opt_string_kwarg(&args, "name")?.unwrap_or(i.to_string());
+                let required = Self::template_arg::<bool>(args, "required")?.unwrap_or(true);
+                let var = Self::template_arg::<bool>(args, "var")?.unwrap_or(false);
+                let name = Self::template_arg::<String>(args, "name")?.unwrap_or(i.to_string());
 
                 let mut arg_order = arg_order.lock().map_err(Self::lock_error)?;
 
                 if arg_order.contains_key(&name) {
                     trace!("already seen {name}");
-                    return Ok(tera::Value::from(""));
+                    return Ok(json!(""));
                 }
                 arg_order.insert(name.clone(), i);
 
-                let usage = Self::opt_string_kwarg(&args, "usage")?.unwrap_or_default();
-                let help = Self::opt_string_kwarg(&args, "help")?;
-                let help_long = Self::opt_string_kwarg(&args, "help_long")?;
-                let help_md = Self::opt_string_kwarg(&args, "help_md")?;
+                let usage = Self::template_arg::<String>(args, "usage")?.unwrap_or_default();
+                let help = Self::template_arg::<String>(args, "help")?;
+                let help_long = Self::template_arg::<String>(args, "help_long")?;
+                let help_md = Self::template_arg::<String>(args, "help_md")?;
 
-                let var_min = args.get::<i64>("var_min")?.map(|v| v as usize);
-                let var_max = args.get::<i64>("var_max")?.map(|v| v as usize);
+                let var_min = Self::template_arg::<i64>(args, "var_min")?.map(|v| v as usize);
+                let var_max = Self::template_arg::<i64>(args, "var_max")?.map(|v| v as usize);
 
-                let hide = args.get::<bool>("hide")?.unwrap_or(false);
+                let hide = Self::template_arg::<bool>(args, "hide")?.unwrap_or(false);
 
-                let default = Self::opt_string_kwarg(&args, "default")?
+                let default = Self::template_arg::<String>(args, "default")?
                     .map(|s| vec![s])
                     .unwrap_or_default();
 
-                let choices = args
-                    .get::<Vec<String>>("choices")?
+                let choices = Self::template_arg::<Vec<String>>(args, "choices")?
                     .map(|choices| usage::SpecChoices { choices });
 
-                let env = Self::opt_string_kwarg(&args, "env")?;
+                let env = Self::template_arg::<String>(args, "env")?;
 
                 let help_first_line = match &help {
                     Some(h) => {
@@ -304,52 +332,51 @@ impl TaskScriptParser {
                 arg.usage = arg.usage();
 
                 input_args.lock().map_err(Self::lock_error)?.push(arg);
-                Ok(tera::Value::from(""))
+                Ok(json!(""))
             }
         });
 
-        tera.register_function("option", {
+        Self::register_template_function(&mut tera, "option", {
             let input_flags = input_flags.clone();
-            move |args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
-                let name = Self::string_kwarg(&args, "name")?;
+            move |args| {
+                let name = Self::string_arg(args, "name")?;
 
-                let short = Self::opt_string_kwarg(&args, "short")?
+                let short = Self::template_arg::<String>(args, "short")?
                     .map(|s| s.chars().collect())
                     .unwrap_or_default();
 
-                let long = match Self::opt_string_kwarg(&args, "long")? {
+                let long = match Self::template_arg::<String>(args, "long")? {
                     Some(l) => l.split_whitespace().map(|s| s.to_string()).collect(),
                     None => vec![name.clone()],
                 };
 
-                let default = Self::opt_string_kwarg(&args, "default")?
+                let default = Self::template_arg::<String>(args, "default")?
                     .map(|s| vec![s])
                     .unwrap_or_default();
 
-                let var = args.get::<bool>("var")?.unwrap_or(false);
+                let var = Self::template_arg::<bool>(args, "var")?.unwrap_or(false);
 
-                let deprecated = Self::opt_string_kwarg(&args, "deprecated")?;
-                let help = Self::opt_string_kwarg(&args, "help")?;
-                let help_long = Self::opt_string_kwarg(&args, "help_long")?;
-                let help_md = Self::opt_string_kwarg(&args, "help_md")?;
+                let deprecated = Self::template_arg::<String>(args, "deprecated")?;
+                let help = Self::template_arg::<String>(args, "help")?;
+                let help_long = Self::template_arg::<String>(args, "help_long")?;
+                let help_md = Self::template_arg::<String>(args, "help_md")?;
 
-                let hide = args.get::<bool>("hide")?.unwrap_or(false);
+                let hide = Self::template_arg::<bool>(args, "hide")?.unwrap_or(false);
 
-                let global = args.get::<bool>("global")?.unwrap_or(false);
+                let global = Self::template_arg::<bool>(args, "global")?.unwrap_or(false);
 
-                let count = args.get::<bool>("count")?.unwrap_or(false);
+                let count = Self::template_arg::<bool>(args, "count")?.unwrap_or(false);
 
-                let usage = Self::opt_string_kwarg(&args, "usage")?.unwrap_or_default();
+                let usage = Self::template_arg::<String>(args, "usage")?.unwrap_or_default();
 
-                let required = args.get::<bool>("required")?.unwrap_or(false);
+                let required = Self::template_arg::<bool>(args, "required")?.unwrap_or(false);
 
-                let negate = Self::opt_string_kwarg(&args, "negate")?;
+                let negate = Self::template_arg::<String>(args, "negate")?;
 
-                let choices = args
-                    .get::<Vec<String>>("choices")?
+                let choices = Self::template_arg::<Vec<String>>(args, "choices")?
                     .map(|choices| usage::SpecChoices { choices });
 
-                let env = Self::opt_string_kwarg(&args, "env")?;
+                let env = Self::template_arg::<String>(args, "env")?;
 
                 let help_first_line = match &help {
                     Some(h) => {
@@ -394,52 +421,51 @@ impl TaskScriptParser {
 
                 input_flags.lock().map_err(Self::lock_error)?.push(flag);
 
-                Ok(tera::Value::from(""))
+                Ok(json!(""))
             }
         });
 
-        tera.register_function("flag", {
+        Self::register_template_function(&mut tera, "flag", {
             let input_flags = input_flags.clone();
-            move |args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
-                let name = Self::string_kwarg(&args, "name")?;
+            move |args| {
+                let name = Self::string_arg(args, "name")?;
 
-                let short = Self::opt_string_kwarg(&args, "short")?
+                let short = Self::template_arg::<String>(args, "short")?
                     .map(|s| s.chars().collect())
                     .unwrap_or_default();
 
-                let long = match Self::opt_string_kwarg(&args, "long")? {
+                let long = match Self::template_arg::<String>(args, "long")? {
                     Some(l) => l.split_whitespace().map(|s| s.to_string()).collect(),
                     None => vec![name.clone()],
                 };
 
-                let default = Self::opt_string_kwarg(&args, "default")?
+                let default = Self::template_arg::<String>(args, "default")?
                     .map(|s| vec![s])
                     .unwrap_or_default();
 
-                let var = args.get::<bool>("var")?.unwrap_or(false);
+                let var = Self::template_arg::<bool>(args, "var")?.unwrap_or(false);
 
-                let deprecated = Self::opt_string_kwarg(&args, "deprecated")?;
-                let help = Self::opt_string_kwarg(&args, "help")?;
-                let help_long = Self::opt_string_kwarg(&args, "help_long")?;
-                let help_md = Self::opt_string_kwarg(&args, "help_md")?;
+                let deprecated = Self::template_arg::<String>(args, "deprecated")?;
+                let help = Self::template_arg::<String>(args, "help")?;
+                let help_long = Self::template_arg::<String>(args, "help_long")?;
+                let help_md = Self::template_arg::<String>(args, "help_md")?;
 
-                let hide = args.get::<bool>("hide")?.unwrap_or(false);
+                let hide = Self::template_arg::<bool>(args, "hide")?.unwrap_or(false);
 
-                let global = args.get::<bool>("global")?.unwrap_or(false);
+                let global = Self::template_arg::<bool>(args, "global")?.unwrap_or(false);
 
-                let count = args.get::<bool>("count")?.unwrap_or(false);
+                let count = Self::template_arg::<bool>(args, "count")?.unwrap_or(false);
 
-                let usage = Self::opt_string_kwarg(&args, "usage")?.unwrap_or_default();
+                let usage = Self::template_arg::<String>(args, "usage")?.unwrap_or_default();
 
-                let required = args.get::<bool>("required")?.unwrap_or(false);
+                let required = Self::template_arg::<bool>(args, "required")?.unwrap_or(false);
 
-                let negate = Self::opt_string_kwarg(&args, "negate")?;
+                let negate = Self::template_arg::<String>(args, "negate")?;
 
-                let choices = args
-                    .get::<Vec<String>>("choices")?
+                let choices = Self::template_arg::<Vec<String>>(args, "choices")?
                     .map(|choices| usage::SpecChoices { choices });
 
-                let env = Self::opt_string_kwarg(&args, "env")?;
+                let env = Self::template_arg::<String>(args, "env")?;
 
                 let help_first_line = match &help {
                     Some(h) => {
@@ -492,7 +518,7 @@ impl TaskScriptParser {
 
                 input_flags.lock().map_err(Self::lock_error)?.push(flag);
 
-                Ok(tera::Value::from(""))
+                Ok(json!(""))
             }
         });
 
@@ -698,26 +724,25 @@ impl TaskScriptParser {
             };
             let mut tera = self.get_tera();
             Self::register_task_source_files_function(&mut tera, task);
-            tera.register_function("arg", {
+            Self::register_template_function(&mut tera, "arg", {
                 {
                     let usage_args = m.args.clone();
-                    move |args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
+                    move |args| {
                         let seen_args = Arc::new(Mutex::new(HashSet::new()));
                         {
                             let mut seen_args = seen_args.lock().unwrap();
-                            let i = args
-                                .get::<i64>("i")?
+                            let i = Self::template_arg::<i64>(args, "i")?
                                 .map(|i| i as usize)
                                 .unwrap_or_else(|| seen_args.len());
-                            let name =
-                                Self::opt_string_kwarg(&args, "name")?.unwrap_or(i.to_string());
+                            let name = Self::template_arg::<String>(args, "name")?
+                                .unwrap_or(i.to_string());
                             seen_args.insert(name.clone());
-                            Ok(tera::Value::from(
+                            Ok(json!(
                                 usage_args
                                     .iter()
                                     .find(|(arg, _)| arg.name == name)
                                     .map(|(_, value)| escape(value))
-                                    .unwrap_or("".to_string()),
+                                    .unwrap_or("".to_string())
                             ))
                         }
                     }
@@ -726,20 +751,20 @@ impl TaskScriptParser {
             let flag_func = {
                 |default_value: String| {
                     let usage_flags = m.flags.clone();
-                    move |args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<tera::Value> {
-                        let name = Self::string_kwarg(&args, "name")?;
-                        Ok(tera::Value::from(
+                    move |args: &HashMap<String, JsonValue>| {
+                        let name = Self::string_arg(args, "name")?;
+                        Ok(json!(
                             usage_flags
                                 .iter()
                                 .find(|(flag, _)| flag.name == name)
                                 .map(|(_, value)| escape(value))
-                                .unwrap_or(default_value.clone()),
+                                .unwrap_or(default_value.clone())
                         ))
                     }
                 }
             };
-            tera.register_function("option", flag_func("".to_string()));
-            tera.register_function("flag", flag_func(false.to_string()));
+            Self::register_template_function(&mut tera, "option", flag_func("".to_string()));
+            Self::register_template_function(&mut tera, "flag", flag_func(false.to_string()));
             let mut tera_ctx = task.tera_ctx_for_usage(config).await?;
             self.inject_extra_vars(&mut tera_ctx);
             tera_ctx.insert("env", &env);
@@ -897,6 +922,26 @@ fn shell_from_shebang(script: &str) -> Option<Vec<String>> {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct TeraV1Guard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl TeraV1Guard {
+        fn new() -> Self {
+            let lock = TEST_SETTINGS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            Settings::override_with(|settings| settings.tera_v1 = Some(true));
+            Self { _lock: lock }
+        }
+    }
+
+    impl Drop for TeraV1Guard {
+        fn drop(&mut self) {
+            Settings::reset(None);
+        }
+    }
 
     #[tokio::test]
     async fn test_task_parse_arg() {
@@ -1172,6 +1217,29 @@ mod tests {
         let year = parsed_scripts[0].strip_prefix("echo ").unwrap();
         assert_eq!(year.len(), 4);
         assert!(year.chars().all(|c| c.is_ascii_digit()));
+    }
+
+    #[tokio::test]
+    async fn test_task_template_uses_tera_v1_when_enabled() {
+        let config = Config::get().await.unwrap();
+        let _guard = TeraV1Guard::new();
+        let task = Task::default();
+        let parser = TaskScriptParser::new(None);
+        let scripts = vec![
+            "{% macro greet(name) %}hi {{ name }}{% endmacro %}echo {{ self::greet(name=arg(name='name', default='mise')) }} {{ now(timestamp=true) }}"
+                .to_string(),
+        ];
+        let (_, spec) = parser
+            .parse_run_scripts(&config, &task, &scripts, &Default::default())
+            .await
+            .unwrap();
+        let parsed_scripts = parser
+            .parse_run_scripts_with_args(&config, &task, &scripts, &Default::default(), &[], &spec)
+            .await
+            .unwrap();
+        let (greeting, timestamp) = parsed_scripts[0].rsplit_once(' ').unwrap();
+        assert_eq!(greeting, "echo hi mise");
+        assert!(timestamp.chars().all(|c| c.is_ascii_digit()));
     }
 
     #[tokio::test]

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -1160,6 +1160,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_task_template_tera_contrib_helpers() {
+        let config = Config::get().await.unwrap();
+        let task = Task::default();
+        let parser = TaskScriptParser::new(None);
+        let scripts = vec!["echo {{ now() | date(format='%Y') }}".to_string()];
+        let (parsed_scripts, _) = parser
+            .parse_run_scripts(&config, &task, &scripts, &Default::default())
+            .await
+            .unwrap();
+        let year = parsed_scripts[0].strip_prefix("echo ").unwrap();
+        assert_eq!(year.len(), 4);
+        assert!(year.chars().all(|c| c.is_ascii_digit()));
+    }
+
+    #[tokio::test]
     async fn test_task_parse_task_source_files() {
         let cases: &[(&[&str], &str, &str)] = &[
             (&[], "echo {{ task_source_files() }}", "echo []"),

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -988,6 +988,41 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
         },
     );
 
+    // Tera 2 keeps helpers that require additional dependencies in tera-contrib.
+    // Register the complete contrib set so all mise templates see the same helpers.
+    tera.register_filter("b64_encode", tera_contrib::base64::b64_encode);
+    tera.register_filter("b64_decode", tera_contrib::base64::b64_decode);
+    tera.register_function("now", tera_contrib::dates::now);
+    tera.register_filter("date", tera_contrib::dates::date);
+    tera.register_test("before", tera_contrib::dates::is_before);
+    tera.register_test("after", tera_contrib::dates::is_after);
+    tera.register_filter(
+        "filesize_format",
+        tera_contrib::filesize_format::filesize_format,
+    );
+    tera.register_filter(
+        "filesizeformat",
+        tera_contrib::filesize_format::filesize_format,
+    );
+    tera.register_filter("format", tera_contrib::format::format);
+    tera.register_filter("json_encode", tera_contrib::json::json_encode);
+    tera.register_function("get_random", tera_contrib::rand::get_random);
+    tera.register_filter("shuffle", tera_contrib::rand::shuffle);
+    tera.register_filter("striptags", tera_contrib::regex::striptags);
+    tera.register_filter("spaceless", tera_contrib::regex::spaceless);
+    tera.register_filter(
+        "regex_replace",
+        tera_contrib::regex::RegexReplace::default(),
+    );
+    tera.register_test("matching", tera_contrib::regex::Matching::default());
+    tera.register_filter("slug", tera_contrib::slug::slug);
+    tera.register_filter("slugify", tera_contrib::slug::slug);
+    tera.register_filter("urlencode", tera_contrib::urlencode::urlencode);
+    tera.register_filter(
+        "urlencode_strict",
+        tera_contrib::urlencode::urlencode_strict,
+    );
+
     tera
 });
 
@@ -2231,6 +2266,47 @@ mod tests {
         );
         assert_eq!(render("{{ {'ok': true} is object }}"), "true");
         assert_eq!(render("{{ 6 is divisibleby(divisor=3) }}"), "true");
+    }
+
+    #[test]
+    fn test_tera_contrib_helpers() {
+        assert_eq!(render("{{ 'hello' | b64_encode | b64_decode }}"), "hello");
+        assert_eq!(
+            render("{{ '2026-07-13' | date(format='%Y/%m/%d') }}"),
+            "2026/07/13"
+        );
+        assert_eq!(render("{{ now() | date(format='%Y') | length }}"), "4");
+        assert_eq!(
+            render("{{ '2026-01-01' is before(other='2026-02-01') }}"),
+            "true"
+        );
+        assert_eq!(
+            render("{{ '2026-02-01' is after(other='2026-01-01') }}"),
+            "true"
+        );
+        assert_eq!(render("{{ 1024 | filesize_format }}"), "1 KiB");
+        assert_eq!(render("{{ 1024 | filesizeformat }}"), "1 KiB");
+        assert_eq!(render("{{ 42 | format(spec='05') }}"), "00042");
+        assert_eq!(render("{{ {'ok': true} | json_encode }}"), r#"{"ok":true}"#);
+        let random = render("{{ get_random(start=10, end=20, seed='mise') }}")
+            .parse::<i64>()
+            .unwrap();
+        assert!((10..20).contains(&random));
+        assert_eq!(
+            render("{{ [1, 2, 3] | shuffle(seed='mise') | length }}"),
+            "3"
+        );
+        assert_eq!(
+            render("{{ 'abc123' | regex_replace(pattern='[0-9]+', rep='') }}"),
+            "abc"
+        );
+        assert_eq!(render("{{ 'abc123' is matching(pat='[0-9]+$') }}"), "true");
+        assert_eq!(render("{{ '<b>x</b>' | striptags }}"), "x");
+        assert_eq!(render("{{ '<p> </p>' | spaceless }}"), "<p></p>");
+        assert_eq!(render("{{ 'Hello World' | slug }}"), "hello-world");
+        assert_eq!(render("{{ 'Hello World' | slugify }}"), "hello-world");
+        assert_eq!(render("{{ 'a/b c' | urlencode }}"), "a/b%20c");
+        assert_eq!(render("{{ 'a/b c' | urlencode_strict }}"), "a%2Fb%20c");
     }
 
     #[tokio::test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -3,7 +3,6 @@ use std::iter::once;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Utc};
 use heck::{
     ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
     ToUpperCamelCase,
@@ -210,24 +209,6 @@ fn escape_html(s: &str) -> String {
     output
 }
 
-fn slugify(s: &str) -> String {
-    let mut out = String::new();
-    let mut previous_dash = false;
-    for c in s.chars().flat_map(char::to_lowercase) {
-        if c.is_ascii_alphanumeric() {
-            out.push(c);
-            previous_dash = false;
-        } else if !previous_dash && !out.is_empty() {
-            out.push('-');
-            previous_dash = true;
-        }
-    }
-    if previous_dash {
-        out.pop();
-    }
-    out
-}
-
 fn tera_v1_truthy(value: &Value) -> bool {
     if value.is_none() {
         false
@@ -244,41 +225,6 @@ fn tera_v1_truthy(value: &Value) -> bool {
     } else {
         true
     }
-}
-
-fn tera_v1_date(value: Value, args: Kwargs) -> TeraResult<Value> {
-    let format = args.get::<&str>("format")?.unwrap_or("%Y-%m-%d");
-    let formatted = if let Some(n) = value.as_number() {
-        let ts = n
-            .as_integer()
-            .ok_or_else(|| tera_err(format!("Filter `date` was invoked on a float: {value}")))?;
-        let ts = i64::try_from(ts)
-            .map_err(|_| tera_err(format!("Filter `date` timestamp is out of range: {value}")))?;
-        DateTime::<Utc>::from_timestamp(ts, 0)
-            .ok_or_else(|| tera_err(format!("Filter `date` timestamp is out of range: {ts}")))?
-            .format(format)
-            .to_string()
-    } else if let Some(s) = value.as_str() {
-        if s.contains('T') {
-            match DateTime::<FixedOffset>::parse_from_rfc3339(s) {
-                Ok(dt) => dt.format(format).to_string(),
-                Err(_) => NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
-                    .map(|dt| dt.format(format).to_string())
-                    .map_err(|_| tera_err(format!("Error parsing `{s:?}` as a date")))?,
-            }
-        } else {
-            NaiveDate::parse_from_str(s, "%Y-%m-%d")
-                .map(|dt| dt.format(format).to_string())
-                .map_err(|_| tera_err(format!("Error parsing `{s:?}` as YYYY-MM-DD date")))?
-        }
-    } else {
-        return Err(tera_err(format!(
-            "Filter `date` expected an integer timestamp or string, got {}",
-            value.name()
-        )));
-    };
-
-    Ok(Value::from(formatted))
 }
 
 fn tera_v1_int(value: Value, args: Kwargs) -> TeraResult<Value> {
@@ -577,48 +523,6 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
                 .replace('\'', "\\'"),
         )
     });
-    tera.register_filter("slugify", move |s: &str, _: Kwargs, _: &State| {
-        warn_tera_v1_filter(
-            "tera-v1-slugify",
-            "slugify",
-            "Use an explicit slug value or custom template logic instead.",
-        );
-        Value::from(slugify(s))
-    });
-    tera.register_filter("urlencode", move |s: &str, _: Kwargs, _: &State| {
-        warn_tera_v1_filter(
-            "tera-v1-urlencode",
-            "urlencode",
-            "Pre-encode URL components before rendering.",
-        );
-        Value::from(urlencoding::encode(s).replace("%2F", "/"))
-    });
-    tera.register_filter("urlencode_strict", move |s: &str, _: Kwargs, _: &State| {
-        warn_tera_v1_filter(
-            "tera-v1-urlencode-strict",
-            "urlencode_strict",
-            "Pre-encode URL components before rendering.",
-        );
-        Value::from(urlencoding::encode(s).into_owned())
-    });
-    tera.register_filter("striptags", move |s: &str, _: Kwargs, _: &State| {
-        static STRIPTAGS_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"<[^>]*>").unwrap());
-        warn_tera_v1_filter(
-            "tera-v1-striptags",
-            "striptags",
-            "Strip tags before rendering or use custom template logic instead.",
-        );
-        Value::from(STRIPTAGS_RE.replace_all(s, "").to_string())
-    });
-    tera.register_filter("spaceless", move |s: &str, _: Kwargs, _: &State| {
-        static SPACELESS_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r">\s+<").unwrap());
-        warn_tera_v1_filter(
-            "tera-v1-spaceless",
-            "spaceless",
-            "Minify whitespace before rendering or use custom template logic instead.",
-        );
-        Value::from(SPACELESS_RE.replace_all(s, "><").to_string())
-    });
     tera.register_filter(
         "truncate",
         move |s: &str, args: Kwargs, _: &State| -> TeraResult<Value> {
@@ -767,47 +671,6 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
                 }
             }
             Ok(Value::from(out))
-        },
-    );
-    tera.register_filter(
-        "json_encode",
-        move |value: Value, args: Kwargs, _: &State| -> TeraResult<Value> {
-            warn_tera_v1_filter(
-                "tera-v1-json-encode",
-                "json_encode",
-                "Use Tera 2 JSON helpers when available or pre-encode JSON before rendering.",
-            );
-            let pretty = args.get::<bool>("pretty")?.unwrap_or(false);
-            let encoded = if pretty {
-                serde_json::to_string_pretty(&value)
-            } else {
-                serde_json::to_string(&value)
-            }
-            .map_err(|e| tera_err(e.to_string()))?;
-            Ok(Value::from(encoded))
-        },
-    );
-    tera.register_filter(
-        "date",
-        move |value: Value, args: Kwargs, _: &State| -> TeraResult<Value> {
-            warn_tera_v1_filter("tera-v1-date", "date", "Format dates before rendering.");
-            tera_v1_date(value, args)
-        },
-    );
-    tera.register_filter(
-        "filesizeformat",
-        move |value: Value, _: Kwargs, _: &State| -> TeraResult<Value> {
-            warn_tera_v1_filter(
-                "tera-v1-filesizeformat",
-                "filesizeformat",
-                "Format file sizes before rendering.",
-            );
-            let size = value
-                .as_number()
-                .and_then(|n| n.as_integer())
-                .and_then(|n| u64::try_from(n).ok())
-                .ok_or_else(|| tera_err("filesizeformat filter expects a non-negative integer"))?;
-            Ok(Value::from(bytesize::ByteSize(size).to_string()))
         },
     );
     tera.register_filter(


### PR DESCRIPTION
## Summary
- enable every `tera-contrib` feature and register its filters, functions, and tests in the shared Tera v2 renderer
- make task usage/script rendering honor `tera_v1` by registering task helpers into either the Tera v1 or v2 engine through shared adapters
- keep `slugify` and `filesizeformat` as warning-free contrib aliases and remove the overridden compatibility registrations
- document the distinct Tera v1 and Tera v2 syntax and cover both paths

## Root cause
Tera v2 moved dependency-backed built-ins such as `now()` into `tera-contrib`. mise did not register those helpers, and task usage/script templates instantiated the Tera v2 renderer directly, bypassing the normal renderer selection that checks `tera_v1`.

## Impact
Without `tera_v1`, task and configuration templates use Tera v2 with the complete `tera-contrib` helper set and no deprecation warnings. With `tera_v1 = true`, regular config and task templates use the actual Tera v1 engine, preserving original syntax such as macros and `now(timestamp=true)`.

## Tests
- `mise run lint-fix`
- `cargo test tera::tests`
- `cargo test task::task_script_parser::tests`
- explicit task-template coverage for both Tera v1 and Tera v2

Refs #10825.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core template rendering for config and tasks across two Tera versions; behavior changes for templates that relied on deprecated shims or assumed v2-only task paths.
> 
> **Overview**
> Adds **`tera-contrib`** and wires its filters, functions, and tests into the shared **Tera v2** renderer so helpers like `now()`, `date`, base64, slug, and `json_encode` work without the old shim implementations (and their deprecation warnings). **`slugify`** / **`filesizeformat`** remain as aliases on the contrib implementations.
> 
> **Task** usage and run-script rendering now goes through **`get_tera` / `TeraEngine`** instead of always using v2, so **`tera_v1`** selects the real Tera v1 engine (e.g. macros, `now(timestamp=true)`). Custom task functions (`arg`, `flag`, `task_source_files`, etc.) are registered via a shared adapter for both engines.
> 
> Docs clarify default **v2 + contrib** vs **`tera_v1`** escape hatch and updated helper signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d86fa06c3f86ec7bea3d1c35618559992a9a5a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Tera 2 template helpers from `tera-contrib`, including base64, `now`/`date`, formatting, JSON encoding, randomization/shuffle, regex, slug/slugify, and URL/file-size utilities.
  * Task template rendering now uses consistent helper behavior across Tera versions.
* **Documentation**
  * Updated Tera 2 template docs to reflect current helper and function signatures, including `now`, `get_random`, and relative date tests.
  * Added a compatibility note confirming `tera-contrib` helpers work without deprecation warnings.
* **Bug Fixes / Tests**
  * Expanded automated coverage to validate helper outputs (including deterministic and formatted results).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->