### PR TITLE
test(oci): e2e happy-path push coverage against a real registry

### DIFF
--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -162,7 +162,14 @@ mise oci push [--image-dir DIR]
 - `<REGISTRY_REF>` — fully-qualified destination (e.g.
   `ghcr.io/me/devenv:latest`). Must include a registry host. Loopback
   registries (`localhost:5000/…`) are contacted over plain HTTP, the
-  same insecure-by-default convention docker applies.
+  same insecure-by-default convention docker applies. Non-loopback
+  plain-HTTP registries (a homelab `registry.lan:5000`) must be opted
+  in via the `oci.insecure_registries` setting:
+
+  ```toml
+  [settings.oci]
+  insecure_registries = ["registry.lan:5000"]
+  ```
 - `--image-dir` — push an existing OCI layout instead of building.
 
 - `--owner UID[:GID]` — numeric owner for generated layer entries when

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -170,6 +170,7 @@ mise oci push [--image-dir DIR]
   [settings.oci]
   insecure_registries = ["registry.lan:5000"]
   ```
+
 - `--image-dir` — push an existing OCI layout instead of building.
 
 - `--owner UID[:GID]` — numeric owner for generated layer entries when

--- a/e2e/oci/test_oci_push_registry
+++ b/e2e/oci/test_oci_push_registry
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Happy-path test for `mise oci push` against a real registry.
+#
+# Uses `crane registry serve` (an in-memory OCI Distribution registry) on a
+# loopback port, so it needs no external services and runs everywhere. crane
+# also acts as an independent client to validate what mise pushed.
+
+export MISE_EXPERIMENTAL=1
+# Deterministic image config so a rebuild produces identical blobs.
+export SOURCE_DATE_EPOCH=1700000000
+
+mise install crane@latest >/dev/null 2>&1
+
+find_available_port() {
+  python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1]); s.close()"
+}
+
+REGISTRY_PID=""
+cleanup() {
+  if [[ -n ${REGISTRY_PID:-} ]]; then
+    kill "$REGISTRY_PID" 2>/dev/null || true
+    wait "$REGISTRY_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# --- Start the registry ---
+PORT="$(find_available_port)"
+REGISTRY="127.0.0.1:$PORT"
+mise x crane@latest -- crane registry serve --address "$REGISTRY" >/dev/null 2>&1 &
+REGISTRY_PID=$!
+for _ in $(seq 1 50); do
+  if curl -fsS "http://$REGISTRY/v2/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+assert_succeed "curl -fsS http://$REGISTRY/v2/"
+
+cat >mise.toml <<EOF
+[tools]
+jq = "1.8.1"
+EOF
+mise install >/dev/null 2>&1
+assert "mise current jq" "1.8.1"
+
+REF="$REGISTRY/e2e/devenv:v1"
+
+# --- 1. Build (offline, scratch base) and push ---
+assert_succeed "mise oci build -o ./img --from scratch --no-mise"
+assert_contains "mise oci push --image-dir ./img $REF" "pushed sha256:"
+
+# --- 2. Idempotent re-push: every blob must already be present ---
+assert_contains "mise oci push --image-dir ./img $REF" "0 blob(s) uploaded"
+
+# --- 3. Remote digest matches the local manifest byte-for-byte ---
+local_digest="$(jq -r '.manifests[0].digest' ./img/index.json)"
+assert "mise x crane@latest -- crane digest --insecure $REF" "$local_digest"
+
+# --- 4. Independent client validates the pushed image end-to-end
+# (manifest/config/layer digests and sizes all consistent) ---
+assert_succeed "mise x crane@latest -- crane validate --insecure --remote $REF"
+
+# --- 5. Manifest content survives the round-trip (tool layer annotation) ---
+assert_contains "mise x crane@latest -- crane manifest --insecure $REF" '"dev.mise.tool.short":"jq"'
+
+# --- 6. Push by digest reference ---
+assert_contains "mise oci push --image-dir ./img $REGISTRY/e2e/devenv@$local_digest" \
+  "0 blob(s) uploaded"
+
+# --- 7. Build+push in one shot (no --image-dir) to a second tag; the
+# reproducible rebuild produces identical blobs so nothing re-uploads ---
+assert_contains "mise oci push --from scratch --no-mise $REGISTRY/e2e/devenv:v2" \
+  "0 blob(s) uploaded"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1339,6 +1339,13 @@
               "default": "/mise",
               "description": "Path inside OCI images where mise tools are installed.",
               "type": "string"
+            },
+            "insecure_registries": {
+              "description": "Registries (host or host:port) contacted over plain HTTP instead of HTTPS.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/settings.toml
+++ b/settings.toml
@@ -1810,6 +1810,25 @@ Defaults to `/mise`. The resulting image sets `MISE_DATA_DIR` to this path.
 env = "MISE_OCI_DEFAULT_MOUNT_POINT"
 type = "String"
 
+[oci.insecure_registries]
+description = "Registries (host or host:port) contacted over plain HTTP instead of HTTPS."
+docs = """
+Registries that `mise oci push` / `mise oci build --from` contact over plain
+HTTP instead of HTTPS, matching docker's `insecure-registries` daemon option.
+Loopback registries (`localhost:5000`, `127.0.0.1:5000`) are always treated as
+insecure and don't need to be listed. Entries match on exact `host` or
+`host:port`:
+
+```toml
+[settings.oci]
+insecure_registries = ["registry.lan:5000", "10.0.0.8:5000"]
+```
+"""
+env = "MISE_OCI_INSECURE_REGISTRIES"
+optional = true
+rust_type = "Vec<String>"
+type = "ListString"
+
 [offline]
 description = "Disable all HTTP requests. Tools will only use locally cached data."
 docs = """

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -90,7 +90,9 @@ impl Reference {
         };
         // Loopback registries (localhost:5000 etc.) serve plain HTTP — the
         // same insecure-by-default convention docker applies to 127.0.0.0/8.
-        let scheme = if is_loopback_registry(host) {
+        // Non-loopback plain-HTTP registries must be opted in via the
+        // `oci.insecure_registries` setting.
+        let scheme = if is_insecure_registry(host) {
             "http"
         } else {
             "https"
@@ -99,15 +101,39 @@ impl Reference {
     }
 }
 
-/// True when `registry` (a `host[:port]` / `[v6]:port` string) points at a
-/// loopback address, in which case the distribution API is spoken over
-/// plain HTTP.
-fn is_loopback_registry(registry: &str) -> bool {
-    let host = if let Some(rest) = registry.strip_prefix('[') {
+/// True when `registry` (a `host[:port]` / `[v6]:port` string) should be
+/// contacted over plain HTTP: loopback addresses always, plus anything listed
+/// in the `oci.insecure_registries` setting.
+fn is_insecure_registry(registry: &str) -> bool {
+    let settings = crate::config::Settings::get();
+    let entries = settings.oci.insecure_registries.as_deref().unwrap_or(&[]);
+    is_insecure_registry_in(registry, entries)
+}
+
+/// Settings-free core of [`is_insecure_registry`]: loopback, or listed in
+/// `entries` (matched on the exact `host[:port]` string or the bare host).
+fn is_insecure_registry_in(registry: &str, entries: &[String]) -> bool {
+    if is_loopback_registry(registry) {
+        return true;
+    }
+    let host = registry_host(registry);
+    entries
+        .iter()
+        .any(|entry| entry == registry || entry == host)
+}
+
+/// The host portion of a `host[:port]` / `[v6]:port` registry string.
+fn registry_host(registry: &str) -> &str {
+    if let Some(rest) = registry.strip_prefix('[') {
         rest.split(']').next().unwrap_or(rest)
     } else {
         registry.rsplit_once(':').map_or(registry, |(h, _)| h)
-    };
+    }
+}
+
+/// True when `registry` points at a loopback address.
+fn is_loopback_registry(registry: &str) -> bool {
+    let host = registry_host(registry);
     host == "localhost"
         || host
             .parse::<std::net::IpAddr>()
@@ -662,12 +688,20 @@ pub async fn push_image(image_dir: &Path, reference: &str) -> Result<PushSummary
     let session = AuthSession::new(r.clone(), "pull,push").await?;
     if !session.has_credential() {
         // Not fatal — local registries accept anonymous pushes — but worth
-        // surfacing before a 401 does.
-        warn!(
-            "no registry credentials found for {} — pushing anonymously. \
-             Run `docker login {}` (or `podman login`) if the push is rejected.",
-            r.registry, r.registry
-        );
+        // surfacing before a 401 does. For loopback / configured-insecure
+        // registries anonymous is the normal case, so don't warn there.
+        if is_insecure_registry(&r.registry) {
+            debug!(
+                "no registry credentials found for {} — pushing anonymously",
+                r.registry
+            );
+        } else {
+            warn!(
+                "no registry credentials found for {} — pushing anonymously. \
+                 Run `docker login {}` (or `podman login`) if the push is rejected.",
+                r.registry, r.registry
+            );
+        }
     }
     let mut pusher = Pusher {
         base_url: r.registry_url(),
@@ -911,6 +945,29 @@ mod tests {
         assert_eq!(r.registry, "docker.io");
         assert_eq!(r.repository, "library/ubuntu");
         assert_eq!(r.tag, digest);
+    }
+
+    #[test]
+    fn registry_host_strips_port_and_brackets() {
+        assert_eq!(registry_host("registry.lan:5000"), "registry.lan");
+        assert_eq!(registry_host("registry.lan"), "registry.lan");
+        assert_eq!(registry_host("[::1]:5000"), "::1");
+        assert_eq!(registry_host("10.0.0.8:5000"), "10.0.0.8");
+    }
+
+    #[test]
+    fn insecure_registry_entries_match_exact_or_bare_host() {
+        let entries = vec!["registry.lan:5000".to_string(), "10.0.0.8".to_string()];
+        // exact host:port entry
+        assert!(is_insecure_registry_in("registry.lan:5000", &entries));
+        // bare-host entry matches any port on that host
+        assert!(is_insecure_registry_in("10.0.0.8:5000", &entries));
+        assert!(is_insecure_registry_in("10.0.0.8", &entries));
+        // a host:port entry does not cover other ports
+        assert!(!is_insecure_registry_in("registry.lan:9999", &entries));
+        assert!(!is_insecure_registry_in("ghcr.io", &entries));
+        // loopback needs no entry
+        assert!(is_insecure_registry_in("localhost:5000", &[]));
     }
 
     #[test]

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -81,21 +81,24 @@ impl Reference {
     }
 
     pub fn registry_url(&self) -> String {
+        // Loopback registries (localhost:5000 etc.) serve plain HTTP — the
+        // same insecure-by-default convention docker applies to 127.0.0.0/8.
+        // Non-loopback plain-HTTP registries must be opted in via the
+        // `oci.insecure_registries` setting. Evaluate against the
+        // user-facing registry name (not the docker.io→registry-1 rewrite
+        // below) so it matches the lookups `push_image` does with
+        // `self.registry`.
+        let scheme = if is_insecure_registry(&self.registry) {
+            "http"
+        } else {
+            "https"
+        };
         // docker.io is special — the distribution API is served from
         // registry-1.docker.io even though the canonical name is docker.io.
         let host = if self.registry == "docker.io" {
             "registry-1.docker.io"
         } else {
             &self.registry
-        };
-        // Loopback registries (localhost:5000 etc.) serve plain HTTP — the
-        // same insecure-by-default convention docker applies to 127.0.0.0/8.
-        // Non-loopback plain-HTTP registries must be opted in via the
-        // `oci.insecure_registries` setting.
-        let scheme = if is_insecure_registry(host) {
-            "http"
-        } else {
-            "https"
         };
         format!("{scheme}://{host}")
     }


### PR DESCRIPTION
## Summary

Follow-up to #11132 (item 5 of the follow-up list: CI coverage).

The oci e2e suite covered only error paths — CI had no registry to push to, so happy-path regressions in the native push client had to be caught by hand. This adds real coverage with zero CI-infrastructure changes:

- **New `e2e/oci/test_oci_push_registry`** (fast lane, runs in every PR tranche): starts `crane registry serve` — an in-memory OCI Distribution registry — on a loopback port inside the test's own environment (same pattern as `test_s3_minio_slow`), then uses crane as an *independent* client to verify what mise pushed:
  - build (scratch base, offline) + push
  - idempotent re-push reports `0 blob(s) uploaded`
  - `crane digest` == local manifest digest byte-for-byte
  - `crane validate --remote` deep-validates manifest/config/layer digests & sizes
  - tool-layer annotations survive the round-trip
  - push by digest reference
  - build+push in one shot; reproducible rebuild uploads nothing

- **New `oci.insecure_registries` setting** (docker's `insecure-registries` equivalent): non-loopback plain-HTTP registries (`registry.lan:5000`) can now be pushed to by opting in. Loopback stays insecure-by-default, and the anonymous-push warning is downgraded to debug for insecure registries where anonymous is the normal case there.

## Verification

Test passes locally in ~5s (after tool downloads): all 7 assertions green, including crane's deep validation (`PASS`). 1780 unit tests pass (new coverage for the insecure-registries matcher and host parsing); lint clean; `mise run render:schema` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how registry base URLs and TLS vs HTTP are chosen for pushes; misconfiguration could send traffic to the wrong scheme, though opt-in only affects listed hosts.
> 
> **Overview**
> Adds **CI happy-path coverage** for `mise oci push` via `e2e/oci/test_oci_push_registry`, which runs an in-memory `crane registry serve` on loopback and checks build/push, idempotent re-push (`0 blob(s) uploaded`), digest parity, `crane validate --remote`, annotations, digest refs, and build+push in one shot.
> 
> Introduces **`settings.oci.insecure_registries`** (schema, `settings.toml`, docs) so non-loopback registries can use plain HTTP like Docker’s insecure-registries. The registry client now picks HTTP via **`is_insecure_registry`** (loopback unchanged + configured hosts, with host/port matching) instead of loopback-only checks, and **downgrades the anonymous-push warning to debug** for those registries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4189a449fcd6f2454e182f7287fdd71957acb94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly enabling non-loopback OCI registries over plain HTTP via `oci.insecure_registries` (including `MISE_OCI_INSECURE_REGISTRIES`), with host/port and bare-host matching.
* **Bug Fixes**
  * Improved registry URL scheme selection (loopback always treated as insecure; non-loopback requires configuration).
  * Reduced anonymous-push warnings for configured insecure registries.
* **Documentation**
  * Added guidance and TOML examples for opting into insecure registries.
* **Tests**
  * Added end-to-end OCI push coverage (idempotency, digest/reference validation, and manifest consistency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->