### PR TITLE
fix(schema): add missing plugin manifest fields

### DIFF
--- a/schema/mise.plugin.json
+++ b/schema/mise.plugin.json
@@ -43,6 +43,17 @@
         }
       }
     },
+    "list-idiomatic-filenames": {
+      "description": "configuration for idiomatic filename discovery",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "data": {
+          "description": "list of idiomatic filenames to check for",
+          "type": "string"
+        }
+      }
+    },
     "list-bin-paths": {
       "description": "configuration for bin/list-bin-paths script",
       "$ref": "#/$defs/plugin-script-config"
@@ -50,6 +61,35 @@
     "exec-env": {
       "description": "configuration for bin/exec-env script",
       "$ref": "#/$defs/plugin-script-config"
+    },
+    "package-manager": {
+      "description": "configuration for a package-manager plugin",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "requires": {
+          "description": "host binaries required by the package-manager plugin",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "supports_version_pins": {
+          "description": "whether the package manager supports version-pinned requests",
+          "type": "boolean"
+        },
+        "supports-version-pins": {
+          "description": "whether the package manager supports version-pinned requests",
+          "type": "boolean"
+        },
+        "os": {
+          "description": "operating systems supported by the package-manager plugin",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/src/plugins/mise_plugin_toml.rs
+++ b/src/plugins/mise_plugin_toml.rs
@@ -147,6 +147,18 @@ mod tests {
         let cf = MisePluginToml::from_file(&dirs::HOME.join("fixtures/mise.plugin.toml")).unwrap();
 
         assert_debug_snapshot!(cf.exec_env);
+        assert_eq!(
+            cf.list_idiomatic_filenames.data.as_deref(),
+            Some("test-idiomatic-filenames")
+        );
+        assert_eq!(
+            cf.package_manager,
+            MisePluginTomlPackageManagerConfig {
+                requires: vec!["helm".into(), "kubectl".into()],
+                supports_version_pins: true,
+                os: Some(vec!["macos".into(), "linux".into()]),
+            }
+        );
     }
 
     #[test]

--- a/test/fixtures/mise.plugin.toml
+++ b/test/fixtures/mise.plugin.toml
@@ -2,3 +2,11 @@
 
 [exec-env]
 cache-key = ["{{'1234'}}"]
+
+[list-idiomatic-filenames]
+data = "test-idiomatic-filenames"
+
+[package-manager]
+requires = ["helm", "kubectl"]
+supports-version-pins = true
+os = ["macos", "linux"]


### PR DESCRIPTION
## Summary

- allow `list-idiomatic-filenames` in `mise.plugin.toml` alongside `list-legacy-filenames`
- describe the `package-manager` manifest table and its `requires`, version-pin support, and `os` settings
- accept both version-pin key spellings recognized by the Rust parser

## Why

The plugin manifest schema had fallen behind `MisePluginToml`: it still exposed only the legacy idiomatic-filename key and did not include the recently added package-manager configuration. Editors and schema validators therefore rejected configuration that mise itself accepts.

## Validation

- `mise run lint-fix`
- validated a representative manifest instance with `ajv` against `schema/mise.plugin.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new top-level `package-manager` plugin configuration to declare required tools, supported OS list, and version-pinning support.
  * Extended `list-idiomatic-filenames` configuration to include a `data` value.
* **Documentation**
  * Updated configuration schema/validation to recognize the new `package-manager` and updated `list-idiomatic-filenames` fields.
* **Tests**
  * Expanded unit test coverage and TOML fixtures to verify parsing of the new configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->