### PR TITLE
fix(task): require trust for remote metadata

### DIFF
--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -14,8 +14,9 @@ import socketserver
 from pathlib import Path
 
 class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
-    def __init__(self, *args, repo_dir=None, **kwargs):
+    def __init__(self, *args, repo_dir=None, request_log=None, **kwargs):
         self.repo_dir = repo_dir
+        self.request_log = request_log
         super().__init__(*args, **kwargs)
 
     def do_GET(self):
@@ -25,6 +26,10 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         self.handle_git_request()
 
     def handle_git_request(self):
+        if self.request_log:
+            with open(self.request_log, 'a') as log:
+                log.write(f'{self.command} {self.path}\n')
+
         # Set up environment for git-http-backend
         env = os.environ.copy()
         env['GIT_PROJECT_ROOT'] = str(self.repo_dir)
@@ -102,7 +107,7 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         except Exception as e:
             self.send_error(500, f"Server error: {str(e)}")
 
-def create_test_repo(repo_path):
+def create_test_repo(repo_path, server_port):
     """Create a minimal test repository"""
     # Create a regular (non-bare) repository
     subprocess.run(['git', 'init', repo_path], check=True)
@@ -119,6 +124,29 @@ def create_test_repo(repo_path):
     remote_task_file.write_text('#!/usr/bin/env bash\necho "remote task executed"\n')
     remote_task_file.chmod(0o755)
 
+    # A config-declared remote task whose script filename ends in .toml. This
+    # exercises the script-header path rather than task-include TOML parsing.
+    remote_task_dir = Path(repo_path) / 'xtasks' / 'remote'
+    remote_task_dir.mkdir(parents=True)
+    remote_metadata_file = remote_task_dir / 'remote_metadata.toml'
+    remote_metadata_file.write_text(
+        '#!/usr/bin/env bash\n'
+        '#MISE description="remote git metadata"\n'
+        '#MISE tools={dummy="1.0.0"}\n'
+        '#MISE env._.file="remote.env"\n'
+        'echo "remote path: $0"\n'
+        'echo "$REMOTE_RELATIVE_ENV"\n'
+        'dummy\n'
+    )
+    remote_metadata_file.chmod(0o755)
+    (remote_task_dir / 'remote.env').write_text('REMOTE_RELATIVE_ENV="relative env loaded"\n')
+    nested_remote_file = remote_task_dir / 'nested'
+    nested_remote_file.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "nested remote task executed"\n'
+    )
+    nested_remote_file.chmod(0o755)
+
     # A toml task file colocated with the executable scripts. Keys are task
     # names; values are the run command (or a table). Used by tests covering
     # remote toml task includes.
@@ -129,6 +157,9 @@ def create_test_repo(repo_path):
         '[toml_table_task]\n'
         'run = "echo toml_table_task executed"\n'
         'description = "TOML task with table form"\n'
+        '\n'
+        '[nested_remote]\n'
+        f'file = "git::http://localhost:{server_port}/repo.git//xtasks/remote/nested"\n'
     )
 
     # A standalone toml file in a sibling directory to test the
@@ -166,17 +197,23 @@ def start_server(port=0):
     temp_dir = Path(tempfile.mkdtemp(prefix='mise_git_http_'))
     repo_path = temp_dir / 'repo'
 
-    print(f"Creating test repository at {repo_path}")
-    create_test_repo(str(repo_path))
-
     # Create handler with repo directory
+    request_log = os.environ.get('MISE_GIT_HTTP_REQUEST_LOG')
+
     def handler(*args, **kwargs):
-        return GitHTTPHandler(*args, repo_dir=temp_dir, **kwargs)
+        return GitHTTPHandler(
+            *args,
+            repo_dir=temp_dir,
+            request_log=request_log,
+            **kwargs
+        )
 
     # Let the OS assign an available port if port=0
     # This avoids race conditions between finding and binding
     with socketserver.TCPServer(("", port), handler) as httpd:
         actual_port = httpd.server_address[1]
+        print(f"Creating test repository at {repo_path}")
+        create_test_repo(str(repo_path), actual_port)
         print(f"Git HTTP server running on port {actual_port}")
         print(f"Repository URL: http://localhost:{actual_port}/repo.git")
 

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -21,6 +21,10 @@ HEADERS_LOG_DIR = None
 
 
 class TestFileHandler(http.server.SimpleHTTPRequestHandler):
+    changing_remote_revision = 0
+    changing_alias_revision = 0
+    raw_help_revision = 0
+
     def do_GET(self):
         """Handle GET requests for test files"""
         self._log_headers()
@@ -31,6 +35,114 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
             self.send_header('Content-Type', 'text/plain')
             self.end_headers()
             content = '#!/usr/bin/env bash\necho "running mytask"\n'
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-template':
+            if marker := os.environ.get('MISE_HTTP_REQUEST_MARKER'):
+                Path(marker).touch()
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE description="{{ exec(command=\'touch $MISE_REMOTE_TEMPLATE_MARKER\') }}"\n'
+                '#MISE depends=["remote_dep"]\n'
+                '#USAGE flag "--remote-flag" help="Remote usage flag"\n'
+                'echo "remote template task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-raw-help':
+            TestFileHandler.raw_help_revision += 1
+            revision = TestFileHandler.raw_help_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE raw_args=true\n'
+                f'echo "remote raw help revision {revision}"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-deferred-template':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE confirm="\\u007b\\u007b exec(command=\'touch $MISE_REMOTE_DEFERRED_MARKER\') \\u007d\\u007d"\n'
+                '#MISE env={REMOTE_DEFERRED="\\u007b\\u007b exec(command=\'touch $MISE_REMOTE_DEFERRED_MARKER\') \\u007d\\u007d"}\n'
+                'echo "remote deferred task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-source':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            source_path = json.dumps(os.environ['MISE_REMOTE_SOURCE_SCRIPT'])
+            venv_path = json.dumps(os.environ['MISE_REMOTE_VENV'])
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE confirm="run remote source task?"\n'
+                '#MISE env={_={source=%s,python={venv={path=%s}}}}\n'
+                'echo "remote source task ran: VIRTUAL_ENV=$VIRTUAL_ENV"\n'
+            ) % (source_path, venv_path)
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-sops-file':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            sops_file = json.dumps(os.environ['MISE_REMOTE_SOPS_FILE'])
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE env={_={file=%s}}\n'
+                'echo "remote sops task ran: $REMOTE_SOPS_VALUE"\n'
+            ) % sops_file
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-tools':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE alias="remote-tools-alias"\n'
+                '#MISE tools={dummy="1.0.0"}\n'
+                'if command -v dummy >/dev/null 2>&1; then dummy; else echo "dummy not installed"; fi\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-changing-alias':
+            TestFileHandler.changing_alias_revision += 1
+            revision = TestFileHandler.changing_alias_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            alias = '#MISE alias="remote-changing-alias"\n' if revision == 1 else ''
+            content = (
+                '#!/usr/bin/env bash\n'
+                f'{alias}'
+                f'echo "remote changing alias revision {revision}"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-hidden':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE hide=true\n'
+                '#MISE description="hidden remote metadata"\n'
+                'echo "hidden remote task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-changing':
+            TestFileHandler.changing_remote_revision += 1
+            revision = TestFileHandler.changing_remote_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                f'#MISE description="remote revision {revision}"\n'
+                f'echo "remote revision {revision}"\n'
+            )
             self.wfile.write(content.encode('utf-8'))
         else:
             # Return 404 for other paths

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -7,14 +7,16 @@
 PORT_FILE="$TMPDIR/mise_git_http_port"
 READY_FILE="$TMPDIR/mise_git_http_ready"
 INFO_FILE="$TMPDIR/mise_git_http_info"
+REQUEST_LOG="$TMPDIR/mise_git_http_requests"
 
 # Clean up any previous server files
-rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE"
+rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$REQUEST_LOG"
 
 # Start local git HTTP server with OS-assigned port to avoid race conditions
 MISE_GIT_HTTP_PORT_FILE="$PORT_FILE" \
   MISE_GIT_HTTP_READY_FILE="$READY_FILE" \
   MISE_GIT_HTTP_INFO_FILE="$INFO_FILE" \
+  MISE_GIT_HTTP_REQUEST_LOG="$REQUEST_LOG" \
   python3 "${TEST_ROOT}/helpers/scripts/git_http_backend_server.py" 0 &
 SERVER_PID=$!
 
@@ -50,7 +52,7 @@ git init
 # Ensure cleanup on exit
 cleanup() {
   kill "$SERVER_PID" 2>/dev/null || true
-  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE"
+  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$REQUEST_LOG"
 }
 trap cleanup EXIT
 
@@ -64,6 +66,12 @@ includes = [
     "git::${LOCAL_GIT_URL}//xtasks/lint"
 ]
 EOF
+
+# Safe-mode config parsing must not clone an untrusted remote include before
+# enforcing the defining config's actual trust.
+: >"$REQUEST_LOG"
+assert_fail "MISE_SAFE=1 MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 mise tasks"
+assert_fail "test -s '$REQUEST_LOG'"
 
 # The xtasks/lint directory contains multiple task files
 # We should be able to see and run them
@@ -103,7 +111,10 @@ includes = [
 ]
 EOF
 
-assert_succeed "MISE_TASK_REMOTE_NO_CACHE=true mise run remote-task" # Remote task should be redownloaded
+INCLUDE_ARTIFACT_TMPDIR="$TMPDIR/remote-git-include-artifacts"
+mkdir -p "$INCLUDE_ARTIFACT_TMPDIR"
+assert_succeed "TMPDIR=$INCLUDE_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote-task" # Remote task should be redownloaded
+assert_fail "find '$INCLUDE_ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
 assert_directory_not_exists "${REMOTE_TASKS_DIR}"
 
 assert_succeed "mise run remote-task" # Cache should be used
@@ -159,6 +170,22 @@ assert_contains "mise tasks" "toml_table_task"
 assert_contains "mise run toml_task" "toml_task executed"
 assert_contains "mise run toml_table_task" "toml_table_task executed"
 
+# A remote TOML include can itself declare a remote file task. Both the outer
+# include clone and inner script clone must remain alive through execution and
+# then be cleaned when no-cache mode bypasses the static task cache.
+NESTED_ARTIFACT_TMPDIR="$TMPDIR/nested-remote-git-artifacts"
+mkdir -p "$NESTED_ARTIFACT_TMPDIR"
+assert_contains "TMPDIR=$NESTED_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run nested_remote" "nested remote task executed"
+assert_fail "find '$NESTED_ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
+
+# Authorizing the local config before cloning must also preserve it as the
+# provenance for nested remote metadata. The fetched cache files must never
+# need their own trust markers.
+PROVENANCE_STATE_DIR="$TMPDIR/remote-git-provenance-state"
+mkdir -p "$PROVENANCE_STATE_DIR"
+assert_contains "MISE_STATE_DIR=$PROVENANCE_STATE_DIR MISE_TRUSTED_CONFIG_PATHS='' MISE_YES=1 mise run nested_remote" "nested remote task executed"
+assert "find '$PROVENANCE_STATE_DIR/trusted-configs' -mindepth 1 \\( -type f -o -type l \\) 2>/dev/null | wc -l | tr -d ' '" "1"
+
 mise cache clear # Clear cache to force redownload
 
 #################################################################################
@@ -174,5 +201,30 @@ EOF
 
 assert_contains "mise tasks" "standalone_task"
 assert_contains "mise run standalone_task" "standalone_task executed"
