### PR TITLE
fix(shim): prevent recursion when directory env is filtered

### DIFF
--- a/crates/mise-shim/src/main.rs
+++ b/crates/mise-shim/src/main.rs
@@ -1,7 +1,21 @@
 // Based on https://github.com/iki/mise-shim by Jan Killian (MIT License)
 
 use std::env;
+use std::path::Path;
 use std::process::{Command, exit};
+
+const MISE_SHIM_PATH_ENV: &str = "__MISE_SHIM_PATH";
+
+fn paths_eq(a: &Path, b: &Path) -> bool {
+    let a = std::fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
+    let b = std::fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
+    if cfg!(windows) {
+        a.to_string_lossy()
+            .eq_ignore_ascii_case(&b.to_string_lossy())
+    } else {
+        a == b
+    }
+}
 
 fn main() {
     let exe = env::current_exe().unwrap_or_else(|e| {
@@ -16,9 +30,22 @@ fn main() {
         })
         .to_os_string();
 
+    if env::var_os(MISE_SHIM_PATH_ENV)
+        .as_deref()
+        .is_some_and(|previous| paths_eq(Path::new(previous), &exe))
+    {
+        eprintln!(
+            "mise-shim: recursive shim invocation detected for {}: {}",
+            tool.to_string_lossy(),
+            exe.display()
+        );
+        exit(1);
+    }
+
     let args = env::args_os().skip(1);
 
     let status = Command::new("mise")
+        .env(MISE_SHIM_PATH_ENV, &exe)
         .arg("x")
         .arg("--")
         .arg(&tool)

--- a/crates/mise-shim/src/main.rs
+++ b/crates/mise-shim/src/main.rs
@@ -7,13 +7,20 @@ use std::process::{Command, exit};
 const MISE_SHIM_PATH_ENV: &str = "__MISE_SHIM_PATH";
 
 fn paths_eq(a: &Path, b: &Path) -> bool {
-    let a = std::fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
-    let b = std::fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
-    if cfg!(windows) {
-        a.to_string_lossy()
-            .eq_ignore_ascii_case(&b.to_string_lossy())
-    } else {
-        a == b
+    let lexical_eq = |a: &Path, b: &Path| {
+        if cfg!(windows) {
+            a.to_string_lossy()
+                .eq_ignore_ascii_case(&b.to_string_lossy())
+        } else {
+            a == b
+        }
+    };
+    if lexical_eq(a, b) {
+        return true;
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => lexical_eq(&a, &b),
+        _ => false,
     }
 }
 

--- a/e2e-win/shim_recursion.Tests.ps1
+++ b/e2e-win/shim_recursion.Tests.ps1
@@ -53,4 +53,51 @@ echo SHIM_NOT_REAL
         $result | Should -Contain "REAL_TOOL_OUTPUT"
         $result | Should -Not -Contain "SHIM_NOT_REAL"
     }
+
+    It 'native shim resolves a real tool when MISE_DATA_DIR is filtered out' {
+        $customShimPath = Join-Path $TestDrive "custom-shims"
+        New-Item -ItemType Directory -Path $customShimPath -Force | Out-Null
+        Copy-Item (Join-Path $PSScriptRoot "..\target\debug\mise-shim.exe") `
+            (Join-Path $customShimPath "mytool.exe")
+
+        $originalDataDir = $env:MISE_DATA_DIR
+        $previousPath = $env:PATH
+        try {
+            Remove-Item Env:\MISE_DATA_DIR -ErrorAction Ignore
+            $env:PATH = "$customShimPath;$($script:toolDir);$env:PATH"
+
+            $result = & (Join-Path $customShimPath "mytool.exe")
+
+            $LASTEXITCODE | Should -Be 0
+            $result | Should -Contain "REAL_TOOL_OUTPUT"
+        } finally {
+            $env:MISE_DATA_DIR = $originalDataDir
+            $env:PATH = $previousPath
+        }
+    }
+
+    It 'direct executable shim resolves a real tool when MISE_DATA_DIR is filtered out' {
+        $customShimPath = Join-Path $TestDrive "direct-shims"
+        New-Item -ItemType Directory -Path $customShimPath -Force | Out-Null
+        $misePath = Join-Path $PSScriptRoot "..\target\debug\mise.exe"
+        Copy-Item $misePath (Join-Path $customShimPath "mytool.exe")
+
+        $originalDataDir = $env:MISE_DATA_DIR
+        $originalMiseBin = $env:__MISE_BIN
+        $previousPath = $env:PATH
+        try {
+            Remove-Item Env:\MISE_DATA_DIR -ErrorAction Ignore
+            $env:__MISE_BIN = $misePath
+            $env:PATH = "$customShimPath;$($script:toolDir);$env:PATH"
+
+            $result = & (Join-Path $customShimPath "mytool.exe")
+
+            $LASTEXITCODE | Should -Be 0
+            $result | Should -Contain "REAL_TOOL_OUTPUT"
+        } finally {
+            $env:MISE_DATA_DIR = $originalDataDir
+            $env:__MISE_BIN = $originalMiseBin
+            $env:PATH = $previousPath
+        }
+    }
 }

--- a/e2e-win/shim_recursion.Tests.ps1
+++ b/e2e-win/shim_recursion.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'shim_exec_recursion' {
 
     BeforeAll {
         $script:originalPath = Get-Location
+        $script:originalEnvPath = $env:PATH
         Set-Location TestDrive:
         $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
 
@@ -42,6 +43,7 @@ echo SHIM_NOT_REAL
         Remove-Item -Path (Join-Path $script:shimPath "mytool.cmd") -ErrorAction SilentlyContinue
         Remove-Item -Path $script:toolDir -Recurse -ErrorAction SilentlyContinue
         Set-Location $script:originalPath
+        $env:PATH = $script:originalEnvPath
         Remove-Item -Path Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
     }
 
@@ -79,6 +81,34 @@ echo SHIM_NOT_REAL
         }
     }
 
+    It 'native shim preserves a sibling real executable in the same directory' {
+        $customShimPath = Join-Path $TestDrive "same-dir-native-shims"
+        New-Item -ItemType Directory -Path $customShimPath -Force | Out-Null
+        Copy-Item (Join-Path $PSScriptRoot "..\target\debug\mise-shim.exe") `
+            (Join-Path $customShimPath "mytool.exe")
+        @'
+@echo off
+if defined __MISE_SHIM_PATH echo SHIM_PATH_LEAKED
+echo SAME_DIRECTORY_REAL_TOOL
+'@ | Out-File -FilePath (Join-Path $customShimPath "mytool.cmd") -Encoding ascii -NoNewline
+
+        $originalDataDir = $env:MISE_DATA_DIR
+        $previousPath = $env:PATH
+        try {
+            Remove-Item Env:\MISE_DATA_DIR -ErrorAction Ignore
+            $env:PATH = "$customShimPath;$($script:originalEnvPath)"
+
+            $result = & (Join-Path $customShimPath "mytool.exe")
+
+            $LASTEXITCODE | Should -Be 0
+            $result | Should -Contain "SAME_DIRECTORY_REAL_TOOL"
+            $result | Should -Not -Contain "SHIM_PATH_LEAKED"
+        } finally {
+            $env:MISE_DATA_DIR = $originalDataDir
+            $env:PATH = $previousPath
+        }
+    }
+
     It 'file shim resolves a real tool when MISE_DATA_DIR is filtered out' {
         $customShimPath = Join-Path $TestDrive "file-shims"
         New-Item -ItemType Directory -Path $customShimPath -Force | Out-Null
@@ -101,6 +131,37 @@ mise x -- mytool %*
 
             $LASTEXITCODE | Should -Be 0
             $result | Should -Contain "REAL_TOOL_OUTPUT"
+            $result | Should -Not -Contain "SHIM_PATH_LEAKED"
+        } finally {
+            $env:MISE_DATA_DIR = $originalDataDir
+            $env:PATH = $previousPath
+        }
+    }
+
+    It 'file shim preserves a sibling real executable in the same directory' {
+        $customShimPath = Join-Path $TestDrive "same-dir-file-shims"
+        New-Item -ItemType Directory -Path $customShimPath -Force | Out-Null
+        @'
+@echo off
+setlocal
+set "shim_path=%~f0"
+if /I "%__MISE_SHIM_PATH%"=="%shim_path%" exit /b 1
+set "__MISE_SHIM_PATH=%shim_path%"
+mise x -- mytool %*
+'@ | Out-File -FilePath (Join-Path $customShimPath "mytool.cmd") -Encoding ascii -NoNewline
+        Copy-Item $env:ComSpec (Join-Path $customShimPath "mytool.exe")
+
+        $originalDataDir = $env:MISE_DATA_DIR
+        $previousPath = $env:PATH
+        try {
+            Remove-Item Env:\MISE_DATA_DIR -ErrorAction Ignore
+            $env:PATH = "$customShimPath;$($script:originalEnvPath)"
+
+            $result = & (Join-Path $customShimPath "mytool.cmd") /d /c `
+                'if defined __MISE_SHIM_PATH (echo SHIM_PATH_LEAKED) else echo SAME_DIRECTORY_REAL_TOOL'
+
+            $LASTEXITCODE | Should -Be 0
+            $result | Should -Contain "SAME_DIRECTORY_REAL_TOOL"
             $result | Should -Not -Contain "SHIM_PATH_LEAKED"
         } finally {
             $env:MISE_DATA_DIR = $originalDataDir

--- a/e2e-win/shim_recursion.Tests.ps1
+++ b/e2e-win/shim_recursion.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'shim_exec_recursion' {
         New-Item -ItemType Directory -Path $script:toolDir -Force | Out-Null
         @'
 @echo off
+if defined __MISE_SHIM_PATH echo SHIM_PATH_LEAKED
 echo REAL_TOOL_OUTPUT
 '@ | Out-File -FilePath (Join-Path $script:toolDir "mytool.cmd") -Encoding ascii -NoNewline
 
@@ -52,6 +53,7 @@ echo SHIM_NOT_REAL
         $LASTEXITCODE | Should -Be 0
         $result | Should -Contain "REAL_TOOL_OUTPUT"
         $result | Should -Not -Contain "SHIM_NOT_REAL"
+        $result | Should -Not -Contain "SHIM_PATH_LEAKED"
     }
 
     It 'native shim resolves a real tool when MISE_DATA_DIR is filtered out' {
@@ -70,33 +72,68 @@ echo SHIM_NOT_REAL
 
             $LASTEXITCODE | Should -Be 0
             $result | Should -Contain "REAL_TOOL_OUTPUT"
+            $result | Should -Not -Contain "SHIM_PATH_LEAKED"
         } finally {
             $env:MISE_DATA_DIR = $originalDataDir
             $env:PATH = $previousPath
         }
     }
 
-    It 'direct executable shim resolves a real tool when MISE_DATA_DIR is filtered out' {
-        $customShimPath = Join-Path $TestDrive "direct-shims"
+    It 'file shim resolves a real tool when MISE_DATA_DIR is filtered out' {
+        $customShimPath = Join-Path $TestDrive "file-shims"
         New-Item -ItemType Directory -Path $customShimPath -Force | Out-Null
-        $misePath = Join-Path $PSScriptRoot "..\target\debug\mise.exe"
-        Copy-Item $misePath (Join-Path $customShimPath "mytool.exe")
+        @'
+@echo off
+setlocal
+set "shim_path=%~f0"
+if /I "%__MISE_SHIM_PATH%"=="%shim_path%" exit /b 1
+set "__MISE_SHIM_PATH=%shim_path%"
+mise x -- mytool %*
+'@ | Out-File -FilePath (Join-Path $customShimPath "mytool.cmd") -Encoding ascii -NoNewline
 
         $originalDataDir = $env:MISE_DATA_DIR
-        $originalMiseBin = $env:__MISE_BIN
         $previousPath = $env:PATH
         try {
             Remove-Item Env:\MISE_DATA_DIR -ErrorAction Ignore
-            $env:__MISE_BIN = $misePath
             $env:PATH = "$customShimPath;$($script:toolDir);$env:PATH"
 
-            $result = & (Join-Path $customShimPath "mytool.exe")
+            $result = & (Join-Path $customShimPath "mytool.cmd")
 
             $LASTEXITCODE | Should -Be 0
             $result | Should -Contain "REAL_TOOL_OUTPUT"
+            $result | Should -Not -Contain "SHIM_PATH_LEAKED"
         } finally {
             $env:MISE_DATA_DIR = $originalDataDir
-            $env:__MISE_BIN = $originalMiseBin
+            $env:PATH = $previousPath
+        }
+    }
+
+    It 'hardlink shim resolves a real tool when MISE_DATA_DIR is filtered out' {
+        $customShimPath = Join-Path $TestDrive "direct-shims"
+        $directToolDir = Join-Path $TestDrive "direct-toolbin"
+        New-Item -ItemType Directory -Path $customShimPath -Force | Out-Null
+        New-Item -ItemType Directory -Path $directToolDir -Force | Out-Null
+        $misePath = Join-Path $PSScriptRoot "..\target\debug\mise.exe"
+        $localMisePath = Join-Path $customShimPath "mise.exe"
+        Copy-Item $misePath $localMisePath
+        New-Item -ItemType HardLink -Path (Join-Path $customShimPath "mytool.exe") `
+            -Target $localMisePath | Out-Null
+        Copy-Item $env:ComSpec (Join-Path $directToolDir "mytool.exe")
+
+        $originalDataDir = $env:MISE_DATA_DIR
+        $previousPath = $env:PATH
+        try {
+            Remove-Item Env:\MISE_DATA_DIR -ErrorAction Ignore
+            $env:PATH = "$customShimPath;$directToolDir;$env:PATH"
+
+            $result = & mytool.exe /d /c `
+                'if defined __MISE_SHIM_PATH (echo SHIM_PATH_LEAKED) else echo REAL_TOOL_OUTPUT'
+
+            $LASTEXITCODE | Should -Be 0
+            $result | Should -Contain "REAL_TOOL_OUTPUT"
+            $result | Should -Not -Contain "SHIM_PATH_LEAKED"
+        } finally {
+            $env:MISE_DATA_DIR = $originalDataDir
             $env:PATH = $previousPath
         }
     }

--- a/e2e/cli/test_exec_shim_recursion
+++ b/e2e/cli/test_exec_shim_recursion
@@ -43,6 +43,7 @@ fi
 echo SAME_DIRECTORY_REAL_TOOL
 TOOL
 chmod +x "$mixed_dir/siblingtool"
+touch "$mixed_dir/siblingtool.cmd"
 export PATH="$mixed_dir:$PATH"
 
 assert_contains \

--- a/e2e/cli/test_exec_shim_recursion
+++ b/e2e/cli/test_exec_shim_recursion
@@ -28,3 +28,53 @@ export PATH="$shimdir:$tooldir:$PATH"
 # mise x should strip shims from lookup path and find the real tool
 assert_contains "mise x -- mytool" "REAL_TOOL_OUTPUT"
 assert_not_contains "mise x -- mytool" "SHIM_NOT_REAL"
+
+# An active shim outside the configured shim directories must be excluded by
+# identity, not by excluding its entire parent directory. File shims can
+# coexist with a real executable of the same stem but a different extension.
+mixed_dir="$HOME/mixed-bin"
+mkdir -p "$mixed_dir"
+cat >"$mixed_dir/siblingtool" <<'TOOL'
+#!/bin/sh
+if [ -n "${__MISE_SHIM_PATH:-}" ]; then
+  echo SHIM_PATH_LEAKED
+  exit 1
+fi
+echo SAME_DIRECTORY_REAL_TOOL
+TOOL
+chmod +x "$mixed_dir/siblingtool"
+export PATH="$mixed_dir:$PATH"
+
+assert_contains \
+  "__MISE_SHIM_PATH='$mixed_dir/siblingtool.cmd' mise x -- siblingtool" \
+  "SAME_DIRECTORY_REAL_TOOL"
+assert_not_contains \
+  "__MISE_SHIM_PATH='$mixed_dir/siblingtool.cmd' mise x -- siblingtool" \
+  "SHIM_PATH_LEAKED"
+
+# deny-env clears the process environment before lookup. The active shim marker
+# must be captured first so the exact shim is still skipped in that mode.
+active_dir="$HOME/active-bin"
+real_dir="$HOME/real-bin"
+mkdir -p "$active_dir" "$real_dir"
+cat >"$active_dir/guardedtool" <<'SHIM'
+#!/bin/sh
+echo WRONG_ACTIVE_SHIM
+SHIM
+cat >"$real_dir/guardedtool" <<'TOOL'
+#!/bin/sh
+if [ -n "${__MISE_SHIM_PATH:-}" ]; then
+  echo SHIM_PATH_LEAKED
+  exit 1
+fi
+echo DENY_ENV_REAL_TOOL
+TOOL
+chmod +x "$active_dir/guardedtool" "$real_dir/guardedtool"
+export PATH="$active_dir:$real_dir:$PATH"
+
+assert_contains \
+  "__MISE_SHIM_PATH='$active_dir/guardedtool' mise x --deny-env --allow-env PATH -- guardedtool" \
+  "DENY_ENV_REAL_TOOL"
+assert_not_contains \
+  "__MISE_SHIM_PATH='$active_dir/guardedtool' mise x --deny-env --allow-env PATH -- guardedtool" \
+  "WRONG_ACTIVE_SHIM"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -322,6 +322,7 @@ where
         });
         match which::which_in(&program, lookup_path, cwd) {
             Ok(resolved) => resolved.into_os_string(),
+            Err(err) if env::MISE_SHIM_PATH.read().unwrap().is_some() => return Err(err.into()),
             Err(_) => program, // Fall back to original if resolution fails
         }
     };

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -304,25 +304,18 @@ where
             // User-configured paths (_.path/venv) maintain their position
             // relative to tool paths since both are "mise-added".
             // The child process still inherits the full unmodified PATH.
-            let user_shims = &*crate::dirs::SHIMS;
-            let sys_shims = crate::env::MISE_SYSTEM_DATA_DIR.join("shims");
-            let is_shims_dir = |p: &std::path::PathBuf| {
-                let expanded = crate::file::replace_path(p);
-                crate::file::paths_eq(&expanded, user_shims)
-                    || crate::file::paths_eq(&expanded, &sys_shims)
-            };
             let pristine: std::collections::HashSet<_> = crate::env::PATH.iter().collect();
             let all_paths: Vec<_> = std::env::split_paths(&OsString::from(path_val)).collect();
             // Mise-added paths first (preserving relative order)
             let mise_added: Vec<_> = all_paths
                 .iter()
-                .filter(|p| !pristine.contains(p))
+                .filter(|p| !pristine.contains(p) && !crate::file::is_mise_shims_dir(p))
                 .cloned()
                 .collect();
             // Then original system paths (minus shims)
             let original: Vec<_> = all_paths
                 .iter()
-                .filter(|p| pristine.contains(p) && !is_shims_dir(p))
+                .filter(|p| pristine.contains(p) && !crate::file::is_mise_shims_dir(p))
                 .cloned()
                 .collect();
             std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
@@ -332,6 +325,13 @@ where
             Err(_) => program, // Fall back to original if resolution fails
         }
     };
+    if crate::file::is_active_mise_shim(std::path::Path::new(&program)) {
+        return Err(eyre::eyre!(
+            "recursive shim invocation detected: {}",
+            program.to_string_lossy()
+        ));
+    }
+    env::remove_var(env::MISE_SHIM_PATH_ENV);
     // Apply sandbox (Landlock/seccomp on Linux, sandbox-exec on macOS)
     let args_str: Vec<String> = args
         .iter()
@@ -373,13 +373,6 @@ where
     // Reorder PATH for program resolution: mise-added paths first, then
     // original system paths (minus shims). See Unix version for full rationale.
     let lookup_path = env.get(&*env::PATH_KEY).map(|path_val| {
-        let user_shims = &*crate::dirs::SHIMS;
-        let sys_shims = crate::env::MISE_SYSTEM_DATA_DIR.join("shims");
-        let is_shims = |p: &std::path::PathBuf| {
-            let expanded = crate::file::replace_path(p);
-            crate::file::paths_eq(&expanded, user_shims)
-                || crate::file::paths_eq(&expanded, &sys_shims)
-        };
         let pristine: std::collections::HashSet<_> = crate::env::PATH
             .iter()
             .map(|p| {
@@ -397,7 +390,7 @@ where
                     .to_string_lossy()
                     .to_lowercase()
                     .replace('/', "\\");
-                !pristine.contains(&normalized)
+                !pristine.contains(&normalized) && !crate::file::is_mise_shims_dir(p)
             })
             .cloned()
             .collect();
@@ -408,13 +401,20 @@ where
                     .to_string_lossy()
                     .to_lowercase()
                     .replace('/', "\\");
-                pristine.contains(&normalized) && !is_shims(p)
+                pristine.contains(&normalized) && !crate::file::is_mise_shims_dir(p)
             })
             .cloned()
             .collect();
         std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
     });
     let program = which::which_in(program, lookup_path, cwd)?;
+    if crate::file::is_active_mise_shim(&program) {
+        return Err(eyre!(
+            "recursive shim invocation detected: {}",
+            program.to_string_lossy()
+        ));
+    }
+    env::remove_var(env::MISE_SHIM_PATH_ENV);
     let args: Vec<OsString> = args.into_iter().map(Into::into).collect();
 
     // Windows does not support exec in the same way as Unix,

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -276,6 +276,9 @@ where
     U: IntoIterator,
     U::Item: Into<OsString>,
 {
+    // Capture the marker before deny-env removes variables from the process.
+    // The lazy state must retain the dispatching shim for candidate filtering.
+    drop(env::MISE_SHIM_PATH.read().unwrap());
     if sandbox.effective_deny_env() {
         // When env is sandboxed, clear all vars and only set the filtered ones
         for (k, _) in std::env::vars() {
@@ -320,8 +323,16 @@ where
                 .collect();
             std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
         });
-        match which::which_in(&program, lookup_path, cwd) {
-            Ok(resolved) => resolved.into_os_string(),
+        match which::which_in_all(&program, lookup_path, cwd) {
+            Ok(mut candidates) => {
+                match candidates.find(|candidate| !crate::file::is_active_mise_shim(candidate)) {
+                    Some(resolved) => resolved.into_os_string(),
+                    None if env::MISE_SHIM_PATH.read().unwrap().is_some() => {
+                        return Err(which::Error::CannotFindBinaryPath.into());
+                    }
+                    None => program, // Fall back to original if resolution fails
+                }
+            }
             Err(err) if env::MISE_SHIM_PATH.read().unwrap().is_some() => return Err(err.into()),
             Err(_) => program, // Fall back to original if resolution fails
         }
@@ -408,13 +419,9 @@ where
             .collect();
         std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
     });
-    let program = which::which_in(program, lookup_path, cwd)?;
-    if crate::file::is_active_mise_shim(&program) {
-        return Err(eyre!(
-            "recursive shim invocation detected: {}",
-            program.to_string_lossy()
-        ));
-    }
+    let program = which::which_in_all(program, lookup_path, cwd)?
+        .find(|candidate| !crate::file::is_active_mise_shim(candidate))
+        .ok_or(which::Error::CannotFindBinaryPath)?;
     env::remove_var(env::MISE_SHIM_PATH_ENV);
     let args: Vec<OsString> = args.into_iter().map(Into::into).collect();
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -431,7 +431,8 @@ pub static __MISE_SHIM: Lazy<bool> = Lazy::new(|| var_is_true("__MISE_SHIM"));
 /// this remains reliable when a parent process preserves PATH but filters out
 /// mise's directory configuration variables.
 pub const MISE_SHIM_PATH_ENV: &str = "__MISE_SHIM_PATH";
-pub static MISE_SHIM_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| var_path(MISE_SHIM_PATH_ENV));
+pub static MISE_SHIM_PATH: Lazy<RwLock<Option<PathBuf>>> =
+    Lazy::new(|| RwLock::new(var_path(MISE_SHIM_PATH_ENV)));
 
 // true if the current process is running as a shim (not direct mise invocation)
 pub static IS_RUNNING_AS_SHIM: Lazy<bool> = Lazy::new(|| {

--- a/src/env.rs
+++ b/src/env.rs
@@ -427,6 +427,12 @@ pub static __USAGE: Lazy<Option<String>> = Lazy::new(|| var("__USAGE").ok());
 // true if running inside a shim
 pub static __MISE_SHIM: Lazy<bool> = Lazy::new(|| var_is_true("__MISE_SHIM"));
 
+/// Absolute path of the shim that delegated to mise. Unlike `MISE_SHIMS_DIR`,
+/// this remains reliable when a parent process preserves PATH but filters out
+/// mise's directory configuration variables.
+pub const MISE_SHIM_PATH_ENV: &str = "__MISE_SHIM_PATH";
+pub static MISE_SHIM_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| var_path(MISE_SHIM_PATH_ENV));
+
 // true if the current process is running as a shim (not direct mise invocation)
 pub static IS_RUNNING_AS_SHIM: Lazy<bool> = Lazy::new(|| {
     // When running tests, always treat as direct mise invocation

--- a/src/file.rs
+++ b/src/file.rs
@@ -921,22 +921,18 @@ pub fn canonicalize_or_self(path: &Path) -> PathBuf {
 pub fn is_mise_shims_dir(path: &Path) -> bool {
     let resolved = replace_path(path);
     let sys_shims = env::MISE_SYSTEM_DATA_DIR.join("shims");
-    let active_shims = env::MISE_SHIM_PATH
-        .as_ref()
-        .cloned()
-        .and_then(|shim| shim.parent().map(Path::to_path_buf));
+    let active_shim = env::MISE_SHIM_PATH.read().unwrap();
+    let active_shims = active_shim.as_deref().and_then(Path::parent);
     if paths_eq(&resolved, &dirs::SHIMS)
         || paths_eq(&resolved, &sys_shims)
-        || active_shims
-            .as_ref()
-            .is_some_and(|active| paths_eq(&resolved, active))
+        || active_shims.is_some_and(|active| paths_eq(&resolved, active))
     {
         return true;
     }
     let canon_input = canonicalize_or_self(&resolved);
     let canon_user = canonicalize_or_self(&dirs::SHIMS);
     let canon_sys = canonicalize_or_self(&sys_shims);
-    let canon_active = active_shims.as_deref().map(canonicalize_or_self);
+    let canon_active = active_shims.map(canonicalize_or_self);
     paths_eq(&canon_input, &canon_user)
         || paths_eq(&canon_input, &canon_sys)
         || canon_active
@@ -946,8 +942,11 @@ pub fn is_mise_shims_dir(path: &Path) -> bool {
 
 /// Returns true if `path` resolves to the shim that delegated to this mise
 /// process. This is a final fail-safe after PATH filtering and before exec.
+#[cfg(not(test))]
 pub fn is_active_mise_shim(path: &Path) -> bool {
     env::MISE_SHIM_PATH
+        .read()
+        .unwrap()
         .as_ref()
         .is_some_and(|active| paths_eq(&canonicalize_or_self(path), &canonicalize_or_self(active)))
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -907,13 +907,12 @@ pub fn canonicalize_or_self(path: &Path) -> PathBuf {
 
 /// Returns true if `path` is one of mise's shim directories.
 ///
-/// Two dirs qualify: the user shims dir (`dirs::SHIMS`) and the system shims
-/// dir (`$MISE_SYSTEM_DATA_DIR/shims`). Devcontainer / Docker setups built
-/// with `mise install --system` put both on PATH, so subprocess-env filters
-/// that strip "the shims dir" must consider both — otherwise the recursion
-/// these filters were added to prevent (#8475 for `dependency_env`, #8816
-/// for `which_shim`, this for the file.rs helpers) leaks back in through the
-/// remaining dir.
+/// Three dirs can qualify: the configured user shims dir (`dirs::SHIMS`), the
+/// system shims dir (`$MISE_SYSTEM_DATA_DIR/shims`), and the parent directory
+/// of the active shim recorded in `__MISE_SHIM_PATH`. The last one is needed
+/// when a parent process preserves PATH but filters out variables such as
+/// `MISE_DATA_DIR`; in that case the configured directory can no longer be
+/// reconstructed, but the shim must still never resolve back to itself.
 ///
 /// Uses `paths_eq` + `replace_path` for the fast path (expands `~`,
 /// case-insensitive on macOS/Windows), then falls back to `canonicalize_or_self`
@@ -922,13 +921,35 @@ pub fn canonicalize_or_self(path: &Path) -> PathBuf {
 pub fn is_mise_shims_dir(path: &Path) -> bool {
     let resolved = replace_path(path);
     let sys_shims = env::MISE_SYSTEM_DATA_DIR.join("shims");
-    if paths_eq(&resolved, &dirs::SHIMS) || paths_eq(&resolved, &sys_shims) {
+    let active_shims = env::MISE_SHIM_PATH
+        .as_ref()
+        .cloned()
+        .and_then(|shim| shim.parent().map(Path::to_path_buf));
+    if paths_eq(&resolved, &dirs::SHIMS)
+        || paths_eq(&resolved, &sys_shims)
+        || active_shims
+            .as_ref()
+            .is_some_and(|active| paths_eq(&resolved, active))
+    {
         return true;
     }
     let canon_input = canonicalize_or_self(&resolved);
     let canon_user = canonicalize_or_self(&dirs::SHIMS);
     let canon_sys = canonicalize_or_self(&sys_shims);
-    paths_eq(&canon_input, &canon_user) || paths_eq(&canon_input, &canon_sys)
+    let canon_active = active_shims.as_deref().map(canonicalize_or_self);
+    paths_eq(&canon_input, &canon_user)
+        || paths_eq(&canon_input, &canon_sys)
+        || canon_active
+            .as_ref()
+            .is_some_and(|active| paths_eq(&canon_input, active))
+}
+
+/// Returns true if `path` resolves to the shim that delegated to this mise
+/// process. This is a final fail-safe after PATH filtering and before exec.
+pub fn is_active_mise_shim(path: &Path) -> bool {
+    env::MISE_SHIM_PATH
+        .as_ref()
+        .is_some_and(|active| paths_eq(&canonicalize_or_self(path), &canonicalize_or_self(active)))
 }
 
 /// Build a PATH value with mise shims filtered out, suitable for passing to

--- a/src/file.rs
+++ b/src/file.rs
@@ -907,12 +907,11 @@ pub fn canonicalize_or_self(path: &Path) -> PathBuf {
 
 /// Returns true if `path` is one of mise's shim directories.
 ///
-/// Three dirs can qualify: the configured user shims dir (`dirs::SHIMS`), the
-/// system shims dir (`$MISE_SYSTEM_DATA_DIR/shims`), and the parent directory
-/// of the active shim recorded in `__MISE_SHIM_PATH`. The last one is needed
-/// when a parent process preserves PATH but filters out variables such as
-/// `MISE_DATA_DIR`; in that case the configured directory can no longer be
-/// reconstructed, but the shim must still never resolve back to itself.
+/// The configured user shims dir (`dirs::SHIMS`) and system shims dir
+/// (`$MISE_SYSTEM_DATA_DIR/shims`) qualify. An active shim outside these
+/// configured directories is rejected per candidate instead of treating its
+/// entire parent directory as shims, since that directory may also contain
+/// legitimate executables.
 ///
 /// Uses `paths_eq` + `replace_path` for the fast path (expands `~`,
 /// case-insensitive on macOS/Windows), then falls back to `canonicalize_or_self`
@@ -921,28 +920,18 @@ pub fn canonicalize_or_self(path: &Path) -> PathBuf {
 pub fn is_mise_shims_dir(path: &Path) -> bool {
     let resolved = replace_path(path);
     let sys_shims = env::MISE_SYSTEM_DATA_DIR.join("shims");
-    let active_shim = env::MISE_SHIM_PATH.read().unwrap();
-    let active_shims = active_shim.as_deref().and_then(Path::parent);
-    if paths_eq(&resolved, &dirs::SHIMS)
-        || paths_eq(&resolved, &sys_shims)
-        || active_shims.is_some_and(|active| paths_eq(&resolved, active))
-    {
+    if paths_eq(&resolved, &dirs::SHIMS) || paths_eq(&resolved, &sys_shims) {
         return true;
     }
     let canon_input = canonicalize_or_self(&resolved);
     let canon_user = canonicalize_or_self(&dirs::SHIMS);
     let canon_sys = canonicalize_or_self(&sys_shims);
-    let canon_active = active_shims.map(canonicalize_or_self);
-    paths_eq(&canon_input, &canon_user)
-        || paths_eq(&canon_input, &canon_sys)
-        || canon_active
-            .as_ref()
-            .is_some_and(|active| paths_eq(&canon_input, active))
+    paths_eq(&canon_input, &canon_user) || paths_eq(&canon_input, &canon_sys)
 }
 
 /// Returns true if `path` resolves to the shim that delegated to this mise
-/// process. This is a final fail-safe after PATH filtering and before exec.
-#[cfg(not(test))]
+/// process. Candidate-level filtering avoids excluding legitimate sibling
+/// executables that happen to share a directory with the active shim.
 pub fn is_active_mise_shim(path: &Path) -> bool {
     env::MISE_SHIM_PATH
         .read()

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -28,6 +28,17 @@ pub async fn handle_shim() -> Result<()> {
     if env::is_mise_binary(bin_name) || cfg!(test) {
         return Ok(());
     }
+    let shim_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from(&*env::ARGV0));
+    if env::var_path(env::MISE_SHIM_PATH_ENV)
+        .as_ref()
+        .is_some_and(|previous| file::paths_eq(previous, &shim_path))
+    {
+        bail!(
+            "recursive shim invocation detected for {bin_name}: {}",
+            display_path(&shim_path)
+        );
+    }
+    env::set_var(env::MISE_SHIM_PATH_ENV, &shim_path);
     let mut config = Config::get().await?;
     let mut args = env::ARGS.read().unwrap().clone();
     env::PREFER_OFFLINE.store(true, Ordering::Relaxed);
@@ -89,15 +100,8 @@ async fn which_shim(config: &mut Arc<Config>, bin_name: &str) -> Result<PathBuf>
     }
     // fallback for "system"
     let mise_bin = file::canonicalize_or_self(&env::MISE_BIN);
-    let user_shims = file::canonicalize_cached(&dirs::SHIMS);
-    let sys_shims = {
-        let p = env::MISE_SYSTEM_DATA_DIR.join("shims");
-        file::canonicalize_cached(&p)
-    };
     for path in &*env::PATH {
-        if let Some(canon_path) = file::canonicalize_cached(path)
-            && (user_shims.as_ref() == Some(&canon_path) || sys_shims.as_ref() == Some(&canon_path))
-        {
+        if file::is_mise_shims_dir(path) {
             continue;
         }
         let bin = path.join(bin_name);
@@ -333,8 +337,14 @@ fn bash_shim_script(tool: &str) -> String {
     formatdoc! {r#"
         #!/bin/bash
 
+        shim_dir=$(cd -- "$(dirname -- "$0")" && pwd -P)
+        shim_path="$shim_dir/${{0##*/}}"
+        if [ "${{__MISE_SHIM_PATH:-}}" = "$shim_path" ]; then
+          echo "mise: recursive shim invocation detected for {tool}: $shim_path" >&2
+          exit 1
+        fi
+
         if [ -n "${{WSL_DISTRO_NAME:-}}" ] || [ -n "${{WSL_INTEROP:-}}" ] || [ -e /proc/sys/fs/binfmt_misc/WSLInterop ]; then
-          shim_dir=$(cd -- "$(dirname -- "$0")" && pwd -P)
           new_path=
           # disable globbing so a PATH entry containing * ? [ is not expanded
           set -f
@@ -349,6 +359,7 @@ fn bash_shim_script(tool: &str) -> String {
           exec {tool} "$@"
         fi
 
+        export __MISE_SHIM_PATH="$shim_path"
         exec mise x -- {tool} "$@"
         "#}
 }
@@ -391,6 +402,12 @@ fn add_shim(mise_bin: &Path, symlink_path: &Path, shim: &str) -> Result<()> {
                 formatdoc! {r#"
         @echo off
         setlocal
+        set "shim_path=%~f0"
+        if /I "%__MISE_SHIM_PATH%"=="%shim_path%" (
+          echo mise: recursive shim invocation detected for {shim}: %shim_path% 1>&2
+          exit /b 1
+        )
+        set "__MISE_SHIM_PATH=%shim_path%"
         mise x -- {shim} %*
         "#},
             )
@@ -698,6 +715,10 @@ mod tests {
         assert!(script.contains(r#"shim_dir=$(cd -- "$(dirname -- "$0")" && pwd -P)"#));
         // globbing disabled while splitting PATH so wildcard entries are not expanded
         assert!(script.contains("set -f"));
+        // The shim identifies its actual location even if MISE_DATA_DIR is absent.
+        assert!(script.contains(r#"shim_path="$shim_dir/${0##*/}""#));
+        assert!(script.contains(r#"export __MISE_SHIM_PATH="$shim_path""#));
+        assert!(script.contains("recursive shim invocation detected"));
         // In WSL: drop the shim dir and run the native tool directly.
         assert!(script.contains(r#"exec gh "$@""#));
         // Outside WSL: defer to mise as before.

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -133,6 +133,9 @@ async fn which_shim(config: &mut Arc<Config>, bin_name: &str) -> Result<PathBuf>
         }
         let bin = path.join(bin_name);
         if bin.exists() {
+            if file::is_active_mise_shim(&bin) {
+                continue;
+            }
             // Skip if this binary is a mise shim (symlink pointing to the mise binary)
             if file::canonicalize_cached(&bin).is_some_and(|bin| bin == mise_bin) {
                 continue;

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -28,17 +28,26 @@ pub async fn handle_shim() -> Result<()> {
     if env::is_mise_binary(bin_name) || cfg!(test) {
         return Ok(());
     }
-    let shim_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from(&*env::ARGV0));
-    if env::var_path(env::MISE_SHIM_PATH_ENV)
-        .as_ref()
-        .is_some_and(|previous| file::paths_eq(previous, &shim_path))
+    #[cfg(windows)]
     {
-        bail!(
-            "recursive shim invocation detected for {bin_name}: {}",
-            display_path(&shim_path)
-        );
+        let shim_path = invoked_shim_path();
+        if env::var_path(env::MISE_SHIM_PATH_ENV)
+            .as_ref()
+            .is_some_and(|previous| {
+                file::paths_eq(
+                    &file::canonicalize_or_self(previous),
+                    &file::canonicalize_or_self(&shim_path),
+                )
+            })
+        {
+            bail!(
+                "recursive shim invocation detected for {bin_name}: {}",
+                display_path(&shim_path)
+            );
+        }
+        *env::MISE_SHIM_PATH.write().unwrap() = Some(shim_path.clone());
+        env::set_var(env::MISE_SHIM_PATH_ENV, &shim_path);
     }
-    env::set_var(env::MISE_SHIM_PATH_ENV, &shim_path);
     let mut config = Config::get().await?;
     let mut args = env::ARGS.read().unwrap().clone();
     env::PREFER_OFFLINE.store(true, Ordering::Relaxed);
@@ -69,6 +78,24 @@ pub async fn handle_shim() -> Result<()> {
     time!("shim exec");
     exec.run().await?;
     exit(0);
+}
+
+#[cfg(windows)]
+fn invoked_shim_path() -> PathBuf {
+    let argv0 = PathBuf::from(&*env::ARGV0);
+    if argv0.is_absolute() {
+        return argv0;
+    }
+    if argv0.components().count() > 1 {
+        return argv0
+            .absolutize()
+            .map(|path| path.into_owned())
+            .unwrap_or(argv0);
+    }
+    which::which(&argv0)
+        .ok()
+        .or_else(|| std::env::current_exe().ok())
+        .unwrap_or(argv0)
 }
 
 async fn which_shim(config: &mut Arc<Config>, bin_name: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary

- make each shim identify itself by passing its absolute path to mise
- reject only the active shim during executable lookup instead of relying exclusively on reconstructed shim directories
- retain the existing configured user and system shim-directory filtering
- preserve legitimate executables that share a directory with a shim
- retain the active-shim identity across Unix `--deny-env` lookup, then remove the internal marker before starting the real tool
- cover native, file, hardlink, same-directory sibling, and filtered-environment cases on Unix and Windows

## Motivation

Before this change, mise primarily avoided shim recursion by reconstructing its user and system shim directories from the current process environment. That works when the mise process sees the same directory configuration that was used to create or expose the shim.

It is not sufficient whenever a shim remains reachable through `PATH` but the process that mise starts with has different directory context. Examples include:

- `MISE_SHIMS_DIR`, `MISE_DATA_DIR`, `XDG_DATA_HOME`, or `MISE_SYSTEM_DATA_DIR` being filtered or changed
- a shim created by one mise installation invoking another mise installation
- copied, relocated, stale, or otherwise externally exposed shims
- a shim directory being present through a path alias or symlink
- GUI applications, IDEs, CI jobs, or other non-interactive processes inheriting an OS-level `PATH`

This does not require normal shell activation. `mise activate` normally adds the selected tools' real bin directories to `PATH`, but shims are also used independently through `mise activate --shims`, direct OS-level `PATH` configuration, IDE/GUI integration, and CI. An existing shim entry can also be retained when `not_found_auto_install` is enabled.

In the failure case, the active shim delegates to `mise x -- <tool>`. If mise cannot recognize that shim from its reconstructed directories, executable lookup can select the same shim again and recurse.

This is therefore a general shim identity issue rather than behavior specific to any one parent application.

## Implementation

Each native or generated shim sets an internal `__MISE_SHIM_PATH` marker to its own absolute path before delegating to mise. Mise then:

1. captures the marker before `--deny-env` can remove process variables
2. keeps filtering the configured user and system shim directories
3. enumerates executable candidates and skips the exact active shim
4. rejects a direct attempt to execute that same shim recursively
5. removes the marker before launching the selected real executable

The active shim's parent directory is not excluded wholesale. A file shim such as `tool.cmd` can legitimately coexist with a real `tool.exe` in the same directory, so filtering is based on file identity rather than directory membership.

The marker is internal dispatch state; the change does not preserve arbitrary `MISE_*` variables through `--deny-env`.

## Validation

The particular parent-application environment was not reproduced locally. Validation models the general failure condition directly by placing an active shim outside mise's reconstructed shim directories and filtering its directory configuration.

- `mise run lint-fix`
- `mise run format`
- `cargo test --all-features --no-run`
- `mise run test:e2e cli/test_exec_shim_recursion cli/test_system_shims_no_recursion cli/test_shims_fallback`
- Windows CI coverage for native, file, hardlink, and same-directory sibling executables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented recursive shim invocation across native, file-based, and hardlink shims.
  - Improved executable resolution to skip active shims and run the intended real tool.
  - Preserved correct behavior when environment variables are filtered or shim paths are outside configured directories.
  - Added clearer errors when no suitable executable can be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
