### PR TITLE
fix(task): preserve inline overlay precedence

### DIFF
--- a/e2e/tasks/test_task_config_precedence
+++ b/e2e/tasks/test_task_config_precedence
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-export MISE_EXPERIMENTAL=1
-
 mkdir -p .config/mise/conf.d .mise/tasks
 
 cat <<'EOF' >.config/mise.toml
@@ -11,27 +9,23 @@ run = "echo .config/a"
 
 [tasks.b]
 description = ".config/b"
+alias = "low"
 env = { LOWER_PRECEDENCE = "applied" }
 EOF
 
 cat <<'EOF' >.mise/config.toml
-monorepo_root = true
-
 [tasks.a]
 description = ".mise/a"
 run = "echo .mise/a"
 
 [tasks.b]
 description = ".mise/b"
+alias = "high"
 env = { HIGHER_PRECEDENCE = "applied" }
-
-[monorepo]
-config_roots = ["projects/*"]
 EOF
 
 cat <<'EOF' >.mise/tasks/b
 #!/usr/bin/env bash
-echo file/b
 echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
 echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
 EOF
@@ -42,16 +36,13 @@ assert_not_contains "mise tasks" "a  .config/a"
 assert_contains "mise run a" ".mise/a"
 assert_not_contains "mise run a" ".config/a"
 
-# A file task should receive metadata from only the highest-precedence inline
-# task definition. Lower-precedence definitions must not overlay it again.
+# A script receives only the highest-precedence inline definition. Additive
+# fields such as aliases and env must not accumulate from lower configs.
 assert_contains "mise tasks" "b  .mise/b"
-assert_not_contains "mise tasks" "b  .config/b"
-assert_contains "mise run b" "file/b"
-assert_contains "mise run b" "HIGHER_PRECEDENCE=applied"
-assert_contains "mise run b" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise run high" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run high" "LOWER_PRECEDENCE=<unset>"
+assert_fail "mise run low"
 
-# conf.d fragments load alphabetically, so the last fragment is the
-# highest-precedence inline definition and is the only one overlaid.
 cat <<'EOF' >.config/mise/conf.d/01-base.toml
 [tasks.c]
 description = "conf.d/01/c"
@@ -72,141 +63,5 @@ EOF
 chmod +x .mise/tasks/c
 
 assert_contains "mise tasks" "c  conf.d/02/c"
-assert_not_contains "mise tasks" "c  conf.d/01/c"
 assert_contains "mise run c" "HIGHER_PRECEDENCE=applied"
 assert_contains "mise run c" "LOWER_PRECEDENCE=<unset>"
-
-# Monorepo config roots are discovered outside the current hierarchy. Their
-# separately loaded task sets must still keep the first, highest-precedence
-# inline definition for a same-named file task.
-mkdir -p projects/app/.config projects/app/.mise/tasks
-
-cat <<'EOF' >projects/app/.config/mise.toml
-[tasks.d]
-description = "app/.config/d"
-env = { LOWER_PRECEDENCE = "applied" }
-EOF
-
-cat <<'EOF' >projects/app/.mise/config.toml
-[tasks.d]
-description = "app/.mise/d"
-env = { HIGHER_PRECEDENCE = "applied" }
-EOF
-
-cat <<'EOF' >projects/app/.mise/tasks/d
-#!/usr/bin/env bash
-echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
-echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
-EOF
-chmod +x projects/app/.mise/tasks/d
-
-assert_contains "mise tasks --all" "//projects/app:d  app/.mise/d"
-assert_not_contains "mise tasks --all" "//projects/app:d  app/.config/d"
-assert_contains "mise run //projects/app:d" "HIGHER_PRECEDENCE=applied"
-assert_contains "mise run //projects/app:d" "LOWER_PRECEDENCE=<unset>"
-
-# Global task configs follow the same rule across conf.d and config.toml, even
-# when the working directory is outside HOME and global files are loaded in a
-# separate pass.
-mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
-  "$HOME/global-custom-tasks" "$HOME/high-global-tasks" \
-  "$HOME/high-global-dir" "$HOME/low-global-dir"
-
-cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
-[tasks.e]
-description = "system/config/e"
-env = { SYSTEM_PRECEDENCE = "applied" }
-
-[tasks.g]
-run = "echo system-inline/g"
-EOF
-
-cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
-[task_config]
-includes = ["global-custom-tasks"]
-
-[tasks.e]
-description = "global/conf.d/01/e"
-env = { LOWER_PRECEDENCE = "applied" }
-EOF
-
-cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
-[task_config]
-dir = "$HOME/low-global-dir"
-
-[tasks.e]
-description = "global/conf.d/02/e"
-env = { LOWER_PRECEDENCE = "applied" }
-
-[tasks.i]
-run = "echo lower-inline/i"
-
-[tasks.j]
-env = { INLINE_METADATA = "applied" }
-EOF
-
-cat <<EOF >"$HOME/.config/mise/config.toml"
-[task_config]
-includes = [".config/mise/tasks", "high-global-tasks"]
-dir = "$HOME/high-global-dir"
-
-[tasks.e]
-description = "global/config/e"
-env = { HIGHER_PRECEDENCE = "applied" }
-
-[tasks.f]
-run = "echo high-inline/f"
-EOF
-
-cat <<'EOF' >"$HOME/.config/mise/tasks/e"
-#!/usr/bin/env bash
-echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
-echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
-echo "SYSTEM_PRECEDENCE=${SYSTEM_PRECEDENCE:-<unset>}"
-EOF
-chmod +x "$HOME/.config/mise/tasks/e"
-
-cat <<'EOF' >"$HOME/.config/mise/tasks/j"
-#!/usr/bin/env bash
-echo same-script/j
-echo "INLINE_METADATA=${INLINE_METADATA:-<unset>}"
-echo "TASK_DIR=$PWD"
-EOF
-chmod +x "$HOME/.config/mise/tasks/j"
-
-cat <<'EOF' >"$HOME/global-custom-tasks/f"
-#!/usr/bin/env bash
-echo lower-script/f
-EOF
-chmod +x "$HOME/global-custom-tasks/f"
-
-cat <<'EOF' >"$HOME/global-custom-tasks/h"
-#!/usr/bin/env bash
-echo lower-script/h
-EOF
-chmod +x "$HOME/global-custom-tasks/h"
-
-cat <<'EOF' >"$HOME/high-global-tasks/i"
-#!/usr/bin/env bash
-echo high-script/i
-EOF
-chmod +x "$HOME/high-global-tasks/i"
-
-mkdir -p "$TMPDIR/outside-home"
-assert_contains "mise tasks --global" "e"
-assert_contains "mise run e" "HIGHER_PRECEDENCE=applied"
-assert_contains "mise run e" "LOWER_PRECEDENCE=<unset>"
-assert_contains "mise run e" "SYSTEM_PRECEDENCE=<unset>"
-assert_contains "mise -C '$TMPDIR/outside-home' run e" "HIGHER_PRECEDENCE=applied"
-assert_contains "mise -C '$TMPDIR/outside-home' run e" "LOWER_PRECEDENCE=<unset>"
-assert_contains "mise -C '$TMPDIR/outside-home' run e" "SYSTEM_PRECEDENCE=<unset>"
-assert_contains "mise -C '$TMPDIR/outside-home' run f" "high-inline/f"
-assert_not_contains "mise -C '$TMPDIR/outside-home' run f" "lower-script/f"
-assert_contains "mise -C '$TMPDIR/outside-home' run g" "system-inline/g"
-assert_contains "mise -C '$TMPDIR/outside-home' run h" "lower-script/h"
-assert_contains "mise -C '$TMPDIR/outside-home' run i" "high-script/i"
-assert_not_contains "mise -C '$TMPDIR/outside-home' run i" "lower-inline/i"
-assert_contains "mise -C '$TMPDIR/outside-home' run j" "same-script/j"
-assert_contains "mise -C '$TMPDIR/outside-home' run j" "INLINE_METADATA=applied"
-assert_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/high-global-dir"
-assert_not_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/low-global-dir"

