### PR TITLE
fix(hooks): reject nested hook arrays

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -828,7 +828,8 @@ mod tests {
             toml::from_str::<TestHook>(
                 r#"hook = ["echo first", { task = "build" }, { run = "echo last" }]"#
             )
-            .is_ok()
+            .is_ok(),
+            "flat mixed array should be accepted"
         );
 
         for input in [

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -68,8 +68,16 @@ impl HookScripts {
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 pub enum HookDef {
+    One(HookDefItem),
+    /// Array of hook definitions: `enter = ["echo hello", { task = "setup" }]`
+    Array(Vec<HookDefItem>),
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum HookDefItem {
     /// Simple run string: `enter = "echo hello"`
     RunString(String),
     /// Table with run: `enter = { run = "echo hello" }`
@@ -86,8 +94,6 @@ pub enum HookDef {
     },
     /// Task reference: `enter = { task = "setup" }`
     TaskRef { task: String },
-    /// Array of hook definitions: `enter = ["echo hello", { task = "setup" }]`
-    Array(Vec<HookDef>),
 }
 
 #[derive(Debug, Clone)]
@@ -128,7 +134,19 @@ impl HookDef {
     /// Convert to a list of Hook structs with the given hook type
     pub fn into_hooks(self, hook_type: Hooks) -> Vec<Hook> {
         match self {
-            HookDef::RunString(script) => vec![Hook {
+            HookDef::One(def) => vec![def.into_hook(hook_type)],
+            HookDef::Array(arr) => arr
+                .into_iter()
+                .map(|def| def.into_hook(hook_type))
+                .collect(),
+        }
+    }
+}
+
+impl HookDefItem {
+    fn into_hook(self, hook_type: Hooks) -> Hook {
+        match self {
+            HookDefItem::RunString(script) => Hook {
                 hook: hook_type,
                 action: HookAction::Run {
                     run: Some(script),
@@ -138,8 +156,8 @@ impl HookDef {
                     ignored_shell: None,
                 },
                 global: false,
-            }],
-            HookDef::Run(table) => vec![Hook {
+            },
+            HookDefItem::Run(table) => Hook {
                 hook: hook_type,
                 action: HookAction::Run {
                     run: table.run,
@@ -149,26 +167,22 @@ impl HookDef {
                     ignored_shell: None,
                 },
                 global: false,
-            }],
-            HookDef::ScriptTable { script, shell } => vec![Hook {
+            },
+            HookDefItem::ScriptTable { script, shell } => Hook {
                 hook: hook_type,
                 action: script_hook_action(hook_type, script.into_script(), shell, true),
                 global: false,
-            }],
-            HookDef::ScriptsTable { scripts, shell } => vec![Hook {
+            },
+            HookDefItem::ScriptsTable { scripts, shell } => Hook {
                 hook: hook_type,
                 action: script_hook_action(hook_type, scripts.join("\n"), shell, true),
                 global: false,
-            }],
-            HookDef::TaskRef { task } => vec![Hook {
+            },
+            HookDefItem::TaskRef { task } => Hook {
                 hook: hook_type,
                 action: HookAction::Task { task_name: task },
                 global: false,
-            }],
-            HookDef::Array(arr) => arr
-                .into_iter()
-                .flat_map(|d| d.into_hooks(hook_type))
-                .collect(),
+            },
         }
     }
 }
@@ -809,11 +823,31 @@ mod tests {
     }
 
     #[test]
+    fn hook_arrays_reject_nested_arrays() {
+        assert!(
+            toml::from_str::<TestHook>(
+                r#"hook = ["echo first", { task = "build" }, { run = "echo last" }]"#
+            )
+            .is_ok()
+        );
+
+        for input in [
+            r#"hook = [["echo nested"]]"#,
+            r#"hook = ["echo first", [{ task = "build" }]]"#,
+        ] {
+            assert!(
+                toml::from_str::<TestHook>(input).is_err(),
+                "unexpectedly accepted {input}"
+            );
+        }
+    }
+
+    #[test]
     fn scripts_tables_are_legacy_only_when_spawned() {
-        let spawned = HookDef::ScriptsTable {
+        let spawned = HookDef::One(HookDefItem::ScriptsTable {
             scripts: vec!["echo one".into(), "echo two".into()],
             shell: None,
-        }
+        })
         .into_hooks(Hooks::Postinstall);
         assert!(matches!(
             &spawned[0].action,
@@ -823,10 +857,10 @@ mod tests {
             }
         ));
 
-        let current_shell = HookDef::ScriptsTable {
+        let current_shell = HookDef::One(HookDefItem::ScriptsTable {
             scripts: vec!["echo one".into(), "echo two".into()],
             shell: Some("bash".into()),
-        }
+        })
         .into_hooks(Hooks::Enter);
         assert!(matches!(
             &current_shell[0].action,


### PR DESCRIPTION
## Summary

- separate top-level hook definitions from individual hook items
- reject recursively nested hook arrays during configuration deserialization
- preserve strings, tables, and flat mixed hook arrays
- add regression coverage for accepted flat arrays and rejected nested arrays

## Why

The JSON schema permits either one hook item or one array of hook items, but the runtime represented arrays as `Vec<HookDef>`. Since `HookDef` itself included the array variant, runtime deserialization accepted arbitrarily nested arrays and recursively flattened them. This made configurations executable by mise even though schema-aware editors and validators rejected them.

The runtime now models an outer definition separately from a non-array item, matching the schema's single-array-level contract.

## Example

Nested arrays are now rejected:

```toml
[hooks]
enter = [["echo first"], [{ task = "setup" }]]
```

Use one flat array instead:

```toml
[hooks]
enter = ["echo first", { task = "setup" }]
```

## Validation

- `mise x cargo -- cargo test hooks::tests --all-features`
- `mise run lint-fix`
- `mise run test:e2e e2e/config/test_hooks e2e/config/test_hooks_task_ref e2e/config/test_hooks_script_arrays`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for hook configuration entries.
  * Invalid or unexpected fields in hook definitions are now rejected.
  * Nested hook arrays in top-level hook configurations are no longer accepted.
  * Hook actions continue to support commands, scripts, and task references with more consistent configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->