### PR TITLE
fix(shell): guard empty array expansions in bash deactivate under set -u

### DIFF
--- a/src/assets/bash/deactivate.sh
+++ b/src/assets/bash/deactivate.sh
@@ -1,12 +1,12 @@
 # shellcheck shell=bash
 if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
 	_mise_prompt_command=()
-	for _mise_pc in "${PROMPT_COMMAND[@]}"; do
+	for _mise_pc in ${PROMPT_COMMAND[@]+"${PROMPT_COMMAND[@]}"}; do
 		if [[ $_mise_pc != "_mise_hook_prompt_command" && $_mise_pc != "_mise_hook" ]]; then
 			_mise_prompt_command+=("$_mise_pc")
 		fi
 	done
-	PROMPT_COMMAND=("${_mise_prompt_command[@]}")
+	PROMPT_COMMAND=(${_mise_prompt_command[@]+"${_mise_prompt_command[@]}"})
 	unset _mise_prompt_command _mise_pc
 elif [[ ${PROMPT_COMMAND-} == *_mise_hook_prompt_command* ]]; then
 	_mise_prompt_command_value="${PROMPT_COMMAND-}"
@@ -26,12 +26,12 @@ fi
 
 if declare -p chpwd_functions >/dev/null 2>&1; then
 	_mise_chpwd_functions=()
-	for _mise_f in "${chpwd_functions[@]}"; do
+	for _mise_f in ${chpwd_functions[@]+"${chpwd_functions[@]}"}; do
 		if [[ $_mise_f != "_mise_hook_chpwd" && $_mise_f != "_mise_hook" ]]; then
 			_mise_chpwd_functions+=("$_mise_f")
 		fi
 	done
-	chpwd_functions=("${_mise_chpwd_functions[@]}")
+	chpwd_functions=(${_mise_chpwd_functions[@]+"${_mise_chpwd_functions[@]}"})
 	unset _mise_chpwd_functions _mise_f
 fi
 

--- a/src/shell/snapshots/mise__shell__bash__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__bash__tests__deactivate.snap
@@ -5,12 +5,12 @@ expression: replace_path(&deactivate)
 # shellcheck shell=bash
 if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
 	_mise_prompt_command=()
-	for _mise_pc in "${PROMPT_COMMAND[@]}"; do
+	for _mise_pc in ${PROMPT_COMMAND[@]+"${PROMPT_COMMAND[@]}"}; do
 		if [[ $_mise_pc != "_mise_hook_prompt_command" && $_mise_pc != "_mise_hook" ]]; then
 			_mise_prompt_command+=("$_mise_pc")
 		fi
 	done
-	PROMPT_COMMAND=("${_mise_prompt_command[@]}")
+	PROMPT_COMMAND=(${_mise_prompt_command[@]+"${_mise_prompt_command[@]}"})
 	unset _mise_prompt_command _mise_pc
 elif [[ ${PROMPT_COMMAND-} == *_mise_hook_prompt_command* ]]; then
 	_mise_prompt_command_value="${PROMPT_COMMAND-}"
@@ -30,12 +30,12 @@ fi
 
 if declare -p chpwd_functions >/dev/null 2>&1; then
 	_mise_chpwd_functions=()
-	for _mise_f in "${chpwd_functions[@]}"; do
+	for _mise_f in ${chpwd_functions[@]+"${chpwd_functions[@]}"}; do
 		if [[ $_mise_f != "_mise_hook_chpwd" && $_mise_f != "_mise_hook" ]]; then
 			_mise_chpwd_functions+=("$_mise_f")
 		fi
 	done
-	chpwd_functions=("${_mise_chpwd_functions[@]}")
+	chpwd_functions=(${_mise_chpwd_functions[@]+"${_mise_chpwd_functions[@]}"})
 	unset _mise_chpwd_functions _mise_f
 fi
 


### PR DESCRIPTION
## Summary

`mise deactivate`'s bash script crashes under `set -u` on bash < 4.4 (including macOS system bash 3.2.57) with `unbound variable` errors, because bash < 4.4 treats an empty array expansion `"${arr[@]}"` as unbound. This broke the `cli/test_hook_env_fast_path` e2e test on machines where the harness resolves bash to 3.2, since re-running `eval "$(mise activate bash)"` triggers the deactivate path.

Fixes all four empty-array expansions in `src/assets/bash/deactivate.sh` (the `PROMPT_COMMAND` / `chpwd_functions` for-loops and reassignments) using the `${arr[@]+"${arr[@]}"}` guard idiom already used in `activate.sh`, and regenerates the affected snapshot.

## Testing

All on `/bin/bash` 3.2.57 with `set -u`:
- Guard idiom one-liner prints `ok`; the old unguarded form reproduces the `unbound variable` failure
- Sourcing the fixed script succeeds with empty arrays, populated arrays (mise hooks filtered, other entries preserved), and string `PROMPT_COMMAND`
- `mise run test:e2e test_hook_env_fast_path` passes (all 6 assertions)
- Snapshot regenerated via `cargo insta test --accept`; shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted shell-script change aligned with an existing pattern in activate.sh; snapshot-only test update.
> 
> **Overview**
> Fixes **`mise deactivate`** for bash when **`set -u`** is on and the shell is **bash &lt; 4.4** (e.g. macOS 3.2), where expanding an empty **`"${arr[@]}"`** is treated as an unbound variable.
> 
> **`deactivate.sh`** now uses the same **`${arr[@]+"${arr[@]}"}`** guard as **`activate.sh`** on the four **`PROMPT_COMMAND`** / **`chpwd_functions`** loop and reassignment sites, so empty arrays no longer abort deactivate (including paths hit by re-running **`eval "$(mise activate bash)"`** in e2e). The bash deactivate **insta snapshot** is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aca97722404bcdf71bb573be33de59c87e25e060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell hook cleanup when deactivating, preserving existing `PROMPT_COMMAND` and directory-change functions while removing mise-specific hooks.
  * Enhanced compatibility with different Bash array expansion behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->