### PR TITLE
fix(copr): add PIE flag for aws-lc probe

### DIFF
--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -227,6 +227,16 @@ replace-with = "vendored-sources"
 directory = "vendor"
 CARGO_EOF
 
+# aws-lc-sys compiles and links its memcmp compiler probe in one command. It
+# intentionally ignores CFLAGS, but still applies Fedora's LDFLAGS, whose
+# hardened linker specs produce a PIE executable. Add the matching compiler
+# flag so the probe's object file is position-independent as well.
+%if 0%{?fedora}
+%ifarch x86_64
+export LDFLAGS="${LDFLAGS:-} -fPIE"
+%endif
+%endif
+
 # On RHEL/EPEL x86_64, nasm lives in CRB which is not enabled in COPR
 # chroots. Use prebuilt NASM objects bundled inside the aws-lc-sys crate
 # instead. This works at all Cargo profile/optimization levels including


### PR DESCRIPTION
## Summary

- append `-fPIE` to Fedora x86_64 COPR `LDFLAGS`
- preserve the existing Fedora RPM hardening linker flags
- document why the flag is needed for the `aws-lc-sys` compiler probe

## Root cause

`aws-lc-sys` compiles and links its `memcmp_invalid_stripped_check` probe in a single compiler invocation. The probe intentionally ignores `CFLAGS`, but applies Fedora's `LDFLAGS`. Fedora 44's hardened linker specs produce a PIE executable, while the probe's object is compiled without `-fPIE`, causing an `R_X86_64_32` relocation failure.

Adding `-fPIE` to `LDFLAGS` supplies the matching compile flag in that combined invocation without removing Fedora's hardening flags.

Related to https://github.com/jdx/mise/discussions/10921.

## Validation

- reproduced the original failure with the exact `aws-lc-sys 0.42.0` probe in a Fedora 44 x86_64 container
- confirmed the probe compiles and runs successfully with the added `-fPIE`
- expanded the generated spec successfully with Fedora 44 `rpmspec`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change scoped to Fedora x86_64 COPR RPM builds; no runtime application logic.
> 
> **Overview**
> Fixes **Fedora x86_64 COPR** builds that fail during the **`aws-lc-sys`** `memcmp` compiler probe when hardened linker flags produce a PIE binary but the probe object is not position-independent.
> 
> The generated RPM **`%build`** section now exports **`LDFLAGS="${LDFLAGS:-} -fPIE"`** for **`%if 0%{?fedora}`** and **`%ifarch x86_64`**, appending the compile flag in the same combined compile/link step without dropping existing Fedora hardening. Inline comments document why **`CFLAGS`** are ignored by the probe and why this workaround is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4897545cae42b712f23927192413722b4792d980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fedora x86_64 package builds by ensuring compiler checks use position-independent code.
  * Increased compatibility and reliability for RPM packaging on supported Fedora systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->