### PR TITLE
fix(config): reject conflicting tool selectors

### DIFF
--- a/e2e/config/test_schema_tool_selectors
+++ b/e2e/config/test_schema_tool_selectors
@@ -33,7 +33,10 @@ ruby = [{ prefix = "3.3", os = "linux-x64" }]
 run = "echo check"
 
 [tasks.check.tools]
-node = { version = "20", prefix = "backend-option", backend_options = { nested = [1, true] } }
+node = { version = "20", backend_options = { nested = [1, true] } }
+go = { prefix = "1.22" }
+python = { ref = "main" }
+shellcheck = { path = "/opt/shellcheck" }
 TOML
 
 cd "$HOME/workdir"
@@ -56,6 +59,15 @@ cat >mise-bad-tool-selectors.toml <<'TOML'
 run = "echo check"
 
 [tasks.check.tools]
-node = { prefix = "20" }
+node = { version = "20", prefix = "20" }
+TOML
+assert_fail "$TOMBI_LINT mise-bad-tool-selectors.toml"
+
+cat >mise-bad-tool-selectors.toml <<'TOML'
+[tasks.check]
+run = "echo check"
+
+[tasks.check.tools]
+node = { os = "linux" }
 TOML
 assert_fail "$TOMBI_LINT mise-bad-tool-selectors.toml"

--- a/e2e/config/test_schema_tool_selectors
+++ b/e2e/config/test_schema_tool_selectors
@@ -5,6 +5,7 @@ TOMBI_VERSION="0.9.22"
 mise use -g tombi@$TOMBI_VERSION
 
 SCHEMA_PATH="$ROOT/schema/mise.json"
+TASK_SCHEMA_PATH="$ROOT/schema/mise-task.json"
 TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
 TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
 assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
@@ -19,6 +20,10 @@ strict = true
 [[schemas]]
 path = "file://$SCHEMA_PATH"
 include = ["mise-tool-selectors.toml", "mise-bad-tool-selectors.toml"]
+
+[[schemas]]
+path = "file://$TASK_SCHEMA_PATH"
+include = ["mise-task-tool-selectors.toml", "mise-bad-task-tool-selectors.toml"]
 EOF
 
 cat >"$HOME/workdir/mise-tool-selectors.toml" <<'TOML'
@@ -42,11 +47,50 @@ TOML
 cd "$HOME/workdir"
 assert_succeed "$TOMBI_LINT mise-tool-selectors.toml"
 
+cat >mise-task-tool-selectors.toml <<'TOML'
+[check]
+run = "echo check"
+
+[check.tools]
+node = { version = "20", backend_options = { nested = [1, true] } }
+go = { prefix = "1.22" }
+python = { ref = "main" }
+shellcheck = { path = "/opt/shellcheck" }
+TOML
+assert_succeed "$TOMBI_LINT mise-task-tool-selectors.toml"
+
 cat >mise-bad-tool-selectors.toml <<'TOML'
 [tools]
 node = { version = "20", prefix = "20" }
 TOML
 assert_fail "$TOMBI_LINT mise-bad-tool-selectors.toml"
+
+cat >mise-bad-task-tool-selectors.toml <<'TOML'
+[check]
+run = "echo check"
+
+[check.tools]
+node = { version = "20", prefix = "20" }
+TOML
+assert_fail "$TOMBI_LINT mise-bad-task-tool-selectors.toml"
+
+cat >mise-bad-task-tool-selectors.toml <<'TOML'
+[check]
+run = "echo check"
+
+[check.tools]
+node = { os = "linux" }
+TOML
+assert_fail "$TOMBI_LINT mise-bad-task-tool-selectors.toml"
+
+cat >mise-bad-task-tool-selectors.toml <<'TOML'
+[check]
+run = "echo check"
+
+[check.tools]
+node = { prefix = 20 }
+TOML
+assert_fail "$TOMBI_LINT mise-bad-task-tool-selectors.toml"
 
 cat >mise-bad-tool-selectors.toml <<'TOML'
 [tools]

--- a/e2e/config/test_schema_tool_selectors
+++ b/e2e/config/test_schema_tool_selectors
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+TOMBI_VERSION="0.9.22"
+
+mise use -g tombi@$TOMBI_VERSION
+
+SCHEMA_PATH="$ROOT/schema/mise.json"
+TOMBI="mise x tombi@$TOMBI_VERSION -- tombi"
+TOMBI_LINT="$TOMBI lint --offline --no-cache --error-on-warnings --quiet"
+assert_contains "$TOMBI --version" "tombi $TOMBI_VERSION"
+
+cat >"$HOME/tombi.toml" <<EOF
+toml-version = "v1.0.0"
+
+[schema]
+enabled = true
+strict = true
+
+[[schemas]]
+path = "file://$SCHEMA_PATH"
+include = ["mise-tool-selectors.toml", "mise-bad-tool-selectors.toml"]
+EOF
+
+cat >"$HOME/workdir/mise-tool-selectors.toml" <<'TOML'
+[tools]
+node = { version = "20" }
+go = { prefix = "1.22" }
+python = { ref = "main" }
+shellcheck = { path = "/opt/shellcheck" }
+ruby = [{ prefix = "3.3", os = "linux-x64" }]
+
+[tasks.check]
+run = "echo check"
+
+[tasks.check.tools]
+node = { version = "20", prefix = "backend-option", backend_options = { nested = [1, true] } }
+TOML
+
+cd "$HOME/workdir"
+assert_succeed "$TOMBI_LINT mise-tool-selectors.toml"
+
+cat >mise-bad-tool-selectors.toml <<'TOML'
+[tools]
+node = { version = "20", prefix = "20" }
+TOML
+assert_fail "$TOMBI_LINT mise-bad-tool-selectors.toml"
+
+cat >mise-bad-tool-selectors.toml <<'TOML'
+[tools]
+node = [{ path = "/opt/node", ref = "main" }]
+TOML
+assert_fail "$TOMBI_LINT mise-bad-tool-selectors.toml"
+
+cat >mise-bad-tool-selectors.toml <<'TOML'
+[tasks.check]
+run = "echo check"
+
+[tasks.check.tools]
+node = { prefix = "20" }
+TOML
+assert_fail "$TOMBI_LINT mise-bad-tool-selectors.toml"

--- a/e2e/tasks/test_task_tools
+++ b/e2e/tasks/test_task_tools
@@ -25,3 +25,11 @@ rm -rf "$MISE_DATA_DIR/installs/dummy"
 rm -rf "$MISE_DATA_DIR/installs/needs-dummy"
 
 assert "MISE_JOBS=1 mise run structured-options" "needs-dummy v1.0.0"
+
+cat <<EOF >mise.toml
+[tasks.selector]
+tools = { tiny = { prefix = "1" } }
+run = "rtx-tiny"
+EOF
+
+assert "mise run selector" "rtx-tiny: v1.1.0 args:"

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -995,11 +995,36 @@
           "description": "version of the tool to install",
           "type": "string"
         },
+        "path": {
+          "description": "path to a custom compiled version",
+          "type": "string"
+        },
+        "prefix": {
+          "description": "version prefix to resolve",
+          "type": "string"
+        },
+        "ref": {
+          "description": "version control reference to compile",
+          "type": "string"
+        },
         "os": {
           "$ref": "#/$defs/os_filter"
         }
       },
-      "required": ["version"],
+      "oneOf": [
+        {
+          "required": ["version"]
+        },
+        {
+          "required": ["path"]
+        },
+        {
+          "required": ["prefix"]
+        },
+        {
+          "required": ["ref"]
+        }
+      ],
       "type": "object"
     },
     "env_directive": {

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -799,34 +799,7 @@
               "$ref": "#/$defs/tool_options"
             },
             {
-              "properties": {
-                "install_env": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "#/$defs/env_value"
-                  },
-                  "description": "environment variables during tool installation"
-                },
-                "depends": {
-                  "oneOf": [
-                    {
-                      "description": "tools that must be installed before this tool",
-                      "type": "string"
-                    },
-                    {
-                      "description": "tools that must be installed before this tool",
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ]
-                },
-                "postinstall": {
-                  "description": "command to run after tool installation",
-                  "type": "string"
-                }
-              }
+              "$ref": "#/$defs/tool_common_options"
             }
           ],
           "type": "object",
