### PR TITLE
chore: release 2026.7.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,87 @@
 # Changelog
 
+## [2026.7.12](https://github.com/jdx/mise/compare/v2026.7.11..v2026.7.12) - 2026-07-22
+
+### 🚀 Features
+
+- **(bootstrap)** support relative paths in [bootstrap.repos] by @lilienblum in [#11155](https://github.com/jdx/mise/pull/11155)
+- **(config)** add MISE_SAFE mode to block repo-controlled code execution by @jdx in [#11146](https://github.com/jdx/mise/pull/11146)
+- **(config)** ignore project [env]/aliases/settings and skip trust in safe mode by @jdx in [#11151](https://github.com/jdx/mise/pull/11151)
+- **(core)** verify node/swift signatures in-process with rpgp, drop external gpg by @jdx in [#11148](https://github.com/jdx/mise/pull/11148)
+- **(lock)** add `mise lock --bump` to advance lockfile selectors by @jdx in [#11145](https://github.com/jdx/mise/pull/11145)
+- **(npm)** resolve versions over HTTP, groundwork for embedding aube by @jdx in [#11147](https://github.com/jdx/mise/pull/11147)
+- **(npm)** embed aube for node-free npm: version resolution and installs by @jdx in [#11149](https://github.com/jdx/mise/pull/11149)
+- **(oci)** built-in registry push client, drop skopeo/crane dependency by @jdx in [#11132](https://github.com/jdx/mise/pull/11132)
+- **(oci)** chunked uploads, retries, cross-repo mounts, progress bars by @jdx in [#11141](https://github.com/jdx/mise/pull/11141)
+- **(oci)** reuse unchanged tool layers from the previously pushed image by @jdx in [#11142](https://github.com/jdx/mise/pull/11142)
+- **(oci)** multi-arch image index support (--update-index) by @jdx in [#11144](https://github.com/jdx/mise/pull/11144)
+
+### 🐛 Bug Fixes
+
+- **(activate)** avoid zsh/parameter autoload during zsh activation by @jdx in [#11188](https://github.com/jdx/mise/pull/11188)
+- **(backend)** detect qualified prerelease suffixes by @risu729 in [#11179](https://github.com/jdx/mise/pull/11179)
+- **(brew)** allow cask binaries to symlink into /usr/local on arm64 by @jdx in [#11174](https://github.com/jdx/mise/pull/11174)
+- **(brew-cask)** case-insensitive app lookup + preflight-generated wrappers by @donbeave in [#11164](https://github.com/jdx/mise/pull/11164)
+- **(completions)** avoid network lookup during usage completion by @jdx in [#11169](https://github.com/jdx/mise/pull/11169)
+- **(config)** align env and vars array parsing by @risu729 in [#11060](https://github.com/jdx/mise/pull/11060)
+- **(config)** avoid panic when config set descends into a non-table value by @Marukome0743 in [#11153](https://github.com/jdx/mise/pull/11153)
+- **(config)** honor trusted_config_paths over previously-ignored configs by @JamBalaya56562 in [#11152](https://github.com/jdx/mise/pull/11152)
+- **(config)** improve unsupported semver range warnings by @risu729 in [#11176](https://github.com/jdx/mise/pull/11176)
+- **(env)** resolve a real POSIX bash for _.source on Windows by @JamBalaya56562 in [#11097](https://github.com/jdx/mise/pull/11097)
+- **(env)** expand cross-file references in _.file env files by @Marukome0743 in [#11158](https://github.com/jdx/mise/pull/11158)
+- **(hook-env)** show concise warning instead of full error for untrusted configs by @lilienblum in [#11159](https://github.com/jdx/mise/pull/11159)
+- **(http)** don't cap remote-fetch commands to 3s under prefer_offline by @jdx in [#11190](https://github.com/jdx/mise/pull/11190)
+- **(link)** clear stale incomplete marker when linking a tool by @Marukome0743 in [#11150](https://github.com/jdx/mise/pull/11150)
+- **(lock)** preserve os-restricted tool entries by @jdx in [#11175](https://github.com/jdx/mise/pull/11175)
+- **(shim)** actionable error for unresolved Windows exe-shim dispatch by @jdx in [#11189](https://github.com/jdx/mise/pull/11189)
+- **(vfox)** preserve inner quotes with cmd.exe by @finalchild in [#11166](https://github.com/jdx/mise/pull/11166)
+- extend match of Linux musl asset for Android by @bltavares in [#10730](https://github.com/jdx/mise/pull/10730)
+
+### 📚 Documentation
+
+- document environment-backed file-task arguments by @zeitlinger in [#11165](https://github.com/jdx/mise/pull/11165)
+
+### 🧪 Testing
+
+- **(nix)** skip macos defaults test in sandbox by @laozc in [#11170](https://github.com/jdx/mise/pull/11170)
+- **(oci)** e2e happy-path push coverage against a real registry by @jdx in [#11140](https://github.com/jdx/mise/pull/11140)
+
+### 📦️ Dependency Updates
+
+- update namespacelabs/nscloud-cache-action digest to c5f8dab by @renovate[bot] in [#11079](https://github.com/jdx/mise/pull/11079)
+- avoid tool installation during dry runs by @risu729 in [#11016](https://github.com/jdx/mise/pull/11016)
+- remove orphaned npm dependencies by @risu729 in [#11100](https://github.com/jdx/mise/pull/11100)
+- enforce experimental gate for task providers by @risu729 in [#11177](https://github.com/jdx/mise/pull/11177)
+
+### 📦 Registry
+
+- disable cargo-release test by @jdx in [#11143](https://github.com/jdx/mise/pull/11143)
+
+### Chore
+
+- **(ci)** bump release linux runner to xlarge by @jdx in [#11196](https://github.com/jdx/mise/pull/11196)
+- **(ci)** increase release build timeouts by @jdx in [#11200](https://github.com/jdx/mise/pull/11200)
+
+### New Contributors
+
+- @donbeave made their first contribution in [#11164](https://github.com/jdx/mise/pull/11164)
+- @lilienblum made their first contribution in [#11159](https://github.com/jdx/mise/pull/11159)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (5)
+
+- [`abhinav/git-spice`](https://github.com/abhinav/git-spice)
+- [`envoyproxy/gateway/egctl`](https://github.com/envoyproxy/gateway)
+- [`envoyproxy/gateway/envoy-gateway`](https://github.com/envoyproxy/gateway)
+- [`tedilabs/ota`](https://github.com/tedilabs/ota)
+- [`yvgude/lean-ctx`](https://github.com/yvgude/lean-ctx)
+
+#### Updated Packages (2)
+
+- [`supernovae-st/nika`](https://github.com/supernovae-st/nika)
+- [`suzuki-shunsuke/tfcmt`](https://github.com/suzuki-shunsuke/tfcmt)
+
 ## [2026.7.11](https://github.com/jdx/mise/compare/v2026.7.10..v2026.7.11) - 2026-07-20
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.11"
+version = "2026.7.12"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.11"
+version = "2026.7.12"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.11 macos-arm64 (2026-07-20)
+2026.7.12 macos-arm64 (2026-07-22)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_11.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_12.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_11.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_12.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_11.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_12.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_11.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_12.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/crates/vfox/embedded-plugins/vfox-gcloud/hooks/post_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-gcloud/hooks/post_install.lua
@@ -3,6 +3,9 @@
 --- @field ctx.rootPath string The installation directory
 
 local file = require("file")
+local os = require("os")
+local log = require("log")
+local strings = require("strings")
 
 --- Compare version strings
 --- Returns true if v1 >= v2
@@ -28,6 +31,68 @@ local function version_gte(v1, v2)
         end
     end
     return true
+end
+
+local function get_home_dir()
+    return os.getenv("HOME") or os.getenv("USERPROFILE") or ""
+end
+
+local function find_default_components_file()
+    local filename = ".default-cloud-sdk-components"
+    local home = get_home_dir()
+    local cloudsdk_config = os.getenv("CLOUDSDK_CONFIG")
+    if not cloudsdk_config or cloudsdk_config == "" then
+        if RUNTIME.osType == "windows" or RUNTIME.osType == "Windows" then
+            cloudsdk_config = file.join_path(os.getenv("APPDATA") or home, "gcloud")
+        else
+            cloudsdk_config = file.join_path(home, ".config", "gcloud")
+        end
+    end
+
+    for _, dir in ipairs({ cloudsdk_config, home }) do
+        local path = file.join_path(dir, filename)
+        if file.exists(path) then
+            return path
+        end
+    end
+end
+
+local function install_default_components(gcloud_bin)
+    local components_file = find_default_components_file()
+    if not components_file then
+        return
+    end
+
+    log.info("Installing default Cloud SDK components from " .. components_file)
+
+    local contents = file.read(components_file)
+    if not contents or contents == "" then
+        return
+    end
+
+    local components = {}
+    for _, line in ipairs(strings.split(contents, "\n")) do
+        local trimmed = strings.trim_space(line)
+        if trimmed ~= "" and not string.find(trimmed, "^#") then
+            if string.match(trimmed, "^[%w%-_%.]+$") then
+                table.insert(components, trimmed)
+            else
+                log.info("Skipping invalid component name: " .. trimmed)
+            end
+        end
+    end
+
+    if #components == 0 then
+        return
+    end
+
+    local cmd = string.format('"%s" --quiet components install %s', gcloud_bin, table.concat(components, " "))
+    local status = os.execute(cmd)
+    if status ~= 0 and status ~= true then
+        log.error("Failed to install default Cloud SDK components")
+        return
+    end
+    log.info("Default Cloud SDK components installed successfully")
 end
 
 function PLUGIN:PostInstall(ctx)
@@ -80,4 +145,11 @@ function PLUGIN:PostInstall(ctx)
     if status ~= 0 and status ~= true then
         error("Failed to run gcloud install script")
     end
+
+    -- Install default SDK components
+    local gcloud_bin = file.join_path(sdk_path, "bin", "gcloud")
+    if RUNTIME.osType == "windows" or RUNTIME.osType == "Windows" then
+        gcloud_bin = gcloud_bin .. ".cmd"
+    end
+    install_default_components(gcloud_bin)
 end

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.11";
+  version = "2026.7.12";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "30.9k",
+      stars: "31k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.11
+Version: 2026.7.12
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.11"
+version: "2026.7.12"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "b630f47e707ae0c3eba85f7fc74c0d911e7fa58d"
+  "tag": "f5255a020e80ad66ef746094bfe80519ad4cd0e4"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -10786,6 +10786,111 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: abhinav
+    repo_name: git-spice
+    description: Manage stacked Git branches
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0-beta4")
+        asset: git-spice.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: gs
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.5.2")
+        asset: git-spice.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: gs
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.23.0")
+        asset: git-spice.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: gs
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 0.31.1")
+        asset: git-spice.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: git-spice
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: "true"
+        asset: git-spice.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: git-spice
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/abhinav/git-spice/.github/workflows/publish-release.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+  - type: github_release
     repo_owner: abice
     repo_name: go-enum
     description: An enum generator for go
@@ -36435,6 +36540,52 @@ packages:
       type: github_release
       asset: terratag_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+  - name: envoyproxy/gateway/egctl
+    type: github_release
+    repo_owner: envoyproxy
+    repo_name: gateway
+    description: Manages Envoy Proxy as a Standalone or Kubernetes-based Application Gateway
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.3.3")
+        asset: egctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: egctl
+            src: bin/{{.OS}}/{{.Arch}}/egctl
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: egctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: egctl
+            src: bin/{{.OS}}/{{.Arch}}/egctl
+        overrides:
+          - goos: windows
+            format: zip
+  - name: envoyproxy/gateway/envoy-gateway
+    type: github_release
+    repo_owner: envoyproxy
+    repo_name: gateway
+    description: Manages Envoy Proxy as a Standalone or Kubernetes-based Application Gateway
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 1.2.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: envoy-gateway_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: envoy-gateway
+            src: bin/{{.OS}}/{{.Arch}}/envoy-gateway
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: equinix-labs
     repo_name: otel-cli
@@ -88064,6 +88215,19 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.80.0-alpha.4")
         no_asset: true
+      - version_constraint: semver("<= 0.104.0")
+        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
         format: tar.gz
@@ -88074,6 +88238,8 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
         supported_envs:
           - linux
           - darwin
@@ -89653,7 +89819,7 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
-      - version_constraint: "true"
+      - version_constraint: semver("<= 4.14.12")
         asset: tfcmt_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -89670,6 +89836,48 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/suzuki-shunsuke/tfcmt/releases/download/{{.Version}}/tfcmt_{{trimV .Version}}_checksums.txt.sig
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
+      - version_constraint: semver("<= 4.14.15")
+        asset: tfcmt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: tfcmt_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: tfcmt_{{trimV .Version}}_checksums.txt.bundle
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
+      - version_constraint: "true"
+        asset: tfcmt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: tfcmt_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: tfcmt_{{trimV .Version}}_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
@@ -91366,6 +91574,25 @@ packages:
         supported_envs:
           - linux
           - darwin
+  - type: github_release
+    repo_owner: tedilabs
+    repo_name: ota
+    description: k9s for Okta — a Go/Bubbletea TUI to inspect Okta admin resources
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ota_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: tedilabs
     repo_name: tfvault
@@ -101336,6 +101563,88 @@ packages:
     slsa_provenance:
       type: github_release
       asset: multiple.intoto.jsonl
+  - type: github_release
+    repo_owner: yvgude
+    repo_name: lean-ctx
+    description: Local-first context intelligence layer for AI agents
+    version_filter: not (Version startsWith "vscode-")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.7.0")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 2.4.0")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.1.5")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: zaghaghi
     repo_name: openapi-tui


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** support relative paths in [bootstrap.repos] by @lilienblum in [#11155](https://github.com/jdx/mise/pull/11155)
- **(config)** add MISE_SAFE mode to block repo-controlled code execution by @jdx in [#11146](https://github.com/jdx/mise/pull/11146)
- **(config)** ignore project [env]/aliases/settings and skip trust in safe mode by @jdx in [#11151](https://github.com/jdx/mise/pull/11151)
- **(core)** verify node/swift signatures in-process with rpgp, drop external gpg by @jdx in [#11148](https://github.com/jdx/mise/pull/11148)
- **(lock)** add `mise lock --bump` to advance lockfile selectors by @jdx in [#11145](https://github.com/jdx/mise/pull/11145)
- **(npm)** resolve versions over HTTP, groundwork for embedding aube by @jdx in [#11147](https://github.com/jdx/mise/pull/11147)
- **(npm)** embed aube for node-free npm: version resolution and installs by @jdx in [#11149](https://github.com/jdx/mise/pull/11149)
- **(oci)** built-in registry push client, drop skopeo/crane dependency by @jdx in [#11132](https://github.com/jdx/mise/pull/11132)
- **(oci)** chunked uploads, retries, cross-repo mounts, progress bars by @jdx in [#11141](https://github.com/jdx/mise/pull/11141)
- **(oci)** reuse unchanged tool layers from the previously pushed image by @jdx in [#11142](https://github.com/jdx/mise/pull/11142)
- **(oci)** multi-arch image index support (--update-index) by @jdx in [#11144](https://github.com/jdx/mise/pull/11144)

### 🐛 Bug Fixes

- **(activate)** avoid zsh/parameter autoload during zsh activation by @jdx in [#11188](https://github.com/jdx/mise/pull/11188)
- **(backend)** detect qualified prerelease suffixes by @risu729 in [#11179](https://github.com/jdx/mise/pull/11179)
- **(brew)** allow cask binaries to symlink into /usr/local on arm64 by @jdx in [#11174](https://github.com/jdx/mise/pull/11174)
- **(brew-cask)** case-insensitive app lookup + preflight-generated wrappers by @donbeave in [#11164](https://github.com/jdx/mise/pull/11164)
- **(completions)** avoid network lookup during usage completion by @jdx in [#11169](https://github.com/jdx/mise/pull/11169)
- **(config)** align env and vars array parsing by @risu729 in [#11060](https://github.com/jdx/mise/pull/11060)
- **(config)** avoid panic when config set descends into a non-table value by @Marukome0743 in [#11153](https://github.com/jdx/mise/pull/11153)
- **(config)** honor trusted_config_paths over previously-ignored configs by @JamBalaya56562 in [#11152](https://github.com/jdx/mise/pull/11152)
- **(config)** improve unsupported semver range warnings by @risu729 in [#11176](https://github.com/jdx/mise/pull/11176)
- **(env)** resolve a real POSIX bash for _.source on Windows by @JamBalaya56562 in [#11097](https://github.com/jdx/mise/pull/11097)
- **(env)** expand cross-file references in _.file env files by @Marukome0743 in [#11158](https://github.com/jdx/mise/pull/11158)
- **(hook-env)** show concise warning instead of full error for untrusted configs by @lilienblum in [#11159](https://github.com/jdx/mise/pull/11159)
- **(http)** don't cap remote-fetch commands to 3s under prefer_offline by @jdx in [#11190](https://github.com/jdx/mise/pull/11190)
- **(link)** clear stale incomplete marker when linking a tool by @Marukome0743 in [#11150](https://github.com/jdx/mise/pull/11150)
- **(lock)** preserve os-restricted tool entries by @jdx in [#11175](https://github.com/jdx/mise/pull/11175)
- **(shim)** actionable error for unresolved Windows exe-shim dispatch by @jdx in [#11189](https://github.com/jdx/mise/pull/11189)
- **(vfox)** preserve inner quotes with cmd.exe by @finalchild in [#11166](https://github.com/jdx/mise/pull/11166)
- extend match of Linux musl asset for Android by @bltavares in [#10730](https://github.com/jdx/mise/pull/10730)

### 📚 Documentation

- document environment-backed file-task arguments by @zeitlinger in [#11165](https://github.com/jdx/mise/pull/11165)

### 🧪 Testing

- **(nix)** skip macos defaults test in sandbox by @laozc in [#11170](https://github.com/jdx/mise/pull/11170)
- **(oci)** e2e happy-path push coverage against a real registry by @jdx in [#11140](https://github.com/jdx/mise/pull/11140)

### 📦️ Dependency Updates

- update namespacelabs/nscloud-cache-action digest to c5f8dab by @renovate[bot] in [#11079](https://github.com/jdx/mise/pull/11079)
- avoid tool installation during dry runs by @risu729 in [#11016](https://github.com/jdx/mise/pull/11016)
- remove orphaned npm dependencies by @risu729 in [#11100](https://github.com/jdx/mise/pull/11100)
- enforce experimental gate for task providers by @risu729 in [#11177](https://github.com/jdx/mise/pull/11177)

### 📦 Registry

- disable cargo-release test by @jdx in [#11143](https://github.com/jdx/mise/pull/11143)

### Chore

- **(ci)** bump release linux runner to xlarge by @jdx in [#11196](https://github.com/jdx/mise/pull/11196)
- **(ci)** increase release build timeouts by @jdx in [#11200](https://github.com/jdx/mise/pull/11200)

### New Contributors

- @donbeave made their first contribution in [#11164](https://github.com/jdx/mise/pull/11164)
- @lilienblum made their first contribution in [#11159](https://github.com/jdx/mise/pull/11159)

## 📦 Aqua Registry Updates

### New Packages (5)

- [`abhinav/git-spice`](https://github.com/abhinav/git-spice)
- [`envoyproxy/gateway/egctl`](https://github.com/envoyproxy/gateway)
- [`envoyproxy/gateway/envoy-gateway`](https://github.com/envoyproxy/gateway)
- [`tedilabs/ota`](https://github.com/tedilabs/ota)
- [`yvgude/lean-ctx`](https://github.com/yvgude/lean-ctx)

### Updated Packages (2)

- [`supernovae-st/nika`](https://github.com/supernovae-st/nika)
- [`suzuki-shunsuke/tfcmt`](https://github.com/suzuki-shunsuke/tfcmt)