### PR TITLE
fix(task): omit empty templated dependency args

### DIFF
--- a/e2e/tasks/test_task_dep_args
+++ b/e2e/tasks/test_task_dep_args
@@ -32,6 +32,20 @@ EOF
 assert_contains "mise run package --target linux" "compiling for linux"
 assert_contains "mise run package --target linux" "packaging for linux"
 
+# Test conditionally passing a boolean flag with structured dependency syntax
+cat <<'EOF' >mise.toml
+[tasks."lint:check"]
+usage = 'flag "--fix" default=#false'
+run = 'echo "fix=$usage_fix"'
+
+[tasks.lint]
+usage = 'flag "--fix" default=#false'
+depends = [{ task = "lint:check", args = ["{% if usage.fix %}--fix{% endif %}"] }]
+EOF
+
+assert_contains "mise run lint" "fix=false"
+assert_contains "mise run lint --fix" "fix=true"
+
 # Test with multiple args
 cat <<'EOF' >mise.toml
 [tasks.start-backend]

--- a/src/task/task_dep.rs
+++ b/src/task/task_dep.rs
@@ -24,11 +24,18 @@ impl TaskDep {
         if contains_template_syntax(&self.task) {
             self.task = render_str(tera, &self.task, tera_ctx)?;
         }
-        for a in &mut self.args {
+        let mut rendered_args = Vec::with_capacity(self.args.len());
+        for a in &self.args {
             if contains_template_syntax(a) {
-                *a = render_str(tera, a, tera_ctx)?;
+                let rendered = render_str(tera, a, tera_ctx)?;
+                if !rendered.is_empty() {
+                    rendered_args.push(rendered);
+                }
+            } else {
+                rendered_args.push(a.clone());
             }
         }
+        self.args = rendered_args;
         // Render env values through Tera
         for v in self.env.values_mut() {
             if contains_template_syntax(v) {
@@ -330,6 +337,39 @@ mod tests {
         assert_eq!(td.task, "mytask");
         assert_eq!(td.args, vec!["arg1", "arg2"]);
         assert!(td.env.is_empty());
+    }
+
+    #[test]
+    fn test_task_dep_render_omits_empty_templated_args() {
+        let mut td = TaskDep {
+            task: "lint".to_string(),
+            args: vec![
+                "{% if usage.fix %}--fix{% endif %}".to_string(),
+                String::new(),
+            ],
+            env: Default::default(),
+        };
+        let mut tera = TeraEngine::V2(Box::default());
+        let mut ctx = tera::Context::new();
+        ctx.insert("usage", &serde_json::json!({ "fix": false }));
+        td.render(&mut tera, &ctx).unwrap();
+
+        assert_eq!(td.args, vec![""]);
+    }
+
+    #[test]
+    fn test_task_dep_render_keeps_non_empty_templated_args() {
+        let mut td = TaskDep {
+            task: "lint".to_string(),
+            args: vec!["{% if usage.fix %}--fix{% endif %}".to_string()],
+            env: Default::default(),
+        };
+        let mut tera = TeraEngine::V2(Box::default());
+        let mut ctx = tera::Context::new();
+        ctx.insert("usage", &serde_json::json!({ "fix": true }));
+        td.render(&mut tera, &ctx).unwrap();
+
+        assert_eq!(td.args, vec!["--fix"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- omit structured dependency arguments that contain Tera syntax and render to an empty string
- preserve literal empty arguments that were not produced by a template
- cover conditional boolean flag forwarding with unit and end-to-end tests

## Root cause
Structured dependency `args` were rendered one-for-one. A false conditional such as `{% if usage.fix %}--fix{% endif %}` therefore became a real empty argument, which the child task's usage parser rejected as `unexpected word:`. String-form dependencies did not have the same problem because shell splitting discarded the empty rendered word.

This makes structured dependency syntax support the conditional boolean flag pattern discussed in https://github.com/jdx/mise/discussions/11044.

## Validation
- `mise run format`
- `cargo test task_dep::tests`
- `mise run test:e2e test_task_dep_args`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to `TaskDep::render` arg handling with targeted tests; no auth, data, or broad API surface impact.
> 
> **Overview**
> Structured task dependency **`args`** that use Tera and render to an empty string are no longer forwarded to the child task, fixing failures like `unexpected word:` when a false conditional (e.g. `{% if usage.fix %}--fix{% endif %}`) used to become a real empty argv entry. **Literal** empty arguments without template syntax are unchanged.
> 
> Adds unit coverage for omit-vs-keep behavior and an e2e case where `lint` optionally passes `--fix` to `lint:check`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed5fbbe94a7f52160f77a5c11c1fcfabb9f691f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task dependency arguments can now be generated conditionally based on flag values.
  * Arguments that resolve to empty template output are automatically omitted, while explicitly empty arguments are preserved.

* **Tests**
  * Added coverage for conditional dependency arguments and templated argument rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->