### PR TITLE
feat(config): alias --file and --path options

### DIFF
--- a/e2e/cli/test_config_target_aliases
+++ b/e2e/cli/test_config_target_aliases
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+config_file="$PWD/aliases.toml"
+
+# Tool config commands accept --file as an alias for --path.
+mise use --file "$config_file" dummy@1
+assert "mise config get --file $config_file tools.dummy" "1"
+mise unuse --file "$config_file" --no-prune dummy
+assert_fail "mise config get --file $config_file tools.dummy"
+
+# Environment config commands accept --path as an alias for --file.
+mise set --path "$config_file" ALIAS_VAR=value
+assert "mise config get --path $config_file env.ALIAS_VAR" "value"
+mise unset --path "$config_file" ALIAS_VAR
+assert_fail "mise config get --path $config_file env.ALIAS_VAR"
+
+# Config commands accept --path as an alias for --file.
+mise config set --path "$config_file" env.CONFIG_ALIAS configured
+assert "mise config get --path $config_file env.CONFIG_ALIAS" "configured"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1097,7 +1097,7 @@ Write to the local config instead of the global config
 \fB\-n, \-\-dry\-run\fR
 Print the config change without writing it
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 \fBArguments:\fR
 .PP
@@ -1121,7 +1121,7 @@ Write to the local config instead of the global config
 \fB\-n, \-\-dry\-run\fR
 Print the config change without writing it
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 \fBArguments:\fR
 .PP
@@ -1158,7 +1158,7 @@ Import every linked formula, including dependencies
 \fB\-n, \-\-dry\-run\fR
 Print the config change without writing config
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 .SH "MISE BOOTSTRAP PACKAGES PRUNE"
 Prune installed system packages no longer declared in `[bootstrap.packages]`
@@ -1254,7 +1254,7 @@ Write to the global config (~/.config/mise/config.toml) instead of the local one
 \fB\-n, \-\-dry\-run\fR
 Print the commands that would run without writing config or installing
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 .TP
 \fB\-y, \-\-yes\fR
@@ -1461,7 +1461,7 @@ Display the value of a setting in a mise.toml file
 \fBOptions:\fR
 .PP
 .TP
-\fB\-f, \-\-file\fR \fI<FILE>\fR
+\fB\-f, \-\-file, \-\-path\fR \fI<FILE>\fR
 The path to the mise.toml file to edit
 
 If not provided, the nearest mise.toml file will be used
@@ -1494,7 +1494,7 @@ Set the value of a setting in a mise.toml file
 \fBOptions:\fR
 .PP
 .TP
-\fB\-f, \-\-file\fR \fI<FILE>\fR
+\fB\-f, \-\-file, \-\-path\fR \fI<FILE>\fR
 The path to the mise.toml file to edit
 
 If not provided, the nearest mise.toml file will be used
@@ -1538,7 +1538,7 @@ Dotfile mode to write
 \fB\-n, \-\-dry\-run\fR
 Print the config/source updates without writing anything
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 .TP
 \fB\-s, \-\-source\fR \fI<PATH>\fR
@@ -3212,7 +3212,7 @@ Can be used multiple times. Requires \-\-age\-encrypt.
 \fB\-\-complete\fR
 Render completions
 .TP
-\fB\-\-file\fR \fI<FILE>\fR
+\fB\-\-file, \-\-path\fR \fI<FILE>\fR
 The TOML file to update
 
 Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
@@ -4148,7 +4148,7 @@ By default, this command modifies `mise.toml` in the current directory.
 \fBOptions:\fR
 .PP
 .TP
-\fB\-f, \-\-file\fR \fI<FILE>\fR
+\fB\-f, \-\-file, \-\-path\fR \fI<FILE>\fR
 Specify a file to use instead of `mise.toml`
 
 Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.en.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.en.dev/configuration.html#mise_global_config_file) to choose a different global config path.
