### PR TITLE
fix(deps): update rust crate sigstore-verify to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3474,7 +3474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -8262,7 +8262,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -8278,9 +8278,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b51b097b7e9d898efad51e1031c855ce4008b4866d0c38ac8b0fac5745a84c"
+checksum = "5948e95f63e900fa92936ecf72c7f2251f83d27560a35a4aae560cc745f8b687"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8295,9 +8295,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1210ea5dd0dd07b1466449a6c5c79000f8ca10ac30b4e8f64031c3bed4c5c662"
+checksum = "22f27364b37bec104a904f10a675c8cdf05d5e48a980569368f0cd0c119b2652"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -8317,9 +8317,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae98f8a270885497dbe84e6dae10fa29066df0388f62980923728e38d844716"
+checksum = "0ee85fd9fb550efd7c8a59447cb0ef4eb02f1258f3ffa80c88d38427c3930af3"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8330,9 +8330,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1c153f4f89f7570d0f625f660cadcb1b2fba72583f378d2d2b308c752ac45f"
+checksum = "9b97c5a866f849a9445ae657bef0caa2db053a82827e6dae3a2b3de9c15a6a1a"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8348,9 +8348,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded6afc37295a10dba6569e033dd15f85f04f00980bfcf2c64009bc8ed279985"
+checksum = "389b54d1b8ace20ba86fdf90e5e655495f65f1abbc7d5d0eb7494defa9ad32f0"
 dependencies = [
  "base64 0.22.1",
  "directories",
@@ -8370,9 +8370,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88505b71600a791e52bed3777ed9cfeefd4b03dee6575d38c5542ae80e2bbdc"
+checksum = "b58fe92d4d8cf4b7215b927b70bc1245b6e0d70d801febdfe0cd265ad97ebf8b"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -8396,9 +8396,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tuf"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc7cced094bd306ef561312cfffa3ea05ac7eea4a62cfa81680c07a10addbc0"
+checksum = "eedac50883a917b7b434db22e2e6e853ace8c00f4a9c27f53e1e9c87e6d89fe4"
 dependencies = [
  "globset",
  "hex",
@@ -8418,9 +8418,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f034e86c3b8d91b32608c83f4a18939eed32c6ca08d17d2f52b88be365aac6"
+checksum = "236474c535a3157839926a0ae18f9c0c22b151e49634da6e5b18ad7cac8a3b69"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8432,9 +8432,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4720f300d093ecac6dcd75d4498fd1b2d9133600e679837bb9d944a4229eda7"
+checksum = "558f71aad0e1c5925d29ae2024f55f0f8898a7ad450c93668f99086624c421e0"
 dependencies = [
  "base64 0.22.1",
  "cms",
@@ -8835,7 +8835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/crates/mise-sigstore/Cargo.toml
+++ b/crates/mise-sigstore/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
-sigstore-verify = { version = "0.10.0", default-features = false }
+sigstore-verify = { version = "0.11.0", default-features = false }
 snap = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "time"] }

--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -706,17 +706,7 @@ pub async fn verify_cosign_signature_with_key(
         // Bundle path: needs the trust root for tlog (Rekor) verification.
         let trusted_root = production_trusted_root().await?;
         let artifact = tokio::fs::read(artifact_path).await?;
-        let result = sigstore_verify::verify_with_key(
-            artifact.as_slice(),
-            &bundle,
-            &public_key,
-            &trusted_root,
-        )?;
-        if !result.success {
-            return Err(AttestationError::Verification(
-                "sigstore verification returned false".to_string(),
-            ));
-        }
+        sigstore_verify::verify_with_key(artifact.as_slice(), &bundle, &public_key, &trusted_root)?;
         return Ok(true);
     }
 
@@ -1239,11 +1229,6 @@ fn verify_bundle<'a>(
         policy = policy.skip_sct();
     }
     let result = sigstore_verify::verify(artifact, bundle, &policy, trusted_root)?;
-    if !result.success {
-        return Err(AttestationError::Verification(
-            "sigstore verification returned false".to_string(),
-        ));
-    }
 
     verify_signer_workflow_identity(result.identity.as_deref(), signer_workflow)?;
 


### PR DESCRIPTION
## Summary

- update `sigstore-verify` from 0.10.0 to 0.11.0 using Renovate's commit unchanged
- adapt mise-sigstore to the 0.11 verification result semantics

## Root cause

`sigstore-verify` 0.11 removes `VerificationResult::success`. A successful verification now returns `Ok(VerificationResult)`, while verification failures return `Err`. The old field checks therefore prevented mise-sigstore from compiling.

## Validation

- `mise run lint-fix`
- `mise x cargo -- cargo test -p mise-sigstore --lib` (26 passed)

## Stack

Stacked on #11091. Target branch remains `main`. This branch carries Renovate commit `bce592f71` unchanged and adds the compatibility fix in a separate commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signature verification handling for key-based and bundle-based verification.
  * Verification errors are now reported more consistently, while successful validations continue directly to identity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->