### PR TITLE
fix(schema): add launchd calendar intervals

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -74,6 +74,17 @@ e2e_args = { default = "--headless", redact = true }
 
 [tool_alias.java.versions]
 "11.0" = "temurin-11"
+
+[bootstrap.macos.launchd.agents.daily]
+program = "/bin/echo"
+start_calendar_interval = { hour = 2, minute = 0 }
+
+[bootstrap.macos.launchd.agents.boundaries]
+program = "/bin/echo"
+start_calendar_interval = [
+  { minute = 0, hour = 0, day = 1, weekday = 0, month = 1 },
+  { minute = 59, hour = 23, day = 31, weekday = 7, month = 12 },
+]
 TOML
 
 # Create a separate file for age schema coverage so mise does not try to decrypt
@@ -163,7 +174,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -261,6 +272,25 @@ shell = "bash -c"
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-watch-files.toml"
+
+# Verify that launchd calendar intervals match runtime validation
+for interval in \
+  '{}' \
+  '[]' \
+  '[{}]' \
+  '{ minute = 60 }' \
+  '{ hour = 24 }' \
+  '{ day = 0 }' \
+  '{ weekday = 8 }' \
+  '{ month = 13 }' \
+  '{ second = 0 }'; do
+  cat >"$HOME/workdir/mise-bad-launchd-calendar.toml" <<TOML
+[bootstrap.macos.launchd.agents.invalid]
+program = "/bin/echo"
+start_calendar_interval = $interval
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-launchd-calendar.toml"
+done
 
 cat >"$HOME/workdir/mise-bad-task-os.toml" <<'TOML'
 [build]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2942,6 +2942,39 @@
       ],
       "unevaluatedProperties": false,
       "type": "object"
+    },
+    "launchd_calendar_interval": {
+      "type": "object",
+      "description": "calendar schedule fields for launchd StartCalendarInterval",
+      "properties": {
+        "minute": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 59
+        },
+        "hour": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 23
+        },
+        "day": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 31
+        },
+        "weekday": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 7
+        },
+        "month": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 12
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
     }
   },
   "unevaluatedProperties": false,
@@ -3472,6 +3505,21 @@
                         "type": "integer",
                         "minimum": 0,
                         "description": "write StartInterval in seconds"
+                      },
+                      "start_calendar_interval": {
+                        "description": "write one or more StartCalendarInterval schedules",
+                        "oneOf": [
+                          {
+                            "$ref": "#/$defs/launchd_calendar_interval"
+                          },
+                          {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                              "$ref": "#/$defs/launchd_calendar_interval"
+                            }
+                          }
+                        ]
                       },
                       "environment": {
                         "type": "object",


### PR DESCRIPTION
## Summary

- add `bootstrap.macos.launchd.agents.<name>.start_calendar_interval` to the published schema
- support both a single calendar table and a non-empty array of schedules
- validate minute, hour, day, weekday, and month using the runtime ranges
- reject empty schedules, empty arrays, unknown fields, and out-of-range values

## Why

mise supports launchd `StartCalendarInterval` schedules at runtime and documents both configuration forms, but the published schema omitted the key. Strict schema validators therefore rejected valid launchd bootstrap configuration.

## Impact

Editors and strict TOML validators can now accept valid launchd calendar schedules and catch the same malformed values rejected by mise at runtime.

## Validation

- `mise run render:schema`
- `mise run test:e2e config/test_schema_tombi`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring macOS `launchd` agent schedules with calendar intervals.
  * Calendar intervals can be specified as a single schedule or an array of schedules.
  * Added validation for supported fields and value ranges, including minute, hour, day, weekday, and month.

* **Bug Fixes**
  * Improved detection and reporting of invalid calendar interval configurations during strict linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->