### PR TITLE
fix(nix): set TZDIR so timezone tests pass in the sandbox

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,6 +32,11 @@ rustPlatform.buildRustPackage {
 
   LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
 
+  # tera-contrib's now() resolves its timezone by name (TimeZone::get("UTC")),
+  # which requires a tzdb. The build sandbox provides none, so tests calling
+  # now() fail with "Unknown timezone: UTC".
+  TZDIR = "${pkgs.tzdata}/share/zoneinfo";
+
   prePatch = ''
     substituteInPlace ./src/test.rs ./test/data/plugins/**/bin/* \
       --replace '/usr/bin/env bash' '${bash}/bin/bash'


### PR DESCRIPTION
`tera-contrib`'s `now()` resolves its timezone via a named tzdb lookup (`TimeZone::get("UTC")`), unlike `date()` which uses the compiled-in constant, so `tera::tests::test_tera_contrib_helpers` and `task::task_script_parser::tests::test_task_template_tera_contrib_helpers` fail with `Unknown timezone: UTC` in the Nix sandbox, which provides no zoneinfo.

Setting `TZDIR` makes both pass rather than skipping them: `1662 passed; 0 failed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test failures involving timezone resolution in sandboxed build environments.
  * Tests that use the current time now reliably recognize the UTC timezone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->