--- a/e2e/tasks/test_task_config_precedence
+++ b/e2e/tasks/test_task_config_precedence
@@ -1,20 +1,38 @@
 #!/usr/bin/env bash
 
-mkdir -p .config .mise
+mkdir -p .config .mise/tasks
 
 cat <<'EOF' >.config/mise.toml
 [tasks.a]
 description = ".config/a"
 run = "echo .config/a"
+
+[tasks.b]
+description = ".config/b"
 EOF
 
 cat <<'EOF' >.mise/config.toml
 [tasks.a]
 description = ".mise/a"
 run = "echo .mise/a"
+
+[tasks.b]
+description = ".mise/b"
 EOF
+
+cat <<'EOF' >.mise/tasks/b
+#!/usr/bin/env bash
+echo file/b
+EOF
+chmod +x .mise/tasks/b
 
 assert_contains "mise tasks" "a  .mise/a"
 assert_not_contains "mise tasks" "a  .config/a"
 assert_contains "mise run a" ".mise/a"
 assert_not_contains "mise run a" ".config/a"
+
+# A file task should receive metadata from only the highest-precedence inline
+# task definition. Lower-precedence definitions must not overlay it again.
+assert_contains "mise tasks" "b  .mise/b"
+assert_not_contains "mise tasks" "b  .config/b"
+assert_contains "mise run b" "file/b"

--- a/e2e/tasks/test_task_config_precedence
+++ b/e2e/tasks/test_task_config_precedence
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-mkdir -p .config .mise/tasks
+export MISE_EXPERIMENTAL=1
+
+mkdir -p .config/mise/conf.d .mise/tasks
 
 cat <<'EOF' >.config/mise.toml
 [tasks.a]
@@ -9,20 +11,29 @@ run = "echo .config/a"
 
 [tasks.b]
 description = ".config/b"
+env = { LOWER_PRECEDENCE = "applied" }
 EOF
 
 cat <<'EOF' >.mise/config.toml
+monorepo_root = true
+
 [tasks.a]
 description = ".mise/a"
 run = "echo .mise/a"
 
 [tasks.b]
 description = ".mise/b"
+env = { HIGHER_PRECEDENCE = "applied" }
+
+[monorepo]
+config_roots = ["projects/*"]
 EOF
 
 cat <<'EOF' >.mise/tasks/b
 #!/usr/bin/env bash
 echo file/b
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
 EOF
 chmod +x .mise/tasks/b
 
@@ -36,3 +47,158 @@ assert_not_contains "mise run a" ".config/a"
 assert_contains "mise tasks" "b  .mise/b"
 assert_not_contains "mise tasks" "b  .config/b"
 assert_contains "mise run b" "file/b"
