### PR TITLE
feat(task): minimal OpenTelemetry trace export for task executions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5407,6 +5407,9 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "openssl",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "path-absolutize",
  "petgraph",
  "phf 0.14.0",
@@ -5889,6 +5892,83 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.2",
+ "opentelemetry",
+ "reqwest 0.12.28",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
+dependencies = [
+ "futures-core",
+ "http 1.4.2",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -6429,6 +6509,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7210,7 +7313,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -9261,6 +9366,27 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,17 @@ nucleo-matcher = "0.3"
 num_cpus = "1"
 once_cell = "1"
 openssl = { version = "0.10", optional = true }
+opentelemetry = { version = "0.29", features = ["trace"] }
+opentelemetry-otlp = { version = "0.29", default-features = false, features = [
+  "http-proto",
+  "trace",
+  "reqwest-client",
+] }
+opentelemetry_sdk = { version = "0.29", features = [
+  "trace",
+  "rt-tokio",
+  "experimental_trace_batch_span_processor_with_async_runtime",
+] }
 path-absolutize = { version = "3", features = ["unsafe_cache"] }
 petgraph = "0.8"
 phf = "0.14"
@@ -263,6 +274,7 @@ clap-sort = "1"
 ctor = "1"
 insta = { version = "1", features = ["filters", "json"] }
 mockito = "1"
+opentelemetry_sdk = { version = "0.29", features = ["testing"] }
 pretty_assertions = "1"
 test-log = "0.2"
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1355,6 +1355,17 @@
           "description": "OS to use for precompiled binaries.",
           "type": "string"
         },
+        "otel": {
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "[experimental] Enable OpenTelemetry trace export for task executions.",
+              "type": "boolean"
+            }
+          }
+        },
         "override_config_filenames": {
           "default": [],
           "description": "If set, mise will ignore default config files like `mise.toml` and use these filenames instead.",

--- a/settings.toml
+++ b/settings.toml
@@ -1835,6 +1835,11 @@ Configure the collector endpoint and other options using the standard OpenTeleme
 environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
 `OTEL_SERVICE_NAME`, etc.).
 
