### PR TITLE
fix(schema): add systemd timer and lifecycle options

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -347,7 +347,8 @@ done
 for unit in \
   '{ description = "service missing exec_start" }' \
   '{ persistent = true }' \
-  '{ exec_start = "/bin/true", on_boot_sec = "1min" }'; do
+  '{ exec_start = "/bin/true", on_boot_sec = "1min" }' \
+  '{ exec_start = "/bin/true", type = "daemon" }'; do
   cat >"$HOME/workdir/mise-bad-systemd.toml" <<TOML
 [bootstrap.linux.systemd.units]
 invalid = $unit

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -86,6 +86,25 @@ start_calendar_interval = [
   { minute = 59, hour = 23, day = 31, weekday = 7, month = 12 },
 ]
 
+[bootstrap.linux.systemd.units.sync]
+exec_start = "/usr/bin/rsync --archive source/ destination/"
+type = "oneshot"
+remain_after_exit = true
+exec_stop = "/usr/bin/umount destination"
+timeout_start_sec = "2min"
+timeout_stop_sec = "30s"
+no_new_privileges = true
+private_tmp = true
+
+[bootstrap.linux.systemd.units.sync-timer]
+on_boot_sec = "2min"
+on_unit_inactive_sec = "5min"
+randomized_delay_sec = "30s"
+accuracy_sec = "1s"
+persistent = true
+unit = "dev.mise.sync.service"
+wanted_by = ["timers.target"]
+
 [bootstrap.mise_shell_activate]
 bash = true
 zsh = false
@@ -192,7 +211,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -322,6 +341,18 @@ program = "/bin/echo"
 start_calendar_interval = $interval
 TOML
   assert_fail "$TOMBI_LINT mise-bad-launchd-calendar.toml"
+done
+
+# Verify that systemd service/timer declarations match runtime validation
+for unit in \
+  '{ description = "service missing exec_start" }' \
+  '{ persistent = true }' \
+  '{ exec_start = "/bin/true", on_boot_sec = "1min" }'; do
+  cat >"$HOME/workdir/mise-bad-systemd.toml" <<TOML
+[bootstrap.linux.systemd.units]
+invalid = $unit
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-systemd.toml"
 done
 
 # Verify that OCI copy entries match runtime validation

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3745,6 +3745,16 @@
                       },
                       "type": {
                         "type": "string",
+                        "enum": [
+                          "simple",
+                          "exec",
+                          "forking",
+                          "oneshot",
+                          "dbus",
+                          "notify",
+                          "notify-reload",
+                          "idle"
+                        ],
                         "description": "write Type in the [Service] section"
                       },
                       "remain_after_exit": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3708,11 +3708,11 @@
           "properties": {
             "systemd": {
               "type": "object",
-              "description": "systemd user service bootstrap config",
+              "description": "systemd user service and timer bootstrap config",
               "properties": {
                 "units": {
                   "type": "object",
-                  "description": "systemd user services to write and start with `mise bootstrap linux systemd-units apply`",
+                  "description": "systemd user services and timers to write and start with `mise bootstrap linux systemd-units apply`",
                   "propertyNames": {
                     "pattern": "^[A-Za-z0-9._@-]+$"
                   },
@@ -3743,6 +3743,34 @@
                         "pattern": ".*\\S.*",
                         "description": "write ExecStart in the [Service] section"
                       },
+                      "type": {
+                        "type": "string",
+                        "description": "write Type in the [Service] section"
+                      },
+                      "remain_after_exit": {
+                        "type": "boolean",
+                        "description": "write RemainAfterExit in the [Service] section"
+                      },
+                      "exec_stop": {
+                        "type": "string",
+                        "description": "write ExecStop in the [Service] section"
+                      },
+                      "timeout_start_sec": {
+                        "type": "string",
+                        "description": "write TimeoutStartSec in the [Service] section"
+                      },
+                      "timeout_stop_sec": {
+                        "type": "string",
+                        "description": "write TimeoutStopSec in the [Service] section"
+                      },
+                      "no_new_privileges": {
+                        "type": "boolean",
+                        "description": "write NoNewPrivileges in the [Service] section"
+                      },
+                      "private_tmp": {
+                        "type": "boolean",
+                        "description": "write PrivateTmp in the [Service] section"
+                      },
                       "environment": {
                         "type": "object",
                         "description": "environment variables for Environment entries",
@@ -3770,9 +3798,41 @@
                         "type": "string",
                         "description": "write StandardError in the [Service] section"
                       },
+                      "on_boot_sec": {
+                        "type": "string",
+                        "description": "write OnBootSec in the [Timer] section"
+                      },
+                      "on_unit_active_sec": {
+                        "type": "string",
+                        "description": "write OnUnitActiveSec in the [Timer] section"
+                      },
+                      "on_unit_inactive_sec": {
+                        "type": "string",
+                        "description": "write OnUnitInactiveSec in the [Timer] section"
+                      },
+                      "on_calendar": {
+                        "type": "string",
+                        "description": "write OnCalendar in the [Timer] section"
+                      },
+                      "randomized_delay_sec": {
+                        "type": "string",
+                        "description": "write RandomizedDelaySec in the [Timer] section"
+                      },
+                      "accuracy_sec": {
+                        "type": "string",
+                        "description": "write AccuracySec in the [Timer] section"
+                      },
+                      "persistent": {
+                        "type": "boolean",
+                        "description": "write Persistent in the [Timer] section"
+                      },
+                      "unit": {
+                        "type": "string",
+                        "description": "write Unit in the [Timer] section"
+                      },
                       "start": {
                         "type": "boolean",
-                        "description": "restart the service after writing it; when false, stop the service after writing it"
+                        "description": "restart the unit after writing it; when false, stop the unit after writing it"
                       },
                       "wanted_by": {
                         "type": "array",
@@ -3782,7 +3842,109 @@
                         }
                       }
                     },
-                    "required": ["exec_start"]
+                    "oneOf": [
+                      {
+                        "title": "systemd service",
+                        "required": ["exec_start"],
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": ["on_boot_sec"]
+                            },
+                            {
+                              "required": ["on_unit_active_sec"]
+                            },
+                            {
+                              "required": ["on_unit_inactive_sec"]
+                            },
+                            {
+                              "required": ["on_calendar"]
+                            },
+                            {
+                              "required": ["randomized_delay_sec"]
+                            },
+                            {
+                              "required": ["accuracy_sec"]
+                            },
+                            {
+                              "required": ["persistent"]
+                            },
+                            {
+                              "required": ["unit"]
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "title": "systemd timer",
+                        "anyOf": [
+                          {
+                            "required": ["on_boot_sec"]
+                          },
+                          {
+                            "required": ["on_unit_active_sec"]
+                          },
+                          {
+                            "required": ["on_unit_inactive_sec"]
+                          },
+                          {
+                            "required": ["on_calendar"]
+                          }
+                        ],
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": ["exec_start"]
+                            },
+                            {
+                              "required": ["type"]
+                            },
+                            {
+                              "required": ["remain_after_exit"]
+                            },
+                            {
+                              "required": ["exec_stop"]
+                            },
+                            {
+                              "required": ["timeout_start_sec"]
+                            },
+                            {
+                              "required": ["timeout_stop_sec"]
+                            },
+                            {
+                              "required": ["no_new_privileges"]
+                            },
+                            {
+                              "required": ["private_tmp"]
+                            },
+                            {
+                              "required": ["environment"],
+                              "properties": {
+                                "environment": {
+                                  "type": "object",
+                                  "minProperties": 1
+                                }
+                              }
+                            },
+                            {
+                              "required": ["working_directory"]
+                            },
+                            {
+                              "required": ["restart"]
+                            },
+                            {
+                              "required": ["restart_sec"]
+                            },
+                            {
+                              "required": ["standard_output"]
+                            },
+                            {
+                              "required": ["standard_error"]
+                            }
+                          ]
+                        }
+                      }
+                    ]
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- add the systemd timer fields accepted by the runtime to `schema/mise.json`
- add the service lifecycle and hardening fields introduced with timer support
- model service and timer declarations separately so services require `exec_start` while timers require a schedule and reject service-only directives
- extend strict Tombi schema coverage for valid and invalid systemd units