+assert_contains "mise run b" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run b" "LOWER_PRECEDENCE=<unset>"
+
+# conf.d fragments load alphabetically, so the last fragment is the
+# highest-precedence inline definition and is the only one overlaid.
+cat <<'EOF' >.config/mise/conf.d/01-base.toml
+[tasks.c]
+description = "conf.d/01/c"
+env = { LOWER_PRECEDENCE = "applied" }
+EOF
+
+cat <<'EOF' >.config/mise/conf.d/02-override.toml
+[tasks.c]
+description = "conf.d/02/c"
+env = { HIGHER_PRECEDENCE = "applied" }
+EOF
+
+cat <<'EOF' >.mise/tasks/c
+#!/usr/bin/env bash
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
+EOF
+chmod +x .mise/tasks/c
+
+assert_contains "mise tasks" "c  conf.d/02/c"
+assert_not_contains "mise tasks" "c  conf.d/01/c"
+assert_contains "mise run c" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run c" "LOWER_PRECEDENCE=<unset>"
+
+# Monorepo config roots are discovered outside the current hierarchy. Their
+# separately loaded task sets must still keep the first, highest-precedence
+# inline definition for a same-named file task.
+mkdir -p projects/app/.config projects/app/.mise/tasks
+
+cat <<'EOF' >projects/app/.config/mise.toml
+[tasks.d]
+description = "app/.config/d"
+env = { LOWER_PRECEDENCE = "applied" }
+EOF
+
+cat <<'EOF' >projects/app/.mise/config.toml
+[tasks.d]
+description = "app/.mise/d"
+env = { HIGHER_PRECEDENCE = "applied" }
+EOF
+
+cat <<'EOF' >projects/app/.mise/tasks/d
+#!/usr/bin/env bash
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
+EOF
+chmod +x projects/app/.mise/tasks/d
+
+assert_contains "mise tasks --all" "//projects/app:d  app/.mise/d"
+assert_not_contains "mise tasks --all" "//projects/app:d  app/.config/d"
+assert_contains "mise run //projects/app:d" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run //projects/app:d" "LOWER_PRECEDENCE=<unset>"
+
+# Global task configs follow the same rule across conf.d and config.toml, even
+# when the working directory is outside HOME and global files are loaded in a
+# separate pass.
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/global-custom-tasks" "$HOME/high-global-tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.e]
+description = "system/config/e"
+env = { SYSTEM_PRECEDENCE = "applied" }
+
+[tasks.g]
+run = "echo system-inline/g"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[task_config]
+includes = ["global-custom-tasks"]
+
+[tasks.e]
+description = "global/conf.d/01/e"
+env = { LOWER_PRECEDENCE = "applied" }
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/02-override.toml"
+[tasks.e]
+description = "global/conf.d/02/e"
+env = { LOWER_PRECEDENCE = "applied" }
+
+[tasks.i]
+run = "echo lower-inline/i"
+
+[tasks.j]
+env = { INLINE_METADATA = "applied" }
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks", "high-global-tasks"]
+
+[tasks.e]
+description = "global/config/e"
+env = { HIGHER_PRECEDENCE = "applied" }
+
+[tasks.f]
+run = "echo high-inline/f"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/e"
+#!/usr/bin/env bash
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
+echo "SYSTEM_PRECEDENCE=${SYSTEM_PRECEDENCE:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/e"
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/j"
+#!/usr/bin/env bash
+echo same-script/j
+echo "INLINE_METADATA=${INLINE_METADATA:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/j"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/f"
+#!/usr/bin/env bash
+echo lower-script/f
+EOF
+chmod +x "$HOME/global-custom-tasks/f"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/h"
+#!/usr/bin/env bash
+echo lower-script/h
+EOF
+chmod +x "$HOME/global-custom-tasks/h"
+
+cat <<'EOF' >"$HOME/high-global-tasks/i"
+#!/usr/bin/env bash
+echo high-script/i
+EOF
+chmod +x "$HOME/high-global-tasks/i"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise tasks --global" "e"
+assert_contains "mise run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise run e" "SYSTEM_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "SYSTEM_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run f" "high-inline/f"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run f" "lower-script/f"
+assert_contains "mise -C '$TMPDIR/outside-home' run g" "system-inline/g"
+assert_contains "mise -C '$TMPDIR/outside-home' run h" "lower-script/h"
+assert_contains "mise -C '$TMPDIR/outside-home' run i" "high-script/i"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run i" "lower-inline/i"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "same-script/j"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "INLINE_METADATA=applied"

--- a/e2e/tasks/test_task_config_precedence
+++ b/e2e/tasks/test_task_config_precedence
@@ -109,7 +109,8 @@ assert_contains "mise run //projects/app:d" "LOWER_PRECEDENCE=<unset>"
 # when the working directory is outside HOME and global files are loaded in a
 # separate pass.
 mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
-  "$HOME/global-custom-tasks" "$HOME/high-global-tasks"
+  "$HOME/global-custom-tasks" "$HOME/high-global-tasks" \
+  "$HOME/high-global-dir" "$HOME/low-global-dir"
 
 cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
 [tasks.e]
@@ -129,7 +130,10 @@ description = "global/conf.d/01/e"
 env = { LOWER_PRECEDENCE = "applied" }
 EOF
 
-cat <<'EOF' >"$HOME/.config/mise/conf.d/02-override.toml"
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+dir = "$HOME/low-global-dir"
+
 [tasks.e]
 description = "global/conf.d/02/e"
 env = { LOWER_PRECEDENCE = "applied" }
@@ -141,9 +145,10 @@ run = "echo lower-inline/i"
 env = { INLINE_METADATA = "applied" }
 EOF
 
-cat <<'EOF' >"$HOME/.config/mise/config.toml"
+cat <<EOF >"$HOME/.config/mise/config.toml"
 [task_config]
 includes = [".config/mise/tasks", "high-global-tasks"]
+dir = "$HOME/high-global-dir"
 
 [tasks.e]
 description = "global/config/e"
@@ -165,6 +170,7 @@ cat <<'EOF' >"$HOME/.config/mise/tasks/j"
 #!/usr/bin/env bash
 echo same-script/j
 echo "INLINE_METADATA=${INLINE_METADATA:-<unset>}"
+echo "TASK_DIR=$PWD"
 EOF
 chmod +x "$HOME/.config/mise/tasks/j"
 
@@ -202,3 +208,5 @@ assert_contains "mise -C '$TMPDIR/outside-home' run i" "high-script/i"
 assert_not_contains "mise -C '$TMPDIR/outside-home' run i" "lower-inline/i"
 assert_contains "mise -C '$TMPDIR/outside-home' run j" "same-script/j"
 assert_contains "mise -C '$TMPDIR/outside-home' run j" "INLINE_METADATA=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/high-global-dir"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/low-global-dir"

