### PR TITLE
test(cargo): align binstall fallback coverage

### DIFF
--- a/e2e/backend/test_cargo_binstall_slow
+++ b/e2e/backend/test_cargo_binstall_slow
@@ -4,11 +4,10 @@ require_cmd cargo
 export MISE_CARGO_BINSTALL=1
 echo "tools.cargo-binstall = 'latest'" >mise.toml
 mise i
-assert "mise x cargo:eza@0.18.24 -- eza -v" "eza - A modern, maintained replacement for ls
+assert "MISE_CARGO_BINSTALL_ONLY=1 mise x cargo:eza@0.18.24 -- eza -v" "eza - A modern, maintained replacement for ls
 v0.18.24 [+git]
 https://github.com/eza-community/eza"
 
-export MISE_CARGO_BINSTALL_ONLY=1
 cat >mise.toml <<EOF
 tools.cargo-binstall = "latest"
 tools."cargo:cargo-show" = "latest"


### PR DESCRIPTION
## Summary

- exercise `cargo.binstall_only` with `eza`, which has a prebuilt artifact
- let `cargo-show` cover mise's exit-94 `cargo install` fallback
- keep the custom registry integration coverage aligned with the new fallback ownership

## Root cause

`test_cargo_binstall_slow` exported `MISE_CARGO_BINSTALL_ONLY=1` for `cargo-show`. Since `cargo-show` has no prebuilt artifact and binstall-only now intentionally prohibits mise's compile fallback, the test asserted behavior that no longer matches the setting.

## Validation

- `mise run test:e2e e2e/backend/test_cargo_binstall_slow`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for installing and running the specified Cargo tool with `MISE_CARGO_BINSTALL_ONLY=1`.
  * The test continues to verify successful command output using the targeted `eza` version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->