### PR TITLE
fix(hooks): deprecate spawned scripts form

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -57,7 +57,7 @@ platforms, a hook with only `run_windows` is skipped.
 postinstall = { run = "echo installed", run_windows = "Write-Output installed" }
 ```
 
-For `preinstall` and `postinstall`, `script = ...` is a legacy alias for `run = ...`. If a `shell` is also set on a `script`/`scripts` hook, mise warns that the shell is ignored and still runs the script with the default inline shell. Use `run = ...` with `shell = "bash -c"` to choose the inline shell command. The `script` alias for install hooks is deprecated.
+For `preinstall` and `postinstall`, `script = ...` and `scripts = ...` are legacy aliases for `run = ...`. If a `shell` is also set on a `script`/`scripts` hook, mise warns that the shell is ignored and still runs the script with the default inline shell. Use `run = ...` with `shell = "bash -c"` to choose the inline shell command. The `script` and `scripts` aliases for install hooks are deprecated.
 
 A `mise install` that finds nothing to install (all configured tools are already present) still runs the `postinstall` hook — it is not skipped on a no-op install.
 
@@ -223,7 +223,7 @@ scripts = [
 when the active `mise activate` shell matches.
 
 Use `run` when the hook should execute as an inline command in a subprocess. `preinstall` and
-`postinstall` do not have a current shell, so `script` is only kept there as a legacy alias for `run`;
+`postinstall` do not have a current shell, so `script`/`scripts` are only kept there as legacy aliases for `run`;
 if `shell` is set with `script`/`scripts` on those hooks, it is ignored.
 
 ::: warning

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -157,7 +157,7 @@ impl HookDef {
             }],
             HookDef::ScriptsTable { scripts, shell } => vec![Hook {
                 hook: hook_type,
-                action: script_hook_action(hook_type, scripts.join("\n"), shell, false),
+                action: script_hook_action(hook_type, scripts.join("\n"), shell, true),
                 global: false,
             }],
             HookDef::TaskRef { task } => vec![Hook {
@@ -559,7 +559,7 @@ async fn execute(
             "2026.9.0",
             "2027.3.0",
             "hook_script_table_spawned_run",
-            "hook tables using `script` for spawned commands are deprecated. Use `run` instead."
+            "hook tables using `script` or `scripts` for spawned commands are deprecated. Use `run` instead."
         );
     }
     if ignored_shell.is_some() && matches!(hook.hook, Hooks::Preinstall | Hooks::Postinstall) {
@@ -776,6 +776,32 @@ mod tests {
             }
             action => panic!("expected run hook, got {action:?}"),
         }
+    }
+
+    #[test]
+    fn scripts_tables_are_legacy_only_when_spawned() {
+        let spawned = HookDef::ScriptsTable {
+            scripts: vec!["echo one".into(), "echo two".into()],
+            shell: None,
+        }
+        .into_hooks(Hooks::Postinstall);
+        assert!(matches!(
+            &spawned[0].action,
+            HookAction::Run {
+                legacy_script: true,
+                ..
+            }
+        ));
+
+        let current_shell = HookDef::ScriptsTable {
+            scripts: vec!["echo one".into(), "echo two".into()],
+            shell: Some("bash".into()),
+        }
+        .into_hooks(Hooks::Enter);
+        assert!(matches!(
+            &current_shell[0].action,
+            HookAction::CurrentShell { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- mark plural `scripts` hook tables as legacy when they execute as spawned commands
- preserve supported current-shell `scripts` behavior for `enter`, `leave`, and `cd`
- update the scheduled deprecation message and hook documentation to cover both aliases
- add focused regression coverage for spawned and current-shell conversion

## Why

Singular `script` and plural `scripts` tables have the same spawned-command compatibility behavior, but `ScriptsTable` passed `legacy_script = false` while `ScriptTable` passed `true`. As a result, plural `scripts` bypassed the deprecation scheduled to warn in mise 2026.9.0 and be removed in 2027.3.0.

This was discovered while reviewing #11041 but is independent and does not need to be stacked on it.

## Validation

- `cargo test hooks::tests::scripts_tables_are_legacy_only_when_spawned --all-features`
- `mise run test:e2e config/test_hooks_run_warnings`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `preinstall` and `postinstall` support both `script` and `scripts` as legacy aliases for `run`.

* **Bug Fixes**
  * Updated deprecation warnings to accurately reference both legacy aliases.
  * Improved handling of spawned hook scripts while preserving current-shell behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->