### PR TITLE
fix(task): parse remote task file headers

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -322,7 +322,7 @@ impl Run {
         // Fetch remote task files before parsing usage specs, so that
         // file-based remote tasks have their files resolved to local cache.
         let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
-        fetcher.fetch_tasks(&mut task_list).await?;
+        fetcher.fetch_tasks(&config, &mut task_list).await?;
 
         // Re-render dependency templates with parent task's usage arg/flag values.
         // This enables patterns like: depends = ["child {{usage.app}}"]
@@ -682,7 +682,7 @@ impl Run {
     /// Dependencies should already be resolved via resolve_depends() before calling this.
     async fn prepare_tasks(&mut self, config: &Arc<Config>, mut tasks: Vec<Task>) -> Result<Deps> {
         let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
-        fetcher.fetch_tasks(&mut tasks).await?;
+        fetcher.fetch_tasks(config, &mut tasks).await?;
         let mut tasks = Deps::new(config, tasks).await?;
         tasks.mark_ambiguous_prefixes();
         self.is_linear = tasks.is_linear();

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -47,7 +47,9 @@ impl TasksInfo {
             let mut tasks = vec![task.clone()];
             // always pass no_cache=false as the command doesn't take no-cache argument
             // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
-            TaskFetcher::new(false).fetch_tasks(&mut tasks).await?;
+            TaskFetcher::new(false)
+                .fetch_tasks(&config, &mut tasks)
+                .await?;
             let task = &tasks[0];
 
             if self.json {

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -131,7 +131,9 @@ impl TasksLs {
         let mut tasks = tasks;
         // always pass no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
-        TaskFetcher::new(false).fetch_tasks(&mut tasks).await?;
+        TaskFetcher::new(false)
+            .fetch_tasks(&config, &mut tasks)
+            .await?;
 
         // Warn about non-executable files only when there are truly no tasks at all
         // (not just filtered out by --hidden/--local/--global)

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -68,7 +68,7 @@ impl TasksValidate {
         // always no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
-            .fetch_tasks(&mut resolved_tasks)
+            .fetch_tasks(&config, &mut resolved_tasks)
             .await?;
         let all_tasks: BTreeMap<String, Task> = resolved_tasks
             .into_iter()

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -82,7 +82,7 @@ impl Deps {
                 .is_some_and(|f| TaskFetcher::is_remote_source(&f.to_string_lossy()))
             {
                 let mut tasks_to_fetch = vec![a];
-                fetcher.fetch_tasks(&mut tasks_to_fetch).await?;
+                fetcher.fetch_tasks(config, &mut tasks_to_fetch).await?;
                 a = tasks_to_fetch.into_iter().next().unwrap();
             }
             // Re-render dependency templates with usage values (including defaults)

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -1,7 +1,8 @@
-use crate::config::Settings;
+use crate::config::{Config, Settings};
 use crate::task::Task;
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
 use eyre::{Result, bail};
+use std::sync::Arc;
 
 /// Handles fetching remote task files and converting them to local paths
 pub struct TaskFetcher {
@@ -14,7 +15,7 @@ impl TaskFetcher {
     }
 
     /// Fetch remote task files, converting remote paths to local cached paths
-    pub async fn fetch_tasks(&self, tasks: &mut Vec<Task>) -> Result<()> {
+    pub async fn fetch_tasks(&self, config: &Arc<Config>, tasks: &mut Vec<Task>) -> Result<()> {
         let no_cache = self.no_cache || Settings::get().task.remote_no_cache.unwrap_or(false);
         let task_file_providers = TaskFileProvidersBuilder::new()
             .with_cache(!no_cache)
@@ -36,11 +37,43 @@ impl TaskFetcher {
                 }
 
                 let local_path = provider.unwrap().get_local_path(&source).await?;
+                let original = t.clone();
+                let config_root = original
+                    .config_root
+                    .clone()
+                    .or_else(|| original.config_source.parent().map(|p| p.to_path_buf()))
+                    .unwrap_or_default();
+                let prefix = local_path.parent().unwrap_or(&local_path);
 
-                // Store the original remote source before replacing with local path
-                // This is used to determine if the task should use monorepo config file context
-                t.remote_file_source = Some(source);
-                t.file = Some(local_path);
+                // Parse the downloaded script as a regular file task so all #MISE
+                // metadata is honored. The inline TOML task remains the higher-
+                // precedence overlay, matching local file-task behavior.
+                let mut remote = Task::from_path_unrendered_with_cf(
+                    &local_path,
+                    prefix,
+                    &config_root,
+                    original.cf.clone(),
+                )?;
+                remote.name.clone_from(&original.name);
+                remote.display_name.clone_from(&original.display_name);
+
+                // Restore runtime render context before rendering remote headers.
+                // Templates in those headers may depend on task vars or env inherited
+                // from the invocation that selected this task.
+                remote.args.clone_from(&original.args);
+                remote.trailing_args.clone_from(&original.trailing_args);
+                remote.show_args_in_prefix = original.show_args_in_prefix;
+                remote.inherited_env.clone_from(&original.inherited_env);
+                remote.overlay_env.clone_from(&original.overlay_env);
+                remote.overlay_vars.clone_from(&original.overlay_vars);
+                remote.render(config, &config_root).await?;
+                remote.merge_toml_overlay(original.clone());
+
+                // Preserve runtime state that is not task metadata and therefore is
+                // intentionally not handled by merge_toml_overlay().
+                remote.global = original.global;
+                remote.remote_file_source = Some(source);
+                *t = remote;
             }
         }
 
@@ -52,5 +85,152 @@ impl TaskFetcher {
         source.starts_with("git::")
             || source.starts_with("http://")
             || source.starts_with("https://")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::env_directive::EnvDirective;
+    use crate::task::TaskToolValue;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_fetch_remote_task_parses_headers_and_applies_toml_overlay() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/task")
+            .with_status(200)
+            .with_body(
+                r#"#!/usr/bin/env bash
+#MISE description="remote description"
+#MISE hide=true
+#MISE quiet=true
+#MISE tools={node="24", python="3.12"}
+echo ok
+"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let config = Config::get().await.unwrap();
+        let config_root = tempfile::tempdir().unwrap();
+        let source = format!("{}/task", server.url());
+        let mut task = Task {
+            name: "lint".into(),
+            display_name: "lint".into(),
+            description: "toml description".into(),
+            config_source: config_root.path().join("mise.toml"),
+            config_root: Some(config_root.path().to_path_buf()),
+            file: Some(PathBuf::from(&source)),
+            args: vec!["--fix".into()],
+            tools: [("python".into(), TaskToolValue::String("3.13".into()))]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+
+        let mut tasks = vec![task];
+        TaskFetcher::new(true)
+            .fetch_tasks(&config, &mut tasks)
+            .await
+            .unwrap();
+        task = tasks.pop().unwrap();
+
+        remote.assert_async().await;
+        assert_eq!(task.name, "lint");
+        assert_eq!(task.display_name, "lint");
+        assert_eq!(task.description, "toml description");
+        assert!(task.hide);
+        assert!(task.quiet);
+        assert_eq!(task.args, ["--fix"]);
+        assert_eq!(task.config_root.as_deref(), Some(config_root.path()));
+        assert_eq!(task.remote_file_source.as_deref(), Some(source.as_str()));
+        assert!(task.is_remote());
+        assert_eq!(
+            task.tools.get("node"),
+            Some(&TaskToolValue::String("24".into()))
+        );
+        assert_eq!(
+            task.tools.get("python"),
+            Some(&TaskToolValue::String("3.13".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_cached_remote_task_parses_headers() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/cached-task")
+            .with_status(200)
+            .with_body("#!/usr/bin/env bash\n#MISE description=\"from cache\"\necho ok\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let config = Config::get().await.unwrap();
+        let config_root = tempfile::tempdir().unwrap();
+        let source = format!("{}/cached-task", server.url());
+        let new_task = || Task {
+            name: "cached".into(),
+            config_source: config_root.path().join("mise.toml"),
+            config_root: Some(config_root.path().to_path_buf()),
+            file: Some(PathBuf::from(&source)),
+            ..Default::default()
+        };
+
+        for _ in 0..2 {
+            let mut tasks = vec![new_task()];
+            TaskFetcher::new(false)
+                .fetch_tasks(&config, &mut tasks)
+                .await
+                .unwrap();
+            assert_eq!(tasks[0].description, "from cache");
+        }
+
+        remote.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_remote_header_templates_use_original_runtime_context() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/templated-task")
+            .with_status(200)
+            .with_body(
+                "#!/usr/bin/env bash\n#MISE description=\"{{vars.runtime_value}}\"\necho ok\n",
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let config = Config::get().await.unwrap();
+        let config_root = tempfile::tempdir().unwrap();
+        let source = format!("{}/templated-task", server.url());
+        let config_source = config_root.path().join("mise.toml");
+        let mut tasks = vec![Task {
+            name: "templated".into(),
+            config_source: config_source.clone(),
+            config_root: Some(config_root.path().to_path_buf()),
+            file: Some(PathBuf::from(&source)),
+            overlay_vars: vec![(
+                EnvDirective::Val(
+                    "runtime_value".into(),
+                    "rendered from runtime context".into(),
+                    Default::default(),
+                ),
+                config_source,
+            )],
+            ..Default::default()
+        }];
+
+        TaskFetcher::new(true)
+            .fetch_tasks(&config, &mut tasks)
+            .await
+            .unwrap();
+
+        remote.assert_async().await;
+        assert_eq!(tasks[0].description, "rendered from runtime context");
     }
 }

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 use crate::{
     dirs, env,
-    file::display_path,
+    file::{self, display_path},
     git::{self, CloneOptions},
     hash,
     lock_file::LockFile,
@@ -68,6 +68,21 @@ impl GitRepoStructure {
 }
 
 impl RemoteTaskGit {
+    /// Make fetched task files executable while leaving task include directories intact.
+    fn prepare_remote_path(path: &PathBuf) -> Result<()> {
+        let metadata = path.symlink_metadata()?;
+        if metadata.file_type().is_file() {
+            return file::make_executable(path);
+        }
+        if metadata.file_type().is_dir() {
+            return Ok(());
+        }
+        eyre::bail!(
+            "remote task path is not a regular file or directory: {}",
+            display_path(path)
+        )
+    }
+
     fn get_cache_key(&self, repo_structure: &GitRepoStructure) -> String {
         let key = format!(
             "{}{}",
@@ -128,6 +143,7 @@ impl TaskFileProvider for RemoteTaskGit {
             trace!("Cache mode enabled");
             if full_path.exists() {
                 debug!("Using cached file: {:?}", full_path);
+                Self::prepare_remote_path(&full_path)?;
                 return Ok(full_path);
             }
         } else {
@@ -170,6 +186,7 @@ impl TaskFileProvider for RemoteTaskGit {
             }
         }
 
+        Self::prepare_remote_path(&full_path)?;
         Ok(full_path)
     }
 }
@@ -178,6 +195,51 @@ impl TaskFileProvider for RemoteTaskGit {
 mod tests {
 
     use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn test_prepare_remote_path_makes_non_executable_file_executable() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let task_file = temp_dir.path().join("task");
+        fs::write(&task_file, "#!/usr/bin/env bash\necho ok\n").unwrap();
+        fs::set_permissions(&task_file, fs::Permissions::from_mode(0o644)).unwrap();
+
+        RemoteTaskGit::prepare_remote_path(&task_file).unwrap();
+
+        assert!(file::is_executable(&task_file));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_prepare_remote_path_rejects_symlink_without_modifying_target() {
+        use std::fs;
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let target = temp_dir.path().join("target");
+        let task_file = temp_dir.path().join("task");
+        fs::write(&target, "#!/usr/bin/env bash\necho ok\n").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+        symlink(&target, &task_file).unwrap();
+
+        let error = RemoteTaskGit::prepare_remote_path(&task_file).unwrap_err();
+
+        assert!(error.to_string().contains("not a regular file"));
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+    }
+
+    #[test]
+    fn test_prepare_remote_path_allows_task_include_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        RemoteTaskGit::prepare_remote_path(&temp_dir.path().to_path_buf()).unwrap();
+    }
 
     #[test]
     fn test_valid_parse_ssh() {


### PR DESCRIPTION
## Summary
- parse all `#MISE` headers after downloading HTTP and Git-backed task files
- apply inline TOML task metadata as the higher-precedence overlay, matching local file-task behavior
- preserve runtime render context, task identity, configuration context, and remote-source tracking
- make regular Git-backed task files executable after cloning and on cache hits so mode `100644` files remain visible
- preserve Git task include directories while rejecting symlinked and special-file task paths before changing permissions

## Root cause
Remote task files were downloaded and their `file` paths were replaced with cache paths, but the downloaded scripts were never parsed as file tasks. As a result, headers such as `tools`, `description`, and `hide` were ignored.

Remote-header templates also need the original invocation context before rendering. Git-backed task files require executable normalization, but paths must be classified first so task include directories remain supported and permission changes cannot follow symlinks.

Fixes https://github.com/jdx/mise/discussions/5267

## Validation
- `mise exec rust@stable -- cargo check`
- `mise exec rust@stable -- cargo fmt --all -- --check`
- `mise exec rust@stable -- cargo test task::task_fetcher::tests` (3 passed)
- `mise exec rust@stable -- cargo test task::task_file_providers::remote_task_git::tests` (11 passed)
- `target/debug/mise run --tool rust@stable --tool cmake@latest --skip-tools test:e2e e2e/tasks/test_task_local_overrides_git_include e2e/tasks/test_task_remote_git_includes` (2 passed)

`cargo clippy --all-targets --all-features -- -D warnings` was also attempted. It is currently blocked by 16 pre-existing `clippy::useless_borrows_in_formatting` errors in `crates/vfox` under Rust 1.97; none are in this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote tasks now render using the active configuration and the original task’s runtime context, applying `#MISE` header metadata and merging inline TOML overrides with correct precedence.
  * Ensures fetched/cached remote task files are regular executable files.
* **Bug Fixes**
  * Improved consistency across commands (run, ls, info, validate, dependency resolution) when fetching and rendering remote tasks.
  * Prevents symlinked remote task files from having their permissions changed during preparation.
* **Tests**
  * Added coverage for remote `#MISE` parsing/template rendering and Unix permission/executable-bit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->