### PR TITLE
fix(schema): correct root hook definitions

### DIFF
--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -171,7 +171,7 @@ In general, [tasks](/tasks/) are a good way to ensure that the mise environment 
 
 ### Hooks and shims
 
-The [hooks](/hooks.html) `cd`, `enter`, `exit`, and `watch_files` only trigger with `mise activate`. However `preinstall` and `postinstall` still work with shims because they don't require shell integration.
+The [hooks](/hooks.html) `cd`, `enter`, and `leave` only trigger with `mise activate`. The separate [`watch_files`](/hooks.html#watch-files) configuration also requires `mise activate`. However `preinstall` and `postinstall` still work with shims because they don't require shell integration.
 
 ### `which`
 

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -171,7 +171,7 @@ In general, [tasks](/tasks/) are a good way to ensure that the mise environment 
 
 ### Hooks and shims
 
-The [hooks](/hooks.html) `cd`, `enter`, and `leave` only trigger with `mise activate`. The separate [`watch_files`](/hooks.html#watch-files) configuration also requires `mise activate`. However `preinstall` and `postinstall` still work with shims because they don't require shell integration.
+The [hooks](/hooks.html) `cd`, `enter`, and `leave` only trigger with `mise activate`. The separate [`watch_files`](/hooks.html#watch-files-hook) configuration also requires `mise activate`. However `preinstall` and `postinstall` still work with shims because they don't require shell integration.
 
 ### `which`
 

--- a/e2e/config/test_schema_root_hook_keys
+++ b/e2e/config/test_schema_root_hook_keys
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+TOMBI_VERSION="0.9.22"
+
+mise use -g tombi@$TOMBI_VERSION
+
+SCHEMA_PATH="$ROOT/schema/mise.json"
+TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
+assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
+
+cat >"$HOME/tombi.toml" <<EOF
+toml-version = "v1.0.0"
+
+[schema]
+enabled = true
+strict = true
+
+[[schemas]]
+path = "file://$SCHEMA_PATH"
+include = ["mise-hooks.toml", "mise-bad-hooks.toml"]
+EOF
+
+cat >"$HOME/workdir/mise-hooks.toml" <<'TOML'
+[hooks]
+enter = "echo enter"
+leave = "echo leave"
+cd = "echo cd"
+preinstall = "echo preinstall"
+postinstall = "echo postinstall"
+TOML
+
+cat >"$HOME/workdir/mise-bad-hooks.toml" <<'TOML'
+[hooks]
+unknown = "echo unknown"
+TOML
+
+cd "$HOME/workdir"
+assert_succeed "$TOMBI_LINT mise-hooks.toml"
+assert_fail "$TOMBI_LINT mise-bad-hooks.toml"

--- a/e2e/config/test_schema_root_hook_keys
+++ b/e2e/config/test_schema_root_hook_keys
@@ -18,16 +18,26 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-hooks.toml", "mise-bad-hooks.toml"]
+include = ["mise-hooks.toml", "mise-deprecated-script.toml", "mise-deprecated-scripts.toml", "mise-bad-hooks.toml"]
 EOF
 
 cat >"$HOME/workdir/mise-hooks.toml" <<'TOML'
 [hooks]
-enter = "echo enter"
-leave = "echo leave"
-cd = "echo cd"
-preinstall = "echo preinstall"
-postinstall = "echo postinstall"
+enter = { script = "echo enter", shell = "bash" }
+leave = { scripts = ["echo leave"] }
+cd = [{ task = "change-directory" }, { run = "echo cd", shell = "bash -c" }]
+preinstall = { run = "echo preinstall" }
+postinstall = [{ run = "echo postinstall" }, { task = "after-install" }]
+TOML
+
+cat >"$HOME/workdir/mise-deprecated-script.toml" <<'TOML'
+[hooks]
+preinstall = { script = "echo preinstall" }
+TOML
+
+cat >"$HOME/workdir/mise-deprecated-scripts.toml" <<'TOML'
+[hooks]
+postinstall = { scripts = ["echo postinstall"] }
 TOML
 
 cat >"$HOME/workdir/mise-bad-hooks.toml" <<'TOML'
@@ -37,4 +47,6 @@ TOML
 
 cd "$HOME/workdir"
 assert_succeed "$TOMBI_LINT mise-hooks.toml"
+assert_fail "$TOMBI_LINT mise-deprecated-script.toml"
+assert_fail "$TOMBI_LINT mise-deprecated-scripts.toml"
 assert_fail "$TOMBI_LINT mise-bad-hooks.toml"

--- a/e2e/config/test_schema_root_hook_keys
+++ b/e2e/config/test_schema_root_hook_keys
@@ -6,6 +6,7 @@ mise use -g tombi@$TOMBI_VERSION
 
 SCHEMA_PATH="$ROOT/schema/mise.json"
 TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+TOMBI_LINT_ALLOW_WARNINGS="$TOMBI lint --offline --no-cache --quiet"
 TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
 
@@ -18,24 +19,34 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-hooks.toml", "mise-deprecated-script.toml", "mise-deprecated-scripts.toml", "mise-bad-hooks.toml"]
+include = ["mise-hooks.toml", "mise-deprecated-current-script.toml", "mise-deprecated-current-scripts.toml", "mise-deprecated-install-script.toml", "mise-deprecated-install-scripts.toml", "mise-bad-hooks.toml"]
 EOF
 
 cat >"$HOME/workdir/mise-hooks.toml" <<'TOML'
 [hooks]
 enter = { script = "echo enter", shell = "bash" }
-leave = { scripts = ["echo leave"] }
+leave = { scripts = ["echo leave"], shell = "zsh" }
 cd = [{ task = "change-directory" }, { run = "echo cd", shell = "bash -c" }]
 preinstall = { run = "echo preinstall" }
 postinstall = [{ run = "echo postinstall" }, { task = "after-install" }]
 TOML
 
-cat >"$HOME/workdir/mise-deprecated-script.toml" <<'TOML'
+cat >"$HOME/workdir/mise-deprecated-current-script.toml" <<'TOML'
 [hooks]
-preinstall = { script = "echo preinstall" }
+enter = { script = "echo enter" }
 TOML
 
-cat >"$HOME/workdir/mise-deprecated-scripts.toml" <<'TOML'
+cat >"$HOME/workdir/mise-deprecated-current-scripts.toml" <<'TOML'
+[hooks]
+leave = { scripts = ["echo leave"] }
+TOML
+
+cat >"$HOME/workdir/mise-deprecated-install-script.toml" <<'TOML'
+[hooks]
+preinstall = { script = "echo preinstall", shell = "bash" }
+TOML
+
+cat >"$HOME/workdir/mise-deprecated-install-scripts.toml" <<'TOML'
 [hooks]
 postinstall = { scripts = ["echo postinstall"] }
 TOML
@@ -47,6 +58,12 @@ TOML
 
 cd "$HOME/workdir"
 assert_succeed "$TOMBI_LINT mise-hooks.toml"
-assert_fail "$TOMBI_LINT mise-deprecated-script.toml"
-assert_fail "$TOMBI_LINT mise-deprecated-scripts.toml"
+assert_succeed "$TOMBI_LINT_ALLOW_WARNINGS mise-deprecated-current-script.toml"
+assert_succeed "$TOMBI_LINT_ALLOW_WARNINGS mise-deprecated-current-scripts.toml"
+assert_succeed "$TOMBI_LINT_ALLOW_WARNINGS mise-deprecated-install-script.toml"
+assert_succeed "$TOMBI_LINT_ALLOW_WARNINGS mise-deprecated-install-scripts.toml"
+assert_fail "$TOMBI_LINT mise-deprecated-current-script.toml"
+assert_fail "$TOMBI_LINT mise-deprecated-current-scripts.toml"
+assert_fail "$TOMBI_LINT mise-deprecated-install-script.toml"
+assert_fail "$TOMBI_LINT mise-deprecated-install-scripts.toml"
 assert_fail "$TOMBI_LINT mise-bad-hooks.toml"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2414,11 +2414,11 @@
       "unevaluatedProperties": false,
       "properties": {
         "script": {
-          "description": "current-shell script/scripts for enter/leave/cd hooks",
+          "description": "script or scripts to evaluate in the active shell for enter/leave/cd hooks",
           "$ref": "#/$defs/hook_script_value"
         },
         "shell": {
-          "description": "current shell name for script hooks, such as \"bash\"",
+          "description": "active shell name for current-shell hooks, such as \"bash\"",
           "type": "string"
         }
       },
@@ -2429,11 +2429,45 @@
       "unevaluatedProperties": false,
       "properties": {
         "scripts": {
-          "description": "current-shell scripts for enter/leave/cd hooks",
+          "description": "scripts to evaluate in the active shell for enter/leave/cd hooks",
           "$ref": "#/$defs/hook_scripts_value"
         },
         "shell": {
-          "description": "current shell name for script hooks, such as \"bash\"",
+          "description": "active shell name for current-shell hooks, such as \"bash\"",
+          "type": "string"
+        }
+      },
+      "required": ["scripts"],
+      "type": "object"
+    },
+    "hook_install_script_table": {
+      "deprecated": true,
+      "unevaluatedProperties": false,
+      "properties": {
+        "script": {
+          "deprecated": true,
+          "description": "deprecated alias for run in preinstall/postinstall hooks; executes in a subprocess",
+          "$ref": "#/$defs/hook_script_value"
+        },
+        "shell": {
+          "description": "ignored for this deprecated form; use a run hook to select an inline shell",
+          "type": "string"
+        }
+      },
+      "required": ["script"],
+      "type": "object"
+    },
+    "hook_install_scripts_table": {
+      "deprecated": true,
+      "unevaluatedProperties": false,
+      "properties": {
+        "scripts": {
+          "deprecated": true,
+          "description": "deprecated alias for run in preinstall/postinstall hooks; joins the scripts and executes them in a subprocess",
+          "$ref": "#/$defs/hook_scripts_value"
+        },
+        "shell": {
+          "description": "ignored for this deprecated form; use a run hook to select an inline shell",
           "type": "string"
         }
       },
@@ -2484,6 +2518,39 @@
         }
       ]
     },
