### PR TITLE
fix(task): prevent setup side effects during dry runs

### DIFF
--- a/e2e/tasks/test_task_dry_run_side_effects
+++ b/e2e/tasks/test_task_dry_run_side_effects
@@ -4,6 +4,9 @@ cat >mise.toml <<'EOF'
 [tools]
 tiny = "1"
 
+[hooks]
+postinstall = "touch postinstall-ran"
+
 [deps.setup]
 auto = true
 run = "touch deps-ran"
@@ -14,15 +17,22 @@ tools = { dummy = "1.0.0" }
 run = "touch task-ran"
 EOF
 
-rm -rf "$MISE_DATA_DIR/installs/tiny" "$MISE_DATA_DIR/installs/dummy"
+rm -rf "$MISE_DATA_DIR/installs/tiny" "$MISE_DATA_DIR/installs/dummy" "$MISE_DATA_DIR/shims"
+rm -f deps-ran task-ran postinstall-ran mise.lock
 
 output="$(mise run --dry-run check 2>&1)"
 echo "$output"
 assert_contains_text "$output" "tiny@1"
 assert_contains_text "$output" "dummy@1.0.0"
 assert_contains_text "$output" "Would install dependency: setup"
+assert_contains_text "$output" "Would run postinstall hook"
 assert_contains_text "$output" "touch task-ran"
+tiny_previews="$(printf '%s\n' "$output" | grep -c 'tiny@1' || true)"
+assert "[ '$tiny_previews' -eq 1 ]"
 assert_fail "test -e deps-ran"
 assert_fail "test -e task-ran"
-assert_fail "test -d '$MISE_DATA_DIR/installs/tiny/1.1.0'"
-assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "test -e postinstall-ran"
+assert_fail "test -d '$MISE_DATA_DIR/installs/tiny'"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy'"
+assert_fail "test -d '$MISE_DATA_DIR/shims'"
+assert_fail "test -e mise.lock"

--- a/e2e/tasks/test_task_dry_run_side_effects
+++ b/e2e/tasks/test_task_dry_run_side_effects
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+cat >mise.toml <<'EOF'
+[tools]
+tiny = "1"
+
+[deps.setup]
+auto = true
+run = "touch deps-ran"
+outputs = ["deps-ran"]
+
+[tasks.check]
+tools = { dummy = "1.0.0" }
+run = "touch task-ran"
+EOF
+
+rm -rf "$MISE_DATA_DIR/installs/tiny" "$MISE_DATA_DIR/installs/dummy"
+
+output="$(mise run --dry-run check 2>&1)"
+echo "$output"
+assert_contains_text "$output" "tiny@1"
+assert_contains_text "$output" "dummy@1.0.0"
+assert_contains_text "$output" "Would install dependency: setup"
+assert_contains_text "$output" "touch task-ran"
+assert_fail "test -e deps-ran"
+assert_fail "test -e task-ran"
+assert_fail "test -d '$MISE_DATA_DIR/installs/tiny/1.1.0'"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -387,6 +387,7 @@ impl Run {
         let opts = InstallOptions {
             jobs: self.jobs,
             raw: self.raw,
+            dry_run: self.dry_run,
             missing_args_only: !Settings::get().task.run_auto_install,
             skip_auto_install: !Settings::get().task.run_auto_install
                 || !Settings::get().auto_install,
@@ -405,13 +406,19 @@ impl Run {
                 engine.add_config_files(subdir_configs);
             }
 
-            engine
+            let result = engine
                 .run(DepsOptions {
                     auto_only: true, // Only run providers with auto=true
+                    dry_run: self.dry_run,
                     env,
                     ..Default::default()
                 })
                 .await?;
+            for step in result.steps {
+                if let crate::deps::DepsStepResult::WouldRun(id, reason) = step {
+                    info!("[dry-run] Would install dependency: {id} ({reason})");
+                }
+            }
         }
 
         // Apply global timeout for entire run if configured
@@ -756,7 +763,7 @@ impl Run {
             &self.context_builder,
             &self.tool,
         );
-        installer.install_tools(config, tasks).await
+        installer.install_tools(config, tasks, self.dry_run).await
     }
 
     // ============================================================================

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,4 +1,5 @@
 use crate::errors::Error;
+use std::collections::HashSet;
 use std::iter::once;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -7,7 +8,7 @@ use std::time::Duration;
 use super::args::ToolArg;
 use crate::cli::{Cli, unescape_task_args};
 use crate::config::{Config, Settings};
