### PR TITLE
registry: disable cargo-release test

### DIFF
--- a/registry/cargo-release.toml
+++ b/registry/cargo-release.toml
@@ -1,3 +1,4 @@
 backends = ["github:crate-ci/cargo-release"]
 description = "Cargo subcommand for releasing crates"
-test = { cmd = "cargo release --version", expected = "cargo-release {{version}}" }
+# Temporarily disabled because the GitHub "latest" release has no Linux asset.
+# test = { cmd = "cargo release --version", expected = "cargo-release {{version}}" }


### PR DESCRIPTION
## Summary

- comment out the `cargo-release` registry test
- document that the test is disabled because GitHub's current latest release has no Linux asset

## Root cause

The GitHub backend resolves `crate-ci/cargo-release` to the release GitHub currently marks as latest (`v1.1.0`). That release only provides macOS and Windows assets, so registry CI fails on Linux with `No matching asset found for platform linux-x64` even after retrying.

This keeps the existing registry mapping available while preventing the unrelated upstream packaging issue from failing all-registry test runs.

## Popularity

- GitHub: 1,578 stars and 135 forks
- Active maintenance: last repository push 2026-07-16

## Validation

- `mise run lint-fix`
- full pre-commit `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry metadata-only change with no runtime or install-path behavior changes beyond skipping one CI test.
> 
> **Overview**
> **Disables the `cargo-release` registry smoke test** so all-registry CI no longer fails on Linux when the GitHub backend resolves `crate-ci/cargo-release` to a “latest” release that ships only macOS/Windows assets.
> 
> The `test` block in `registry/cargo-release.toml` is commented out and a short note explains the upstream packaging gap; the tool mapping and description are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54dd69a5ac18ff2efef1bcdd04bac86a8da9c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled a release verification check because the latest GitHub release does not include a Linux asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->