### PR TITLE
fix(install): treat false install env values as removals

### DIFF
--- a/e2e/backend/test_vfox_install_env
+++ b/e2e/backend/test_vfox_install_env
@@ -33,7 +33,7 @@ LUA
 cat >"$PLUGIN_DIR/hooks/post_install.lua" <<LUA
 function PLUGIN:PostInstall(ctx)
 	local cmd = require("cmd")
-	cmd.exec("printf '%s' \"\$MISE_TEST_INSTALL_ENV_VALUE\" > \"$MARKER\"")
+	cmd.exec("printf '%s:%s' \"\$MISE_TEST_INSTALL_ENV_VALUE\" \"\${MISE_TEST_INSTALL_ENV_REMOVE-unset}\" > \"$MARKER\"")
 end
 LUA
 
@@ -52,8 +52,8 @@ cat >mise.toml <<EOF
 unix_default_inline_shell_args = "sh -c"
 
 [tools]
-"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", install_env = { MISE_TEST_INSTALL_ENV_VALUE = "available" } }
+"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", install_env = { MISE_TEST_INSTALL_ENV_VALUE = "available", MISE_TEST_INSTALL_ENV_REMOVE = false } }
 EOF
 
-mise install
-assert "cat '$MARKER'" "available"
+MISE_TEST_INSTALL_ENV_REMOVE="inherited" mise install
+assert "cat '$MARKER'" "available:unset"

--- a/e2e/config/test_hooks_postinstall_env
+++ b/e2e/config/test_hooks_postinstall_env
@@ -15,14 +15,14 @@ EXPLICIT_PRE_TOOLS = {value = "explicitly_pre_tools", tools = false}
 POST_TOOLS_VAR = {value = "available_after_tools", tools = true}
 
 [tools]
-dummy = { version = "latest", install_env = { INSTALL_ENV_VAR = "available_during_install" }, postinstall = "echo PRE_TOOLS_VAR=\$PRE_TOOLS_VAR; echo EXPLICIT_PRE_TOOLS=\$EXPLICIT_PRE_TOOLS; echo POST_TOOLS_VAR=\$POST_TOOLS_VAR; echo INSTALL_ENV_VAR=\$INSTALL_ENV_VAR" }
+dummy = { version = "latest", install_env = { INSTALL_ENV_VAR = "available_during_install", INSTALL_ENV_REMOVE = false }, postinstall = "echo PRE_TOOLS_VAR=\$PRE_TOOLS_VAR; echo EXPLICIT_PRE_TOOLS=\$EXPLICIT_PRE_TOOLS; echo POST_TOOLS_VAR=\$POST_TOOLS_VAR; echo INSTALL_ENV_VAR=\$INSTALL_ENV_VAR; echo INSTALL_ENV_REMOVE=\${INSTALL_ENV_REMOVE-unset}" }
 EOF
 
 # Remove any existing dummy installation to force reinstall
 rm -rf ~/.mise/installs/dummy
 
 # Run install and capture output
-output=$(mise install dummy 2>&1)
+output=$(INSTALL_ENV_REMOVE=inherited mise install dummy 2>&1)
 
 # Check that pre_tools environment variables are available in postinstall
 if [[ $output == *"PRE_TOOLS_VAR=available_before_tools"* ]]; then
@@ -45,6 +45,14 @@ if [[ $output == *"INSTALL_ENV_VAR=available_during_install"* ]]; then
   echo "✓ INSTALL_ENV_VAR is available in postinstall"
 else
   echo "✗ INSTALL_ENV_VAR is NOT available in postinstall"
+  echo "Output: $output"
+  exit 1
+fi
+
+if [[ $output == *"INSTALL_ENV_REMOVE=unset"* ]]; then
+  echo "✓ false install_env removes inherited variables from postinstall"
+else
+  echo "✗ false install_env did not remove inherited variable from postinstall"
   echo "Output: $output"
   exit 1
 fi

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -141,11 +141,11 @@ TOML
 
 cat >"$HOME/workdir/mise-os.toml" <<'TOML'
 [tools]
-node = { version = "latest", os = ["linux", "macos/arm64", "darwin/aarch64", "win/amd64"], backend_options = { nested = true } }
+node = { version = "latest", os = ["linux", "macos/arm64", "darwin/aarch64", "win/amd64"], install_env = { KEEP = "value", REMOVE = false, RETRIES = 2 }, backend_options = { nested = true } }
 go = { version = "latest", os = "linux/x64" }
 
 [tasks.build.tools]
-rust = { version = "latest", os = ["linux/x64", "macos/arm64"], profile = "release", targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"], backend_options = { nested = { enabled = true, retries = 2 } } }
+rust = { version = "latest", os = ["linux/x64", "macos/arm64"], install_env = { KEEP = "value", REMOVE = false, RETRIES = 2 }, profile = "release", targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"], backend_options = { nested = { enabled = true, retries = 2 } } }
 TOML
 
 cat >"$HOME/workdir/mise-task-os.toml" <<'TOML'
@@ -153,7 +153,7 @@ cat >"$HOME/workdir/mise-task-os.toml" <<'TOML'
 run = "echo ok"
 
 [build.tools]
-node = { version = "latest", os = ["linux/x64", "macos/arm64"], profile = "release", matching = ["node", "npm"], platforms = { linux-x64 = { bin = ["node", "npm"], env = { NODE_ENV = "test" } } } }
+node = { version = "latest", os = ["linux/x64", "macos/arm64"], install_env = { KEEP = "value", REMOVE = false, RETRIES = 2 }, profile = "release", matching = ["node", "npm"], platforms = { linux-x64 = { bin = ["node", "npm"], env = { NODE_ENV = "test" } } } }
 TOML
 
 cat >"$HOME/workdir/mise-registry-tool.toml" <<'TOML'
@@ -192,11 +192,11 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
-include = ["mise-bad-task-os.toml"]
+include = ["mise-bad-task-os.toml", "mise-bad-task-install-env-float.toml"]
 
 [[schemas]]
 path = "file://$REGISTRY_TOOL_SCHEMA_PATH"
@@ -238,6 +238,20 @@ _.file = { path = ".env", required = 123 }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-env-directive.toml"
+
+cat >"$HOME/workdir/mise-bad-env-float.toml" <<'TOML'
+[env]
+FLOAT = 1.23
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-env-float.toml"
+
+cat >"$HOME/workdir/mise-bad-install-env-float.toml" <<'TOML'
+[tools]
+node = { version = "latest", install_env = { FLOAT = 1.23 } }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-install-env-float.toml"
 
 cat >"$HOME/workdir/mise-bad-vars.toml" <<'TOML'
 [vars]
@@ -362,6 +376,16 @@ node = { version = "latest", os = true }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-task-os.toml"
+
+cat >"$HOME/workdir/mise-bad-task-install-env-float.toml" <<'TOML'
+[build]
+run = "echo ok"
+
+[build.tools]
+node = { version = "latest", install_env = { FLOAT = 1.23 } }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-task-install-env-float.toml"
 
 cat >"$HOME/workdir/mise-bad-registry-tool.toml" <<'TOML'
 backends = [

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -451,13 +451,7 @@
             "description": "[experimental] age-encrypted environment variable"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": "number"
-          },
-          {
-            "type": "boolean"
+            "$ref": "#/$defs/env_value"
           }
         ]
       },
