### PR TITLE
feat(oci): built-in registry push client, drop skopeo/crane dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2368,7 +2368,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2588,7 +2588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4982,7 +4982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5002,7 +5002,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5515,6 +5515,7 @@ dependencies = [
  "test-log",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "toml 1.1.3+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
  "ubi",
@@ -5762,7 +5763,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5972,7 +5973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6609,7 +6610,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7631,7 +7632,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7690,7 +7691,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8907,10 +8908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8978,7 +8979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10062,7 +10063,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "charset",
   "http2",
   "socks",
+  "stream",
   "system-proxy",
 ] }
 rmcp = { version = "2.0", features = ["server", "transport-io", "schemars"] }
@@ -203,6 +204,7 @@ tera-contrib = { version = "0.2", features = [
 terminal_size = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["io"] }
 toml = { version = "1.0", features = ["parse", "preserve_order"] }
 toml_edit = { version = "0.25", features = ["parse"] }
 ubi = { version = "0.9", default-features = false }

--- a/docs/cli/oci/build.md
+++ b/docs/cli/oci/build.md
@@ -67,7 +67,7 @@ Inspect the result with skopeo:
 $ skopeo inspect oci:./mise-oci
 
 Push to a registry:
-$ skopeo copy oci:./mise-oci docker://ghcr.io/me/dev:latest
+$ mise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest
 ```
 
 Notes:

--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -6,12 +6,16 @@
 
 [experimental] Build an OCI image and push it to a registry
 
-Requires `skopeo` (or `crane`) on PATH. If `--image-dir` is not passed,
-builds fresh from the current mise.toml first, then shells out to
-`skopeo copy oci:<dir> docker://<ref>` (or `crane push <dir> <ref>`).
-Authentication is handled by the underlying tool — configure it the same
-way you would for a plain `skopeo` / `crane` push (e.g. `docker login`,
-`REGISTRY_AUTH_FILE`, `~/.config/containers/auth.json`).
+Pushes with mise's built-in registry client — no skopeo/crane/docker
+required. If `--image-dir` is not passed, builds fresh from the current
+mise.toml first. Only blobs the registry doesn't already have are
+uploaded, so repeat pushes of mostly-unchanged toolsets are cheap.
+
+Credentials are read from the same places docker and podman use:
+`$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,
+`~/.config/containers/auth.json`, and `~/.docker/config.json`
+(including credential helpers) — so `docker login` / `podman login`
+is all the setup needed.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 
@@ -51,18 +55,6 @@ UID[:GID] to assign to every tar entry when building (conflicts with --image-dir
 
 Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
 
-### `--tool <TOOL>`
-
-Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`
-
-**Choices:**
-
-- `auto`
-- `skopeo`
-- `crane`
-
-**Default:** `auto`
-
 Examples:
 
 ```
@@ -72,16 +64,15 @@ $ mise oci push ghcr.io/me/devenv:latest
 Push an image built earlier:
 $ mise oci build -o ./img
 $ mise oci push --image-dir ./img ghcr.io/me/devenv:v1
-
-Force a specific push tool:
-$ mise oci push --tool crane ghcr.io/me/devenv:latest
 ```
 
 Auth:
 
 ```
-mise shells out to skopeo (preferred) or crane; configure registry
-credentials the usual way — `docker login`, `REGISTRY_AUTH_FILE`,
-or `~/.config/containers/auth.json` for skopeo; `crane auth login`
-for crane.
+Credentials are resolved the same way docker/podman resolve them:
+$REGISTRY_AUTH_FILE, $XDG_RUNTIME_DIR/containers/auth.json,
+~/.config/containers/auth.json, then ~/.docker/config.json
+(inline auths and credential helpers). Log in with either:
+$ docker login ghcr.io
+$ podman login ghcr.io
 ```

--- a/docs/cli/oci/run.md
+++ b/docs/cli/oci/run.md
@@ -7,12 +7,12 @@
 [experimental] Build an OCI image from the current mise.toml and run a command in it
 
 Equivalent to `mise oci build` followed by `docker run` / `podman run`.
-The built image is loaded into the local container engine (podman is
-preferred; docker works via skopeo) and the given command is executed
-inside it with stdin/stdout/stderr inherited.
+The built image is loaded into the local container engine (podman pulls
+the OCI layout natively; docker receives it via `docker load`) and the
+given command is executed inside it with stdin/stdout/stderr inherited.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and
-one of: `podman`, `docker+skopeo`.
+one of: `podman`, `docker`.
 
 ## Arguments
 
@@ -107,6 +107,6 @@ $ mise oci build -o ./img && mise oci run --image-dir ./img -- node -e 'console.
 Engines:
 
 ```
-Prefers podman (loads OCI layouts natively). Falls back to
-docker + skopeo. Pass --engine podman or --engine docker to override.
+Prefers podman (loads OCI layouts natively). Falls back to docker
+(loaded via docker load). Pass --engine podman or --engine docker to override.
 ```

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -30,7 +30,7 @@ Flags, output layout, and defaults may change in future releases.
 | ---------------- | ------------------------------------------------------------------------ |
 | `mise oci build` | Produce an OCI image layout on disk.                                     |
 | `mise oci run`   | Build (or reuse) an image and run a command inside it via podman/docker. |
-| `mise oci push`  | Build (or reuse) an image and push it to a registry via skopeo or crane. |
+| `mise oci push`  | Build (or reuse) an image and push it to a registry.                     |
 
 ## Quick start
 
@@ -40,15 +40,14 @@ Flags, output layout, and defaults may change in future releases.
 mise oci build
 
 # Run an interactive shell in the image (uses podman if present, else
-# docker + skopeo).
+# docker).
 mise oci run -it -- bash
 
-# Push to a registry (shells out to skopeo; falls back to crane).
+# Push to a registry with the built-in client (no skopeo/crane needed).
 mise oci push ghcr.io/me/devenv:latest
 
-# You can also go through skopeo/crane manually:
+# The output is a standard OCI image layout, so external tools work too:
 skopeo inspect oci:./mise-oci
-skopeo copy oci:./mise-oci docker://ghcr.io/me/devenv:latest
 ```
 
 ## How layering works
@@ -144,25 +143,26 @@ mise oci run --image-dir ./img -- node --version
 ```
 
 **Requirements:** either `podman` (native OCI-layout support) or
-`docker + skopeo` (skopeo loads the layout into the docker daemon).
+`docker` (mise streams the image into the daemon via `docker load`).
 
 ## `mise oci push`
 
-Build (or reuse) an image and push it to a registry via `skopeo` or
-`crane`. mise never handles credentials itself — configure the
-underlying tool (`docker login`, `REGISTRY_AUTH_FILE`, `crane auth
-login`, etc.).
+Build (or reuse) an image and push it to a registry with mise's
+built-in registry client — no skopeo, crane, or docker daemon
+required. Only blobs the registry doesn't already have are uploaded,
+so repeat pushes of a mostly-unchanged toolset transfer very little.
 
 ```sh
-mise oci push [--tool TOOL] [--image-dir DIR]
+mise oci push [--image-dir DIR]
               [--from REF] [--mount-point PATH] [--no-mise]
               [--owner UID[:GID]]
               <REGISTRY_REF>
 ```
 
 - `<REGISTRY_REF>` — fully-qualified destination (e.g.
-  `ghcr.io/me/devenv:latest`). Must include a registry host.
-- `--tool` — `auto` (default, prefers skopeo), `skopeo`, or `crane`.
+  `ghcr.io/me/devenv:latest`). Must include a registry host. Loopback
+  registries (`localhost:5000/…`) are contacted over plain HTTP, the
+  same insecure-by-default convention docker applies.
 - `--image-dir` — push an existing OCI layout instead of building.
 
 - `--owner UID[:GID]` — numeric owner for generated layer entries when
@@ -178,6 +178,25 @@ mise oci push ghcr.io/me/devenv:latest
 mise oci build -o ./img
 mise oci push --image-dir ./img ghcr.io/me/devenv:v1
 ```
+
+### Push authentication
+
+Credentials are resolved from the same sources docker and podman use,
+in this order:
+
+1. `$REGISTRY_AUTH_FILE`
+2. `$XDG_RUNTIME_DIR/containers/auth.json` (podman)
+3. `~/.config/containers/auth.json`
+4. `~/.docker/config.json` (or `$DOCKER_CONFIG/config.json`)
+
+Both inline `auths` entries and credential helpers
+(`credsStore` / `credHelpers`, e.g. `docker-credential-osxkeychain`,
+`docker-credential-ecr-login`) are supported — so a plain
+`docker login ghcr.io` or `podman login ghcr.io` is all the setup
+needed. When no credentials are found, mise pushes anonymously (useful
+for local registries) and warns.
+
+For ghcr.io, the token needs the `write:packages` scope.
 
 ### `[oci]` section in `mise.toml`
 
@@ -317,16 +336,11 @@ out with a clear message.
 
 ## Registry base-image support
 
-v1 can pull base images from any OCI Distribution v2 registry that
-accepts anonymous pulls:
-
-- Docker Hub (`debian`, `ubuntu`, `node`, …) — token auth handled
-  anonymously.
-- GitHub Container Registry (`ghcr.io/…`) — public images only.
-- Quay.io (`quay.io/…`) — public images only.
-- Self-hosted / other registries — work if no auth is required.
-
-Authenticated pulls (private base images) are a follow-up.
+Base images can be pulled from any OCI Distribution v2 registry —
+Docker Hub, ghcr.io, quay.io, self-hosted, etc. Anonymous token auth
+is handled automatically for public images; when you're logged in
+(`docker login` / `podman login`), those credentials are used, so
+private base images work too.
 
 Digest references are supported:
 
@@ -362,18 +376,14 @@ works). mise prints a warning when this mismatch is detected.
 ## Known limitations (v1)
 
 - `asdf` / `vfox` backends are rejected (see above).
-- Only anonymous registry pulls for `--from`; no auth yet.
-  (`mise oci push` does handle auth — it just delegates to skopeo/crane
-  which already do.)
 - Cross-platform builds produce broken images (binaries are host-native);
   run the build on a linux host.
 - Alpine / musl base images will break most tools.
-- `mise oci run` / `oci push` shell out to external tools
-  (podman, docker+skopeo, crane). No built-in container runtime or
-  registry client.
+- `mise oci run` needs a container engine (podman or docker) — mise has
+  no built-in container runtime. Pushing needs no external tools.
 
 ## See also
 
 - [`mise oci build`](/cli/oci/build.md) — full CLI reference
 - [OCI Image Spec](https://github.com/opencontainers/image-spec)
-- [skopeo](https://github.com/containers/skopeo) for pushing images
+- [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec)

--- a/e2e/oci/test_oci_run_push_errors_slow
+++ b/e2e/oci/test_oci_run_push_errors_slow
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Tests error paths for `mise oci run` and `mise oci push` — the ones we can
-# exercise without docker/podman/skopeo available in CI. The happy paths are
+# exercise without docker/podman available in CI. The happy paths are
 # covered by test_oci_build_slow plus manual testing; this file just asserts
-# that argument validation and tool-detection errors surface with useful
+# that argument validation and engine-detection errors surface with useful
 # messages rather than panics.
 
 export MISE_EXPERIMENTAL=1
@@ -24,6 +24,13 @@ assert_fail "mise oci push justname" "fully-qualified reference"
 mkdir -p ./not-a-layout
 assert_fail "mise oci push --image-dir ./not-a-layout ghcr.io/x/y:z" "OCI image layout"
 
+# --- push: unreachable registry fails with a useful error, not a panic ---
+# Build a real (base-less, offline) layout, then push at a loopback port
+# that is never listening; the native push client should surface the
+# connection failure while probing /v2/.
+mise oci build --from scratch --no-mise -o ./img >/dev/null 2>&1
+assert_fail "mise oci push --image-dir ./img 127.0.0.1:1/x/y:z" "127.0.0.1:1"
+
 # --- run: --image-dir must look like a layout ---
 assert_fail "mise oci run --image-dir ./not-a-layout -- true" "OCI image layout"
 
@@ -36,12 +43,4 @@ if ! command -v podman >/dev/null 2>&1; then
 fi
 if ! command -v docker >/dev/null 2>&1; then
   assert_fail "mise oci run --engine docker -- true" "docker"
-fi
-
-# --- push: --tool forces the same way ---
-if ! command -v skopeo >/dev/null 2>&1; then
-  assert_fail "mise oci push --tool skopeo ghcr.io/x/y:z" "skopeo"
-fi
-if ! command -v crane >/dev/null 2>&1; then
-  assert_fail "mise oci push --tool crane ghcr.io/x/y:z" "crane"
 fi

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2405,12 +2405,16 @@ Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it
 .SH "MISE OCI PUSH"
 [experimental] Build an OCI image and push it to a registry
 
-Requires `skopeo` (or `crane`) on PATH. If `\-\-image\-dir` is not passed,
-builds fresh from the current mise.toml first, then shells out to
-`skopeo copy oci:<dir> docker://<ref>` (or `crane push <dir> <ref>`).
-Authentication is handled by the underlying tool — configure it the same
-way you would for a plain `skopeo` / `crane` push (e.g. `docker login`,
-`REGISTRY_AUTH_FILE`, `~/.config/containers/auth.json`).
+Pushes with mise's built\-in registry client — no skopeo/crane/docker
+required. If `\-\-image\-dir` is not passed, builds fresh from the current
+mise.toml first. Only blobs the registry doesn't already have are
+uploaded, so repeat pushes of mostly\-unchanged toolsets are cheap.
+
+Credentials are read from the same places docker and podman use:
+`$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,
+`~/.config/containers/auth.json`, and `~/.docker/config.json`
+(including credential helpers) — so `docker login` / `podman login`
+is all the setup needed.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 .PP
@@ -2440,12 +2444,6 @@ Don't embed the mise binary (ignored with \-\-image\-dir)
 UID[:GID] to assign to every tar entry when building (conflicts with \-\-image\-dir)
 
 Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
-.TP
-\fB\-\-tool\fR \fI<TOOL>\fR
-Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`
-.RS
-\fIDefault: \fRauto
-.RE
 \fBArguments:\fR
 .PP
 .TP
@@ -2455,12 +2453,12 @@ Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)
 [experimental] Build an OCI image from the current mise.toml and run a command in it
 
 Equivalent to `mise oci build` followed by `docker run` / `podman run`.
