### PR TITLE
registry: add zmx (github:neurosnap/zmx)

### DIFF
--- a/registry/zmx.toml
+++ b/registry/zmx.toml
@@ -1,0 +1,4 @@
+backends = ["github:neurosnap/zmx"]
+description = "Session attach/detach for the terminal"
+os = ["linux", "macos"]
+test = { cmd = "zmx --version | head -n1 | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+'", expected = "{{version}}" }


### PR DESCRIPTION
https://zmx.sh -- 1.9k stars, session management without terminal emulation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a terminal session attach/detach integration via the registry for Linux and macOS.
  * Includes a built-in version check to verify the underlying tool matches the expected version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->