### PR TITLE
fix(http): fail fast when network is unavailable

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -748,6 +748,11 @@ type = "Duration"
 aliases = ["fetch_remote_version_timeout"]
 default = "20s"
 description = "Timeout in seconds for HTTP requests to fetch new tool versions in mise."
+docs = """
+Fast commands using `prefer_offline` cap this timeout at 3 seconds so shims and
+shell activation do not block for a long time when cached data is insufficient
+and the network is unavailable.
+"""
 env = "MISE_FETCH_REMOTE_VERSIONS_TIMEOUT"
 type = "Duration"
 
@@ -1205,6 +1210,10 @@ treated as permanent and not retried.
 
 Backoff schedule with jitter: ~200ms / ~1s / ~4s / ~15s. Set to 0 to disable
 retries entirely.
+
+Retries are automatically disabled for fast commands using `prefer_offline`,
+including shims and shell activation. These paths make one network attempt when
+cached data is insufficient, then fail or fall back immediately.
 
 When a retry rescues a request, a warning is logged with the original error so
 flaky infrastructure doesn't silently mask itself.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -898,7 +898,12 @@ impl Settings {
     }
 
     pub fn fetch_remote_versions_timeout(&self) -> Duration {
-        duration::parse_duration(&self.fetch_remote_versions_timeout).unwrap()
+        let timeout = duration::parse_duration(&self.fetch_remote_versions_timeout).unwrap();
+        if self.prefer_offline() {
+            timeout.min(Duration::from_secs(3))
+        } else {
+            timeout
+        }
     }
 
     /// duration that remote version cache is kept for
