### PR TITLE
fix(config): deprecate experimental monorepo root key

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -302,7 +302,7 @@ impl MiseToml {
         if let Some(legacy_monorepo_root) = rf.experimental_monorepo_root.take() {
             deprecated_at!(
                 "2026.7.7",
-                "2027.7.7",
+                "2027.12.0",
                 "config.experimental_monorepo_root",
                 "`experimental_monorepo_root` in {} is deprecated. Use `monorepo_root` instead.",
                 display_path(path)

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -45,8 +45,6 @@ use super::min_version::MinVersionSpec;
 
 const LEGACY_ENV_KEYS_DEPRECATED_WARN_AT: &str = "2026.4.17";
 const LEGACY_ENV_KEYS_DEPRECATED_REMOVE_AT: &str = "2027.4.0";
-const EXPERIMENTAL_MONOREPO_ROOT_DEPRECATED_WARN_AT: &str = "2026.12.12";
-const EXPERIMENTAL_MONOREPO_ROOT_DEPRECATED_REMOVE_AT: &str = "2027.12.12";
 
 /// Convert a `toml::Value` to a `toml_edit::Value` for serialization.
 fn toml_value_to_edit(v: toml::Value) -> Value {
@@ -303,8 +301,8 @@ impl MiseToml {
         };
         if let Some(legacy_monorepo_root) = rf.experimental_monorepo_root.take() {
             deprecated_at!(
-                EXPERIMENTAL_MONOREPO_ROOT_DEPRECATED_WARN_AT,
-                EXPERIMENTAL_MONOREPO_ROOT_DEPRECATED_REMOVE_AT,
+                "2026.7.7",
+                "2027.7.7",
                 "config.experimental_monorepo_root",
                 "`experimental_monorepo_root` in {} is deprecated. Use `monorepo_root` instead.",
                 display_path(path)

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -45,6 +45,8 @@ use super::min_version::MinVersionSpec;
 
 const LEGACY_ENV_KEYS_DEPRECATED_WARN_AT: &str = "2026.4.17";
 const LEGACY_ENV_KEYS_DEPRECATED_REMOVE_AT: &str = "2027.4.0";
+const EXPERIMENTAL_MONOREPO_ROOT_DEPRECATED_WARN_AT: &str = "2026.12.12";
+const EXPERIMENTAL_MONOREPO_ROOT_DEPRECATED_REMOVE_AT: &str = "2027.12.12";
 
 /// Convert a `toml::Value` to a `toml_edit::Value` for serialization.
 fn toml_value_to_edit(v: toml::Value) -> Value {
@@ -188,8 +190,11 @@ pub struct MiseToml {
     #[serde(default)]
     settings: SettingsPartial,
     /// Marks this config as a monorepo root, enabling target path syntax for tasks
-    #[serde(default, alias = "experimental_monorepo_root")]
+    #[serde(default)]
     monorepo_root: Option<bool>,
+    /// Legacy name for monorepo_root, retained during its deprecation period
+    #[serde(default)]
+    experimental_monorepo_root: Option<bool>,
     /// Configuration for monorepo task discovery
     #[serde(default)]
     monorepo: Option<MonorepoConfig>,
@@ -296,6 +301,16 @@ impl MiseToml {
                 return Err(toml_parse_error(&err, body, path));
             }
         };
+        if let Some(legacy_monorepo_root) = rf.experimental_monorepo_root.take() {
+            deprecated_at!(
+                EXPERIMENTAL_MONOREPO_ROOT_DEPRECATED_WARN_AT,
+                EXPERIMENTAL_MONOREPO_ROOT_DEPRECATED_REMOVE_AT,
+                "config.experimental_monorepo_root",
+                "`experimental_monorepo_root` in {} is deprecated. Use `monorepo_root` instead.",
+                display_path(path)
+            );
+            rf.monorepo_root.get_or_insert(legacy_monorepo_root);
+        }
         rf.context = BASE_CONTEXT.clone();
         rf.context.insert(
             "config_root",
@@ -1292,6 +1307,7 @@ impl Clone for MiseToml {
             dotfiles: self.dotfiles.clone(),
             vars: self.vars.clone(),
             monorepo_root: self.monorepo_root,
+            experimental_monorepo_root: self.experimental_monorepo_root,
             monorepo: self.monorepo.clone(),
         }
     }


### PR DESCRIPTION
## Summary

- deprecate `experimental_monorepo_root` immediately and schedule removal for 2027.12.0
- retain compatibility by normalizing the legacy key into `monorepo_root` during deserialization
- prefer the canonical key when both spellings are configured

## Why

Monorepo support graduated from experimental in June 2026, but the old configuration key remained a silent compatibility alias. Since the old key was explicitly experimental, it can begin warning immediately while retaining compatibility until December 2027.

## Review notes

Deprecation warnings intentionally deduplicate globally by deprecation ID. The warning signals that the legacy key must be migrated; it is not intended to enumerate every config file containing it. Emitting it once also avoids warning spam when mise loads many config files.

## Performance

This does not parse TOML a second time. It adds one optional boolean field and normalizes it during the existing config deserialization path, so canonical configurations have only a negligible branch at load time and no recurring runtime cost.

## Validation

- `mise run lint-fix`
- `mise run test:e2e e2e/tasks/test_task_monorepo_validation`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy configuration files that use `experimental_monorepo_root`.
  * When `experimental_monorepo_root` is detected, the system now shows a deprecation notice.
  * If `monorepo_root` is not set, the legacy value is migrated into `monorepo_root` without overriding any explicitly configured setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