## Root cause

The runtime, tests, and documentation were updated in #10984, but the manually maintained systemd section of `schema/mise.json` retained the earlier service-only shape.

Fixes the schema mismatch reported in [discussion #11049](https://github.com/jdx/mise/discussions/11049).

## Validation
- `mise run render:schema`
- `mise run test:e2e e2e/config/test_schema_tombi`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and e2e validation only; no runtime bootstrap apply logic changes in this diff.
> 
> **Overview**
> Brings **`schema/mise.json`** in line with the systemd bootstrap behavior added in runtime/docs: `bootstrap.linux.systemd.units` now documents **services and timers**, not services only.
> 
> **Service** entries gain lifecycle and hardening fields (`type`, `remain_after_exit`, `exec_stop`, timeouts, `no_new_privileges`, `private_tmp`). **Timer** entries gain schedule and linkage fields (`on_boot_sec`, `on_unit_*_sec`, `on_calendar`, delay/accuracy, `persistent`, `unit`). A **`oneOf`** splits the two shapes so services require `exec_start` and forbid timer-only keys, while timers require at least one schedule field and forbid service-only keys (including mixed `exec_start` + `on_boot_sec`).
> 
> **`e2e/config/test_schema_tombi`** adds passing examples for a rich service and a timer, registers **`mise-bad-systemd.toml`**, and asserts Tombi strict lint fails on missing `exec_start`, timer-only `persistent`, service/timer mixes, and invalid `type`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ff031eccb4bd49147436a206e38a1af6735043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Linux systemd configuration support to include both services and timers.
  * Added options for service behavior, shutdown handling, privileges, temporary directories, scheduling, persistence, and timer relationships.
  * Improved validation to enforce the correct fields for each systemd unit type.

* **Bug Fixes**
  * Added regression coverage for invalid systemd configurations, including missing required fields and unsupported property combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->