### PR TITLE
fix(schema): require arrays for deps provider paths

### DIFF
--- a/e2e/config/test_schema_deps_provider_arrays
+++ b/e2e/config/test_schema_deps_provider_arrays
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+TOMBI_VERSION="0.9.22"
+
+mise use -g tombi@$TOMBI_VERSION
+
+SCHEMA_PATH="$ROOT/schema/mise.json"
+TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
+assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
+
+cat >"$HOME/tombi.toml" <<EOF
+toml-version = "v1.0.0"
+
+[schema]
+enabled = true
+strict = true
+
+[[schemas]]
+path = "file://$SCHEMA_PATH"
+include = ["mise-deps.toml", "mise-bad-deps.toml"]
+EOF
+
+cat >"$HOME/workdir/mise-deps.toml" <<'TOML'
+[deps.npm]
+sources = ["package.json", "package-lock.json"]
+outputs = ["node_modules/"]
+
+[deps.codegen]
+sources = ["schema/*.graphql"]
+outputs = ["src/generated/"]
+run = "npm run codegen"
+TOML
+
+cd "$HOME/workdir"
+assert_succeed "$TOMBI_LINT mise-deps.toml"
+
+for field in sources outputs; do
+  cat >"$HOME/workdir/mise-bad-deps.toml" <<TOML
+[deps.codegen]
+$field = "single-path"
+run = "npm run codegen"
+TOML
+  assert_fail "$TOMBI_LINT mise-bad-deps.toml"
+done

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2647,31 +2647,17 @@
           "description": "Auto-run before `mise x` and `mise run`"
         },
         "sources": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "description": "Files/patterns to check for changes"
         },
         "outputs": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "description": "Files/directories that should be newer than sources"
         },
         "run": {


### PR DESCRIPTION
## Summary

- require arrays for dependency-provider `sources` and `outputs` in the published schema
- add strict Tombi coverage for valid array forms and invalid scalar forms
- leave runtime deserialization unchanged

## Why

`DepsProviderConfig` has always deserialized both fields as `Vec<String>`, and the dependency-provider documentation describes them as `string[]`. The schema incorrectly also accepted a scalar string, so strict schema validation could approve configuration that mise then rejected at runtime.

## Impact

The schema now matches the existing runtime and documented contract. Task `sources` and `outputs` syntax is unaffected; this change applies only to `[deps.<provider>]`.

## Validation

- `mise run format`
- `mise run test:e2e e2e/config/test_schema_deps_provider_arrays`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for dependency provider outputs so configurations must use an array of file or directory paths.
  * Added validation coverage to ensure invalid single-path values are correctly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->