### PR TITLE
fix(config): deprecate env.mise directives

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -327,7 +327,7 @@ strings. They will be removed in mise 2026.12.0. This does not affect `value` in
 variable objects or options for plugin-provided directives.
 
 The legacy `env.mise.*` spelling is deprecated. Use `env._.*` instead. It will be removed in mise
-2027.7.0.
+2026.12.0.
 :::
 
 ### `env._.file`

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -325,6 +325,9 @@ The `value` and `values` keys in built-in `file`, `path`, and `source` directive
 `env._` or `vars._` are deprecated. Use `path`, which accepts either a single string or an array of
 strings. They will be removed in mise 2026.12.0. This does not affect `value` in ordinary environment
 variable objects or options for plugin-provided directives.
+
+The legacy `env.mise.*` spelling is deprecated. Use `env._.*` instead. It will be removed in mise
+2027.7.0.
 :::
 
 ### `env._.file`

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -327,7 +327,7 @@ strings. They will be removed in mise 2026.12.0. This does not affect `value` in
 variable objects or options for plugin-provided directives.
 
 The legacy `env.mise.*` spelling is deprecated. Use `env._.*` instead. It will be removed in mise
-2026.12.0.
+2027.7.0.
 :::
 
 ### `env._.file`

--- a/e2e/env/test_env_file
+++ b/e2e/env/test_env_file
@@ -6,6 +6,7 @@ mise.file = ['.test-env']
 EOF
 echo FOO_FROM_FILE=foo_from_file >.test-env
 echo TEST_ENV2=foo >.test-env2