@@ -4202,7 +4202,7 @@ Create/modify an environment\-specific config file like .mise.<env>.toml
 \fB\-g, \-\-global\fR
 Use the global config file (`~/.config/mise/config.toml`) instead of the local one
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Specify a path to a config file or directory
 
 If a directory is specified, it will look for a config file in that directory following the rules above.
@@ -4328,7 +4328,7 @@ Number of jobs to run in parallel
 \fB\-n, \-\-dry\-run\fR
 Perform a dry run, showing what would be installed and modified without making changes
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Specify a path to a config file or directory
 
 If a directory is specified, it will look for a config file in that directory following the rules above.

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -524,7 +524,7 @@ Examples:
 """#
                 flag "-l --local" help="Write to the local config instead of the global config"
                 flag "-n --dry-run" help="Print the config change without writing it"
-                flag "-p --path" help="Write to this config file or directory" {
+                flag "-p --path --file" help="Write to this config file or directory" {
                     arg <PATH>
                 }
                 arg <TAP> help="Tap name, e.g. `owner/repo`"
@@ -540,7 +540,7 @@ Examples:
 """#
                 flag "-l --local" help="Write to the local config instead of the global config"
                 flag "-n --dry-run" help="Print the config change without writing it"
-                flag "-p --path" help="Write to this config file or directory" {
+                flag "-p --path --file" help="Write to this config file or directory" {
                     arg <PATH>
                 }
                 arg <TAPS>… help="Tap name(s), e.g. `owner/repo`" var=#true
@@ -574,7 +574,7 @@ Examples:
             }
             flag --all help="Import every linked formula, including dependencies"
             flag "-n --dry-run" help="Print the config change without writing config"
-            flag "-p --path" help="Write to this config file or directory" {
+            flag "-p --path --file" help="Write to this config file or directory" {
                 arg <PATH>
             }
         }
@@ -676,7 +676,7 @@ Examples:
             }
             flag "-g --global" help="Write to the global config (~/.config/mise/config.toml) instead of the local one"
             flag "-n --dry-run" help="Print the commands that would run without writing config or installing"
-            flag "-p --path" help="Write to this config file or directory" {
+            flag "-p --path --file" help="Write to this config file or directory" {
                 arg <PATH>
             }
             flag "-y --yes" help="Skip the confirmation prompt"
@@ -831,7 +831,7 @@ Examples:
     3.12
 
 """#
-        flag "-f --file" help="The path to the mise.toml file to edit" {
+        flag "-f --file --path" help="The path to the mise.toml file to edit" {
             long_help #"""
 The path to the mise.toml file to edit
 
@@ -869,7 +869,7 @@ Examples:
     $ mise config set settings.jobs 4
 
 """#
-        flag "-f --file" help="The path to the mise.toml file to edit" {
+        flag "-f --file --path" help="The path to the mise.toml file to edit" {
             long_help #"""
 The path to the mise.toml file to edit
 
@@ -996,7 +996,7 @@ Examples:
             arg <MODE>
         }
         flag "-n --dry-run" help="Print the config/source updates without writing anything"
