### PR TITLE
fix(task): inherit output from task templates

### DIFF
--- a/docs/tasks/templates.md
+++ b/docs/tasks/templates.md
@@ -54,6 +54,7 @@ When a task extends a template, fields are merged according to these rules:
 | `depends`, `depends_post`, `wait_for`             | Local overrides completely (not merged)                     |
 | `dir`                                             | Local overrides; defaults to config_root if not in template |
 | `sources`, `outputs`                              | Local overrides completely                                  |
+| `output`                                          | Local overrides template (if set)                           |
 | Sandbox deny fields                               | Compose with task-local settings                            |
 | Sandbox allow fields                              | Template and task-local values are combined                 |
 | `description`, `shell`, `timeout`, etc.           | Local overrides template (if set)                           |

--- a/e2e/tasks/test_task_templates
+++ b/e2e/tasks/test_task_templates
@@ -81,6 +81,23 @@ EOF
 assert_contains "mise tasks build" "Local description"
 assert_not_contains "mise tasks build" "Template description"
 
+# Test output style inheritance and local override
+cat <<'EOF' >mise.toml
+[task_templates.base]
+run = "echo task output"
+output = "silent"
+
+[tasks.inherited]
+extends = "base"
+
+[tasks.overridden]
+extends = "base"
+output = "interleave"
+EOF
+
+assert_not_contains "mise run inherited" "task output"
+assert "mise run overridden" "task output"
+
 # Test depends from template (using task name, not :prefix syntax)
 cat <<'EOF' >mise.toml
 [task_templates."python:test"]

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -1,7 +1,7 @@
 use crate::config::config_file::mise_toml::EnvList;
 use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
-use crate::task::{RunEntry, Silent, Task, TaskConfirm, TaskDep, TaskToolValue};
+use crate::task::{RunEntry, Silent, Task, TaskConfirm, TaskDep, TaskOutput, TaskToolValue};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
@@ -31,6 +31,8 @@ pub struct TaskTemplate {
     pub sources: Vec<String>,
     #[serde(default)]
     pub outputs: TaskOutputs,
+    #[serde(default)]
+    pub output: Option<TaskOutput>,
     #[serde(default)]
     pub shell: Option<String>,
     #[serde(default)]
@@ -160,6 +162,11 @@ impl Task {
         // outputs: local overrides completely if default
         if self.outputs == TaskOutputs::default() && template.outputs != TaskOutputs::default() {
             self.outputs = template.outputs.clone();
+        }
+
+        // output: use template only if local not set
+        if self.output.is_none() {
+            self.output = template.output;
         }
 
         // shell: use template only if local not set
@@ -300,6 +307,25 @@ mod tests {
         };
         task2.merge_template(&template);
         assert_eq!(task2.description, "Local description");
+    }
+
+    #[test]
+    fn test_merge_template_output() {
+        let template = TaskTemplate {
+            output: Some(TaskOutput::KeepOrder),
+            ..Default::default()
+        };
+
+        let mut inherited = Task::default();
+        inherited.merge_template(&template);
+        assert_eq!(inherited.output, Some(TaskOutput::KeepOrder));
+
+        let mut overridden = Task {
+            output: Some(TaskOutput::Interleave),
+            ..Default::default()
+        };
+        overridden.merge_template(&template);
+        assert_eq!(overridden.output, Some(TaskOutput::Interleave));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- deserialize `output` in task templates
- inherit the template output style when a task does not set one
- preserve task-local output overrides
- document and test the merge behavior

## Root cause

PR #10885 added the per-task `output` field and exposed it through the shared task schema, but did not add the field to `TaskTemplate` or its merge logic. Schema-aware tooling therefore accepted template output styles that mise ignored at runtime.

Unlike the task-only boolean flags, `output` is represented as `Option<TaskOutput>`, so template inheritance can distinguish an unset task value from an explicit local override.

## Validation

- `mise x cargo -- cargo test task_template::tests --all-features`
- `mise run test:e2e e2e/tasks/test_task_templates`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task templates can now define a default output style.
  * Tasks inherit the template’s output style unless they specify their own.

* **Documentation**
  * Clarified how task-level output settings override template values.

* **Bug Fixes**
  * Ensured local output settings are preserved when applying task templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->