@@ -809,17 +803,7 @@
                 "install_env": {
                   "type": "object",
                   "additionalProperties": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "boolean"
-                      }
-                    ]
+                    "$ref": "#/$defs/env_value"
                   },
                   "description": "environment variables during tool installation"
                 },
@@ -954,12 +938,13 @@
       ]
     },
     "env_value": {
+      "description": "environment variable value; false removes the variable",
       "oneOf": [
         {
           "type": "string"
         },
         {
-          "type": "number"
+          "type": "integer"
         },
         {
           "type": "boolean"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -94,12 +94,13 @@
       ]
     },
     "env_value": {
+      "description": "environment variable value; false removes the variable",
       "oneOf": [
         {
           "type": "string"
         },
         {
-          "type": "number"
+          "type": "integer"
         },
         {
           "type": "boolean"
@@ -318,13 +319,7 @@
             "description": "[experimental] age-encrypted environment variable"
           },
           {
-            "type": "string"
-          },
-          {
-            "type": "number"
-          },
-          {
-            "type": "boolean"
+            "$ref": "#/$defs/env_value"
           }
         ]
       },
@@ -2288,17 +2283,7 @@
                 "install_env": {
                   "type": "object",
                   "additionalProperties": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "boolean"
-                      }
-                    ]
+                    "$ref": "#/$defs/env_value"
                   },
                   "description": "environment variables during tool installation"
                 },

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -177,7 +177,10 @@ impl AsdfBackend {
             sm = sm.with_env(k, value);
         }
         for (key, value) in tv.install_env() {
-            sm = sm.with_env(key, value.clone());
+            sm = match value.into_string() {
+                Some(value) => sm.with_env(key, value),
+                None => sm.without_env(key),
+            };
         }
         if let Some(project_root) = &config.project_root {
             let project_root = project_root.to_string_lossy().to_string();

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -351,7 +351,7 @@ impl CargoBackend {
             .arg(tv.install_path())
             .with_pr(ctx.pr.as_ref())
             .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
             .prepend_path(
                 self.dependency_toolset(&ctx.config)

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -120,7 +120,7 @@ impl Backend for DotnetBackend {
 
         cli.with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()?;
 
         Ok(tv)

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -94,7 +94,7 @@ impl Backend for GemBackend {
             .arg(tv.install_path().join("libexec"))
             .with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()?;
 
         // We install the gem to {install_path}/libexec and create a wrapper script for each executable

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -144,7 +144,7 @@ impl Backend for GoBackend {
             cmd.arg(format!("{}@{v}", self.tool_name()))
                 .with_pr(ctx.pr.as_ref())
                 .envs(self.dependency_env(&ctx.config).await?)
-                .envs(tv.install_env())
+                .env_values(tv.install_env())
                 .env("GOBIN", tv.install_path().join("bin"))
                 .execute()
         };

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2305,7 +2305,18 @@ pub trait Backend: Debug + Send + Sync {
                 env_vars.entry(k).or_insert(v);
             }
         }
-        env_vars.extend(tv.request.options().core.install_env);
+        let mut install_env_removals = Vec::new();
+        for (key, value) in tv.install_env() {
+            match value.into_string() {
+                Some(value) => {
+                    env_vars.insert(key, value);
+                }
+                None => {
+                    env_vars.remove(&key);
+                    install_env_removals.push(key);
+                }
+            }
+        }
 
         // Surface `tools = true` `[env]` *value* directives (e.g. `CLOUDSDK_PYTHON =
         // "{{ tools.python.path }}/bin/python3"`) for the tool-level `postinstall`
@@ -2392,6 +2403,9 @@ pub trait Backend: Debug + Send + Sync {
             .with_pr(ctx.pr.as_ref())
             .cmd_body_args(shell_args, &rendered_script)
             .envs(env_vars);
+        for key in install_env_removals {
+            runner = runner.env_remove(key);
+        }
 
         // Set MISE_CONFIG_ROOT and MISE_PROJECT_ROOT from the tool's source config file
         if let Some(source_path) = tv.request.source().path() {

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -407,7 +407,7 @@ impl Backend for NPMBackend {
                     .arg(format!("{}@{}", self.tool_name(), tv.version))
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .envs(tv.install_env())
+                    .env_values(tv.install_env())
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(
                         self.dependency_toolset(&ctx.config)
@@ -434,7 +434,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .envs(tv.install_env())
+                    .env_values(tv.install_env())
                     .env("BUN_INSTALL_GLOBAL_DIR", tv.install_path())
                     .env("BUN_INSTALL_BIN", tv.install_path().join("bin"))
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
@@ -464,7 +464,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .envs(tv.install_env())
+                    .env_values(tv.install_env())
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(
                         self.dependency_toolset(&ctx.config)
@@ -509,7 +509,7 @@ impl Backend for NPMBackend {
                     .args(install_before_args)
                     .with_pr(ctx.pr.as_ref())
                     .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .envs(tv.install_env())
+                    .env_values(tv.install_env())
                     .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
                     .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
                     .prepend_path(
@@ -1553,7 +1553,7 @@ mod tests {
         );
         options.install_env.insert(
             "NPM_CONFIG_REGISTRY".to_string(),
-            "https://registry.example.com".to_string(),
+            crate::config::env_directive::EnvValue::from("https://registry.example.com"),
         );
 
         let request =

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -537,7 +537,7 @@ impl PIPXBackend {
         }
         cmd.with_pr(pr)
             .envs(ts.env_with_path_without_tools(config).await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .env("UV_TOOL_DIR", tv.install_path())
             .env("UV_TOOL_BIN_DIR", tv.install_path().join("bin"))
             .env("UV_INDEX", Self::get_index_url()?)
@@ -560,7 +560,7 @@ impl PIPXBackend {
         }
         cmd.with_pr(pr)
             .envs(ts.env_with_path_without_tools(config).await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             // pipx 1.12+ auto-picks uv on PATH; this path passes pip-only --pip-args.
             .env("PIPX_DEFAULT_BACKEND", "pip")
             .env("PIP_INDEX_URL", Self::get_index_url()?)

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -406,7 +406,7 @@ impl SPMBackend {
             .arg("--cache-path")
             .arg(dirs::CACHE.join("spm"))
             .with_pr(ctx.pr.as_ref())
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .prepend_path(
                 self.dependency_toolset(&ctx.config)
                     .await?
@@ -510,7 +510,10 @@ impl SPMBackend {
 
 fn with_install_env(mut command: Expression, tv: &ToolVersion) -> Expression {
     for (key, value) in tv.install_env() {
-        command = command.env(key, value);
+        command = match value.into_string() {
+            Some(value) => command.env(key, value),
+            None => command.env_remove(key),
+        };
     }
     command
 }

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -37,6 +37,21 @@ pub struct VfoxBackend {
     system_deps: OnceLock<Vec<crate::system::deps::SystemDep>>,
 }
 
+fn remove_env_var(env: &mut indexmap::IndexMap<String, String>, key: &str) {
+    #[cfg(windows)]
+    {
+        if let Some(existing) = env
+            .keys()
+            .find(|existing| existing.eq_ignore_ascii_case(key))
+            .cloned()
+        {
+            env.shift_remove(&existing);
+        }
+    }
+    #[cfg(not(windows))]
+    env.shift_remove(key);
+}
+
 #[async_trait]
 impl Backend for VfoxBackend {
     fn get_type(&self) -> BackendType {
@@ -161,7 +176,18 @@ impl Backend for VfoxBackend {
             .unwrap_or_default()
             .into_iter()
             .collect();
-        cmd_env.extend(tv.install_env());
+        let mut install_env_removals = Vec::new();
+        for (key, value) in tv.install_env() {
+            match value.into_string() {
+                Some(value) => {
+                    cmd_env.insert(key, value);
+                }
+                None => {
+                    remove_env_var(&mut cmd_env, &key);
+                    install_env_removals.push(key);
+                }
+            }
+        }
         // Surface `tools = true` `[env]` *value* directives (e.g.
         // `CLOUDSDK_PYTHON = "{{ tools.python.path }}/bin/python3"`) so the plugin's
         // install hooks (including os.execute) see the resolved value during a
@@ -203,6 +229,9 @@ impl Backend for VfoxBackend {
                 }
                 Err(e) => debug!("vfox: skipping tools=true value directives: {e:#}"),
             }
+        }
+        for key in install_env_removals {
+            remove_env_var(&mut cmd_env, &key);
         }
         if !cmd_env.is_empty() {
             vfox.cmd_env = Some(cmd_env);

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -869,14 +869,20 @@ mod tests {
     async fn test_parse_backend_opts_core_fields() {
         let _config = Config::get().await.unwrap();
         let ba: BackendArg =
-            "pipx:ruff[depends=python,os=linux,install_env.PIPX_HOME=/tmp/pipx]".into();
+            "pipx:ruff[depends=python,os=linux,install_env.PIPX_HOME=/tmp/pipx,install_env.REMOVE=false]".into();
         let opts = ba.opts();
 
         assert_eq!(opts.depends, Some(vec!["python".to_string()]));
         assert_eq!(opts.os, Some(vec!["linux".to_string()]));
         assert_eq!(
-            opts.install_env.get("PIPX_HOME").map(String::as_str),
-            Some("/tmp/pipx")
+            opts.install_env.get("PIPX_HOME"),
+            Some(&crate::config::env_directive::EnvValue::String(
+                "/tmp/pipx".to_string()
+            ))
+        );
+        assert_eq!(
+            opts.install_env.get("REMOVE"),
+            Some(&crate::config::env_directive::EnvValue::Boolean(false))
         );
         assert!(!opts.opts.contains_key("depends"));
         assert!(!opts.opts.contains_key("os"));

--- a/src/cli/tool_stub.rs
+++ b/src/cli/tool_stub.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::backend::static_helpers::lookup_platform_key;
 use crate::config::Config;
+use crate::config::env_directive::EnvValue;
 use crate::dirs;
 use crate::file;
 use crate::hash;
@@ -23,7 +24,7 @@ pub struct ToolStubFile {
     pub bin: Option<String>,  // defaults to filename if not specified
     pub tool: Option<String>, // explicit tool name override
     #[serde(default)]
-    pub install_env: indexmap::IndexMap<String, String>,
+    pub install_env: indexmap::IndexMap<String, EnvValue>,
     #[serde(default)]
     pub os: Option<Vec<String>>,
     pub lock: Option<ToolStubLock>,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -26,6 +26,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as TokioBufReader};
 use tokio::process::Command;
 
 use crate::config::Settings;
+use crate::config::env_directive::EnvValue;
 use crate::env;
 use crate::env::PATH_KEY;
 use crate::errors::Error::ScriptFailed;
@@ -447,6 +448,20 @@ impl<'a> CmdLineRunner<'a> {
         V: AsRef<OsStr>,
     {
         self.cmd.envs(vars);
+        self
+    }
+
+    pub fn env_values<I, K>(mut self, vars: I) -> Self
+    where
+        I: IntoIterator<Item = (K, EnvValue)>,
+        K: AsRef<OsStr>,
+    {
+        for (key, value) in vars {
+            match value.into_string() {
+                Some(value) => self.cmd.env(key, value),
+                None => self.cmd.env_remove(key),
+            };
+        }
         self
     }
 
@@ -1493,6 +1508,33 @@ mod tests {
             .unwrap_err();
         assert!(err.to_string().contains("exited with non-zero status"));
         assert_eq!(stderr.lock().unwrap().as_slice(), ["err"]);
+    }
+
+    #[test]
+    fn test_env_values_treats_false_as_removal() {
+        use std::ffi::OsStr;
+
+        let runner = super::CmdLineRunner::new("true")
+            .env("REMOVE", "inherited")
+            .env_values([
+                (
+                    "KEEP",
+                    crate::config::env_directive::EnvValue::from("value"),
+                ),
+                (
+                    "REMOVE",
+                    crate::config::env_directive::EnvValue::from(false),
+                ),
+            ]);
+
+        let env = runner.cmd.as_std().get_envs().collect::<Vec<_>>();
+        assert!(env.iter().any(|(key, value)| {
+            *key == OsStr::new("KEEP") && value == &Some(OsStr::new("value"))
+        }));
+        assert!(
+            env.iter()
+                .any(|(key, value)| *key == OsStr::new("REMOVE") && value.is_none())
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -21,7 +21,9 @@ use crate::config::config_file::{
     ConfigFile, TaskConfig, config_trust_root, is_ignored, trust, trust_check,
 };
 use crate::config::config_file::{config_root, toml::deserialize_arr};
-use crate::config::env_directive::{AgeFormat, EnvDirective, EnvDirectiveOptions, RequiredValue};
+use crate::config::env_directive::{
+    AgeFormat, EnvDirective, EnvDirectiveOptions, EnvValue, RequiredValue,
+};
 use crate::config::settings::SettingsPartial;
 use crate::config::{Alias, AliasMap, Config, Settings};
 use crate::deps::DepsConfig;
@@ -1699,31 +1701,6 @@ impl<'de> de::Deserialize<'de> for EnvList {
                         _ => {
                             #[derive(Deserialize)]
                             #[serde(untagged)]
-                            pub enum PrimitiveVal {
-                                Str(String),
-                                Int(i64),
-                                Bool(bool),
-                            }
-                            impl PrimitiveVal {
-                                fn into_value_string(self) -> Option<String> {
-                                    match self {
-                                        PrimitiveVal::Str(s) => Some(s),
-                                        PrimitiveVal::Int(i) => Some(i.to_string()),
-                                        PrimitiveVal::Bool(true) => Some("true".to_string()),
-                                        PrimitiveVal::Bool(false) => None,
-                                    }
-                                }
-
-                                fn into_default_string(self) -> Option<String> {
-                                    match self {
-                                        PrimitiveVal::Str(s) => Some(s),
-                                        PrimitiveVal::Int(i) => Some(i.to_string()),
-                                        PrimitiveVal::Bool(_) => None,
-                                    }
-                                }
-                            }
-                            #[derive(Deserialize)]
-                            #[serde(untagged)]
                             enum Val {
                                 AgeComplex {
                                     age: AgeComplexVal,
@@ -1734,12 +1711,12 @@ impl<'de> de::Deserialize<'de> for EnvList {
                                     options: EnvDirectiveOptions,
                                 },
                                 Map {
-                                    value: PrimitiveVal,
+                                    value: EnvValue,
                                     #[serde(flatten)]
                                     options: EnvDirectiveOptions,
                                 },
                                 DefaultMap {
-                                    default: PrimitiveVal,
+                                    default: EnvValue,
                                     #[serde(flatten)]
                                     options: EnvDirectiveOptions,
                                 },
@@ -1747,7 +1724,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
                                     #[serde(flatten)]
                                     options: EnvDirectiveOptions,
                                 },
-                                Primitive(PrimitiveVal),
+                                Primitive(EnvValue),
                             }
 
                             #[derive(Deserialize)]
@@ -1813,7 +1790,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
                             }
 
                             let directive = match val_result {
-                                Val::Primitive(p) => match p.into_value_string() {
+                                Val::Primitive(value) => match value.into_string() {
                                     Some(s) => {
                                         EnvDirective::Val(key, s, EnvDirectiveOptions::default())
                                     }
@@ -1827,7 +1804,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
                                             key
                                         )));
                                     }
-                                    match value.into_value_string() {
+                                    match value.into_string() {
                                         Some(s) => EnvDirective::Val(key, s, options),
                                         None => EnvDirective::Rm(key, options),
                                     }
@@ -2627,8 +2604,8 @@ mod tests {
 
         assert_eq!(opts.depends, Some(vec!["{{version}}".to_string()]));
         assert_eq!(
-            opts.install_env.get("FOO").map(String::as_str),
-            Some("{{version}}")
+            opts.install_env.get("FOO"),
+            Some(&EnvValue::String("{{version}}".to_string()))
         );
         assert_eq!(opts.get("url"), Some("https://example.com/{version}"));
         file::remove_file(&p).unwrap();
@@ -3323,7 +3300,7 @@ run = 'echo "template"'
         };
         options
             .install_env
-            .insert("FOO".to_string(), "bar".to_string());
+            .insert("FOO".to_string(), EnvValue::from("bar"));
 
         cf.replace_versions(
             &needs_dummy,

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -114,6 +114,80 @@ pub struct EnvDirectiveOptions {
     pub(crate) required: RequiredValue,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum EnvValue {
+    String(String),
+    Integer(i64),
+    Boolean(bool),
+}
+
+impl EnvValue {
+    pub fn into_string(self) -> Option<String> {
+        match self {
+            Self::String(value) => Some(value),
+            Self::Integer(value) => Some(value.to_string()),
+            Self::Boolean(true) => Some("true".to_string()),
+            Self::Boolean(false) => None,
+        }
+    }
+
+    pub fn into_default_string(self) -> Option<String> {
+        match self {
+            Self::String(value) => Some(value),
+            Self::Integer(value) => Some(value.to_string()),
+            Self::Boolean(_) => None,
+        }
+    }
+}
+
+impl TryFrom<&toml::Value> for EnvValue {
+    type Error = String;
+
+    fn try_from(value: &toml::Value) -> Result<Self, Self::Error> {
+        match value {
+            toml::Value::String(value) => Ok(Self::String(value.clone())),
+            toml::Value::Integer(value) => Ok(Self::Integer(*value)),
+            toml::Value::Boolean(value) => Ok(Self::Boolean(*value)),
+            _ => Err("environment values must be strings, integers, or booleans".to_string()),
+        }
+    }
+}
+
+impl From<String> for EnvValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<&str> for EnvValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<i64> for EnvValue {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<bool> for EnvValue {
+    fn from(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+}
+
+impl From<EnvValue> for toml_edit::Value {
+    fn from(value: EnvValue) -> Self {
+        match value {
+            EnvValue::String(value) => Self::from(value),
+            EnvValue::Integer(value) => Self::from(value),
+            EnvValue::Boolean(value) => Self::from(value),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum EnvDirective {
     /// simple key/value pair

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -49,7 +49,7 @@ impl BunPlugin {
         CmdLineRunner::new(self.bun_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("-v")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -49,7 +49,7 @@ impl DenoPlugin {
         CmdLineRunner::new(self.deno_bin(tv))
             .with_pr(pr)
             .arg("-V")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -76,7 +76,7 @@ impl DotnetPlugin {
         let sdks = CmdLineRunner::new(DOTNET_BIN)
             .with_pr(ctx.pr.as_ref())
             .arg("--list-sdks")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .envs(self.exec_env(&ctx.config, &ctx.ts, tv).await?)
             .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
             .read()
@@ -209,7 +209,7 @@ impl Backend for DotnetPlugin {
             .set_message(format!("Installing .NET {} {}", install_type, tv.version));
         install_cmd(&script_path, &install_dir, &tv.version, runtime.as_deref())
             .with_pr(ctx.pr.as_ref())
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .envs(self.exec_env(&ctx.config, &ctx.ts, &tv).await?)
             .execute()?;
 

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -44,7 +44,7 @@ impl ElixirPlugin {
         CmdLineRunner::new(self.elixir_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .envs(self.dependency_env(&ctx.config).await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .arg("--version")
             .execute()
     }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -340,7 +340,7 @@ impl ErlangPlugin {
             .with_pr(ctx.pr.as_ref())
             .arg("-minimal")
             .arg(tv.install_path())
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()?;
 
         Ok(Some(tv))
@@ -551,7 +551,10 @@ impl ErlangPlugin {
                 )
                 .env("MAKEFLAGS", format!("-j{}", num_cpus::get()));
                 for (key, value) in source_build_kerl_env(tv.install_env(), &kerl_base_dir) {
-                    cmd = cmd.env(key, value);
+                    cmd = match value {
+                        Some(value) => cmd.env(key, value),
+                        None => cmd.env_remove(key),
+                    };
                 }
                 cmd.run()?;
             }
@@ -709,25 +712,28 @@ impl Backend for ErlangPlugin {
 }
 
 fn source_build_kerl_env(
-    install_env: IndexMap<String, String>,
+    install_env: IndexMap<String, crate::config::env_directive::EnvValue>,
     kerl_base_dir: &Path,
-) -> IndexMap<String, OsString> {
+) -> IndexMap<String, Option<OsString>> {
     let mut env = install_env
         .into_iter()
-        .map(|(key, value)| (key, OsString::from(value)))
+        .map(|(key, value)| (key, value.into_string().map(OsString::from)))
         .collect::<IndexMap<_, _>>();
     // Source lock metadata resolves a GitHub archive and stages it here. Keep
     // kerl from selecting another backend or download directory and silently
     // building a different archive instead.
     env.insert(
         "KERL_BASE_DIR".to_string(),
-        kerl_base_dir.as_os_str().to_owned(),
+        Some(kerl_base_dir.as_os_str().to_owned()),
     );
     env.insert(
         "KERL_DOWNLOAD_DIR".to_string(),
-        kerl_base_dir.join("archives").into_os_string(),
+        Some(kerl_base_dir.join("archives").into_os_string()),
     );
-    env.insert("KERL_BUILD_BACKEND".to_string(), OsString::from("git"));
+    env.insert(
+        "KERL_BUILD_BACKEND".to_string(),
+        Some(OsString::from("git")),
+    );
     env
 }
 
@@ -766,26 +772,38 @@ mod tests {
     #[test]
     fn test_source_build_kerl_env_pins_staged_archive() {
         let install_env = IndexMap::from([
-            ("KERL_BUILD_BACKEND".to_string(), "tarball".to_string()),
+            (
+                "KERL_BUILD_BACKEND".to_string(),
+                crate::config::env_directive::EnvValue::from("tarball"),
+            ),
             (
                 "KERL_DOWNLOAD_DIR".to_string(),
-                "/custom/downloads".to_string(),
+                crate::config::env_directive::EnvValue::from("/custom/downloads"),
             ),
             (
                 "KERL_CONFIGURE_OPTIONS".to_string(),
-                "--without-javac".to_string(),
+                crate::config::env_directive::EnvValue::from("--without-javac"),
             ),
         ]);
         let kerl_base_dir = Path::new("/mise/kerl");
         let env = source_build_kerl_env(install_env, kerl_base_dir);
 
-        assert_eq!(env["KERL_BUILD_BACKEND"], "git");
-        assert_eq!(env["KERL_BASE_DIR"], kerl_base_dir.as_os_str());
         assert_eq!(
-            env["KERL_DOWNLOAD_DIR"],
-            kerl_base_dir.join("archives").as_os_str()
+            env["KERL_BUILD_BACKEND"].as_deref(),
+            Some(std::ffi::OsStr::new("git"))
         );
-        assert_eq!(env["KERL_CONFIGURE_OPTIONS"], "--without-javac");
+        assert_eq!(
+            env["KERL_BASE_DIR"].as_deref(),
+            Some(kerl_base_dir.as_os_str())
+        );
+        assert_eq!(
+            env["KERL_DOWNLOAD_DIR"].as_deref(),
+            Some(kerl_base_dir.join("archives").as_os_str())
+        );
+        assert_eq!(
+            env["KERL_CONFIGURE_OPTIONS"].as_deref(),
+            Some(std::ffi::OsStr::new("--without-javac"))
+        );
     }
 
     #[test]

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -94,7 +94,7 @@ impl GoPlugin {
                 .arg("install")
                 .arg(package)
                 .envs(self._exec_env(tv)?)
-                .envs(tv.install_env())
+                .env_values(tv.install_env())
                 .execute()?;
         }
         Ok(())
@@ -107,7 +107,7 @@ impl GoPlugin {
             .current_dir(tv.install_path())
             .with_pr(pr)
             .arg("version")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -189,7 +189,7 @@ impl JavaPlugin {
         CmdLineRunner::new(self.java_bin(tv))
             .with_pr(pr)
             .env("JAVA_HOME", tv.install_path())
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .arg("-version")
             .execute()
     }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -283,7 +283,7 @@ impl NodePlugin {
         if let Some(cflags) = settings.node.cflags() {
             cmd = cmd.env("CFLAGS", cflags);
         }
-        cmd = cmd.envs(tv.install_env());
+        cmd = cmd.env_values(tv.install_env());
         Ok(cmd)
     }
 
@@ -369,7 +369,7 @@ impl NodePlugin {
             .arg(sig_file)
             .arg(shasums_file)
             .with_pr(ctx.pr.as_ref())
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()?;
         Ok(())
     }
@@ -399,7 +399,7 @@ impl NodePlugin {
         Ok(CmdLineRunner::new(self.npm_path(tv))
             .with_pr(pr)
             .envs(config.env().await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .env("NPM_CONFIG_UPDATE_NOTIFIER", "false"))
     }
@@ -456,7 +456,7 @@ impl NodePlugin {
         CmdLineRunner::new(corepack)
             .with_pr(pr)
             .arg("enable")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()?;
         Ok(())
@@ -470,7 +470,7 @@ impl NodePlugin {
             .arg("enable")
             .arg("npm")
             .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .env(&*env::PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()?;
         Ok(())
@@ -487,7 +487,7 @@ impl NodePlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -431,7 +431,7 @@ impl PythonPlugin {
             .arg(tv.version.as_str())
             .arg(tv.install_path())
             .envs(ctx.config.env().await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .env("PIP_REQUIRE_VIRTUALENV", "false");
         if Settings::get().verbose {
             cmd = cmd.arg("--verbose");
@@ -487,7 +487,7 @@ impl PythonPlugin {
             .arg("-r")
             .arg(packages_file)
             .envs(config.env().await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .env("PIP_REQUIRE_VIRTUALENV", "false")
             .execute()
     }
@@ -549,7 +549,7 @@ impl PythonPlugin {
             .with_pr(pr)
             .arg("--version")
             .envs(config.env().await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -257,7 +257,7 @@ impl RubyPlugin {
                 .with_pr(pr)
                 .arg("install")
                 .envs(config.env().await?)
-                .envs(tv.install_env());
+                .env_values(tv.install_env());
             match package.split_once(' ') {
                 Some((name, "--pre")) => cmd = cmd.arg(name).arg("--pre"),
                 Some((name, version)) => cmd = cmd.arg(name).arg("--version").arg(version),
@@ -308,7 +308,7 @@ impl RubyPlugin {
         Ok(cmd
             .with_pr(pr)
             .envs(config.env().await?)
-            .envs(tv.install_env()))
+            .env_values(tv.install_env()))
     }
     fn install_args_ruby_build(&self, tv: &ToolVersion) -> Result<Vec<String>> {
         let settings = Settings::get();

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -69,7 +69,7 @@ impl RubyPlugin {
                 .with_pr(pr)
                 .arg("install")
                 .envs(config.env().await?)
-                .envs(tv.install_env());
+                .env_values(tv.install_env());
             match package.split_once(' ') {
                 Some((name, "--pre")) => cmd = cmd.arg(name).arg("--pre"),
                 Some((name, version)) => cmd = cmd.arg(name).arg("--version").arg(version),
@@ -92,7 +92,7 @@ impl RubyPlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()
     }
 
@@ -107,7 +107,7 @@ impl RubyPlugin {
             .with_pr(pr)
             .arg("-v")
             .envs(config.env().await?)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .env(&*PATH_KEY, plugins::core::path_env_with_tv_path(tv)?)
             .execute()
     }

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -120,7 +120,7 @@ impl RustPlugin {
             .arg("--default-toolchain")
             .arg("none")
             .arg("-y")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .envs(self.exec_env(&ctx.config, ts, tv).await?);
         if let Some(host) = settings.rust.default_host.as_ref() {
             cmd = cmd.arg("--default-host").arg(host);
@@ -135,7 +135,7 @@ impl RustPlugin {
         CmdLineRunner::new(RUSTC_BIN)
             .with_pr(ctx.pr.as_ref())
             .arg("-V")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .envs(self.exec_env(&ctx.config, ts, tv).await?)
             .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
             .execute()
@@ -364,7 +364,7 @@ impl Backend for RustPlugin {
             .opt_args("--component", components)
             .opt_args("--target", targets)
             .prepend_path(self.list_bin_paths(&ctx.config, &tv).await?)?
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .envs(self.exec_env(&ctx.config, ts, &tv).await?);
         if let Some(profile) = profile.as_ref() {
             cmd = cmd.arg("--profile").arg(profile);

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -37,7 +37,7 @@ impl SwiftPlugin {
         CmdLineRunner::new(self.swift_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("--version")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()
     }
 
@@ -79,7 +79,7 @@ impl SwiftPlugin {
                 .arg(tarball_path)
                 .arg(&tmp)
                 .with_pr(ctx.pr.as_ref())
-                .envs(tv.install_env())
+                .env_values(tv.install_env())
                 .execute()?;
             file::remove_all(tv.install_path())?;
             file::rename(
@@ -142,7 +142,7 @@ impl SwiftPlugin {
             .arg("--verify")
             .arg(&sig_path)
             .arg(tarball_path)
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()?;
         Ok(())
     }

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -62,7 +62,7 @@ impl ZigPlugin {
         CmdLineRunner::new(self.zig_bin(tv))
             .with_pr(ctx.pr.as_ref())
             .arg("version")
-            .envs(tv.install_env())
+            .env_values(tv.install_env())
             .execute()
     }
 

--- a/src/plugins/script_manager.rs
+++ b/src/plugins/script_manager.rs
@@ -116,6 +116,29 @@ impl ScriptManager {
         self
     }
 
+    pub fn without_env<K>(mut self, key: K) -> Self
+    where
+        K: Into<OsString>,
+    {
+        let key = key.into();
+        #[cfg(windows)]
+        if let Some(existing) = self
+            .env
+            .keys()
+            .find(|existing| {
+                existing
+                    .to_string_lossy()
+                    .eq_ignore_ascii_case(&key.to_string_lossy())
+            })
+            .cloned()
+        {
+            self.env.remove(&existing);
+        }
+        #[cfg(not(windows))]
+        self.env.remove(&key);
+        self
+    }
+
     pub fn prepend_path(&mut self, path: PathBuf) {
         let k: OsString = PATH_KEY.to_string().into();
         let mut paths = env::split_paths(&self.env[&k]).collect::<Vec<_>>();

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -7,6 +7,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::backend::{ABackend, VersionInfo};
 use crate::cli::args::BackendArg;
+use crate::config::env_directive::EnvValue;
 use crate::config::{Config, Settings};
 #[cfg(windows)]
 use crate::file;
@@ -215,7 +216,7 @@ impl ToolVersion {
         path
     }
 
-    pub fn install_env(&self) -> IndexMap<String, String> {
+    pub fn install_env(&self) -> IndexMap<String, EnvValue> {
         self.request.options().core.install_env
     }
 
@@ -923,7 +924,7 @@ mod tests {
         };
         options.install_env.insert(
             "NODE_OPTIONS".to_string(),
-            "--enable-source-maps".to_string(),
+            EnvValue::from("--enable-source-maps"),
         );
         options.opts.insert(
             "registry".to_string(),
@@ -950,8 +951,8 @@ mod tests {
         assert_eq!(tv.ba().full_without_opts(), "npm:npm");
         assert_eq!(options.depends, Some(vec!["node".to_string()]));
         assert_eq!(
-            options.install_env.get("NODE_OPTIONS").map(String::as_str),
-            Some("--enable-source-maps")
+            options.install_env.get("NODE_OPTIONS"),
+            Some(&EnvValue::String("--enable-source-maps".to_string()))
         );
         assert_eq!(
             options.opts.get("registry"),

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -1,6 +1,8 @@
 use indexmap::IndexMap;
 use std::ops::{Deref, DerefMut};
 
+use crate::config::env_directive::EnvValue;
+
 /// Option keys that are only relevant during initial installation and should not
 /// be persisted in the manifest or serialized into task/backend option specs.
 // install_env is a core field on CoreToolOptions, but parse_tool_options()
@@ -20,7 +22,7 @@ pub struct CoreToolOptions {
     #[serde(default)]
     pub depends: Option<Vec<String>>,
     #[serde(default)]
-    pub install_env: IndexMap<String, String>,
+    pub install_env: IndexMap<String, EnvValue>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -346,7 +348,7 @@ impl ToolOptions {
                     .ok_or_else(|| "install_env must be a table".to_string())?;
                 for (key, value) in env {
                     self.install_env
-                        .insert(key.clone(), env_value_to_string(value)?);
+                        .insert(key.clone(), EnvValue::try_from(value)?);
                 }
                 Ok(true)
             }
@@ -363,7 +365,7 @@ impl ToolOptions {
                 if let Some(env_key) = key.strip_prefix("install_env.") {
                     self.install_env.insert(
                         env_key.to_string(),
-                        env_value_to_string(value)
+                        EnvValue::try_from(value)
                             .map_err(|_| format!("{key} must be a string, integer, or boolean"))?,
                     );
                     Ok(true)
@@ -496,15 +498,6 @@ fn parse_string_or_array(value: &toml::Value, key: &str) -> Result<Vec<String>, 
     }
 }
 
-fn env_value_to_string(value: &toml::Value) -> Result<String, String> {
-    match value {
-        toml::Value::String(s) => Ok(s.clone()),
-        toml::Value::Integer(i) => Ok(i.to_string()),
-        toml::Value::Boolean(b) => Ok(b.to_string()),
-        _ => Err("install_env values must be strings, integers, or booleans".to_string()),
-    }
-}
-
 fn normalize_backend_option_value(key: &str, value: toml::Value) -> toml::Value {
     if preserves_backend_option_type(key) {
         return value;
@@ -601,8 +594,9 @@ fn parse_manual_tool_options_raw(s: &str) -> IndexMap<String, toml::Value> {
     for opt in split_tool_option_segments(s) {
         if let Some((k, v)) = opt.split_once('=') {
             if !k.trim().is_empty() {
-                raw.insert(k.trim().to_string(), parse_tool_option_value(v));
-                current_key = Some(k.trim().to_string());
+                let key = k.trim().to_string();
+                raw.insert(key.clone(), parse_tool_option_value(&key, v));
+                current_key = Some(key);
             }
         } else if !opt.is_empty() {
             // No '=' found, append to the previous value or create a new key
@@ -653,13 +647,13 @@ fn split_tool_option_segments(s: &str) -> Vec<String> {
     segments
 }
 
-fn parse_tool_option_value(raw: &str) -> toml::Value {
+fn parse_tool_option_value(key: &str, raw: &str) -> toml::Value {
     let trimmed = raw.trim();
 
-    if ((trimmed.starts_with('"') && trimmed.ends_with('"'))
+    let quoted = ((trimmed.starts_with('"') && trimmed.ends_with('"'))
         || (trimmed.starts_with('\'') && trimmed.ends_with('\'')))
-        && trimmed.len() >= 2
-    {
+        && trimmed.len() >= 2;
+    if quoted || key == "install_env" || key.starts_with("install_env.") {
         let toml_str = format!("_x_ = {trimmed}");
         if let Ok(value) = toml::from_str::<toml::Value>(&toml_str)
             && let Some(parsed) = value.get("_x_")
@@ -830,7 +824,7 @@ mod tests {
 
     #[test]
     fn test_parse_tool_options_core_keys_from_toml() {
-        let input = r#"depends=["python","node"],os="linux",install_env={ FOO = "bar", RETRIES = 2 },postinstall="echo hi",minimum_release_age="7d",install_before="2024-01-01""#;
+        let input = r#"depends=["python","node"],os="linux",install_env={ FOO = "bar", RETRIES = 2, REMOVE = false },postinstall="echo hi",minimum_release_age="7d",install_before="2024-01-01""#;
         let opts = parse_tool_options(input);
 
         assert_eq!(
@@ -838,10 +832,14 @@ mod tests {
             Some(vec!["python".to_string(), "node".to_string()])
         );
         assert_eq!(opts.os, Some(vec!["linux".to_string()]));
-        assert_eq!(opts.install_env.get("FOO").map(String::as_str), Some("bar"));
         assert_eq!(
-            opts.install_env.get("RETRIES").map(String::as_str),
-            Some("2")
+            opts.install_env.get("FOO"),
+            Some(&EnvValue::String("bar".to_string()))
+        );
+        assert_eq!(opts.install_env.get("RETRIES"), Some(&EnvValue::Integer(2)));
+        assert_eq!(
+            opts.install_env.get("REMOVE"),
+            Some(&EnvValue::Boolean(false))
         );
         assert_eq!(opts.get("postinstall"), Some("echo hi"));
         assert_eq!(opts.get("minimum_release_age"), Some("7d"));
@@ -873,12 +871,20 @@ mod tests {
     #[test]
     fn test_parse_tool_options_core_keys_from_manual_syntax() {
         let opts = parse_tool_options(
-            "depends=python,os=linux,install_env.FOO=bar,postinstall=echo hi,minimum_release_age=7d",
+            "depends=python,os=linux,install_env.FOO=bar,install_env.REMOVE=false,install_env.RETRIES=2,postinstall=echo hi,minimum_release_age=7d",
         );
 
         assert_eq!(opts.depends, Some(vec!["python".to_string()]));
         assert_eq!(opts.os, Some(vec!["linux".to_string()]));
-        assert_eq!(opts.install_env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(
+            opts.install_env.get("FOO"),
+            Some(&EnvValue::String("bar".to_string()))
+        );
+        assert_eq!(
+            opts.install_env.get("REMOVE"),
+            Some(&EnvValue::Boolean(false))
+        );
+        assert_eq!(opts.install_env.get("RETRIES"), Some(&EnvValue::Integer(2)));
         assert_eq!(opts.get("postinstall"), Some("echo hi"));
         assert_eq!(opts.get("minimum_release_age"), Some("7d"));
         assert!(!opts.opts.contains_key("depends"));
@@ -913,7 +919,10 @@ mod tests {
 
         assert_eq!(opts.os, Some(vec!["linux".to_string()]));
         assert_eq!(opts.depends, Some(vec!["node".to_string()]));
-        assert_eq!(opts.install_env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(
+            opts.install_env.get("FOO"),
+            Some(&EnvValue::String("bar".to_string()))
+        );
         assert_eq!(opts.get("exe"), Some("rg"));
         assert_eq!(opts.get_string("strip_components"), Some("1".to_string()));
         assert!(!opts.opts.contains_key("os"));
@@ -1084,7 +1093,7 @@ mod tests {
                 depends: Some(vec!["node".to_string()]),
                 install_env: [(
                     "NPM_CONFIG_REGISTRY".to_string(),
-                    "https://example.com".to_string(),
+                    EnvValue::from("https://example.com"),
                 )]
                 .iter()
                 .cloned()
@@ -1105,7 +1114,7 @@ mod tests {
         let config_opts = ToolVersionOptions {
             core: CoreToolOptions {
                 os: Some(vec!["linux".to_string()]),
-                install_env: [("CONFIG_ONLY".to_string(), "1".to_string())]
+                install_env: [("CONFIG_ONLY".to_string(), EnvValue::from("1"))]
                     .iter()
                     .cloned()
                     .collect(),
@@ -1116,7 +1125,7 @@ mod tests {
         let inline_opts = ToolVersionOptions {
             core: CoreToolOptions {
                 depends: Some(vec!["node".to_string()]),
-                install_env: [("INLINE_ONLY".to_string(), "2".to_string())]
+                install_env: [("INLINE_ONLY".to_string(), EnvValue::from("2"))]
                     .iter()
                     .cloned()
                     .collect(),
@@ -1243,7 +1252,7 @@ mod tests {
             core: CoreToolOptions {
                 os: Some(vec!["linux".to_string()]),
                 depends: Some(vec!["node".to_string()]),
-                install_env: [("BASE".to_string(), "1".to_string())]
+                install_env: [("BASE".to_string(), EnvValue::from("1"))]
                     .iter()
                     .cloned()
                     .collect(),
@@ -1260,7 +1269,7 @@ mod tests {
             core: CoreToolOptions {
                 os: Some(vec!["macos".to_string()]),
                 depends: Some(vec!["python".to_string()]),
-                install_env: [("BASE".to_string(), "2".to_string())]
+                install_env: [("BASE".to_string(), EnvValue::from("2"))]
                     .iter()
                     .cloned()
                     .collect(),
@@ -1275,7 +1284,10 @@ mod tests {
 
         assert_eq!(base.os, Some(vec!["macos".to_string()]));
         assert_eq!(base.depends, Some(vec!["python".to_string()]));
-        assert_eq!(base.install_env.get("BASE").map(String::as_str), Some("2"));
+        assert_eq!(
+            base.install_env.get("BASE"),
+            Some(&EnvValue::String("2".to_string()))
+        );
         assert_eq!(base.get("api_url"), Some("https://inline.example"));
         assert_eq!(base.get("version_prefix"), Some("v"));
     }


### PR DESCRIPTION
## Summary

- share an `EnvValue` representation between regular environment parsing and per-tool `install_env`
- preserve `false` as a removal operation across core, asdf, vfox, SPM, postinstall, and tool-stub installer paths
- preserve boolean and integer values in legacy bracket options such as `install_env.REMOVE=false`
- reuse `$defs.env_value` for direct `env` values and `install_env` values in both schemas
- restrict schema numeric values to integers, matching the existing Rust parser

## Root cause

`install_env` eagerly converted every scalar to `String`. That turned `false` into the literal value `"false"`, while regular `[env]` parsing treats `false` as an unset operation. By the time installer commands were constructed, the original intent had been lost.

The shared enum retains the TOML scalar until the environment is applied. Strings, integers, and `true` become string environment values; `false` calls `env_remove` or removes the key from a full environment map.

## Review follow-ups

- explicitly remove inherited variables from tool-level postinstall processes instead of only deleting them from a partial overlay
- reapply vfox removals after tool-derived environment values are merged
- remove keys case-insensitively from asdf/vfox full-environment maps on Windows
- preserve typed values in the legacy manual backend-option parser
- preserve #11021's structured task-tool schema while sharing the same `install_env` value definition

## Schema note

The schema now describes the same shared scalar contract used by Rust: string, integer, or boolean, with `false` removing the variable. Direct `[env]` values and `install_env` both reference that definition instead of maintaining duplicate alternatives.

Floats were already rejected by both Rust parsing paths, so changing `number` to `integer` fixes an existing schema/runtime mismatch rather than changing runtime behavior.

## Validation

- `mise run lint-fix`
- `mise run render:schema`
- `mise x cargo -- cargo check`
- targeted unit tests for regular env removal, legacy bracket parsing, backend args, and Erlang source-build env handling
- `mise run test:e2e config/test_hooks_postinstall_env backend/test_vfox_install_env config/test_schema_tombi`
- pinned Tombi 0.9.22 validates false/integer task `install_env` values and rejects floats in both main and standalone task schemas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation environment settings now support text, integer, and boolean values.
  * Setting an environment variable to `false` removes it during tool installation and verification.
  * Install-time environment handling is applied consistently across supported tool backends and plugins, including post-install hooks.

* **Bug Fixes**
  * Corrected environment inheritance/override behavior so removed variables show as `unset` where applicable.

* **Documentation**
  * Updated and tightened configuration schemas/strict-schema fixtures to validate the supported environment value types and reject invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->