@@ -1025,6 +998,37 @@
           "required": ["ref"]
         }
       ],
+      "type": "object"
+    },
+    "tool_common_options": {
+      "properties": {
+        "install_env": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/env_value"
+          },
+          "description": "environment variables during tool installation"
+        },
+        "depends": {
+          "oneOf": [
+            {
+              "description": "tools that must be installed before this tool",
+              "type": "string"
+            },
+            {
+              "description": "tools that must be installed before this tool",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "postinstall": {
+          "description": "command to run after tool installation",
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "env_directive": {

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -799,7 +799,34 @@
               "$ref": "#/$defs/tool_options"
             },
             {
-              "$ref": "#/$defs/tool_common_options"
+              "properties": {
+                "install_env": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/$defs/env_value"
+                  },
+                  "description": "environment variables during tool installation"
+                },
+                "depends": {
+                  "oneOf": [
+                    {
+                      "description": "tools that must be installed before this tool",
+                      "type": "string"
+                    },
+                    {
+                      "description": "tools that must be installed before this tool",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "postinstall": {
+                  "description": "command to run after tool installation",
+                  "type": "string"
+                }
+              }
             }
           ],
           "type": "object",
@@ -998,37 +1025,6 @@
           "required": ["ref"]
         }
       ],
-      "type": "object"
-    },
-    "tool_common_options": {
-      "properties": {
-        "install_env": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/env_value"
-          },
-          "description": "environment variables during tool installation"
-        },
-        "depends": {
-          "oneOf": [
-            {
-              "description": "tools that must be installed before this tool",
-              "type": "string"
-            },
-            {
-              "description": "tools that must be installed before this tool",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          ]
-        },
-        "postinstall": {
-          "description": "command to run after tool installation",
-          "type": "string"
-        }
-      },
       "type": "object"
     },
     "env_directive": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2306,45 +2306,6 @@
         }
       ]
     },
-    "root_tool": {
-      "oneOf": [
-        {
-          "description": "version of the tool to install",
-          "type": "string"
-        },
-        {
-          "allOf": [
-            {
-              "$ref": "#/$defs/root_tool_options"
-            },
-            {
-              "$ref": "#/$defs/tool_common_options"
-            }
-          ],
-          "type": "object",
-          "unevaluatedProperties": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "array"
-              },
-              {
-                "type": "object",
-                "additionalProperties": true
-              }
-            ]
-          }
-        }
-      ]
-    },
     "tool_common_options": {
       "properties": {
         "install_env": {
@@ -2377,19 +2338,6 @@
       "type": "object"
     },
     "tool_options": {
-      "properties": {
-        "version": {
-          "description": "version of the tool to install",
-          "type": "string"
-        },
-        "os": {
-          "$ref": "#/$defs/os_filter"
-        }
-      },
-      "required": ["version"],
-      "type": "object"
-    },
-    "root_tool_options": {
       "properties": {
         "version": {
           "description": "version of the tool to install",
@@ -4224,12 +4172,12 @@
         "oneOf": [
           {
             "items": {
-              "$ref": "#/$defs/root_tool"
+              "$ref": "#/$defs/tool"
             },
             "type": "array"
           },
           {
-            "$ref": "#/$defs/root_tool"
+            "$ref": "#/$defs/tool"
           }
         ]
       },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2279,34 +2279,7 @@
               "$ref": "#/$defs/tool_options"
             },
             {
-              "properties": {
-                "install_env": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "#/$defs/env_value"
-                  },
-                  "description": "environment variables during tool installation"
-                },
-                "depends": {
-                  "oneOf": [
-                    {
-                      "description": "tools that must be installed before this tool",
-                      "type": "string"
-                    },
-                    {
-                      "description": "tools that must be installed before this tool",
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ]
-                },
-                "postinstall": {
-                  "description": "command to run after tool installation",
-                  "type": "string"
-                }
-              }
+              "$ref": "#/$defs/tool_common_options"
             }
           ],
           "type": "object",
@@ -2333,6 +2306,76 @@
         }
       ]
     },
+    "root_tool": {
+      "oneOf": [
+        {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/root_tool_options"
+            },
+            {
+              "$ref": "#/$defs/tool_common_options"
+            }
+          ],
+          "type": "object",
+          "unevaluatedProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array"
+              },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "tool_common_options": {
+      "properties": {
+        "install_env": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/env_value"
+          },
+          "description": "environment variables during tool installation"
+        },
+        "depends": {
+          "oneOf": [
+            {
+              "description": "tools that must be installed before this tool",
+              "type": "string"
+            },
+            {
+              "description": "tools that must be installed before this tool",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "postinstall": {
+          "description": "command to run after tool installation",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "tool_options": {
       "properties": {
         "version": {
@@ -2344,6 +2387,44 @@
         }
       },
       "required": ["version"],
+      "type": "object"
+    },
+    "root_tool_options": {
+      "properties": {
+        "version": {
+          "description": "version of the tool to install",
+          "type": "string"
+        },
+        "path": {
+          "description": "path to a custom compiled version",
+          "type": "string"
+        },
+        "prefix": {
+          "description": "version prefix to resolve",
+          "type": "string"
+        },
+        "ref": {
+          "description": "version control reference to compile",
+          "type": "string"
+        },
+        "os": {
+          "$ref": "#/$defs/os_filter"
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["version"]
+        },
+        {
+          "required": ["path"]
+        },
+        {
+          "required": ["prefix"]
+        },
+        {
+          "required": ["ref"]
+        }
+      ],
       "type": "object"
     },
     "hook_run_string": {
@@ -4143,12 +4224,12 @@
         "oneOf": [
           {
             "items": {
-              "$ref": "#/$defs/tool"
+              "$ref": "#/$defs/root_tool"
             },
             "type": "array"
           },
           {
-            "$ref": "#/$defs/tool"
+            "$ref": "#/$defs/root_tool"
           }
         ]
       },

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2279,7 +2279,34 @@
               "$ref": "#/$defs/tool_options"
             },
             {
-              "$ref": "#/$defs/tool_common_options"
+              "properties": {
+                "install_env": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/$defs/env_value"
+                  },
+                  "description": "environment variables during tool installation"
+                },
+                "depends": {
+                  "oneOf": [
+                    {
+                      "description": "tools that must be installed before this tool",
+                      "type": "string"
+                    },
+                    {
+                      "description": "tools that must be installed before this tool",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "postinstall": {
+                  "description": "command to run after tool installation",
+                  "type": "string"
+                }
+              }
             }
           ],
           "type": "object",
@@ -2305,37 +2332,6 @@
           }
         }
       ]