+    "hook_install_definition_item": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/hook_run_string"
+        },
+        {
+          "$ref": "#/$defs/hook_run_table"
+        },
+        {
+          "$ref": "#/$defs/hook_install_script_table"
+        },
+        {
+          "$ref": "#/$defs/hook_install_scripts_table"
+        },
+        {
+          "$ref": "#/$defs/hook_task_ref"
+        }
+      ]
+    },
+    "hook_install_definition": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/hook_install_definition_item"
+        },
+        {
+          "description": "install hooks to run",
+          "items": {
+            "$ref": "#/$defs/hook_install_definition_item"
+          },
+          "type": "array"
+        }
+      ]
+    },
     "hooks": {
       "description": "hooks to run",
       "type": "object",
@@ -2498,10 +2565,10 @@
           "$ref": "#/$defs/hook_definition"
         },
         "preinstall": {
-          "$ref": "#/$defs/hook_definition"
+          "$ref": "#/$defs/hook_install_definition"
         },
         "postinstall": {
-          "$ref": "#/$defs/hook_definition"
+          "$ref": "#/$defs/hook_install_definition"
         }
       },
       "additionalProperties": false

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2487,9 +2487,24 @@
     "hooks": {
       "description": "hooks to run",
       "type": "object",
-      "additionalProperties": {
-        "$ref": "#/$defs/hook_definition"
-      }
+      "properties": {
+        "enter": {
+          "$ref": "#/$defs/hook_definition"
+        },
+        "leave": {
+          "$ref": "#/$defs/hook_definition"
+        },
+        "cd": {
+          "$ref": "#/$defs/hook_definition"
+        },
+        "preinstall": {
+          "$ref": "#/$defs/hook_definition"
+        },
+        "postinstall": {
+          "$ref": "#/$defs/hook_definition"
+        }
+      },
+      "additionalProperties": false
     },
     "watch_files": {
       "description": "files to watch for changes",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2410,7 +2410,7 @@
         "type": "string"
       }
     },
