### PR TITLE
fix(bootstrap): compare repo origins transport-agnostically

### DIFF
--- a/docs/bootstrap/repos.md
+++ b/docs/bootstrap/repos.md
@@ -23,11 +23,14 @@ from that checkout.
   for that path.
 - **Safe updates only** — mise clones missing repos or empty target
   directories and updates existing repos only when the worktree is clean and
-  the configured `origin` URL matches. Common network URL forms are compared
-  transport-agnostically: `git@host:path`, `ssh://git@host/path`, and
-  `https://host/path` identify the same repo. Different hosts, ssh aliases,
-  explicit ports, paths, or non-`git` ssh users still conflict, and local
-  paths and `file://` URLs require an exact match.
+  the configured `origin` URL matches. Exactly three network URL forms are
+  compared transport-agnostically: `git@host:path`, `ssh://git@host/path`,
+  and `https://host/path` identify the same repo. Different hosts, ssh
+  aliases, explicit ports, paths, or non-`git` ssh users still conflict.
+  Everything else requires an exact match: `http://` and `git://` origins
+  (an insecure transport is never silently treated as the https config),
+  ssh origins without a user (git resolves those to the login user, not
+  `git`), URLs carrying a query string, local paths, and `file://` URLs.
 - **No implicit writes** — repos are changed only by explicit `apply`, `update`,
   `exec`, or top-level `mise bootstrap` commands. Applying never pulls an
   existing repo without a configured `ref`; use `mise bootstrap repos update`

--- a/docs/bootstrap/repos.md
+++ b/docs/bootstrap/repos.md
@@ -23,7 +23,11 @@ from that checkout.
   for that path.
 - **Safe updates only** — mise clones missing repos or empty target
   directories and updates existing repos only when the worktree is clean and
-  the configured `origin` URL matches.
+  the configured `origin` URL matches. Common network URL forms are compared
+  transport-agnostically: `git@host:path`, `ssh://git@host/path`, and
+  `https://host/path` identify the same repo. Different hosts, ssh aliases,
+  explicit ports, paths, or non-`git` ssh users still conflict, and local
+  paths and `file://` URLs require an exact match.
 - **No implicit writes** — repos are changed only by explicit `apply`, `update`,
   `exec`, or top-level `mise bootstrap` commands. Applying never pulls an
   existing repo without a configured `ref`; use `mise bootstrap repos update`

