### PR TITLE
fix(bootstrap): support cask array position helpers

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1412,13 +1412,14 @@ mod tests {
         shim: &Path,
         cask: &Path,
         staged_path: &Path,
+        version: &str,
     ) -> std::io::Result<std::process::Output> {
         std::process::Command::new(ruby)
             .arg(shim)
             .env("LANG", "zz_ZZ.UTF-8")
             .env("MISE_BREW_CASK_FILE", cask)
             .env("MISE_BREW_CASK_TOKEN", "example")
-            .env("MISE_BREW_CASK_VERSION", "1.0.0")
+            .env("MISE_BREW_CASK_VERSION", version)
             .env("MISE_BREW_CASK_STAGED_PATH", staged_path)
             .env("MISE_BREW_CASK_APPDIR", staged_path)
             .env("MISE_BREW_PREFIX", staged_path)
@@ -1480,7 +1481,7 @@ end
 "##,
         )?;
 
-        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path())?;
+        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path(), "1.0.0")?;
         assert!(
             output.status.success(),
             "{}",
@@ -1492,6 +1493,39 @@ end
             "-linux"
         };
         assert_eq!(file::read_to_string(result)?, format!("en-US{suffix}"));
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cask_shim_supports_csv_version_array_helpers() -> Result<()> {
+        let Some(ruby) = file::which("ruby") else {
+            return Ok(());
+        };
+        let tmp = tempfile::tempdir()?;
+        let shim = tmp.path().join("cask_shim.rb");
+        let cask = tmp.path().join("example.rb");
+        let result = tmp.path().join("result");
+        file::write(&shim, CASK_SHIM_RB)?;
+        file::write(
+            &cask,
+            r#"cask "example" do
+  version "2.2.1,20628"
+  url "https://example.com/OrbStack_v#{version.csv.first}_#{version.csv.second}.dmg"
+  preflight do
+    File.write staged_path/"result", version.csv.second
+  end
+end
+"#,
+        )?;
+
+        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path(), "2.2.1,20628")?;
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(file::read_to_string(result)?, "20628");
         Ok(())
     }
 
@@ -1515,7 +1549,7 @@ end
             format!("cask \"example\" do\n  on_system_conditional {conditional}\nend\n"),
         )?;
 
-        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path())?;
+        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path(), "1.0.0")?;
         assert!(!output.status.success());
         assert!(String::from_utf8_lossy(&output.stderr).contains(&format!(
             "Error: cask uses `on_system_conditional without {platform}`"

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -12,6 +12,24 @@ require "fileutils"
 require "pathname"
 require "rbconfig"
 
+class Array
+  def second
+    self[1]
+  end
+
+  def third
+    self[2]
+  end
+
+  def fourth
+    self[3]
+  end
+
+  def fifth
+    self[4]
+  end
+end
+
 MISE_BREW_CASK_FILE = Pathname.new(ENV.fetch("MISE_BREW_CASK_FILE"))
 MISE_BREW_CASK_TOKEN = ENV.fetch("MISE_BREW_CASK_TOKEN")
 MISE_BREW_CASK_VERSION = ENV.fetch("MISE_BREW_CASK_VERSION")


### PR DESCRIPTION
## Summary

- add Homebrew-compatible `Array#second`, `#third`, `#fourth`, and `#fifth` helpers to the cask lifecycle shim
- cover CSV cask versions with OrbStack's exact `version.csv.first` / `version.csv.second` URL pattern

## Problem

OrbStack's cask evaluates:

```ruby
version.csv.second
```

The mise cask shim returns a normal Ruby array from `Version#csv`, but does not provide the positional helpers from Homebrew's `extend/array.rb`. The lifecycle hook therefore fails before `postflight` runs:

```text
undefined method `second` for an instance of Array (NoMethodError)
```

Homebrew defines the four helpers added here with the same index semantics.

## Validation

- `cargo test cask_shim_supports_csv_version_array_helpers`
- `cargo test cask_shim_supports_language_and_system_conditionals`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew cask version handling when versions are provided in CSV-style formats.
  * Ensured cask shims correctly resolve individual version components.

* **Tests**
  * Added coverage for CSV-formatted version arrays.
  * Updated existing checks to validate version propagation through the cask shim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->