+assert_contains "mise env 2>&1" "deprecated [config.env.mise]"
 assert "mise x -- env | grep FOO_FROM_FILE" "FOO_FROM_FILE=foo_from_file"
 assert "MISE_ENV_FILE=.test-env2 mise x -- env | grep TEST_ENV2" "TEST_ENV2=foo"
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1899,16 +1899,14 @@ where
     D: de::Deserializer<'de>,
 {
     let value = toml::Value::deserialize(deserializer)?;
-    let contains_mise = match &value {
-        toml::Value::Table(table) => table.contains_key("mise"),
-        toml::Value::Array(values) => values.iter().any(|value| {
-            value
-                .as_table()
-                .is_some_and(|table| table.contains_key("mise"))
-        }),
-        _ => false,
-    };
-    if contains_mise {
+    fn contains_mise(value: &toml::Value) -> bool {
+        match value {
+            toml::Value::Table(table) => table.contains_key("mise"),
+            toml::Value::Array(values) => values.iter().any(contains_mise),
+            _ => false,
+        }
+    }
+    if contains_mise(&value) {
         return Err(de::Error::custom("`vars.mise` is not supported"));
     }
     EnvList::deserialize(value).map_err(de::Error::custom)
@@ -3034,6 +3032,11 @@ run = 'echo "template"'
         "#})
         .unwrap_err()
         .to_string();
+        assert!(err.contains("`vars.mise` is not supported"), "{err}");
+
+        let err = toml::from_str::<MiseToml>(r#"vars = [[{ mise = { file = ".env" } }]]"#)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("`vars.mise` is not supported"), "{err}");
     }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -183,7 +183,7 @@ pub struct MiseToml {
     bootstrap: Option<BootstrapTomlConfig>,
     #[serde(default)]
     dotfiles: Option<DotfilesTomlConfig>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vars")]
     vars: EnvList,
     #[serde(default)]
     settings: SettingsPartial,
@@ -1506,6 +1506,14 @@ impl<'de> de::Deserialize<'de> for EnvList {
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
                         "_" | "mise" => {
+                            if key == "mise" {
+                                deprecated_at!(
+                                    "2026.7.7",
+                                    "2027.7.0",
+                                    "config.env.mise",
+                                    "`env.mise` is deprecated. Use `env._` instead."
+                                );
+                            }
                             #[derive(Deserialize)]
                             #[serde(untagged)]
                             enum MiseTomlEnvDirectiveValue {
@@ -1884,6 +1892,26 @@ impl<'de> de::Deserialize<'de> for EnvList {
 
         deserializer.deserialize_any(EnvManVisitor)
     }
+}
+
+pub(crate) fn deserialize_vars<'de, D>(deserializer: D) -> std::result::Result<EnvList, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let value = toml::Value::deserialize(deserializer)?;
+    let contains_mise = match &value {
+        toml::Value::Table(table) => table.contains_key("mise"),
+        toml::Value::Array(values) => values.iter().any(|value| {
+            value
+                .as_table()
+                .is_some_and(|table| table.contains_key("mise"))
+        }),
+        _ => false,
+    };
+    if contains_mise {
+        return Err(de::Error::custom("`vars.mise` is not supported"));
+    }
+    EnvList::deserialize(value).map_err(de::Error::custom)
 }
 
 impl<'de> de::Deserialize<'de> for MiseTomlToolList {
@@ -2996,6 +3024,17 @@ run = 'echo "template"'
         foo2=2
         foo3=3
         "#);
+    }
+
+    #[test]
+    fn test_vars_mise_is_not_a_directive_namespace() {
+        let err = toml::from_str::<MiseToml>(indoc! {r#"
+            [vars.mise]
+            file = ".env"
+        "#})
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("`vars.mise` is not supported"), "{err}");
     }
 
     #[test]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1509,7 +1509,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
                             if key == "mise" {
                                 deprecated_at!(
                                     "2026.7.0",
-                                    "2026.12.0",
+                                    "2027.7.0",
                                     "config.env.mise",
                                     "`env.mise` is deprecated. Use `env._` instead."
                                 );

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1509,7 +1509,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
                             if key == "mise" {
                                 deprecated_at!(
                                     "2026.7.0",
-                                    "2027.7.0",
+                                    "2026.12.0",
                                     "config.env.mise",
                                     "`env.mise` is deprecated. Use `env._` instead."
                                 );

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1508,8 +1508,8 @@ impl<'de> de::Deserialize<'de> for EnvList {
                         "_" | "mise" => {
                             if key == "mise" {
                                 deprecated_at!(
-                                    "2026.7.7",
-                                    "2027.7.0",
+                                    "2026.7.0",
+                                    "2026.12.0",
                                     "config.env.mise",
                                     "`env.mise` is deprecated. Use `env._` instead."
                                 );

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::config_file::mise_toml::EnvList;
+use crate::config::config_file::mise_toml::{EnvList, deserialize_vars};
 use crate::config::config_file::toml::{TrackingTomlParser, deserialize_arr};
 use crate::config::env_directive::{EnvDirective, EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::{self, Config};
@@ -459,7 +459,7 @@ pub struct Task {
     pub wait_for: Vec<TaskDep>,
     #[serde(default)]
     pub env: EnvList,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vars")]
     pub vars: EnvList,
     /// Env vars inherited from parent tasks at runtime (not used for task identity/deduplication)
     #[serde(skip)]

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -1,4 +1,4 @@
-use crate::config::config_file::mise_toml::EnvList;
+use crate::config::config_file::mise_toml::{EnvList, deserialize_vars};
 use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{RunEntry, Silent, Task, TaskConfirm, TaskDep, TaskOutput, TaskToolValue};
@@ -23,7 +23,7 @@ pub struct TaskTemplate {
     pub wait_for: Vec<TaskDep>,
     #[serde(default)]
     pub env: EnvList,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vars")]
     pub vars: EnvList,
     #[serde(default)]
     pub dir: Option<String>,


### PR DESCRIPTION
## Summary

- warn when the legacy `env.mise` directive namespace is used starting in mise 2026.7.0
- remove `env.mise` support in mise 2026.12.0
- reject the accidental `vars.mise` directive namespace without a deprecation period, including through nested arrays
- apply the vars behavior consistently to config vars, task vars, and task-template vars
- document the canonical `env._` replacement

## Why

`env.mise` predates the canonical `env._` spelling and has remained as an undocumented compatibility alias. `env._` has been supported since January 2024, so this PR intentionally uses a shortened deprecation window from 2026.7.0 to 2026.12.0 rather than the normal 12-month window. The replacement has already been available for more than two years.

`vars.mise` was only accepted because vars reused the environment directive deserializer; it was never documented or represented in the schema, so it is removed without a deprecation period.

## Impact

Existing `env.mise.*` configurations continue to work through mise 2026.11.x but emit a warning directing users to `env._.*`. Support is removed starting in mise 2026.12.0. `vars.mise` configurations now fail parsing; `vars._` remains supported. The schema already exposes only `_`, so no schema change is needed.

## Validation

- `mise run format` (includes lint-fix, cargo check, schema validation, shellcheck, and formatting checks)
- `mise run test:unit test_vars_mise_is_not_a_directive_namespace`
- `mise run test:e2e e2e/env/test_env_file`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Added warnings for the legacy `env.mise` spelling.
  * Use `env._` instead; the legacy spelling is scheduled for removal in mise 2026.12.0.

* **Bug Fixes**
  * Configuration entries using `vars.mise` are now rejected with a clear error message.
  * Deprecation warnings are consistently shown when legacy environment settings are detected.

* **Documentation**
  * Updated environment configuration guidance to explain the migration from `env.mise` to `env._`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->