### PR TITLE
feat(backend): skip remote discovery for exact versions in more backends

### DIFF
--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -91,6 +91,18 @@ impl Backend for DotnetBackend {
             .collect())
     }
 
+    async fn resolve_exact_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> eyre::Result<Option<String>> {
+        // NuGet allows legacy 4-part versions, which do not parse as semver
+        // and keep using remote discovery. A full semver request is exact;
+        // `dotnet tool install --version` fails when it does not exist
+        // upstream.
+        Ok(versions::SemVer::new(version).map(|_| version.to_string()))
+    }
+
     async fn install_version_(
         &self,
         ctx: &crate::install_context::InstallContext,
@@ -218,6 +230,40 @@ mod tests {
         let mut opts = ToolVersionOptions::default();
         opts.opts.insert("prerelease".to_string(), value);
         opts
+    }
+
+    #[tokio::test]
+    async fn exact_semver_versions_resolve_without_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = DotnetBackend::from_arg("dotnet:GitVersion.Tool".into());
+
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "5.12.0")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("5.12.0")
+        );
+    }
+
+    #[tokio::test]
+    async fn non_semver_versions_require_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = DotnetBackend::from_arg("dotnet:GitVersion.Tool".into());
+
+        // Legacy 4-part NuGet versions are not semver and must keep
+        // resolving against the remote version list.
+        for version in ["latest", "5", "5.12", "1.2.3.4"] {
+            assert_eq!(
+                backend
+                    .resolve_exact_version(&config, version)
+                    .await
+                    .unwrap(),
+                None,
+                "{version} should use remote discovery"
+            );
+        }
     }
 
     #[test]

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -74,6 +74,18 @@ impl Backend for GemBackend {
         Ok(versions)
     }
 
+    async fn resolve_exact_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> eyre::Result<Option<String>> {
+        // RubyGems allows non-semver versions (4-part like rails 5.0.0.1,
+        // dotted prereleases like 1.2.3.rc1) — those keep using remote
+        // discovery. A full semver request is exact; `gem install --version`
+        // fails when it does not exist upstream.
+        Ok(versions::SemVer::new(version).map(|_| version.to_string()))
+    }
+
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         // Check if gem is available
         self.warn_if_dependency_missing(
@@ -471,6 +483,40 @@ fn extract_minor_version(version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn exact_semver_versions_resolve_without_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = GemBackend::from_arg("gem:rubocop".into());
+
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "1.69.0")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.69.0")
+        );
+    }
+
+    #[tokio::test]
+    async fn non_semver_versions_require_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = GemBackend::from_arg("gem:rails".into());
+
+        // 4-part and dotted-prerelease RubyGems versions are not semver and
+        // must keep resolving against the remote version list.
+        for version in ["latest", "5", "5.0", "5.0.0.1", "1.2.3.rc1"] {
+            assert_eq!(
+                backend
+                    .resolve_exact_version(&config, version)
+                    .await
+                    .unwrap(),
+                None,
+                "{version} should use remote discovery"
+            );
+        }
+    }
 
     #[test]
     fn test_extract_minor_version() {

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -122,6 +122,18 @@ impl Backend for GoBackend {
         .await
     }
 
+    async fn resolve_exact_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> eyre::Result<Option<String>> {
+        // Go module versions are strict semver, so a full semver request is
+        // exact. `go install mod@vX.Y.Z` validates the version against the
+        // module proxy and fails when it does not exist.
+        let version = version.strip_prefix('v').unwrap_or(version);
+        Ok(versions::SemVer::new(version).map(|_| version.to_string()))
+    }
+
     async fn install_version_(
         &self,
         ctx: &InstallContext,
@@ -641,6 +653,47 @@ async fn fetch_proxy_version_infos(
 mod tests {
     use super::*;
     use crate::toolset::ToolVersionOptions;
+
+    #[tokio::test]
+    async fn exact_semver_versions_resolve_without_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = GoBackend::from_arg("go:github.com/example/tool".into());
+
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "1.2.3")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.2.3")
+        );
+        // "v" prefixes are normalized away, matching how versions are listed.
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "v1.2.3")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.2.3")
+        );
+    }
+
+    #[tokio::test]
+    async fn fuzzy_versions_require_remote_discovery() {
+        let config = Config::get().await.unwrap();
+        let backend = GoBackend::from_arg("go:github.com/example/tool".into());
+
+        for version in ["latest", "1", "1.2", "^1.2.3", "main"] {
+            assert_eq!(
+                backend
+                    .resolve_exact_version(&config, version)
+                    .await
+                    .unwrap(),
+                None,
+                "{version} should use remote discovery"
+            );
+        }
+    }
 
     #[test]
     fn go_options_reads_tags() {

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -376,6 +376,18 @@ impl Backend for NPMBackend {
         .cloned()
     }
 
+    async fn resolve_exact_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> eyre::Result<Option<String>> {
+        // npm registry versions are strict semver and dist-tags may not be
+        // valid semver, so a full semver request is exact. Installation
+        // passes `pkg@version` through to the package manager, which fails
+        // when the version does not exist upstream.
+        Ok(versions::SemVer::new(version).map(|_| version.to_string()))
+    }
+
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         let package_manager = self
             .package_manager_for_install(&ctx.config, Some(&ctx.ts))
@@ -1071,6 +1083,46 @@ mod tests {
             BackendResolution::new(true),
         );
         NPMBackend::from_arg(ba)
+    }
+
+    #[tokio::test]
+    async fn exact_semver_versions_resolve_without_remote_discovery() {
+        let config = crate::config::Config::get().await.unwrap();
+        let backend = create_npm_backend("prettier");
+
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "3.1.0")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("3.1.0")
+        );
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "1.1.0-beta.1")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1.1.0-beta.1")
+        );
+    }
+
+    #[tokio::test]
+    async fn fuzzy_versions_require_remote_discovery() {
+        let config = crate::config::Config::get().await.unwrap();
+        let backend = create_npm_backend("prettier");
+
+        for version in ["latest", "3", "3.1", "^3.1.0", ">=3.1.0", "next"] {
+            assert_eq!(
+                backend
+                    .resolve_exact_version(&config, version)
+                    .await
+                    .unwrap(),
+                None,
+                "{version} should use remote discovery"
+            );
+        }
     }
 
     #[test]

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -255,6 +255,26 @@ impl Backend for PIPXBackend {
         }
     }
 
