### PR TITLE
chore(release): publish rolling zstd registry archive

### DIFF
--- a/scripts/publish-s3.sh
+++ b/scripts/publish-s3.sh
@@ -35,10 +35,9 @@ aws s3 cp "./schema/mise-task.json" "s3://$AWS_S3_BUCKET/schema/mise-task.json" 
 # tested by this release without downloading the entire source repository.
 registry_tmpdir="$(mktemp -d)"
 trap 'rm -rf "$registry_tmpdir"' EXIT
-registry_archive="$registry_tmpdir/registry.tar.gz"
-git archive --format=tar HEAD registry | gzip -n >"$registry_archive"
-aws s3 cp "$registry_archive" "s3://$AWS_S3_BUCKET/registry/$MISE_VERSION.tar.gz" --cache-control "$cache_week" --no-progress --content-type "application/gzip"
-aws s3 cp "$registry_archive" "s3://$AWS_S3_BUCKET/registry/latest.tar.gz" --cache-control "$cache_hour" --no-progress --content-type "application/gzip"
+registry_archive="$registry_tmpdir/registry.tar.zst"
+git archive --format=tar HEAD registry | zstd -q -10 -c >"$registry_archive"
+aws s3 cp "$registry_archive" "s3://$AWS_S3_BUCKET/registry/latest.tar.zst" --cache-control "$cache_hour" --no-progress --content-type "application/zstd"
 
 # Upload shell-specific mise.run scripts
 aws s3 cp artifacts/mise.run/zsh "s3://$AWS_S3_BUCKET/mise.run/zsh" --cache-control "$cache_week" --no-progress --content-type "text/plain"


### PR DESCRIPTION
## Summary

- publish the release-tested mise registry as `registry/latest.tar.zst`
- use zstd instead of gzip for a smaller, faster-decoding archive
- publish only the rolling artifact needed by floating-registry clients
- leave all existing R2 objects untouched

## Why

#10971 needs a live release artifact before its end-to-end test can pass. Publishing that artifact from the runtime PR would create a circular dependency, so this prerequisite must merge and ship first.

## Validation

- `mise exec -- shfmt -d scripts/publish-s3.sh`
- `mise exec -- shellcheck scripts/publish-s3.sh`
- archive round-trip through zstd and tar, verifying `registry/jq.toml`

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only S3 publish script change; no runtime or auth logic, though clients must expect zstd and the new URL shape.
> 
> **Overview**
> Release publishing now ships the release-tested `registry/` tree as **`registry/latest.tar.zst`** instead of gzip tarballs.
> 
> The archive is built with **`zstd -q -10`** (replacing `gzip -n`) and uploaded with **`application/zstd`**. The per-version **`registry/$MISE_VERSION.tar.gz`** upload is removed so only the rolling **`latest`** artifact is published for floating-registry clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c34dae4bc5a0dd497766f965cedf2a29479cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry-only publishing to use Zstandard-compressed archives.
  * Simplified registry archive uploads to a single latest archive with updated metadata and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->