### PR TITLE
feat(bootstrap): support systemd timers

### DIFF
--- a/docs/bootstrap/systemd.md
+++ b/docs/bootstrap/systemd.md
@@ -46,6 +46,11 @@ persistent = true
 unit = "dev.mise.healthcheck.service"
 ```
 
+A timer must set at least one of `on_boot_sec`, `on_unit_active_sec`,
+`on_unit_inactive_sec`, or `on_calendar`. Service-only keys such as
+`exec_start`, `environment`, and `restart` are rejected on timer entries; use a
+separate service entry for the unit triggered by the timer.
+
 Each unit is written to `~/.config/systemd/user/dev.mise.<name>.service` or
 `~/.config/systemd/user/dev.mise.<name>.timer` and
 managed with `systemctl --user`. Unit names may contain letters, numbers, `.`,
@@ -95,7 +100,9 @@ unit running.
 
 - **Declarative and additive** — unit names merge across the
   [config hierarchy](/configuration.html) (global → project). A more local
-  config replaces the full declaration for the same unit name.
+  config replaces the full declaration for the same unit name. When an entry
+  changes between a service and timer, mise stops, disables, and removes the
+  stale sibling unit.
 - **Linux-only** — on other platforms the section is inert:
   `mise bootstrap linux systemd-units status` lists entries as skipped and
   `mise bootstrap linux systemd-units apply` ignores them.

--- a/docs/bootstrap/systemd.md
+++ b/docs/bootstrap/systemd.md
@@ -1,6 +1,6 @@
 # systemd
 
-mise can declare Linux systemd user services in
+mise can declare Linux systemd user services and timers in
 `[bootstrap.linux.systemd.units]` and apply them with
 `mise bootstrap linux systemd-units apply` or as part of
 [`mise bootstrap`](/bootstrap.html):
@@ -19,33 +19,77 @@ standard_output = "append:%h/.local/state/my-sync.log"
 standard_error = "journal"
 ```
 
-Each unit is written to `~/.config/systemd/user/dev.mise.<name>.service` and
+Oneshot and hardened services can use additional service directives:
+
+```toml
+[bootstrap.linux.systemd.units.daemon-lifecycle]
+type = "oneshot"
+remain_after_exit = true
+exec_start = "~/.local/bin/daemon start"
+exec_stop = "~/.local/bin/daemon stop"
+timeout_start_sec = "120"
+timeout_stop_sec = "30"
+no_new_privileges = true
+private_tmp = true
+```
+
+An entry containing a timer key is rendered as a `.timer` instead of a
+`.service`. For example:
+
+```toml
+[bootstrap.linux.systemd.units.healthcheck-timer]
+description = "periodically check daemon health"
+on_boot_sec = "2min"
+on_unit_inactive_sec = "5min"
+randomized_delay_sec = "30s"
+persistent = true
+unit = "dev.mise.healthcheck.service"
+```
+
+Each unit is written to `~/.config/systemd/user/dev.mise.<name>.service` or
+`~/.config/systemd/user/dev.mise.<name>.timer` and
 managed with `systemctl --user`. Unit names may contain letters, numbers, `.`,
-`_`, `-`, and `@`. mise owns only the service files it creates with the
+`_`, `-`, and `@`. mise owns only the unit files it creates with the
 `dev.mise.` prefix.
 
 ## Supported keys
 
-| TOML key            | systemd key                    |
-| ------------------- | ------------------------------ |
-| `description`       | `Description`                  |
-| `after`             | `After`                        |
-| `wants`             | `Wants`                        |
-| `exec_start`        | `ExecStart`                    |
-| `environment`       | `Environment`                  |
-| `working_directory` | `WorkingDirectory`             |
-| `restart`           | `Restart`                      |
-| `restart_sec`       | `RestartSec`                   |
-| `standard_output`   | `StandardOutput`               |
-| `standard_error`    | `StandardError`                |
-| `wanted_by`         | `WantedBy`                     |
-| `start`             | run `systemctl --user restart` |
+| TOML key               | systemd key                    |
+| ---------------------- | ------------------------------ |
+| `description`          | `Description`                  |
+| `after`                | `After`                        |
+| `wants`                | `Wants`                        |
+| `exec_start`           | `ExecStart`                    |
+| `type`                 | `Type`                         |
+| `remain_after_exit`    | `RemainAfterExit`              |
+| `exec_stop`            | `ExecStop`                     |
+| `timeout_start_sec`    | `TimeoutStartSec`              |
+| `timeout_stop_sec`     | `TimeoutStopSec`               |
+| `no_new_privileges`    | `NoNewPrivileges`              |
+| `private_tmp`          | `PrivateTmp`                   |
+| `environment`          | `Environment`                  |
+| `working_directory`    | `WorkingDirectory`             |
+| `restart`              | `Restart`                      |
+| `restart_sec`          | `RestartSec`                   |
+| `standard_output`      | `StandardOutput`               |
+| `standard_error`       | `StandardError`                |
+| `on_boot_sec`          | `OnBootSec`                    |
+| `on_unit_active_sec`   | `OnUnitActiveSec`              |
+| `on_unit_inactive_sec` | `OnUnitInactiveSec`            |
+| `on_calendar`          | `OnCalendar`                   |
+| `randomized_delay_sec` | `RandomizedDelaySec`           |
+| `accuracy_sec`         | `AccuracySec`                  |
+| `persistent`           | `Persistent`                   |
+| `unit`                 | `Unit`                         |
+| `wanted_by`            | `WantedBy`                     |
+| `start`                | run `systemctl --user restart` |
 
 `exec_start` and `working_directory` expand bare `~` and `~/` to the current
 user's home directory before writing the service file. `wanted_by` defaults to
