### PR TITLE
fix(watch): propagate --env to watched tasks

### DIFF
--- a/e2e/cli/test_watch_env_flag
+++ b/e2e/cli/test_watch_env_flag
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+mise use -g watchexec@latest
+
+cat <<'EOF' >mise.dev.toml
+[tasks.watch-env]
+run = 'echo "MISE_ENV=$MISE_ENV"'
+EOF
+
+LOG_FILE=$(mktemp)
+mise --env dev watch watch-env >"$LOG_FILE" 2>&1 &
+WATCH_PID=$!
+
+trap 'kill "$WATCH_PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 40); do
+  grep -q "MISE_ENV=dev" "$LOG_FILE" && break
+  sleep 0.5
+done
+
+if ! grep -q "MISE_ENV=dev" "$LOG_FILE"; then
+  fail "Expected watched task to inherit MISE_ENV=dev, got: $(tr -d '\0' <"$LOG_FILE")"
+fi
+
+ok "mise watch propagates --env to watched tasks"

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -342,6 +342,10 @@ impl Watch {
         for (k, v) in ts.env_with_path(&config).await? {
             cmd = cmd.env(k, v);
         }
+        // Propagate profiles selected with -E/--env to the nested `mise run` command.
+        if !env::MISE_ENV.is_empty() {
+            cmd = cmd.env("MISE_ENV", env::MISE_ENV.join(","));
+        }
 
         // Save terminal state before running watchexec, because --clear=reset
         // sends a full terminal reset (RIS) which can corrupt terminal settings


### PR DESCRIPTION

## Summary

Propagate profiles selected with `-E`/`--env` through the watchexec process so the nested `mise run` invocation loads the same environment-specific configuration.

Without this, `mise --env dev watch task` resolves the task using the dev profile initially, but the watched invocation loses that profile and may fail to find or correctly run the task.

Add an end-to-end regression test that defines a task only in `mise.dev.toml` and verifies that the watched task receives `MISE_ENV=dev`.

Fixes https://github.com/jdx/mise/discussions/4439

## Testing

- `mise run test:e2e e2e/cli/test_watch_env_flag e2e/cli/test_watch e2e/cli/test_watch_ignore e2e/tasks/test_task_watch_skip_deps e2e/tasks/test_task_watch_cwd_escape`
- `mise run test:unit`
- `mise run render`
- `cargo check --all-features`
- `cargo fmt --all -- --check`
- `shellcheck -x e2e/cli/test_watch_env_flag`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment selection for watch tasks so the active environment is correctly propagated to commands executed by the file watcher.
  * Added end-to-end coverage to verify that the selected environment is available during watch execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->