### PR TITLE
fix(config): align env and vars array parsing

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -551,16 +551,15 @@ For a working example, see the [mise-env-plugin-template](https://github.com/jdx
 
 ## Multiple `env._` Directives
 
-It may be necessary to use multiple `env._` directives, however TOML fails with this syntax
-because it has 2 identical keys in a table:
+Some directives accept an array when you need to apply them more than once. For example,
+multiple scripts can be sourced in order with a single `_.source` key:
 
 ```toml
 [env]
-_.source = "./script_1.sh"
-_.source = "./script_2.sh" # invalid // [!code error]
+_.source = ["./script_1.sh", "./script_2.sh"]
 ```
 
-For this use-case, you can optionally make `[env]` an array-of-tables instead by using `[[env]]` instead:
+The `[[env]]` array-of-tables form remains supported for compatibility:
 
 ```toml
 [[env]]
@@ -569,7 +568,7 @@ _.source = "./script_1.sh"
 _.source = "./script_2.sh"
 ```
 
-It works identically but you can have multiple tables.
+For new configurations, prefer arrays on the directive itself when the directive supports them.
 
 ## Templates
 

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -559,17 +559,6 @@ multiple scripts can be sourced in order with a single `_.source` key:
 _.source = ["./script_1.sh", "./script_2.sh"]
 ```
 
-The `[[env]]` array-of-tables form remains supported for compatibility:
-
-```toml
-[[env]]
-_.source = "./script_1.sh"
-[[env]]
-_.source = "./script_2.sh"
-```
-
-For new configurations, prefer arrays on the directive itself when the directive supports them.
-
 ## Templates
 
 Environment variable values can be templates, see [Templates](/templates) for details.

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -147,7 +147,7 @@ pub struct MiseToml {
     env_file: Vec<String>,
     #[serde(default, deserialize_with = "deserialize_arr")]
     dotenv: Vec<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_root_env")]
     env: EnvList,
     #[serde(default, deserialize_with = "deserialize_arr")]
     env_path: Vec<String>,
@@ -1498,18 +1498,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
         impl<'de> Visitor<'de> for EnvManVisitor {
             type Value = EnvList;
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-                formatter.write_str("env table or array of env tables")
-            }
-
-            fn visit_seq<S>(self, mut seq: S) -> std::result::Result<Self::Value, S::Error>
-            where
-                S: de::SeqAccess<'de>,
-            {
-                let mut env = vec![];
-                while let Some(list) = seq.next_element::<EnvList>()? {
-                    env.extend(list.0);
-                }
-                Ok(EnvList(env))
+                formatter.write_str("environment variable table")
             }
 
             fn visit_map<M>(self, mut map: M) -> std::result::Result<Self::Value, M::Error>
@@ -1904,7 +1893,7 @@ impl<'de> de::Deserialize<'de> for EnvList {
             }
         }
 
-        deserializer.deserialize_any(EnvManVisitor)
+        deserializer.deserialize_map(EnvManVisitor)
     }
 }
 
@@ -1924,6 +1913,41 @@ where
         return Err(de::Error::custom("`vars.mise` is not supported"));
     }
     EnvList::deserialize(value).map_err(de::Error::custom)
+}
+
+fn deserialize_root_env<'de, D>(deserializer: D) -> std::result::Result<EnvList, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    struct RootEnvVisitor;
+
+    impl<'de> Visitor<'de> for RootEnvVisitor {
+        type Value = EnvList;
+
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("env table or flat array of env tables")
+        }
+
+        fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
+        where
+            M: de::MapAccess<'de>,
+        {
+            EnvList::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+
+        fn visit_seq<S>(self, mut seq: S) -> std::result::Result<Self::Value, S::Error>
+        where
+            S: de::SeqAccess<'de>,
+        {
+            let mut env = vec![];
+            while let Some(list) = seq.next_element::<EnvList>()? {
+                env.extend(list.0);
+            }
+            Ok(EnvList(env))
+        }
+    }
+
+    deserializer.deserialize_any(RootEnvVisitor)
 }
 
 impl<'de> de::Deserialize<'de> for MiseTomlToolList {
@@ -2769,6 +2793,61 @@ mod tests {
         bar2=qux
         quux
         ");
+    }
+
+    #[test]
+    fn test_env_and_vars_array_boundaries() {
+        assert!(toml::from_str::<MiseToml>(r#"env = [{ FOO = "one" }, { BAR = "two" }]"#).is_ok());
+        assert!(toml::from_str::<MiseToml>("env = []").is_ok());
+        assert!(
+            toml::from_str::<MiseToml>(
+                r#"
+                [env]
+                _.source = ["./first.sh", "./second.sh"]
+
+                [vars]
+                _.file = ["./first.env", "./second.env"]
+                "#,
+            )
+            .is_ok()
+        );
+
+        for invalid in [
+            r#"env = [[{ FOO = "bar" }]]"#,
+            r#"env = [{ FOO = "bar" }, [{ BAR = "baz" }]]"#,
+            r#"vars = []"#,
+            r#"vars = [{ FOO = "bar" }]"#,
+            r#"vars = [[{ FOO = "bar" }]]"#,
+        ] {
+            assert!(
+                toml::from_str::<MiseToml>(invalid).is_err(),
+                "expected config to be rejected: {invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_task_env_and_vars_arrays_invalid() {
+        for field in ["env", "vars"] {
+            let config = formatdoc! {r#"
+                [tasks.example]
+                run = "echo ok"
+                {field} = [{{ FOO = "bar" }}]
+            "#};
+            assert!(
+                toml::from_str::<MiseToml>(&config).is_err(),
+                "expected task {field} array to be rejected"
+            );
+
+            let config = formatdoc! {r#"
+                [task_templates.example]
+                {field} = [{{ FOO = "bar" }}]
+            "#};
+            assert!(
+                toml::from_str::<MiseToml>(&config).is_err(),
+                "expected task template {field} array to be rejected"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/config/config_file/toml.rs
+++ b/src/config/config_file/toml.rs
@@ -214,6 +214,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_env_requires_table() {
+        let table = toml::from_str(r#"env = [{ FOO = "bar" }]"#).unwrap();
+        assert!(TomlParser::new(&table).parse_env("env").is_err());
+
+        let table = toml::from_str(
+            r#"
+            [env]
+            _.source = ["./first.sh", "./second.sh"]
+            "#,
+        )
+        .unwrap();
+        assert!(TomlParser::new(&table).parse_env("env").is_ok());
+    }
+
+    #[test]
     fn test_parse_table() {
         let toml = r#"table = {foo = "bar", baz = "qux", num = 123}"#;
         let table = toml::from_str(toml).unwrap();


### PR DESCRIPTION
## Summary

- make the shared `EnvList` deserializer table-only so runtime rejects accidental array forms for root `vars`, task `env`/`vars`, task-template `env`/`vars`, and task-file headers
- preserve the intentional public root `env` boundary with a dedicated wrapper that accepts a table or exactly one flat array level
- reject recursive and mixed nested root `env` arrays
- recommend directive-level arrays in the environment docs while retaining `[[env]]` compatibility

The checked-in schemas already represent this boundary, so no generated schema changes are needed.

## Examples

Accepted:

```toml
[env]
_.source = ["./first.sh", "./second.sh"]

[vars]
TARGET = "linux"
```

The compatibility form remains accepted:

```toml
[[env]]
FOO = "one"

[[env]]
BAR = "two"
```

Rejected:

```toml
env = [[{ FOO = "bar" }]]
vars = [{ TARGET = "linux" }]

[tasks.example]
run = "echo ok"
env = [{ FOO = "bar" }]
```

## Compatibility

This intentionally removes undocumented parser behavior for outer `vars` and task arrays. Directive-internal arrays such as `env._.source`, `env._.file`, `env._.path`, and `vars._.file` remain supported.

Stacked on #11053. Target branch remains `main`.

Related audit: https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=213401680

## Testing

- `cargo test test_env_and_vars_array_boundaries`
- `cargo test test_task_env_and_vars_arrays_invalid`
- `cargo test test_parse_env_requires_table`
- `cargo test test_env_array_valid`
- `cargo test test_vars_mise_is_not_a_directive_namespace`
- `mise run lint-fix`
- `mise run test:e2e config/test_schema_tombi`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Environment configuration now supports applying certain directives multiple times using array values (for example, providing multiple scripts via a single `_.source` array).
  - Top-level environment blocks can be provided as either one table or an array of tables.

- **Documentation**
  - Updated the environment configuration guide to focus on the directive-array approach and removed older TOML conflict/workaround wording.

- **Bug Fixes**
  - Strengthened TOML validation for supported `env`/`vars` shapes, boundaries, and invalid placements, with clearer error reporting.

- **Tests**
  - Added unit tests covering valid and invalid TOML layouts for `env` parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->