### PR TITLE
fix(prune): preserve runtime symlinks during dry runs

### DIFF
--- a/e2e/cli/test_prune
+++ b/e2e/cli/test_prune
@@ -7,9 +7,9 @@ cd "$(mktemp -d)" || exit 1 # mise should not prune these files even though they
 assert_contains "mise prune --dry-run 2>&1" "mise dummy@2.0.0 [dryrun]"
 assert_contains "mise prune --dry-run 2>&1" "mise tiny@2.0.0 [dryrun]"
 
-# Dry-run previews removals but must not perform runtime-symlink cleanup.
+# Dry-run must not perform runtime-symlink cleanup.
 ln -s ./missing "$MISE_DATA_DIR/installs/dummy/latest"
-assert_contains "mise prune --dry-run 2>&1" "remove"
+assert "mise prune --dry-run"
 assert "test -L '$MISE_DATA_DIR/installs/dummy/latest'"
 
 # Test: --dry-run-code should exit non-zero when there are tools to prune
@@ -23,6 +23,7 @@ assert "ls $MISE_DATA_DIR/installs/dummy/2.0.0"
 assert_fail "ls $MISE_DATA_DIR/installs/tiny/2.0.0"
 assert "mise prune"
 assert_fail "ls $MISE_DATA_DIR/installs/dummy/2.0.0"
+assert "test \"\$(readlink '$MISE_DATA_DIR/installs/dummy/latest')\" = ./3.0.0"
 assert "ls $MISE_DATA_DIR/installs/dummy/3.0.0"
 assert "ls $MISE_DATA_DIR/installs/tiny/3.0.0"
 

--- a/e2e/cli/test_prune
+++ b/e2e/cli/test_prune
@@ -7,11 +7,17 @@ cd "$(mktemp -d)" || exit 1 # mise should not prune these files even though they
 assert_contains "mise prune --dry-run 2>&1" "mise dummy@2.0.0 [dryrun]"
 assert_contains "mise prune --dry-run 2>&1" "mise tiny@2.0.0 [dryrun]"
 
+# Dry-run previews removals but must not perform runtime-symlink cleanup.
+ln -s ./missing "$MISE_DATA_DIR/installs/dummy/latest"
+assert_contains "mise prune --dry-run 2>&1" "remove"
+assert "test -L '$MISE_DATA_DIR/installs/dummy/latest'"
+
 # Test: --dry-run-code should exit non-zero when there are tools to prune
 assert_fail_contains "mise prune --dry-run-code 2>&1" "[dryrun]"
 # Verify nothing was actually pruned
 assert "ls $MISE_DATA_DIR/installs/dummy/2.0.0"
 assert "ls $MISE_DATA_DIR/installs/tiny/2.0.0"
+assert "test -L '$MISE_DATA_DIR/installs/dummy/latest'"
 assert "mise prune tiny"
 assert "ls $MISE_DATA_DIR/installs/dummy/2.0.0"
 assert_fail "ls $MISE_DATA_DIR/installs/tiny/2.0.0"

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -167,7 +167,9 @@ async fn delete(
         let pr = mpr.add(&prefix);
         p.uninstall_version(config, &tv, pr.as_ref(), dry_run)
             .await?;
-        runtime_symlinks::remove_missing_symlinks(p)?;
+        if !dry_run {
+            runtime_symlinks::remove_missing_symlinks(p)?;
+        }
         pr.finish();
     }
     Ok(())


### PR DESCRIPTION
## Summary
- keep runtime-symlink cleanup behind the same dry-run guard as version removal
- retain the existing uninstall/remove preview output
- cover both `--dry-run` and `--dry-run-code`

## Root cause
Backend uninstall correctly skipped deletion in dry-run mode, but the following runtime-symlink cleanup call was unconditional and could remove dangling generated symlinks.

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `mise run test:e2e e2e/cli/test_prune`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `mise prune --dry-run` no longer removes broken runtime symlinks; existing symlinks remain intact after the command.
  * `mise prune --dry-run-code` still exits non-zero when prune candidates are present, without performing any pruning or symlink cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->