### PR TITLE
perf: cut ~2ms of startup by fixing config glob scans and clap double-build

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,7 +5,7 @@ use crate::ui::{self, ctrlc};
 use crate::{Result, backend};
 use crate::{cli::args::ToolArg, path::PathExt};
 use crate::{hook_env as hook_env_module, logger, migrate, shims};
-use clap::{ArgAction, CommandFactory, Parser, Subcommand};
+use clap::{ArgAction, CommandFactory, Subcommand};
 use eyre::bail;
 use std::path::PathBuf;
 
@@ -473,8 +473,8 @@ fn uses_deprecated_backends_alias(cmd: &clap::Command, args: &[String]) -> bool 
     )
 }
 
-fn warn_deprecated_backends_alias(cmd: &clap::Command, args: &[String]) {
-    if uses_deprecated_backends_alias(cmd, args) {
+fn warn_deprecated_backends_alias(uses_alias: bool) {
+    if uses_alias {
         deprecated_at!(
             "2026.4.0",
             "2027.4.0",
@@ -656,13 +656,20 @@ impl Cli {
             });
         }
         // Pre-process args to handle naked runs before clap parsing
-        let cmd = Cli::command();
+        let cmd = measure!("build_cli_command", { Cli::command() });
         let processed_args = preprocess_args_for_naked_run(&cmd, args);
         // Escape flags after task names so they go to tasks, not mise
         let processed_args = escape_task_args(&cmd, &processed_args);
+        let deprecated_backends_alias = uses_deprecated_backends_alias(&cmd, args);
 
+        // Reuse the already-built clap command rather than letting
+        // `Cli::parse_from` construct the whole tree a second time.
         let cli = measure!("get_matches_from", {
-            Cli::parse_from(processed_args.iter())
+            let matches = cmd.get_matches_from(processed_args.iter());
+            match <Cli as clap::FromArgMatches>::from_arg_matches(&matches) {
+                Ok(cli) => cli,
+                Err(err) => err.format(&mut Cli::command()).exit(),
+            }
         });
         // Validate --cd path BEFORE Settings processes it and changes the directory
         validate_cd_path(&cli.cd)?;
@@ -673,7 +680,7 @@ impl Cli {
             measure!("registry::refresh", { crate::registry::refresh().await });
             let _ = measure!("backend::load_tools", { backend::load_tools().await });
         }
-        warn_deprecated_backends_alias(&cmd, args);
+        warn_deprecated_backends_alias(deprecated_backends_alias);
         measure!("migrate", { migrate::run().await });
         if let Err(err) = crate::cache::auto_prune() {
             warn!("auto_prune failed: {err:?}");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1378,11 +1378,7 @@ pub fn load_config_paths(config_filenames: &[String], include_ignored: bool) -> 
             if config_dir_is_ignored(dir, include_ignored) {
                 vec![]
             } else {
-                config_filenames
-                    .iter()
-                    .rev()
-                    .flat_map(|f| glob(dir, f).unwrap_or_default().into_iter().rev())
-                    .collect()
+                config_paths_in_dir_with_filenames(dir, config_filenames)
             }
         })
         .collect::<Vec<_>>();

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -476,8 +476,10 @@ impl Settings {
                 CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
             ))
             .env();
+        time!("try_get builder1+env");
 
         let mut settings = sb.load()?;
+        time!("try_get load1");
         if let Some(mut cd) = settings.cd {
             static ORIG_PATH: Lazy<std::io::Result<PathBuf>> = Lazy::new(env::current_dir);
             if cd.is_relative() {
@@ -492,12 +494,16 @@ impl Settings {
                 CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
             ))
             .env();
+        time!("try_get builder2+env");
         for file in Self::all_settings_files() {
             sb = sb.preloaded(file);
         }
+        time!("try_get all_settings_files");
         sb = sb.preloaded(DEFAULT_SETTINGS.clone());
+        time!("try_get default_settings");
 
         settings = sb.load()?;
+        time!("try_get load2");
         if !settings.legacy_version_file {
             settings.idiomatic_version_file = Some(false);
         }


### PR DESCRIPTION
## Summary

Profiling `mise version` / `mise hook-env` startup (via `MISE_TIMINGS` checkpoints) found two fixed costs paid by every invocation:

- **`load_config_paths()` ran `glob::glob()` for every config filename in every ancestor directory** — ~19 patterns × cwd depth ≈ 200 glob compiles + filesystem walks per startup, even though only `conf.d/*.toml` contains a wildcard. This accounted for 2–4ms of the first `Settings::try_get()`. Fixed by reusing `config_paths_in_dir_with_filenames()`, which stats literal filenames and only globs actual `*` patterns (same logic the per-dir lookup already used).
- **The clap command tree was built twice**: once for naked-run/task-arg preprocessing, then again inside `Cli::parse_from`. Now the already-built tree is used for parsing. The `mise b` deprecation check is computed before the tree is consumed.

Also adds `MISE_TIMINGS` checkpoints inside `Settings::try_get()` so the settings phases (env layers, settings files, defaults, load passes) show up in future profiling.

## Benchmarks

macOS arm64 (M-series), hyperfine, warm runs, isolated `MISE_DATA_DIR`/`MISE_CACHE_DIR`/`MISE_CONFIG_DIR`, one tool installed (`node@22.17.0` via `.tool-versions`):

| Scenario | before | after |
|---|---|---|
| `mise version` | 8.1 ms | 6.6 ms |
| `mise hook-env -s zsh` (full run) | 10.9 ms | 9.3 ms |
| `mise hook-env -s zsh` (early-exit fast path) | — | 6.3 ms |
| `mise exec -- node --version` | 20.8 ms | 18.8 ms |
| shim `node --version` | 20.7 ms | 18.9 ms |

Remaining startup floor (~5ms) is process spawn + dyld on the ~100MB binary plus config/toolset resolution, not these code paths.

## Verification

- Config discovery output verified byte-identical against the previous release on a nested layout exercising `conf.d/*.toml` globs, `.config/mise/config.toml`, `mise.local.toml`, and settings layering (`mise config ls`, `mise env`, `mise settings`)
- e2e: `test_config_ls`, `test_config_ceiling_paths`, `test_config_ignore`, `test_config_ignored_paths`, `test_config_env`, `test_hook_env`, `test_hook_env_dir_mtime_stabilizes`, `test_activate_export`, `test_exec_chdir` pass
- clippy clean

(While testing this I hit a pre-existing, unrelated bash 3.2 `set -u` crash in `src/assets/bash/deactivate.sh` empty-array expansions, which makes `test_hook_env_fast_path` fail when the e2e harness resolves to the macOS system bash — will address separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only refactors on config discovery and CLI parsing with intended behavior parity; risk is mainly regression in config file ordering or edge-case CLI parsing, not security or data handling.
> 
> **Overview**
> **Startup performance** for every `mise` invocation: config discovery and CLI parsing no longer pay redundant work on the hot path.
> 
> `load_config_paths()` now delegates per-directory discovery to `config_paths_in_dir_with_filenames()` instead of running `glob()` for every config filename pattern. Literal names are resolved with existence checks; only patterns containing `*` still glob—matching behavior already used elsewhere and cutting hundreds of glob walks during the first `Settings::try_get()`.
> 
> CLI startup builds the clap command tree once, then parses with `get_matches_from` + `FromArgMatches` instead of `Cli::parse_from` (which rebuilt the tree). The deprecated `mise b` alias check runs before parsing and `warn_deprecated_backends_alias` takes a precomputed bool.
> 
> `Settings::try_get()` gains `MISE_TIMINGS` checkpoints around env layers, settings file enumeration, defaults, and both load passes for finer profiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 590f4bd74052daaa579ce1bfcbfa32efbac0f39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved command-line startup efficiency by avoiding repeated command construction during argument parsing.
  * Added more detailed timing measurements for configuration and settings loading.

* **Bug Fixes**
  * Centralized configuration file discovery to provide consistent filename and glob handling.
  * Preserved clearer handling of deprecated backend-alias warnings during CLI execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->