### PR TITLE
perf(activate): skip redundant initial fish prompt hook

### DIFF
--- a/e2e/shell/fish_first_prompt.fish
+++ b/e2e/shell/fish_first_prompt.fish
@@ -1,5 +1,24 @@
 #!/usr/bin/env fish
 
+set -g mise_fish_mode disable_arrow
+mise activate fish | source
+
+set -g mise_env_eval_count 0
+function __mise_env_eval
+    set -g mise_env_eval_count (math $mise_env_eval_count + 1)
+end
+
+set -l activate_pwd $PWD
+cd ..
+__mise_env_eval_on_prompt
+test $mise_env_eval_count -eq 1
+or begin
+    echo "expected a directory change before the first fish_prompt event to run hook-env"
+    exit 1
+end
+cd $activate_pwd
+
+mise deactivate
 mise activate fish | source
 
 set -g mise_env_eval_count 0

--- a/e2e/shell/fish_first_prompt.fish
+++ b/e2e/shell/fish_first_prompt.fish
@@ -1,0 +1,24 @@
+#!/usr/bin/env fish
+
+mise activate fish | source
+
+set -g mise_env_eval_count 0
+function __mise_env_eval
+    set -g mise_env_eval_count (math $mise_env_eval_count + 1)
+end
+
+__mise_env_eval_on_prompt
+test $mise_env_eval_count -eq 0
+or begin
+    echo "expected the first fish_prompt event to skip hook-env"
+    exit 1
+end
+
+__mise_env_eval_on_prompt
+test $mise_env_eval_count -eq 1
+or begin
+    echo "expected the second fish_prompt event to run hook-env"
+    exit 1
+end
+
+mise deactivate

