### PR TITLE
fix(config): deprecate env directive value aliases

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -321,9 +321,10 @@ we make use of this fact by creating a key named "\_" which is a
 TOML table for the configuration of these directives.
 
 ::: warning
-The `value` and `values` keys in `env._.*` directive objects are deprecated. Use `path`, which
-accepts either a single string or an array of strings. They will be removed in mise 2026.12.0.
-This does not affect `value` in ordinary environment variable objects.
+The `value` and `values` keys in built-in `file`, `path`, and `source` directive objects under
+`env._` or `vars._` are deprecated. Use `path`, which accepts either a single string or an array of
+strings. They will be removed in mise 2026.12.0. This does not affect `value` in ordinary environment
+variable objects or options for plugin-provided directives.
 :::
 
 ### `env._.file`

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -320,6 +320,12 @@ from a file). Since nested environment variables do not make sense,
 we make use of this fact by creating a key named "\_" which is a
 TOML table for the configuration of these directives.
 
+::: warning
+The `value` and `values` keys in `env._.*` directive objects are deprecated. Use `path`, which
+accepts either a single string or an array of strings. They will be removed in mise 2026.12.0.
+This does not affect `value` in ordinary environment variable objects.
+:::
+
 ### `env._.file`
 
 In `mise.toml`: `env._.file` can be used to specify a [dotenv](https://dotenv.org) file to load.

--- a/e2e/env/test_env_file
+++ b/e2e/env/test_env_file
@@ -27,7 +27,16 @@ cat <<EOF >mise.toml
 _.file = { value = 'b.json' }
 EOF
 echo '{"B": 2}' >b.json
+assert_contains "mise env 2>&1" "deprecated [config.env.directive.value]"
 assert "mise env | grep -v PATH" "export B=2"
+
+cat <<EOF >mise.toml
+[env]
+_.file = { values = ['a', 'b.json'] }
+EOF
+assert_contains "mise env 2>&1" "deprecated [config.env.directive.values]"
+assert "mise env | grep -v PATH" "export A=1
+export B=2"
 
 cat <<EOF >mise.toml
 [env]

--- a/e2e/env/test_env_file
+++ b/e2e/env/test_env_file
@@ -27,14 +27,14 @@ cat <<EOF >mise.toml
 _.file = { value = 'b.json' }
 EOF
 echo '{"B": 2}' >b.json
-assert_contains "mise env 2>&1" "deprecated [config.env.directive.value]"
+assert_contains "mise env 2>&1" "deprecated [config.directive.value]"
 assert "mise env | grep -v PATH" "export B=2"
 
 cat <<EOF >mise.toml
 [env]
 _.file = { values = ['a', 'b.json'] }
 EOF
-assert_contains "mise env 2>&1" "deprecated [config.env.directive.values]"
+assert_contains "mise env 2>&1" "deprecated [config.directive.values]"
 assert "mise env | grep -v PATH" "export A=1
 export B=2"
 

--- a/e2e/env/test_env_path
+++ b/e2e/env/test_env_path
@@ -35,6 +35,14 @@ assert "mise dr path" "$PWD/a"
 
 cat <<'EOF' >mise.toml
 [env]
+_.path = { paths = ["a", "b"], tools = true }
+EOF
+assert_not_contains "mise dr path 2>&1" "deprecated [config.directive"
+assert "mise dr path" "$PWD/a
+$PWD/b"
+
+cat <<'EOF' >mise.toml
+[env]
 _.path = [{ path = "a", tools = true }, "b"]
 EOF
 assert "mise dr path" "$PWD/a

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1547,16 +1547,16 @@ impl<'de> de::Deserialize<'de> for EnvList {
                                         deprecated_at!(
                                             "2026.7.0",
                                             "2026.12.0",
-                                            "config.env.directive.value",
-                                            "`value` in environment directive objects is deprecated. Use `path` instead."
+                                            "config.directive.value",
+                                            "`value` in built-in `file`, `path`, and `source` directive objects is deprecated. Use `path` instead."
                                         );
                                     }
                                     if uses_values {
                                         deprecated_at!(
                                             "2026.7.0",
                                             "2026.12.0",
-                                            "config.env.directive.values",
-                                            "`values` in environment directive objects is deprecated. Use `path` instead."
+                                            "config.directive.values",
+                                            "`values` in built-in `file`, `path`, and `source` directive objects is deprecated. Use `path` instead."
                                         );
                                     }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1508,28 +1508,69 @@ impl<'de> de::Deserialize<'de> for EnvList {
                         "_" | "mise" => {
                             #[derive(Deserialize)]
                             #[serde(untagged)]
-                            enum MiseTomlEnvDirective {
+                            enum MiseTomlEnvDirectiveValue {
                                 Single {
-                                    #[serde(alias = "path")]
-                                    value: String,
+                                    #[serde(alias = "value")]
+                                    path: String,
                                     #[serde(flatten)]
                                     options: EnvDirectiveOptions,
                                 },
                                 Multiple {
-                                    #[serde(alias = "value", alias = "path", alias = "paths")]
-                                    values: Vec<String>,
+                                    #[serde(alias = "value", alias = "values", alias = "paths")]
+                                    path: Vec<String>,
                                     #[serde(flatten)]
                                     options: EnvDirectiveOptions,
                                 },
                             }
 
+                            struct MiseTomlEnvDirective(MiseTomlEnvDirectiveValue);
+
+                            impl<'de> Deserialize<'de> for MiseTomlEnvDirective {
+                                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                                where
+                                    D: Deserializer<'de>,
+                                {
+                                    let value = toml::Value::deserialize(deserializer)?;
+                                    let (uses_value, uses_values) = value
+                                        .as_table()
+                                        .map(|table| {
+                                            (
+                                                table.contains_key("value"),
+                                                table.contains_key("values"),
+                                            )
+                                        })
+                                        .unwrap_or_default();
+                                    let directive = MiseTomlEnvDirectiveValue::deserialize(value)
+                                        .map_err(de::Error::custom)?;
+
+                                    if uses_value {
+                                        deprecated_at!(
+                                            "2026.7.0",
+                                            "2026.12.0",
+                                            "config.env.directive.value",
+                                            "`value` in environment directive objects is deprecated. Use `path` instead."
+                                        );
+                                    }
+                                    if uses_values {
+                                        deprecated_at!(
+                                            "2026.7.0",
+                                            "2026.12.0",
+                                            "config.env.directive.values",
+                                            "`values` in environment directive objects is deprecated. Use `path` instead."
+                                        );
+                                    }
+
+                                    Ok(MiseTomlEnvDirective(directive))
+                                }
+                            }
+
                             impl FromStr for MiseTomlEnvDirective {
                                 type Err = String;
                                 fn from_str(s: &str) -> Result<Self, Self::Err> {
-                                    Ok(MiseTomlEnvDirective::Single {
-                                        value: s.to_string(),
+                                    Ok(MiseTomlEnvDirective(MiseTomlEnvDirectiveValue::Single {
+                                        path: s.to_string(),
                                         options: Default::default(),
-                                    })
+                                    }))
                                 }
                             }
 
@@ -1658,11 +1699,11 @@ impl<'de> de::Deserialize<'de> for EnvList {
                             where
                                 F: Fn(String, EnvDirectiveOptions) -> EnvDirective + 'static,
                             {
-                                directives.into_iter().flat_map(move |d| match d {
-                                    MiseTomlEnvDirective::Single { value, options } => {
-                                        vec![constructor(value, options)]
+                                directives.into_iter().flat_map(move |d| match d.0 {
+                                    MiseTomlEnvDirectiveValue::Single { path, options } => {
+                                        vec![constructor(path, options)]
                                     }
-                                    MiseTomlEnvDirective::Multiple { values, options } => values
+                                    MiseTomlEnvDirectiveValue::Multiple { path, options } => path
                                         .into_iter()
                                         .map(|v| constructor(v, options.clone()))
                                         .collect(),


### PR DESCRIPTION
## Summary

- deprecate `value` and `values` in built-in `file`, `path`, and `source` directive objects starting in mise 2026.7.0
- direct users to canonical `path`, which accepts both a string and an array of strings
- retain compatibility until removal in mise 2026.12.0
- document the precise scope and cover deprecated warnings plus canonical plural-path behavior end to end

## Why

The public schema and current documentation expose `path`/`paths`, but runtime parsing still accepts the older `value` spelling and the incidental `values` spelling. These forms are old enough to use the same shortened deprecation window as the related `env.mise` deprecation in #11053.

The schema intentionally remains unchanged: it already exposes only the canonical `path` and `paths` forms.

## Impact

Built-in `file`, `path`, and `source` directive objects under `env._` or `vars._` that use `value` or `values` continue to work through mise 2026.11.x and now emit a warning. `path` accepts either a scalar string or an array, while `paths` remains supported for arrays.

Ordinary environment variable objects such as `FOO = { value = "bar" }` and options for plugin-provided directives are unaffected.

## Validation

- `mise run format`
- `cargo check --all-features`
- `mise run test:e2e e2e/env/test_env_file e2e/env/test_env_path`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance that the legacy `value` and `values` keys for built-in environment file, path, and source directives are deprecated.
  * Documented the recommended `path` syntax and removal timeline in mise 2026.12.0.

* **Bug Fixes**
  * Added clearer deprecation warnings when legacy directive keys are used.
  * Improved support for configuring multiple paths while preserving environment variable and PATH resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->