### PR TITLE
fix(schema): require watch file patterns

### DIFF
--- a/e2e/config/test_schema_watch_files_patterns
+++ b/e2e/config/test_schema_watch_files_patterns
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+TOMBI_VERSION="0.9.22"
+
+mise use -g tombi@$TOMBI_VERSION
+
+SCHEMA_PATH="$ROOT/schema/mise.json"
+TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
+assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
+
+cat >"$HOME/tombi.toml" <<EOF
+toml-version = "v1.0.0"
+
+[schema]
+enabled = true
+strict = true
+
+[[schemas]]
+path = "file://$SCHEMA_PATH"
+include = ["mise-watch-files.toml", "mise-bad-watch-files.toml"]
+EOF
+
+cat >"$HOME/workdir/mise-watch-files.toml" <<'TOML'
+[[watch_files]]
+patterns = []
+run = "echo changed"
+
+[[watch_files]]
+patterns = ["src/**/*.rs"]
+task = "check"
+TOML
+
+cd "$HOME/workdir"
+assert_succeed "$TOMBI_LINT mise-watch-files.toml"
+
+for action in \
+  'run = "echo changed"' \
+  'task = "check"'; do
+  cat >"$HOME/workdir/mise-bad-watch-files.toml" <<TOML
+[[watch_files]]
+$action
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-watch-files.toml"
+done

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2517,7 +2517,7 @@
                 }
               }
             },
-            "required": ["run"]
+            "required": ["run", "patterns"]
           },
           {
             "unevaluatedProperties": false,
@@ -2534,7 +2534,7 @@
                 }
               }
             },
-            "required": ["task"]
+            "required": ["task", "patterns"]
           }
         ]
       }


### PR DESCRIPTION
## Summary

- require `patterns` for `watch_files` entries using `run`
- require `patterns` for `watch_files` entries using `task`
- add isolated strict validation coverage with pinned Tombi 0.9.22

## Why

`WatchFile.patterns` is a required Rust field without a Serde default, so mise rejects entries that omit it. The published schema only required the selected `run` or `task` action, allowing configurations that the runtime cannot deserialize.

The regression also confirms that an explicitly empty pattern array remains valid, matching the runtime type.

## Validation

- `mise run test:e2e config/test_schema_watch_files_patterns`
- `mise run render:schema`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for `watch_files` configurations.
  - Watch entries using `run` or `task` now require a `patterns` field.
  - Invalid watch file configurations are now correctly rejected, while valid configurations continue to pass linting.

- **Tests**
  - Added end-to-end coverage for valid and invalid `watch_files` patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->