### PR TITLE
fix(go): resolve direct package module prefixes

### DIFF
--- a/e2e/backend/test_go_install
+++ b/e2e/backend/test_go_install
@@ -38,6 +38,12 @@ assert_matches \
   "GOPROXY=direct mise install --dry-run 'go:github.com/jdx/go-example/deep/cmd/tool/v2@latest' 2>&1" \
   'go:github.com/jdx/go-example/deep/cmd/tool/v2@2\.0\.0-[0-9]{14}-[0-9a-f]+'
 
+# Package in a subdirectory of an untagged root module; direct mode must walk
+# parent paths to resolve the module's pseudo-version.
+assert_matches \
+  "GOPROXY=direct mise install --dry-run 'go:github.com/noperator/sol/cmd/sol@latest' 2>&1" \
+  'go:github.com/noperator/sol/cmd/sol@0\.0\.0-[0-9]{14}-[0-9a-f]+'
+
 # Required to properly cleanup as go installs read-only sources
 if [ -d ~/go ]; then
   chmod -R +w ~/go

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -97,13 +97,22 @@ impl Backend for GoBackend {
                     return Ok(versions);
                 }
 
-                // Fall back to `go list -m -versions` for GOPROXY=direct
-                match self.fetch_go_module_versions(config, &tool_name).await {
-                    Ok(Some(versions)) if !versions.is_empty() => return Ok(versions),
-                    Ok(_) => {}
-                    Err(err) => {
-                        warn!("failed to list Go module versions for {tool_name}: {err:#}");
+                // Fall back to `go list -m -versions` for GOPROXY=direct. Package
+                // paths are not necessarily module paths, so walk their prefixes
+                // just as the proxy resolver does.
+                let mut resolution_error = None;
+                for mod_path in module_path_candidates(&tool_name) {
+                    match self.fetch_go_module_versions(config, &mod_path).await {
+                        Ok(Some(versions)) if !versions.is_empty() => return Ok(versions),
+                        Ok(_) => {}
+                        Err(err) => {
+                            debug!("failed to resolve Go module candidate {mod_path}: {err:#}");
+                            resolution_error.get_or_insert(err);
+                        }
                     }
+                }
+                if let Some(err) = resolution_error {
+                    warn!("failed to resolve Go module path for {tool_name}: {err:#}");
                 }
 
                 Ok(vec![])
@@ -203,11 +212,7 @@ impl GoBackend {
             return Ok(None);
         }
 
-        let parts: Vec<&str> = tool_name.split('/').collect();
-        let candidates: Vec<String> = (1..=parts.len())
-            .rev()
-            .map(|i| parts[..i].join("/"))
-            .collect();
+        let candidates = module_path_candidates(tool_name);
 
         let mut join_set = tokio::task::JoinSet::new();
         for (idx, path) in candidates.iter().enumerate() {
@@ -403,6 +408,14 @@ impl GoBackend {
             })
             .collect()
     }
+}
+
+fn module_path_candidates(tool_name: &str) -> Vec<String> {
+    let parts: Vec<&str> = tool_name.split('/').collect();
+    (1..=parts.len())
+        .rev()
+        .map(|i| parts[..i].join("/"))
+        .collect()
 }
 
 enum ProxyListResult {
@@ -691,6 +704,20 @@ mod tests {
         let info: GoModuleVersionMetadata = serde_json::from_str(raw).unwrap();
         assert_eq!(info.version, "v1.2.3");
         assert_eq!(info.time, Some("2026-04-08T12:56:30Z".to_string()));
+    }
+
+    #[test]
+    fn module_candidates_are_deepest_first() {
+        assert_eq!(
+            module_path_candidates("github.com/example/tool/cmd/tool"),
+            vec![
+                "github.com/example/tool/cmd/tool",
+                "github.com/example/tool/cmd",
+                "github.com/example/tool",
+                "github.com/example",
+                "github.com",
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reuse the Go module path candidate traversal for direct `go list` resolution
- continue from package paths to parent module prefixes before resolving `@latest`
- add coverage for a nested command in an untagged root module

## Root cause

The proxy resolver checked the requested package path and each parent prefix, but the direct/VCS fallback only queried the complete package path. For nested commands in untagged modules, that path is a package rather than a module, so mise could not obtain the module's concrete pseudo-version even though `go install <package>@latest` worked.

## User impact

Go tools in subdirectories of untagged modules can now resolve `@latest` when the module must be discovered through direct Go resolution. Installation still uses the original package path with the resolved concrete pseudo-version.

Related discussions:

- https://github.com/jdx/mise/discussions/11045
- https://github.com/jdx/mise/discussions/3822

## Validation

- `mise run format`
- `cargo test backend::go::tests`
- `mise run test:e2e e2e/backend/test_go_install`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Go backend version-resolution change with tests; install still uses the original package path with the resolved version.
> 
> **Overview**
> Fixes **GOPROXY=direct** version listing when a `go:` tool points at a **package path** inside an untagged module (e.g. `…/cmd/sol`), not at the module root.
> 
> The direct fallback now walks **deepest-first parent path candidates** via shared `module_path_candidates`, matching the proxy resolver, instead of calling `go list` only on the full package path. Failed candidates are logged at debug; a single warn remains if nothing resolves.
> 
> Adds a unit test for candidate ordering and an e2e dry-run assert for `github.com/noperator/sol/cmd/sol@latest` pseudo-version resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424b4c84053d654206b1d486579070c47c82e0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->