### PR TITLE
refactor: adopt jdx-tar for tar handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,9 +4789,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jdx-tar"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a069d2701497da4e7202dd2aaebbd8c3d55284f759b8698a631ad9f0bab1601"
+checksum = "ea172082e0f86db95eb1eb387cf802b02749322e79219378e59ca390dd0cd284"
 dependencies = [
  "filetime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4788,6 +4788,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jdx-tar"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a069d2701497da4e7202dd2aaebbd8c3d55284f759b8698a631ad9f0bab1601"
+dependencies = [
+ "filetime",
+]
+
+[[package]]
 name = "jiff"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5390,6 +5399,7 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.15.0",
+ "jdx-tar",
  "jiff",
  "junction",
  "landlock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5452,7 +5452,6 @@ dependencies = [
  "supports-hyperlinks",
  "tabled",
  "taplo",
- "tar",
  "tempfile",
  "tera 1.20.1",
  "tera 2.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,6 @@ strum = { version = "0.28", features = ["derive"] }
 supports-hyperlinks = "3"
 tabled = { version = "0.21", features = ["ansi"] }
 taplo = "0.14"
-tar = "0.4"
 tempfile = "3"
 tera = "2"
 tera1 = { package = "tera", version = "1.20.1" }
@@ -265,6 +264,7 @@ ctor = "1"
 insta = { version = "1", features = ["filters", "json"] }
 mockito = "1"
 pretty_assertions = "1"
+tar = "0.4"
 test-log = "0.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ indexmap = { version = "2", features = ["serde"] }
 clx = "2"
 indoc = "2"
 itertools = "0.15"
+jdx-tar = "1.0.0"
 jiff = "0.2"
 junction = "2"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,6 @@ ctor = "1"
 insta = { version = "1", features = ["filters", "json"] }
 mockito = "1"
 pretty_assertions = "1"
-tar = "0.4"
 test-log = "0.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ indexmap = { version = "2", features = ["serde"] }
 clx = "2"
 indoc = "2"
 itertools = "0.15"
-jdx-tar = "1.0.0"
+jdx-tar = "1.1.0"
 jiff = "0.2"
 junction = "2"
 log = "0.4"

--- a/crates/aqua-registry/src/template.rs
+++ b/crates/aqua-registry/src/template.rs
@@ -1,4 +1,4 @@
-use eyre::{ContextCompat, Result, bail};
+use eyre::{ContextCompat, Result, bail, eyre};
 use heck::ToTitleCase;
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -39,7 +39,7 @@ impl Value for StringValue {
     }
 
     fn get_property(&self, _prop: &str) -> Result<String> {
-        bail!("cannot access property on string")
+        Err(eyre!("cannot access property on string"))
     }
 }
 
@@ -62,7 +62,7 @@ impl Value for SemVerValue {
             "Major" => self.major.to_string(),
             "Minor" => self.minor.to_string(),
             "Patch" => self.patch.to_string(),
-            _ => bail!("unknown semver property: {prop}"),
+            _ => return Err(eyre!("unknown semver property: {prop}")),
         })
     }
 }
@@ -265,7 +265,7 @@ fn parse_primary(tokens: &mut std::iter::Peekable<std::slice::Iter<Token>>) -> R
 
             Expr::FuncCall(func_name, args)
         }
-        _ => bail!("unexpected token: {token:?}"),
+        _ => return Err(eyre!("unexpected token: {token:?}")),
     };
 
     parse_property_chain(tokens, expr)
@@ -294,7 +294,7 @@ fn parse_arg(tokens: &mut std::iter::Peekable<std::slice::Iter<Token>>) -> Resul
             tokens.next();
             Ok(Expr::Literal(s.to_string()))
         }
-        _ => bail!("expected argument"),
+        _ => Err(eyre!("expected argument")),
     }
 }
 
@@ -442,7 +442,7 @@ impl<'a> Evaluator<'a> {
                 full_args.push(Expr::Literal(input.as_string()));
                 self.eval_func(func, &full_args)
             }
-            _ => bail!("can only pipe to function calls"),
+            _ => Err(eyre!("can only pipe to function calls")),
         }
     }
 