-`["default.target"]`; set `wanted_by = []` to write the unit and disable any
-previous enablement. `start` defaults to `true`; set `start = false` to write
-and enable without keeping the unit running.
+`["default.target"]` for services and `["timers.target"]` for timers; set
+`wanted_by = []` to write the unit and disable any previous enablement. `start`
+defaults to `true`; set `start = false` to write and enable without keeping the
+unit running.
 
 ## Semantics
 
@@ -55,13 +99,13 @@ and enable without keeping the unit running.
 - **Linux-only** — on other platforms the section is inert:
   `mise bootstrap linux systemd-units status` lists entries as skipped and
   `mise bootstrap linux systemd-units apply` ignores them.
-- **User services only** — mise writes to `~/.config/systemd/user` and uses
+- **User units only** — mise writes to `~/.config/systemd/user` and uses
   `systemctl --user`. System services in `/etc/systemd/system` are not
   supported.
 - **Target user only** — run mise as the user who owns the services, with a
   reachable systemd user manager. `sudo mise` is skipped because `systemctl --user`
   would target the wrong user manager.
-- **Manual application only** — mise never writes or starts systemd services
+- **Manual application only** — mise never writes or starts systemd units
   implicitly; only `mise bootstrap linux systemd-units apply` and `mise bootstrap` do.
 
 ## Commands
