### PR TITLE
perf(activate): skip unchanged initial zsh prompt hook

### DIFF
--- a/e2e/env/test_zsh_consecutive_precmd_runs
+++ b/e2e/env/test_zsh_consecutive_precmd_runs
@@ -2,9 +2,11 @@
 # shellcheck disable=SC1071
 set -eu
 
-# Verify that zsh does not fall into an every-other-prompt pattern after the
-# first precmd run. Two consecutive precmd runs without a directory change
-# should both run hook-env normally.
+# Verify that zsh skips the first precmd hook when PATH is unchanged, runs later
+# prompts normally, and retains the first-prompt refresh when PATH or MISE_*
+# variables change.
+
+export MISE_TIMINGS=1
 
 eval "$(mise activate zsh --status)"
 
@@ -18,10 +20,22 @@ if [[ ${__MISE_ZSH_CHPWD_RAN:-unset} != "0" ]]; then
   exit 1
 fi
 
-_mise_hook_precmd >/dev/null 2>&1
+first_output="$(mktemp)"
+second_output="$(mktemp)"
+changed_path_output="$(mktemp)"
+changed_env_output="$(mktemp)"
+trap 'rm -f "$first_output" "$second_output" "$changed_path_output" "$changed_env_output"' EXIT
+
+_mise_hook_precmd >"$first_output" 2>&1
 
 if [[ ${__MISE_ZSH_PRECMD_RUN:-unset} != "1" ]]; then
-  echo "expected first precmd to run hook-env and set __MISE_ZSH_PRECMD_RUN=1"
+  echo "expected first precmd to set __MISE_ZSH_PRECMD_RUN=1"
+  exit 1
+fi
+
+if [[ -s $first_output ]]; then
+  echo "expected unchanged first precmd to skip hook-env"
+  cat "$first_output"
   exit 1
 fi
 
@@ -30,14 +44,45 @@ if [[ ${__MISE_ZSH_CHPWD_RAN:-unset} != "0" ]]; then
   exit 1
 fi
 
-_mise_hook_precmd >/dev/null 2>&1
+_mise_hook_precmd >"$second_output" 2>&1
 
 if [[ ${__MISE_ZSH_PRECMD_RUN:-unset} != "1" ]]; then
   echo "expected second consecutive precmd to run normally"
   exit 1
 fi
 
+if ! grep -q '\[TIME\]' "$second_output"; then
+  echo "expected second consecutive precmd to run hook-env"
+  cat "$second_output"
+  exit 1
+fi
+
 if [[ ${__MISE_ZSH_CHPWD_RAN:-unset} != "0" ]]; then
   echo "expected no chpwd skip flag after the second precmd"
+  exit 1
+fi
+
+eval "$(mise activate zsh --status)"
+export PATH="/path-added-after-activation:$PATH"
+_mise_hook_precmd >"$changed_path_output" 2>&1
+
+if ! grep -q '\[TIME\]' "$changed_path_output"; then
+  echo "expected first precmd to run hook-env after PATH changed"
+  cat "$changed_path_output"
+  exit 1
+fi
+
+if [[ ${__MISE_ZSH_PRECMD_RUN:-unset} != "1" ]]; then
+  echo "expected PATH-changing first precmd to set __MISE_ZSH_PRECMD_RUN=1"
+  exit 1
+fi
+
+eval "$(mise activate zsh --status)"
+export MISE_TEST_CHANGED_AFTER_ACTIVATION=1
+_mise_hook_precmd >"$changed_env_output" 2>&1
+
+if ! grep -q '\[TIME\]' "$changed_env_output"; then
+  echo "expected first precmd to run hook-env after MISE environment changed"
+  cat "$changed_env_output"
   exit 1
 fi

--- a/e2e/env/test_zsh_consecutive_precmd_runs
+++ b/e2e/env/test_zsh_consecutive_precmd_runs
@@ -91,3 +91,29 @@ if ((mise_hook_calls != 1)); then
   echo "expected first precmd to run hook-env after MISE environment changed"
   exit 1
 fi
