### PR TITLE
perf: cap default tokio worker threads at 16

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,13 @@ fn main() -> eyre::Result<()> {
     let nprocs = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or_default();
-    let threads = crate::env::MISE_JOBS.unwrap_or(nprocs).max(8);
+    // Tokio spawns every worker thread eagerly when the runtime is built, so
+    // the default worker count is startup cost paid by every invocation —
+    // clone + stack + TLS per thread before any work happens. Async I/O
+    // doesn't need a worker per core (blocking work uses tokio's separate
+    // on-demand pool), so cap the default on many-core machines. An explicit
+    // MISE_JOBS still raises it without limit.
+    let threads = crate::env::MISE_JOBS.unwrap_or_else(|| nprocs.min(16)).max(8);
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .worker_threads(threads)

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,9 @@ fn main() -> eyre::Result<()> {
     // doesn't need a worker per core (blocking work uses tokio's separate
     // on-demand pool), so cap the default on many-core machines. An explicit
     // MISE_JOBS still raises it without limit.
-    let threads = crate::env::MISE_JOBS.unwrap_or_else(|| nprocs.min(16)).max(8);
+    let threads = crate::env::MISE_JOBS
+        .unwrap_or_else(|| nprocs.min(16))
+        .max(8);
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .worker_threads(threads)


### PR DESCRIPTION
## Summary

Linux leg of the startup-perf work (#11025, #11027). Benchmarked the shipped v2026.7.7 binary on a 32-core Arch Linux box against asdf 0.20 and profiled where the time goes.

The Linux-specific finding: startup is **system-time dominated** (6ms sys for `mise version`, ~2200 minor faults), and a big contributor scales with core count — the tokio runtime is built with `worker_threads = nprocs.max(8)`, and tokio spawns every worker **eagerly** at build. On a 32-core machine that's 32 threads (clone + stack + TLS faults each) before any work happens, on every invocation including the per-prompt hook-env fast path. Async I/O doesn't need a worker per core; blocking work runs on tokio's separate on-demand pool.

This caps the *default* at 16 (floor of 8 unchanged). Machines with ≤16 cores see no behavior change. Explicit `MISE_JOBS` still raises it without limit.

## Benchmarks (32-core Linux, hyperfine -N, warm, isolated env; worker count simulated via MISE_JOBS on the release binary)

| workers | `mise version` | hook-env fast path (per prompt) | sys time |
|---|---|---|---|
| 32 (old default) | 6.3 ms | 4.1 ms | 6.1 ms |
| 16 (new default) | 5.8 ms | ~3.4 ms | 4.5 ms |
| 8 | 5.6 ms | 3.3 ms | 4.0 ms |

Parallel install of multiple tools verified working with the cap.

## Other Linux findings (no PR needed)

- glibc's dynamic loader is *not* the problem: `LD_DEBUG=statistics` shows relocation processing of the 125k RELA entries takes only ~0.15ms (~84% of loader time but tiny in absolute terms).
- `-z pack-relative-relocs` (RELR) is not shippable: binaries would fail to load on glibc < 2.36, and the release pipeline explicitly validates Amazon Linux 2 (glibc 2.26) compatibility. It would only save ~0.15ms + ~3MB anyway.
- The remaining gap to asdf (~1.1ms total) is first-touch page faults across the large text segment — that's the PGO/BOLT territory (BOLT is Linux-only), for which jdx/aube's `benchmarks/pgo.bash` pipeline is a ready-made template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only default thread cap with unchanged explicit `MISE_JOBS` override; machines with ≤16 cores are unaffected.
> 
> **Overview**
> **Reduces CLI startup cost on many-core machines** by changing how the default Tokio multi-thread worker count is chosen in `main`.
> 
> Previously the runtime used `available_parallelism()` with a floor of 8, so a 32-core host eagerly spawned 32 workers at build time (each paying clone/stack/TLS cost on every invocation, including hook-env). The default is now `min(nprocs, 16)` with the same floor of 8; hosts with ≤16 cores behave as before. An explicit **`MISE_JOBS`** still sets the count with no cap.
> 
> Inline comments document why async I/O does not need one worker per core and that blocking work uses Tokio’s separate pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7301b72410110f763e56d5bb768418baa9ea5040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved default resource usage by limiting background task workers to a maximum of 16 while maintaining a minimum of 8.
  * Explicit worker-count settings continue to be honored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->