### PR TITLE
registry: add shuck to registry

### DIFF
--- a/registry/shuck.toml
+++ b/registry/shuck.toml
@@ -1,0 +1,3 @@
+backends = ["github:ewhauser/shuck"]
+description = "A lightning fast shell linter/formatter/LSP server"
+test = { cmd = "shuck --version", expected = "shuck {{version}}" }


### PR DESCRIPTION
Add `shuck`, a shell linter, formatter, and language server to the `mise` registry.

`shuck` currently has 76 stars.

CC @ewhauser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new registry configuration entry for the Shuck backend.
  * Added an automated version check that runs `shuck --version` and verifies it matches the expected version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->