### PR TITLE
fix(cache): handle concurrent writes during clear

### DIFF
--- a/src/cli/cache/clear.rs
+++ b/src/cli/cache/clear.rs
@@ -1,5 +1,5 @@
 use crate::dirs::CACHE;
-use crate::file::{display_path, remove_all};
+use crate::file::{display_path, remove_all_with_retry};
 use crate::toolset::env_cache::CachedEnv;
 use eyre::Result;
 use filetime::set_file_times;
@@ -57,7 +57,7 @@ impl CacheClear {
             for p in cache_dirs {
                 if p.exists() {
                     debug!("clearing cache from {}", display_path(&p));
-                    remove_all(p)?;
+                    handle_remove_result(&p, remove_all_with_retry(&p))?;
                 }
             }
             // Also clear env cache when clearing all caches
@@ -70,5 +70,47 @@ impl CacheClear {
             }
         }
         Ok(())
+    }
+}
+
+fn handle_remove_result(path: &std::path::Path, result: Result<()>) -> Result<()> {
+    match result {
+        Err(err)
+            if err
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|err| err.kind() == std::io::ErrorKind::DirectoryNotEmpty) =>
+        {
+            debug!(
+                "cache was recreated while being cleared: {}",
+                display_path(path)
+            );
+            Ok(())
+        }
+        result => result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use eyre::Context;
+
+    use super::*;
+
+    #[test]
+    fn test_handle_remove_result_tolerates_directory_not_empty() {
+        let err = Err::<(), _>(std::io::Error::from(std::io::ErrorKind::DirectoryNotEmpty))
+            .wrap_err("failed rm -rf")
+            .unwrap_err();
+        handle_remove_result(std::path::Path::new("cache"), Err(err)).unwrap();
+    }
+
+    #[test]
+    fn test_handle_remove_result_propagates_other_errors() {
+        let err = std::io::Error::from(std::io::ErrorKind::PermissionDenied).into();
+        let err = handle_remove_result(std::path::Path::new("cache"), Err(err)).unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<std::io::Error>().map(|err| err.kind()),
+            Some(std::io::ErrorKind::PermissionDenied)
+        );
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -77,6 +77,35 @@ pub fn remove_all<P: AsRef<Path>>(path: P) -> Result<()> {
     Ok(())
 }
 
+/// Removes a path, retrying when a concurrent writer recreates directory entries while
+/// [`fs::remove_dir_all`] is running.
+///
+/// This remains a strict removal operation: if the directory is still non-empty after the
+/// retries are exhausted, the final error is returned to the caller.
+pub fn remove_all_with_retry<P: AsRef<Path>>(path: P) -> Result<()> {
+    let path = path.as_ref();
+    retry_remove_all(|| remove_all(path))
+}
+
+fn retry_remove_all(mut remove: impl FnMut() -> Result<()>) -> Result<()> {
+    const MAX_ATTEMPTS: u32 = 5;
+
+    for attempt in 0..MAX_ATTEMPTS {
+        match remove() {
+            Err(err)
+                if attempt + 1 < MAX_ATTEMPTS
+                    && err
+                        .downcast_ref::<std::io::Error>()
+                        .is_some_and(|err| err.kind() == std::io::ErrorKind::DirectoryNotEmpty) =>
+            {
+                std::thread::sleep(Duration::from_millis(10 * (1 << attempt)));
+            }
+            result => return result,
+        }
+    }
+    unreachable!()
+}
+
 pub fn remove_file_or_dir<P: AsRef<Path>>(path: P) -> Result<()> {
     let path = path.as_ref();
     match path.metadata().map(|m| m.file_type()) {
@@ -1809,6 +1838,39 @@ mod tests {
     use crate::config::Config;
 
     use super::*;
+
+    #[test]
+    fn test_retry_remove_all_retries_directory_not_empty() {
+        let mut attempts = 0;
+        retry_remove_all(|| {
+            attempts += 1;
+            if attempts < 3 {
+                Err(std::io::Error::from(std::io::ErrorKind::DirectoryNotEmpty))
+                    .wrap_err("failed rm -rf")
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap();
+
+        assert_eq!(attempts, 3);
+    }
+
+    #[test]
+    fn test_retry_remove_all_does_not_retry_other_errors() {
+        let mut attempts = 0;
+        let err = retry_remove_all(|| {
+            attempts += 1;
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied).into())
+        })
+        .unwrap_err();
+
+        assert_eq!(attempts, 1);
+        assert_eq!(
+            err.downcast_ref::<std::io::Error>().map(|err| err.kind()),
+            Some(std::io::ErrorKind::PermissionDenied)
+        );
+    }
 
     #[test]
     #[cfg(unix)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -88,22 +88,22 @@ pub fn remove_all_with_retry<P: AsRef<Path>>(path: P) -> Result<()> {
 }
 
 fn retry_remove_all(mut remove: impl FnMut() -> Result<()>) -> Result<()> {
-    const MAX_ATTEMPTS: u32 = 5;
+    const MAX_RETRIES: u32 = 4;
 
-    for attempt in 0..MAX_ATTEMPTS {
+    for retry in 0..MAX_RETRIES {
         match remove() {
+            Ok(()) => return Ok(()),
             Err(err)
-                if attempt + 1 < MAX_ATTEMPTS
-                    && err
-                        .downcast_ref::<std::io::Error>()
-                        .is_some_and(|err| err.kind() == std::io::ErrorKind::DirectoryNotEmpty) =>
+                if err
+                    .downcast_ref::<std::io::Error>()
+                    .is_some_and(|err| err.kind() == std::io::ErrorKind::DirectoryNotEmpty) =>
             {
-                std::thread::sleep(Duration::from_millis(10 * (1 << attempt)));
+                std::thread::sleep(Duration::from_millis(10 * (1 << retry)));
             }
-            result => return result,
+            Err(err) => return Err(err),
         }
     }
-    unreachable!()
+    remove()
 }
 
 pub fn remove_file_or_dir<P: AsRef<Path>>(path: P) -> Result<()> {
@@ -1869,6 +1869,22 @@ mod tests {
         assert_eq!(
             err.downcast_ref::<std::io::Error>().map(|err| err.kind()),
             Some(std::io::ErrorKind::PermissionDenied)
+        );
+    }
+
+    #[test]
+    fn test_retry_remove_all_propagates_final_attempt() {
+        let mut attempts = 0;
+        let err = retry_remove_all(|| {
+            attempts += 1;
+            Err(std::io::Error::from(std::io::ErrorKind::DirectoryNotEmpty).into())
+        })
+        .unwrap_err();
+
+        assert_eq!(attempts, 5);
+        assert_eq!(
+            err.downcast_ref::<std::io::Error>().map(|err| err.kind()),
+            Some(std::io::ErrorKind::DirectoryNotEmpty)
         );
     }
 


### PR DESCRIPTION
## Summary

- add a strict `remove_all_with_retry` file helper that retries `DirectoryNotEmpty` with bounded exponential backoff
- let `mise cache clear` tolerate a final `DirectoryNotEmpty` when another mise process recreates cache entries
- continue propagating permission failures and other unexpected I/O errors

## Root cause

`mise cache clear` called `remove_dir_all` once. A concurrent environment-resolution process could create and atomically rename a cache file while the cache tree was being removed, causing macOS to return `DirectoryNotEmpty`.

The generic helper remains strict after its retries are exhausted. Only `cache clear` applies the cache-specific policy that concurrently recreated entries may remain.

Related discussion: https://github.com/jdx/mise/discussions/10988

## Validation

- `cargo test test_retry_remove_all`
- `cargo test test_handle_remove_result`
- `mise run test:e2e e2e/cli/test_cache_clear`
- `mise run lint-fix`
- discussion reproduction with a concurrent `mise hook-env -s zsh`

*This PR was prepared with the help of an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to cache clearing and a new file helper; non-DirectoryNotEmpty errors remain strict, with tests covering retry and tolerance behavior.
> 
> **Overview**
> Fixes **`mise cache clear`** failing when another mise process writes cache files mid-removal (e.g. during `hook-env`), which could surface as **`DirectoryNotEmpty`** on macOS.
> 
> Adds **`remove_all_with_retry`** in `file.rs`: it wraps **`remove_all`** and retries only on **`DirectoryNotEmpty`**, with bounded exponential backoff (up to five attempts total). Other I/O errors fail immediately.
> 
> **`cache clear`** switches to that helper and adds **`handle_remove_result`**, which treats a **remaining** **`DirectoryNotEmpty`** after retries as success (logs at debug) when entries were recreated concurrently; permission and other errors still propagate.
> 
> Unit tests cover retry behavior and cache-specific error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5f357c7eea7b234aaa626cf80d2a17afbcd2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache clearing reliability when files are created or modified during removal.
  * Added automatic retries for transient directory-removal conflicts.
  * Non-recoverable removal errors continue to be reported normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->