### PR TITLE
fix(schema): add bootstrap hooks configuration

### DIFF
--- a/e2e/config/test_schema_bootstrap_hooks
+++ b/e2e/config/test_schema_bootstrap_hooks
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+TOMBI_VERSION="0.9.22"
+
+mise use -g tombi@$TOMBI_VERSION
+
+SCHEMA_PATH="$ROOT/schema/mise.json"
+TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
+assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
+
+cat >"$HOME/tombi.toml" <<EOF
+toml-version = "v1.0.0"
+
+[schema]
+enabled = true
+strict = true
+
+[[schemas]]
+path = "file://$SCHEMA_PATH"
+include = ["mise-hooks.toml", "mise-bad-hooks.toml"]
+EOF
+
+cat >"$HOME/workdir/mise-hooks.toml" <<'TOML'
+[bootstrap.hooks]
+pre-packages = "echo pre-packages"
+post-packages = ["echo post-packages one", "echo post-packages two"]
+pre-repos = { run = "echo pre-repos" }
+post-repos = { run = ["echo post-repos one", "echo post-repos two"] }
+pre-dotfiles = "echo pre-dotfiles"
+post-dotfiles = "echo post-dotfiles"
+pre-defaults = "echo pre-defaults"
+post-defaults = "echo post-defaults"
+pre-user = "echo pre-user"
+post-user = "echo post-user"
+final = "echo final"
+pre_packages = "echo underscore alias"
+post_packages = { run = "echo forward-compatible hook", future = { nested = true } }
+pre_repos = "echo underscore alias"
+post_repos = "echo underscore alias"
+pre_dotfiles = "echo underscore alias"
+post_dotfiles = "echo underscore alias"
+pre_defaults = "echo underscore alias"
+post_defaults = "echo underscore alias"
+pre_user = "echo underscore alias"
+post_user = "echo underscore alias"
+pre_tools = "echo underscore alias"
+post_tools = "echo underscore alias"
+
+[bootstrap.hooks.pre-tools]
+run = "echo pre-tools"
+
+[bootstrap.hooks.post-tools]
+run = ["echo post-tools one", "echo post-tools two"]
+TOML
+
+cd "$HOME/workdir"
+assert_succeed "$TOMBI_LINT mise-hooks.toml"
+
+for invalid_hook in \
+  'unknown = "echo unknown"' \
+  'pre-packages = 1' \
+  'pre-packages = ["echo valid", 1]' \
+  'pre-packages = {}' \
+  'pre-packages = { run = 1 }' \
+  'pre-packages = { command = "echo missing run" }'; do
+  cat >"$HOME/workdir/mise-bad-hooks.toml" <<TOML
+[bootstrap.hooks]
+$invalid_hook
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-hooks.toml"
+done

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2965,6 +2965,40 @@
       "minProperties": 1,
       "additionalProperties": false
     },
+    "bootstrap_hook": {
+      "description": "command or commands to run for a bootstrap phase",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "run": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            }
+          },
+          "required": ["run"],
+          "additionalProperties": true
+        }
+      ]
+    },
     "bootstrap_shell_activation": {
       "oneOf": [
         {
@@ -3713,6 +3747,88 @@
               }
             }
           }
+        },
+        "hooks": {
+          "type": "object",
+          "description": "commands to run before and after bootstrap phases",
+          "properties": {
+            "pre-packages": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre_packages": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post-packages": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post_packages": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre-repos": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre_repos": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post-repos": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post_repos": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre-dotfiles": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre_dotfiles": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post-dotfiles": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post_dotfiles": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre-defaults": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre_defaults": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post-defaults": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post_defaults": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre-user": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre_user": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post-user": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post_user": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre-tools": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "pre_tools": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post-tools": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "post_tools": {
+              "$ref": "#/$defs/bootstrap_hook"
+            },
+            "final": {
+              "$ref": "#/$defs/bootstrap_hook"
+            }
+          },
+          "additionalProperties": false
         },
         "mise_shell_activate": {
           "type": "object",


### PR DESCRIPTION
## Summary

- add schema support for every bootstrap hook phase
- accept string, string-array, and `run` table forms supported by the runtime parser
- include the parser's underscore phase aliases and forward-compatible hook table fields
- add isolated strict validation coverage with pinned Tombi 0.9.22

## Why

Mise supports `[bootstrap.hooks]` at runtime, but the published schema omitted the table entirely. Strict schema validation therefore rejected valid bootstrap configurations, requiring temporary `schema.strict = false` workarounds in risu729/dotfiles#3725 and risu729/dotfiles#3726.

The schema uses an explicit `$defs` hook value and explicit phase properties so Tombi 0.9.22 can validate the references and reject unknown phases without relying on unsupported regex lookarounds or unreliable `not` handling.

This PR is standalone on `main`; it does not overlap with #11015 or #11016.

## Validation

- `mise run test:e2e config/test_schema_bootstrap_hooks`
- `mise run render:schema`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema support for bootstrap hooks in TOMBI configuration.
  * Supports hook commands as strings, command lists, or objects with a `run` property.
  * Added validation for pre- and post-bootstrap stages, including package, repository, dotfile, default, user, tool, and final hooks.
  * Supports both hyphenated and underscored hook names.

* **Tests**
  * Added end-to-end validation covering valid configurations and invalid hook definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->