### PR TITLE
fix(github): skip package assets during autodetection

### DIFF
--- a/e2e/backend/test_github_matching
+++ b/e2e/backend/test_github_matching
@@ -15,6 +15,12 @@
 
 export MISE_EXPERIMENTAL=1
 
+# Package-manager archives are not directly executable and the github backend
+# does not extract them. Autodetection must reject a release containing only
+# .deb/.rpm assets instead of installing the package itself as the executable.
+# Regression test for https://github.com/jdx/mise/discussions/10987.
+assert_fail 'mise install "github:dirk/quickhook@1.6.2"' "No matching asset found for platform"
+
 # A `matching` value that excludes every asset must fail asset selection with an
 # error that names the filter (proves the option is parsed + threaded, and that
 # the failure isn't a misleading "no asset for this platform"). Run this BEFORE

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -341,7 +341,9 @@ impl AssetPicker {
         };
         scored_assets
             .into_iter()
-            .filter(|(score, asset)| *score > 0 && !self.has_arch_mismatch(asset))
+            .filter(|(score, asset)| {
+                *score > 0 && !self.has_arch_mismatch(asset) && !is_unsupported_package_asset(asset)
+            })
             .min_by(|(score_a, name_a), (score_b, name_b)| {
                 score_b
                     .cmp(score_a)
@@ -644,6 +646,17 @@ impl AssetPicker {
             _ => 0,
         }
     }
+}
+
+/// Package-manager archives are not directly executable and mise does not
+/// extract them. Keep them out of automatic selection while still allowing an
+/// explicit `asset_pattern` or URL to select one for custom installation logic.
+fn is_unsupported_package_asset(asset: &str) -> bool {
+    let asset = asset.to_lowercase();
+    asset.ends_with(".deb")
+        || asset.contains(".deb.")
+        || asset.ends_with(".rpm")
+        || asset.contains(".rpm.")
 }
 
 fn asset_matches_preferred_name(asset: &str, preferred_name: &str) -> bool {
@@ -2389,6 +2402,25 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
             picker.pick_best_asset(&["tool.jar".to_string()]).as_deref(),
             Some("tool.jar")
         );
