### PR TITLE
feat(registry): add optional floating registries

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -321,7 +321,7 @@ fn registry_code(entries: &[(String, String)]) -> String {
     for (key, tool) in entries {
         code.push_str(&format!("        ({key:?}, {tool}),\n"));
     }
-    code.push_str("    ],\n    lookup: ");
+    code.push_str("    ],\n    lookup: RegistryLookup::Static(");
     code.push_str(&phf_usize_map_code(
         entries
             .iter()
@@ -329,7 +329,7 @@ fn registry_code(entries: &[(String, String)]) -> String {
             .map(|(index, (key, _))| (key.clone(), index.to_string()))
             .collect::<Vec<_>>(),
     ));
-    code.push_str(",\n}");
+    code.push_str("),\n}");
     code
 }
 

--- a/docs/dev-tools/backends/aqua.md
+++ b/docs/dev-tools/backends/aqua.md
@@ -9,6 +9,12 @@ the [aqua registry](https://github.com/aquaproj/aqua-registry) that gets compile
 Here's an example package entry: [`aqua:hashicorp/terraform`](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/hashicorp/terraform/registry.yaml).
 mise has a reimplementation of aqua that knows how to work with these files to install tools.
 
+By default, the bundled snapshot is used. The opt-in
+[`registry_floating`](/configuration/settings.html#registry_floating) setting checks the current
+official aqua registry first while retaining the bundled snapshot as a fallback. It also floats
+mise's shorthand registry; see [Floating registries](/registry.html#floating-registries) for the
+tradeoffs and cache behavior.
+
 As of this writing, aqua is relatively new to mise and because a lot of tools are being converted from
 asdf to aqua, there may be some configuration in aqua tools that need to be tightened up. I put some
 common issues below and would strongly recommend contributing changes back to the aqua registry if you

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -34,8 +34,10 @@ registry data without replacing the mise executable:
 mise settings registry_floating=true
 ```
 
-With this enabled, mise fetches the current official mise shorthand registry and aqua registry.
-The bundled snapshots remain available as fallbacks when the remote registries cannot be loaded.
+With this enabled, mise fetches the shorthand registry published with the latest mise release and
+the current official aqua registry. The bundled snapshots remain available as fallbacks when the
+remote registries cannot be loaded. Fast and offline commands never refresh the mise registry; they
+use an existing cached copy or the bundled snapshot.
 The mise registry is cached for [`registry_cache_ttl`](/configuration/settings.html#registry_cache_ttl),
 which defaults to one hour; aqua continues to use
 [`aqua.registry_cache_ttl`](/configuration/settings.html#aqua-registry_cache_ttl), which defaults to

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -24,6 +24,27 @@ mise use aqua:aws/aws-cli
 
 If a tool is not available in the registry, you can install it by its full name. [github](./dev-tools/backends/github.html) and [aqua](./dev-tools/backends/aqua.html) give you for example access to almost all programs available on GitHub.
 
+## Floating registries
+
+By default, mise uses the mise and aqua registry snapshots that were tested and bundled with that
+mise release. Users whose system package manager ships mise updates slowly can opt in to current
+registry data without replacing the mise executable:
+
+```shell
+mise settings registry_floating=true
+```
+
+With this enabled, mise fetches the current official mise shorthand registry and aqua registry.
+The bundled snapshots remain available as fallbacks when the remote registries cannot be loaded.
+The mise registry is cached for [`registry_cache_ttl`](/configuration/settings.html#registry_cache_ttl),
+which defaults to one hour; aqua continues to use
+[`aqua.registry_cache_ttl`](/configuration/settings.html#aqua-registry_cache_ttl), which defaults to
+one week. `mise cache clear` forces both to be downloaded again on their next online use.
+
+This behavior is opt-in because a floating registry may contain changes that were made after the
+installed mise version was tested. Updating mise remains preferable when an updated package is
+available.
+
 ## Backends
 
 In addition to built-in [core tools](/core-tools.html), `mise` supports a variety of [backends](/dev-tools/backends/) to install tools.

--- a/e2e/cli/test_registry_floating
+++ b/e2e/cli/test_registry_floating
@@ -5,6 +5,7 @@
 # fallback behavior; this verifies that floating mode can download the R2
 # artifact, validate it, and install it in the cache.
 
+: "${MISE_CACHE_DIR:?Environment variable MISE_CACHE_DIR must be set}"
 archive="$MISE_CACHE_DIR/mise-registry/registry.tar.zst"
 rm -rf "$MISE_CACHE_DIR/mise-registry"
 

--- a/e2e/cli/test_registry_floating
+++ b/e2e/cli/test_registry_floating
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This is intentionally a live end-to-end check of the registry artifact
+# published by the release workflow. Unit tests cover archive parsing and
+# fallback behavior; this verifies that floating mode can download the R2
+# artifact, validate it, and install it in the cache.
+
+archive="$MISE_CACHE_DIR/mise-registry/registry.tar.gz"
+rm -rf "$MISE_CACHE_DIR/mise-registry"
+
+MISE_REGISTRY_FLOATING=1 MISE_REGISTRY_CACHE_TTL=0s mise registry jq >/dev/null
+
+if [[ ! -f $archive ]]; then
+  fail "floating registry was not downloaded to $archive"
+fi
+
+if ! tar -tzf "$archive" | grep -qx 'registry/jq.toml'; then
+  fail "floating registry archive does not contain registry/jq.toml"
+fi

--- a/e2e/cli/test_registry_floating
+++ b/e2e/cli/test_registry_floating
@@ -5,7 +5,7 @@
 # fallback behavior; this verifies that floating mode can download the R2
 # artifact, validate it, and install it in the cache.
 
-archive="$MISE_CACHE_DIR/mise-registry/registry.tar.gz"
+archive="$MISE_CACHE_DIR/mise-registry/registry.tar.zst"
 rm -rf "$MISE_CACHE_DIR/mise-registry"
 
 MISE_REGISTRY_FLOATING=1 MISE_REGISTRY_CACHE_TTL=0s mise registry jq >/dev/null
@@ -14,6 +14,5 @@ if [[ ! -f $archive ]]; then
   fail "floating registry was not downloaded to $archive"
 fi
 
-if ! tar -tzf "$archive" | grep -qx 'registry/jq.toml'; then
-  fail "floating registry archive does not contain registry/jq.toml"
-fi
+# The archive is parsed and validated before it is moved into this cache path,
+# so its presence proves the downloaded zstd archive was usable.

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1394,15 +1394,6 @@
             }
           }
         },
-        "registry_cache_ttl": {
-          "description": "How long to cache the floating mise registry.",
-          "type": "string"
-        },
-        "registry_floating": {
-          "default": false,
-          "description": "Fetch current mise and aqua registries instead of using only the snapshots baked into this mise release.",
-          "type": "boolean"
-        },
         "plugin_autoupdate_last_check_duration": {
           "default": "7d",
           "description": "How long to wait before updating plugins automatically (note this isn't currently implemented).",
@@ -1507,6 +1498,15 @@
         },
         "raw": {
           "description": "Connect stdin/stdout/stderr to child processes.",
+          "type": "boolean"
+        },
+        "registry_cache_ttl": {
+          "description": "How long to cache the floating mise registry.",
+          "type": "string"
+        },
+        "registry_floating": {
+          "default": false,
+          "description": "Fetch current mise and aqua registries instead of using only the snapshots baked into this mise release.",
           "type": "boolean"
         },
         "ruby": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1394,6 +1394,15 @@
             }
           }
         },
+        "registry_cache_ttl": {
+          "description": "How long to cache the floating mise registry.",
+          "type": "string"
+        },
+        "registry_floating": {
+          "default": false,
+          "description": "Fetch current mise and aqua registries instead of using only the snapshots baked into this mise release.",
+          "type": "boolean"
+        },
         "plugin_autoupdate_last_check_duration": {
           "default": "7d",
           "description": "How long to wait before updating plugins automatically (note this isn't currently implemented).",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1506,7 +1506,7 @@
         },
         "registry_floating": {
           "default": false,
-          "description": "Fetch current mise and aqua registries instead of using only the snapshots baked into this mise release.",
+          "description": "Fetch the latest released mise registry and current aqua registry instead of using only the snapshots baked into this mise release.",
           "type": "boolean"
         },
         "ruby": {

--- a/settings.toml
+++ b/settings.toml
@@ -1889,33 +1889,6 @@ You can also use the HTML endpoint by setting this to `https://pypi.org/simple/{
 env = "MISE_PIPX_REGISTRY_URL"
 type = "String"
 
-[registry_cache_ttl]
-default_docs = "1h"
-description = "How long to cache the floating mise registry."
-docs = """
-How long the downloaded mise registry remains fresh when [`registry_floating`](#registry_floating)
-is enabled. Set to `0s` to check for registry updates every time.
-"""
-env = "MISE_REGISTRY_CACHE_TTL"
-optional = true
-type = "Duration"
-
-[registry_floating]
-default = false
-description = "Fetch current mise and aqua registries instead of using only the snapshots baked into this mise release."
-docs = """
-Fetch the current official mise and aqua registries, with the snapshots baked into this mise release
-used as a fallback when a remote registry cannot be loaded.
-
-This is disabled by default because each mise release is tested with its bundled registry snapshots.
-It can be useful on distributions whose mise package updates lag behind registry changes.
-
-The downloaded mise registry is cached according to [`registry_cache_ttl`](#registry_cache_ttl).
-The downloaded aqua registry uses [`aqua.registry_cache_ttl`](#aqua-registry_cache_ttl).
-"""
-env = "MISE_REGISTRY_FLOATING"
-type = "Bool"
-
 [pipx.uvx]
 default_docs = "true"
 description = "Use uvx instead of pipx if uv is installed and on PATH."
@@ -2124,6 +2097,33 @@ type = "Bool"
 [raw]
 description = "Connect stdin/stdout/stderr to child processes."
 env = "MISE_RAW"
+type = "Bool"
+
+[registry_cache_ttl]
+default_docs = "1h"
+description = "How long to cache the floating mise registry."
+docs = """
+How long the downloaded mise registry remains fresh when [`registry_floating`](#registry_floating)
+is enabled. Set to `0s` to check for registry updates every time.
+"""
+env = "MISE_REGISTRY_CACHE_TTL"
+optional = true
+type = "Duration"
+
+[registry_floating]
+default = false
+description = "Fetch current mise and aqua registries instead of using only the snapshots baked into this mise release."
+docs = """
+Fetch the current official mise and aqua registries, with the snapshots baked into this mise release
+used as a fallback when a remote registry cannot be loaded.
+
+This is disabled by default because each mise release is tested with its bundled registry snapshots.
+It can be useful on distributions whose mise package updates lag behind registry changes.
+
+The downloaded mise registry is cached according to [`registry_cache_ttl`](#registry_cache_ttl).
+The downloaded aqua registry uses [`aqua.registry_cache_ttl`](#aqua-registry_cache_ttl).
+"""
+env = "MISE_REGISTRY_FLOATING"
 type = "Bool"
 
 [ruby.apply_patches]

--- a/settings.toml
+++ b/settings.toml
@@ -1889,6 +1889,33 @@ You can also use the HTML endpoint by setting this to `https://pypi.org/simple/{
 env = "MISE_PIPX_REGISTRY_URL"
 type = "String"
 
+[registry_cache_ttl]
+default_docs = "1h"
+description = "How long to cache the floating mise registry."
+docs = """
+How long the downloaded mise registry remains fresh when [`registry_floating`](#registry_floating)
+is enabled. Set to `0s` to check for registry updates every time.
+"""
+env = "MISE_REGISTRY_CACHE_TTL"
+optional = true
+type = "Duration"
+
+[registry_floating]
+default = false
+description = "Fetch current mise and aqua registries instead of using only the snapshots baked into this mise release."
+docs = """
+Fetch the current official mise and aqua registries, with the snapshots baked into this mise release
+used as a fallback when a remote registry cannot be loaded.
+
+This is disabled by default because each mise release is tested with its bundled registry snapshots.
+It can be useful on distributions whose mise package updates lag behind registry changes.
+
+The downloaded mise registry is cached according to [`registry_cache_ttl`](#registry_cache_ttl).
+The downloaded aqua registry uses [`aqua.registry_cache_ttl`](#aqua-registry_cache_ttl).
+"""
+env = "MISE_REGISTRY_FLOATING"
+type = "Bool"
+
 [pipx.uvx]
 default_docs = "true"
 description = "Use uvx instead of pipx if uv is installed and on PATH."

--- a/settings.toml
+++ b/settings.toml
@@ -2112,15 +2112,16 @@ type = "Duration"
 
 [registry_floating]
 default = false
-description = "Fetch current mise and aqua registries instead of using only the snapshots baked into this mise release."
+description = "Fetch the latest released mise registry and current aqua registry instead of using only the snapshots baked into this mise release."
 docs = """
-Fetch the current official mise and aqua registries, with the snapshots baked into this mise release
-used as a fallback when a remote registry cannot be loaded.
+Fetch the latest released official mise registry and the current aqua registry, with the snapshots
+baked into this mise release used as a fallback when a remote registry cannot be loaded.
 
 This is disabled by default because each mise release is tested with its bundled registry snapshots.
 It can be useful on distributions whose mise package updates lag behind registry changes.
 
-The downloaded mise registry is cached according to [`registry_cache_ttl`](#registry_cache_ttl).
+The downloaded mise registry is refreshed only for commands that allow network access and is cached
+according to [`registry_cache_ttl`](#registry_cache_ttl). Fast and offline commands never refresh it.
 The downloaded aqua registry uses [`aqua.registry_cache_ttl`](#aqua-registry_cache_ttl).
 """
 env = "MISE_REGISTRY_FLOATING"

--- a/src/aqua/aqua_registry_wrapper.rs
+++ b/src/aqua/aqua_registry_wrapper.rs
@@ -33,6 +33,7 @@ impl AquaRegistry {
             settings.aqua.baked_registry,
             settings.prefer_offline(),
             settings.aqua_registry_cache_ttl(),
+            settings.registry_floating,
         )
     }
 
@@ -42,16 +43,20 @@ impl AquaRegistry {
         use_baked_registry: bool,
         prefer_offline: bool,
         source_cache_ttl: duration::Duration,
+        fallback_official_registry_errors: bool,
     ) -> Self {
         let cache = RegistryCache::new(cache_dir);
         let mut registries = registry_urls
             .into_iter()
             .map(|registry_url| {
+                let fallback_on_error =
+                    fallback_official_registry_errors && is_official_aqua_registry(&registry_url);
                 RegistrySource::Downloaded(DownloadedRegistry::new(
                     registry_url,
                     cache.clone(),
                     prefer_offline,
                     source_cache_ttl,
+                    fallback_on_error,
                 ))
             })
             .collect::<Vec<_>>();
@@ -74,6 +79,13 @@ impl RegistrySource {
             Self::Downloaded(registry) => match registry.package(package_id).await {
                 Ok(package) => Ok(Some(package)),
                 Err(AquaRegistryError::PackageNotFound(_)) => Ok(None),
+                Err(err) if registry.fallback_on_error => {
+                    warn!(
+                        "failed to load floating aqua registry {}, using baked-in fallback: {err}",
+                        registry.registry_url
+                    );
+                    Ok(None)
+                }
                 Err(err) => Err(err),
             },
             Self::Baked => super::standard_registry::package(package_id).transpose(),
@@ -89,13 +101,26 @@ impl RegistrySource {
 }
 
 fn configured_registry_urls(settings: &Settings) -> Vec<String> {
-    if let Some(registries) = settings.aqua.registries.clone() {
+    let mut registries = if let Some(registries) = settings.aqua.registries.clone() {
         registries
     } else if settings.aqua.baked_registry {
         Vec::new()
     } else {
         vec![AQUA_DEFAULT_REGISTRY_URL.into()]
+    };
+    if settings.registry_floating
+        && !registries
+            .iter()
+            .any(|registry| is_official_aqua_registry(registry))
+    {
+        registries.push(AQUA_DEFAULT_REGISTRY_URL.into());
     }
+    registries
+}
+
+fn is_official_aqua_registry(registry_url: &str) -> bool {
+    github_repo_slug(registry_url)
+        .is_some_and(|(owner, repo)| owner == "aquaproj" && repo == "aqua-registry")
 }
 
 #[derive(Debug)]
@@ -103,6 +128,7 @@ struct DownloadedRegistry {
     registry_url: String,
     prefer_offline: bool,
     source_cache_ttl: duration::Duration,
+    fallback_on_error: bool,
     cache: RegistryCache,
     registry: OnceCell<std::result::Result<Arc<ActiveRegistry>, String>>,
 }
@@ -113,11 +139,13 @@ impl DownloadedRegistry {
         cache: RegistryCache,
         prefer_offline: bool,
         source_cache_ttl: duration::Duration,
+        fallback_on_error: bool,
     ) -> Self {
         Self {
             registry_url,
             prefer_offline,
             source_cache_ttl,
+            fallback_on_error,
             cache,
             registry: OnceCell::new(),
         }
@@ -589,6 +617,33 @@ mod tests {
         assert_eq!(configured_registry_urls(&settings), Vec::<String>::new());
     }
 
+    #[test]
+    fn floating_registry_adds_downloaded_official_registry_before_baked_fallback() {
+        let mut settings = Settings::default();
+        settings.aqua.baked_registry = true;
+        settings.registry_floating = true;
+
+        assert_eq!(
+            configured_registry_urls(&settings),
+            vec![AQUA_DEFAULT_REGISTRY_URL.to_string()]
+        );
+    }
+
+    #[test]
+    fn floating_registry_keeps_custom_registries_ahead_of_official_registry() {
+        let mut settings = Settings::default();
+        settings.aqua.registries = Some(vec!["https://example.com/custom".into()]);
+        settings.registry_floating = true;
+
+        assert_eq!(
+            configured_registry_urls(&settings),
+            vec![
+                "https://example.com/custom".to_string(),
+                AQUA_DEFAULT_REGISTRY_URL.to_string()
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn registry_load_failure_does_not_check_later_registries() {
         let temp = tempfile::tempdir().unwrap();
@@ -603,6 +658,22 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(err, AquaRegistryError::RegistryNotAvailable(_)));
+    }
+
+    #[tokio::test]
+    async fn unavailable_floating_official_registry_uses_baked_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let registry = AquaRegistry::new(
+            temp.path().to_path_buf(),
+            vec![AQUA_DEFAULT_REGISTRY_URL.to_string()],
+            true,
+            true,
+            DEFAULT_AQUA_REGISTRY_CACHE_TTL,
+            true,
+        );
+
+        let package = registry.fetch_package("01mf02/jaq").await.unwrap();
+        assert_eq!(package.repo_name, "jaq");
     }
 
     #[tokio::test]
@@ -760,6 +831,7 @@ mod tests {
             false,
             true,
             DEFAULT_AQUA_REGISTRY_CACHE_TTL,
+            false,
         );
 
         let err = first_downloaded_registry(&fetcher)
@@ -876,6 +948,7 @@ packages:
             use_baked_registry,
             false,
             DEFAULT_AQUA_REGISTRY_CACHE_TTL,
+            false,
         )
     }
 

--- a/src/aqua/aqua_registry_wrapper.rs
+++ b/src/aqua/aqua_registry_wrapper.rs
@@ -80,7 +80,7 @@ impl RegistrySource {
                 Ok(package) => Ok(Some(package)),
                 Err(AquaRegistryError::PackageNotFound(_)) => Ok(None),
                 Err(err) if registry.fallback_on_error => {
-                    warn!(
+                    warn_once!(
                         "failed to load floating aqua registry {}, using baked-in fallback: {err}",
                         registry.registry_url
                     );

--- a/src/aqua/aqua_registry_wrapper.rs
+++ b/src/aqua/aqua_registry_wrapper.rs
@@ -1,5 +1,6 @@
 use crate::config::Settings;
 use crate::http::HTTP;
+use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{dirs, duration};
 use aqua_registry::{AquaRegistryError, CompiledRegistry, ParsedRegistry, RegistryCache};
 use eyre::Result;
@@ -299,7 +300,17 @@ impl DownloadedRegistry {
                 });
         }
 
-        let source = download_registry_source(registry_url).await?;
+        let pr = MultiProgressReport::get().add("aqua registry");
+        let source = match download_registry_source(registry_url).await {
+            Ok(source) => {
+                pr.finish();
+                source
+            }
+            Err(err) => {
+                pr.abandon();
+                return Err(err);
+            }
+        };
         self.cache.write_source(registry_url, &source)?;
         Ok(source)
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -647,6 +647,14 @@ impl Cli {
         measure!("handle_shim", { shims::handle_shim().await })?;
         ctrlc::init();
         let print_version = version::print_version_if_requested(args)?;
+        // Clap's tool argument parsers consult installed plugin/tool metadata while
+        // resolving registry options. Initialize that filesystem-only state before
+        // parsing, while leaving full backend loading until after registry refresh.
+        if !print_version {
+            measure!("install_state::init", {
+                crate::toolset::install_state::init().await?
+            });
+        }
         // Pre-process args to handle naked runs before clap parsing
         let cmd = Cli::command();
         let processed_args = preprocess_args_for_naked_run(&cmd, args);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -647,8 +647,6 @@ impl Cli {
         measure!("handle_shim", { shims::handle_shim().await })?;
         ctrlc::init();
         let print_version = version::print_version_if_requested(args)?;
-        let _ = measure!("backend::load_tools", { backend::load_tools().await });
-
         // Pre-process args to handle naked runs before clap parsing
         let cmd = Cli::command();
         let processed_args = preprocess_args_for_naked_run(&cmd, args);
@@ -663,6 +661,10 @@ impl Cli {
         measure!("add_cli_matches", { Settings::add_cli_matches(&cli) });
         let _ = measure!("settings", { Settings::try_get() });
         measure!("logger", { logger::init() });
+        if !print_version {
+            measure!("registry::refresh", { crate::registry::refresh().await });
+            let _ = measure!("backend::load_tools", { backend::load_tools().await });
+        }
         warn_deprecated_backends_alias(&cmd, args);
         measure!("migrate", { migrate::run().await });
         if let Err(err) = crate::cache::auto_prune() {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -942,6 +942,15 @@ impl Settings {
             .unwrap_or(crate::aqua::aqua_registry_wrapper::DEFAULT_AQUA_REGISTRY_CACHE_TTL)
     }
 
+    pub fn registry_cache_ttl(&self) -> Duration {
+        self.registry_cache_ttl
+            .as_deref()
+            .map(duration::parse_duration)
+            .transpose()
+            .unwrap()
+            .unwrap_or(duration::HOURLY)
+    }
+
     pub fn task_timeout_duration(&self) -> Option<Duration> {
         self.task
             .timeout

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -3,6 +3,7 @@ use crate::cli::args::BackendArg;
 use crate::config::Settings;
 use crate::http::HTTP;
 use crate::toolset::{RawBackendOptions, ToolVersionOptions};
+use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{dirs, file};
 use eyre::{Context, Result, bail, ensure};
 use flate2::read::GzDecoder;
@@ -29,7 +30,11 @@ pub static REGISTRY: Lazy<&'static Registry> = Lazy::new(|| {
         return &BAKED_REGISTRY;
     }
 
-    match load_floating_registry() {
+    if !registry_cache_path().exists() {
+        return &BAKED_REGISTRY;
+    }
+
+    match load_cached_floating_registry() {
         Ok(registry) => Box::leak(Box::new(registry)),
         Err(err) => {
             warn!("failed to load floating mise registry, using baked-in registry: {err:#}");
@@ -38,8 +43,7 @@ pub static REGISTRY: Lazy<&'static Registry> = Lazy::new(|| {
     }
 });
 
-const MISE_REGISTRY_ARCHIVE_URL: &str =
-    "https://github.com/jdx/mise/archive/refs/heads/main.tar.gz";
+const MISE_REGISTRY_ARCHIVE_URL: &str = "https://mise.jdx.dev/registry/latest.tar.gz";
 
 pub struct Registry {
     entries: &'static [(&'static str, RegistryTool)],
@@ -127,25 +131,13 @@ pub struct RegistryBackend {
     pub options: &'static [(&'static str, &'static str)],
 }
 
-fn load_floating_registry() -> Result<Registry> {
-    let settings = Settings::get();
-    let cache_path = dirs::CACHE.join("mise-registry").join("main.tar.gz");
+fn registry_cache_path() -> PathBuf {
+    dirs::CACHE.join("mise-registry").join("registry.tar.gz")
+}
 
-    if cache_is_fresh(&cache_path, settings.registry_cache_ttl()) {
-        match parse_registry_archive(&cache_path) {
-            Ok(registry) => return Ok(registry),
-            Err(err) => warn!("failed to parse cached floating mise registry: {err:#}"),
-        }
-    }
-
-    if !settings.prefer_offline() {
-        match download_registry_archive(&cache_path) {
-            Ok(registry) => return Ok(registry),
-            Err(err) => warn!("failed to refresh floating mise registry: {err:#}"),
-        }
-    }
-
-    parse_registry_archive(&cache_path).wrap_err("failed to load cached floating mise registry")
+fn load_cached_floating_registry() -> Result<Registry> {
+    parse_registry_archive(&registry_cache_path())
+        .wrap_err("failed to load cached floating mise registry")
 }
 
 fn cache_is_fresh(path: &Path, ttl: Duration) -> bool {
@@ -155,31 +147,57 @@ fn cache_is_fresh(path: &Path, ttl: Duration) -> bool {
         .is_ok_and(|age| age < ttl)
 }
 
-fn download_registry_archive(cache_path: &Path) -> Result<Registry> {
-    let download_path = cache_path.with_extension("tar.gz.download");
-    if download_path.exists() {
-        file::remove_file(&download_path)?;
+/// Refresh the floating mise registry before anything initializes [`REGISTRY`].
+/// Fast and offline commands use the cached archive (or the baked registry) without networking.
+pub async fn refresh() {
+    let settings = Settings::get();
+    if !settings.registry_floating || settings.prefer_offline() {
+        return;
     }
 
-    let path = download_path.clone();
-    let result = std::thread::spawn(move || -> Result<()> {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-        runtime.block_on(HTTP.download_file(MISE_REGISTRY_ARCHIVE_URL, &path, None))
-    })
-    .join()
-    .map_err(|_| eyre::eyre!("floating registry download thread panicked"))?;
-    result?;
-
-    let registry = parse_registry_archive(&download_path)
-        .wrap_err("downloaded mise registry archive is invalid")?;
-    #[cfg(windows)]
-    if cache_path.exists() {
-        file::remove_file(cache_path)?;
+    let cache_path = registry_cache_path();
+    if cache_is_fresh(&cache_path, settings.registry_cache_ttl()) {
+        return;
     }
-    file::rename(&download_path, cache_path)?;
-    Ok(registry)
+
+    if let Err(err) = download_registry_archive(&cache_path).await {
+        warn!("failed to refresh floating mise registry: {err:#}");
+    }
+}
+
+async fn download_registry_archive(cache_path: &Path) -> Result<()> {
+    let download_path = cache_path.with_extension(format!("download-{}", std::process::id()));
+    let pr = MultiProgressReport::get().add_pre_backend("mise registry");
+    if let Err(err) = HTTP
+        .download_file(MISE_REGISTRY_ARCHIVE_URL, &download_path, Some(pr.as_ref()))
+        .await
+    {
+        let _ = file::remove_file(&download_path);
+        pr.abandon();
+        return Err(err);
+    }
+
+    let result = (|| {
+        parse_registry_archive(&download_path)
+            .wrap_err("downloaded mise registry archive is invalid")?;
+        #[cfg(windows)]
+        if cache_path.exists() {
+            file::remove_file(cache_path)?;
+        }
+        file::rename(&download_path, cache_path)?;
+        Ok(())
+    })();
+    match result {
+        Ok(()) => {
+            pr.finish();
+            Ok(())
+        }
+        Err(err) => {
+            let _ = file::remove_file(&download_path);
+            pr.abandon();
+            Err(err)
+        }
+    }
 }
 
 fn parse_registry_archive(path: &Path) -> Result<Registry> {
@@ -198,16 +216,10 @@ fn parse_registry_archive(path: &Path) -> Result<Registry> {
             .components()
             .map(|component| component.as_os_str())
             .collect::<Vec<_>>();
-        let Some(registry_index) = components
-            .iter()
-            .position(|component| *component == "registry")
-        else {
-            continue;
-        };
-        if components.len() != registry_index + 2 {
+        if components.len() != 2 || components[0] != "registry" {
             continue;
         }
-        let file_path = PathBuf::from(components[registry_index + 1]);
+        let file_path = PathBuf::from(components[1]);
         if file_path
             .extension()
             .is_none_or(|extension| extension != "toml")
@@ -589,6 +601,27 @@ pub fn tool_enabled<T: Ord>(
 mod tests {
     use crate::config::Config;
 
+    fn registry_archive(entries: &[(&str, &str)]) -> tempfile::NamedTempFile {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        use std::io::Cursor;
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let encoder = GzEncoder::new(file.reopen().unwrap(), Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        for (path, contents) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            archive
+                .append_data(&mut header, path, Cursor::new(contents.as_bytes()))
+                .unwrap();
+        }
+        archive.into_inner().unwrap().finish().unwrap();
+        file
+    }
+
     #[test]
     fn test_dynamic_registry_parses_tools_aliases_and_options() {
         use super::*;
@@ -618,6 +651,37 @@ test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
             Some("example")
         );
         assert_eq!(tool.test.as_ref().unwrap().tools, &["node"]);
+    }
+
+    #[test]
+    fn test_registry_archive_only_reads_top_level_registry_directory() {
+        use super::*;
+
+        let archive = registry_archive(&[
+            ("registry/example.toml", "backends = [\"aqua:good/tool\"]"),
+            (
+                "e2e/registry/example.toml",
+                "backends = [\"aqua:wrong/tool\"]",
+            ),
+        ]);
+        let registry = parse_registry_archive(archive.path()).unwrap();
+
+        assert_eq!(
+            registry.get("example").unwrap().backends[0].full,
+            "aqua:good/tool"
+        );
+    }
+
+    #[test]
+    fn test_registry_archive_rejects_nested_registry_directory() {
+        use super::*;
+
+        let archive = registry_archive(&[(
+            "e2e/registry/example.toml",
+            "backends = [\"aqua:wrong/tool\"]",
+        )]);
+
+        assert!(parse_registry_archive(archive.path()).is_err());
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,24 +1,54 @@
 use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
 use crate::config::Settings;
+use crate::http::HTTP;
 use crate::toolset::{RawBackendOptions, ToolVersionOptions};
+use crate::{dirs, file};
+use eyre::{Context, Result, bail, ensure};
+use flate2::read::GzDecoder;
 use heck::ToShoutySnakeCase;
 use indexmap::IndexMap;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use serde::Serialize as _;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 use std::env::consts::OS;
 use std::fmt::Display;
+use std::fs::File;
+use std::io::Read;
 use std::iter::Iterator;
+use std::path::{Path, PathBuf};
 use std::sync::{LazyLock as Lazy, Mutex};
+use std::time::Duration;
 use strum::IntoEnumIterator;
 use url::Url;
 
 // the registry is generated from registry/ in the project root
-pub static REGISTRY: Registry = include!(concat!(env!("OUT_DIR"), "/registry.rs"));
+static BAKED_REGISTRY: Registry = include!(concat!(env!("OUT_DIR"), "/registry.rs"));
+pub static REGISTRY: Lazy<&'static Registry> = Lazy::new(|| {
+    if !Settings::get().registry_floating {
+        return &BAKED_REGISTRY;
+    }
+
+    match load_floating_registry() {
+        Ok(registry) => Box::leak(Box::new(registry)),
+        Err(err) => {
+            warn!("failed to load floating mise registry, using baked-in registry: {err:#}");
+            &BAKED_REGISTRY
+        }
+    }
+});
+
+const MISE_REGISTRY_ARCHIVE_URL: &str =
+    "https://github.com/jdx/mise/archive/refs/heads/main.tar.gz";
 
 pub struct Registry {
     entries: &'static [(&'static str, RegistryTool)],
-    lookup: phf::Map<&'static str, usize>,
+    lookup: RegistryLookup,
+}
+
+enum RegistryLookup {
+    Static(phf::Map<&'static str, usize>),
+    Dynamic(HashMap<&'static str, usize>),
 }
 
 impl Registry {
@@ -27,7 +57,7 @@ impl Registry {
     }
 
     pub fn contains_key(&self, name: &str) -> bool {
-        self.lookup.contains_key(name)
+        self.lookup.get(name).is_some()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, &'static RegistryTool)> {
@@ -40,6 +70,32 @@ impl Registry {
 
     pub fn values(&self) -> impl Iterator<Item = &'static RegistryTool> {
         self.entries.iter().map(|(_, tool)| tool)
+    }
+
+    fn dynamic(entries: BTreeMap<String, RegistryTool>) -> Self {
+        let entries = entries
+            .into_iter()
+            .map(|(name, tool)| (leak_string(name), tool))
+            .collect::<Vec<_>>();
+        let entries = leak_vec(entries);
+        let lookup = entries
+            .iter()
+            .enumerate()
+            .map(|(index, (name, _))| (*name, index))
+            .collect();
+        Self {
+            entries,
+            lookup: RegistryLookup::Dynamic(lookup),
+        }
+    }
+}
+
+impl RegistryLookup {
+    fn get(&self, name: &str) -> Option<&usize> {
+        match self {
+            Self::Static(lookup) => lookup.get(name),
+            Self::Dynamic(lookup) => lookup.get(name),
+        }
     }
 }
 
@@ -69,6 +125,252 @@ pub struct RegistryBackend {
     pub full: &'static str,
     pub platforms: &'static [&'static str],
     pub options: &'static [(&'static str, &'static str)],
+}
+
+fn load_floating_registry() -> Result<Registry> {
+    let settings = Settings::get();
+    let cache_path = dirs::CACHE.join("mise-registry").join("main.tar.gz");
+
+    if cache_is_fresh(&cache_path, settings.registry_cache_ttl()) {
+        match parse_registry_archive(&cache_path) {
+            Ok(registry) => return Ok(registry),
+            Err(err) => warn!("failed to parse cached floating mise registry: {err:#}"),
+        }
+    }
+
+    if !settings.prefer_offline() {
+        match download_registry_archive(&cache_path) {
+            Ok(registry) => return Ok(registry),
+            Err(err) => warn!("failed to refresh floating mise registry: {err:#}"),
+        }
+    }
+
+    parse_registry_archive(&cache_path).wrap_err("failed to load cached floating mise registry")
+}
+
+fn cache_is_fresh(path: &Path, ttl: Duration) -> bool {
+    path.metadata()
+        .and_then(|metadata| metadata.modified())
+        .and_then(|modified| modified.elapsed().map_err(std::io::Error::other))
+        .is_ok_and(|age| age < ttl)
+}
+
+fn download_registry_archive(cache_path: &Path) -> Result<Registry> {
+    let download_path = cache_path.with_extension("tar.gz.download");
+    if download_path.exists() {
+        file::remove_file(&download_path)?;
+    }
+
+    let path = download_path.clone();
+    let result = std::thread::spawn(move || -> Result<()> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(HTTP.download_file(MISE_REGISTRY_ARCHIVE_URL, &path, None))
+    })
+    .join()
+    .map_err(|_| eyre::eyre!("floating registry download thread panicked"))?;
+    result?;
+
+    let registry = parse_registry_archive(&download_path)
+        .wrap_err("downloaded mise registry archive is invalid")?;
+    #[cfg(windows)]
+    if cache_path.exists() {
+        file::remove_file(cache_path)?;
+    }
+    file::rename(&download_path, cache_path)?;
+    Ok(registry)
+}
+
+fn parse_registry_archive(path: &Path) -> Result<Registry> {
+    let file = File::open(path)?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut sources = BTreeMap::new();
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let path = entry.path()?;
+        let components = path
+            .components()
+            .map(|component| component.as_os_str())
+            .collect::<Vec<_>>();
+        let Some(registry_index) = components
+            .iter()
+            .position(|component| *component == "registry")
+        else {
+            continue;
+        };
+        if components.len() != registry_index + 2 {
+            continue;
+        }
+        let file_path = PathBuf::from(components[registry_index + 1]);
+        if file_path
+            .extension()
+            .is_none_or(|extension| extension != "toml")
+        {
+            continue;
+        }
+        let short = file_path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .ok_or_else(|| eyre::eyre!("invalid registry filename: {}", path.display()))?
+            .to_string();
+        let mut source = String::new();
+        entry.read_to_string(&mut source)?;
+        sources.insert(short, source);
+    }
+
+    ensure!(
+        !sources.is_empty(),
+        "archive does not contain registry entries"
+    );
+    registry_from_sources(sources)
+}
+
+fn registry_from_sources(sources: BTreeMap<String, String>) -> Result<Registry> {
+    let mut entries = BTreeMap::new();
+    for (short, source) in sources {
+        let value: toml::Value = toml::from_str(&source)
+            .wrap_err_with(|| format!("failed to parse registry/{short}.toml"))?;
+        let tool = parse_registry_tool(&short, &value)
+            .wrap_err_with(|| format!("invalid registry/{short}.toml"))?;
+        entries.insert(short, tool.clone());
+        for alias in tool.aliases {
+            entries.insert((*alias).to_string(), tool.clone());
+        }
+    }
+    Ok(Registry::dynamic(entries))
+}
+
+fn parse_registry_tool(short: &str, value: &toml::Value) -> Result<RegistryTool> {
+    let table = value
+        .as_table()
+        .ok_or_else(|| eyre::eyre!("registry tool must be a TOML table"))?;
+    let backends = table
+        .get("backends")
+        .and_then(toml::Value::as_array)
+        .ok_or_else(|| eyre::eyre!("backends must be an array"))?
+        .iter()
+        .map(parse_registry_backend)
+        .collect::<Result<Vec<_>>>()?;
+    ensure!(!backends.is_empty(), "backends must not be empty");
+
+    let aliases = string_array(table.get("aliases"), "aliases")?;
+    let overrides = string_array(table.get("overrides"), "overrides")?;
+    let os = string_array(table.get("os"), "os")?;
+    let idiomatic_files = string_array(table.get("idiomatic_files"), "idiomatic_files")?;
+    let detect = string_array(table.get("detect"), "detect")?;
+    let description = table
+        .get("description")
+        .map(|value| {
+            value
+                .as_str()
+                .map(|value| leak_string(value.to_string()))
+                .ok_or_else(|| eyre::eyre!("description must be a string"))
+        })
+        .transpose()?;
+    let test = table.get("test").map(parse_registry_test).transpose()?;
+
+    Ok(RegistryTool {
+        short: leak_string(short.to_string()),
+        description,
+        backends: leak_vec(backends),
+        aliases: leak_vec(aliases),
+        overrides: leak_vec(overrides),
+        test: Box::leak(Box::new(test)),
+        os: leak_vec(os),
+        idiomatic_files: leak_vec(idiomatic_files),
+        detect: leak_vec(detect),
+    })
+}
+
+fn parse_registry_backend(value: &toml::Value) -> Result<RegistryBackend> {
+    match value {
+        toml::Value::String(full) => Ok(RegistryBackend {
+            full: leak_string(full.clone()),
+            platforms: &[],
+            options: &[],
+        }),
+        toml::Value::Table(table) => {
+            let full = table
+                .get("full")
+                .and_then(toml::Value::as_str)
+                .ok_or_else(|| eyre::eyre!("backend full must be a string"))?;
+            let platforms = string_array(table.get("platforms"), "backend platforms")?;
+            let options = table
+                .get("options")
+                .and_then(toml::Value::as_table)
+                .map(|options| {
+                    options
+                        .iter()
+                        .map(|(key, value)| {
+                            let mut serialized = String::new();
+                            value.serialize(toml::ser::ValueSerializer::new(&mut serialized))?;
+                            Ok((leak_string(key.clone()), leak_string(serialized)))
+                        })
+                        .collect::<Result<Vec<_>>>()
+                })
+                .transpose()?
+                .unwrap_or_default();
+            Ok(RegistryBackend {
+                full: leak_string(full.to_string()),
+                platforms: leak_vec(platforms),
+                options: leak_vec(options),
+            })
+        }
+        _ => bail!("backend must be a string or table"),
+    }
+}
+
+fn parse_registry_test(value: &toml::Value) -> Result<RegistryToolTest> {
+    let table = value
+        .as_table()
+        .ok_or_else(|| eyre::eyre!("test must be a table"))?;
+    let cmd = table
+        .get("cmd")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| eyre::eyre!("test.cmd must be a string"))?;
+    let expected = table
+        .get("expected")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| eyre::eyre!("test.expected must be a string"))?;
+    let tools = string_array(table.get("tools"), "test.tools")?;
+    Ok(RegistryToolTest {
+        cmd: leak_string(cmd.to_string()),
+        expected: leak_string(expected.to_string()),
+        tools: leak_vec(tools),
+    })
+}
+
+fn string_array(value: Option<&toml::Value>, name: &str) -> Result<Vec<&'static str>> {
+    value
+        .map(|value| {
+            value
+                .as_array()
+                .ok_or_else(|| eyre::eyre!("{name} must be an array"))?
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(|value| leak_string(value.to_string()))
+                        .ok_or_else(|| eyre::eyre!("{name} must contain only strings"))
+                })
+                .collect()
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
+}
+
+fn leak_string(value: String) -> &'static str {
+    Box::leak(value.into_boxed_str())
+}
+
+fn leak_vec<T>(value: Vec<T>) -> &'static [T] {
+    Box::leak(value.into_boxed_slice())
 }
 
 // Cache for environment variable overrides
@@ -286,6 +588,37 @@ pub fn tool_enabled<T: Ord>(
 #[cfg(test)]
 mod tests {
     use crate::config::Config;
+
+    #[test]
+    fn test_dynamic_registry_parses_tools_aliases_and_options() {
+        use super::*;
+
+        let registry = registry_from_sources(BTreeMap::from([(
+            "example".to_string(),
+            r#"
+aliases = ["example-alias"]
+description = "Example tool"
+backends = [
+  "aqua:example/tool",
+  { full = "github:example/tool", platforms = ["linux-x64"], options = { bin = "example" } },
+]
+test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
+"#
+            .to_string(),
+        )]))
+        .unwrap();
+
+        let tool = registry.get("example-alias").unwrap();
+        assert_eq!(tool.short, "example");
+        assert_eq!(tool.description, Some("Example tool"));
+        assert_eq!(tool.backends[0].full, "aqua:example/tool");
+        assert_eq!(tool.backends[1].platforms, &["linux-x64"]);
+        assert_eq!(
+            tool.backend_options("github:example/tool").get("bin"),
+            Some("example")
+        );
+        assert_eq!(tool.test.as_ref().unwrap().tools, &["node"]);
+    }
 
     #[test]
     fn test_tool_disabled() {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,7 +6,6 @@ use crate::toolset::{RawBackendOptions, ToolVersionOptions};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{dirs, file};
 use eyre::{Context, Result, bail, ensure};
-use flate2::read::GzDecoder;
 use heck::ToShoutySnakeCase;
 use indexmap::IndexMap;
 use serde::Serialize as _;
@@ -43,7 +42,7 @@ pub static REGISTRY: Lazy<&'static Registry> = Lazy::new(|| {
     }
 });
 
-const MISE_REGISTRY_ARCHIVE_URL: &str = "https://mise.jdx.dev/registry/latest.tar.gz";
+const MISE_REGISTRY_ARCHIVE_URL: &str = "https://mise.jdx.dev/registry/latest.tar.zst";
 const MAX_REGISTRY_ARCHIVE_ENTRIES: usize = 4096;
 const MAX_REGISTRY_ARCHIVE_ENTRY_SIZE: u64 = 1024 * 1024;
 const MAX_REGISTRY_ARCHIVE_SIZE: u64 = 16 * 1024 * 1024;
@@ -135,7 +134,7 @@ pub struct RegistryBackend {
 }
 
 fn registry_cache_path() -> PathBuf {
-    dirs::CACHE.join("mise-registry").join("registry.tar.gz")
+    dirs::CACHE.join("mise-registry").join("registry.tar.zst")
 }
 
 fn load_cached_floating_registry() -> Result<Registry> {
@@ -233,7 +232,7 @@ fn replace_registry_cache(download_path: &Path, cache_path: &Path) -> Result<()>
 
 fn parse_registry_archive(path: &Path) -> Result<Registry> {
     let file = File::open(path)?;
-    let decoder = GzDecoder::new(file);
+    let decoder = zstd::Decoder::new(file)?;
     let mut archive = tar::Archive::new(decoder);
     let mut sources = BTreeMap::new();
     let mut archive_size = 0_u64;
@@ -658,12 +657,10 @@ mod tests {
     use crate::config::Config;
 
     fn registry_archive(entries: &[(&str, &str)]) -> tempfile::NamedTempFile {
-        use flate2::Compression;
-        use flate2::write::GzEncoder;
         use std::io::Cursor;
 
         let file = tempfile::NamedTempFile::new().unwrap();
-        let encoder = GzEncoder::new(file.reopen().unwrap(), Compression::default());
+        let encoder = zstd::Encoder::new(file.reopen().unwrap(), 0).unwrap();
         let mut archive = tar::Builder::new(encoder);
         for (path, contents) in entries {
             let mut header = tar::Header::new_gnu();

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -44,6 +44,9 @@ pub static REGISTRY: Lazy<&'static Registry> = Lazy::new(|| {
 });
 
 const MISE_REGISTRY_ARCHIVE_URL: &str = "https://mise.jdx.dev/registry/latest.tar.gz";
+const MAX_REGISTRY_ARCHIVE_ENTRIES: usize = 4096;
+const MAX_REGISTRY_ARCHIVE_ENTRY_SIZE: u64 = 1024 * 1024;
+const MAX_REGISTRY_ARCHIVE_SIZE: u64 = 16 * 1024 * 1024;
 
 pub struct Registry {
     entries: &'static [(&'static str, RegistryTool)],
@@ -157,7 +160,10 @@ pub async fn refresh() {
 
     let cache_path = registry_cache_path();
     if cache_is_fresh(&cache_path, settings.registry_cache_ttl()) {
-        return;
+        if parse_registry_archive(&cache_path).is_ok() {
+            return;
+        }
+        warn!("cached floating mise registry is invalid; refreshing it");
     }
 
     if let Err(err) = download_registry_archive(&cache_path).await {
@@ -180,11 +186,7 @@ async fn download_registry_archive(cache_path: &Path) -> Result<()> {
     let result = (|| {
         parse_registry_archive(&download_path)
             .wrap_err("downloaded mise registry archive is invalid")?;
-        #[cfg(windows)]
-        if cache_path.exists() {
-            file::remove_file(cache_path)?;
-        }
-        file::rename(&download_path, cache_path)?;
+        replace_registry_cache(&download_path, cache_path)?;
         Ok(())
     })();
     match result {
@@ -200,14 +202,45 @@ async fn download_registry_archive(cache_path: &Path) -> Result<()> {
     }
 }
 
+#[cfg(not(windows))]
+fn replace_registry_cache(download_path: &Path, cache_path: &Path) -> Result<()> {
+    file::rename(download_path, cache_path)
+}
+
+#[cfg(windows)]
+fn replace_registry_cache(download_path: &Path, cache_path: &Path) -> Result<()> {
+    let backup_path = cache_path.with_extension(format!("backup-{}", std::process::id()));
+    let had_cache = cache_path.exists();
+    if backup_path.exists() {
+        file::remove_file(&backup_path)?;
+    }
+    if had_cache {
+        file::rename(cache_path, &backup_path)?;
+    }
+    if let Err(install_err) = file::rename(download_path, cache_path) {
+        if had_cache && let Err(restore_err) = file::rename(&backup_path, cache_path) {
+            return Err(install_err).wrap_err(format!(
+                "failed to install downloaded registry and restore cached registry: {restore_err:#}"
+            ));
+        }
+        return Err(install_err).wrap_err("failed to install downloaded registry");
+    }
+    if had_cache {
+        file::remove_file(&backup_path)?;
+    }
+    Ok(())
+}
+
 fn parse_registry_archive(path: &Path) -> Result<Registry> {
     let file = File::open(path)?;
     let decoder = GzDecoder::new(file);
     let mut archive = tar::Archive::new(decoder);
     let mut sources = BTreeMap::new();
+    let mut archive_size = 0_u64;
 
-    for entry in archive.entries()? {
+    for (index, entry) in archive.entries()?.enumerate() {
         let mut entry = entry?;
+        track_registry_archive_entry(index, entry.size(), &mut archive_size)?;
         if !entry.header().entry_type().is_file() {
             continue;
         }
@@ -241,6 +274,29 @@ fn parse_registry_archive(path: &Path) -> Result<Registry> {
         "archive does not contain registry entries"
     );
     registry_from_sources(sources)
+}
+
+fn track_registry_archive_entry(
+    index: usize,
+    entry_size: u64,
+    archive_size: &mut u64,
+) -> Result<()> {
+    ensure!(
+        index < MAX_REGISTRY_ARCHIVE_ENTRIES,
+        "registry archive contains too many entries"
+    );
+    ensure!(
+        entry_size <= MAX_REGISTRY_ARCHIVE_ENTRY_SIZE,
+        "registry archive entry is too large"
+    );
+    *archive_size = archive_size
+        .checked_add(entry_size)
+        .ok_or_else(|| eyre::eyre!("registry archive size overflow"))?;
+    ensure!(
+        *archive_size <= MAX_REGISTRY_ARCHIVE_SIZE,
+        "registry archive is too large"
+    );
+    Ok(())
 }
 
 fn registry_from_sources(sources: BTreeMap<String, String>) -> Result<Registry> {
@@ -682,6 +738,32 @@ test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
         )]);
 
         assert!(parse_registry_archive(archive.path()).is_err());
+    }
+
+    #[test]
+    fn test_registry_archive_limits() {
+        use super::*;
+
+        let mut size = 0;
+        assert!(
+            track_registry_archive_entry(MAX_REGISTRY_ARCHIVE_ENTRIES, 0, &mut size)
+                .unwrap_err()
+                .to_string()
+                .contains("too many entries")
+        );
+        assert!(
+            track_registry_archive_entry(0, MAX_REGISTRY_ARCHIVE_ENTRY_SIZE + 1, &mut size)
+                .unwrap_err()
+                .to_string()
+                .contains("entry is too large")
+        );
+        size = MAX_REGISTRY_ARCHIVE_SIZE;
+        assert!(
+            track_registry_archive_entry(0, 1, &mut size)
+                .unwrap_err()
+                .to_string()
+                .contains("archive is too large")
+        );
     }
 
     #[test]

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -86,6 +86,17 @@ impl MultiProgressReport {
         self.add_with_options(prefix, false)
     }
 
+    /// Create a progress report before backends are loaded, when normal prefix sizing is unavailable.
+    pub(crate) fn add_pre_backend(&self, prefix: &str) -> Box<dyn SingleReport> {
+        if self.quiet {
+            Box::new(QuietReport::new())
+        } else if self.use_progress_ui {
+            Box::new(ProgressReport::new_with_pad(prefix.to_string(), 15))
+        } else {
+            Box::new(VerboseReport::new_with_pad(prefix.to_string(), 15))
+        }
+    }
+
     pub fn add_with_options(&self, prefix: &str, dry_run: bool) -> Box<dyn SingleReport> {
         if self.quiet {
             progress_trace!(

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -88,8 +88,11 @@ pub struct ProgressReport {
 
 impl ProgressReport {
     pub fn new(prefix: String) -> ProgressReport {
+        Self::new_with_pad(prefix, *LONGEST_PLUGIN_NAME)
+    }
+
+    pub fn new_with_pad(prefix: String, pad: usize) -> ProgressReport {
         ui::ctrlc::show_cursor_after_ctrl_c();
-        let pad = *LONGEST_PLUGIN_NAME;
         let formatted_prefix = normal_prefix(pad, &prefix);
 
         // Template: prefix + message + optional bytes/progress bar + spinner on right
@@ -176,10 +179,14 @@ pub struct VerboseReport {
 
 impl VerboseReport {
     pub fn new(prefix: String) -> VerboseReport {
+        Self::new_with_pad(prefix, *LONGEST_PLUGIN_NAME)
+    }
+
+    pub fn new_with_pad(prefix: String, pad: usize) -> VerboseReport {
         VerboseReport {
             prefix,
             prev_message: Mutex::new("".to_string()),
-            pad: *LONGEST_PLUGIN_NAME,
+            pad,
             total_operations: Mutex::new(None),
             current_operation: Mutex::new(0),
         }


### PR DESCRIPTION
## Summary

- add opt-in `registry_floating` support for the latest released mise registry and the current official aqua registry
- refresh the mise registry asynchronously only on network-eligible command paths, with visible progress and atomic cache replacement
- keep fast/offline commands cache-or-baked only; keep aqua fetching lazy and show progress when it is actually downloaded
- strictly accept only `registry/<tool>.toml` from the release artifact and preserve baked fallbacks

## Release artifact

#10991 merged and v2026.7.7 now publishes `registry/latest.tar.zst`. The live end-to-end test passes against the public artifact.

## Motivation

Distribution packages can lag behind mise releases while registry entries continue to change. This gives users on distributions such as Arch Linux an explicit way to consume newer registry metadata without changing the release-pinned default for everyone else.

The R2 artifact is produced from a registry that passed the release test suite, avoiding both the full repository download and an untested `main` snapshot.

## Validation

- `mise run lint-fix`
- `cargo check --all-features`
- `cargo test registry::tests`
- `cargo test aqua::aqua_registry_wrapper::tests`
- `mise run render:schema`
- isolated fast-command smoke test confirming no registry cache/network initialization

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI startup order and how tool shorthand resolves from remote data; mitigated by opt-in default, TTL cache, strict archive validation, and baked fallbacks on parse or network failure.
> 
> **Overview**
> Adds opt-in **floating registries** so mise can use newer shorthand and aqua metadata without upgrading the binary, while keeping release-bundled snapshots as the default and fallback.
> 
> When `registry_floating` is enabled, mise downloads and caches `registry/latest.tar.zst`, parses only `registry/<tool>.toml` entries (with size/count limits), and builds a dynamic registry; invalid or missing cache falls back to the baked registry with a warning. **`registry_cache_ttl`** (default 1h) controls refresh; offline/prefer-offline and fast paths skip network refresh. Startup now runs **`install_state::init`** before Clap parsing, then **`registry::refresh`** before **`backend::load_tools`** (skipped for version-only invocations).
> 
> The aqua wrapper prepends the official registry when floating is on, treats load failures on that source as non-fatal (warn + baked fallback), and shows progress on aqua registry download. Docs/schema/settings document the feature; an e2e script verifies live download of the published artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1bcfcb0d3000ff62f569c7d596307381a905ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional “floating” registries to fetch the latest mise and official aqua data, with bundled snapshots as fallbacks.
  * Added configurable floating-registry cache TTL and automatic refresh when online.
  * Added support for registry aliases and improved download progress reporting.
* **Documentation**
  * Documented floating registry setup, caching/TTL behavior, offline behavior, and cache clearing.
* **Performance**
  * Version-only commands now avoid unnecessary startup work.
* **Chores**
  * Registry archives are now published and downloaded as `tar.zst` for more efficient updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