--- a/e2e/shell/test_fish_first_prompt
+++ b/e2e/shell/test_fish_first_prompt
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+require_cmd fish
+exec fish --no-config "$TEST_DIR/fish_first_prompt.fish"

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -83,9 +83,12 @@ impl Shell for Fish {
             end;
 
             function __mise_env_eval_on_prompt --on-event fish_prompt --description {description};
-                if set -q __mise_skip_first_prompt;
-                    set -e __mise_skip_first_prompt;
-                    return;
+                if set -q __mise_skip_first_prompt_pwd;
+                    set -l activate_pwd "$__mise_skip_first_prompt_pwd";
+                    set -e __mise_skip_first_prompt_pwd;
+                    if test "$PWD" = "$activate_pwd";
+                        return;
+                    end;
                 end;
 
                 __mise_env_eval;
@@ -102,7 +105,7 @@ impl Shell for Fish {
             end;
 
             __mise_env_eval
-            set -g __mise_skip_first_prompt 1
+            set -g __mise_skip_first_prompt_pwd "$PWD"
         "#});
         }
         if Settings::get().not_found_auto_install {
@@ -135,7 +138,7 @@ impl Shell for Fish {
           functions --erase __mise_env_eval_2
           functions --erase __mise_cd_hook
           functions --erase mise
-          set -e __mise_skip_first_prompt
+          set -e __mise_skip_first_prompt_pwd
           set -e MISE_SHELL
           set -e __MISE_DIFF
           set -e __MISE_SESSION

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -68,7 +68,7 @@ impl Shell for Fish {
         if !opts.no_hook_env {
             out.push_str(&formatdoc! {r#"
 
-            function __mise_env_eval --on-event fish_prompt --description {description};
+            function __mise_env_eval --description {description};
                 {exe} hook-env{flags} -s fish | source;
 
                 if test "$mise_fish_mode" != "disable_arrow";
@@ -82,6 +82,15 @@ impl Shell for Fish {
                 end;
             end;
 
+            function __mise_env_eval_on_prompt --on-event fish_prompt --description {description};
+                if set -q __mise_skip_first_prompt;
+                    set -e __mise_skip_first_prompt;
+                    return;
+                end;
+
+                __mise_env_eval;
+            end;
+
             function __mise_env_eval_2 --on-event fish_preexec --description {description};
                 if set -q __mise_env_again;
                     set -e __mise_env_again;
@@ -93,6 +102,7 @@ impl Shell for Fish {
             end;
 
             __mise_env_eval
+            set -g __mise_skip_first_prompt 1
         "#});
         }
         if Settings::get().not_found_auto_install {
@@ -121,9 +131,11 @@ impl Shell for Fish {
     fn deactivate(&self) -> String {
         formatdoc! {r#"
           functions --erase __mise_env_eval
+          functions --erase __mise_env_eval_on_prompt
           functions --erase __mise_env_eval_2
           functions --erase __mise_cd_hook
           functions --erase mise
+          set -e __mise_skip_first_prompt
           set -e MISE_SHELL
           set -e __MISE_DIFF
           set -e __MISE_SESSION

--- a/src/shell/snapshots/mise__shell__fish__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__activate.snap
@@ -51,9 +51,12 @@ function __mise_env_eval --description 'Update mise environment when changing di
 end;
 
 function __mise_env_eval_on_prompt --on-event fish_prompt --description 'Update mise environment when changing directories';
-    if set -q __mise_skip_first_prompt;
-        set -e __mise_skip_first_prompt;
-        return;
+    if set -q __mise_skip_first_prompt_pwd;
+        set -l activate_pwd "$__mise_skip_first_prompt_pwd";
+        set -e __mise_skip_first_prompt_pwd;
+        if test "$PWD" = "$activate_pwd";
+            return;
+        end;
     end;
 
     __mise_env_eval;
@@ -70,7 +73,7 @@ function __mise_env_eval_2 --on-event fish_preexec --description 'Update mise en
 end;
 
 __mise_env_eval
-set -g __mise_skip_first_prompt 1
+set -g __mise_skip_first_prompt_pwd "$PWD"
 if functions -q fish_command_not_found; and not functions -q __mise_fish_command_not_found
     functions -e __mise_fish_command_not_found
     functions -c fish_command_not_found __mise_fish_command_not_found

--- a/src/shell/snapshots/mise__shell__fish__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__activate.snap
@@ -36,7 +36,7 @@ function mise
   end
 end
 
-function __mise_env_eval --on-event fish_prompt --description 'Update mise environment when changing directories';
+function __mise_env_eval --description 'Update mise environment when changing directories';
     /some/dir/mise hook-env --status -s fish | source;
 
     if test "$mise_fish_mode" != "disable_arrow";
@@ -50,6 +50,15 @@ function __mise_env_eval --on-event fish_prompt --description 'Update mise envir
     end;
 end;
 
+function __mise_env_eval_on_prompt --on-event fish_prompt --description 'Update mise environment when changing directories';
+    if set -q __mise_skip_first_prompt;
+        set -e __mise_skip_first_prompt;
+        return;
+    end;
+
+    __mise_env_eval;
+end;
+
 function __mise_env_eval_2 --on-event fish_preexec --description 'Update mise environment when changing directories';
     if set -q __mise_env_again;
         set -e __mise_env_again;
@@ -61,6 +70,7 @@ function __mise_env_eval_2 --on-event fish_preexec --description 'Update mise en
 end;
 
 __mise_env_eval
+set -g __mise_skip_first_prompt 1
 if functions -q fish_command_not_found; and not functions -q __mise_fish_command_not_found
     functions -e __mise_fish_command_not_found
     functions -c fish_command_not_found __mise_fish_command_not_found

--- a/src/shell/snapshots/mise__shell__fish__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__deactivate.snap
@@ -7,7 +7,7 @@ functions --erase __mise_env_eval_on_prompt
 functions --erase __mise_env_eval_2
 functions --erase __mise_cd_hook
 functions --erase mise
-set -e __mise_skip_first_prompt
+set -e __mise_skip_first_prompt_pwd
 set -e MISE_SHELL
 set -e __MISE_DIFF
 set -e __MISE_SESSION

--- a/src/shell/snapshots/mise__shell__fish__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__deactivate.snap
@@ -3,9 +3,11 @@ source: src/shell/fish.rs
 expression: replace_path(&deactivate)
 ---
 functions --erase __mise_env_eval
+functions --erase __mise_env_eval_on_prompt
 functions --erase __mise_env_eval_2
 functions --erase __mise_cd_hook
 functions --erase mise
+set -e __mise_skip_first_prompt
 set -e MISE_SHELL
 set -e __MISE_DIFF
 set -e __MISE_SESSION


### PR DESCRIPTION
## Summary

- split Fish prompt dispatch from the reusable `__mise_env_eval` function
- skip the first `fish_prompt` dispatch after activation already performed a full environment refresh
- clean up the prompt wrapper and one-shot state during deactivation
- add focused Fish e2e coverage and update activation snapshots

## Why

`mise activate fish` calls `__mise_env_eval` immediately, then Fish emits `fish_prompt` shortly afterward. The second invocation takes mise's unchanged-session early-exit path, but still launches a process and initializes runtime state.

With Fish 4.8.1 and an isolated empty configuration on this machine, a debug-build benchmark through the first prompt improved from **36.83 ms** to **29.88 ms** on average across 30 runs, saving **6.95 ms**. Absolute debug timings are machine-specific; the comparison isolates the redundant prompt dispatch.

Direct calls to `__mise_env_eval` remain supported. Only the first event-driven prompt dispatch is skipped.

## Validation

- `cargo test shell::fish::tests`
- `mise run test:e2e shell/test_fish_first_prompt`
- `mise run test:e2e shell/test_fish cli/test_deactivate_fish cli/test_activate_multiple_fish`
- `mise run lint-fix`
- pre-commit `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Fish shell hook wiring with explicit e2e tests; no auth, data, or core runtime logic changes.
> 
> **Overview**
> Fish activation already runs a full **`hook-env`** via **`__mise_env_eval`** at source time, but the old **`fish_prompt`** hook fired again right away and still spawned **`mise`** even when nothing changed. **`__mise_env_eval`** is now a plain function (no prompt event), and a new **`__mise_env_eval_on_prompt`** handler owns **`fish_prompt`**.
> 
> After activation, **`__mise_skip_first_prompt_pwd`** records **`$PWD`**. The **first** prompt dispatch clears that flag and **returns without calling **`__mise_env_eval`** if the directory is unchanged**; later prompts and a directory change before the first prompt still run the hook as before. **Deactivation** erases the prompt wrapper and the skip flag.
> 
> E2E coverage (**`fish_first_prompt.fish`**) asserts skip-on-first-prompt vs run-on-second-prompt behavior; activation/deactivate snapshots are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e911e3527b1cf5177ce6e2065900305de2ed550d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fish shell integration so environment re-evaluation is skipped on the initial prompt and runs on subsequent prompts.
  * Ensures proper cleanup of the prompt-handling behavior when Fish integration is deactivated.

* **Tests**
  * Added new end-to-end coverage for Fish prompt behavior, including verifying the first prompt skip and the second prompt performing environment evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->