-use crate::deps::{DepsEngine, DepsOptions};
+use crate::deps::{DepsEngine, DepsOptions, DepsStepResult};
 use crate::duration;
 use crate::env;
 use crate::file::display_path;
@@ -17,7 +18,7 @@ use crate::task::task_list::{get_task_lists, resolve_depends};
 use crate::task::task_output::TaskOutput;
 use crate::task::task_output_handler::OutputHandler;
 use crate::task::{Deps, Task};
-use crate::toolset::{InstallOptions, ResolveOptions, ToolsetBuilder};
+use crate::toolset::{InstallOptions, ResolveOptions, ToolVersion, ToolsetBuilder};
 use crate::ui::{ctrlc, info, style};
 use clap::{CommandFactory, ValueHint};
 use eyre::{Result, bail, eyre};
@@ -393,9 +394,16 @@ impl Run {
                 || !Settings::get().auto_install,
             ..Default::default()
         };
-        if !self.skip_tools {
-            let _ = ts.install_missing_versions(&mut config, &opts).await?;
-        }
+        let previewed_tools = if !self.skip_tools {
+            let (installed, _) = ts.install_missing_versions(&mut config, &opts).await?;
+            if self.dry_run {
+                installed.into_iter().collect()
+            } else {
+                HashSet::new()
+            }
+        } else {
+            HashSet::new()
+        };
 
         // Run auto-enabled deps steps (unless --no-deps)
         if !self.no_deps {
@@ -415,7 +423,7 @@ impl Run {
                 })
                 .await?;
             for step in result.steps {
-                if let crate::deps::DepsStepResult::WouldRun(id, reason) = step {
+                if let DepsStepResult::WouldRun(id, reason) = step {
                     info!("[dry-run] Would install dependency: {id} ({reason})");
                 }
             }
@@ -429,11 +437,15 @@ impl Run {
         };
 
         if let Some(timeout) = timeout {
-            tokio::time::timeout(timeout, self.parallelize_tasks(config, resolved_tasks))
-                .await
-                .map_err(|_| eyre!("mise run timed out after {:?}", timeout))??
+            tokio::time::timeout(
+                timeout,
+                self.parallelize_tasks(config, resolved_tasks, previewed_tools),
+            )
+            .await
+            .map_err(|_| eyre!("mise run timed out after {:?}", timeout))??
         } else {
-            self.parallelize_tasks(config, resolved_tasks).await?
+            self.parallelize_tasks(config, resolved_tasks, previewed_tools)
+                .await?
         }
 
         time!("run done");
@@ -448,7 +460,12 @@ impl Run {
             .clone()
     }
 
-    async fn parallelize_tasks(mut self, mut config: Arc<Config>, tasks: Vec<Task>) -> Result<()> {
+    async fn parallelize_tasks(
+        mut self,
+        mut config: Arc<Config>,
+        tasks: Vec<Task>,
+        previewed_tools: HashSet<ToolVersion>,
+    ) -> Result<()> {
         time!("parallelize_tasks start");
 
         // Step 1: Prepare tasks (resolve dependencies, fetch, validate)
@@ -461,7 +478,8 @@ impl Run {
 
         // Step 3: Install tools needed by tasks
         if !self.skip_tools {
-            self.install_task_tools(&mut config, &tasks).await?;
+            self.install_task_tools(&mut config, &tasks, &previewed_tools)
+                .await?;
         }
 
         // Step 4: Create TaskExecutor after tool installation
@@ -758,12 +776,19 @@ impl Run {
     }
 
     /// Collect and install all tools needed by tasks
-    async fn install_task_tools(&self, config: &mut Arc<Config>, tasks: &Deps) -> Result<()> {
+    async fn install_task_tools(
+        &self,
+        config: &mut Arc<Config>,
+        tasks: &Deps,
+        previewed_tools: &HashSet<ToolVersion>,
+    ) -> Result<()> {
         let installer = crate::task::task_tool_installer::TaskToolInstaller::new(
             &self.context_builder,
             &self.tool,
         );
-        installer.install_tools(config, tasks, self.dry_run).await
+        installer
+            .install_tools(config, tasks, self.dry_run, previewed_tools)
+            .await
     }
 
     // ============================================================================

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -23,7 +23,12 @@ impl<'a> TaskToolInstaller<'a> {
     }
 
     /// Collect and install all tools needed by tasks
-    pub async fn install_tools(&self, config: &mut Arc<Config>, tasks: &Deps) -> Result<()> {
+    pub async fn install_tools(
+        &self,
+        config: &mut Arc<Config>,
+        tasks: &Deps,
+        dry_run: bool,
+    ) -> Result<()> {
         let mut all_tools = self.cli_tools.to_vec();
         let mut all_tool_requests = vec![];
         let all_tasks: Vec<_> = tasks.all().collect();
@@ -53,7 +58,7 @@ impl<'a> TaskToolInstaller<'a> {
         let toolset = self
             .build_toolset(config, all_tools, all_tool_requests)
             .await?;
-        self.install_toolset(config, toolset).await?;
+        self.install_toolset(config, toolset, dry_run).await?;
 
         Ok(())
     }
@@ -180,11 +185,17 @@ impl<'a> TaskToolInstaller<'a> {
     }
 
     /// Install missing versions from the toolset
-    async fn install_toolset(&self, config: &mut Arc<Config>, mut ts: Toolset) -> Result<()> {
+    async fn install_toolset(
+        &self,
+        config: &mut Arc<Config>,
+        mut ts: Toolset,
+        dry_run: bool,
+    ) -> Result<()> {
         let _ = ts
             .install_missing_versions(
                 config,
                 &InstallOptions {
+                    dry_run,
                     missing_args_only: !Settings::get().task.run_auto_install,
                     skip_auto_install: !Settings::get().task.run_auto_install
                         || !Settings::get().auto_install,

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -3,8 +3,9 @@ use crate::config::{Config, Settings};
 use crate::task::Deps;
 use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_helpers::canonicalize_path;
-use crate::toolset::{InstallOptions, ToolSource, Toolset};
+use crate::toolset::{InstallOptions, ToolSource, ToolVersion, Toolset};
 use eyre::Result;
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -28,6 +29,7 @@ impl<'a> TaskToolInstaller<'a> {
         config: &mut Arc<Config>,
         tasks: &Deps,
         dry_run: bool,
+        previewed_tools: &HashSet<ToolVersion>,
     ) -> Result<()> {
         let mut all_tools = self.cli_tools.to_vec();
         let mut all_tool_requests = vec![];
@@ -58,7 +60,8 @@ impl<'a> TaskToolInstaller<'a> {
         let toolset = self
             .build_toolset(config, all_tools, all_tool_requests)
             .await?;
-        self.install_toolset(config, toolset, dry_run).await?;
+        self.install_toolset(config, toolset, dry_run, previewed_tools)
+            .await?;
 
         Ok(())
     }
@@ -190,7 +193,13 @@ impl<'a> TaskToolInstaller<'a> {
         config: &mut Arc<Config>,
         mut ts: Toolset,
         dry_run: bool,
+        previewed_tools: &HashSet<ToolVersion>,
     ) -> Result<()> {
+        if dry_run {
+            for tvl in ts.versions.values_mut() {
+                tvl.versions.retain(|tv| !previewed_tools.contains(tv));
+            }
+        }
         let _ = ts
             .install_missing_versions(
                 config,

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -57,6 +57,13 @@ impl Toolset {
         // Ensure options from toolset are preserved during auto-install
         self.init_request_options(&mut versions);
         let installed = self.install_all_versions(config, versions, opts).await?;
+        if opts.dry_run {
+            // Dry-run install results describe the planned installs. They are not
+            // present on disk, so rebuilding shims/runtime symlinks or updating
+            // lockfiles for them would both mutate state and advertise tools that
+            // cannot be executed.
+            return Ok((installed, missing));
+        }
         if !installed.is_empty() {
             let ts = config.get_toolset().await?;
             config::rebuild_shims_and_runtime_symlinks(


### PR DESCRIPTION
## Summary
- propagate task dry-run mode into project tool installation and automatic dependency setup
- preview project tools, task-level tools, automatic dependency providers, and task commands
- avoid installing tools or executing dependency/task commands during `mise run --dry-run`

## Root cause
Task execution honored dry-run only at the final command runner. Its setup phases still used normal install/dependency options, and task-level tools were installed unconditionally.

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `mise run test:e2e e2e/tasks/test_task_dry_run_side_effects`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dry-run support for task execution and automatic tool installation, including clearer “Would install dependency” previews.
  * Dry-run previews now reflect planned postinstall hooks and task commands.

* **Bug Fixes**
  * Prevented dry-run mode from applying disk changes such as shims/runtime updates, lockfile writes, tool installs, or marker/flag files.

* **Tests**
  * Added an end-to-end test fixture validating dry-run output content and confirming no side effects occur (no installs, shims, lockfile, or marker files created).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->