### PR TITLE
feat(bootstrap): add package manager plugin support

### DIFF
--- a/crates/vfox/src/hooks/mod.rs
+++ b/crates/vfox/src/hooks/mod.rs
@@ -5,6 +5,7 @@ pub mod backend_list_versions;
 pub mod env_keys;
 pub mod mise_env;
 pub mod mise_path;
+pub mod package;
 pub mod parse_legacy_file;
 pub mod post_install;
 pub mod pre_install;

--- a/crates/vfox/src/hooks/package.rs
+++ b/crates/vfox/src/hooks/package.rs
@@ -1,0 +1,178 @@
+use mlua::{FromLua, IntoLua, Lua, Value, prelude::LuaError};
+
+use crate::{Plugin, error::Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageRequest {
+    pub name: String,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageInstalledContext {
+    pub packages: Vec<PackageRequest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageActionContext {
+    pub packages: Vec<PackageRequest>,
+    pub dry_run: bool,
+    pub update: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledPackage {
+    pub name: String,
+    pub state: String,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageInstalledResponse {
+    pub packages: Vec<InstalledPackage>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PackageActionResponse;
+
+impl Plugin {
+    pub async fn package_installed(
+        &self,
+        ctx: PackageInstalledContext,
+    ) -> Result<PackageInstalledResponse> {
+        debug!("[vfox:{}] package_installed", &self.name);
+        self.eval_async(chunk! {
+            require "hooks/package_installed"
+            return PLUGIN:PackageInstalled($ctx)
+        })
+        .await
+    }
+
+    pub async fn package_install(
+        &self,
+        ctx: PackageActionContext,
+    ) -> Result<PackageActionResponse> {
+        debug!("[vfox:{}] package_install", &self.name);
+        self.eval_async(chunk! {
+            require "hooks/package_install"
+            return PLUGIN:PackageInstall($ctx)
+        })
+        .await
+    }
+
+    pub async fn package_upgrade(
+        &self,
+        ctx: PackageActionContext,
+    ) -> Result<PackageActionResponse> {
+        debug!("[vfox:{}] package_upgrade", &self.name);
+        self.eval_async(chunk! {
+            require "hooks/package_upgrade"
+            return PLUGIN:PackageUpgrade($ctx)
+        })
+        .await
+    }
+}
+
+fn packages_into_lua(packages: Vec<PackageRequest>, lua: &Lua) -> mlua::Result<Value> {
+    let list = lua.create_table()?;
+    for (index, package) in packages.into_iter().enumerate() {
+        let item = lua.create_table()?;
+        item.set("name", package.name)?;
+        item.set("version", package.version)?;
+        list.set(index + 1, item)?;
+    }
+    Ok(Value::Table(list))
+}
+
+impl IntoLua for PackageInstalledContext {
+    fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+        let table = lua.create_table()?;
+        table.set("packages", packages_into_lua(self.packages, lua)?)?;
+        Ok(Value::Table(table))
+    }
+}
+
+impl IntoLua for PackageActionContext {
+    fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+        let table = lua.create_table()?;
+        table.set("packages", packages_into_lua(self.packages, lua)?)?;
+        table.set("dry_run", self.dry_run)?;
+        table.set("update", self.update)?;
+        Ok(Value::Table(table))
+    }
+}
+
+impl FromLua for PackageInstalledResponse {
+    fn from_lua(value: Value, _: &Lua) -> mlua::Result<Self> {
+        let Value::Table(table) = value else {
+            return Err(LuaError::FromLuaConversionError {
+                from: value.type_name(),
+                to: "PackageInstalledResponse".to_string(),
+                message: Some("Expected table".to_string()),
+            });
+        };
+        let packages = table
+            .get::<mlua::Table>("packages")?
+            .sequence_values::<mlua::Table>()
+            .map(|item| {
+                let item = item?;
+                Ok(InstalledPackage {
+                    name: item.get("name")?,
+                    state: item.get("state")?,
+                    version: item.get("version")?,
+                })
+            })
+            .collect::<mlua::Result<Vec<_>>>()?;
+        Ok(Self { packages })
+    }
+}
+
+impl FromLua for PackageActionResponse {
+    fn from_lua(value: Value, _: &Lua) -> mlua::Result<Self> {
+        match value {
+            Value::Table(_) | Value::Nil => Ok(Self),
+            _ => Err(LuaError::FromLuaConversionError {
+                from: value.type_name(),
+                to: "PackageActionResponse".to_string(),
+                message: Some("Expected table or nil".to_string()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_context_serializes_versions_as_opaque_strings() {
+        let lua = Lua::new();
+        let value = PackageActionContext {
+            packages: vec![PackageRequest {
+                name: "extension".into(),
+                version: Some("nightly-2026.07".into()),
+            }],
+            dry_run: true,
+            update: false,
+        }
+        .into_lua(&lua)
+        .unwrap();
+        let table = value.as_table().unwrap();
+        let packages = table.get::<mlua::Table>("packages").unwrap();
+        let package = packages.get::<mlua::Table>(1).unwrap();
+        assert_eq!(package.get::<String>("version").unwrap(), "nightly-2026.07");
+        assert!(table.get::<bool>("dry_run").unwrap());
+    }
+
+    #[test]
+    fn installed_response_deserializes() {
+        let lua = Lua::new();
+        let value: Value = lua
+            .load(r#"return { packages = {{ name = "diff", state = "installed", version = "1.3.4" }, { name = "s3", state = "missing" }}}"#)
+            .eval()
+            .unwrap();
+        let response = PackageInstalledResponse::from_lua(value, &lua).unwrap();
+        assert_eq!(response.packages[0].version.as_deref(), Some("1.3.4"));
+        assert_eq!(response.packages[1].state, "missing");
+    }
+}

--- a/crates/vfox/src/lib.rs
+++ b/crates/vfox/src/lib.rs
@@ -8,6 +8,10 @@ extern crate mlua;
 
 pub use error::Result as VfoxResult;
 pub use error::VfoxError;
+pub use hooks::package::{
+    PackageActionContext, PackageActionResponse, PackageInstalledContext, PackageInstalledResponse,
+    PackageRequest,
+};
 pub use hooks::pre_install::VerifiedAttestation;
 pub use metadata::{Metadata, SystemDependency};
 pub use plugin::Plugin;

--- a/crates/vfox/src/lua_mod/hooks.rs
+++ b/crates/vfox/src/lua_mod/hooks.rs
@@ -10,7 +10,7 @@ pub struct HookFunc {
 }
 
 #[rustfmt::skip]
-pub const HOOK_FUNCS: [HookFunc; 12] = [
+pub const HOOK_FUNCS: [HookFunc; 15] = [
     HookFunc { _name: "Available", filename: "available" },
     HookFunc { _name: "PreInstall", filename: "pre_install" },
     HookFunc { _name: "EnvKeys", filename: "env_keys" },
@@ -23,6 +23,11 @@ pub const HOOK_FUNCS: [HookFunc; 12] = [
     HookFunc { _name: "BackendListVersions", filename: "backend_list_versions" },
     HookFunc { _name: "BackendInstall", filename: "backend_install" },
     HookFunc { _name: "BackendExecEnv", filename: "backend_exec_env" },
+
+    // package manager
+    HookFunc { _name: "PackageInstalled", filename: "package_installed" },
+    HookFunc { _name: "PackageInstall", filename: "package_install" },
+    HookFunc { _name: "PackageUpgrade", filename: "package_upgrade" },
 
     // mise
     HookFunc { _name: "MiseEnv", filename: "mise_env" },

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -16,6 +16,9 @@ use crate::hooks::backend_list_versions::BackendListVersionsContext;
 use crate::hooks::env_keys::{EnvKey, EnvKeysContext};
 use crate::hooks::mise_env::{MiseEnvContext, MiseEnvResult};
 use crate::hooks::mise_path::MisePathContext;
+use crate::hooks::package::{
+    PackageActionContext, PackageActionResponse, PackageInstalledContext, PackageInstalledResponse,
+};
 use crate::hooks::parse_legacy_file::ParseLegacyFileResponse;
 use crate::hooks::post_install::PostInstallContext;
 use crate::hooks::pre_install::{PreInstall, PreInstallAttestation, VerifiedAttestation};
@@ -470,6 +473,30 @@ impl Vfox {
             options,
         };
         plugin.backend_exec_env(ctx).await.map(|r| r.env_vars)
+    }
+
+    pub async fn package_installed(
+        &self,
+        sdk: &str,
+        ctx: PackageInstalledContext,
+    ) -> Result<PackageInstalledResponse> {
+        self.get_sdk_with_env(sdk)?.package_installed(ctx).await
+    }
+
+    pub async fn package_install(
+        &self,
+        sdk: &str,
+        ctx: PackageActionContext,
+    ) -> Result<PackageActionResponse> {
+        self.get_sdk_with_env(sdk)?.package_install(ctx).await
+    }
+
+    pub async fn package_upgrade(
+        &self,
+        sdk: &str,
+        ctx: PackageActionContext,
+    ) -> Result<PackageActionResponse> {
+        self.get_sdk_with_env(sdk)?.package_upgrade(ctx).await
     }
 
     pub async fn mise_path<T: serde::Serialize>(

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -256,6 +256,9 @@ impl BackendArg {
                             "vfox-backend plugin '{plugin_name}' exists but '{tool_name}' is not available or the plugin is not properly installed"
                         );
                     }
+                    PluginType::Package => {
+                        bail!("package plugin '{plugin_name}' is not a tool backend");
+                    }
                 }
             } else {
                 // Plugin doesn't exist
@@ -323,6 +326,7 @@ impl BackendArg {
                     PluginType::Vfox => BackendType::Vfox,
                     PluginType::VfoxBackend => BackendType::VfoxBackend(plugin_name.to_string()),
                     PluginType::Asdf => BackendType::Asdf,
+                    PluginType::Package => BackendType::Unknown,
                 };
             }
         }
@@ -349,6 +353,7 @@ impl BackendArg {
                 PluginType::Vfox => BackendType::Vfox,
                 PluginType::VfoxBackend => BackendType::VfoxBackend(self.short.to_string()),
                 PluginType::Asdf => BackendType::Asdf,
+                PluginType::Package => BackendType::Unknown,
             };
         }
         BackendType::Unknown
@@ -376,6 +381,7 @@ impl BackendArg {
                     PluginType::Asdf => format!("asdf:{url}"),
                     PluginType::Vfox => format!("vfox:{short}"),
                     PluginType::VfoxBackend => short.to_string(),
+                    PluginType::Package => short.to_string(),
                 };
             }
 
@@ -424,6 +430,7 @@ impl BackendArg {
                     // because the plugin itself is the backend specification
                     PluginType::Vfox => short.to_string(),
                     PluginType::VfoxBackend => short.to_string(),
+                    PluginType::Package => short.to_string(),
                 }
             } else if plugin_name.starts_with("asdf-") {
                 // Handle asdf plugin:tool format even if not installed
@@ -436,6 +443,7 @@ impl BackendArg {
                 PluginType::Asdf => format!("asdf:{short}"),
                 PluginType::Vfox => format!("vfox:{short}"),
                 PluginType::VfoxBackend => short.to_string(),
+                PluginType::Package => short.to_string(),
             }
         } else if let Some(full) = REGISTRY
             .get(short)
@@ -582,6 +590,7 @@ impl BackendArg {
                     PluginType::Asdf => format!("asdf:{short}"),
                     PluginType::Vfox => format!("vfox:{short}"),
                     PluginType::VfoxBackend => short.to_string(),
+                    PluginType::Package => short.to_string(),
                 }
             } else {
                 self.full()

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1150,13 +1150,12 @@ impl BootstrapStatus {
         let mut json_out = serde_json::Map::new();
         for mp in system::packages_from_config(config) {
             let name = mp.manager.name();
-            let unavailable = mp.manager.unavailable_reason_async().await;
-            if mp.disabled || unavailable.is_some() {
-                let reason = if mp.disabled {
-                    "excluded by the system_packages.managers setting".to_string()
-                } else {
-                    unavailable.unwrap()
-                };
+            let reason = if mp.disabled {
+                Some("excluded by the system_packages.managers setting".to_string())
+            } else {
+                mp.manager.unavailable_reason_async().await
+            };
+            if let Some(reason) = reason {
                 for req in &mp.requests {
                     report.row(
                         "packages",

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -515,7 +515,7 @@ impl Bootstrap {
                 debug!("bootstrap: no [bootstrap.packages] configured, skipping");
             } else {
                 info!("bootstrap: system packages");
-                follow_up.add_package_skips(&mgrs);
+                follow_up.add_package_skips(&mgrs).await;
                 let opts = DriverOpts {
                     manager: None,
                     explicit: false,
@@ -905,13 +905,13 @@ impl BootstrapFollowUp {
         }
     }
 
-    fn add_package_skips(&mut self, mgrs: &[system::ManagerPackages]) {
+    async fn add_package_skips(&mut self, mgrs: &[system::ManagerPackages]) {
         for mp in mgrs {
             let name = mp.manager.name();
             let reason = if mp.disabled {
                 Some("excluded by the system_packages.managers setting".to_string())
-            } else if !mp.manager.is_available() {
-                Some(mp.manager.unavailable_reason())
+            } else if let Some(reason) = mp.manager.unavailable_reason_async().await {
+                Some(reason)
             } else {
                 None
             };
@@ -1152,11 +1152,12 @@ impl BootstrapStatus {
         let mut json_out = serde_json::Map::new();
         for mp in system::packages_from_config(config) {
             let name = mp.manager.name();
-            if mp.disabled || !mp.manager.is_available() {
+            let unavailable = mp.manager.unavailable_reason_async().await;
+            if mp.disabled || unavailable.is_some() {
                 let reason = if mp.disabled {
                     "excluded by the system_packages.managers setting".to_string()
                 } else {
-                    mp.manager.unavailable_reason()
+                    unavailable.unwrap()
                 };
                 for req in &mp.requests {
                     report.row(

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -910,10 +910,8 @@ impl BootstrapFollowUp {
             let name = mp.manager.name();
             let reason = if mp.disabled {
                 Some("excluded by the system_packages.managers setting".to_string())
-            } else if let Some(reason) = mp.manager.unavailable_reason_async().await {
-                Some(reason)
             } else {
-                None
+                mp.manager.unavailable_reason_async().await
             };
             if let Some(reason) = reason {
                 self.add_skipped(format!(

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -478,11 +478,12 @@ impl Doctor {
         let mut total_missing = 0;
         for mp in mgrs {
             let name = mp.manager.name();
-            if mp.disabled || !mp.manager.is_available() {
+            let unavailable = mp.manager.unavailable_reason_async().await;
+            if mp.disabled || unavailable.is_some() {
                 let reason = if mp.disabled {
                     "excluded by the system_packages.managers setting".to_string()
                 } else {
-                    mp.manager.unavailable_reason()
+                    unavailable.unwrap()
                 };
                 map.insert(
                     name.into(),
@@ -713,11 +714,12 @@ impl Doctor {
         let mut total_missing = 0;
         for mp in mgrs {
             let name = mp.manager.name();
-            if mp.disabled || !mp.manager.is_available() {
+            let unavailable = mp.manager.unavailable_reason_async().await;
+            if mp.disabled || unavailable.is_some() {
                 let reason = if mp.disabled {
                     "excluded by the system_packages.managers setting".to_string()
                 } else {
-                    mp.manager.unavailable_reason()
+                    unavailable.unwrap()
                 };
                 lines.push(format!(
                     "{name}: unavailable ({reason}), {} package(s) skipped",

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -478,13 +478,12 @@ impl Doctor {
         let mut total_missing = 0;
         for mp in mgrs {
             let name = mp.manager.name();
-            let unavailable = mp.manager.unavailable_reason_async().await;
-            if mp.disabled || unavailable.is_some() {
-                let reason = if mp.disabled {
-                    "excluded by the system_packages.managers setting".to_string()
-                } else {
-                    unavailable.unwrap()
-                };
+            let reason = if mp.disabled {
+                Some("excluded by the system_packages.managers setting".to_string())
+            } else {
+                mp.manager.unavailable_reason_async().await
+            };
+            if let Some(reason) = reason {
                 map.insert(
                     name.into(),
                     serde_json::json!({
@@ -714,13 +713,12 @@ impl Doctor {
         let mut total_missing = 0;
         for mp in mgrs {
             let name = mp.manager.name();
-            let unavailable = mp.manager.unavailable_reason_async().await;
-            if mp.disabled || unavailable.is_some() {
-                let reason = if mp.disabled {
-                    "excluded by the system_packages.managers setting".to_string()
-                } else {
-                    unavailable.unwrap()
-                };
+            let reason = if mp.disabled {
+                Some("excluded by the system_packages.managers setting".to_string())
+            } else {
+                mp.manager.unavailable_reason_async().await
+            };
+            if let Some(reason) = reason {
                 lines.push(format!(
                     "{name}: unavailable ({reason}), {} package(s) skipped",
                     mp.requests.len()

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -1187,6 +1187,7 @@ fn plugin_type_name(plugin_type: PluginType) -> &'static str {
         PluginType::Asdf => "asdf",
         PluginType::Vfox => "vfox",
         PluginType::VfoxBackend => "vfox_backend",
+        PluginType::Package => "package",
     }
 }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -152,9 +152,15 @@ impl Install {
         // packages that would actually be checked is unchanged, so editing
         // [bootstrap.packages] or widening system_packages.managers re-checks
         // immediately
+        let mut available = std::collections::HashSet::new();
+        for mp in &mgrs {
+            if !mp.disabled && mp.manager.unavailable_reason_async().await.is_none() {
+                available.insert(mp.manager.name().to_string());
+            }
+        }
         let fingerprint = mgrs
             .iter()
-            .filter(|mp| !mp.disabled && mp.manager.is_available())
+            .filter(|mp| available.contains(mp.manager.name()))
             .flat_map(|mp| {
                 mp.requests
                     .iter()
@@ -176,7 +182,7 @@ impl Install {
         let mut missing = 0;
         let mut all_queries_ok = true;
         for mp in mgrs {
-            if mp.disabled || !mp.manager.is_available() {
+            if !available.contains(mp.manager.name()) {
                 continue;
             }
             match mp.manager.installed(&mp.requests).await {

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -78,16 +78,13 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
             debug!("{name}: skipping, excluded by system_packages.managers");
             continue;
         }
-        if !mp.manager.is_available() {
+        if let Some(reason) = mp.manager.unavailable_reason_async().await {
             if d.manager.is_some() || d.explicit {
                 // explicitly requested (via --manager or manager:package
                 // specs) — failing silently would be a lie
-                bail!(
-                    "{name} is not available: {}",
-                    mp.manager.unavailable_reason()
-                );
+                bail!("{name} is not available: {}", reason);
             }
-            debug!("{name}: skipping, {}", mp.manager.unavailable_reason());
+            debug!("{name}: skipping, {reason}");
             continue;
         }
         let statuses = mp.manager.installed(&mp.requests).await?;

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -28,11 +28,12 @@ impl SystemStatus {
         let mut json_out = serde_json::Map::new();
         for mp in mgrs {
             let name = mp.manager.name();
-            if mp.disabled || !mp.manager.is_available() {
+            let unavailable = mp.manager.unavailable_reason_async().await;
+            if mp.disabled || unavailable.is_some() {
                 let reason = if mp.disabled {
                     "excluded by the system_packages.managers setting".to_string()
                 } else {
-                    mp.manager.unavailable_reason()
+                    unavailable.unwrap()
                 };
                 if self.json {
                     json_out.insert(

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -28,13 +28,12 @@ impl SystemStatus {
         let mut json_out = serde_json::Map::new();
         for mp in mgrs {
             let name = mp.manager.name();
-            let unavailable = mp.manager.unavailable_reason_async().await;
-            if mp.disabled || unavailable.is_some() {
-                let reason = if mp.disabled {
-                    "excluded by the system_packages.managers setting".to_string()
-                } else {
-                    unavailable.unwrap()
-                };
+            let reason = if mp.disabled {
+                Some("excluded by the system_packages.managers setting".to_string())
+            } else {
+                mp.manager.unavailable_reason_async().await
+            };
+            if let Some(reason) = reason {
                 if self.json {
                     json_out.insert(
                         name.to_string(),

--- a/src/cli/system/use.rs
+++ b/src/cli/system/use.rs
@@ -117,11 +117,13 @@ impl SystemUse {
         // this machine.
         if !self.dry_run {
             for mp in &mgrs {
-                if !mp.disabled && !mp.manager.is_available() {
+                if !mp.disabled
+                    && let Some(reason) = mp.manager.unavailable_reason_async().await
+                {
                     info!(
                         "{}: {} — added to config without installing",
                         mp.manager.name(),
-                        mp.manager.unavailable_reason()
+                        reason
                     );
                 }
             }

--- a/src/plugins/mise_plugin_toml.rs
+++ b/src/plugins/mise_plugin_toml.rs
@@ -13,8 +13,16 @@ pub struct MisePluginTomlScriptConfig {
     pub data: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct MisePluginTomlPackageManagerConfig {
+    pub requires: Vec<String>,
+    pub supports_version_pins: bool,
+    pub os: Option<Vec<String>>,
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct MisePluginToml {
+    pub package_manager: MisePluginTomlPackageManagerConfig,
     pub exec_env: MisePluginTomlScriptConfig,
     pub list_aliases: MisePluginTomlScriptConfig,
     pub list_bin_paths: MisePluginTomlScriptConfig,
@@ -49,6 +57,7 @@ impl MisePluginToml {
                 "list-idiomatic-filenames" | "list-legacy-filenames" => {
                     self.list_idiomatic_filenames = self.parse_script_config(k, v)?
                 }
+                "package-manager" => self.package_manager = self.parse_package_manager(k, v)?,
                 // this is an old key used in rtx-python
                 // this file is invalid, so just stop parsing entirely if we see it
                 "idiomatic-filenames" | "legacy-filenames" => return Ok(()),
@@ -56,6 +65,30 @@ impl MisePluginToml {
             }
         }
         Ok(())
+    }
+
+    fn parse_package_manager(
+        &mut self,
+        key: &str,
+        v: &Item,
+    ) -> Result<MisePluginTomlPackageManagerConfig> {
+        let Some(table) = v.as_table_like() else {
+            parse_error!(key, v, "table");
+        };
+        let mut config = MisePluginTomlPackageManagerConfig::default();
+        for (k, v) in table.iter() {
+            let full_key = format!("{key}.{k}");
+            match k {
+                "requires" => config.requires = self.parse_string_array(&full_key, v)?,
+                "supports_version_pins" | "supports-version-pins" => match v.as_bool() {
+                    Some(value) => config.supports_version_pins = value,
+                    None => parse_error!(full_key, v, "boolean"),
+                },
+                "os" => config.os = Some(self.parse_string_array(&full_key, v)?),
+                _ => parse_error!(full_key, v, "one of: requires, supports_version_pins, os"),
+            }
+        }
+        Ok(config)
     }
 
     fn parse_script_config(&mut self, key: &str, v: &Item) -> Result<MisePluginTomlScriptConfig> {
@@ -140,6 +173,26 @@ mod tests {
             data: None,
         }
         "#);
+    }
+
+    #[test]
+    fn test_package_manager() {
+        let cf = parse(
+            r#"
+            [package-manager]
+            requires = ["helm", "kubectl"]
+            supports_version_pins = true
+            os = ["macos", "linux"]
+            "#,
+        );
+        assert_eq!(
+            cf.package_manager,
+            MisePluginTomlPackageManagerConfig {
+                requires: vec!["helm".into(), "kubectl".into()],
+                supports_version_pins: true,
+                os: Some(vec!["macos".into(), "linux".into()]),
+            }
+        );
     }
 
     fn parse(s: &str) -> MisePluginToml {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -35,6 +35,7 @@ pub enum PluginType {
     Asdf,
     Vfox,
     VfoxBackend,
+    Package,
 }
 
 #[derive(Debug)]
@@ -42,6 +43,7 @@ pub enum PluginEnum {
     Asdf(Arc<AsdfPlugin>),
     Vfox(Arc<VfoxPlugin>),
     VfoxBackend(Arc<VfoxPlugin>),
+    Package(Arc<VfoxPlugin>),
 }
 
 impl PluginEnum {
@@ -50,6 +52,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.name(),
             PluginEnum::Vfox(plugin) => plugin.name(),
             PluginEnum::VfoxBackend(plugin) => plugin.name(),
+            PluginEnum::Package(plugin) => plugin.name(),
         }
     }
 
@@ -58,6 +61,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.path(),
             PluginEnum::Vfox(plugin) => plugin.path(),
             PluginEnum::VfoxBackend(plugin) => plugin.path(),
+            PluginEnum::Package(plugin) => plugin.path(),
         }
     }
 
@@ -66,6 +70,7 @@ impl PluginEnum {
             PluginEnum::Asdf(_) => PluginType::Asdf,
             PluginEnum::Vfox(_) => PluginType::Vfox,
             PluginEnum::VfoxBackend(_) => PluginType::VfoxBackend,
+            PluginEnum::Package(_) => PluginType::Package,
         }
     }
 
@@ -74,6 +79,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.get_remote_url(),
             PluginEnum::Vfox(plugin) => plugin.get_remote_url(),
             PluginEnum::VfoxBackend(plugin) => plugin.get_remote_url(),
+            PluginEnum::Package(plugin) => plugin.get_remote_url(),
         }
     }
 
@@ -82,6 +88,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.set_remote_url(url),
             PluginEnum::Vfox(plugin) => plugin.set_remote_url(url),
             PluginEnum::VfoxBackend(plugin) => plugin.set_remote_url(url),
+            PluginEnum::Package(plugin) => plugin.set_remote_url(url),
         }
     }
 
@@ -90,6 +97,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.current_abbrev_ref(),
             PluginEnum::Vfox(plugin) => plugin.current_abbrev_ref(),
             PluginEnum::VfoxBackend(plugin) => plugin.current_abbrev_ref(),
+            PluginEnum::Package(plugin) => plugin.current_abbrev_ref(),
         }
     }
 
@@ -98,6 +106,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.current_sha_short(),
             PluginEnum::Vfox(plugin) => plugin.current_sha_short(),
             PluginEnum::VfoxBackend(plugin) => plugin.current_sha_short(),
+            PluginEnum::Package(plugin) => plugin.current_sha_short(),
         }
     }
 
@@ -106,6 +115,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.remote_sha(),
             PluginEnum::Vfox(plugin) => plugin.remote_sha(),
             PluginEnum::VfoxBackend(plugin) => plugin.remote_sha(),
+            PluginEnum::Package(plugin) => plugin.remote_sha(),
         }
     }
 
@@ -114,6 +124,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.external_commands(),
             PluginEnum::Vfox(plugin) => plugin.external_commands(),
             PluginEnum::VfoxBackend(plugin) => plugin.external_commands(),
+            PluginEnum::Package(plugin) => plugin.external_commands(),
         }
     }
 
@@ -122,6 +133,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.execute_external_command(command, args),
             PluginEnum::Vfox(plugin) => plugin.execute_external_command(command, args),
             PluginEnum::VfoxBackend(plugin) => plugin.execute_external_command(command, args),
+            PluginEnum::Package(plugin) => plugin.execute_external_command(command, args),
         }
     }
 
@@ -130,6 +142,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.update(pr, gitref).await,
             PluginEnum::Vfox(plugin) => plugin.update(pr, gitref).await,
             PluginEnum::VfoxBackend(plugin) => plugin.update(pr, gitref).await,
+            PluginEnum::Package(plugin) => plugin.update(pr, gitref).await,
         }
     }
 
@@ -138,6 +151,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.uninstall(pr).await,
             PluginEnum::Vfox(plugin) => plugin.uninstall(pr).await,
             PluginEnum::VfoxBackend(plugin) => plugin.uninstall(pr).await,
+            PluginEnum::Package(plugin) => plugin.uninstall(pr).await,
         }
     }
 
@@ -146,6 +160,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.is_installed(),
             PluginEnum::Vfox(plugin) => plugin.is_installed(),
             PluginEnum::VfoxBackend(plugin) => plugin.is_installed(),
+            PluginEnum::Package(plugin) => plugin.is_installed(),
         }
     }
 
@@ -154,6 +169,7 @@ impl PluginEnum {
             PluginEnum::Asdf(plugin) => plugin.is_installed_err(),
             PluginEnum::Vfox(plugin) => plugin.is_installed_err(),
             PluginEnum::VfoxBackend(plugin) => plugin.is_installed_err(),
+            PluginEnum::Package(plugin) => plugin.is_installed_err(),
         }
     }
 
@@ -170,6 +186,9 @@ impl PluginEnum {
             PluginEnum::VfoxBackend(plugin) => {
                 plugin.ensure_installed(config, mpr, force, dry_run).await
             }
+            PluginEnum::Package(plugin) => {
+                plugin.ensure_installed(config, mpr, force, dry_run).await
+            }
         }
     }
 }
@@ -180,6 +199,7 @@ impl PluginType {
             Some("asdf") => Ok(Self::Asdf),
             Some("vfox") => Ok(Self::Vfox),
             Some("vfox-backend") => Ok(Self::VfoxBackend),
+            Some("package") => Ok(Self::Package),
             _ => Err(eyre!("unknown plugin type: {full}")),
         }
     }
@@ -189,6 +209,8 @@ impl PluginType {
             (Self::Vfox, name)
         } else if let Some(name) = key.strip_prefix("vfox-backend:") {
             (Self::VfoxBackend, name)
+        } else if let Some(name) = key.strip_prefix("package:") {
+            (Self::Package, name)
         } else if let Some(name) = key.strip_prefix("asdf:") {
             (Self::Asdf, name)
         } else {
@@ -199,7 +221,9 @@ impl PluginType {
 
     pub fn from_plugin_path(path: &Path) -> Option<Self> {
         if path.join("metadata.lua").exists() {
-            if path.join("hooks").join("backend_install.lua").exists() {
+            if path.join("hooks").join("package_install.lua").exists() {
+                Some(Self::Package)
+            } else if path.join("hooks").join("backend_install.lua").exists() {
                 Some(Self::VfoxBackend)
             } else {
                 Some(Self::Vfox)
@@ -219,6 +243,7 @@ impl PluginType {
             PluginType::VfoxBackend => {
                 PluginEnum::VfoxBackend(Arc::new(VfoxPlugin::new(short, path)))
             }
+            PluginType::Package => PluginEnum::Package(Arc::new(VfoxPlugin::new(short, path))),
         }
     }
 }
@@ -635,6 +660,14 @@ mod tests {
             (PluginType::VfoxBackend, "npm")
         );
         assert_eq!(
+            PluginType::from_plugin_config("package:vscode"),
+            (PluginType::Package, "vscode")
+        );
+        assert_eq!(
+            PluginType::from_full("package:vscode").unwrap(),
+            PluginType::Package
+        );
+        assert_eq!(
             PluginType::from_plugin_config("asdf:node"),
             (PluginType::Asdf, "node")
         );
@@ -671,6 +704,15 @@ mod tests {
         assert_eq!(
             PluginType::from_plugin_path(backend.path()),
             Some(PluginType::VfoxBackend)
+        );
+
+        let package = tempfile::tempdir().unwrap();
+        fs::write(package.path().join("metadata.lua"), "").unwrap();
+        file::create_dir_all(package.path().join("hooks")).unwrap();
+        fs::write(package.path().join("hooks/package_install.lua"), "").unwrap();
+        assert_eq!(
+            PluginType::from_plugin_path(package.path()),
+            Some(PluginType::Package)
         );
     }
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -221,10 +221,13 @@ impl PluginType {
 
     pub fn from_plugin_path(path: &Path) -> Option<Self> {
         if path.join("metadata.lua").exists() {
-            if path.join("hooks").join("package_install.lua").exists() {
-                Some(Self::Package)
-            } else if path.join("hooks").join("backend_install.lua").exists() {
+            let hooks = path.join("hooks");
+            if hooks.join("backend_install.lua").exists() {
                 Some(Self::VfoxBackend)
+            } else if hooks.join("package_install.lua").exists()
+                && hooks.join("package_installed.lua").exists()
+            {
+                Some(Self::Package)
             } else {
                 Some(Self::Vfox)
             }
@@ -712,7 +715,18 @@ mod tests {
         fs::write(package.path().join("hooks/package_install.lua"), "").unwrap();
         assert_eq!(
             PluginType::from_plugin_path(package.path()),
+            Some(PluginType::Vfox)
+        );
+        fs::write(package.path().join("hooks/package_installed.lua"), "").unwrap();
+        assert_eq!(
+            PluginType::from_plugin_path(package.path()),
             Some(PluginType::Package)
+        );
+
+        fs::write(package.path().join("hooks/backend_install.lua"), "").unwrap();
+        assert_eq!(
+            PluginType::from_plugin_path(package.path()),
+            Some(PluginType::VfoxBackend)
         );
     }
 

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -284,10 +284,20 @@ impl Plugin for VfoxPlugin {
         let prefix = format!("plugin:{}", style(&self.name).blue().for_stderr());
         let pr = mpr.add_with_options(&prefix, dry_run);
         if !dry_run {
-            let _lock = lock_file::get(&self.plugin_path, force)?;
+            let plugin_lock = lock_file::get(&self.plugin_path, force)?;
             self.install(config, pr.as_ref()).await?;
             let plugin_type =
                 PluginType::from_plugin_path(&self.plugin_path).unwrap_or(PluginType::Vfox);
+            if plugin_type == PluginType::Package
+                && crate::system::packages::is_builtin_manager_name(&self.name)
+            {
+                drop(plugin_lock);
+                file::remove_all(&self.plugin_path)?;
+                bail!(
+                    "package plugin '{}' collides with a built-in package manager",
+                    self.name
+                );
+            }
             install_state::add_plugin(&self.name, plugin_type).await?;
             backend::remove(&self.name);
             warn_if_env_plugin_shadows_registry(&self.name, &self.plugin_path);

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -463,7 +463,7 @@ fn extract_version(text: &str) -> Option<String> {
 /// Pick the first available, settings-enabled package manager that has a hint
 /// for `dep`. Mirrors the manager selection [`crate::system`] applies so we
 /// never propose a manager the driver would reject.
-pub fn pick_manager(dep: &SystemDep) -> Option<Arc<dyn SystemPackageManager>> {
+pub async fn pick_manager(dep: &SystemDep) -> Option<Arc<dyn SystemPackageManager>> {
     let enabled = Settings::get().system_packages.managers.clone();
     for m in packages::all_managers() {
         let name = m.name();
@@ -473,7 +473,7 @@ pub fn pick_manager(dep: &SystemDep) -> Option<Arc<dyn SystemPackageManager>> {
         {
             continue;
         }
-        if !m.is_available() {
+        if m.unavailable_reason_async().await.is_some() {
             continue;
         }
         if dep.packages.contains_key(name) {
@@ -486,13 +486,13 @@ pub fn pick_manager(dep: &SystemDep) -> Option<Arc<dyn SystemPackageManager>> {
 /// Group missing deps into per-manager [`PackageRequest`]s for remediation.
 /// Returns `(by_manager, unremediable)` where `unremediable` are deps with no
 /// available manager hint.
-pub fn build_requests(
+pub async fn build_requests(
     missing: &[&SystemDep],
 ) -> (IndexMap<String, Vec<PackageRequest>>, Vec<SystemDep>) {
     let mut by_mgr: IndexMap<String, Vec<PackageRequest>> = IndexMap::new();
     let mut unremediable = vec![];
     for dep in missing {
-        match pick_manager(dep) {
+        match pick_manager(dep).await {
             Some(m) => {
                 let pkg = dep.packages.get(m.name()).cloned().unwrap_or_default();
                 let requests = by_mgr.entry(m.name().to_string()).or_default();
@@ -512,8 +512,8 @@ pub fn build_requests(
 
 /// Copy-pasteable install hint commands for `missing`, grouped by the manager
 /// that would satisfy each. Used by warn mode.
-pub fn hint_commands(missing: &[&SystemDep]) -> Vec<String> {
-    let (by_mgr, _) = build_requests(missing);
+pub async fn hint_commands(missing: &[&SystemDep]) -> Vec<String> {
+    let (by_mgr, _) = build_requests(missing).await;
     by_mgr
         .into_iter()
         .map(|(mgr, requests)| {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1233,6 +1233,10 @@ fn resolve_managers(
         .system_packages
         .managers
         .clone();
+    let managers = packages::all_managers()
+        .into_iter()
+        .map(|manager| (manager.name().to_string(), manager))
+        .collect::<IndexMap<_, _>>();
     let mut out = vec![];
     for (name, requests) in by_mgr {
         let disabled = enabled.as_ref().is_some_and(|e| !e.contains(&name));
@@ -1243,9 +1247,9 @@ fn resolve_managers(
                 enabled.as_deref().unwrap_or_default().join(", ")
             );
         }
-        match packages::get_manager(&name) {
+        match managers.get(&name) {
             Some(manager) => out.push(ManagerPackages {
-                manager,
+                manager: manager.clone(),
                 requests,
                 disabled,
             }),

--- a/src/system/packages/apk.rs
+++ b/src/system/packages/apk.rs
@@ -52,7 +52,7 @@ fn apk_name(req: &PackageRequest) -> String {
 
 #[async_trait(?Send)]
 impl SystemPackageManager for ApkManager {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "apk"
     }
 

--- a/src/system/packages/apt.rs
+++ b/src/system/packages/apt.rs
@@ -103,7 +103,7 @@ fn parse_dpkg_query(output: &str, requests: &[PackageRequest]) -> Vec<PackageSta
 
 #[async_trait(?Send)]
 impl SystemPackageManager for AptManager {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "apt"
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -192,7 +192,7 @@ impl BinaryArtifact {
 
 #[async_trait(?Send)]
 impl SystemPackageManager for BrewCaskManager {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "brew-cask"
     }
 

--- a/src/system/packages/brew/mod.rs
+++ b/src/system/packages/brew/mod.rs
@@ -194,7 +194,7 @@ impl BrewManager {
 
 #[async_trait(?Send)]
 impl SystemPackageManager for BrewManager {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "brew"
     }
 

--- a/src/system/packages/dnf.rs
+++ b/src/system/packages/dnf.rs
@@ -87,7 +87,7 @@ fn parse_rpm_query(output: &str, requests: &[PackageRequest]) -> Vec<PackageStat
 
 #[async_trait(?Send)]
 impl SystemPackageManager for DnfManager {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "dnf"
     }
 

--- a/src/system/packages/flatpak.rs
+++ b/src/system/packages/flatpak.rs
@@ -74,7 +74,7 @@ async fn run_flatpak(args: &[String], action: &str) -> Result<()> {
 
 #[async_trait(?Send)]
 impl SystemPackageManager for FlatpakManager {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "flatpak"
     }
 

--- a/src/system/packages/mas.rs
+++ b/src/system/packages/mas.rs
@@ -201,7 +201,7 @@ async fn mas_list() -> Result<Vec<InstalledApp>> {
 
 #[async_trait(?Send)]
 impl SystemPackageManager for MasManager {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "mas"
     }
 

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -88,6 +88,15 @@ pub trait SystemPackageManager: Send + Sync {
     /// human-readable reason `is_available()` is false, for `status`/`doctor`
     fn unavailable_reason(&self) -> String;
 
+    /// Return why this manager cannot run, or `None` when it is available.
+    ///
+    /// The async form lets plugin managers resolve host binaries from mise's
+    /// global toolset as well as the process PATH and shims. Built-in managers
+    /// use the synchronous checks above by default.
+    async fn unavailable_reason_async(&self) -> Option<String> {
+        (!self.is_available()).then(|| self.unavailable_reason())
+    }
+
     /// Query installed state. Must be side-effect free and never elevate.
     async fn installed(&self, pkgs: &[PackageRequest]) -> Result<Vec<PackageStatus>>;
 
@@ -113,6 +122,7 @@ pub trait SystemPackageManager: Send + Sync {
     }
 
     /// Whether this manager is supplied by a package plugin.
+    #[allow(dead_code)] // used by the stacked bootstrap orchestration change
     fn is_plugin(&self) -> bool {
         false
     }

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -155,7 +155,10 @@ pub fn all_managers() -> Vec<Arc<dyn SystemPackageManager>> {
         .iter()
         .map(|manager| manager.name().to_string())
         .collect::<std::collections::HashSet<_>>();
-    for (name, plugin_type) in crate::toolset::install_state::list_plugins().iter() {
+    let Some(plugins) = crate::toolset::install_state::try_list_plugins() else {
+        return managers;
+    };
+    for (name, plugin_type) in plugins.iter() {
         if *plugin_type != crate::plugins::PluginType::Package {
             continue;
         }
@@ -171,8 +174,4 @@ pub fn all_managers() -> Vec<Arc<dyn SystemPackageManager>> {
         }
     }
     managers
-}
-
-pub fn get_manager(name: &str) -> Option<Arc<dyn SystemPackageManager>> {
-    all_managers().into_iter().find(|m| m.name() == name)
 }

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -17,6 +17,7 @@ pub mod dnf;
 pub mod flatpak;
 pub mod mas;
 pub mod pacman;
+pub mod plugin;
 
 /// A single package entry from `[bootstrap.packages]` — the part after the
 /// `manager:` prefix of a `"manager:package" = "version"` config entry.
@@ -77,7 +78,7 @@ pub struct InstallOpts {
 #[async_trait(?Send)]
 pub trait SystemPackageManager: Send + Sync {
     /// config key, e.g. "apt", "brew"
-    fn name(&self) -> &'static str;
+    fn name(&self) -> &str;
 
     /// whether this manager can run on this machine (OS + required binaries).
     /// Entries for unavailable managers are silently skipped so configs can be
@@ -110,9 +111,14 @@ pub trait SystemPackageManager: Send + Sync {
     fn supports_version_pins(&self) -> bool {
         true
     }
+
+    /// Whether this manager is supplied by a package plugin.
+    fn is_plugin(&self) -> bool {
+        false
+    }
 }
 
-pub fn all_managers() -> Vec<Arc<dyn SystemPackageManager>> {
+pub fn builtin_managers() -> Vec<Arc<dyn SystemPackageManager>> {
     vec![
         Arc::new(apk::ApkManager::new()),
         Arc::new(apt::AptManager::new()),
@@ -125,6 +131,36 @@ pub fn all_managers() -> Vec<Arc<dyn SystemPackageManager>> {
         Arc::new(mas::MasManager::new()),
         Arc::new(pacman::PacmanManager::new()),
     ]
+}
+
+pub fn is_builtin_manager_name(name: &str) -> bool {
+    builtin_managers()
+        .iter()
+        .any(|manager| manager.name() == name)
+}
+
+pub fn all_managers() -> Vec<Arc<dyn SystemPackageManager>> {
+    let mut managers = builtin_managers();
+    let builtins = managers
+        .iter()
+        .map(|manager| manager.name().to_string())
+        .collect::<std::collections::HashSet<_>>();
+    for (name, plugin_type) in crate::toolset::install_state::list_plugins().iter() {
+        if *plugin_type != crate::plugins::PluginType::Package {
+            continue;
+        }
+        if builtins.contains(name) {
+            warn!(
+                "package plugin '{name}' collides with a built-in package manager; ignoring plugin"
+            );
+            continue;
+        }
+        match plugin::PackagePluginManager::new(name.clone()) {
+            Ok(manager) => managers.push(Arc::new(manager)),
+            Err(err) => warn!("failed to load package plugin '{name}': {err:#}"),
+        }
+    }
+    managers
 }
 
 pub fn get_manager(name: &str) -> Option<Arc<dyn SystemPackageManager>> {

--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -75,7 +75,7 @@ fn parse_pacman_query(output: &str, requests: &[PackageRequest]) -> Vec<PackageS
 
 #[async_trait(?Send)]
 impl SystemPackageManager for PacmanManager {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "pacman"
     }
 

--- a/src/system/packages/plugin.rs
+++ b/src/system/packages/plugin.rs
@@ -1,0 +1,232 @@
+use std::env::{join_paths, split_paths};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::{WrapErr, bail};
+use heck::ToKebabCase;
+use indexmap::IndexMap;
+use tokio::sync::OnceCell;
+use vfox::{PackageActionContext, PackageInstalledContext, PackageRequest as VfoxPackageRequest};
+
+use super::{InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager};
+use crate::config::Config;
+use crate::plugins::mise_plugin_toml::{MisePluginToml, MisePluginTomlPackageManagerConfig};
+use crate::plugins::vfox_plugin::VfoxPlugin;
+use crate::result::Result;
+use crate::toolset::{ConfigScope, ToolsetBuilder};
+
+#[derive(Debug)]
+pub struct PackagePluginManager {
+    name: String,
+    plugin: Arc<VfoxPlugin>,
+    config: MisePluginTomlPackageManagerConfig,
+    hook_env: OnceCell<IndexMap<String, String>>,
+}
+
+impl PackagePluginManager {
+    pub fn new(name: String) -> Result<Self> {
+        let plugin_path = crate::dirs::PLUGINS.join(name.to_kebab_case());
+        let config =
+            MisePluginToml::from_file(&plugin_path.join("mise.plugin.toml"))?.package_manager;
+        let plugin = Arc::new(VfoxPlugin::new(name.clone(), plugin_path));
+        Ok(Self {
+            name,
+            plugin,
+            config,
+            hook_env: OnceCell::new(),
+        })
+    }
+
+    fn platform_available(&self) -> bool {
+        self.config.os.as_ref().is_none_or(|oses| {
+            oses.iter()
+                .any(|os| os == crate::config::Settings::get().os())
+        })
+    }
+
+    fn sync_lookup_path() -> Vec<PathBuf> {
+        let mut paths: Vec<PathBuf> = std::env::var_os("PATH")
+            .map(|path| split_paths(&path).collect())
+            .unwrap_or_default();
+        if !paths.iter().any(|path| path == *crate::dirs::SHIMS) {
+            paths.push(crate::dirs::SHIMS.to_path_buf());
+        }
+        paths
+    }
+
+    fn missing_from_path(&self, paths: &[PathBuf]) -> Option<&str> {
+        let path = join_paths(paths).ok()?;
+        let cwd = std::env::current_dir().ok()?;
+        self.config
+            .requires
+            .iter()
+            .find(|binary| which::which_in(binary, Some(&path), &cwd).is_err())
+            .map(String::as_str)
+    }
+
+    async fn hook_env(&self) -> Result<&IndexMap<String, String>> {
+        self.hook_env
+            .get_or_try_init(|| async {
+                let config = Config::get().await?;
+                let toolset = ToolsetBuilder::new()
+                    .with_scope(ConfigScope::GlobalOnly)
+                    .build(&config)
+                    .await?;
+                let mut paths = Self::sync_lookup_path();
+                paths.extend(toolset.list_paths(&config).await);
+                let path =
+                    join_paths(&paths).wrap_err("failed to construct package plugin PATH")?;
+                let mut env: IndexMap<String, String> = std::env::vars().collect();
+                env.insert("PATH".into(), path.to_string_lossy().into_owned());
+                Ok(env)
+            })
+            .await
+    }
+
+    async fn checked_hook_env(&self) -> Result<&IndexMap<String, String>> {
+        let env = self.hook_env().await?;
+        let paths = env
+            .get("PATH")
+            .map(|path| split_paths(path).collect::<Vec<_>>())
+            .unwrap_or_default();
+        if let Some(binary) = self.missing_from_path(&paths) {
+            bail!(
+                "{} is not available: required binary '{binary}' not found; add it to [tools] or install it manually",
+                self.name
+            );
+        }
+        Ok(env)
+    }
+
+    fn requests(pkgs: &[PackageRequest]) -> Vec<VfoxPackageRequest> {
+        pkgs.iter()
+            .map(|pkg| VfoxPackageRequest {
+                name: pkg.name.clone(),
+                version: pkg.version.clone(),
+            })
+            .collect()
+    }
+
+    fn vfox(&self, env: &IndexMap<String, String>) -> Result<vfox::Vfox> {
+        let (mut vfox, _) = self.plugin.vfox()?;
+        vfox.cmd_env = Some(env.clone());
+        Ok(vfox)
+    }
+
+    async fn action(
+        &self,
+        pkgs: &[PackageRequest],
+        opts: &InstallOpts,
+        upgrade: bool,
+    ) -> Result<()> {
+        let env = self.checked_hook_env().await?;
+        let vfox = self.vfox(env)?;
+        let ctx = PackageActionContext {
+            packages: Self::requests(pkgs),
+            dry_run: opts.dry_run,
+            update: opts.update,
+        };
+        if upgrade
+            && self
+                .plugin
+                .plugin_path
+                .join("hooks/package_upgrade.lua")
+                .exists()
+        {
+            vfox.package_upgrade(&self.name, ctx).await?;
+        } else {
+            vfox.package_install(&self.name, ctx).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl SystemPackageManager for PackagePluginManager {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn is_available(&self) -> bool {
+        self.platform_available() && self.missing_from_path(&Self::sync_lookup_path()).is_none()
+    }
+
+    fn unavailable_reason(&self) -> String {
+        if !self.platform_available() {
+            return format!("not available on {}", crate::config::Settings::get().os());
+        }
+        match self.missing_from_path(&Self::sync_lookup_path()) {
+            Some(binary) => format!(
+                "required binary '{binary}' not found; add it to [tools] or install it manually"
+            ),
+            None => "unavailable".to_string(),
+        }
+    }
+
+    async fn installed(&self, pkgs: &[PackageRequest]) -> Result<Vec<PackageStatus>> {
+        let env = self.checked_hook_env().await?;
+        let response = self
+            .vfox(env)?
+            .package_installed(
+                &self.name,
+                PackageInstalledContext {
+                    packages: Self::requests(pkgs),
+                },
+            )
+            .await?;
+        let by_name: std::collections::HashMap<_, _> = response
+            .packages
+            .into_iter()
+            .map(|pkg| (pkg.name.clone(), pkg))
+            .collect();
+        pkgs.iter()
+            .map(|request| {
+                let returned = by_name.get(&request.name);
+                let state = match returned {
+                    Some(pkg) if pkg.state == "installed" => {
+                        let installed = pkg.version.clone().unwrap_or_default();
+                        match &request.version {
+                            Some(requested) if requested != &installed => {
+                                PackageState::VersionMismatch { installed }
+                            }
+                            _ => PackageState::Installed { version: installed },
+                        }
+                    }
+                    Some(pkg) if pkg.state == "missing" => PackageState::Missing,
+                    Some(pkg) => bail!(
+                        "{} package hook returned invalid state '{}' for '{}'",
+                        self.name,
+                        pkg.state,
+                        request.name
+                    ),
+                    None => bail!(
+                        "{} package hook did not return state for '{}'",
+                        self.name,
+                        request.name
+                    ),
+                };
+                Ok(PackageStatus {
+                    request: request.clone(),
+                    state,
+                })
+            })
+            .collect()
+    }
+
+    async fn install(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        self.action(pkgs, opts, false).await
+    }
+
+    async fn upgrade(&self, pkgs: &[PackageRequest], opts: &InstallOpts) -> Result<()> {
+        self.action(pkgs, opts, true).await
+    }
+
+    fn supports_version_pins(&self) -> bool {
+        self.config.supports_version_pins
+    }
+
+    fn is_plugin(&self) -> bool {
+        true
+    }
+}

--- a/src/system/packages/plugin.rs
+++ b/src/system/packages/plugin.rs
@@ -164,6 +164,28 @@ impl SystemPackageManager for PackagePluginManager {
         }
     }
 
+    async fn unavailable_reason_async(&self) -> Option<String> {
+        if !self.platform_available() {
+            return Some(format!(
+                "not available on {}",
+                crate::config::Settings::get().os()
+            ));
+        }
+        let env = match self.hook_env().await {
+            Ok(env) => env,
+            Err(err) => return Some(format!("failed to resolve host tool PATH: {err:#}")),
+        };
+        let paths = env
+            .get("PATH")
+            .map(|path| split_paths(path).collect::<Vec<_>>())
+            .unwrap_or_default();
+        self.missing_from_path(&paths).map(|binary| {
+            format!(
+                "required binary '{binary}' not found; add it to [tools] or install it manually"
+            )
+        })
+    }
+
     async fn installed(&self, pkgs: &[PackageRequest]) -> Result<Vec<PackageStatus>> {
         let env = self.checked_hook_env().await?;
         let response = self

--- a/src/toolset/helpers.rs
+++ b/src/toolset/helpers.rs
@@ -122,7 +122,7 @@ async fn preflight_system_deps_inner(
         .map(|(_, s)| s.dep.clone())
         .collect();
     let refs: Vec<&SystemDep> = missing_deps.iter().collect();
-    let (mut by_mgr, unremediable) = deps::build_requests(&refs);
+    let (mut by_mgr, unremediable) = deps::build_requests(&refs).await;
     // Attach any `[bootstrap.brew.taps]` git URLs so a tapped formula hint can
     // be installed the same way `mise bootstrap packages use` handles it.
     crate::system::attach_brew_tap_urls(config, &mut by_mgr);
@@ -138,7 +138,7 @@ async fn preflight_system_deps_inner(
     }
 
     if effective == SystemDepsMode::Warn {
-        for line in deps::hint_commands(&refs) {
+        for line in deps::hint_commands(&refs).await {
             warn!("install with: {line}");
         }
         return Ok(());
@@ -176,11 +176,12 @@ async fn preflight_system_deps_inner(
     // package-manager hint), bypassing the memo cache. Deps with no hint, or
     // that the user declined at the driver prompt, are excluded — warning that
     // they "were installed but not detected" would be wrong.
-    let remediated: Vec<SystemDep> = missing_deps
-        .iter()
-        .filter(|d| deps::pick_manager(d).is_some())
-        .cloned()
-        .collect();
+    let mut remediated = vec![];
+    for dep in &missing_deps {
+        if deps::pick_manager(dep).await.is_some() {
+            remediated.push(dep.clone());
+        }
+    }
     for status in deps::detect_fresh(&remediated).await {
         if !status.satisfied {
             warn!(

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -438,12 +438,15 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
 }
 
 pub fn list_plugins() -> Arc<BTreeMap<String, PluginType>> {
+    try_list_plugins().expect("INSTALL_STATE_PLUGINS is None")
+}
+
+pub fn try_list_plugins() -> Option<Arc<BTreeMap<String, PluginType>>> {
     INSTALL_STATE_PLUGINS
         .lock()
         .expect("INSTALL_STATE_PLUGINS lock failed")
         .as_ref()
-        .expect("INSTALL_STATE_PLUGINS is None")
-        .clone()
+        .cloned()
 }
 
 fn is_banned_plugin(path: &Path) -> bool {

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -416,6 +416,7 @@ async fn init_tools() -> MutexResult<InstallStateTools> {
             PluginType::Asdf => format!("asdf:{short}"),
             PluginType::Vfox => format!("vfox:{short}"),
             PluginType::VfoxBackend => short.clone(),
+            PluginType::Package => continue,
         };
         let tool = tools
             .entry(short.clone())


### PR DESCRIPTION
## Summary
- add `PluginType::Package` and Lua package installed/install/upgrade hooks to the vfox runtime
- adapt installed package plugins to `SystemPackageManager`, including metadata-driven requirements, OS filtering, opaque version matching, and upgrade fallback
- discover plugin managers alongside built-ins while preserving built-in precedence and rejecting install-time name collisions
- inject shims and global toolset bin paths into package hook subprocesses

## Validation
- `mise run lint-fix`
- `mise run test` (1,703 unit tests plus E2E task)
- `mise --cd crates/vfox run test` (91 passed, 2 ignored)
- focused package-plugin E2E coverage is included in the stacked follow-up PR

## Follow-up
A stacked PR adds `[bootstrap.plugins]`, two-phase bootstrap orchestration, generated CLI/schema artifacts, end-to-end coverage, and documentation.

## Out of scope (v1)
- uninstall/prune of removed package entries (`PackageUninstall` remains a future extension)
- registry shorthands for package plugins
- Windows E2E coverage beyond keeping the vfox code path enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches system package orchestration and plugin classification across bootstrap, doctor, and install paths; incorrect availability or hook env could skip or mis-run package installs, but built-in precedence and collision guards limit blast radius.
> 
> **Overview**
> Adds **package manager plugins** as a first-class `PluginType::Package`, wired through new vfox Lua hooks (`PackageInstalled`, `PackageInstall`, `PackageUpgrade`) and Rust↔Lua types for package lists, dry-run, and opaque version strings.
> 
> Plugins that expose `hooks/package_install.lua` and `hooks/package_installed.lua` are discovered as managers alongside built-ins via `PackagePluginManager`, which implements `SystemPackageManager` using `mise.plugin.toml` **`[package-manager]`** (required binaries, OS filter, version-pin support). Hook subprocesses get PATH from shims plus the **global toolset**; built-in manager names win on collisions and install is rejected if a package plugin shadows a built-in.
> 
> **`unavailable_reason_async`** replaces sync `is_available()` checks in bootstrap, doctor, install hints, system driver/status/use, and system-deps remediation so plugin managers can resolve host tools asynchronously. Package plugins are explicitly **not** tool backends in `BackendArg` resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88dfea27ec4f2ca5a8cb5501443f41d1aab6b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Lua-backed package hook entry points for querying installed packages and triggering install/upgrade actions.
  - Introduced a `[package-manager]` configuration section for package-manager plugins (requirements, version-pin support, optional platform constraints).
  - Package plugins are now recognized as package managers via `package:` identifiers, including hook loading and install/upgrade dispatch.

- **Bug Fixes**
  - Prevented package plugins from colliding with built-in package manager names.
  - Improved package-manager availability diagnostics and skipping across system status, install, bootstrap, system-use, and dependency remediation by using async unavailability reasoning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->