-        flag "-p --path" help="Write to this config file or directory" {
+        flag "-p --path --file" help="Write to this config file or directory" {
             arg <PATH>
         }
         flag "-s --source" help="Source path to use for a single target" {
@@ -3131,7 +3131,7 @@ Can be used multiple times. Requires --age-encrypt.
         arg <PATH_OR_PUBKEY>
     }
     flag --complete help="Render completions" hide=#true
-    flag --file help="The TOML file to update" {
+    flag "--file --path" help="The TOML file to update" {
         long_help #"""
 The TOML file to update
 
@@ -4068,7 +4068,7 @@ Examples:
     $ mise unset NODE_ENV -g
 
 """#
-    flag "-f --file" help="Specify a file to use instead of `mise.toml`" {
+    flag "-f --file --path" help="Specify a file to use instead of `mise.toml`" {
         long_help #"""
 Specify a file to use instead of `mise.toml`
 
@@ -4127,7 +4127,7 @@ Examples:
         arg <ENV>
     }
     flag "-g --global" help="Use the global config file (`~/.config/mise/config.toml`) instead of the local one"
-    flag "-p --path" help="Specify a path to a config file or directory" {
+    flag "-p --path --file" help="Specify a path to a config file or directory" {
         long_help #"""
 Specify a path to a config file or directory
 
@@ -4304,7 +4304,7 @@ Number of jobs to run in parallel
         arg <JOBS>
     }
     flag "-n --dry-run" help="Perform a dry run, showing what would be installed and modified without making changes"
-    flag "-p --path" help="Specify a path to a config file or directory" {
+    flag "-p --path --file" help="Specify a path to a config file or directory" {
         long_help #"""
 Specify a path to a config file or directory
 

--- a/src/cli/config/get.rs
+++ b/src/cli/config/get.rs
@@ -13,7 +13,7 @@ pub struct ConfigGet {
     /// The path to the mise.toml file to edit
     ///
     /// If not provided, the nearest mise.toml file will be used
-    #[clap(short, long)]
+    #[clap(short, long, visible_alias = "path")]
     pub file: Option<PathBuf>,
 }
 

--- a/src/cli/config/set.rs
+++ b/src/cli/config/set.rs
@@ -19,7 +19,7 @@ pub struct ConfigSet {
     /// The path to the mise.toml file to edit
     ///
     /// If not provided, the nearest mise.toml file will be used
-    #[clap(short, long)]
+    #[clap(short, long, visible_alias = "path")]
     pub file: Option<PathBuf>,
 
     #[clap(value_enum, short, long, default_value_t)]

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -45,7 +45,7 @@ pub struct DotfilesAdd {
     pub(super) dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with_all = ["global", "local"])]
+    #[clap(long, short, visible_alias = "file", value_name = "PATH", conflicts_with_all = ["global", "local"])]
     pub(super) path: Option<PathBuf>,
 
     /// Source path to use for a single target

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -854,6 +854,57 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_config_target_file_and_path_aliases() {
+        let cases: &[(&[&str], &str, &str, bool)] = &[
+            (&["use"], "path", "file", true),
+            (&["unuse"], "path", "file", true),
+            (&["set"], "file", "path", true),
+            (&["unset"], "file", "path", true),
+            (&["config", "get"], "file", "path", true),
+            (&["config", "set"], "file", "path", true),
+            (&["bootstrap", "packages", "use"], "path", "file", true),
+            (&["bootstrap", "packages", "import"], "path", "file", true),
+            (
+                &["bootstrap", "packages", "brew", "tap"],
+                "path",
+                "file",
+                cfg!(not(windows)),
+            ),
+            (
+                &["bootstrap", "packages", "brew", "untap"],
+                "path",
+                "file",
+                cfg!(not(windows)),
+            ),
+            (&["dotfiles", "add"], "path", "file", true),
+        ];
+        let root = Cli::command();
+
+        for (path, arg_name, alias, available) in cases {
+            if !available {
+                continue;
+            }
+            let command = path.iter().fold(&root, |command, name| {
+                command
+                    .get_subcommands()
+                    .find(|subcommand| subcommand.get_name() == *name)
+                    .unwrap_or_else(|| panic!("missing command path {}", path.join(" ")))
+            });
+            let arg = command
+                .get_arguments()
+                .find(|arg| arg.get_id() == *arg_name)
+                .unwrap_or_else(|| panic!("missing --{arg_name} on {}", path.join(" ")));
+
+            assert!(
+                arg.get_visible_aliases()
+                    .is_some_and(|aliases| aliases.contains(alias)),
+                "missing visible --{alias} alias for --{arg_name} on {}",
+                path.join(" ")
+            );
+        }
+    }
+
+    #[test]
     fn test_subcommands_are_sorted() {
         let cmd = Cli::command();
         // Check all subcommands except watch (which has many watchexec passthrough args)

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -70,7 +70,7 @@ pub struct Set {
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.en.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
     /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.en.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[clap(long, verbatim_doc_comment, required = false, value_hint = clap::ValueHint::AnyPath)]
+    #[clap(long, visible_alias = "path", verbatim_doc_comment, required = false, value_hint = clap::ValueHint::AnyPath)]
     file: Option<PathBuf>,
 
     /// Show raw values instead of redacting secrets

--- a/src/cli/system/brew/tap.rs
+++ b/src/cli/system/brew/tap.rs
@@ -28,7 +28,13 @@ pub struct SystemBrewTap {
     dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with = "local")]
+    #[clap(
+        long,
+        short,
+        visible_alias = "file",
+        value_name = "PATH",
+        conflicts_with = "local"
+    )]
     path: Option<PathBuf>,
 }
 

--- a/src/cli/system/brew/untap.rs
+++ b/src/cli/system/brew/untap.rs
@@ -24,7 +24,13 @@ pub struct SystemBrewUntap {
     dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with = "local")]
+    #[clap(
+        long,
+        short,
+        visible_alias = "file",
+        value_name = "PATH",
+        conflicts_with = "local"
+    )]
     path: Option<PathBuf>,
 }
 

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -53,7 +53,13 @@ pub struct SystemImport {
     dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with = "global")]
