### PR TITLE
fix(task): resolve task source files from task directory

### DIFF
--- a/e2e/tasks/test_task_run_sources
+++ b/e2e/tasks/test_task_run_sources
@@ -78,3 +78,13 @@ assert_empty "mise build"
 assert "rm src/foo.txt"
 assert "mise build" "done"
 assert_empty "mise build"
+
+mkdir source-files-project && cd source-files-project || exit 1
+cat <<EOF >mise.toml
+[tasks.source-files]
+sources = ["pen", "apple"]
+run = "echo {{ task_source_files() | join(sep=' ') }} {{ arg(name='value') }}"
+EOF
+touch pen apple
+mkdir child && cd child || exit 1
+assert "mise run -q source-files test" "pen apple test"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1273,7 +1273,11 @@ impl Task {
             (spec, vec![])
         } else {
             let scripts_only = self.run_script_strings();
-            let (scripts, spec) = Self::make_script_parser(cwd, extra_vars)
+            let parser_dir = match cwd {
+                Some(cwd) => Some(cwd),
+                None => self.dir(config).await?,
+            };
+            let (scripts, spec) = Self::make_script_parser(parser_dir, extra_vars)
                 .parse_run_scripts(config, self, &scripts_only, &env)
                 .await?;
             (spec, scripts)
@@ -1337,8 +1341,12 @@ impl Task {
         if !self.should_bypass_usage_parser() && has_any_args_defined(&spec) {
             let mut env = env.clone();
             clear_usage_env(&mut env);
+            let parser_dir = match cwd {
+                Some(cwd) => Some(cwd),
+                None => self.dir(config).await?,
+            };
             let scripts_only = self.run_script_strings();
-            let scripts = Self::make_script_parser(cwd, extra_vars)
+            let scripts = Self::make_script_parser(parser_dir, extra_vars)
                 .parse_run_scripts_with_args(config, self, &scripts_only, &env, args, &spec)
                 .await?;
             Ok(scripts.into_iter().map(|s| (s, vec![])).collect())

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -12,7 +12,7 @@ use serde::de::DeserializeOwned;
 use serde_json::{Value as JsonValue, json};
 use std::collections::{HashMap, HashSet};
 use std::iter::once;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 type TeraSpecParsingResult = (
@@ -156,20 +156,22 @@ impl TaskScriptParser {
         }
     }
 
-    fn register_task_source_files_function(tera: &mut TeraEngine, task: &Task) {
+    fn register_task_source_files_function(&self, tera: &mut TeraEngine, task: &Task) {
         Self::register_template_function(tera, "task_source_files", {
             let glob_patterns = Arc::new(crate::task::task_source_checker::source_glob_patterns(
                 &task.sources,
             ));
-            // Anchor the matcher at the process cwd. `is_source` handles
+            // Anchor the matcher at the task directory. `is_source` handles
             // absolute paths outside this root by trusting the glob result,
-            // so absolute outside-cwd patterns (e.g. workspace-root paths)
+            // so absolute outside-root patterns (e.g. workspace-root paths)
             // still flow through.
-            let cwd = crate::dirs::CWD
+            let root = self
+                .dir
                 .clone()
+                .or_else(|| crate::dirs::CWD.clone())
                 .unwrap_or_else(|| std::path::PathBuf::from("."));
             let matcher = Arc::new(crate::task::task_source_checker::build_source_matcher(
-                &cwd,
+                &root,
                 &task.sources,
             ));
 
@@ -182,6 +184,7 @@ impl TaskScriptParser {
                 };
 
                 let mut resolved = Vec::with_capacity(glob_patterns.len());
+                let escaped_root = glob::Pattern::escape(root.to_string_lossy().as_ref());
 
                 for pattern in glob_patterns.iter() {
                     if contains_template_syntax(pattern) {
@@ -192,8 +195,19 @@ impl TaskScriptParser {
                         continue;
                     }
 
+                    let pattern_path = Path::new(pattern);
+                    let is_relative = pattern_path.is_relative();
+                    let rooted_pattern = if is_relative {
+                        Path::new(&escaped_root)
+                            .join(pattern_path)
+                            .to_string_lossy()
+                            .to_string()
+                    } else {
+                        pattern.clone()
+                    };
+
                     match glob::glob_with(
-                        pattern,
+                        &rooted_pattern,
                         glob::MatchOptions {
                             case_sensitive: false,
                             require_literal_separator: false,
@@ -223,7 +237,12 @@ impl TaskScriptParser {
                                             );
                                             continue;
                                         }
-                                        let source = path.display();
+                                        let source = if is_relative {
+                                            path.strip_prefix(&root).unwrap_or(&path)
+                                        } else {
+                                            &path
+                                        };
+                                        let source = source.display();
                                         trace!(
                                             "tera::render::resolve_task_sources resolved source from pattern '{pattern}': {source}"
                                         );
@@ -522,7 +541,7 @@ impl TaskScriptParser {
             }
         });
 
-        Self::register_task_source_files_function(&mut tera, task);
+        self.register_task_source_files_function(&mut tera, task);
 
         (tera, arg_order, input_args, input_flags)
     }
@@ -723,7 +742,7 @@ impl TaskScriptParser {
                 }
             };
             let mut tera = self.get_tera();
-            Self::register_task_source_files_function(&mut tera, task);
+            self.register_task_source_files_function(&mut tera, task);
             Self::register_template_function(&mut tera, "arg", {
                 {
                     let usage_args = m.args.clone();
@@ -1321,6 +1340,28 @@ mod tests {
 
             assert_eq!(parsed, vec![expected]);
         }
+    }
+
+    #[tokio::test]
+    async fn test_task_source_files_resolves_relative_to_parser_dir() {
+        let config = Config::get().await.unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("project[1]");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("input.txt"), "test").unwrap();
+        let task = Task {
+            sources: vec!["*.txt".to_string()],
+            ..Default::default()
+        };
+        let parser = TaskScriptParser::new(Some(root));
+        let scripts = vec!["echo {{ task_source_files() | first }}".to_string()];
+
+        let (parsed, _) = parser
+            .parse_run_scripts(&config, &task, &scripts, &Default::default())
+            .await
+            .unwrap();
+
+        assert_eq!(parsed, vec!["echo input.txt"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- resolve relative `task_source_files()` globs from the task/config directory
- preserve relative paths returned to task templates
- add unit and end-to-end coverage for invocation from a child directory

## Context
This addresses the unresolved behavior reported in https://github.com/jdx/mise/discussions/7171. The template helper previously anchored source globs to the process working directory, so launching mise below the project root returned no files.

## Tests
- `cargo fmt --check`
- `cargo test test_task_source_files_resolves_relative_to_parser_dir`
- `cargo test test_task_parse_task_source_files`
- `mise run test:e2e e2e/tasks/test_task_run_sources`

*This PR was prepared by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `task_source_files()` so source globs resolve relative to the task/parser’s configured directory rather than the process working directory.
  * Ensured resolved source paths are emitted consistently (root-relative for relative patterns), including when running with a custom working directory.

* **Tests**
  * Added an end-to-end test that verifies `task_source_files()` expands to the expected space-separated list when combined with additional task arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->