### PR TITLE
fix(http): make raw executables readable, not just executable

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -763,7 +763,7 @@ pub fn make_executable<P: AsRef<Path>>(_path: P) -> Result<()> {
 pub async fn make_executable_async<P: AsRef<Path>>(path: P) -> Result<()> {
     trace!("chmod +x {}", display_path(&path));
     let path = path.as_ref();
-    let mut perms = tokio::fs::metadata(path).await?.permissions();
+    let mut perms = path.metadata()?.permissions();
     perms.set_mode(executable_mode(perms.mode()));
     tokio::fs::set_permissions(path, perms)
         .await

--- a/src/file.rs
+++ b/src/file.rs
@@ -737,10 +737,21 @@ pub fn make_executable<P: AsRef<Path>>(path: P) -> Result<()> {
     trace!("chmod +x {}", display_path(&path));
     let path = path.as_ref();
     let mut perms = path.metadata()?.permissions();
-    perms.set_mode(perms.mode() | 0o111);
+    perms.set_mode(executable_mode(perms.mode()));
     fs::set_permissions(path, perms)
         .wrap_err_with(|| format!("failed to chmod +x: {}", display_path(path)))?;
     Ok(())
+}
+
+/// Add execute bits along with the matching read bits.
+///
+/// A file that only receives the execute bits (`mode | 0o111`) can end up executable but not
+/// readable (e.g. a `0o600` tempfile becomes `0o711`). For interpreted executables like PHP PHARs
+/// the interpreter must be able to *read* the file, so any class that gains execute must also gain
+/// read. See https://github.com/jdx/mise/discussions/11108.
+#[cfg(unix)]
+fn executable_mode(mode: u32) -> u32 {
+    mode | 0o111 | 0o444
 }
 
 #[cfg(windows)]
@@ -753,7 +764,7 @@ pub async fn make_executable_async<P: AsRef<Path>>(path: P) -> Result<()> {
     trace!("chmod +x {}", display_path(&path));
     let path = path.as_ref();
     let mut perms = path.metadata()?.permissions();
-    perms.set_mode(perms.mode() | 0o111);
+    perms.set_mode(executable_mode(perms.mode()));
     tokio::fs::set_permissions(path, perms)
         .await
         .wrap_err_with(|| format!("failed to chmod +x: {}", display_path(path)))
@@ -1755,6 +1766,20 @@ mod tests {
     use crate::config::Config;
 
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_executable_mode_adds_read_with_execute() {
+        // a restrictive tempfile (0o600) must end up readable, not just executable (0o711)
+        assert_eq!(executable_mode(0o600), 0o755);
+        assert_eq!(executable_mode(0o640), 0o755);
+        // owner-only read/write/exec preserved and widened to be world readable+executable
+        assert_eq!(executable_mode(0o700), 0o755);
+        // already-correct modes are unchanged
+        assert_eq!(executable_mode(0o755), 0o755);
+        // group/other write bits are preserved
+        assert_eq!(executable_mode(0o660), 0o775);
+    }
 
     #[test]
     fn test_retry_remove_all_retries_directory_not_empty() {

--- a/src/file.rs
+++ b/src/file.rs
@@ -763,7 +763,7 @@ pub fn make_executable<P: AsRef<Path>>(_path: P) -> Result<()> {
 pub async fn make_executable_async<P: AsRef<Path>>(path: P) -> Result<()> {
     trace!("chmod +x {}", display_path(&path));
     let path = path.as_ref();
-    let mut perms = path.metadata()?.permissions();
+    let mut perms = tokio::fs::metadata(path).await?.permissions();
     perms.set_mode(executable_mode(perms.mode()));
     tokio::fs::set_permissions(path, perms)
         .await


### PR DESCRIPTION
## Problem

Reported in #11108. When a raw executable (e.g. a PHP PHAR like Composer) is installed via the HTTP backend, mise creates it with mode `0711` instead of `0755`.

`file::make_executable` only *added* the execute bits:

```rust
perms.set_mode(perms.mode() | 0o111);
```

The downloaded tempfile is created with restrictive perms (`0600`), so after `+x` it becomes `0711` — executable by everyone but readable only by the owner. For system-wide installs owned by root, a non-owner user can execute the file but the interpreter (PHP) can't *read* the PHAR, so:

```
$ composer --version
Could not open input file: /usr/local/bin/composer
```

This affects both the raw-file and decompressed-raw-file paths in `src/backend/http.rs`.

## Fix

Add the matching read bits alongside the execute bits, so any class that gains execute also gains read (`mode | 0o111 | 0o444`). Existing write bits are preserved; an already-`0755` file is unchanged.

This is applied in the shared `make_executable` / `make_executable_async` helpers, so it hardens the invariant "executable ⇒ readable" everywhere, not just the HTTP backend.

## Test

Added a unit test covering the mode transformation (`0o600 → 0o755`, `0o640 → 0o755`, `0o660 → 0o775`, `0o755` unchanged).

Fixes #11108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized Unix permission logic with unit tests; broad call sites only widen read on paths already being marked executable.
> 
> **Overview**
> Fixes interpreted executables (e.g. PHP PHARs from the HTTP backend) that were left **executable but not world-readable** when installs started from restrictive temp modes like `0600` (`0711` after `chmod +x`).
> 
> On Unix, **`make_executable`** and **`make_executable_async`** now set modes via a shared **`executable_mode`** helper that applies **`mode | 0o111 | 0o444`**, so any class that gains execute also gains the matching read bits while preserving existing write bits; modes that are already correct (e.g. `0755`) stay unchanged.
> 
> Adds a **`test_executable_mode_adds_read_with_execute`** unit test for the mode mapping (`600`/`640` → `755`, `660` → `775`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1331ecc871e233400610d93d722709a87775673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix file permission behavior when marking files as executable, ensuring the corresponding read permission bits are also applied.
  * Updated both synchronous and async permission updates to preserve correct, expected permissions.
* **Tests**
  * Added a Unix-only unit test to verify restrictive modes are widened to readable+executable as intended, without changing already-correct permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->