### PR TITLE
fix(backend): detect separatorless prerelease versions

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -990,6 +990,12 @@ mod tests {
         });
         assert!(rc.prerelease);
 
+        let php_rc = mark_prerelease(VersionInfo {
+            version: "8.5.9RC1".into(),
+            ..Default::default()
+        });
+        assert!(php_rc.prerelease);
+
         let already_flagged = mark_prerelease(VersionInfo {
             version: "2.0.0".into(),
             prerelease: true,

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -266,7 +266,7 @@ pub fn warn_if_env_plugin_shadows_registry(name: &str, plugin_path: &Path) {
 
 pub static VERSION_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
     Regex::new(
-        r"(?i)(^Available versions:|-src|[-\\.]dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|-test|-nightly|-canary|-experimental|-insider|-edge|snapshot|SNAPSHOT|master)"
+        r"(?i)(^Available versions:|-src|[-\\.]dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|-test|-nightly|-canary|-experimental|-insider|-edge|snapshot|SNAPSHOT|master|\d(?:alpha|beta|rc)\d+$)"
     )
         .unwrap()
 });
@@ -740,6 +740,11 @@ mod tests {
         assert!(VERSION_REGEX.is_match("1.0.0-dev"));
         assert!(VERSION_REGEX.is_match("1.0.0-pre1"));
         assert!(VERSION_REGEX.is_match("1.0.0.pre1"));
+
+        // PHP separator-less pre-release suffixes (GitHub discussion #4720)
+        assert!(VERSION_REGEX.is_match("8.5.9alpha1"));
+        assert!(VERSION_REGEX.is_match("8.5.9beta2"));
+        assert!(VERSION_REGEX.is_match("8.5.9RC1"));
 
         // PEP 440 dot-separated dev versions (GitHub discussion #8784)
         assert!(


### PR DESCRIPTION
## Summary

- recognize separatorless prerelease suffixes such as `8.5.9RC1`
- cover PHP-style `alpha`, `beta`, and `RC` versions in the global prerelease regex
- verify the backend marks these versions as prereleases before filtering

## Root cause

The global prerelease matcher recognized delimiter-based forms such as `8.5.9-rc1` and `8.5.9.rc1`, but PHP publishes separatorless tags such as `8.5.9RC1`. As a result, the vfox PHP backend treated an RC as stable and could resolve `php@8.5` to it.

Fixes the behavior reported in https://github.com/jdx/mise/discussions/4720#discussioncomment-17656381.

## Validation

- `cargo test prerelease`
- `cargo fmt --all -- --check`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to version-string matching and prerelease flagging, with unit tests; no auth, install, or network behavior changes beyond which versions count as stable.
> 
> **Overview**
> Extends the global **`VERSION_REGEX`** so prerelease detection covers **PHP-style tags without a separator** (e.g. `8.5.9RC1`, `8.5.9alpha1`, `8.5.9beta2`), not only forms like `8.5.9-rc1` or `8.5.9.rc1`.
> 
> Those versions are now stamped as prereleases via **`mark_prerelease`** and excluded from default stable resolution (e.g. **`php@8.5`** no longer picking an RC). Tests cover the regex and backend marking for `8.5.9RC1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc8f56b99599b2058a7c56b6fef51915482c5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version recognition for PHP-style prerelease labels such as `alpha1`, `beta2`, and `RC1`.
  * Prerelease versions using these formats are now correctly identified and filtered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->