-    "hook_script_table": {
+    "hook_current_shell_script_table": {
       "unevaluatedProperties": false,
       "properties": {
         "script": {
@@ -2422,10 +2422,10 @@
           "type": "string"
         }
       },
-      "required": ["script"],
+      "required": ["script", "shell"],
       "type": "object"
     },
-    "hook_scripts_table": {
+    "hook_current_shell_scripts_table": {
       "unevaluatedProperties": false,
       "properties": {
         "scripts": {
@@ -2435,6 +2435,32 @@
         "shell": {
           "description": "active shell name for current-shell hooks, such as \"bash\"",
           "type": "string"
+        }
+      },
+      "required": ["scripts", "shell"],
+      "type": "object"
+    },
+    "hook_spawned_script_table": {
+      "deprecated": true,
+      "unevaluatedProperties": false,
+      "properties": {
+        "script": {
+          "deprecated": true,
+          "description": "deprecated alias for run when an enter/leave/cd hook has no shell",
+          "$ref": "#/$defs/hook_script_value"
+        }
+      },
+      "required": ["script"],
+      "type": "object"
+    },
+    "hook_spawned_scripts_table": {
+      "deprecated": true,
+      "unevaluatedProperties": false,
+      "properties": {
+        "scripts": {
+          "deprecated": true,
+          "description": "deprecated alias for run when an enter/leave/cd hook has no shell",
+          "$ref": "#/$defs/hook_scripts_value"
         }
       },
       "required": ["scripts"],
@@ -2494,10 +2520,16 @@
           "$ref": "#/$defs/hook_run_table"
         },
         {
-          "$ref": "#/$defs/hook_script_table"
+          "$ref": "#/$defs/hook_current_shell_script_table"
         },
         {
-          "$ref": "#/$defs/hook_scripts_table"
+          "$ref": "#/$defs/hook_current_shell_scripts_table"
+        },
+        {
+          "$ref": "#/$defs/hook_spawned_script_table"
+        },
+        {
+          "$ref": "#/$defs/hook_spawned_scripts_table"
         },
         {
           "$ref": "#/$defs/hook_task_ref"


### PR DESCRIPTION
## Summary

- restrict root `[hooks]` entries to `enter`, `leave`, `cd`, `preinstall`, and `postinstall`
- require `shell` for the supported current-shell `script`/`scripts` forms on `enter`/`leave`/`cd`
- model shell-less activation aliases and install-hook aliases separately, marking both `script` and `scripts` forms deprecated
- correct the shims documentation to use `leave`, describe `watch_files` as separate configuration, and link its actual heading
- add strict validation coverage with pinned Tombi 0.9.22

## Why

Mise deserializes root hook names into the five-variant `Hooks` enum, so unknown names are rejected by the runtime. The published schema previously accepted arbitrary root hook names.

For `enter`, `leave`, and `cd`, `script` and `scripts` run in the active shell only when `shell` is present. Without it, runtime treats them as deprecated aliases for a spawned `run` hook. `preinstall` and `postinstall` likewise accept them only as deprecated spawned compatibility forms. Separate definitions let schema-aware editors expose the correct behavior and deprecation warnings without relying on JSON Schema `not`, which pinned Tombi 0.9.22 does not reliably enforce.

## Validation

- `mise run test:e2e e2e/config/test_schema_root_hook_keys`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved hook configuration schema validation to support `enter`, `leave`, `cd`, `preinstall`, and `postinstall`, with stricter shape checking.
  - Added validation support for deprecated hook aliases (with warnings).
- **Bug Fixes**
  - Now rejects unknown/unsupported hook keys during configuration linting.
  - Enforces stricter lint outcomes: deprecated or invalid hook definitions fail in strict mode.
- **Documentation**
  - Updated “Hooks and shims” guidance: `mise activate --shims` requires `mise activate` for `cd`, `enter`, `leave`, and `watch_files`.
- **Tests**
  - Expanded end-to-end lint tests for valid, deprecated, and invalid hook fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->