+
+eval "$(mise activate zsh --status)"
+mise_hook_calls=0
+function _mise_hook() {
+  mise_hook_calls=$((mise_hook_calls + 1))
+  export __MISE_ZSH_PRECMD_RUN=1
+}
+export __MISE_ZSH_CHPWD_RAN=1
+_mise_hook_precmd
+
+if ((mise_hook_calls != 0)); then
+  echo "expected precmd immediately after chpwd to skip hook-env"
+  exit 1
+fi
+
+if [[ -n ${__MISE_ZSH_ACTIVATE_PATH:-} || -n ${__MISE_ZSH_ACTIVATE_ENV:-} ]]; then
+  echo "expected chpwd deferral to clear activation snapshots"
+  exit 1
+fi
+
+_mise_hook_precmd
+
+if ((mise_hook_calls != 1)); then
+  echo "expected precmd after chpwd deferral to run hook-env"
+  exit 1
+fi

--- a/e2e/env/test_zsh_consecutive_precmd_runs
+++ b/e2e/env/test_zsh_consecutive_precmd_runs
@@ -4,11 +4,16 @@ set -eu
 
 # Verify that zsh skips the first precmd hook when PATH is unchanged, runs later
 # prompts normally, and retains the first-prompt refresh when PATH or MISE_*
-# variables change.
-
-export MISE_TIMINGS=1
+# variables change. Stub _mise_hook after activation so invocation detection is
+# independent of hook-env's output and early-exit behavior.
 
 eval "$(mise activate zsh --status)"
+
+mise_hook_calls=0
+function _mise_hook() {
+  mise_hook_calls=$((mise_hook_calls + 1))
+  export __MISE_ZSH_PRECMD_RUN=1
+}
 
 if [[ ${__MISE_ZSH_PRECMD_RUN:-unset} != "0" ]]; then
   echo "expected __MISE_ZSH_PRECMD_RUN=0 after activation"
@@ -20,22 +25,15 @@ if [[ ${__MISE_ZSH_CHPWD_RAN:-unset} != "0" ]]; then
   exit 1
 fi
 
-first_output="$(mktemp)"
-second_output="$(mktemp)"
-changed_path_output="$(mktemp)"
-changed_env_output="$(mktemp)"
-trap 'rm -f "$first_output" "$second_output" "$changed_path_output" "$changed_env_output"' EXIT
-
-_mise_hook_precmd >"$first_output" 2>&1
+_mise_hook_precmd
 
 if [[ ${__MISE_ZSH_PRECMD_RUN:-unset} != "1" ]]; then
   echo "expected first precmd to set __MISE_ZSH_PRECMD_RUN=1"
   exit 1
 fi
 
-if [[ -s $first_output ]]; then
+if ((mise_hook_calls != 0)); then
   echo "expected unchanged first precmd to skip hook-env"
-  cat "$first_output"
   exit 1
 fi
 
@@ -44,16 +42,15 @@ if [[ ${__MISE_ZSH_CHPWD_RAN:-unset} != "0" ]]; then
   exit 1
 fi
 
-_mise_hook_precmd >"$second_output" 2>&1
+_mise_hook_precmd
 
 if [[ ${__MISE_ZSH_PRECMD_RUN:-unset} != "1" ]]; then
   echo "expected second consecutive precmd to run normally"
   exit 1
 fi
 
-if ! grep -q '\[TIME\]' "$second_output"; then
+if ((mise_hook_calls != 1)); then
   echo "expected second consecutive precmd to run hook-env"
-  cat "$second_output"
   exit 1
 fi
 
@@ -64,11 +61,15 @@ fi
 
 eval "$(mise activate zsh --status)"
 export PATH="/path-added-after-activation:$PATH"
-_mise_hook_precmd >"$changed_path_output" 2>&1
+mise_hook_calls=0
+function _mise_hook() {
+  mise_hook_calls=$((mise_hook_calls + 1))
+  export __MISE_ZSH_PRECMD_RUN=1
+}
+_mise_hook_precmd
 
-if ! grep -q '\[TIME\]' "$changed_path_output"; then
+if ((mise_hook_calls != 1)); then
   echo "expected first precmd to run hook-env after PATH changed"
-  cat "$changed_path_output"
   exit 1
 fi
 
@@ -79,10 +80,14 @@ fi
 
 eval "$(mise activate zsh --status)"
 export MISE_TEST_CHANGED_AFTER_ACTIVATION=1