@@ -470,7 +470,7 @@ impl<'a> Evaluator<'a> {
         if let Some(func_impl) = FUNCTION_REGISTRY.get(func) {
             func_impl(&evaluated_args)
         } else {
-            bail!("unknown function: {func}")
+            Err(eyre!("unknown function: {func}"))
         }
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1227,7 +1227,6 @@ pub fn untar(
     let tar = open_tar(format, archive)?;
     create_dir_all(dest).wrap_err_with(err)?;
     let mut unpack_opts = UnpackOptions::default();
-    unpack_opts.strip_components = opts.strip_components;
     unpack_opts.preserve_mtime = opts.preserve_mtime;
     unpack_opts.on_entry = Some(Box::new(|entry| {
         trace!("extracting {}", entry.path.display());
@@ -1236,7 +1235,12 @@ pub fn untar(
         .unpack(dest, &mut unpack_opts)
         .wrap_err_with(err)?;
     debug!("tar extraction summary: {summary:?}");
-    Ok(())
+    strip_archive_path_components(dest, opts.strip_components).wrap_err_with(|| {
+        format!(
+            "failed to strip path components from tar archive: {}",
+            display_path(archive)
+        )
+    })
 }
 
 fn open_tar(format: ExtractionFormat, archive: &Path) -> Result<Box<dyn std::io::Read>> {
@@ -1909,6 +1913,47 @@ mod tests {
 
         let err = archive_content_files(&archive_path, ExtractionFormat::Tar, 0).unwrap_err();
         assert!(err.to_string().contains("non-regular archive entry"));
+    }
+
+    #[test]
+    fn test_extract_archive_tar_strip_preserves_root_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("tool.tar");
+        let dest = dir.path().join("out");
+        {
+            let file = File::create(&archive_path).unwrap();
+            let mut builder = jdx_tar::Builder::new(file);
+
+            let mut readme = jdx_tar::Header::new_gnu(EntryType::File);
+            readme.set_size(6);
+            readme.set_mode(0o644);
+            builder
+                .append_data(&mut readme, "README", &b"readme"[..])
+                .unwrap();
+
+            let mut tool = jdx_tar::Header::new_gnu(EntryType::File);
+            tool.set_size(4);
+            tool.set_mode(0o644);
+            builder
+                .append_data(&mut tool, "pkg/tool", &b"tool"[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        extract_archive(
+            &archive_path,
+            &dest,
+            ExtractionFormat::Tar,
+            &ExtractOptions {
+                strip_components: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(fs::read(dest.join("README")).unwrap(), b"readme");
+        assert_eq!(fs::read(dest.join("tool")).unwrap(), b"tool");
+        assert!(!dest.join("pkg").exists());
     }
 
     #[tokio::test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1876,13 +1876,13 @@ mod tests {
         let archive_path = dir.path().join("tool.tar");
         {
             let file = File::create(&archive_path).unwrap();
-            let mut builder = tar::Builder::new(file);
-            let mut header = tar::Header::new_gnu();
-            header.set_path("pkg/tool").unwrap();
+            let mut builder = jdx_tar::Builder::new(file);
+            let mut header = jdx_tar::Header::new_gnu(EntryType::File);
             header.set_size(4);
             header.set_mode(0o755);
-            header.set_cksum();
-            builder.append(&header, &b"tool"[..]).unwrap();
+            builder
+                .append_data(&mut header, "pkg/tool", &b"tool"[..])
+                .unwrap();
             builder.finish().unwrap();
         }
 
@@ -1898,15 +1898,12 @@ mod tests {
         let archive_path = dir.path().join("tool.tar");
         {
             let file = File::create(&archive_path).unwrap();
-            let mut builder = tar::Builder::new(file);
-            let mut header = tar::Header::new_gnu();
-            header.set_entry_type(tar::EntryType::Symlink);
-            header.set_path("tool-link").unwrap();
-            header.set_link_name("tool").unwrap();
-            header.set_size(0);
+            let mut builder = jdx_tar::Builder::new(file);
+            let mut header = jdx_tar::Header::new_gnu(EntryType::Symlink);
             header.set_mode(0o777);
-            header.set_cksum();
-            builder.append(&header, std::io::empty()).unwrap();
+            builder
+                .append_link(&mut header, "tool-link", "tool")
+                .unwrap();
             builder.finish().unwrap();
         }
 
@@ -2063,7 +2060,7 @@ mod tests {
         // This reproduces the bug from https://github.com/jdx/mise/discussions/7862
         use flate2::Compression;
         use flate2::write::GzEncoder;
-        use tar::Builder;
+        use jdx_tar::{Builder, Header};
         use tempfile::NamedTempFile;
 
         // Create a temp tar.gz with "./" prefixed paths (like unison's archive)
@@ -2075,11 +2072,9 @@ mod tests {
         // ./dir1/file1
         // ./dir2/file2
         // ./standalone
-        let mut header = tar::Header::new_gnu();
+        let mut header = Header::new_gnu(EntryType::File);
         header.set_size(0);
         header.set_mode(0o755);
-        header.set_entry_type(tar::EntryType::Regular);
-        header.set_cksum();
 
         // Add ./dir1/file1
         builder

--- a/src/file.rs
+++ b/src/file.rs
@@ -1225,6 +1225,7 @@ pub fn untar(
     };
 
     let tar = open_tar(format, archive)?;
+    create_dir_all(dest).wrap_err_with(err)?;
     let mut unpack_opts = UnpackOptions::default();
     unpack_opts.strip_components = opts.strip_components;
     unpack_opts.preserve_mtime = opts.preserve_mtime;

--- a/src/file.rs
+++ b/src/file.rs
@@ -2636,19 +2636,29 @@ mod tests {
         let archive_path = dir.path().join("pax-xattr.tar");
         let dest_dir = dir.path().join("out");
         let archive = File::create(&archive_path).unwrap();
-        let mut builder = tar::Builder::new(archive);
+        let mut builder = jdx_tar::Builder::new(archive);
+
+        let key = "LIBARCHIVE.xattr.com.apple.cs.CodeSignature";
+        let value = b"signature\nmetadata";
+        let rest_len = 3 + key.len() + value.len();
+        let mut digits = 1;
+        while (rest_len + digits).to_string().len() != digits {
+            digits += 1;
+        }
+        let record_len = rest_len + digits;
+        let mut pax = format!("{record_len} {key}=").into_bytes();
+        pax.extend_from_slice(value);
+        pax.push(b'\n');
+        let mut pax_header = jdx_tar::Header::new_gnu(EntryType::Other(b'x'));
+        pax_header.set_size(pax.len() as u64);
         builder
-            .append_pax_extensions([(
-                "LIBARCHIVE.xattr.com.apple.cs.CodeSignature",
-                b"signature\nmetadata".as_slice(),
-            )])
+            .append_data(&mut pax_header, "pax-xattr", pax.as_slice())
             .unwrap();
 
         let contents = b"hello world";
-        let mut header = tar::Header::new_ustar();
+        let mut header = jdx_tar::Header::new_gnu(EntryType::File);
         header.set_size(contents.len() as u64);
         header.set_mode(0o755);
-        header.set_cksum();
         builder
             .append_data(&mut header, "tool", contents.as_slice())
             .unwrap();

--- a/src/file.rs
+++ b/src/file.rs
@@ -19,9 +19,9 @@ use eyre::bail;
 use filetime::{FileTime, set_file_times};
 use flate2::read::GzDecoder;
 use itertools::Itertools;
+use jdx_tar::{Archive, EntryType, UnpackOptions};
 use sha2::{Digest, Sha256};
 use std::sync::LazyLock as Lazy;
-use tar::Archive;
 use walkdir::WalkDir;
 use zip::ZipArchive;
 
@@ -1225,114 +1225,17 @@ pub fn untar(
     };
 
     let tar = open_tar(format, archive)?;
-    // TODO: put this back in when we can read+write in parallel
-    // let mut cur = Cursor::new(vec![]);
-    // let mut total = 0;
-    // loop {
-    //     let mut buf = Cursor::new(vec![0; 1024 * 1024]);
-    //     let n = tar.read(buf.get_mut()).wrap_err_with(err)?;
-    //     cur.get_mut().extend_from_slice(&buf.get_ref()[..n]);
-    //     if n == 0 {
-    //         break;
-    //     }
-    //     if let Some(pr) = &opts.pr {
-    //         total += n as u64;
-    //         pr.set_length(total);
-    //     }
-    // }
-    create_dir_all(dest).wrap_err_with(err)?;
-
-    // Try to extract using the tar crate, detecting sparse files during extraction
-    let mut needs_system_tar = false;
-    for entry in Archive::new(tar).entries().wrap_err_with(err)? {
-        let mut entry = entry.wrap_err_with(err)?;
-
-        let entry_path = entry.path().wrap_err_with(err)?.into_owned();
-        if tar_entry_is_sparse(&mut entry).wrap_err_with(err)?
-            || path_has_gnu_sparse_artifact(&entry_path)
-        {
-            debug!("Detected sparse tar entry, falling back to system tar");
-            needs_system_tar = true;
-            break;
-        }
-
-        // Configure mtime preservation based on options
-        entry.set_preserve_mtime(opts.preserve_mtime);
-
-        trace!("extracting {}", entry_path.display());
-        entry.unpack_in(dest).wrap_err_with(err)?;
-    }
-
-    if needs_system_tar {
-        // Use system tar for archives with problematic sparse files
-        // The tar crate doesn't properly handle certain GNU sparse formats
-        debug!("Using system tar for: {}", archive.display());
-
-        remove_all(dest)?;
-        create_dir_all(dest)?;
-        extract_with_system_tar(archive, dest, opts)?;
-    }
-
-    // Always use our manual strip to ensure consistent behavior across backends
-    strip_archive_path_components(dest, opts.strip_components).wrap_err_with(err)?;
+    let mut unpack_opts = UnpackOptions::default();
+    unpack_opts.strip_components = opts.strip_components;
+    unpack_opts.preserve_mtime = opts.preserve_mtime;
+    unpack_opts.on_entry = Some(Box::new(|entry| {
+        trace!("extracting {}", entry.path.display());
+    }));
+    let summary = Archive::new(tar)
+        .unpack(dest, &mut unpack_opts)
+        .wrap_err_with(err)?;
+    debug!("tar extraction summary: {summary:?}");
     Ok(())
-}
-
-fn tar_entry_is_sparse<R: Read>(entry: &mut tar::Entry<'_, R>) -> std::io::Result<bool> {
-    if entry.header().entry_type().is_gnu_sparse() {
-        return Ok(true);
-    }
-
-    let Some(pax_extensions) = entry.pax_extensions()? else {
-        return Ok(false);
-    };
-
-    for extension in pax_extensions {
-        let extension = match extension {
-            Ok(extension) => extension,
-            Err(err) => {
-                debug!(
-                    "Ignoring malformed PAX extension while checking for sparse metadata: {err}"
-                );
-                continue;
-            }
-        };
-        if extension
-            .key()
-            .is_ok_and(|key| key.starts_with("GNU.sparse."))
-        {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
-}
-
-fn path_has_gnu_sparse_artifact(path: &Path) -> bool {
-    path.components().any(|component| {
-        component
-            .as_os_str()
-            .to_str()
-            .is_some_and(|name| name.starts_with("GNUSparseFile."))
-    })
-}
-
-fn extract_with_system_tar(archive: &Path, dest: &Path, opts: &ExtractOptions) -> Result<()> {
-    // When preserve_mtime is false, use -m flag to not restore modification times.
-    // This causes extracted files to have current time, which is important for
-    // cache invalidation and autopruning. Works on both BSD and GNU tar.
-    let result = if opts.preserve_mtime {
-        cmd!("tar", "-xf", archive, "-C", dest).run()
-    } else {
-        cmd!("tar", "-mxf", archive, "-C", dest).run()
-    };
-
-    result.map(|_| ()).wrap_err_with(|| {
-        format!(
-            "failed to extract {} using system tar for sparse archive fallback",
-            archive.display()
-        )
-    })
 }
 
 fn open_tar(format: ExtractionFormat, archive: &Path) -> Result<Box<dyn std::io::Read>> {
@@ -1573,7 +1476,7 @@ pub fn inspect_tar_contents(
     for entry in archive.entries()? {
         let entry = entry?;
         let path = entry.path()?;
-        let header = entry.header();
+        let entry_type = entry.entry_type();
 
         // Get the first non-CurDir component of the path (top-level directory/file)
         let mut components = skip_curdir_components(&path);
@@ -1583,7 +1486,7 @@ pub fn inspect_tar_contents(
 
             // Check if this entry indicates the component is a directory
             // It's a directory if the entry type is dir OR if there are more components after the first
-            let is_directory = header.entry_type().is_dir() || components.next().is_some();
+            let is_directory = entry_type == EntryType::Directory || components.next().is_some();
 
             // Update the component's directory status
             // A component is a directory if ANY entry indicates it's a directory
@@ -1727,11 +1630,11 @@ fn archive_content_files_tar(
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?.into_owned();
-        let entry_type = entry.header().entry_type();
-        if entry_type.is_dir() {
+        let entry_type = entry.entry_type();
+        if entry_type == EntryType::Directory {
             continue;
         }
-        if !entry_type.is_file() {
+        if entry_type != EntryType::File {
             bail!(
                 "content-level SLSA verification does not support non-regular archive entry: {}",
                 path.display()
@@ -2685,35 +2588,6 @@ mod tests {
     }
 
     #[test]
-    fn test_tar_entry_is_sparse_detects_pax_sparse_metadata() {
-        use std::io::Cursor;
-
-        let mut builder = tar::Builder::new(Vec::new());
-        builder
-            .append_pax_extensions([("GNU.sparse.name", b"pkg/disk.img".as_slice())])
-            .unwrap();
-
-        let mut header = tar::Header::new_ustar();
-        header.set_size(0);
-        header.set_mode(0o644);
-        header.set_cksum();
-        builder
-            .append_data(
-                &mut header,
-                "pkg/GNUSparseFile.0/disk.img",
-                std::io::empty(),
-            )
-            .unwrap();
-
-        let data = builder.into_inner().unwrap();
-        let mut archive = Archive::new(Cursor::new(data));
-        let mut entries = archive.entries().unwrap();
-        let mut entry = entries.next().unwrap().unwrap();
-
-        assert!(tar_entry_is_sparse(&mut entry).unwrap());
-    }
-
-    #[test]
     fn test_extract_archive_ignores_malformed_non_sparse_pax_metadata() {
         use tempfile::tempdir;
 
@@ -2751,16 +2625,8 @@ mod tests {
     }
 
     #[test]
-    fn test_path_has_gnu_sparse_artifact_detects_nested_paths() {
-        assert!(path_has_gnu_sparse_artifact(Path::new(
-            "pkg/GNUSparseFile.0/disk.img"
-        )));
-        assert!(!path_has_gnu_sparse_artifact(Path::new("pkg/disk.img")));
-    }
-
-    #[test]
     #[cfg(unix)]
-    fn test_extract_archive_falls_back_for_pax_sparse_tar() {
+    fn test_extract_archive_handles_pax_sparse_tar() {
         use std::io::{Seek, SeekFrom, Write};
         use std::process::Command;
         use tempfile::tempdir;

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -20,7 +20,9 @@ use std::str::FromStr;
 use eyre::{Context, Result};
 use flate2::Compression;
 use flate2::write::GzEncoder;
-use jdx_tar::{Archive, Builder, EntryType, Header};
+#[cfg(test)]
+use jdx_tar::Archive;
+use jdx_tar::{Builder, EntryType, Header};
 use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -20,8 +20,8 @@ use std::str::FromStr;
 use eyre::{Context, Result};
 use flate2::Compression;
 use flate2::write::GzEncoder;
+use jdx_tar::{Archive, Builder, EntryType, Header};
 use sha2::{Digest, Sha256};
-use tar::{EntryType, Header};
 use walkdir::WalkDir;
 
 /// The result of building a layer blob.
@@ -205,8 +205,7 @@ pub fn build_layer_from_files_and_dirs(
 
     let mut tar_bytes = Vec::new();
     {
-        let mut builder = tar::Builder::new(&mut tar_bytes);
-        builder.mode(tar::HeaderMode::Deterministic);
+        let mut builder = Builder::new(&mut tar_bytes);
 
         // Track which parent directories we've emitted so we don't repeat them.
         let mut emitted_dirs: std::collections::BTreeSet<String> = Default::default();
@@ -228,13 +227,11 @@ pub fn build_layer_from_files_and_dirs(
                     emit_dir(&mut builder, &dir, owner)?;
                 }
             }
-            let mut header = Header::new_gnu();
-            header.set_entry_type(EntryType::Regular);
+            let mut header = Header::new_gnu(EntryType::File);
             header.set_mode(*mode);
             apply_owner(&mut header, owner);
             header.set_size(contents.len() as u64);
             header.set_mtime(0);
-            header.set_cksum();
             builder
                 .append_data(&mut header, path, contents.as_slice())
                 .wrap_err_with(|| format!("writing file entry {path}"))?;
@@ -338,9 +335,7 @@ fn build_layer_from_entries(
 
     let mut tar_bytes = Vec::new();
     {
-        let mut builder = tar::Builder::new(&mut tar_bytes);
-        builder.mode(tar::HeaderMode::Deterministic);
-        builder.follow_symlinks(false);
+        let mut builder = Builder::new(&mut tar_bytes);
 
         // Always emit a directory entry for the target prefix chain itself
         // (e.g. `/mise`, `/mise/installs`, `/mise/installs/node`). This
@@ -369,13 +364,11 @@ fn build_layer_from_entries(
                     }
                 }
                 EntryKind::File => {
-                    let mut header = Header::new_gnu();
-                    header.set_entry_type(EntryType::Regular);
+                    let mut header = Header::new_gnu(EntryType::File);
                     header.set_mode(e.mode);
                     apply_owner(&mut header, e.owner);
                     header.set_size(e.size);
                     header.set_mtime(0);
-                    header.set_cksum();
                     let f = std::fs::File::open(&e.abs)
                         .wrap_err_with(|| format!("opening {}", e.abs.display()))?;
                     builder
@@ -383,8 +376,7 @@ fn build_layer_from_entries(
                         .wrap_err_with(|| format!("writing {path_in_tar}"))?;
                 }
                 EntryKind::Symlink(target) => {
-                    let mut header = Header::new_gnu();
-                    header.set_entry_type(EntryType::Symlink);
+                    let mut header = Header::new_gnu(EntryType::Symlink);
                     header.set_mode(e.mode);
                     apply_owner(&mut header, e.owner);
                     header.set_size(0);
@@ -432,23 +424,21 @@ fn owner_from_metadata(_md: &std::fs::Metadata) -> LayerOwner {
     LayerOwner::default()
 }
 
-fn emit_dir<W: Write>(builder: &mut tar::Builder<W>, path: &str, owner: LayerOwner) -> Result<()> {
+fn emit_dir<W: Write>(builder: &mut Builder<W>, path: &str, owner: LayerOwner) -> Result<()> {
     emit_dir_with_mode(builder, path, owner, 0o755)
 }
 
 fn emit_dir_with_mode<W: Write>(
-    builder: &mut tar::Builder<W>,
+    builder: &mut Builder<W>,
     path: &str,
     owner: LayerOwner,
     mode: u32,
 ) -> Result<()> {
-    let mut header = Header::new_gnu();
-    header.set_entry_type(EntryType::Directory);
+    let mut header = Header::new_gnu(EntryType::Directory);
     header.set_mode(mode);
     apply_owner(&mut header, owner);
     header.set_size(0);
     header.set_mtime(0);
-    header.set_cksum();
     let path_with_slash = if path.ends_with('/') {
         path.to_string()
     } else {
@@ -664,7 +654,7 @@ mod tests {
         let blob =
             build_layer_from_path(&source, "/opt/app/greeting.txt", LayerOwner::default()).unwrap();
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
-        let mut archive = tar::Archive::new(decoder);
+        let mut archive = Archive::new(decoder);
         let paths = archive
             .entries()
             .unwrap()
@@ -698,7 +688,7 @@ mod tests {
         )
         .unwrap();
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
-        let mut archive = tar::Archive::new(decoder);
+        let mut archive = Archive::new(decoder);
         let paths = archive
             .entries()
             .unwrap()
@@ -850,14 +840,14 @@ mod tests {
 
     fn assert_layer_owner(blob: &LayerBlob, uid: u64, gid: u64) {
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
-        let mut archive = tar::Archive::new(decoder);
+        let mut archive = Archive::new(decoder);
         let mut entries_seen = 0;
 
         for entry in archive.entries().unwrap() {
             let entry = entry.unwrap();
             let path = entry.path().unwrap().to_string_lossy().into_owned();
-            assert_eq!(entry.header().uid().unwrap(), uid, "uid for {path}");
-            assert_eq!(entry.header().gid().unwrap(), gid, "gid for {path}");
+            assert_eq!(entry.header().uid(), uid, "uid for {path}");
+            assert_eq!(entry.header().gid(), gid, "gid for {path}");
             entries_seen += 1;
         }
 
@@ -866,17 +856,13 @@ mod tests {
 
     fn assert_layer_mode(blob: &LayerBlob, expected_path: &str, expected_mode: u32) {
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
-        let mut archive = tar::Archive::new(decoder);
+        let mut archive = Archive::new(decoder);
 
         for entry in archive.entries().unwrap() {
             let entry = entry.unwrap();
             let path = entry.path().unwrap().to_string_lossy().into_owned();
             if path.trim_end_matches('/') == expected_path.trim_end_matches('/') {
-                assert_eq!(
-                    entry.header().mode().unwrap(),
-                    expected_mode,
-                    "mode for {path}"
-                );
+                assert_eq!(entry.header().mode(), expected_mode, "mode for {path}");
                 return;
             }
         }
@@ -887,14 +873,14 @@ mod tests {
     #[cfg(unix)]
     fn assert_layer_entry_owner(blob: &LayerBlob, expected_path: &str, uid: u64, gid: u64) {
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
-        let mut archive = tar::Archive::new(decoder);
+        let mut archive = Archive::new(decoder);
 
         for entry in archive.entries().unwrap() {
             let entry = entry.unwrap();
             let path = entry.path().unwrap().to_string_lossy().into_owned();
             if path == expected_path {
-                assert_eq!(entry.header().uid().unwrap(), uid, "uid for {path}");
-                assert_eq!(entry.header().gid().unwrap(), gid, "gid for {path}");
+                assert_eq!(entry.header().uid(), uid, "uid for {path}");
+                assert_eq!(entry.header().gid(), gid, "gid for {path}");
                 return;
             }
         }
@@ -975,13 +961,13 @@ mod tests {
 
         // The GNU @LongLink extension must round-trip back to the full target.
         let decoder = flate2::read::GzDecoder::new(blob.bytes.as_slice());
-        let mut archive = tar::Archive::new(decoder);
+        let mut archive = Archive::new(decoder);
         let mut found = false;
         for entry in archive.entries().unwrap() {
             let entry = entry.unwrap();
             let path = entry.path().unwrap().to_string_lossy().into_owned();
             if path == "mise/bin/cli" {
-                let link = entry.link_name().unwrap().unwrap();
+                let link = entry.header().link_name().unwrap();
                 assert_eq!(&*link, Path::new(&long_target));
                 found = true;
             }

--- a/src/oci/packages.rs
+++ b/src/oci/packages.rs
@@ -15,6 +15,7 @@ use std::process::Command;
 
 use eyre::{Context, Result, bail};
 use flate2::read::GzDecoder;
+use jdx_tar::{Archive, EntryUnpacker, UnpackOptions};
 use tempfile::TempDir;
 use walkdir::WalkDir;
 
@@ -123,7 +124,10 @@ fn unpack_base_layers(layout: &ImageLayout, layers: &[Descriptor], rootfs: &Path
     for layer in layers {
         let path = layout.blob_path(&layer.digest);
         let reader = open_layer_reader(layer, &path)?;
-        let mut archive = tar::Archive::new(reader);
+        let mut archive = Archive::new(reader);
+        let mut options = UnpackOptions::default();
+        let mut unpacker = EntryUnpacker::new(rootfs, &mut options)
+            .wrap_err_with(|| format!("preparing base layer extraction {}", layer.digest))?;
         for entry in archive
             .entries()
             .wrap_err_with(|| format!("reading base layer {}", layer.digest))?
@@ -135,10 +139,13 @@ fn unpack_base_layers(layout: &ImageLayout, layers: &[Descriptor], rootfs: &Path
             if rel.as_os_str().is_empty() || apply_oci_whiteout(rootfs, &rel)? {
                 continue;
             }
-            entry
-                .unpack_in(rootfs)
+            unpacker
+                .unpack(&mut entry)
                 .wrap_err_with(|| format!("unpacking base layer {}", layer.digest))?;
         }
+        unpacker
+            .finish()
+            .wrap_err_with(|| format!("finishing base layer extraction {}", layer.digest))?;
     }
     Ok(())
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -233,14 +233,14 @@ fn replace_registry_cache(download_path: &Path, cache_path: &Path) -> Result<()>
 fn parse_registry_archive(path: &Path) -> Result<Registry> {
     let file = File::open(path)?;
     let decoder = zstd::Decoder::new(file)?;
-    let mut archive = tar::Archive::new(decoder);
+    let mut archive = jdx_tar::Archive::new(decoder);
     let mut sources = BTreeMap::new();
     let mut archive_size = 0_u64;
 
     for (index, entry) in archive.entries()?.enumerate() {
         let mut entry = entry?;
         track_registry_archive_entry(index, entry.size(), &mut archive_size)?;
-        if !entry.header().entry_type().is_file() {
+        if entry.entry_type() != jdx_tar::EntryType::File {
             continue;
         }
         let path = entry.path()?;
@@ -661,12 +661,11 @@ mod tests {
 
         let file = tempfile::NamedTempFile::new().unwrap();
         let encoder = zstd::Encoder::new(file.reopen().unwrap(), 0).unwrap();
-        let mut archive = tar::Builder::new(encoder);
+        let mut archive = jdx_tar::Builder::new(encoder);
         for (path, contents) in entries {
-            let mut header = tar::Header::new_gnu();
+            let mut header = jdx_tar::Header::new_gnu(jdx_tar::EntryType::File);
             header.set_size(contents.len() as u64);
             header.set_mode(0o644);
-            header.set_cksum();
             archive
                 .append_data(&mut header, path, Cursor::new(contents.as_bytes()))
                 .unwrap();


### PR DESCRIPTION
## Summary
- use jdx-tar 1.1.0 for tar extraction, inspection, and content-level verification
- use jdx-tar for floating-registry archives and deterministic OCI layer reading and writing
- preserve mise's historical strip behavior for root files while removing sparse heuristics and the system tar fallback
- remove mise's direct tar-rs dependency; the remaining tar crate in Cargo.lock is transitive through other dependencies

## Why
jdx-tar now covers secure GNU sparse extraction, per-entry extraction, and deterministic archive writing. Consolidating production tar handling makes behavior consistent across platforms and removes the system tar dependency and duplicate tar implementation from mise's runtime dependency graph.

## Testing
- cargo check --tests
- cargo test --all-features oci:: -- --nocapture
- cargo test --all-features registry::tests:: -- --nocapture
- cargo test --all-features file::tests::test_archive -- --nocapture
- cargo test --all-features file::tests::test_inspect_tar -- --nocapture
- cargo test --all-features file::tests::test_extract_archive_tar_strip_preserves_root_files -- --nocapture
- cargo test --all-features file::tests::test_extract_archive -- --nocapture
- mise run test:unit (1,706 passed)
- mise run lint-fix
- mise run test:e2e ^test_http$

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tar extraction and OCI/registry unpack paths are central to installs and image builds; behavior changes include removing the system-tar sparse fallback in favor of jdx-tar’s unified unpack.
> 
> **Overview**
> Replaces the runtime **`tar`** crate with **`jdx-tar` 1.1.0** across extraction, inspection, registry archives, OCI layer build/read, and apt bootstrap layer unpack.
> 
> **Tar extraction (`file.rs`)** no longer walks entries with sparse/PAX heuristics or shells out to system `tar`. It uses **`Archive::unpack`** with **`UnpackOptions`** (`preserve_mtime`, per-entry tracing), then keeps mise’s existing **`strip_archive_path_components`** pass. Inspection and SLSA content hashing now use **`entry_type()`** / **`EntryType`** instead of header helpers.
> 
> **OCI** layer writing and base-layer unpacking move to **`jdx_tar::Builder`** / **`EntryUnpacker`**; headers are created with **`Header::new_gnu(EntryType::…)`** without manual checksums. **Registry** zstd-tar parsing uses the same library.
> 
> Tests and fixtures are updated for the new API; coverage adds **strip-components preserving root-level files** while sparse handling is delegated to **`jdx-tar`** (renamed/adjusted sparse test on Unix).
> 
> **`crates/aqua-registry`** template parsing switches several **`bail!`** sites to **`Err(eyre!(…))`** (no tar change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf48d193e74778d5ad294e2cb06357f4d6c1f6bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TAR extraction and inspection across layers, bootstrap package extraction, and registry archive parsing, with more accurate file vs. directory handling.
  * Enhanced archive verification reliability, including preserved timestamps and correct entry classification.
  * Improved template parsing/evaluation error messages for clearer failures.
* **Tests**
  * Updated TAR test fixtures/builders to match the new entry typing behavior.
  * Removed the pax-sparse sparse-metadata test and gated pax-sparse extraction to Unix platforms only.
* **Chores**
  * Refreshed TAR-related dependency usage in the project manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->