### PR TITLE
fix(task): allow false to override script headers

### DIFF
--- a/e2e/tasks/test_task_file_toml_merge
+++ b/e2e/tasks/test_task_file_toml_merge
@@ -103,3 +103,31 @@ EOF
 
 assert_contains "mise run parent --app demo" "child got: demo"
 assert_contains "mise run parent --app demo" "parent app=demo"
+
+# Explicit false values in TOML override true values from the script header.
+# Omitted values continue to preserve the header metadata.
+cat <<'SCRIPT' >.mise/tasks/bool-overrides
+#!/usr/bin/env bash
+#MISE hide=true
+#MISE raw=true
+#MISE raw_args=true
+#MISE interactive=true
+#MISE quiet=true
+#MISE silent=true
+echo bool-overrides
+SCRIPT
+chmod +x .mise/tasks/bool-overrides
+
+cat <<'EOF' >>mise.toml
+
+[tasks.bool-overrides]
+hide = false
+raw = false
+raw_args = false
+interactive = false
+quiet = false
+silent = false
+EOF
+
+assert "mise tasks ls --json | jq -c '.[] | select(.name == \"bool-overrides\") | {hide, raw, interactive, quiet, silent}'" '{"hide":false,"raw":false,"interactive":false,"quiet":false,"silent":false}'
+assert_contains "mise run bool-overrides --help" "Source: ~/workdir/.mise/tasks/bool-overrides, ~/workdir/mise.toml"

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -35,7 +35,7 @@ use crate::redactions::Redactions;
 use crate::registry::REGISTRY;
 use crate::system::{BootstrapTomlConfig, DotfilesTomlConfig};
 use crate::task::workspace::WorkspaceProjectOverride;
-use crate::task::{Task, TaskTemplate};
+use crate::task::{Task, TaskTemplate, TaskTomlBoolPresence};
 use crate::tera::{BASE_CONTEXT, contains_template_syntax, get_tera, render_str};
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource, ToolVersionOptions};
 use crate::watch_files::WatchFile;
@@ -2192,6 +2192,41 @@ impl<'de> de::Deserialize<'de> for MiseTomlTool {
     }
 }
 
+struct TaskBoolPresenceMapAccess<'a, M> {
+    inner: M,
+    presence: &'a mut TaskTomlBoolPresence,
+}
+
+impl<'de, M> de::MapAccess<'de> for TaskBoolPresenceMapAccess<'_, M>
+where
+    M: de::MapAccess<'de>,
+{
+    type Error = M::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        let Some(key) = self.inner.next_key::<String>()? else {
+            return Ok(None);
+        };
+        self.presence.record(&key);
+        seed.deserialize(de::value::StringDeserializer::<M::Error>::new(key))
+            .map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        self.inner.next_value_seed(seed)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.inner.size_hint()
+    }
+}
+
 impl<'de> de::Deserialize<'de> for Tasks {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
@@ -2250,10 +2285,15 @@ impl<'de> de::Deserialize<'de> for Tasks {
                             where
                                 M: de::MapAccess<'de>,
                             {
-                                let t = de::Deserialize::deserialize(
-                                    de::value::MapAccessDeserializer::new(map),
-                                )?;
-                                Ok(TaskDef(t))
+                                let mut presence = TaskTomlBoolPresence::default();
+                                let map = TaskBoolPresenceMapAccess {
+                                    inner: map,
+                                    presence: &mut presence,
+                                };
+                                let mut task =
+                                    Task::deserialize(de::value::MapAccessDeserializer::new(map))?;
+                                task.toml_bool_presence = presence;
+                                Ok(TaskDef(task))
                             }
                         }
                         deserializer.deserialize_any(TaskDefVisitor)
@@ -2468,6 +2508,7 @@ mod tests {
 
     use crate::dirs;
     use crate::file;
+    use crate::task::Silent;
     use crate::test::replace_path;
     use crate::toolset::{CoreToolOptions, ToolRequest};
     use crate::{config::Config, dirs::CWD};
@@ -2507,6 +2548,53 @@ mod tests {
             BTreeSet::from(["node:legacy".to_string()])
         );
         assert!(projects.get("node:legacy").unwrap().remove);
+    }
+
+    #[test]
+    fn test_task_toml_boolean_overlay_presence() {
+        let Tasks(mut tasks) = toml::from_str(
+            r#"
+            [explicit]
+            hide = false
+            raw = false
+            raw_args = false
+            interactive = false
+            quiet = false
+            silent = false
+
+            [omitted]
+            description = "no boolean overrides"
+            "#,
+        )
+        .unwrap();
+
+        let script_task = || Task {
+            hide: true,
+            raw: true,
+            raw_args: true,
+            interactive: true,
+            quiet: true,
+            silent: Silent::Bool(true),
+            ..Default::default()
+        };
+
+        let mut explicit = script_task();
+        explicit.merge_toml_overlay(tasks.remove("explicit").unwrap());
+        assert!(!explicit.hide);
+        assert!(!explicit.raw);
+        assert!(!explicit.raw_args);
+        assert!(!explicit.interactive);
+        assert!(!explicit.quiet);
+        assert_eq!(explicit.silent, Silent::Off);
+
+        let mut omitted = script_task();
+        omitted.merge_toml_overlay(tasks.remove("omitted").unwrap());
+        assert!(omitted.hide);
+        assert!(omitted.raw);
+        assert!(omitted.raw_args);
+        assert!(omitted.interactive);
+        assert!(omitted.quiet);
+        assert_eq!(omitted.silent, Silent::Bool(true));
     }
 
     #[tokio::test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -379,6 +379,34 @@ pub enum Silent {
     Stderr,
 }
 
