### PR TITLE
chore(ci): restore nightly build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,9 @@ use aqua_registry::types::{AquaPackage, RegistryPackageRow, RegistryYaml};
 use eyre::{Result, eyre};
 use serde_yaml::Value;
 
+// cfg_aliases 0.2.1 emits semicolon-terminated helper macros in expression
+// position, which the latest nightly compiler rejects as future-incompatible.
+#[allow(semicolon_in_expressions_from_macros)]
 fn main() -> Result<()> {
     cfg_aliases::cfg_aliases! {
         asdf: { any(feature = "asdf", not(target_os = "windows")) },

--- a/crates/aqua-registry/src/lib.rs
+++ b/crates/aqua-registry/src/lib.rs
@@ -1,3 +1,6 @@
+// eyre 0.6.12 emits a trailing semicolon from bail!, which nightly rejects.
+#![allow(semicolon_in_expressions_from_macros)]
+
 //! Aqua Registry
 //!
 //! This crate provides functionality for working with Aqua package registry files.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![allow(unknown_lints)]
 #![allow(clippy::literal_string_with_formatting_args)]
+// eyre 0.6.12 emits a trailing semicolon from bail!, which nightly rejects.
+#![allow(semicolon_in_expressions_from_macros)]
 
 use std::{
     panic,


### PR DESCRIPTION
## Summary

- allow `semicolon_in_expressions_from_macros` in the mise and aqua-registry crate roots
- scope the same allowance to the build script entry point for `cfg_aliases`
- restore compatibility with the 2026-07-16 Rust nightly compiler without changing runtime behavior

## Root cause

Rust 1.99.0-nightly (d0babd8b6 2026-07-15) began denying the future-incompatible `semicolon_in_expressions_from_macros` lint. `eyre` 0.6.12's `bail!` macro and `cfg_aliases` 0.2.1 expand with trailing semicolons in expression position, causing the nightly all-features build to fail across existing call sites.

The allowances are limited to the affected crate roots and build script so they can be removed when the upstream macros are updated.

## Validation

- `cargo +nightly build --all-features`
- `mise run lint`
- `cargo test -p aqua-registry template::tests` (38 passed)

Fixes the nightly failure observed in https://github.com/jdx/mise/actions/runs/29467699443/job/87524235396.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time lint suppressions only; no logic, security, or runtime behavior changes.
> 
> **Overview**
> Restores **`cargo +nightly build --all-features`** after Rust nightly started denying the future-incompatible **`semicolon_in_expressions_from_macros`** lint.
> 
> Adds **`#![allow(semicolon_in_expressions_from_macros)]`** at the **`mise`** and **`aqua-registry`** crate roots (macro expansions from **`eyre`** **`bail!`**) and on **`build.rs`**’s **`main`** ( **`cfg_aliases`** ). Comments note upstream macro behavior; runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32fecedb2ebf2a9d5f4971a528523da260b4dfb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved nightly compiler compatibility issues caused by semicolon-terminated macros.
  * Ensured the project builds successfully with current macro-generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->