### PR TITLE
docs: fix dead VersionFox and MCP documentation links

### DIFF
--- a/crates/vfox/plugins/dummy/README.md
+++ b/crates/vfox/plugins/dummy/README.md
@@ -1,6 +1,6 @@
 # vfox-nodejs
 
-Node.js plugin for [vfox](https://vfox.lhan.me/).
+Node.js plugin for [vfox](https://vfox.dev/).
 
 ## Install
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -84,7 +84,7 @@ mise supports multiple backends for installing tools from different sources:
 : Universal Binary Installer for tools distributed as single binaries. See [ubi backend](/dev-tools/backends/ubi).
 
 **vfox**
-: Backend compatible with [VersionFox](https://vfox.lhan.me/) plugins. See [vfox backend](/dev-tools/backends/vfox).
+: Backend compatible with [VersionFox](https://vfox.dev/) plugins. See [vfox backend](/dev-tools/backends/vfox).
 
 ## Shell Integration
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -142,4 +142,4 @@ The MCP server implementation can be found in [`src/cli/mcp.rs`](https://github.
 - Tool invocation (task execution)
 - JSON-RPC communication over stdio
 
-For more information about the Model Context Protocol, visit the [official MCP documentation](https://modelcontextprotocol.io/).
+For more information about the Model Context Protocol, visit the [official MCP documentation](https://modelcontextprotocol.io/docs/getting-started/intro).


### PR DESCRIPTION
## Summary
- Fix dead **VersionFox** homepage in the glossary (`vfox.lhan.me` DNS NXDOMAIN → [vfox.dev](https://vfox.dev/)).
- Fix **MCP** docs footer link: bare `https://modelcontextprotocol.io/` returns HTTP 308; point at the stable intro page that resolves 200.

## Motivation
Readers hitting these external links from the docs currently get hard failures (DNS or redirect-only roots without a comfortable landing).

## Verification
```text
# before
vfox.lhan.me → NXDOMAIN
modelcontextprotocol.io/ → HTTP 308

# after
https://vfox.dev/ → 200
https://modelcontextprotocol.io/docs/getting-started/intro → 200
```

Docs-only; no runtime change.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h  
**Claim:** sera

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the vfox glossary link to point to the current VersionFox website.
  * Updated the Model Context Protocol reference to the official getting-started documentation.
  * Updated the Node.js plugin README link to point to the current VersionFox website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->