### PR TITLE
fix(hooks): reject unknown hook table fields

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -68,7 +68,7 @@ impl HookScripts {
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum HookDef {
     /// Simple run string: `enter = "echo hello"`
     RunString(String),
@@ -775,6 +775,36 @@ mod tests {
                 assert_eq!(shell.as_deref(), Some("bash -c"));
             }
             action => panic!("expected run hook, got {action:?}"),
+        }
+    }
+
+    #[test]
+    fn hook_tables_reject_unknown_fields() {
+        for input in [
+            r#"hook = { script = "echo script", typo = true }"#,
+            r#"hook = { scripts = ["echo scripts"], typo = true }"#,
+            r#"hook = { task = "build", typo = true }"#,
+        ] {
+            assert!(
+                toml::from_str::<TestHook>(input).is_err(),
+                "unexpectedly accepted {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn hook_tables_reject_mixed_actions() {
+        for input in [
+            r#"hook = { run = "echo run", script = "echo script" }"#,
+            r#"hook = { run = "echo run", task = "build" }"#,
+            r#"hook = { script = "echo script", scripts = ["echo scripts"] }"#,
+            r#"hook = { script = "echo script", task = "build" }"#,
+            r#"hook = { scripts = ["echo scripts"], task = "build" }"#,
+        ] {
+            assert!(
+                toml::from_str::<TestHook>(input).is_err(),
+                "unexpectedly accepted {input}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- reject unknown fields in every hook table form
- reject hook tables that mix multiple action keys
- add regression tests for ignored typos and untagged-enum fallthrough

## Root cause

`HookDef` is an untagged Serde enum. The `run` table already rejected unknown fields, but the inline `script`, `scripts`, and `task` variants used Serde's default behavior and silently discarded extra fields. This also allowed mixed tables such as `{ run = "...", task = "..." }` to fall through to another variant and execute a different action.

Applying `deny_unknown_fields` to the enum makes every table form follow the existing schema and the `run` table's runtime behavior.

## Stacking

Stacked on #11043 because both changes touch `HookDef` tests and behavior. Target branch remains `main`.

## Validation

- `mise x cargo -- cargo test hooks::tests`
- `mise run test:e2e e2e/config/test_hooks e2e/config/test_hooks_task_ref e2e/config/test_hooks_script_arrays`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for hook configuration tables by rejecting unknown fields and incompatible combinations.
  * Updated legacy script handling for spawned run actions.
  * Expanded deprecation warnings to cover both `script` and `scripts` formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->