### PR TITLE
chore(nix): remove unused inputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, fetchFromGitHub, rustPlatform, coreutils, bash, direnv, openssl, git }:
+{ pkgs, lib, rustPlatform, coreutils, bash, direnv, openssl, git }:
 
 rustPlatform.buildRustPackage {
   pname = "mise";

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
             inputsFrom = [ mise ];
 
             nativeBuildInputs = with pkgs; [
-              just
               clippy
               rustfmt
               shellcheck


### PR DESCRIPTION
## Summary

- remove just from the Nix development shell
- remove the unused fetchFromGitHub argument from default.nix
- keep the remaining Nix build and development inputs unchanged

## Why

The repository migrated its Justfile tasks to mise in 2024 and deleted the Justfile, so the development shell no longer uses just. The package source is taken directly from the repository with lib.cleanSource, leaving fetchFromGitHub unused in the default.nix function interface.

## Impact

The Nix development shell installs one fewer unused tool, and default.nix no longer requests an unused callPackage input. Build and runtime behavior are unchanged.

## Validation

- mise run lint-fix
- git diff --check

Nix is not installed in the local validation environment, so flake evaluation was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default development environment toolset by removing the Just command runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->