+/// Boolean fields present in a structured TOML task definition.
+///
+/// `Task` keeps resolved booleans for runtime use, but an overlay also needs to
+/// distinguish an omitted field from an explicit `false`.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TaskTomlBoolPresence {
+    hide: bool,
+    raw: bool,
+    raw_args: bool,
+    interactive: bool,
+    quiet: bool,
+    silent: bool,
+}
+
+impl TaskTomlBoolPresence {
+    pub(crate) fn record(&mut self, key: &str) {
+        match key {
+            "hide" => self.hide = true,
+            "raw" => self.raw = true,
+            "raw_args" => self.raw_args = true,
+            "interactive" => self.interactive = true,
+            "quiet" => self.quiet = true,
+            "silent" => self.silent = true,
+            _ => {}
+        }
+    }
+}
+
 impl Silent {
     pub fn is_silent(&self) -> bool {
         matches!(self, Silent::Bool(true) | Silent::Stdout | Silent::Stderr)
@@ -548,6 +576,9 @@ pub struct Task {
     /// as `overlay_env`.
     #[serde(skip)]
     pub overlay_vars: Vec<(EnvDirective, PathBuf)>,
+    /// Boolean fields explicitly present in a structured TOML task definition.
+    #[serde(skip)]
+    pub(crate) toml_bool_presence: TaskTomlBoolPresence,
     #[serde(default)]
     pub dir: Option<String>,
     #[serde(default)]
@@ -1975,6 +2006,13 @@ impl Task {
                 self.additional_config_sources.push(source.to_path_buf());
             }
         }
+
+        fn merge_bool(base: &mut bool, overlay: bool, explicit: bool) {
+            if explicit || overlay {
+                *base = overlay;
+            }
+        }
+
         if !other.description.is_empty() {
             self.description = other.description;
         }
@@ -2025,22 +2063,20 @@ impl Task {
         if other.dir.is_some() {
             self.dir = other.dir;
         }
-        if other.hide {
-            self.hide = true;
-        }
-        if other.raw {
-            self.raw = true;
-        }
-        if other.raw_args {
-            self.raw_args = true;
-        }
-        if other.interactive {
-            self.interactive = true;
-        }
-        if other.quiet {
-            self.quiet = true;
-        }
-        if !matches!(other.silent, Silent::Off) {
+        merge_bool(&mut self.hide, other.hide, other.toml_bool_presence.hide);
+        merge_bool(&mut self.raw, other.raw, other.toml_bool_presence.raw);
+        merge_bool(
+            &mut self.raw_args,
+            other.raw_args,
+            other.toml_bool_presence.raw_args,
+        );
+        merge_bool(
+            &mut self.interactive,
+            other.interactive,
+            other.toml_bool_presence.interactive,
+        );
+        merge_bool(&mut self.quiet, other.quiet, other.toml_bool_presence.quiet);
+        if other.toml_bool_presence.silent || !matches!(other.silent, Silent::Off) {
             self.silent = other.silent;
         }
         if other.output.is_some() {
@@ -2573,6 +2609,7 @@ impl Default for Task {
             inherited_env: Default::default(),
             overlay_env: vec![],
             overlay_vars: vec![],
+            toml_bool_presence: Default::default(),
             dir: None,
             hide: false,
             global: false,


### PR DESCRIPTION
## Summary

- preserve whether task booleans were explicitly present in a structured TOML definition
- allow explicit `false` values to override `true` values from a same-named script task's `#MISE` header
- continue preserving script-header values when the corresponding TOML fields are omitted

This applies to `hide`, `raw`, `raw_args`, `interactive`, `quiet`, and `silent`.

## Bug

Runtime tasks store these settings as resolved booleans. During deserialization, both an omitted TOML field and an explicit `false` therefore became the same default value.

`merge_toml_overlay` could safely apply `true`, but it could not tell whether `false` meant “clear the script header” or “leave the script header unchanged.” As a result, a TOML metadata overlay could not disable a setting enabled by its script.

## Fix

Structured TOML task definitions now record which boolean fields were present while deserializing the original TOML map directly. Overlay merging uses the parsed value when present and retains the existing behavior for omitted fields and programmatically constructed tasks.

Changing the runtime `Task` fields to `Option<bool>` would spread tri-state handling through execution, output, argument parsing, and programmatic task construction. This PR keeps the runtime model stable; a separate follow-up item tracks splitting definition merging from resolved task state.

The branch is rebased directly onto `main` now that #11103 has merged; loader precedence, source deduplication, and remote-task lifecycle changes remain in their respective related PRs.

## Tests

- `cargo test --all-features test_task_toml_boolean_overlay_presence`
- `mise run test:e2e e2e/tasks/test_task_file_toml_merge`
- `mise run test:e2e e2e/config/test_tool_postinstall_type`
- `hk fix --pr`
- `git diff --check`


*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*