### PR TITLE
fix(schema): use integer types for integer settings

### DIFF
--- a/e2e/config/test_schema_integer_settings
+++ b/e2e/config/test_schema_integer_settings
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+SCHEMA_PATH="$ROOT/schema/mise.json"
+
+assert "jq -r '.[\"\$defs\"].settings.properties.http_retries.type' '$SCHEMA_PATH'" "integer"
+assert "jq -r '.[\"\$defs\"].settings.properties.jobs.type' '$SCHEMA_PATH'" "integer"
+assert "jq -r '.[\"\$defs\"].settings.properties.node.properties.concurrency.type' '$SCHEMA_PATH'" "integer"
+assert "jq -r '.[\"\$defs\"].settings.properties.task.properties.monorepo_depth.type' '$SCHEMA_PATH'" "integer"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1091,7 +1091,7 @@
         "http_retries": {
           "default": 3,
           "description": "Number of retries for transient HTTP failures in mise.",
-          "type": "number"
+          "type": "integer"
         },
         "http_timeout": {
           "default": "30s",
@@ -1147,7 +1147,7 @@
         "jobs": {
           "default": 8,
           "description": "How many jobs to run concurrently such as tool installs.",
-          "type": "number"
+          "type": "integer"
         },
         "legacy_version_file": {
           "default": true,
@@ -1244,7 +1244,7 @@
             },
             "concurrency": {
               "description": "How many jobs should be used in compilation.",
-              "type": "number"
+              "type": "integer"
             },
             "configure_opts": {
               "description": "Additional ./configure options.",
@@ -1772,7 +1772,7 @@
             "monorepo_depth": {
               "default": 5,
               "description": "Maximum depth to search for task files in monorepo subdirectories.",
-              "type": "number"
+              "type": "integer"
             },
             "monorepo_exclude_dirs": {
               "default": [],

--- a/xtasks/render/schema.ts
+++ b/xtasks/render/schema.ts
@@ -128,7 +128,7 @@ function buildElement(key: string, props: Props): Element {
     Url: "string",
     Duration: "string",
     Bool: "boolean",
-    Integer: "number",
+    Integer: "integer",
     ListString: "string[]",
     ListPath: "string[]",
     SetString: "string[]",


### PR DESCRIPTION
## Summary

- generate JSON Schema `integer` types for settings declared as `Integer`
- update the four affected settings in `schema/mise.json`
- add focused regression coverage for the generated schema types

## Why

The schema generator mapped Rust integer settings to JSON Schema `number`, which also accepts floating-point values. This made the published schema less strict than mise's configuration types for `http_retries`, `jobs`, `node.concurrency`, and `task.monorepo_depth`.

## Validation

- `mise run render:schema`
- `mise run test:e2e config/test_schema_integer_settings`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened configuration validation so retry counts, job counts, concurrency limits, and task depth settings accept only whole numbers.
  * Improved generated schema accuracy for integer-valued settings.
  * Added automated validation to prevent these schema definitions from regressing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->