+    }
+
+    #[test]
+    fn test_unsupported_package_assets_not_picked() {
+        // Regression test for https://github.com/jdx/mise/discussions/10987.
+        // The github backend cannot extract .deb/.rpm packages, so treating one
+        // as a raw executable produces a successful but unusable installation.
+        let assets = vec![
+            "quickhook-1.6.2-linux-amd64.deb".to_string(),
+            "quickhook-1.6.2-linux-amd64.rpm".to_string(),
+            "quickhook-1.6.2-linux-amd64.deb.sha256".to_string(),
+            "quickhook-1.6.2-linux-arm64.deb".to_string(),
+            "quickhook-1.6.2-linux-arm64.rpm".to_string(),
+        ];
+        let picker = AssetPicker::with_libc("linux".to_string(), "x86_64".to_string(), None)
+            .with_preferred_name("quickhook");
+
+        assert_eq!(picker.pick_best_asset(&assets), None);
+        assert_eq!(picker.with_matching(".deb").pick_best_asset(&assets), None);
     }
 
     #[test]

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -342,7 +342,9 @@ impl AssetPicker {
         scored_assets
             .into_iter()
             .filter(|(score, asset)| {
-                *score > 0 && !self.has_arch_mismatch(asset) && !is_unsupported_package_asset(asset)
+                *score > 0
+                    && !self.has_arch_mismatch(asset)
+                    && !is_package_or_installer_asset(asset)
             })
             .min_by(|(score_a, name_a), (score_b, name_b)| {
                 score_b
@@ -648,15 +650,28 @@ impl AssetPicker {
     }
 }
 
-/// Package-manager archives are not directly executable and mise does not
-/// extract them. Keep them out of automatic selection while still allowing an
-/// explicit `asset_pattern` or URL to select one for custom installation logic.
-fn is_unsupported_package_asset(asset: &str) -> bool {
+/// Package archives and installers are not directly executable and mise does
+/// not extract them. Keep them out of automatic selection while still allowing
+/// an explicit `asset_pattern` or URL to select one for custom installation
+/// logic.
+fn is_package_or_installer_asset(asset: &str) -> bool {
     let asset = asset.to_lowercase();
-    asset.ends_with(".deb")
-        || asset.contains(".deb.")
-        || asset.ends_with(".rpm")
-        || asset.contains(".rpm.")
+    asset.split('.').any(|extension| {
+        matches!(
+            extension,
+            "apk"
+                | "appx"
+                | "appxbundle"
+                | "deb"
+                | "dmg"
+                | "mpkg"
+                | "msi"
+                | "msix"
+                | "msixbundle"
+                | "pkg"
+                | "rpm"
+        )
+    })
 }
 
 fn asset_matches_preferred_name(asset: &str, preferred_name: &str) -> bool {
@@ -2421,6 +2436,44 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
 
         assert_eq!(picker.pick_best_asset(&assets), None);
         assert_eq!(picker.with_matching(".deb").pick_best_asset(&assets), None);
+    }
+
+    #[test]
+    fn test_package_and_installer_assets_not_picked() {
+        let cases = [
+            (
+                "linux",
+                "x86_64",
+                vec!["tool-linux-amd64.apk", "tool-linux-amd64.apk.sha256"],
+            ),
+            (
+                "macos",
+                "aarch64",
+                vec![
+                    "tool-macos-arm64.dmg",
+                    "tool-macos-arm64.pkg",
+                    "tool-macos-arm64.mpkg",
+                ],
+            ),
+            (
+                "windows",
+                "x86_64",
+                vec![
+                    "tool-windows-x86_64.msi",
+                    "tool-windows-x86_64.MSI.SHA256",
+                    "tool-windows-x86_64.msix",
+                    "tool-windows-x86_64.msixbundle",
+                    "tool-windows-x86_64.appx",
+                    "tool-windows-x86_64.appxbundle",
+                ],
+            ),
+        ];
+
+        for (os, arch, assets) in cases {
+            let assets = assets.into_iter().map(str::to_string).collect::<Vec<_>>();
+            let picker = AssetPicker::with_libc(os.to_string(), arch.to_string(), None);
+            assert_eq!(picker.pick_best_asset(&assets), None, "failed for {os}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- exclude unsupported OS package and installer assets from automatic asset selection
- cover `.apk`, `.deb`, `.rpm`, macOS DMG/PKG, and Windows MSI/MSIX/AppX formats and their sidecars
- keep explicit `asset_pattern` and URL selection behavior unchanged
- cover the Quickhook reproduction and cross-platform installer formats with unit and end-to-end regressions

## Root cause

The asset matcher scored package and installer assets as valid OS/architecture matches. Because the generic artifact installer does not recognize these formats, it treated the selected package as a raw executable and reported a successful but unusable installation.

This change filters those assets only in automatic matching, so releases containing only unsupported packages now report that no platform asset matches. Explicit selection remains available for custom installation logic.

## Backend scope

This does not remove DMG or PKG support from the `aqua:` backend. Aqua registry entries provide explicit format and file metadata, and Aqua has dedicated DMG/PKG extraction paths using `hdiutil` and `pkgutil`.

The generic `github:` backend has neither that registry metadata nor DMG/PKG extraction dispatch; without this filter it guesses from the filename and installs those assets as raw executables. The same automatic matcher is shared by the generic `gitlab:` and `forgejo:` backends.

Addresses https://github.com/jdx/mise/discussions/10987.

## Testing

- `mise x cargo -- cargo test backend::asset_matcher::tests::test_unsupported_package_assets_not_picked`
- `mise x cargo -- cargo test backend::asset_matcher::tests::test_package_and_installer_assets_not_picked`
- `mise run test:e2e e2e/backend/test_github_matching`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub release asset matching to prevent auto-selecting package/installer archives (including Debian/RPM and other installer formats) as platform executables.
  * When a release contains only unsupported package archives, installation now correctly reports that no compatible asset is available.
* **Tests**
  * Added negative regression coverage to verify these unsupported artifacts are not selected for installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
