### PR TITLE
chore: release 2026.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,91 @@
 # Changelog
 
+## [2026.7.8](https://github.com/jdx/mise/compare/v2026.7.7..v2026.7.8) - 2026-07-16
+
+### 🚀 Features
+
+- **(bootstrap)** add repos update and exec commands by @jdx in [#11022](https://github.com/jdx/mise/pull/11022)
+- **(bootstrap)** add package manager plugin support by @jdx in [#11023](https://github.com/jdx/mise/pull/11023)
+- **(bootstrap)** add declarative package plugins by @jdx in [#11024](https://github.com/jdx/mise/pull/11024)
+- **(registry)** add optional floating registries by @jdx in [#10971](https://github.com/jdx/mise/pull/10971)
+
+### 🐛 Bug Fixes
+
+- **(backend)** detect separatorless prerelease versions by @jdx in [#11032](https://github.com/jdx/mise/pull/11032)
+- **(bootstrap)** preserve Homebrew cask metadata by @jdx in [#11012](https://github.com/jdx/mise/pull/11012)
+- **(bootstrap)** compare repo origins transport-agnostically by @jeremy in [#11034](https://github.com/jdx/mise/pull/11034)
+- **(bootstrap)** handle static systemd units in status by @jdx in [#11056](https://github.com/jdx/mise/pull/11056)
+- **(cargo)** restore sparse index version discovery by @Turbo87 in [#11011](https://github.com/jdx/mise/pull/11011)
+- **(go)** resolve direct package module prefixes by @jdx in [#11054](https://github.com/jdx/mise/pull/11054)
+- **(hooks)** deprecate spawned scripts form by @risu729 in [#11043](https://github.com/jdx/mise/pull/11043)
+- **(hooks)** reject unknown hook table fields by @risu729 in [#11047](https://github.com/jdx/mise/pull/11047)
+- **(install)** preview hooks during dry runs by @risu729 in [#11010](https://github.com/jdx/mise/pull/11010)
+- **(install)** treat false install env values as removals by @risu729 in [#11033](https://github.com/jdx/mise/pull/11033)
+- **(launchd)** tolerate bootout EIO for not-loaded agents on macOS by @hsbt in [#10965](https://github.com/jdx/mise/pull/10965)
+- **(lockfile)** preserve platform-specific option variants by @jdx in [#10999](https://github.com/jdx/mise/pull/10999)
+- **(nix)** set TZDIR so timezone tests pass in the sandbox by @coryzibell in [#11019](https://github.com/jdx/mise/pull/11019)
+- **(prune)** preserve runtime symlinks during dry runs by @risu729 in [#11017](https://github.com/jdx/mise/pull/11017)
+- **(schema)** add oci copy entries by @risu729 in [#11009](https://github.com/jdx/mise/pull/11009)
+- **(schema)** add bootstrap shell activation config by @risu729 in [#11004](https://github.com/jdx/mise/pull/11004)
+- **(schema)** allow structured task tool options by @risu729 in [#11021](https://github.com/jdx/mise/pull/11021)
+- **(schema)** require watch file patterns by @risu729 in [#11040](https://github.com/jdx/mise/pull/11040)
+- **(schema)** add missing plugin manifest fields by @risu729 in [#11035](https://github.com/jdx/mise/pull/11035)
+- **(schema)** correct root hook definitions by @risu729 in [#11041](https://github.com/jdx/mise/pull/11041)
+- **(schema)** use integer types for integer settings by @risu729 in [#11037](https://github.com/jdx/mise/pull/11037)
+- **(schema)** add bootstrap hooks configuration by @risu729 in [#11039](https://github.com/jdx/mise/pull/11039)
+- **(schema)** add systemd timer and lifecycle options by @jdx in [#11050](https://github.com/jdx/mise/pull/11050)
+- **(shell)** support hyphenated tool names by @risu729 in [#10961](https://github.com/jdx/mise/pull/10961)
+- **(shell)** guard empty array expansions in bash deactivate under set -u by @jdx in [#11026](https://github.com/jdx/mise/pull/11026)
+- **(shim)** prevent recursion when directory env is filtered by @risu729 in [#10982](https://github.com/jdx/mise/pull/10982)
+- **(task)** omit empty templated dependency args by @jdx in [#11055](https://github.com/jdx/mise/pull/11055)
+- **(task)** inherit output from task templates by @risu729 in [#11059](https://github.com/jdx/mise/pull/11059)
+
+### 🚜 Refactor
+
+- adopt jdx-tar for tar handling by @jdx in [#11028](https://github.com/jdx/mise/pull/11028)
+
+### 📚 Documentation
+
+- **(templates)** clarify exec behavior in dry runs by @risu729 in [#11018](https://github.com/jdx/mise/pull/11018)
+
+### ⚡ Performance
+
+- **(release)** target macOS 12 in tarball builds for chained fixups by @jdx in [#11027](https://github.com/jdx/mise/pull/11027)
+- **(release)** add PGO builds for natively-trainable release targets by @jdx in [#11031](https://github.com/jdx/mise/pull/11031)
+- cut ~2ms of startup by fixing config glob scans and clap double-build by @jdx in [#11025](https://github.com/jdx/mise/pull/11025)
+- cap default tokio worker threads at 16 by @jdx in [#11029](https://github.com/jdx/mise/pull/11029)
+
+### 🧪 Testing
+
+- **(config)** cover settings lookup with --cd by @risu729 in [#10981](https://github.com/jdx/mise/pull/10981)
+
+### 📦 Registry
+
+- add zmx ([github:neurosnap/zmx](https://github.com/neurosnap/zmx)) by @offbyone in [#11006](https://github.com/jdx/mise/pull/11006)
+- switch docker-compose from aqua to github backend by @konono in [#10823](https://github.com/jdx/mise/pull/10823)
+
+### Chore
+
+- **(ci)** restore nightly build by @jdx in [#11030](https://github.com/jdx/mise/pull/11030)
+- **(ci)** tighten required CI guards by @risu729 in [#11038](https://github.com/jdx/mise/pull/11038)
+
+### New Contributors
+
+- @jeremy made their first contribution in [#11034](https://github.com/jdx/mise/pull/11034)
+- @Turbo87 made their first contribution in [#11011](https://github.com/jdx/mise/pull/11011)
+- @coryzibell made their first contribution in [#11019](https://github.com/jdx/mise/pull/11019)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (1)
+
+- [`conceptadev/fvm`](https://github.com/conceptadev/fvm)
+
+#### Updated Packages (2)
+
+- [`ricoberger/grafana-kubernetes-plugin`](https://github.com/ricoberger/grafana-kubernetes-plugin)
+- [`tldr-pages/tlrc`](https://github.com/tldr-pages/tlrc)
+
 ## [2026.7.7](https://github.com/jdx/mise/compare/v2026.7.6..v2026.7.7) - 2026-07-15
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.7"
+version = "2026.7.8"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.7"
+version = "2026.7.8"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.7 macos-arm64 (2026-07-15)
+2026.7.8 macos-arm64 (2026-07-16)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_7.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_8.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_7.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_8.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_7.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_8.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_7.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_8.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.7";
+  version = "2026.7.8";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.7
+Version: 2026.7.8
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.7"
+version: "2026.7.8"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "3a3985e850b3d8f3df0b5d6a049b6525893d5616"
+  "tag": "36b75b9bdbb8c0b81a1d9e6622d36384478ab03c"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -28088,6 +28088,210 @@ packages:
         supported_envs:
           - linux/amd64
           - windows/amd64
+  - type: github_release
+    repo_owner: conceptadev
+    repo_name: fvm
+    aliases:
+      - name: leoafarias/fvm
+    description: "Flutter Version Management: A simple CLI to manage Flutter SDK versions"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.13")
+        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.2.8")
+        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.0")
+        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.8.3")
+        no_asset: true
+      - version_constraint: Version == "App-1.0.0-alpha"
+        asset: fvm-app-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "App-1.0.0-alpha.1"
+        asset: fvm_{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver("<= 1.2.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.3.4")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.3.8")
+        no_asset: true
+      - version_constraint: semver("<= 2.2.4")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "2.2.5-dev"
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "2.2.5-dev.1"
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 2.3.1")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2.4.1")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+      - version_constraint: semver("<= 3.0.0-alpha.2")
+        no_asset: true
+      - version_constraint: semver("<= 4.0.0")
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm.bat
+      - version_constraint: "true"
+        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: fvm
+            src: fvm/fvm
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: fvm
+                src: fvm/fvm
   - name: concourse/concourse/concourse
     type: github_release
     repo_owner: concourse
@@ -60747,208 +60951,6 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
-    repo_owner: leoafarias
-    repo_name: fvm
-    description: "Flutter Version Management: A simple CLI to manage Flutter SDK versions"
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.1.13")
-        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.2.8")
-        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.3.0")
-        asset: fvm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.8.3")
-        no_asset: true
-      - version_constraint: Version == "App-1.0.0-alpha"
-        asset: fvm-app-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        supported_envs:
-          - windows/amd64
-      - version_constraint: Version == "App-1.0.0-alpha.1"
-        asset: fvm_{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        supported_envs:
-          - windows/amd64
-      - version_constraint: semver("<= 1.2.3")
-        no_asset: true
-      - version_constraint: semver("<= 1.3.4")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.3.8")
-        no_asset: true
-      - version_constraint: semver("<= 2.2.4")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "2.2.5-dev"
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "2.2.5-dev.1"
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-        supported_envs:
-          - linux/amd64
-      - version_constraint: semver("<= 2.3.1")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 2.4.1")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-      - version_constraint: semver("<= 3.0.0-alpha.2")
-        no_asset: true
-      - version_constraint: semver("<= 4.0.0")
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.bat
-      - version_constraint: "true"
-        asset: fvm-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: fvm
-            src: fvm/fvm
-        replacements:
-          amd64: x64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: fvm
-                src: fvm/fvm.exe
-  - type: github_release
     repo_owner: levibostian
     repo_name: decaf
     description: Calm & reliable automated deployments. No more coffee breaks to deploy your code
@@ -78483,10 +78485,16 @@ packages:
         files:
           - name: kubectl-grafana
             src: kubectl-grafana-{{.OS}}-{{.Arch}}
+      - version_constraint: semver("< 0.6.0")
+        asset: kubectl-grafana-{{.OS}}-{{.Arch}}.tar.gz
+        format: tar.gz
+        windows_arm_emulation: true
       - version_constraint: "true"
         asset: kubectl-grafana-{{.OS}}-{{.Arch}}.tar.gz
         format: tar.gz
         windows_arm_emulation: true
+        github_artifact_attestations:
+          signer_workflow: ricoberger/grafana-kubernetes-plugin/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: rlmcpherson
     repo_name: s3gof3r
@@ -93151,13 +93159,32 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.13.0")
         asset: tlrc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        github_artifact_attestations:
+          signer_workflow: tldr-pages/tlrc/.github/workflows/build-release.yml
+      - version_constraint: "true"
+        asset: tlrc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add repos update and exec commands by @jdx in [#11022](https://github.com/jdx/mise/pull/11022)
- **(bootstrap)** add package manager plugin support by @jdx in [#11023](https://github.com/jdx/mise/pull/11023)
- **(bootstrap)** add declarative package plugins by @jdx in [#11024](https://github.com/jdx/mise/pull/11024)
- **(registry)** add optional floating registries by @jdx in [#10971](https://github.com/jdx/mise/pull/10971)

### 🐛 Bug Fixes

- **(backend)** detect separatorless prerelease versions by @jdx in [#11032](https://github.com/jdx/mise/pull/11032)
- **(bootstrap)** preserve Homebrew cask metadata by @jdx in [#11012](https://github.com/jdx/mise/pull/11012)
- **(bootstrap)** compare repo origins transport-agnostically by @jeremy in [#11034](https://github.com/jdx/mise/pull/11034)
- **(bootstrap)** handle static systemd units in status by @jdx in [#11056](https://github.com/jdx/mise/pull/11056)
- **(cargo)** restore sparse index version discovery by @Turbo87 in [#11011](https://github.com/jdx/mise/pull/11011)
- **(go)** resolve direct package module prefixes by @jdx in [#11054](https://github.com/jdx/mise/pull/11054)
- **(hooks)** deprecate spawned scripts form by @risu729 in [#11043](https://github.com/jdx/mise/pull/11043)
- **(hooks)** reject unknown hook table fields by @risu729 in [#11047](https://github.com/jdx/mise/pull/11047)
- **(install)** preview hooks during dry runs by @risu729 in [#11010](https://github.com/jdx/mise/pull/11010)
- **(install)** treat false install env values as removals by @risu729 in [#11033](https://github.com/jdx/mise/pull/11033)
- **(launchd)** tolerate bootout EIO for not-loaded agents on macOS by @hsbt in [#10965](https://github.com/jdx/mise/pull/10965)
- **(lockfile)** preserve platform-specific option variants by @jdx in [#10999](https://github.com/jdx/mise/pull/10999)
- **(nix)** set TZDIR so timezone tests pass in the sandbox by @coryzibell in [#11019](https://github.com/jdx/mise/pull/11019)
- **(prune)** preserve runtime symlinks during dry runs by @risu729 in [#11017](https://github.com/jdx/mise/pull/11017)
- **(schema)** add oci copy entries by @risu729 in [#11009](https://github.com/jdx/mise/pull/11009)
- **(schema)** add bootstrap shell activation config by @risu729 in [#11004](https://github.com/jdx/mise/pull/11004)
- **(schema)** allow structured task tool options by @risu729 in [#11021](https://github.com/jdx/mise/pull/11021)
- **(schema)** require watch file patterns by @risu729 in [#11040](https://github.com/jdx/mise/pull/11040)
- **(schema)** add missing plugin manifest fields by @risu729 in [#11035](https://github.com/jdx/mise/pull/11035)
- **(schema)** correct root hook definitions by @risu729 in [#11041](https://github.com/jdx/mise/pull/11041)
- **(schema)** use integer types for integer settings by @risu729 in [#11037](https://github.com/jdx/mise/pull/11037)
- **(schema)** add bootstrap hooks configuration by @risu729 in [#11039](https://github.com/jdx/mise/pull/11039)
- **(schema)** add systemd timer and lifecycle options by @jdx in [#11050](https://github.com/jdx/mise/pull/11050)
- **(shell)** support hyphenated tool names by @risu729 in [#10961](https://github.com/jdx/mise/pull/10961)
- **(shell)** guard empty array expansions in bash deactivate under set -u by @jdx in [#11026](https://github.com/jdx/mise/pull/11026)
- **(shim)** prevent recursion when directory env is filtered by @risu729 in [#10982](https://github.com/jdx/mise/pull/10982)
- **(task)** omit empty templated dependency args by @jdx in [#11055](https://github.com/jdx/mise/pull/11055)
- **(task)** inherit output from task templates by @risu729 in [#11059](https://github.com/jdx/mise/pull/11059)

### 🚜 Refactor

- adopt jdx-tar for tar handling by @jdx in [#11028](https://github.com/jdx/mise/pull/11028)

### 📚 Documentation

- **(templates)** clarify exec behavior in dry runs by @risu729 in [#11018](https://github.com/jdx/mise/pull/11018)

### ⚡ Performance

- **(release)** target macOS 12 in tarball builds for chained fixups by @jdx in [#11027](https://github.com/jdx/mise/pull/11027)
- **(release)** add PGO builds for natively-trainable release targets by @jdx in [#11031](https://github.com/jdx/mise/pull/11031)
- cut ~2ms of startup by fixing config glob scans and clap double-build by @jdx in [#11025](https://github.com/jdx/mise/pull/11025)
- cap default tokio worker threads at 16 by @jdx in [#11029](https://github.com/jdx/mise/pull/11029)

### 🧪 Testing

- **(config)** cover settings lookup with --cd by @risu729 in [#10981](https://github.com/jdx/mise/pull/10981)

### 📦 Registry

- add zmx ([github:neurosnap/zmx](https://github.com/neurosnap/zmx)) by @offbyone in [#11006](https://github.com/jdx/mise/pull/11006)
- switch docker-compose from aqua to github backend by @konono in [#10823](https://github.com/jdx/mise/pull/10823)

### Chore

- **(ci)** restore nightly build by @jdx in [#11030](https://github.com/jdx/mise/pull/11030)
- **(ci)** tighten required CI guards by @risu729 in [#11038](https://github.com/jdx/mise/pull/11038)

### New Contributors

- @jeremy made their first contribution in [#11034](https://github.com/jdx/mise/pull/11034)
- @Turbo87 made their first contribution in [#11011](https://github.com/jdx/mise/pull/11011)
- @coryzibell made their first contribution in [#11019](https://github.com/jdx/mise/pull/11019)

## 📦 Aqua Registry Updates

### New Packages (1)

- [`conceptadev/fvm`](https://github.com/conceptadev/fvm)

### Updated Packages (2)

- [`ricoberger/grafana-kubernetes-plugin`](https://github.com/ricoberger/grafana-kubernetes-plugin)
- [`tldr-pages/tlrc`](https://github.com/tldr-pages/tlrc)