### PR TITLE
fix(aqua): honor explicit false overrides

### DIFF
--- a/crates/aqua-registry/src/cache.rs
+++ b/crates/aqua-registry/src/cache.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-const COMPILED_REGISTRY_CACHE_VERSION: &str = "v6";
+const COMPILED_REGISTRY_CACHE_VERSION: &str = "v7";
 
 #[derive(Debug, Clone)]
 pub struct RegistryCache {

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -87,7 +87,7 @@ pub struct AquaPackage {
     version_constraint: String,
     #[rkyv(omit_bounds)]
     pub version_overrides: Vec<AquaPackage>,
-    pub no_asset: bool,
+    pub no_asset: Option<bool>,
     pub private: bool,
     pub error_message: Option<String>,
     pub path: Option<String>,
@@ -404,7 +404,7 @@ impl Default for AquaPackage {
             overrides: Vec::new(),
             version_constraint: String::new(),
             version_overrides: Vec::new(),
-            no_asset: false,
+            no_asset: None,
             private: false,
             error_message: None,
             path: None,
@@ -1084,8 +1084,8 @@ fn apply_override(mut orig: AquaPackage, avo: &AquaPackage) -> AquaPackage {
         }
     }
 
-    if avo.no_asset {
-        orig.no_asset = true;
+    if avo.no_asset.is_some() {
+        orig.no_asset = avo.no_asset;
     }
     if let Some(error_message) = avo.error_message.clone() {
         orig.error_message = Some(error_message);
@@ -1573,6 +1573,23 @@ packages:
     }
 
     #[test]
+    fn test_no_asset_can_be_disabled_by_version_override() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - no_asset: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: false
+"#,
+        )
+        .with_version(&["1.0.0"], "linux", "amd64");
+
+        assert_eq!(pkg.no_asset, Some(false));
+    }
+
+    #[test]
     fn test_omitted_emulation_flags_preserve_base_values() {
         let pkg = first_registry_package(
             r#"
@@ -1592,6 +1609,23 @@ packages:
             pkg.asset("1.0.0", "darwin", "arm64").unwrap(),
             "tool-darwin-amd64"
         );
+    }
+
+    #[test]
+    fn test_omitted_no_asset_preserves_base_value() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - no_asset: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        format: raw
+"#,
+        )
+        .with_version(&["1.0.0"], "linux", "amd64");
+
+        assert_eq!(pkg.no_asset, Some(true));
     }
 
     #[test]

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -60,8 +60,8 @@ pub struct AquaPackage {
     pub url: String,
     pub description: Option<String>,
     pub format: String,
-    pub rosetta2: bool,
-    pub windows_arm_emulation: bool,
+    pub rosetta2: Option<bool>,
+    pub windows_arm_emulation: Option<bool>,
     pub complete_windows_ext: Option<bool>,
     pub windows_ext: String,
     pub append_ext: Option<bool>,
@@ -382,8 +382,8 @@ impl Default for AquaPackage {
             url: String::new(),
             description: None,
             format: String::new(),
-            rosetta2: false,
-            windows_arm_emulation: false,
+            rosetta2: None,
+            windows_arm_emulation: None,
             complete_windows_ext: None,
             windows_ext: String::new(),
             append_ext: None,
@@ -712,8 +712,8 @@ impl AquaPackage {
     }
 
     fn actual_arch<'a>(&self, os: &str, arch: &'a str) -> &'a str {
-        if (os == "darwin" && arch == "arm64" && self.rosetta2)
-            || (os == "windows" && arch == "arm64" && self.windows_arm_emulation)
+        if (os == "darwin" && arch == "arm64" && self.rosetta2.unwrap_or(false))
+            || (os == "windows" && arch == "arm64" && self.windows_arm_emulation.unwrap_or(false))
         {
             "amd64"
         } else {
@@ -994,11 +994,11 @@ fn apply_override(mut orig: AquaPackage, avo: &AquaPackage) -> AquaPackage {
     if !avo.format.is_empty() {
         orig.format = avo.format.clone();
     }
-    if avo.rosetta2 {
-        orig.rosetta2 = true;
+    if avo.rosetta2.is_some() {
+        orig.rosetta2 = avo.rosetta2;
     }
-    if avo.windows_arm_emulation {
-        orig.windows_arm_emulation = true;
+    if avo.windows_arm_emulation.is_some() {
+        orig.windows_arm_emulation = avo.windows_arm_emulation;
     }
     if avo.complete_windows_ext.is_some() {
         orig.complete_windows_ext = avo.complete_windows_ext;
@@ -1520,6 +1520,78 @@ packages:
         .with_version(&["1.0.0"], "linux", "amd64");
 
         assert!(pkg.private);
+    }
+
+    #[test]
+    fn test_emulation_flags_can_be_disabled_by_version_override() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - asset: tool-{{.OS}}-{{.Arch}}
+    rosetta2: true
+    windows_arm_emulation: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: false
+        windows_arm_emulation: false
+"#,
+        )
+        .with_version(&["1.0.0"], "darwin", "arm64");
+
+        assert_eq!(pkg.rosetta2, Some(false));
+        assert_eq!(pkg.windows_arm_emulation, Some(false));
+        assert_eq!(
+            pkg.asset("1.0.0", "darwin", "arm64").unwrap(),
+            "tool-darwin-arm64"
+        );
+        assert_eq!(
+            pkg.asset("1.0.0", "windows", "arm64").unwrap(),
+            "tool-windows-arm64.exe"
+        );
+    }
+
+    #[test]
+    fn test_emulation_flags_can_be_disabled_by_platform_override() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - asset: tool-{{.OS}}-{{.Arch}}
+    rosetta2: true
+    overrides:
+      - goos: darwin
+        rosetta2: false
+"#,
+        )
+        .with_version(&["1.0.0"], "darwin", "arm64");
+
+        assert_eq!(pkg.rosetta2, Some(false));
+        assert_eq!(
+            pkg.asset("1.0.0", "darwin", "arm64").unwrap(),
+            "tool-darwin-arm64"
+        );
+    }
+
+    #[test]
+    fn test_omitted_emulation_flags_preserve_base_values() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - asset: tool-{{.OS}}-{{.Arch}}
+    rosetta2: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        format: raw
+"#,
+        )
+        .with_version(&["1.0.0"], "darwin", "arm64");
+
+        assert_eq!(pkg.rosetta2, Some(true));
+        assert_eq!(
+            pkg.asset("1.0.0", "darwin", "arm64").unwrap(),
+            "tool-darwin-amd64"
+        );
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -4211,7 +4211,7 @@ fn versioned_package_from_tag(
 }
 
 fn package_has_asset(pkg: &AquaPackage) -> bool {
-    !pkg.no_asset && pkg.error_message.is_none()
+    !pkg.no_asset.unwrap_or(false) && pkg.error_message.is_none()
 }
 
 /// Get tags with optional created_at timestamps and a pre-release flag.
