### PR TITLE
chore: release 2026.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [2026.7.9](https://github.com/jdx/mise/compare/v2026.7.8..v2026.7.9) - 2026-07-16
+
+### 🚀 Features
+
+- **(cargo)** skip remote discovery for exact versions by @Turbo87 in [#11013](https://github.com/jdx/mise/pull/11013)
+- **(task)** skip dependencies with empty templated names by @risu729 in [#11057](https://github.com/jdx/mise/pull/11057)
+
+### 🐛 Bug Fixes
+
+- **(bootstrap)** ignore macos metadata in cask artifacts by @jdx in [#11063](https://github.com/jdx/mise/pull/11063)
+- **(config)** deprecate env directive value aliases by @risu729 in [#11062](https://github.com/jdx/mise/pull/11062)
+- **(config)** deprecate env.mise directives by @risu729 in [#11053](https://github.com/jdx/mise/pull/11053)
+- **(config)** reject non-string postinstall hooks by @risu729 in [#11061](https://github.com/jdx/mise/pull/11061)
+- **(config)** deprecate experimental monorepo root key by @risu729 in [#11052](https://github.com/jdx/mise/pull/11052)
+- **(hooks)** reject nested hook arrays by @risu729 in [#11051](https://github.com/jdx/mise/pull/11051)
+- **(http)** fail fast when network is unavailable by @jdx in [#11066](https://github.com/jdx/mise/pull/11066)
+- **(schema)** require arrays for deps provider paths by @risu729 in [#11064](https://github.com/jdx/mise/pull/11064)
+- **(task)** prevent setup side effects during dry runs by @risu729 in [#11015](https://github.com/jdx/mise/pull/11015)
+
+### 📦 Registry
+
+- replace eza asdf backend with vfox by @jdx in [#11068](https://github.com/jdx/mise/pull/11068)
+
+### Chore
+
+- **(ci)** align macos pgo toolchain by @jdx in [#11071](https://github.com/jdx/mise/pull/11071)
+
 ## [2026.7.8](https://github.com/jdx/mise/compare/v2026.7.7..v2026.7.8) - 2026-07-16
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.8"
+version = "2026.7.9"
 dependencies = [
  "age",
  "aho-corasick",
@@ -9744,7 +9744,7 @@ dependencies = [
 
 [[package]]
 name = "vfox"
-version = "2026.7.1"
+version = "2026.7.2"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.8"
+version = "2026.7.9"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.8 macos-arm64 (2026-07-16)
+2026.7.9 macos-arm64 (2026-07-16)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_8.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_9.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_8.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_9.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_8.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_9.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_8.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_9.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfox"
-version = "2026.7.1"
+version = "2026.7.2"
 edition = "2024"
 license = "MIT"
 description = "Interface to vfox plugins"

--- a/crates/vfox/embedded-plugins/vfox-android-sdk/hooks/available.lua
+++ b/crates/vfox/embedded-plugins/vfox-android-sdk/hooks/available.lua
@@ -3,9 +3,8 @@
 --- @return table Descriptions of available versions and accompanying tool descriptions
 function PLUGIN:Available(ctx)
     local http = require("http")
-    local env = require("env")
 
-    local base_url = env.ANDROID_SDK_MIRROR_URL or "https://dl.google.com/android/repository"
+    local base_url = os.getenv("ANDROID_SDK_MIRROR_URL") or "https://dl.google.com/android/repository"
     local metadata_url = base_url .. "/repository2-3.xml"
 
     local resp = http.get({ url = metadata_url })
@@ -30,9 +29,21 @@ function PLUGIN:Available(ctx)
         end
     end
 
-    -- Sort versions (simple string sort, works for numeric versions)
+    -- Android command-line tool versions are numeric and must be newest first.
+    -- vfox uses the first available version to resolve an unspecified version.
     table.sort(versions, function(a, b)
-        return a.version < b.version
+        local a_number = tonumber(a.version)
+        local b_number = tonumber(b.version)
+
+        if a_number and b_number then
+            return a_number > b_number
+        elseif a_number then
+            return true
+        elseif b_number then
+            return false
+        end
+
+        return a.version > b.version
     end)
 
     return versions

--- a/crates/vfox/embedded-plugins/vfox-android-sdk/hooks/env_keys.lua
+++ b/crates/vfox/embedded-plugins/vfox-android-sdk/hooks/env_keys.lua
@@ -11,7 +11,7 @@ function PLUGIN:EnvKeys(ctx)
     -- Structure is: install_path/cmdline-tools/VERSION/bin
     local bin_path = file.join_path(install_path, "cmdline-tools", version, "bin")
 
-    return {
+    local env_vars = {
         {
             key = "PATH",
             value = bin_path,
@@ -25,4 +25,18 @@ function PLUGIN:EnvKeys(ctx)
             value = install_path,
         },
     }
+
+    -- Add tools installed with sdkmanager to PATH, if they exist
+    local optional_bin_paths = { "platform-tools", "emulator" }
+    for _, relative_optional_bin_path in ipairs(optional_bin_paths) do
+        local optional_bin_path = file.join_path(install_path, relative_optional_bin_path)
+        if file.exists(optional_bin_path) then
+            table.insert(env_vars, {
+                key = "PATH",
+                value = optional_bin_path,
+            })
+        end
+    end
+
+    return env_vars
 end

--- a/crates/vfox/embedded-plugins/vfox-android-sdk/hooks/post_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-android-sdk/hooks/post_install.lua
@@ -24,26 +24,66 @@ function PLUGIN:PostInstall(ctx)
     -- So we need to reorganize: move rootPath/* to rootPath/cmdline-tools/VERSION/
 
     local temp_path = root_path .. "-temp"
+    local parent_path = file.join_path(root_path, "cmdline-tools")
     local target_path = file.join_path(root_path, "cmdline-tools", version)
+    local is_windows = RUNTIME.osType == "windows"
 
-    -- Move current rootPath to temp location
-    os.execute("mv " .. root_path .. " " .. temp_path)
+    if is_windows then
+        local cmd = require("cmd")
+        local system_root = os.getenv("SystemRoot") or "C:\\Windows"
+        local function run_powershell(command, env)
+            cmd.exec("powershell.exe -NoLogo -NoProfile -NonInteractive -Command " .. command, {
+                cwd = system_root,
+                env = env,
+            })
+        end
 
-    -- Recreate rootPath with proper structure
-    os.execute("mkdir -p " .. target_path)
+        -- Remove stale temp from a previous failed install
+        if file.exists(temp_path) then
+            run_powershell("Remove-Item -LiteralPath $env:TEMP_PATH -Recurse -Force", {
+                TEMP_PATH = temp_path,
+            })
+        end
 
-    -- Move contents from temp to target
-    os.execute("mv " .. temp_path .. "/* " .. target_path .. "/")
+        -- Move current rootPath to a temporary location
+        run_powershell("Move-Item -LiteralPath $env:ROOT_PATH -Destination $env:TEMP_PATH", {
+            ROOT_PATH = root_path,
+            TEMP_PATH = temp_path,
+        })
 
-    -- Clean up temp
-    os.execute("rm -rf " .. temp_path)
+        -- Recreate parent directory structure
+        run_powershell("New-Item -ItemType Directory -Force -Path $env:PARENT_PATH", {
+            PARENT_PATH = parent_path,
+        })
+
+        -- Move temp to target (renames the directory)
+        run_powershell("Move-Item -LiteralPath $env:TEMP_PATH -Destination $env:TARGET_PATH", {
+            TEMP_PATH = temp_path,
+            TARGET_PATH = target_path,
+        })
+    else
+        -- Remove stale temp from a previous failed install
+        os.execute('rm -rf "' .. temp_path .. '"')
+
+        -- Move current rootPath to temp location
+        os.execute('mv "' .. root_path .. '" "' .. temp_path .. '"')
+
+        -- Recreate parent directory structure
+        os.execute('mkdir -p "' .. parent_path .. '"')
+
+        -- Move temp to target (renames the directory)
+        os.execute('mv "' .. temp_path .. '" "' .. target_path .. '"')
+    end
 
     -- Verify installation
-    local sdkmanager_path = file.join_path(target_path, "bin", "sdkmanager")
+    local sdkmanager_name = is_windows and "sdkmanager.bat" or "sdkmanager"
+    local sdkmanager_path = file.join_path(target_path, "bin", sdkmanager_name)
     if not file.exists(sdkmanager_path) then
         error("Installation verification failed: sdkmanager not found at " .. sdkmanager_path)
     end
 
     -- Make sure binaries are executable (for Unix systems)
-    os.execute("chmod +x " .. file.join_path(target_path, "bin", "*") .. " 2>/dev/null || true")
+    if not is_windows then
+        os.execute('chmod +x "' .. file.join_path(target_path, "bin") .. '"/* 2>/dev/null || true')
+    end
 end

--- a/crates/vfox/embedded-plugins/vfox-android-sdk/hooks/pre_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-android-sdk/hooks/pre_install.lua
@@ -3,7 +3,6 @@
 --- @return table Version information
 function PLUGIN:PreInstall(ctx)
     local http = require("http")
-    local env = require("env")
 
     local version = ctx.version
 
@@ -31,7 +30,7 @@ function PLUGIN:PreInstall(ctx)
         error("Unsupported architecture: " .. arch_type)
     end
 
-    local base_url = env.ANDROID_SDK_MIRROR_URL or "https://dl.google.com/android/repository"
+    local base_url = os.getenv("ANDROID_SDK_MIRROR_URL") or "https://dl.google.com/android/repository"
     local metadata_url = base_url .. "/repository2-3.xml"
 
     local resp = http.get({ url = metadata_url })

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.8";
+  version = "2026.7.9";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.8
+Version: 2026.7.9
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.8"
+version: "2026.7.9"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "36b75b9bdbb8c0b81a1d9e6622d36384478ab03c"
+  "tag": "252af8fff47e35d84451c3ad9ce2f75df766ec5b"
 }


### PR DESCRIPTION
### 🚀 Features

- **(cargo)** skip remote discovery for exact versions by @Turbo87 in [#11013](https://github.com/jdx/mise/pull/11013)
- **(task)** skip dependencies with empty templated names by @risu729 in [#11057](https://github.com/jdx/mise/pull/11057)

### 🐛 Bug Fixes

- **(bootstrap)** ignore macos metadata in cask artifacts by @jdx in [#11063](https://github.com/jdx/mise/pull/11063)
- **(config)** deprecate env directive value aliases by @risu729 in [#11062](https://github.com/jdx/mise/pull/11062)
- **(config)** deprecate env.mise directives by @risu729 in [#11053](https://github.com/jdx/mise/pull/11053)
- **(config)** reject non-string postinstall hooks by @risu729 in [#11061](https://github.com/jdx/mise/pull/11061)
- **(config)** deprecate experimental monorepo root key by @risu729 in [#11052](https://github.com/jdx/mise/pull/11052)
- **(hooks)** reject nested hook arrays by @risu729 in [#11051](https://github.com/jdx/mise/pull/11051)
- **(http)** fail fast when network is unavailable by @jdx in [#11066](https://github.com/jdx/mise/pull/11066)
- **(schema)** require arrays for deps provider paths by @risu729 in [#11064](https://github.com/jdx/mise/pull/11064)
- **(task)** prevent setup side effects during dry runs by @risu729 in [#11015](https://github.com/jdx/mise/pull/11015)

### 📦 Registry

- replace eza asdf backend with vfox by @jdx in [#11068](https://github.com/jdx/mise/pull/11068)

### Chore

- **(ci)** align macos pgo toolchain by @jdx in [#11071](https://github.com/jdx/mise/pull/11071)