### PR TITLE
fix(release): keep macos pgo instrumentation rust-only

### DIFF
--- a/scripts/pgo.bash
+++ b/scripts/pgo.bash
@@ -83,6 +83,21 @@ if [ "$PGO_BUILD_TOOL" = "cross" ]; then
 	export CROSS_CONTAINER_OPTS="${CROSS_CONTAINER_OPTS:-} -v $PGO_DATA_DIR:$PGO_DATA_DIR:rw"
 fi
 
+# Keep PGO Rust-only on macOS. The cc crate mirrors -Cprofile-generate /
+# -Cprofile-use from RUSTFLAGS into the C compiler command line
+# (-fprofile-generate / -fprofile-use), so vendored C code (openssl, lua)
+# gets instrumented by Apple clang — whose profile-runtime format follows
+# Xcode's LLVM, not rustc's. When those disagree (Xcode 16 = raw version 8,
+# rustc 1.97 = 10), the instrumented binary aborts every profile write with
+#   LLVM Profile Error: Runtime and instrumentation version mismatch
+# and training produces zero .profraw files. C-side profiles couldn't be
+# consumed by a mismatched clang in phase 3b anyway. cc appends environment
+# flags after rustc-inherited ones, so these -fno- overrides win.
+if [ "$(uname -s)" = "Darwin" ]; then
+	export CFLAGS="${CFLAGS:-} -fno-profile-generate -fno-profile-use"
+	export CXXFLAGS="${CXXFLAGS:-} -fno-profile-generate -fno-profile-use"
+fi
+
 # ---------- Phase 1: instrumented build ----------
 echo ">>> [1/3] Building instrumented binary ($PGO_BUILD_TOOL, profile=$PGO_PROFILE${PGO_TARGET:+, target=$PGO_TARGET})"
 # shellcheck disable=SC2086 # intentional word-splitting on $target_arg


### PR DESCRIPTION
Fixes the `build-tarball-macos-arm64` failure that has broken every release since PGO landed in #11031:

```
LLVM Profile Error: Runtime and instrumentation version mismatch : expected 10, but get 8
ERROR: no .profraw files written to .../target/pgo-data/profraw after training
```

## Root cause

The [`cc` crate mirrors `-Cprofile-generate`/`-Cprofile-use` from RUSTFLAGS onto the C compiler command line](https://github.com/rust-lang/cc-rs/blob/main/src/flags.rs) (`-fprofile-generate`/`-fprofile-use`). The macOS tarball builds vendored C code (`openssl/vendored`, `vfox/vendored-lua`), so those objects were instrumented by **Apple clang**, whose profile format follows Xcode's LLVM — not rustc's:

- release runner: Xcode 16 / Apple clang 16 → compiler-rt **raw profile version 8**
- rustc 1.97 (LLVM 22) `profiler_builtins` → **raw profile version 10**

At link, the C objects' version-8 `__llvm_profile_raw_version` won symbol coalescing (verified in the CI-built binary: `__TEXT,__const` value `0x…08`), while the Rust profile runtime doing the writes expects 10 → every profile write aborts → training produces zero `.profraw` files.

This is why #11071 (toolchain pinning) couldn't fix it — the rogue instrumentation comes from the C compiler, not a mismatched rust toolchain — and why it doesn't reproduce on machines where Xcode's LLVM happens to match rustc's generation (e.g. clang 21 also uses version 10).

## Fix

Export `-fno-profile-generate -fno-profile-use` via `CFLAGS`/`CXXFLAGS` on Darwin in `scripts/pgo.bash`. `cc` appends environment flags after the rustc-inherited ones, so the overrides win and PGO stays Rust-only. C-side PGO could never work here anyway: Apple clang 16 can't consume profdata merged by rustup's LLVM-22 `llvm-profdata`, so phase 3b would have failed next.

Linux PGO is untouched (it's green today; gcc's gcov-style flags don't hit this conflict).

## Validation

Ran on the actual `namespace-profile-endev-macos-arm64` runner via `workflow_dispatch` on this branch (with the release workflow temporarily trimmed to the macOS tarball path, since tarball jobs don't run on regular PRs):

- **Repro of the bug** (pre-fix, with link forensics): [run 29762515264](https://github.com/jdx/mise/actions/runs/29762515264) — final binary carries version-8 metadata from the C objects, reproduces the exact error
- **Fix validation** (full `MISE_PGO=1 scripts/build-tarball.sh aarch64-apple-darwin` incl. codesigning): [run 29762962943](https://github.com/jdx/mise/actions/runs/29762962943) — ✅ 54 `.profraw` collected, 84.5 MB merged profile, optimized rebuild, signed tarballs produced

Note: the `cargo-release` registry failure on the release branch is a separate issue (upstream re-published `v1.1.0` with incomplete assets, so `/releases/latest` resolves to a release with no Linux builds) and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Darwin-only change to release build flags; Linux PGO is untouched and the override is documented to win over inherited profile flags.
> 
> **Overview**
> **Fixes macOS PGO release builds** that failed during training with an LLVM profile runtime/instrumentation version mismatch and zero `.profraw` files.
> 
> On Darwin, `scripts/pgo.bash` now exports **`CFLAGS`/`CXXFLAGS` with `-fno-profile-generate` and `-fno-profile-use`** before the instrumented build. That stops the `cc` crate from forwarding rustc’s PGO flags to Apple clang for vendored C (e.g. OpenSSL, Lua), so only Rust stays instrumented and profile writes succeed. Linux behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03bdfa34f7631917db36568143d72eba4ffc459d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS profiling reliability by preventing incompatible instrumentation in bundled native components.
  - Resolved an issue that could cause profiling runs to fail when generating runtime profile data during later profiling phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->