### PR TITLE
feat(oci): reuse unchanged tool layers from the previously pushed image

### DIFF
--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -11,6 +11,11 @@ required. If `--image-dir` is not passed, builds fresh from the current
 mise.toml first. Only blobs the registry doesn't already have are
 uploaded, so repeat pushes of mostly-unchanged toolsets are cheap.
 
+Tool layers whose tool, version, mount point, and file owner match the
+previously pushed image (or `--cache-from`) are reused without being
+rebuilt — those tools don't even need to be installed locally. Pass
+`--no-cache` to force a full local rebuild.
+
 Credentials are read from the same places docker and podman use:
 `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,
 `~/.config/containers/auth.json`, and `~/.docker/config.json`
@@ -26,6 +31,12 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)
 
 ## Flags
+
+### `--cache-from <REF>`
+
+Reuse unchanged tool layers from this image instead of the destination ref
+
+Must live in the same repository as the destination. Useful when each push gets a unique tag (e.g. per-commit tags in CI): `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
 
 ### `--from <FROM>`
 
@@ -44,6 +55,10 @@ See `mise oci build --help` for details.
 ### `--mount-point <MOUNT_POINT>`
 
 Override in-image mount point (ignored with --image-dir)
+
+### `--no-cache`
+
+Don't reuse tool layers from the previously pushed image
 
 ### `--no-mise`
 

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -156,6 +156,35 @@ cross-repository mounted instead of re-uploaded (no bytes transferred).
 Large layers upload in chunks with progress bars, and transient network
 failures are retried with backoff (`http_retries` controls attempts).
 
+### Layer reuse
+
+Tool layers whose cache key (tool, version, in-image prefix, and file
+owner) matches the previously pushed image are **reused from the
+registry instead of rebuilt** — skipping the tar/gzip work entirely.
+Reused tools don't even need to be installed locally, which makes CI
+pushes fast: only tools whose version actually changed get installed
+and packaged.
+
+- By default the cache is the destination ref itself (the image
+  previously pushed under that tag).
+- `--cache-from REF` reuses layers from another tag in the **same
+  repository** — useful when every push gets a unique tag:
+
+  ```sh
+  mise oci push --cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$GIT_SHA
+  ```
+
+- `--no-cache` disables reuse and rebuilds every layer from the local
+  installs (docker-style escape hatch — reuse trusts that the
+  registry's layer content matches its annotations, rather than
+  rebuilding the exact bytes locally).
+
+One caveat: environment derivation (`JAVA_HOME`-style `exec_env` vars)
+runs against local installs. For a reused tool that isn't installed,
+most backends still derive paths correctly, but exotic backends may
+contribute incomplete env — pass `--no-cache` (with the tool installed)
+if the image config looks wrong.
+
 ```sh
 mise oci push [--image-dir DIR]
               [--from REF] [--mount-point PATH] [--no-mise]

--- a/e2e/oci/test_oci_push_layer_reuse
+++ b/e2e/oci/test_oci_push_layer_reuse
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Tests `mise oci push` layer reuse (discussion #11121): tool layers that
+# match the previously pushed image (tool, version, prefix, owner) are taken
+# from the registry instead of rebuilt — the tool doesn't even need to be
+# installed locally.
+
+export MISE_EXPERIMENTAL=1
+export SOURCE_DATE_EPOCH=1700000000
+
+mise install crane@latest >/dev/null 2>&1
+
+find_available_port() {
+  python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1]); s.close()"
+}
+
+REGISTRY_PID=""
+cleanup() {
+  if [[ -n ${REGISTRY_PID:-} ]]; then
+    kill "$REGISTRY_PID" 2>/dev/null || true
+    wait "$REGISTRY_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+PORT="$(find_available_port)"
+REGISTRY="127.0.0.1:$PORT"
+mise x crane@latest -- crane registry serve --address "$REGISTRY" >/dev/null 2>&1 &
+REGISTRY_PID=$!
+for _ in $(seq 1 50); do
+  if curl -fsS "http://$REGISTRY/v2/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+assert_succeed "curl -fsS http://$REGISTRY/v2/"
+
+cat >mise.toml <<EOF
+[tools]
+jq = "1.8.1"
+EOF
+mise install >/dev/null 2>&1
+
+# --- 1. First push builds everything (nothing to reuse yet) ---
+mise oci push --from scratch --no-mise "$REGISTRY/e2e/devenv:v1" >push1.log 2>&1
+assert_contains "cat push1.log" "pushed sha256:"
+assert_not_contains "cat push1.log" "reused from previous image"
+jq_digest_v1="$(mise x crane@latest -- crane manifest --insecure "$REGISTRY/e2e/devenv:v1" |
+  jq -r '.layers[] | select(.annotations."dev.mise.tool.short" == "jq") | .digest')"
+
+# --- 2. Uninstall the tool entirely; re-push to the same tag must reuse
+# the layer from the registry without rebuilding or reinstalling ---
+mise uninstall jq >/dev/null 2>&1
+assert_fail "mise oci build -o ./no-reuse --from scratch --no-mise" "install path does not exist"
+assert_contains "mise oci push --from scratch --no-mise $REGISTRY/e2e/devenv:v1" \
+  "1 tool layer(s) reused from previous image"
+
+# --- 3. --cache-from: push to a NEW tag reusing layers from v1
+# (the per-commit-tag CI pattern) ---
+assert_contains "mise oci push --from scratch --no-mise --cache-from $REGISTRY/e2e/devenv:v1 $REGISTRY/e2e/devenv:v2" \
+  "1 tool layer(s) reused from previous image"
+
+# The reused jq layer digest is identical across tags, and the new image
+# validates end-to-end (all blobs actually present in the repo).
+jq_digest_v2="$(mise x crane@latest -- crane manifest --insecure "$REGISTRY/e2e/devenv:v2" |
+  jq -r '.layers[] | select(.annotations."dev.mise.tool.short" == "jq") | .digest')"
+assert "echo $jq_digest_v2" "$jq_digest_v1"
+assert_succeed "mise x crane@latest -- crane validate --insecure --remote $REGISTRY/e2e/devenv:v2"
+
+# --- 4. --cache-from must be in the destination repository ---
+assert_fail "mise oci push --from scratch --no-mise --cache-from $REGISTRY/other/repo:v1 $REGISTRY/e2e/devenv:v3" \
+  "same repository"
+
+# --- 5. --no-cache forces a local rebuild, which fails while the tool
+# is uninstalled ---
+assert_fail "mise oci push --no-cache --from scratch --no-mise $REGISTRY/e2e/devenv:v1" \
+  "install path does not exist"
+
+# --- 6. Reinstall and --no-cache pushes a byte-identical image ---
+mise install >/dev/null 2>&1
+assert_contains "mise oci push --no-cache --from scratch --no-mise $REGISTRY/e2e/devenv:v1" \
+  "0 blob(s) uploaded"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2432,6 +2432,11 @@ required. If `\-\-image\-dir` is not passed, builds fresh from the current
 mise.toml first. Only blobs the registry doesn't already have are
 uploaded, so repeat pushes of mostly\-unchanged toolsets are cheap.
 
+Tool layers whose tool, version, mount point, and file owner match the
+previously pushed image (or `\-\-cache\-from`) are reused without being
+rebuilt — those tools don't even need to be installed locally. Pass
+`\-\-no\-cache` to force a full local rebuild.
+
 Credentials are read from the same places docker and podman use:
 `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,
 `~/.config/containers/auth.json`, and `~/.docker/config.json`