@@ -4239,7 +4239,7 @@ async fn get_tags_with_created_at(
 }
 
 fn validate(pkg: &AquaPackage) -> Result<()> {
-    if pkg.no_asset {
+    if pkg.no_asset.unwrap_or(false) {
         bail!("no asset released");
     }
     if let Some(message) = &pkg.error_message {
@@ -4533,10 +4533,12 @@ version_overrides:
         let mut pkg = AquaPackage::default();
         assert!(package_has_asset(&pkg));
 
-        pkg.no_asset = true;
+        pkg.no_asset = Some(true);
         assert!(!package_has_asset(&pkg));
 
-        pkg.no_asset = false;
+        pkg.no_asset = Some(false);
+        assert!(package_has_asset(&pkg));
+
         pkg.error_message = Some("unsupported version".to_string());
         assert!(!package_has_asset(&pkg));
     }


### PR DESCRIPTION
## Summary

- preserve the distinction between omitted Aqua boolean fields and explicit `false`
- allow version overrides to disable inherited `rosetta2`, `windows_arm_emulation`, and `no_asset` values
- allow platform overrides to disable inherited emulation values
- bump the compiled registry cache namespace for the archived package schema change

## Root cause

`rosetta2`, `windows_arm_emulation`, and `no_asset` were deserialized as plain booleans. During override merging, mise could therefore copy an explicit `true`, but could not distinguish an explicit `false` from an omitted field.

This diverged from Aqua's version override model, where all three fields are optional booleans. It could leave emulation enabled after a matching override disabled it, or leave a package marked as having no asset after a version override made assets available.

## Tests

- `mise run lint-fix`
- `mise --cd crates/aqua-registry run test` (1,667 unit tests plus the end-to-end task passed before rebasing)
- `cargo test -p aqua-registry emulation_flags` (3 passed post-rebase)
- `cargo test -p aqua-registry no_asset` (2 passed post-rebase)
- `cargo test package_has_asset_rejects_no_asset_and_errors` (passed post-rebase)

The complete post-rebase package suite has one unrelated base-branch failure: `test_override_envs_all_matches_any_platform` expects a raw Windows URL without `.exe`, while the existing implementation appends `.exe`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of emulation and “no asset” settings when they are omitted or explicitly disabled, ensuring correct behavior in platform/version overrides.
  * Overrides now only change emulation and asset availability when a new value is provided, preserving existing settings otherwise.
* **Chores**
  * Updated compiled registry cache versioning to ensure refreshed cache data is used.
* **Tests**
  * Updated/additional unit tests to cover optional emulation and asset flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->