### PR TITLE
fix(link): clear stale incomplete marker when linking a tool

### DIFF
--- a/e2e/cli/test_link
+++ b/e2e/cli/test_link
@@ -5,3 +5,19 @@ mkdir -p tmp/tiny
 mise link tiny@9.8.7 tmp/tiny
 
 assert_contains "mise ls tiny" "tiny  9.8.7 (symlink)"
+
+# Regression test for https://github.com/jdx/mise/discussions/3539:
+# a stale `incomplete` marker left behind by a previously-interrupted install
+# must not cause a freshly-linked tool to be reported as missing (`mise use`
+# and `mise doctor` treat any version with an `incomplete` marker as not
+# installed). `mise link` should clear that marker.
+mkdir -p tmp/tiny2
+mkdir -p "$MISE_CACHE_DIR/tiny/9.9.9"
+touch "$MISE_CACHE_DIR/tiny/9.9.9/incomplete"
+mise link tiny@9.9.9 tmp/tiny2
+
+# `mise ls -i` only lists versions considered installed; the linked version
+# must appear despite the pre-existing stale marker.
+assert_contains "mise ls -i tiny" "tiny  9.9.9 (symlink)"
+# the stale marker should have been removed by `mise link`.
+assert "test ! -f \"$MISE_CACHE_DIR/tiny/9.9.9/incomplete\""

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -7,6 +7,7 @@ use eyre::bail;
 use path_absolutize::Absolutize;
 
 use crate::file::{make_symlink, remove_all};
+use crate::toolset::install_state;
 use crate::{cli::args::ToolArg, config::Config};
 use crate::{config, file};
 
@@ -43,7 +44,7 @@ impl Link {
                 style(path.to_string_lossy()).cyan().for_stderr()
             );
         }
-        let target = self.tool.ba.installs_path.join(version);
+        let target = self.tool.ba.installs_path.join(&version);
         if target.exists() {
             if self.force {
                 remove_all(&target)?;
@@ -57,6 +58,13 @@ impl Link {
         }
         file::create_dir_all(target.parent().unwrap())?;
         make_symlink(&path, &target)?;
+
+        // A linked tool is complete by definition. Clear any stale `incomplete`
+        // marker left in the cache by a previously-interrupted install so that
+        // `mise use`/`mise doctor` don't treat the linked version as missing.
+        // See discussion #3539.
+        let incomplete = install_state::incomplete_file_path(&self.tool.ba.short, &version);
+        let _ = file::remove_file(&incomplete);
 
         let config = Config::reset().await?;
         let ts = config.get_toolset().await?;


### PR DESCRIPTION
## Summary

`mise link` created the install symlink but left behind any stale `incomplete` marker in the cache from a previously-interrupted install. Because `Backend::is_version_installed` treats a version whose cache has an `incomplete` marker as not installed, `mise use` and `mise doctor` reported freshly-linked tools as missing (and re-downloaded them), even though `mise ls` still showed them as `(symlink)`.

Remove the marker when linking, since a linked tool is complete by definition.

Root cause was diagnosed in the discussion via `MISE_TRACE=1`: the linked tool showed `... (incomplete)` at `src/backend/mod.rs`, and manually removing `~/.cache/mise/<tool>/<version>/incomplete` fixed both `mise use` and `mise doctor`.

## Testing

- Extends `e2e/cli/test_link` with a regression case: create a stale `incomplete` marker in the cache, `mise link` the version, and assert it is now listed by `mise ls -i` (installed-only) and that the marker was cleared.

Fixes https://github.com/jdx/mise/discussions/3539

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `mise link` so linked tool versions are recognized correctly even when a stale installation marker exists.
  * Automatically removes leftover incomplete-install markers after linking a tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->