### PR TITLE
docs: retarget dead registry_comment.yml link in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -633,13 +633,15 @@ of the full backend specification.
 
 ### Guidelines and Requirements
 
-When adding a new tool, the following requirements apply (automatically
-enforced by [GitHub Actions workflow](https://github.com/jdx/mise/blob/main/.github/workflows/registry_comment.yml)):
+When adding a new tool, the following requirements apply:
 
 - **A test is required in `registry/`** - Must include a `test` field to
-  verify installation.
+  verify installation. This is automatically enforced by the
+  [`validate-new-tools` job](https://github.com/jdx/mise/blob/main/.github/workflows/registry.yml)
+  in the registry workflow.
 - **Tools may be rejected if they are not notable** - The tool should be
-  reasonably popular and well-maintained. There are no specific guidelines for this and
+  reasonably popular and well-maintained. Notability is decided by maintainer
+  review (not CI). There are no specific guidelines for this and
   a lot of factors are taken into account. @jdx won't explain why a given tool wasn't
   accepted. Include a brief popularity summary (stars, downloads, recent release date) in
   the PR description so the policy can be applied without re-doing the research.


### PR DESCRIPTION
## Summary

- Replace a dead link in `docs/contributing.md` that pointed at the removed `registry_comment.yml` workflow (404).
- Point the required `test` field at the live `validate-new-tools` job in [`.github/workflows/registry.yml`](https://github.com/jdx/mise/blob/main/.github/workflows/registry.yml), and clarify that notability is maintainer review (not CI).

## Motivation

Contributors following the registry guidelines hit a broken workflow link. That file was removed for security in #7769 (`pull_request_target` RCE risk). Test enforcement still exists under `registry.yml` → `validate-new-tools`; notability was never CI-automated.

## Verification

- `curl -sI https://raw.githubusercontent.com/jdx/mise/main/.github/workflows/registry_comment.yml` → **404**
- `curl -sI https://raw.githubusercontent.com/jdx/mise/main/.github/workflows/registry.yml` → **200**
- Confirmed `.github/workflows/registry.yml` defines `validate-new-tools` (checks new tools include a `test =` field)
- `rg registry_comment` on the branch → clean
- Dup search: no open PR retargeting this link (only historical #7769 / workflow rename trail)
- Docs-only; no runtime change

## Notes

- Does **not** resurrect a comment-bot workflow — only documents current enforcement.
- Does not change registry acceptance policy wording beyond the notability/CI split already true in practice.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 24h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines for adding new tools.
  * Clarified that registry test coverage is required and validated automatically.
  * Expanded guidance on tool notability and maintainer review criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->