### PR TITLE
fix(config): reject non-string postinstall hooks

### DIFF
--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -211,11 +211,11 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
-include = ["mise-bad-task-os.toml", "mise-bad-task-install-env-float.toml"]
+include = ["mise-bad-task-os.toml", "mise-bad-task-install-env-float.toml", "mise-bad-task-postinstall.toml"]
 
 [[schemas]]
 path = "file://$REGISTRY_TOOL_SCHEMA_PATH"
@@ -271,6 +271,24 @@ node = { version = "latest", install_env = { FLOAT = 1.23 } }
 TOML
 
 assert_fail "$TOMBI_LINT mise-bad-install-env-float.toml"
+
+# Tool-level postinstall hooks must be strings in both schemas.
+for postinstall in 123 true 1.23 2026-07-17T12:34:56Z; do
+  cat >"$HOME/workdir/mise-bad-postinstall.toml" <<TOML
+[tools]
+node = { version = "latest", postinstall = $postinstall }
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-postinstall.toml"
+
+  cat >"$HOME/workdir/mise-bad-task-postinstall.toml" <<TOML
+[build]
+run = "echo ok"
+
+[build.tools]
+node = { version = "latest", postinstall = $postinstall }
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-task-postinstall.toml"
+done
 
 cat >"$HOME/workdir/mise-bad-vars.toml" <<'TOML'
 [vars]

--- a/e2e/config/test_tool_postinstall_type
+++ b/e2e/config/test_tool_postinstall_type
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Tool-level postinstall hooks execute shell code, so runtime parsing must match
+# the schema and reject TOML scalars instead of converting them to commands.
+for postinstall in 123 true 1.23 2026-07-17T12:34:56Z; do
+  cat >mise.toml <<TOML
+[tools]
+dummy = { version = "latest", postinstall = $postinstall }
+TOML
+
+  assert_fail "mise config ls" "postinstall must be a string"
+
+  cat >mise.toml <<TOML
+[tasks.build]
+run = "echo ok"
+
+[tasks.build.tools]
+dummy = { version = "latest", postinstall = $postinstall }
+TOML
+
+  assert_fail "mise run build" "postinstall must be a string"
+done
+
+cat >mise.toml <<'TOML'
+[tools]
+dummy = { version = "latest", postinstall = "echo ok" }
+TOML
+
+assert_succeed "mise config ls"

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -352,7 +352,15 @@ impl ToolOptions {
                 }
                 Ok(true)
             }
-            "postinstall" | "minimum_release_age" | "install_before" => {
+            "postinstall" => {
+                let script = value
+                    .as_str()
+                    .ok_or_else(|| "postinstall must be a string".to_string())?;
+                self.opts
+                    .insert(key.to_string(), toml::Value::String(script.to_string()));
+                Ok(true)
+            }
+            "minimum_release_age" | "install_before" => {
                 self.opts.insert(
                     key.to_string(),
                     toml::Value::String(scalar_value_to_string(value).ok_or_else(|| {
@@ -847,6 +855,22 @@ mod tests {
         assert!(!opts.opts.contains_key("depends"));
         assert!(!opts.opts.contains_key("os"));
         assert!(!opts.opts.contains_key("install_env"));
+    }
+
+    #[test]
+    fn test_parse_tool_options_rejects_non_string_postinstall() {
+        for input in [
+            "postinstall=123",
+            "postinstall=true",
+            "postinstall=1.23",
+            "postinstall=2026-07-17T12:34:56Z",
+        ] {
+            assert_eq!(
+                try_parse_tool_options(input),
+                Err("postinstall must be a string".to_string()),
+                "input: {input}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require tool-level `postinstall` hooks to be TOML strings at runtime
- reject integer, boolean, float, and datetime values instead of converting them into shell commands
- cover root tool configuration, task-local tools, inline option parsing, and both published schemas

## Root cause

`postinstall`, `minimum_release_age`, and the legacy `install_before` option shared one scalar-to-string parser branch. That made runtime parsing accept and stringify every TOML scalar even though the main and standalone task schemas define `postinstall` as a string-only shell command.

The parser now handles `postinstall` separately and retains the existing scalar behavior for the date-related options.

## Impact

Configurations such as `postinstall = true` or `postinstall = 1.23` now fail with `postinstall must be a string`, matching strict schema validation and preventing accidental scalar values from becoming executable commands.

Tracks the reverse `postinstall` mismatch in https://github.com/users/risu729/projects/3/views/1?pane=issue&itemId=213401680.

## Validation

- `mise x cargo -- cargo test test_parse_tool_options_rejects_non_string_postinstall`
- `mise run test:e2e config/test_tool_postinstall_type`
- `mise run test:e2e config/test_schema_tombi`
- `mise run lint-fix`
- targeted `shellcheck` and `shfmt` after the final task-runtime coverage update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced that `postinstall` values must be quoted strings.
  * Added clear validation errors when non-string values such as numbers, booleans, or timestamps are used.
  * Improved validation across tool and build-tool configurations.
  * Confirmed valid string commands continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->