+    #[clap(
+        long,
+        short,
+        visible_alias = "file",
+        value_name = "PATH",
+        conflicts_with = "global"
+    )]
     path: Option<PathBuf>,
 }
 

--- a/src/cli/system/use.rs
+++ b/src/cli/system/use.rs
@@ -43,7 +43,13 @@ pub struct SystemUse {
     dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with = "global")]
+    #[clap(
+        long,
+        short,
+        visible_alias = "file",
+        value_name = "PATH",
+        conflicts_with = "global"
+    )]
     path: Option<PathBuf>,
 
     /// Skip the confirmation prompt

--- a/src/cli/unset.rs
+++ b/src/cli/unset.rs
@@ -21,7 +21,7 @@ pub struct Unset {
     ///
     /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.en.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
     /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.en.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[clap(short, long, value_hint = clap::ValueHint::FilePath)]
+    #[clap(short, long, visible_alias = "path", value_hint = clap::ValueHint::FilePath)]
     file: Option<PathBuf>,
 
     /// Use the global config file

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -47,7 +47,7 @@ pub struct Unuse {
     ///
     /// If a directory is specified, it will look for a config file in that directory following
     /// the rules above.
-    #[clap(short, long, overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
+    #[clap(short, long, visible_alias = "file", overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
     path: Option<PathBuf>,
 
     /// Do not also prune the installed version

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -80,7 +80,7 @@ pub struct Use {
     ///
     /// If a directory is specified, it will look for a config file in that directory following
     /// the rules above.
-    #[clap(short, long, overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
+    #[clap(short, long, visible_alias = "file", overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
     path: Option<PathBuf>,
 
     /// Like --dry-run but exits with code 1 if there are changes to make


### PR DESCRIPTION
## Summary

- make `--file` and `--path` interchangeable when selecting a mise configuration file or directory
- preserve every existing canonical option name and short flag
- add regression coverage for command parsing and config updates through the new aliases

This resolves https://github.com/jdx/mise/discussions/4881.

## Commands

Adds `--file` as a visible alias for `--path` on:

- `use`, `unuse`
- `bootstrap packages use`, `bootstrap packages import`
- `bootstrap packages brew tap`, `bootstrap packages brew untap`
- `dotfiles add`

Adds `--path` as a visible alias for `--file` on:

- `set`, `unset`
- `config get`, `config set`

## Compatibility

This is additive only. Existing long options, `-p`/`-f` short options, config resolution, and conflicts with `--global`/`--env` are unchanged. Both names are handled by the same Clap argument for each command.

## Validation

- `mise run test:e2e e2e/cli/test_config_target_aliases`
- `mise run test:unit` (1760 passed locally)
- focused alias unit test
- `cargo fmt --check`
- generated CLI usage and manpage output reviewed

The follow-up commit makes the Homebrew command assertions conditional on non-Windows platforms because those subcommands are not registered in the Windows CLI. This fixes the initial `windows-unit` CI failure.
