### PR TITLE
fix(bootstrap): preserve Homebrew cask metadata

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1118,11 +1118,12 @@ fn installed_version(token: &str) -> Option<String> {
     let versions = entries
         .filter_map(|entry| entry.ok())
         .filter_map(|entry| {
+            let name = entry.file_name().into_string().ok()?;
             entry
                 .file_type()
                 .ok()
-                .filter(|ft| ft.is_dir())
-                .and_then(|_| entry.file_name().into_string().ok())
+                .filter(|ft| ft.is_dir() && name != ".metadata" && !name.starts_with(".mise-tmp-"))
+                .map(|_| name)
         })
         .collect::<Vec<_>>();
     match versions.as_slice() {
@@ -1327,8 +1328,10 @@ fn remove_stale_versions(token_dir: &Path, current_version: &str) -> Result<()> 
         return Ok(());
     };
     for entry in entries.filter_map(|entry| entry.ok()) {
+        let name = entry.file_name();
         if entry.file_type().is_ok_and(|ft| ft.is_dir())
-            && entry.file_name().to_str() != Some(current_version)
+            && name.to_str() != Some(current_version)
+            && name != ".metadata"
         {
             file::remove_all(entry.path())?;
         }
@@ -2421,18 +2424,39 @@ end
     }
 
     #[test]
-    fn remove_stale_versions_keeps_current_version() -> Result<()> {
+    fn installed_version_ignores_homebrew_metadata() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let token_dir = caskroom_token_dir("actual-token");
+        file::create_dir_all(token_dir.join("2.0.0"))?;
+        file::create_dir_all(token_dir.join(".metadata/2.0.0/timestamp/Casks"))?;
+        file::create_dir_all(token_dir.join(".mise-tmp-interrupted"))?;
+
+        assert_eq!(installed_version("actual-token"), Some("2.0.0".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn remove_stale_versions_keeps_current_version_and_homebrew_metadata() -> Result<()> {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let token_dir = caskroom_token_dir("actual-token");
         file::create_dir_all(token_dir.join("1.0.0"))?;
         file::create_dir_all(token_dir.join("2.0.0"))?;
+        let metadata = token_dir.join(".metadata/2.0.0/timestamp/Casks");
+        file::create_dir_all(&metadata)?;
+        crate::file::write(metadata.join("actual-token.json"), "metadata")?;
 
         remove_stale_versions(&token_dir, "2.0.0")?;
 
         assert!(!token_dir.join("1.0.0").exists());
         assert!(token_dir.join("2.0.0").exists());
+        assert_eq!(
+            crate::file::read_to_string(metadata.join("actual-token.json"))?,
+            "metadata"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- ignore Homebrew's `.metadata` directory when detecting installed cask versions
- preserve `.metadata` while removing stale cask version directories
- ignore interrupted mise cask staging directories during version detection
- add regression tests for Homebrew metadata adoption and cleanup

## Root cause

A Homebrew-managed cask contains both a version directory and a `.metadata` directory under `Caskroom/<token>`. mise counted both as installed versions, entered the reinstall path, and then removed `.metadata` as though it were a stale version. This left Homebrew unable to inspect or upgrade the adopted cask.

Fixes the behavior reported in https://github.com/jdx/mise/discussions/11007.

## Validation

- `cargo test --all-features system::packages::brew::cask::tests -- --nocapture` (49 passed)
- `mise run lint-fix`
- `git diff --check`

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to macOS brew-cask Caskroom directory scanning and cleanup; behavior change is additive filtering with targeted tests.
> 
> **Overview**
> Fixes mise brew-cask handling when a cask was installed or adopted by Homebrew, which leaves a **`.metadata`** tree (and sometimes **`.mise-tmp-*`** staging dirs) next to the real version folder under `Caskroom/<token>`.
> 
> **`installed_version`** now treats only real version directories as installed versions—it skips **`.metadata`** and names starting with **`.mise-tmp-`**, so Homebrew metadata is no longer counted as a second version (which previously triggered “multiple versions” warnings and unnecessary reinstalls).
> 
> **`remove_stale_versions`** still deletes old version dirs but **never removes `.metadata`**, so post-install cleanup cannot strip Homebrew’s adoption/upgrade metadata.
> 
> Regression tests cover version detection with metadata and interrupted tmp dirs, and cleanup that removes stale versions while keeping metadata intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a29ac11cd57e67e4cb7e5deebfbaddc05b17641b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew package handling to ignore metadata and temporary staging directories when detecting installed versions.
  * Prevented cleanup operations from accidentally deleting Homebrew metadata.
  * Ensured outdated package versions are still removed while required metadata remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->