### PR TITLE
chore: release 2026.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,85 @@
 # Changelog
 
+## [2026.7.11](https://github.com/jdx/mise/compare/v2026.7.10..v2026.7.11) - 2026-07-20
+
+### 🐛 Bug Fixes
+
+- **(bootstrap)** support auto-updating cask metadata by @casparbreloh in [#11107](https://github.com/jdx/mise/pull/11107)
+- **(bootstrap)** resolve bare systemd timer unit names to dev.mise.<name>.service by @jdx in [#11128](https://github.com/jdx/mise/pull/11128)
+- **(bootstrap)** macos defaults bail if key or domain does not exist yet by @roele in [#11118](https://github.com/jdx/mise/pull/11118)
+- **(config)** reject conflicting tool selectors by @risu729 in [#11069](https://github.com/jdx/mise/pull/11069)
+- **(http)** make raw executables readable, not just executable by @jdx in [#11135](https://github.com/jdx/mise/pull/11135)
+- **(java)** prefer base vendor for latest command and ensure proper sorting by @roele in [#11109](https://github.com/jdx/mise/pull/11109)
+- **(release)** keep macos pgo instrumentation rust-only by @jdx in [#11129](https://github.com/jdx/mise/pull/11129)
+- **(release)** don't re-dispatch release workflow while one is active by @jdx in [#11137](https://github.com/jdx/mise/pull/11137)
+- **(task)** parse remote task file headers by @Marukome0743 in [#11111](https://github.com/jdx/mise/pull/11111)
+- **(task)** mark global config file tasks as global by @risu729 in [#11106](https://github.com/jdx/mise/pull/11106)
+- **(task)** report all task definition sources by @risu729 in [#11098](https://github.com/jdx/mise/pull/11098)
+- **(watch)** propagate --env to watched tasks by @Marukome0743 in [#11114](https://github.com/jdx/mise/pull/11114)
+- **(windows)** remove dangling runtime symlink pointer files on uninstall by @JamBalaya56562 in [#11095](https://github.com/jdx/mise/pull/11095)
+
+### 📚 Documentation
+
+- **(environments)** clarify mise directory variables by @jdx in [#11127](https://github.com/jdx/mise/pull/11127)
+- fix dead VersionFox and MCP documentation links by @Bartok9 in [#11117](https://github.com/jdx/mise/pull/11117)
+
+### ⚡ Performance
+
+- **(activate)** skip redundant initial fish prompt hook by @jdx in [#11130](https://github.com/jdx/mise/pull/11130)
+- **(activate)** skip redundant initial bash prompt hook by @jdx in [#11131](https://github.com/jdx/mise/pull/11131)
+- **(activate)** skip unchanged initial zsh prompt hook by @jdx in [#11134](https://github.com/jdx/mise/pull/11134)
+- **(backend)** run archive extraction via block_in_place by @jdx in [#11136](https://github.com/jdx/mise/pull/11136)
+
+### 📦️ Dependency Updates
+
+- update actions/setup-node digest to 2499707 by @renovate[bot] in [#11074](https://github.com/jdx/mise/pull/11074)
+- update ghcr.io/jdx/mise:alpine docker digest to 60f8876 by @renovate[bot] in [#11075](https://github.com/jdx/mise/pull/11075)
+- update rust crate jiff to v0.2.32 by @renovate[bot] in [#11086](https://github.com/jdx/mise/pull/11086)
+- update ghcr.io/jdx/mise:deb docker digest to bdcdb1e by @renovate[bot] in [#11076](https://github.com/jdx/mise/pull/11076)
+- update ghcr.io/jdx/mise:rpm docker digest to d93ee51 by @renovate[bot] in [#11077](https://github.com/jdx/mise/pull/11077)
+- update rust crate ignore to v0.4.28 by @renovate[bot] in [#11083](https://github.com/jdx/mise/pull/11083)
+- update rust docker digest to 9a2cd30 by @renovate[bot] in [#11080](https://github.com/jdx/mise/pull/11080)
+- update jdx/mise-action digest to dad1bfd by @renovate[bot] in [#11078](https://github.com/jdx/mise/pull/11078)
+- update dependency prettier to v3.9.5 by @renovate[bot] in [#11082](https://github.com/jdx/mise/pull/11082)
+- update ghcr.io/jdx/mise:alpine docker digest to f024c27 by @renovate[bot] in [#11085](https://github.com/jdx/mise/pull/11085)
+- update ubuntu:26.04 docker digest to 3131b4c by @renovate[bot] in [#11081](https://github.com/jdx/mise/pull/11081)
+- update rust crate regex to v1.13.0 by @renovate[bot] in [#11088](https://github.com/jdx/mise/pull/11088)
+- update rust crate usage-lib to v3.5.5 by @renovate[bot] in [#11087](https://github.com/jdx/mise/pull/11087)
+- update rust crate x509-cert to 0.3 by @risu729 in [#11102](https://github.com/jdx/mise/pull/11102)
+- update rust crate mlua to 0.12 by @risu729 in [#11099](https://github.com/jdx/mise/pull/11099)
+- update dependency typescript to v7 by @renovate[bot] in [#11093](https://github.com/jdx/mise/pull/11093)
+- update rust crate sigstore-verify to 0.11.0 by @renovate[bot] in [#11091](https://github.com/jdx/mise/pull/11091)
+- update rattler by @renovate[bot] in [#11089](https://github.com/jdx/mise/pull/11089)
+- lock file maintenance by @renovate[bot] in [#11120](https://github.com/jdx/mise/pull/11120)
+
+### 📦 Registry
+
+- allow nub postinstall by @risu729 in [#11126](https://github.com/jdx/mise/pull/11126)
+
+### Chore
+
+- **(nix)** remove unused inputs by @risu729 in [#11104](https://github.com/jdx/mise/pull/11104)
+- **(release)** stop cutting vfox tags on embedded-plugin churn by @jdx in [#11133](https://github.com/jdx/mise/pull/11133)
+- **(vfox)** remove unused development tools by @risu729 in [#11105](https://github.com/jdx/mise/pull/11105)
+
+### New Contributors
+
+- @Bartok9 made their first contribution in [#11117](https://github.com/jdx/mise/pull/11117)
+- @LukasKnuth made their first contribution in [#11110](https://github.com/jdx/mise/pull/11110)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (2)
+
+- [`kbrdn1/gwm-cli`](https://github.com/kbrdn1/gwm-cli)
+- [`planetscale/ghcommit`](https://github.com/planetscale/ghcommit)
+
+#### Updated Packages (3)
+
+- [`anthropics/claude-code`](https://github.com/anthropics/claude-code)
+- [`skaji/relocatable-perl`](https://github.com/skaji/relocatable-perl)
+- [`suzuki-shunsuke/tfrstate`](https://github.com/suzuki-shunsuke/tfrstate)
+
 ## [2026.7.10](https://github.com/jdx/mise/compare/v2026.7.8..v2026.7.10) - 2026-07-17
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5400,7 +5400,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.10"
+version = "2026.7.11"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.10"
+version = "2026.7.11"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.10 macos-arm64 (2026-07-17)
+2026.7.11 macos-arm64 (2026-07-20)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_10.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_11.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_10.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_11.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_10.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_11.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_10.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_11.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.10";
+  version = "2026.7.11";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.10
+Version: 2026.7.11
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.10"
+version: "2026.7.11"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "971b7bc4bff7fd74918e8813880421adbe4e1221"
+  "tag": "b630f47e707ae0c3eba85f7fc74c0d911e7fa58d"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -13612,7 +13612,6 @@ packages:
     description: Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands
     files:
       - name: claude
-    version_source: github_tag
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v2.1.88"
@@ -55788,6 +55787,34 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: kbrdn1
+    repo_name: gwm-cli
+    description: git worktree manager — Rust CLI + ratatui TUI, native libgit2, per-repo bootstrap via .gwm.toml
+    files:
+      - name: gwm
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gwm-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: gwm
+            src: "{{.AssetWithoutExt}}/gwm"
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: kcl-lang
     repo_name: cli
     description: The KCL Command Line Interface (CLI)
@@ -74768,6 +74795,22 @@ packages:
       asset: pscale_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: planetscale
+    repo_name: ghcommit
+    description: Use GitHub's GraphQL API to commit files to a GitHub repository
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghcommit_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: plexsystems
     repo_name: sinker
     description: A tool to sync images from one container registry to another
@@ -83599,12 +83642,20 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 5.42.2.0")
+        asset: perl-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: perl-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         supported_envs:
           - linux
           - darwin
+        github_artifact_attestations:
+          signer_workflow: skaji/relocatable-perl/\.github/workflows/ci\.yml
   - type: github_release
     repo_owner: skanehira
     repo_name: ghost
@@ -89705,6 +89756,9 @@ packages:
               - https://github.com/suzuki-shunsuke/tfrstate/releases/download/{{.Version}}/tfrstate_{{trimV .Version}}_checksums.txt.sig
               - --certificate
               - https://github.com/suzuki-shunsuke/tfrstate/releases/download/{{.Version}}/tfrstate_{{trimV .Version}}_checksums.txt.pem
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(bootstrap)** support auto-updating cask metadata by @casparbreloh in [#11107](https://github.com/jdx/mise/pull/11107)
- **(bootstrap)** resolve bare systemd timer unit names to dev.mise.<name>.service by @jdx in [#11128](https://github.com/jdx/mise/pull/11128)
- **(bootstrap)** macos defaults bail if key or domain does not exist yet by @roele in [#11118](https://github.com/jdx/mise/pull/11118)
- **(config)** reject conflicting tool selectors by @risu729 in [#11069](https://github.com/jdx/mise/pull/11069)
- **(http)** make raw executables readable, not just executable by @jdx in [#11135](https://github.com/jdx/mise/pull/11135)
- **(java)** prefer base vendor for latest command and ensure proper sorting by @roele in [#11109](https://github.com/jdx/mise/pull/11109)
- **(release)** keep macos pgo instrumentation rust-only by @jdx in [#11129](https://github.com/jdx/mise/pull/11129)
- **(release)** don't re-dispatch release workflow while one is active by @jdx in [#11137](https://github.com/jdx/mise/pull/11137)
- **(task)** parse remote task file headers by @Marukome0743 in [#11111](https://github.com/jdx/mise/pull/11111)
- **(task)** mark global config file tasks as global by @risu729 in [#11106](https://github.com/jdx/mise/pull/11106)
- **(task)** report all task definition sources by @risu729 in [#11098](https://github.com/jdx/mise/pull/11098)
- **(watch)** propagate --env to watched tasks by @Marukome0743 in [#11114](https://github.com/jdx/mise/pull/11114)
- **(windows)** remove dangling runtime symlink pointer files on uninstall by @JamBalaya56562 in [#11095](https://github.com/jdx/mise/pull/11095)

### 📚 Documentation

- **(environments)** clarify mise directory variables by @jdx in [#11127](https://github.com/jdx/mise/pull/11127)
- fix dead VersionFox and MCP documentation links by @Bartok9 in [#11117](https://github.com/jdx/mise/pull/11117)

### ⚡ Performance

- **(activate)** skip redundant initial fish prompt hook by @jdx in [#11130](https://github.com/jdx/mise/pull/11130)
- **(activate)** skip redundant initial bash prompt hook by @jdx in [#11131](https://github.com/jdx/mise/pull/11131)
- **(activate)** skip unchanged initial zsh prompt hook by @jdx in [#11134](https://github.com/jdx/mise/pull/11134)
- **(backend)** run archive extraction via block_in_place by @jdx in [#11136](https://github.com/jdx/mise/pull/11136)

### 📦️ Dependency Updates

- update actions/setup-node digest to 2499707 by @renovate[bot] in [#11074](https://github.com/jdx/mise/pull/11074)
- update ghcr.io/jdx/mise:alpine docker digest to 60f8876 by @renovate[bot] in [#11075](https://github.com/jdx/mise/pull/11075)
- update rust crate jiff to v0.2.32 by @renovate[bot] in [#11086](https://github.com/jdx/mise/pull/11086)
- update ghcr.io/jdx/mise:deb docker digest to bdcdb1e by @renovate[bot] in [#11076](https://github.com/jdx/mise/pull/11076)
- update ghcr.io/jdx/mise:rpm docker digest to d93ee51 by @renovate[bot] in [#11077](https://github.com/jdx/mise/pull/11077)
- update rust crate ignore to v0.4.28 by @renovate[bot] in [#11083](https://github.com/jdx/mise/pull/11083)
- update rust docker digest to 9a2cd30 by @renovate[bot] in [#11080](https://github.com/jdx/mise/pull/11080)
- update jdx/mise-action digest to dad1bfd by @renovate[bot] in [#11078](https://github.com/jdx/mise/pull/11078)
- update dependency prettier to v3.9.5 by @renovate[bot] in [#11082](https://github.com/jdx/mise/pull/11082)
- update ghcr.io/jdx/mise:alpine docker digest to f024c27 by @renovate[bot] in [#11085](https://github.com/jdx/mise/pull/11085)
- update ubuntu:26.04 docker digest to 3131b4c by @renovate[bot] in [#11081](https://github.com/jdx/mise/pull/11081)
- update rust crate regex to v1.13.0 by @renovate[bot] in [#11088](https://github.com/jdx/mise/pull/11088)
- update rust crate usage-lib to v3.5.5 by @renovate[bot] in [#11087](https://github.com/jdx/mise/pull/11087)
- update rust crate x509-cert to 0.3 by @risu729 in [#11102](https://github.com/jdx/mise/pull/11102)
- update rust crate mlua to 0.12 by @risu729 in [#11099](https://github.com/jdx/mise/pull/11099)
- update dependency typescript to v7 by @renovate[bot] in [#11093](https://github.com/jdx/mise/pull/11093)
- update rust crate sigstore-verify to 0.11.0 by @renovate[bot] in [#11091](https://github.com/jdx/mise/pull/11091)
- update rattler by @renovate[bot] in [#11089](https://github.com/jdx/mise/pull/11089)
- lock file maintenance by @renovate[bot] in [#11120](https://github.com/jdx/mise/pull/11120)

### 📦 Registry

- allow nub postinstall by @risu729 in [#11126](https://github.com/jdx/mise/pull/11126)

### Chore

- **(nix)** remove unused inputs by @risu729 in [#11104](https://github.com/jdx/mise/pull/11104)
- **(release)** stop cutting vfox tags on embedded-plugin churn by @jdx in [#11133](https://github.com/jdx/mise/pull/11133)
- **(vfox)** remove unused development tools by @risu729 in [#11105](https://github.com/jdx/mise/pull/11105)

### New Contributors

- @Bartok9 made their first contribution in [#11117](https://github.com/jdx/mise/pull/11117)
- @LukasKnuth made their first contribution in [#11110](https://github.com/jdx/mise/pull/11110)

## 📦 Aqua Registry Updates

### New Packages (2)

- [`kbrdn1/gwm-cli`](https://github.com/kbrdn1/gwm-cli)
- [`planetscale/ghcommit`](https://github.com/planetscale/ghcommit)

### Updated Packages (3)

- [`anthropics/claude-code`](https://github.com/anthropics/claude-code)
- [`skaji/relocatable-perl`](https://github.com/skaji/relocatable-perl)
- [`suzuki-shunsuke/tfrstate`](https://github.com/suzuki-shunsuke/tfrstate)