### PR TITLE
fix(status): respect status.truncate for show_env output

### DIFF
--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -238,7 +238,7 @@ impl HookEnv {
             env_diff.extend(removed_keys);
             if !env_diff.is_empty() {
                 let env_diff = env_diff.into_iter().map(patch_to_status).join(" ");
-                info!("{}", truncate_str(&env_diff, TERM_WIDTH.max(60) - 5, "…"));
+                info!("{}", format_status(&env_diff));
             }
             // Use passed config_paths instead of calling config.path_dirs()
             let old_paths = &PREV_SESSION.config_paths;


### PR DESCRIPTION
## Summary

`status.show_env` output ignored the `status.truncate` setting and was always truncated.

[#4986](https://github.com/jdx/mise/pull/4986) added the `status.truncate` setting and the `format_status()` helper, but the env-diff line in `display_status()` was missed and kept calling `truncate_str()` directly. As a result, setting `status.truncate = false` still truncated the `status.show_env` line. This routes it through `format_status()` like the other status lines.

- Before

```console
$ cd mise-sandbox
mise +DEMO_VAR_01 +DEMO_VAR_02 +DEMO_VAR_03 +DEMO_VAR_04 +DEMO_VAR_05 +DEMO_VAR_06 +DEMO_VAR_07 +DE…
```

- After

```console
$ cd mise-sandbox
mise +DEMO_VAR_01 +DEMO_VAR_02 +DEMO_VAR_03 +DEMO_VAR_04 +DEMO_VAR_05 +DEMO_VAR_06 +DEMO_VAR_07 +DEMO_VAR_08 +DEMO_VAR_09 +DEMO_VAR_10
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment difference status output now respects the configured truncation setting, providing consistent status formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->