### PR TITLE
perf(release): target macOS 12 in tarball builds for chained fixups

### DIFF
--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -75,6 +75,14 @@ if [[ $os == "linux" ]] && [[ $arch == "armv7" ]]; then
 	features="$features,aws-lc-rs"
 fi
 
+if [[ $os == "macos" ]]; then
+	# Targeting macOS 12+ makes ld emit chained fixups (LC_DYLD_CHAINED_FIXUPS),
+	# which dyld applies lazily per page instead of eagerly interpreting ~170k
+	# legacy rebase/bind opcodes on every launch. Measurably faster startup for
+	# a binary this large. macOS 11 (EOL since 2023) cannot run these binaries.
+	export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12.0}
+fi
+
 if [[ $os == "linux" ]]; then
 	cross build --profile=serious --target "$RUST_TRIPLE" --no-default-features --features "$features"
 else


### PR DESCRIPTION
## Summary

Follow-up to #11025, attacking the *pre-main* portion of startup. Profiling showed that after the code-path fixes, ~4.4ms of a trivial `mise` invocation on macOS happens before `main()` — dominated by dyld work and first-touch page-ins on a ~100MB binary.

A large, fixable chunk: the tarball binaries target macOS 11 (`minos 11.0`), so ld emits **legacy `LC_DYLD_INFO_ONLY` rebase/bind opcodes (~170k)** that dyld interprets eagerly on *every launch*. Targeting macOS 12+ switches the linker to **chained fixups (`LC_DYLD_CHAINED_FIXUPS`)**, applied lazily per page. One env var in `scripts/build-tarball.sh`.

## Benchmarks

macOS arm64 (M-series), hyperfine `-N`, warm, isolated env, `mise version`:

| build | fixups | size | pages touched | time |
|---|---|---|---|---|
| release profile | legacy | 103.0 MB | 1810 | 8.0 ms |
| release + target 12 | chained | 103.0 MB | 1358 | 7.2 ms |
| serious (shipped tarball config) | legacy | 84.5 MB | 1646 | 7.1 ms |
| **serious + target 12 (this PR)** | **chained** | 84.5 MB | **1279** | **6.6 ms** |

`mise current`: 11.6 → 10.0 ms; hook-env early-exit fast path (the per-prompt cost of `mise activate`): 6.8 → 6.0 ms. Gains are independent of #11025 and stack with it.

## Compatibility

- **This drops macOS 11 Big Sur support for the official binaries** (EOL since September 2023). On macOS 11 the binary now fails with a clear "requires macOS 12.0" load error instead of running. `MACOSX_DEPLOYMENT_TARGET` is only defaulted (`:-`), so it can still be overridden to produce 11.0-compatible builds if needed.
- Homebrew builds (plain `release` profile, no LTO) are unaffected by this script but show the same relative win if built with a 12.0 target — happy to follow up on the formula.

## Notes from the wider investigation

- Startup attribution with in-binary checkpoints (fast path, warm): env statics 0.19ms, tokio runtime build 0.36ms + ~0.2ms drop, eyre 43µs, session decode 80µs — nothing else worth chasing in-process except `Settings` load, which #11025 addresses.
- `panic = "abort"` for the serious profile would cut ~10MB of unwind tables but is unsafe: the task runner relies on `catch_unwind` (`src/cli/run.rs`, `src/deps/engine.rs`).
- Remaining floor after both PRs is first-touch page-ins across ~50MB of `__text`; the next meaningful lever would be PGO/function ordering for the release builds, which is a much larger CI change.
- Linux may have an analogous win via RELR (`-z pack-relative-relocs`, glibc ≥ 2.36) — not included here.

## Verification

- `otool -l` confirms `LC_DYLD_CHAINED_FIXUPS` + `minos 12.0` on the new binary, legacy opcodes on the old
- Built with the exact tarball feature set (`--no-default-features --features rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored`); binary runs the full benchmark suite correctly
- `shellcheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-script change with a documented platform floor; no runtime app logic, but release artifacts no longer run on macOS 11 unless the target is overridden.
> 
> **Overview**
> **Official macOS tarball builds** now default `MACOSX_DEPLOYMENT_TARGET` to **12.0** in `scripts/build-tarball.sh`, so the linker emits **chained fixups** instead of legacy dyld rebase/bind opcodes—aimed at faster cold startup on large binaries.
> 
> The default uses `${MACOSX_DEPLOYMENT_TARGET:-12.0}`, so it can still be overridden for older targets. **Shipped macOS 11–compatible official binaries are dropped**; those systems get a clear load error instead of running the release binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce323159bdb1bb07a862028c85f2c745ee10167c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build compatibility by applying a default minimum macOS deployment target when none is specified.
  * Preserved any deployment target explicitly configured by the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->