### PR TITLE
fix(file): ignore malformed pax metadata during sparse detection

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1250,7 +1250,15 @@ fn tar_entry_is_sparse<R: Read>(entry: &mut tar::Entry<'_, R>) -> std::io::Resul
     };
 
     for extension in pax_extensions {
-        let extension = extension?;
+        let extension = match extension {
+            Ok(extension) => extension,
+            Err(err) => {
+                debug!(
+                    "Ignoring malformed PAX extension while checking for sparse metadata: {err}"
+                );
+                continue;
+            }
+        };
         if extension
             .key()
             .is_ok_and(|key| key.starts_with("GNU.sparse."))
@@ -2616,6 +2624,43 @@ mod tests {
         let mut entry = entries.next().unwrap().unwrap();
 
         assert!(tar_entry_is_sparse(&mut entry).unwrap());
+    }
+
+    #[test]
+    fn test_extract_archive_ignores_malformed_non_sparse_pax_metadata() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let archive_path = dir.path().join("pax-xattr.tar");
+        let dest_dir = dir.path().join("out");
+        let archive = File::create(&archive_path).unwrap();
+        let mut builder = tar::Builder::new(archive);
+        builder
+            .append_pax_extensions([(
+                "LIBARCHIVE.xattr.com.apple.cs.CodeSignature",
+                b"signature\nmetadata".as_slice(),
+            )])
+            .unwrap();
+
+        let contents = b"hello world";
+        let mut header = tar::Header::new_ustar();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "tool", contents.as_slice())
+            .unwrap();
+        builder.finish().unwrap();
+
+        extract_archive(
+            &archive_path,
+            &dest_dir,
+            ExtractionFormat::Tar,
+            &ExtractOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(dest_dir.join("tool")).unwrap(), contents);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ignore malformed PAX records while scanning tar entries for `GNU.sparse.*` metadata
- preserve the system-tar fallback for valid sparse metadata
- add regression coverage for libarchive code-signature xattrs containing embedded newlines

## Root cause
PR #10821 fixed PAX sparse extraction by inspecting every PAX extension before unpacking. That change also made any PAX parser error fatal because the sparse detector propagated errors from `tar::PaxExtensions`.

The Ollama macOS archive reported in discussion #10976 contains `LIBARCHIVE.xattr.com.apple.cs.CodeSignature` metadata with embedded newlines. `tar` 0.4.46 treats those records as malformed, so the sparse-detection change in #10821 regressed an otherwise extractable, non-sparse archive.

This change restores the previous tolerant extraction behavior for malformed non-sparse metadata while continuing to detect valid `GNU.sparse.*` records.

## Validation
- `mise run format` (includes repository lint/check tasks)
- `cargo test test_tar_entry_is_sparse_detects_pax_sparse_metadata`
- `cargo test test_extract_archive_ignores_malformed_non_sparse_pax_metadata`

Discussion: https://github.com/jdx/mise/discussions/10976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TAR archive extraction when archives contain malformed or unsupported PAX metadata.
  * Extraction now continues successfully by ignoring invalid metadata that does not affect file contents.
  * Added coverage to verify successful extraction from affected archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->