-    },
-    "tool_common_options": {
-      "properties": {
-        "install_env": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/env_value"
-          },
-          "description": "environment variables during tool installation"
-        },
-        "depends": {
-          "oneOf": [
-            {
-              "description": "tools that must be installed before this tool",
-              "type": "string"
-            },
-            {
-              "description": "tools that must be installed before this tool",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          ]
-        },
-        "postinstall": {
-          "description": "command to run after tool installation",
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "tool_options": {
       "properties": {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -104,48 +104,56 @@ where
     options.insert_option(key, value).map_err(de::Error::custom)
 }
 
+#[derive(Deserialize)]
+#[serde(try_from = "RawToolMap")]
 pub(crate) struct ParsedToolMap {
     pub request: String,
     pub options: IndexMap<String, toml::Value>,
 }
 
-pub(crate) fn parse_tool_map<E>(
-    fields: impl IntoIterator<Item = (String, toml::Value)>,
-) -> std::result::Result<ParsedToolMap, E>
-where
-    E: de::Error,
-{
-    let mut selector: Option<(String, String)> = None;
-    let mut options = IndexMap::new();
+#[derive(Deserialize)]
+struct RawToolMap {
+    version: Option<String>,
+    path: Option<String>,
+    prefix: Option<String>,
+    #[serde(rename = "ref")]
+    ref_: Option<String>,
+    #[serde(flatten)]
+    options: IndexMap<String, toml::Value>,
+}
 
-    for (key, value) in fields {
-        if !matches!(key.as_str(), "version" | "path" | "prefix" | "ref") {
-            options.insert(key, value);
-            continue;
-        }
+impl TryFrom<RawToolMap> for ParsedToolMap {
+    type Error = String;
 
-        let selector_value = value
-            .as_str()
-            .ok_or_else(|| de::Error::custom(format!("tool selector `{key}` must be a string")))?;
-        let request = if key == "version" {
-            selector_value.to_string()
-        } else {
-            format!("{key}:{selector_value}")
+    fn try_from(raw: RawToolMap) -> std::result::Result<Self, Self::Error> {
+        let selectors = [
+            raw.version.map(|value| ("version", value)),
+            raw.path.map(|value| ("path", value)),
+            raw.prefix.map(|value| ("prefix", value)),
+            raw.ref_.map(|value| ("ref", value)),
+        ];
+        let mut selectors = selectors.into_iter().flatten();
+        let Some((key, value)) = selectors.next() else {
+            return Err(
+                "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`"
+                    .to_string(),
+            );
         };
-        if let Some((previous, _)) = &selector {
-            return Err(de::Error::custom(format!(
-                "tool definition cannot specify both `{previous}` and `{key}`"
-            )));
+        if let Some((other, _)) = selectors.next() {
+            return Err(format!(
+                "tool definition cannot specify both `{key}` and `{other}`"
+            ));
         }
-        selector = Some((key, request));
+        let request = if key == "version" {
+            value
+        } else {
+            format!("{key}:{value}")
+        };
+        Ok(Self {
+            request,
+            options: raw.options,
+        })
     }
-
-    let request = selector.map(|(_, request)| request).ok_or_else(|| {
-        de::Error::custom(
-            "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
-        )
-    })?;
-    Ok(ParsedToolMap { request, options })
 }
 
 fn insert_core_options(table: &mut InlineTable, options: ToolVersionOptions) {
@@ -251,13 +259,10 @@ pub struct MiseTomlTool {
     pub options: Option<ToolVersionOptions>,
 }
 
-fn parse_mise_toml_tool_map<E>(
-    fields: impl IntoIterator<Item = (String, toml::Value)>,
-) -> std::result::Result<MiseTomlTool, E>
+fn parse_mise_toml_tool_map<E>(parsed: ParsedToolMap) -> std::result::Result<MiseTomlTool, E>
 where
     E: de::Error,
 {
-    let parsed = parse_tool_map::<E>(fields)?;
     let tt = parsed.request.parse().map_err(de::Error::custom)?;
     let mut options = ToolVersionOptions::default();
     for (key, value) in parsed.options {
@@ -2026,11 +2031,10 @@ impl<'de> de::Deserialize<'de> for MiseTomlToolList {
             where
                 M: de::MapAccess<'de>,
             {
-                let fields = IndexMap::<String, toml::Value>::deserialize(
-                    de::value::MapAccessDeserializer::new(map),
-                )?;
+                let parsed =
+                    ParsedToolMap::deserialize(de::value::MapAccessDeserializer::new(map))?;
                 Ok(MiseTomlToolList(vec![
-                    parse_mise_toml_tool_map::<M::Error>(fields)?,
+                    parse_mise_toml_tool_map::<M::Error>(parsed)?,
                 ]))
             }
         }
@@ -2066,10 +2070,9 @@ impl<'de> de::Deserialize<'de> for MiseTomlTool {
             where
                 M: de::MapAccess<'de>,
             {
-                let fields = IndexMap::<String, toml::Value>::deserialize(
-                    de::value::MapAccessDeserializer::new(map),
-                )?;
-                parse_mise_toml_tool_map::<M::Error>(fields)
+                let parsed =
+                    ParsedToolMap::deserialize(de::value::MapAccessDeserializer::new(map))?;
+                parse_mise_toml_tool_map::<M::Error>(parsed)
             }
         }
 
@@ -2457,10 +2460,7 @@ mod tests {
                 "[tools]\nnode = [{ os = \"linux-x64\" }]\n",
                 "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
             ),
-            (
-                "[tools]\nnode = { prefix = 20 }\n",
-                "tool selector `prefix` must be a string",
-            ),
+            ("[tools]\nnode = { prefix = 20 }\n", "expected a string"),
         ] {
             let err = match toml::from_str::<ToolConfig>(config) {
                 Ok(_) => panic!("expected tool selector validation to fail"),

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -113,13 +113,24 @@ pub(crate) struct ParsedToolMap {
 
 #[derive(Deserialize)]
 struct RawToolMap {
-    version: Option<String>,
-    path: Option<String>,
-    prefix: Option<String>,
+    version: Option<toml::Value>,
+    path: Option<toml::Value>,
+    prefix: Option<toml::Value>,
     #[serde(rename = "ref")]
-    ref_: Option<String>,
+    ref_: Option<toml::Value>,
     #[serde(flatten)]
     options: IndexMap<String, toml::Value>,
+}
+
+fn parse_tool_selector(
+    key: &'static str,
+    value: Option<toml::Value>,
+) -> std::result::Result<Option<(&'static str, String)>, String> {
+    match value {
+        Some(toml::Value::String(value)) => Ok(Some((key, value))),
+        Some(_) => Err(format!("tool selector `{key}` must be a string")),
+        None => Ok(None),
+    }
 }
 
 impl TryFrom<RawToolMap> for ParsedToolMap {
@@ -127,10 +138,10 @@ impl TryFrom<RawToolMap> for ParsedToolMap {
 
     fn try_from(raw: RawToolMap) -> std::result::Result<Self, Self::Error> {
         let selectors = [
-            raw.version.map(|value| ("version", value)),
-            raw.path.map(|value| ("path", value)),
-            raw.prefix.map(|value| ("prefix", value)),
-            raw.ref_.map(|value| ("ref", value)),
+            parse_tool_selector("version", raw.version)?,
+            parse_tool_selector("path", raw.path)?,
+            parse_tool_selector("prefix", raw.prefix)?,
+            parse_tool_selector("ref", raw.ref_)?,
         ];
         let mut selectors = selectors.into_iter().flatten();
         let Some((key, value)) = selectors.next() else {
@@ -2460,7 +2471,10 @@ mod tests {
                 "[tools]\nnode = [{ os = \"linux-x64\" }]\n",
                 "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
             ),
-            ("[tools]\nnode = { prefix = 20 }\n", "expected a string"),
+            (
+                "[tools]\nnode = { prefix = 20 }\n",
+                "tool selector `prefix` must be a string",
+            ),
         ] {
             let err = match toml::from_str::<ToolConfig>(config) {
                 Ok(_) => panic!("expected tool selector validation to fail"),

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -104,10 +104,10 @@ where
     options.insert_option(key, value).map_err(de::Error::custom)
 }
 
-fn parse_tool_selector<E>(
+pub(crate) fn parse_tool_selector<E>(
     key: &str,
     value: &toml::Value,
-) -> std::result::Result<Option<ToolVersionType>, E>
+) -> std::result::Result<Option<String>, E>
 where
     E: de::Error,
 {
@@ -123,7 +123,7 @@ where
     } else {
         format!("{key}:{value}")
     };
-    value.parse().map(Some).map_err(de::Error::custom)
+    Ok(Some(value))
 }
 
 fn insert_core_options(table: &mut InlineTable, options: ToolVersionOptions) {
@@ -1989,12 +1989,13 @@ impl<'de> de::Deserialize<'de> for MiseTomlToolList {
                 let mut options: ToolVersionOptions = Default::default();
                 let mut selector: Option<(String, ToolVersionType)> = None;
                 while let Some((k, v)) = map.next_entry::<String, toml::Value>()? {
-                    if let Some(tt) = parse_tool_selector::<M::Error>(&k, &v)? {
+                    if let Some(selector_value) = parse_tool_selector::<M::Error>(&k, &v)? {
                         if let Some((previous, _)) = &selector {
                             return Err(de::Error::custom(format!(
                                 "tool definition cannot specify both `{previous}` and `{k}`"
                             )));
                         }
+                        let tt = selector_value.parse().map_err(de::Error::custom)?;
                         selector = Some((k, tt));
                     } else {
                         insert_tool_option(&mut options, k, v)?;
@@ -2046,12 +2047,13 @@ impl<'de> de::Deserialize<'de> for MiseTomlTool {
                 let mut options: ToolVersionOptions = Default::default();
                 let mut selector: Option<(String, ToolVersionType)> = None;
                 while let Some((k, v)) = map.next_entry::<String, toml::Value>()? {
-                    if let Some(tt) = parse_tool_selector::<M::Error>(&k, &v)? {
+                    if let Some(selector_value) = parse_tool_selector::<M::Error>(&k, &v)? {
                         if let Some((previous, _)) = &selector {
                             return Err(de::Error::custom(format!(
                                 "tool definition cannot specify both `{previous}` and `{k}`"
                             )));
                         }
+                        let tt = selector_value.parse().map_err(de::Error::custom)?;
                         selector = Some((k, tt));
                     } else {
                         insert_tool_option(&mut options, k, v)?;

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -104,51 +104,48 @@ where
     options.insert_option(key, value).map_err(de::Error::custom)
 }
 
-#[derive(Default)]
-pub(crate) struct ToolSelector {
-    selector: Option<(String, String)>,
+pub(crate) struct ParsedToolMap {
+    pub request: String,
+    pub options: IndexMap<String, toml::Value>,
 }
 
-impl ToolSelector {
-    pub(crate) fn parse_field<E>(
-        &mut self,
-        key: &str,
-        value: &toml::Value,
-    ) -> std::result::Result<bool, E>
-    where
-        E: de::Error,
-    {
-        if !matches!(key, "version" | "path" | "prefix" | "ref") {
-            return Ok(false);
+pub(crate) fn parse_tool_map<E>(
+    fields: impl IntoIterator<Item = (String, toml::Value)>,
+) -> std::result::Result<ParsedToolMap, E>
+where
+    E: de::Error,
+{
+    let mut selector: Option<(String, String)> = None;
+    let mut options = IndexMap::new();
+
+    for (key, value) in fields {
+        if !matches!(key.as_str(), "version" | "path" | "prefix" | "ref") {
+            options.insert(key, value);
+            continue;
         }
 
-        let value = value
+        let selector_value = value
             .as_str()
             .ok_or_else(|| de::Error::custom(format!("tool selector `{key}` must be a string")))?;
         let request = if key == "version" {
-            value.to_string()
+            selector_value.to_string()
         } else {
-            format!("{key}:{value}")
+            format!("{key}:{selector_value}")
         };
-        if let Some((previous, _)) = &self.selector {
+        if let Some((previous, _)) = &selector {
             return Err(de::Error::custom(format!(
                 "tool definition cannot specify both `{previous}` and `{key}`"
             )));
         }
-        self.selector = Some((key.to_string(), request));
-        Ok(true)
+        selector = Some((key, request));
     }
 
-    pub(crate) fn finish<E>(self) -> std::result::Result<String, E>
-    where
-        E: de::Error,
-    {
-        self.selector.map(|(_, request)| request).ok_or_else(|| {
-            de::Error::custom(
-                "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
-            )
-        })
-    }
+    let request = selector.map(|(_, request)| request).ok_or_else(|| {
+        de::Error::custom(
+            "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
+        )
+    })?;
+    Ok(ParsedToolMap { request, options })
 }
 
 fn insert_core_options(table: &mut InlineTable, options: ToolVersionOptions) {
@@ -252,6 +249,24 @@ pub struct MiseTomlToolList(Vec<MiseTomlTool>);
 pub struct MiseTomlTool {
     pub tt: ToolVersionType,
     pub options: Option<ToolVersionOptions>,
+}
+
+fn parse_mise_toml_tool_map<E>(
+    fields: impl IntoIterator<Item = (String, toml::Value)>,
+) -> std::result::Result<MiseTomlTool, E>
+where
+    E: de::Error,
+{
+    let parsed = parse_tool_map::<E>(fields)?;
+    let tt = parsed.request.parse().map_err(de::Error::custom)?;
+    let mut options = ToolVersionOptions::default();
+    for (key, value) in parsed.options {
+        insert_tool_option(&mut options, key, value)?;
+    }
+    Ok(MiseTomlTool {
+        tt,
+        options: Some(options),
+    })
 }
 
 #[derive(Debug, Default, Clone)]
@@ -2007,25 +2022,16 @@ impl<'de> de::Deserialize<'de> for MiseTomlToolList {
                 Ok(MiseTomlToolList(tools))
             }
 
-            fn visit_map<M>(self, mut map: M) -> std::result::Result<Self::Value, M::Error>
+            fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
             where
                 M: de::MapAccess<'de>,
             {
-                let mut options: ToolVersionOptions = Default::default();
-                let mut selector = ToolSelector::default();
-                while let Some((k, v)) = map.next_entry::<String, toml::Value>()? {
-                    if !selector.parse_field::<M::Error>(&k, &v)? {
-                        insert_tool_option(&mut options, k, v)?;
-                    }
-                }
-                let tt = selector
-                    .finish::<M::Error>()?
-                    .parse()
-                    .map_err(de::Error::custom)?;
-                Ok(MiseTomlToolList(vec![MiseTomlTool {
-                    tt,
-                    options: Some(options),
-                }]))
+                let fields = IndexMap::<String, toml::Value>::deserialize(
+                    de::value::MapAccessDeserializer::new(map),
+                )?;
+                Ok(MiseTomlToolList(vec![
+                    parse_mise_toml_tool_map::<M::Error>(fields)?,
+                ]))
             }
         }
 
@@ -2056,25 +2062,14 @@ impl<'de> de::Deserialize<'de> for MiseTomlTool {
                 Ok(MiseTomlTool { tt, options: None })
             }
 
-            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
             where
                 M: de::MapAccess<'de>,
             {
-                let mut options: ToolVersionOptions = Default::default();
-                let mut selector = ToolSelector::default();
-                while let Some((k, v)) = map.next_entry::<String, toml::Value>()? {
-                    if !selector.parse_field::<M::Error>(&k, &v)? {
-                        insert_tool_option(&mut options, k, v)?;
-                    }
-                }
-                let tt = selector
-                    .finish::<M::Error>()?
-                    .parse()
-                    .map_err(de::Error::custom)?;
-                Ok(MiseTomlTool {
-                    tt,
-                    options: Some(options),
-                })
+                let fields = IndexMap::<String, toml::Value>::deserialize(
+                    de::value::MapAccessDeserializer::new(map),
+                )?;
+                parse_mise_toml_tool_map::<M::Error>(fields)
             }
         }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -104,6 +104,28 @@ where
     options.insert_option(key, value).map_err(de::Error::custom)
 }
 
+fn parse_tool_selector<E>(
+    key: &str,
+    value: &toml::Value,
+) -> std::result::Result<Option<ToolVersionType>, E>
+where
+    E: de::Error,
+{
+    if !matches!(key, "version" | "path" | "prefix" | "ref") {
+        return Ok(None);
+    }
+
+    let value = value
+        .as_str()
+        .ok_or_else(|| de::Error::custom(format!("tool selector `{key}` must be a string")))?;
+    let value = if key == "version" {
+        value.to_string()
+    } else {
+        format!("{key}:{value}")
+    };
+    value.parse().map(Some).map_err(de::Error::custom)
+}
+
 fn insert_core_options(table: &mut InlineTable, options: ToolVersionOptions) {
     let core = options.core;
     if let Some(os) = core.os
@@ -1965,32 +1987,28 @@ impl<'de> de::Deserialize<'de> for MiseTomlToolList {
                 M: de::MapAccess<'de>,
             {
                 let mut options: ToolVersionOptions = Default::default();
-                let mut tt: Option<ToolVersionType> = None;
+                let mut selector: Option<(String, ToolVersionType)> = None;
                 while let Some((k, v)) = map.next_entry::<String, toml::Value>()? {
-                    match k.as_str() {
-                        "version" => {
-                            tt = Some(v.as_str().unwrap().parse().map_err(de::Error::custom)?);
+                    if let Some(tt) = parse_tool_selector::<M::Error>(&k, &v)? {
+                        if let Some((previous, _)) = &selector {
+                            return Err(de::Error::custom(format!(
+                                "tool definition cannot specify both `{previous}` and `{k}`"
+                            )));
                         }
-                        "path" | "prefix" | "ref" => {
-                            tt = Some(
-                                format!("{k}:{}", v.as_str().unwrap())
-                                    .parse()
-                                    .map_err(de::Error::custom)?,
-                            );
-                        }
-                        _ => {
-                            insert_tool_option(&mut options, k, v)?;
-                        }
+                        selector = Some((k, tt));
+                    } else {
+                        insert_tool_option(&mut options, k, v)?;
                     }
                 }
-                if let Some(tt) = tt {
-                    Ok(MiseTomlToolList(vec![MiseTomlTool {
-                        tt,
-                        options: Some(options),
-                    }]))
-                } else {
-                    Err(de::Error::custom("missing version"))
-                }
+                let (_, tt) = selector.ok_or_else(|| {
+                    de::Error::custom(
+                        "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
+                    )
+                })?;
+                Ok(MiseTomlToolList(vec![MiseTomlTool {
+                    tt,
+                    options: Some(options),
+                }]))
             }
         }
 
@@ -2026,22 +2044,24 @@ impl<'de> de::Deserialize<'de> for MiseTomlTool {
                 M: de::MapAccess<'de>,
             {
                 let mut options: ToolVersionOptions = Default::default();
-                let mut tt = ToolVersionType::System;
+                let mut selector: Option<(String, ToolVersionType)> = None;
                 while let Some((k, v)) = map.next_entry::<String, toml::Value>()? {
-                    match k.as_str() {
-                        "version" => {
-                            tt = v.as_str().unwrap().parse().map_err(de::Error::custom)?;
+                    if let Some(tt) = parse_tool_selector::<M::Error>(&k, &v)? {
+                        if let Some((previous, _)) = &selector {
+                            return Err(de::Error::custom(format!(
+                                "tool definition cannot specify both `{previous}` and `{k}`"
+                            )));
                         }
-                        "path" | "prefix" | "ref" => {
-                            tt = format!("{k}:{}", v.as_str().unwrap())
-                                .parse()
-                                .map_err(de::Error::custom)?;
-                        }
-                        _ => {
-                            insert_tool_option(&mut options, k, v)?;
-                        }
+                        selector = Some((k, tt));
+                    } else {
+                        insert_tool_option(&mut options, k, v)?;
                     }
                 }
+                let (_, tt) = selector.ok_or_else(|| {
+                    de::Error::custom(
+                        "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
+                    )
+                })?;
                 Ok(MiseTomlTool {
                     tt,
                     options: Some(options),
@@ -2400,6 +2420,50 @@ mod tests {
             "{:#?}",
             cf.to_tool_request_set().unwrap().tools
         )));
+    }
+
+    #[test]
+    fn test_tool_selectors() {
+        #[derive(Deserialize)]
+        struct ToolConfig {
+            #[allow(dead_code)]
+            tools: IndexMap<BackendArg, MiseTomlToolList>,
+        }
+
+        let valid = indoc! {r#"
+        [tools]
+        node = { version = "20" }
+        go = { prefix = "1.22" }
+        python = { ref = "main" }
+        shellcheck = { path = "/opt/shellcheck" }
+        ruby = [{ prefix = "3.3", os = "linux-x64" }]
+        "#};
+        assert!(toml::from_str::<ToolConfig>(valid).is_ok());
+
+        for (config, expected) in [
+            (
+                "[tools]\nnode = { version = \"20\", prefix = \"20\" }\n",
+                "tool definition cannot specify both `version` and `prefix`",
+            ),
+            (
+                "[tools]\nnode = [{ path = \"/opt/node\", ref = \"main\" }]\n",
+                "tool definition cannot specify both `path` and `ref`",
+            ),
+            (
+                "[tools]\nnode = [{ os = \"linux-x64\" }]\n",
+                "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
+            ),
+            (
+                "[tools]\nnode = { prefix = 20 }\n",
+                "tool selector `prefix` must be a string",
+            ),
+        ] {
+            let err = match toml::from_str::<ToolConfig>(config) {
+                Ok(_) => panic!("expected tool selector validation to fail"),
+                Err(err) => err,
+            };
+            assert!(err.to_string().contains(expected), "{err}");
+        }
     }
 
     #[tokio::test]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -104,26 +104,51 @@ where
     options.insert_option(key, value).map_err(de::Error::custom)
 }
 
-pub(crate) fn parse_tool_selector<E>(
-    key: &str,
-    value: &toml::Value,
-) -> std::result::Result<Option<String>, E>
-where
-    E: de::Error,
-{
-    if !matches!(key, "version" | "path" | "prefix" | "ref") {
-        return Ok(None);
+#[derive(Default)]
+pub(crate) struct ToolSelector {
+    selector: Option<(String, String)>,
+}
+
+impl ToolSelector {
+    pub(crate) fn parse_field<E>(
+        &mut self,
+        key: &str,
+        value: &toml::Value,
+    ) -> std::result::Result<bool, E>
+    where
+        E: de::Error,
+    {
+        if !matches!(key, "version" | "path" | "prefix" | "ref") {
+            return Ok(false);
+        }
+
+        let value = value
+            .as_str()
+            .ok_or_else(|| de::Error::custom(format!("tool selector `{key}` must be a string")))?;
+        let request = if key == "version" {
+            value.to_string()
+        } else {
+            format!("{key}:{value}")
+        };
+        if let Some((previous, _)) = &self.selector {
+            return Err(de::Error::custom(format!(
+                "tool definition cannot specify both `{previous}` and `{key}`"
+            )));
+        }
+        self.selector = Some((key.to_string(), request));
+        Ok(true)
     }
 
-    let value = value
-        .as_str()
-        .ok_or_else(|| de::Error::custom(format!("tool selector `{key}` must be a string")))?;
-    let value = if key == "version" {
-        value.to_string()
-    } else {
-        format!("{key}:{value}")
-    };
-    Ok(Some(value))
+    pub(crate) fn finish<E>(self) -> std::result::Result<String, E>
+    where
+        E: de::Error,
+    {
+        self.selector.map(|(_, request)| request).ok_or_else(|| {
+            de::Error::custom(
+                "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
+            )
+        })
+    }
 }
 
 fn insert_core_options(table: &mut InlineTable, options: ToolVersionOptions) {
@@ -1987,25 +2012,16 @@ impl<'de> de::Deserialize<'de> for MiseTomlToolList {
                 M: de::MapAccess<'de>,
             {
                 let mut options: ToolVersionOptions = Default::default();
-                let mut selector: Option<(String, ToolVersionType)> = None;
+                let mut selector = ToolSelector::default();
                 while let Some((k, v)) = map.next_entry::<String, toml::Value>()? {
-                    if let Some(selector_value) = parse_tool_selector::<M::Error>(&k, &v)? {
-                        if let Some((previous, _)) = &selector {
-                            return Err(de::Error::custom(format!(
-                                "tool definition cannot specify both `{previous}` and `{k}`"
-                            )));
-                        }
-                        let tt = selector_value.parse().map_err(de::Error::custom)?;
-                        selector = Some((k, tt));
-                    } else {
+                    if !selector.parse_field::<M::Error>(&k, &v)? {
                         insert_tool_option(&mut options, k, v)?;
                     }
                 }
-                let (_, tt) = selector.ok_or_else(|| {
-                    de::Error::custom(
-                        "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
-                    )
-                })?;
+                let tt = selector
+                    .finish::<M::Error>()?
+                    .parse()
+                    .map_err(de::Error::custom)?;
                 Ok(MiseTomlToolList(vec![MiseTomlTool {
                     tt,
                     options: Some(options),
@@ -2045,25 +2061,16 @@ impl<'de> de::Deserialize<'de> for MiseTomlTool {
                 M: de::MapAccess<'de>,
             {
                 let mut options: ToolVersionOptions = Default::default();
-                let mut selector: Option<(String, ToolVersionType)> = None;
+                let mut selector = ToolSelector::default();
                 while let Some((k, v)) = map.next_entry::<String, toml::Value>()? {
-                    if let Some(selector_value) = parse_tool_selector::<M::Error>(&k, &v)? {
-                        if let Some((previous, _)) = &selector {
-                            return Err(de::Error::custom(format!(
-                                "tool definition cannot specify both `{previous}` and `{k}`"
-                            )));
-                        }
-                        let tt = selector_value.parse().map_err(de::Error::custom)?;
-                        selector = Some((k, tt));
-                    } else {
+                    if !selector.parse_field::<M::Error>(&k, &v)? {
                         insert_tool_option(&mut options, k, v)?;
                     }
                 }
-                let (_, tt) = selector.ok_or_else(|| {
-                    de::Error::custom(
-                        "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
-                    )
-                })?;
+                let tt = selector
+                    .finish::<M::Error>()?
+                    .parse()
+                    .map_err(de::Error::custom)?;
                 Ok(MiseTomlTool {
                     tt,
                     options: Some(options),

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::config_file::mise_toml::{EnvList, deserialize_vars, parse_tool_selector};
+use crate::config::config_file::mise_toml::{EnvList, ToolSelector, deserialize_vars};
 use crate::config::config_file::toml::{TrackingTomlParser, deserialize_arr};
 use crate::config::env_directive::{EnvDirective, EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::{self, Config};
@@ -118,26 +118,15 @@ impl TaskToolValueMap {
         E: serde::de::Error,
     {
         let mut opts = IndexMap::new();
-        let mut selector: Option<(String, String)> = None;
+        let mut selector = ToolSelector::default();
 
         for (key, value) in fields {
-            if let Some(request) = parse_tool_selector::<E>(&key, &value)? {
-                if let Some((previous, _)) = &selector {
-                    return Err(serde::de::Error::custom(format!(
-                        "tool definition cannot specify both `{previous}` and `{key}`"
-                    )));
-                }
-                selector = Some((key, request));
-            } else {
+            if !selector.parse_field::<E>(&key, &value)? {
                 opts.insert(key, value);
             }
         }
 
-        let (_, version) = selector.ok_or_else(|| {
-            serde::de::Error::custom(
-                "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
-            )
-        })?;
+        let version = selector.finish::<E>()?;
         Ok(Self { version, opts })
     }
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -81,11 +81,26 @@ use task_sources::{RawOutputTemplates, TaskOutputs};
 /// Represents a tool value in task-level tools field.
 /// Supports both string syntax (e.g., "1.0.0") and object syntax
 /// (e.g., { version = "1.0.0", targets = ["x86_64"] })
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum TaskToolValue {
     String(String),
     Map(TaskToolValueMap),
+}
+
+impl<'de> Deserialize<'de> for TaskToolValue {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match toml::Value::deserialize(deserializer)? {
+            toml::Value::String(value) => Ok(Self::String(value)),
+            toml::Value::Table(fields) => TaskToolValueMap::from_fields(fields).map(Self::Map),
+            _ => Err(serde::de::Error::custom(
+                "task tool definition must be a string or table",
+            )),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -95,17 +110,18 @@ pub struct TaskToolValueMap {
     pub opts: IndexMap<String, toml::Value>,
 }
 
-impl<'de> Deserialize<'de> for TaskToolValueMap {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+impl TaskToolValueMap {
+    fn from_fields<E>(
+        fields: impl IntoIterator<Item = (String, toml::Value)>,
+    ) -> std::result::Result<Self, E>
     where
-        D: serde::Deserializer<'de>,
+        E: serde::de::Error,
     {
-        let fields = IndexMap::<String, toml::Value>::deserialize(deserializer)?;
         let mut opts = IndexMap::new();
         let mut selector: Option<(String, String)> = None;
 
         for (key, value) in fields {
-            if let Some(request) = parse_tool_selector::<D::Error>(&key, &value)? {
+            if let Some(request) = parse_tool_selector::<E>(&key, &value)? {
                 if let Some((previous, _)) = &selector {
                     return Err(serde::de::Error::custom(format!(
                         "tool definition cannot specify both `{previous}` and `{key}`"
@@ -123,6 +139,15 @@ impl<'de> Deserialize<'de> for TaskToolValueMap {
             )
         })?;
         Ok(Self { version, opts })
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskToolValueMap {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::from_fields(IndexMap::<String, toml::Value>::deserialize(deserializer)?)
     }
 }
 
@@ -3915,6 +3940,35 @@ echo "test"
 
     #[tokio::test]
     #[cfg(unix)]
+    async fn test_file_task_reports_tool_selector_errors() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let tasks_dir = temp_dir.path().join("tasks");
+        fs::create_dir(&tasks_dir).unwrap();
+        let task_file = tasks_dir.join("invalid-tools");
+        fs::write(
+            &task_file,
+            "#!/usr/bin/env bash\n#MISE tools={node={version=\"20\", prefix=\"20\"}}\n",
+        )
+        .unwrap();
+        fs::set_permissions(&task_file, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let config = Config::get().await.unwrap();
+        let err = Task::from_path(&config, &task_file, &tasks_dir, temp_dir.path())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains(
+                "failed to parse task tool `node`: tool definition cannot specify both `version` and `prefix`"
+            ),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
     async fn test_multi_line_tools_merge() {
         // Regression test for https://github.com/jdx/mise/discussions/7839
         // Multiple #MISE tools.X=Y lines should be merged into a single tools table
@@ -4160,12 +4214,25 @@ echo "test"
             Some(&vec![toml::Value::Integer(1), toml::Value::Boolean(true)])
         );
 
-        for invalid in [
-            "[tools]\nnode = { version = \"20\", prefix = \"20\" }\n",
-            "[tools]\nnode = { os = \"linux\" }\n",
-            "[tools]\nnode = { prefix = 20 }\n",
+        for (invalid, expected) in [
+            (
+                "[tools]\nnode = { version = \"20\", prefix = \"20\" }\n",
+                "tool definition cannot specify both `version` and `prefix`",
+            ),
+            (
+                "[tools]\nnode = { os = \"linux\" }\n",
+                "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
+            ),
+            (
+                "[tools]\nnode = { prefix = 20 }\n",
+                "tool selector `prefix` must be a string",
+            ),
         ] {
-            assert!(toml::from_str::<TaskTools>(invalid).is_err(), "{invalid}");
+            let err = match toml::from_str::<TaskTools>(invalid) {
+                Ok(_) => panic!("expected task tool selector validation to fail"),
+                Err(err) => err,
+            };
+            assert!(err.to_string().contains(expected), "{err}");
         }
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::config_file::mise_toml::{EnvList, deserialize_vars};
+use crate::config::config_file::mise_toml::{EnvList, deserialize_vars, parse_tool_selector};
 use crate::config::config_file::toml::{TrackingTomlParser, deserialize_arr};
 use crate::config::env_directive::{EnvDirective, EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::{self, Config};
@@ -88,11 +88,42 @@ pub enum TaskToolValue {
     Map(TaskToolValueMap),
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct TaskToolValueMap {
     pub version: String,
     #[serde(flatten)]
     pub opts: IndexMap<String, toml::Value>,
+}
+
+impl<'de> Deserialize<'de> for TaskToolValueMap {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let fields = IndexMap::<String, toml::Value>::deserialize(deserializer)?;
+        let mut opts = IndexMap::new();
+        let mut selector: Option<(String, String)> = None;
+
+        for (key, value) in fields {
+            if let Some(request) = parse_tool_selector::<D::Error>(&key, &value)? {
+                if let Some((previous, _)) = &selector {
+                    return Err(serde::de::Error::custom(format!(
+                        "tool definition cannot specify both `{previous}` and `{key}`"
+                    )));
+                }
+                selector = Some((key, request));
+            } else {
+                opts.insert(key, value);
+            }
+        }
+
+        let (_, version) = selector.ok_or_else(|| {
+            serde::de::Error::custom(
+                "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
+            )
+        })?;
+        Ok(Self { version, opts })
+    }
 }
 
 impl TaskToolValue {
@@ -901,31 +932,14 @@ impl Task {
             .parse_table("tools")
             .map(|t| {
                 t.into_iter()
-                    .filter_map(|(k, v)| {
-                        if let toml::Value::String(s) = &v {
-                            Some((k, TaskToolValue::String(s.clone())))
-                        } else if let toml::Value::Table(table) = &v {
-                            if let Some(toml::Value::String(version)) = table.get("version") {
-                                let mut opts = IndexMap::new();
-                                for (ok, ov) in table.iter().filter(|(ok, _)| *ok != "version") {
-                                    opts.insert(ok.clone(), ov.clone());
-                                }
-                                Some((
-                                    k,
-                                    TaskToolValue::Map(TaskToolValueMap {
-                                        version: version.clone(),
-                                        opts,
-                                    }),
-                                ))
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
+                    .map(|(tool, value)| {
+                        TaskToolValue::deserialize(value)
+                            .map(|value| (tool.clone(), value))
+                            .map_err(|err| eyre!("failed to parse task tool `{tool}`: {err}"))
                     })
-                    .collect()
+                    .collect::<Result<IndexMap<_, _>>>()
             })
+            .transpose()?
             .unwrap_or_default();
 
         let mut unparsed = p.unparsed_keys();
@@ -2756,6 +2770,7 @@ mod tests {
 
     use crate::task::{RunEntry, Task};
     use crate::{config::Config, dirs};
+    use indexmap::IndexMap;
     use pretty_assertions::assert_eq;
 
     #[cfg(unix)]
@@ -3837,7 +3852,7 @@ echo "hello world"
 #MISE quiet=true
 #MISE silent=true
 #MISE output="prefix"
-#MISE tools={node="20", python="3.11"}
+#MISE tools={node={prefix="20"}, python="3.11"}
 #MISE confirm="Are you sure?"
 echo "test"
 "#;
@@ -3864,6 +3879,13 @@ echo "test"
         assert_eq!(task.quiet, true);
         assert_eq!(task.output, Some(TaskOutput::Prefix));
         assert!(!task.tools.is_empty());
+        assert_eq!(
+            task.tools.get("node"),
+            Some(&super::TaskToolValue::Map(super::TaskToolValueMap {
+                version: "prefix:20".to_string(),
+                opts: IndexMap::new(),
+            }))
+        );
         assert_eq!(
             task.confirm,
             Some(TaskConfirm::Message("Are you sure?".to_string()))
@@ -4094,6 +4116,57 @@ echo "test"
         );
         assert_eq!(options.os, Some(vec!["linux".to_string()]));
         assert_eq!(options.depends, Some(vec!["node".to_string()]));
+    }
+
+    #[test]
+    fn test_task_tool_map_selectors() {
+        use serde::Deserialize;
+
+        use super::TaskToolValue;
+
+        #[derive(Deserialize)]
+        struct TaskTools {
+            tools: IndexMap<String, TaskToolValue>,
+        }
+
+        let parsed: TaskTools = toml::from_str(
+            r#"
+            [tools]
+            node = { version = "20", backend_options = { nested = [1, true] } }
+            go = { prefix = "1.22" }
+            python = { ref = "main" }
+            shellcheck = { path = "/opt/shellcheck" }
+            "#,
+        )
+        .unwrap();
+
+        for (tool, expected) in [
+            ("node", "20"),
+            ("go", "prefix:1.22"),
+            ("python", "ref:main"),
+            ("shellcheck", "path:/opt/shellcheck"),
+        ] {
+            let TaskToolValue::Map(value) = &parsed.tools[tool] else {
+                panic!("expected mapped task tool for {tool}");
+            };
+            assert_eq!(value.version, expected);
+        }
+
+        let TaskToolValue::Map(node) = &parsed.tools["node"] else {
+            panic!("expected mapped node task tool");
+        };
+        assert_eq!(
+            node.opts["backend_options"]["nested"].as_array(),
+            Some(&vec![toml::Value::Integer(1), toml::Value::Boolean(true)])
+        );
+
+        for invalid in [
+            "[tools]\nnode = { version = \"20\", prefix = \"20\" }\n",
+            "[tools]\nnode = { os = \"linux\" }\n",
+            "[tools]\nnode = { prefix = 20 }\n",
+        ] {
+            assert!(toml::from_str::<TaskTools>(invalid).is_err(), "{invalid}");
+        }
     }
 
     #[tokio::test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::config_file::mise_toml::{EnvList, ToolSelector, deserialize_vars};
+use crate::config::config_file::mise_toml::{EnvList, deserialize_vars, parse_tool_map};
 use crate::config::config_file::toml::{TrackingTomlParser, deserialize_arr};
 use crate::config::env_directive::{EnvDirective, EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::{self, Config};
@@ -95,7 +95,7 @@ impl<'de> Deserialize<'de> for TaskToolValue {
     {
         match toml::Value::deserialize(deserializer)? {
             toml::Value::String(value) => Ok(Self::String(value)),
-            toml::Value::Table(fields) => TaskToolValueMap::from_fields(fields).map(Self::Map),
+            toml::Value::Table(fields) => parse_task_tool_map(fields).map(Self::Map),
             _ => Err(serde::de::Error::custom(
                 "task tool definition must be a string or table",
             )),
@@ -110,25 +110,17 @@ pub struct TaskToolValueMap {
     pub opts: IndexMap<String, toml::Value>,
 }
 
-impl TaskToolValueMap {
-    fn from_fields<E>(
-        fields: impl IntoIterator<Item = (String, toml::Value)>,
-    ) -> std::result::Result<Self, E>
-    where
-        E: serde::de::Error,
-    {
-        let mut opts = IndexMap::new();
-        let mut selector = ToolSelector::default();
-
-        for (key, value) in fields {
-            if !selector.parse_field::<E>(&key, &value)? {
-                opts.insert(key, value);
-            }
-        }
-
-        let version = selector.finish::<E>()?;
-        Ok(Self { version, opts })
-    }
+fn parse_task_tool_map<E>(
+    fields: impl IntoIterator<Item = (String, toml::Value)>,
+) -> std::result::Result<TaskToolValueMap, E>
+where
+    E: serde::de::Error,
+{
+    let parsed = parse_tool_map::<E>(fields)?;
+    Ok(TaskToolValueMap {
+        version: parsed.request,
+        opts: parsed.options,
+    })
 }
 
 impl<'de> Deserialize<'de> for TaskToolValueMap {
@@ -136,7 +128,7 @@ impl<'de> Deserialize<'de> for TaskToolValueMap {
     where
         D: serde::Deserializer<'de>,
     {
-        Self::from_fields(IndexMap::<String, toml::Value>::deserialize(deserializer)?)
+        parse_task_tool_map(IndexMap::<String, toml::Value>::deserialize(deserializer)?)
     }
 }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -93,18 +93,40 @@ impl<'de> Deserialize<'de> for TaskToolValue {
     where
         D: serde::Deserializer<'de>,
     {
-        match toml::Value::deserialize(deserializer)? {
-            toml::Value::String(value) => Ok(Self::String(value)),
-            toml::Value::Table(fields) => {
-                let parsed: ParsedToolMap = toml::Value::Table(fields)
-                    .try_into()
-                    .map_err(serde::de::Error::custom)?;
-                Ok(Self::Map(TaskToolValueMap::from(parsed)))
+        struct TaskToolValueVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for TaskToolValueVisitor {
+            type Value = TaskToolValue;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str("a task tool definition as a string or table")
             }
-            _ => Err(serde::de::Error::custom(
-                "task tool definition must be a string or table",
-            )),
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(TaskToolValue::String(value.to_string()))
+            }
+
+            fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(TaskToolValue::String(value))
+            }
+
+            fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
+            where
+                M: serde::de::MapAccess<'de>,
+            {
+                let parsed =
+                    ParsedToolMap::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(TaskToolValue::Map(parsed.into()))
+            }
         }
+
+        deserializer.deserialize_any(TaskToolValueVisitor)
     }
 }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -4205,7 +4205,10 @@ echo "test"
                 "[tools]\nnode = { os = \"linux\" }\n",
                 "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
             ),
-            ("[tools]\nnode = { prefix = 20 }\n", "expected a string"),
+            (
+                "[tools]\nnode = { prefix = 20 }\n",
+                "tool selector `prefix` must be a string",
+            ),
         ] {
             let err = match toml::from_str::<TaskTools>(invalid) {
                 Ok(_) => panic!("expected task tool selector validation to fail"),

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::config_file::mise_toml::{EnvList, deserialize_vars, parse_tool_map};
+use crate::config::config_file::mise_toml::{EnvList, ParsedToolMap, deserialize_vars};
 use crate::config::config_file::toml::{TrackingTomlParser, deserialize_arr};
 use crate::config::env_directive::{EnvDirective, EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::{self, Config};
@@ -95,7 +95,12 @@ impl<'de> Deserialize<'de> for TaskToolValue {
     {
         match toml::Value::deserialize(deserializer)? {
             toml::Value::String(value) => Ok(Self::String(value)),
-            toml::Value::Table(fields) => parse_task_tool_map(fields).map(Self::Map),
+            toml::Value::Table(fields) => {
+                let parsed: ParsedToolMap = toml::Value::Table(fields)
+                    .try_into()
+                    .map_err(serde::de::Error::custom)?;
+                Ok(Self::Map(TaskToolValueMap::from(parsed)))
+            }
             _ => Err(serde::de::Error::custom(
                 "task tool definition must be a string or table",
             )),
@@ -110,17 +115,13 @@ pub struct TaskToolValueMap {
     pub opts: IndexMap<String, toml::Value>,
 }
 
-fn parse_task_tool_map<E>(
-    fields: impl IntoIterator<Item = (String, toml::Value)>,
-) -> std::result::Result<TaskToolValueMap, E>
-where
-    E: serde::de::Error,
-{
-    let parsed = parse_tool_map::<E>(fields)?;
-    Ok(TaskToolValueMap {
-        version: parsed.request,
-        opts: parsed.options,
-    })
+impl From<ParsedToolMap> for TaskToolValueMap {
+    fn from(parsed: ParsedToolMap) -> Self {
+        Self {
+            version: parsed.request,
+            opts: parsed.options,
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for TaskToolValueMap {
@@ -128,7 +129,7 @@ impl<'de> Deserialize<'de> for TaskToolValueMap {
     where
         D: serde::Deserializer<'de>,
     {
-        parse_task_tool_map(IndexMap::<String, toml::Value>::deserialize(deserializer)?)
+        Ok(ParsedToolMap::deserialize(deserializer)?.into())
     }
 }
 
@@ -4204,10 +4205,7 @@ echo "test"
                 "[tools]\nnode = { os = \"linux\" }\n",
                 "tool definition must include exactly one of `version`, `path`, `prefix`, or `ref`",
             ),
-            (
-                "[tools]\nnode = { prefix = 20 }\n",
-                "tool selector `prefix` must be a string",
-            ),
+            ("[tools]\nnode = { prefix = 20 }\n", "expected a string"),
         ] {
             let err = match toml::from_str::<TaskTools>(invalid) {
                 Ok(_) => panic!("expected task tool selector validation to fail"),


### PR DESCRIPTION
## Summary

- require structured tool definitions to select exactly one of `version`, `path`, `prefix`, or `ref`
- support those selectors consistently in root `[tools]`, inline task definitions, task templates, and file-task headers
- keep structured backend/core options intact while normalizing selector aliases into ordinary tool requests
- use the same `$defs/tool` schema contract for root and task tools, including the generated standalone task schema

## Why

Root `[tools]` objects already accepted all four selectors at runtime, but the published schema required `version`. The runtime also had unsafe or ambiguous failure modes: non-string selectors could panic, multiple selectors silently used whichever entry was visited last, and selector-less objects inside arrays defaulted to `system`.

Task tool objects were introduced in #9087 with the goal of matching top-level `[tools]`, but their runtime type only recognized `version`. As a result, `path`, `prefix`, and `ref` were treated as backend options, and file-task headers silently dropped object entries that lacked `version`.

This makes runtime parsing and both published schemas describe one contract.

## Behavior

All of these forms now work in root and task tool maps:

```toml
node = { version = "20" }
go = { prefix = "1.22" }
python = { ref = "main" }
shellcheck = { path = "/opt/shellcheck" }
```

Structured options remain supported beside the selector:

```toml
node = { version = "20", os = "linux-x64", backend_options = { nested = [1, true] } }
```

Objects with multiple selectors, no selector, or a non-string selector now fail with a targeted configuration error. Task-tool errors retain the tool name and selector-specific diagnostic through both TOML task definitions and file-task headers.

## Compatibility

Scalar tool requests are unchanged. In object syntax, `version`, `path`, `prefix`, and `ref` are now reserved selector keys, so using one as a backend option beside another selector is rejected as ambiguous. Selector-less array entries that previously became `system` are also rejected.

## Validation

- `mise run lint-fix`
- `mise run render:schema` followed by `git diff --exit-code`
- `mise x cargo -- cargo test --all-features tool_selector`
- `mise x cargo -- cargo test --all-features task_tool_map_selectors`
- `mise run test:e2e e2e/config/test_schema_tool_selectors e2e/tasks/test_task_tools`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded tool configuration to support selector-style specification via `version`, `path`, `prefix`, or `ref` (with optional OS filtering).
  * Enabled selector-style tool definitions in task tool configuration.

* **Bug Fixes**
  * Strengthened validation to require exactly one selector, reject conflicting/malformed selector inputs, and remove any fallback when no selector is provided.
  * Improved error messaging for invalid selector types/structures.

* **Tests**
  * Added end-to-end coverage for valid and invalid tool-selector TOML.
  * Updated and expanded unit tests for selector parsing and nested tool options handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->