### PR TITLE
feat(npm): embed aube for node-free npm: version resolution and installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,9 +519,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c9b704982f4ae95591c87b9d96e774841a8b1951ce2dd9ba3954518da8278"
+checksum = "937ba27a96fe9311f73a2ee9fe2a5efdc06b3323bf832337c3f9f0d8f28657f1"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3032ff00dbb2bc359afa1d50239bf125d865ca7cbe20900fa016a054f4f5b76"
+checksum = "dfc04a075a2022e1e0099bebd6bf8f0f4061df10d491e4d9af30597e5f6ae919"
 dependencies = [
  "serde",
  "serde_json",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407c1bb0447948330aa5fde8240032ea08fbb1e25defb51d5eb451b7e8f0209b"
+checksum = "92ef5d3896d505c334f11a6eb0e887c79126275c14f0330538caff063f881f6b"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23adca5cc9c6ee601f899012a1386024e5bdba827d03a4d83c6d2124009fc9da"
+checksum = "b833b8b5ed6ae74faa8c5f89e2ad6bf1f9bb8261edbd17524fb45997fd3c9f15"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d7911a3a6a06b021db479b41626f2e486be565847e67002d7435f76fa84607"
+checksum = "5623df032108290ba325050fe728cd2108503ca0a871539c4efd2e2027f7b011"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752f808983d7c0c912aad809f57719f22d95c390b377b82d0683ec1188df0b04"
+checksum = "9c88cf69ccdb1bb87b6760e5a016a6c9f062e6f4eef87c1c53211170ea438f1c"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d53eb4f1168ac4a7bc6bb295d364c540a3cc3fabd845d4c26df14e464eaf80"
+checksum = "da4f3fd114312f073d4066ac6d56c34cb7d8e90412252e7eb852d1ffb503fda6"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f8d22f69708fd0795956c879d5b2b79892cd61de8541224519859f2e4c8c0"
+checksum = "8f2841ffaca859ffbb0615331e321fb3b9f8d0a4286f672fb0eeeca7f8dec36a"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2526206f65af77dd32df0a45939ccab78e03242ee274cf80ac0141da06bf9f04"
+checksum = "4989123bd09bf08eb384a105ac442963258e57cfe6e1f3721aa13c9edb39d233"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4272e2cd3fe1d6117ccf9015b21f825848314f53d895dd6c73c5bb3e6d4fd8ed"
+checksum = "ae9fd6881256ad7d7fedef2439d6b14290df7c35a2bf6e801c1cf206083a9aaa"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557008ba55c810b5fff14588b93f1a639546f056af691af2b2b7e6ef3e430a6f"
+checksum = "62a4fd231797170572d902d724b37f8856156bab128471133662a9da700062fa"
 dependencies = [
  "aube-util",
  "base64 0.22.1",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae909206160ab082051d4062e5e3748a05f4de0d0d3313f70b41832ec884fc1"
+checksum = "a164be1cb18767f7ca807dcd6c8263b5e36370a6e484fb2329f4fbf9d13c7e2f"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffe87b24848d067f6301ed129e9b9ab25fd765fb50354d29e4333c432ce897c"
+checksum = "ec6e9fc70400dc7ea28378dc7888d9a913c0a0dbbfc5bc31701090521948adc8"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +516,125 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aube-codes"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27d0a242ee1bb99d7192886d912786219f3da92bd52bf1109ed6b69c62aec54"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "aube-manifest"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca6168a3bb82b9d939a82187ce40b3a9e4054263f41480bc569d9e80b30896c"
+dependencies = [
+ "aube-codes",
+ "aube-util",
+ "miette",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sonic-rs",
+ "thiserror 2.0.19",
+ "yaml_serde",
+ "yamlpatch",
+ "yamlpath",
+]
+
+[[package]]
+name = "aube-registry"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebceb3898f1241d77f6bb939fb9c459391363c7bc1fd818ccd7bf38fcbbf1ac"
+dependencies = [
+ "aube-codes",
+ "aube-manifest",
+ "aube-settings",
+ "aube-store",
+ "aube-util",
+ "base64 0.22.1",
+ "blake3",
+ "bytes",
+ "miette",
+ "node-semver",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "sonic-rs",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "zip 8.6.0",
+]
+
+[[package]]
+name = "aube-settings"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8badea5749f7a417717180a8cc892d1689dda2ddd4bbfda65351b9776fd06dc6"
+dependencies = [
+ "aube-codes",
+ "aube-util",
+ "serde",
+ "toml 1.1.3+spec-1.1.0",
+ "tracing",
+ "yaml_serde",
+]
+
+[[package]]
+name = "aube-store"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a883bce3e9d8264bbd2a347338e074b9ca62af232ebca1b81ed26b2fce419b"
+dependencies = [
+ "aube-util",
+ "base64 0.22.1",
+ "blake3",
+ "decmpfs",
+ "flate2",
+ "hex",
+ "libc",
+ "log",
+ "miette",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sonic-rs",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.19",
+ "xx",
+]
+
+[[package]]
+name = "aube-util"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff2d1c210b3ff256a32df126c80b2b20621c48e9e0a0c08bd8c82c066f8c316"
+dependencies = [
+ "aube-codes",
+ "blake3",
+ "bytes",
+ "foldhash 0.2.0",
+ "libc",
+ "reflink-copy",
+ "reqwest 0.13.4",
+ "rustc-hash 2.1.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "webpki-root-certs",
+]
 
 [[package]]
 name = "autocfg"
@@ -1193,6 +1327,8 @@ dependencies = [
  "cfg-if",
  "constant_time_eq 0.4.2",
  "cpufeatures 0.3.0",
+ "memmap2",
+ "rayon-core",
 ]
 
 [[package]]
@@ -1231,6 +1367,27 @@ checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1807,6 +1964,7 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
+ "brotli",
  "bzip2 0.6.1",
  "compression-core",
  "flate2",
@@ -2348,6 +2506,18 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "decmpfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "651715809b4119e14ba1ba88650756d8a7012686473a32ec14c0e602e90fc47f"
+dependencies = [
+ "libc",
+ "sha2 0.10.9",
+ "windows-sys 0.59.0",
+ "zstd",
+]
 
 [[package]]
 name = "deflate64"
@@ -2970,6 +3140,18 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "faststr"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
+dependencies = [
+ "bytes",
+ "rkyv",
+ "serde",
+ "simdutf8",
+]
 
 [[package]]
 name = "ff"
@@ -5455,6 +5637,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
+name = "line-index"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e27e0ed5a392a7f5ba0b3808a2afccff16c64933312c84b57618b49d1209bd2"
+dependencies = [
+ "nohash-hasher",
+ "text-size",
+]
+
+[[package]]
 name = "link-section"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5757,6 +5955,7 @@ dependencies = [
  "aqua-registry",
  "async-backtrace",
  "async-trait",
+ "aube-registry",
  "aws-config",
  "aws-lc-rs",
  "aws-sdk-s3",
@@ -6062,6 +6261,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "node-semver"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1a233ea5dc37d2cfba31cfc87a5a56cc2a9c04e3672c15d179ca118dae40a7"
+dependencies = [
+ "bytecount",
+ "miette",
+ "nom 7.1.3",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "nodejs-semver"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6073,6 +6285,12 @@ dependencies = [
  "thiserror 2.0.19",
  "winnow 0.7.15",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -9227,6 +9445,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "sonic-number"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3775c3390edf958191f1ab1e8c5c188907feebd0f3ce1604cb621f72961dbf32"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "sonic-rs"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
+dependencies = [
+ "ahash",
+ "bumpalo",
+ "bytes",
+ "cfg-if",
+ "faststr",
+ "itoa",
+ "ref-cast",
+ "serde",
+ "simdutf8",
+ "sonic-number",
+ "sonic-simd",
+ "thiserror 2.0.19",
+ "zmij",
+]
+
+[[package]]
+name = "sonic-simd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9263,6 +9520,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -9319,6 +9582,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "subfeature"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae27fccb1615a3b3ae930cf93c0c4d32b7daffb57477ca0406f07fc0e68ea57"
+dependencies = [
+ "memchr",
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -10068,6 +10342,45 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax 0.8.11",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-iter"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cbef0ee83b87916292355e78f4fdee268d719ececa729be8914882428ca86b0"
+dependencies = [
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -11282,9 +11595,11 @@ dependencies = [
  "duct",
  "filetime",
  "flate2",
+ "fslock",
  "getrandom 0.4.3",
  "globwalk",
  "homedir",
+ "libc",
  "log",
  "miette",
  "rand 0.10.2",
@@ -11309,6 +11624,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "yamlpatch"
+version = "1.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919764173d845c2b685a44ca9a028534ef1127bcf713edc6b69787430f18b030"
+dependencies = [
+ "indexmap 2.14.0",
+ "line-index",
+ "serde_json",
+ "subfeature",
+ "thiserror 2.0.19",
+ "yaml_serde",
+ "yamlpath",
+]
+
+[[package]]
+name = "yamlpath"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1362068e6e34bf985c39ee42ee8d410fcc398fedbd5f9303602616db26f542b5"
+dependencies = [
+ "line-index",
+ "self_cell 1.3.0",
+ "serde",
+ "thiserror 2.0.19",
+ "tree-sitter",
+ "tree-sitter-iter",
+ "tree-sitter-yaml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,20 +518,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "aube-codes"
-version = "1.30.0"
+name = "aube"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27d0a242ee1bb99d7192886d912786219f3da92bd52bf1109ed6b69c62aec54"
+checksum = "109c9b704982f4ae95591c87b9d96e774841a8b1951ce2dd9ba3954518da8278"
+dependencies = [
+ "aube-codes",
+ "aube-linker",
+ "aube-lockfile",
+ "aube-manifest",
+ "aube-registry",
+ "aube-resolver",
+ "aube-runtime",
+ "aube-scripts",
+ "aube-settings",
+ "aube-store",
+ "aube-util",
+ "aube-workspace",
+ "base64 0.22.1",
+ "blake3",
+ "bytes",
+ "ci_info",
+ "clap",
+ "clap_usage",
+ "clx",
+ "console",
+ "demand",
+ "diffy",
+ "flate2",
+ "glob",
+ "hex",
+ "ignore",
+ "is_ci",
+ "libc",
+ "miette",
+ "node-semver",
+ "pathdiff",
+ "pluralizer",
+ "rayon",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "strum 0.28.0",
+ "tar",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "toml 1.1.3+spec-1.1.0",
+ "tracing",
+ "tracing-subscriber",
+ "xx",
+ "yaml_serde",
+]
+
+[[package]]
+name = "aube-codes"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3032ff00dbb2bc359afa1d50239bf125d865ca7cbe20900fa016a054f4f5b76"
 dependencies = [
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "aube-manifest"
-version = "1.30.0"
+name = "aube-linker"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca6168a3bb82b9d939a82187ce40b3a9e4054263f41480bc569d9e80b30896c"
+checksum = "407c1bb0447948330aa5fde8240032ea08fbb1e25defb51d5eb451b7e8f0209b"
+dependencies = [
+ "aube-codes",
+ "aube-lockfile",
+ "aube-store",
+ "aube-util",
+ "diffy",
+ "glob",
+ "hex",
+ "junction",
+ "miette",
+ "pathdiff",
+ "rayon",
+ "reflink-copy",
+ "rustc-hash 2.1.3",
+ "serde_json",
+ "sha2 0.11.0",
+ "strum 0.28.0",
+ "tempfile",
+ "thiserror 2.0.19",
+ "tracing",
+ "xx",
+]
+
+[[package]]
+name = "aube-lockfile"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23adca5cc9c6ee601f899012a1386024e5bdba827d03a4d83c6d2124009fc9da"
+dependencies = [
+ "aube-codes",
+ "aube-manifest",
+ "aube-settings",
+ "aube-util",
+ "base64 0.22.1",
+ "blake3",
+ "glob",
+ "memchr",
+ "miette",
+ "node-semver",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sonic-rs",
+ "thiserror 2.0.19",
+ "tracing",
+ "yaml_serde",
+]
+
+[[package]]
+name = "aube-manifest"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d7911a3a6a06b021db479b41626f2e486be565847e67002d7435f76fa84607"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -548,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.30.0"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebceb3898f1241d77f6bb939fb9c459391363c7bc1fd818ccd7bf38fcbbf1ac"
+checksum = "752f808983d7c0c912aad809f57719f22d95c390b377b82d0683ec1188df0b04"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -574,10 +684,85 @@ dependencies = [
 ]
 
 [[package]]
-name = "aube-settings"
-version = "1.30.0"
+name = "aube-resolver"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8badea5749f7a417717180a8cc892d1689dda2ddd4bbfda65351b9776fd06dc6"
+checksum = "80d53eb4f1168ac4a7bc6bb295d364c540a3cc3fabd845d4c26df14e464eaf80"
+dependencies = [
+ "aube-codes",
+ "aube-lockfile",
+ "aube-manifest",
+ "aube-registry",
+ "aube-store",
+ "aube-util",
+ "flate2",
+ "miette",
+ "node-semver",
+ "pathdiff",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sonic-rs",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "aube-runtime"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134f8d22f69708fd0795956c879d5b2b79892cd61de8541224519859f2e4c8c0"
+dependencies = [
+ "aube-codes",
+ "aube-manifest",
+ "aube-util",
+ "base64 0.22.1",
+ "flate2",
+ "hex",
+ "node-semver",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tar",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "xx",
+ "zip 8.6.0",
+]
+
+[[package]]
+name = "aube-scripts"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2526206f65af77dd32df0a45939ccab78e03242ee274cf80ac0141da06bf9f04"
+dependencies = [
+ "aube-codes",
+ "aube-manifest",
+ "aube-util",
+ "landlock",
+ "libc",
+ "miette",
+ "regex",
+ "seccompiler",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "aube-settings"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4272e2cd3fe1d6117ccf9015b21f825848314f53d895dd6c73c5bb3e6d4fd8ed"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -589,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.30.0"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a883bce3e9d8264bbd2a347338e074b9ca62af232ebca1b81ed26b2fce419b"
+checksum = "557008ba55c810b5fff14588b93f1a639546f056af691af2b2b7e6ef3e430a6f"
 dependencies = [
  "aube-util",
  "base64 0.22.1",
@@ -616,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.30.0"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff2d1c210b3ff256a32df126c80b2b20621c48e9e0a0c08bd8c82c066f8c316"
+checksum = "6ae909206160ab082051d4062e5e3748a05f4de0d0d3313f70b41832ec884fc1"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -634,6 +819,21 @@ dependencies = [
  "tokio",
  "tracing",
  "webpki-root-certs",
+]
+
+[[package]]
+name = "aube-workspace"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ffe87b24848d067f6301ed129e9b9ab25fd765fb50354d29e4333c432ce897c"
+dependencies = [
+ "aube-codes",
+ "aube-manifest",
+ "glob",
+ "miette",
+ "pathdiff",
+ "thiserror 2.0.19",
+ "tracing",
 ]
 
 [[package]]
@@ -1790,6 +1990,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clap_usage"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7179a7bcab80d71e4524ae4a384cb9180b6ca3eb30d8e398add707541989ce4a"
+dependencies = [
+ "clap",
+ "usage-lib 2.18.2",
+]
+
+[[package]]
 name = "clru"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +2923,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "diffy"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10aec8f7f9393bd6a4f2762be0ceb012d3cbe2478987258cc9960de148561914"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,6 +3446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -5643,6 +5863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879917b256f6317769b9f374b435805a8697013098aacce5a38ac106cd6a9469"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "line-index"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5955,6 +6185,7 @@ dependencies = [
  "aqua-registry",
  "async-backtrace",
  "async-trait",
+ "aube",
  "aube-registry",
  "aws-config",
  "aws-lc-rs",
@@ -6071,7 +6302,7 @@ dependencies = [
  "ubi",
  "url",
  "urlencoding",
- "usage-lib",
+ "usage-lib 3.5.5",
  "versions",
  "vfox",
  "walkdir",
@@ -6731,6 +6962,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7061,6 +7298,16 @@ dependencies = [
  "quick-xml 0.41.0",
  "serde",
  "time",
+]
+
+[[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -8231,6 +8478,12 @@ dependencies = [
  "rmp",
  "serde",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "roff"
@@ -10116,6 +10369,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -10327,6 +10581,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10336,12 +10600,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -10655,6 +10922,30 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usage-lib"
+version = "2.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1851c9ddbc3a428af152852227363e7f66b73ca2ce732c8db3c2d4ab37eb63d2"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "kdl",
+ "log",
+ "miette",
+ "regex",
+ "roff 0.2.2",
+ "serde",
+ "shell-words",
+ "strum 0.28.0",
+ "tera 1.20.1",
+ "thiserror 2.0.19",
+ "versions",
+ "xx",
+]
+
+[[package]]
+name = "usage-lib"
 version = "3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1478c4f133213053eb72013c4fd67941253324e7e10d048bc93d39038eced62"
@@ -10667,7 +10958,7 @@ dependencies = [
  "log",
  "miette",
  "regex",
- "roff",
+ "roff 1.1.1",
  "serde",
  "shell-words",
  "strum 0.28.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ opt-level = 3
 [dependencies]
 age = { version = "0.11", features = ["ssh"] }
 aho-corasick = "1"
+aube-registry = { version = "1.30", default-features = false, features = [
+  "rustls",
+] }
 async-backtrace = "0.2"
 async-trait = "0.1"
 aws-config = { version = "1.5", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,10 @@ opt-level = 3
 [dependencies]
 age = { version = "0.11", features = ["ssh"] }
 aho-corasick = "1"
-aube-registry = { version = "1.30", default-features = false, features = [
+aube-registry = { version = "1.31", default-features = false, features = [
   "rustls",
 ] }
+aube = { version = "1.31", default-features = false, features = ["rustls"] }
 async-backtrace = "0.2"
 async-trait = "0.1"
 aws-config = { version = "1.5", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,10 @@ opt-level = 3
 [dependencies]
 age = { version = "0.11", features = ["ssh"] }
 aho-corasick = "1"
-aube-registry = { version = "1.31", default-features = false, features = [
+aube-registry = { version = "1.32", default-features = false, features = [
   "rustls",
 ] }
-aube = { version = "1.31", default-features = false, features = ["rustls"] }
+aube = { version = "1.32", default-features = false, features = ["rustls"] }
 async-backtrace = "0.2"
 async-trait = "0.1"
 aws-config = { version = "1.5", default-features = false, features = [

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -7,46 +7,44 @@ The code for this is inside of the mise repository at [`./src/backend/npm.rs`](h
 
 ## Dependencies
 
-Version resolution (`mise ls-remote`, resolving `latest`) queries the npm
-registry directly over HTTP, so no node/npm installation is needed for it. The
-registry, scoped registries (`@scope:registry`), and auth tokens configured in
-`~/.npmrc` (or `NPM_CONFIG_USERCONFIG`) and `NPM_CONFIG_*` environment
-variables are honored. If your setup relies on npm-only configuration such as
-`cafile`, client certificates, or an auth token helper, set
-[`npm.use_npm_view`](/configuration/settings.html#npm_use_npm_view) to shell
-out to `npm view` for version metadata instead (this requires npm to be
-installed).
+By default mise handles `npm:` tools without needing node or a package manager
+CLI installed. Version resolution (`mise ls-remote`, resolving `latest`) queries
+the npm registry directly over HTTP, and packages are installed with mise's
+embedded [aube](https://github.com/jdx/aube) package manager. The registry,
+scoped registries (`@scope:registry`), and auth tokens configured in `~/.npmrc`
+(or `NPM_CONFIG_USERCONFIG`) and `NPM_CONFIG_*` environment variables are honored
+by both. `node` is only needed to _run_ the installed tools (and any package
+lifecycle scripts), not to install them.
 
-Installing packages relies on the configured package manager.
-With the default `npm.package_manager = "auto"` setting, mise uses
-[`aube`](https://aube.jdx.dev/) for installing npm packages when it is installed,
-similar to how the pipx backend uses `uv` when available.
-If you use `aube`, `pnpm`, or `bun` as the package manager, that package manager
-must also be installed.
+To shell out to the npm CLI instead — `npm view` for metadata and
+`npm install -g` for installs — set
+[`npm.shell_out`](/configuration/settings.html#npm-shell-out) (requires npm to
+be installed). Use it if you rely on npm-only configuration the built-in
+implementation does not support, such as `cafile`, client certificates, or an
+auth token helper.
+
+You can also pick a specific installer with
+[`npm.package_manager`](/configuration/settings.html#npm-package-manager). The
+default `auto` uses the embedded aube; setting it to `bun`, `pnpm`, or `npm`
+shells out to that tool, which must then be installed.
 
 The npm backend forwards [`minimum_release_age`](/configuration/settings.html#minimum_release_age)
-to transitive dependency resolution during install. This relies on the
-configured package manager supporting its native release-age flag:
+to transitive dependency resolution during install. The embedded aube installer
+honors it natively. When shelling out, it relies on the package manager
+supporting its release-age flag:
 
-- `aube` using its `minimumReleaseAge` setting
 - `pnpm >= 10.16.0` using `--config.minimumReleaseAge=<minutes>`
 - `bun >= 1.3.0` using `--minimum-release-age <seconds>`
 - `npm >= 11.10.0` using `--min-release-age=<days>`; `npm 6.9.0–11.9.x` using `--before <timestamp>` (sub-day `minimum_release_age` windows also use `--before` since `--min-release-age` is day-granular)
 
-If you want transitive protection, install and use a package manager version that meets the
-corresponding requirement above. Older versions may fail while processing the forwarded argument.
+If you want transitive protection when shelling out, install and use a package
+manager version that meets the corresponding requirement above. Older versions
+may fail while processing the forwarded argument.
 
-Here is how to install `npm` with mise:
-
-```sh
-mise use -g node
-```
-
-To install `aube`, `pnpm`, or `bun`:
+`node` is installed automatically as a dependency. To use a specific package
+manager CLI instead of the embedded installer:
 
 ```sh
-mise use -g aube
-# or
 mise use -g pnpm
 # or
 mise use -g bun
@@ -86,32 +84,31 @@ package-provided commands such as `preinstall`, `install`, `postinstall`, and `p
 allowing them means allowing code from the selected package and its dependencies to run during
 installation.
 
-With the default `npm.package_manager = "auto"` setting, mise installs through `aube` when `aube` is
-installed. If `aube` is not installed, mise installs through `npm`. Setting
-`npm.package_manager = "aube"`, `"pnpm"`, `"bun"`, or `"npm"` chooses that package manager
-explicitly. The `allow_builds`, `trust_policy_excludes`, `aube_args`, `pnpm_args`, `bun_args`, and
-`npm_args` options only affect the package manager that is actually used; an approval option for one
-package manager does not change the behavior of another.
+With the default `npm.package_manager = "auto"` setting, mise installs through its embedded `aube`
+package manager. Setting `npm.package_manager = "aube"`, `"pnpm"`, `"bun"`, or `"npm"` chooses a
+package manager explicitly (`aube` also uses the embedded one; the others shell out).
+[`npm.shell_out`](/configuration/settings.html#npm-shell-out) forces the npm CLI. The `allow_builds`,
+`trust_policy_excludes`, `pnpm_args`, `bun_args`, and `npm_args` options only affect the package
+manager that is actually used; an approval option for one does not change the behavior of another.
 
-For tools that need reviewed dependency build scripts, use `allow_builds` with `aube`, `pnpm`, or
-npm 11.16.0+.
+For tools that need reviewed dependency build scripts, use `allow_builds` with `aube` (default),
+`pnpm`, or npm 11.16.0+.
 
-### `aube`
+### `aube` (default)
 
-[`aube`](https://aube.jdx.dev/package-manager/lifecycle-scripts) follows the pnpm v11 build approval
-model: dependency lifecycle scripts are denied unless explicitly allowlisted. Use `allow_builds` for
-reviewed dependency builds:
+The embedded [`aube`](https://aube.jdx.dev/package-manager/lifecycle-scripts) installer follows the
+pnpm v11 build approval model: dependency lifecycle scripts are denied unless explicitly allowlisted.
+Use `allow_builds` for reviewed dependency builds:
 
 ```toml
 [tools]
 "npm:some-tool" = { version = "latest", allow_builds = ["esbuild"] }
 ```
 
-`allow_builds` is passed to `aube add --global` as one `--allow-build=<pkg>` flag per package.
-Use `trust_policy_excludes` for reviewed aube trust-policy exceptions, or `aube_args` for other
-raw aube flags.
-Set `allow_builds = true` to pass `--dangerously-allow-all-builds` when you explicitly accept that
-every dependency build script may run.
+`allow_builds` is written to the install's `aube.allowBuilds` manifest field.
+Use `trust_policy_excludes` for reviewed aube trust-policy exceptions.
+Set `allow_builds = true` to allow every dependency build script when you explicitly accept the risk.
+(The `aube_args` option is ignored now that installs run in-process rather than via the `aube` CLI.)
 
 ### `pnpm`
 

--- a/e2e/backend/test_backend_missing_deps
+++ b/e2e/backend/test_backend_missing_deps
@@ -61,7 +61,7 @@ test_npm() {
   MISE_NPM_PACKAGE_MANAGER=bun assert_contains "mise ls-remote npm:left-pad" "1.3.0"
 
   # Legacy `npm view` mode still needs npm and warns when it is missing
-  export MISE_NPM_USE_NPM_VIEW=1
+  export MISE_NPM_SHELL_OUT=1
   test_backend_warning "npm" "mise ls-remote npm:test-package" "npm may be required but was not found"
 
   # Check for helpful install instructions
@@ -69,10 +69,12 @@ test_npm() {
   output=$(MISE_LOG_LEVEL=warn mise ls-remote npm:test-package 2>&1 || true)
   test_error_message "npm suggests installing node" "$output" "mise use node@latest"
   test_error_message "npm mentions npm is needed for queries" "$output" "npm is required for querying package information"
-  unset MISE_NPM_USE_NPM_VIEW
-
-  # Test install - should show warning but continue
+  # Install through the npm CLI (shell_out) still needs npm and warns.
   test_backend_warning "npm" "mise install npm:test-package@latest" "npm may be required but was not found"
+  unset MISE_NPM_SHELL_OUT
+
+  # The default install path uses the embedded aube package manager, which
+  # does not require an npm binary (only node, to run installed tools).
 }
 
 # Test cargo backend

--- a/e2e/backend/test_npm_aube
+++ b/e2e/backend/test_npm_aube
@@ -2,8 +2,13 @@
 
 install_dir="$MISE_DATA_DIR/installs/npm-cowsay/1.6.0"
 
-assert_contains "mise x node@20.11.1 aube@latest npm:cowsay@1.6.0 -- cowsay hello" "hello"
-assert_succeed "test -d '$install_dir/global-aube'"
-lockfile="$(find "$install_dir/global-aube" -mindepth 2 -maxdepth 2 -name aube-lock.yaml -print -quit)"
-assert_succeed "test -f '$lockfile'"
-assert_contains "cat '$lockfile'" "cowsay@1.6.0"
+# npm: tools install via the embedded aube package manager in-process — no
+# aube binary on PATH is required, only node to run the tool.
+assert_contains "mise x node@20.11.1 npm:cowsay@1.6.0 -- cowsay hello" "hello"
+
+# Embedded aube installs into a per-tool project dir: node_modules holds the
+# package + bin shims, and an aube lockfile is written at the project root.
+assert_succeed "test -d '$install_dir/node_modules'"
+assert_succeed "test -x '$install_dir/node_modules/.bin/cowsay'"
+assert_succeed "test -f '$install_dir/aube-lock.yaml'"
+assert_contains "cat '$install_dir/aube-lock.yaml'" "cowsay@1.6.0"

--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -97,21 +97,13 @@ assert_contains "cat '$PNPM_DEBUG_LOG'" "--allow-build=tiny"
 echo "✓ npm backend successfully installs package using pnpm (package_manager=pnpm)"
 mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 
-# Test 4: npm.package_manager = "aube"
+# Test 4: npm.package_manager = "aube" (embedded — no aube binary needed)
 echo "Testing npm.package_manager=aube..."
 export MISE_NPM_PACKAGE_MANAGER=aube
 
-# Ensure aube is available after the default package manager test, since
-# npm.package_manager=auto uses aube when it is already installed.
-# Pin to the current aube release checked for this test. Remove this test's
-# MISE_MINIMUM_RELEASE_AGE override; the explicit version bypasses the default
-# release-age filter.
-AUBE_TEST_VERSION="1.16.0"
-if ! command -v aube >/dev/null 2>&1; then
-  echo "aube not available in test environment, installing..."
-  assert_succeed "env -u MISE_MINIMUM_RELEASE_AGE mise use aube@$AUBE_TEST_VERSION"
-fi
-
+# The embedded aube installer runs in-process; there is no aube CLI to shell
+# out to, so `aube_args` is ignored (with a warning) and `allow_builds` is
+# written to the install's manifest rather than passed as a CLI flag.
 cat >.mise.toml <<EOF
 [tools]
 "npm:tiny" = { version = "latest", aube_args = "--reporter append-only", allow_builds = "tiny" }
@@ -122,9 +114,13 @@ if ! MISE_DEBUG=1 mise install >"$AUBE_DEBUG_LOG" 2>&1; then
   cat "$AUBE_DEBUG_LOG"
   exit 1
 fi
-assert_contains "cat '$AUBE_DEBUG_LOG'" "--reporter"
-assert_contains "cat '$AUBE_DEBUG_LOG'" "append-only"
-assert_contains "cat '$AUBE_DEBUG_LOG'" "--allow-build=tiny"
+# Installed via the embedded package manager (node_modules layout), not a
+# shelled-out `aube add --global`.
+tiny_install_dir="$MISE_DATA_DIR/installs/npm-tiny"
+assert_succeed "test -d '$tiny_install_dir'"
+assert_succeed "find '$tiny_install_dir' -type d -name node_modules -print -quit | grep -q ."
+# aube_args is not forwarded to any CLI; mise warns that it is ignored.
+assert_contains "cat '$AUBE_DEBUG_LOG'" "aube_args"
 echo "✓ npm backend successfully installs package using aube (package_manager=aube)"
 mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 

--- a/e2e/backend/test_npm_shim_recursion_system_dir
+++ b/e2e/backend/test_npm_shim_recursion_system_dir
@@ -16,7 +16,7 @@
 # Version queries only shell out to `npm view` in legacy mode now; the
 # default path queries the registry over HTTP and never spawns npm. Pin the
 # legacy mode so this test keeps covering the shim-recursion guard.
-export MISE_NPM_USE_NPM_VIEW=1
+export MISE_NPM_SHELL_OUT=1
 
 export MISE_SYSTEM_DATA_DIR="$HOME/.local/share/mise-system"
 mkdir -p "$MISE_SYSTEM_DATA_DIR/shims"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1324,9 +1324,9 @@
               "type": "string",
               "enum": ["auto", "npm", "aube", "bun", "pnpm"]
             },
-            "use_npm_view": {
+            "shell_out": {
               "default": false,
-              "description": "Use the npm CLI (`npm view`) for version metadata queries instead of mise's built-in registry client.",
+              "description": "Shell out to the npm CLI for `npm:` version metadata and installs instead of mise's built-in aube-based implementation.",
               "type": "boolean"
             }
           }

--- a/settings.toml
+++ b/settings.toml
@@ -1781,21 +1781,28 @@ env = "MISE_NPM_PACKAGE_MANAGER"
 rust_type = "NpmPackageManager"
 type = "String"
 
-[npm.use_npm_view]
+[npm.shell_out]
 default = false
-description = "Use the npm CLI (`npm view`) for version metadata queries instead of mise's built-in registry client."
+description = "Shell out to the npm CLI for `npm:` version metadata and installs instead of mise's built-in aube-based implementation."
 docs = """
-By default, mise queries npm version metadata (`mise ls-remote`, `latest` resolution)
-directly from the npm registry over HTTP, honoring the registry, scoped registries,
-and auth tokens configured in `~/.npmrc` and `NPM_CONFIG_*` environment variables.
-This means node/npm do not need to be installed to resolve `npm:` tool versions.
+By default, mise handles `npm:` tools without needing node/npm installed:
+version metadata (`mise ls-remote`, `latest` resolution) is queried directly
+from the npm registry over HTTP, and packages are installed with mise's
+embedded [aube](https://github.com/jdx/aube) package manager. Both honor the
+registry, scoped registries, and auth tokens configured in `~/.npmrc` and
+`NPM_CONFIG_*` environment variables.
 
-Enable this setting to shell out to `npm view` instead, e.g. if your setup relies on
-npm-specific configuration that mise's registry client does not support, such as
-`cafile`, client certificates, or an auth token helper. When enabled, npm must be
-installed for version queries to work.
+Enable this setting to shell out to the npm CLI instead — `npm view` for
+metadata and `npm install -g` for installs. Use it if your setup relies on
+npm-specific configuration the built-in implementation does not support (such
+as `cafile`, client certificates, or an auth token helper). When enabled, npm
+must be installed.
+
+This applies to the default/`auto` package manager. Explicitly selecting a
+package manager with [`npm.package_manager`](#npm-package-manager) (`bun`,
+`pnpm`, or `npm`) always shells out to that tool regardless of this setting.
 """
-env = "MISE_NPM_USE_NPM_VIEW"
+env = "MISE_NPM_SHELL_OUT"
 type = "Bool"
 
 [oci.default_from]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -253,32 +253,42 @@ impl Backend for NPMBackend {
         // tools (and any lifecycle scripts) need a runtime. Explicit non-aube
         // package managers — or `npm.shell_out` — need their CLI on PATH.
         let settings = Settings::get();
-        let package_manager = settings.npm.package_manager;
+        let shell_out = settings.npm.shell_out;
         let tool_name = self.tool_name();
 
-        // `npm.shell_out` routes both metadata and install through the npm CLI.
-        if settings.npm.shell_out {
-            return Ok(vec!["node", "npm"]);
-        }
+        // Resolve the effective installer the same way `package_manager_for_install`
+        // does: `auto` is the embedded aube, or npm under `shell_out`; an explicit
+        // choice is always honored.
+        let installer = match settings.npm.package_manager {
+            NpmPackageManager::Auto if shell_out => NpmPackageManager::Npm,
+            NpmPackageManager::Auto => NpmPackageManager::Aube,
+            package_manager => package_manager,
+        };
 
         // Avoid a circular dependency when installing the configured external
         // package manager itself (e.g. npm:bun with package_manager=bun):
-        // bootstrap that install through npm. Embedded aube (Auto/Aube) has no
-        // such cycle — it installs any package, including bun/pnpm/npm.
-        if tool_name == package_manager.to_string()
-            && !matches!(
-                package_manager,
-                NpmPackageManager::Auto | NpmPackageManager::Aube
-            )
+        // bootstrap that install through npm. Embedded aube has no such cycle —
+        // it installs any package, including bun/pnpm/npm.
+        if tool_name == installer.to_string()
+            && !matches!(installer, NpmPackageManager::Auto | NpmPackageManager::Aube)
         {
             return Ok(vec!["node", "npm"]);
         }
 
         let mut deps = vec!["node"];
-        match package_manager {
+        // `shell_out` routes metadata through `npm view`, which needs npm even
+        // when an explicit non-npm installer does the install.
+        if shell_out {
+            deps.push("npm");
+        }
+        match installer {
             // Embedded aube — no external package-manager binary required.
             NpmPackageManager::Auto | NpmPackageManager::Aube => {}
-            NpmPackageManager::Npm => deps.push("npm"),
+            NpmPackageManager::Npm => {
+                if !deps.contains(&"npm") {
+                    deps.push("npm");
+                }
+            }
             NpmPackageManager::Bun => deps.push("bun"),
             NpmPackageManager::Pnpm => deps.push("pnpm"),
         }
@@ -831,13 +841,13 @@ impl NPMBackend {
         _ts: Option<&Toolset>,
     ) -> NpmPackageManager {
         let settings = Settings::get();
-        // `shell_out` opts out of the embedded package manager entirely.
-        if settings.npm.shell_out {
-            return NpmPackageManager::Npm;
-        }
         match settings.npm.package_manager {
-            // aube is embedded, so `auto` always resolves to it — no need to
-            // probe for an `aube` binary on PATH.
+            // aube is embedded, so `auto` normally resolves to it — no need to
+            // probe for an `aube` binary on PATH. `shell_out` opts the default
+            // path out of embedding, into the npm CLI. An explicit
+            // `package_manager` (including `aube`) is always honored, matching
+            // the `npm.shell_out` docs.
+            NpmPackageManager::Auto if settings.npm.shell_out => NpmPackageManager::Npm,
             NpmPackageManager::Auto => NpmPackageManager::Aube,
             package_manager => package_manager,
         }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -891,6 +891,11 @@ impl NPMBackend {
             // invocation flag. `None` leaves scripts skipped (aube's default).
             dangerously_allow_all_builds: matches!(allow_builds, AllowBuilds::All),
             control: aube::embed::InstallControl::default(),
+            // Run dependency lifecycle scripts on the node mise resolved as a
+            // dependency, so `allow_builds` installs work even when node isn't
+            // on the ambient PATH (the in-process installer doesn't inherit the
+            // per-command PATH the old `aube add --global` subprocess got).
+            node_bin_dir: self.aube_embed_node_bin_dir(ctx).await,
             ..Default::default()
         };
         opts.ignore_scripts = matches!(allow_builds, AllowBuilds::None);
@@ -900,6 +905,15 @@ impl NPMBackend {
             .await
             .map_err(|e| eyre::eyre!("aube install failed: {e}"))?;
         Ok(())
+    }
+
+    /// Directory containing the `node` mise resolved as a dependency, handed to
+    /// the embedded aube installer so lifecycle scripts spawn on it. `None` (no
+    /// node dependency resolved) lets aube fall back to an ambient `node`.
+    async fn aube_embed_node_bin_dir(&self, ctx: &InstallContext) -> Option<PathBuf> {
+        let ts = self.dependency_toolset(&ctx.config).await.ok()?;
+        let node = ts.which_bin(&ctx.config, "node").await?;
+        node.parent().map(Path::to_path_buf)
     }
 
     /// Write the throwaway project's `package.json` + `.npmrc` for an embedded

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -44,8 +44,6 @@ pub struct NPMBackend {
     ba: Arc<BackendArg>,
     // use a mutex to prevent deadlocks that occurs due to reentrant cache access
     latest_version_cache: TokioMutex<CacheManager<Option<String>>>,
-    // one packument fetch serves both version listing and dist-tag lookup
-    packument: tokio::sync::OnceCell<Arc<npm_registry::Packument>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -322,21 +320,9 @@ impl Backend for NPMBackend {
         }
         // Query the registry directly over HTTP so node/npm are not required
         // for version metadata. User .npmrc and NPM_CONFIG_* registry/auth
-        // settings still apply via NPM_REGISTRY_CONFIG.
+        // settings still apply via aube-registry's config loader.
         timeout::run_with_timeout_async(
-            async || {
-                let packument = self.fetch_packument().await?;
-                Ok(packument
-                    .versions_with_time()
-                    .into_iter()
-                    .map(|(version, created_at)| VersionInfo {
-                        version: version.to_string(),
-                        created_at: created_at.map(|s| s.to_string()),
-                        prerelease: is_semver_prerelease(version),
-                        ..Default::default()
-                    })
-                    .collect())
-            },
+            async || npm_registry::list_versions(&self.tool_name()).await,
             Settings::get().fetch_remote_versions_timeout(),
         )
         .await
@@ -356,7 +342,7 @@ impl Backend for NPMBackend {
                         if Settings::get().npm.use_npm_view {
                             return this.latest_dist_tag_npm_view(config).await;
                         }
-                        Ok(this.fetch_packument().await?.latest_dist_tag())
+                        npm_registry::latest_dist_tag(&this.tool_name()).await
                     })
                     .await
             },
@@ -555,19 +541,7 @@ impl NPMBackend {
                     .build(),
             ),
             ba: Arc::new(ba),
-            packument: tokio::sync::OnceCell::new(),
         }
-    }
-
-    async fn fetch_packument(&self) -> eyre::Result<&Arc<npm_registry::Packument>> {
-        self.packument
-            .get_or_try_init(|| async {
-                let packument = npm_registry::NPM_REGISTRY_CONFIG
-                    .fetch_packument(&self.tool_name())
-                    .await?;
-                Ok(Arc::new(packument))
-            })
-            .await
     }
 
     /// Legacy `npm view` version listing, kept behind `npm.use_npm_view` for
@@ -1056,7 +1030,7 @@ impl NPMBackend {
 /// Stricter than the generic `VERSION_REGEX` channel-tag list — for npm it
 /// catches any pre-release tag the maintainer chooses, not just the well-known
 /// names mise happens to recognize.
-fn is_semver_prerelease(version: &str) -> bool {
+pub(crate) fn is_semver_prerelease(version: &str) -> bool {
     let core_and_pre = version.split_once('+').map_or(version, |(v, _)| v);
     core_and_pre.contains('-')
 }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -34,7 +34,6 @@ use tokio::sync::Mutex as TokioMutex;
 const BEFORE_DATE_TOLERANCE_SECS: u64 = 60;
 const NPM_ALLOW_SCRIPTS_VERSION: &str = "11.16.0";
 const NPM_MIN_RELEASE_AGE_VERSION: &str = "11.10.0";
-const AUBE_PROGRAM: &str = if cfg!(windows) { "aube.exe" } else { "aube" };
 const BUN_MIN_RELEASE_AGE_VERSION: &str = "1.3.0";
 const NPM_IGNORE_SCRIPTS_ARG: &str = "--ignore-scripts=true";
 const PNPM_MIN_RELEASE_AGE_VERSION: &str = "10.16.0";
@@ -248,49 +247,40 @@ impl Backend for NPMBackend {
     }
 
     fn get_dependencies(&self) -> eyre::Result<Vec<&str>> {
-        // Version queries go directly to the npm registry over HTTP, so npm is
-        // only needed when it is (or may be) the installer, or when the legacy
-        // `npm.use_npm_view` setting routes queries through the npm CLI. We
-        // avoid listing all package managers to prevent incorrect dependency
-        // edges.
+        // Version queries hit the npm registry over HTTP and installs use the
+        // embedded aube package manager, so by default neither needs a
+        // package-manager binary. `node` is still listed because installed JS
+        // tools (and any lifecycle scripts) need a runtime. Explicit non-aube
+        // package managers — or `npm.shell_out` — need their CLI on PATH.
         let settings = Settings::get();
         let package_manager = settings.npm.package_manager;
-        let use_npm_view = settings.npm.use_npm_view;
         let tool_name = self.tool_name();
 
-        // Explicit `npm:npm` still bootstraps through node's bundled npm even
-        // when the registry shorthand prefers aqua. Keep node here so users of
-        // the npm backend, or the registry fallback, wait for that bootstrap
-        // npm before installation starts.
-        if tool_name == "npm" {
-            return match package_manager {
-                NpmPackageManager::Auto => Ok(vec!["node"]),
-                NpmPackageManager::Aube => Ok(vec!["node", "aube"]),
-                NpmPackageManager::Bun => Ok(vec!["node", "bun"]),
-                NpmPackageManager::Pnpm => Ok(vec!["node", "pnpm"]),
-                NpmPackageManager::Npm => Ok(vec!["node"]),
-            };
-        }
-
-        // Avoid circular dependency when installing the configured package manager
-        // e.g., npm:bun with bun configured, or npm:pnpm with pnpm configured.
-        // npm stays here as the bootstrap installer for that package manager.
-        if tool_name == package_manager.to_string() {
+        // `npm.shell_out` routes both metadata and install through the npm CLI.
+        if settings.npm.shell_out {
             return Ok(vec!["node", "npm"]);
         }
 
-        // For regular packages: node + the configured package manager. npm is
-        // included when it may end up doing the install (Auto falls back to it)
-        // or when `npm.use_npm_view` needs it for version queries.
+        // Avoid a circular dependency when installing the configured external
+        // package manager itself (e.g. npm:bun with package_manager=bun):
+        // bootstrap that install through npm. Embedded aube (Auto/Aube) has no
+        // such cycle — it installs any package, including bun/pnpm/npm.
+        if tool_name == package_manager.to_string()
+            && !matches!(
+                package_manager,
+                NpmPackageManager::Auto | NpmPackageManager::Aube
+            )
+        {
+            return Ok(vec!["node", "npm"]);
+        }
+
         let mut deps = vec!["node"];
         match package_manager {
-            NpmPackageManager::Auto | NpmPackageManager::Npm => deps.push("npm"),
-            NpmPackageManager::Aube => deps.push("aube"),
+            // Embedded aube — no external package-manager binary required.
+            NpmPackageManager::Auto | NpmPackageManager::Aube => {}
+            NpmPackageManager::Npm => deps.push("npm"),
             NpmPackageManager::Bun => deps.push("bun"),
             NpmPackageManager::Pnpm => deps.push("pnpm"),
-        }
-        if use_npm_view && !deps.contains(&"npm") {
-            deps.push("npm");
         }
         Ok(deps)
     }
@@ -315,7 +305,7 @@ impl Backend for NPMBackend {
     }
 
     async fn _list_remote_versions(&self, config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
-        if Settings::get().npm.use_npm_view {
+        if Settings::get().npm.shell_out {
             return self.list_remote_versions_npm_view(config).await;
         }
         // Query the registry directly over HTTP so node/npm are not required
@@ -329,7 +319,7 @@ impl Backend for NPMBackend {
     }
 
     async fn latest_stable_version(&self, config: &Arc<Config>) -> eyre::Result<Option<String>> {
-        if Settings::get().npm.use_npm_view {
+        if Settings::get().npm.shell_out {
             self.ensure_npm_for_version_check(config).await;
         }
 
@@ -339,7 +329,7 @@ impl Backend for NPMBackend {
             async || {
                 cache
                     .get_or_try_init_async(async || {
-                        if Settings::get().npm.use_npm_view {
+                        if Settings::get().npm.shell_out {
                             return this.latest_dist_tag_npm_view(config).await;
                         }
                         npm_registry::latest_dist_tag(&this.tool_name()).await
@@ -384,31 +374,7 @@ impl Backend for NPMBackend {
         match package_manager {
             NpmPackageManager::Auto => unreachable!("auto package manager should be resolved"),
             NpmPackageManager::Aube => {
-                let aube_program = self
-                    .dependency_path_for_install(&ctx.config, Some(&ctx.ts), AUBE_PROGRAM)
-                    .await
-                    .unwrap_or_else(|| AUBE_PROGRAM.into());
-                self.write_aube_npmrc(&tv.install_path(), ctx.before_date, &options)?;
-                let mut cmd = CmdLineRunner::new(aube_program)
-                    .arg("add")
-                    .arg("--global")
-                    .arg(format!("{}@{}", self.tool_name(), tv.version))
-                    .with_pr(ctx.pr.as_ref())
-                    .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .env_values(tv.install_env())
-                    .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
-                    .prepend_path(
-                        self.dependency_toolset(&ctx.config)
-                            .await?
-                            .list_paths(&ctx.config)
-                            .await,
-                    )?
-                    .current_dir(tv.install_path());
-                if let Some(args) = options.aube_args() {
-                    cmd = cmd.args(shell_words::split(args)?);
-                }
-                cmd = cmd.args(options.allow_build_args()?);
-                cmd.execute()?;
+                self.install_via_aube_embed(ctx, &tv, &options).await?;
             }
             NpmPackageManager::Bun => {
                 let mut cmd = CmdLineRunner::new("bun")
@@ -525,10 +491,22 @@ impl Backend for NPMBackend {
         _config: &Arc<Config>,
         tv: &crate::toolset::ToolVersion,
     ) -> eyre::Result<Vec<std::path::PathBuf>> {
-        Ok(Self::windows_bin_paths_for_install_path(&tv.install_path())
+        Ok(Self::bin_paths_for_install_path(&tv.install_path())
             .into_iter()
             .map(|path| runtime_path_for_install_path(tv, path))
             .collect())
+    }
+
+    #[cfg(unix)]
+    async fn list_bin_paths(
+        &self,
+        _config: &Arc<Config>,
+        tv: &crate::toolset::ToolVersion,
+    ) -> eyre::Result<Vec<std::path::PathBuf>> {
+        if matches!(tv.request, ToolRequest::System { .. }) {
+            return Ok(vec![]);
+        }
+        Ok(Self::bin_paths_for_install_path(&tv.runtime_path()))
     }
 }
 
@@ -544,7 +522,7 @@ impl NPMBackend {
         }
     }
 
-    /// Legacy `npm view` version listing, kept behind `npm.use_npm_view` for
+    /// Legacy `npm view` version listing, kept behind `npm.shell_out` for
     /// setups relying on npm-only config (cafile, client certs, token helpers).
     /// --prefix points at a neutral cache dir so project package.json (e.g.
     /// devEngines) cannot fail the query. Install already uses --prefix the
@@ -800,26 +778,11 @@ impl NPMBackend {
         &self,
         config: &Arc<Config>,
         package_manager: NpmPackageManager,
-        ts: Option<&Toolset>,
+        _ts: Option<&Toolset>,
     ) {
         match package_manager {
-            NpmPackageManager::Aube => {
-                if let Some(ts) = ts
-                    && ts.which_bin(config, AUBE_PROGRAM).await.is_some()
-                {
-                    return;
-                }
-                self.warn_if_dependency_missing(
-                    config,
-                    "aube",
-                    &["aube"],
-                    "To use npm packages with aube, you need to install aube first:\n\
-                          mise use aube@latest\n\n\
-                        Or switch back to npm by setting:\n\
-                          mise settings npm.package_manager=npm",
-                )
-                .await
-            }
+            // Embedded aube is compiled into mise — nothing to check for.
+            NpmPackageManager::Aube => {}
             NpmPackageManager::Bun => {
                 self.warn_if_dependency_missing(
                     config,
@@ -864,39 +827,95 @@ impl NPMBackend {
 
     async fn package_manager_for_install(
         &self,
-        config: &Arc<Config>,
-        ts: Option<&Toolset>,
+        _config: &Arc<Config>,
+        _ts: Option<&Toolset>,
     ) -> NpmPackageManager {
         let settings = Settings::get();
+        // `shell_out` opts out of the embedded package manager entirely.
+        if settings.npm.shell_out {
+            return NpmPackageManager::Npm;
+        }
         match settings.npm.package_manager {
-            NpmPackageManager::Auto if self.aube_is_installed(config, ts).await => {
-                NpmPackageManager::Aube
-            }
-            NpmPackageManager::Auto => NpmPackageManager::Npm,
+            // aube is embedded, so `auto` always resolves to it — no need to
+            // probe for an `aube` binary on PATH.
+            NpmPackageManager::Auto => NpmPackageManager::Aube,
             package_manager => package_manager,
         }
     }
 
-    async fn aube_is_installed(&self, config: &Arc<Config>, ts: Option<&Toolset>) -> bool {
-        self.dependency_path_for_install(config, ts, AUBE_PROGRAM)
+    /// Install an npm package by embedding aube's package manager in-process
+    /// (`aube::embed::add`) instead of shelling out to the `aube` binary.
+    ///
+    /// The install directory doubles as a throwaway project: a seed
+    /// `package.json` + `.npmrc` carry the install-scoped config (release age,
+    /// build-script allowlist) that aube reads during resolution, exactly as
+    /// the `aube add --global` path did via its written `.npmrc`. aube installs
+    /// into `<install>/node_modules`; the resulting `node_modules/.bin` shims
+    /// are linked into `<install>/bin` so mise's default `list_bin_paths`
+    /// (which points at `<install>/bin`) keeps working unchanged.
+    async fn install_via_aube_embed(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+        options: &NpmOptions<'_>,
+    ) -> Result<()> {
+        let install_path = tv.install_path();
+        crate::file::create_dir_all(&install_path)?;
+
+        let allow_builds = options.allow_builds()?;
+        self.write_aube_embed_project(&install_path, ctx.before_date, options, &allow_builds)?;
+
+        if let Some(args) = options.aube_args() {
+            warn!(
+                "aube_args ({args:?}) are ignored for npm:{}: mise installs through the embedded aube package manager and no longer shells out to the aube CLI",
+                self.tool_name()
+            );
+        }
+
+        let mut opts = aube::embed::AddToProjectOptions {
+            // Global-style installs pin the exact resolved version, matching
+            // what `aube add --global` wrote to its synthetic manifest.
+            save_exact: true,
+            // Per-package allowlists are written to the seed package.json's
+            // `aube.allowBuilds`; only the "allow everything" case needs the
+            // invocation flag. `None` leaves scripts skipped (aube's default).
+            dangerously_allow_all_builds: matches!(allow_builds, AllowBuilds::All),
+            control: aube::embed::InstallControl::default(),
+            ..Default::default()
+        };
+        opts.ignore_scripts = matches!(allow_builds, AllowBuilds::None);
+
+        let package = format!("{}@{}", self.tool_name(), tv.version);
+        aube::embed::add(&install_path, std::slice::from_ref(&package), opts)
             .await
-            .is_some()
+            .map_err(|e| eyre::eyre!("aube install failed: {e}"))?;
+        Ok(())
     }
 
-    fn write_aube_npmrc(
+    /// Write the throwaway project's `package.json` + `.npmrc` for an embedded
+    /// aube install. `allowBuilds` package lists go in `package.json` (aube's
+    /// manifest namespace); release age and trust-policy excludes go in
+    /// `.npmrc`, which aube's resolver reads from the project dir.
+    fn write_aube_embed_project(
         &self,
         install_path: &Path,
         before_date: Option<Timestamp>,
         options: &NpmOptions,
+        allow_builds: &AllowBuilds,
     ) -> Result<()> {
-        let bin_dir = install_path.join("bin");
-        crate::file::create_dir_all(install_path)?;
-        crate::file::create_dir_all(&bin_dir)?;
-        let mut npmrc = format!(
-            "globalDir={}\nglobalBinDir={}\n",
-            Self::npmrc_path_value(install_path),
-            Self::npmrc_path_value(&bin_dir)
-        );
+        let mut manifest = serde_json::json!({
+            "name": "mise-npm-install",
+            "private": true,
+        });
+        if let AllowBuilds::Packages(packages) = allow_builds {
+            manifest["aube"] = serde_json::json!({ "allowBuilds": packages });
+        }
+        crate::file::write(
+            install_path.join("package.json"),
+            format!("{}\n", serde_json::to_string_pretty(&manifest)?),
+        )?;
+
+        let mut npmrc = String::new();
         if let Some(before_date) = before_date {
             let minutes = Self::build_aube_minimum_release_age(elapsed_seconds_ceil(
                 before_date,
@@ -910,10 +929,6 @@ impl NPMBackend {
         }
         crate::file::write(install_path.join(".npmrc"), npmrc)?;
         Ok(())
-    }
-
-    fn npmrc_path_value(path: &Path) -> String {
-        path.to_string_lossy().replace('\\', "/")
     }
 
     fn build_aube_minimum_release_age(seconds: u64) -> u64 {
@@ -1009,14 +1024,28 @@ impl NPMBackend {
             .collect()
     }
 
-    #[cfg(any(windows, test))]
-    fn windows_bin_paths_for_install_path(install_path: &Path) -> Vec<std::path::PathBuf> {
+    /// Directories to expose on PATH for an installed npm tool.
+    ///
+    /// Embedded-aube installs place bin shims in `node_modules/.bin` (the
+    /// shims resolve their target relative to that location, so they can't be
+    /// moved). Other package managers — bun/pnpm/npm global installs, and
+    /// legacy `aube add --global` installs — use `bin/`. Whichever exists is
+    /// returned; the bare install path is the last-resort fallback (some npm
+    /// global layouts drop executables at the root on Windows).
+    fn bin_paths_for_install_path(install_path: &Path) -> Vec<std::path::PathBuf> {
+        let node_bin = install_path.join("node_modules").join(".bin");
         let bin_dir = install_path.join("bin");
-        if bin_dir.exists() {
-            vec![bin_dir]
-        } else {
-            vec![install_path.to_path_buf()]
+        let mut paths = Vec::new();
+        if node_bin.exists() {
+            paths.push(node_bin);
         }
+        if bin_dir.exists() {
+            paths.push(bin_dir);
+        }
+        if paths.is_empty() {
+            paths.push(install_path.to_path_buf());
+        }
+        paths
     }
 }
 
@@ -1169,13 +1198,11 @@ mod tests {
 
     #[test]
     fn test_get_dependencies_default_package_manager() {
-        // With default settings (npm), packages should depend on node + npm
+        // Default (auto) installs via the embedded aube package manager, so a
+        // package only needs node at runtime — no npm/aube/bun/pnpm binary.
         let backend = create_npm_backend("prettier");
         let deps = backend.get_dependencies().unwrap();
-        assert!(deps.contains(&"node"));
-        assert!(deps.contains(&"npm"));
-        assert!(!deps.contains(&"bun"));
-        assert!(!deps.contains(&"pnpm"));
+        assert_eq!(deps, vec!["node"]);
     }
 
     #[test]
@@ -1447,32 +1474,42 @@ mod tests {
     }
 
     #[test]
-    fn test_npmrc_path_value_uses_forward_slashes() {
+    fn test_bin_paths_prefers_node_modules_bin() {
+        // Embedded-aube installs put runnable shims in node_modules/.bin;
+        // that must come first on PATH.
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("npm-cowsay").join("1.6.0");
+        std::fs::create_dir_all(install_path.join("node_modules").join(".bin")).unwrap();
+        std::fs::create_dir_all(install_path.join("bin")).unwrap();
+
         assert_eq!(
-            NPMBackend::npmrc_path_value(Path::new(r"C:\Users\me\mise\npm-cowsay\1.6.0")),
-            "C:/Users/me/mise/npm-cowsay/1.6.0"
+            NPMBackend::bin_paths_for_install_path(&install_path),
+            vec![
+                install_path.join("node_modules").join(".bin"),
+                install_path.join("bin"),
+            ]
         );
     }
 
     #[test]
-    fn test_windows_bin_paths_prefers_created_bin_dir() {
+    fn test_bin_paths_uses_bin_dir_for_non_aube_installs() {
         let tmp = tempfile::tempdir().unwrap();
         let install_path = tmp.path().join("npm-cowsay").join("1.6.0");
         std::fs::create_dir_all(install_path.join("bin")).unwrap();
 
         assert_eq!(
-            NPMBackend::windows_bin_paths_for_install_path(&install_path),
+            NPMBackend::bin_paths_for_install_path(&install_path),
             vec![install_path.join("bin")]
         );
     }
 
     #[test]
-    fn test_windows_bin_paths_falls_back_to_install_path() {
+    fn test_bin_paths_falls_back_to_install_path() {
         let tmp = tempfile::tempdir().unwrap();
         let install_path = tmp.path().join("npm-cowsay").join("1.6.0");
 
         assert_eq!(
-            NPMBackend::windows_bin_paths_for_install_path(&install_path),
+            NPMBackend::bin_paths_for_install_path(&install_path),
             vec![install_path]
         );
     }
@@ -1702,10 +1739,11 @@ mod tests {
     }
 
     #[test]
-    fn test_write_aube_npmrc_includes_trust_policy_excludes() {
+    fn test_write_aube_embed_project_emits_npmrc_and_manifest() {
         let backend = create_npm_backend("vercel");
         let tmp = tempfile::tempdir().unwrap();
         let install_path = tmp.path().join("npm-vercel").join("54.20.1");
+        crate::file::create_dir_all(&install_path).unwrap();
         let mut raw_options = ToolVersionOptions::default();
         raw_options.opts.insert(
             "trust_policy_excludes".to_string(),
@@ -1714,14 +1752,24 @@ mod tests {
                 toml::Value::String("undici".into()),
             ]),
         );
+        raw_options.opts.insert(
+            "allow_builds".to_string(),
+            toml::Value::Array(vec![toml::Value::String("esbuild".into())]),
+        );
         let options = NpmOptions::new(&raw_options);
+        let allow_builds = options.allow_builds().unwrap();
 
         backend
-            .write_aube_npmrc(&install_path, None, &options)
+            .write_aube_embed_project(&install_path, None, &options, &allow_builds)
             .unwrap();
 
+        // Trust-policy excludes go in .npmrc for the resolver to read.
         let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
         assert!(npmrc.contains("trustPolicyExclude=undici,undici@^5\n"));
+        // The build-script allowlist goes in package.json's aube namespace.
+        let manifest = std::fs::read_to_string(install_path.join("package.json")).unwrap();
+        assert!(manifest.contains("\"allowBuilds\""));
+        assert!(manifest.contains("esbuild"));
     }
 
     #[test]

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -15,19 +15,39 @@
 use std::path::PathBuf;
 use std::sync::LazyLock as Lazy;
 
+use aube_registry::NetworkMode;
 use aube_registry::client::RegistryClient;
 use aube_registry::config::NpmConfig;
 use eyre::Result;
 
 use crate::backend::VersionInfo;
 use crate::backend::npm::is_semver_prerelease;
+use crate::config::Settings;
 
 /// Process-wide npm registry client. Registry URLs, scoped registries, and
 /// auth are read once from the environment and the user's `~/.npmrc`; the
 /// neutral project dir keeps a cwd `.npmrc` out of mise-owned queries.
+///
+/// The network mode honors mise's offline flags so metadata queries don't hit
+/// the network when the user asked for offline — `offline()` fails on a cold
+/// cache, `prefer_offline()` serves the cache and only falls back to the
+/// network on a miss. (Offline state is set from the CLI/env at startup, so
+/// resolving it once at client construction is sufficient.)
 static CLIENT: Lazy<RegistryClient> = Lazy::new(|| {
     let config = NpmConfig::load(&meta_dir());
-    RegistryClient::from_config(config)
+    let settings = Settings::get();
+    let mode = if settings.offline() {
+        NetworkMode::Offline
+    } else if settings.prefer_offline() {
+        NetworkMode::PreferOffline
+    } else {
+        NetworkMode::Online
+    };
+    // Create the on-disk packument cache dir once here (client init runs at
+    // most once per process) rather than on every async fetch — keeps the
+    // blocking mkdir + its sync lock off the Tokio worker in the hot path.
+    let _ = crate::file::create_dir_all(meta_dir());
+    RegistryClient::from_config(config).with_network_mode(mode)
 });
 
 /// Neutral mise-owned directory used both as the client's "project dir" (so
@@ -41,10 +61,8 @@ fn meta_dir() -> PathBuf {
 /// on-disk cache. The full (non-corgi) route is used so the `time` map is
 /// present for release-date / `minimum_release_age` filtering.
 async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
-    let cache_dir = meta_dir();
-    crate::file::create_dir_all(&cache_dir)?;
     Ok(CLIENT
-        .fetch_packument_with_time_cached(name, &cache_dir)
+        .fetch_packument_with_time_cached(name, &meta_dir())
         .await?)
 }
 

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -1,682 +1,79 @@
-//! Minimal npm registry HTTP client used for version metadata queries.
+//! npm registry metadata queries backed by the `aube-registry` crate
+//! (<https://github.com/jdx/aube>).
 //!
 //! Replaces shelling out to `npm view`, so listing versions for `npm:` tools
-//! does not require node/npm to be installed. Config semantics (`.npmrc`
-//! parsing, `${VAR}` expansion, scoped registries, nerf-dart auth lookup,
-//! `NPM_CONFIG_*` env translation) are ported from the `aube-registry` crate
-//! (<https://github.com/jdx/aube>), trimmed to what read-only packument
-//! fetches need.
+//! does not require node/npm to be installed. `aube-registry` owns all the
+//! npm config semantics (`.npmrc` parsing, `${VAR}` expansion, scoped
+//! registries, nerf-dart auth lookup, `NPM_CONFIG_*` env translation).
 //!
-//! Scope notes, matching what `npm view` did when invoked with a neutral
-//! `--prefix` (the previous behavior):
-//! - user-level `~/.npmrc` (or `NPM_CONFIG_USERCONFIG`) and `NPM_CONFIG_*` /
-//!   `npm_config_*` env vars apply; project `.npmrc` files do not
-//! - proxies come from the standard `HTTP(S)_PROXY` env vars via mise's HTTP
-//!   client; npm-only TLS knobs (`cafile`, client certs) and token helpers are
-//!   not supported — set `npm.use_npm_view = true` to keep using the npm CLI
-//!   for metadata in those environments
+//! Scope note, matching what `npm view` did when invoked with a neutral
+//! `--prefix` (the previous behavior): the client's project dir is a
+//! mise-owned cache dir, so a project `.npmrc` in the cwd cannot redirect or
+//! authenticate mise-owned metadata queries. User-level `~/.npmrc` (or
+//! `NPM_CONFIG_USERCONFIG`) and `NPM_CONFIG_*` env vars still apply.
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::LazyLock as Lazy;
 
-use base64::Engine;
-use eyre::{Result, eyre};
-use indexmap::IndexMap;
-use reqwest::header::{HeaderMap, HeaderValue};
-use serde::Deserialize;
+use aube_registry::client::RegistryClient;
+use aube_registry::config::NpmConfig;
+use eyre::Result;
 
-use crate::env;
+use crate::backend::VersionInfo;
+use crate::backend::npm::is_semver_prerelease;
 
-pub static NPM_REGISTRY_CONFIG: Lazy<NpmRegistryConfig> = Lazy::new(NpmRegistryConfig::load);
+/// Process-wide npm registry client. Registry URLs, scoped registries, and
+/// auth are read once from the environment and the user's `~/.npmrc`; the
+/// neutral project dir keeps a cwd `.npmrc` out of mise-owned queries.
+static CLIENT: Lazy<RegistryClient> = Lazy::new(|| {
+    let config = NpmConfig::load(&meta_dir());
+    RegistryClient::from_config(config)
+});
 
-const DEFAULT_REGISTRY: &str = "https://registry.npmjs.org/";
-/// Accept header for the full packument route. The full document (not the
-/// abbreviated `vnd.npm.install-v1+json` corgi) is required because only it
-/// carries the `time` map used for release dates / `minimum_release_age`.
-const PACKUMENT_ACCEPT: &str = "application/json; q=1.0, */*";
-
-#[derive(Debug, Default)]
-pub struct NpmRegistryConfig {
-    /// Default registry URL, normalized with a trailing slash.
-    registry: String,
-    /// Scoped registry overrides: "@scope" -> registry URL.
-    scoped_registries: BTreeMap<String, String>,
-    /// Auth entries keyed by normalized nerf-dart URI ("//host/path/").
-    auth_by_uri: BTreeMap<String, NpmAuth>,
+/// Neutral mise-owned directory used both as the client's "project dir" (so
+/// no real project `.npmrc` is read) and as `aube-registry`'s on-disk
+/// packument cache location.
+fn meta_dir() -> PathBuf {
+    crate::dirs::CACHE.join("npm-meta")
 }
 
-#[derive(Debug, Default, Clone)]
-struct NpmAuth {
-    /// `_authToken` — sent as `Authorization: Bearer <token>`.
-    auth_token: Option<String>,
-    /// `_auth` — pre-encoded base64("user:pass"), sent as `Basic`.
-    auth: Option<String>,
-    username: Option<String>,
-    /// `_password` — npm stores this base64-encoded.
-    password: Option<String>,
+/// Fetch the full packument for `name`, honoring the configured registry and
+/// on-disk cache. The full (non-corgi) route is used so the `time` map is
+/// present for release-date / `minimum_release_age` filtering.
+async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
+    let cache_dir = meta_dir();
+    crate::file::create_dir_all(&cache_dir)?;
+    Ok(CLIENT
+        .fetch_packument_with_time_cached(name, &cache_dir)
+        .await?)
 }
 
-impl NpmAuth {
-    fn authorization_header(&self) -> Option<String> {
-        if let Some(token) = &self.auth_token {
-            return Some(format!("Bearer {token}"));
-        }
-        if let Some(auth) = &self.auth {
-            return Some(format!("Basic {auth}"));
-        }
-        let username = self.username.as_ref()?;
-        let password = base64::engine::general_purpose::STANDARD
-            .decode(self.password.as_ref()?)
-            .ok()?;
-        let mut raw = Vec::with_capacity(username.len() + 1 + password.len());
-        raw.extend_from_slice(username.as_bytes());
-        raw.push(b':');
-        raw.extend_from_slice(&password);
-        Some(format!(
-            "Basic {}",
-            base64::engine::general_purpose::STANDARD.encode(raw)
-        ))
-    }
-}
-
-impl NpmRegistryConfig {
-    pub fn load() -> Self {
-        let env_vars: Vec<(String, String)> = env::vars_safe().collect();
-        Self::load_with_env(user_npmrc_path(&env_vars), &env_vars)
-    }
-
-    fn load_with_env(user_npmrc: Option<PathBuf>, env_vars: &[(String, String)]) -> Self {
-        let mut config = Self {
-            registry: DEFAULT_REGISTRY.to_string(),
+/// List a package's versions as [`VersionInfo`], semver-ascending with publish
+/// timestamps. npm registry versions are strict semver (the registry enforces
+/// it) but the packument's `versions` map is keyed lexically, so the keys are
+/// sorted to match the order `npm view versions` produced — prefix resolution
+/// (e.g. `npm:@angular/cli@19`) depends on it. Anything unparseable keeps a
+/// stable position at the end.
+pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
+    let packument = fetch_packument(name).await?;
+    let mut versions: Vec<&String> = packument.versions.keys().collect();
+    versions.sort_by_cached_key(|v| {
+        let parsed = versions::SemVer::new(v);
+        (parsed.is_none(), parsed)
+    });
+    Ok(versions
+        .into_iter()
+        .map(|version| VersionInfo {
+            version: version.clone(),
+            created_at: packument.time.get(version).cloned(),
+            prerelease: is_semver_prerelease(version),
             ..Default::default()
-        };
-        let mut entries = Vec::new();
-        if let Some(path) = user_npmrc
-            && path.is_file()
-        {
-            match std::fs::read_to_string(&path) {
-                Ok(content) => entries.extend(parse_npmrc(&content, Some(env_vars))),
-                Err(err) => debug!("failed to read {}: {err}", path.display()),
-            }
-        }
-        // Env entries apply after .npmrc entries so last-write-wins gives env
-        // the higher precedence npm documents.
-        entries.extend(npm_config_env_entries(env_vars));
-        config.apply(entries);
-        config
-    }
-
-    fn apply(&mut self, entries: Vec<(String, String)>) {
-        // Bare `_authToken` / `_auth` (no `//uri` prefix) apply to whatever
-        // default registry ends up configured, so collect them and resolve
-        // after all entries are seen.
-        let mut bare_auth_token = None;
-        let mut bare_auth = None;
-        for (key, value) in entries {
-            if value.is_empty() {
-                continue;
-            }
-            if key == "registry" {
-                self.registry = normalize_registry_url(&value);
-            } else if let Some(rest) = key.strip_prefix('@') {
-                if let Some((scope, tail)) = rest.split_once(':')
-                    && tail.eq_ignore_ascii_case("registry")
-                {
-                    self.scoped_registries.insert(
-                        format!("@{}", scope.to_ascii_lowercase()),
-                        normalize_registry_url(&value),
-                    );
-                }
-            } else if key.starts_with("//") {
-                let Some((uri, suffix)) = key.rsplit_once(':') else {
-                    continue;
-                };
-                // Scoped per-URI auth (`//host/:@scope:_authToken`) is not
-                // supported; skip rather than send a token for the wrong
-                // packages.
-                if uri
-                    .rsplit_once(':')
-                    .is_some_and(|(_, s)| s.starts_with('@'))
-                {
-                    debug!("ignoring scoped npm auth key: {key}");
-                    continue;
-                }
-                let uri_key = normalize_npmrc_uri_key(uri);
-                let entry = self.auth_by_uri.entry(uri_key).or_default();
-                match suffix {
-                    "_authToken" => entry.auth_token = Some(value),
-                    "_auth" => entry.auth = Some(value),
-                    "username" => entry.username = Some(value),
-                    "_password" => entry.password = Some(value),
-                    _ => {}
-                }
-            } else if key == "_authToken" {
-                bare_auth_token = Some(value);
-            } else if key == "_auth" {
-                bare_auth = Some(value);
-            }
-        }
-        if bare_auth_token.is_some() || bare_auth.is_some() {
-            let uri_key = registry_uri_key(&self.registry);
-            let entry = self.auth_by_uri.entry(uri_key).or_default();
-            if entry.auth_token.is_none() {
-                entry.auth_token = bare_auth_token;
-            }
-            if entry.auth.is_none() {
-                entry.auth = bare_auth;
-            }
-        }
-    }
-
-    /// Registry URL for a package, honoring `@scope:registry` overrides.
-    pub fn registry_for(&self, name: &str) -> &str {
-        package_scope(name)
-            .and_then(|scope| self.scoped_registries.get(scope))
-            .unwrap_or(&self.registry)
-    }
-
-    fn authorization_for(&self, registry_url: &str) -> Option<String> {
-        let uri_key = registry_uri_key(registry_url);
-        lookup_by_uri_prefix(&self.auth_by_uri, &uri_key)?.authorization_header()
-    }
-
-    /// Fetch the full packument for a package from its configured registry.
-    pub async fn fetch_packument(&self, name: &str) -> Result<Packument> {
-        let registry = self.registry_for(name);
-        let url = format!("{registry}{}", encode_package_name(name));
-        let mut headers = HeaderMap::new();
-        headers.insert("Accept", HeaderValue::from_static(PACKUMENT_ACCEPT));
-        if let Some(auth) = self.authorization_for(registry) {
-            let mut value = HeaderValue::from_str(&auth)
-                .map_err(|err| eyre!("invalid npm auth for {registry}: {err}"))?;
-            value.set_sensitive(true);
-            headers.insert("Authorization", value);
-        }
-        let packument: Packument = crate::http::HTTP_FETCH
-            .json_with_headers(&url, &headers)
-            .await
-            .map_err(|err| eyre!("failed to fetch npm metadata for {name} from {url}: {err}"))?;
-        Ok(packument)
-    }
+        })
+        .collect())
 }
 
-/// Full packument, trimmed to the fields version listing needs.
-#[derive(Debug, Deserialize)]
-pub struct Packument {
-    #[serde(default)]
-    versions: IndexMap<String, serde::de::IgnoredAny>,
-    #[serde(default, rename = "dist-tags")]
-    dist_tags: serde_json::Value,
-    #[serde(default)]
-    time: serde_json::Value,
-}
-
-impl Packument {
-    /// Versions sorted ascending by semver with their publish timestamps.
-    ///
-    /// The packument document is in publish order, which differs from semver
-    /// order when maintainers backport patches to old release lines. `npm
-    /// view versions` sorted semver-ascending, and prefix resolution (e.g.
-    /// `npm:@angular/cli@19`) picks the last match, so the sort is load-bearing.
-    /// npm registry versions are strictly semver (the registry enforces it);
-    /// anything unparseable keeps document order at the end.
-    pub fn versions_with_time(&self) -> Vec<(&str, Option<&str>)> {
-        let time = self.time.as_object();
-        let mut versions: Vec<&str> = self.versions.keys().map(|v| v.as_str()).collect();
-        versions.sort_by_cached_key(|v| {
-            let parsed = versions::SemVer::new(v);
-            (parsed.is_none(), parsed)
-        });
-        versions
-            .into_iter()
-            .map(|version| {
-                let created_at = time
-                    .and_then(|time| time.get(version))
-                    .and_then(|v| v.as_str());
-                (version, created_at)
-            })
-            .collect()
-    }
-
-    pub fn latest_dist_tag(&self) -> Option<String> {
-        Some(self.dist_tags.get("latest")?.as_str()?.to_string())
-    }
-}
-
-/// The user-level npmrc path: `NPM_CONFIG_USERCONFIG` or `~/.npmrc`.
-fn user_npmrc_path(env_vars: &[(String, String)]) -> Option<PathBuf> {
-    for (key, value) in env_vars {
-        if (key.eq_ignore_ascii_case("npm_config_userconfig")) && !value.is_empty() {
-            return Some(PathBuf::from(value));
-        }
-    }
-    Some(env::HOME.join(".npmrc"))
-}
-
-/// Parse .npmrc content into key=value pairs. Supports comments (`#`/`;`),
-/// backslash line continuation, matched-quote stripping, and `${VAR}`
-/// expansion (when `expand_env` is provided), mirroring npm's `ini` parser.
-fn parse_npmrc(content: &str, expand_env: Option<&[(String, String)]>) -> Vec<(String, String)> {
-    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
-    let mut entries = Vec::new();
-
-    // Fold backslash-continuation before line iteration: a trailing `\` joins
-    // the next physical line, used for long auth tokens.
-    let mut logical: Vec<String> = Vec::new();
-    let mut acc = String::new();
-    for raw in content.lines() {
-        if let Some(stripped) = raw.strip_suffix('\\') {
-            acc.push_str(stripped);
-            continue;
-        }
-        acc.push_str(raw);
-        logical.push(std::mem::take(&mut acc));
-    }
-    if !acc.is_empty() {
-        logical.push(acc);
-    }
-
-    for line in &logical {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
-            continue;
-        }
-        if let Some((key, value)) = line.split_once('=') {
-            let key = maybe_substitute_env(key.trim(), expand_env);
-            let value = maybe_substitute_env(strip_matched_quotes(value.trim()), expand_env);
-            entries.push((key, value));
-        }
-    }
-    entries
-}
-
-fn maybe_substitute_env(value: &str, expand_env: Option<&[(String, String)]>) -> String {
-    match expand_env {
-        Some(env_vars) => substitute_env(value, env_vars),
-        None => value.to_string(),
-    }
-}
-
-/// Strip a single layer of matched surrounding `"` or `'`, mirroring npm's
-/// `ini` parser (`_auth="abc=="` keeps its `=` padding).
-fn strip_matched_quotes(value: &str) -> &str {
-    let bytes = value.as_bytes();
-    if bytes.len() >= 2
-        && (bytes[0] == b'"' || bytes[0] == b'\'')
-        && bytes[bytes.len() - 1] == bytes[0]
-    {
-        &value[1..value.len() - 1]
-    } else {
-        value
-    }
-}
-
-/// Substitute `${VAR}` references from the given env snapshot.
-fn substitute_env(value: &str, env_vars: &[(String, String)]) -> String {
-    let mut result = String::with_capacity(value.len());
-    let mut chars = value.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '$' && chars.peek() == Some(&'{') {
-            chars.next(); // consume '{'
-            let mut var_name = String::new();
-            for c in chars.by_ref() {
-                if c == '}' {
-                    break;
-                }
-                var_name.push(c);
-            }
-            if let Some((_, val)) = env_vars.iter().find(|(k, _)| *k == var_name) {
-                result.push_str(val);
-            }
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
-
-/// Synthesize `.npmrc`-style entries from `npm_config_*` / `NPM_CONFIG_*` env
-/// vars. Only registry/scoped-registry/auth keys are translated; everything
-/// else is owned by other subsystems (proxies come from the standard env vars
-/// via mise's HTTP client).
-fn npm_config_env_entries(env_vars: &[(String, String)]) -> Vec<(String, String)> {
-    let mut out = Vec::new();
-    let mut uri_scoped = Vec::new();
-    for (name, value) in env_vars {
-        if value.is_empty() {
-            continue;
-        }
-        let Some(suffix) = strip_npm_config_prefix(name) else {
-            continue;
-        };
-        // Per-URI auth keys carry `.npmrc` syntax in the env-var name
-        // (e.g. `npm_config_//registry.example.com/:_authToken`).
-        if suffix.starts_with("//") && is_url_scoped_env_auth_key(suffix) {
-            uri_scoped.push((suffix.to_string(), value.clone()));
-            continue;
-        }
-        // Scoped-registry keys: `@myorg:registry` (scope lowercased; npm
-        // scopes are case-insensitive on the registry side).
-        if let Some(rest) = suffix.strip_prefix('@')
-            && let Some((scope, tail)) = rest.split_once(':')
-            && tail.eq_ignore_ascii_case("registry")
-        {
-            out.push((
-                format!("@{}:registry", scope.to_ascii_lowercase()),
-                value.clone(),
-            ));
-            continue;
-        }
-        if suffix.eq_ignore_ascii_case("registry") {
-            out.push(("registry".to_string(), value.clone()));
-        }
-    }
-    out.extend(uri_scoped);
-    out
-}
-
-fn strip_npm_config_prefix(name: &str) -> Option<&str> {
-    let prefix = "npm_config_";
-    let candidate = name.get(..prefix.len())?;
-    if candidate.eq_ignore_ascii_case(prefix) {
-        Some(&name[prefix.len()..])
-    } else {
-        None
-    }
-}
-
-fn is_url_scoped_env_auth_key(key: &str) -> bool {
-    key.rsplit_once(':').is_some_and(|(_, suffix)| {
-        matches!(suffix, "_authToken" | "_auth" | "username" | "_password")
-    })
-}
-
-/// Extract the scope from a package name ("@myorg/pkg" -> "@myorg").
-fn package_scope(name: &str) -> Option<&str> {
-    if name.starts_with('@') {
-        name.find('/').map(|idx| &name[..idx])
-    } else {
-        None
-    }
-}
-
-/// Scoped package names URL-encode the separating slash.
-fn encode_package_name(name: &str) -> String {
-    if name.starts_with('@') {
-        name.replacen('/', "%2F", 1)
-    } else {
-        name.to_string()
-    }
-}
-
-/// Ensure a registry URL ends with a trailing slash.
-fn normalize_registry_url(url: &str) -> String {
-    let url = url.trim();
-    if url.ends_with('/') {
-        url.to_string()
-    } else {
-        format!("{url}/")
-    }
-}
-
-/// Convert a registry URL to the nerf-dart URI key used in .npmrc auth
-/// lookups: "https://registry.example.com/" -> "//registry.example.com/".
-/// Strips only the scheme's own default port (`:443` for https, `:80` for
-/// http), matching npm's behavior.
-fn registry_uri_key(url: &str) -> String {
-    let (rest, default_port) = if let Some(rest) = url.strip_prefix("https:") {
-        (rest, ":443")
-    } else if let Some(rest) = url.strip_prefix("http:") {
-        (rest, ":80")
-    } else {
-        return url.to_string();
-    };
-    strip_authority_port_suffix(rest, default_port)
-}
-
-/// Normalize an `//host[:port]/path` key from `.npmrc` so it matches what
-/// `registry_uri_key` produces on the lookup side. Ingest can't know the
-/// intended scheme (npmrc keys are scheme-less), so both default ports are
-/// stripped.
-fn normalize_npmrc_uri_key(key: &str) -> String {
-    let stripped = strip_authority_port_suffix(key, ":443");
-    if stripped != key {
-        return stripped;
-    }
-    strip_authority_port_suffix(key, ":80")
-}
-
-fn strip_authority_port_suffix(key: &str, port_suffix: &str) -> String {
-    let Some(after) = key.strip_prefix("//") else {
-        return key.to_string();
-    };
-    let (authority, path) = match after.find('/') {
-        Some(idx) => (&after[..idx], &after[idx..]),
-        None => (after, ""),
-    };
-    let Some(authority) = authority.strip_suffix(port_suffix) else {
-        return key.to_string();
-    };
-    format!("//{authority}{path}")
-}
-
-/// Look up `key`, falling back to longest-prefix matching by trimming path
-/// segments from the right (npm/pnpm auth resolution). Stops before falling
-/// all the way to the host-less `//` prefix.
-fn lookup_by_uri_prefix<'a, V>(map: &'a BTreeMap<String, V>, key: &str) -> Option<&'a V> {
-    if let Some(v) = map.get(key) {
-        return Some(v);
-    }
-    let trimmed = key.trim_end_matches('/');
-    if !trimmed.is_empty()
-        && trimmed != key
-        && let Some(v) = map.get(trimmed)
-    {
-        return Some(v);
-    }
-    let mut cursor = trimmed;
-    while let Some(idx) = cursor.rfind('/') {
-        cursor = &cursor[..idx];
-        if cursor.len() <= 2 {
-            break;
-        }
-        let with_slash = format!("{cursor}/");
-        if let Some(v) = map.get(&with_slash) {
-            return Some(v);
-        }
-        if let Some(v) = map.get(cursor) {
-            return Some(v);
-        }
-    }
-    None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn env(entries: &[(&str, &str)]) -> Vec<(String, String)> {
-        entries
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect()
-    }
-
-    fn config_from(npmrc: &str, env_vars: &[(String, String)]) -> NpmRegistryConfig {
-        let mut config = NpmRegistryConfig {
-            registry: DEFAULT_REGISTRY.to_string(),
-            ..Default::default()
-        };
-        let mut entries = parse_npmrc(npmrc, Some(env_vars));
-        entries.extend(npm_config_env_entries(env_vars));
-        config.apply(entries);
-        config
-    }
-
-    #[test]
-    fn test_parse_npmrc_basics() {
-        let entries = parse_npmrc(
-            "# comment\n; also comment\nregistry=https://r.example.com\n_auth=\"abc==\"\n",
-            None,
-        );
-        assert_eq!(
-            entries,
-            vec![
-                ("registry".to_string(), "https://r.example.com".to_string()),
-                ("_auth".to_string(), "abc==".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_parse_npmrc_line_continuation() {
-        let entries = parse_npmrc("//h.example.com/:_authToken=abc\\\ndef\n", None);
-        assert_eq!(
-            entries,
-            vec![(
-                "//h.example.com/:_authToken".to_string(),
-                "abcdef".to_string()
-            )]
-        );
-    }
-
-    #[test]
-    fn test_parse_npmrc_env_expansion() {
-        let env_vars = env(&[("NPM_TOKEN", "secret")]);
-        let entries = parse_npmrc(
-            "//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n",
-            Some(&env_vars),
-        );
-        assert_eq!(entries[0].1, "secret");
-    }
-
-    #[test]
-    fn test_registry_for_scoped() {
-        let config = config_from(
-            "registry=https://r.example.com\n@myorg:registry=https://scoped.example.com\n",
-            &[],
-        );
-        assert_eq!(config.registry_for("left-pad"), "https://r.example.com/");
-        assert_eq!(
-            config.registry_for("@myorg/tool"),
-            "https://scoped.example.com/"
-        );
-        assert_eq!(config.registry_for("@other/tool"), "https://r.example.com/");
-    }
-
-    #[test]
-    fn test_env_overrides_npmrc() {
-        let env_vars = env(&[("NPM_CONFIG_REGISTRY", "https://env.example.com")]);
-        let config = config_from("registry=https://file.example.com\n", &env_vars);
-        assert_eq!(config.registry_for("x"), "https://env.example.com/");
-    }
-
-    #[test]
-    fn test_env_scoped_registry() {
-        let env_vars = env(&[("npm_config_@MyOrg:registry", "https://env.example.com")]);
-        let config = config_from("", &env_vars);
-        assert_eq!(
-            config.registry_for("@myorg/tool"),
-            "https://env.example.com/"
-        );
-    }
-
-    #[test]
-    fn test_auth_token_lookup_with_default_port() {
-        let config = config_from(
-            "registry=https://r.example.com:443/npm/\n//r.example.com/npm/:_authToken=tok\n",
-            &[],
-        );
-        assert_eq!(
-            config.authorization_for(config.registry_for("x")),
-            Some("Bearer tok".to_string())
-        );
-    }
-
-    #[test]
-    fn test_auth_prefix_fallback() {
-        let config = config_from("//r.example.com/:_authToken=tok\n", &[]);
-        assert_eq!(
-            config.authorization_for("https://r.example.com/deep/path/"),
-            Some("Bearer tok".to_string())
-        );
-        assert_eq!(config.authorization_for("https://other.example.com/"), None);
-    }
-
-    #[test]
-    fn test_basic_auth_from_username_password() {
-        // base64("s3cret") == "czNjcmV0"
-        let config = config_from(
-            "//r.example.com/:username=user\n//r.example.com/:_password=czNjcmV0\n",
-            &[],
-        );
-        // base64("user:s3cret") == "dXNlcjpzM2NyZXQ="
-        assert_eq!(
-            config.authorization_for("https://r.example.com/"),
-            Some("Basic dXNlcjpzM2NyZXQ=".to_string())
-        );
-    }
-
-    #[test]
-    fn test_bare_auth_applies_to_default_registry() {
-        let config = config_from("registry=https://r.example.com\n_authToken=tok\n", &[]);
-        assert_eq!(
-            config.authorization_for("https://r.example.com/"),
-            Some("Bearer tok".to_string())
-        );
-    }
-
-    #[test]
-    fn test_env_uri_scoped_auth() {
-        let env_vars = env(&[("npm_config_//r.example.com/:_authToken", "envtok")]);
-        let config = config_from("", &env_vars);
-        assert_eq!(
-            config.authorization_for("https://r.example.com/"),
-            Some("Bearer envtok".to_string())
-        );
-    }
-
-    #[test]
-    fn test_scoped_per_uri_auth_ignored() {
-        let config = config_from("//r.example.com/:@myorg:_authToken=tok\n", &[]);
-        assert_eq!(config.authorization_for("https://r.example.com/"), None);
-    }
-
-    #[test]
-    fn test_encode_package_name() {
-        assert_eq!(encode_package_name("left-pad"), "left-pad");
-        assert_eq!(encode_package_name("@myorg/tool"), "@myorg%2Ftool");
-    }
-
-    #[test]
-    fn test_packument_versions_semver_sorted_with_time() {
-        // Document order is publish order (1.2.0 backported after 1.10.0);
-        // output must be semver-ascending like `npm view versions` was.
-        let packument: Packument = serde_json::from_str(
-            r#"{
-                "name": "x",
-                "dist-tags": {"latest": "2.0.0"},
-                "versions": {"1.0.0": {}, "1.10.0": {}, "1.2.0": {}},
-                "time": {"created": "2020-01-01T00:00:00Z", "1.0.0": "2020-01-02T00:00:00Z"}
-            }"#,
-        )
-        .unwrap();
-        assert_eq!(
-            packument.versions_with_time(),
-            vec![
-                ("1.0.0", Some("2020-01-02T00:00:00Z")),
-                ("1.2.0", None),
-                ("1.10.0", None),
-            ]
-        );
-        assert_eq!(packument.latest_dist_tag(), Some("2.0.0".to_string()));
-    }
-
-    #[test]
-    fn test_packument_tolerates_missing_fields() {
-        let packument: Packument = serde_json::from_str(r#"{"name": "x"}"#).unwrap();
-        assert!(packument.versions_with_time().is_empty());
-        assert_eq!(packument.latest_dist_tag(), None);
-    }
+/// Resolve the `latest` dist-tag for a package, if the registry publishes one.
+pub async fn latest_dist_tag(name: &str) -> Result<Option<String>> {
+    let packument = fetch_packument(name).await?;
+    Ok(packument.dist_tags.get("latest").cloned())
 }


### PR DESCRIPTION
## Summary

Embeds the [aube](https://github.com/jdx/aube) package manager into the `npm:` backend so mise handles `npm:` tools **without needing node or a package-manager CLI installed** — version metadata is fetched from the registry over HTTP, and packages are installed in-process. `node` is only needed to *run* installed tools (and their lifecycle scripts), not to install them.

This supersedes the inline npm registry client from #11147 and replaces the `aube add --global` / `npm install -g` subprocess. It's the mise half of a cross-repo effort; the enabling upstream work is jdx/aube#1068 (MSRV 1.91 + backend-agnostic library crates), jdx/aube#1069 (embeddable `aube` crate: publish/DNS/TLS feature-gated), and jdx/aube#1079 (host-supplied node runtime for lifecycle scripts), released as aube **1.32**.

## What changed

**Version metadata → `aube-registry` (HTTP).** `mise ls-remote npm:*` and `latest` resolution query the registry directly through the published `aube-registry` crate (replacing the ~500-line inline port from #11147). npmrc/scoped-registry/auth semantics live in one maintained place. Honors mise's `offline()` / `prefer_offline()` via `NetworkMode`.

**Installs → `aube::embed::add` (in-process).** The tool's install dir doubles as a throwaway project (seed `package.json` + `.npmrc`); aube installs into `node_modules`, and its bin shims are exposed on PATH via `list_bin_paths` → `node_modules/.bin` (the shims resolve relative to their own location). `auto` now always resolves to the embedded aube (it's compiled in), so `get_dependencies` drops the `aube`/`npm` edges — default `npm:` installs depend only on `node`. `minimum_release_age`, `trust_policy_excludes`, and `allow_builds` flow through the seed `package.json`/`.npmrc` that aube's resolver reads.

**Lifecycle scripts run on mise's node.** For `allow_builds` installs, mise passes its dependency node's bin dir to the embedded installer via aube 1.32's `node_bin_dir`, so dependency lifecycle scripts find node even when it isn't on the ambient PATH (restoring what the old subprocess got via `prepend_path`).

**Setting consolidation.** The unreleased `npm.use_npm_view` is replaced by **`npm.shell_out`** (`MISE_NPM_SHELL_OUT`), which routes *both* metadata (`npm view`) and installs (`npm install -g`) through the npm CLI — for setups that rely on npm-only config (`cafile`, client certs, token helpers). Only affects the `auto` path; explicit `npm.package_manager = bun|pnpm|npm` still shells out to that tool.

## Dependencies

`aube` and `aube-registry` are pulled with `default-features = false, features = ["rustls"]`: their defaults also enable `hickory-dns`, which — via cargo feature unification — would flip the default DNS resolver for every reqwest client in the mise binary. `rustls` is already in mise's tree; no new TLS stack is added. sigstore's publish/signing stack is excluded via aube's `publish` feature gate (jdx/aube#1069).

## Behavior parity & validation

- `ls-remote` output is byte-identical (same versions, same semver-ascending order) vs. the previous inline client for `npm:prettier`, `npm:@angular/cli` (582 versions incl. backported patch lines), and `npm:left-pad`, with node/npm absent.
- Install validated with **only node on PATH** (no aube/npm binary): `mise x npm:cowsay@1.6.0 -- cowsay`.
- Lifecycle scripts validated with **no node on the ambient PATH**: `npm:esbuild@0.21.5` + `allow_builds` runs its `node install.js` postinstall and produces a working binary.
- 46 npm unit tests pass; `test_npm_aube`, `test_npm_package_manager`, `test_backend_missing_deps`, and `test_npm_shim_recursion_system_dir` e2e updated for the embedded model and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced npm version discovery, including more reliable `latest` dist-tag resolution and improved semver ordering.
  * Reduced redundant registry work by removing packument caching and simplifying registry interactions.
  * Updated embedded `aube` npm installs to run in-process, with updated tool locations (preferring `node_modules/.bin` when embedded).

* **Configuration / Docs**
  * Replaced `npm.use_npm_view` with `npm.shell_out` (`MISE_NPM_SHELL_OUT`) to control when the npm CLI is required for metadata and installs.

* **Tests**
  * Updated e2e tests to use `MISE_NPM_SHELL_OUT` and to assert the new embedded install layout and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->