### PR TITLE
registry: replace eza asdf backend with vfox

### DIFF
--- a/registry/eza.toml
+++ b/registry/eza.toml
@@ -2,7 +2,7 @@ backends = [
   { full = "aqua:eza-community/eza", platforms = [
     "linux",
   ] },
-  "asdf:mise-plugins/mise-eza",
+  "vfox:jdx/vfox-eza",
   "cargo:eza",
 ]
 description = "A modern, maintained replacement for ls"


### PR DESCRIPTION
## Summary

- replace the macOS-default asdf backend for eza with `vfox:jdx/vfox-eza`
- keep Aqua as the first-choice Linux backend and Cargo as the final fallback
- use cargo-quickinstall's prebuilt eza artifacts through the new vfox plugin

## Popularity

- GitHub: 22.6k stars and 472 forks
- Latest release: v0.23.5 on 2026-07-09

## Validation

- `cargo test registry::tests` (25 passed)
- [vfox-eza CI](https://github.com/jdx/vfox-eza/actions/runs/29526421382) (Linux, macOS, and Windows)
- clean macOS ARM install of eza 0.23.4 through the vfox plugin

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry backend reorder with no application or security logic changes; install behavior may differ only on platforms that used the old asdf plugin.
> 
> **Overview**
> **eza** install resolution now uses **`vfox:jdx/vfox-eza`** instead of **`asdf:mise-plugins/mise-eza`** as the non-Linux path before the existing **`cargo:eza`** fallback.
> 
> Linux still prefers **`aqua:eza-community/eza`** first; only the middle backend in the chain changes, so macOS and other platforms get prebuilt artifacts via the vfox plugin rather than the asdf plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa615534d92e582dc63410a217b08b10096e5ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the eza plugin source to use the new backend, improving installation and version management reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->