### PR TITLE
fix(task): mark global config file tasks as global

### DIFF
--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -19,13 +19,27 @@ cat <<'EOF' >~/dotfiles/tasks/customglobalfile
 echo "PROJECT_ROOT=$MISE_PROJECT_ROOT"
 EOF
 chmod +x ~/dotfiles/tasks/customglobalfile
+mkdir -p "$PWD/system-config" "$PWD/system-tasks"
+cat >"$PWD/system-config/config.toml" <<EOF
+[task_config]
+includes = ["$PWD/system-tasks"]
+EOF
+cat <<'EOF' >"$PWD/system-tasks/systemglobalfile"
+#!/usr/bin/env bash
+echo "PROJECT_ROOT=$MISE_PROJECT_ROOT"
+EOF
+chmod +x "$PWD/system-tasks/systemglobalfile"
+export MISE_SYSTEM_CONFIG_FILE="$PWD/system-config/config.toml"
 
 assert "mise tasks" "customglobalfile
 myglobal
 myglobalfile
-mylocal"
+mylocal
+systemglobalfile"
 assert "mise tasks --local" "mylocal"
 assert "mise tasks --global" "customglobalfile
 myglobal
-myglobalfile"
+myglobalfile
+systemglobalfile"
 assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"
+assert "mise run systemglobalfile" "PROJECT_ROOT=$PWD"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -1,17 +1,31 @@
 #!/usr/bin/env bash
 
 echo "tasks.mylocal = { run = 'echo mylocal' }" >mise.toml
-echo "tasks.myglobal = { run = 'echo myglobal' }" >~/.config/mise/config.toml
+cat >~/.config/mise/config.toml <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = [".config/mise/tasks", "dotfiles/tasks"]
+TOML
 mkdir -p ~/.config/mise/tasks
 cat <<'EOF' >~/.config/mise/tasks/myglobalfile
 #!/usr/bin/env bash
 echo myglobalfile
 EOF
 chmod +x ~/.config/mise/tasks/myglobalfile
+mkdir -p ~/dotfiles/tasks
+cat <<'EOF' >~/dotfiles/tasks/customglobalfile
+#!/usr/bin/env bash
+echo "PROJECT_ROOT=$MISE_PROJECT_ROOT"
+EOF
+chmod +x ~/dotfiles/tasks/customglobalfile
 
-assert "mise tasks" "myglobal
+assert "mise tasks" "customglobalfile
+myglobal
 myglobalfile
 mylocal"
 assert "mise tasks --local" "mylocal"
-assert "mise tasks --global" "myglobal
+assert "mise tasks --global" "customglobalfile
+myglobal
 myglobalfile"
+assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3010,6 +3010,7 @@ async fn load_file_tasks(
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
 ) -> Result<Vec<Task>> {
+    let is_global = is_global_config(cf.get_path());
     let includes = cf
         .task_config_includes()?
         .unwrap_or_else(default_task_includes);
@@ -3039,7 +3040,7 @@ async fn load_file_tasks(
                 require_task_include_trust,
             )
             .await?;
-            if is_global_task_include_path(&path) {
+            if is_global || is_global_task_include_path(&path) {
                 mark_tasks_as_global(&mut loaded);
             }
             tasks.extend(loaded);


### PR DESCRIPTION
## Summary
- mark file tasks loaded by user-global or system configs as global regardless of their physical include path
- preserve the existing behavior that treats scripts in standard global task directories as global
- cover custom user-global and system task includes in task listing and project-root behavior

## Root cause

File tasks were classified as global solely from the resolved include path. A user-global or system config could load scripts from a custom directory such as `~/dotfiles/tasks` or an administrator-managed path, but those tasks retained `global = false`, causing incorrect `--global`/`--local` filtering and project-root selection.

## User impact

Custom scripts included by user-global and system configs now remain available globally, appear under `mise tasks --global`, stay out of `mise tasks --local`, and use the invoking local project root.

## Validation
- `mise run test:e2e test_task_ls_global`
- `mise run lint-fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Global task files included via the global configuration are now correctly recognized as global tasks.
  * Task listing now includes all configured global tasks alongside local tasks.
  * Running an included global task now correctly sets `MISE_PROJECT_ROOT`.
* **Tests**
  * Updated end-to-end coverage to validate global and system-scoped task configuration behavior and expected task outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->