### PR TITLE
registry: allow nub postinstall

### DIFF
--- a/registry/nub.toml
+++ b/registry/nub.toml
@@ -1,3 +1,7 @@
-backends = ["npm:@nubjs/nub"]
+backends = [
+  { full = "npm:@nubjs/nub", options = { allow_builds = [
+    "@nubjs/nub",
+  ] } },
+]
 description = "A Rust CLI that augments Node.js - a fast script runner, a TypeScript-just-works runtime, and a pnpm-compatible package manager"
 test = { cmd = "nub --version", expected = "{{version}}" }


### PR DESCRIPTION
## Summary

- allow only `@nubjs/nub` to run its reviewed lifecycle script
- preserve mise's default-deny behavior for every other package in the install graph
- remove the skipped-`postinstall` warning for supported npm, aube, and pnpm installs

## Why keep the npm backend

Nub publishes platform-specific GitHub release archives, and mise's GitHub backend can select and install them correctly. However, extracting those archives is not equivalent to installing the npm package.

`@nubjs/nub`'s `postinstall.js` performs installer-side fixups. In addition to setting executable bits for the platform binaries, it refreshes existing `~/.nub/shims` hardlinks so an upgrade does not leave the optional `npm`, `pnpm`, and `yarn` shims pointing at the previous Nub binary. A direct GitHub-backend extraction bypasses that refresh; affected users would have to rerun `nub pm shim` manually after upgrades.

Keeping the existing npm backend and setting `allow_builds = ["@nubjs/nub"]` preserves upstream's install behavior without opting into arbitrary lifecycle scripts. On npm 11.16.0 and newer, mise translates this to the per-package `--allow-scripts=@nubjs/nub` flag. The same registry option maps to the corresponding narrow build approval for aube and pnpm.

Discussion: https://github.com/jdx/mise/discussions/11119

## Popularity

- GitHub: 2,961 stars, 46 forks, last push 2026-07-20
- Latest release: v0.4.13, published 2026-07-15
- npm: 80,092 downloads from 2026-06-20 through 2026-07-19

## Validation

- `mise run build`
- `mise run lint-fix`
- installed `@nubjs/nub@0.4.13` using Node 26.5.0's bundled npm 11.17.0 with `--allow-scripts=@nubjs/nub --foreground-scripts`
- confirmed the postinstall ran and `nub --version` returned `v0.4.13`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to use an explicit npm backend setup.
  * Enabled build support for the `@nubjs/nub` package.
  * Existing package description and test configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->