### PR TITLE
feat(oci): multi-arch image index support (--update-index)

### DIFF
--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -70,6 +70,12 @@ UID[:GID] to assign to every tar entry when building (conflicts with --image-dir
 
 Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
 
+### `--update-index`
+
+Maintain the tag as a multi-arch image index
+
+Pushes this build's manifest by digest and points the tag at an OCI image index containing one entry per platform, preserving entries other architectures pushed. Run `mise oci push --update-index` from one runner per platform to assemble a multi-arch tag.
+
 Examples:
 
 ```

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -414,6 +414,33 @@ For a working image, run `mise oci build` on a linux host (or inside a
 linux container — `docker run -v $PWD:/src -w /src debian mise oci build`
 works). mise prints a warning when this mismatch is detected.
 
+### Multi-arch images
+
+A single host builds a single platform, but `mise oci push
+--update-index` lets one runner per architecture assemble a multi-arch
+tag: each push uploads its platform manifest by digest and points the
+tag at an OCI **image index** that preserves the entries other
+platforms pushed.
+
+```yaml
+# CI sketch: one job per arch, same tag
+jobs:
+  push-amd64: # runs-on: ubuntu-24.04
+    run: mise oci push --update-index ghcr.io/me/dev:latest
+  push-arm64: # runs-on: ubuntu-24.04-arm
+    needs: push-amd64 # sequence to avoid a read-modify-write race
+    run: mise oci push --update-index ghcr.io/me/dev:latest
+```
+
+Re-pushing the same platform replaces its entry (no duplicates), and a
+previously single-arch tag is upgraded to an index without losing the
+existing platform. Layer reuse works through indexes — the cache
+resolves to the entry matching the build platform.
+
+Note the index update is read-modify-write (the Distribution API has no
+conditional writes), so concurrent pushes to the same tag from
+different runners can race — sequence them as above.
+
 ## Known limitations (v1)
 
 - `asdf` / `vfox` backends are rejected (see above).

--- a/e2e/oci/test_oci_push_update_index
+++ b/e2e/oci/test_oci_push_update_index
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Tests `mise oci push --update-index`: the tag becomes an OCI image index
+# with one entry per platform. A single host can only build one platform, so
+# this covers: creating the index, idempotent re-push (same platform upserts
+# rather than duplicates), and upgrading a previously single-arch tag.
+
+export MISE_EXPERIMENTAL=1
+export SOURCE_DATE_EPOCH=1700000000
+
+mise install crane@latest >/dev/null 2>&1
+
+find_available_port() {
+  python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1]); s.close()"
+}
+
+REGISTRY_PID=""
+cleanup() {
+  if [[ -n ${REGISTRY_PID:-} ]]; then
+    kill "$REGISTRY_PID" 2>/dev/null || true
+    wait "$REGISTRY_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+PORT="$(find_available_port)"
+REGISTRY="127.0.0.1:$PORT"
+mise x crane@latest -- crane registry serve --address "$REGISTRY" >/dev/null 2>&1 &
+REGISTRY_PID=$!
+for _ in $(seq 1 50); do
+  if curl -fsS "http://$REGISTRY/v2/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+assert_succeed "curl -fsS http://$REGISTRY/v2/"
+
+cat >mise.toml <<EOF
+[tools]
+jq = "1.8.1"
+EOF
+mise install >/dev/null 2>&1
+
+host_arch="$(uname -m)"
+case "$host_arch" in
+  x86_64) host_arch=amd64 ;;
+  aarch64) host_arch=arm64 ;;
+esac
+
+# --- 1. --update-index on a fresh tag creates an index with one entry ---
+assert_contains "mise oci push --update-index --from scratch --no-mise $REGISTRY/e2e/devenv:latest" \
+  "updated image index: sha256:"
+manifest="$(mise x crane@latest -- crane manifest --insecure "$REGISTRY/e2e/devenv:latest")"
+assert_contains "echo '$manifest'" '"application/vnd.oci.image.index.v1+json"'
+assert "echo '$manifest' | jq '.manifests | length'" "1"
+assert "echo '$manifest' | jq -r '.manifests[0].platform.architecture'" "$host_arch"
+assert "echo '$manifest' | jq -r '.manifests[0].platform.os'" "linux"
+
+# crane resolves the index to the platform manifest and validates it.
+assert_succeed "mise x crane@latest -- crane validate --insecure --remote $REGISTRY/e2e/devenv:latest"
+
+# --- 2. Re-push upserts (still exactly one entry, identical index) ---
+index_digest_1="$(mise x crane@latest -- crane digest --insecure "$REGISTRY/e2e/devenv:latest")"
+assert_contains "mise oci push --update-index --from scratch --no-mise $REGISTRY/e2e/devenv:latest" \
+  "updated image index: $index_digest_1"
+assert "mise x crane@latest -- crane manifest --insecure $REGISTRY/e2e/devenv:latest | jq '.manifests | length'" "1"
+
+# --- 3. Layer reuse still works through the index (the cache descends
+# into this platform's entry) ---
+mise uninstall jq >/dev/null 2>&1
+assert_contains "mise oci push --update-index --from scratch --no-mise $REGISTRY/e2e/devenv:latest" \
+  "1 tool layer(s) reused from previous image"
+mise install >/dev/null 2>&1
+
+# --- 4. A previously single-arch tag upgrades to an index without losing
+# the existing platform entry ---
+assert_contains "mise oci push --from scratch --no-mise $REGISTRY/e2e/devenv:single" "pushed sha256:"
+assert_contains "mise oci push --update-index --from scratch --no-mise $REGISTRY/e2e/devenv:single" \
+  "updated image index: sha256:"
+single="$(mise x crane@latest -- crane manifest --insecure "$REGISTRY/e2e/devenv:single")"
+assert_contains "echo '$single'" '"application/vnd.oci.image.index.v1+json"'
+# Same platform, so the wrapped old entry and the new push collapse to one.
+assert "echo '$single' | jq '.manifests | length'" "1"
+assert_succeed "mise x crane@latest -- crane validate --insecure --remote $REGISTRY/e2e/devenv:single"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2479,6 +2479,11 @@ Don't embed the mise binary (ignored with \-\-image\-dir)
 UID[:GID] to assign to every tar entry when building (conflicts with \-\-image\-dir)
 
 Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+.TP
+\fB\-\-update\-index\fR
+Maintain the tag as a multi\-arch image index
+
+Pushes this build's manifest by digest and points the tag at an OCI image index containing one entry per platform, preserving entries other architectures pushed. Run `mise oci push \-\-update\-index` from one runner per platform to assemble a multi\-arch tag.
 \fBArguments:\fR
 .PP
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2313,6 +2313,13 @@ Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it
 """#
             arg "<UID[:GID]>"
         }
+        flag --update-index help="Maintain the tag as a multi-arch image index" {
+            long_help #"""
+Maintain the tag as a multi-arch image index
+
+Pushes this build's manifest by digest and points the tag at an OCI image index containing one entry per platform, preserving entries other architectures pushed. Run `mise oci push --update-index` from one runner per platform to assemble a multi-arch tag.
+"""#
+        }
         arg <REF> help="Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)"
     }
     cmd run help="[experimental] Build an OCI image from the current mise.toml and run a command in it" {

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -75,6 +75,15 @@ pub struct Push {
     /// controls the image USER directive.
     #[clap(long, value_name = "UID[:GID]")]
     owner: Option<LayerOwner>,
+
+    /// Maintain the tag as a multi-arch image index
+    ///
+    /// Pushes this build's manifest by digest and points the tag at an OCI
+    /// image index containing one entry per platform, preserving entries
+    /// other architectures pushed. Run `mise oci push --update-index` from
+    /// one runner per platform to assemble a multi-arch tag.
+    #[clap(long)]
+    update_index: bool,
 }
 
 impl Push {
@@ -121,7 +130,7 @@ impl Push {
                 (out_dir, Some(td))
             };
 
-        let summary = registry::push_image(&image_dir, &self.reference).await?;
+        let summary = registry::push_image(&image_dir, &self.reference, self.update_index).await?;
         let mut extras = String::new();
         if summary.mounted > 0 {
             extras.push_str(&format!(", {} mounted from base repo", summary.mounted));
@@ -138,6 +147,9 @@ impl Push {
             summary.uploaded,
             summary.skipped
         );
+        if let Some(index_digest) = &summary.index_digest {
+            miseprintln!("updated image index: {index_digest}");
+        }
         Ok(())
     }
 

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -1129,7 +1129,7 @@ fn upsert_platform_manifest(mut entries: Vec<Descriptor>, entry: Descriptor) -> 
     entries.push(entry);
     // Deterministic order so re-pushing the same platforms yields the same
     // index bytes (and digest).
-    entries.sort_by(|a, b| key(a).cmp(&key(b)));
+    entries.sort_by_key(key);
     entries
 }
 

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -1066,31 +1066,64 @@ pub async fn push_image(
     })
 }
 
-/// Read the platform (architecture/os/variant) out of the image config blob.
+/// Read the platform out of the image config blob.
 fn platform_from_config(
     layout: &ImageLayout,
     config_digest: &str,
 ) -> Result<crate::oci::manifest::Platform> {
     let config: serde_json::Value = serde_json::from_slice(&layout.read_blob(config_digest)?)?;
-    let get = |k: &str| config.get(k).and_then(|v| v.as_str()).map(String::from);
+    platform_from_config_value(&config)
+}
+
+/// Build an index-entry platform from an image config JSON, normalizing
+/// arch/os to the OCI-spec values (`amd64`/`arm64`, `linux`) so index entries
+/// and the host-comparison in `fetch_remote_image` agree, and preserving
+/// `os.version` / `os.features` (relevant for Windows images) rather than
+/// dropping them.
+fn platform_from_config_value(
+    config: &serde_json::Value,
+) -> Result<crate::oci::manifest::Platform> {
+    let get = |k: &str| config.get(k).and_then(|v| v.as_str());
+    let architecture = crate::oci::normalize_arch(
+        get("architecture").ok_or_else(|| eyre::eyre!("image config has no architecture"))?,
+    )
+    .to_string();
+    let os =
+        crate::oci::normalize_os(get("os").ok_or_else(|| eyre::eyre!("image config has no os"))?)
+            .to_string();
     Ok(crate::oci::manifest::Platform {
-        architecture: get("architecture")
-            .ok_or_else(|| eyre::eyre!("image config has no architecture"))?,
-        os: get("os").ok_or_else(|| eyre::eyre!("image config has no os"))?,
-        os_version: None,
-        os_features: vec![],
-        variant: get("variant"),
+        architecture,
+        os,
+        os_version: get("os.version").map(String::from),
+        os_features: config
+            .get("os.features")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        variant: get("variant").map(String::from),
     })
 }
 
-/// Upsert `entry` into an index's manifest list, replacing any existing
-/// entry for the same platform (architecture + os + variant) and preserving
-/// the rest. Entries without platform info are preserved as-is.
+/// Upsert `entry` into an index's manifest list, replacing any existing entry
+/// for the same platform and preserving the rest. Entries without platform
+/// info are preserved as-is.
 fn upsert_platform_manifest(mut entries: Vec<Descriptor>, entry: Descriptor) -> Vec<Descriptor> {
+    // Full platform identity (incl. os.version) so e.g. two Windows platforms
+    // differing only by os.version don't collide.
+    fn platform_key(p: &crate::oci::manifest::Platform) -> (String, String, String, String) {
+        (
+            p.os.clone(),
+            p.architecture.clone(),
+            p.variant.clone().unwrap_or_default(),
+            p.os_version.clone().unwrap_or_default(),
+        )
+    }
     let same_platform = |d: &Descriptor| match (&d.platform, &entry.platform) {
-        (Some(a), Some(b)) => {
-            a.architecture == b.architecture && a.os == b.os && a.variant == b.variant
-        }
+        (Some(a), Some(b)) => platform_key(a) == platform_key(b),
         _ => false,
     };
     entries.retain(|d| !same_platform(d));
@@ -1098,18 +1131,7 @@ fn upsert_platform_manifest(mut entries: Vec<Descriptor>, entry: Descriptor) -> 
     // Deterministic order so re-pushing the same platforms yields the same
     // index bytes (and digest).
     entries.sort_by(|a, b| {
-        let key = |d: &Descriptor| {
-            d.platform
-                .as_ref()
-                .map(|p| {
-                    (
-                        p.os.clone(),
-                        p.architecture.clone(),
-                        p.variant.clone().unwrap_or_default(),
-                    )
-                })
-                .unwrap_or_default()
-        };
+        let key = |d: &Descriptor| d.platform.as_ref().map(platform_key).unwrap_or_default();
         key(a).cmp(&key(b))
     });
     entries
@@ -1523,15 +1545,7 @@ impl Pusher {
         );
         let config_bytes = download_blob(&mut self.session, &config_url, None).await?;
         let config: serde_json::Value = serde_json::from_slice(&config_bytes)?;
-        let get = |k: &str| config.get(k).and_then(|v| v.as_str()).map(String::from);
-        let platform = crate::oci::manifest::Platform {
-            architecture: get("architecture")
-                .ok_or_else(|| eyre::eyre!("existing image config has no architecture"))?,
-            os: get("os").ok_or_else(|| eyre::eyre!("existing image config has no os"))?,
-            os_version: None,
-            os_features: vec![],
-            variant: get("variant"),
-        };
+        let platform = platform_from_config_value(&config)?;
         Ok(Descriptor {
             media_type,
             size: bytes.len() as u64,
@@ -1740,6 +1754,29 @@ mod tests {
         assert!(digests.contains(&"sha256:new-amd64"));
         assert!(digests.contains(&"sha256:arm64"));
         assert!(!digests.contains(&"sha256:old-amd64"));
+    }
+
+    #[test]
+    fn upsert_distinguishes_platforms_by_os_version() {
+        // Two windows entries differing only by os.version must not collide.
+        let win = |ver: &str, digest: &str| Descriptor {
+            media_type: MEDIA_TYPE_OCI_MANIFEST.to_string(),
+            size: 1,
+            digest: digest.to_string(),
+            annotations: Default::default(),
+            platform: Some(crate::oci::manifest::Platform {
+                architecture: "amd64".to_string(),
+                os: "windows".to_string(),
+                os_version: Some(ver.to_string()),
+                os_features: vec![],
+                variant: None,
+            }),
+        };
+        let out = upsert_platform_manifest(
+            vec![win("10.0.20348", "sha256:2022")],
+            win("10.0.17763", "sha256:2019"),
+        );
+        assert_eq!(out.len(), 2);
     }
 
     #[test]

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -777,10 +777,37 @@ pub async fn fetch_remote_image(reference: &str) -> Result<Option<RemoteImage>> 
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => return Ok(None),
         s => bail!("fetching {manifest_url} failed: {}", s.as_u16()),
     }
-    let body: serde_json::Value = resp.json().await?;
-    // An index (multi-arch) can't be used as a single-image cache.
+    let mut body: serde_json::Value = resp.json().await?;
+    // An index (multi-arch, e.g. a tag maintained with --update-index):
+    // descend into the entry for the build platform so its layers remain
+    // reusable.
     if body.get("manifests").map(|m| m.is_array()).unwrap_or(false) {
-        return Ok(None);
+        let arch = crate::oci::normalize_arch(std::env::consts::ARCH);
+        let os = crate::oci::normalize_os(std::env::consts::OS);
+        let digest = body
+            .get("manifests")
+            .and_then(|m| m.as_array())
+            .and_then(|entries| {
+                entries.iter().find(|e| {
+                    let p = e.get("platform");
+                    let get = |k: &str| {
+                        p.and_then(|p| p.get(k))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                    };
+                    get("architecture") == arch && get("os") == os
+                })
+            })
+            .and_then(|e| e.get("digest"))
+            .and_then(|d| d.as_str())
+            .map(String::from);
+        let Some(digest) = digest else {
+            return Ok(None); // no entry for this platform — nothing to reuse
+        };
+        crate::oci::layout::validate_sha256_digest(&digest)?;
+        let child_url = format!("{base_url}/v2/{}/manifests/{digest}", r.repository);
+        let (child, _ct) = fetch_manifest_json(&mut session, &child_url, &accept).await?;
+        body = child;
     }
     let manifest: ImageManifest = match serde_json::from_value(body) {
         Ok(m) => m,
@@ -827,6 +854,8 @@ pub struct PushSummary {
     pub skipped: usize,
     /// Blobs satisfied by cross-repository mount (no bytes transferred).
     pub mounted: usize,
+    /// Digest of the image index the tag now points at (`--update-index`).
+    pub index_digest: Option<String>,
 }
 
 /// Blobs above this size upload in chunks (`PATCH` per chunk) instead of a
@@ -846,7 +875,17 @@ pub const ANNOTATION_BASE_NAME: &str = "org.opencontainers.image.base.name";
 /// blob), then PUTs the manifest under the reference's tag (or digest).
 /// Base-image blobs hosted on the same registry are cross-repo mounted
 /// instead of re-uploaded when possible.
-pub async fn push_image(image_dir: &Path, reference: &str) -> Result<PushSummary> {
+///
+/// With `update_index`, the manifest is pushed by digest and the tag is
+/// updated to an OCI image index that carries one entry per platform —
+/// the existing index's other-platform entries are preserved, so runners
+/// of different architectures can each push the same tag and end up with
+/// a multi-arch image.
+pub async fn push_image(
+    image_dir: &Path,
+    reference: &str,
+    update_index: bool,
+) -> Result<PushSummary> {
     eyre::ensure!(
         !crate::config::Settings::get().offline(),
         "offline mode is enabled"
@@ -974,17 +1013,94 @@ pub async fn push_image(image_dir: &Path, reference: &str) -> Result<PushSummary
         }
     }
 
-    pusher
-        .put_manifest(&r.tag, &manifest_desc.media_type, &manifest_bytes)
-        .await
-        .wrap_err_with(|| format!("pushing manifest to {reference}"))?;
+    let index_digest = if update_index {
+        // Push the platform manifest by digest, then point the tag at an
+        // index that includes it alongside any other platforms already there.
+        pusher
+            .put_manifest(
+                &manifest_desc.digest,
+                &manifest_desc.media_type,
+                &manifest_bytes,
+            )
+            .await
+            .wrap_err_with(|| format!("pushing manifest to {reference}"))?;
+        let platform = platform_from_config(&layout, &manifest.config.digest)?;
+        let entry = Descriptor {
+            media_type: manifest_desc.media_type.clone(),
+            size: manifest_bytes.len() as u64,
+            digest: manifest_desc.digest.clone(),
+            annotations: Default::default(),
+            platform: Some(platform),
+        };
+        let digest = pusher
+            .update_tag_index(&r.tag, entry)
+            .await
+            .wrap_err_with(|| format!("updating image index for {reference}"))?;
+        Some(digest)
+    } else {
+        pusher
+            .put_manifest(&r.tag, &manifest_desc.media_type, &manifest_bytes)
+            .await
+            .wrap_err_with(|| format!("pushing manifest to {reference}"))?;
+        None
+    };
 
     Ok(PushSummary {
         manifest_digest: manifest_desc.digest.clone(),
         uploaded,
         skipped,
         mounted,
+        index_digest,
     })
+}
+
+/// Read the platform (architecture/os/variant) out of the image config blob.
+fn platform_from_config(
+    layout: &ImageLayout,
+    config_digest: &str,
+) -> Result<crate::oci::manifest::Platform> {
+    let config: serde_json::Value = serde_json::from_slice(&layout.read_blob(config_digest)?)?;
+    let get = |k: &str| config.get(k).and_then(|v| v.as_str()).map(String::from);
+    Ok(crate::oci::manifest::Platform {
+        architecture: get("architecture")
+            .ok_or_else(|| eyre::eyre!("image config has no architecture"))?,
+        os: get("os").ok_or_else(|| eyre::eyre!("image config has no os"))?,
+        os_version: None,
+        os_features: vec![],
+        variant: get("variant"),
+    })
+}
+
+/// Upsert `entry` into an index's manifest list, replacing any existing
+/// entry for the same platform (architecture + os + variant) and preserving
+/// the rest. Entries without platform info are preserved as-is.
+fn upsert_platform_manifest(mut entries: Vec<Descriptor>, entry: Descriptor) -> Vec<Descriptor> {
+    let same_platform = |d: &Descriptor| match (&d.platform, &entry.platform) {
+        (Some(a), Some(b)) => {
+            a.architecture == b.architecture && a.os == b.os && a.variant == b.variant
+        }
+        _ => false,
+    };
+    entries.retain(|d| !same_platform(d));
+    entries.push(entry);
+    // Deterministic order so re-pushing the same platforms yields the same
+    // index bytes (and digest).
+    entries.sort_by(|a, b| {
+        let key = |d: &Descriptor| {
+            d.platform
+                .as_ref()
+                .map(|p| {
+                    (
+                        p.os.clone(),
+                        p.architecture.clone(),
+                        p.variant.clone().unwrap_or_default(),
+                    )
+                })
+                .unwrap_or_default()
+        };
+        key(a).cmp(&key(b))
+    });
+    entries
 }
 
 /// Progress label for a blob: the tool name when the descriptor carries the
@@ -1273,6 +1389,145 @@ impl Pusher {
         }
         Ok(())
     }
+
+    /// Point `tag` at an OCI image index containing `entry` plus whatever
+    /// other-platform entries the tag already carries. Returns the digest of
+    /// the pushed index.
+    ///
+    /// NOTE: read-modify-write without registry-side concurrency control (the
+    /// Distribution spec has no conditional manifest PUT), so two runners
+    /// updating the same tag at the same instant can race — sequence
+    /// per-platform pushes in CI when that matters.
+    async fn update_tag_index(&mut self, tag: &str, entry: Descriptor) -> Result<String> {
+        let existing = self.existing_index_entries(tag).await?;
+        let manifests = upsert_platform_manifest(existing, entry);
+        let index = ImageIndex {
+            schema_version: 2,
+            media_type: MEDIA_TYPE_OCI_INDEX.to_string(),
+            manifests,
+        };
+        let bytes = serde_json::to_vec(&index)?;
+        let digest = {
+            use sha2::{Digest, Sha256};
+            let mut h = Sha256::new();
+            h.update(&bytes);
+            format!("sha256:{}", crate::oci::layer::hex_encode(&h.finalize()))
+        };
+        self.put_manifest(tag, MEDIA_TYPE_OCI_INDEX, &bytes).await?;
+        Ok(digest)
+    }
+
+    /// The entries the tag's current image index carries, for merging.
+    ///
+    ///  - tag doesn't exist → empty
+    ///  - tag is an index / manifest list → its entries
+    ///  - tag is a single-platform manifest → one entry wrapping it (platform
+    ///    read from its config), so `--update-index` can upgrade a
+    ///    previously single-arch tag without dropping that platform. If the
+    ///    wrap fails, the entry is dropped with a warning rather than
+    ///    failing the push.
+    async fn existing_index_entries(&mut self, tag: &str) -> Result<Vec<Descriptor>> {
+        let url = format!("{}/v2/{}/manifests/{tag}", self.base_url, self.repository);
+        let accept = [
+            MEDIA_TYPE_OCI_INDEX,
+            MEDIA_TYPE_DOCKER_MANIFEST_LIST,
+            MEDIA_TYPE_OCI_MANIFEST,
+            MEDIA_TYPE_DOCKER_MANIFEST,
+        ]
+        .join(", ");
+        let resp = self
+            .session
+            .send(|auth| {
+                let mut rb = HTTP.reqwest().get(&url).header("Accept", &accept);
+                if let Some(a) = auth {
+                    rb = rb.header("Authorization", a);
+                }
+                rb
+            })
+            .await
+            .wrap_err_with(|| format!("GET {url}"))?;
+        match resp.status() {
+            StatusCode::OK => {}
+            StatusCode::NOT_FOUND => return Ok(vec![]),
+            s => bail!("fetching current index for {url} failed: {}", s.as_u16()),
+        }
+        let content_type = header_str(&resp, "content-type");
+        let bytes = resp.bytes().await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+        // Already an index — take its entries.
+        if body.get("manifests").map(|m| m.is_array()).unwrap_or(false) {
+            let index: ImageIndex =
+                serde_json::from_slice(&bytes).wrap_err("parsing existing image index")?;
+            return Ok(index.manifests);
+        }
+
+        // A single-platform manifest: wrap it as an index entry so its
+        // platform survives the upgrade to an index.
+        match self
+            .wrap_single_manifest(&bytes, &body, &content_type)
+            .await
+        {
+            Ok(entry) => Ok(vec![entry]),
+            Err(e) => {
+                warn!(
+                    "could not preserve the existing single-platform manifest at {tag} \
+                     in the new index: {e}"
+                );
+                Ok(vec![])
+            }
+        }
+    }
+
+    /// Build an index entry for a single-platform manifest the tag currently
+    /// points at, reading its platform from its config blob.
+    async fn wrap_single_manifest(
+        &mut self,
+        bytes: &[u8],
+        body: &serde_json::Value,
+        content_type: &str,
+    ) -> Result<Descriptor> {
+        let digest = {
+            use sha2::{Digest, Sha256};
+            let mut h = Sha256::new();
+            h.update(bytes);
+            format!("sha256:{}", crate::oci::layer::hex_encode(&h.finalize()))
+        };
+        let media_type = body
+            .get("mediaType")
+            .and_then(|m| m.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| content_type.to_string());
+        let config_digest = body
+            .get("config")
+            .and_then(|c| c.get("digest"))
+            .and_then(|d| d.as_str())
+            .ok_or_else(|| eyre::eyre!("manifest has no config digest"))?
+            .to_string();
+        crate::oci::layout::validate_sha256_digest(&config_digest)?;
+        let config_url = format!(
+            "{}/v2/{}/blobs/{config_digest}",
+            self.base_url, self.repository
+        );
+        let config_bytes = download_blob(&mut self.session, &config_url, None).await?;
+        let config: serde_json::Value = serde_json::from_slice(&config_bytes)?;
+        let get = |k: &str| config.get(k).and_then(|v| v.as_str()).map(String::from);
+        let platform = crate::oci::manifest::Platform {
+            architecture: get("architecture")
+                .ok_or_else(|| eyre::eyre!("existing image config has no architecture"))?,
+            os: get("os").ok_or_else(|| eyre::eyre!("existing image config has no os"))?,
+            os_version: None,
+            os_features: vec![],
+            variant: get("variant"),
+        };
+        Ok(Descriptor {
+            media_type,
+            size: bytes.len() as u64,
+            digest,
+            annotations: Default::default(),
+            platform: Some(platform),
+        })
+    }
 }
 
 /// Slot for an I/O error raised inside an upload-body closure so the caller
@@ -1440,6 +1695,53 @@ mod tests {
                 .registry_url(),
             "https://ghcr.io"
         );
+    }
+
+    fn platform_entry(arch: &str, os: &str, digest: &str) -> Descriptor {
+        Descriptor {
+            media_type: MEDIA_TYPE_OCI_MANIFEST.to_string(),
+            size: 1,
+            digest: digest.to_string(),
+            annotations: Default::default(),
+            platform: Some(crate::oci::manifest::Platform {
+                architecture: arch.to_string(),
+                os: os.to_string(),
+                os_version: None,
+                os_features: vec![],
+                variant: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn upsert_replaces_same_platform_and_preserves_others() {
+        let existing = vec![
+            platform_entry("amd64", "linux", "sha256:old-amd64"),
+            platform_entry("arm64", "linux", "sha256:arm64"),
+        ];
+        let out = upsert_platform_manifest(
+            existing,
+            platform_entry("amd64", "linux", "sha256:new-amd64"),
+        );
+        assert_eq!(out.len(), 2);
+        let digests: Vec<&str> = out.iter().map(|d| d.digest.as_str()).collect();
+        assert!(digests.contains(&"sha256:new-amd64"));
+        assert!(digests.contains(&"sha256:arm64"));
+        assert!(!digests.contains(&"sha256:old-amd64"));
+    }
+
+    #[test]
+    fn upsert_is_deterministically_ordered() {
+        let a = upsert_platform_manifest(
+            vec![platform_entry("arm64", "linux", "sha256:a")],
+            platform_entry("amd64", "linux", "sha256:b"),
+        );
+        let b = upsert_platform_manifest(
+            vec![platform_entry("amd64", "linux", "sha256:b")],
+            platform_entry("arm64", "linux", "sha256:a"),
+        );
+        let order = |v: &[Descriptor]| v.iter().map(|d| d.digest.clone()).collect::<Vec<_>>();
+        assert_eq!(order(&a), order(&b));
     }
 
     #[test]

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -1184,6 +1184,14 @@ fn blob_label(desc: &Descriptor) -> String {
         .unwrap_or_else(|| short_digest(&desc.digest).to_string())
 }
 
+/// `sha256:<hex>` digest of `bytes`.
+fn sha256_digest(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    format!("sha256:{}", crate::oci::layer::hex_encode(&h.finalize()))
+}
+
 /// First 12 hex chars of a `sha256:…` digest, for display.
 fn short_digest(digest: &str) -> &str {
     let hex = digest.trim_start_matches("sha256:");
@@ -1479,12 +1487,7 @@ impl Pusher {
             manifests,
         };
         let bytes = serde_json::to_vec(&index)?;
-        let digest = {
-            use sha2::{Digest, Sha256};
-            let mut h = Sha256::new();
-            h.update(&bytes);
-            format!("sha256:{}", crate::oci::layer::hex_encode(&h.finalize()))
-        };
+        let digest = sha256_digest(&bytes);
         self.put_manifest(tag, MEDIA_TYPE_OCI_INDEX, &bytes).await?;
         Ok(digest)
     }
@@ -1559,12 +1562,7 @@ impl Pusher {
         body: &serde_json::Value,
         content_type: &str,
     ) -> Result<Descriptor> {
-        let digest = {
-            use sha2::{Digest, Sha256};
-            let mut h = Sha256::new();
-            h.update(bytes);
-            format!("sha256:{}", crate::oci::layer::hex_encode(&h.finalize()))
-        };
+        let digest = sha256_digest(bytes);
         let media_type = body
             .get("mediaType")
             .and_then(|m| m.as_str())

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -752,13 +752,25 @@ pub async fn fetch_remote_image(reference: &str) -> Result<Option<RemoteImage>> 
     let mut session = AuthSession::new(r.clone(), "pull").await?;
 
     let manifest_url = format!("{base_url}/v2/{}/manifests/{}", r.repository, r.tag);
-    let accept = [MEDIA_TYPE_OCI_MANIFEST, MEDIA_TYPE_DOCKER_MANIFEST];
+    // Accept indexes too: a tag maintained with `--update-index` is an image
+    // index, and strict registries (GHCR) return 404/"manifest unknown"
+    // unless the index media types are in the Accept header — which would
+    // otherwise make the index-descent below unreachable there.
+    let index_accept = [
+        MEDIA_TYPE_OCI_INDEX,
+        MEDIA_TYPE_DOCKER_MANIFEST_LIST,
+        MEDIA_TYPE_OCI_MANIFEST,
+        MEDIA_TYPE_DOCKER_MANIFEST,
+    ];
+    // Descending into an index entry resolves a single-platform child, so the
+    // child fetch only needs the manifest types.
+    let manifest_accept = [MEDIA_TYPE_OCI_MANIFEST, MEDIA_TYPE_DOCKER_MANIFEST];
     let resp = session
         .send(|auth| {
             let mut rb = HTTP
                 .reqwest()
                 .get(&manifest_url)
-                .header("Accept", accept.join(", "));
+                .header("Accept", index_accept.join(", "));
             if let Some(a) = auth {
                 rb = rb.header("Authorization", a);
             }
@@ -806,7 +818,7 @@ pub async fn fetch_remote_image(reference: &str) -> Result<Option<RemoteImage>> 
         };
         crate::oci::layout::validate_sha256_digest(&digest)?;
         let child_url = format!("{base_url}/v2/{}/manifests/{digest}", r.repository);
-        let (child, _ct) = fetch_manifest_json(&mut session, &child_url, &accept).await?;
+        let (child, _ct) = fetch_manifest_json(&mut session, &child_url, &manifest_accept).await?;
         body = child;
     }
     let manifest: ImageManifest = match serde_json::from_value(body) {

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -794,20 +794,26 @@ pub async fn fetch_remote_image(reference: &str) -> Result<Option<RemoteImage>> 
     // descend into the entry for the build platform so its layers remain
     // reusable.
     if body.get("manifests").map(|m| m.is_array()).unwrap_or(false) {
-        let arch = crate::oci::normalize_arch(std::env::consts::ARCH);
-        let os = crate::oci::normalize_os(std::env::consts::OS);
+        // Match the same canonical identity `upsert_platform_manifest` uses,
+        // so descent and upsert agree on which entry represents this host's
+        // platform (arch/os normalized, arm64 variant filled). The host has
+        // no variant / os.version.
+        let host =
+            platform_identity_parts(std::env::consts::ARCH, std::env::consts::OS, None, None);
         let digest = body
             .get("manifests")
             .and_then(|m| m.as_array())
             .and_then(|entries| {
                 entries.iter().find(|e| {
                     let p = e.get("platform");
-                    let get = |k: &str| {
-                        p.and_then(|p| p.get(k))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                    };
-                    get("architecture") == arch && get("os") == os
+                    let get = |k: &str| p.and_then(|p| p.get(k)).and_then(|v| v.as_str());
+                    let ident = platform_identity_parts(
+                        get("architecture").unwrap_or(""),
+                        get("os").unwrap_or(""),
+                        get("variant"),
+                        get("os.version"),
+                    );
+                    ident == host
                 })
             })
             .and_then(|e| e.get("digest"))
@@ -1112,29 +1118,61 @@ fn platform_from_config_value(
 /// for the same platform and preserving the rest. Entries without platform
 /// info are preserved as-is.
 fn upsert_platform_manifest(mut entries: Vec<Descriptor>, entry: Descriptor) -> Vec<Descriptor> {
-    // Full platform identity (incl. os.version) so e.g. two Windows platforms
-    // differing only by os.version don't collide.
-    fn platform_key(p: &crate::oci::manifest::Platform) -> (String, String, String, String) {
-        (
-            p.os.clone(),
-            p.architecture.clone(),
-            p.variant.clone().unwrap_or_default(),
-            p.os_version.clone().unwrap_or_default(),
-        )
-    }
-    let same_platform = |d: &Descriptor| match (&d.platform, &entry.platform) {
-        (Some(a), Some(b)) => platform_key(a) == platform_key(b),
-        _ => false,
+    let key = |d: &Descriptor| {
+        d.platform
+            .as_ref()
+            .map(platform_identity)
+            .unwrap_or_default()
     };
-    entries.retain(|d| !same_platform(d));
+    let entry_key = key(&entry);
+    entries.retain(|d| key(d) != entry_key);
     entries.push(entry);
     // Deterministic order so re-pushing the same platforms yields the same
     // index bytes (and digest).
-    entries.sort_by(|a, b| {
-        let key = |d: &Descriptor| d.platform.as_ref().map(platform_key).unwrap_or_default();
-        key(a).cmp(&key(b))
-    });
+    entries.sort_by(|a, b| key(a).cmp(&key(b)));
     entries
+}
+
+/// Canonical identity used to match/dedupe platforms across index entries,
+/// consistent between `upsert_platform_manifest` and the index-descent in
+/// [`fetch_remote_image`]. Normalizes arch/os to OCI-spec values and fills the
+/// implied CPU variant (`arm64` → `v8`) so entries written by different tools
+/// compare equal — mise writes no variant, buildx writes `arm64/v8`, and both
+/// name the same platform. `os.version` stays in the identity so
+/// otherwise-identical Windows platforms don't collide.
+///
+/// Returned as `(os, architecture, variant, os_version)` so the derived
+/// ordering groups by OS then arch.
+fn platform_identity(p: &crate::oci::manifest::Platform) -> (String, String, String, String) {
+    platform_identity_parts(
+        &p.architecture,
+        &p.os,
+        p.variant.as_deref(),
+        p.os_version.as_deref(),
+    )
+}
+
+fn platform_identity_parts(
+    architecture: &str,
+    os: &str,
+    variant: Option<&str>,
+    os_version: Option<&str>,
+) -> (String, String, String, String) {
+    let arch = crate::oci::normalize_arch(architecture);
+    let os = crate::oci::normalize_os(os);
+    let variant = match (arch, variant) {
+        // arm64's canonical variant is v8; a missing/empty variant means the
+        // same platform (containerd's normalization).
+        ("arm64", None | Some("") | Some("v8")) => "v8",
+        (_, Some(v)) => v,
+        (_, None) => "",
+    };
+    (
+        os.to_string(),
+        arch.to_string(),
+        variant.to_string(),
+        os_version.unwrap_or("").to_string(),
+    )
 }
 
 /// Progress label for a blob: the tool name when the descriptor carries the
@@ -1777,6 +1815,44 @@ mod tests {
             win("10.0.17763", "sha256:2019"),
         );
         assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn upsert_treats_arm64_no_variant_as_v8() {
+        // mise writes arm64 with no variant; buildx writes arm64/v8. Pushing
+        // the former must replace the latter, not add a duplicate.
+        let with_variant = Descriptor {
+            media_type: MEDIA_TYPE_OCI_MANIFEST.to_string(),
+            size: 1,
+            digest: "sha256:buildx-arm64v8".to_string(),
+            annotations: Default::default(),
+            platform: Some(crate::oci::manifest::Platform {
+                architecture: "arm64".to_string(),
+                os: "linux".to_string(),
+                os_version: None,
+                os_features: vec![],
+                variant: Some("v8".to_string()),
+            }),
+        };
+        let out = upsert_platform_manifest(
+            vec![with_variant],
+            platform_entry("arm64", "linux", "sha256:mise-arm64"),
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].digest, "sha256:mise-arm64");
+    }
+
+    #[test]
+    fn platform_identity_normalizes_arch() {
+        // A config using the Rust-style arch name matches the normalized host.
+        assert_eq!(
+            platform_identity_parts("x86_64", "linux", None, None),
+            platform_identity_parts("amd64", "linux", None, None)
+        );
+        assert_eq!(
+            platform_identity_parts("aarch64", "linux", None, None),
+            platform_identity_parts("arm64", "linux", Some("v8"), None)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #11132 (item 4: multi-arch), **stacked on #11142** (base retargets when it merges; only the last commit is new here).

A single host builds one platform, so single-manifest push couldn't produce a multi-arch image. `mise oci push --update-index` fixes that: it pushes the built platform manifest by digest, then points the tag at an OCI **image index** carrying one entry per platform — preserving entries other architectures pushed. One runner per arch assembles a multi-arch tag.

- **Upsert**: re-pushing the same platform replaces its entry (no duplicates); the manifest list is sorted deterministically so an unchanged platform set yields byte-identical index bytes and digest.
- **Single-arch upgrade**: a tag that was previously a plain manifest is wrapped as an index entry (platform read from its config blob) so that platform survives the upgrade.
- **Reuse composes**: `fetch_remote_image` now descends an index into the build-platform entry, so layer reuse (#11142) keeps working against `--update-index` tags.
- **Race documented**: the index update is read-modify-write (Distribution has no conditional manifest PUT); docs show sequencing per-platform CI jobs to avoid clobbering.

## Verification

New e2e `test_oci_push_update_index` (runs every tranche, ~7s):
1. `--update-index` on a fresh tag → index media type, one entry, correct host platform, `crane validate --remote` passes
2. re-push → still one entry, **identical index digest** (deterministic)
3. reuse-through-index: `uninstall jq` then re-push → `1 tool layer(s) reused`
4. single-arch tag → `--update-index` upgrades it to an index without losing the platform

Unit tests cover upsert replace/preserve and deterministic ordering. All three OCI e2e tests pass together; 1792 unit tests pass; lint clean; docs + CLI reference regenerated.

This is the last of the four follow-ups from #11132 (CI coverage #11140, push robustness #11141, layer reuse #11142, multi-arch here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes registry push and remote cache behavior for tagged refs; index updates are read-modify-write and can race under concurrent pushes, though documented and tested.
> 
> **Overview**
> Adds **`--update-index`** to `mise oci push`: the platform manifest is pushed by digest, then the tag is updated to an OCI **image index** that **upserts** this platform and keeps other architectures’ entries. Re-pushing the same platform replaces rather than duplicates; a plain single-arch tag can be **wrapped** into the index on first use. The CLI prints **`updated image index: sha256:…`** when applicable.
> 
> Registry push logic gains **read-modify-write** index maintenance (`update_tag_index`, platform identity normalization including arm64/v8). **`fetch_remote_image`** now accepts index media types, **descends** into the host platform’s manifest so **layer reuse** still works when the cache tag is an index.
> 
> Docs (CLI, man, usage KDL, mise-oci) describe CI sequencing to avoid index update races. New **e2e** `test_oci_push_update_index` and **unit tests** for upsert/deterministic ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e09866804991928a728c3badb4acc142a34f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--update-index` option to `mise oci push` to keep tags as multi-architecture OCI image indexes by merging per-platform entries while preserving previously published platforms.
  * Re-pushing the same platform updates (upserts) its entry without increasing the index entry count; single-platform tags can be upgraded to multi-arch indexes.
  * Improves cross-platform layer/config reuse through the index.
* **Documentation**
  * Expanded CLI help and added “Multi-arch images” guidance, including recommended per-platform sequencing to avoid update races.
* **Tests**
  * Added an end-to-end test covering index creation, upsert/upgrade behavior, and remote validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->