-_mise_hook_precmd >"$changed_env_output" 2>&1
+mise_hook_calls=0
+function _mise_hook() {
+  mise_hook_calls=$((mise_hook_calls + 1))
+  export __MISE_ZSH_PRECMD_RUN=1
+}
+_mise_hook_precmd
 
-if ! grep -q '\[TIME\]' "$changed_env_output"; then
+if ((mise_hook_calls != 1)); then
   echo "expected first precmd to run hook-env after MISE environment changed"
-  cat "$changed_env_output"
   exit 1
 fi

--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -32,10 +32,13 @@ mise() {
 
 autoload -Uz add-zsh-hook
 _mise_hook() {
-  eval "$(/some/dir/mise hook-env --status -s zsh)";
+  eval "$(/some/dir/mise hook-env --status -s zsh "$@")";
 }
 _mise_hook_env_state() {
-  typeset -p ${(ok)parameters[(I)MISE_*]} 2>/dev/null
+  local -a keys=(${(ok)parameters[(I)MISE_*]})
+  if (( $#keys > 0 )); then
+    typeset -p "${keys[@]}" 2>/dev/null
+  fi
 }
 _mise_hook_precmd() {
   if [[ "${__MISE_ZSH_CHPWD_RAN:-0}" == "1" ]]; then
@@ -52,11 +55,11 @@ _mise_hook_precmd() {
   fi
   unset __MISE_ZSH_ACTIVATE_PATH
   unset __MISE_ZSH_ACTIVATE_ENV
-  eval "$(/some/dir/mise hook-env --status -s zsh --reason precmd)";
+  _mise_hook --reason precmd
 }
 _mise_hook_chpwd() {
   export __MISE_ZSH_CHPWD_RAN=1
-  eval "$(/some/dir/mise hook-env --status -s zsh --reason chpwd)";
+  _mise_hook --reason chpwd
 }
 add-zsh-hook precmd _mise_hook_precmd
 add-zsh-hook chpwd _mise_hook_chpwd

--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -43,6 +43,8 @@ _mise_hook_env_state() {
 _mise_hook_precmd() {
   if [[ "${__MISE_ZSH_CHPWD_RAN:-0}" == "1" ]]; then
     export __MISE_ZSH_CHPWD_RAN=0
+    unset __MISE_ZSH_ACTIVATE_PATH
+    unset __MISE_ZSH_ACTIVATE_ENV
     return
   fi
   if [[ "${__MISE_ZSH_PRECMD_RUN:-0}" == "0" &&

--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -34,11 +34,24 @@ autoload -Uz add-zsh-hook
 _mise_hook() {
   eval "$(/some/dir/mise hook-env --status -s zsh)";
 }
+_mise_hook_env_state() {
+  typeset -p ${(ok)parameters[(I)MISE_*]} 2>/dev/null
+}
 _mise_hook_precmd() {
   if [[ "${__MISE_ZSH_CHPWD_RAN:-0}" == "1" ]]; then
     export __MISE_ZSH_CHPWD_RAN=0
     return
   fi
+  if [[ "${__MISE_ZSH_PRECMD_RUN:-0}" == "0" &&
+        "$PATH" == "${__MISE_ZSH_ACTIVATE_PATH:-}" &&
+        "$(_mise_hook_env_state)" == "${__MISE_ZSH_ACTIVATE_ENV:-}" ]]; then
+    export __MISE_ZSH_PRECMD_RUN=1
+    unset __MISE_ZSH_ACTIVATE_PATH
+    unset __MISE_ZSH_ACTIVATE_ENV
+    return
+  fi
+  unset __MISE_ZSH_ACTIVATE_PATH
+  unset __MISE_ZSH_ACTIVATE_ENV
   eval "$(/some/dir/mise hook-env --status -s zsh --reason precmd)";
 }
 _mise_hook_chpwd() {
@@ -49,6 +62,8 @@ add-zsh-hook precmd _mise_hook_precmd
 add-zsh-hook chpwd _mise_hook_chpwd
 
 _mise_hook
+export __MISE_ZSH_ACTIVATE_PATH="$PATH"
+export __MISE_ZSH_ACTIVATE_ENV="$(_mise_hook_env_state)"
 if [ -z "${_mise_cmd_not_found:-}" ]; then
     _mise_cmd_not_found=1
     [ -n "$(declare -f command_not_found_handler)" ] && eval "${$(declare -f command_not_found_handler)/command_not_found_handler/_command_not_found_handler}"

--- a/src/shell/snapshots/mise__shell__zsh__tests__deactivate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__deactivate.snap
@@ -8,9 +8,12 @@ add-zsh-hook -d chpwd _mise_hook_chpwd 2>/dev/null
 (( $+functions[_mise_hook_precmd] )) && unset -f _mise_hook_precmd
 (( $+functions[_mise_hook_chpwd] )) && unset -f _mise_hook_chpwd
 (( $+functions[_mise_hook] )) && unset -f _mise_hook
+(( $+functions[_mise_hook_env_state] )) && unset -f _mise_hook_env_state
 (( $+functions[mise] )) && unset -f mise
 unset MISE_SHELL
 unset __MISE_DIFF
 unset __MISE_SESSION
 unset __MISE_ZSH_PRECMD_RUN
 unset __MISE_ZSH_CHPWD_RAN
+unset __MISE_ZSH_ACTIVATE_PATH
+unset __MISE_ZSH_ACTIVATE_ENV

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -65,11 +65,24 @@ impl Shell for Zsh {
             _mise_hook() {{
               eval "$({exe} hook-env{flags} -s zsh)";
             }}
+            _mise_hook_env_state() {{
+              typeset -p ${{(ok)parameters[(I)MISE_*]}} 2>/dev/null
+            }}
             _mise_hook_precmd() {{
               if [[ "${{__MISE_ZSH_CHPWD_RAN:-0}}" == "1" ]]; then
                 export __MISE_ZSH_CHPWD_RAN=0
                 return
               fi
+              if [[ "${{__MISE_ZSH_PRECMD_RUN:-0}}" == "0" &&
+                    "$PATH" == "${{__MISE_ZSH_ACTIVATE_PATH:-}}" &&
+                    "$(_mise_hook_env_state)" == "${{__MISE_ZSH_ACTIVATE_ENV:-}}" ]]; then
+                export __MISE_ZSH_PRECMD_RUN=1
+                unset __MISE_ZSH_ACTIVATE_PATH
+                unset __MISE_ZSH_ACTIVATE_ENV
+                return
+              fi
+              unset __MISE_ZSH_ACTIVATE_PATH
+              unset __MISE_ZSH_ACTIVATE_ENV
               eval "$({exe} hook-env{flags} -s zsh --reason precmd)";
             }}
             _mise_hook_chpwd() {{
@@ -80,6 +93,8 @@ impl Shell for Zsh {
             add-zsh-hook chpwd _mise_hook_chpwd
 
             _mise_hook
+            export __MISE_ZSH_ACTIVATE_PATH="$PATH"
+            export __MISE_ZSH_ACTIVATE_ENV="$(_mise_hook_env_state)"
             "#});
         }
         if Settings::get().not_found_auto_install {
@@ -114,12 +129,15 @@ impl Shell for Zsh {
         (( $+functions[_mise_hook_precmd] )) && unset -f _mise_hook_precmd
         (( $+functions[_mise_hook_chpwd] )) && unset -f _mise_hook_chpwd
         (( $+functions[_mise_hook] )) && unset -f _mise_hook
+        (( $+functions[_mise_hook_env_state] )) && unset -f _mise_hook_env_state
         (( $+functions[mise] )) && unset -f mise
         unset MISE_SHELL
         unset __MISE_DIFF
         unset __MISE_SESSION
         unset __MISE_ZSH_PRECMD_RUN
         unset __MISE_ZSH_CHPWD_RAN
+        unset __MISE_ZSH_ACTIVATE_PATH
+        unset __MISE_ZSH_ACTIVATE_ENV
         "#}
     }
 

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -63,10 +63,13 @@ impl Shell for Zsh {
 
             autoload -Uz add-zsh-hook
             _mise_hook() {{
-              eval "$({exe} hook-env{flags} -s zsh)";
+              eval "$({exe} hook-env{flags} -s zsh "$@")";
             }}
             _mise_hook_env_state() {{
-              typeset -p ${{(ok)parameters[(I)MISE_*]}} 2>/dev/null
+              local -a keys=(${{(ok)parameters[(I)MISE_*]}})
+              if (( $#keys > 0 )); then
+                typeset -p "${{keys[@]}}" 2>/dev/null
+              fi
             }}
             _mise_hook_precmd() {{
               if [[ "${{__MISE_ZSH_CHPWD_RAN:-0}}" == "1" ]]; then
@@ -83,11 +86,11 @@ impl Shell for Zsh {
               fi
               unset __MISE_ZSH_ACTIVATE_PATH
               unset __MISE_ZSH_ACTIVATE_ENV
-              eval "$({exe} hook-env{flags} -s zsh --reason precmd)";
+              _mise_hook --reason precmd
             }}
             _mise_hook_chpwd() {{
               export __MISE_ZSH_CHPWD_RAN=1
-              eval "$({exe} hook-env{flags} -s zsh --reason chpwd)";
+              _mise_hook --reason chpwd
             }}
             add-zsh-hook precmd _mise_hook_precmd
             add-zsh-hook chpwd _mise_hook_chpwd

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -74,6 +74,8 @@ impl Shell for Zsh {
             _mise_hook_precmd() {{
               if [[ "${{__MISE_ZSH_CHPWD_RAN:-0}}" == "1" ]]; then
                 export __MISE_ZSH_CHPWD_RAN=0
+                unset __MISE_ZSH_ACTIVATE_PATH
+                unset __MISE_ZSH_ACTIVATE_ENV
                 return
               fi
               if [[ "${{__MISE_ZSH_PRECMD_RUN:-0}}" == "0" &&


### PR DESCRIPTION
## Summary

- snapshot PATH and `MISE_*` state after Zsh's immediate activation refresh
- skip the first `precmd` process only when both snapshots remain unchanged
- retain the existing full first-prompt refresh when `.zshrc` changes PATH or a `MISE_*` variable after activation
- clean up the snapshot helper/state during deactivation
- extend Zsh e2e coverage for unchanged, PATH-changed, and `MISE_*`-changed startup paths

## Why

Zsh intentionally forces its first `precmd` `hook-env` run so PATH changes later in `.zshrc` are reconciled. When no relevant shell state changed, however, this repeats the full refresh performed during activation.

In an isolated empty configuration using the debug build, a paired benchmark through the first Zsh prompt improved from **45.28 ms** to **31.07 ms** on average across 30 runs, saving **14.21 ms**. Absolute debug timings are machine-specific; the comparison isolates the guarded prompt dispatch.

## Validation

- `cargo test shell::zsh::tests`
- `mise run test:e2e env/test_zsh_consecutive_precmd_runs cli/test_zsh_precmd_runs_once`
- e2e assertions verify PATH and `MISE_*` changes still run the first prompt refresh
- `mise run lint-fix`
- pre-commit `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes every Zsh user’s prompt hook path at shell startup; behavior is guarded by snapshots and extended e2e tests, but missed edge cases could leave PATH/MISE env stale on first prompt.
> 
> **Overview**
> **Skips redundant `hook-env` on Zsh’s first `precmd` when nothing relevant changed after activation**, while keeping the existing “first prompt” refresh when `PATH` or `MISE_*` variables were modified later in startup (e.g. `.zshrc`).
> 
> Activation now records **`__MISE_ZSH_ACTIVATE_PATH`** and **`__MISE_ZSH_ACTIVATE_ENV`** (via new **`_mise_hook_env_state`**) right after the immediate post-activate hook. The first `precmd` compares current `PATH` and `MISE_*` state to those snapshots; if they match and **`__MISE_ZSH_PRECMD_RUN`** is still `0`, it marks the first prompt as handled **without** calling `hook-env`. Otherwise it runs **`_mise_hook --reason precmd`** as before. **`_mise_hook`** and **`chpwd`** paths are refactored to forward args through a shared wrapper; **`chpwd`** deferral clears the activation snapshots. **Deactivate** tears down the new helper and snapshot variables.
> 
> **E2E** coverage is expanded (stubbed **`_mise_hook`**) for unchanged first prompt, PATH/`MISE_*` changes, and post-**`chpwd`** deferral behavior; activate/deactivate snapshots are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47dd5ced486d2d4048f304ae66f8b64dcb017df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zsh environment hooks to detect changes to `PATH` and other relevant environment settings.
  * Ensured environment updates trigger hook execution when needed, while unchanged consecutive prompts avoid unnecessary work.
  * Improved cleanup when deactivating the shell integration, preventing leftover activation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->