### PR TITLE
chore(ci): align macos pgo toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,11 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERTS_P12 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERTS_P12_PASS }}
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - name: Setup Rust target
-        run: rustup target add ${{matrix.target}}
+      - name: Setup Rust toolchain
+        run: rustup toolchain install stable --profile minimal --target ${{matrix.target}}
       - name: Install llvm-tools (PGO)
         if: matrix.pgo
-        run: rustup component add llvm-tools
+        run: rustup component add --toolchain stable llvm-tools
       - name: build-tarball ${{matrix.target}}
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
@@ -118,7 +118,10 @@ jobs:
         with:
           timeout_minutes: 90
           max_attempts: 3
-          command: scripts/build-tarball.sh ${{matrix.target}}
+          # Keep rustc, rust-std, and the profiling runtime on the same
+          # toolchain. A mismatched runner default makes PGO training fail
+          # before it can write any profile data.
+          command: rustup run stable scripts/build-tarball.sh ${{matrix.target}}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: tarball-${{matrix.target}}


### PR DESCRIPTION
## Summary
- install the stable rustup toolchain explicitly for macOS release builds
- install `llvm-tools` into that same toolchain
- run the tarball build through `rustup run stable`

## Root cause
The v2026.7.8 macOS ARM64 release build compiled PGO instrumentation with a different LLVM profiling ABI than the profiling runtime selected from the runner default. Training failed with `Runtime and instrumentation version mismatch: expected 10, but get 8`, produced no `.profraw` files, and prevented the release job from running.

Keeping `rustc`, `rust-std`, and `llvm-tools` on one explicitly selected rustup toolchain prevents that mismatch.

## Impact
macOS release artifacts use a consistent Rust/LLVM toolchain, allowing ARM64 PGO training to complete instead of blocking the release.

## Validation
- `mise run lint-fix`
- release-equivalent macOS ARM64 PGO instrument/train/merge using the stable rustup toolchain with `MISE_PGO_SKIP_FINAL_BUILD=1`
  - collected 54 `.profraw` files
  - merged an 85,901,248-byte profile successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow changes with no application runtime or auth logic touched; scope is toolchain selection for macOS tarball builds.
> 
> **Overview**
> Fixes macOS release CI so **PGO** on ARM64 uses one consistent Rust/LLVM stack instead of mixing the runner default with separately added components.
> 
> The **build-tarball-macos** job now installs the **stable** rustup toolchain (with the matrix target), adds **llvm-tools** to that same toolchain, and runs **`rustup run stable scripts/build-tarball.sh`**. That replaces only adding a target and invoking the build on whatever default `rustc` the runner had—behavior that caused instrumentation vs profiling runtime version mismatch, failed training, and blocked releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b723e4f61787ecd17ee29503c150dc0076fb5aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release builds by ensuring Rust compilation and profiling tools use a consistent, pinned toolchain.
  * Increased reliability and reproducibility of macOS tarball generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->