### PR TITLE
fix(bootstrap): support auto-updating cask metadata

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1516,6 +1516,7 @@ end
             r#"cask "example" do
   version "2.2.1,20628"
   url "https://example.com/OrbStack_v#{version.csv.first}_#{version.csv.second}.dmg"
+  auto_updates true
   preflight do
     File.write staged_path/"result", version.csv.second
   end

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -257,6 +257,7 @@ class CaskContext
   def desc(*) nil end
   def homepage(*) nil end
   def livecheck(*) nil end
+  def auto_updates(*) nil end
   def conflicts_with(*) nil end
   def depends_on(*) nil end
   def caveats(*) nil end


### PR DESCRIPTION
## Summary

- accept Homebrew casks that declare `auto_updates`
- treat it as metadata in the bootstrap cask shim
- cover the current OrbStack cask shape in the existing regression test

## Test

- `cargo test cask_shim_supports_csv_version_array_helpers`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew cask compatibility by recognizing the `auto_updates` setting in cask definitions.
  * Casks that use this setting can now be processed without triggering unsupported lifecycle errors.
  * Existing cask version handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->