### PR TITLE
fix(bootstrap): handle static systemd units in status

### DIFF
--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -648,6 +648,11 @@ async fn is_enabled(unit: &str) -> Result<bool> {
         .await
         .map_err(|_| eyre!("`systemctl --user {}` timed out", shell_words::join(&args)))??;
     let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    debug!(
+        "`systemctl --user {}` state: {}",
+        shell_words::join(&args),
+        state
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         if !stderr.is_empty() {
@@ -931,6 +936,7 @@ mod tests {
             "generated",
             "transient",
             "not-found",
+            "bad",
         ] {
             assert!(!unit_file_state_is_enabled(state), "{state}");
         }

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -635,12 +635,34 @@ async fn is_active(unit: &str) -> Result<bool> {
 }
 
 async fn is_enabled(unit: &str) -> Result<bool> {
-    systemctl_status(&[
-        "is-enabled".to_string(),
-        "--quiet".to_string(),
-        unit.to_string(),
-    ])
-    .await
+    let args = ["is-enabled".to_string(), unit.to_string()];
+    debug!("$ systemctl --user {}", shell_words::join(&args));
+    let mut cmd = tokio::process::Command::new("systemctl");
+    cmd.arg("--user")
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let output = tokio::time::timeout(SYSTEMCTL_TIMEOUT, cmd.output())
+        .await
+        .map_err(|_| eyre!("`systemctl --user {}` timed out", shell_words::join(&args)))??;
+    let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if !stderr.is_empty() {
+            debug!(
+                "`systemctl --user {}` exited non-zero: {}",
+                shell_words::join(&args),
+                stderr
+            );
+        }
+    }
+    Ok(unit_file_state_is_enabled(&state))
+}
+
+fn unit_file_state_is_enabled(state: &str) -> bool {
+    matches!(state, "enabled" | "enabled-runtime")
 }
 
 async fn systemctl_status(args: &[String]) -> Result<bool> {
@@ -890,6 +912,28 @@ mod tests {
             state: SystemdState::Inactive,
         };
         assert!(inactive_stopped.is_desired());
+    }
+
+    #[test]
+    fn test_unit_file_state_is_enabled() {
+        for state in ["enabled", "enabled-runtime"] {
+            assert!(unit_file_state_is_enabled(state), "{state}");
+        }
+        for state in [
+            "static",
+            "disabled",
+            "linked",
+            "linked-runtime",
+            "alias",
+            "masked",
+            "masked-runtime",
+            "indirect",
+            "generated",
+            "transient",
+            "not-found",
+        ] {
+            assert!(!unit_file_state_is_enabled(state), "{state}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- parse the textual state from `systemctl --user is-enabled`
- only treat `enabled` and `enabled-runtime` as enabled
- cover static and other non-enabled systemd unit-file states

## Root cause

`systemctl is-enabled` returns a successful exit code for states such as `static`, `alias`, `indirect`, `generated`, and `transient`. Mise previously converted that exit status directly into its `enabled` boolean, so a unit rendered without an `[Install]` section by `wanted_by = []` was incorrectly reported as enabled and permanently differed from its desired state.

Fixes the behavior reported in https://github.com/jdx/mise/discussions/11048.

## Validation

- `mise run format`
- `mise run test:unit` (1,711 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to bootstrap systemd status detection with unit tests; no auth, data, or apply-path behavior changes beyond correct enable reporting.
> 
> **Overview**
> **Bootstrap Linux systemd status** now derives the `enabled` flag from the **textual** `systemctl --user is-enabled` output instead of treating a zero exit code as “enabled.”
> 
> Only **`enabled`** and **`enabled-runtime`** count as enabled via new helper `unit_file_state_is_enabled`. States such as **`static`**, **`alias`**, **`indirect`**, and **`generated`** (which can still exit successfully) are no longer misclassified, so units rendered without an `[Install]` section (e.g. `wanted_by = []`) align with desired enablement in `status()` comparisons.
> 
> Adds a unit test covering the full set of known unit-file states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211dfc9187704c8898f4c53fe6b6a495663abd5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of whether a user service unit is enabled by directly querying the unit’s enabled state and interpreting the returned status.
  * Ensures only `enabled` and `enabled-runtime` are treated as enabled, preventing incorrect “enabled” reporting for other unit states.
* **Tests**
  * Added coverage to verify the enabled-state mapping for supported unit states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->