@@ -2444,6 +2449,11 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 .PP
 \fBOptions:\fR
 .PP
+.TP
+\fB\-\-cache\-from\fR \fI<REF>\fR
+Reuse unchanged tool layers from this image instead of the destination ref
+
+Must live in the same repository as the destination. Useful when each push gets a unique tag (e.g. per\-commit tags in CI): `\-\-cache\-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
 .TP
 \fB\-\-from\fR \fI<FROM>\fR
 Base image for the build (ignored with \-\-image\-dir)
@@ -2458,6 +2468,9 @@ See `mise oci build \-\-help` for details.
 .TP
 \fB\-\-mount\-point\fR \fI<MOUNT_POINT>\fR
 Override in\-image mount point (ignored with \-\-image\-dir)
+.TP
+\fB\-\-no\-cache\fR
+Don't reuse tool layers from the previously pushed image
 .TP
 \fB\-\-no\-mise\fR
 Don't embed the mise binary (ignored with \-\-image\-dir)

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2246,6 +2246,11 @@ required. If `--image-dir` is not passed, builds fresh from the current
 mise.toml first. Only blobs the registry doesn't already have are
 uploaded, so repeat pushes of mostly-unchanged toolsets are cheap.
 
+Tool layers whose tool, version, mount point, and file owner match the
+previously pushed image (or `--cache-from`) are reused without being
+rebuilt — those tools don't even need to be installed locally. Pass
+`--no-cache` to force a full local rebuild.
+
 Credentials are read from the same places docker and podman use:
 `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,
 `~/.config/containers/auth.json`, and `~/.docker/config.json`
