### PR TITLE
registry: add tfvault

### DIFF
--- a/registry/tfvault.toml
+++ b/registry/tfvault.toml
@@ -1,0 +1,3 @@
+backends = ["github:tedilabs/tfvault", "aqua:tedilabs/tfvault"]
+description = "Universal Terraform credentials helper with pluggable secret backends"
+test = { cmd = "tfvault version", expected = "tfvault {{version}}" }


### PR DESCRIPTION
## Summary

Adds [tfvault](https://github.com/tedilabs/tfvault) — a universal Terraform credentials helper with pluggable secret backends (OS keyring, pass/gopass, environment variables). It implements Terraform's credentials-helper protocol so `terraform login` tokens can live in a real secret store, with per-profile isolation for multiple accounts.

```toml
backends = ["github:tedilabs/tfvault", "aqua:tedilabs/tfvault"]
description = "Universal Terraform credentials helper with pluggable secret backends"
test = { cmd = "tfvault version", expected = "tfvault {{version}}" }
```

## Notes

- Releases ship `tfvault_<version>_{darwin,linux}_{amd64,arm64}.tar.gz` plus `checksums.txt`; the github backend resolves them out of the box (verified locally: `mise x github:tedilabs/tfvault@0.2.0 -- tfvault version` → `tfvault 0.2.0 (commit 4ec178b, ...)`).
- The tool was just accepted into the aqua registry (aquaproj/aqua-registry#56948, merged today) but isn't in a tagged aqua-registry release yet, so it's missing from the vendored registry — that's why `github:` is listed first for now. Happy to reorder to aqua-first once the vendor bump lands, or drop either backend per your preference.
- No windows assets (darwin/linux only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TFVault to the Terraform credentials helper registry.
  * Added support for multiple installation backends.
  * Added version verification during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->