+W3C trace context is propagated in both directions: if `TRACEPARENT` is set in the
+environment (e.g. by CI or an outer `mise run`), the run joins that trace, and each
+task's environment receives `TRACEPARENT`/`TRACESTATE` so nested `mise run` and
+OTEL-aware tools join the task's span.
+
 This flag prevents mise from unexpectedly emitting spans in environments that set
 `OTEL_EXPORTER_OTLP_ENDPOINT` for other tools.
 """

--- a/settings.toml
+++ b/settings.toml
@@ -1823,6 +1823,24 @@ env = "MISE_OS"
 optional = true
 type = "String"
 
+[otel.enabled]
+default = false
+description = "[experimental] Enable OpenTelemetry trace export for task executions."
+docs = """
+When `true`, mise exports OpenTelemetry traces for `mise run` executions, provided a
+traces endpoint is configured (`OTEL_EXPORTER_OTLP_ENDPOINT` or
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`).
+
+Configure the collector endpoint and other options using the standard OpenTelemetry
+environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
+`OTEL_SERVICE_NAME`, etc.).
+
+This flag prevents mise from unexpectedly emitting spans in environments that set
+`OTEL_EXPORTER_OTLP_ENDPOINT` for other tools.
+"""
+env = "MISE_OTEL_ENABLED"
+type = "Bool"
+
 [override_config_filenames]
 default = []
 description = "If set, mise will ignore default config files like `mise.toml` and use these filenames instead."

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -884,6 +884,7 @@ impl Bootstrap {
             allow_write: vec![],
             allow_net: vec![],
             allow_env: vec![],
+            otel: None,
         }
         .run()
         .await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -741,6 +741,7 @@ impl Cli {
                         allow_write: vec![],
                         allow_net: vec![],
                         allow_env: vec![],
+                        otel: None,
                     })));
                 } else if let Some(cmd) = external::COMMANDS.get(&task) {
                     external::execute(

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -602,6 +602,7 @@ impl Run {
                 .otel
                 .as_ref()
                 .map(|otel| otel.start_task(&task, ctx.config.project_root.as_ref()));
+            let trace_env = otel_span.as_ref().and_then(crate::otel::trace_env);
             let (result, panicked) = match AssertUnwindSafe(this.run_task_sched(
                 &task,
                 &ctx.config,
@@ -610,6 +611,7 @@ impl Run {
                 dep_ran,
                 semaphore,
                 &mut permit,
+                trace_env,
             ))
             .catch_unwind()
             .await
@@ -824,6 +826,7 @@ impl Run {
         dep_ran: bool,
         semaphore: Arc<tokio::sync::Semaphore>,
         permit: &mut Option<tokio::sync::OwnedSemaphorePermit>,
+        trace_env: Option<crate::otel::TraceEnv>,
     ) -> Result<bool> {
         self.executor
             .as_ref()
@@ -836,6 +839,7 @@ impl Run {
                 dep_ran,
                 semaphore,
                 permit,
+                trace_env,
             )
             .await
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -224,6 +224,9 @@ pub struct Run {
 
     #[clap(skip)]
     pub executor: Option<crate::task::task_executor::TaskExecutor>,
+
+    #[clap(skip)]
+    pub otel: Option<crate::otel::RunTelemetry>,
 }
 
 impl Run {
@@ -307,6 +310,11 @@ impl Run {
             .collect_vec();
 
         let mut task_list = get_task_lists(&config, &args, true, self.skip_deps).await?;
+
+        // Capture the user-requested task names before dependency resolution,
+        // so the OpenTelemetry root span is named after what was invoked
+        // rather than the (much larger) resolved dep set.
+        let requested_task_names: Vec<String> = task_list.iter().map(|t| t.name.clone()).collect();
 
         // Args after -- go directly to tasks (no prefix). They are also
         // recorded on `trailing_args` so the task renderer can detect
@@ -414,6 +422,11 @@ impl Run {
                 .await?;
         }
 
+        // Initialize OpenTelemetry before the timeout wrapper. RunTelemetry
+        // finalizes on drop, so traces are flushed even when the run is
+        // cancelled by --timeout.
+        self.otel = crate::otel::RunTelemetry::init_if_enabled(&requested_task_names);
+
         // Apply global timeout for entire run if configured
         let timeout = if let Some(timeout_str) = &self.timeout {
             Some(duration::parse_duration(timeout_str)?)
@@ -490,7 +503,16 @@ impl Run {
             )
             .await?;
 
-        scheduler.join_all(this.continue_on_error).await?;
+        let join_result = scheduler.join_all(this.continue_on_error).await;
+
+        if let Some(otel) = &this.otel {
+            if join_result.is_ok() && !this.is_stopping() {
+                otel.set_succeeded();
+            }
+            // Finalize the root span and flush before displaying results.
+            otel.finish();
+        }
+        join_result?;
 
         // Step 5: Display results and handle failures
         let results_display = crate::task::task_results_display::TaskResultsDisplay::new(
@@ -576,6 +598,10 @@ impl Run {
                 let deps = deps_for_remove.lock().await;
                 (deps.handled_task_keys(), deps.any_dep_ran(&task))
             };
+            let otel_span = this
+                .otel
+                .as_ref()
+                .map(|otel| otel.start_task(&task, ctx.config.project_root.as_ref()));
             let (result, panicked) = match AssertUnwindSafe(this.run_task_sched(
                 &task,
                 &ctx.config,
@@ -594,6 +620,9 @@ impl Run {
                     true,
                 ),
             };
+            if let (Some(otel), Some(span)) = (&this.otel, otel_span) {
+                otel.end_task(span, &task, &result);
+            }
             // If the task actually ran (not skipped) and has sources defined,
             // mark it so dependents' source freshness checks are invalidated.
             // Tasks without sources always run and should not trigger invalidation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ mod migrate;
 mod minisign;
 mod netrc;
 mod oci;
+mod otel;
 pub(crate) mod parallel;
 mod path;
 mod path_env;

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,0 +1,492 @@
+//! OpenTelemetry trace export for `mise run`.
+//!
+//! When `otel.enabled` is set and an OTLP endpoint is configured, each
+//! `mise run` exports a root span covering the whole invocation, one span
+//! per executed task, and (in monorepos) a group span per config root.
+//!
+//! Spans are real SDK spans started when the task starts and ended when it
+//! finishes — the SDK's `BatchSpanProcessor` handles IDs, batching, and
+//! export. Because task spans are alive while the task runs, their span
+//! context is available for future log correlation without any ID
+//! reservation machinery.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use eyre::Result;
+use opentelemetry::trace::{Span as _, Status, TraceContextExt, Tracer, TracerProvider as _};
+use opentelemetry::{Array, Context, KeyValue, StringValue, Value};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::runtime;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+
+use crate::config::Settings;
+use crate::task::Task;
+
+/// A live span for a running task. Ended via [`RunTelemetry::end_task`];
+/// if the task future is cancelled instead, the SDK ends it on drop.
+pub type TaskSpan = opentelemetry_sdk::trace::Span;
+
+/// Trace export is enabled only when the mise setting is on AND an OTLP
+/// traces endpoint is configured. The env var requirement prevents mise
+/// from emitting spans in environments that set `otel.enabled` globally
+/// but point no collector at this machine — and vice versa, the setting
+/// prevents surprise emission in environments that set
+/// `OTEL_EXPORTER_OTLP_*` for other tools.
+fn enabled() -> bool {
+    Settings::get().otel.enabled
+        && (std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok()
+            || std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").is_ok())
+}
+
+/// All OpenTelemetry state for a single `mise run` invocation.
+///
+/// Cheap to clone (`Arc` inner). The root span is finalized and pending
+/// spans are flushed by [`RunTelemetry::finish`] on the normal path, or by
+/// `Drop` when the run future is cancelled (e.g. `--timeout`). The root
+/// span defaults to an error status; `set_succeeded` marks the happy path.
+#[derive(Clone)]
+pub struct RunTelemetry {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    provider: SdkTracerProvider,
+    tracer: opentelemetry_sdk::trace::SdkTracer,
+    /// Context holding the live root span; parents task and group spans.
+    root_cx: Context,
+    /// Live monorepo group spans keyed by config root.
+    groups: Mutex<HashMap<PathBuf, Context>>,
+    succeeded: AtomicBool,
+    finished: AtomicBool,
+}
+
+impl RunTelemetry {
+    /// Build the OTLP exporter pipeline and start the root span, or return
+    /// `None` when trace export is not enabled.
+    ///
+    /// The OTLP crate natively reads the standard env vars
+    /// (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, ...);
+    /// `Resource::builder` reads `OTEL_SERVICE_NAME` and
+    /// `OTEL_RESOURCE_ATTRIBUTES`.
+    pub fn init_if_enabled(requested_task_names: &[String]) -> Option<Self> {
+        if !enabled() {
+            return None;
+        }
+        let exporter = match opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .build()
+        {
+            Ok(exporter) => exporter,
+            Err(err) => {
+                debug!("otel: failed to build span exporter: {err}");
+                return None;
+            }
+        };
+        let mut resource = Resource::builder();
+        // Only default the service name when the user hasn't set one, since
+        // with_service_name would override the env var.
+        if std::env::var("OTEL_SERVICE_NAME").is_err() {
+            resource = resource.with_service_name("mise");
+        }
+        let provider = SdkTracerProvider::builder()
+            .with_span_processor(
+                opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor::builder(
+                    exporter,
+                    runtime::Tokio,
+                )
+                .build(),
+            )
+            .with_resource(resource.build())
+            .build();
+        Some(Self::new(requested_task_names, provider))
+    }
+
+    fn new(requested_task_names: &[String], provider: SdkTracerProvider) -> Self {
+        let root_name = if requested_task_names.is_empty() {
+            "mise run".to_string()
+        } else {
+            format!("mise run {}", requested_task_names.join(" "))
+        };
+        let tracer = provider.tracer("mise.tasks");
+        let mut root_span = tracer.start_with_context(root_name, &Context::new());
+        root_span.set_attribute(KeyValue::new("mise.span_type", "run"));
+        let root_cx = Context::new().with_span(root_span);
+        Self {
+            inner: Arc::new(Inner {
+                provider,
+                tracer,
+                root_cx,
+                groups: Mutex::new(HashMap::new()),
+                succeeded: AtomicBool::new(false),
+                finished: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Start a span for a task, parented under its monorepo group span
+    /// (created lazily) or directly under the root span.
+    pub fn start_task(&self, task: &Task, project_root: Option<&PathBuf>) -> TaskSpan {
+        let parent_cx = match &task.config_root {
+            // A task belongs to a monorepo group when its config root
+            // differs from the project root.
+            Some(cr) if project_root.is_none_or(|pr| cr != pr) => self.group_cx(cr, project_root),
+            _ => self.inner.root_cx.clone(),
+        };
+        self.inner
+            .tracer
+            .start_with_context(task_span_name(task), &parent_cx)
+    }
+
+    fn group_cx(&self, config_root: &Path, project_root: Option<&PathBuf>) -> Context {
+        let mut groups = self.inner.groups.lock().unwrap();
+        groups
+            .entry(config_root.to_path_buf())
+            .or_insert_with(|| {
+                let mut span = self.inner.tracer.start_with_context(
+                    group_display_name(config_root, project_root),
+                    &self.inner.root_cx,
+                );
+                span.set_attribute(KeyValue::new("mise.span_type", "monorepo_group"));
+                span.set_attribute(KeyValue::new(
+                    "mise.config_root",
+                    config_root.display().to_string(),
+                ));
+                self.inner.root_cx.with_span(span)
+            })
+            .clone()
+    }
+
+    /// End a task span with attributes and status derived from the result
+    /// (`Ok(true)` ran, `Ok(false)` skipped, `Err` failed).
+    pub fn end_task(&self, mut span: TaskSpan, task: &Task, result: &Result<bool>) {
+        for attr in task_attributes(task) {
+            span.set_attribute(attr);
+        }
+        match result {
+            Ok(true) => {
+                span.set_attribute(KeyValue::new("process.exit.code", 0i64));
+                span.set_status(Status::Ok);
+            }
+            Ok(false) => {
+                span.set_attribute(KeyValue::new("mise.task.skipped", true));
+                // Skipped tasks didn't run; per CLI semconv, exit code is 0.
+                span.set_attribute(KeyValue::new("process.exit.code", 0i64));
+            }
+            Err(err) => {
+                let code = crate::errors::Error::get_exit_status(err).unwrap_or(1);
+                span.set_attribute(KeyValue::new("process.exit.code", code as i64));
+                span.set_status(Status::error(err.to_string()));
+            }
+        }
+        span.end();
+    }
+
+    /// Mark the run as succeeded so the root span ends with an OK status.
+    /// Anything short of an explicit success — including cancellation —
+    /// produces an errored root span.
+    pub fn set_succeeded(&self) {
+        self.inner.succeeded.store(true, Ordering::Relaxed);
+    }
+
+    /// End group and root spans, then shut down the provider to flush all
+    /// pending spans to the collector. Idempotent; also runs on drop so
+    /// traces survive cancellation (e.g. `--timeout`).
+    pub fn finish(&self) {
+        self.inner.finish();
+    }
+}
+
+impl Inner {
+    fn finish(&self) {
+        if self.finished.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        for (_, cx) in self.groups.lock().unwrap().drain() {
+            cx.span().end();
+        }
+        let root = self.root_cx.span();
+        if self.succeeded.load(Ordering::Relaxed) {
+            root.set_status(Status::Ok);
+        } else {
+            root.set_status(Status::error(""));
+        }
+        root.end();
+        if let Err(err) = self.provider.shutdown() {
+            debug!("otel: failed to flush spans: {err}");
+        }
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+/// Human-readable span name for a task (display name + args).
+fn task_span_name(task: &Task) -> String {
+    let base = if task.display_name.is_empty() {
+        task.name.clone()
+    } else {
+        task.display_name.clone()
+    };
+    if task.args.is_empty() {
+        base
+    } else {
+        format!("{base} {}", task.args.join(" "))
+    }
+}
+
+/// Display name for a monorepo group span: the config root relative to the
+/// project root when possible, otherwise its last path component.
+fn group_display_name(config_root: &Path, project_root: Option<&PathBuf>) -> String {
+    if let Some(pr) = project_root
+        && let Ok(rel) = config_root.strip_prefix(pr)
+    {
+        let rel = rel.to_string_lossy();
+        if !rel.is_empty() {
+            return rel.into_owned();
+        }
+    }
+    config_root
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| config_root.display().to_string())
+}
+
+/// Attributes attached to every task span, following the CLI semantic
+/// conventions (https://opentelemetry.io/docs/specs/semconv/cli/cli-spans).
+fn task_attributes(task: &Task) -> Vec<KeyValue> {
+    let mut attrs = vec![
+        KeyValue::new("mise.task.name", task.name.clone()),
+        KeyValue::new("mise.task.source", task.config_source.display().to_string()),
+    ];
+    // Args are exported verbatim — no different from what's already visible
+    // in terminal output and process listings.
+    if !task.args.is_empty() {
+        attrs.push(KeyValue::new("mise.task.args", task.args.join(" ")));
+    }
+    if let Some(cr) = &task.config_root {
+        attrs.push(KeyValue::new(
+            "mise.task.config_root",
+            cr.display().to_string(),
+        ));
+    }
+    let argv: Vec<StringValue> = ["mise", task.name.as_str()]
+        .into_iter()
+        .map(String::from)
+        .chain(task.args.iter().cloned())
+        .map(StringValue::from)
+        .collect();
+    attrs.push(KeyValue::new(
+        "process.command_args",
+        Value::Array(Array::String(argv)),
+    ));
+    attrs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::trace::{SpanData, SpanExporter};
+
+    /// Like the SDK's `InMemorySpanExporter`, but keeps its records across
+    /// `shutdown()` (which `finish()` always triggers).
+    #[derive(Clone, Debug, Default)]
+    struct RetainingSpanExporter {
+        spans: Arc<Mutex<Vec<SpanData>>>,
+    }
+
+    impl SpanExporter for RetainingSpanExporter {
+        fn export(
+            &self,
+            batch: Vec<SpanData>,
+        ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+            self.spans.lock().unwrap().extend(batch);
+            std::future::ready(Ok(()))
+        }
+    }
+
+    impl RetainingSpanExporter {
+        fn finished_spans(&self) -> Vec<SpanData> {
+            self.spans.lock().unwrap().clone()
+        }
+    }
+
+    fn test_telemetry(task_names: &[&str]) -> (RunTelemetry, RetainingSpanExporter) {
+        let exporter = RetainingSpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let names: Vec<String> = task_names.iter().map(|s| s.to_string()).collect();
+        (RunTelemetry::new(&names, provider), exporter)
+    }
+
+    fn task_for(name: &str, args: &[&str], config_root: Option<&str>) -> Task {
+        Task {
+            name: name.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            config_source: PathBuf::from("/w/mise.toml"),
+            config_root: config_root.map(PathBuf::from),
+            ..Default::default()
+        }
+    }
+
+    fn span<'a>(spans: &'a [SpanData], name: &str) -> &'a SpanData {
+        spans.iter().find(|s| s.name == name).unwrap_or_else(|| {
+            let names: Vec<_> = spans.iter().map(|s| s.name.as_ref()).collect();
+            panic!("missing span {name}; got {names:?}")
+        })
+    }
+
+    #[test]
+    fn task_spans_are_children_of_root() {
+        let (t, exporter) = test_telemetry(&["build"]);
+        let task = task_for("build", &["--fast"], None);
+        let s = t.start_task(&task, None);
+        t.end_task(s, &task, &Ok(true));
+        t.set_succeeded();
+        t.finish();
+
+        let spans = exporter.finished_spans();
+        let root = span(&spans, "mise run build");
+        let task_span = span(&spans, "build --fast");
+        assert_eq!(task_span.parent_span_id, root.span_context.span_id());
+        assert_eq!(
+            task_span.span_context.trace_id(),
+            root.span_context.trace_id()
+        );
+        assert_eq!(root.status, Status::Ok);
+        assert_eq!(task_span.status, Status::Ok);
+    }
+
+    #[test]
+    fn monorepo_tasks_share_a_group_span() {
+        let (t, exporter) = test_telemetry(&[]);
+        let project_root = PathBuf::from("/w");
+        let a = task_for("a", &[], Some("/w/pkg/x"));
+        let b = task_for("b", &[], Some("/w/pkg/x"));
+        let sa = t.start_task(&a, Some(&project_root));
+        let sb = t.start_task(&b, Some(&project_root));
+        t.end_task(sa, &a, &Ok(true));
+        t.end_task(sb, &b, &Ok(true));
+        t.set_succeeded();
+        t.finish();
+
+        let spans = exporter.finished_spans();
+        let root = span(&spans, "mise run");
+        let group = span(&spans, "pkg/x");
+        assert_eq!(group.parent_span_id, root.span_context.span_id());
+        assert_eq!(
+            span(&spans, "a").parent_span_id,
+            group.span_context.span_id()
+        );
+        assert_eq!(
+            span(&spans, "b").parent_span_id,
+            group.span_context.span_id()
+        );
+        assert_eq!(spans.len(), 4); // one group span, not two
+    }
+
+    #[test]
+    fn task_at_project_root_is_not_grouped() {
+        let (t, exporter) = test_telemetry(&[]);
+        let project_root = PathBuf::from("/w");
+        let task = task_for("build", &[], Some("/w"));
+        let s = t.start_task(&task, Some(&project_root));
+        t.end_task(s, &task, &Ok(true));
+        t.finish();
+
+        let spans = exporter.finished_spans();
+        let root = span(&spans, "mise run");
+        assert_eq!(
+            span(&spans, "build").parent_span_id,
+            root.span_context.span_id()
+        );
+    }
+
+    #[test]
+    fn failed_task_records_error_status_and_exit_code() {
+        let (t, exporter) = test_telemetry(&[]);
+        let task = task_for("build", &[], None);
+        let s = t.start_task(&task, None);
+        t.end_task(s, &task, &Err(eyre::eyre!("boom")));
+        t.finish();
+
+        let spans = exporter.finished_spans();
+        let task_span = span(&spans, "build");
+        assert!(
+            matches!(&task_span.status, Status::Error { description } if description == "boom")
+        );
+        let exit = task_span
+            .attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == "process.exit.code")
+            .unwrap();
+        assert_eq!(exit.value, Value::I64(1));
+        // root defaults to error unless set_succeeded was called
+        assert!(matches!(
+            span(&spans, "mise run").status,
+            Status::Error { .. }
+        ));
+    }
+
+    #[test]
+    fn skipped_task_is_marked() {
+        let (t, exporter) = test_telemetry(&[]);
+        let task = task_for("build", &[], None);
+        let s = t.start_task(&task, None);
+        t.end_task(s, &task, &Ok(false));
+        t.finish();
+
+        let spans = exporter.finished_spans();
+        let task_span = span(&spans, "build");
+        assert_eq!(task_span.status, Status::Unset);
+        assert!(
+            task_span
+                .attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "mise.task.skipped" && kv.value == Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn task_attributes_follow_cli_semconv() {
+        let task = task_for("build", &["x", "y"], Some("/w/pkg/x"));
+        let attrs = task_attributes(&task);
+        let get = |k: &str| {
+            attrs
+                .iter()
+                .find(|kv| kv.key.as_str() == k)
+                .map(|kv| kv.value.clone())
+        };
+        assert_eq!(get("mise.task.name"), Some(Value::from("build")));
+        assert_eq!(get("mise.task.args"), Some(Value::from("x y")));
+        assert_eq!(get("mise.task.config_root"), Some(Value::from("/w/pkg/x")));
+        let argv: Vec<StringValue> = ["mise", "build", "x", "y"]
+            .map(String::from)
+            .map(StringValue::from)
+            .to_vec();
+        assert_eq!(
+            get("process.command_args"),
+            Some(Value::Array(Array::String(argv)))
+        );
+    }
+
+    #[test]
+    fn drop_flushes_and_errors_root_span_on_cancellation() {
+        let (t, exporter) = test_telemetry(&[]);
+        // Simulate cancellation: telemetry dropped without finish/set_succeeded.
+        drop(t);
+        let spans = exporter.finished_spans();
+        assert!(matches!(
+            span(&spans, "mise run").status,
+            Status::Error { .. }
+        ));
+    }
+}

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -17,9 +17,11 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use eyre::Result;
+use opentelemetry::propagation::TextMapPropagator;
 use opentelemetry::trace::{Span as _, Status, TraceContextExt, Tracer, TracerProvider as _};
 use opentelemetry::{Array, Context, KeyValue, StringValue, Value};
 use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::runtime;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 
@@ -106,13 +108,21 @@ impl RunTelemetry {
     }
 
     fn new(requested_task_names: &[String], provider: SdkTracerProvider) -> Self {
+        Self::new_with_parent(requested_task_names, provider, parent_cx_from_env())
+    }
+
+    fn new_with_parent(
+        requested_task_names: &[String],
+        provider: SdkTracerProvider,
+        parent_cx: Context,
+    ) -> Self {
         let root_name = if requested_task_names.is_empty() {
             "mise run".to_string()
         } else {
             format!("mise run {}", requested_task_names.join(" "))
         };
         let tracer = provider.tracer("mise.tasks");
-        let mut root_span = tracer.start_with_context(root_name, &Context::new());
+        let mut root_span = tracer.start_with_context(root_name, &parent_cx);
         root_span.set_attribute(KeyValue::new("mise.span_type", "run"));
         let root_cx = Context::new().with_span(root_span);
         Self {
@@ -227,6 +237,46 @@ impl Drop for Inner {
     }
 }
 
+/// W3C Trace Context env vars for a task's environment, so nested
+/// `mise run` and OTEL-aware tools the task invokes join this trace.
+/// Plain strings — the task executor never sees OTEL types.
+/// https://opentelemetry.io/docs/specs/otel/context/env-carriers/
+pub struct TraceEnv {
+    pub traceparent: String,
+    pub tracestate: Option<String>,
+}
+
+/// Render a live task span's context as `TRACEPARENT`/`TRACESTATE` values
+/// using the standard W3C propagator.
+pub fn trace_env(span: &TaskSpan) -> Option<TraceEnv> {
+    let cx = Context::new().with_remote_span_context(span.span_context().clone());
+    let mut carrier: HashMap<String, String> = HashMap::new();
+    TraceContextPropagator::new().inject_context(&cx, &mut carrier);
+    Some(TraceEnv {
+        traceparent: carrier.remove("traceparent")?,
+        tracestate: carrier.remove("tracestate").filter(|ts| !ts.is_empty()),
+    })
+}
+
+/// Parent context extracted from the `TRACEPARENT`/`TRACESTATE` env vars,
+/// set by an OTEL-aware parent (CI, or an outer `mise run`). An invalid or
+/// absent traceparent yields an empty context, i.e. a new root trace.
+fn parent_cx_from_env() -> Context {
+    match std::env::var("TRACEPARENT") {
+        Ok(tp) => extract_parent_cx(&tp, std::env::var("TRACESTATE").ok().as_deref()),
+        Err(_) => Context::new(),
+    }
+}
+
+fn extract_parent_cx(traceparent: &str, tracestate: Option<&str>) -> Context {
+    let mut carrier = HashMap::new();
+    carrier.insert("traceparent".to_string(), traceparent.to_string());
+    if let Some(ts) = tracestate {
+        carrier.insert("tracestate".to_string(), ts.to_string());
+    }
+    TraceContextPropagator::new().extract(&carrier)
+}
+
 /// Human-readable span name for a task (display name + args).
 fn task_span_name(task: &Task) -> String {
     let base = if task.display_name.is_empty() {
@@ -324,7 +374,9 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
         let names: Vec<String> = task_names.iter().map(|s| s.to_string()).collect();
-        (RunTelemetry::new(&names, provider), exporter)
+        // new_with_parent so tests are hermetic to TRACEPARENT in the env
+        let t = RunTelemetry::new_with_parent(&names, provider, Context::new());
+        (t, exporter)
     }
 
     fn task_for(name: &str, args: &[&str], config_root: Option<&str>) -> Task {
@@ -476,6 +528,70 @@ mod tests {
             get("process.command_args"),
             Some(Value::Array(Array::String(argv)))
         );
+    }
+
+    const UPSTREAM_TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+    #[test]
+    fn root_span_joins_upstream_trace_from_traceparent() {
+        let exporter = RetainingSpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let parent_cx = extract_parent_cx(UPSTREAM_TRACEPARENT, Some("vendor=value"));
+        let t = RunTelemetry::new_with_parent(&[], provider, parent_cx);
+        t.finish();
+
+        let root = &exporter.finished_spans()[0];
+        assert_eq!(
+            root.span_context.trace_id().to_string(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+        assert_eq!(root.parent_span_id.to_string(), "b7ad6b7169203331");
+        assert_eq!(root.span_context.trace_state().header(), "vendor=value");
+    }
+
+    #[test]
+    fn invalid_traceparent_starts_a_new_trace() {
+        let exporter = RetainingSpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let parent_cx = extract_parent_cx("00-not-valid-01", None);
+        let t = RunTelemetry::new_with_parent(&[], provider, parent_cx);
+        t.finish();
+
+        let root = &exporter.finished_spans()[0];
+        assert_eq!(root.parent_span_id, opentelemetry::trace::SpanId::INVALID);
+        assert!(root.span_context.is_valid());
+    }
+
+    #[test]
+    fn trace_env_carries_the_live_task_span_context() {
+        let (t, _exporter) = test_telemetry(&[]);
+        let task = task_for("build", &[], None);
+        let span = t.start_task(&task, None);
+        let te = trace_env(&span).unwrap();
+        assert_eq!(
+            te.traceparent,
+            format!(
+                "00-{}-{}-01",
+                span.span_context().trace_id(),
+                span.span_context().span_id()
+            )
+        );
+        // Round-trip: a nested run extracting this env joins the same trace.
+        let cx = extract_parent_cx(&te.traceparent, te.tracestate.as_deref());
+        assert_eq!(
+            cx.span().span_context().trace_id(),
+            span.span_context().trace_id()
+        );
+        assert_eq!(
+            cx.span().span_context().span_id(),
+            span.span_context().span_id()
+        );
+        t.end_task(span, &task, &Ok(true));
+        t.finish();
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -263,6 +263,7 @@ impl TaskExecutor {
         dep_ran: bool,
         semaphore: Arc<Semaphore>,
         permit: &mut Option<OwnedSemaphorePermit>,
+        trace_env: Option<crate::otel::TraceEnv>,
     ) -> Result<bool> {
         let prefix = task.estyled_prefix();
         let total_start = std::time::Instant::now();
@@ -346,6 +347,26 @@ impl TaskExecutor {
                 "MISE_ENV",
                 crate::env::MISE_ENV.join(","),
             );
+        }
+        // Propagate W3C trace context so nested `mise run` and OTEL-aware
+        // tools the task invokes join this task's distributed trace.
+        // Excluded from __MISE_DIFF so a nested `mise hook-env` doesn't
+        // treat them as mise-managed env and unset/overwrite them.
+        if let Some(te) = &trace_env {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "TRACEPARENT",
+                te.traceparent.clone(),
+            );
+            if let Some(ts) = &te.tracestate {
+                Self::insert_env_excluded_from_nested_mise_diff(
+                    &mut env,
+                    &mut nested_mise_diff_exclude_keys,
+                    "TRACESTATE",
+                    ts.clone(),
+                );
+            }
         }
         if let Some(cwd) = &*crate::dirs::CWD {
             Self::insert_env_excluded_from_nested_mise_diff(


### PR DESCRIPTION
> [!NOTE]
> This is a **draft exploration, not a competing submission**. It exists to inform the review of #9069 by answering one question concretely: *how much of that PR's size is intrinsic to the feature?* The span model, attribute set, and settings design here are all taken directly from @MatthiasGrandl's work in #9069 — this just restructures how spans are produced.

## What this does

Traces-only OpenTelemetry export for `mise run`, gated behind `otel.enabled` + an `OTEL_EXPORTER_OTLP_*` endpoint (same double opt-in as #9069):

- a root span covering the whole invocation (`mise run build test`)
- one span per executed task, with the same attributes as #9069 (`mise.task.*`, CLI semconv `process.command_args` / `process.exit.code`, error status with description, skipped-task marker)
- monorepo group spans per `config_root`
- W3C trace context propagation in both directions: the run joins an upstream trace from `TRACEPARENT`/`TRACESTATE` (CI, outer `mise run`), and each task's env receives `TRACEPARENT`/`TRACESTATE` derived from its live span (excluded from `__MISE_DIFF` so nested `hook-env` doesn't clobber them) — added after @MatthiasGrandl's feedback that propagation should be in from the start
- traces flushed on cancellation (`--timeout`) via `Drop`; root span defaults to error status unless the run explicitly succeeds

## How it stays small

#9069 reserves span IDs up front and emits synthetic, already-finished spans at the end — that architecture is a holdover from its original dependency-free OTLP client, and it's what forces the 785-line span tracker (manual ID generation, min/max timing folds, reserve-vs-started state machine, lock-ordering concerns) plus threading a `StartedSpan` through seven `task_executor` signatures.

This version instead uses the SDK's span lifecycle directly: start a real span when the task starts, end it when the task ends. The SDK handles IDs, parenting, batching, and export. Consequences:

- root/group timing needs no aggregation — the spans are simply alive for the right duration (root span covers the whole invocation, which also makes mise's own overhead visible as the gap before the first task span)
- `task_executor.rs` and `cmd.rs` are untouched; `run.rs` is touched in 4 small places
- **log export is not painted into a corner**: a task's span is alive while the task runs, so its span context is right there for future log correlation — the ID-reservation machinery was never a prerequisite for logs

| | #9069 | this draft |
|---|---|---|
| total additions | ~2,560 | ~840 (of which ~140 lockfile/schema) |
| production code | ~1,000 across 4 modules | ~280 in one module |
| unit tests | ~730 | ~330 |
| `task_executor.rs` changes | +76, threading `StartedSpan` through 7 signatures | +21, one param on `run_task_sched` carrying two env strings |
| `cmd.rs` changes | +28, stdio behavior changes | none |

## Deliberately out of scope

- **Log export** (`otel.logs`, stdout/stderr hooks, stdio piping changes) — a separate trust boundary and a real behavior change (piped stdio affects `isatty()`); deserves its own PR where those trade-offs are the subject of review
- **oats acceptance tests + docs page** from #9069 — portable to whichever implementation lands

## Verification

- 10 unit tests (span hierarchy, monorepo grouping, status/attribute mapping, cancellation-drop flush, traceparent extract/inject round-trip)
- manually verified against a local OTLP/HTTP collector: success, failing task (error status + `process.exit.code`), setting disabled → no export, collector unreachable → run unaffected
- propagation verified end-to-end: exported root span carries an injected upstream `TRACEPARENT`'s trace/parent-span IDs; tasks see a valid `TRACEPARENT`; a nested `mise run` inside a task shares the outer run's trace ID

---
*This PR was generated by an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental OpenTelemetry tracing for `mise run` task executions.
  * Records a run-level trace and per-task spans with status, skipped tasks, errors, and corresponding exit codes.
  * Supports monorepo task grouping for trace hierarchy.
  * Propagates distributed-tracing context to task subprocesses (W3C `TRACEPARENT`/`TRACESTATE`) and ensures traces are finalized even on timeout/cancellation.

* **Configuration**
  * Added `otel.enabled` (default `false`), configurable via `MISE_OTEL_ENABLED`.
  * When enabled, exports traces via configured OTLP endpoints and standard OpenTelemetry env vars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->