@@ -2274,6 +2279,14 @@ Auth:
     $ podman login ghcr.io
 
 """#
+        flag --cache-from help="Reuse unchanged tool layers from this image instead of the destination ref" {
+            long_help #"""
+Reuse unchanged tool layers from this image instead of the destination ref
+
+Must live in the same repository as the destination. Useful when each push gets a unique tag (e.g. per-commit tags in CI): `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
+"""#
+            arg <REF>
+        }
         flag --from help="Base image for the build (ignored with --image-dir)" {
             arg <FROM>
         }
@@ -2290,6 +2303,7 @@ See `mise oci build --help` for details.
         flag --mount-point help="Override in-image mount point (ignored with --image-dir)" {
             arg <MOUNT_POINT>
         }
+        flag --no-cache help="Don't reuse tool layers from the previously pushed image"
         flag --no-mise help="Don't embed the mise binary (ignored with --image-dir)"
         flag --owner help="UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)" {
             long_help #"""

--- a/src/cli/oci/build.rs
+++ b/src/cli/oci/build.rs
@@ -76,6 +76,9 @@ impl Build {
             owner: self.owner,
             include_mise: !self.no_mise,
             copy: self.copy.clone(),
+            // Layer reuse would leave blob-less holes in the layout; `build`
+            // must produce a complete, standalone image directory.
+            reuse_from: None,
         };
         let out = perform_build(opts, self.include_global).await?;
 

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -15,6 +15,11 @@ use crate::oci::{BuildOptions, LayerOwner, registry};
 /// mise.toml first. Only blobs the registry doesn't already have are
 /// uploaded, so repeat pushes of mostly-unchanged toolsets are cheap.
 ///
+/// Tool layers whose tool, version, mount point, and file owner match the
+/// previously pushed image (or `--cache-from`) are reused without being
+/// rebuilt — those tools don't even need to be installed locally. Pass
+/// `--no-cache` to force a full local rebuild.
+///
 /// Credentials are read from the same places docker and podman use:
 /// `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,
 /// `~/.config/containers/auth.json`, and `~/.docker/config.json`