+    async fn resolve_exact_version(
+        &self,
+        _config: &Arc<Config>,
+        version: &str,
+    ) -> eyre::Result<Option<String>> {
+        // Git-sourced tools resolve versions from repo tags, which cannot be
+        // validated from the version string alone.
+        if !matches!(
+            self.tool_name().parse::<PipxRequest>(),
+            Ok(PipxRequest::Pypi(_))
+        ) {
+            return Ok(None);
+        }
+        // PEP 440 allows non-semver versions (1.2.3.4, 1.2.3rc1, 1.2.3.post1)
+        // — those keep using remote discovery. A full semver request is
+        // exact; `pipx install pkg==version` / `uv tool install` fail when it
+        // does not exist upstream.
+        Ok(versions::SemVer::new(version).map(|_| version.to_string()))
+    }
+
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         let request_options = tv.request.options();
         let options = PipxOptions::new(&request_options);
@@ -827,6 +847,63 @@ mod tests {
     use indexmap::IndexMap;
     use pretty_assertions::assert_eq;
     use std::ffi::OsString;
+
+    #[tokio::test]
+    async fn exact_semver_versions_resolve_without_remote_discovery() {
+        use crate::backend::Backend;
+        let config = crate::config::Config::get().await.unwrap();
+        let backend = PIPXBackend::from_arg("pipx:black".into());
+
+        assert_eq!(
+            backend
+                .resolve_exact_version(&config, "24.3.0")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("24.3.0")
+        );
+    }
+
+    #[tokio::test]
+    async fn non_semver_versions_require_remote_discovery() {
+        use crate::backend::Backend;
+        let config = crate::config::Config::get().await.unwrap();
+        let backend = PIPXBackend::from_arg("pipx:black".into());
+
+        // PEP 440 versions that are not semver must keep resolving against
+        // the remote version list.
+        for version in ["latest", "24", "24.3", "1.2.3.4", "1.2.3rc1", "1.2.3.post1"] {
+            assert_eq!(
+                backend
+                    .resolve_exact_version(&config, version)
+                    .await
+                    .unwrap(),
+                None,
+                "{version} should use remote discovery"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn git_tools_keep_remote_discovery() {
+        use crate::backend::Backend;
+        let config = crate::config::Config::get().await.unwrap();
+
+        for tool in [
+            "pipx:psf/black",
+            "pipx:git+https://github.com/psf/black.git",
+        ] {
+            let backend = PIPXBackend::from_arg(tool.into());
+            assert_eq!(
+                backend
+                    .resolve_exact_version(&config, "24.3.0")
+                    .await
+                    .unwrap(),
+                None,
+                "{tool} should use remote discovery"
+            );
+        }
+    }
 
     #[test]
     fn test_extras_accepts_string_or_array() {

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -268,6 +268,10 @@ impl Backend for PIPXBackend {
         ) {
             return Ok(None);
         }
+        // Surface malformed registry configuration at resolve time like
+        // remote discovery would — installation only sees the derived index
+        // URL, which skips this validation.
+        Self::get_registry_url()?;
         // PEP 440 allows non-semver versions (1.2.3.4, 1.2.3rc1, 1.2.3.post1)
         // — those keep using remote discovery. A full semver request is
         // exact; `pipx install pkg==version` / `uv tool install` fail when it


### PR DESCRIPTION
## Summary

Extends the `resolve_exact_version` fast path introduced for cargo in #11013 to the **npm, go, gem, pipx, and dotnet** backends.

When a version request parses as full semver (`versions::SemVer`), resolution now skips fetching the remote version list entirely and defers authoritative validation to the underlying installer, which fails cleanly when the version doesn't exist upstream:

| Backend | Installer validation |
|---|---|
| npm | `npm/bun/pnpm/aube install pkg@version` |
| go | `go install mod@vX.Y.Z` (validates against the module proxy; `v`-prefixed requests are normalized to match listed versions) |
| gem | `gem install --version` |
| pipx | `pipx install pkg==version` / `uv tool install` |
| dotnet | `dotnet tool install --version` |

This mostly benefits flows the lockfile short-circuit doesn't cover: exact pins in `mise.toml` without a lockfile, first-time `mise install tool@x.y.z`, and `mise x tool@x.y.z`.

## What still uses remote discovery

- Fuzzy/prefix/channel requests (`latest`, `3`, `3.1`, `^1.2.3`, `next`)
- Non-semver version schemes, so prefix promotion keeps working where those schemes exist: RubyGems 4-part versions (`5.0.0.1`) and dotted prereleases (`1.2.3.rc1`), PEP 440 (`1.2.3.post1`, `1.2.3rc1`, `1.2.3.4`), legacy 4-part NuGet versions
- Git-sourced pipx tools (`pipx:owner/repo`, `pipx:git+...`) — versions there are repo tags, mirroring the cargo `git_url` escape hatch

## Behavior tradeoff (same as #11013)

An exact 3-part pin that does not exist upstream now fails at install time with the installer's error, instead of being silently promoted to a separator-suffixed variant (`1.2.3` → `1.2.3.4` / `1.2.3-rc1`) during resolution. Explicit exact pins also stay outside release-age filtering, per the existing comment in `tool_version.rs`.

## Verification

- 11 new unit tests mirroring the cargo ones (exact resolves, fuzzy/non-semver/git fall through) — all pass
- Traced end-to-end with a debug build: `mise install --dry-run npm:cowsay@1.6.0` resolves with **zero** remote calls (no `npm view`), while the fuzzy control `npm:cowsay@1.6` still fetches the version list and resolves to `1.6.0`

---
*This PR was generated by an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes version resolution behavior for exact pins across five install backends; wrong semver classification could skip needed remote discovery or change failure mode from resolution promotion to install-time errors.
> 
> **Overview**
> Extends the **`resolve_exact_version`** fast path (from cargo) to **npm**, **go**, **gem**, **pipx**, and **dotnet**. When a pin parses as full semver via `versions::SemVer`, mise **skips remote version-list fetches** and treats the string as exact; missing versions surface at **install time** from the package manager instead of during resolution.
> 
> **Backend-specific rules:** **go** strips a leading `v` before semver checks; **pipx** only applies the fast path for PyPI tools (git-sourced tools still use remote discovery); **gem**, **dotnet**, and **pipx** leave non-semver schemes (RubyGems 4-part/dotted prereleases, NuGet 4-part, PEP 440) on the remote-discovery path so prefix promotion keeps working.
> 
> **Tradeoff:** exact semver pins that do not exist upstream no longer get silently promoted to separator-suffixed variants during resolution—they fail with the installer’s error instead.
> 
> Adds **unit tests** on each backend mirroring cargo (exact semver resolves, fuzzy/non-semver/git fall through).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6fd9d20f48cdb165869b432c5085ea52edcf860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved version resolution for .NET, RubyGems, Go, npm, and pipx packages.
  * Exact semantic versions, including supported prerelease versions and Go’s `v` prefix, can now resolve directly.
  * Non-semantic, partial, range-based, legacy, and Git-based version references continue through remote discovery for more accurate results.

* **Tests**
  * Added coverage for exact, fuzzy, legacy, prerelease, and unsupported version formats across supported package ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->