### PR TITLE
fix(windows): remove dangling runtime symlink pointer files on uninstall

### DIFF
--- a/e2e-win/uninstall_symlink.Tests.ps1
+++ b/e2e-win/uninstall_symlink.Tests.ps1
@@ -18,7 +18,7 @@ yq = "4.45.4"
         Remove-Item $cfg -ErrorAction Ignore
     }
 
-    # https://github.com/jdx/mise/discussions/5260 — on Windows, version
+    # https://github.com/jdx/mise/discussions/5260 - on Windows, version
     # pointer files (regular files containing the target path) were left
     # behind on uninstall because they never look like missing symlinks
     It 'removes stale version pointers when a version is uninstalled' {
@@ -35,7 +35,8 @@ yq = "4.45.4"
     }
 
     It 'removes the tool directory when the last version is uninstalled' {
-        mise uninstall yq@4.45.4
+        # --all keeps this independent of the previous test's uninstall
+        mise uninstall --all yq
         Test-Path $yqDir | Should -BeFalse
     }
 }

--- a/e2e-win/uninstall_symlink.Tests.ps1
+++ b/e2e-win/uninstall_symlink.Tests.ps1
@@ -1,0 +1,41 @@
+Describe 'uninstall runtime symlink cleanup' {
+
+    BeforeAll {
+        $cfg = ".\mise.local.toml"
+
+        $content = @"
+[tools]
+yq = "4.45.4"
+"@
+        $content | Out-File $cfg
+
+        mise install yq@4.44.3 yq@4.45.4
+        # derive the installs dir from a real install so any MISE_DATA_DIR works
+        $script:yqDir = Split-Path -Parent (mise where yq@4.45.4)
+    }
+
+    AfterAll {
+        Remove-Item $cfg -ErrorAction Ignore
+    }
+
+    # https://github.com/jdx/mise/discussions/5260 — on Windows, version
+    # pointer files (regular files containing the target path) were left
+    # behind on uninstall because they never look like missing symlinks
+    It 'removes stale version pointers when a version is uninstalled' {
+        Test-Path (Join-Path $yqDir "4.44") | Should -BeTrue
+
+        mise uninstall yq@4.44.3
+
+        Test-Path (Join-Path $yqDir "4.44.3") | Should -BeFalse
+        Test-Path (Join-Path $yqDir "4.44") | Should -BeFalse
+        # pointers for the remaining version are kept
+        Test-Path (Join-Path $yqDir "4.45") | Should -BeTrue
+        Test-Path (Join-Path $yqDir "latest") | Should -BeTrue
+        mise x yq@4.45.4 -- yq --version | Should -Match "4.45.4"
+    }
+
+    It 'removes the tool directory when the last version is uninstalled' {
+        mise uninstall yq@4.45.4
+        Test-Path $yqDir | Should -BeFalse
+    }
+}

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -234,8 +234,7 @@ fn remove_missing_symlinks_in_dir(installs_dir: &Path) -> Result<()> {
         // target, so `path.exists()` cannot detect a dangling pointer — resolve
         // the stored target and check that instead. On unix this is equivalent
         // to following the symlink. (#5260)
-        if is_runtime_symlink(&path)
-            && let Ok(Some(target)) = file::resolve_symlink(&path)
+        if let Some(target) = runtime_symlink_target(&path)
             && !installs_dir.join(target).exists()
         {
             trace!("Removing missing symlink: {}", path.display());
@@ -248,10 +247,18 @@ fn remove_missing_symlinks_in_dir(installs_dir: &Path) -> Result<()> {
 }
 
 pub fn is_runtime_symlink(path: &Path) -> bool {
-    if let Ok(Some(link)) = file::resolve_symlink(path) {
-        return link.starts_with("./");
+    runtime_symlink_target(path).is_some()
+}
+
+/// Returns the (relative) target a runtime symlink points to, or None if
+/// `path` is not a runtime symlink.
+fn runtime_symlink_target(path: &Path) -> Option<PathBuf> {
+    if let Ok(Some(link)) = file::resolve_symlink(path)
+        && link.starts_with("./")
+    {
+        return Some(link);
     }
-    false
+    None
 }
 
 #[cfg(test)]

--- a/src/runtime_symlinks.rs
+++ b/src/runtime_symlinks.rs
@@ -230,7 +230,14 @@ fn remove_missing_symlinks_in_dir(installs_dir: &Path) -> Result<()> {
     for entry in std::fs::read_dir(installs_dir)? {
         let entry = entry?;
         let path = entry.path();
-        if is_runtime_symlink(&path) && !path.exists() {
+        // On Windows runtime symlinks are regular files containing the relative
+        // target, so `path.exists()` cannot detect a dangling pointer — resolve
+        // the stored target and check that instead. On unix this is equivalent
+        // to following the symlink. (#5260)
+        if is_runtime_symlink(&path)
+            && let Ok(Some(target)) = file::resolve_symlink(&path)
+            && !installs_dir.join(target).exists()
+        {
             trace!("Removing missing symlink: {}", path.display());
             file::remove_file(path)?;
         }
@@ -245,4 +252,51 @@ pub fn is_runtime_symlink(path: &Path) -> bool {
         return link.starts_with("./");
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    // https://github.com/jdx/mise/discussions/5260 — on Windows runtime
+    // symlinks are regular files containing the target, so dangling pointers
+    // were never detected as missing.
+    #[test]
+    fn remove_missing_symlinks_in_dir_removes_dangling_pointers() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let installs_dir = temp_dir.path().join("installs").join("dummy");
+        fs::create_dir_all(installs_dir.join("1.0.0"))?;
+        // valid pointer -> concrete install
+        make_symlink_or_file(Path::new("./1.0.0"), &installs_dir.join("1"))?;
+        // dangling pointer -> version that no longer exists
+        make_symlink_or_file(Path::new("./2.0.0"), &installs_dir.join("2"))?;
+
+        remove_missing_symlinks_in_dir(&installs_dir)?;
+
+        // a dangling unix symlink still has metadata even though `exists()` is
+        // false, so this asserts actual removal on both platforms
+        assert!(fs::symlink_metadata(installs_dir.join("2")).is_err());
+        // concrete install and valid pointer retained
+        assert!(installs_dir.join("1.0.0").is_dir());
+        assert!(is_runtime_symlink(&installs_dir.join("1")));
+        Ok(())
+    }
+
+    #[test]
+    fn remove_missing_symlinks_in_dir_removes_dir_when_only_dangling_pointers_remain() -> Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let installs_dir = temp_dir.path().join("installs").join("dummy");
+        fs::create_dir_all(&installs_dir)?;
+        fs::write(installs_dir.join(".mise.backend.json"), "{}")?;
+        make_symlink_or_file(Path::new("./2.0.0"), &installs_dir.join("2"))?;
+        make_symlink_or_file(Path::new("./2.0.0"), &installs_dir.join("latest"))?;
+
+        remove_missing_symlinks_in_dir(&installs_dir)?;
+
+        // all pointers were dangling -> whole dir removed (metadata ignored)
+        assert!(!installs_dir.exists());
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- resolve a runtime symlink's stored target and check its existence when pruning dangling version pointers, instead of `path.exists()` on the pointer itself
- add unit coverage for `remove_missing_symlinks_in_dir` (none existed)
- add a Windows e2e test covering uninstall cleanup of pointer files

## Context
Fixes https://github.com/jdx/mise/discussions/5260.

On Windows, runtime "symlinks" (the partial-version pointers like `16`, `16.20`, `latest` in `installs\<tool>\`) are regular files containing the relative target path (`make_symlink_or_file`). The cleanup in `remove_missing_symlinks_in_dir` gated removal on `is_runtime_symlink(&path) && !path.exists()` — on unix `exists()` follows the real symlink and turns false once the target is gone, but on Windows the pointer is an ordinary file that always exists, so stale pointers were never removed after `mise uninstall`. The leftover files also kept `remove_dir_ignore` from removing the now-empty tool directory.

The fix resolves the stored target via `file::resolve_symlink` and checks that against the installs dir, which is exactly what `exists()` computed on unix (runtime symlink targets are always `./`-relative to the installs dir), so unix behavior is unchanged.

Reproduced on Windows 11 with v2026.7.7 in an isolated `MISE_DATA_DIR`:

```
> mise install yq@4.44.3 yq@4.45.4
> mise uninstall yq@4.44.3
# installs\yq afterwards still contains:
#   4.44  ->  .\4.44.3   (dangling pointer, target dir deleted)
```

## Tests
- `cargo fmt --check`
- new unit tests: `cargo test remove_missing_symlinks` (fail on Windows before the fix, pass after; pass on unix both before and after, documenting parity)
- new `e2e-win/uninstall_symlink.Tests.ps1`: installs two yq versions, uninstalls one, asserts the stale pointer is gone while the remaining version's pointers survive; then asserts the tool dir disappears when the last version is uninstalled

*This PR was prepared by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows uninstall cleanup for versioned tool installations.
  * Removed stale version pointers while preserving valid versions and the `latest` pointer.
  * Removed the tool’s installation directory when no versions remain.
* **Tests**
  * Added end-to-end and unit coverage for dangling runtime pointers and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->