### PR TITLE
docs(environments): clarify mise directory variables

### DIFF
--- a/docs/directories.md
+++ b/docs/directories.md
@@ -82,6 +82,11 @@ latest -> ./20.15.0
 
 You can set the `MISE_INSTALLS_DIR` environment variable to override this location.
 
+`MISE_INSTALLS_DIR` is read when mise starts. Set it in the environment before invoking mise and keep
+it set for later mise and shim invocations. Do not set it in the `[env]` section of `mise.toml`: `[env]`
+describes the environment mise exports, after mise has already selected its installation directory.
+Setting it there can make an install use one directory while later commands and shims look in another.
+
 ### `~/.local/share/mise/shims`
 
 This is where mise places shims. Generally these are used for IDE integration or if `mise activate`

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -117,8 +117,12 @@ env = { _.file = '/path/to/file.env', "MY_VAR" = "my variable" }
 ## Lazy eval
 
 Environment variables typically are resolved before tools—that way you can configure tool installation
-with environment variables. However, sometimes you want to access environment variables produced by
-tools. To do that, turn the value into a map with `tools = true`:
+subprocesses with environment variables. This does not apply to variables that configure mise itself,
+such as `MISE_DATA_DIR` or `MISE_INSTALLS_DIR`. Mise reads those variables when the process starts, so
+set them in the shell or CI environment before invoking mise rather than in `[env]`.
+
+Sometimes you want to access environment variables produced by tools. To do that, turn the value into
+a map with `tools = true`:
 
 ```toml
 [env]

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -118,7 +118,7 @@ env = { _.file = '/path/to/file.env', "MY_VAR" = "my variable" }
 
 Environment variables typically are resolved before tools—that way you can configure tool installation
 subprocesses with environment variables. This does not apply to variables that configure mise itself,
-such as `MISE_DATA_DIR` or `MISE_INSTALLS_DIR`. mise reads those variables when the process starts, so
+such as `MISE_DATA_DIR` or `MISE_INSTALLS_DIR`. These variables are read when the process starts, so
 set them in the shell or CI environment before invoking mise rather than in `[env]`.
 
 Sometimes you want to access environment variables produced by tools. To do that, turn the value into

--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -118,7 +118,7 @@ env = { _.file = '/path/to/file.env', "MY_VAR" = "my variable" }
 
 Environment variables typically are resolved before tools—that way you can configure tool installation
 subprocesses with environment variables. This does not apply to variables that configure mise itself,
-such as `MISE_DATA_DIR` or `MISE_INSTALLS_DIR`. Mise reads those variables when the process starts, so
+such as `MISE_DATA_DIR` or `MISE_INSTALLS_DIR`. mise reads those variables when the process starts, so
 set them in the shell or CI environment before invoking mise rather than in `[env]`.
 
 Sometimes you want to access environment variables produced by tools. To do that, turn the value into


### PR DESCRIPTION
## Summary
- clarify that `[env]` configures tool installation subprocesses, not mise's own startup directories
- document that `MISE_DATA_DIR` and `MISE_INSTALLS_DIR` must be set before mise starts
- warn that putting `MISE_INSTALLS_DIR` in `[env]` can make installs and later shim resolution use different directories

## Why
[jdx/mise-action#565](https://github.com/jdx/mise-action/issues/565) exposed an ambiguity in the current documentation. It says environment variables are resolved before tools so they can configure installation, while the directory reference says `MISE_INSTALLS_DIR` overrides the install location. In practice, mise selects its own directories from the process environment before project `[env]` is exported.

## Validation
- `mise run lint-fix`
- pre-commit `mise run lint`
- `mise run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording changes with no runtime or configuration behavior changes.
> 
> **Overview**
> **Documentation-only** clarification after [mise-action#565](https://github.com/jdx/mise-action/issues/565): mise picks its own data/install paths from the **process environment at startup**, which is separate from what `[env]` exports for tools and tasks.
> 
> In **`docs/directories.md`**, the `MISE_INSTALLS_DIR` section now says to set it before invoking mise and keep it consistent for later commands and shims, and explicitly warns **not** to put it in `[env]` because that can split installs from shim resolution.
> 
> In **`docs/environments/index.md`**, the “Lazy eval” intro is tightened: `[env]` still applies to variables used when configuring **tool installation subprocesses**, but **`MISE_DATA_DIR`** and **`MISE_INSTALLS_DIR`** are called out as startup-only and must be set in the shell or CI before running mise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21682d17112870ecc3f54814e05b57d7f9d3b3b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that mise-specific environment variables are read at process startup and must be set before invoking mise.
  * Explained that `MISE_INSTALLS_DIR` is determined at startup and should remain consistent for subsequent mise and shim invocations.
  * Warned against setting `MISE_INSTALLS_DIR` in the `mise.toml` `[env]` section, since it’s applied after directory selection.
  * Improved “lazy eval” guidance for accessing tool-generated environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->