### PR TITLE
feat(cargo): skip remote discovery for exact versions

### DIFF
--- a/e2e/cli/test_error_display
+++ b/e2e/cli/test_error_display
@@ -48,8 +48,8 @@ local_assert_fail "mise install core:node@invalid-version" \
 
 # Test 2: Backend error (cargo)
 echo "Test 2: Cargo backend error"
-local_assert_fail "mise install cargo:nonexistent-crate-12345@1.0.0" \
-  "mise ERROR Failed to install cargo:nonexistent-crate-12345@1.0.0: HTTP status client error (404 Not Found) for url (https://index.crates.io/no/ne/nonexistent-crate-12345)"
+local_assert_fail "MISE_CARGO_BINSTALL=0 mise install cargo:nonexistent-crate-12345@1.0.0" \
+  "mise ERROR Failed to install cargo:nonexistent-crate-12345@1.0.0: cargo exited with non-zero status: exit code 101"
 
 # Test 3: GitHub repository not found
 echo "Test 3: GitHub repository not found"
@@ -88,8 +88,8 @@ local_assert_fail "mise install core:node@invalid-version" \
 
 # Test 2: Backend error (cargo) - check for error format with full chain
 echo "Test 2: Cargo backend error"
-local_assert_fail "mise install cargo:nonexistent-crate-12345@1.0.0" \
-  "0: Failed to install cargo:nonexistent-crate-12345@1.0.0: HTTP status client error (404 Not Found) for url (https://index.crates.io/no/ne/nonexistent-crate-12345)"
+local_assert_fail "MISE_CARGO_BINSTALL=0 mise install cargo:nonexistent-crate-12345@1.0.0" \
+  "0: Failed to install cargo:nonexistent-crate-12345@1.0.0: cargo exited with non-zero status: exit code 101"
 
 # Test 3: GitHub repository not found - check for error format with full chain
 echo "Test 3: GitHub repository not found"

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -165,6 +165,19 @@ impl Backend for CargoBackend {
         parse_crate_versions(&response)
     }
 
+    async fn resolve_exact_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> eyre::Result<Option<String>> {
+        if self.git_url().is_some() {
+            return Ok(None);
+        }
+
+        let version = version.strip_prefix('=').unwrap_or(version);
+        Ok(versions::SemVer::new(version).map(|_| version.to_string()))
+    }
+
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         // Check if cargo is available
         self.warn_if_dependency_missing(
@@ -459,6 +472,60 @@ mod tests {
     use super::*;
     use crate::platform::Platform;
     use crate::toolset::parse_tool_options;
+
+    #[tokio::test]
+    async fn exact_semver_versions_resolve_without_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = CargoBackend::from_arg("cargo:tool".into());
+
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "=1.2.3")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.2.3")
+        );
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "1.2.3")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.2.3")
+        );
+    }
+
+    #[tokio::test]
+    async fn fuzzy_versions_require_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = CargoBackend::from_arg("cargo:tool".into());
+
+        for version in ["latest", "1", "1.2", "^1.2.3", ">=1.2.3"] {
+            assert_eq!(
+                backend
+                    .resolve_exact_version(&config, version)
+                    .await
+                    .unwrap(),
+                None,
+                "{version} should use remote discovery"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn git_versions_keep_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = CargoBackend::from_arg("cargo:owner/repo".into());
+
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "1.2.3")
+                .await
+                .unwrap(),
+            None
+        );
+    }
 
     #[test]
     fn test_lockfile_options_uses_target_platform_bin() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1525,9 +1525,10 @@ pub trait Backend: Debug + Send + Sync {
 
     /// Backend-specific fast path for exact version requests.
     ///
-    /// Return `Ok(None)` when the backend cannot cheaply prove that `version`
-    /// is an exact upstream version. Callers must still fall back to normal
-    /// prefix/latest resolution in that case.
+    /// Return the normalized version when the backend can cheaply prove that
+    /// `version` exists upstream or can defer authoritative validation to its
+    /// installer. Return `Ok(None)` to fall back to normal prefix/latest
+    /// resolution.
     async fn resolve_exact_version(
         &self,
         _config: &Arc<Config>,

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -526,10 +526,12 @@ impl ToolVersion {
         if prefer_offline && !opts.latest_versions && v.matches('.').count() >= 2 {
             return build(v);
         }
-        // Exact pinned GitHub versions do not need the full releases list when
-        // the backend can cheaply prove the tag exists. If it cannot, fall
-        // through to normal prefix resolution so requests like "1.2.3" can
-        // still resolve to "1.2.3.4" when that is the latest matching version.
+        // Exact pinned versions do not need the full versions list when the
+        // backend can validate them directly or defer validation to its
+        // installer. This also keeps explicit pins outside release-age
+        // filtering. If the backend returns None, fall through to normal
+        // prefix resolution so requests like "1.2.3" can still resolve to
+        // "1.2.3.4" when that is the latest matching version.
         if v.matches('.').count() >= 2
             && let Some(v) = backend.resolve_exact_version(config, &v).await?
         {


### PR DESCRIPTION
The Cargo backend now normalizes exact SemVer pins and delegates existence checks to `cargo install`. Fuzzy and Git-based requests keep remote discovery, while exact pins avoid crates.io version-list availability and release-age filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exact Cargo package versions are now resolved directly when valid.
  * Version selectors prefixed with `=` are automatically normalized.

* **Bug Fixes**
  * Non-exact selectors (ranges, partials, `latest`, etc.) continue using the standard remote discovery flow.
  * For git-backed Cargo tools and cases where exact verification isn’t possible, resolution falls back cleanly to the usual prefix/latest behavior.

* **Tests**
  * Updated e2e CLI error-display expectations for cargo backend failures in both friendly and detailed modes (including the expected exit code).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->