@@ -920,6 +925,17 @@ impl Settings {
 
     pub fn http_download_timeout(&self) -> Duration {
         duration::parse_duration(&self.http_download_timeout).unwrap()
+    }
+
+    /// Fast-path commands should make at most one network attempt before falling
+    /// back to cached/local behavior. In particular, shims must not multiply a
+    /// stalled resolver timeout by the configured retry count.
+    pub fn http_retries(&self) -> i64 {
+        if self.prefer_offline() {
+            0
+        } else {
+            self.http_retries
+        }
     }
 
     /// Returns true if offline mode is enabled via setting or CLI flag/env var.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -898,12 +898,16 @@ impl Settings {
     }
 
     pub fn fetch_remote_versions_timeout(&self) -> Duration {
-        let timeout = duration::parse_duration(&self.fetch_remote_versions_timeout).unwrap();
+        let timeout = self.configured_fetch_remote_versions_timeout();
         if self.prefer_offline() {
             timeout.min(Duration::from_secs(3))
         } else {
             timeout
         }
+    }
+
+    pub fn configured_fetch_remote_versions_timeout(&self) -> Duration {
+        duration::parse_duration(&self.fetch_remote_versions_timeout).unwrap()
     }
 
     /// duration that remote version cache is kept for

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -82,7 +82,7 @@ fn mise_retry_config() -> RetryConfig {
     let settings = crate::config::Settings::get();
     RetryConfig {
         timeout: settings.http_timeout(),
-        retries: settings.http_retries.max(0) as usize,
+        retries: settings.http_retries().max(0) as usize,
         ..RetryConfig::default()
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -42,6 +42,11 @@ pub static HTTP_FETCH: Lazy<Client> = Lazy::new(|| {
 type CachedResult = Arc<OnceCell<Result<String, String>>>;
 static HTTP_CACHE: Lazy<Mutex<HashMap<String, CachedResult>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
+/// Hosts that returned a hard connection failure during this process. Once a
+/// host is known to be unreachable, later requests should fail immediately
+/// instead of paying the same resolver/connect timeout again.
+static UNAVAILABLE_HTTP_HOSTS: Lazy<Mutex<HashSet<String>>> =
+    Lazy::new(|| Mutex::new(HashSet::new()));
 type RetryStateHandle = Arc<Mutex<RetryState>>;
 
 struct RetryState {
@@ -207,7 +212,7 @@ impl Client {
             client: self,
             url: url.into_url().unwrap(),
             extra_headers: HeaderMap::new(),
-            retries: Settings::get().http_retries,
+            retries: Settings::get().http_retries(),
         }
     }
 
@@ -475,7 +480,7 @@ impl Client {
             url,
             headers,
             verb_label,
-            Settings::get().http_retries,
+            Settings::get().http_retries(),
             true,
         )
         .await
@@ -493,7 +498,7 @@ impl Client {
             url,
             headers,
             verb_label,
-            Settings::get().http_retries,
+            Settings::get().http_retries(),
             false,
         )
         .await
@@ -610,6 +615,12 @@ impl Client {
     ) -> Result<Response> {
         let original_url = url.clone();
         apply_url_replacements(&mut url);
+        let host_key = http_host_key(&url);
+        if let Some(host) = &host_key
+            && UNAVAILABLE_HTTP_HOSTS.lock().unwrap().contains(host)
+        {
+            bail!("HTTP host {host} is unavailable after an earlier connection failure");
+        }
         debug!("{} {}", verb_label, &url);
 
         // Apply netrc credentials after URL replacement.
@@ -635,6 +646,11 @@ impl Client {
         let resp = match req.send().await {
             Ok(resp) => resp,
             Err(err) => {
+                if is_hard_connection_failure(&err)
+                    && let Some(host) = host_key
+                {
+                    UNAVAILABLE_HTTP_HOSTS.lock().unwrap().insert(host);
+                }
                 if err.is_timeout() {
                     let (setting, env_var) = match self.kind {
                         ClientKind::Http => ("http_timeout", "MISE_HTTP_TIMEOUT"),
@@ -1095,9 +1111,36 @@ fn is_connection_error(err: &Report) -> bool {
     })
 }
 
+fn http_host_key(url: &Url) -> Option<String> {
+    let host = url.host_str()?;
+    let port = url.port_or_known_default()?;
+    Some(format!("{}://{host}:{port}", url.scheme()))
+}
+
+/// hyper-util exposes DNS failures in the error chain as a `dns error` source,
+/// but reqwest intentionally erases the concrete connector type. Match that
+/// stable connector error label rather than platform-specific getaddrinfo text.
+fn is_dns_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(err);
+    while let Some(source) = current {
+        if source.to_string() == "dns error" {
+            return true;
+        }
+        current = source.source();
+    }
+    false
+}
+
+fn is_hard_connection_failure(err: &reqwest::Error) -> bool {
+    is_dns_error(err) || (err.is_connect() && !err.is_timeout())
+}
+
 /// Classifies an error as transient (should retry) vs permanent.
 /// Walks the error chain so wrapped errors (e.g. our timeout hint) still match.
 pub(crate) fn is_transient(err: &Report) -> bool {
+    if is_dns_error(err.as_ref()) {
+        return false;
+    }
     err.chain().any(|e| {
         let Some(reqwest_err) = e.downcast_ref::<reqwest::Error>() else {
             return false;
@@ -1126,7 +1169,7 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<T>>,
 {
-    retry_async_with_retries(verb_label, url, Settings::get().http_retries, f).await
+    retry_async_with_retries(verb_label, url, Settings::get().http_retries(), f).await
 }
 
 pub(crate) async fn retry_async_with_retries<F, Fut, T>(
@@ -1263,6 +1306,14 @@ mod tests {
         let lock = TEST_SETTINGS_LOCK.lock().unwrap();
         let mut settings = crate::config::settings::SettingsPartial::empty();
         settings.http_retries = Some(retries);
+        crate::config::Settings::reset(Some(settings));
+        SettingsGuard { _lock: lock }
+    }
+    fn set_test_prefer_offline(http_retries: i64) -> SettingsGuard {
+        let lock = TEST_SETTINGS_LOCK.lock().unwrap();
+        let mut settings = crate::config::settings::SettingsPartial::empty();
+        settings.prefer_offline = Some(true);
+        settings.http_retries = Some(http_retries);
         crate::config::Settings::reset(Some(settings));
         SettingsGuard { _lock: lock }
     }
@@ -1661,6 +1712,72 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(resp.status().is_success());
         // Should have served 3 connections: two 502s + one 200.
         assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_prefer_offline_disables_http_retries() {
+        let _guard = set_test_prefer_offline(3);
+        let (port, count) = spawn_canned_server(vec![bad_gateway_response(), ok_response()]).await;
+        let url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+        let err = client.get_async(url).await.unwrap_err();
+
+        assert!(format!("{err:?}").contains("502"));
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(
+            Settings::get().fetch_remote_versions_timeout(),
+            Duration::from_secs(3)
+        );
+    }
+
+    #[test]
+    fn test_dns_errors_are_not_transient() {
+        let err = eyre!("dns error");
+        assert!(!is_transient(&err));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_hard_connection_failure_opens_host_circuit() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let _guard = set_test_http_retries(0);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
+        let host_key = http_host_key(&url).unwrap();
+        UNAVAILABLE_HTTP_HOSTS.lock().unwrap().remove(&host_key);
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+        let first_err = client.get_async(url.clone()).await.unwrap_err();
+        assert!(is_connection_error(&first_err));
+        assert!(UNAVAILABLE_HTTP_HOSTS.lock().unwrap().contains(&host_key));
+
+        // Bring the host online after the first failure. The process-local
+        // circuit should still reject the next request without connecting.
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+            .await
+            .unwrap();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let accepted_inner = accepted.clone();
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                accepted_inner.fetch_add(1, Ordering::SeqCst);
+                let mut request = [0u8; 4096];
+                let _ = socket.read(&mut request).await;
+                let _ = socket.write_all(ok_response().as_bytes()).await;
+            }
+        });
+
+        let second_err = client.get_async(url).await.unwrap_err();
+        assert!(
+            second_err
+                .to_string()
+                .contains("earlier connection failure")
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(accepted.load(Ordering::SeqCst), 0);
+        UNAVAILABLE_HTTP_HOSTS.lock().unwrap().remove(&host_key);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -42,12 +42,30 @@ pub static HTTP_FETCH: Lazy<Client> = Lazy::new(|| {
 type CachedResult = Arc<OnceCell<Result<String, String>>>;
 static HTTP_CACHE: Lazy<Mutex<HashMap<String, CachedResult>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
-/// Hosts that returned a hard connection failure during this process. Once a
-/// host is known to be unreachable, later requests should fail immediately
-/// instead of paying the same resolver/connect timeout again.
-static UNAVAILABLE_HTTP_HOSTS: Lazy<Mutex<HashSet<String>>> =
-    Lazy::new(|| Mutex::new(HashSet::new()));
+/// Origins that returned a hard connection failure during a prefer-offline
+/// process. Keep the original error text so a short-circuited request remains
+/// actionable rather than hiding the reason the circuit opened.
+static UNAVAILABLE_HTTP_HOSTS: Lazy<Mutex<HashMap<String, String>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 type RetryStateHandle = Arc<Mutex<RetryState>>;
+
+#[derive(Debug)]
+struct UnavailableHttpHost {
+    origin: String,
+    cause: String,
+}
+
+impl std::fmt::Display for UnavailableHttpHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "HTTP host {} is unavailable after an earlier connection failure: {}",
+            self.origin, self.cause
+        )
+    }
+}
+
+impl std::error::Error for UnavailableHttpHost {}
 
 struct RetryState {
     headers: HeaderMap,
@@ -583,7 +601,10 @@ impl Client {
             .await
         {
             Ok(resp) => Ok(resp),
-            Err(err) if url.scheme() == "http" && is_connection_error(&err) => {
+            Err(err)
+                if url.scheme() == "http"
+                    && (is_connection_error(&err) || is_unavailable_http_host_error(&err)) =>
+            {
                 let mut url = url;
                 url.set_scheme("https").unwrap();
                 self.send_once_with_retry_headers(method, url, headers, verb_label, options)
@@ -616,10 +637,15 @@ impl Client {
         let original_url = url.clone();
         apply_url_replacements(&mut url);
         let host_key = http_host_key(&url);
-        if let Some(host) = &host_key
-            && UNAVAILABLE_HTTP_HOSTS.lock().unwrap().contains(host)
+        if Settings::get().prefer_offline()
+            && let Some(host) = &host_key
+            && let Some(cause) = UNAVAILABLE_HTTP_HOSTS.lock().unwrap().get(host).cloned()
         {
-            bail!("HTTP host {host} is unavailable after an earlier connection failure");
+            return Err(UnavailableHttpHost {
+                origin: host.clone(),
+                cause,
+            }
+            .into());
         }
         debug!("{} {}", verb_label, &url);
 
@@ -646,10 +672,14 @@ impl Client {
         let resp = match req.send().await {
             Ok(resp) => resp,
             Err(err) => {
-                if is_hard_connection_failure(&err)
+                if Settings::get().prefer_offline()
+                    && is_hard_connection_failure(&err)
                     && let Some(host) = host_key
                 {
-                    UNAVAILABLE_HTTP_HOSTS.lock().unwrap().insert(host);
+                    UNAVAILABLE_HTTP_HOSTS
+                        .lock()
+                        .unwrap()
+                        .insert(host, err.to_string());
                 }
                 if err.is_timeout() {
                     let (setting, env_var) = match self.kind {
@@ -1117,6 +1147,11 @@ fn http_host_key(url: &Url) -> Option<String> {
     Some(format!("{}://{host}:{port}", url.scheme()))
 }
 
+fn is_unavailable_http_host_error(err: &Report) -> bool {
+    err.chain()
+        .any(|err| err.downcast_ref::<UnavailableHttpHost>().is_some())
+}
+
 /// hyper-util exposes DNS failures in the error chain as a `dns error` source,
 /// but reqwest intentionally erases the concrete connector type. Match that
 /// stable connector error label rather than platform-specific getaddrinfo text.
@@ -1323,6 +1358,30 @@ mod tests {
         settings.offline = Some(true);
         crate::config::Settings::reset(Some(settings));
         SettingsGuard { _lock: lock }
+    }
+
+    struct UnavailableHostsGuard {
+        host_keys: Vec<String>,
+    }
+    impl UnavailableHostsGuard {
+        fn new(host_keys: Vec<String>) -> Self {
+            let mut unavailable = UNAVAILABLE_HTTP_HOSTS.lock().unwrap();
+            for host_key in &host_keys {
+                unavailable.remove(host_key);
+            }
+            drop(unavailable);
+            Self { host_keys }
+        }
+    }
+    impl Drop for UnavailableHostsGuard {
+        fn drop(&mut self) {
+            let mut unavailable = UNAVAILABLE_HTTP_HOSTS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            for host_key in &self.host_keys {
+                unavailable.remove(host_key);
+            }
+        }
     }
 
     struct GithubOauthSettingsGuard {
@@ -1730,54 +1789,97 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         );
     }
 
-    #[test]
-    fn test_dns_errors_are_not_transient() {
-        let err = eyre!("dns error");
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_reqwest_dns_error_is_not_transient_and_opens_circuit() {
+        let _settings_guard = set_test_prefer_offline(3);
+        let timeout = Duration::from_secs(3);
+        let client = Client {
+            reqwest: Client::_new()
+                .no_proxy()
+                .read_timeout(timeout)
+                .connect_timeout(timeout)
+                .build()
+                .unwrap(),
+            timeout,
+            kind: ClientKind::Fetch,
+        };
+        let url: Url = "https://mise-dns-regression.invalid/".parse().unwrap();
+        let host_key = http_host_key(&url).unwrap();
+        let _hosts_guard = UnavailableHostsGuard::new(vec![host_key.clone()]);
+
+        let err = client.get_async(url).await.unwrap_err();
+
+        assert!(is_dns_error(err.as_ref()), "unexpected error: {err:#}");
         assert!(!is_transient(&err));
+        assert!(
+            UNAVAILABLE_HTTP_HOSTS
+                .lock()
+                .unwrap()
+                .contains_key(&host_key)
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_hard_connection_failure_opens_host_circuit() {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-        let _guard = set_test_http_retries(0);
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    async fn test_circuit_broken_http_origin_falls_back_to_https() {
+        let _settings_guard = set_test_prefer_offline(3);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
-        drop(listener);
+        let http_url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
+        let https_url: Url = format!("https://127.0.0.1:{port}/").parse().unwrap();
+        let http_origin = http_host_key(&http_url).unwrap();
+        let https_origin = http_host_key(&https_url).unwrap();
+        let _hosts_guard = UnavailableHostsGuard::new(vec![http_origin.clone(), https_origin]);
+        UNAVAILABLE_HTTP_HOSTS
+            .lock()
+            .unwrap()
+            .insert(http_origin, "connection refused".to_string());
 
-        let url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
-        let host_key = http_host_key(&url).unwrap();
-        UNAVAILABLE_HTTP_HOSTS.lock().unwrap().remove(&host_key);
-        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
-        let first_err = client.get_async(url.clone()).await.unwrap_err();
-        assert!(is_connection_error(&first_err));
-        assert!(UNAVAILABLE_HTTP_HOSTS.lock().unwrap().contains(&host_key));
-
-        // Bring the host online after the first failure. The process-local
-        // circuit should still reject the next request without connecting.
-        let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
-            .await
-            .unwrap();
         let accepted = Arc::new(AtomicUsize::new(0));
         let accepted_inner = accepted.clone();
-        tokio::spawn(async move {
+        let server = tokio::spawn(async move {
             if let Ok((mut socket, _)) = listener.accept().await {
                 accepted_inner.fetch_add(1, Ordering::SeqCst);
-                let mut request = [0u8; 4096];
-                let _ = socket.read(&mut request).await;
-                let _ = socket.write_all(ok_response().as_bytes()).await;
+                let _ = socket.shutdown().await;
             }
         });
 
-        let second_err = client.get_async(url).await.unwrap_err();
-        assert!(
-            second_err
-                .to_string()
-                .contains("earlier connection failure")
-        );
-        tokio::task::yield_now().await;
-        assert_eq!(accepted.load(Ordering::SeqCst), 0);
-        UNAVAILABLE_HTTP_HOSTS.lock().unwrap().remove(&host_key);
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+        let err = client.get_async(http_url).await.unwrap_err();
+        server.await.unwrap();
+
+        assert_eq!(accepted.load(Ordering::SeqCst), 1);
+        assert!(!is_unavailable_http_host_error(&err));
+    }
+
+    #[test]
+    fn test_unavailable_host_error_preserves_original_cause() {
+        let err: Report = UnavailableHttpHost {
+            origin: "https://example.com:443".to_string(),
+            cause: "connection refused".to_string(),
+        }
+        .into();
+
+        assert!(is_unavailable_http_host_error(&err));
+        assert!(err.to_string().contains("connection refused"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_circuit_breaker_is_disabled_without_prefer_offline() {
+        let _settings_guard = set_test_http_retries(0);
+        let (port, count) = spawn_canned_server(vec![ok_response()]).await;
+        let url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
+        let host_key = http_host_key(&url).unwrap();
+        let _hosts_guard = UnavailableHostsGuard::new(vec![host_key.clone()]);
+        UNAVAILABLE_HTTP_HOSTS
+            .lock()
+            .unwrap()
+            .insert(host_key, "connection refused".to_string());
+
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+        let resp = client.get_async(url).await.unwrap();
+
+        assert!(resp.status().is_success());
+        assert_eq!(count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -29,7 +29,7 @@ pub static HTTP: Lazy<Client> =
 
 pub static HTTP_FETCH: Lazy<Client> = Lazy::new(|| {
     Client::new(
-        Settings::get().fetch_remote_versions_timeout(),
+        Settings::get().configured_fetch_remote_versions_timeout(),
         ClientKind::Fetch,
     )
     .unwrap()
@@ -146,6 +146,15 @@ impl Client {
             .user_agent(format!("mise/{v} {shell}").trim())
             .gzip(true)
             .zstd(true)
+    }
+
+    fn request_timeout(&self) -> Duration {
+        match self.kind {
+            ClientKind::Fetch if Settings::get().prefer_offline() => {
+                self.timeout.min(Duration::from_secs(3))
+            }
+            _ => self.timeout,
+        }
     }
 
     pub async fn get_bytes<U: IntoUrl>(&self, url: U) -> Result<impl AsRef<[u8]>> {
@@ -667,11 +676,16 @@ impl Client {
                 apply_netrc_credentials(final_headers, &original_url, &url, netrc_headers(&url));
         }
 
+        let request_timeout = self.request_timeout();
         let mut req = self.reqwest.request(method.clone(), url.clone());
+        if matches!(self.kind, ClientKind::Fetch) {
+            req = req.timeout(request_timeout);
+        }
         req = req.headers(final_headers.clone());
         let resp = match req.send().await {
             Ok(resp) => resp,
             Err(err) => {
+                let err = err.without_url();
                 if Settings::get().prefer_offline()
                     && is_hard_connection_failure(&err)
                     && let Some(host) = host_key
@@ -691,7 +705,7 @@ impl Client {
                     };
                     let hint = format!(
                         "HTTP timed out after {} for {} (change with `{}` or env `{}`).",
-                        format_duration(self.timeout),
+                        format_duration(request_timeout),
                         url,
                         setting,
                         env_var
@@ -1789,6 +1803,14 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         );
     }
 
+    #[test]
+    fn test_fetch_client_applies_prefer_offline_timeout_at_request_time() {
+        let client = Client::new(Duration::from_secs(30), ClientKind::Fetch).unwrap();
+        let _guard = set_test_prefer_offline(3);
+
+        assert_eq!(client.request_timeout(), Duration::from_secs(3));
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn test_reqwest_dns_error_is_not_transient_and_opens_circuit() {
         let _settings_guard = set_test_prefer_offline(3);
@@ -1803,7 +1825,9 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
             timeout,
             kind: ClientKind::Fetch,
         };
-        let url: Url = "https://mise-dns-regression.invalid/".parse().unwrap();
+        let url: Url = "https://mise-dns-regression.invalid/?token=secret"
+            .parse()
+            .unwrap();
         let host_key = http_host_key(&url).unwrap();
         let _hosts_guard = UnavailableHostsGuard::new(vec![host_key.clone()]);
 
@@ -1816,6 +1840,14 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
                 .lock()
                 .unwrap()
                 .contains_key(&host_key)
+        );
+        assert!(
+            !UNAVAILABLE_HTTP_HOSTS
+                .lock()
+                .unwrap()
+                .get(&host_key)
+                .unwrap()
+                .contains("token=secret")
         );
     }
 


### PR DESCRIPTION
## Summary

- treat DNS resolver failures as non-retryable
- open a process-local circuit after hard DNS or connection failures
- disable HTTP retries and cap remote-version lookups at 3 seconds under `prefer_offline`
- document the fast-path policy and add regression coverage

## Root cause

When a fuzzy tool request had no matching installed version, shims and other fast commands had to resolve it remotely. DNS and connection failures were classified as transient, so each endpoint repeated the full timeout and retry schedule. Multiple lookups to the same unavailable origin paid that cost independently.

## User impact

Shims, shell activation, and `mise x` now make one bounded remote-version attempt when cached data is insufficient. Repeated requests to an origin that already failed hard return immediately. Artifact download timeouts remain unchanged.

Context: https://github.com/jdx/mise/discussions/4598

## Testing

- `mise run test:unit` — 1,727 tests passed
- `mise run lint-fix`
- `mise run render:schema`
- `git diff --check`

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the shared HTTP stack and settings used by shims and version resolution, but the new limits and circuit breaker apply only when `prefer_offline` is active; full install/download paths keep prior retry and timeout behavior.
> 
> **Overview**
> **Fast commands** (shims, shell activation, and anything using `prefer_offline`) no longer stack long timeouts and HTTP retries when remote version lookups miss cache and the network is down.
> 
> `Settings` now **caps** `fetch_remote_versions_timeout` at **3 seconds** and forces **`http_retries` to 0** under `prefer_offline`, with docs updated for `fetch_remote_versions_timeout` and `http_retries`. The fetch HTTP client applies that shorter timeout **per request** at send time (the static client still uses the configured timeout).
> 
> In **`src/http.rs`**, a **process-local circuit** records hard DNS/connect failures per origin during `prefer_offline` and **short-circuits** later requests with the original cause (without leaking query strings). **DNS failures** are treated as **non-retryable**; HTTP→HTTPS fallback still runs when the circuit blocks an `http` attempt. Sigstore retry config follows the new `http_retries()` helper.
> 
> Unit tests cover prefer-offline retry disabling, fetch timeout clamping, DNS/circuit behavior, and HTTPS fallback when the circuit is open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63445140560865dab80eeb991fc1fea1c0f37055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline-aware HTTP “circuit breaker” to quickly fail repeat requests to unreachable hosts while preserving the original error.
* **Bug Fixes**
  * Improved offline-preferred behavior by capping the remote-versions timeout, reducing the per-request timeout, and disabling HTTP retries for fast commands.
  * Expanded HTTP→HTTPS fallback to also handle circuit-breaker failures.
  * Treated DNS failures as non-transient to avoid unnecessary retries.
* **Documentation**
  * Updated settings descriptions to clarify fast-command timeout and retry behavior.
* **Tests**
  * Added coverage for circuit behavior, HTTPS fallback, cause preservation, and DNS/cause handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->