### PR TITLE
fix(bootstrap): ignore macos metadata in cask artifacts

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1048,6 +1048,7 @@ fn find_artifact(root: &Path, name: &str) -> Option<PathBuf> {
     let name_path = Path::new(name);
     WalkDir::new(root)
         .into_iter()
+        .filter_entry(|entry| entry.file_name() != "__MACOSX")
         .filter_map(|entry| entry.ok())
         .find(|entry| {
             entry
@@ -1583,6 +1584,21 @@ end
             cask_extraction_format(&archive, "claude-1.0.0-claude")?,
             ExtractionFormat::Raw
         );
+        Ok(())
+    }
+
+    #[test]
+    fn artifact_lookup_ignores_macos_metadata_directories() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let metadata_app = tmp.path().join("__MACOSX/Pearcleaner.app");
+        file::create_dir_all(&metadata_app)?;
+
+        assert_eq!(find_app(tmp.path(), "Pearcleaner.app"), None);
+
+        let app = tmp.path().join("Pearcleaner.app");
+        file::create_dir_all(&app)?;
+
+        assert_eq!(find_app(tmp.path(), "Pearcleaner.app"), Some(app));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- prune `__MACOSX` subtrees while locating extracted Homebrew cask artifacts
- add regression coverage for Finder-created ZIPs containing an AppleDouble app twin

## Root cause

Cask ZIP extraction preserves `__MACOSX` metadata directories. Artifact lookup previously returned the first path whose suffix matched the requested artifact, so filesystem traversal could select the metadata-only app bundle instead of the real bundle. Installing that bundle then caused later `$APPDIR` binary staging to fail.

This matches Homebrew's behavior of excluding `__MACOSX` metadata from usable extracted artifacts.

Fixes the root cause reported in https://github.com/jdx/mise/discussions/11058.

## Validation

- `mise run format`
- `cargo test --all-features artifact_lookup_ignores_macos_metadata_directories`
- `cargo test --all-features system::packages::brew::cask::tests` (50 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to macOS cask extraction lookup with a focused regression test; no auth or data-path changes.
> 
> **Overview**
> Homebrew cask artifact lookup now **skips `__MACOSX` directories** while walking extracted archives, so Finder-style ZIPs cannot satisfy an app/binary/pkg/font match with AppleDouble metadata instead of the real bundle.
> 
> The change is a single `WalkDir::filter_entry` guard on `find_artifact`, which also drives `find_app` and downstream `$APPDIR` binary staging. A regression test covers the case where only `__MACOSX/…app` exists versus when the real `.app` is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da912f2adc031a3799798e9f02a9f80064ddebf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS application artifact detection by ignoring metadata directories.
  * Prevented incorrect matches when staged applications include `__MACOSX` folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->