-The built image is loaded into the local container engine (podman is
-preferred; docker works via skopeo) and the given command is executed
-inside it with stdin/stdout/stderr inherited.
+The built image is loaded into the local container engine (podman pulls
+the OCI layout natively; docker receives it via `docker load`) and the
+given command is executed inside it with stdin/stdout/stderr inherited.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and
-one of: `podman`, `docker+skopeo`.
+one of: `podman`, `docker`.
 .PP
 \fBUsage:\fR mise oci run [OPTIONS] [<CMD>] ...
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2163,7 +2163,7 @@ Examples:
     $ skopeo inspect oci:./mise-oci
 
     Push to a registry:
-    $ skopeo copy oci:./mise-oci docker://ghcr.io/me/dev:latest
+    $ mise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest
 
 Notes:
 
@@ -2213,12 +2213,16 @@ Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it
         long_help #"""
 [experimental] Build an OCI image and push it to a registry
 
-Requires `skopeo` (or `crane`) on PATH. If `--image-dir` is not passed,
-builds fresh from the current mise.toml first, then shells out to
-`skopeo copy oci:<dir> docker://<ref>` (or `crane push <dir> <ref>`).
-Authentication is handled by the underlying tool — configure it the same
-way you would for a plain `skopeo` / `crane` push (e.g. `docker login`,
-`REGISTRY_AUTH_FILE`, `~/.config/containers/auth.json`).
+Pushes with mise's built-in registry client — no skopeo/crane/docker
+required. If `--image-dir` is not passed, builds fresh from the current
+mise.toml first. Only blobs the registry doesn't already have are
+uploaded, so repeat pushes of mostly-unchanged toolsets are cheap.
+
+Credentials are read from the same places docker and podman use:
+`$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,
+`~/.config/containers/auth.json`, and `~/.docker/config.json`
+(including credential helpers) — so `docker login` / `podman login`
+is all the setup needed.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 """#
@@ -2232,15 +2236,14 @@ Examples:
     $ mise oci build -o ./img
     $ mise oci push --image-dir ./img ghcr.io/me/devenv:v1
 
-    Force a specific push tool:
-    $ mise oci push --tool crane ghcr.io/me/devenv:latest
-
 Auth:
 
-    mise shells out to skopeo (preferred) or crane; configure registry
-    credentials the usual way — `docker login`, `REGISTRY_AUTH_FILE`,
-    or `~/.config/containers/auth.json` for skopeo; `crane auth login`
-    for crane.
+    Credentials are resolved the same way docker/podman resolve them:
+    $REGISTRY_AUTH_FILE, $XDG_RUNTIME_DIR/containers/auth.json,
+    ~/.config/containers/auth.json, then ~/.docker/config.json
+    (inline auths and credential helpers). Log in with either:
+    $ docker login ghcr.io
+    $ podman login ghcr.io
 
 """#
         flag --from help="Base image for the build (ignored with --image-dir)" {
@@ -2268,11 +2271,6 @@ Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it
 """#
             arg "<UID[:GID]>"
         }
-        flag --tool help="Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`" default=auto {
-            arg <TOOL> {
-                choices auto skopeo crane
-            }
-        }
         arg <REF> help="Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)"
     }
     cmd run help="[experimental] Build an OCI image from the current mise.toml and run a command in it" {
@@ -2280,12 +2278,12 @@ Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it
 [experimental] Build an OCI image from the current mise.toml and run a command in it
 
 Equivalent to `mise oci build` followed by `docker run` / `podman run`.
-The built image is loaded into the local container engine (podman is
-preferred; docker works via skopeo) and the given command is executed
-inside it with stdin/stdout/stderr inherited.
+The built image is loaded into the local container engine (podman pulls
+the OCI layout natively; docker receives it via `docker load`) and the
+given command is executed inside it with stdin/stdout/stderr inherited.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and
-one of: `podman`, `docker+skopeo`.
+one of: `podman`, `docker`.
 """#
         after_long_help #"""
 Examples:
@@ -2302,8 +2300,8 @@ Examples:
 
 Engines:
 
-    Prefers podman (loads OCI layouts natively). Falls back to
-    docker + skopeo. Pass --engine podman or --engine docker to override.
+    Prefers podman (loads OCI layouts natively). Falls back to docker
+    (loaded via docker load). Pass --engine podman or --engine docker to override.
 
 """#
         flag --engine help="Container engine to use (`auto`, `podman`, or `docker`)" default=auto {

--- a/src/cli/oci/build.rs
+++ b/src/cli/oci/build.rs
@@ -108,7 +108,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>skopeo inspect oci:./mise-oci</bold>
 
     Push to a registry:
-    $ <bold>skopeo copy oci:./mise-oci docker://ghcr.io/me/dev:latest</bold>
+    $ <bold>mise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest</bold>
 
 <bold><underline>Notes:</underline></bold>
 

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::process::Command;
 
 use clap::ValueHint;
 use eyre::{Context, Result, bail};
@@ -7,17 +6,20 @@ use tempfile::TempDir;
 
 use crate::cli::oci::common::perform_build;
 use crate::config::Settings;
-use crate::file;
-use crate::oci::{BuildOptions, LayerOwner};
+use crate::oci::{BuildOptions, LayerOwner, registry};
 
 /// [experimental] Build an OCI image and push it to a registry
 ///
-/// Requires `skopeo` (or `crane`) on PATH. If `--image-dir` is not passed,
-/// builds fresh from the current mise.toml first, then shells out to
-/// `skopeo copy oci:<dir> docker://<ref>` (or `crane push <dir> <ref>`).
-/// Authentication is handled by the underlying tool — configure it the same
-/// way you would for a plain `skopeo` / `crane` push (e.g. `docker login`,
-/// `REGISTRY_AUTH_FILE`, `~/.config/containers/auth.json`).
+/// Pushes with mise's built-in registry client — no skopeo/crane/docker
+/// required. If `--image-dir` is not passed, builds fresh from the current
+/// mise.toml first. Only blobs the registry doesn't already have are
+/// uploaded, so repeat pushes of mostly-unchanged toolsets are cheap.
+///
+/// Credentials are read from the same places docker and podman use:
+/// `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,
+/// `~/.config/containers/auth.json`, and `~/.docker/config.json`
+/// (including credential helpers) — so `docker login` / `podman login`
+/// is all the setup needed.
 ///
 /// Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 #[derive(Debug, clap::Args)]
@@ -56,25 +58,12 @@ pub struct Push {
     /// controls the image USER directive.
     #[clap(long, value_name = "UID[:GID]")]
     owner: Option<LayerOwner>,
-
-    /// Force the push tool (`auto`, `skopeo`, `crane`). Default `auto`.
-    #[clap(long, default_value = "auto")]
-    tool: Tool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
-enum Tool {
-    Auto,
-    Skopeo,
-    Crane,
 }
 
 impl Push {
     pub async fn run(self) -> Result<()> {
         Settings::get().ensure_experimental("mise oci push")?;
 
-        // Validate arguments BEFORE we go looking for an external tool,
-        // so argument errors always win over "tool not installed" errors.
         if !self.reference.contains('/') {
             bail!(
                 "push destination must be a fully-qualified reference \
@@ -112,71 +101,15 @@ impl Push {
                 (out_dir, Some(td))
             };
 
-        // Resolve tool after argument validation so bad args don't mask
-        // "tool missing" errors (and vice versa).
-        let tool = select_tool(self.tool)?;
-
-        match tool {
-            Tool::Skopeo => {
-                let src = format!("oci:{}", image_dir.display());
-                let dst = format!("docker://{}", self.reference);
-                info!("skopeo copy {src} {dst}");
-                let status = Command::new("skopeo")
-                    .args(["copy", &src, &dst])
-                    .status()
-                    .wrap_err("running `skopeo copy`")?;
-                if !status.success() {
-                    bail!("skopeo copy exited with {status:?}");
-                }
-            }
-            Tool::Crane => {
-                // `crane push <dir> <ref>` takes an OCI image layout directly.
-                info!("crane push {} {}", image_dir.display(), self.reference);
-                let status = Command::new("crane")
-                    .arg("push")
-                    .arg(&image_dir)
-                    .arg(&self.reference)
-                    .status()
-                    .wrap_err("running `crane push`")?;
-                if !status.success() {
-                    bail!("crane push exited with {status:?}");
-                }
-            }
-            Tool::Auto => unreachable!(),
-        }
-
-        miseprintln!("pushed {} to {}", image_dir.display(), self.reference);
+        let summary = registry::push_image(&image_dir, &self.reference).await?;
+        miseprintln!(
+            "pushed {} to {} ({} blob(s) uploaded, {} already present)",
+            summary.manifest_digest,
+            self.reference,
+            summary.uploaded,
+            summary.skipped
+        );
         Ok(())
-    }
-}
-
-fn select_tool(requested: Tool) -> Result<Tool> {
-    match requested {
-        Tool::Skopeo => {
-            if file::which("skopeo").is_none() {
-                bail!("--tool skopeo requested but `skopeo` was not found on PATH");
-            }
-            Ok(Tool::Skopeo)
-        }
-        Tool::Crane => {
-            if file::which("crane").is_none() {
-                bail!("--tool crane requested but `crane` was not found on PATH");
-            }
-            Ok(Tool::Crane)
-        }
-        Tool::Auto => {
-            if file::which("skopeo").is_some() {
-                Ok(Tool::Skopeo)
-            } else if file::which("crane").is_some() {
-                Ok(Tool::Crane)
-            } else {
-                bail!(
-                    "no supported push tool found. Install one of:\n  \
-                       - skopeo (recommended)\n  \
-                       - crane\nand configure registry auth for it."
-                )
-            }
-        }
     }
 }
 
@@ -190,14 +123,13 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise oci build -o ./img</bold>
     $ <bold>mise oci push --image-dir ./img ghcr.io/me/devenv:v1</bold>
 
-    Force a specific push tool:
-    $ <bold>mise oci push --tool crane ghcr.io/me/devenv:latest</bold>
-
 <bold><underline>Auth:</underline></bold>
 
-    mise shells out to <bold>skopeo</bold> (preferred) or <bold>crane</bold>; configure registry
-    credentials the usual way — `docker login`, `REGISTRY_AUTH_FILE`,
-    or `~/.config/containers/auth.json` for skopeo; `crane auth login`
-    for crane.
+    Credentials are resolved the same way docker/podman resolve them:
+    <bold>$REGISTRY_AUTH_FILE</bold>, <bold>$XDG_RUNTIME_DIR/containers/auth.json</bold>,
+    <bold>~/.config/containers/auth.json</bold>, then <bold>~/.docker/config.json</bold>
+    (inline auths and credential helpers). Log in with either:
+    $ <bold>docker login ghcr.io</bold>
+    $ <bold>podman login ghcr.io</bold>
 "#
 );

--- a/src/cli/oci/run.rs
+++ b/src/cli/oci/run.rs
@@ -13,12 +13,12 @@ use crate::oci::{BuildOptions, LayerOwner};
 /// [experimental] Build an OCI image from the current mise.toml and run a command in it
 ///
 /// Equivalent to `mise oci build` followed by `docker run` / `podman run`.
-/// The built image is loaded into the local container engine (podman is
-/// preferred; docker works via skopeo) and the given command is executed
-/// inside it with stdin/stdout/stderr inherited.
+/// The built image is loaded into the local container engine (podman pulls
+/// the OCI layout natively; docker receives it via `docker load`) and the
+/// given command is executed inside it with stdin/stdout/stderr inherited.
 ///
 /// Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and
-/// one of: `podman`, `docker+skopeo`.
+/// one of: `podman`, `docker`.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Run {
@@ -148,7 +148,7 @@ impl Run {
 
         // 4. Load into the engine. Returns the image reference to actually
         // pass to `podman run` / `docker run` (podman uses an image ID;
-        // docker uses the tag skopeo copied under).
+        // docker uses the tag the archive was loaded under).
         let image_ref = load_image(engine, &image_dir)?;
 
         // 5. docker/podman run <flags> <image-ref> <cmd...>
@@ -229,25 +229,15 @@ fn select_engine(requested: Engine) -> Result<Engine> {
             if file::which("docker").is_none() {
                 bail!("--engine docker requested but `docker` was not found on PATH");
             }
-            if file::which("skopeo").is_none() {
-                bail!(
-                    "--engine docker requires `skopeo` (to load the OCI layout into the \
-                     docker daemon). Install skopeo or use `--engine podman`."
-                );
-            }
             Ok(Engine::Docker)
         }
         Engine::Auto => {
             if file::which("podman").is_some() {
                 Ok(Engine::Podman)
-            } else if file::which("docker").is_some() && file::which("skopeo").is_some() {
+            } else if file::which("docker").is_some() {
                 Ok(Engine::Docker)
             } else {
-                bail!(
-                    "no supported container engine found. Install one of:\n  \
-                       - podman (native OCI-layout support)\n  \
-                       - docker + skopeo (to load the OCI layout into the docker daemon)"
-                )
+                bail!("no supported container engine found. Install podman or docker.")
             }
         }
     }
@@ -292,11 +282,11 @@ fn load_image(engine: Engine, image_dir: &Path) -> Result<String> {
             Ok(id)
         }
         Engine::Docker => {
-            // skopeo is the portable way to get an OCI layout into a docker
-            // daemon. Pick a per-invocation tag so concurrent `mise oci run`
-            // calls don't clobber each other — a shared `mise-oci:run` tag
-            // would otherwise race: the second skopeo copy would overwrite
-            // the first image before the first container started.
+            // Stream the layout into `docker load` as a docker-archive. Pick
+            // a per-invocation tag so concurrent `mise oci run` calls don't
+            // clobber each other — a shared `mise-oci:run` tag would
+            // otherwise race: the second load would overwrite the first
+            // image before the first container started.
             let tag = format!(
                 "mise-oci:run-{}-{}",
                 std::process::id(),
@@ -305,18 +295,7 @@ fn load_image(engine: Engine, image_dir: &Path) -> Result<String> {
                     .map(|d| d.as_nanos())
                     .unwrap_or(0)
             );
-            let src = format!("oci:{}", image_dir.display());
-            let dst = format!("docker-daemon:{tag}");
-            let status = Command::new("skopeo")
-                .args(["copy", &src, &dst])
-                .status()
-                .wrap_err("running `skopeo copy`")?;
-            if !status.success() {
-                bail!(
-                    "skopeo copy failed ({status:?}). Ensure the docker daemon is running and \
-                     your user has access to the socket."
-                );
-            }
+            crate::oci::docker_archive::load_into_docker(image_dir, &tag)?;
             Ok(tag)
         }
         Engine::Auto => unreachable!(),
@@ -338,7 +317,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 <bold><underline>Engines:</underline></bold>
 
-    Prefers <bold>podman</bold> (loads OCI layouts natively). Falls back to
-    <bold>docker + skopeo</bold>. Pass <bold>--engine podman</bold> or <bold>--engine docker</bold> to override.
+    Prefers <bold>podman</bold> (loads OCI layouts natively). Falls back to <bold>docker</bold>
+    (loaded via <bold>docker load</bold>). Pass <bold>--engine podman</bold> or <bold>--engine docker</bold> to override.
 "#
 );

--- a/src/http.rs
+++ b/src/http.rs
@@ -163,22 +163,6 @@ impl Client {
         Ok(resp.bytes().await?)
     }
 
-    /// Like `get_bytes`, but lets the caller supply the exact headers used
-    /// for the request. Does NOT merge `host_auth_headers` — this mirrors
-    /// `json_headers_with_headers` so callers get consistent behavior
-    /// between manifest JSON fetches and blob byte fetches to the same host
-    /// (e.g. `ghcr.io`, where the OCI Bearer token must not be mixed with
-    /// the GitHub token that host_auth_headers would inject).
-    pub async fn get_bytes_with_headers<U: IntoUrl>(
-        &self,
-        url: U,
-        headers: &HeaderMap,
-    ) -> Result<impl AsRef<[u8]>> {
-        let url = url.into_url().unwrap();
-        let resp = self.get_async_with_headers(url, headers).await?;
-        Ok(resp.bytes().await?)
-    }
-
     pub async fn get_async<U: IntoUrl>(&self, url: U) -> Result<Response> {
         let url = url.into_url()?;
         let headers = host_auth_headers(&url)?;

--- a/src/oci/auth.rs
+++ b/src/oci/auth.rs
@@ -71,21 +71,30 @@ pub fn resolve_credential(registry: &str) -> Result<Option<Credential>> {
         if !path.is_file() {
             continue;
         }
-        let raw = crate::file::read_to_string(&path)
-            .wrap_err_with(|| format!("reading {}", path.display()))?;
+        // No single source should hard-fail resolution — a later file (or
+        // anonymous access) may still work. Warn and move on for unreadable,
+        // malformed, or otherwise erroring files.
+        let raw = match crate::file::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(e) => {
+                warn!("skipping unreadable auth file {}: {e}", path.display());
+                continue;
+            }
+        };
         let file: AuthFile = match serde_json::from_str(&raw) {
             Ok(f) => f,
             Err(e) => {
-                // A malformed auth file shouldn't hard-fail the push when a
-                // later file (or anonymous auth) might still work — but the
-                // user should know we skipped it.
                 warn!("skipping malformed auth file {}: {e}", path.display());
                 continue;
             }
         };
-        if let Some(cred) = credential_from_file(&file, registry)? {
-            debug!("using registry credentials from {}", path.display());
-            return Ok(Some(cred));
+        match credential_from_file(&file, registry) {
+            Ok(Some(cred)) => {
+                debug!("using registry credentials from {}", path.display());
+                return Ok(Some(cred));
+            }
+            Ok(None) => {}
+            Err(e) => warn!("skipping auth file {} ({e})", path.display()),
         }
     }
     Ok(None)
@@ -111,10 +120,18 @@ fn auth_file_paths() -> Vec<PathBuf> {
 fn credential_from_file(file: &AuthFile, registry: &str) -> Result<Option<Credential>> {
     let aliases = registry_aliases(registry);
 
-    // 1. Per-registry credential helper.
+    // 1. Per-registry credential helper. A helper that exits non-zero when it
+    // has no entry for the host (the docker "credentials not found"
+    // convention) is a miss, not a failure — fall through to inline auths /
+    // credsStore / the next file rather than aborting the whole push.
     for (key, helper) in &file.cred_helpers {
         if key_matches(key, &aliases) {
-            return run_credential_helper(helper, registry).map(Some);
+            match run_credential_helper(helper, registry) {
+                Ok(cred) => return Ok(Some(cred)),
+                Err(e) => {
+                    debug!("credHelpers helper {helper} has no credentials for {registry}: {e}");
+                }
+            }
         }
     }
 

--- a/src/oci/auth.rs
+++ b/src/oci/auth.rs
@@ -135,13 +135,17 @@ fn credential_from_file(file: &AuthFile, registry: &str) -> Result<Option<Creden
         }
     }
 
-    // 2. Inline auths.
+    // 2. Inline auths. A malformed matching entry (bad base64/UTF-8/shape) is
+    // warned about and skipped rather than aborting — a valid credsStore or a
+    // later file may still have usable credentials for this registry.
     for (key, entry) in &file.auths {
         if !key_matches(key, &aliases) {
             continue;
         }
-        if let Some(cred) = credential_from_entry(entry, key)? {
-            return Ok(Some(cred));
+        match credential_from_entry(entry, key) {
+            Ok(Some(cred)) => return Ok(Some(cred)),
+            Ok(None) => {}
+            Err(e) => warn!("ignoring malformed auth entry for {key}: {e}"),
         }
     }
 
@@ -329,9 +333,27 @@ mod tests {
     }
 
     #[test]
-    fn malformed_base64_errors() {
+    fn malformed_entry_is_skipped_not_fatal() {
+        // A corrupt matching entry must not abort resolution: it's skipped so
+        // a credsStore (or a later file) can still provide credentials.
         let file = parse(r#"{"auths": {"ghcr.io": {"auth": "!!!"}}}"#);
-        assert!(credential_from_file(&file, "ghcr.io").is_err());
+        assert!(credential_from_file(&file, "ghcr.io").unwrap().is_none());
+    }
+
+    #[test]
+    fn malformed_entry_falls_through_to_other_entry() {
+        // `credential_from_entry` surfaces malformed base64 as an error; ensure
+        // it doesn't shadow a second, valid entry for the same registry.
+        assert!(
+            credential_from_entry(
+                &AuthEntry {
+                    auth: Some("!!!".into()),
+                    ..Default::default()
+                },
+                "ghcr.io"
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/oci/auth.rs
+++ b/src/oci/auth.rs
@@ -1,0 +1,328 @@
+//! Registry credential resolution for `mise oci push` (and private pulls).
+//!
+//! Reads the same credential sources as docker / podman / skopeo so that
+//! `docker login` / `podman login` "just work" with the native push client:
+//!
+//! 1. `$REGISTRY_AUTH_FILE` (podman/skopeo convention)
+//! 2. `$XDG_RUNTIME_DIR/containers/auth.json` (podman default)
+//! 3. `$XDG_CONFIG_HOME/containers/auth.json`
+//! 4. `$DOCKER_CONFIG/config.json`, falling back to `~/.docker/config.json`
+//!
+//! Within a file, credentials come from (in order) `credHelpers.<host>`,
+//! inline `auths` entries, then the global `credsStore`. Credential helpers
+//! are the `docker-credential-<name>` executables (osxkeychain, desktop,
+//! ecr-login, gcloud, …) that docker itself shells out to.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+use eyre::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::env;
+
+/// A username/secret pair for registry auth. `username == "<token>"` is the
+/// docker credential-helper convention for an identity token; the OCI token
+/// endpoint treats it the same as a password grant, so we don't special-case
+/// it beyond passing it through.
+#[derive(Debug, Clone)]
+pub struct Credential {
+    pub username: String,
+    pub secret: String,
+}
+
+impl Credential {
+    pub fn basic_auth_header(&self) -> String {
+        let raw = format!("{}:{}", self.username, self.secret);
+        format!("Basic {}", BASE64_STANDARD.encode(raw))
+    }
+}
+
+/// docker/podman `config.json` / `auth.json` — only the fields we read.
+#[derive(Debug, Default, Deserialize)]
+struct AuthFile {
+    #[serde(default)]
+    auths: indexmap::IndexMap<String, AuthEntry>,
+    #[serde(default, rename = "credHelpers")]
+    cred_helpers: indexmap::IndexMap<String, String>,
+    #[serde(default, rename = "credsStore")]
+    creds_store: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct AuthEntry {
+    #[serde(default)]
+    auth: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    password: Option<String>,
+    #[serde(default, rename = "identitytoken")]
+    identity_token: Option<String>,
+}
+
+/// Resolve credentials for `registry` (a bare host like `ghcr.io` or
+/// `docker.io`). Returns `None` when no credential source has an entry —
+/// the caller should proceed anonymously.
+pub fn resolve_credential(registry: &str) -> Result<Option<Credential>> {
+    for path in auth_file_paths() {
+        if !path.is_file() {
+            continue;
+        }
+        let raw = crate::file::read_to_string(&path)
+            .wrap_err_with(|| format!("reading {}", path.display()))?;
+        let file: AuthFile = match serde_json::from_str(&raw) {
+            Ok(f) => f,
+            Err(e) => {
+                // A malformed auth file shouldn't hard-fail the push when a
+                // later file (or anonymous auth) might still work — but the
+                // user should know we skipped it.
+                warn!("skipping malformed auth file {}: {e}", path.display());
+                continue;
+            }
+        };
+        if let Some(cred) = credential_from_file(&file, registry)? {
+            debug!("using registry credentials from {}", path.display());
+            return Ok(Some(cred));
+        }
+    }
+    Ok(None)
+}
+
+fn auth_file_paths() -> Vec<PathBuf> {
+    let mut paths = vec![];
+    if let Some(p) = env::var_os("REGISTRY_AUTH_FILE") {
+        paths.push(PathBuf::from(p));
+    }
+    if let Some(p) = env::var_os("XDG_RUNTIME_DIR") {
+        paths.push(PathBuf::from(p).join("containers/auth.json"));
+    }
+    paths.push(env::XDG_CONFIG_HOME.join("containers/auth.json"));
+    if let Some(p) = env::var_os("DOCKER_CONFIG") {
+        paths.push(PathBuf::from(p).join("config.json"));
+    } else {
+        paths.push(env::HOME.join(".docker/config.json"));
+    }
+    paths
+}
+
+fn credential_from_file(file: &AuthFile, registry: &str) -> Result<Option<Credential>> {
+    let aliases = registry_aliases(registry);
+
+    // 1. Per-registry credential helper.
+    for (key, helper) in &file.cred_helpers {
+        if key_matches(key, &aliases) {
+            return run_credential_helper(helper, registry).map(Some);
+        }
+    }
+
+    // 2. Inline auths.
+    for (key, entry) in &file.auths {
+        if !key_matches(key, &aliases) {
+            continue;
+        }
+        if let Some(cred) = credential_from_entry(entry, key)? {
+            return Ok(Some(cred));
+        }
+    }
+
+    // 3. Global credential store. Only consult it if the file mentions one —
+    // and treat "helper has no entry for this registry" as a miss rather
+    // than an error so resolution can fall through to the next file.
+    if let Some(helper) = &file.creds_store {
+        match run_credential_helper(helper, registry) {
+            Ok(cred) => return Ok(Some(cred)),
+            Err(e) => {
+                debug!("credsStore helper {helper} has no credentials for {registry}: {e}");
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn credential_from_entry(entry: &AuthEntry, key: &str) -> Result<Option<Credential>> {
+    let (mut username, mut secret) = (entry.username.clone(), entry.password.clone());
+    if let Some(auth) = entry.auth.as_deref().filter(|a| !a.is_empty()) {
+        let decoded = BASE64_STANDARD
+            .decode(auth.trim())
+            .wrap_err_with(|| format!("decoding base64 `auth` for {key}"))?;
+        let decoded = String::from_utf8(decoded)
+            .wrap_err_with(|| format!("`auth` for {key} is not valid UTF-8"))?;
+        let Some((u, p)) = decoded.split_once(':') else {
+            bail!("`auth` for {key} is not `user:password`");
+        };
+        username = Some(u.to_string());
+        secret = Some(p.to_string());
+    }
+    // An identity token (docker.io "Docker Desktop" login flow) replaces the
+    // password; the username from `auth` is ignored by registries in this
+    // mode but `<token>` is the conventional placeholder.
+    if let Some(token) = entry.identity_token.as_deref().filter(|t| !t.is_empty()) {
+        return Ok(Some(Credential {
+            username: "<token>".to_string(),
+            secret: token.to_string(),
+        }));
+    }
+    match (username, secret) {
+        (Some(u), Some(p)) => Ok(Some(Credential {
+            username: u,
+            secret: p,
+        })),
+        _ => Ok(None),
+    }
+}
+
+/// All keys under which credentials for `registry` may be stored. Docker Hub
+/// is the messy one — logins are stored under the legacy v1 endpoint.
+fn registry_aliases(registry: &str) -> Vec<String> {
+    let mut aliases = vec![registry.to_string()];
+    if matches!(
+        registry,
+        "docker.io" | "index.docker.io" | "registry-1.docker.io"
+    ) {
+        aliases.extend([
+            "docker.io".into(),
+            "index.docker.io".into(),
+            "registry-1.docker.io".into(),
+            "https://index.docker.io/v1/".into(),
+        ]);
+    }
+    aliases
+}
+
+/// Match an auth-file key against the alias list. Keys may carry a scheme
+/// and/or path (`https://ghcr.io/v2/`); compare on the host portion.
+fn key_matches(key: &str, aliases: &[String]) -> bool {
+    if aliases.iter().any(|a| a == key) {
+        return true;
+    }
+    let stripped = key
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let host = stripped.split('/').next().unwrap_or(stripped);
+    aliases.iter().any(|a| a == host)
+}
+
+/// Shell out to `docker-credential-<helper> get`, passing the registry on
+/// stdin, and parse the `{"Username": …, "Secret": …}` response — the same
+/// protocol docker itself uses.
+fn run_credential_helper(helper: &str, registry: &str) -> Result<Credential> {
+    let bin = format!("docker-credential-{helper}");
+    // Docker Hub helpers store the credential under the legacy v1 URL.
+    let server = if registry == "docker.io" || registry == "registry-1.docker.io" {
+        "https://index.docker.io/v1/"
+    } else {
+        registry
+    };
+    debug!("running {bin} get for {server}");
+    let mut child = Command::new(&bin)
+        .arg("get")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .wrap_err_with(|| format!("spawning {bin} (from credHelpers/credsStore)"))?;
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().expect("stdin piped");
+        stdin.write_all(server.as_bytes())?;
+    }
+    let out = child.wait_with_output()?;
+    if !out.status.success() {
+        bail!(
+            "{bin} get failed for {server}: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    #[derive(Deserialize)]
+    struct HelperResponse {
+        #[serde(rename = "Username")]
+        username: String,
+        #[serde(rename = "Secret")]
+        secret: String,
+    }
+    let resp: HelperResponse = serde_json::from_slice(&out.stdout)
+        .wrap_err_with(|| format!("parsing {bin} get output"))?;
+    Ok(Credential {
+        username: resp.username,
+        secret: resp.secret,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> AuthFile {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn inline_auth_base64() {
+        let file = parse(r#"{"auths": {"ghcr.io": {"auth": "dXNlcjpwYXNz"}}}"#);
+        let cred = credential_from_file(&file, "ghcr.io").unwrap().unwrap();
+        assert_eq!(cred.username, "user");
+        assert_eq!(cred.secret, "pass");
+    }
+
+    #[test]
+    fn inline_auth_username_password() {
+        let file = parse(r#"{"auths": {"ghcr.io": {"username": "u", "password": "p"}}}"#);
+        let cred = credential_from_file(&file, "ghcr.io").unwrap().unwrap();
+        assert_eq!(cred.username, "u");
+        assert_eq!(cred.secret, "p");
+    }
+
+    #[test]
+    fn dockerhub_legacy_key_matches() {
+        let file = parse(r#"{"auths": {"https://index.docker.io/v1/": {"auth": "dXNlcjpwYXNz"}}}"#);
+        let cred = credential_from_file(&file, "docker.io").unwrap().unwrap();
+        assert_eq!(cred.username, "user");
+    }
+
+    #[test]
+    fn scheme_prefixed_key_matches() {
+        let file = parse(r#"{"auths": {"https://ghcr.io": {"auth": "dXNlcjpwYXNz"}}}"#);
+        assert!(credential_from_file(&file, "ghcr.io").unwrap().is_some());
+    }
+
+    #[test]
+    fn identity_token_wins() {
+        let file =
+            parse(r#"{"auths": {"ghcr.io": {"auth": "dXNlcjpwYXNz", "identitytoken": "idtok"}}}"#);
+        let cred = credential_from_file(&file, "ghcr.io").unwrap().unwrap();
+        assert_eq!(cred.username, "<token>");
+        assert_eq!(cred.secret, "idtok");
+    }
+
+    #[test]
+    fn no_entry_returns_none() {
+        let file = parse(r#"{"auths": {"ghcr.io": {"auth": "dXNlcjpwYXNz"}}}"#);
+        assert!(credential_from_file(&file, "quay.io").unwrap().is_none());
+    }
+
+    #[test]
+    fn empty_auth_entry_is_none() {
+        // `docker logout` can leave empty entries behind.
+        let file = parse(r#"{"auths": {"ghcr.io": {}}}"#);
+        assert!(credential_from_file(&file, "ghcr.io").unwrap().is_none());
+    }
+
+    #[test]
+    fn malformed_base64_errors() {
+        let file = parse(r#"{"auths": {"ghcr.io": {"auth": "!!!"}}}"#);
+        assert!(credential_from_file(&file, "ghcr.io").is_err());
+    }
+
+    #[test]
+    fn basic_auth_header_roundtrip() {
+        let cred = Credential {
+            username: "user".into(),
+            secret: "pass".into(),
+        };
+        assert_eq!(cred.basic_auth_header(), "Basic dXNlcjpwYXNz");
+    }
+}

--- a/src/oci/docker_archive.rs
+++ b/src/oci/docker_archive.rs
@@ -1,0 +1,270 @@
+//! Load an OCI image layout into the docker daemon via `docker load`.
+//!
+//! Docker can't consume an OCI layout directory directly (that's why skopeo
+//! was previously required for `mise oci run --engine docker`). It can,
+//! however, load a docker-archive tarball from stdin. This module converts
+//! the layout on the fly — config + decompressed layers + `manifest.json` —
+//! and streams it straight into `docker load` without materializing the
+//! archive on disk.
+//!
+//! Layers are decompressed because the docker-archive format stores plain
+//! tars: the daemon matches layer content against the config's
+//! `rootfs.diff_ids`, which are digests of the *uncompressed* streams.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use eyre::{Context, Result, bail};
+use jdx_tar::{Builder, EntryType, Header};
+use serde::Serialize;
+
+use crate::oci::layout::ImageLayout;
+use crate::oci::manifest::{ImageIndex, ImageManifest};
+
+#[derive(Serialize)]
+struct ManifestEntry {
+    #[serde(rename = "Config")]
+    config: String,
+    #[serde(rename = "RepoTags")]
+    repo_tags: Vec<String>,
+    #[serde(rename = "Layers")]
+    layers: Vec<String>,
+}
+
+/// Stream the OCI layout at `image_dir` into `docker load`, tagging the
+/// loaded image as `tag`.
+pub fn load_into_docker(image_dir: &Path, tag: &str) -> Result<()> {
+    let layout = ImageLayout {
+        root: image_dir.to_path_buf(),
+    };
+    let index_bytes = crate::file::read(image_dir.join("index.json"))?;
+    let index: ImageIndex = serde_json::from_slice(&index_bytes).wrap_err("parsing index.json")?;
+    let manifest_desc = match index.manifests.as_slice() {
+        [one] => one,
+        _ => bail!(
+            "{}: expected exactly one manifest in index.json",
+            image_dir.display()
+        ),
+    };
+    let manifest_bytes = layout.read_blob(&manifest_desc.digest)?;
+    let manifest: ImageManifest =
+        serde_json::from_slice(&manifest_bytes).wrap_err("parsing image manifest blob")?;
+    let config_bytes = layout.read_blob(&manifest.config.digest)?;
+
+    let mut child = Command::new("docker")
+        .args(["load", "--quiet"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .wrap_err("spawning `docker load`")?;
+    let stdin = child.stdin.take().expect("stdin piped");
+
+    // Write the archive; any pipe error surfaces as an io error here and is
+    // paired with docker's stderr below for diagnosis.
+    let write_result = write_docker_archive(stdin, &layout, &manifest, &config_bytes, tag);
+
+    let out = child
+        .wait_with_output()
+        .wrap_err("waiting for `docker load`")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        bail!(
+            "`docker load` failed ({}): {}. Ensure the docker daemon is running and \
+             your user has access to the socket.",
+            out.status,
+            stderr.trim()
+        );
+    }
+    // A broken pipe with a zero exit status shouldn't happen, but don't
+    // swallow the write error if it does.
+    write_result?;
+    Ok(())
+}
+
+fn write_docker_archive<W: Write>(
+    out: W,
+    layout: &ImageLayout,
+    manifest: &ImageManifest,
+    config_bytes: &[u8],
+    tag: &str,
+) -> Result<()> {
+    let mut builder = Builder::new(out);
+
+    let config_name = format!("{}.json", hex_of(&manifest.config.digest));
+    append_bytes(&mut builder, &config_name, config_bytes)?;
+
+    let mut layer_names = Vec::new();
+    for (i, layer) in manifest.layers.iter().enumerate() {
+        let name = format!("{i}/layer.tar");
+        let blob_path = layout.blob_path(&layer.digest);
+        let mut tmp = tempfile::tempfile().wrap_err("creating temp file for layer")?;
+        decompress_blob(&blob_path, &mut tmp)
+            .wrap_err_with(|| format!("decompressing layer {}", layer.digest))?;
+        let size = tmp.seek(SeekFrom::End(0))?;
+        tmp.seek(SeekFrom::Start(0))?;
+        let mut header = file_header(size);
+        builder.append_data(&mut header, &name, &mut tmp)?;
+        layer_names.push(name);
+    }
+
+    let entries = vec![ManifestEntry {
+        config: config_name,
+        repo_tags: vec![tag.to_string()],
+        layers: layer_names,
+    }];
+    append_bytes(
+        &mut builder,
+        "manifest.json",
+        &serde_json::to_vec(&entries)?,
+    )?;
+
+    builder.into_inner()?.flush()?;
+    Ok(())
+}
+
+/// Decompress a layer blob into `dst`, sniffing the compression from magic
+/// bytes rather than trusting the manifest media type — base images pass
+/// their layers through byte-for-byte, so we can see OCI gzip, docker gzip,
+/// zstd, or plain tar here.
+fn decompress_blob(path: &Path, dst: &mut std::fs::File) -> Result<()> {
+    let mut f = std::fs::File::open(path)?;
+    let mut magic = [0u8; 4];
+    let n = f.read(&mut magic)?;
+    f.seek(SeekFrom::Start(0))?;
+    if n >= 2 && magic[0] == 0x1f && magic[1] == 0x8b {
+        // MultiGzDecoder: layer blobs are occasionally multi-member gzip
+        // streams (pigz, some registries' recompression).
+        std::io::copy(&mut flate2::read::MultiGzDecoder::new(f), dst)?;
+    } else if n >= 4 && magic == [0x28, 0xb5, 0x2f, 0xfd] {
+        zstd::stream::copy_decode(f, &mut *dst)?;
+    } else {
+        std::io::copy(&mut f, dst)?;
+    }
+    Ok(())
+}
+
+fn append_bytes<W: Write>(builder: &mut Builder<W>, name: &str, bytes: &[u8]) -> Result<()> {
+    let mut header = file_header(bytes.len() as u64);
+    builder.append_data(&mut header, name, bytes)?;
+    Ok(())
+}
+
+fn file_header(size: u64) -> Header {
+    let mut header = Header::new_gnu(EntryType::File);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(size);
+    header
+}
+
+fn hex_of(digest: &str) -> &str {
+    digest.trim_start_matches("sha256:")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oci::manifest::{Descriptor, MEDIA_TYPE_OCI_CONFIG, MEDIA_TYPE_OCI_MANIFEST};
+    use jdx_tar::Archive;
+
+    fn descriptor(media_type: &str, digest: String, size: u64) -> Descriptor {
+        Descriptor {
+            media_type: media_type.to_string(),
+            size,
+            digest,
+            annotations: Default::default(),
+            platform: None,
+        }
+    }
+
+    /// Build a tiny layout, write the docker archive to memory, and verify
+    /// its structure: config json, decompressed layer, manifest.json.
+    #[test]
+    fn writes_valid_docker_archive() {
+        let td = tempfile::tempdir().unwrap();
+        let layout = ImageLayout::init(td.path()).unwrap();
+
+        // A gzipped "layer" (content doesn't need to be a real tar for the
+        // writer — docker validates that, not us).
+        let layer_tar = b"fake layer tar bytes".to_vec();
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        gz.write_all(&layer_tar).unwrap();
+        let layer_gz = gz.finish().unwrap();
+        let (layer_digest, layer_size) = layout.write_blob(&layer_gz).unwrap();
+
+        let config_bytes =
+            br#"{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]}}"#
+                .to_vec();
+        let (config_digest, config_size) = layout.write_blob(&config_bytes).unwrap();
+
+        let manifest = ImageManifest {
+            schema_version: 2,
+            media_type: MEDIA_TYPE_OCI_MANIFEST.to_string(),
+            config: descriptor(MEDIA_TYPE_OCI_CONFIG, config_digest.clone(), config_size),
+            layers: vec![descriptor(
+                crate::oci::manifest::MEDIA_TYPE_OCI_LAYER_GZIP,
+                layer_digest,
+                layer_size,
+            )],
+            annotations: Default::default(),
+        };
+
+        let mut archive_bytes = Vec::new();
+        write_docker_archive(
+            &mut archive_bytes,
+            &layout,
+            &manifest,
+            &config_bytes,
+            "mise-oci:test",
+        )
+        .unwrap();
+
+        let mut archive = Archive::new(archive_bytes.as_slice());
+        let mut entries = std::collections::HashMap::new();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().to_string();
+            let mut contents = Vec::new();
+            entry.read_to_end(&mut contents).unwrap();
+            entries.insert(path, contents);
+        }
+
+        let config_name = format!("{}.json", hex_of(&config_digest));
+        assert_eq!(entries[&config_name], config_bytes);
+        // Layer must be the *decompressed* bytes.
+        assert_eq!(entries["0/layer.tar"], layer_tar);
+        let manifest_json: serde_json::Value =
+            serde_json::from_slice(&entries["manifest.json"]).unwrap();
+        assert_eq!(manifest_json[0]["Config"], config_name.as_str());
+        assert_eq!(manifest_json[0]["RepoTags"][0], "mise-oci:test");
+        assert_eq!(manifest_json[0]["Layers"][0], "0/layer.tar");
+    }
+
+    #[test]
+    fn decompress_sniffs_zstd_and_plain() {
+        let td = tempfile::tempdir().unwrap();
+        let data = b"plain tar-ish content".to_vec();
+
+        let zst_path = td.path().join("blob.zst");
+        std::fs::write(&zst_path, zstd::encode_all(data.as_slice(), 0).unwrap()).unwrap();
+        let mut out = tempfile::tempfile().unwrap();
+        decompress_blob(&zst_path, &mut out).unwrap();
+        out.seek(SeekFrom::Start(0)).unwrap();
+        let mut got = Vec::new();
+        out.read_to_end(&mut got).unwrap();
+        assert_eq!(got, data);
+
+        let plain_path = td.path().join("blob.tar");
+        std::fs::write(&plain_path, &data).unwrap();
+        let mut out = tempfile::tempfile().unwrap();
+        decompress_blob(&plain_path, &mut out).unwrap();
+        out.seek(SeekFrom::Start(0)).unwrap();
+        let mut got = Vec::new();
+        out.read_to_end(&mut got).unwrap();
+        assert_eq!(got, data);
+    }
+}

--- a/src/oci/docker_archive.rs
+++ b/src/oci/docker_archive.rs
@@ -61,24 +61,47 @@ pub fn load_into_docker(image_dir: &Path, tag: &str) -> Result<()> {
         .wrap_err("spawning `docker load`")?;
     let stdin = child.stdin.take().expect("stdin piped");
 
-    // Write the archive; any pipe error surfaces as an io error here and is
-    // paired with docker's stderr below for diagnosis.
-    let write_result = write_docker_archive(stdin, &layout, &manifest, &config_bytes, tag);
+    // Write the archive on a separate thread so the parent can drain docker's
+    // stdout+stderr concurrently via `wait_with_output`. Writing the whole
+    // archive before draining would deadlock if docker hit a fatal mid-load
+    // error (disk full, overlay failure) on a large image: docker would stop
+    // reading stdin and block once its stderr pipe buffer (~64 KB) filled,
+    // while we blocked writing stdin.
+    let writer = {
+        let root = layout.root.clone();
+        let manifest = manifest.clone();
+        let tag = tag.to_string();
+        std::thread::spawn(move || {
+            let layout = ImageLayout { root };
+            write_docker_archive(stdin, &layout, &manifest, &config_bytes, &tag)
+        })
+    };
 
     let out = child
         .wait_with_output()
         .wrap_err("waiting for `docker load`")?;
+    let write_result = writer
+        .join()
+        .map_err(|_| eyre::eyre!("docker archive writer thread panicked"))?;
+
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
-        bail!(
+        let mut msg = format!(
             "`docker load` failed ({}): {}. Ensure the docker daemon is running and \
              your user has access to the socket.",
             out.status,
             stderr.trim()
         );
+        // A write error here is usually the broken pipe caused by docker
+        // dying (so docker's stderr is the real cause), but if it's something
+        // else — e.g. a layer failed to decompress — surface it too so the
+        // truncated-archive error from docker doesn't mask the root cause.
+        if let Err(e) = &write_result {
+            msg.push_str(&format!("\n(while writing archive: {e})"));
+        }
+        bail!(msg);
     }
-    // A broken pipe with a zero exit status shouldn't happen, but don't
-    // swallow the write error if it does.
+    // docker succeeded — don't swallow a writer error if one somehow occurred.
     write_result?;
     Ok(())
 }

--- a/src/oci/docker_archive.rs
+++ b/src/oci/docker_archive.rs
@@ -52,6 +52,14 @@ pub fn load_into_docker(image_dir: &Path, tag: &str) -> Result<()> {
         serde_json::from_slice(&manifest_bytes).wrap_err("parsing image manifest blob")?;
     let config_bytes = layout.read_blob(&manifest.config.digest)?;
 
+    // Validate every layer digest before it's used as a path component in
+    // `write_docker_archive` (which reads via `blob_path`, bypassing the
+    // check `read_blob` performs) — a crafted `--image-dir` layout could
+    // otherwise escape the blobs directory with `sha256:../…`.
+    for layer in &manifest.layers {
+        crate::oci::layout::validate_sha256_digest(&layer.digest)?;
+    }
+
     let mut child = Command::new("docker")
         .args(["load", "--quiet"])
         .stdin(Stdio::piped())

--- a/src/oci/layout.rs
+++ b/src/oci/layout.rs
@@ -82,7 +82,6 @@ impl ImageLayout {
         self.root.join("blobs/sha256").join(hex)
     }
 
-    #[allow(dead_code)]
     pub fn read_blob(&self, digest: &str) -> Result<Vec<u8>> {
         let path = self.blob_path(digest);
         std::fs::read(&path).wrap_err_with(|| format!("reading blob {}", path.display()))

--- a/src/oci/layout.rs
+++ b/src/oci/layout.rs
@@ -83,6 +83,10 @@ impl ImageLayout {
     }
 
     pub fn read_blob(&self, digest: &str) -> Result<Vec<u8>> {
+        // Validate before turning the digest into a path component — a crafted
+        // layout (`mise oci push/run --image-dir <untrusted>`) could otherwise
+        // use `sha256:../../etc/passwd` to read outside the blobs directory.
+        validate_sha256_digest(digest)?;
         let path = self.blob_path(digest);
         std::fs::read(&path).wrap_err_with(|| format!("reading blob {}", path.display()))
     }
@@ -161,5 +165,13 @@ mod tests {
     fn accepts_valid_digest() {
         let d = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         assert!(validate_sha256_digest(d).is_ok());
+    }
+
+    #[test]
+    fn read_blob_rejects_traversal_digest() {
+        // A crafted layout must not be able to read outside blobs/sha256.
+        let tmp = tempfile::tempdir().unwrap();
+        let layout = ImageLayout::init(tmp.path()).unwrap();
+        assert!(layout.read_blob("sha256:../../../../etc/passwd").is_err());
     }
 }

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -6,7 +6,9 @@
 //! exactly one content-addressable blob. See `builder.rs` for how this is
 //! orchestrated.
 
+pub mod auth;
 pub mod builder;
+pub mod docker_archive;
 pub mod layer;
 pub mod layout;
 pub mod manifest;

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -152,64 +152,120 @@ fn parse_auth_challenge(www_auth: &str) -> Option<AuthChallenge> {
     realm.map(|realm| AuthChallenge::Bearer { realm, service })
 }
 
-/// Determine the `Authorization` header to use against a registry, by probing
-/// `GET /v2/` and answering its challenge.
-///
-///  - 200 → no auth needed (`None`)
-///  - 401 + `Bearer` challenge → token fetch (anonymous or with credentials)
-///  - 401 + `Basic` challenge → credentials passed through as Basic
-///
-/// `actions` is the scope verb list (`"pull"` or `"pull,push"`).
-async fn authorization_for(
-    r: &Reference,
-    actions: &str,
-    credential: Option<&Credential>,
-) -> Result<Option<String>> {
-    let probe_url = format!("{}/v2/", r.registry_url());
-    let resp = HTTP
-        .get_async_with_headers_allow_error_status(&probe_url, &HeaderMap::new())
-        .await
-        .wrap_err_with(|| format!("probing {probe_url}"))?;
-    if resp.status().is_success() {
-        return Ok(None);
-    }
-    if resp.status() != StatusCode::UNAUTHORIZED {
-        bail!(
-            "unexpected status {} probing {probe_url}",
-            resp.status().as_u16()
-        );
-    }
-    let www_auth = resp
-        .headers()
-        .get("www-authenticate")
+/// Read a response header as an owned `String` (empty when absent / non-ASCII).
+fn header_str(resp: &reqwest::Response, name: &str) -> String {
+    resp.headers()
+        .get(name)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
-        .to_string();
-    match parse_auth_challenge(&www_auth) {
-        Some(AuthChallenge::Bearer { realm, service }) => {
-            let token = fetch_bearer_token(
-                &realm,
-                service.as_deref(),
-                &r.repository,
-                actions,
-                credential,
-            )
-            .await?;
-            Ok(token.map(|t| format!("Bearer {t}")))
+        .to_string()
+}
+
+/// Tracks the `Authorization` header for a sequence of requests to one
+/// registry repository, (re)negotiating it from a `WWW-Authenticate`
+/// challenge as needed.
+///
+/// Auth is challenge-driven rather than assumed from the `/v2/` probe: some
+/// registries answer `200` on `GET /v2/` yet still challenge the actual
+/// manifest / blob / upload requests (e.g. anonymous read but authenticated
+/// push, or per-repository policies). The probe is only an upfront
+/// optimization so the first real request usually already carries a token;
+/// callers must still retry once when an operation returns `401`, feeding the
+/// operation's own challenge back into [`AuthSession::answer_challenge`].
+struct AuthSession {
+    reference: Reference,
+    credential: Option<Credential>,
+    /// Scope verb list for token requests (`"pull"` or `"pull,push"`).
+    actions: &'static str,
+    authorization: Option<String>,
+}
+
+impl AuthSession {
+    async fn new(reference: Reference, actions: &'static str) -> Result<Self> {
+        let credential = crate::oci::auth::resolve_credential(&reference.registry)?;
+        let mut session = Self {
+            reference,
+            credential,
+            actions,
+            authorization: None,
+        };
+        session.probe().await?;
+        Ok(session)
+    }
+
+    fn header(&self) -> Option<&str> {
+        self.authorization.as_deref()
+    }
+
+    fn has_credential(&self) -> bool {
+        self.credential.is_some()
+    }
+
+    /// Best-effort upfront probe of `GET /v2/`. A `401` gets answered now so
+    /// the first real request carries a token; a `200` (or a challenge we
+    /// can't satisfy yet) simply leaves us anonymous until an operation's own
+    /// `401` re-triggers negotiation.
+    async fn probe(&mut self) -> Result<()> {
+        let url = format!("{}/v2/", self.reference.registry_url());
+        let resp = HTTP
+            .get_async_with_headers_allow_error_status(&url, &HeaderMap::new())
+            .await
+            .wrap_err_with(|| format!("probing {url}"))?;
+        if resp.status() == StatusCode::UNAUTHORIZED {
+            let www_auth = header_str(&resp, "www-authenticate");
+            self.answer_challenge(&www_auth).await?;
         }
-        Some(AuthChallenge::Basic) => match credential {
-            Some(c) => Ok(Some(c.basic_auth_header())),
-            None => bail!(
-                "registry {} requires Basic auth but no credentials were found; \
-                 run `docker login {}` (or `podman login`) first",
-                r.registry,
-                r.registry
-            ),
-        },
-        None => bail!(
-            "registry {} returned an unsupported auth challenge: {www_auth:?}",
-            r.registry
-        ),
+        Ok(())
+    }
+
+    /// Negotiate authorization from a `WWW-Authenticate` challenge string,
+    /// storing the resulting header. Returns whether a usable `Authorization`
+    /// header was obtained (a Basic challenge with no credentials yields
+    /// `false` so the caller can surface an actionable message).
+    async fn answer_challenge(&mut self, www_auth: &str) -> Result<bool> {
+        match parse_auth_challenge(www_auth) {
+            Some(AuthChallenge::Bearer { realm, service }) => {
+                let token = fetch_bearer_token(
+                    &realm,
+                    service.as_deref(),
+                    &self.reference.repository,
+                    self.actions,
+                    self.credential.as_ref(),
+                )
+                .await?;
+                self.authorization = token.map(|t| format!("Bearer {t}"));
+                Ok(self.authorization.is_some())
+            }
+            Some(AuthChallenge::Basic) => match &self.credential {
+                Some(c) => {
+                    self.authorization = Some(c.basic_auth_header());
+                    Ok(true)
+                }
+                None => Ok(false),
+            },
+            // No / unrecognized challenge — stay with whatever we have.
+            None => Ok(false),
+        }
+    }
+
+    /// Send a request and, if it returns `401`, answer the response's own
+    /// challenge and retry once with refreshed authorization. `build` is
+    /// called with the current `Authorization` header (if any) and must
+    /// produce a complete request — it may be invoked twice, so it reopens
+    /// any streamed body itself.
+    async fn send<F>(&mut self, build: F) -> Result<reqwest::Response>
+    where
+        F: Fn(Option<&str>) -> reqwest::RequestBuilder,
+    {
+        let resp = build(self.header()).send().await?;
+        if resp.status() != StatusCode::UNAUTHORIZED {
+            return Ok(resp);
+        }
+        let www_auth = header_str(&resp, "www-authenticate");
+        if self.answer_challenge(&www_auth).await? {
+            return Ok(build(self.header()).send().await?);
+        }
+        Ok(resp)
     }
 }
 
@@ -290,16 +346,49 @@ fn auth_headers(authorization: Option<&str>, accept: &[&str]) -> Result<HeaderMa
     Ok(headers)
 }
 
-async fn get_with_token<T: serde::de::DeserializeOwned>(
+/// Fetch a manifest (or index) as JSON, retrying once on `401` with a
+/// negotiated token. Returns the parsed body and the response `Content-Type`
+/// (the caller uses it to distinguish a single manifest from an index).
+async fn fetch_manifest_json(
+    session: &mut AuthSession,
     url: &str,
-    authorization: Option<&str>,
     accept: &[&str],
-) -> Result<(T, HeaderMap)> {
-    let headers = auth_headers(authorization, accept)?;
-    let (body, h) = HTTP
-        .json_headers_with_headers::<T, _>(url, &headers)
-        .await?;
-    Ok((body, h))
+) -> Result<(serde_json::Value, String)> {
+    let accept_hdr = accept.join(", ");
+    let resp = session
+        .send(|auth| {
+            let mut rb = HTTP.reqwest().get(url).header("Accept", &accept_hdr);
+            if let Some(a) = auth {
+                rb = rb.header("Authorization", a);
+            }
+            rb
+        })
+        .await
+        .wrap_err_with(|| format!("fetching {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let hint = if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+            if session.has_credential() {
+                " — the stored credentials were rejected or lack access to this image"
+            } else {
+                " — the image may be private; run `docker login` (or `podman login`) for this registry"
+            }
+        } else {
+            ""
+        };
+        let body = resp.text().await.unwrap_or_default();
+        bail!(
+            "fetching {url} failed: {}{hint}\n{}",
+            status.as_u16(),
+            body.trim()
+        );
+    }
+    let content_type = header_str(&resp, "content-type");
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .wrap_err_with(|| format!("parsing JSON response from {url}"))?;
+    Ok((body, content_type))
 }
 
 async fn get_bytes_with_token(
@@ -340,28 +429,21 @@ pub async fn pull_base_image(
         MEDIA_TYPE_DOCKER_MANIFEST_LIST,
     ];
 
-    // Use stored credentials when the user has them (private base images);
-    // fall back to anonymous tokens otherwise.
-    let credential = crate::oci::auth::resolve_credential(&r.registry)?;
-    let token = authorization_for(&r, "pull", credential.as_ref()).await?;
+    // Negotiate auth (stored credentials for private images, anonymous
+    // tokens otherwise). Auth is challenge-driven per request, so a registry
+    // that answers 200 on /v2/ but guards the manifest still works.
+    let mut session = AuthSession::new(r.clone(), "pull").await?;
 
     // Try OCI/Docker manifest or an index (multi-arch).
-    let (body, headers) =
-        get_with_token::<serde_json::Value>(&manifest_url, token.as_deref(), &accept)
-            .await
-            .wrap_err_with(|| format!("fetching manifest for {reference}"))?;
-
-    let content_type = headers
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("")
-        .to_string();
+    let (body, content_type) = fetch_manifest_json(&mut session, &manifest_url, &accept)
+        .await
+        .wrap_err_with(|| format!("fetching manifest for {reference}"))?;
 
     let manifest = resolve_manifest(
         body,
         &r,
         base_url.as_str(),
-        token.as_deref(),
+        &mut session,
         desired_platform,
         &content_type,
     )
@@ -381,7 +463,7 @@ pub async fn pull_base_image(
         "{base_url}/v2/{}/blobs/{}",
         r.repository, manifest.config.digest
     );
-    let config_bytes = get_bytes_with_token(&config_url, token.as_deref(), &[]).await?;
+    let config_bytes = get_bytes_with_token(&config_url, session.header(), &[]).await?;
     // Preserve the byte-level digest by writing under the exact digest name.
     layout.write_blob_with_digest(&manifest.config.digest, &config_bytes)?;
 
@@ -391,7 +473,7 @@ pub async fn pull_base_image(
         if blob_path.exists() {
             continue;
         }
-        let bytes = get_bytes_with_token(&layer_url, token.as_deref(), &[]).await?;
+        let bytes = get_bytes_with_token(&layer_url, session.header(), &[]).await?;
         layout.write_blob_with_digest(&layer.digest, &bytes)?;
     }
 
@@ -421,7 +503,7 @@ async fn resolve_manifest(
     body: serde_json::Value,
     r: &Reference,
     base_url: &str,
-    token: Option<&str>,
+    session: &mut AuthSession,
     desired_platform: Option<(&str, &str)>,
     content_type: &str,
 ) -> Result<ImageManifest> {
@@ -471,7 +553,7 @@ async fn resolve_manifest(
             .ok_or_else(|| eyre::eyre!("manifest entry missing digest"))?;
         let manifest_url = format!("{base_url}/v2/{}/manifests/{digest}", r.repository);
         let accept = [MEDIA_TYPE_OCI_MANIFEST, MEDIA_TYPE_DOCKER_MANIFEST];
-        let (body, _h) = get_with_token::<serde_json::Value>(&manifest_url, token, &accept).await?;
+        let (body, _content_type) = fetch_manifest_json(session, &manifest_url, &accept).await?;
         return parse_single_manifest(body);
     }
 
@@ -526,8 +608,10 @@ pub async fn push_image(image_dir: &Path, reference: &str) -> Result<PushSummary
     let manifest: ImageManifest =
         serde_json::from_slice(&manifest_bytes).wrap_err("parsing image manifest blob")?;
 
-    let credential = crate::oci::auth::resolve_credential(&r.registry)?;
-    if credential.is_none() {
+    // Negotiate auth once up front; individual requests still re-negotiate on
+    // a 401 (a registry may 200 on /v2/ yet challenge the push operations).
+    let session = AuthSession::new(r.clone(), "pull,push").await?;
+    if !session.has_credential() {
         // Not fatal — local registries accept anonymous pushes — but worth
         // surfacing before a 401 does.
         warn!(
@@ -536,11 +620,10 @@ pub async fn push_image(image_dir: &Path, reference: &str) -> Result<PushSummary
             r.registry, r.registry
         );
     }
-    let authorization = authorization_for(&r, "pull,push", credential.as_ref()).await?;
-    let pusher = Pusher {
+    let mut pusher = Pusher {
         base_url: r.registry_url(),
         repository: r.repository.clone(),
-        authorization,
+        session,
     };
 
     // Config + layers, deduped (identical layers can legitimately repeat).
@@ -589,40 +672,47 @@ pub async fn push_image(image_dir: &Path, reference: &str) -> Result<PushSummary
 struct Pusher {
     base_url: String,
     repository: String,
-    authorization: Option<String>,
+    session: AuthSession,
 }
 
 impl Pusher {
-    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        match &self.authorization {
-            Some(a) => req.header("Authorization", a),
-            None => req,
-        }
-    }
-
-    async fn blob_exists(&self, digest: &str) -> Result<bool> {
+    /// Returns true only when the registry confirms the blob is present
+    /// (`200`). Any other response — `404`, an auth status, or an oddity like
+    /// `405 Method Not Allowed` from a proxy that doesn't implement blob
+    /// HEAD — is treated as "not present", so the upload proceeds and any
+    /// genuine problem surfaces there with a clearer message.
+    async fn blob_exists(&mut self, digest: &str) -> Result<bool> {
         let url = format!("{}/v2/{}/blobs/{digest}", self.base_url, self.repository);
         let resp = self
-            .apply_auth(HTTP.reqwest().head(&url))
-            .send()
+            .session
+            .send(|auth| {
+                let mut rb = HTTP.reqwest().head(&url);
+                if let Some(a) = auth {
+                    rb = rb.header("Authorization", a);
+                }
+                rb
+            })
             .await
             .wrap_err_with(|| format!("HEAD {url}"))?;
-        match resp.status() {
-            StatusCode::OK => Ok(true),
-            // Treat auth failures on HEAD as "not there" — the subsequent
-            // upload will surface a clearer 401/403 with context.
-            StatusCode::NOT_FOUND | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Ok(false),
-            s => bail!("unexpected status {s} from HEAD {url}"),
-        }
+        Ok(resp.status() == StatusCode::OK)
     }
 
-    async fn upload_blob(&self, path: &Path, digest: &str, size: u64) -> Result<()> {
+    async fn upload_blob(&mut self, path: &Path, digest: &str, size: u64) -> Result<()> {
+        let had_credential = self.session.has_credential();
         // 1. Open an upload session.
         let start_url = format!("{}/v2/{}/blobs/uploads/", self.base_url, self.repository);
         let resp = self
-            .apply_auth(HTTP.reqwest().post(&start_url))
-            .header("Content-Length", "0")
-            .send()
+            .session
+            .send(|auth| {
+                let mut rb = HTTP
+                    .reqwest()
+                    .post(&start_url)
+                    .header("Content-Length", "0");
+                if let Some(a) = auth {
+                    rb = rb.header("Authorization", a);
+                }
+                rb
+            })
             .await
             .wrap_err_with(|| format!("POST {start_url}"))?;
         let status = resp.status();
@@ -631,7 +721,7 @@ impl Pusher {
                 "starting blob upload failed: {} {}{}",
                 status.as_u16(),
                 start_url,
-                push_auth_hint(status, self.authorization.is_some()),
+                push_auth_hint(status, had_credential),
             );
         }
         let location = resp
@@ -645,18 +735,33 @@ impl Pusher {
         } else {
             url::Url::parse(&format!("{}{}", self.base_url, location))?
         };
-        // 2. Monolithic PUT with ?digest=…
+        // 2. Monolithic PUT with ?digest=… . The upload session was just
+        // authorized, so the PUT reuses that token; reopen the file on each
+        // attempt in case the challenge retry fires.
         upload_url.query_pairs_mut().append_pair("digest", digest);
-        let file = tokio::fs::File::open(path)
-            .await
-            .wrap_err_with(|| format!("opening blob {}", path.display()))?;
-        let body = reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(file));
+        let upload_url = upload_url.to_string();
+        let path = path.to_path_buf();
         let resp = self
-            .apply_auth(HTTP.reqwest().put(upload_url.as_str()))
-            .header("Content-Type", "application/octet-stream")
-            .header("Content-Length", size)
-            .body(body)
-            .send()
+            .session
+            .send(|auth| {
+                let file = match std::fs::File::open(&path) {
+                    Ok(f) => tokio::fs::File::from_std(f),
+                    // Defer the error to send(): return a request that will
+                    // fail loudly rather than silently uploading nothing.
+                    Err(_) => return HTTP.reqwest().put(&upload_url).body(Vec::new()),
+                };
+                let body = reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(file));
+                let mut rb = HTTP
+                    .reqwest()
+                    .put(&upload_url)
+                    .header("Content-Type", "application/octet-stream")
+                    .header("Content-Length", size)
+                    .body(body);
+                if let Some(a) = auth {
+                    rb = rb.header("Authorization", a);
+                }
+                rb
+            })
             .await
             .wrap_err("PUT blob upload")?;
         let status = resp.status();
@@ -665,20 +770,30 @@ impl Pusher {
             bail!(
                 "blob upload failed: {}{}\n{}",
                 status.as_u16(),
-                push_auth_hint(status, self.authorization.is_some()),
+                push_auth_hint(status, had_credential),
                 body.trim(),
             );
         }
         Ok(())
     }
 
-    async fn put_manifest(&self, tag: &str, media_type: &str, bytes: &[u8]) -> Result<()> {
+    async fn put_manifest(&mut self, tag: &str, media_type: &str, bytes: &[u8]) -> Result<()> {
+        let had_credential = self.session.has_credential();
         let url = format!("{}/v2/{}/manifests/{tag}", self.base_url, self.repository);
+        let body = bytes.to_vec();
         let resp = self
-            .apply_auth(HTTP.reqwest().put(&url))
-            .header("Content-Type", media_type)
-            .body(bytes.to_vec())
-            .send()
+            .session
+            .send(|auth| {
+                let mut rb = HTTP
+                    .reqwest()
+                    .put(&url)
+                    .header("Content-Type", media_type)
+                    .body(body.clone());
+                if let Some(a) = auth {
+                    rb = rb.header("Authorization", a);
+                }
+                rb
+            })
             .await
             .wrap_err_with(|| format!("PUT {url}"))?;
         let status = resp.status();
@@ -687,7 +802,7 @@ impl Pusher {
             bail!(
                 "manifest push failed: {} {url}{}\n{}",
                 status.as_u16(),
-                push_auth_hint(status, self.authorization.is_some()),
+                push_auth_hint(status, had_credential),
                 body.trim(),
             );
         }
@@ -695,9 +810,9 @@ impl Pusher {
     }
 }
 
-fn push_auth_hint(status: StatusCode, had_authorization: bool) -> &'static str {
+fn push_auth_hint(status: StatusCode, had_credential: bool) -> &'static str {
     match status {
-        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN if !had_authorization => {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN if !had_credential => {
             " — no credentials were found; run `docker login` (or `podman login`) for this registry"
         }
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -131,7 +131,8 @@ enum AuthChallenge {
 }
 
 fn parse_auth_challenge(www_auth: &str) -> Option<AuthChallenge> {
-    let lower = www_auth.trim_start().to_ascii_lowercase();
+    let trimmed = www_auth.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
     if lower.starts_with("basic") {
         return Some(AuthChallenge::Basic);
     }
@@ -141,15 +142,62 @@ fn parse_auth_challenge(www_auth: &str) -> Option<AuthChallenge> {
     // WWW-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io"
     let mut realm: Option<String> = None;
     let mut service: Option<String> = None;
-    for part in www_auth.trim_start()[6..].split(',') {
-        let part = part.trim();
-        if let Some(rest) = part.strip_prefix("realm=") {
-            realm = Some(rest.trim_matches('"').to_string());
-        } else if let Some(rest) = part.strip_prefix("service=") {
-            service = Some(rest.trim_matches('"').to_string());
+    for (key, value) in parse_challenge_params(&trimmed["bearer".len()..]) {
+        match key.as_str() {
+            "realm" => realm = Some(value),
+            "service" => service = Some(value),
+            _ => {}
         }
     }
     realm.map(|realm| AuthChallenge::Bearer { realm, service })
+}
+
+/// Parse the comma-separated `key=value` / `key="value"` parameters of an
+/// auth-scheme challenge. Double-quoted values are honored, so a realm URL
+/// with a query string (`realm="https://a/token?x=1,y=2"`) or an echoed
+/// scope (`scope="repository:name:pull,push"`) isn't truncated at an
+/// interior comma — the bug a naive `split(',')` would hit.
+fn parse_challenge_params(s: &str) -> Vec<(String, String)> {
+    let bytes = s.as_bytes();
+    let n = bytes.len();
+    let mut params = Vec::new();
+    let mut i = 0;
+    while i < n {
+        // Skip separators / whitespace between parameters.
+        while i < n && (bytes[i] == b',' || bytes[i].is_ascii_whitespace()) {
+            i += 1;
+        }
+        // Read the key up to '=' (or ',' for a valueless token we ignore).
+        let key_start = i;
+        while i < n && bytes[i] != b'=' && bytes[i] != b',' {
+            i += 1;
+        }
+        let key = s[key_start..i].trim().to_ascii_lowercase();
+        if i >= n || bytes[i] == b',' {
+            continue; // no value — skip
+        }
+        i += 1; // consume '='
+        let value = if i < n && bytes[i] == b'"' {
+            i += 1;
+            let value_start = i;
+            while i < n && bytes[i] != b'"' {
+                i += 1;
+            }
+            let value = s[value_start..i].to_string();
+            i += 1; // consume closing quote (if present)
+            value
+        } else {
+            let value_start = i;
+            while i < n && bytes[i] != b',' {
+                i += 1;
+            }
+            s[value_start..i].trim().to_string()
+        };
+        if !key.is_empty() {
+            params.push((key, value));
+        }
+    }
+    params
 }
 
 /// Read a response header as an owned `String` (empty when absent / non-ASCII).
@@ -335,17 +383,6 @@ async fn fetch_bearer_token(
     Ok(resp.token.or(resp.access_token))
 }
 
-fn auth_headers(authorization: Option<&str>, accept: &[&str]) -> Result<HeaderMap> {
-    let mut headers = HeaderMap::new();
-    if let Some(a) = authorization {
-        headers.insert("Authorization", HeaderValue::from_str(a)?);
-    }
-    if !accept.is_empty() {
-        headers.insert("Accept", HeaderValue::from_str(&accept.join(", "))?);
-    }
-    Ok(headers)
-}
-
 /// Fetch a manifest (or index) as JSON, retrying once on `401` with a
 /// negotiated token. Returns the parsed body and the response `Content-Type`
 /// (the caller uses it to distinguish a single manifest from an index).
@@ -391,14 +428,26 @@ async fn fetch_manifest_json(
     Ok((body, content_type))
 }
 
-async fn get_bytes_with_token(
-    url: &str,
-    authorization: Option<&str>,
-    accept: &[&str],
-) -> Result<Vec<u8>> {
-    let headers = auth_headers(authorization, accept)?;
-    let bytes = HTTP.get_bytes_with_headers(url, &headers).await?;
-    Ok(bytes.as_ref().to_vec())
+/// Download a blob (config or layer) into memory, retrying once on `401`
+/// with a renegotiated token. Going through [`AuthSession::send`] rather
+/// than a fixed header means a token that expires partway through a large
+/// multi-layer pull is refreshed transparently instead of failing the pull.
+async fn download_blob(session: &mut AuthSession, url: &str) -> Result<Vec<u8>> {
+    let resp = session
+        .send(|auth| {
+            let mut rb = HTTP.reqwest().get(url);
+            if let Some(a) = auth {
+                rb = rb.header("Authorization", a);
+            }
+            rb
+        })
+        .await
+        .wrap_err_with(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        bail!("fetching blob {url} failed: {}", status.as_u16());
+    }
+    Ok(resp.bytes().await?.to_vec())
 }
 
 /// The result of pulling a base image — the config blob and an ordered list
@@ -463,7 +512,7 @@ pub async fn pull_base_image(
         "{base_url}/v2/{}/blobs/{}",
         r.repository, manifest.config.digest
     );
-    let config_bytes = get_bytes_with_token(&config_url, session.header(), &[]).await?;
+    let config_bytes = download_blob(&mut session, &config_url).await?;
     // Preserve the byte-level digest by writing under the exact digest name.
     layout.write_blob_with_digest(&manifest.config.digest, &config_bytes)?;
 
@@ -473,7 +522,7 @@ pub async fn pull_base_image(
         if blob_path.exists() {
             continue;
         }
-        let bytes = get_bytes_with_token(&layer_url, session.header(), &[]).await?;
+        let bytes = download_blob(&mut session, &layer_url).await?;
         layout.write_blob_with_digest(&layer.digest, &bytes)?;
     }
 
@@ -699,6 +748,11 @@ impl Pusher {
 
     async fn upload_blob(&mut self, path: &Path, digest: &str, size: u64) -> Result<()> {
         let had_credential = self.session.has_credential();
+        // Fail early (and clearly) if the blob file is unreadable, rather than
+        // letting an empty-body PUT surface later as a confusing registry
+        // digest/upload error with no hint about the real cause.
+        std::fs::File::open(path)
+            .wrap_err_with(|| format!("opening blob {} for upload", path.display()))?;
         // 1. Open an upload session.
         let start_url = format!("{}/v2/{}/blobs/uploads/", self.base_url, self.repository);
         let resp = self
@@ -904,6 +958,30 @@ mod tests {
     fn bearer_challenge_without_realm_is_none() {
         assert!(parse_auth_challenge("Bearer service=\"x\"").is_none());
         assert!(parse_auth_challenge("Negotiate").is_none());
+    }
+
+    #[test]
+    fn bearer_challenge_preserves_commas_inside_quotes() {
+        // A realm query string and an echoed scope both contain commas that a
+        // naive split(',') would truncate at.
+        let www = r#"Bearer realm="https://auth.example.com/token?a=1,b=2",service="reg,istry",scope="repository:me/app:pull,push""#;
+        match parse_auth_challenge(www) {
+            Some(AuthChallenge::Bearer { realm, service }) => {
+                assert_eq!(realm, "https://auth.example.com/token?a=1,b=2");
+                assert_eq!(service.as_deref(), Some("reg,istry"));
+            }
+            _ => panic!("expected bearer challenge"),
+        }
+    }
+
+    #[test]
+    fn challenge_params_handle_unquoted_and_spaced_values() {
+        let params = parse_challenge_params(r#" realm=https://x/token , service="y" "#);
+        assert_eq!(
+            params[0],
+            ("realm".to_string(), "https://x/token".to_string())
+        );
+        assert_eq!(params[1], ("service".to_string(), "y".to_string()));
     }
 
     #[test]

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -1,18 +1,26 @@
-//! Anonymous OCI Distribution Spec v2 client for pulling base images.
+//! OCI Distribution Spec v2 client.
 //!
-//! Supports Docker Hub / GHCR / quay.io style references and anonymous token
-//! auth (no login flow). Used by `mise oci build --from <ref>` to stream a
-//! base image's layers into the output layout byte-for-byte so digests match.
+//! Pull side: used by `mise oci build --from <ref>` to stream a base image's
+//! layers into the output layout byte-for-byte so digests match.
+//!
+//! Push side: used by `mise oci push` to upload an OCI image layout directly
+//! — no skopeo/crane required. Credentials come from the same sources docker
+//! and podman use (see `crate::oci::auth`); anonymous access is used when no
+//! credentials are found (e.g. a local `registry:2`).
 
-use eyre::{Context, Result};
+use std::path::Path;
+
+use eyre::{Context, Result, bail};
+use reqwest::StatusCode;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde::Deserialize;
 
 use crate::http::HTTP;
+use crate::oci::auth::Credential;
 use crate::oci::layout::ImageLayout;
 use crate::oci::manifest::{
-    Descriptor, ImageManifest, MEDIA_TYPE_DOCKER_MANIFEST, MEDIA_TYPE_DOCKER_MANIFEST_LIST,
-    MEDIA_TYPE_OCI_INDEX, MEDIA_TYPE_OCI_MANIFEST,
+    Descriptor, ImageIndex, ImageManifest, MEDIA_TYPE_DOCKER_MANIFEST,
+    MEDIA_TYPE_DOCKER_MANIFEST_LIST, MEDIA_TYPE_OCI_INDEX, MEDIA_TYPE_OCI_MANIFEST,
 };
 
 /// A parsed registry reference.
@@ -80,8 +88,31 @@ impl Reference {
         } else {
             &self.registry
         };
-        format!("https://{host}")
+        // Loopback registries (localhost:5000 etc.) serve plain HTTP — the
+        // same insecure-by-default convention docker applies to 127.0.0.0/8.
+        let scheme = if is_loopback_registry(host) {
+            "http"
+        } else {
+            "https"
+        };
+        format!("{scheme}://{host}")
     }
+}
+
+/// True when `registry` (a `host[:port]` / `[v6]:port` string) points at a
+/// loopback address, in which case the distribution API is spoken over
+/// plain HTTP.
+fn is_loopback_registry(registry: &str) -> bool {
+    let host = if let Some(rest) = registry.strip_prefix('[') {
+        rest.split(']').next().unwrap_or(rest)
+    } else {
+        registry.rsplit_once(':').map_or(registry, |(h, _)| h)
+    };
+    host == "localhost"
+        || host
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false)
 }
 
 #[derive(Debug, Deserialize)]
@@ -90,14 +121,27 @@ struct TokenResponse {
     access_token: Option<String>,
 }
 
-/// Fetch an anonymous bearer token from a registry's auth endpoint if needed.
-/// Many public images require a token even for anonymous pulls (Docker Hub
-/// especially).
-async fn fetch_anonymous_token(www_auth: &str, repository: &str) -> Result<Option<String>> {
+/// A parsed `WWW-Authenticate` challenge.
+enum AuthChallenge {
+    Bearer {
+        realm: String,
+        service: Option<String>,
+    },
+    Basic,
+}
+
+fn parse_auth_challenge(www_auth: &str) -> Option<AuthChallenge> {
+    let lower = www_auth.trim_start().to_ascii_lowercase();
+    if lower.starts_with("basic") {
+        return Some(AuthChallenge::Basic);
+    }
+    if !lower.starts_with("bearer") {
+        return None;
+    }
     // WWW-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io"
     let mut realm: Option<String> = None;
     let mut service: Option<String> = None;
-    for part in www_auth.trim_start_matches("Bearer ").split(',') {
+    for part in www_auth.trim_start()[6..].split(',') {
         let part = part.trim();
         if let Some(rest) = part.strip_prefix("realm=") {
             realm = Some(rest.trim_matches('"').to_string());
@@ -105,52 +149,165 @@ async fn fetch_anonymous_token(www_auth: &str, repository: &str) -> Result<Optio
             service = Some(rest.trim_matches('"').to_string());
         }
     }
-    let Some(realm) = realm else { return Ok(None) };
-    let scope = format!("repository:{repository}:pull");
-    let mut url = url::Url::parse(&realm)?;
+    realm.map(|realm| AuthChallenge::Bearer { realm, service })
+}
+
+/// Determine the `Authorization` header to use against a registry, by probing
+/// `GET /v2/` and answering its challenge.
+///
+///  - 200 → no auth needed (`None`)
+///  - 401 + `Bearer` challenge → token fetch (anonymous or with credentials)
+///  - 401 + `Basic` challenge → credentials passed through as Basic
+///
+/// `actions` is the scope verb list (`"pull"` or `"pull,push"`).
+async fn authorization_for(
+    r: &Reference,
+    actions: &str,
+    credential: Option<&Credential>,
+) -> Result<Option<String>> {
+    let probe_url = format!("{}/v2/", r.registry_url());
+    let resp = HTTP
+        .get_async_with_headers_allow_error_status(&probe_url, &HeaderMap::new())
+        .await
+        .wrap_err_with(|| format!("probing {probe_url}"))?;
+    if resp.status().is_success() {
+        return Ok(None);
+    }
+    if resp.status() != StatusCode::UNAUTHORIZED {
+        bail!(
+            "unexpected status {} probing {probe_url}",
+            resp.status().as_u16()
+        );
+    }
+    let www_auth = resp
+        .headers()
+        .get("www-authenticate")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    match parse_auth_challenge(&www_auth) {
+        Some(AuthChallenge::Bearer { realm, service }) => {
+            let token = fetch_bearer_token(
+                &realm,
+                service.as_deref(),
+                &r.repository,
+                actions,
+                credential,
+            )
+            .await?;
+            Ok(token.map(|t| format!("Bearer {t}")))
+        }
+        Some(AuthChallenge::Basic) => match credential {
+            Some(c) => Ok(Some(c.basic_auth_header())),
+            None => bail!(
+                "registry {} requires Basic auth but no credentials were found; \
+                 run `docker login {}` (or `podman login`) first",
+                r.registry,
+                r.registry
+            ),
+        },
+        None => bail!(
+            "registry {} returned an unsupported auth challenge: {www_auth:?}",
+            r.registry
+        ),
+    }
+}
+
+/// Fetch a bearer token from a registry's token endpoint. Anonymous when
+/// `credential` is `None` (public pulls); authenticated via Basic auth on the
+/// token request otherwise. Docker Hub identity tokens (from Docker Desktop
+/// logins) use the OAuth2 refresh-token POST flow instead.
+async fn fetch_bearer_token(
+    realm: &str,
+    service: Option<&str>,
+    repository: &str,
+    actions: &str,
+    credential: Option<&Credential>,
+) -> Result<Option<String>> {
+    let scope = format!("repository:{repository}:{actions}");
+
+    if let Some(c) = credential
+        && c.username == "<token>"
+    {
+        // OAuth2 identity-token flow.
+        let mut form = vec![
+            ("grant_type", "refresh_token"),
+            ("refresh_token", c.secret.as_str()),
+            ("client_id", "mise"),
+            ("scope", scope.as_str()),
+        ];
+        if let Some(s) = service {
+            form.push(("service", s));
+        }
+        let resp = HTTP
+            .reqwest()
+            .post(realm)
+            .form(&form)
+            .send()
+            .await
+            .wrap_err_with(|| format!("fetching OAuth2 token from {realm}"))?
+            .error_for_status()?;
+        let resp: TokenResponse = resp.json().await?;
+        return Ok(resp.access_token.or(resp.token));
+    }
+
+    let mut url = url::Url::parse(realm)?;
     {
         let mut q = url.query_pairs_mut();
         if let Some(s) = service {
-            q.append_pair("service", &s);
+            q.append_pair("service", s);
         }
         q.append_pair("scope", &scope);
     }
-    let resp: TokenResponse = HTTP.json(url.as_str()).await?;
+    let mut headers = HeaderMap::new();
+    if let Some(c) = credential {
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&c.basic_auth_header())?,
+        );
+    }
+    let resp: TokenResponse = HTTP
+        .json_with_headers(url.as_str(), &headers)
+        .await
+        .wrap_err_with(|| match credential {
+            Some(c) => format!(
+                "fetching token from {realm} as {} (are the stored credentials still valid?)",
+                c.username
+            ),
+            None => format!("fetching anonymous token from {realm}"),
+        })?;
     Ok(resp.token.or(resp.access_token))
 }
 
-async fn get_with_token<T: serde::de::DeserializeOwned>(
-    url: &str,
-    token: Option<&str>,
-    accept: &[&str],
-) -> Result<(T, HeaderMap)> {
+fn auth_headers(authorization: Option<&str>, accept: &[&str]) -> Result<HeaderMap> {
     let mut headers = HeaderMap::new();
-    if let Some(t) = token {
-        headers.insert(
-            "Authorization",
-            HeaderValue::from_str(&format!("Bearer {t}"))?,
-        );
+    if let Some(a) = authorization {
+        headers.insert("Authorization", HeaderValue::from_str(a)?);
     }
     if !accept.is_empty() {
         headers.insert("Accept", HeaderValue::from_str(&accept.join(", "))?);
     }
+    Ok(headers)
+}
+
+async fn get_with_token<T: serde::de::DeserializeOwned>(
+    url: &str,
+    authorization: Option<&str>,
+    accept: &[&str],
+) -> Result<(T, HeaderMap)> {
+    let headers = auth_headers(authorization, accept)?;
     let (body, h) = HTTP
         .json_headers_with_headers::<T, _>(url, &headers)
         .await?;
     Ok((body, h))
 }
 
-async fn get_bytes_with_token(url: &str, token: Option<&str>, accept: &[&str]) -> Result<Vec<u8>> {
-    let mut headers = HeaderMap::new();
-    if let Some(t) = token {
-        headers.insert(
-            "Authorization",
-            HeaderValue::from_str(&format!("Bearer {t}"))?,
-        );
-    }
-    if !accept.is_empty() {
-        headers.insert("Accept", HeaderValue::from_str(&accept.join(", "))?);
-    }
+async fn get_bytes_with_token(
+    url: &str,
+    authorization: Option<&str>,
+    accept: &[&str],
+) -> Result<Vec<u8>> {
+    let headers = auth_headers(authorization, accept)?;
     let bytes = HTTP.get_bytes_with_headers(url, &headers).await?;
     Ok(bytes.as_ref().to_vec())
 }
@@ -183,7 +340,10 @@ pub async fn pull_base_image(
         MEDIA_TYPE_DOCKER_MANIFEST_LIST,
     ];
 
-    let token = fetch_token_if_needed(&manifest_url, &r.repository).await?;
+    // Use stored credentials when the user has them (private base images);
+    // fall back to anonymous tokens otherwise.
+    let credential = crate::oci::auth::resolve_credential(&r.registry)?;
+    let token = authorization_for(&r, "pull", credential.as_ref()).await?;
 
     // Try OCI/Docker manifest or an index (multi-arch).
     let (body, headers) =
@@ -255,26 +415,6 @@ pub async fn pull_base_image(
     })
 }
 
-/// Fetch an anonymous bearer token for registries that require one. We skip
-/// the HEAD probe because the shared HTTP client errors on 401 (hiding the
-/// www-authenticate header); instead we just check the host and use the
-/// known-good anonymous realm. Private images and registries beyond this set
-/// are explicit follow-ups (see `--from` docs).
-async fn fetch_token_if_needed(manifest_url: &str, repository: &str) -> Result<Option<String>> {
-    let realm = if manifest_url.contains("registry-1.docker.io") {
-        "Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\""
-    } else if manifest_url.contains("ghcr.io") {
-        "Bearer realm=\"https://ghcr.io/token\",service=\"ghcr.io\""
-    } else if manifest_url.contains("quay.io") {
-        // quay.io publishes an anonymous token endpoint; many public repos
-        // require it even for unauthenticated pulls.
-        "Bearer realm=\"https://quay.io/v2/auth\",service=\"quay.io\""
-    } else {
-        return Ok(None);
-    };
-    fetch_anonymous_token(realm, repository).await
-}
-
 /// Given a manifest body (possibly an index with multiple architectures),
 /// resolve to a concrete single-image manifest and return its parsed form.
 async fn resolve_manifest(
@@ -344,6 +484,230 @@ fn parse_single_manifest(body: serde_json::Value) -> Result<ImageManifest> {
     Ok(manifest)
 }
 
+// ---------------------------------------------------------------------------
+// Push
+// ---------------------------------------------------------------------------
+
+/// Summary of a completed push, for CLI reporting.
+pub struct PushSummary {
+    pub manifest_digest: String,
+    pub uploaded: usize,
+    pub skipped: usize,
+}
+
+/// Push an OCI image layout directory to a registry reference.
+///
+/// Uploads only blobs the registry doesn't already have (HEAD check per
+/// blob), then PUTs the manifest under the reference's tag (or digest).
+pub async fn push_image(image_dir: &Path, reference: &str) -> Result<PushSummary> {
+    eyre::ensure!(
+        !crate::config::Settings::get().offline(),
+        "offline mode is enabled"
+    );
+    let r = Reference::parse(reference)?;
+    let layout = ImageLayout {
+        root: image_dir.to_path_buf(),
+    };
+
+    // Resolve the layout's single manifest. `mise oci build` always writes
+    // exactly one manifest into index.json.
+    let index_bytes = crate::file::read(image_dir.join("index.json"))?;
+    let index: ImageIndex = serde_json::from_slice(&index_bytes).wrap_err("parsing index.json")?;
+    let manifest_desc = match index.manifests.as_slice() {
+        [one] => one,
+        [] => bail!("{}: index.json lists no manifests", image_dir.display()),
+        many => bail!(
+            "{}: index.json lists {} manifests; multi-manifest layouts are not supported",
+            image_dir.display(),
+            many.len()
+        ),
+    };
+    let manifest_bytes = layout.read_blob(&manifest_desc.digest)?;
+    let manifest: ImageManifest =
+        serde_json::from_slice(&manifest_bytes).wrap_err("parsing image manifest blob")?;
+
+    let credential = crate::oci::auth::resolve_credential(&r.registry)?;
+    if credential.is_none() {
+        // Not fatal — local registries accept anonymous pushes — but worth
+        // surfacing before a 401 does.
+        warn!(
+            "no registry credentials found for {} — pushing anonymously. \
+             Run `docker login {}` (or `podman login`) if the push is rejected.",
+            r.registry, r.registry
+        );
+    }
+    let authorization = authorization_for(&r, "pull,push", credential.as_ref()).await?;
+    let pusher = Pusher {
+        base_url: r.registry_url(),
+        repository: r.repository.clone(),
+        authorization,
+    };
+
+    // Config + layers, deduped (identical layers can legitimately repeat).
+    let mut blobs: Vec<&Descriptor> = vec![&manifest.config];
+    let mut seen = std::collections::HashSet::new();
+    seen.insert(manifest.config.digest.as_str());
+    for layer in &manifest.layers {
+        if seen.insert(layer.digest.as_str()) {
+            blobs.push(layer);
+        }
+    }
+
+    let mut uploaded = 0;
+    let mut skipped = 0;
+    for desc in blobs {
+        crate::oci::layout::validate_sha256_digest(&desc.digest)?;
+        if pusher.blob_exists(&desc.digest).await? {
+            debug!("blob {} already present, skipping", desc.digest);
+            skipped += 1;
+            continue;
+        }
+        info!(
+            "uploading {} ({:.1} MiB)",
+            desc.digest,
+            desc.size as f64 / (1024.0 * 1024.0)
+        );
+        pusher
+            .upload_blob(&layout.blob_path(&desc.digest), &desc.digest, desc.size)
+            .await
+            .wrap_err_with(|| format!("uploading blob {}", desc.digest))?;
+        uploaded += 1;
+    }
+
+    pusher
+        .put_manifest(&r.tag, &manifest_desc.media_type, &manifest_bytes)
+        .await
+        .wrap_err_with(|| format!("pushing manifest to {reference}"))?;
+
+    Ok(PushSummary {
+        manifest_digest: manifest_desc.digest.clone(),
+        uploaded,
+        skipped,
+    })
+}
+
+struct Pusher {
+    base_url: String,
+    repository: String,
+    authorization: Option<String>,
+}
+
+impl Pusher {
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.authorization {
+            Some(a) => req.header("Authorization", a),
+            None => req,
+        }
+    }
+
+    async fn blob_exists(&self, digest: &str) -> Result<bool> {
+        let url = format!("{}/v2/{}/blobs/{digest}", self.base_url, self.repository);
+        let resp = self
+            .apply_auth(HTTP.reqwest().head(&url))
+            .send()
+            .await
+            .wrap_err_with(|| format!("HEAD {url}"))?;
+        match resp.status() {
+            StatusCode::OK => Ok(true),
+            // Treat auth failures on HEAD as "not there" — the subsequent
+            // upload will surface a clearer 401/403 with context.
+            StatusCode::NOT_FOUND | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Ok(false),
+            s => bail!("unexpected status {s} from HEAD {url}"),
+        }
+    }
+
+    async fn upload_blob(&self, path: &Path, digest: &str, size: u64) -> Result<()> {
+        // 1. Open an upload session.
+        let start_url = format!("{}/v2/{}/blobs/uploads/", self.base_url, self.repository);
+        let resp = self
+            .apply_auth(HTTP.reqwest().post(&start_url))
+            .header("Content-Length", "0")
+            .send()
+            .await
+            .wrap_err_with(|| format!("POST {start_url}"))?;
+        let status = resp.status();
+        if status != StatusCode::ACCEPTED {
+            bail!(
+                "starting blob upload failed: {} {}{}",
+                status.as_u16(),
+                start_url,
+                push_auth_hint(status, self.authorization.is_some()),
+            );
+        }
+        let location = resp
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| eyre::eyre!("registry returned no Location for blob upload"))?;
+        let mut upload_url = if location.starts_with("http://") || location.starts_with("https://")
+        {
+            url::Url::parse(location)?
+        } else {
+            url::Url::parse(&format!("{}{}", self.base_url, location))?
+        };
+        // 2. Monolithic PUT with ?digest=…
+        upload_url.query_pairs_mut().append_pair("digest", digest);
+        let file = tokio::fs::File::open(path)
+            .await
+            .wrap_err_with(|| format!("opening blob {}", path.display()))?;
+        let body = reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(file));
+        let resp = self
+            .apply_auth(HTTP.reqwest().put(upload_url.as_str()))
+            .header("Content-Type", "application/octet-stream")
+            .header("Content-Length", size)
+            .body(body)
+            .send()
+            .await
+            .wrap_err("PUT blob upload")?;
+        let status = resp.status();
+        if status != StatusCode::CREATED && status != StatusCode::ACCEPTED {
+            let body = resp.text().await.unwrap_or_default();
+            bail!(
+                "blob upload failed: {}{}\n{}",
+                status.as_u16(),
+                push_auth_hint(status, self.authorization.is_some()),
+                body.trim(),
+            );
+        }
+        Ok(())
+    }
+
+    async fn put_manifest(&self, tag: &str, media_type: &str, bytes: &[u8]) -> Result<()> {
+        let url = format!("{}/v2/{}/manifests/{tag}", self.base_url, self.repository);
+        let resp = self
+            .apply_auth(HTTP.reqwest().put(&url))
+            .header("Content-Type", media_type)
+            .body(bytes.to_vec())
+            .send()
+            .await
+            .wrap_err_with(|| format!("PUT {url}"))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            bail!(
+                "manifest push failed: {} {url}{}\n{}",
+                status.as_u16(),
+                push_auth_hint(status, self.authorization.is_some()),
+                body.trim(),
+            );
+        }
+        Ok(())
+    }
+}
+
+fn push_auth_hint(status: StatusCode, had_authorization: bool) -> &'static str {
+    match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN if !had_authorization => {
+            " — no credentials were found; run `docker login` (or `podman login`) for this registry"
+        }
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+            " — the stored credentials were rejected or lack push permission \
+             (for ghcr.io, the token needs the `write:packages` scope)"
+        }
+        _ => "",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -378,6 +742,53 @@ mod tests {
         assert_eq!(r.registry, "docker.io");
         assert_eq!(r.repository, "library/ubuntu");
         assert_eq!(r.tag, digest);
+    }
+
+    #[test]
+    fn loopback_registries_use_http() {
+        assert!(is_loopback_registry("localhost:5000"));
+        assert!(is_loopback_registry("127.0.0.1:5000"));
+        assert!(is_loopback_registry("[::1]:5000"));
+        assert!(!is_loopback_registry("ghcr.io"));
+        assert!(!is_loopback_registry("registry.example.com:5000"));
+        assert_eq!(
+            Reference::parse("localhost:5000/me/dev:v1")
+                .unwrap()
+                .registry_url(),
+            "http://localhost:5000"
+        );
+        assert_eq!(
+            Reference::parse("ghcr.io/me/dev:v1")
+                .unwrap()
+                .registry_url(),
+            "https://ghcr.io"
+        );
+    }
+
+    #[test]
+    fn parses_bearer_challenge() {
+        let www = r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io""#;
+        match parse_auth_challenge(www) {
+            Some(AuthChallenge::Bearer { realm, service }) => {
+                assert_eq!(realm, "https://auth.docker.io/token");
+                assert_eq!(service.as_deref(), Some("registry.docker.io"));
+            }
+            _ => panic!("expected bearer challenge"),
+        }
+    }
+
+    #[test]
+    fn parses_basic_challenge() {
+        assert!(matches!(
+            parse_auth_challenge(r#"Basic realm="registry""#),
+            Some(AuthChallenge::Basic)
+        ));
+    }
+
+    #[test]
+    fn bearer_challenge_without_realm_is_none() {
+        assert!(parse_auth_challenge("Bearer service=\"x\"").is_none());
+        assert!(parse_auth_challenge("Negotiate").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removes the external-tool dependency from `mise oci`: pushing now uses a built-in OCI Distribution Spec client, and `mise oci run --engine docker` streams the image into `docker load` instead of requiring skopeo. Related context: discussion #11121 (reusing unchanged layers from the previously pushed image) — the native client gets the upload-side half of that for free via per-blob HEAD checks.

### `mise oci push`
- **Native push client** ([src/oci/registry.rs](../blob/claude/mise-discussion-11121-3e9391/src/oci/registry.rs)): HEAD existence check per blob → only new blobs are uploaded (repeat pushes of a mostly-unchanged toolset transfer almost nothing), POST/PUT monolithic upload streamed from disk, manifest PUT under tag or digest.
- **Credential resolution** ([src/oci/auth.rs](../blob/claude/mise-discussion-11121-3e9391/src/oci/auth.rs)) mirrors docker/podman: `$REGISTRY_AUTH_FILE` → `$XDG_RUNTIME_DIR/containers/auth.json` → `~/.config/containers/auth.json` → `~/.docker/config.json`, with inline `auths`, `credsStore`/`credHelpers` credential helpers, and Docker Hub identity tokens (OAuth2 refresh flow). `docker login` / `podman login` is all the setup needed.
- **Challenge-based auth**: probes `/v2/` and answers the `WWW-Authenticate` challenge (Bearer token fetch or Basic) instead of the previous hardcoded realm list — as a side effect, `--from` base image pulls now work against any registry and support private images when logged in.
- Loopback registries (`localhost:5000`) use plain HTTP, matching docker's insecure-by-default convention.
- `--tool` is removed. Escape hatch stays structural: `mise oci build -o ./img && skopeo copy oci:./img docker://…`.

### `mise oci run --engine docker`
- New [src/oci/docker_archive.rs](../blob/claude/mise-discussion-11121-3e9391/src/oci/docker_archive.rs) converts the OCI layout to a docker-archive on the fly (layers decompressed via magic-byte sniffing — gzip/zstd/plain — to match `rootfs.diff_ids`) and streams it into `docker load` stdin. No skopeo needed; podman path unchanged.

## Verification

Ran live against docker 29.5.1 with **no skopeo/crane installed**:

- `mise oci push localhost:5000/test/devenv:v1` against `registry:2` — full push, then idempotent re-push with `SOURCE_DATE_EPOCH` reporting `0 blob(s) uploaded, 4 already present`; served manifest digest verified byte-identical via the registry API.
- Same against an htpasswd-protected `registry:2`: anonymous push fails with an actionable `docker login` hint; with `REGISTRY_AUTH_FILE` the Basic-auth push succeeds.
- `mise oci run --engine docker --no-mise -- jq --version` → `jq-1.8.1` (docker-load path).
- Base image pulls from docker.io exercised the new challenge-based token flow.

Tests: 1770 unit tests pass (new coverage for auth-file parsing, challenge parsing, loopback detection, docker-archive structure); `test_oci_run_push_errors_slow` (updated: `--tool` cases replaced with an unreachable-registry native-push case) and `test_oci_build_slow` pass. Docs regenerated with `mise run render`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds network registry push/pull/auth and credential-helper execution; behavior changes for oci push/run and base-image pulls, though scope is limited to experimental OCI commands.
> 
> **Overview**
> **`mise oci push`** no longer shells out to skopeo or crane. It uploads through an in-tree OCI Distribution v2 client (`registry::push_image`), skipping blobs the registry already has (HEAD per digest) and reporting uploaded vs skipped counts. Registry auth is resolved like docker/podman (`src/oci/auth.rs`: auth files, inline `auths`, credential helpers, Docker Hub identity tokens). The **`--tool`** flag is removed.
> 
> **`mise oci run --engine docker`** loads the layout by streaming a docker-archive into **`docker load`** (`docker_archive::load_into_docker`) instead of **`skopeo copy`**. Only **podman** or **docker** is required (no docker+skopeo).
> 
> **`src/oci/registry.rs`** pull path is reworked: challenge-driven **`AuthSession`** replaces hardcoded anonymous token realms, so **`--from`** can use logged-in credentials for private base images. Loopback registries use HTTP.
> 
> **Hardening:** `read_blob` validates digests before path use; push streams blobs with **`tokio-util`**. Docs and e2e updated (unreachable-registry push test replaces `--tool` cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bcf8ef5adeb8d62336d43cd8e763d0a49abdd45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise oci push` now uses mise’s built-in registry client (no external push tools) and uploads only missing blobs on repeat pushes.
  * Registry authentication is resolved automatically from Docker/Podman auth locations and credential helpers.
  * `mise oci run` loads the built OCI image into Docker via `docker load` (Podman loads natively); engine requirement is now `docker` or `podman`.
* **Bug Fixes**
  * Improved registry connection/auth error messages, including clearer failures for unreachable registries.
* **Documentation**
  * Updated manuals and CLI docs for `oci push`/`oci run`, including revised authentication guidance and removal of the prior forced push tool option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->