### PR TITLE
feat(config): add MISE_SAFE mode to block repo-controlled code execution

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -38,6 +38,21 @@ script: |
   ./bin/mise x -- npm test
 ```
 
+## Running against untrusted config (safe mode)
+
+When a job resolves tool versions from configuration it does not control — most commonly a bot
+that refreshes `mise.lock` on pull request branches — set `MISE_SAFE=1` so that project
+configuration cannot execute code. In safe mode mise refuses (with an error, never a silent
+fallback) to run template `exec()`/`read_file()`, `_.source` scripts, hooks, tasks, asdf plugin
+scripts, or plugin installs, while version resolution over HTTP-based backends continues to work.
+
+```yaml
+script: |
+  MISE_SAFE=1 mise lock --bump --json
+```
+
+See [Safe mode](/security.html#safe-mode) for the full list of what is and isn't allowed.
+
 ## GitHub Actions
 
 If you use GitHub Actions, we provide a [mise-action](https://github.com/jdx/mise-action) that wraps the installation of Mise and the tools. All you need to do is to add the action to your workflow:

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -245,6 +245,19 @@ mise lock --bump --dry-run --json
 ]
 ```
 
+::: tip Run bump automation in safe mode
+When the job runs against configuration you don't control — most commonly a bot bumping
+`mise.lock` on pull request branches — set [`MISE_SAFE=1`](/security.html#safe-mode) so the
+project's config cannot execute code. Safe mode refuses template `exec()`, `_.source` scripts,
+hooks, tasks, asdf plugin scripts, and plugin installs, while `--bump` version resolution over
+HTTP-based backends keeps working:
+
+```sh
+MISE_SAFE=1 mise lock --bump --json
+```
+
+:::
+
 ### Pinning a Locked Version
 
 You can pin a specific version in the lockfile while keeping a fuzzy specifier in `mise.toml`:

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -78,6 +78,12 @@ not just when the lockfile is first generated.
 This behavior can also be enabled independently via the
 [`locked_verify_provenance`](/configuration/settings.html#locked_verify_provenance) setting.
 
+## See also
+
+[Safe mode](/security.html#safe-mode) (`MISE_SAFE=1`) is a related but distinct control: where
+paranoid tightens _trust_ (which configs are loaded and re-verified), safe mode is a hard boundary
+on _code execution_ for running mise against configuration you do not control.
+
 ## More?
 
 If you have suggestions for more that could be added to paranoid, please let

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,6 +27,47 @@ export MISE_AQUA_MINISIGN=false
 
 For lockfile checksum and provenance behavior, see [mise.lock](/dev-tools/mise-lock.html).
 
+## Safe mode
+
+Safe mode (`MISE_SAFE=1`, or the [`safe`](/configuration/settings.html#safe) setting) is a hard
+boundary against **project configuration executing code**. It is intended for running mise against
+configuration you do not control — most notably automation that refreshes `mise.lock` on pull
+request branches, such as a scheduled `mise lock --bump` job (see
+[mise.lock](/dev-tools/mise-lock.html)).
+
+```sh
+# resolve tool versions from untrusted config without executing any of it
+MISE_SAFE=1 mise lock --bump --dry-run --json
+```
+
+When enabled, mise **refuses with an error** (never a silent fallback) to:
+
+- run `exec()` or `read_file()` in config templates
+- source shell scripts via the `_.source` env directive
+- run hooks (suppressed like `--no-hooks`, since hooks fire ambiently from `mise env`/`hook-env`)
+- run tasks
+- execute asdf plugin scripts
+- install plugins
+
+Version resolution still works for every HTTP-based backend — `core`, `aqua`, `github`, `gitlab`,
+`http`, `cargo`, `pipx`, `gem`, `dotnet`, and `npm` — as well as `go` (which runs with
+`GOTOOLCHAIN=local` so a project `go.mod` cannot trigger a toolchain download). Refreshing
+`mise.lock` and listing installed tools work normally.
+
+Already-installed and embedded vfox plugins also keep working: their code was chosen by the
+operator, not by the repository being processed, and version resolution short-circuits on
+plugins that are not installed without executing anything.
+
+::: tip
+Safe mode is a code-execution boundary; it does not replace the [trust](/cli/trust.html)
+system. Untrusted configs still require `mise trust` (or a
+[trusted config path](/configuration/settings.html#trusted_config_paths)). Safe mode limits what a
+config can do; trust limits which configs are loaded.
+:::
+
+`MISE_SAFE` is `global_only`, so it can only be set via the environment or global config — a project
+`mise.toml` cannot turn it off for itself.
+
 ## Minimum release age
 
 To limit supply-chain risk, you can restrict mise to only install versions released before a

--- a/docs/security.md
+++ b/docs/security.md
@@ -33,7 +33,7 @@ Safe mode (`MISE_SAFE=1`, or the [`safe`](/configuration/settings.html#safe) set
 boundary against **project configuration executing code**. It is intended for running mise against
 configuration you do not control — most notably automation that refreshes `mise.lock` on pull
 request branches, such as a scheduled `mise lock --bump` job (see
-[mise.lock](/dev-tools/mise-lock.html)).
+[Bumping Locked Versions](/dev-tools/mise-lock.html#bumping-locked-versions)).
 
 ```sh
 # resolve tool versions from untrusted config without executing any of it

--- a/e2e/config/test_safe_mode
+++ b/e2e/config/test_safe_mode
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Test MISE_SAFE=1 (safe mode): a hard boundary against repo-controlled code
+# execution. Config templates using exec()/read_file(), `_.source` directives,
+# hooks, tasks, asdf plugin scripts, and plugin installation are refused with
+# an error. Plain templates, HTTP-backed version resolution, and embedded vfox
+# plugins keep working.
+
+export MISE_LOCKFILE=1
+
+echo "=== template exec() is refused ==="
+cat <<'EOF' >mise.toml
+[env]
+FOO = "{{ exec(command='echo pwned') }}"
+EOF
+assert_fail "MISE_SAFE=1 mise env" "exec() is disabled in safe mode (MISE_SAFE=1)"
+# without safe mode it still works
+assert_contains "mise env" "export FOO=pwned"
+
+echo "=== template read_file() is refused ==="
+echo "secret" >data.txt
+cat <<'EOF' >mise.toml
+[env]
+FOO = "{{ read_file(file='data.txt') }}"
+EOF
+assert_fail "MISE_SAFE=1 mise env" "read_file() is disabled in safe mode (MISE_SAFE=1)"
+
+echo "=== plain templates still render ==="
+cat <<'EOF' >mise.toml
+[env]
+BAR = "{{ config_root }}"
+EOF
+assert_contains "MISE_SAFE=1 mise env" "export BAR="
+
+echo "=== _.source is refused ==="
+echo 'export BAZ=frombash' >env.sh
+cat <<'EOF' >mise.toml
+[env]
+_.source = "env.sh"
+EOF
+assert_fail "MISE_SAFE=1 mise env" "sourcing scripts via"
+
+echo "=== tasks are refused ==="
+cat <<'EOF' >mise.toml
+[tasks.hello]
+run = "echo hello"
+EOF
+assert_fail "MISE_SAFE=1 mise run hello" "running tasks is disabled in safe mode (MISE_SAFE=1)"
+assert_contains "mise run hello" "hello"
+
+echo "=== hooks are skipped ==="
+cat <<'EOF' >mise.toml
+[hooks]
+enter = "echo HOOK_RAN"
+EOF
+assert_not_contains "MISE_SAFE=1 mise hook-env -s bash" "HOOK_RAN"
+
+echo "=== asdf plugin scripts are refused ==="
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "1"
+EOF
+assert_fail "MISE_SAFE=1 mise latest dummy" "executing asdf plugin scripts is disabled in safe mode (MISE_SAFE=1)"
+# without safe mode the same command works
+assert "mise latest dummy@1" "1.1.0"
+
+echo "=== plugin installation is refused ==="
+assert_fail "MISE_SAFE=1 mise plugins install tiny https://github.com/jdx/vfox-tiny" "installing plugins is disabled in safe mode (MISE_SAFE=1)"

--- a/e2e/config/test_safe_mode
+++ b/e2e/config/test_safe_mode
@@ -62,7 +62,7 @@ dummy = "1"
 EOF
 assert_fail "MISE_SAFE=1 mise latest dummy" "executing asdf plugin scripts is disabled in safe mode (MISE_SAFE=1)"
 # without safe mode the same command works
-assert "mise latest dummy@1" "1.1.0"
+assert "mise latest dummy" "2.0.0"
 
 echo "=== plugin installation is refused ==="
 assert_fail "MISE_SAFE=1 mise plugins install tiny https://github.com/jdx/vfox-tiny" "installing plugins is disabled in safe mode (MISE_SAFE=1)"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1597,6 +1597,11 @@
             }
           }
         },
+        "safe": {
+          "default": false,
+          "description": "Prevent project configuration from executing code during config loading and version resolution.",
+          "type": "boolean"
+        },
         "sandbox": {
           "type": "object",
           "unevaluatedProperties": false,

--- a/settings.toml
+++ b/settings.toml
@@ -2316,11 +2316,11 @@ When enabled, mise refuses (with an error, never a silent fallback) to:
 - execute asdf plugin scripts
 - install plugins (already-installed and embedded vfox plugins still work — their
   code was chosen by the operator, not the repository)
-- shell out to `npm` or `go` for version listing (HTTP-based listing still works)
 
-Operations that only need HTTP metadata — resolving versions for core, aqua,
-github, gitlab, http, cargo, pipx, gem, and dotnet backends, refreshing
-`mise.lock`, listing installed tools — work normally.
+Version resolution still works for every HTTP-based backend (core, aqua, github,
+gitlab, http, cargo, pipx, gem, dotnet, npm) as well as `go` (which runs with
+`GOTOOLCHAIN=local` so a project `go.mod` cannot trigger a toolchain download).
+Refreshing `mise.lock` and listing installed tools work normally.
 """
 env = "MISE_SAFE"
 global_only = true

--- a/settings.toml
+++ b/settings.toml
@@ -2298,6 +2298,34 @@ env = "MISE_RUSTUP_HOME"
 optional = true
 type = "Path"
 
+[safe]
+default = false
+description = "Prevent project configuration from executing code during config loading and version resolution."
+docs = """
+Safe mode is a hard boundary against repo-controlled code execution, designed for
+running mise against untrusted project configuration — for example a bot that
+updates `mise.lock` on pull request branches (`mise lock --bump`), or CI jobs that
+resolve tool versions from configs the operator did not author.
+
+When enabled, mise refuses (with an error, never a silent fallback) to:
+
+- run `exec()` or `read_file()` in config templates
+- source shell scripts via the `_.source` env directive
+- run hooks
+- run tasks
+- execute asdf plugin scripts
+- install plugins (already-installed and embedded vfox plugins still work — their
+  code was chosen by the operator, not the repository)
+- shell out to `npm` or `go` for version listing (HTTP-based listing still works)
+
+Operations that only need HTTP metadata — resolving versions for core, aqua,
+github, gitlab, http, cargo, pipx, gem, and dotnet backends, refreshing
+`mise.lock`, listing installed tools — work normally.
+"""
+env = "MISE_SAFE"
+global_only = true
+type = "Bool"
+
 [sandbox.deny_all]
 default = false
 description = "Deny filesystem reads and writes, network access, and environment variable inheritance by default for `mise run` and `mise exec`."

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -123,6 +123,7 @@ impl AsdfBackend {
             //         sm.prepend_path(p);
             //     }
             // }
+            Settings::ensure_not_safe("executing asdf plugin scripts")?;
             let output = sm.cmd(&Script::ListBinPaths).read()?;
             output
                 .split_whitespace()

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -100,6 +100,13 @@ impl Backend for GoBackend {
                 // Fall back to `go list -m -versions` for GOPROXY=direct. Package
                 // paths are not necessarily module paths, so walk their prefixes
                 // just as the proxy resolver does.
+                // Check safe mode here rather than only inside
+                // fetch_go_module_versions: the loop below swallows per-candidate
+                // errors, and a safe-mode refusal must fail loudly instead of
+                // degrading to an empty version list.
+                Settings::ensure_not_safe(
+                    "go version listing via `go list` (GOPROXY=direct fallback)",
+                )?;
                 let mut resolution_error = None;
                 for mod_path in module_path_candidates(&tool_name) {
                     match self.fetch_go_module_versions(config, &mod_path).await {

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -293,6 +293,9 @@ impl GoBackend {
         config: &Arc<Config>,
         mod_path: &str,
     ) -> eyre::Result<Option<Vec<VersionInfo>>> {
+        // The GOPROXY HTTP path has already been tried by the caller; this
+        // fallback shells out to `go list`, which safe mode does not allow.
+        Settings::ensure_not_safe("go version listing via `go list` (GOPROXY=direct fallback)")?;
         let cache = self
             .module_versions_cache
             .entry(mod_path.to_string())

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -99,14 +99,9 @@ impl Backend for GoBackend {
 
                 // Fall back to `go list -m -versions` for GOPROXY=direct. Package
                 // paths are not necessarily module paths, so walk their prefixes
-                // just as the proxy resolver does.
-                // Check safe mode here rather than only inside
-                // fetch_go_module_versions: the loop below swallows per-candidate
-                // errors, and a safe-mode refusal must fail loudly instead of
-                // degrading to an empty version list.
-                Settings::ensure_not_safe(
-                    "go version listing via `go list` (GOPROXY=direct fallback)",
-                )?;
+                // just as the proxy resolver does. `go list` runs with
+                // GOTOOLCHAIN=local (see go_list_env), so it is safe against
+                // untrusted config and does not need a safe-mode gate.
                 let mut resolution_error = None;
                 for mod_path in module_path_candidates(&tool_name) {
                     match self.fetch_go_module_versions(config, &mod_path).await {
@@ -295,14 +290,25 @@ impl GoBackend {
         Ok(None)
     }
 
+    /// Environment for `go list` metadata queries.
+    ///
+    /// Adds `GOTOOLCHAIN=local` on top of the normal dependency env so that an
+    /// untrusted project `go.mod` cannot make `go` download and re-exec a
+    /// different toolchain (Go >= 1.21). This is what lets `go list` run under
+    /// safe mode: version listing then only performs module-metadata queries
+    /// (including VCS access for GOPROXY=direct) without any toolchain
+    /// download-and-execute step.
+    async fn go_list_env(&self, config: &Arc<Config>) -> eyre::Result<BTreeMap<String, String>> {
+        let mut env = self.dependency_env(config).await?;
+        env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
+        Ok(env)
+    }
+
     async fn fetch_go_module_versions(
         &self,
         config: &Arc<Config>,
         mod_path: &str,
     ) -> eyre::Result<Option<Vec<VersionInfo>>> {
-        // The GOPROXY HTTP path has already been tried by the caller; this
-        // fallback shells out to `go list`, which safe mode does not allow.
-        Settings::ensure_not_safe("go version listing via `go list` (GOPROXY=direct fallback)")?;
         let cache = self
             .module_versions_cache
             .entry(mod_path.to_string())
@@ -326,7 +332,7 @@ impl GoBackend {
                     "-json",
                     mod_path
                 )
-                .full_env(self.dependency_env(config).await?)
+                .full_env(self.go_list_env(config).await?)
                 .read()
                 {
                     Ok(raw) => raw,
@@ -357,7 +363,7 @@ impl GoBackend {
         config: &Arc<Config>,
         mod_path: &str,
     ) -> eyre::Result<Option<Vec<VersionInfo>>> {
-        let env = self.dependency_env(config).await?;
+        let env = self.go_list_env(config).await?;
         let raw = cmd!(
             "go",
             "list",
@@ -381,7 +387,7 @@ impl GoBackend {
         mod_path: &str,
         versions: &[String],
     ) -> Vec<VersionInfo> {
-        let env = match self.dependency_env(config).await {
+        let env = match self.go_list_env(config).await {
             Ok(env) => env,
             Err(_) => {
                 return versions

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -239,6 +239,8 @@ impl Run {
             return Ok(());
         }
 
+        Settings::ensure_not_safe("running tasks")?;
+
         // Unescape task args early so we can check for help flags
         self.args = unescape_task_args(&self.args);
         self.args_last = unescape_task_args(&self.args_last);

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -861,16 +861,21 @@ impl EnvResults {
             trust_check(path)?;
             let tera = tera.get_or_insert_with(|| {
                 let mut tera = get_tera(path.parent());
-                if let TeraEngine::V2(tera) = &mut tera {
-                    tera.register_function(
-                        "exec",
-                        tera_exec(path.parent().map(|d| d.to_path_buf()), exec_env.clone()),
-                    );
-                } else if let TeraEngine::V1(tera) = &mut tera {
-                    tera.register_function(
-                        "exec",
-                        tera1_exec(path.parent().map(|d| d.to_path_buf()), exec_env.clone()),
-                    );
+                // Re-bind exec() to the accumulated env vars — but never in safe
+                // mode, where get_tera has installed an erroring stub that this
+                // registration must not override.
+                if !Settings::get().safe {
+                    if let TeraEngine::V2(tera) = &mut tera {
+                        tera.register_function(
+                            "exec",
+                            tera_exec(path.parent().map(|d| d.to_path_buf()), exec_env.clone()),
+                        );
+                    } else if let TeraEngine::V1(tera) = &mut tera {
+                        tera.register_function(
+                            "exec",
+                            tera1_exec(path.parent().map(|d| d.to_path_buf()), exec_env.clone()),
+                        );
+                    }
                 }
                 tera
             });

--- a/src/config/env_directive/source.rs
+++ b/src/config/env_directive/source.rs
@@ -19,6 +19,7 @@ impl EnvResults {
         env_vars: &EnvMap,
         input: String,
     ) -> Result<IndexMap<PathBuf, IndexMap<String, String>>> {
+        crate::config::Settings::ensure_not_safe("sourcing scripts via `_.source`")?;
         let mut out = IndexMap::new();
         let s = r.parse_template(ctx, tera, source, exec_env, &input)?;
         let orig_path = env_vars.get(&*env::PATH_KEY).cloned().unwrap_or_default();

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1097,8 +1097,7 @@ impl Settings {
     pub fn ensure_not_safe(operation: &str) -> Result<()> {
         if Settings::get().safe {
             bail!(
-                "{operation} is disabled in safe mode (MISE_SAFE=1)
-                 See https://mise.en.dev/configuration/settings.html#safe"
+                "{operation} is disabled in safe mode (MISE_SAFE=1)\nSee https://mise.en.dev/configuration/settings.html#safe"
             );
         }
         Ok(())

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1089,6 +1089,20 @@ impl Settings {
                     .take_while(|a| *a != "--")
                     .any(|a| a == "--no-hooks")
     }
+
+    /// Errors when safe mode (`MISE_SAFE=1`) is enabled. Call this before any
+    /// operation that would execute code controlled by project configuration.
+    /// Safe mode is a security boundary: blocked operations must fail loudly,
+    /// never silently fall back to something that executes.
+    pub fn ensure_not_safe(operation: &str) -> Result<()> {
+        if Settings::get().safe {
+            bail!(
+                "{operation} is disabled in safe mode (MISE_SAFE=1)
+                 See https://mise.en.dev/configuration/settings.html#safe"
+            );
+        }
+        Ok(())
+    }
 }
 
 impl Display for Settings {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -360,6 +360,11 @@ pub async fn run_one_hook_with_context(
     if Settings::no_hooks() || Settings::get().no_hooks.unwrap_or(false) {
         return;
     }
+    // Hooks are suppressed rather than refused in safe mode (matching
+    // --no-hooks semantics) because they fire ambiently from commands like
+    // `mise env`/`hook-env` that safe-mode automation still needs to run —
+    // erroring here would break every resolution command instead of blocking
+    // just the hook.
     if Settings::get().safe {
         debug!("skipping hooks: safe mode (MISE_SAFE=1)");
         return;

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -297,7 +297,7 @@ pub fn schedule_hook(hook: Hooks) {
 }
 
 pub async fn run_all_hooks(config: &Arc<Config>, ts: &Toolset, shell: &dyn Shell) {
-    if Settings::no_hooks() || Settings::get().no_hooks.unwrap_or(false) {
+    if Settings::no_hooks() || Settings::get().no_hooks.unwrap_or(false) || Settings::get().safe {
         return;
     }
     let hooks = {
@@ -360,6 +360,10 @@ pub async fn run_one_hook_with_context(
     if Settings::no_hooks() || Settings::get().no_hooks.unwrap_or(false) {
         return;
     }
+    if Settings::get().safe {
+        debug!("skipping hooks: safe mode (MISE_SAFE=1)");
+        return;
+    }
     let shell_name = shell.map(|s| s.to_string()).unwrap_or_default();
     for (root, h) in all_hooks(config).await {
         if hook != h.hook || !matches_shell(h, &shell_name) {
@@ -408,7 +412,7 @@ pub async fn run_enter_hooks_for_newly_loaded_configs(
     ts: &Toolset,
     shell: &dyn Shell,
 ) {
-    if Settings::no_hooks() || Settings::get().no_hooks.unwrap_or(false) {
+    if Settings::no_hooks() || Settings::get().no_hooks.unwrap_or(false) || Settings::get().safe {
         return;
     }
     if hook_env::dir_change().is_some() {

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -102,6 +102,7 @@ impl AsdfPlugin {
         Ok(())
     }
     pub fn fetch_remote_versions(&self) -> eyre::Result<Vec<String>> {
+        Settings::ensure_not_safe("executing asdf plugin scripts")?;
         let cmd = self.script_man.cmd(&Script::ListAll);
         let result = run_with_timeout(
             move || {
@@ -357,6 +358,7 @@ impl Plugin for AsdfPlugin {
     }
 
     async fn install(&self, config: &Arc<Config>, pr: &dyn SingleReport) -> eyre::Result<()> {
+        Settings::ensure_not_safe("installing plugins")?;
         let repository = self.get_repo_url(config)?;
         let source = PluginSource::parse(&repository);
         debug!("asdf_plugin[{}]:install {:?}", self.name, repository);
@@ -455,6 +457,7 @@ Plugins could support local directories in the future but for now a symlink is r
                 .join(format!("command-{command}.bash")),
             args,
         );
+        Settings::ensure_not_safe("executing asdf plugin scripts")?;
         let result = self.script_man.cmd(&script).unchecked().run()?;
         exit(result.status.code().unwrap_or(-1));
     }

--- a/src/plugins/script_manager.rs
+++ b/src/plugins/script_manager.rs
@@ -178,6 +178,7 @@ impl ScriptManager {
     }
 
     pub fn read(&self, script: &Script) -> Result<String> {
+        Settings::ensure_not_safe("executing asdf plugin scripts")?;
         let mut cmd = self.cmd(script);
         let settings = &Settings::try_get()?;
         if !settings.verbose {
@@ -188,6 +189,7 @@ impl ScriptManager {
     }
 
     pub fn run_by_line(&self, script: &Script, pr: &dyn SingleReport) -> Result<()> {
+        Settings::ensure_not_safe("executing asdf plugin scripts")?;
         let path = self.get_script_path(script);
         pr.set_message(display_path(&path));
         let mut cmd = CmdLineRunner::new(path.clone());

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -369,6 +369,7 @@ impl Plugin for VfoxPlugin {
     }
 
     async fn install(&self, config: &Arc<Config>, pr: &dyn SingleReport) -> eyre::Result<()> {
+        Settings::ensure_not_safe("installing plugins")?;
         let repository = self.get_repo_url(config)?;
         let source = PluginSource::parse(repository.as_str());
         debug!("vfox_plugin[{}]:install {:?}", self.name, repository);

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1181,17 +1181,48 @@ fn tera1_path_filter(
 pub(crate) fn get_tera_v2(dir: Option<&Path>) -> Tera {
     let mut tera = TERA.clone();
     let dir = dir.map(PathBuf::from);
-    tera.register_function("exec", tera_exec(dir.clone(), env::PRISTINE_ENV.clone()));
-    tera.register_function("read_file", tera_read_file(dir));
+    if Settings::get().safe {
+        tera.register_function("exec", safe_disabled_fn("exec"));
+        tera.register_function("read_file", safe_disabled_fn("read_file"));
+    } else {
+        tera.register_function("exec", tera_exec(dir.clone(), env::PRISTINE_ENV.clone()));
+        tera.register_function("read_file", tera_read_file(dir));
+    }
     tera
 }
 
 fn get_tera_v1(dir: Option<&Path>) -> tera1::Tera {
     let mut tera = TERA1.clone();
     let dir = dir.map(PathBuf::from);
-    tera.register_function("exec", tera1_exec(dir.clone(), env::PRISTINE_ENV.clone()));
-    tera.register_function("read_file", tera1_read_file(dir));
+    if Settings::get().safe {
+        tera.register_function("exec", safe_disabled_fn_v1("exec"));
+        tera.register_function("read_file", safe_disabled_fn_v1("read_file"));
+    } else {
+        tera.register_function("exec", tera1_exec(dir.clone(), env::PRISTINE_ENV.clone()));
+        tera.register_function("read_file", tera1_read_file(dir));
+    }
     tera
+}
+
+/// Replacement for template functions that must not run in safe mode. Kept
+/// registered (rather than absent) so templates fail with a safe-mode error
+/// instead of a confusing "function not found".
+fn safe_disabled_fn(name: &'static str) -> impl Fn(Kwargs, &State) -> TeraResult<Value> {
+    move |_args: Kwargs, _: &State| -> TeraResult<Value> {
+        Err(tera_err(format!(
+            "{name}() is disabled in safe mode (MISE_SAFE=1)"
+        )))
+    }
+}
+
+fn safe_disabled_fn_v1(
+    name: &'static str,
+) -> impl Fn(&HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |_args: &HashMap<String, JsonValue>| -> tera1::Result<JsonValue> {
+        Err(tera1_err(format!(
+            "{name}() is disabled in safe mode (MISE_SAFE=1)"
+        )))
+    }
 }
 
 /// Returns a Tera instance for use during early initialization (miserc loading).


### PR DESCRIPTION
## What

Adds a `safe` setting (`MISE_SAFE=1`, global-only so project config cannot influence it) that makes mise refuse — with an error, never a silent fallback — any operation where **project configuration controls what code executes**:

| Blocked in safe mode | Gate |
|---|---|
| `exec()` / `read_file()` in config templates | erroring stubs registered instead of the real functions (both tera engines, incl. the env-directive re-registration that rebinds `exec` to accumulated env) |
| `_.source` env directives | `EnvResults::source` |
| hooks | existing `no_hooks` chokepoints + the enter-hooks path that bypasses them |
| tasks (`mise run`) | `Run::run` |
| asdf plugin scripts | `ScriptManager::read`/`run_by_line` + the three direct `script_man.cmd()` execution sites (list-all, list-bin-paths, external commands) |
| installing plugins | `install()` on both plugin types — covers config-named plugin URLs |
| ~~`npm`/`go` subprocess version listing~~ | **No longer gated** — see "npm and go" below. |

**What keeps working:** plain templates, all HTTP-based resolution (core, aqua, github, gitlab, http, cargo, pipx, gem, dotnet, **npm**, **go**), lockfile refresh/bump, and **already-installed or embedded vfox plugins** — their code was chosen by the operator, not by the repository being processed, and resolution already short-circuits on uninstalled plugins without executing anything.

## Why

This is the trust boundary that lockfile-update automation needs. Renovate's mise manager can only update `mise.lock` after self-hosted administrators allowlist mise via `allowedUnsafeExecutions`, because running mise against a PR branch's config is arbitrary code execution ([renovatebot/renovate#43606](https://github.com/renovatebot/renovate/pull/43606)). With `MISE_SAFE=1`, a bot can run `mise lock --bump` (#11145) against untrusted branches: version selectors resolve over HTTP, and anything that would execute repo-controlled code fails loudly instead of running.

```sh
MISE_SAFE=1 mise lock --bump --dry-run --json   # detect updates, zero code execution
```

## Notes

### npm and go

`MISE_SAFE` blocks repo-controlled *code* execution; `npm view` and `go list` don't cross that line, so both run under safe mode:

- **npm**: the built-in npm registry HTTP client has since landed on `main`, so npm version listing is HTTP-native by default and needs no gate — this branch rebased onto it and carries no npm changes. (The optional `npm.use_npm_view` CLI fallback is a read-only metadata query that never runs install scripts, so it's also fine under safe mode.)
- **go**: hardened rather than gated. `go list` now runs with `GOTOOLCHAIN=local` (via `go_list_env`), closing the one real exec vector — an untrusted `go.mod` `toolchain` directive can no longer make go download and re-exec a different toolchain. With that closed it only does module-metadata queries (incl. VCS for GOPROXY=direct). Verified the env var reaches every `go list` invocation on the direct path.
- Safe mode does not change the trust system: untrusted configs still require `mise trust`. Making `MISE_SAFE` imply trust (since the dangerous surface is closed) is a possible follow-up but a separate decision.
- A blocked operation fails the whole command rather than being skipped — deny-by-default. The one deliberate exception is hooks, which are suppressed (like `--no-hooks`) rather than refused: they fire ambiently from `mise env`/`hook-env`, which safe-mode automation still needs to run. Per-tool structured refusals in `mise lock --bump --json` could be a follow-up if bots want partial results.

## Testing

- New e2e test `e2e/config/test_safe_mode` covering every gate plus the allowed paths (plain templates, prefix resolution without safe mode).
- Full unit suite passes (1792 tests).
- Manually verified: aqua/core `mise lock --bump --json` works under `MISE_SAFE=1`; embedded vfox plugin (`ant`) version listing works; template exec verified blocked safe-first with cold caches (the env-directive re-registration escape was caught and fixed this way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches security-sensitive config loading, templates, hooks, tasks, and plugin execution paths; incorrect gating could break CI lock bumps or leave an execution vector open.
> 
> **Overview**
> Introduces **safe mode** (`MISE_SAFE=1` / `settings.safe`, **global-only**) as a hard boundary so project config cannot run arbitrary code when mise is used on untrusted branches (e.g. `mise lock --bump` in CI).
> 
> **Blocked with errors:** template `exec()` / `read_file()` (erroring stubs; env-directive path no longer re-registers real `exec`), `_.source`, `mise run` tasks, asdf plugin script execution, and plugin installs. **Hooks** are skipped (like `--no-hooks`), not failed, so `mise env` / `hook-env` still work for automation.
> 
> **Still allowed:** plain templates, HTTP-backed version listing, lock refresh/bump, and already-installed / embedded plugins. **Go** version queries now use `GOTOOLCHAIN=local` on all `go list` paths so untrusted `go.mod` cannot trigger toolchain download/exec.
> 
> Docs cover CI, lock bump, security vs paranoid/trust; schema and `settings.toml` document the setting. New e2e `test_safe_mode` exercises the gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8132e2e305b2aa9208acd6e8213fbe23e294e099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Safe mode, enabled with `MISE_SAFE=1`, to prevent project-controlled code execution during configuration and version resolution.
  * Safe mode blocks template commands, script sourcing, task and hook execution, and plugin installation or script execution.
  * Added configuration schema and documentation for the new `settings.safe` option.
  * Safe mode continues to support non-executable template rendering and safe version lookups where applicable.

* **Tests**
  * Added end-to-end coverage for blocked and permitted Safe mode behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