@@ -77,6 +121,6 @@ mise bootstrap linux systemd-units apply --yes     # skip the confirmation promp
 ```
 
 `status` reports each unit as `active`, `inactive`, `differs`, or `missing`.
-`apply` rewrites changed service files, runs `systemctl --user daemon-reload`,
+`apply` rewrites changed unit files, runs `systemctl --user daemon-reload`,
 enables units with `wanted_by`, disables units with `wanted_by = []`, and
 restarts them when `start = true` or stops them when `start = false`.

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -185,17 +185,23 @@ else
   assert_contains "mise bootstrap macos launchd-agents status" "skipped"
 fi
 
-# systemd user services are declarative and safe to inspect in dry-runs
+# systemd user services and timers are declarative and safe to inspect in dry-runs
 cat <<EOF >mise.toml
 [bootstrap.linux.systemd.units.my-sync]
 description = "sync files"
 exec_start = "~/.local/bin/my-sync --watch"
 restart = "on-failure"
+
+[bootstrap.linux.systemd.units.my-sync-timer]
+on_boot_sec = "2min"
+on_unit_inactive_sec = "5min"
+unit = "dev.mise.my-sync.service"
 EOF
 mkdir -p runtime/systemd/private
 XDG_RUNTIME_DIR="$PWD/runtime" assert_succeed "mise bootstrap --dry-run"
 XDG_RUNTIME_DIR="$PWD/runtime" assert_contains "mise bootstrap systemd status" "my-sync"
 XDG_RUNTIME_DIR="$PWD/runtime" assert_contains "mise bootstrap linux systemd-units status" "my-sync"
+XDG_RUNTIME_DIR="$PWD/runtime" assert_contains "mise bootstrap systemd status" "dev.mise.my-sync-timer.timer"
 
 # unavailable system package managers are skipped, not errors
 cat <<EOF >mise.toml

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -3407,12 +3407,29 @@ run = 'echo "template"'
         after = ["network-online.target"]
         wants = ["network-online.target"]
         exec_start = "~/.local/bin/my-sync --watch"
+        type = "oneshot"
+        remain_after_exit = true
+        exec_stop = "~/.local/bin/my-sync --stop"
+        timeout_start_sec = "120"
+        timeout_stop_sec = "30"
+        no_new_privileges = true
+        private_tmp = true
         environment = { PATH = "/usr/bin:/bin" }
         working_directory = "~"
         restart = "on-failure"
         restart_sec = "5s"
         standard_output = "append:%h/.local/state/my-sync.log"
         wanted_by = ["default.target"]
+
+        [bootstrap.linux.systemd.units.my-sync-timer]
+        on_boot_sec = "2min"
+        on_unit_active_sec = "10min"
+        on_unit_inactive_sec = "5min"
+        on_calendar = "hourly"
+        randomized_delay_sec = "30s"
+        accuracy_sec = "1s"
+        persistent = true
+        unit = "dev.mise.my-sync.service"
         "#,
         )
         .unwrap();
@@ -3426,6 +3443,16 @@ run = 'echo "template"'
             unit.exec_start.as_deref(),
             Some("~/.local/bin/my-sync --watch")
         );
+        assert_eq!(unit.service_type.as_deref(), Some("oneshot"));
+        assert_eq!(unit.remain_after_exit, Some(true));
+        assert_eq!(
+            unit.exec_stop.as_deref(),
+            Some("~/.local/bin/my-sync --stop")
+        );
+        assert_eq!(unit.timeout_start_sec.as_deref(), Some("120"));
+        assert_eq!(unit.timeout_stop_sec.as_deref(), Some("30"));
+        assert_eq!(unit.no_new_privileges, Some(true));
+        assert_eq!(unit.private_tmp, Some(true));
         assert_eq!(
             unit.environment.get("PATH").map(String::as_str),
             Some("/usr/bin:/bin")
@@ -3441,6 +3468,15 @@ run = 'echo "template"'
             unit.wanted_by.as_deref(),
             Some(["default.target".to_string()].as_slice())
         );
+        let timer = system.linux.systemd.units.get("my-sync-timer").unwrap();
+        assert_eq!(timer.on_boot_sec.as_deref(), Some("2min"));
+        assert_eq!(timer.on_unit_active_sec.as_deref(), Some("10min"));
+        assert_eq!(timer.on_unit_inactive_sec.as_deref(), Some("5min"));
+        assert_eq!(timer.on_calendar.as_deref(), Some("hourly"));
+        assert_eq!(timer.randomized_delay_sec.as_deref(), Some("30s"));
+        assert_eq!(timer.accuracy_sec.as_deref(), Some("1s"));
+        assert_eq!(timer.persistent, Some(true));
+        assert_eq!(timer.unit.as_deref(), Some("dev.mise.my-sync.service"));
         file::remove_file(&p).unwrap();
     }
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -119,15 +119,15 @@ pub struct BootstrapMacosLaunchdTomlConfig {
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct BootstrapLinuxTomlConfig {
     /// `[bootstrap.linux.systemd.units.<name>]`: declarative systemd user
-    /// services rendered to ~/.config/systemd/user.
+    /// services and timers rendered to ~/.config/systemd/user.
     #[serde(default)]
     pub systemd: BootstrapLinuxSystemdTomlConfig,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct BootstrapLinuxSystemdTomlConfig {
-    /// User services, keyed by a short stable name. mise gives these a
-    /// `dev.mise.<name>.service` unit name when rendering the unit file.
+    /// User services and timers, keyed by a short stable name. mise gives
+    /// these a `dev.mise.<name>.<service|timer>` unit name when rendering.
     #[serde(default)]
     pub units: IndexMap<String, SystemdTomlConfig>,
 }

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -160,8 +160,42 @@ impl SystemdRequest {
         if kind == SystemdUnitKind::Service && exec_start.as_deref().is_none_or(str::is_empty) {
             bail!("service unit '{name}' must set a non-empty `exec_start`");
         }
-        if kind == SystemdUnitKind::Timer && exec_start.is_some() {
-            bail!("timer unit '{name}' cannot set `exec_start`");
+        if kind == SystemdUnitKind::Timer {
+            let service_only_fields = [
+                (exec_start.is_some(), "exec_start"),
+                (config.service_type.is_some(), "type"),
+                (config.remain_after_exit.is_some(), "remain_after_exit"),
+                (config.exec_stop.is_some(), "exec_stop"),
+                (config.timeout_start_sec.is_some(), "timeout_start_sec"),
+                (config.timeout_stop_sec.is_some(), "timeout_stop_sec"),
+                (config.no_new_privileges.is_some(), "no_new_privileges"),
+                (config.private_tmp.is_some(), "private_tmp"),
+                (!config.environment.is_empty(), "environment"),
+                (config.working_directory.is_some(), "working_directory"),
+                (config.restart.is_some(), "restart"),
+                (config.restart_sec.is_some(), "restart_sec"),
+                (config.standard_output.is_some(), "standard_output"),
+                (config.standard_error.is_some(), "standard_error"),
+            ]
+            .into_iter()
+            .filter_map(|(is_set, field)| is_set.then_some(field))
+            .collect::<Vec<_>>();
+            if !service_only_fields.is_empty() {
+                bail!(
+                    "timer unit '{name}' cannot set service-only directive(s): {}",
+                    service_only_fields.join(", ")
+                );
+            }
+            if config.on_boot_sec.is_none()
+                && config.on_unit_active_sec.is_none()
+                && config.on_unit_inactive_sec.is_none()
+                && config.on_calendar.is_none()
+            {
+                bail!(
+                    "timer unit '{name}' must set at least one of `on_boot_sec`, \
+                     `on_unit_active_sec`, `on_unit_inactive_sec`, or `on_calendar`"
+                );
+            }
         }
         let wanted_by = config.wanted_by.unwrap_or_else(|| match kind {
             SystemdUnitKind::Service => vec!["default.target".to_string()],
@@ -256,14 +290,16 @@ pub async fn status(requests: &[SystemdRequest]) -> Result<Vec<SystemdStatus>> {
         let active = is_active(&req.unit).await?;
         let enabled = is_enabled(&req.unit).await?;
         let desired_enabled = !req.wanted_by.is_empty();
-        let state =
-            if normalize(&current) != normalize(&render_unit(req)) || enabled != desired_enabled {
-                SystemdState::Differs
-            } else if active {
-                SystemdState::Active
-            } else {
-                SystemdState::Inactive
-            };
+        let state = if sibling_unit_path(req).exists()
+            || normalize(&current) != normalize(&render_unit(req))
+            || enabled != desired_enabled
+        {
+            SystemdState::Differs
+        } else if active {
+            SystemdState::Active
+        } else {
+            SystemdState::Inactive
+        };
         out.push(SystemdStatus {
             request: req.clone(),
             path,
@@ -278,7 +314,6 @@ pub async fn status(requests: &[SystemdRequest]) -> Result<Vec<SystemdStatus>> {
 pub async fn apply(requests: &[SystemdRequest], dry_run: bool) -> Result<()> {
     if dry_run {
         for req in requests {
-            let path = unit_path(req);
             miseprintln!(
                 "{}",
                 shell_words::join([
@@ -287,6 +322,44 @@ pub async fn apply(requests: &[SystemdRequest], dry_run: bool) -> Result<()> {
                     user_units_dir().display().to_string(),
                 ])
             );
+            let sibling = sibling_unit(req);
+            let sibling_path = sibling_unit_path(req);
+            if sibling_path.exists() {
+                miseprintln!(
+                    "{}",
+                    shell_words::join([
+                        "systemctl".to_string(),
+                        "--user".to_string(),
+                        "stop".to_string(),
+                        sibling.clone(),
+                    ])
+                );
+                miseprintln!(
+                    "{}",
+                    shell_words::join([
+                        "systemctl".to_string(),
+                        "--user".to_string(),
+                        "disable".to_string(),
+                        sibling,
+                    ])
+                );
+                miseprintln!(
+                    "{}",
+                    shell_words::join(["rm".to_string(), sibling_path.display().to_string()])
+                );
+            }
+            miseprintln!(
+                "{}",
+                shell_words::join([
+                    "systemctl".to_string(),
+                    "--user".to_string(),
+                    "disable".to_string(),
+                    req.unit.clone(),
+                ])
+            );
+        }
+        for req in requests {
+            let path = unit_path(req);
             miseprintln!("write {}", shell_words::join([path.display().to_string()]));
         }
         miseprintln!(
@@ -298,15 +371,6 @@ pub async fn apply(requests: &[SystemdRequest], dry_run: bool) -> Result<()> {
             ])
         );
         for req in requests {
-            miseprintln!(
-                "{}",
-                shell_words::join([
-                    "systemctl".to_string(),
-                    "--user".to_string(),
-                    "disable".to_string(),
-                    req.unit.clone(),
-                ])
-            );
             if !req.wanted_by.is_empty() {
                 miseprintln!(
                     "{}",
@@ -345,6 +409,13 @@ pub async fn apply(requests: &[SystemdRequest], dry_run: bool) -> Result<()> {
 
     std::fs::create_dir_all(user_units_dir())?;
     for req in requests {
+        let sibling = sibling_unit(req);
+        let sibling_path = sibling_unit_path(req);
+        if sibling_path.exists() {
+            stop_unit(&sibling).await?;
+            disable_unit(&sibling).await?;
+            std::fs::remove_file(sibling_path)?;
+        }
         disable_unit(&req.unit).await?;
     }
     for req in requests {
@@ -486,6 +557,21 @@ fn unit_path(request: &SystemdRequest) -> PathBuf {
     user_units_dir().join(&request.unit)
 }
 
+fn sibling_unit(request: &SystemdRequest) -> String {
+    format!(
+        "dev.mise.{}.{}",
+        request.name,
+        match request.kind {
+            SystemdUnitKind::Service => "timer",
+            SystemdUnitKind::Timer => "service",
+        }
+    )
+}
+
+fn sibling_unit_path(request: &SystemdRequest) -> PathBuf {
+    user_units_dir().join(sibling_unit(request))
+}
+
 fn expand_path_string(path: &str) -> String {
     if path == "~" {
         return crate::dirs::HOME.to_string_lossy().to_string();
@@ -605,12 +691,26 @@ async fn disable_unit(unit: &str) -> Result<()> {
     }
 }
 
+async fn stop_unit(unit: &str) -> Result<()> {
+    match systemctl(&["stop".to_string(), unit.to_string()]).await {
+        Ok(()) => Ok(()),
+        Err(err) if unit_operation_error_is_noop(&err.to_string()) => {
+            debug!("systemd: ignoring stop for {unit}: {err}");
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
 fn disable_unit_error_is_noop(error: &str) -> bool {
-    error.contains("does not exist")
-        || error.contains("not loaded")
+    unit_operation_error_is_noop(error)
         || error.contains("no [Install] section")
         || error.contains("has no installation config")
         || error.contains("is a static unit")
+}
+
+fn unit_operation_error_is_noop(error: &str) -> bool {
+    error.contains("does not exist") || error.contains("not loaded")
 }
 
 #[cfg(test)]
@@ -630,6 +730,29 @@ mod tests {
         assert_eq!(request.unit, "dev.mise.my-service.service");
         assert_eq!(request.wanted_by, vec!["default.target"]);
         assert!(SystemdRequest::from_toml("bad/name".to_string(), Default::default()).is_err());
+
+        let err = SystemdRequest::from_toml(
+            "modifier-only-timer".to_string(),
+            SystemdTomlConfig {
+                persistent: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("must set at least one"));
+
+        let err = SystemdRequest::from_toml(
+            "invalid-timer".to_string(),
+            SystemdTomlConfig {
+                on_boot_sec: Some("1min".to_string()),
+                restart: Some("on-failure".to_string()),
+                environment: IndexMap::from([("KEY".to_string(), "value".to_string())]),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("restart"));
+        assert!(err.to_string().contains("environment"));
     }
 
     #[test]
@@ -709,6 +832,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(request.unit, "dev.mise.healthcheck.timer");
+        assert_eq!(sibling_unit(&request), "dev.mise.healthcheck.service");
         assert_eq!(request.wanted_by, vec!["timers.target"]);
         assert_eq!(
             render_unit(&request),

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -276,6 +276,17 @@ pub async fn status(requests: &[SystemdRequest]) -> Result<Vec<SystemdStatus>> {
         let current = match std::fs::read_to_string(&path) {
             Ok(current) => current,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let sibling = sibling_unit(req);
+                if sibling_unit_path(req).exists() {
+                    out.push(SystemdStatus {
+                        request: req.clone(),
+                        path,
+                        active: is_active(&sibling).await?,
+                        enabled: is_enabled(&sibling).await?,
+                        state: SystemdState::Differs,
+                    });
+                    continue;
+                }
                 out.push(SystemdStatus {
                     request: req.clone(),
                     path,
@@ -322,6 +333,10 @@ pub async fn apply(requests: &[SystemdRequest], dry_run: bool) -> Result<()> {
                     user_units_dir().display().to_string(),
                 ])
             );
+            let path = unit_path(req);
+            miseprintln!("write {}", shell_words::join([path.display().to_string()]));
+        }
+        for req in requests {
             let sibling = sibling_unit(req);
             let sibling_path = sibling_unit_path(req);
             if sibling_path.exists() {
@@ -357,10 +372,6 @@ pub async fn apply(requests: &[SystemdRequest], dry_run: bool) -> Result<()> {
                     req.unit.clone(),
                 ])
             );
-        }
-        for req in requests {
-            let path = unit_path(req);
-            miseprintln!("write {}", shell_words::join([path.display().to_string()]));
         }
         miseprintln!(
             "{}",
@@ -409,6 +420,11 @@ pub async fn apply(requests: &[SystemdRequest], dry_run: bool) -> Result<()> {
 
     std::fs::create_dir_all(user_units_dir())?;
     for req in requests {
+        let path = unit_path(req);
+        let unit = render_unit(req);
+        std::fs::write(&path, unit)?;
+    }
+    for req in requests {
         let sibling = sibling_unit(req);
         let sibling_path = sibling_unit_path(req);
         if sibling_path.exists() {
@@ -417,11 +433,6 @@ pub async fn apply(requests: &[SystemdRequest], dry_run: bool) -> Result<()> {
             std::fs::remove_file(sibling_path)?;
         }
         disable_unit(&req.unit).await?;
-    }
-    for req in requests {
-        let path = unit_path(req);
-        let unit = render_unit(req);
-        std::fs::write(&path, unit)?;
     }
     systemctl(&["daemon-reload".to_string()]).await?;
     for req in requests {

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -1,6 +1,6 @@
-//! systemd user services for `[bootstrap.linux.systemd.units]`.
+//! systemd user services and timers for `[bootstrap.linux.systemd.units]`.
 //!
-//! Entries are rendered to `~/.config/systemd/user/dev.mise.<name>.service`
+//! Entries are rendered to `~/.config/systemd/user/dev.mise.<name>.<service|timer>`
 //! and managed with `systemctl --user` when explicitly applied.
 
 use std::path::{Path, PathBuf};
@@ -23,6 +23,20 @@ pub struct SystemdTomlConfig {
     pub wants: Vec<String>,
     #[serde(default)]
     pub exec_start: Option<String>,
+    #[serde(default, rename = "type")]
+    pub service_type: Option<String>,
+    #[serde(default)]
+    pub remain_after_exit: Option<bool>,
+    #[serde(default)]
+    pub exec_stop: Option<String>,
+    #[serde(default)]
+    pub timeout_start_sec: Option<String>,
+    #[serde(default)]
+    pub timeout_stop_sec: Option<String>,
+    #[serde(default)]
+    pub no_new_privileges: Option<bool>,
+    #[serde(default)]
+    pub private_tmp: Option<bool>,
     #[serde(default)]
     pub environment: IndexMap<String, String>,
     #[serde(default)]
@@ -35,26 +49,64 @@ pub struct SystemdTomlConfig {
     pub standard_output: Option<String>,
     #[serde(default)]
     pub standard_error: Option<String>,
+    #[serde(default)]
+    pub on_boot_sec: Option<String>,
+    #[serde(default)]
+    pub on_unit_active_sec: Option<String>,
+    #[serde(default)]
+    pub on_unit_inactive_sec: Option<String>,
+    #[serde(default)]
+    pub on_calendar: Option<String>,
+    #[serde(default)]
+    pub randomized_delay_sec: Option<String>,
+    #[serde(default)]
+    pub accuracy_sec: Option<String>,
+    #[serde(default)]
+    pub persistent: Option<bool>,
+    #[serde(default)]
+    pub unit: Option<String>,
     #[serde(default = "default_start")]
     pub start: bool,
     #[serde(default)]
     pub wanted_by: Option<Vec<String>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemdUnitKind {
+    Service,
+    Timer,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SystemdRequest {
     pub name: String,
     pub unit: String,
+    pub kind: SystemdUnitKind,
     pub description: Option<String>,
     pub after: Vec<String>,
     pub wants: Vec<String>,
-    pub exec_start: String,
+    pub exec_start: Option<String>,
+    pub service_type: Option<String>,
+    pub remain_after_exit: Option<bool>,
+    pub exec_stop: Option<String>,
+    pub timeout_start_sec: Option<String>,
+    pub timeout_stop_sec: Option<String>,
+    pub no_new_privileges: Option<bool>,
+    pub private_tmp: Option<bool>,
     pub environment: IndexMap<String, String>,
     pub working_directory: Option<String>,
     pub restart: Option<String>,
     pub restart_sec: Option<String>,
     pub standard_output: Option<String>,
     pub standard_error: Option<String>,
+    pub on_boot_sec: Option<String>,
+    pub on_unit_active_sec: Option<String>,
+    pub on_unit_inactive_sec: Option<String>,
+    pub on_calendar: Option<String>,
+    pub randomized_delay_sec: Option<String>,
+    pub accuracy_sec: Option<String>,
+    pub persistent: Option<bool>,
+    pub timer_unit: Option<String>,
     pub start: bool,
     pub wanted_by: Vec<String>,
 }
@@ -91,29 +143,67 @@ impl SystemdRequest {
         if !valid_name(&name) {
             bail!("unit name '{name}' must contain only letters, numbers, '.', '_', '-', or '@'");
         }
-        let Some(exec_start) = config.exec_start.map(|s| s.trim().to_string()) else {
-            bail!("unit '{name}' must set `exec_start`");
+        let is_timer = config.on_boot_sec.is_some()
+            || config.on_unit_active_sec.is_some()
+            || config.on_unit_inactive_sec.is_some()
+            || config.on_calendar.is_some()
+            || config.randomized_delay_sec.is_some()
+            || config.accuracy_sec.is_some()
+            || config.persistent.is_some()
+            || config.unit.is_some();
+        let kind = if is_timer {
+            SystemdUnitKind::Timer
+        } else {
+            SystemdUnitKind::Service
         };
-        if exec_start.is_empty() {
-            bail!("unit '{name}' must set a non-empty `exec_start`");
+        let exec_start = config.exec_start.map(|s| s.trim().to_string());
+        if kind == SystemdUnitKind::Service && exec_start.as_deref().is_none_or(str::is_empty) {
+            bail!("service unit '{name}' must set a non-empty `exec_start`");
         }
+        if kind == SystemdUnitKind::Timer && exec_start.is_some() {
+            bail!("timer unit '{name}' cannot set `exec_start`");
+        }
+        let wanted_by = config.wanted_by.unwrap_or_else(|| match kind {
+            SystemdUnitKind::Service => vec!["default.target".to_string()],
+            SystemdUnitKind::Timer => vec!["timers.target".to_string()],
+        });
         Ok(Self {
-            unit: format!("dev.mise.{name}.service"),
+            unit: format!(
+                "dev.mise.{name}.{}",
+                match kind {
+                    SystemdUnitKind::Service => "service",
+                    SystemdUnitKind::Timer => "timer",
+                }
+            ),
             name,
+            kind,
             description: config.description,
             after: config.after,
             wants: config.wants,
             exec_start,
+            service_type: config.service_type,
+            remain_after_exit: config.remain_after_exit,
+            exec_stop: config.exec_stop,
+            timeout_start_sec: config.timeout_start_sec,
+            timeout_stop_sec: config.timeout_stop_sec,
+            no_new_privileges: config.no_new_privileges,
+            private_tmp: config.private_tmp,
             environment: config.environment,
             working_directory: config.working_directory,
             restart: config.restart,
             restart_sec: config.restart_sec,
             standard_output: config.standard_output,
             standard_error: config.standard_error,
+            on_boot_sec: config.on_boot_sec,
+            on_unit_active_sec: config.on_unit_active_sec,
+            on_unit_inactive_sec: config.on_unit_inactive_sec,
+            on_calendar: config.on_calendar,
+            randomized_delay_sec: config.randomized_delay_sec,
+            accuracy_sec: config.accuracy_sec,
+            persistent: config.persistent,
+            timer_unit: config.unit,
             start: config.start,
-            wanted_by: config
-                .wanted_by
-                .unwrap_or_else(|| vec!["default.target".to_string()]),
+            wanted_by,
         })
     }
 }
@@ -288,11 +378,43 @@ pub fn render_unit(request: &SystemdRequest) -> String {
     if !request.wants.is_empty() {
         out.push_str(&format!("Wants={}\n", request.wants.join(" ")));
     }
+    match request.kind {
+        SystemdUnitKind::Service => render_service(request, &mut out),
+        SystemdUnitKind::Timer => render_timer(request, &mut out),
+    }
+    if !request.wanted_by.is_empty() {
+        out.push_str("\n[Install]\n");
+        out.push_str(&format!("WantedBy={}\n", request.wanted_by.join(" ")));
+    }
+    out
+}
+
+fn render_service(request: &SystemdRequest, out: &mut String) {
     out.push_str("\n[Service]\n");
-    out.push_str(&format!(
-        "ExecStart={}\n",
-        expand_path_string(&request.exec_start)
-    ));
+    if let Some(service_type) = &request.service_type {
+        out.push_str(&format!("Type={service_type}\n"));
+    }
+    if let Some(exec_start) = &request.exec_start {
+        out.push_str(&format!("ExecStart={}\n", expand_path_string(exec_start)));
+    }
+    if let Some(remain_after_exit) = request.remain_after_exit {
+        out.push_str(&format!("RemainAfterExit={}\n", yes_no(remain_after_exit)));
+    }
+    if let Some(exec_stop) = &request.exec_stop {
+        out.push_str(&format!("ExecStop={}\n", expand_path_string(exec_stop)));
+    }
+    if let Some(timeout_start_sec) = &request.timeout_start_sec {
+        out.push_str(&format!("TimeoutStartSec={timeout_start_sec}\n"));
+    }
+    if let Some(timeout_stop_sec) = &request.timeout_stop_sec {
+        out.push_str(&format!("TimeoutStopSec={timeout_stop_sec}\n"));
+    }
+    if let Some(no_new_privileges) = request.no_new_privileges {
+        out.push_str(&format!("NoNewPrivileges={}\n", yes_no(no_new_privileges)));
+    }
+    if let Some(private_tmp) = request.private_tmp {
+        out.push_str(&format!("PrivateTmp={}\n", yes_no(private_tmp)));
+    }
     if let Some(path) = &request.working_directory {
         out.push_str(&format!("WorkingDirectory={}\n", expand_path_string(path)));
     }
@@ -314,11 +436,32 @@ pub fn render_unit(request: &SystemdRequest) -> String {
     if let Some(standard_error) = &request.standard_error {
         out.push_str(&format!("StandardError={standard_error}\n"));
     }
-    if !request.wanted_by.is_empty() {
-        out.push_str("\n[Install]\n");
-        out.push_str(&format!("WantedBy={}\n", request.wanted_by.join(" ")));
+}
+
+fn render_timer(request: &SystemdRequest, out: &mut String) {
+    out.push_str("\n[Timer]\n");
+    for (key, value) in [
+        ("OnBootSec", &request.on_boot_sec),
+        ("OnUnitActiveSec", &request.on_unit_active_sec),
+        ("OnUnitInactiveSec", &request.on_unit_inactive_sec),
+        ("OnCalendar", &request.on_calendar),
+        ("RandomizedDelaySec", &request.randomized_delay_sec),
+        ("AccuracySec", &request.accuracy_sec),
+    ] {
+        if let Some(value) = value {
+            out.push_str(&format!("{key}={value}\n"));
+        }
     }
-    out
+    if let Some(persistent) = request.persistent {
+        out.push_str(&format!("Persistent={}\n", yes_no(persistent)));
+    }
+    if let Some(unit) = &request.timer_unit {
+        out.push_str(&format!("Unit={unit}\n"));
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
 }
 
 fn default_start() -> bool {
@@ -494,22 +637,32 @@ mod tests {
         let mut environment = IndexMap::new();
         environment.insert("PATH".to_string(), "/usr/bin:/bin".to_string());
         environment.insert("QUOTED".to_string(), "hello \"there\"".to_string());
-        let request = SystemdRequest {
-            name: "sync".to_string(),
-            unit: "dev.mise.sync.service".to_string(),
-            description: Some("sync files".to_string()),
-            after: vec!["network-online.target".to_string()],
-            wants: vec!["network-online.target".to_string()],
-            exec_start: "~/.local/bin/sync --watch".to_string(),
-            environment,
-            working_directory: Some("~".to_string()),
-            restart: Some("on-failure".to_string()),
-            restart_sec: Some("5s".to_string()),
-            standard_output: Some("append:%h/.local/state/sync.log".to_string()),
-            standard_error: Some("journal".to_string()),
-            start: true,
-            wanted_by: vec!["default.target".to_string()],
-        };
+        let request = SystemdRequest::from_toml(
+            "sync".to_string(),
+            SystemdTomlConfig {
+                description: Some("sync files".to_string()),
+                after: vec!["network-online.target".to_string()],
+                wants: vec!["network-online.target".to_string()],
+                exec_start: Some("~/.local/bin/sync --watch".to_string()),
+                service_type: Some("oneshot".to_string()),
+                remain_after_exit: Some(true),
+                exec_stop: Some("~/.local/bin/sync --stop".to_string()),
+                timeout_start_sec: Some("120".to_string()),
+                timeout_stop_sec: Some("30".to_string()),
+                no_new_privileges: Some(true),
+                private_tmp: Some(true),
+                environment,
+                working_directory: Some("~".to_string()),
+                restart: Some("on-failure".to_string()),
+                restart_sec: Some("5s".to_string()),
+                standard_output: Some("append:%h/.local/state/sync.log".to_string()),
+                standard_error: Some("journal".to_string()),
+                start: true,
+                wanted_by: Some(vec!["default.target".to_string()]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
         let unit = render_unit(&request);
         assert!(unit.contains("[Unit]\n"));
         assert!(unit.contains("Description=sync files\n"));
@@ -519,6 +672,16 @@ mod tests {
             "ExecStart={}\n",
             expand_path_string("~/.local/bin/sync --watch")
         )));
+        assert!(unit.contains("Type=oneshot\n"));
+        assert!(unit.contains("RemainAfterExit=yes\n"));
+        assert!(unit.contains(&format!(
+            "ExecStop={}\n",
+            expand_path_string("~/.local/bin/sync --stop")
+        )));
+        assert!(unit.contains("TimeoutStartSec=120\n"));
+        assert!(unit.contains("TimeoutStopSec=30\n"));
+        assert!(unit.contains("NoNewPrivileges=yes\n"));
+        assert!(unit.contains("PrivateTmp=yes\n"));
         assert!(unit.contains(&format!("WorkingDirectory={}\n", expand_path_string("~"))));
         assert!(unit.contains("Environment=\"PATH=/usr/bin:/bin\"\n"));
         assert!(unit.contains("Environment=\"QUOTED=hello \\\"there\\\"\"\n"));
@@ -527,6 +690,30 @@ mod tests {
         assert!(unit.contains("StandardOutput=append:%h/.local/state/sync.log\n"));
         assert!(unit.contains("StandardError=journal\n"));
         assert!(unit.contains("[Install]\nWantedBy=default.target\n"));
+    }
+
+    #[test]
+    fn test_render_timer_unit() {
+        let request = SystemdRequest::from_toml(
+            "healthcheck".to_string(),
+            SystemdTomlConfig {
+                on_boot_sec: Some("2min".to_string()),
+                on_unit_inactive_sec: Some("5min".to_string()),
+                randomized_delay_sec: Some("30s".to_string()),
+                accuracy_sec: Some("1s".to_string()),
+                persistent: Some(true),
+                unit: Some("dev.mise.healthcheck.service".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(request.unit, "dev.mise.healthcheck.timer");
+        assert_eq!(request.wanted_by, vec!["timers.target"]);
+        assert_eq!(
+            render_unit(&request),
+            "[Unit]\n\n[Timer]\nOnBootSec=2min\nOnUnitInactiveSec=5min\nRandomizedDelaySec=30s\nAccuracySec=1s\nPersistent=yes\nUnit=dev.mise.healthcheck.service\n\n[Install]\nWantedBy=timers.target\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add advanced systemd service directives for oneshot lifecycle and hardened services
- render timer entries as `.timer` units with scheduling, persistence, target-unit, and `timers.target` support
- preserve existing apply, status, dry-run, enable, disable, start, and stop behavior for both unit kinds
- document the configuration and add renderer, parser, and end-to-end coverage

Implements the request in https://github.com/jdx/mise/discussions/10979.

## Validation
- `cargo test system::systemd::tests`
- `cargo test test_bootstrap_linux_systemd_units`
- `mise run test:e2e test_bootstrap`
- `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how user systemd units are written and torn down on apply; misconfiguration could stop/disable units, but scope stays limited to `dev.mise.*` user units under bootstrap.
> 
> **Overview**
> Extends **`[bootstrap.linux.systemd.units]`** so mise can manage **user `.timer` units** as well as services, with docs and tests aligned to the new behavior.
> 
> **Timers** are inferred when timer-related keys are set; they render to `dev.mise.<name>.timer`, default **`wanted_by = ["timers.target"]`**, and must include at least one schedule (`on_boot_sec`, `on_unit_active_sec`, `on_unit_inactive_sec`, or `on_calendar`). Service-only keys on timer entries are rejected.
> 
> **Services** gain optional directives: `type`, `remain_after_exit`, `exec_stop`, start/stop timeouts, and `no_new_privileges` / `private_tmp`.
> 
> **Apply / status**: if a unit name flips between service and timer, mise treats the old sibling unit as **differs**, then on apply **stops, disables, and removes** the stale `.service` or `.timer` file before enabling the new one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8b422e0538706a3c29e859747ab18051c62070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring and managing systemd user timers alongside services.
  - Added timer scheduling options (calendar/interval, randomization, accuracy, persistence) and automatic linkage to the corresponding service.
- **Bug Fixes**
  - Prevented stale sibling units from remaining enabled/active when switching between service and timer types.
  - Improved validation for compatible service vs timer configurations.
- **Documentation**
  - Expanded systemd bootstrap docs to cover timers, supported keys, rendering rules, and updated apply/dry-run behavior.
- **Tests**
  - Extended CLI and unit rendering tests to cover timer generation and output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->