### PR TITLE
fix(bootstrap): macos defaults bail if key or domain does not exist yet

### DIFF
--- a/e2e/cli/test_system_defaults
+++ b/e2e/cli/test_system_defaults
@@ -73,3 +73,16 @@ cat <<EOF >mise.toml
 [bootstrap.macos.defaults]
 EOF
 assert_succeed "mise bootstrap macos defaults status"
+
+if [[ $(uname) == "Darwin" ]]; then
+  # status must not fail when keys don't exist yet (initial setup)
+  cat <<EOF >mise.toml
+[bootstrap.macos.defaults]
+NSGlobalDomain = { "_mise_test_nonexistent_key_42" = true }
+"com.mise.nonexistent" = { TestKey = true }
+EOF
+  assert_succeed "mise bootstrap macos defaults status"
+  assert_contains "mise bootstrap macos defaults status" "unset"
+  # dry-run must not fail either
+  assert_succeed "mise bootstrap macos defaults apply --dry-run --yes"
+fi

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -7,6 +7,9 @@
 //! or `mise bootstrap`.
 
 use std::process::Stdio;
+use std::sync::LazyLock;
+
+use regex::Regex;
 
 use crate::result::Result;
 
@@ -209,11 +212,16 @@ async fn defaults_cmd(args: &[&str]) -> Result<Option<String>> {
         .output()
         .await?;
     if !output.status.success() {
-        // "does not exist" is the expected missing-key/-domain answer; any
-        // other failure (cfprefsd unavailable, managed domain, ...) must not
+        // "does not exist" is the expected missing-key/-domain answer;
+        // "could not find key" is the same for `read-type`;
+        // "Domain [...] not found" is the expected answer when the domain does not exist;
+        // any other failure (cfprefsd unavailable, managed domain, ...) must not
         // masquerade as Unset
+        static MISSING_KEY_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"(?i)does not exist|could not find key|Domain .* not found").unwrap()
+        });
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("does not exist") {
+        if MISSING_KEY_RE.is_match(&stderr) {
             return Ok(None);
         }
         eyre::bail!(
@@ -292,5 +300,39 @@ mod tests {
 
         assert!(DefaultsValue::Str("left".into()).matches("string", "left"));
         assert!(!DefaultsValue::Str("left".into()).matches("string", "right"));
+    }
+
+    /// `status()` must not fail when keys don't exist yet — this is
+    /// the expected path on a fresh macOS install. Non-zero exits from
+    /// `defaults read` / `read-type` are treated as "unset" only for known
+    /// missing key/domain errors.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn test_status_missing_keys_are_unset() {
+        let reqs = vec![
+            // key doesn't exist in a real domain
+            DefaultsRequest {
+                domain: "NSGlobalDomain".into(),
+                key: "_mise_test_nonexistent_key_42".into(),
+                value: DefaultsValue::Bool(true),
+            },
+            // domain doesn't exist at all
+            DefaultsRequest {
+                domain: "com.mise.nonexistent".into(),
+                key: "TestKey".into(),
+                value: DefaultsValue::Bool(true),
+            },
+        ];
+        let statuses = status(&reqs).await.unwrap();
+        assert_eq!(statuses.len(), 2);
+        for s in &statuses {
+            assert_eq!(
+                s.state,
+                DefaultsState::Unset,
+                "expected Unset for {}, got {:?}",
+                s.request,
+                s.state
+            );
+        }
     }
 }


### PR DESCRIPTION
Adds handling of more error messages when a key or domain does not yet exist when settings defaults on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS defaults status handling when expected configuration keys or entire domains are missing.
  * Missing defaults are now recognized as **unset** instead of causing a failure, with more flexible matching of error messages.

* **Tests**
  * Added macOS-focused end-to-end coverage for initial-setup scenarios to confirm **unset** reporting and that the macOS defaults dry-run flow completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->