### PR TITLE
fix(bootstrap): resolve bare systemd timer unit names to dev.mise.<name>.service

### DIFF
--- a/docs/bootstrap/systemd.md
+++ b/docs/bootstrap/systemd.md
@@ -43,8 +43,13 @@ on_boot_sec = "2min"
 on_unit_inactive_sec = "5min"
 randomized_delay_sec = "30s"
 persistent = true
-unit = "dev.mise.healthcheck.service"
+unit = "healthcheck"
 ```
+
+A bare `unit` value (no unit-type suffix) is resolved to the mise-owned service
+`dev.mise.<unit>.service` — so `unit = "healthcheck"` targets the `healthcheck`
+service entry above. To point a timer at an unmanaged unit, give the fully
+qualified name (e.g. `unit = "nginx.service"`), which is written verbatim.
 
 A timer must set at least one of `on_boot_sec`, `on_unit_active_sec`,
 `on_unit_inactive_sec`, or `on_calendar`. Service-only keys such as

--- a/src/system/systemd.rs
+++ b/src/system/systemd.rs
@@ -538,7 +538,33 @@ fn render_timer(request: &SystemdRequest, out: &mut String) {
         out.push_str(&format!("Persistent={}\n", yes_no(persistent)));
     }
     if let Some(unit) = &request.timer_unit {
-        out.push_str(&format!("Unit={unit}\n"));
+        out.push_str(&format!("Unit={}\n", resolve_timer_unit(unit)));
+    }
+}
+
+/// systemd unit-type suffixes. A `unit` value ending in one of these is treated
+/// as a fully-qualified unit name and written verbatim (e.g. pointing a timer at
+/// a foreign unit). A bare name is resolved to the `dev.mise.<name>.service` unit
+/// mise writes for the same-named service entry.
+const UNIT_SUFFIXES: &[&str] = &[
+    ".service",
+    ".socket",
+    ".device",
+    ".mount",
+    ".automount",
+    ".swap",
+    ".target",
+    ".path",
+    ".timer",
+    ".slice",
+    ".scope",
+];
+
+fn resolve_timer_unit(unit: &str) -> String {
+    if UNIT_SUFFIXES.iter().any(|suffix| unit.ends_with(suffix)) {
+        unit.to_string()
+    } else {
+        format!("dev.mise.{unit}.service")
     }
 }
 
@@ -876,6 +902,36 @@ mod tests {
             render_unit(&request),
             "[Unit]\n\n[Timer]\nOnBootSec=2min\nOnUnitInactiveSec=5min\nRandomizedDelaySec=30s\nAccuracySec=1s\nPersistent=yes\nUnit=dev.mise.healthcheck.service\n\n[Install]\nWantedBy=timers.target\n"
         );
+    }
+
+    #[test]
+    fn test_resolve_timer_unit() {
+        // bare name resolves to the mise-owned service unit
+        assert_eq!(
+            resolve_timer_unit("dotfiles-maintain"),
+            "dev.mise.dotfiles-maintain.service"
+        );
+        // already-qualified names are written verbatim
+        assert_eq!(
+            resolve_timer_unit("dev.mise.dotfiles-maintain.service"),
+            "dev.mise.dotfiles-maintain.service"
+        );
+        assert_eq!(resolve_timer_unit("nginx.service"), "nginx.service");
+        assert_eq!(resolve_timer_unit("foo.target"), "foo.target");
+    }
+
+    #[test]
+    fn test_render_timer_bare_unit() {
+        let request = SystemdRequest::from_toml(
+            "dotfiles-maintain-timer".to_string(),
+            SystemdTomlConfig {
+                on_calendar: Some("daily".to_string()),
+                unit: Some("dotfiles-maintain".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(render_unit(&request).contains("Unit=dev.mise.dotfiles-maintain.service\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Reported in [#11122](https://github.com/jdx/mise/discussions/11122). With a config like:

```toml
[bootstrap.linux.systemd.units.dotfiles-maintain]
type = "oneshot"
exec_start = "%h/.local/bin/dotfiles-maintain"

[bootstrap.linux.systemd.units.dotfiles-maintain-timer]
unit = "dotfiles-maintain"
on_calendar = "daily"
```

the timer's `unit` value was written to `Unit=` verbatim, producing `Unit=dotfiles-maintain`. systemd rejects the suffix-less name (`Unit type not valid, ignoring: dotfiles-maintain`) and falls back to the timer's default same-name service, which doesn't exist, so `mise bootstrap` fails:

```
dev.mise.dotfiles-maintain-timer.timer: Refusing to start, unit dev.mise.dotfiles-maintain-timer.service to trigger not loaded.
```

The only working form was the fully-qualified internal name `unit = "dev.mise.dotfiles-maintain.service"`, which forces users to hand-write mise's own naming scheme even though every other entry is referenced by its bare TOML key.

## Fix

`resolve_timer_unit()` resolves a bare `unit` value (no systemd unit-type suffix) to the mise-owned service `dev.mise.<name>.service`. Values already ending in a unit-type suffix (`.service`, `.timer`, `.target`, …) are written verbatim, preserving the escape hatch for pointing a timer at an unmanaged unit (e.g. `unit = "nginx.service"`).

Fully backward compatible — existing fully-qualified configs keep working unchanged.

## Tests

- `test_resolve_timer_unit` — bare vs. qualified resolution
- `test_render_timer_bare_unit` — end-to-end render of the reported config

Docs updated in `docs/bootstrap/systemd.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to timer `Unit=` rendering with backward-compatible behavior for already-qualified names; covered by new tests.
> 
> **Overview**
> Fixes bootstrap systemd timers that set **`unit`** to a bare service key (e.g. `unit = "dotfiles-maintain"`), which previously wrote an invalid `Unit=` line and broke `mise bootstrap`.
> 
> Timer rendering now runs **`unit`** through **`resolve_timer_unit`**: names without a systemd type suffix become **`dev.mise.<name>.service`**; values already ending in `.service`, `.target`, etc. are unchanged so timers can still target external units like **`nginx.service`**. Fully qualified mise names keep working.
> 
> **`docs/bootstrap/systemd.md`** documents the bare-name behavior and updates the healthcheck example. New unit tests cover resolution and end-to-end timer output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1e4b930ba5c6e96be025f21400dfa035809192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timer configurations now support concise bare unit names that automatically target the corresponding managed service.
  * Fully qualified systemd unit names, such as `nginx.service`, continue to be used exactly as specified.

* **Documentation**
  * Updated systemd timer documentation with the new `unit` syntax and resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->