### PR TITLE
fix(release): don't re-dispatch release workflow while one is active

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -17,8 +17,20 @@ git config user.email release@mise.jdx.dev
 latest_tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)"
 if [[ -n $latest_tag ]]; then
 	if ! gh api "repos/$GITHUB_REPOSITORY/releases/tags/$latest_tag" --silent 2>/dev/null; then
-		echo "Tag $latest_tag has no GitHub Release — triggering release workflow"
-		gh workflow run release.yml --ref "$latest_tag"
+		# Don't stack dispatches. release-plz runs on every push to main, so without
+		# this guard each merge re-triggers release.yml for the same tag. That trips
+		# the workflow's `release-<ref>` concurrency group, which cancels the still
+		# -pending prior attempt — so during a busy merge window no run ever survives
+		# long enough to finish and the release can never publish (a self-perpetuating
+		# loop, since a missing release keeps re-arming this very check). Only
+		# re-trigger when nothing is already queued or in progress for this tag.
+		active_runs="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow release.yml --branch "$latest_tag" --limit 30 --json status --jq '[.[] | select(.status != "completed")] | length' 2>/dev/null || echo 0)"
+		if [[ ${active_runs:-0} -gt 0 ]]; then
+			echo "Release workflow already active for $latest_tag ($active_runs queued/running) — not re-triggering"
+		else
+			echo "Tag $latest_tag has no GitHub Release — triggering release workflow"
+			gh workflow run release.yml --ref "$latest_tag"
+		fi
 	fi
 fi
 

--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -24,7 +24,11 @@ if [[ -n $latest_tag ]]; then
 		# long enough to finish and the release can never publish (a self-perpetuating
 		# loop, since a missing release keeps re-arming this very check). Only
 		# re-trigger when nothing is already queued or in progress for this tag.
-		active_runs="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow release.yml --branch "$latest_tag" --limit 30 --json status --jq '[.[] | select(.status != "completed")] | length' 2>/dev/null || echo 0)"
+		#
+		# Tag-dispatched runs report the tag as `headBranch`, so filter on that.
+		# `gh run list --branch` is documented for branches only and its behavior
+		# with tags is unspecified, so match in jq rather than relying on it.
+		active_runs="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow release.yml --limit 60 --json status,headBranch 2>/dev/null | jq --arg tag "$latest_tag" '[.[] | select(.headBranch == $tag and .status != "completed")] | length' 2>/dev/null || echo 0)"
 		if [[ ${active_runs:-0} -gt 0 ]]; then
 			echo "Release workflow already active for $latest_tag ($active_runs queued/running) — not re-triggering"
 		else


### PR DESCRIPTION
## Problem

No release has published since **v2026.7.7** (2026-07-15) despite dozens of release runs. The tags `v2026.7.8` and `v2026.7.10` exist but their releases never shipped. Root cause is a self-perpetuating dispatch loop, not the build itself:

1. `release-plz` runs on **every push to main**.
2. Its self-heal check re-dispatches `release.yml` for the latest tag whenever that tag has no matching GitHub Release — so it fires on essentially every merge:
   ```sh
   gh workflow run release.yml --ref "$latest_tag"
   ```
3. `release.yml` uses `concurrency: group: release-${{ github.ref_name }}` (no `cancel-in-progress`). Each new dispatch for the same tag cancels the **still-pending** prior attempt.
4. main gets a merge every ~6–12 min; the PGO build needs ~80 min. So each attempt is cancelled while still `pending`, long before it can grab a runner and finish.

The timeline matches 1:1 — every push spawns a release run ~6–8 min later that is then cancelled:

| push to main | → release run | fate |
|---|---|---|
| 18:16 #11089 | 18:24 | cancelled |
| 18:27 #11128 | 18:32 | cancelled |
| 18:34 #11129 | 18:40 | cancelled |
| 18:38 #11118 | 18:48 | cancelled |
| 18:50 #11114 | 18:56 | cancelled |

A missing release keeps re-arming the very check that re-triggers it → the loop never converges while main is active.

## Fix

Guard the retrigger so it only dispatches when there is **no queued or in-progress** `release.yml` run for that tag:

```sh
active_runs="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow release.yml \
  --branch "$latest_tag" --limit 30 --json status \
  --jq '[.[] | select(.status != "completed")] | length' 2>/dev/null || echo 0)"
if [[ ${active_runs:-0} -gt 0 ]]; then
  echo "Release workflow already active for $latest_tag ($active_runs queued/running) — not re-triggering"
else
  gh workflow run release.yml --ref "$latest_tag"
fi
```

With the guard, the first dispatch keeps its runner-queue slot instead of being cancelled, runs to completion (a genuinely in-progress run is already protected by the concurrency group), and publishes the release — after which the retrigger stops firing because the release now exists. A still-`completed`-but-failed run is *not* counted as active, so genuine retry-after-failure still works.

Verified the guard query against current live state (2 active runs for v2026.7.10 → correctly declines to re-trigger); `bash -n` passes.

## Caveat (separate from this fix)

Because the dispatch runs `release.yml` **at the tag ref**, the workflow executed is the version *at that tag*, which predates recent fixes on main (e.g. the PGO instrumentation fix in #11129). This PR stops the churn so a run can finish, but if the tagged workflow itself still fails, shipping v2026.7.10 may additionally need a re-cut tag or a dispatch from a fixed ref. Flagging so it's not mistaken for a complete fix of the 7.10 release on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release orchestration; no runtime product code, with straightforward guard logic and preserved retry when no active run exists.
> 
> **Overview**
> **Fixes a self-perpetuating release loop** where every push to `main` could re-dispatch `release.yml` for the latest tag that still lacked a GitHub Release, stacking dispatches that fought the workflow’s per-tag concurrency and cancelled still-pending runs before long PGO builds could finish.
> 
> The self-heal path in `xtasks/release-plz` now **counts queued or in-progress** `release.yml` runs whose `headBranch` matches the tag (via `gh run list` + `jq`, not `--branch`, which is branch-oriented). It only runs `gh workflow run release.yml --ref "$latest_tag"` when that count is zero; otherwise it logs and skips. **Completed** runs—including failures—are not treated as active, so retry-after-failure behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f01f0ec919bda6b04e2cef40e00e4ab1f6a645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate “release” workflow dispatches when the GitHub Release for the target `v*` tag is already queued or running.
  * When a release is missing, the system now checks recent `release.yml` workflow runs for the matching tag and retries only if no active (non-completed) run is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->