+
+#################################################################################
+# Test config-declared remote git task metadata and tool installation
+#################################################################################
+
+cat <<EOF >mise.toml
+[tasks.remote_metadata_a]
+file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
+
+[tasks.remote_metadata_b]
+file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
+EOF
+
+mise trust
+assert_contains "mise tasks info remote_metadata_a" "remote git metadata"
+assert_contains "mise run remote_metadata_a" "This is Dummy 1.0.0!"
+assert_contains "mise run remote_metadata_a" "relative env loaded"
+ARTIFACT_TMPDIR="$TMPDIR/remote-git-artifacts"
+mkdir -p "$ARTIFACT_TMPDIR"
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_metadata_a ::: remote_metadata_b")
+assert_contains_text "$output" "This is Dummy 1.0.0!"
+assert_contains_text "$output" "relative env loaded"
+path_count=$(grep -o 'remote path: .*' <<<"$output" | sort -u | wc -l)
+[[ $path_count -eq 2 ]] || fail "no-cache Git tasks did not retain two distinct snapshots"
+assert_fail "find '$ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
 
 echo "All tests passed!"

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+
+# Remote task metadata can render Tera templates during discovery and install
+# tools before execution. Both actions must respect the defining config's trust.
+
+HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
+MARKER="$TMPDIR/remote-template-executed"
+DEFERRED_MARKER="$TMPDIR/remote-deferred-template-executed"
+SOURCE_MARKER="$TMPDIR/remote-source-executed"
+SOURCE_SCRIPT="$TMPDIR/remote-source.sh"
+REMOTE_VENV="$TMPDIR/remote-venv"
+SOPS_MARKER="$TMPDIR/remote-sops-executed"
+SOPS_FILE="$TMPDIR/remote-sops.yaml"
+FAKE_SOPS_BIN="$TMPDIR/remote-fake-sops-bin"
+REQUEST_MARKER="$TMPDIR/remote-template-requested"
+mkdir -p "$REMOTE_VENV/bin"
+cat <<'EOF' >"$SOURCE_SCRIPT"
+touch "$MISE_REMOTE_SOURCE_MARKER"
+EOF
+mkdir -p "$FAKE_SOPS_BIN"
+cat <<'EOF' >"$FAKE_SOPS_BIN/sops"
+#!/usr/bin/env bash
+touch "$MISE_REMOTE_SOPS_MARKER"
+cat
+EOF
+chmod +x "$FAKE_SOPS_BIN/sops"
+cat <<'EOF' >"$SOPS_FILE"
+sops:
+  version: "3.8.1"
+REMOTE_SOPS_VALUE: decrypted
+EOF
+MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" \
+  MISE_HTTP_REQUEST_MARKER="$REQUEST_MARKER" \
+  MISE_REMOTE_SOURCE_SCRIPT="$SOURCE_SCRIPT" \
+  MISE_REMOTE_VENV="$REMOTE_VENV" \
+  MISE_REMOTE_SOPS_FILE="$SOPS_FILE" \
+  python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 &
+HTTP_SERVER_PID=$!
+
+cleanup() {
+  kill "$HTTP_SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
+HTTP_PORT=$(cat "$HTTP_PORT_FILE")
+
+UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER MISE_REMOTE_DEFERRED_MARKER=$DEFERRED_MARKER MISE_REMOTE_SOURCE_MARKER=$SOURCE_MARKER MISE_REMOTE_SOURCE_SCRIPT=$SOURCE_SCRIPT MISE_REMOTE_VENV=$REMOTE_VENV MISE_REMOTE_SOPS_MARKER=$SOPS_MARKER"
+
+cat <<EOF >mise.toml
+[tasks.remote_template]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+
+[tasks.remote_dep]
+run = "echo remote dependency"
+EOF
+
+# Safe mode makes config parsing inert, but it must not turn remote discovery
+# into an SSRF-capable trust bypass.
+assert_fail "$UNTRUSTED_ENV MISE_SAFE=1 mise tasks ls" "not trusted"
+[[ ! -e $REQUEST_MARKER ]] || fail "safe-mode discovery fetched an untrusted remote task"
+
+assert_fail "$UNTRUSTED_ENV mise tasks ls" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise tasks deps remote_template" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise run remote_template --help" "not trusted"
+[[ ! -e $REQUEST_MARKER ]] || fail "remote task was fetched during untrusted passive discovery"
+[[ ! -e $MARKER ]] || fail "remote metadata template executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_succeed "$UNTRUSTED_ENV mise tasks ls"
+assert_contains "$UNTRUSTED_ENV mise tasks deps remote_template" "remote_dep"
+assert_contains "$UNTRUSTED_ENV mise run remote_template --help" "--remote-flag"
+[[ -e $REQUEST_MARKER ]] || fail "trusted passive discovery did not fetch the remote task"
+[[ -e $MARKER ]] || fail "trusted remote metadata template did not render"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# A trusted config vouches for an explicitly included task file even when that
+# file is outside the config's trust root. Preserve that provenance when the
+# include declares a remote task, including for temporary no-cache snapshots.
+INCLUDED_TASK_DIR="$TMPDIR/included-remote-tasks"
+mkdir -p "$INCLUDED_TASK_DIR"
+cat <<EOF >"$INCLUDED_TASK_DIR/tasks.toml"
+[included_remote_template]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+EOF
+cat <<EOF >mise.toml
+[task_config]
+includes = ["$INCLUDED_TASK_DIR/tasks.toml"]
+EOF
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV mise tasks info included_remote_template" "remote_dep"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_REMOTE_NO_CACHE=true mise tasks info included_remote_template" "remote_dep"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Deferred metadata (confirmation and task env) can render after initial task
+# discovery, so decoded header templates must still require the defining
+# config's trust before either path gets a chance to execute.
+cat <<EOF >mise.toml
+[tasks.remote_deferred]
+file = "http://localhost:${HTTP_PORT}/test/remote-deferred-template"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run remote_deferred" "not trusted"
+[[ ! -e $DEFERRED_MARKER ]] || fail "deferred remote metadata template executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV MISE_YES=1 mise run remote_deferred" "remote deferred task ran"
+[[ -e $DEFERRED_MARKER ]] || fail "trusted remote task env template did not render"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Template-free env metadata can still execute code or install tooling. It must
+# require the defining config's trust before resolution and before confirmation.
+cat <<EOF >mise.toml
+[tasks.remote_source]
+file = "http://localhost:${HTTP_PORT}/test/remote-source"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run --dry-run remote_source" "not trusted"
+[[ ! -e $SOURCE_MARKER ]] || fail "remote source directive executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV MISE_YES=1 mise run remote_source" "remote source task ran: VIRTUAL_ENV=$REMOTE_VENV"
+[[ -e $SOURCE_MARKER ]] || fail "trusted remote source directive did not execute"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Static file directives read outside the task sandbox, and structured SOPS
+# files can execute the configured sops binary. Neither may happen before the
+# defining config is trusted, including during dry-run.
+cat <<EOF >mise.toml
+[tasks.remote_sops_file]
+file = "http://localhost:${HTTP_PORT}/test/remote-sops-file"
+EOF
+
+assert_fail "$UNTRUSTED_ENV PATH=$FAKE_SOPS_BIN:$PATH MISE_SOPS_ROPS=0 mise run --dry-run remote_sops_file" "not trusted"
+[[ ! -e $SOPS_MARKER ]] || fail "remote sops file executed a tool before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV PATH=$FAKE_SOPS_BIN:$PATH MISE_SOPS_ROPS=0 mise run remote_sops_file" "remote sops task ran: decrypted"
+[[ -e $SOPS_MARKER ]] || fail "trusted remote sops file did not execute the configured tool"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Remote visibility is metadata too: ordinary listings must apply hide after
+# fetching, while --hidden still exposes the task and its remote description.
+cat <<EOF >mise.toml
+[tasks.remote_hidden]
+file = "http://localhost:${HTTP_PORT}/test/remote-hidden"
+EOF
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_not_contains "$UNTRUSTED_ENV mise tasks ls" "remote_hidden"
+assert_contains "$UNTRUSTED_ENV mise tasks ls --hidden" "hidden remote metadata"
+assert_not_contains "$UNTRUSTED_ENV mise tasks deps" "remote_hidden"
+assert_contains "$UNTRUSTED_ENV mise tasks deps --hidden" "remote_hidden"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Locally known hidden metadata is monotonic, so passive listings must not
+# fetch that task merely to discard it afterward.
+rm -f "$REQUEST_MARKER"
+cat <<EOF >mise.toml
+[tasks.locally_hidden_remote]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+hide = true
+EOF
+
+assert_not_contains "$UNTRUSTED_ENV mise tasks deps" "locally_hidden_remote"
+[[ ! -e $REQUEST_MARKER ]] || fail "tasks deps fetched a locally hidden remote task"
+
+# Tool metadata is consumed for runtime activation even when installation is
+# disabled, so every consumption path must require trust. Disabled modes still
+# remain authoritative after trust and must not install the missing fixture.
+cat <<EOF >mise.toml
+[tasks.remote_tools]
+file = "http://localhost:${HTTP_PORT}/test/remote-tools"
+
+[tasks.remote_alias_parent]
+depends = ["remote-tools-alias"]
+run = "echo remote alias parent ran"
+
+[tasks.remote_alias_delegate]
+run = [{ task = "remote-tools-alias" }]
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV mise run --skip-tools remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_fail "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise run --dry-run --skip-tools remote_tools" "not trusted"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV mise tasks info remote-tools-alias" "remote-tools-alias"
+assert_contains "$UNTRUSTED_ENV mise tasks deps remote-tools-alias" "remote_tools"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote-tools-alias" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise remote-tools-alias" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_alias_parent" "remote alias parent ran"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_alias_delegate" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
+assert_contains "$UNTRUSTED_ENV mise run remote_tools" "This is Dummy 1.0.0!"
+
+# A prefixed alias already known from local metadata must not trigger remote
+# alias discovery for unrelated tasks.
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+
+[tasks.local_prefixed_alias]
+alias = "local-alias"
+run = "echo local prefixed alias ran"
+
+[tasks.unrelated_remote]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+EOF
+
+rm -f "$REQUEST_MARKER"
+assert_contains "mise //:local-alias" "local prefixed alias ran"
+[[ ! -e $REQUEST_MARKER ]] || fail "known local prefixed alias fetched unrelated remote metadata"
+
+# Prefixed monorepo aliases must use the same synthesized alias map in bare
+# dispatch and dynamic task delegation as normal `mise run` resolution.
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+
+[tasks.remote_tools]
+file = "http://localhost:${HTTP_PORT}/test/remote-tools"
+
+[tasks.remote_prefixed_alias_delegate]
+run = [{ task = "//:remote-tools-alias" }]
+EOF
+
+assert_contains "MISE_TASK_RUN_AUTO_INSTALL=0 mise //:remote-tools-alias" "This is Dummy 1.0.0!"
+assert_contains "mise run --skip-tools remote_prefixed_alias_delegate" "This is Dummy 1.0.0!"
+
+# Bare remote-alias dispatch must retain the snapshot whose header established
+# the alias, rather than selecting revision 1 and executing a second download.
+cat <<EOF >mise.toml
+[tasks.remote_changing_alias]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing-alias"
+EOF
+
+assert_contains "MISE_TASK_REMOTE_NO_CACHE=true mise remote-changing-alias" "remote changing alias revision 1"
+
+# A remote raw-args task must execute the same snapshot used to decide that
+# --help should pass through, rather than fetching a mutable source twice.
+cat <<EOF >mise.toml
+[tasks.remote_raw_help]
+file = "http://localhost:${HTTP_PORT}/test/remote-raw-help"
+EOF
+
+assert_contains "MISE_TASK_REMOTE_NO_CACHE=true mise run remote_raw_help --help" "remote raw help revision 1"
+
+# Two no-cache tasks using the same mutable URL must retain the exact body that
+# was parsed for each Task instead of both executing the final download path.
+cat <<EOF >mise.toml
+[tasks.remote_revision_a]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing"
+
+[tasks.remote_revision_b]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing"
+EOF
+
+ARTIFACT_TMPDIR="$TMPDIR/remote-artifacts"
+mkdir -p "$ARTIFACT_TMPDIR"
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_revision_a ::: remote_revision_b")
+assert_contains_text "$output" "remote revision 1"
+assert_contains_text "$output" "remote revision 2"
+assert_fail "find '$ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -994,6 +994,7 @@ impl Bootstrap {
             output_handler: None,
             context_builder: Default::default(),
             executor: None,
+            prefetched_tasks: None,
             no_cache: Default::default(),
             timeout: None,
             skip_deps: false,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::{Config, Settings};
 use crate::exit::exit;
-use crate::task::TaskOutput;
+use crate::task::{GetMatchingExt, TaskOutput};
 use crate::ui::{self, ctrlc};
 use crate::{Result, backend};
 use crate::{cli::args::ToolArg, path::PathExt};
@@ -768,7 +768,32 @@ impl Cli {
                 } else {
                     config.tasks().await?
                 };
-                if tasks.iter().any(|(_, t)| t.is_match(&task)) {
+                let mut prefetched_tasks = None;
+                let task_refs = crate::task::build_task_ref_map(tasks.iter());
+                let task_exists = if tasks.iter().any(|(_, candidate)| candidate.is_match(&task))
+                    || !task_refs.get_matching(&task)?.is_empty()
+                {
+                    true
+                } else {
+                    // Remote aliases only exist after parsing #MISE headers.
+                    // Retry command dispatch on a miss and retain the resolved
+                    // snapshots so Run executes the body that established the
+                    // alias.
+                    let resolved_tasks = crate::task::task_fetcher::TaskFetcher::new(false)
+                        .require_trust_before_fetch()
+                        .fetch_task_map(&config, &tasks)
+                        .await?;
+                    let resolved_task_refs = crate::task::build_task_ref_map(resolved_tasks.iter());
+                    let found = resolved_tasks
+                        .values()
+                        .any(|candidate| candidate.is_match(&task))
+                        || !resolved_task_refs.get_matching(&task)?.is_empty();
+                    if found {
+                        prefetched_tasks = Some(resolved_tasks);
+                    }
+                    found
+                };
+                if task_exists {
                     return Ok(Commands::Run(Box::new(run::Run {
                         task,
                         args: self.task_args.unwrap_or_default(),
@@ -791,6 +816,7 @@ impl Cli {
                         output_handler: None,
                         context_builder: Default::default(),
                         executor: None,
+                        prefetched_tasks,
                         no_cache: Default::default(),
                         timeout: None,
                         skip_deps: false,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,5 +1,5 @@
 use crate::errors::Error;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::iter::once;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ use crate::env;
 use crate::file::display_path;
 use crate::task::has_any_usage_spec;
 use crate::task::task_helpers::task_needs_permit;
-use crate::task::task_list::{get_task_lists, resolve_depends};
+use crate::task::task_list::{get_task_lists_with_prefetched, resolve_depends};
 use crate::task::task_output::TaskOutput;
 use crate::task::task_output_handler::OutputHandler;
 use crate::task::{Deps, Task};
@@ -225,6 +225,9 @@ pub struct Run {
 
     #[clap(skip)]
     pub executor: Option<crate::task::task_executor::TaskExecutor>,
+
+    #[clap(skip)]
+    pub prefetched_tasks: Option<BTreeMap<String, Task>>,
 }
 
 impl Run {
@@ -257,20 +260,31 @@ impl Run {
             self.args.contains(&"--help".to_string()) || self.args.contains(&"-h".to_string());
 
         let mut config = Config::get().await?;
+        let mut prefetched_task_list = None;
 
         // Handle task help early to avoid unnecessary toolset/deps work
         if has_help_in_task_args {
-            // Build args list to get the task (filter out --help/-h for task lookup)
+            // Build the same task list normal execution would use so raw-args
+            // tasks can reuse this exact fetched snapshot.
             let args = once(self.task.clone())
-                .chain(
-                    self.args
-                        .iter()
-                        .filter(|a| *a != "--help" && *a != "-h")
-                        .cloned(),
-                )
+                .chain(self.args.iter().cloned())
                 .collect_vec();
 
-            let task_list = get_task_lists(&config, &args, false, false).await?;
+            let mut task_list = get_task_lists_with_prefetched(
+                &config,
+                &args,
+                false,
+                false,
+                self.prefetched_tasks.as_ref(),
+            )
+            .await?;
+
+            // Help is passive discovery, but remote #USAGE and #MISE headers
+            // still need to be fetched before they can be displayed. Require
+            // trust before that fetch, just like `mise tasks info`.
+            let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache)
+                .require_trust_before_fetch();
+            fetcher.fetch_tasks(&config, &mut task_list).await?;
 
             if let Some(task) = task_list.first() {
                 // raw_args tasks act as proxies for tools that handle their
@@ -289,6 +303,7 @@ impl Run {
                     }
                     return Ok(());
                 }
+                prefetched_task_list = Some(task_list);
             } else {
                 // No task found, show run command help
                 self.get_clap_command().print_long_help()?;
@@ -309,7 +324,28 @@ impl Run {
             .chain(self.args.clone())
             .collect_vec();
 
-        let mut task_list = get_task_lists(&config, &args, true, self.skip_deps).await?;
+        let (mut task_list, tasks_already_fetched) = if let Some(mut tasks) = prefetched_task_list {
+            if self.skip_deps {
+                for task in &mut tasks {
+                    task.depends.clear();
+                    task.depends_post.clear();
+                    task.wait_for.clear();
+                }
+            }
+            (tasks, true)
+        } else {
+            (
+                get_task_lists_with_prefetched(
+                    &config,
+                    &args,
+                    true,
+                    self.skip_deps,
+                    self.prefetched_tasks.as_ref(),
+                )
+                .await?,
+                false,
+            )
+        };
 
         // Args after -- go directly to tasks (no prefix). They are also
         // recorded on `trailing_args` so the task renderer can detect
@@ -323,8 +359,10 @@ impl Run {
 
         // Fetch remote task files before parsing usage specs, so that
         // file-based remote tasks have their files resolved to local cache.
-        let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
-        fetcher.fetch_tasks(&config, &mut task_list).await?;
+        if !tasks_already_fetched {
+            let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
+            fetcher.fetch_tasks(&config, &mut task_list).await?;
+        }
 
         // Re-render dependency templates with parent task's usage arg/flag values.
         // This enables patterns like: depends = ["child {{usage.app}}"]

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::config::Config;
+use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Deps, GetMatchingExt, Task, build_task_ref_map};
 use crate::ui::style::{self};
 use crate::ui::tree::print_tree;
@@ -49,9 +50,19 @@ impl TasksDeps {
     async fn get_all_tasks(&self, config: &Arc<Config>) -> Result<Vec<Task>> {
         // Use TaskLoadContext::all() to load tasks from entire monorepo
         let ctx = crate::task::TaskLoadContext::all();
-        Ok(config
-            .tasks_with_context(Some(&ctx))
-            .await?
+        let tasks = config.tasks_with_context(Some(&ctx)).await?;
+        let visible_tasks = tasks
+            .iter()
+            // A local/overlay hide=true survives remote metadata merging, so
+            // do not fetch tasks that cannot appear in ordinary output.
+            .filter(|(_, task)| self.hidden || !task.hide)
+            .map(|(name, task)| (name.clone(), task.clone()))
+            .collect();
+        let resolved = TaskFetcher::new(false)
+            .require_trust_before_fetch()
+            .fetch_task_map(config, &visible_tasks)
+            .await?;
+        Ok(resolved
             .values()
             .filter(|t| self.hidden || !t.hide)
             .cloned()
@@ -74,26 +85,76 @@ impl TasksDeps {
             .filter(|t| t.starts_with("//"))
             .map(|s| s.as_str())
             .collect();
-        let monorepo_tasks = if !monorepo_patterns.is_empty() {
+        let mut monorepo_tasks = if !monorepo_patterns.is_empty() {
             let ctx = crate::task::TaskLoadContext::from_patterns(monorepo_patterns.into_iter());
-            Some(config.tasks_with_context(Some(&ctx)).await?)
+            Some(
+                config
+                    .tasks_with_context(Some(&ctx))
+                    .await?
+                    .as_ref()
+                    .clone(),
+            )
         } else {
             None
         };
 
         // Load non-monorepo tasks once (only if needed)
         let has_regular = task_names.iter().any(|t| !t.starts_with("//"));
-        let regular_tasks = if has_regular {
-            Some(config.tasks().await?)
+        let mut regular_tasks = if has_regular {
+            Some(config.tasks().await?.as_ref().clone())
         } else {
             None
         };
 
-        // Build task ref maps once (not per-task)
+        let monorepo_needs_remote = if let Some(tasks) = &monorepo_tasks {
+            let refs = build_task_ref_map(tasks.iter());
+            task_names
+                .iter()
+                .filter(|name| name.starts_with("//"))
+                .map(|name| refs.get_matching(name))
+                .collect::<Result<Vec<_>>>()?
+                .iter()
+                .any(Vec::is_empty)
+        } else {
+            false
+        };
+        if monorepo_needs_remote && let Some(tasks) = &monorepo_tasks {
+            monorepo_tasks = Some(
+                TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, tasks)
+                    .await?,
+            );
+        }
+
+        let regular_needs_remote = if let Some(tasks) = &regular_tasks {
+            let refs = build_task_ref_map(tasks.iter());
+            task_names
+                .iter()
+                .filter(|name| !name.starts_with("//"))
+                .map(|name| refs.get_matching(name))
+                .collect::<Result<Vec<_>>>()?
+                .iter()
+                .any(Vec::is_empty)
+        } else {
+            false
+        };
+        if regular_needs_remote && let Some(tasks) = &regular_tasks {
+            regular_tasks = Some(
+                TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, tasks)
+                    .await?,
+            );
+        }
+
+        // Build task ref maps once (not per-task), after any remote-alias retry.
         let monorepo_ref_map = monorepo_tasks
             .as_ref()
-            .map(|t| build_task_ref_map(t.iter()));
-        let regular_ref_map = regular_tasks.as_ref().map(|t| build_task_ref_map(t.iter()));
+            .map(|tasks| build_task_ref_map(tasks.iter()));
+        let regular_ref_map = regular_tasks
+            .as_ref()
+            .map(|tasks| build_task_ref_map(tasks.iter()));
 
         // Look up each task from the appropriate cache
         let mut tasks = vec![];
@@ -138,7 +199,7 @@ impl TasksDeps {
     /// ```
     ///
     async fn print_deps_tree(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
-        let deps = Deps::new(config, tasks.clone()).await?;
+        let deps = Deps::new_for_display(config, tasks.clone()).await?;
         // filter out nodes that are not selected
         let start_indexes = deps.graph.node_indices().filter(|&idx| {
             let task = &deps.graph[idx];
@@ -169,7 +230,7 @@ impl TasksDeps {
     /// ```
     //
     async fn print_deps_dot(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
-        let deps = Deps::new(config, tasks).await?;
+        let deps = Deps::new_for_display(config, tasks).await?;
         miseprintln!(
             "{:?}",
             Dot::with_attr_getters(

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -40,7 +40,23 @@ impl TasksInfo {
 
         use crate::task::GetMatchingExt;
         let matching = tasks_with_aliases.get_matching(&task_name).ok();
-        let task = matching.and_then(|m| m.first().cloned().cloned());
+        let mut task =
+            matching.and_then(|matching| matching.into_iter().next().map(|task| (**task).clone()));
+
+        // A remote task's aliases only become available after its #MISE header
+        // is fetched. Avoid fetching every remote task for ordinary name hits,
+        // but retry a miss against trusted, resolved remote metadata.
+        if task.is_none() {
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(&config, &tasks)
+                .await?;
+            let resolved_with_aliases = crate::task::build_task_ref_map(resolved_tasks.iter());
+            task = resolved_with_aliases
+                .get_matching(&task_name)
+                .ok()
+                .and_then(|matching| matching.into_iter().next().map(|task| (**task).clone()));
+        }
 
         if let Some(task) = task {
             // Resolve remote task files before displaying task info
@@ -48,6 +64,7 @@ impl TasksInfo {
             // always pass no_cache=false as the command doesn't take no-cache argument
             // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
             TaskFetcher::new(false)
+                .require_trust_before_fetch()
                 .fetch_tasks(&config, &mut tasks)
                 .await?;
             let task = &tasks[0];

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -118,22 +118,27 @@ impl TasksLs {
 
         let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
 
-        let tasks = all_tasks
+        let mut tasks = all_tasks
             .values()
+            // A local/overlay hide=true is monotonic when remote metadata is
+            // merged, so avoid fetching tasks that can never become visible.
             .filter(|t| self.hidden || !t.hide)
             .filter(|t| !self.local || !t.global)
             .filter(|t| !self.global || t.global)
             .cloned()
-            .sorted_by(|a, b| self.sort(a, b))
             .collect::<Vec<Task>>();
 
         // Resolve remote task files before any operation that may need them
-        let mut tasks = tasks;
         // always pass no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
+            .require_trust_before_fetch()
             .fetch_tasks(&config, &mut tasks)
             .await?;
+        // Remote #MISE headers can contribute hide/alias/description metadata,
+        // so visibility and metadata-based sorting must happen after fetching.
+        tasks.retain(|task| self.hidden || !task.hide);
+        tasks.sort_by(|a, b| self.sort(a, b));
 
         // Warn about non-executable files only when there are truly no tasks at all
         // (not just filtered out by --hidden/--local/--global)

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -70,6 +70,7 @@ impl TasksValidate {
         // always no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
+            .require_trust_before_fetch()
             .fetch_tasks(&config, &mut resolved_tasks)
             .await?;
         let all_tasks: BTreeMap<String, Task> = resolved_tasks

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -351,6 +351,23 @@ pub fn trust_check(path: &Path) -> eyre::Result<()> {
     Err(UntrustedConfig(path.into()))?
 }
 
+/// Require trust before configuration can cause remote network or Git work.
+///
+/// Safe mode makes ordinary config parsing trust-exempt because its executable
+/// features are disabled. A remote fetch is still an external side effect,
+/// though, so safe mode only permits it when the owner was already trusted.
+/// Outside safe mode this preserves the normal interactive trust prompt.
+pub fn trust_check_remote_fetch(path: &Path) -> eyre::Result<()> {
+    if !remote_fetch_trust_allows(Settings::safe_mode(), is_path_trusted(path)) {
+        Err(UntrustedConfig(path.into()))?
+    }
+    trust_check(path)
+}
+
+fn remote_fetch_trust_allows(safe_mode: bool, is_trusted: bool) -> bool {
+    !safe_mode || is_trusted
+}
+
 pub fn is_trusted(path: &Path) -> bool {
     let canonicalized_path = match path.canonicalize() {
         Ok(p) => p,
@@ -832,5 +849,13 @@ mod tests {
             result2,
             Path::new("/tmp/trusted/infra-mise.toml-a1b2c3d4e5f67890.monorepo")
         );
+    }
+
+    #[test]
+    fn test_remote_fetch_trust_policy() {
+        assert!(!remote_fetch_trust_allows(true, false));
+        assert!(remote_fetch_trust_allows(true, true));
+        assert!(remote_fetch_trust_allows(false, false));
+        assert!(remote_fetch_trust_allows(false, true));
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -239,6 +239,19 @@ impl EnvDirective {
             | EnvDirective::Module(_, _, opts) => opts,
         }
     }
+
+    /// Whether resolving this directive can execute code or install tooling.
+    /// Remote task headers are untrusted input, so these directives require the
+    /// local config that selected the task to be trusted before resolution.
+    fn requires_remote_trust(&self) -> bool {
+        matches!(
+            self,
+            EnvDirective::File(..)
+                | EnvDirective::Source(..)
+                | EnvDirective::PythonVenv { .. }
+                | EnvDirective::Module(..)
+        )
+    }
 }
 
 impl From<(String, String)> for EnvDirective {
@@ -325,6 +338,7 @@ pub struct EnvResults {
     pub watch_files: Vec<PathBuf>,
     /// True if any directive declared cacheable=false or is a dynamic module
     pub has_uncacheable: bool,
+    pub(crate) trust_source: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -350,17 +364,35 @@ pub struct EnvResolveOptions {
 impl EnvResults {
     pub async fn resolve(
         config: &Arc<Config>,
+        ctx: tera::Context,
+        initial: &EnvMap,
+        input: Vec<(EnvDirective, PathBuf)>,
+        resolve_opts: EnvResolveOptions,
+    ) -> eyre::Result<Self> {
+        Self::resolve_with_trust_source(config, ctx, initial, input, resolve_opts, None).await
+    }
+
+    /// Resolve directives relative to their source paths while checking trust
+    /// against a separate provenance path. Remote task headers need this:
+    /// relative files belong to the fetched script, but trust belongs to the
+    /// local config that declared the remote task.
+    pub async fn resolve_with_trust_source(
+        config: &Arc<Config>,
         mut ctx: tera::Context,
         initial: &EnvMap,
         input: Vec<(EnvDirective, PathBuf)>,
         resolve_opts: EnvResolveOptions,
+        trust_source: Option<&Path>,
     ) -> eyre::Result<Self> {
         // trace!("resolve: input: {:#?}", &input);
         let mut env = initial
             .iter()
             .map(|(k, v)| (k.clone(), (v.clone(), None)))
             .collect::<IndexMap<_, _>>();
-        let mut r = Self::default();
+        let mut r = Self {
+            trust_source: trust_source.map(Path::to_path_buf),
+            ..Default::default()
+        };
         let normalize_path = |config_root: &Path, p: PathBuf| {
             let p = p.strip_prefix("./").unwrap_or(&p);
             match p.strip_prefix("~/") {
@@ -432,6 +464,13 @@ impl EnvResults {
 
         for (directive, source) in filtered_input {
             let mut tera = None;
+            if directive.requires_remote_trust() && r.trust_source.is_some() {
+                r.trust_check_source(&source).wrap_err_with(|| {
+                    format!(
+                        "remote task environment directive {directive} requires its defining config to be trusted"
+                    )
+                })?;
+            }
             // trace!(
             //     "resolve: directive: {:?}, source: {:?}",
             //     &directive,
@@ -881,7 +920,7 @@ impl EnvResults {
 
         // Step 1: Tera template expansion
         if contains_template_syntax(input) {
-            trust_check(path)?;
+            self.trust_check_source(path)?;
             let tera = tera.get_or_insert_with(|| {
                 let mut tera = get_tera(path.parent());
                 // Re-bind exec() to the accumulated env vars — but never in safe
@@ -924,6 +963,10 @@ impl EnvResults {
         }
 
         Ok(output)
+    }
+
+    fn trust_check_source(&self, fallback: &Path) -> eyre::Result<()> {
+        trust_check(self.trust_source.as_deref().unwrap_or(fallback))
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1168,5 +1211,51 @@ mod tests {
         let keys: Vec<String> = results.env.keys().cloned().collect();
         assert_eq!(keys, vec!["TOOLS_VAL".to_string()]);
         assert!(results.env_paths.is_empty());
+    }
+
+    #[test]
+    fn test_remote_env_directives_requiring_trust() {
+        let options = EnvDirectiveOptions::default();
+        assert!(EnvDirective::File(".env".into(), options.clone()).requires_remote_trust());
+        assert!(EnvDirective::Source("env.sh".into(), options.clone()).requires_remote_trust());
+        assert!(
+            !EnvDirective::Age {
+                key: "SECRET".into(),
+                value: String::new(),
+                format: None,
+                options: options.clone(),
+            }
+            .requires_remote_trust()
+        );
+        assert!(
+            EnvDirective::PythonVenv {
+                path: ".venv".into(),
+                create: false,
+                python: None,
+                uv_create_args: None,
+                python_create_args: None,
+                options: options.clone(),
+            }
+            .requires_remote_trust()
+        );
+        assert!(
+            EnvDirective::Module(
+                "example".into(),
+                toml::Value::Table(Default::default()),
+                options
+            )
+            .requires_remote_trust()
+        );
+        assert!(!EnvDirective::Path("bin".into(), Default::default()).requires_remote_trust());
+        assert!(
+            !EnvDirective::Val("KEY".into(), "value".into(), Default::default())
+                .requires_remote_trust()
+        );
+        assert!(
+            !EnvDirective::Default("KEY".into(), "value".into(), Default::default())
+                .requires_remote_trust()
+        );
+        assert!(!EnvDirective::Rm("KEY".into(), Default::default()).requires_remote_trust());
+        assert!(!EnvDirective::Required("KEY".into(), Default::default()).requires_remote_trust());
     }
 }

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -1,7 +1,6 @@
 use crate::Result;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
-use crate::config::config_file::trust_check;
 use crate::config::env_directive::EnvResults;
 use crate::config::{Config, Settings};
 use crate::env_diff::EnvMap;
@@ -188,7 +187,7 @@ impl EnvResults {
         python_create_args: Option<Vec<String>>,
     ) -> Result<()> {
         trace!("python venv: {} create={create}", display_path(&path));
-        trust_check(source)?;
+        r.trust_check_source(source)?;
         let venv = r.parse_template(ctx, tera, source, exec_env, &path)?;
         let venv = normalize_path(config_root, venv.into());
         let venv_lock = LockFile::new(&venv).lock()?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,7 +28,7 @@ use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
 use crate::file::display_path;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::TaskFileProvidersBuilder;
+use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{Task, TaskCacheConfig, TaskTemplate, monorepo_scope, strip_extension};
 use crate::tera::{contains_template_syntax, get_empty_tera, render_str, take_tera_accessed_files};
@@ -600,8 +600,12 @@ impl Config {
         // Default context (None) becomes TaskLoadContext::default()
         let cache_key = ctx.cloned().unwrap_or_default();
 
-        // Check if already cached
-        if let Some(cached) = self.tasks_cache.get(&cache_key) {
+        // No-cache remote includes own temporary snapshots through their Tasks.
+        // The global Config cache is static and would keep those cleanup guards
+        // alive until process teardown (static destructors do not run), so skip
+        // both cache reads and writes in this mode.
+        let use_cache = !Settings::get().task.remote_no_cache.unwrap_or(false);
+        if use_cache && let Some(cached) = self.tasks_cache.get(&cache_key) {
             return Ok(cached.value().clone());
         }
 
@@ -611,8 +615,9 @@ impl Config {
         });
         let tasks_arc = Arc::new(tasks);
 
-        // Insert into cache
-        self.tasks_cache.insert(cache_key, tasks_arc.clone());
+        if use_cache {
+            self.tasks_cache.insert(cache_key, tasks_arc.clone());
+        }
 
         Ok(tasks_arc)
     }
@@ -847,6 +852,7 @@ impl Config {
                 tool_add_paths: Vec::new(),
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
+                trust_source: None,
             };
             let redact_keys = self
                 .redaction_keys()
@@ -3493,15 +3499,51 @@ fn is_mise_config_file_in_task_include(root: &Path, path: &Path) -> bool {
     })
 }
 
-async fn resolve_git_url_to_path(git_url: &str) -> Result<PathBuf> {
+async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
     let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
     let task_file_providers = TaskFileProvidersBuilder::new()
         .with_cache(!no_cache)
         .build();
 
     match task_file_providers.get_provider(git_url) {
-        Some(provider) => provider.get_local_path(git_url).await,
+        Some(provider) => provider.get_local_artifact(git_url).await,
         None => bail!("No provider found for git URL: {}", git_url),
+    }
+}
+
+fn trust_check_remote_task_include(owner: &Path, include: &str) -> Result<()> {
+    config_file::trust_check_remote_fetch(owner).wrap_err_with(|| {
+        format!(
+            "fetching remote task include {include} requires its defining config {} to be trusted",
+            display_path(owner)
+        )
+    })
+}
+
+/// Authorize every remote include before deriving whether its owner can vouch
+/// for the fetched task files. Outside safe mode this may interactively trust
+/// the owner, so callers must not snapshot `is_path_trusted` first.
+fn trust_check_remote_task_includes(owner: &Path, includes: &[String]) -> Result<bool> {
+    let mut found_remote = false;
+    for include in includes
+        .iter()
+        .filter(|include| include.starts_with("git::"))
+    {
+        trust_check_remote_task_include(owner, include)?;
+        found_remote = true;
+    }
+    Ok(found_remote)
+}
+
+fn preserve_remote_task_trust_source(tasks: &mut [Task], source: &Path) {
+    for task in tasks {
+        if task.file.as_ref().is_some_and(|file| {
+            let file = file.to_string_lossy();
+            file.starts_with("git::") || file.starts_with("http://") || file.starts_with("https://")
+        }) {
+            task.remote_config_source
+                .get_or_insert_with(|| source.to_path_buf());
+        }
     }
 }
 
@@ -3662,6 +3704,7 @@ struct TaskSources {
 struct CascadedTaskConfig {
     task_config: TaskConfig,
     includes_root: PathBuf,
+    includes_source: Option<PathBuf>,
 }
 
 fn merge_cascaded_task_config(
@@ -3689,10 +3732,14 @@ fn merge_cascaded_task_config(
     }) {
         cascaded.task_config.global_pass_through_env = global_pass_through_env;
     }
-    if let Some((includes, root)) = configs
+    if let Some((includes, root, source)) = configs
         .iter()
         .find_map(|cf| match cf.task_config_includes() {
-            Ok(Some(includes)) => Some(Ok((includes, cf.config_root()))),
+            Ok(Some(includes)) => Some(Ok((
+                includes,
+                cf.config_root(),
+                cf.get_path().to_path_buf(),
+            ))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         })
@@ -3700,6 +3747,7 @@ fn merge_cascaded_task_config(
     {
         cascaded.task_config.includes = Some(includes);
         cascaded.includes_root = root;
+        cascaded.includes_source = Some(source);
     }
     Ok(())
 }
@@ -3729,6 +3777,7 @@ fn cascaded_task_config_for_dir(
                 cascaded = Some(CascadedTaskConfig {
                     task_config: TaskConfig::default(),
                     includes_root: root,
+                    includes_source: None,
                 });
             }
             _ => {}
@@ -3831,26 +3880,57 @@ async fn load_task_sources_from_configs(
             cascaded_task_config
         };
     let is_global = configs.iter().any(|cf| is_global_config(cf.get_path()));
-    // a config can only vouch for task include files when it was actually
-    // trusted — safe configs load without trust and cannot vouch for anything
-    let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
-    let (includes, resolve_dir) = configs
+    let (includes, resolve_dir, include_owner) = configs
         .iter()
         .find_map(|cf| match cf.task_config_includes() {
-            Ok(Some(includes)) => Some(Ok((includes, cf.config_root()))),
+            Ok(Some(includes)) => Some(Ok((
+                includes,
+                cf.config_root(),
+                Some(cf.get_path().to_path_buf()),
+            ))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         })
         .transpose()?
         .or_else(|| {
             cascaded_task_config.and_then(|tc| {
-                tc.task_config
-                    .includes
-                    .clone()
-                    .map(|includes| (includes, tc.includes_root.clone()))
+                tc.task_config.includes.clone().map(|includes| {
+                    (
+                        includes,
+                        tc.includes_root.clone(),
+                        tc.includes_source.clone(),
+                    )
+                })
             })
         })
-        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf()));
+        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), None));
+
+    let remote_includes_authorized = match include_owner.as_deref() {
+        Some(owner) => trust_check_remote_task_includes(owner, &includes)?,
+        None if includes.iter().any(|include| include.starts_with("git::")) => {
+            bail!("remote task include has no defining config provenance")
+        }
+        None => false,
+    };
+
+    // An explicit include is vouched for only by the config that declared it.
+    // For implicit default includes, retain the existing directory-level rule:
+    // any trusted config at that root can vouch for the conventional task dir.
+    let vouching_config_source = include_owner
+        .as_ref()
+        .filter(|owner| remote_includes_authorized || is_path_trusted(owner))
+        .cloned()
+        .or_else(|| {
+            if include_owner.is_some() {
+                return None;
+            }
+            configs
+                .iter()
+                .find(|cf| is_path_trusted(cf.get_path()))
+                .map(|cf| cf.get_path().to_path_buf())
+        });
+    // Safe configs load without trust and cannot vouch for task include files.
+    let require_task_include_trust = vouching_config_source.is_none();
 
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.
@@ -3898,12 +3978,16 @@ async fn load_task_sources_from_configs(
         None
     };
     for include in &includes {
-        let paths = if include.starts_with("git::") {
+        let artifacts = if include.starts_with("git::") {
             vec![resolve_git_url_to_path(include).await?]
         } else {
             expand_task_include(&resolve_dir, include)
+                .into_iter()
+                .map(TaskFileArtifact::persistent)
+                .collect()
         };
-        for p in paths {
+        for artifact in artifacts {
+            let p = artifact.path;
             let mut loaded = load_tasks_includes(
                 config,
                 &p,
@@ -3921,6 +4005,14 @@ async fn load_task_sources_from_configs(
                 apply_task_config_inputs(task, config, &task_config.inputs).await?;
                 apply_task_config_cache_default(task, &task_config.cache);
                 task_config.environment.apply(task)?;
+            }
+            if let Some(source) = &vouching_config_source {
+                preserve_remote_task_trust_source(&mut loaded, source);
+            }
+            if let Some(cleanup) = artifact.cleanup {
+                for task in &mut loaded {
+                    task.remote_artifact_cleanups.push(cleanup.clone());
+                }
             }
             if is_global || is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -118,20 +118,27 @@ pub fn task_key(task: &Task) -> TaskKey {
 /// manages a dependency graph of tasks so `mise run` knows what to run next
 impl Deps {
     pub async fn new(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
-        Self::new_with_cycle_limit(config, tasks, Some(1)).await
+        Self::new_with_options(config, tasks, Some(1), false).await
     }
 
     pub(crate) async fn new_for_validation(
         config: &Arc<Config>,
         tasks: Vec<Task>,
     ) -> eyre::Result<Self> {
-        Self::new_with_cycle_limit(config, tasks, None).await
+        Self::new_with_options(config, tasks, None, true).await
     }
 
-    async fn new_with_cycle_limit(
+    /// Build a dependency graph for passive display without allowing remote
+    /// providers to perform network or Git work from an untrusted config.
+    pub async fn new_for_display(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
+        Self::new_with_options(config, tasks, Some(1), true).await
+    }
+
+    async fn new_with_options(
         config: &Arc<Config>,
         tasks: Vec<Task>,
         cycle_limit: Option<usize>,
+        trust_before_fetch: bool,
     ) -> eyre::Result<Self> {
         let mut graph = DiGraph::new();
         let mut indexes = HashMap::new();
@@ -154,7 +161,11 @@ impl Deps {
         }
         let all_tasks_to_run = resolve_depends(config, tasks).await?;
         let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
-        let fetcher = TaskFetcher::new(no_cache);
+        let fetcher = if trust_before_fetch {
+            TaskFetcher::new(no_cache).require_trust_before_fetch()
+        } else {
+            TaskFetcher::new(no_cache)
+        };
         while let Some(mut a) = stack.pop() {
             if seen.contains(&a) {
                 // prevent infinite loop

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -39,6 +39,17 @@ pub(crate) fn reset() {
     TASK_ENV_CACHE.lock().unwrap().clear();
 }
 
+#[derive(Debug)]
+pub(crate) struct TaskNotFoundError(String);
+
+impl Display for TaskNotFoundError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for TaskNotFoundError {}
+
 /// Type alias for tracking failed tasks with their exit codes
 pub type FailedTasks = Arc<std::sync::Mutex<Vec<(Task, Option<i32>)>>>;
 
@@ -1313,7 +1324,7 @@ impl Task {
 
         match resolve(&all_tasks) {
             Ok(depends) => Ok(depends),
-            Err(error) if error.to_string().starts_with("task not found:") => {
+            Err(error) if error.downcast_ref::<TaskNotFoundError>().is_some() => {
                 let resolved_tasks = TaskFetcher::new(false)
                     .require_trust_before_fetch()
                     .fetch_task_map(config, &all_tasks)
@@ -2428,7 +2439,7 @@ fn match_tasks_with_context(
             }
         }
 
-        return Err(eyre!(err_msg));
+        return Err(TaskNotFoundError(err_msg).into());
     };
 
     Ok(matches)

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -9,7 +9,7 @@ use crate::tera::{TeraEngine, contains_template_syntax, get_tera, render_str};
 use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
 use console::{measure_text_width, truncate_str};
-use eyre::{Result, bail, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 use globset::GlobBuilder;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -72,7 +72,7 @@ pub use task_output::TaskOutput;
 pub use task_script_parser::{has_any_args_defined, has_any_usage_spec};
 pub use task_template::TaskTemplate;
 
-use crate::config::config_file::ConfigFile;
+use crate::config::config_file::{ConfigFile, trust_check};
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
 use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
@@ -612,6 +612,23 @@ pub struct Task {
     #[serde(skip)]
     pub remote_file_source: Option<String>,
 
+    /// Config file that declared a remote task. The fetched task's
+    /// `config_source` is its cache path, so retain the defining config path for
+    /// trust checks that must happen after fetching.
+    #[serde(skip)]
+    pub remote_config_source: Option<PathBuf>,
+
+    /// Whether the fetched remote header contributed tool requirements.
+    /// Remote metadata is parsed during discovery, but these requirements must
+    /// not trigger installation until the defining config is trusted.
+    #[serde(skip)]
+    pub remote_metadata_has_tools: bool,
+
+    /// Keeps a no-cache remote snapshot alive while this Task (and any clones)
+    /// may still execute it. The final clone removes the temporary file/repo.
+    #[serde(skip)]
+    pub(crate) remote_artifact_cleanups: Vec<Arc<task_file_providers::TaskFileArtifactCleanup>>,
+
     /// Block reads, writes, network, and env vars
     #[serde(default)]
     pub deny_all: bool,
@@ -713,6 +730,17 @@ pub(crate) fn file_has_decoded_template(path: &Path, body: &str) -> bool {
             .iter()
             .any(toml_value_has_template)
     }
+}
+
+/// Check decoded `#MISE` header values regardless of the script filename.
+/// Remote file tasks are always scripts, even when their URL/path ends in
+/// `.toml`, so extension-based dispatch is not appropriate for them.
+pub(crate) fn script_header_has_decoded_template(body: &str) -> bool {
+    use crate::config::config_file::mise_toml::toml_value_has_template;
+    parse_mise_header_toml(body)
+        .unwrap_or_default()
+        .iter()
+        .any(toml_value_has_template)
 }
 
 fn parse_task_script_usage(file: &Path) -> usage::Result<usage::Spec> {
@@ -866,6 +894,21 @@ impl Task {
     }
 
     pub(crate) fn tool_args(&self) -> Result<Vec<ToolArg>> {
+        if self.remote_metadata_has_tools {
+            let remote_source = self.remote_file_source.as_deref().unwrap_or(&self.name);
+            let config_source = self.remote_config_source.as_deref().ok_or_else(|| {
+                eyre!(
+                    "remote task {remote_source} has tool metadata without defining config provenance"
+                )
+            })?;
+            trust_check(config_source).wrap_err_with(|| {
+                format!(
+                    "tool metadata from remote task {} requires its defining config {} to be trusted",
+                    remote_source,
+                    display_path(config_source)
+                )
+            })?;
+        }
         self.tools
             .iter()
             .map(|(tool, value)| value.to_tool_arg(tool))
@@ -1191,7 +1234,7 @@ impl Task {
         config: &Arc<Config>,
         tasks_to_run: &[Task],
     ) -> Result<(Vec<Task>, Vec<Task>)> {
-        use crate::task::TaskLoadContext;
+        use crate::task::{TaskLoadContext, task_fetcher::TaskFetcher};
 
         let tasks_to_run: HashSet<&Task> = tasks_to_run.iter().collect();
 
@@ -1221,55 +1264,64 @@ impl Task {
         };
 
         let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
-        let tasks = build_task_ref_map(all_tasks.iter());
-        // Skip deps with unresolved {{usage.*}} references — they'll be resolved
-        // later when render_depends_with_usage() is called with actual arg values.
-        let depends = self
-            .depends
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
-            .flatten_ok()
-            .collect_vec();
-        let wait_for = self
-            .wait_for
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| {
-                match_tasks_with_context(&tasks, td, Some(self))
-                    .map(|tasks| tasks.into_iter().map(|t| (t, td)).collect_vec())
-            })
-            .flatten_ok()
-            .filter_map_ok(|(t, td)| {
-                if td.env.is_empty() && td.args.is_empty() {
-                    // Name-based matching: wait for any running instance of this task
-                    // regardless of env/args variant (e.g., "VERBOSE=1 setup" matches "setup").
-                    // Return the actual task from tasks_to_run so the dependency graph
-                    // gets the correct env/args-variant node.
-                    tasks_to_run
-                        .iter()
-                        .find(|tr| tr.name == t.name)
-                        .map(|tr| (*tr).clone())
-                } else {
-                    // Full identity matching: user explicitly wants a specific env/args variant
-                    tasks_to_run.contains(&t).then_some(t)
-                }
-            })
-            .collect_vec();
-        let depends_post = self
-            .depends_post
-            .iter()
-            .filter(|td| !dep_has_usage_ref(td))
-            .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
-            .flatten_ok()
-            .filter_ok(|t| t.name != self.name)
-            .collect::<Result<Vec<_>>>()?;
-        let depends = depends
-            .into_iter()
-            .chain(wait_for)
-            .filter_ok(|t| t.name != self.name)
-            .collect::<Result<_>>()?;
-        Ok((depends, depends_post))
+        let resolve = |all_tasks: &BTreeMap<String, Task>| -> Result<(Vec<Task>, Vec<Task>)> {
+            let tasks = build_task_ref_map(all_tasks.iter());
+            // Skip deps with unresolved {{usage.*}} references — they'll be
+            // resolved later with actual argument values.
+            let depends = self
+                .depends
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
+                .flatten_ok()
+                .collect_vec();
+            let wait_for = self
+                .wait_for
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| {
+                    match_tasks_with_context(&tasks, td, Some(self))
+                        .map(|tasks| tasks.into_iter().map(|t| (t, td)).collect_vec())
+                })
+                .flatten_ok()
+                .filter_map_ok(|(t, td)| {
+                    if td.env.is_empty() && td.args.is_empty() {
+                        tasks_to_run
+                            .iter()
+                            .find(|tr| tr.name == t.name)
+                            .map(|tr| (*tr).clone())
+                    } else {
+                        tasks_to_run.contains(&t).then_some(t)
+                    }
+                })
+                .collect_vec();
+            let depends_post = self
+                .depends_post
+                .iter()
+                .filter(|td| !dep_has_usage_ref(td))
+                .map(|td| match_tasks_with_context(&tasks, td, Some(self)))
+                .flatten_ok()
+                .filter_ok(|t| t.name != self.name)
+                .collect::<Result<Vec<_>>>()?;
+            let depends = depends
+                .into_iter()
+                .chain(wait_for)
+                .filter_ok(|t| t.name != self.name)
+                .collect::<Result<_>>()?;
+            Ok((depends, depends_post))
+        };
+
+        match resolve(&all_tasks) {
+            Ok(depends) => Ok(depends),
+            Err(error) if error.to_string().starts_with("task not found:") => {
+                let resolved_tasks = TaskFetcher::new(false)
+                    .require_trust_before_fetch()
+                    .fetch_task_map(config, &all_tasks)
+                    .await?;
+                resolve(&resolved_tasks)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// True when mise should not run the usage parser against this task's
@@ -2133,7 +2185,7 @@ impl Task {
         env_directives.extend(self.overlay_env.iter().cloned());
 
         // Resolve environment directives using the same system as global env
-        let env_results = EnvResults::resolve(
+        let env_results = EnvResults::resolve_with_trust_source(
             config,
             tera_ctx.clone(),
             &env,
@@ -2143,6 +2195,7 @@ impl Task {
                 tools: ToolsFilter::Both,
                 warn_on_missing_required: false,
             },
+            self.remote_config_source.as_deref(),
         )
         .await?;
         // Register task-specific redactions with the global redactor
@@ -2424,6 +2477,9 @@ impl Default for Task {
             usage: "".to_string(),
             timeout: None,
             remote_file_source: None,
+            remote_config_source: None,
+            remote_metadata_has_tools: false,
+            remote_artifact_cleanups: vec![],
             deny_all: false,
             deny_read: false,
             deny_write: false,

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -9,7 +9,7 @@ use crate::toolset::{Toolset, ToolsetBuilder};
 use eyre::Result;
 use indexmap::IndexMap;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 type EnvResolutionResult = (
@@ -252,7 +252,7 @@ impl TaskContextBuilder {
 
         // Resolve config-level env from ALL config files, not just task_cf
         let config_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries)
+            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries, None)
             .await?;
         Self::apply_env_results(&mut env, &config_env_results);
 
@@ -263,7 +263,13 @@ impl TaskContextBuilder {
 
         let task_env_directives = self.build_task_env_directives(task);
         let task_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, task_env_directives)
+            .resolve_env_directives(
+                config,
+                &tera_ctx,
+                &env,
+                task_env_directives,
+                task.remote_config_source.as_deref(),
+            )
             .await?;
 
         let task_env = self.extract_task_env(&task_env_results);
@@ -408,8 +414,9 @@ impl TaskContextBuilder {
         tera_ctx: &tera::Context,
         env: &BTreeMap<String, String>,
         directives: Vec<(EnvDirective, PathBuf)>,
+        trust_source: Option<&Path>,
     ) -> Result<EnvResults> {
-        EnvResults::resolve(
+        EnvResults::resolve_with_trust_source(
             config,
             tera_ctx.clone(),
             env,
@@ -419,6 +426,7 @@ impl TaskContextBuilder {
                 tools: ToolsFilter::Both,
                 warn_on_missing_required: false,
             },
+            trust_source,
         )
         .await
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -904,16 +904,21 @@ impl TaskExecutor {
             name
         }));
         let tasks = config.tasks_with_context(Some(&ctx)).await?;
-        let tasks_map: BTreeMap<String, Task> = tasks
-            .values()
-            .flat_map(|t| {
-                t.aliases
-                    .iter()
-                    .map(|a| (a.to_string(), t.clone()))
-                    .chain(once((t.name.clone(), t.clone())))
-                    .collect::<Vec<_>>()
-            })
-            .collect();
+        let mut resolved_tasks = tasks.as_ref().clone();
+        let needs_remote_aliases = {
+            let tasks_map = crate::task::build_task_ref_map(resolved_tasks.iter());
+            specs.iter().try_fold(false, |missing, spec| {
+                let (name, _) = split_task_spec(spec);
+                Ok::<_, eyre::Report>(missing || tasks_map.get_matching(name)?.is_empty())
+            })?
+        };
+        if needs_remote_aliases {
+            resolved_tasks = crate::task::task_fetcher::TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &resolved_tasks)
+                .await?;
+        }
+        let tasks_map = crate::task::build_task_ref_map(resolved_tasks.iter());
         let mut to_run: Vec<Task> = vec![];
         for spec in specs {
             let (name, args) = split_task_spec(spec);

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -1,17 +1,31 @@
+use crate::config::config_file::{trust_check, trust_check_remote_fetch};
 use crate::config::{Config, Settings};
-use crate::task::Task;
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
-use eyre::{Result, bail};
+use crate::task::{Task, script_header_has_decoded_template};
+use eyre::{Result, WrapErr, bail};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 /// Handles fetching remote task files and converting them to local paths
 pub struct TaskFetcher {
     no_cache: bool,
+    trust_before_fetch: bool,
 }
 
 impl TaskFetcher {
     pub fn new(no_cache: bool) -> Self {
-        Self { no_cache }
+        Self {
+            no_cache,
+            trust_before_fetch: false,
+        }
+    }
+
+    /// Require trust before a remote provider performs network or Git work.
+    /// Passive discovery commands use this because merely listing tasks is not
+    /// an explicit request to execute a configured remote task.
+    pub fn require_trust_before_fetch(mut self) -> Self {
+        self.trust_before_fetch = true;
+        self
     }
 
     /// Fetch remote task files, converting remote paths to local cached paths
@@ -30,14 +44,37 @@ impl TaskFetcher {
                     continue;
                 }
 
+                let original = t.clone();
+                let defining_cf = original
+                    .cf
+                    .clone()
+                    .or_else(|| config.config_files.get(&original.config_source).cloned());
+                let defining_config_source = original
+                    .remote_config_source
+                    .clone()
+                    .or_else(|| defining_cf.as_ref().map(|cf| cf.get_path().to_path_buf()))
+                    .unwrap_or_else(|| original.config_source.clone());
+
+                if self.trust_before_fetch {
+                    trust_check_remote_fetch(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "fetching remote task {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
+
                 let provider = task_file_providers.get_provider(&source);
 
                 if provider.is_none() {
                     bail!("No provider found for file: {}", source);
                 }
 
-                let local_path = provider.unwrap().get_local_path(&source).await?;
-                let original = t.clone();
+                let artifact = provider
+                    .unwrap()
+                    .get_local_artifact(&source)
+                    .await
+                    .wrap_err_with(|| format!("failed to fetch remote task {source}"))?;
+                let local_path = artifact.path;
                 let config_root = original
                     .config_root
                     .clone()
@@ -48,12 +85,29 @@ impl TaskFetcher {
                 // Parse the downloaded script as a regular file task so all #MISE
                 // metadata is honored. The inline TOML task remains the higher-
                 // precedence overlay, matching local file-task behavior.
+                let body = crate::file::read_to_string(&local_path).wrap_err_with(|| {
+                    format!("failed to read remote task metadata from {source}")
+                })?;
+                let header_has_templates = script_header_has_decoded_template(&body);
                 let mut remote = Task::from_path_unrendered_with_cf(
                     &local_path,
                     prefix,
                     &config_root,
-                    original.cf.clone(),
-                )?;
+                    defining_cf,
+                )
+                .wrap_err_with(|| format!("failed to parse remote task metadata from {source}"))?;
+                // Parsing headers is inert. Check the decoded Task instead of
+                // guessing its format from the fetched filename: Git task scripts
+                // may legitimately end in `.toml`, and escaped TOML delimiters
+                // only become visible after header parsing.
+                if header_has_templates {
+                    trust_check(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "remote task metadata from {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
+                let remote_metadata_has_tools = !remote.tools.is_empty();
                 remote.name.clone_from(&original.name);
                 remote.display_name.clone_from(&original.display_name);
 
@@ -66,18 +120,46 @@ impl TaskFetcher {
                 remote.inherited_env.clone_from(&original.inherited_env);
                 remote.overlay_env.clone_from(&original.overlay_env);
                 remote.overlay_vars.clone_from(&original.overlay_vars);
-                remote.render(config, &config_root).await?;
+                remote
+                    .render(config, &config_root)
+                    .await
+                    .wrap_err_with(|| {
+                        format!("failed to render remote task metadata from {source}")
+                    })?;
                 remote.merge_toml_overlay(original.clone());
 
                 // Preserve runtime state that is not task metadata and therefore is
                 // intentionally not handled by merge_toml_overlay().
                 remote.global = original.global;
                 remote.remote_file_source = Some(source);
+                remote.remote_config_source = Some(defining_config_source);
+                remote.remote_metadata_has_tools = remote_metadata_has_tools;
+                remote
+                    .remote_artifact_cleanups
+                    .extend(original.remote_artifact_cleanups);
+                if let Some(cleanup) = artifact.cleanup {
+                    remote.remote_artifact_cleanups.push(cleanup);
+                }
                 *t = remote;
             }
         }
 
         Ok(())
+    }
+
+    /// Clone and resolve a task map so consumers can retry alias/dependency
+    /// matching against metadata that only exists in remote #MISE headers.
+    pub async fn fetch_task_map(
+        &self,
+        config: &Arc<Config>,
+        tasks: &BTreeMap<String, Task>,
+    ) -> Result<BTreeMap<String, Task>> {
+        let mut resolved = tasks.values().cloned().collect::<Vec<_>>();
+        self.fetch_tasks(config, &mut resolved).await?;
+        Ok(resolved
+            .into_iter()
+            .map(|task| (task.name.clone(), task))
+            .collect())
     }
 
     /// Check if a source path is a remote task file (git or http/https)
@@ -93,7 +175,44 @@ mod tests {
     use super::*;
     use crate::config::env_directive::EnvDirective;
     use crate::task::TaskToolValue;
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf};
+
+    #[test]
+    fn test_remote_script_template_detection_ignores_toml_extension() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("remote-task.toml");
+        fs::write(
+            &path,
+            r#"#!/usr/bin/env bash
+#MISE description="\u007b\u007b exec(command='echo unsafe') \u007d\u007d"
+echo ok
+"#,
+        )
+        .unwrap();
+
+        let task =
+            Task::from_path_unrendered_with_cf(&path, root.path(), root.path(), None).unwrap();
+
+        assert!(task.has_render_templates());
+        assert!(script_header_has_decoded_template(
+            &fs::read_to_string(path).unwrap()
+        ));
+    }
+
+    #[test]
+    fn test_remote_script_detects_deferred_header_templates() {
+        let confirm = r#"#!/usr/bin/env bash
+#MISE confirm="\u007b\u007b exec(command='echo unsafe') \u007d\u007d"
+echo ok
+"#;
+        let env = r#"#!/usr/bin/env bash
+#MISE env={MARKER="{{ exec(command='echo unsafe') }}"}
+echo ok
+"#;
+
+        assert!(script_header_has_decoded_template(confirm));
+        assert!(script_header_has_decoded_template(env));
+    }
 
     #[tokio::test]
     async fn test_fetch_remote_task_parses_headers_and_applies_toml_overlay() {
@@ -147,6 +266,11 @@ echo ok
         assert_eq!(task.args, ["--fix"]);
         assert_eq!(task.config_root.as_deref(), Some(config_root.path()));
         assert_eq!(task.remote_file_source.as_deref(), Some(source.as_str()));
+        assert_eq!(
+            task.remote_config_source.as_deref(),
+            Some(config_root.path().join("mise.toml").as_path())
+        );
+        assert!(task.remote_metadata_has_tools);
         assert!(task.is_remote());
         assert_eq!(
             task.tools.get("node"),
@@ -232,5 +356,41 @@ echo ok
 
         remote.assert_async().await;
         assert_eq!(tasks[0].description, "rendered from runtime context");
+    }
+
+    #[tokio::test]
+    async fn test_remote_header_error_identifies_source_url() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/invalid-task")
+            .with_status(200)
+            .with_body("#!/usr/bin/env bash\n#MISE unsupported_remote_field=true\necho ok\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let config = Config::get().await.unwrap();
+        let config_root = tempfile::tempdir().unwrap();
+        let source = format!("{}/invalid-task", server.url());
+        let mut tasks = vec![Task {
+            name: "invalid".into(),
+            config_source: config_root.path().join("mise.toml"),
+            config_root: Some(config_root.path().to_path_buf()),
+            file: Some(PathBuf::from(&source)),
+            ..Default::default()
+        }];
+
+        let error = TaskFetcher::new(true)
+            .fetch_tasks(&config, &mut tasks)
+            .await
+            .unwrap_err();
+
+        remote.assert_async().await;
+        assert!(error.to_string().contains(&source));
+        assert!(
+            error
+                .to_string()
+                .contains("failed to parse remote task metadata")
+        );
     }
 }

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -89,11 +89,14 @@ impl TaskFetcher {
                     format!("failed to read remote task metadata from {source}")
                 })?;
                 let header_has_templates = script_header_has_decoded_template(&body);
+                // `Task::cf` identifies monorepo task ownership, not general
+                // config provenance. Keep that semantic while trust uses the
+                // separate defining_config_source path above.
                 let mut remote = Task::from_path_unrendered_with_cf(
                     &local_path,
                     prefix,
                     &config_root,
-                    defining_cf,
+                    original.cf.clone(),
                 )
                 .wrap_err_with(|| format!("failed to parse remote task metadata from {source}"))?;
                 // Parsing headers is inert. Check the decoded Task instead of

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, path::PathBuf};
+use std::{fmt::Debug, path::PathBuf, sync::Arc};
 
 mod local_task;
 mod remote_task_git;
@@ -13,6 +13,50 @@ use remote_task_http::RemoteTaskHttpBuilder;
 pub trait TaskFileProvider: Debug + Send + Sync {
     fn is_match(&self, file: &str) -> bool;
     async fn get_local_path(&self, file: &str) -> Result<PathBuf>;
+
+    async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
+        Ok(TaskFileArtifact::persistent(
+            self.get_local_path(file).await?,
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TaskFileArtifactCleanup {
+    path: PathBuf,
+}
+
+impl Drop for TaskFileArtifactCleanup {
+    fn drop(&mut self) {
+        if let Err(err) = crate::file::remove_all(&self.path) {
+            warn!(
+                "failed to clean up remote task artifact {}: {err:#}",
+                crate::file::display_path(&self.path)
+            );
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TaskFileArtifact {
+    pub path: PathBuf,
+    pub(crate) cleanup: Option<Arc<TaskFileArtifactCleanup>>,
+}
+
+impl TaskFileArtifact {
+    pub(crate) fn persistent(path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup: None,
+        }
+    }
+
+    pub(crate) fn temporary(path: PathBuf, cleanup_path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup: Some(Arc::new(TaskFileArtifactCleanup { path: cleanup_path })),
+        }
+    }
 }
 
 pub struct TaskFileProvidersBuilder {

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -12,7 +12,7 @@ use crate::{
     remote_source::{RemoteGitSource, RemoteSource},
 };
 
-use super::TaskFileProvider;
+use super::{TaskFileArtifact, TaskFileProvider};
 
 #[derive(Debug)]
 pub struct RemoteTaskGitBuilder {
@@ -98,6 +98,82 @@ impl RemoteTaskGit {
             .unwrap()
     }
 
+    fn unique_destination(&self, cache_key: &str) -> Result<PathBuf> {
+        file::create_dir_all(&self.storage_path)?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix(&format!("{cache_key}-"))
+            .tempdir_in(&self.storage_path)?;
+        let destination = temp_dir.path().to_path_buf();
+        temp_dir.close()?;
+        Ok(destination)
+    }
+
+    fn fetch_to_destination(
+        &self,
+        repo_structure: &GitRepoStructure,
+        destination: &PathBuf,
+        reuse_existing: bool,
+    ) -> Result<PathBuf> {
+        let repo_file_path = repo_structure.path.clone();
+        let full_path = destination.join(&repo_file_path);
+
+        debug!("Repo structure: {:?}", repo_structure);
+
+        let _lock = LockFile::new(destination)
+            .with_callback(|l| {
+                debug!(
+                    "waiting for lock on remote git task cache: {}",
+                    display_path(l)
+                );
+            })
+            .lock()?;
+
+        if reuse_existing && full_path.exists() {
+            debug!("Using cached file: {:?}", full_path);
+            Self::prepare_remote_path(&full_path)?;
+            return Ok(full_path);
+        }
+
+        let mut tmp_destination = destination.as_os_str().to_os_string();
+        tmp_destination.push(".clone-tmp");
+        let tmp_destination = PathBuf::from(tmp_destination);
+        if tmp_destination.exists() {
+            crate::file::remove_all(&tmp_destination)?;
+        }
+
+        let git_repo = git::Git::new(&tmp_destination);
+        let mut clone_options = CloneOptions::default();
+        if let Some(branch) = &repo_structure.branch {
+            trace!("Use specific branch {}", branch);
+            clone_options = clone_options.branch(branch);
+        }
+
+        match git_repo.clone(repo_structure.url_without_path.as_str(), clone_options) {
+            Ok(()) => {
+                if destination.exists()
+                    && let Err(e) = crate::file::remove_all(destination)
+                {
+                    let _ = crate::file::remove_all(&tmp_destination);
+                    return Err(e);
+                }
+                if let Err(e) = std::fs::rename(&tmp_destination, destination) {
+                    let _ = crate::file::remove_all(&tmp_destination);
+                    return Err(eyre::eyre!(
+                        "failed to move cloned repo into cache at {}: {e}",
+                        display_path(destination)
+                    ));
+                }
+            }
+            Err(e) => {
+                let _ = crate::file::remove_all(&tmp_destination);
+                return Err(e);
+            }
+        }
+
+        Self::prepare_remote_path(&full_path)?;
+        Ok(full_path)
+    }
+
     #[cfg(test)]
     fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
         RemoteSource::parse_git_ssh(file).map(|source| source.into())
@@ -125,69 +201,26 @@ impl TaskFileProvider for RemoteTaskGit {
         let repo_structure = self.get_repo_structure(file);
         let cache_key = self.get_cache_key(&repo_structure);
         let destination = self.storage_path.join(&cache_key);
-        let repo_file_path = repo_structure.path.clone();
-        let full_path = destination.join(&repo_file_path);
+        self.fetch_to_destination(&repo_structure, &destination, self.is_cached)
+    }
 
-        debug!("Repo structure: {:?}", repo_structure);
-
-        let _lock = LockFile::new(&destination)
-            .with_callback(|l| {
-                debug!(
-                    "waiting for lock on remote git task cache: {}",
-                    display_path(l)
-                );
-            })
-            .lock()?;
-
+    async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
         if self.is_cached {
-            trace!("Cache mode enabled");
-            if full_path.exists() {
-                debug!("Using cached file: {:?}", full_path);
-                Self::prepare_remote_path(&full_path)?;
-                return Ok(full_path);
+            return Ok(TaskFileArtifact::persistent(
+                self.get_local_path(file).await?,
+            ));
+        }
+        let repo_structure = self.get_repo_structure(file);
+        let cache_key = self.get_cache_key(&repo_structure);
+        let destination = self.unique_destination(&cache_key)?;
+        let path = match self.fetch_to_destination(&repo_structure, &destination, false) {
+            Ok(path) => path,
+            Err(err) => {
+                let _ = crate::file::remove_all(&destination);
+                return Err(err);
             }
-        } else {
-            trace!("Cache mode disabled");
-        }
-
-        let tmp_destination = self.storage_path.join(format!("{}.clone-tmp", &cache_key));
-        if tmp_destination.exists() {
-            crate::file::remove_all(&tmp_destination)?;
-        }
-
-        let git_repo = git::Git::new(&tmp_destination);
-
-        let mut clone_options = CloneOptions::default();
-
-        if let Some(branch) = &repo_structure.branch {
-            trace!("Use specific branch {}", branch);
-            clone_options = clone_options.branch(branch);
-        }
-
-        match git_repo.clone(repo_structure.url_without_path.as_str(), clone_options) {
-            Ok(()) => {
-                if destination.exists()
-                    && let Err(e) = crate::file::remove_all(&destination)
-                {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(e);
-                }
-                if let Err(e) = std::fs::rename(&tmp_destination, &destination) {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(eyre::eyre!(
-                        "failed to move cloned repo into cache at {}: {e}",
-                        display_path(&destination)
-                    ));
-                }
-            }
-            Err(e) => {
-                let _ = crate::file::remove_all(&tmp_destination);
-                return Err(e);
-            }
-        }
-
-        Self::prepare_remote_path(&full_path)?;
-        Ok(full_path)
+        };
+        Ok(TaskFileArtifact::temporary(path, destination))
     }
 }
 

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use crate::{Result, dirs, env, file, hash, http::HTTP, remote_source::RemoteSource};
 
-use super::TaskFileProvider;
+use super::{TaskFileArtifact, TaskFileProvider};
 
 #[derive(Debug)]
 pub struct RemoteTaskHttpBuilder {
@@ -53,6 +53,23 @@ impl RemoteTaskHttp {
         file::make_executable(destination)?;
         Ok(())
     }
+
+    async fn get_unique_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
+        let cache_key = self.get_cache_key(file);
+        file::create_dir_all(&self.storage_path)?;
+        let temp_file =
+            tempfile::NamedTempFile::with_prefix_in(format!("{cache_key}-"), &self.storage_path)?;
+        let (_, destination) = temp_file.keep()?;
+        file::remove_file(&destination)?;
+        if let Err(error) = self.download_file(file, &destination).await {
+            let _ = file::remove_file(&destination);
+            return Err(error);
+        }
+        Ok(TaskFileArtifact::temporary(
+            destination.clone(),
+            destination,
+        ))
+    }
 }
 
 #[async_trait]
@@ -85,6 +102,15 @@ impl TaskFileProvider for RemoteTaskHttp {
 
         self.download_file(file, &destination).await?;
         Ok(destination)
+    }
+
+    async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
+        if self.is_cached {
+            return Ok(TaskFileArtifact::persistent(
+                self.get_local_path(file).await?,
+            ));
+        }
+        self.get_unique_artifact(file).await
     }
 }
 
@@ -132,12 +158,28 @@ mod tests {
             let request_url = format!("{}{}", server.url(), request_path);
             let cache_key = provider.get_cache_key(&request_url);
 
+            let mut local_paths = vec![];
             for _ in 0..2 {
-                let local_path = provider.get_local_path(&request_url).await.unwrap();
+                let artifact = provider.get_local_artifact(&request_url).await.unwrap();
+                let local_path = artifact.path.clone();
                 assert!(local_path.exists());
                 assert!(local_path.is_file());
-                assert!(local_path.ends_with(&cache_key));
+                assert!(
+                    local_path
+                        .file_name()
+                        .unwrap()
+                        .to_string_lossy()
+                        .starts_with(&cache_key)
+                );
+                local_paths.push((local_path, artifact));
             }
+            assert_ne!(local_paths[0].0, local_paths[1].0);
+            let retained_paths = local_paths
+                .iter()
+                .map(|(path, _)| path.clone())
+                .collect::<Vec<_>>();
+            drop(local_paths);
+            assert!(retained_paths.iter().all(|path| !path.exists()));
 
             mocked_server.assert();
         }

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -47,7 +47,7 @@ impl RemoteTaskHttp {
         hash::hash_sha256_to_str(file)
     }
 
-    async fn download_file(&self, file: &str, destination: &PathBuf) -> Result<()> {
+    async fn download_file_atomically(&self, file: &str, destination: &PathBuf) -> Result<()> {
         trace!("Downloading file: {}", file);
         HTTP.download_file(file, destination, None).await?;
         file::make_executable(destination)?;
@@ -60,8 +60,7 @@ impl RemoteTaskHttp {
         let temp_file =
             tempfile::NamedTempFile::with_prefix_in(format!("{cache_key}-"), &self.storage_path)?;
         let (_, destination) = temp_file.keep()?;
-        file::remove_file(&destination)?;
-        if let Err(error) = self.download_file(file, &destination).await {
+        if let Err(error) = self.download_file_atomically(file, &destination).await {
             let _ = file::remove_file(&destination);
             return Err(error);
         }
@@ -100,7 +99,7 @@ impl TaskFileProvider for RemoteTaskHttp {
             }
         }
 
-        self.download_file(file, &destination).await?;
+        self.download_file_atomically(file, &destination).await?;
         Ok(destination)
     }
 
@@ -137,7 +136,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_http_remote_task_get_local_path_without_cache() {
+    async fn test_http_remote_task_get_local_artifact_without_cache() {
         let paths = vec![
             "/myfile.py",
             "/subpath/myfile.sh",

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -1,5 +1,6 @@
 use crate::config::{self, Config};
 use crate::file::display_path;
+use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{
     GetMatchingExt, Task, TaskLoadContext, extract_monorepo_path, resolve_task_pattern,
 };
@@ -408,6 +409,19 @@ pub async fn get_task_lists(
     prompt: bool,
     only: bool,
 ) -> Result<Vec<Task>> {
+    get_task_lists_with_prefetched(config, args, prompt, only, None).await
+}
+
+/// Resolve task arguments while reusing metadata snapshots fetched during
+/// command dispatch. This keeps remote aliases tied to the exact body that
+/// established them.
+pub async fn get_task_lists_with_prefetched(
+    config: &Arc<Config>,
+    args: &[String],
+    prompt: bool,
+    only: bool,
+    prefetched_tasks: Option<&BTreeMap<String, Task>>,
+) -> Result<Vec<Task>> {
     let args = args
         .iter()
         .map(|s| vec![s.to_string()])
@@ -507,24 +521,46 @@ pub async fn get_task_lists(
         };
 
         let tasks_with_aliases = crate::task::build_task_ref_map(all_tasks.iter());
-
-        let mut cur_tasks = tasks_with_aliases
-            .get_matching(&t)?
-            .into_iter()
-            .cloned()
-            .collect_vec();
-        // If the task name was auto-expanded to monorepo syntax (e.g., "hello" -> "//:hello")
-        // but no monorepo task matched, fall back to the original bare name to find global tasks
+        let find_matching_tasks =
+            |tasks_with_aliases: &BTreeMap<String, &Task>| -> Result<Vec<Task>> {
+                let mut matches = tasks_with_aliases
+                    .get_matching(&t)?
+                    .into_iter()
+                    .map(|task| (**task).clone())
+                    .collect_vec();
+                // If the task name was auto-expanded to monorepo syntax (e.g.,
+                // "hello" -> "//:hello") but no monorepo task matched, fall
+                // back to the original bare name to find global tasks.
+                if matches.is_empty()
+                    && t != original_name
+                    && !original_name.starts_with("//")
+                    && !original_name.starts_with(':')
+                {
+                    matches = tasks_with_aliases
+                        .get_matching(&original_name)?
+                        .into_iter()
+                        .map(|task| (**task).clone())
+                        .collect_vec();
+                }
+                Ok(matches)
+            };
+        let mut cur_tasks = find_matching_tasks(&tasks_with_aliases)?;
         if cur_tasks.is_empty()
-            && t != original_name
-            && !original_name.starts_with("//")
-            && !original_name.starts_with(':')
+            && let Some(prefetched_tasks) = prefetched_tasks
         {
-            cur_tasks = tasks_with_aliases
-                .get_matching(&original_name)?
-                .into_iter()
-                .cloned()
-                .collect_vec();
+            let prefetched_with_aliases = crate::task::build_task_ref_map(prefetched_tasks.iter());
+            cur_tasks = find_matching_tasks(&prefetched_with_aliases)?;
+        }
+        if cur_tasks.is_empty() {
+            // Remote aliases only exist after parsing their #MISE headers.
+            // Retry a miss after trusted passive discovery rather than fetching
+            // every remote task for ordinary name hits.
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &all_tasks)
+                .await?;
+            let resolved_with_aliases = crate::task::build_task_ref_map(resolved_tasks.iter());
+            cur_tasks = find_matching_tasks(&resolved_with_aliases)?;
         }
         if cur_tasks.is_empty() {
             // Check if this is a "default" task (either plain "default" or monorepo syntax like "//:default")
@@ -620,13 +656,29 @@ pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<V
     };
 
     let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
+    let resolve = |all_tasks: &BTreeMap<String, Task>| {
+        tasks
+            .iter()
+            .cloned()
+            .map(|task| {
+                let depends = task.all_depends(all_tasks)?;
+                Ok(once(task).chain(depends).collect::<Vec<_>>())
+            })
+            .flatten_ok()
+            .collect::<Result<Vec<_>>>()
+    };
 
-    tasks
-        .into_iter()
-        .map(|t| {
-            let depends = t.all_depends(&all_tasks)?;
-            Ok(once(t).chain(depends).collect::<Vec<_>>())
-        })
-        .flatten_ok()
-        .collect()
+    match resolve(&all_tasks) {
+        Ok(tasks) => Ok(tasks),
+        Err(error) if error.to_string().starts_with("task not found:") => {
+            // A dependency may name an alias declared only in a remote header.
+            // Retry the failed graph resolution against trusted remote metadata.
+            let resolved_tasks = TaskFetcher::new(false)
+                .require_trust_before_fetch()
+                .fetch_task_map(config, &all_tasks)
+                .await?;
+            resolve(&resolved_tasks)
+        }
+        Err(error) => Err(error),
+    }
 }

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -670,7 +670,11 @@ pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<V
 
     match resolve(&all_tasks) {
         Ok(tasks) => Ok(tasks),
-        Err(error) if error.to_string().starts_with("task not found:") => {
+        Err(error)
+            if error
+                .downcast_ref::<crate::task::TaskNotFoundError>()
+                .is_some() =>
+        {
             // A dependency may name an alias declared only in a remote header.
             // Retry the failed graph resolution against trusted remote metadata.
             let resolved_tasks = TaskFetcher::new(false)

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -220,6 +220,7 @@ impl<'a> TaskToolInstaller<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::task::Task;
 
     #[test]
     fn test_task_tool_installer_new() {
@@ -227,5 +228,23 @@ mod tests {
         let cli_tools: Vec<ToolArg> = vec![];
         let installer = TaskToolInstaller::new(&context_builder, &cli_tools);
         assert_eq!(installer.cli_tools.len(), 0);
+    }
+
+    #[test]
+    fn test_remote_tool_metadata_without_provenance_fails_closed() {
+        let task = Task {
+            name: "remote".into(),
+            remote_file_source: Some("https://example.com/task".into()),
+            remote_metadata_has_tools: true,
+            ..Default::default()
+        };
+
+        let error = task.tool_args().unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("tool metadata without defining config provenance")
+        );
     }
 }


### PR DESCRIPTION
## Work order

1. #12000 — preserve Git task snapshots and establish the Git artifact lifecycle layer
2. #11113 — enforce remote-task trust, metadata provenance, and Git checkout containment on that foundation
3. #11203 — harden the remaining HTTP/cache lifecycle behavior

Prerequisite #11222 is merged. This branch is rebased directly onto #12000's head commit; GitHub still displays `main` as the base because the stack branches live in a fork.

## Summary

- require trust in the defining config before passive commands fetch remote tasks, including safe-mode discovery and remote Git task includes
- require trust before decoded remote templates, side-effectful env directives (`file`, `source`, modules, and Python venvs), or remote tool metadata can execute, resolve, activate, or install anything
- preserve defining-config provenance through explicitly included and nested remote task files
- resolve aliases and visibility supplied by remote `#MISE` headers consistently across run, bare dispatch, info, dependency, dynamic, and listing paths
- keep remote env paths relative to the fetched script while attributing trust to the local config that selected it
- reject traversal, Windows absolute/backslash paths, and symlink escapes from remote Git checkouts for both task files and Git includes
- rely on #12000 for task-owned no-cache snapshots so the body executed is the same body whose metadata selected it

## Root cause

#11111 began parsing remote task headers during discovery. That made remote templates, tools, environment directives, aliases, and visibility active metadata, but the remote task path did not consistently retain or enforce the trust of the local config that selected it. Passive discovery could also perform HTTP or Git work before trust, including in safe mode.

Remote Git paths also needed a shared containment check after checkout canonicalization; parser-only traversal checks do not prevent an intermediate symlink from escaping the artifact root.

Broader cache publication, locking, cleanup policy, retention, and cache-key hardening remain intentionally separate in #11203.

## Validation

- `mise run lint-fix`
- `cargo check --locked`
- focused unit tests for task fetching, remote source parsing, Git path containment, and env directives
- `mise run test:e2e e2e/tasks/test_task_remote_metadata_trust`
- `mise run test:e2e e2e/tasks/test_task_remote_git_includes`

Follow-up to #11111.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*