@@ -28,6 +33,14 @@ pub struct Push {
     /// Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)
     #[clap(value_name = "REF")]
     reference: String,
+
+    /// Reuse unchanged tool layers from this image instead of the destination ref
+    ///
+    /// Must live in the same repository as the destination. Useful when each
+    /// push gets a unique tag (e.g. per-commit tags in CI):
+    /// `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
+    #[clap(long, value_name = "REF", conflicts_with_all = &["no_cache", "image_dir"])]
+    cache_from: Option<String>,
 
     /// Base image for the build (ignored with --image-dir)
     #[clap(long)]
@@ -46,6 +59,10 @@ pub struct Push {
     /// Override in-image mount point (ignored with --image-dir)
     #[clap(long)]
     mount_point: Option<String>,
+
+    /// Don't reuse tool layers from the previously pushed image
+    #[clap(long)]
+    no_cache: bool,
 
     /// Don't embed the mise binary (ignored with --image-dir)
     #[clap(long)]
@@ -74,6 +91,7 @@ impl Push {
         // Keep the temp dir alive for the duration of the push — it removes
         // itself on drop, so multi-hundred-megabyte image layouts don't
         // accumulate in /tmp.
+        let mut reused_layers = 0;
         let (image_dir, _tempdir_guard): (PathBuf, Option<TempDir>) =
             if let Some(d) = &self.image_dir {
                 if !d.join("index.json").is_file() {
@@ -95,26 +113,73 @@ impl Push {
                     owner: self.owner,
                     include_mise: !self.no_mise,
                     copy: vec![],
+                    reuse_from: self.fetch_layer_cache().await?,
                 };
                 let built = perform_build(opts, self.include_global).await?;
+                reused_layers = built.tool_layers.iter().filter(|l| l.reused).count();
                 info!("built image: {}", built.manifest_digest);
                 (out_dir, Some(td))
             };
 
         let summary = registry::push_image(&image_dir, &self.reference).await?;
-        let mounted = if summary.mounted > 0 {
-            format!(", {} mounted from base repo", summary.mounted)
-        } else {
-            String::new()
-        };
+        let mut extras = String::new();
+        if summary.mounted > 0 {
+            extras.push_str(&format!(", {} mounted from base repo", summary.mounted));
+        }
+        if reused_layers > 0 {
+            extras.push_str(&format!(
+                ", {reused_layers} tool layer(s) reused from previous image"
+            ));
+        }
         miseprintln!(
-            "pushed {} to {} ({} blob(s) uploaded, {} already present{mounted})",
+            "pushed {} to {} ({} blob(s) uploaded, {} already present{extras})",
             summary.manifest_digest,
             self.reference,
             summary.uploaded,
             summary.skipped
         );
         Ok(())
+    }
+
+    /// Fetch the layer-reuse cache image: `--cache-from` if given, otherwise
+    /// the destination ref itself (the previously pushed image under this
+    /// tag). Returns `None` with `--no-cache`, when no previous image exists,
+    /// or when the lookup fails — a broken cache must never fail the push.
+    async fn fetch_layer_cache(&self) -> Result<Option<registry::RemoteImage>> {
+        if self.no_cache {
+            return Ok(None);
+        }
+        let cache_ref = self.cache_from.as_deref().unwrap_or(&self.reference);
+        if let Some(cache_from) = &self.cache_from {
+            // Reused layer blobs are never uploaded — they must already live
+            // in the destination repository, so a cache image from a
+            // different repo would produce a manifest referencing blobs the
+            // destination doesn't have.
+            let dest = registry::Reference::parse(&self.reference)?;
+            let cache = registry::Reference::parse(cache_from)?;
+            if dest.registry != cache.registry || dest.repository != cache.repository {
+                bail!(
+                    "--cache-from must reference the same repository as the destination \
+                     (got {}/{}, destination is {}/{})",
+                    cache.registry,
+                    cache.repository,
+                    dest.registry,
+                    dest.repository
+                );
+            }
+        }
+        match registry::fetch_remote_image(cache_ref).await {
+            Ok(remote) => {
+                if remote.is_none() {
+                    debug!("no previous image at {cache_ref} — building all layers locally");
+                }
+                Ok(remote)
+            }
+            Err(e) => {
+                warn!("could not fetch layer cache from {cache_ref}: {e} — building all layers");
+                Ok(None)
+            }
+        }
     }
 }
 

--- a/src/cli/oci/run.rs
+++ b/src/cli/oci/run.rs
@@ -140,6 +140,9 @@ impl Run {
                     owner: self.owner,
                     include_mise: !self.no_mise,
                     copy: vec![],
+                    // The layout is loaded into a local engine, which needs
+                    // every blob present — no remote reuse.
+                    reuse_from: None,
                 };
                 let built = perform_build(opts, self.include_global).await?;
                 info!("built image: {}", built.manifest_digest);

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -23,6 +23,14 @@ use crate::system::ManagerPackages;
 use crate::system::files::{FileMode, FileRequest};
 use crate::toolset::{ToolVersion, Toolset};
 
+/// Annotations mise writes on tool layer descriptors. Together they form the
+/// cache key for reusing a layer from a previously pushed image: same tool,
+/// same version, same in-image prefix, same file ownership.
+pub const ANNOTATION_TOOL_SHORT: &str = "dev.mise.tool.short";
+pub const ANNOTATION_TOOL_VERSION: &str = "dev.mise.tool.version";
+pub const ANNOTATION_LAYER_PREFIX: &str = "dev.mise.layer.prefix";
+pub const ANNOTATION_LAYER_OWNER: &str = "dev.mise.layer.owner";
+
 /// Options passed to the builder from the CLI.
 #[derive(Debug, Clone)]
 pub struct BuildOptions {
@@ -40,6 +48,65 @@ pub struct BuildOptions {
     pub include_mise: bool,
     /// CLI-provided host paths copied after config-provided entries.
     pub copy: Vec<OciCopy>,
+    /// A previously pushed image to reuse unchanged tool layers from
+    /// (`mise oci push` only). Reused layers skip the local tar/gzip build
+    /// entirely — and the tool doesn't even need to be installed locally.
+    /// NOTE: the resulting layout omits reused layer blobs, so it is only
+    /// valid to push to the repository the cache image came from.
+    pub reuse_from: Option<registry::RemoteImage>,
+}
+
+/// Cache key for tool-layer reuse. All four parts must match — a layer built
+/// for a different mount point or file owner has different bytes even for
+/// the same tool version.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct ReuseKey {
+    short: String,
+    version: String,
+    prefix: String,
+    owner: String,
+}
+
+/// A tool layer taken verbatim from the remote cache image.
+#[derive(Debug, Clone)]
+struct ReusedLayer {
+    media_type: String,
+    digest: String,
+    size: u64,
+    diff_id: String,
+}
+
+/// Index a remote image's tool layers by their reuse cache key. Layers
+/// missing any key annotation (e.g. images pushed by older mise versions)
+/// are simply not reusable.
+fn build_reuse_index(remote: &registry::RemoteImage) -> IndexMap<ReuseKey, ReusedLayer> {
+    let mut index = IndexMap::new();
+    for (layer, diff_id) in remote.manifest.layers.iter().zip(&remote.diff_ids) {
+        let a = &layer.annotations;
+        let (Some(short), Some(version), Some(prefix), Some(owner)) = (
+            a.get(ANNOTATION_TOOL_SHORT),
+            a.get(ANNOTATION_TOOL_VERSION),
+            a.get(ANNOTATION_LAYER_PREFIX),
+            a.get(ANNOTATION_LAYER_OWNER),
+        ) else {
+            continue;
+        };
+        index.insert(
+            ReuseKey {
+                short: short.clone(),
+                version: version.clone(),
+                prefix: prefix.clone(),
+                owner: owner.clone(),
+            },
+            ReusedLayer {
+                media_type: layer.media_type.clone(),
+                digest: layer.digest.clone(),
+                size: layer.size,
+                diff_id: diff_id.clone(),
+            },
+        );
+    }
+    index
 }
 
 pub struct Builder {
@@ -63,6 +130,8 @@ pub struct ToolLayerInfo {
     pub version: String,
     pub digest: String,
     pub size: u64,
+    /// Taken verbatim from the remote cache image instead of built locally.
+    pub reused: bool,
 }
 
 impl Builder {
@@ -193,7 +262,32 @@ impl Builder {
             base_config_json = Some(pull.config_json);
         }
 
-        // --- 2. Validate tool installs before any package work ---
+        // --- 2. Decide layer reuse and validate tool installs ---
+        // A tool layer is reused from the remote cache image when tool,
+        // version, in-image prefix, and file owner all match — in that case
+        // the layer is never built locally and the tool doesn't need to be
+        // installed at all.
+        let owner_str = format!("{}:{}", owner.uid, owner.gid);
+        let reuse_index = self
+            .opts
+            .reuse_from
+            .as_ref()
+            .map(build_reuse_index)
+            .unwrap_or_default();
+        let tool_reuse: Vec<Option<ReusedLayer>> = versions
+            .iter()
+            .map(|(_, tv)| {
+                reuse_index
+                    .get(&ReuseKey {
+                        short: tv.ba().short.clone(),
+                        version: tv.version.clone(),
+                        prefix: tool_tar_prefix(&mount_point, tv),
+                        owner: owner_str.clone(),
+                    })
+                    .cloned()
+            })
+            .collect();
+
         // Tool installs are host-native binaries. On non-linux hosts they'll
         // fail at runtime inside the linux container with `Exec format error`
         // — emit a single warning up front so the user isn't surprised after
@@ -209,7 +303,10 @@ impl Builder {
                 n = versions.len()
             );
         }
-        for (_, tv) in &versions {
+        for (i, (_, tv)) in versions.iter().enumerate() {
+            if tool_reuse[i].is_some() {
+                continue; // layer comes from the cache image; no install needed
+            }
             let install_path = tv.install_path();
             if !install_path.is_dir() {
                 bail!(
@@ -232,13 +329,36 @@ impl Builder {
         )?;
 
         // --- 4. Per-tool layers ---
-        let mut tool_layers: Vec<(String, String, LayerBlob)> = Vec::new();
-        for (_, tv) in &versions {
-            let install_path = tv.install_path();
+        struct ToolLayerEntry {
+            short: String,
+            version: String,
+            prefix: String,
+            layer: ToolLayer,
+        }
+        enum ToolLayer {
+            Built(LayerBlob),
+            Reused(ReusedLayer),
+        }
+        let mut tool_layers: Vec<ToolLayerEntry> = Vec::new();
+        for (i, (_, tv)) in versions.iter().enumerate() {
             let tv_prefix = tool_tar_prefix(&mount_point, tv);
-            let blob = layer::build_layer_from_dir(&install_path, &tv_prefix, owner)
-                .wrap_err_with(|| format!("building layer for {}", tv.style()))?;
-            tool_layers.push((tv.ba().short.clone(), tv.version.clone(), blob));
+            let layer = if let Some(reused) = &tool_reuse[i] {
+                info!(
+                    "oci: reusing {} layer from the destination image (unchanged)",
+                    tv.style()
+                );
+                ToolLayer::Reused(reused.clone())
+            } else {
+                let blob = layer::build_layer_from_dir(&tv.install_path(), &tv_prefix, owner)
+                    .wrap_err_with(|| format!("building layer for {}", tv.style()))?;
+                ToolLayer::Built(blob)
+            };
+            tool_layers.push(ToolLayerEntry {
+                short: tv.ba().short.clone(),
+                version: tv.version.clone(),
+                prefix: tv_prefix,
+                layer,
+            });
         }
 
         // --- 5. Arbitrary host-path layers ---
@@ -339,24 +459,48 @@ impl Builder {
             all_diff_ids.push(blob.diff_id.clone());
         }
 
-        for (short, version, blob) in &tool_layers {
-            layout.write_blob_with_digest(&blob.digest, &blob.bytes)?;
+        for entry in &tool_layers {
             let mut annotations = IndexMap::new();
-            annotations.insert("dev.mise.tool.short".to_string(), short.clone());
-            annotations.insert("dev.mise.tool.version".to_string(), version.clone());
+            annotations.insert(ANNOTATION_TOOL_SHORT.to_string(), entry.short.clone());
+            annotations.insert(ANNOTATION_TOOL_VERSION.to_string(), entry.version.clone());
+            annotations.insert(ANNOTATION_LAYER_PREFIX.to_string(), entry.prefix.clone());
+            annotations.insert(ANNOTATION_LAYER_OWNER.to_string(), owner_str.clone());
+            let (media_type, digest, size, diff_id, reused) = match &entry.layer {
+                ToolLayer::Built(blob) => {
+                    layout.write_blob_with_digest(&blob.digest, &blob.bytes)?;
+                    (
+                        manifest::MEDIA_TYPE_OCI_LAYER_GZIP.to_string(),
+                        blob.digest.clone(),
+                        blob.size,
+                        blob.diff_id.clone(),
+                        false,
+                    )
+                }
+                // Reused layers reference the remote blob; no local bytes
+                // exist, which is fine because the push destination (where
+                // the cache image lives) already has them.
+                ToolLayer::Reused(r) => (
+                    r.media_type.clone(),
+                    r.digest.clone(),
+                    r.size,
+                    r.diff_id.clone(),
+                    true,
+                ),
+            };
             manifest_layers.push(Descriptor {
-                media_type: manifest::MEDIA_TYPE_OCI_LAYER_GZIP.to_string(),
-                size: blob.size,
-                digest: blob.digest.clone(),
+                media_type,
+                size,
+                digest: digest.clone(),
                 annotations,
                 platform: None,
             });
-            all_diff_ids.push(blob.diff_id.clone());
+            all_diff_ids.push(diff_id);
             tool_layer_infos.push(ToolLayerInfo {
-                short: short.clone(),
-                version: version.clone(),
-                digest: blob.digest.clone(),
-                size: blob.size,
+                short: entry.short.clone(),
+                version: entry.version.clone(),
+                digest,
+                size,
+                reused,
             });
         }
 
@@ -1039,6 +1183,69 @@ fn sanitize_label(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn layer(annotations: &[(&str, &str)], digest: &str) -> Descriptor {
+        Descriptor {
+            media_type: manifest::MEDIA_TYPE_OCI_LAYER_GZIP.to_string(),
+            size: 100,
+            digest: digest.to_string(),
+            annotations: annotations
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            platform: None,
+        }
+    }
+
+    #[test]
+    fn reuse_index_keys_on_all_four_annotations() {
+        let full = [
+            (ANNOTATION_TOOL_SHORT, "jq"),
+            (ANNOTATION_TOOL_VERSION, "1.8.1"),
+            (ANNOTATION_LAYER_PREFIX, "mise/installs/jq/1.8.1"),
+            (ANNOTATION_LAYER_OWNER, "0:0"),
+        ];
+        // Second layer lacks prefix/owner (pushed by an older mise) —
+        // not reusable.
+        let partial = [
+            (ANNOTATION_TOOL_SHORT, "node"),
+            (ANNOTATION_TOOL_VERSION, "20.0.0"),
+        ];
+        let remote = registry::RemoteImage {
+            manifest: ImageManifest {
+                schema_version: 2,
+                media_type: manifest::MEDIA_TYPE_OCI_MANIFEST.to_string(),
+                config: layer(&[], "sha256:cfg"),
+                layers: vec![layer(&full, "sha256:aaa"), layer(&partial, "sha256:bbb")],
+                annotations: Default::default(),
+            },
+            diff_ids: vec!["sha256:diff-a".into(), "sha256:diff-b".into()],
+        };
+
+        let index = build_reuse_index(&remote);
+        assert_eq!(index.len(), 1);
+        let hit = index
+            .get(&ReuseKey {
+                short: "jq".into(),
+                version: "1.8.1".into(),
+                prefix: "mise/installs/jq/1.8.1".into(),
+                owner: "0:0".into(),
+            })
+            .unwrap();
+        assert_eq!(hit.digest, "sha256:aaa");
+        assert_eq!(hit.diff_id, "sha256:diff-a");
+        // Different owner -> miss.
+        assert!(
+            index
+                .get(&ReuseKey {
+                    short: "jq".into(),
+                    version: "1.8.1".into(),
+                    prefix: "mise/installs/jq/1.8.1".into(),
+                    owner: "1000:1000".into(),
+                })
+                .is_none()
+        );
+    }
 
     #[test]
     fn resolve_layer_owner_defaults_to_root() {

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -294,13 +294,18 @@ impl Builder {
         // the image appears to build successfully. (`--no-mise` silences the
         // mise-binary warning below but doesn't help with tool binaries; only
         // running the build on a linux host does.)
-        if !versions.is_empty() && std::env::consts::OS != "linux" {
+        // Count only layers actually built on this host; reused layers came
+        // from the cache image and aren't rebuilt, so they don't carry
+        // host-native binaries. Warning on reused-only pushes (the CI re-push
+        // the reuse feature speeds up) would be a false alarm.
+        let built_tool_count = tool_reuse.iter().filter(|r| r.is_none()).count();
+        if built_tool_count > 0 && std::env::consts::OS != "linux" {
             warn!(
-                "building on {host} host — the {n} tool layer(s) contain {host} binaries that \
+                "building on {host} host — {n} tool layer(s) contain {host} binaries that \
                  will fail with `Exec format error` inside a linux container. Run \
                  `mise oci build` on a linux host (or in a linux container) for a working image.",
                 host = std::env::consts::OS,
-                n = versions.len()
+                n = built_tool_count
             );
         }
         for (i, (_, tv)) in versions.iter().enumerate() {

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -344,7 +344,7 @@ impl Builder {
             let tv_prefix = tool_tar_prefix(&mount_point, tv);
             let layer = if let Some(reused) = &tool_reuse[i] {
                 info!(
-                    "oci: reusing {} layer from the destination image (unchanged)",
+                    "oci: reusing {} layer from the cache image (unchanged)",
                     tv.style()
                 );
                 ToolLayer::Reused(reused.clone())

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -731,6 +731,91 @@ fn parse_single_manifest(body: serde_json::Value) -> Result<ImageManifest> {
     Ok(manifest)
 }
 
+/// A remote image's manifest paired with its config's `rootfs.diff_ids`
+/// (index-aligned with `manifest.layers`). Used as the layer-reuse cache for
+/// `mise oci push`.
+#[derive(Debug, Clone)]
+pub struct RemoteImage {
+    pub manifest: ImageManifest,
+    pub diff_ids: Vec<String>,
+}
+
+/// Fetch the manifest + config diff_ids of `reference` for layer reuse.
+///
+/// Returns `Ok(None)` when the reference doesn't exist yet (the first push)
+/// or points at an image index rather than a single manifest. Other errors
+/// propagate — the caller treats them as a cache miss with a warning, since
+/// a broken cache lookup should never fail a push.
+pub async fn fetch_remote_image(reference: &str) -> Result<Option<RemoteImage>> {
+    let r = Reference::parse(reference)?;
+    let base_url = r.registry_url();
+    let mut session = AuthSession::new(r.clone(), "pull").await?;
+
+    let manifest_url = format!("{base_url}/v2/{}/manifests/{}", r.repository, r.tag);
+    let accept = [MEDIA_TYPE_OCI_MANIFEST, MEDIA_TYPE_DOCKER_MANIFEST];
+    let resp = session
+        .send(|auth| {
+            let mut rb = HTTP
+                .reqwest()
+                .get(&manifest_url)
+                .header("Accept", accept.join(", "));
+            if let Some(a) = auth {
+                rb = rb.header("Authorization", a);
+            }
+            rb
+        })
+        .await
+        .wrap_err_with(|| format!("fetching {manifest_url}"))?;
+    match resp.status() {
+        StatusCode::OK => {}
+        // No previous image under this ref (404), or the ref exists but the
+        // registry won't serve it as a single manifest with our Accept
+        // headers — both are just "no cache".
+        StatusCode::NOT_FOUND => return Ok(None),
+        // An auth failure here (private repo we can't read) is also a cache
+        // miss rather than a push-stopping error.
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => return Ok(None),
+        s => bail!("fetching {manifest_url} failed: {}", s.as_u16()),
+    }
+    let body: serde_json::Value = resp.json().await?;
+    // An index (multi-arch) can't be used as a single-image cache.
+    if body.get("manifests").map(|m| m.is_array()).unwrap_or(false) {
+        return Ok(None);
+    }
+    let manifest: ImageManifest = match serde_json::from_value(body) {
+        Ok(m) => m,
+        Err(_) => return Ok(None),
+    };
+
+    // Same guards as pull_base_image: digests become path/URL components.
+    crate::oci::layout::validate_sha256_digest(&manifest.config.digest)?;
+    for layer in &manifest.layers {
+        crate::oci::layout::validate_sha256_digest(&layer.digest)?;
+    }
+
+    let config_url = format!(
+        "{base_url}/v2/{}/blobs/{}",
+        r.repository, manifest.config.digest
+    );
+    let config_bytes = download_blob(&mut session, &config_url, None).await?;
+    let config: serde_json::Value = serde_json::from_slice(&config_bytes)?;
+    let diff_ids: Vec<String> = config
+        .get("rootfs")
+        .and_then(|r| r.get("diff_ids"))
+        .and_then(|d| d.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    if diff_ids.len() != manifest.layers.len() {
+        // Malformed remote image — don't reuse anything from it.
+        return Ok(None);
+    }
+    Ok(Some(RemoteImage { manifest, diff_ids }))
+}
+
 // ---------------------------------------------------------------------------
 // Push
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements discussion #11121 — **stacked on #11141** (base retargets when it merges; only the last commit is new here).

`mise oci push` now fetches the destination ref's manifest (or `--cache-from REF`) and reuses tool layers whose cache key matches, **skipping the tar/gzip build entirely**. Reused tools don't even need to be installed locally — in CI, only tools whose version actually changed get installed and packaged.

Addressing the two caveats from the discussion:
- **Cache-key completeness**: the key is (tool short, version, in-image prefix, file owner). Tool layer descriptors now carry `dev.mise.layer.prefix` and `dev.mise.layer.owner` annotations alongside the existing short/version; images pushed by older mise versions just aren't reusable until pushed once more.
- **Trust model**: `--no-cache` forces a full local rebuild (docker-style escape hatch). Reused descriptors + config diff_ids are taken verbatim from the remote manifest/config.

Design notes:
- Default cache source is the destination ref itself; `--cache-from` supports per-commit-tag CI (`mise oci push --cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`) and is validated to be in the **same repository** — reused blobs are never re-uploaded, so they must already live where we push.
- Cache lookup failures are soft (warn + full rebuild); a broken cache can't fail a push.
- `mise oci build` / `oci run` never reuse — their output layouts must contain every blob.
- Caveat documented: `exec_env` derivation runs against local installs, so an uninstalled reused tool with an exotic backend could contribute incomplete env vars; `--no-cache` with the tool installed is the escape hatch.

## Verification

New e2e `test_oci_push_layer_reuse` (runs in every PR tranche, ~7s) proves the full story against a live registry:
1. first push → no reuse
2. **`mise uninstall jq` → same-tag re-push succeeds**: `1 tool layer(s) reused from previous image`, while `mise oci build` without cache correctly fails
3. `--cache-from` to a new tag → reuse works, jq layer digest identical across tags, `crane validate --remote` passes (blobs really are all present)
4. cross-repo `--cache-from` rejected with a clear error
5. `--no-cache` + uninstalled tool → clear "run mise install" failure
6. reinstall + `--no-cache` → byte-identical image (`0 blob(s) uploaded`)

Unit test covers the reuse-index keying (missing annotations → not reusable; owner mismatch → miss). 1790 unit tests pass; lint clean; CLI docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reused layers trust remote manifest annotations and omit local blobs (same-repo push only); wrong cache or exotic `exec_env` on uninstalled tools could yield incomplete image config until `--no-cache`.
> 
> **Overview**
> **`mise oci push`** can now skip rebuilding tool layers when they match a previously pushed image: same tool, version, in-image prefix, and file owner. Matching layers are taken from the registry manifest (no local tar/gzip, and the tool does not need to be installed). Push output reports how many layers were reused.
> 
> New flags: **`--cache-from REF`** (reuse from another tag in the **same repository**, e.g. `latest` → per-commit SHA), **`--no-cache`** (force full local rebuild). Cache lookup defaults to the destination ref; failures are treated as a miss with a warning so pushes still succeed. **`--cache-from`** across repos is rejected because reused blobs are not re-uploaded.
> 
> The builder adds layer annotations **`dev.mise.layer.prefix`** and **`dev.mise.layer.owner`** for the cache key; **`oci build`** and **`oci run`** always set `reuse_from: None` so on-disk layouts stay complete. Docs, usage KDL, man page, unit test for reuse indexing, and e2e **`test_oci_push_layer_reuse`** cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8df93378b13f3e8e7373e9cfcf28ad4cd00590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `mise oci push` with tool-layer reuse caching, reusing unchanged tool layers from the previously pushed image or from `--cache-from`.
  * Added `--no-cache` to force a full local rebuild.
  * Push output now reports how many tool layers were reused.

* **Documentation**
  * Updated `mise oci push` docs (including the man page) with clearer layer reuse rules, `--cache-from`/`--no-cache` behavior, and reuse caveats.

* **Tests**
  * Added an end-to-end test validating layer reuse, `--cache-from` behavior, and `--no-cache` rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->