### PR TITLE
chore(release): stop cutting vfox tags on embedded-plugin churn

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -48,7 +48,7 @@ subcrate_diff_pathspec() {
 	pathspec=("$crate_dir")
 	case "$crate_name" in
 	vfox)
-		pathspec+=(':(exclude)crates/vfox/embedded-plugins')
+		pathspec+=(":(exclude)${crate_dir}/embedded-plugins")
 		;;
 	esac
 }
@@ -98,12 +98,10 @@ use_published_aqua_registry() {
 
 # Check if the given git pathspecs have uncommitted changes (staged or unstaged)
 has_uncommitted_changes() {
-	# Args: one or more git pathspecs (e.g. a crate dir plus `:(exclude)` entries)
-	if git diff --quiet HEAD -- "$@" 2>/dev/null && git diff --quiet --cached -- "$@" 2>/dev/null; then
-		# Also check for untracked files
-		if [[ -z $(git ls-files --others --exclude-standard -- "$@") ]]; then
-			return 1 # No changes
-		fi
+	# Args: one or more git pathspecs (e.g. a crate dir plus `:(exclude)` entries).
+	# --porcelain covers staged, unstaged, and untracked changes in one check.
+	if [[ -z $(git status --porcelain -- "$@" 2>/dev/null) ]]; then
+		return 1 # No changes
 	fi
 	return 0 # Has changes
 }

--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -34,6 +34,25 @@ exists_on_crates() {
 	return 1
 }
 
+# Git pathspecs used to decide whether a subcrate has meaningfully changed.
+# Some crates embed vendored/generated content that the release process refreshes
+# on every run (e.g. vfox's embedded-plugins are deleted and re-cloned each
+# release). Counting that churn as a change would bump, tag, and publish the crate
+# on every single release even when its hand-written source is untouched, producing
+# a flood of pointless `<crate>-v*` tags. Excluding that content here means a new
+# subcrate version is only cut when the real source actually changes.
+# Populates the caller-declared `pathspec` array (bash 3.2 compatible).
+subcrate_diff_pathspec() {
+	local crate_name="$1"
+	local crate_dir="$2"
+	pathspec=("$crate_dir")
+	case "$crate_name" in
+	vfox)
+		pathspec+=(':(exclude)crates/vfox/embedded-plugins')
+		;;
+	esac
+}
+
 # Check if a subcrate has changes since its last tagged release
 # Returns 0 if changes exist (should publish), 1 if no changes
 has_crate_changes() {
@@ -49,12 +68,15 @@ has_crate_changes() {
 		return 0
 	fi
 
-	# Check if there are changes in the crate directory since the tag
-	if git diff --quiet "$latest_tag" -- "$crate_dir"; then
-		echo "No changes in $crate_name since $latest_tag"
+	# Check if there are changes in the crate directory since the tag,
+	# ignoring vendored/generated content (see subcrate_diff_pathspec).
+	local pathspec
+	subcrate_diff_pathspec "$crate_name" "$crate_dir"
+	if git diff --quiet "$latest_tag" -- "${pathspec[@]}"; then
+		echo "No source changes in $crate_name since $latest_tag"
 		return 1
 	else
-		echo "Changes detected in $crate_name since $latest_tag"
+		echo "Source changes detected in $crate_name since $latest_tag"
 		return 0
 	fi
 }
@@ -74,13 +96,12 @@ use_published_aqua_registry() {
 	cargo add --build "aqua-registry@$version"
 }
 
-# Check if a directory has uncommitted changes (staged or unstaged)
+# Check if the given git pathspecs have uncommitted changes (staged or unstaged)
 has_uncommitted_changes() {
-	local dir="$1"
-	# Check for any changes (staged or unstaged) in the directory
-	if git diff --quiet HEAD -- "$dir" 2>/dev/null && git diff --quiet --cached -- "$dir" 2>/dev/null; then
+	# Args: one or more git pathspecs (e.g. a crate dir plus `:(exclude)` entries)
+	if git diff --quiet HEAD -- "$@" 2>/dev/null && git diff --quiet --cached -- "$@" 2>/dev/null; then
 		# Also check for untracked files
-		if [[ -z $(git ls-files --others --exclude-standard -- "$dir") ]]; then
+		if [[ -z $(git ls-files --others --exclude-standard -- "$@") ]]; then
 			return 1 # No changes
 		fi
 	fi
@@ -92,7 +113,11 @@ bump_subcrate_if_changed() {
 	local crate_name="$1"
 	local crate_dir="$2"
 
-	if ! has_uncommitted_changes "$crate_dir"; then
+	# Ignore vendored/generated content (see subcrate_diff_pathspec) so refreshed
+	# embedded content doesn't force an otherwise-unnecessary version bump.
+	local pathspec
+	subcrate_diff_pathspec "$crate_name" "$crate_dir"
+	if ! has_uncommitted_changes "${pathspec[@]}"; then
 		echo "No uncommitted changes in $crate_name, keeping current version"
 		return
 	fi


### PR DESCRIPTION
## Problem

The release pipeline has accumulated a flood of subcrate tags — **~71 `vfox-v*`** and ~69 `aqua-registry-v*` — most of which correspond to no real source change.

`xtasks/release-plz` re-versions, tags (`git tag -s "<crate>-v<ver>"`), and publishes a subcrate whenever `has_crate_changes` sees *any* diff in its directory since the last tag:

```bash
git diff --quiet "$latest_tag" -- "$crate_dir"
```

For **vfox**, the release prep deletes and re-clones `crates/vfox/embedded-plugins/` on every run. So a diff is present almost every release even when vfox's Rust source is untouched. Confirmed example — `vfox-v2026.7.8 → 7.9`:

```
 crates/vfox/Cargo.toml                         |   2 +-   (version line only)
 crates/vfox/embedded-plugins/vfox-php/...      | (removed)
 crates/vfox/embedded-plugins/vfox-scala/...    | (added)
```

Zero `src/` changes — a signed tag + crates.io publish for a plugin-set swap.

## Fix

Exclude the generated `embedded-plugins/` directory from the change detection, in **both** the prep-phase (`bump_subcrate_if_changed`) and release-phase (`has_crate_changes`) checks. A new vfox version/tag is now only cut when its real source changes.

- Change detection now takes a git pathspec list via a small `subcrate_diff_pathspec` helper; `has_uncommitted_changes` was generalized to accept pathspecs.
- bash 3.2 compatible (no `mapfile`).
- Easy to extend to other subcrates if they grow vendored/generated content.

### Verified

| Scenario | Old | New |
|---|---|---|
| embedded-plugins-only churn (7.8→7.9) | DIFF → bump + tag | **no diff → no tag** |
| real source change (7.12→7.13) | DIFF → bump | DIFF → bump (unchanged) |

The version-line bump that also appears in churn diffs is no longer pre-applied, because the prep phase now skips the bump for plugin-only churn — so at release time the working-tree version equals the last tag and the diff is genuinely empty.

## Tradeoff

Refreshed embedded plugins still ship inside every mise release (mise consumes vfox via a workspace **path** dep, always built from fresh source). Only the **crates.io** copy of the `vfox` crate can lag its bundled plugins by up to one release — harmless, since those embedded plugins are just the offline fallback and mise refreshes them from `mise-plugins` at runtime.

## Not changed

`aqua-registry` and the other subcrates are left alone: their recent tags reflect genuine source changes and their vendored data lives outside the crate dir (`vendor/`), so they don't have the same generated-content-in-crate churn. Happy to extend the same exclusion if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI release versioning and crates.io publish decisions; behavior change is scoped to pathspec filtering but a misconfigured exclude could skip a needed vfox release.
> 
> **Overview**
> **Release change detection** for subcrates now ignores regenerated vendored content so `vfox` is not re-versioned, tagged, and published on every mise release when only `embedded-plugins/` was refreshed.
> 
> Adds `subcrate_diff_pathspec` to build git pathspecs (today: exclude `crates/vfox/embedded-plugins` for `vfox`, extensible via `case`). **`has_crate_changes`** and **`bump_subcrate_if_changed`** use those pathspecs instead of diffing the whole crate directory. **`has_uncommitted_changes`** now accepts multiple pathspecs and uses `git status --porcelain` instead of separate diff/ls-files checks on a single directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043f2b002d7bc2a5feabd7121217c114a2be9944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented refreshed embedded content from triggering unnecessary subcrate version bumps and releases.
  * Improved change detection so only relevant source changes are considered when evaluating release updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->