### PR TITLE
fix(schema): add oci copy entries

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -308,8 +308,6 @@ for copy in \
   '{ host = "assets", image = "srv/app" }' \
   '{ host = "assets", image = "/" }' \
   '{ host = "assets", image = "////" }' \
-  '{ host = "assets", image = "/srv/./app" }' \
-  '{ host = "assets", image = "/srv/../app" }' \
   '{ host = "assets", image = "/srv/app", extra = true }'; do
   cat >"$HOME/workdir/mise-bad-oci-copy.toml" <<TOML
 [oci]

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -308,6 +308,8 @@ for copy in \
   '{ host = "assets", image = "srv/app" }' \
   '{ host = "assets", image = "/" }' \
   '{ host = "assets", image = "////" }' \
+  '{ host = "assets", image = "/srv/./app" }' \
+  '{ host = "assets", image = "/srv/../app" }' \
   '{ host = "assets", image = "/srv/app", extra = true }'; do
   cat >"$HOME/workdir/mise-bad-oci-copy.toml" <<TOML
 [oci]

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -85,6 +85,14 @@ start_calendar_interval = [
   { minute = 0, hour = 0, day = 1, weekday = 0, month = 1 },
   { minute = 59, hour = 23, day = 31, weekday = 7, month = 12 },
 ]
+
+[[oci.copy]]
+host = "dist/my-app"
+image = "/usr/local/bin/my-app"
+
+[[oci.copy]]
+host = "assets"
+image = "//srv//.assets///"
 TOML
 
 # Create a separate file for age schema coverage so mise does not try to decrypt
@@ -174,7 +182,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-oci-copy.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -290,6 +298,24 @@ program = "/bin/echo"
 start_calendar_interval = $interval
 TOML
   assert_fail "$TOMBI_LINT mise-bad-launchd-calendar.toml"
+done
+
+# Verify that OCI copy entries match runtime validation
+for copy in \
+  '{ image = "/srv/app" }' \
+  '{ host = "assets" }' \
+  '{ host = "", image = "/srv/app" }' \
+  '{ host = "assets", image = "srv/app" }' \
+  '{ host = "assets", image = "/" }' \
+  '{ host = "assets", image = "////" }' \
+  '{ host = "assets", image = "/srv/./app" }' \
+  '{ host = "assets", image = "/srv/../app" }' \
+  '{ host = "assets", image = "/srv/app", extra = true }'; do
+  cat >"$HOME/workdir/mise-bad-oci-copy.toml" <<TOML
+[oci]
+copy = [$copy]
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-oci-copy.toml"
 done
 
 cat >"$HOME/workdir/mise-bad-task-os.toml" <<'TOML'

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3232,8 +3232,8 @@
               },
               "image": {
                 "type": "string",
-                "pattern": "^/+(?:[^./][^/]*|\\.[^./][^/]*|\\.\\.[^/]+)(?:/+(?:[^./][^/]*|\\.[^./][^/]*|\\.\\.[^/]+))*/*$",
-                "description": "absolute non-root image path without `.` or `..` components"
+                "pattern": "^/.*[^/]",
+                "description": "absolute image path that is not the root"
               }
             },
             "required": ["host", "image"],

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3233,7 +3233,10 @@
               "image": {
                 "type": "string",
                 "pattern": "^/.*[^/]",
-                "description": "absolute image path that is not the root"
+                "not": {
+                  "pattern": "(^|/)\\.{1,2}(/|$)"
+                },
+                "description": "absolute non-root image path without `.` or `..` components"
               }
             },
             "required": ["host", "image"],

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3219,6 +3219,27 @@
           "type": "string",
           "description": "Override where mise installs go in the image (default /mise)"
         },
+        "copy": {
+          "type": "array",
+          "description": "Host files or directories copied into the image as independent layers",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "minLength": 1,
+                "description": "host path to copy, relative to the config file when not absolute"
+              },
+              "image": {
+                "type": "string",
+                "pattern": "^/+(?:[^./][^/]*|\\.[^./][^/]*|\\.\\.[^/]+)(?:/+(?:[^./][^/]*|\\.[^./][^/]*|\\.\\.[^/]+))*/*$",
+                "description": "absolute non-root image path without `.` or `..` components"
+              }
+            },
+            "required": ["host", "image"],
+            "additionalProperties": false
+          }
+        },
         "env": {
           "type": "object",
           "additionalProperties": {


### PR DESCRIPTION
## Summary

- add `[[oci.copy]]` entries to the published mise configuration schema
- require `host` and `image` and reject unknown fields
- validate non-empty host paths and absolute, non-root image paths without `.` or `..` components
- add strict Tombi coverage for valid and invalid copy entries

## Why

mise supports and documents OCI copy layers at runtime, but the published schema omitted `[oci].copy`. Strict schema validators therefore rejected valid `[[oci.copy]]` configuration.

## Impact

Editors and strict TOML validators can now accept OCI copy entries and catch the same malformed values rejected by mise at runtime.

## Validation

- `mise run render:schema`
- `mise run test:e2e config/test_schema_tombi`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `oci.copy` configuration entries to enable independent OCI layer copy instructions, each requiring `host` and `image`.

* **Bug Fixes**
  * Improved schema validation for `oci.copy`, rejecting missing or extra fields.
  * Tightened `image` path rules to require an absolute, non-root path and disallow `.` / `..` path components.

* **Tests**
  * Expanded strict-mode end-to-end schema regression with negative cases to confirm `tombi lint` fails for invalid `oci.copy` configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
