### PR TITLE
test(config): cover settings lookup with --cd

### DIFF
--- a/e2e/cli/test_chdir
+++ b/e2e/cli/test_chdir
@@ -2,11 +2,17 @@
 
 mkdir -p ./test
 cat <<EOF >./test/mise.toml
+[settings]
+experimental = true
+
 [tasks.hello]
 run = 'echo "Hello, World!"'
 EOF
 
 assert_contains "mise config --cd $PWD/test ls" "test/mise.toml"
+
+unset MISE_EXPERIMENTAL
+assert "mise -C $PWD/test settings get experimental" "true"
 
 assert_contains "mise run --cd $PWD/test hello" "Hello, World!"
 assert_contains "mise run --cd ./test hello" "Hello, World!"


### PR DESCRIPTION
## Summary

- extend the existing chdir E2E fixture with a target-local `[settings]` block
- verify `mise -C <dir> settings get experimental` reads that target configuration
- remove the E2E harness override before the assertion so the test exercises file-backed settings discovery

## Why

Discussion #9693 reported that `-C` loaded target tools and environment configuration but skipped the target `[settings]` block. PR #10945 fixed the stale settings-file discovery path, and the exact CLI regression should remain covered independently of its bootstrap-focused unit tests.

## User impact

Future changes to settings initialization or config-path caching will fail CI if `-C` stops loading settings from the effective working directory.

## Validation

- `mise run test:e2e e2e/cli/test_chdir`
- `mise run lint-fix`

Related: https://github.com/jdx/mise/discussions/9693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded command-line validation for changing directories and reading experimental settings.
  * Added coverage for multiple directory path formats when running tasks.
  * Updated test configuration to explicitly enable experimental features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->