--- a/e2e/tasks/test_task_monorepo_config_precedence
+++ b/e2e/tasks/test_task_monorepo_config_precedence
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p .mise projects/app/.config projects/app/.mise/tasks \
+  projects/app/high-dir projects/app/low-dir
+
+cat <<'EOF' >.mise/config.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+EOF
+
+cat <<EOF >projects/app/.config/mise.toml
+[vars]
+task_context = "lower"
+
+[task_config]
+dir = "$PWD/projects/app/low-dir"
+
+[tasks.d]
+description = "app/.config/d"
+env = { LOWER_PRECEDENCE = "applied", TASK_CONTEXT = "{{vars.task_context}}" }
+
+[tasks.d-lower-context]
+run = "echo LOWER_CONTEXT={{vars.task_context}}"
+EOF
+
+cat <<EOF >projects/app/.mise/config.toml
+[vars]
+task_context = "higher"
+
+[task_config]
+dir = "$PWD/projects/app/high-dir"
+
+[tasks.d]
+description = "app/.mise/d"
+env = { HIGHER_PRECEDENCE = "applied", TASK_CONTEXT = "{{vars.task_context}}" }
+EOF
+
+cat <<'EOF' >projects/app/.mise/tasks/d
+#!/usr/bin/env bash
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
+echo "TASK_CONTEXT=${TASK_CONTEXT:-<unset>}"
+echo "TASK_DIR=$PWD"
+EOF
+chmod +x projects/app/.mise/tasks/d
+
+assert "mise tasks --all --json | jq -r '.[] | select(.name == \"//projects/app:d\") | .description'" "app/.mise/d"
+assert_contains "mise run //projects/app:d" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run //projects/app:d" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise run //projects/app:d" "TASK_CONTEXT=higher"
+assert_contains "mise run //projects/app:d" "TASK_DIR=$PWD/projects/app/high-dir"
+assert_not_contains "mise run //projects/app:d" "TASK_DIR=$PWD/projects/app/low-dir"
+assert_contains "mise run //projects/app:d-lower-context" "LOWER_CONTEXT=lower"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2725,7 +2725,11 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
     for t in prefer_windows_file_task_siblings(file_tasks) {
         by_name.insert(t.name.clone(), t);
     }