--- a/src/system/repos.rs
+++ b/src/system/repos.rs
@@ -455,8 +455,13 @@ fn repo_identity(url: &str) -> Option<String> {
         if url.query().is_some() || url.fragment().is_some() {
             return None;
         }
-        if scheme == "ssh" && url.username().is_empty() {
-            return None;
+        // https userinfo is credential material, not repository identity — it
+        // must not occupy the same identity slot as an ssh user. ssh needs an
+        // explicit user (an omitted one means the login user, not `git`).
+        match scheme.as_str() {
+            "https" if !url.username().is_empty() || url.password().is_some() => return None,
+            "ssh" if url.username().is_empty() => return None,
+            _ => {}
         }
         let host = url.host_str()?.to_string();
         repo_identity_parts(url.username(), &host, url.port(), url.path())
@@ -932,6 +937,7 @@ mod tests {
             "https://github.com/jdx/mise?tenant=a",   // query strings are not identity
             "http://github.com/jdx/mise.git",         // insecure transport is not equivalent
             "git://github.com/jdx/mise.git",          // insecure transport is not equivalent
+            "https://alice@github.com/jdx/mise.git",  // https userinfo is credentials, not identity
             "ftp://github.com/jdx/mise.git",          // unrecognized scheme
         ] {
             assert!(
@@ -959,6 +965,11 @@ mod tests {
         assert!(!origin_matches_config(
             Some("https://github.com/jdx/mise?tenant=a"),
             "https://github.com/jdx/mise?tenant=b"
+        ));
+        // https userinfo never occupies the ssh-user identity slot
+        assert!(!origin_matches_config(
+            Some("ssh://alice@example.com/team/repo.git"),
+            "https://alice@example.com/team/repo.git"
         ));
         // local and file:// forms keep exact matching
         assert!(!origin_matches_config(

--- a/src/system/repos.rs
+++ b/src/system/repos.rs
@@ -9,13 +9,15 @@
 //!
 //! Repos are applied only during explicit bootstrap commands. Existing repos
 //! are updated only when the worktree is clean and the configured origin
-//! matches.
+//! matches. Origins are compared transport-agnostically for common network
+//! forms, so an ssh origin matches its https equivalent.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use eyre::{Result, bail, eyre};
 use serde::Deserialize;
+use url::Url;
 
 use crate::file;
 
@@ -422,7 +424,61 @@ fn origin_matches_config(origin: Option<&str>, config_url: &str) -> bool {
     let Some(origin) = origin else {
         return false;
     };
-    origin == config_url || normalize_remote_url(origin) == normalize_remote_url(config_url)
+    if origin == config_url || normalize_remote_url(origin) == normalize_remote_url(config_url) {
+        return true;
+    }
+    match (repo_identity(origin), repo_identity(config_url)) {
+        (Some(origin), Some(config)) => origin == config,
+        _ => false,
+    }
+}
+
+/// Reduces a network remote URL to a host/path identity so the same repo is
+/// recognized across transports: `git@host:path`, `ssh://git@host/path`, and
+/// `https://host/path` all compare equal. Explicit ports and non-`git` users
+/// stay part of the identity since they can address different repositories.
+/// Local paths, `file://` URLs, and unrecognized syntax return `None` and keep
+/// exact matching.
+fn repo_identity(url: &str) -> Option<String> {
+    let url = normalize_remote_url(url);
+    if let Some((scheme, _)) = url.split_once("://") {
+        if !matches!(
+            scheme.to_ascii_lowercase().as_str(),
+            "ssh" | "git" | "http" | "https"
+        ) {
+            return None;
+        }
+        let url = Url::parse(&url).ok()?;
+        let host = url.host_str()?.to_string();
+        repo_identity_parts(url.username(), &host, url.port(), url.path())
+    } else if is_scp_like_url(&url) {
+        let (authority, path) = url.split_once(':')?;
+        if authority.contains(['[', ']']) {
+            return None;
+        }
+        let (user, host) = match authority.rsplit_once('@') {
+            Some((user, host)) => (user, host),
+            None => ("", authority),
+        };
+        repo_identity_parts(user, host, None, path)
+    } else {
+        None
+    }
+}
+
+fn repo_identity_parts(user: &str, host: &str, port: Option<u16>, path: &str) -> Option<String> {
+    let path = path.trim_matches('/');
+    if host.is_empty() || path.is_empty() {
+        return None;
+    }
+    // the conventional `git` ssh user is transport metadata on forges
+    let user = match user {
+        "" | "git" => String::new(),
+        user => format!("{user}@"),
+    };
+    let host = host.to_ascii_lowercase();
+    let port = port.map(|port| format!(":{port}")).unwrap_or_default();
+    Some(format!("{user}{host}{port}/{path}"))
 }
 
 fn normalize_remote_url(url: &str) -> String {
@@ -811,6 +867,114 @@ mod tests {
         assert!(!is_scp_like_url(r"C:\repos\foo.git"));
         assert!(is_scp_like_url("git@github.com:jdx/mise.git"));
         assert!(!origin_matches_config(None, "https://github.com/jdx/mise"));
+    }
+
+    #[test]
+    fn origin_urls_match_the_same_repo_across_transports() {
+        let https = "https://github.com/jdx/mise.git";
+        for origin in [
+            "git@github.com:jdx/mise.git",
+            "git@github.com:jdx/mise",
+            "ssh://git@github.com/jdx/mise.git",
+            "ssh://git@github.com/jdx/mise",
+            "git://github.com/jdx/mise.git",
+            "http://github.com/jdx/mise",
+            "https://GitHub.com/jdx/mise.git",
+        ] {
+            assert!(
+                origin_matches_config(Some(origin), https),
+                "{origin} should match {https}"
+            );
+            assert!(
+                origin_matches_config(Some(https), origin),
+                "{https} should match {origin}"
+            );
+        }
+        // the same non-git user on both sides is the same identity
+        assert!(origin_matches_config(
+            Some("alice@example.com:team/repo.git"),
+            "ssh://alice@example.com/team/repo"
+        ));
+        // scp paths compare without their optional leading slash
+        assert!(origin_matches_config(
+            Some("git@example.com:/srv/git/repo.git"),
+            "ssh://git@example.com/srv/git/repo"
+        ));
+        // explicit ports match when they agree
+        assert!(origin_matches_config(
+            Some("ssh://git@example.com:2222/team/repo.git"),
+            "ssh://git@example.com:2222/team/repo"
+        ));
+    }
+
+    #[test]
+    fn origin_urls_conflict_across_hosts_users_ports_and_paths() {
+        let https = "https://github.com/jdx/mise.git";
+        for origin in [
+            "git@gitlab.com:jdx/mise.git",            // different host
+            "git@github-work:jdx/mise.git",           // ssh alias
+            "ssh://git@github.com:2222/jdx/mise.git", // explicit port
+            "git@github.com:jdx/other.git",           // different repo
+            "git@github.com:other/mise.git",          // different owner
+            "alice@github.com:jdx/mise.git",          // non-git ssh user
+            "ssh://alice@github.com/jdx/mise.git",    // non-git ssh user (url form)
+            "ftp://github.com/jdx/mise.git",          // unrecognized scheme
+        ] {
+            assert!(
+                !origin_matches_config(Some(origin), https),
+                "{origin} should not match {https}"
+            );
+        }
+        assert!(!origin_matches_config(
+            Some("ssh://git@github.com:2222/jdx/mise.git"),
+            "ssh://git@github.com/jdx/mise.git"
+        ));
+        assert!(!origin_matches_config(
+            Some("alice@github.com:jdx/mise.git"),
+            "git@github.com:jdx/mise.git"
+        ));
+        // local and file:// forms keep exact matching
+        assert!(!origin_matches_config(
+            Some("/srv/git/mise.git"),
+            "file:///srv/git/mise.git"
+        ));
+        assert!(!origin_matches_config(
+            Some(r"C:\repos\mise"),
+            "https://github.com/jdx/mise"
+        ));
+    }
+
+    #[test]
+    fn status_recognizes_origin_across_transports() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        init_repo(&repo);
+        test_git(
+            &repo,
+            &["remote", "add", "origin", "git@github.com:jdx/mise.git"],
+        );
+
+        let request = RepoRequest {
+            path_raw: repo.display().to_string(),
+            path: repo.clone(),
+            url: "https://github.com/jdx/mise.git".to_string(),
+            git_ref: None,
+        };
+        assert_eq!(status_one(&request).unwrap().state, RepoState::Current);
+
+        test_git(
+            &repo,
+            &[
+                "remote",
+                "set-url",
+                "origin",
+                "git@github.com:other/mise.git",
+            ],
+        );
+        assert_eq!(
+            status_one(&request).unwrap().state,
+            RepoState::Conflict("origin does not match configured url".to_string())
+        );
     }
 
     #[test]

--- a/src/system/repos.rs
+++ b/src/system/repos.rs
@@ -434,21 +434,30 @@ fn origin_matches_config(origin: Option<&str>, config_url: &str) -> bool {
 }
 
 /// Reduces a network remote URL to a host/path identity so the same repo is
-/// recognized across transports: `git@host:path`, `ssh://git@host/path`, and
-/// `https://host/path` all compare equal. Explicit ports and non-`git` users
-/// stay part of the identity since they can address different repositories.
-/// Local paths, `file://` URLs, and unrecognized syntax return `None` and keep
-/// exact matching.
+/// recognized across transports — exactly the forms agreed in #10997:
+/// `git@host:path`, `ssh://git@host/path`, and `https://host/path` compare
+/// equal. Everything else keeps exact matching: `http://` and `git://` stay
+/// distinct so an insecure transport is never silently preserved as
+/// equivalent to a configured https url; ssh forms without a user are not
+/// normalized (git resolves an omitted ssh user to the current login user,
+/// not `git`); URLs carrying a query or fragment, local paths, `file://`
+/// URLs, and unrecognized syntax return `None`. Explicit ports and non-`git`
+/// users stay part of the identity since they can address different
+/// repositories.
 fn repo_identity(url: &str) -> Option<String> {
     let url = normalize_remote_url(url);
     if let Some((scheme, _)) = url.split_once("://") {
-        if !matches!(
-            scheme.to_ascii_lowercase().as_str(),
-            "ssh" | "git" | "http" | "https"
-        ) {
+        let scheme = scheme.to_ascii_lowercase();
+        if !matches!(scheme.as_str(), "ssh" | "https") {
             return None;
         }
         let url = Url::parse(&url).ok()?;
+        if url.query().is_some() || url.fragment().is_some() {
+            return None;
+        }
+        if scheme == "ssh" && url.username().is_empty() {
+            return None;
+        }
         let host = url.host_str()?.to_string();
         repo_identity_parts(url.username(), &host, url.port(), url.path())
     } else if is_scp_like_url(&url) {
@@ -456,10 +465,12 @@ fn repo_identity(url: &str) -> Option<String> {
         if authority.contains(['[', ']']) {
             return None;
         }
-        let (user, host) = match authority.rsplit_once('@') {
-            Some((user, host)) => (user, host),
-            None => ("", authority),
-        };
+        // scp-like syntax is always ssh: no user means the login user, so
+        // only explicit-user forms participate in identity comparison.
+        let (user, host) = authority.rsplit_once('@')?;
+        if user.is_empty() {
+            return None;
+        }
         repo_identity_parts(user, host, None, path)
     } else {
         None
@@ -877,8 +888,6 @@ mod tests {
             "git@github.com:jdx/mise",
             "ssh://git@github.com/jdx/mise.git",
             "ssh://git@github.com/jdx/mise",
-            "git://github.com/jdx/mise.git",
-            "http://github.com/jdx/mise",
             "https://GitHub.com/jdx/mise.git",
         ] {
             assert!(
@@ -918,6 +927,11 @@ mod tests {
             "git@github.com:other/mise.git",          // different owner
             "alice@github.com:jdx/mise.git",          // non-git ssh user
             "ssh://alice@github.com/jdx/mise.git",    // non-git ssh user (url form)
+            "ssh://github.com/jdx/mise.git",          // userless ssh = login user, not git
+            "github.com:jdx/mise.git",                // userless scp = login user, not git
+            "https://github.com/jdx/mise?tenant=a",   // query strings are not identity
+            "http://github.com/jdx/mise.git",         // insecure transport is not equivalent
+            "git://github.com/jdx/mise.git",          // insecure transport is not equivalent
             "ftp://github.com/jdx/mise.git",          // unrecognized scheme
         ] {
             assert!(
@@ -932,6 +946,19 @@ mod tests {
         assert!(!origin_matches_config(
             Some("alice@github.com:jdx/mise.git"),
             "git@github.com:jdx/mise.git"
+        ));
+        // userless ssh and query-carrying URLs only match themselves exactly
+        assert!(origin_matches_config(
+            Some("ssh://github.com/jdx/mise.git"),
+            "ssh://github.com/jdx/mise.git"
+        ));
+        assert!(!origin_matches_config(
+            Some("ssh://github.com/jdx/mise.git"),
+            "git@github.com:jdx/mise.git"
+        ));
+        assert!(!origin_matches_config(
+            Some("https://github.com/jdx/mise?tenant=a"),
+            "https://github.com/jdx/mise?tenant=b"
         ));
         // local and file:// forms keep exact matching
         assert!(!origin_matches_config(


### PR DESCRIPTION
Implements the direction agreed in #10997: `[bootstrap.repos]` rejected an existing checkout whose `origin` uses a different transport than the configured `url`, even when both identify the same repository (e.g. `git@github.com:jdx/mise.git` vs `https://github.com/jdx/mise.git`). Updates fetch and pull through the checkout's own `origin`, so the configured `url` acts as a repository identity check, not a fetch source.

### What changed

`origin_matches_config` now falls back to comparing a `repo_identity` for common network URL forms — `git@host:path`, `ssh://user@host[:port]/path`, and `https://host/path` — exactly the three forms from the discussion — reduced to `[user@]host[:port]/path` with the `.git` suffix stripped.

Per the contract in the discussion:

- **Still conflicts**: different hosts, ssh aliases, explicit ports, and paths.
- **Non-`git` ssh users stay part of the identity** — they can identify different repositories on generic ssh servers. Only the conventional `git` user is treated as transport metadata.
- **Exact matching preserved** for local paths, `file://` URLs, Windows paths, and unrecognized syntax (unknown schemes, remote-helper forms).

Docs updated to state the comparison rules.

### Tests

- `origin_urls_match_the_same_repo_across_transports`: positive ssh↔https coverage across scp, `ssh://`, suffixless, host-case, same-non-git-user, leading-slash scp paths, and agreeing explicit ports — both directions.
- `origin_urls_conflict_across_hosts_users_ports_and_paths`: negative coverage for different host, ssh alias, explicit port, different path/owner, non-git ssh user (scp and url forms), userless ssh (git resolves an omitted user to the login user, not `git`), query-carrying URLs, `http://` and `git://` (an insecure transport is never treated as the https config), unrecognized scheme, local vs `file://`, and Windows paths.
- `status_recognizes_origin_across_transports`: real-git fixture through `status_one` — ssh origin against an https config reports `current`, a foreign owner reports the unchanged `origin does not match configured url` conflict.

Also verified against a locally built binary with real fixture repos: all six spellings of the declared repo report `current`; foreign owner / different host / ssh alias / explicit port / non-git user report `conflict`; dirty checkouts still hard-stop with `has local changes`; linked worktrees (`.git` file) are recognized; `repos update` (#11022) flows through the same comparison. The released 2026.7.5 binary reports `conflict` for the ssh-origin case as a control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository update checks with transport-agnostic matching across supported remote URL formats (including optional `.git`, host casing normalization, and explicit port handling).
  * Added stricter conflict detection for mismatches (hosts/users/ports/paths) and for unsupported or insecure/local/file-like URL forms, query/fragment components, and invalid SSH/HTTPS credentials.
  * Updated status behavior to reflect “current” when the configured origin matches the remote identity, otherwise “conflict”.
* **Documentation**
  * Expanded “Safe updates only” guidance to define exactly which origin URL variants are treated as equivalent and which are conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
