### PR TITLE
Docs Example: Alias multiple tools from one github release

### DIFF
--- a/docs/dev-tools/aliases.md
+++ b/docs/dev-tools/aliases.md
@@ -30,8 +30,8 @@ dhall-json = { version = "v1.42.2", matching = "dhall-json" }
 dhall-lsp = { version = "latest", matching = "dhall-lsp-server" }
 ```
 
-The example above uses the [GitHub backend's `matching`](backend/github#matching) feature to download
-two distinct binaries from different releases in the same GitHub respository.
+The example above uses the [GitHub backend's `matching`](backends/github#matching) feature to download
+two distinct binaries from different releases in the same GitHub repository.
 
 ## Aliased Versions
 

--- a/docs/dev-tools/aliases.md
+++ b/docs/dev-tools/aliases.md
@@ -18,6 +18,21 @@ node = 'github:company/our-custom-node'   # shorthand for https://github.com/com
 erlang = 'aqua:company/our-custom-erlang' # use an aqua registry entry
 ```
 
+This can also be used to install multiple tools from the same GitHub release:
+
+```toml [~/.config/mise/config.toml]
+[tool_alias]
+dhall-json = 'github:dhall-lang/dhall-haskell'
+dhall-lsp = 'github:dhall-lang/dhall-haskell'
+
+[tools]
+dhall-json = { version = "v1.42.2", matching = "dhall-json" }
+dhall-lsp = { version = "latest", matching = "dhall-lsp-server" }
+```
+
+The example above uses the [GitHub backend's `matching`](backend/github#matching) feature to download
+two distinct binaries from different releases in the same GitHub respository.
+
 ## Aliased Versions
 
 mise supports aliasing the versions of runtimes. One use-case for this is to define a stable name


### PR DESCRIPTION
I found this was possible due to https://github.com/jdx/mise/discussions/9074 and wanted to add it to the docs specifically.

I'm not sure how specific this is to the Github backend though, perhaps it makes more sense to move it to the that specific page?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an example under **Aliased Backends** showing how tool aliases can install multiple tools from the same GitHub release.
  * Included configuration guidance to select distinct binaries using `version` and `matching` with the GitHub backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->