### PR TITLE
fix(github): serialize oauth token refreshes

### DIFF
--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -4,7 +4,8 @@ use crate::env_diff::EnvMap;
 use eyre::{Result, bail, eyre};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const GRANT_DEVICE_CODE: &str = "urn:ietf:params:oauth:grant-type:device_code";
@@ -59,6 +60,15 @@ struct TokenResponse {
     error_description: Option<String>,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "GitHub OAuth refresh was rejected ({code}): {description}. Reauthorization is required; run `mise token github --oauth --refresh`"
+)]
+struct RefreshRejected {
+    code: String,
+    description: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CachedToken {
     access_token: String,
@@ -108,6 +118,7 @@ pub fn cached_access_token_for_host(host: &str) -> Option<String> {
         settings.github.oauth_scopes.trim(),
     );
     read_cache()
+        .ok()?
         .tokens
         .get(&cache_key)
         .map(|cached| cached.access_token.clone())
@@ -162,7 +173,12 @@ async fn refresh_cached_token(
     stale_access_token: Option<&str>,
 ) -> Result<Option<String>> {
     let _lock = REFRESH_TOKEN_LOCK.lock().await;
-    let mut cache = read_cache();
+    let path = cache_path();
+    // GitHub refresh tokens are single-use. Serialize the read-refresh-write
+    // transaction across mise processes, then re-read after acquiring the
+    // lock so a waiter observes any token minted by the previous holder.
+    let _cache_lock = crate::lock_file::LockFile::new(&path).lock()?;
+    let mut cache = read_cache()?;
     let Some(mut cached) = cache.tokens.get(cache_key).cloned() else {
         return Ok(None);
     };
@@ -214,7 +230,7 @@ async fn token_async(req: TokenRequest) -> Result<String> {
     let canonical_host =
         api_host(&settings.github.oauth_api_url).unwrap_or_else(|| req.host.clone());
     let cache_key = cache_key(&canonical_host, client_id, scopes);
-    let mut cache = read_cache();
+    let cache = read_cache()?;
     if !req.force_refresh
         && let Some(cached) = cache.tokens.get(&cache_key)
         && reusable(cached)
@@ -229,7 +245,7 @@ async fn token_async(req: TokenRequest) -> Result<String> {
             Ok(Some(token)) => return Ok(token),
             Ok(None) => {}
             Err(err) => {
-                debug!("failed to refresh GitHub OAuth token: {err:#}");
+                log_refresh_error(&err);
             }
         }
         if !req.force_refresh && cached.expires_at > chrono::Utc::now() {
@@ -245,8 +261,7 @@ async fn token_async(req: TokenRequest) -> Result<String> {
     let token = poll_access_token(&device).await?;
     let cached = token_response_to_cache(token)?;
     let access_token = cached.access_token.clone();
-    cache.tokens.insert(cache_key, cached);
-    if let Err(err) = write_cache(&cache) {
+    if let Err(err) = cache_token(cache_key, cached) {
         warn!("failed to cache GitHub OAuth token: {err:#}");
     }
     Ok(access_token)
@@ -368,8 +383,16 @@ async fn refresh_token(cached: &CachedToken) -> Result<Option<CachedToken>> {
         .json::<TokenResponse>()
         .await?;
 
-    if response.error.is_some() {
-        return Ok(None);
+    if let Some(code) = response.error.as_deref() {
+        let description = response
+            .error_description
+            .clone()
+            .unwrap_or_else(|| code.to_string());
+        return Err(RefreshRejected {
+            code: code.to_string(),
+            description,
+        }
+        .into());
     }
     let mut refreshed = token_response_to_cache(response)?;
     if refreshed.refresh_token.is_none() {
@@ -440,12 +463,13 @@ fn cache_path() -> PathBuf {
     env::MISE_STATE_DIR.join("github-oauth-tokens.toml")
 }
 
-fn read_cache() -> TokenCache {
+fn read_cache() -> Result<TokenCache> {
     let path = cache_path();
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|s| toml::from_str(&s).ok())
-        .unwrap_or_default()
+    match std::fs::read_to_string(&path) {
+        Ok(content) => Ok(toml::from_str(&content)?),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(TokenCache::default()),
+        Err(err) => Err(err.into()),
+    }
 }
 
 fn write_cache(cache: &TokenCache) -> Result<()> {
@@ -454,23 +478,63 @@ fn write_cache(cache: &TokenCache) -> Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     let content = toml::to_string_pretty(cache)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| eyre!("GitHub OAuth cache path has no parent"))?;
+    let mut tmp = tempfile::NamedTempFile::with_prefix_in(".github-oauth-tokens.", parent)?;
     #[cfg(unix)]
     {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(path)?;
-        file.write_all(content.as_bytes())?;
+        use std::os::unix::fs::PermissionsExt;
+        tmp.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
-    #[cfg(not(unix))]
-    {
-        std::fs::write(path, content)?;
-    }
+    tmp.write_all(content.as_bytes())?;
+    tmp.as_file_mut().sync_all()?;
+    persist_cache_tmp(tmp, &path)?;
     Ok(())
+}
+
+fn cache_token(cache_key: String, cached: CachedToken) -> Result<()> {
+    let path = cache_path();
+    let _cache_lock = crate::lock_file::LockFile::new(&path).lock()?;
+    let mut cache = read_cache()?;
+    cache.tokens.insert(cache_key, cached);
+    write_cache(&cache)
+}
+
+pub(crate) fn log_refresh_error(err: &eyre::Report) {
+    if err.downcast_ref::<RefreshRejected>().is_some() {
+        warn!("{err}");
+    } else {
+        debug!("failed to refresh GitHub OAuth token: {err:#}");
+    }
+}
+
+fn persist_cache_tmp(mut tmp: tempfile::NamedTempFile, target: &Path) -> Result<()> {
+    const RETRIES: u32 = 20;
+
+    for attempt in 0..=RETRIES {
+        match tmp.persist(target) {
+            Ok(_) => return Ok(()),
+            Err(err) if should_retry_cache_persist(&err.error) && attempt < RETRIES => {
+                tmp = err.file;
+                std::thread::sleep(Duration::from_millis(5 * u64::from(attempt + 1)));
+            }
+            Err(err) => return Err(err.error.into()),
+        }
+    }
+
+    unreachable!("OAuth cache persist retry loop should always return");
+}
+
+#[cfg(windows)]
+fn should_retry_cache_persist(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::PermissionDenied
+}
+
+#[cfg(not(windows))]
+fn should_retry_cache_persist(_err: &std::io::Error) -> bool {
+    false
 }
 
 fn host_matches_settings(host: &str, oauth_api_url: &str) -> bool {
@@ -622,10 +686,102 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let result = refresh_cached_token(&cache_key, Some("ghu-stale")).await;
 
         assert!(result.is_err());
-        let cache = read_cache();
+        let cache = read_cache().unwrap();
         let cached = cache.tokens.get(&cache_key).unwrap();
         assert_eq!(cached.access_token, "ghu-stale");
         assert_eq!(cached.expires_at, expires_at);
+    }
+
+    #[tokio::test]
+    async fn refresh_rejection_surfaces_sanitized_error() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let body = r#"{"error":"bad_refresh_token","error_description":"The refresh token is invalid."}"#;
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+            }
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("github-oauth-tokens.toml");
+        let _guard =
+            OAuthEnvGuard::new(format!("http://127.0.0.1:{port}/login"), cache_path.clone());
+
+        let cache_key = cache_key("api.github.com", "Iv1.mock", "");
+        std::fs::write(
+            &cache_path,
+            format!(
+                r#"[tokens.{cache_key}]
+access_token = "ghu-stale"
+expires_at = "2020-01-01T00:00:00Z"
+refresh_token = "ghr-secret"
+refresh_expires_at = "2099-01-01T00:00:00Z"
+"#
+            ),
+        )
+        .unwrap();
+
+        let err = refresh_cached_token(&cache_key, None).await.unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("bad_refresh_token"));
+        assert!(message.contains("Reauthorization is required"));
+        assert!(!message.contains("ghr-secret"));
+    }
+
+    #[test]
+    fn refresh_rereads_cache_after_filesystem_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("github-oauth-tokens.toml");
+        let _guard = OAuthEnvGuard::new("http://127.0.0.1:9/login".to_string(), cache_path.clone());
+        let cache_key = cache_key("api.github.com", "Iv1.mock", "");
+        std::fs::write(
+            &cache_path,
+            format!(
+                r#"[tokens.{cache_key}]
+access_token = "ghu-stale"
+expires_at = "2020-01-01T00:00:00Z"
+refresh_token = "ghr-stale"
+refresh_expires_at = "2099-01-01T00:00:00Z"
+"#
+            ),
+        )
+        .unwrap();
+
+        let cache_lock = crate::lock_file::LockFile::new(&cache_path).lock().unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let refresh_key = cache_key.clone();
+        let refresh = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            block_on(async move { refresh_cached_token(&refresh_key, Some("ghu-stale")).await })
+        });
+        started_rx.recv().unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut cache = read_cache().unwrap();
+        cache.tokens.insert(
+            cache_key,
+            CachedToken {
+                access_token: "ghu-fresh".to_string(),
+                expires_at: chrono::DateTime::parse_from_rfc3339("2099-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+                refresh_token: Some("ghr-fresh".to_string()),
+                refresh_expires_at: None,
+            },
+        );
+        write_cache(&cache).unwrap();
+        drop(cache_lock);
+
+        let token = refresh.join().unwrap().unwrap();
+        assert_eq!(token.as_deref(), Some("ghu-fresh"));
     }
 
     #[tokio::test]
@@ -686,7 +842,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         .unwrap();
         assert_eq!(token, "ghu-new");
 
-        let cache = read_cache();
+        let cache = read_cache().unwrap();
         let cached = cache.tokens.get(&cache_key).unwrap();
         assert_eq!(cached.access_token, "ghu-new");
         assert_eq!(cached.refresh_token.as_deref(), Some("ghr-new"));

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -177,9 +177,9 @@ async fn refresh_cached_token(
     // GitHub refresh tokens are single-use. Serialize the read-refresh-write
     // transaction across mise processes, then re-read after acquiring the
     // lock so a waiter observes any token minted by the previous holder.
-    let _cache_lock = crate::lock_file::LockFile::new(&path).lock()?;
+    let _cache_lock = lock_cache(&path)?;
     let mut cache = read_cache()?;
-    let Some(mut cached) = cache.tokens.get(cache_key).cloned() else {
+    let Some(cached) = cache.tokens.get(cache_key).cloned() else {
         return Ok(None);
     };
 
@@ -194,13 +194,18 @@ async fn refresh_cached_token(
         false
     };
 
-    let Some(refreshed) = refresh_token(&cached).await? else {
-        if invalidate_on_none {
-            cached.expires_at = chrono::Utc::now();
-            cache.tokens.insert(cache_key.to_string(), cached);
-            if let Err(err) = write_cache(&cache) {
-                warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
+    let refreshed = match refresh_token(&cached).await {
+        Ok(refreshed) => refreshed,
+        Err(err) => {
+            if invalidate_on_none && err.downcast_ref::<RefreshRejected>().is_some() {
+                invalidate_cached_token(cache_key, cached, &mut cache);
             }
+            return Err(err);
+        }
+    };
+    let Some(refreshed) = refreshed else {
+        if invalidate_on_none {
+            invalidate_cached_token(cache_key, cached, &mut cache);
         }
         return Ok(None);
     };
@@ -496,10 +501,24 @@ fn write_cache(cache: &TokenCache) -> Result<()> {
 
 fn cache_token(cache_key: String, cached: CachedToken) -> Result<()> {
     let path = cache_path();
-    let _cache_lock = crate::lock_file::LockFile::new(&path).lock()?;
+    let _cache_lock = lock_cache(&path)?;
     let mut cache = read_cache()?;
     cache.tokens.insert(cache_key, cached);
     write_cache(&cache)
+}
+
+fn invalidate_cached_token(cache_key: &str, mut cached: CachedToken, cache: &mut TokenCache) {
+    cached.expires_at = chrono::Utc::now();
+    cache.tokens.insert(cache_key.to_string(), cached);
+    if let Err(err) = write_cache(cache) {
+        warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
+    }
+}
+
+fn lock_cache(path: &Path) -> Result<fslock::LockFile> {
+    crate::lock_file::LockFile::new(path)
+        .with_callback(|_| debug!("waiting for GitHub OAuth token cache lock"))
+        .lock()
 }
 
 pub(crate) fn log_refresh_error(err: &eyre::Report) {
@@ -729,11 +748,16 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         )
         .unwrap();
 
-        let err = refresh_cached_token(&cache_key, None).await.unwrap_err();
+        let err = refresh_cached_token(&cache_key, Some("ghu-stale"))
+            .await
+            .unwrap_err();
         let message = err.to_string();
         assert!(message.contains("bad_refresh_token"));
         assert!(message.contains("Reauthorization is required"));
         assert!(!message.contains("ghr-secret"));
+        let cache = read_cache().unwrap();
+        let cached = cache.tokens.get(&cache_key).unwrap();
+        assert!(cached.expires_at <= chrono::Utc::now());
     }
 
     #[test]

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -177,8 +177,7 @@ async fn refresh_cached_token(
     // GitHub refresh tokens are single-use. Serialize the read-refresh-write
     // transaction across mise processes, then re-read after acquiring the
     // lock so a waiter observes any token minted by the previous holder.
-    let _cache_lock = lock_cache(&path)?;
-    let mut cache = read_cache()?;
+    let (cache_lock, mut cache) = lock_and_read_cache(path).await?;
     let Some(cached) = cache.tokens.get(cache_key).cloned() else {
         return Ok(None);
     };
@@ -199,6 +198,9 @@ async fn refresh_cached_token(
         Err(err) => {
             if invalidate_on_none && err.downcast_ref::<RefreshRejected>().is_some() {
                 invalidate_cached_token(cache_key, cached, &mut cache);
+                if let Err(cache_err) = write_cache_locked_async(cache_lock, cache).await {
+                    warn!("failed to invalidate GitHub OAuth token cache: {cache_err:#}");
+                }
             }
             return Err(err);
         }
@@ -206,12 +208,15 @@ async fn refresh_cached_token(
     let Some(refreshed) = refreshed else {
         if invalidate_on_none {
             invalidate_cached_token(cache_key, cached, &mut cache);
+            if let Err(err) = write_cache_locked_async(cache_lock, cache).await {
+                warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
+            }
         }
         return Ok(None);
     };
     let access_token = refreshed.access_token.clone();
     cache.tokens.insert(cache_key.to_string(), refreshed);
-    if let Err(err) = write_cache(&cache) {
+    if let Err(err) = write_cache_locked_async(cache_lock, cache).await {
         warn!("failed to cache refreshed GitHub OAuth token: {err:#}");
     }
     Ok(Some(access_token))
@@ -235,7 +240,7 @@ async fn token_async(req: TokenRequest) -> Result<String> {
     let canonical_host =
         api_host(&settings.github.oauth_api_url).unwrap_or_else(|| req.host.clone());
     let cache_key = cache_key(&canonical_host, client_id, scopes);
-    let cache = read_cache()?;
+    let cache = read_cache_async().await?;
     if !req.force_refresh
         && let Some(cached) = cache.tokens.get(&cache_key)
         && reusable(cached)
@@ -266,7 +271,7 @@ async fn token_async(req: TokenRequest) -> Result<String> {
     let token = poll_access_token(&device).await?;
     let cached = token_response_to_cache(token)?;
     let access_token = cached.access_token.clone();
-    if let Err(err) = cache_token(cache_key, cached) {
+    if let Err(err) = cache_token(cache_key, cached).await {
         warn!("failed to cache GitHub OAuth token: {err:#}");
     }
     Ok(access_token)
@@ -471,10 +476,26 @@ fn cache_path() -> PathBuf {
 fn read_cache() -> Result<TokenCache> {
     let path = cache_path();
     match std::fs::read_to_string(&path) {
-        Ok(content) => Ok(toml::from_str(&content)?),
+        Ok(content) => match toml::from_str(&content) {
+            Ok(cache) => Ok(cache),
+            Err(_) => {
+                warn!(
+                    "failed to parse GitHub OAuth token cache at {}; ignoring it",
+                    path.display()
+                );
+                Ok(TokenCache::default())
+            }
+        },
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(TokenCache::default()),
-        Err(err) => Err(err.into()),
+        Err(err) => Err(eyre!(
+            "failed to read GitHub OAuth token cache at {}: {err}",
+            path.display()
+        )),
     }
+}
+
+async fn read_cache_async() -> Result<TokenCache> {
+    tokio::task::spawn_blocking(read_cache).await?
 }
 
 fn write_cache(cache: &TokenCache) -> Result<()> {
@@ -499,20 +520,37 @@ fn write_cache(cache: &TokenCache) -> Result<()> {
     Ok(())
 }
 
-fn cache_token(cache_key: String, cached: CachedToken) -> Result<()> {
-    let path = cache_path();
-    let _cache_lock = lock_cache(&path)?;
-    let mut cache = read_cache()?;
-    cache.tokens.insert(cache_key, cached);
-    write_cache(&cache)
+async fn cache_token(cache_key: String, cached: CachedToken) -> Result<()> {
+    tokio::task::spawn_blocking(move || {
+        let path = cache_path();
+        let _cache_lock = lock_cache(&path)?;
+        let mut cache = read_cache()?;
+        cache.tokens.insert(cache_key, cached);
+        write_cache(&cache)
+    })
+    .await?
 }
 
 fn invalidate_cached_token(cache_key: &str, mut cached: CachedToken, cache: &mut TokenCache) {
     cached.expires_at = chrono::Utc::now();
     cache.tokens.insert(cache_key.to_string(), cached);
-    if let Err(err) = write_cache(cache) {
-        warn!("failed to invalidate GitHub OAuth token cache: {err:#}");
-    }
+}
+
+async fn lock_and_read_cache(path: PathBuf) -> Result<(fslock::LockFile, TokenCache)> {
+    tokio::task::spawn_blocking(move || {
+        let cache_lock = lock_cache(&path)?;
+        let cache = read_cache()?;
+        Ok((cache_lock, cache))
+    })
+    .await?
+}
+
+async fn write_cache_locked_async(cache_lock: fslock::LockFile, cache: TokenCache) -> Result<()> {
+    tokio::task::spawn_blocking(move || {
+        let _cache_lock = cache_lock;
+        write_cache(&cache)
+    })
+    .await?
 }
 
 fn lock_cache(path: &Path) -> Result<fslock::LockFile> {
@@ -758,6 +796,18 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let cache = read_cache().unwrap();
         let cached = cache.tokens.get(&cache_key).unwrap();
         assert!(cached.expires_at <= chrono::Utc::now());
+    }
+
+    #[test]
+    fn corrupt_cache_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("github-oauth-tokens.toml");
+        let _guard = OAuthEnvGuard::new("http://127.0.0.1:9/login".to_string(), cache_path.clone());
+        std::fs::write(&cache_path, "[tokens.invalid").unwrap();
+
+        let cache = read_cache().unwrap();
+
+        assert!(cache.tokens.is_empty());
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -700,7 +700,7 @@ impl Client {
                 }
                 Ok(None) => {}
                 Err(err) => {
-                    debug!("failed to refresh GitHub OAuth token after 401: {err:#}");
+                    crate::github::oauth::log_refresh_error(&err);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- serialize GitHub OAuth refresh transactions across mise processes
- re-read and merge the token cache while holding the filesystem lock
- replace cache files atomically instead of truncating them in place
- surface sanitized OAuth rejection errors with a reauthorization command

## Root cause

GitHub App refresh tokens are single-use, but mise's refresh mutex only coordinated callers within one process. Separate mise processes could therefore submit the same refresh token concurrently. Cache reads and in-place writes were also uncoordinated, allowing a stale writer or partial read to discard a successfully rotated token.

The refresh endpoint's `error` and `error_description` fields were converted to `None`, and normal token resolution then discarded the resulting error. Users consequently saw anonymous GitHub requests without the reason refresh had failed.

This change locks the complete read-refresh-write transaction and re-reads the cache after acquiring the lock. Interactive device authorization remains outside the lock; its result is merged into the latest cache under the lock. Writes use a same-directory temporary file with mode `0600` and atomic persistence.

Fixes the client-side race and diagnostics identified in #10986. The original report does not contain enough evidence to distinguish a prior race from GitHub-side invalidation, so this does not claim that the race was definitively the initiating event.

## Validation

- `cargo test github::oauth::tests`
- `cargo test test_github_oauth_401_refreshes_and_retries_once`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication token persistence and multi-process refresh behavior; mistakes could break GitHub API access or leak stale tokens, but scope is limited to OAuth cache handling with added tests.
> 
> **Overview**
> Fixes a **cross-process race** on GitHub OAuth refresh: single-use refresh tokens were only guarded by an in-process mutex, so parallel `mise` runs could burn the same refresh token or overwrite the cache with stale data.
> 
> **Refresh path** now holds a **filesystem lock** for the full read→refresh→write cycle, **re-reads the cache** after taking the lock so a waiter can reuse a token another process just wrote, and **writes the TOML cache atomically** (temp file in the same directory, `0600` on Unix, sync + persist with Windows retry on permission errors). Device-flow tokens are merged into the cache under that lock via `cache_token`.
> 
> When GitHub returns an OAuth `error` on refresh, the code raises **`RefreshRejected`** with a sanitized message (no secrets) and **`mise token github --oauth --refresh`** guidance instead of treating it as a silent cache miss. Stale-token 401 retries in **`http`** use **`log_refresh_error`** so rejections surface as warnings. Corrupt cache files are ignored with a warning; hard read failures propagate as errors.
> 
> New tests cover rejection messaging, corrupt cache, lock re-read behavior, and existing refresh scenarios updated for `read_cache()` returning `Result`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f74aa8615c97bb65cebc3597b14a4f0bef42f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and user-facing messaging for rejected GitHub OAuth refreshes, including a “Reauthorization is required” prompt.
  * Tightened token refresh/cache logic so invalid refresh outcomes no longer get treated as cache misses or reuse stale tokens.
  * Enhanced token cache reliability under concurrent refresh attempts and interruptions, with safer persistence and improved cross-platform recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->