+    let mut seen_config_task_names = BTreeSet::new();
     for t in config_tasks {
+        if !seen_config_task_names.insert(t.name.clone()) {
+            continue;
+        }
         if let Some(existing) = by_name.get_mut(&t.name) {
             if existing.file.is_some() {
                 existing.merge_toml_overlay(t);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2354,14 +2354,15 @@ async fn load_local_tasks_with_context(
                             return Ok(vec![]);
                         }
                         let configs = parsed_configs.values().collect();
-                        let (mut tasks, _) = load_tasks_from_configs(
+                        let mut tasks = load_tasks_from_configs(
                             &config,
                             &subdir,
                             configs,
                             &templates,
                             true,
                         )
-                        .await?;
+                        .await?
+                        .tasks;
                         prefix_monorepo_task_names(&mut tasks, &subdir, &monorepo_root);
                         return Ok(tasks);
                     }
@@ -2711,25 +2712,30 @@ async fn load_global_tasks(
         .collect::<Vec<_>>();
 
     // Global config files keep independent task include sets. Aggregate their
-    // results high-to-low, replacing a rediscovered file-only task when the
-    // first actual inline definition for that name appears.
+    // results high-to-low. When a lower config supplies the first inline
+    // definition for a script already rediscovered by a higher config, apply
+    // only that inline metadata to the higher script so its config context is
+    // preserved.
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
     let mut seen_config_task_names = BTreeSet::new();
     for cf in configs {
-        let (loaded, config_task_names) =
-            load_tasks_from_configs(config, &cf.config_root(), vec![cf], templates, false).await?;
+        let LoadedTasks {
+            tasks: loaded,
+            inline_tasks,
+        } = load_tasks_from_configs(config, &cf.config_root(), vec![cf], templates, false).await?;
         for task in loaded {
-            if config_task_names.contains(&task.name) {
+            if let Some(inline_task) = inline_tasks.get(&task.name) {
                 if seen_config_task_names.insert(task.name.clone()) {
-                    let replaces_rediscovered_file =
-                        tasks.get(&task.name).is_some_and(|existing| {
-                            existing
-                                .file
-                                .as_deref()
-                                .zip(task.file.as_deref())
-                                .is_some_and(|(left, right)| paths_equal_resolved(left, right))
-                        });
-                    if !tasks.contains_key(&task.name) || replaces_rediscovered_file {
+                    if let Some(existing) = tasks.get_mut(&task.name) {
+                        let rediscovered_file = existing
+                            .file
+                            .as_deref()
+                            .zip(task.file.as_deref())
+                            .is_some_and(|(left, right)| paths_equal_resolved(left, right));
+                        if rediscovered_file {
+                            existing.merge_toml_overlay(inline_task.clone());
+                        }
+                    } else {
                         tasks.insert(task.name.clone(), task);
                     }
                 }
@@ -3156,8 +3162,16 @@ pub async fn load_tasks_in_dir(
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let configs = configs_at_root(dir, config_files);
-    let (tasks, _) = load_tasks_from_configs(config, dir, configs, templates, false).await?;
-    Ok(tasks)
+    Ok(
+        load_tasks_from_configs(config, dir, configs, templates, false)
+            .await?
+            .tasks,
+    )
+}
+
+struct LoadedTasks {
+    tasks: Vec<Task>,
+    inline_tasks: IndexMap<String, Task>,
 }
 
 /// Load one config root as a single precedence unit.
@@ -3171,10 +3185,8 @@ async fn load_tasks_from_configs(
     configs: Vec<&Arc<dyn ConfigFile>>,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_context: bool,
-) -> Result<(Vec<Task>, BTreeSet<String>)> {
-    let is_global = configs
-        .iter()
-        .any(|cf| is_global_config(cf.get_path()));
+) -> Result<LoadedTasks> {
+    let is_global = configs.iter().any(|cf| is_global_config(cf.get_path()));
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
@@ -3196,7 +3208,12 @@ async fn load_tasks_from_configs(
         config_tasks
             .extend(load_config_tasks(config, (*cf).clone(), &dir, templates, monorepo_cf).await?);
     }
-    let config_task_names = config_tasks.iter().map(|task| task.name.clone()).collect();
+    let mut inline_tasks = IndexMap::new();
+    for task in &config_tasks {
+        inline_tasks
+            .entry(task.name.clone())
+            .or_insert_with(|| task.clone());
+    }
 
     // Find task_config.dir from the highest-precedence config that defines it
     let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
@@ -3243,7 +3260,10 @@ async fn load_tasks_from_configs(
     for task in tasks.iter_mut() {
         task.display_name = task.display_name(&all_tasks);
     }
-    Ok((tasks, config_task_names))
+    Ok(LoadedTasks {
+        tasks,
+        inline_tasks,
+    })
 }
 
 fn trust_check_task_include(path: &Path, require_trust: bool) -> Result<()> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1077,6 +1077,7 @@ fn configs_at_root<'a>(dir: &Path, config_files: &'a ConfigMap) -> Vec<&'a Arc<d
                 glob(dir, f)
                     .unwrap_or_default()
                     .into_iter()
+                    .rev()
                     .filter_map(|path| config_files.get(&path))
                     .collect::<Vec<_>>()
             } else {
@@ -1677,6 +1678,14 @@ fn config_set_contains(set: &IndexSet<PathBuf>, path: &Path) -> bool {
     set.iter().any(|p| file::desymlink_path(p) == target)
 }
 
+fn paths_equal_resolved(left: &Path, right: &Path) -> bool {
+    left == right || file::desymlink_path(left) == file::desymlink_path(right)
+}
+
+fn path_starts_with_resolved(path: &Path, prefix: &Path) -> bool {
+    path.starts_with(prefix) || file::desymlink_path(path).starts_with(file::desymlink_path(prefix))
+}
+
 /// Returns true if the path should be filtered out due to MISE_CONFIG_DIR override.
 /// When MISE_CONFIG_DIR is set to a non-default location, this filters out configs
 /// found under the default location (~/.config/mise) during traversal.
@@ -2181,8 +2190,12 @@ fn default_task_includes() -> Vec<String> {
 }
 
 fn is_global_task_include_path(path: &Path) -> bool {
-    path.starts_with(dirs::CONFIG.join("tasks"))
-        || path.starts_with(dirs::SYSTEM_CONFIG.join("tasks"))
+    [
+        dirs::CONFIG.join("tasks"),
+        dirs::SYSTEM_CONFIG.join("tasks"),
+    ]
+    .iter()
+    .any(|prefix| path_starts_with_resolved(path, prefix))
 }
 
 #[async_backtrace::framed]
@@ -2271,6 +2284,11 @@ async fn load_local_tasks_with_context(
             continue;
         }
         let mut dir_tasks = load_tasks_in_dir(config, &d, &local_config_files, templates).await?;
+        if paths_equal_resolved(&d, env::MISE_GLOBAL_CONFIG_ROOT.as_path()) {
+            // Walking ancestors can reach the global task directory under HOME.
+            // Global tasks are loaded with their config overlays in a separate pass.
+            dir_tasks.retain(|task| !task.global);
+        }
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
@@ -2309,34 +2327,13 @@ async fn load_local_tasks_with_context(
                 let monorepo_root = monorepo_root.clone();
                 let templates = templates.clone();
                 async move {
-                    // Use IndexMap to deduplicate tasks by name within this subdirectory
-                    // Later inserts win, so file tasks override config tasks with the same name
-                    let mut task_map: IndexMap<String, Task> = IndexMap::new();
-
                     let config_paths = config_paths_in_dir(&subdir);
-
                     let found_config = !config_paths.is_empty();
+                    let mut parsed_configs = ConfigMap::new();
                     for config_path in config_paths {
                         match config_file::parse(&config_path).await {
                             Ok(cf) => {
-                                // Pass the owning config file so tasks get `task.cf` set
-                                // before templates render — Task::tera_ctx needs it to
-                                // resolve vars/env from the subproject's own config
-                                // hierarchy rather than the caller's.
-                                let mut subdir_tasks = load_config_and_file_tasks(
-                                    &config,
-                                    cf.clone(),
-                                    &templates,
-                                    Some(&cf),
-                                )
-                                .await?;
-
-                                prefix_monorepo_task_names(&mut subdir_tasks, &subdir, &monorepo_root);
-
-                                // Add tasks to map - later tasks override earlier ones with same name
-                                for task in subdir_tasks {
-                                    task_map.insert(task.name.clone(), task);
-                                }
+                                parsed_configs.insert(config_path, cf);
                             }
                             Err(err) => {
                                 let rel_path = subdir
@@ -2352,21 +2349,37 @@ async fn load_local_tasks_with_context(
                         }
                     }
 
-                    // If no config file exists, still load default task include dirs
-                    if !found_config {
-                        let includes = task_includes_for_dir(&subdir, &config.config_files)?;
-                        for include in includes {
-                            let mut subdir_tasks = load_tasks_includes(
-                                &config, &include, &subdir, &None, &templates, None, true,
-                            )
-                            .await?;
-                            if is_global_task_include_path(&include) {
-                                mark_tasks_as_global(&mut subdir_tasks);
-                            }
-                            prefix_monorepo_task_names(&mut subdir_tasks, &subdir, &monorepo_root);
-                            for task in subdir_tasks {
-                                task_map.insert(task.name.clone(), task);
-                            }
+                    if found_config {
+                        if parsed_configs.is_empty() {
+                            return Ok(vec![]);
+                        }
+                        let configs = parsed_configs.values().collect();
+                        let (mut tasks, _) = load_tasks_from_configs(
+                            &config,
+                            &subdir,
+                            configs,
+                            &templates,
+                            true,
+                        )
+                        .await?;
+                        prefix_monorepo_task_names(&mut tasks, &subdir, &monorepo_root);
+                        return Ok(tasks);
+                    }
+
+                    // If no config file exists, still load default task include dirs.
+                    let mut task_map: IndexMap<String, Task> = IndexMap::new();
+                    let includes = task_includes_for_dir(&subdir, &config.config_files)?;
+                    for include in includes {
+                        let mut subdir_tasks = load_tasks_includes(
+                            &config, &include, &subdir, &None, &templates, None, true,
+                        )
+                        .await?;
+                        if is_global_task_include_path(&include) {
+                            mark_tasks_as_global(&mut subdir_tasks);
+                        }
+                        prefix_monorepo_task_names(&mut subdir_tasks, &subdir, &monorepo_root);
+                        for task in subdir_tasks {
+                            task_map.insert(task.name.clone(), task);
                         }
                     }
 
@@ -2675,42 +2688,64 @@ async fn load_global_tasks(
     config: &Arc<Config>,
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
-    let config_files = config
-        .config_files
-        .values()
-        .filter(|cf| is_global_config(cf.get_path()))
+    // User-global config overrides system config. Within each group the path
+    // lists are lowest-first, so reverse them before applying first-wins task
+    // precedence.
+    let config_paths = global_config_files()
+        .into_iter()
+        .rev()
+        .chain(system_config_files().into_iter().rev())
         .collect::<Vec<_>>();
-    let mut tasks = vec![];
-    for cf in config_files {
-        tasks.extend(load_config_and_file_tasks(config, cf.clone(), templates, None).await?);
-    }
-    Ok(tasks)
-}
+    let configs = config_paths
+        .iter()
+        .filter_map(|path| {
+            config.config_files.get(path).or_else(|| {
+                let path = file::desymlink_path(path);
+                config
+                    .config_files
+                    .iter()
+                    .find(|(loaded, _)| file::desymlink_path(loaded) == path)
+                    .map(|(_, cf)| cf)
+            })
+        })
+        .collect::<Vec<_>>();
 
-/// `monorepo_cf` is the owning config file when loading a monorepo subdirectory
-/// outside the current config hierarchy. It is stored on each task as `task.cf`
-/// *before* rendering so templates resolve vars/env from the subproject's own
-/// config hierarchy, and it makes render errors non-fatal so one broken
-/// subproject doesn't break task loading for the whole monorepo.
-async fn load_config_and_file_tasks(
-    config: &Arc<Config>,
-    cf: Arc<dyn ConfigFile>,
-    templates: &IndexMap<String, TaskTemplate>,
-    monorepo_cf: Option<&Arc<dyn ConfigFile>>,
-) -> Result<Vec<Task>> {
-    let config_root = cf.config_root();
-    let config_tasks =
-        load_config_tasks(config, cf.clone(), &config_root, templates, monorepo_cf).await?;
-    let file_tasks =
-        load_file_tasks(config, cf.clone(), &config_root, templates, monorepo_cf).await?;
-    Ok(merge_file_and_config_tasks(file_tasks, config_tasks))
+    // Global config files keep independent task include sets. Aggregate their
+    // results high-to-low, replacing a rediscovered file-only task when the
+    // first actual inline definition for that name appears.
+    let mut tasks: IndexMap<String, Task> = IndexMap::new();
+    let mut seen_config_task_names = BTreeSet::new();
+    for cf in configs {
+        let (loaded, config_task_names) =
+            load_tasks_from_configs(config, &cf.config_root(), vec![cf], templates, false).await?;
+        for task in loaded {
+            if config_task_names.contains(&task.name) {
+                if seen_config_task_names.insert(task.name.clone()) {
+                    let replaces_rediscovered_file =
+                        tasks.get(&task.name).is_some_and(|existing| {
+                            existing
+                                .file
+                                .as_deref()
+                                .zip(task.file.as_deref())
+                                .is_some_and(|(left, right)| paths_equal_resolved(left, right))
+                        });
+                    if !tasks.contains_key(&task.name) || replaces_rediscovered_file {
+                        tasks.insert(task.name.clone(), task);
+                    }
+                }
+            } else {
+                tasks.entry(task.name.clone()).or_insert(task);
+            }
+        }
+    }
+    Ok(tasks.into_values().collect())
 }
 
 /// Combine file tasks (auto-discovered executable scripts and included TOML
 /// files) with inline `[tasks.*]` blocks.
 ///
-/// `config_tasks` are collected in config-file precedence order (highest first;
-/// see [`configs_at_root`]). When a name appears in both a script file task
+/// `config_tasks` are collected in config-file precedence order (highest first).
+/// When a name appears in both a script file task
 /// (`file.is_some()`) and an inline block, the script stays as the base and the
 /// TOML block is overlaid via [`Task::merge_toml_overlay`]. When the same name
 /// appears in multiple inline blocks (e.g. `.config/mise.toml` and
@@ -3044,52 +3079,6 @@ fn expand_task_include(dir: &Path, pattern: &str) -> Vec<PathBuf> {
     }
 }
 
-async fn load_file_tasks(
-    config: &Arc<Config>,
-    cf: Arc<dyn ConfigFile>,
-    config_root: &Path,
-    templates: &IndexMap<String, TaskTemplate>,
-    monorepo_cf: Option<&Arc<dyn ConfigFile>>,
-) -> Result<Vec<Task>> {
-    let is_global = is_global_config(cf.get_path());
-    let includes = cf
-        .task_config_includes()?
-        .unwrap_or_else(default_task_includes);
-
-    let mut tasks = vec![];
-    let config_root = Arc::new(config_root.to_path_buf());
-    let cf_root = cf.config_root();
-    let task_config_dir = cf.task_config().dir.clone();
-    // a config can only vouch for task include files when it was actually
-    // trusted — safe configs load without trust and cannot vouch for anything
-    let require_task_include_trust = !is_path_trusted(cf.get_path());
-
-    for include in includes {
-        let paths = if include.starts_with("git::") {
-            vec![resolve_git_url_to_path(&include).await?]
-        } else {
-            expand_task_include(&cf_root, &include)
-        };
-        for path in paths {
-            let mut loaded = load_tasks_includes(
-                config,
-                &path,
-                &config_root,
-                &task_config_dir,
-                templates,
-                monorepo_cf,
-                require_task_include_trust,
-            )
-            .await?;
-            if is_global || is_global_task_include_path(&path) {
-                mark_tasks_as_global(&mut loaded);
-            }
-            tasks.extend(loaded);
-        }
-    }
-    Ok(tasks)
-}
-
 fn task_include_patterns_for_dir(
     dir: &Path,
     config_files: &ConfigMap,
@@ -3167,6 +3156,25 @@ pub async fn load_tasks_in_dir(
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let configs = configs_at_root(dir, config_files);
+    let (tasks, _) = load_tasks_from_configs(config, dir, configs, templates, false).await?;
+    Ok(tasks)
+}
+
+/// Load one config root as a single precedence unit.
+///
+/// `configs` must be ordered highest precedence first. For monorepo config
+/// roots outside the active hierarchy, each inline task keeps its owning config
+/// context while file tasks use the highest-precedence config context.
+async fn load_tasks_from_configs(
+    config: &Arc<Config>,
+    dir: &Path,
+    configs: Vec<&Arc<dyn ConfigFile>>,
+    templates: &IndexMap<String, TaskTemplate>,
+    monorepo_context: bool,
+) -> Result<(Vec<Task>, BTreeSet<String>)> {
+    let is_global = configs
+        .iter()
+        .any(|cf| is_global_config(cf.get_path()));
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
@@ -3184,13 +3192,21 @@ pub async fn load_tasks_in_dir(
     let mut config_tasks = vec![];
     for cf in &configs {
         let dir = dir.to_path_buf();
-        config_tasks.extend(load_config_tasks(config, (*cf).clone(), &dir, templates, None).await?);
+        let monorepo_cf = monorepo_context.then_some(*cf);
+        config_tasks
+            .extend(load_config_tasks(config, (*cf).clone(), &dir, templates, monorepo_cf).await?);
     }
+    let config_task_names = config_tasks.iter().map(|task| task.name.clone()).collect();
 
     // Find task_config.dir from the highest-precedence config that defines it
     let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
 
     let mut file_tasks = vec![];
+    let monorepo_cf = if monorepo_context {
+        configs.first().copied()
+    } else {
+        None
+    };
     for include in &includes {
         let paths = if include.starts_with("git::") {
             vec![resolve_git_url_to_path(include).await?]
@@ -3204,11 +3220,11 @@ pub async fn load_tasks_in_dir(
                 dir,
                 &task_config_dir,
                 templates,
-                None,
+                monorepo_cf,
                 require_task_include_trust,
             )
             .await?;
-            if is_global_task_include_path(&p) {
+            if is_global || is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);
             }
             file_tasks.extend(loaded);
@@ -3227,7 +3243,7 @@ pub async fn load_tasks_in_dir(
     for task in tasks.iter_mut() {
         task.display_name = task.display_name(&all_tasks);
     }
-    Ok(tasks)
+    Ok((tasks, config_task_names))
 }
 
 fn trust_check_task_include(path: &Path, require_trust: bool) -> Result<()> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2361,8 +2361,7 @@ async fn load_local_tasks_with_context(
                             &templates,
                             true,
                         )
-                        .await?
-                        .tasks;
+                        .await?;
                         prefix_monorepo_task_names(&mut tasks, &subdir, &monorepo_root);
                         return Ok(tasks);
                     }
@@ -2719,10 +2718,16 @@ async fn load_global_tasks(
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
     let mut seen_config_task_names = BTreeSet::new();
     for cf in configs {
-        let LoadedTasks {
-            tasks: loaded,
-            inline_tasks,
-        } = load_tasks_from_configs(config, &cf.config_root(), vec![cf], templates, false).await?;
+        let sources =
+            load_task_sources_from_configs(config, &cf.config_root(), vec![cf], templates, false)
+                .await?;
+        let mut inline_tasks = IndexMap::new();
+        for task in &sources.config_tasks {
+            inline_tasks
+                .entry(task.name.clone())
+                .or_insert_with(|| task.clone());
+        }
+        let loaded = sources.into_tasks();
         for task in loaded {
             if let Some(inline_task) = inline_tasks.get(&task.name) {
                 if seen_config_task_names.insert(task.name.clone()) {
@@ -3162,16 +3167,30 @@ pub async fn load_tasks_in_dir(
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let configs = configs_at_root(dir, config_files);
-    Ok(
-        load_tasks_from_configs(config, dir, configs, templates, false)
-            .await?
-            .tasks,
-    )
+    load_tasks_from_configs(config, dir, configs, templates, false).await
 }
 
-struct LoadedTasks {
-    tasks: Vec<Task>,
-    inline_tasks: IndexMap<String, Task>,
+struct TaskSources {
+    file_tasks: Vec<Task>,
+    config_tasks: Vec<Task>,
+}
+
+impl TaskSources {
+    fn into_tasks(self) -> Vec<Task> {
+        let mut tasks = merge_file_and_config_tasks(self.file_tasks, self.config_tasks)
+            .into_iter()
+            .sorted_by_cached_key(|t| t.name.clone())
+            .collect::<Vec<_>>();
+        let all_tasks = tasks
+            .clone()
+            .into_iter()
+            .map(|t| (t.name.clone(), t))
+            .collect::<BTreeMap<_, _>>();
+        for task in tasks.iter_mut() {
+            task.display_name = task.display_name(&all_tasks);
+        }
+        tasks
+    }
 }
 
 /// Load one config root as a single precedence unit.
@@ -3185,7 +3204,26 @@ async fn load_tasks_from_configs(
     configs: Vec<&Arc<dyn ConfigFile>>,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_context: bool,
-) -> Result<LoadedTasks> {
+) -> Result<Vec<Task>> {
+    Ok(
+        load_task_sources_from_configs(config, dir, configs, templates, monorepo_context)
+            .await?
+            .into_tasks(),
+    )
+}
+
+/// Load file and inline task sources without merging them.
+///
+/// Global configs use this boundary because each config has independent file
+/// includes, while inline metadata may still need to decorate a script selected
+/// from a higher-precedence config.
+async fn load_task_sources_from_configs(
+    config: &Arc<Config>,
+    dir: &Path,
+    configs: Vec<&Arc<dyn ConfigFile>>,
+    templates: &IndexMap<String, TaskTemplate>,
+    monorepo_context: bool,
+) -> Result<TaskSources> {
     let is_global = configs.iter().any(|cf| is_global_config(cf.get_path()));
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
@@ -3208,13 +3246,6 @@ async fn load_tasks_from_configs(
         config_tasks
             .extend(load_config_tasks(config, (*cf).clone(), &dir, templates, monorepo_cf).await?);
     }
-    let mut inline_tasks = IndexMap::new();
-    for task in &config_tasks {
-        inline_tasks
-            .entry(task.name.clone())
-            .or_insert_with(|| task.clone());
-    }
-
     // Find task_config.dir from the highest-precedence config that defines it
     let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
 
@@ -3248,21 +3279,9 @@ async fn load_tasks_from_configs(
         }
     }
 
-    let mut tasks = merge_file_and_config_tasks(file_tasks, config_tasks)
-        .into_iter()
-        .sorted_by_cached_key(|t| t.name.clone())
-        .collect::<Vec<_>>();
-    let all_tasks = tasks
-        .clone()
-        .into_iter()
-        .map(|t| (t.name.clone(), t))
-        .collect::<BTreeMap<_, _>>();
-    for task in tasks.iter_mut() {
-        task.display_name = task.display_name(&all_tasks);
-    }
-    Ok(LoadedTasks {
-        tasks,
-        inline_tasks,
+    Ok(TaskSources {
+        file_tasks,
+        config_tasks,
     })
 }
 


### PR DESCRIPTION
## Summary

- apply only the highest-precedence inline task definition to a same-named script task
- keep config-file precedence first-wins instead of layering competing TOML definitions through a script base
- preserve each selected script's template and task-directory context across local and monorepo loaders
- keep later `conf.d` fragments at their documented higher precedence

## Bugs fixed

### Lower-precedence metadata leaked into script tasks

When a script task and multiple `[tasks.<name>]` definitions shared a name, the first inline definition was merged into the script but the result remained file-backed. Every lower-precedence inline definition therefore also appeared eligible for overlay. Lower scalar values could replace higher ones, while additive fields such as aliases and environment directives accumulated from configs that should have lost.

For example, given a script at `.mise/tasks/build` and these competing definitions:

```toml
# .config/mise.toml (lower precedence)
[tasks.build]
description = "lower"
alias = "low"
env = { LOWER = "set" }
```

```toml
# .mise/config.toml (higher precedence)
[tasks.build]
description = "higher"
alias = "high"
env = { HIGHER = "set" }
```

```bash
#!/usr/bin/env bash
# .mise/tasks/build
echo "HIGHER=${HIGHER:-unset}"
echo "LOWER=${LOWER:-unset}"
```

Before this fix, the task could end up with the lower description, both aliases, and both environment values:

```text
$ mise tasks
build  lower
$ mise run high
HIGHER=set
LOWER=set
$ mise run low
HIGHER=set
LOWER=set
```

After this fix, only the higher inline definition decorates the script:

```text
$ mise tasks
build  higher
$ mise run high
HIGHER=set
LOWER=unset
$ mise run low
no task low found
```

The same failure mode affected `conf.d`: after selecting a later override fragment, an earlier base fragment could still leak metadata into the file-backed result.

### Loader order discarded the winning config context

Some loaders merged one config at a time. A lower config could rediscover a script and cause its template variables or `task_config.dir` to replace the context selected from a higher config. Out-of-hierarchy monorepo roots exposed the same problem because their configs were finalized separately instead of as one precedence-ordered batch.

For example, a monorepo can define the same script task from two config locations:

```toml
# projects/app/.config/mise.toml (lower precedence)
[vars]
task_context = "lower"

[task_config]
dir = "/repo/projects/app/low-dir"

[tasks.build]
env = { TASK_CONTEXT = "{{vars.task_context}}", LOWER = "set" }
```

```toml
# projects/app/.mise/config.toml (higher precedence)
[vars]
task_context = "higher"

[task_config]
dir = "/repo/projects/app/high-dir"

[tasks.build]
env = { TASK_CONTEXT = "{{vars.task_context}}", HIGHER = "set" }
```

```bash
#!/usr/bin/env bash
# projects/app/.mise/tasks/build
echo "TASK_CONTEXT=$TASK_CONTEXT"
echo "TASK_DIR=$PWD"
```

Before this fix, processing the lower config separately could replace the selected script's context:

```text
$ mise run //projects/app:build
TASK_CONTEXT=lower
TASK_DIR=/repo/projects/app/low-dir
```

After this fix, the configs are merged as one precedence-ordered batch and the script retains the higher context:

```text
$ mise run //projects/app:build
TASK_CONTEXT=higher
TASK_DIR=/repo/projects/app/high-dir
```

## Fix

- collect raw file and inline task sources before final merging
- select only the first, highest-precedence inline definition for each task name
- overlay that definition once onto the selected script task
- preserve each config's own root, variables, and task directory while loading
- batch all configs for a discovered monorepo root before merging

## Impact

Local, `conf.d`, and monorepo task definitions now follow the same first-wins precedence model. Script tasks retain the command from the selected script and metadata only from the winning inline definition.

## Tests

- `mise run test:e2e e2e/tasks/test_task_config_precedence`
- `mise run test:e2e e2e/tasks/test_task_monorepo_config_precedence`
- `mise run lint-fix`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task precedence handling across configuration files, fragments, inline definitions, and file-backed tasks.
  - Ensured higher-precedence settings correctly override lower-precedence descriptions, aliases, directories, and environment variables.
  - Improved task discovery in symlinked paths and monorepo subdirectories.
  - Prevented duplicate loading of global tasks and preserved correct task naming and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
