### PR TITLE
chore(release): publish registry artifact

### DIFF
--- a/scripts/publish-s3.sh
+++ b/scripts/publish-s3.sh
@@ -36,7 +36,7 @@ aws s3 cp "./schema/mise-task.json" "s3://$AWS_S3_BUCKET/schema/mise-task.json" 
 registry_tmpdir="$(mktemp -d)"
 trap 'rm -rf "$registry_tmpdir"' EXIT
 registry_archive="$registry_tmpdir/registry.tar.gz"
-tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -cf - registry | gzip -n >"$registry_archive"
+git archive --format=tar HEAD registry | gzip -n >"$registry_archive"
 aws s3 cp "$registry_archive" "s3://$AWS_S3_BUCKET/registry/$MISE_VERSION.tar.gz" --cache-control "$cache_week" --no-progress --content-type "application/gzip"
 aws s3 cp "$registry_archive" "s3://$AWS_S3_BUCKET/registry/latest.tar.gz" --cache-control "$cache_hour" --no-progress --content-type "application/gzip"
 

--- a/scripts/publish-s3.sh
+++ b/scripts/publish-s3.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S mise x aws-cli@2.22.35 -- bash
 set -euxo pipefail
 
-#cache_hour="max-age=3600,s-maxage=3600,public,immutable"
+cache_hour="max-age=3600,s-maxage=3600,public"
 cache_day="max-age=86400,s-maxage=86400,public,immutable"
 cache_week="max-age=604800,s-maxage=604800,public,immutable"
 
@@ -30,6 +30,15 @@ aws s3 cp "$RELEASE_DIR/install.sh.minisig" "s3://$AWS_S3_BUCKET/" --cache-contr
 aws s3 cp "./schema/mise.json" "s3://$AWS_S3_BUCKET/schema/mise.json" --cache-control "$cache_day" --no-progress --content-type "application/json"
 aws s3 cp "./schema/mise.plugin.json" "s3://$AWS_S3_BUCKET/schema/mise.plugin.json" --cache-control "$cache_day" --no-progress --content-type "application/json"
 aws s3 cp "./schema/mise-task.json" "s3://$AWS_S3_BUCKET/schema/mise-task.json" --cache-control "$cache_day" --no-progress --content-type "application/json"
+
+# Publish only the registry files so older mise builds can opt into the registry
+# tested by this release without downloading the entire source repository.
+registry_tmpdir="$(mktemp -d)"
+trap 'rm -rf "$registry_tmpdir"' EXIT
+registry_archive="$registry_tmpdir/registry.tar.gz"
+tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -cf - registry | gzip -n >"$registry_archive"
+aws s3 cp "$registry_archive" "s3://$AWS_S3_BUCKET/registry/$MISE_VERSION.tar.gz" --cache-control "$cache_week" --no-progress --content-type "application/gzip"
+aws s3 cp "$registry_archive" "s3://$AWS_S3_BUCKET/registry/latest.tar.gz" --cache-control "$cache_hour" --no-progress --content-type "application/gzip"
 
 # Upload shell-specific mise.run scripts
 aws s3 cp artifacts/mise.run/zsh "s3://$AWS_S3_BUCKET/mise.run/zsh" --cache-control "$cache_week" --no-progress --content-type "text/plain"


### PR DESCRIPTION
## Summary

- build a deterministic gzip archive containing only `registry/*.toml`
- publish immutable versioned artifacts at `registry/<mise-version>.tar.gz`
- publish the current release artifact at `registry/latest.tar.gz` with a one-hour CDN cache

## Motivation

This bootstraps a small, release-tested registry artifact in R2 before floating-registry clients depend on it. It avoids making clients download and inspect the full mise source archive.

## Validation

- `bash -n scripts/publish-s3.sh`
- `mise x shellcheck -- shellcheck scripts/publish-s3.sh`
- `mise x shfmt -- shfmt -d scripts/publish-s3.sh`

## Follow-up

PR #10971 will consume this artifact after this change lands and a release publishes the initial object.

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script-only change; adds S3 objects and relies on `git` being available at publish time, with no runtime app logic changes.
> 
> **Overview**
> Extends **`scripts/publish-s3.sh`** so each release uploads a **gzip tarball of only the `registry/` tree** (via `git archive` + `gzip -n`), instead of clients pulling the full source repo.
> 
> Objects land at **`registry/<MISE_VERSION>.tar.gz`** (week-long immutable CDN cache) and **`registry/latest.tar.gz`** (one-hour cache via a new `cache_hour` directive without `immutable`). A temp dir and `EXIT` trap clean up the archive after upload.
> 
> **`cache_hour`** is enabled (previously commented out) specifically for the rolling `latest` registry artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc06d2bd65d895c414488a0dc7b62b5214722a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added downloadable registry archives for each release and a “latest” version.
  * Published registry archives with deterministic archive generation and correct `application/gzip` content type.
  * Updated caching behavior for published registry assets to improve freshness and delivery performance.

* **Bug Fixes**
  * Ensured temporary publishing files are automatically cleaned up after the upload process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->