### PR TITLE
feat(config): ignore project [env]/aliases/settings and skip trust in safe mode

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -38,11 +38,33 @@ MISE_SAFE=1 mise lock --bump --dry-run --json
 When enabled, mise **refuses with an error** (never a silent fallback) to:
 
 - run `exec()` or `read_file()` in config templates
-- source shell scripts via the `_.source` env directive
 - run hooks (suppressed like `--no-hooks`, since hooks fire ambiently from `mise env`/`hook-env`)
 - run tasks
 - execute asdf plugin scripts
 - install plugins
+
+It also **ignores environment and shell configuration from project (non-global) config** — `[env]`
+values, `_.path`, `_.file`, and `[shell_alias]` entries. These would otherwise be applied to your
+shell environment (env vars and aliases are emitted through `hook-env`) and to the
+subprocesses mise spawns during version resolution (for example `go list` or a vfox plugin hook),
+which is an indirect code-execution vector (`PATH`, `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`,
+`NODE_OPTIONS`, …) that safe mode is meant to close. Global and system config (e.g.
+`~/.config/mise/config.toml`) is operator-owned and still applies, mirroring the
+[trust](/cli/trust.html) model.
+
+`_.source` is treated as code execution rather than environment injection, so it is ignored in safe
+mode regardless of where it is defined — including operator-owned global config.
+
+`[settings]` from project (non-global) config are also ignored, so an untrusted repo cannot change
+mise's behavior during resolution (for example disabling verification or redirecting a backend).
+Global/system settings still apply. Specific project settings may be allowlisted in the future if
+they are both safe and necessary.
+
+Because a config loaded in safe mode is inert — it can neither execute code nor inject environment —
+**safe mode does not require configs to be trusted.** mise loads untrusted configs without a
+[trust](/cli/trust.html) prompt or error when `safe` is set, since there is nothing a config can do
+to compromise the host. This is what lets automation run `mise lock` against pull-request config
+without a preceding `mise trust`.
 
 Version resolution still works for every HTTP-based backend — `core`, `aqua`, `github`, `gitlab`,
 `http`, `cargo`, `pipx`, `gem`, `dotnet`, and `npm` — as well as `go` (which runs with

--- a/e2e/config/test_safe_mode
+++ b/e2e/config/test_safe_mode
@@ -1,44 +1,58 @@
 #!/usr/bin/env bash
 
 # Test MISE_SAFE=1 (safe mode): a hard boundary against repo-controlled code
-# execution. Config templates using exec()/read_file(), `_.source` directives,
-# hooks, tasks, asdf plugin scripts, and plugin installation are refused with
-# an error. Plain templates, HTTP-backed version resolution, and embedded vfox
+# execution. In safe mode, project (non-global) config `[env]`, `_.path`, and
+# `_.source` are ignored entirely — they would otherwise be applied to the host
+# environment and to subprocesses mise spawns, an indirect code-execution
+# vector (PATH, LD_PRELOAD, ...). Hooks, tasks, asdf plugin scripts, and plugin
+# installation are refused. HTTP-backed version resolution and embedded vfox
 # plugins keep working.
 
 export MISE_LOCKFILE=1
 
-echo "=== template exec() is refused ==="
+echo "=== project [env] (incl. exec/LD_PRELOAD/_.path) is ignored in safe mode ==="
 cat <<'EOF' >mise.toml
 [env]
-FOO = "{{ exec(command='echo pwned') }}"
+PLAIN = "value"
+EVIL = "pwned"
+LD_PRELOAD = "/tmp/evil.so"
+FROM_EXEC = "{{ exec(command='echo pwned') }}"
+_.path = ["/tmp/evilbin"]
 EOF
-assert_fail "MISE_SAFE=1 mise env" "exec() is disabled in safe mode (MISE_SAFE=1)"
-# without safe mode it still works
-assert_contains "mise env" "export FOO=pwned"
+# without safe mode, project env is applied (exec evaluated)
+assert_contains "mise env" "export PLAIN=value"
+assert_contains "mise env" "export FROM_EXEC=pwned"
+assert_contains "mise env" "/tmp/evilbin"
+# in safe mode the whole project [env] block is inert: nothing set, no exec, no error
+assert_not_contains "MISE_SAFE=1 mise env" "PLAIN"
+assert_not_contains "MISE_SAFE=1 mise env" "EVIL"
+assert_not_contains "MISE_SAFE=1 mise env" "LD_PRELOAD"
+assert_not_contains "MISE_SAFE=1 mise env" "FROM_EXEC"
+assert_not_contains "MISE_SAFE=1 mise env" "/tmp/evilbin"
 
-echo "=== template read_file() is refused ==="
-echo "secret" >data.txt
-cat <<'EOF' >mise.toml
-[env]
-FOO = "{{ read_file(file='data.txt') }}"
-EOF
-assert_fail "MISE_SAFE=1 mise env" "read_file() is disabled in safe mode (MISE_SAFE=1)"
-
-echo "=== plain templates still render ==="
-cat <<'EOF' >mise.toml
-[env]
-BAR = "{{ config_root }}"
-EOF
-assert_contains "MISE_SAFE=1 mise env" "export BAR="
-
-echo "=== _.source is refused ==="
+echo "=== _.source is ignored in safe mode (inert, not executed) ==="
 echo 'export BAZ=frombash' >env.sh
 cat <<'EOF' >mise.toml
 [env]
 _.source = "env.sh"
 EOF
-assert_fail "MISE_SAFE=1 mise env" "sourcing scripts via"
+assert_contains "mise env" "export BAZ=frombash"
+assert_not_contains "MISE_SAFE=1 mise env" "BAZ"
+
+# _.source is code execution, so even operator-owned global config is inert
+# (it must not error, unlike a plain refused directive).
+mkdir -p .config/mise
+echo 'export GLOBAL_SOURCED=yes' >global-env.sh
+cat <<EOF >".config/mise/config.toml"
+[env]
+GLOBAL_KEPT = "yes"
+_.source = "$PWD/global-env.sh"
+EOF
+rm -f mise.toml
+# global [env] applies in safe mode, but global _.source is inert and does not error
+assert_contains "MISE_GLOBAL_CONFIG_FILE=$PWD/.config/mise/config.toml MISE_SAFE=1 mise env" "GLOBAL_KEPT"
+assert_not_contains "MISE_GLOBAL_CONFIG_FILE=$PWD/.config/mise/config.toml MISE_SAFE=1 mise env" "GLOBAL_SOURCED"
+rm -rf .config global-env.sh
 
 echo "=== tasks are refused ==="
 cat <<'EOF' >mise.toml
@@ -55,6 +69,23 @@ enter = "echo HOOK_RAN"
 EOF
 assert_not_contains "MISE_SAFE=1 mise hook-env -s bash" "HOOK_RAN"
 
+echo "=== project shell aliases are dropped in safe mode ==="
+cat <<'EOF' >mise.toml
+[shell_alias]
+evilalias = "rm -rf ~"
+EOF
+# emitted through hook-env normally, dropped in safe mode
+assert_contains "mise hook-env -s bash" "evilalias"
+assert_not_contains "MISE_SAFE=1 mise hook-env -s bash" "evilalias"
+
+echo "=== project [settings] are ignored in safe mode ==="
+cat <<'EOF' >mise.toml
+[settings]
+jobs = 7
+EOF
+assert "mise settings get jobs" "7"
+assert_not_contains "MISE_SAFE=1 mise settings get jobs" "7"
+
 echo "=== asdf plugin scripts are refused ==="
 cat <<'EOF' >mise.toml
 [tools]
@@ -66,3 +97,9 @@ assert "mise latest dummy" "2.0.0"
 
 echo "=== plugin installation is refused ==="
 assert_fail "MISE_SAFE=1 mise plugins install tiny https://github.com/jdx/vfox-tiny" "installing plugins is disabled in safe mode (MISE_SAFE=1)"
+
+# Note: safe mode also skips the trust requirement (trust_check returns Ok when
+# `safe` is set). That isn't exercised here because the e2e harness auto-trusts
+# the workdir (MISE_TRUSTED_CONFIG_PATHS) and applies CI-implicit trust, so a
+# genuinely untrusted config can't be simulated reliably; see the unit-level
+# behavior and PR notes.

--- a/settings.toml
+++ b/settings.toml
@@ -2310,12 +2310,18 @@ resolve tool versions from configs the operator did not author.
 When enabled, mise refuses (with an error, never a silent fallback) to:
 
 - run `exec()` or `read_file()` in config templates
-- source shell scripts via the `_.source` env directive
 - run hooks
 - run tasks
 - execute asdf plugin scripts
 - install plugins (already-installed and embedded vfox plugins still work — their
   code was chosen by the operator, not the repository)
+
+It also ignores environment and shell configuration from project (non-global) config —
+`[env]` values, `_.path`, `_.file`, and `[shell_alias]` entries — since those would be
+applied to the host environment (env vars and aliases are emitted through `hook-env`) and
+to subprocesses mise spawns during resolution, an indirect code-execution vector.
+Global/system config is operator-owned and still applies. `_.source` runs a shell script
+(code execution rather than env injection), so it is ignored regardless of source.
 
 Version resolution still works for every HTTP-based backend (core, aqua, github,
 gitlab, http, cargo, pipx, gem, dotnet, npm) as well as `go` (which runs with

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -318,6 +318,13 @@ pub fn is_path_trusted(path: &Path) -> bool {
 }
 
 pub fn trust_check(path: &Path) -> eyre::Result<()> {
+    // In safe mode, config is inert (no code execution, no env injection — see
+    // MISE_SAFE / the `safe` setting), so loading an untrusted config is
+    // harmless and no trust is required. `safe` is global-only, so a project
+    // config cannot disable it for itself.
+    if Settings::safe_mode() {
+        return Ok(());
+    }
     static MUTEX: Mutex<()> = Mutex::new(());
     let _lock = MUTEX.lock().unwrap(); // Prevent multiple checks at once so we don't prompt multiple times for the same path
     let config_root = config_trust_root(path);

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -368,13 +368,33 @@ impl EnvResults {
             }
         };
         let mut paths: Vec<(PathBuf, PathBuf)> = Vec::new();
-        let last_python_venv = input.iter().rev().find_map(|(d, _)| match d {
-            EnvDirective::PythonVenv { .. } => Some(d),
+        let safe_mode = Settings::safe_mode();
+        // In safe mode, environment directives from project (non-global) config are
+        // ignored — they would otherwise be applied to the host environment and to
+        // subprocesses mise spawns during resolution (e.g. `go list`, vfox hooks),
+        // an indirect code-execution vector (PATH, LD_PRELOAD, DYLD_INSERT_LIBRARIES,
+        // NODE_OPTIONS, ...) that safe mode is meant to close. Global/system config
+        // is operator-owned and still applies, mirroring the trust model. `_.source`
+        // runs a shell script (code execution rather than env injection), so it is
+        // ignored regardless of source, including operator-owned global config.
+        let dropped_in_safe_mode = |directive: &EnvDirective, source: &Path| -> bool {
+            safe_mode
+                && (!crate::config::is_global_config(source)
+                    || matches!(directive, EnvDirective::Source(..)))
+        };
+        // Choose the last venv among directives that survive the safe-mode filter,
+        // so a dropped project venv can't cause an operator's global venv to be
+        // skipped as "not the last one".
+        let last_python_venv = input.iter().rev().find_map(|(d, source)| match d {
+            EnvDirective::PythonVenv { .. } if !dropped_in_safe_mode(d, source) => Some(d),
             _ => None,
         });
         let filtered_input = input
             .iter()
             .fold(Vec::new(), |mut acc, (directive, source)| {
+                if dropped_in_safe_mode(directive, source) {
+                    return acc;
+                }
                 // Filter directives based on tools setting
                 let should_include = match &resolve_opts.tools {
                     ToolsFilter::ToolsOnly => directive.options().tools,

--- a/src/config/env_directive/source.rs
+++ b/src/config/env_directive/source.rs
@@ -19,7 +19,8 @@ impl EnvResults {
         env_vars: &EnvMap,
         input: String,
     ) -> Result<IndexMap<PathBuf, IndexMap<String, String>>> {
-        crate::config::Settings::ensure_not_safe("sourcing scripts via `_.source`")?;
+        // Note: in safe mode `_.source` directives are dropped during env
+        // resolution (see EnvResults::resolve), so this is never reached.
         let mut out = IndexMap::new();
         let s = r.parse_template(ctx, tera, source, exec_env, &input)?;
         let orig_path = env_vars.get(&*env::PATH_KEY).cloned().unwrap_or_default();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -717,7 +717,11 @@ impl Config {
             // to parse for trusted files. Untrusted non-MiseToml files (like
             // .tool-versions) don't need trust and will parse fine regardless.
             let trust_root = config_file::config_trust_root(&path);
-            if !config_file::is_trusted(&trust_root)
+            // In safe mode, config is inert and trust is not required, so don't
+            // skip untrusted tracked configs — load them like trusted ones.
+            let safe_mode = Settings::safe_mode();
+            if !safe_mode
+                && !config_file::is_trusted(&trust_root)
                 && !config_file::is_trusted(&path)
                 // safe mise.toml files load without a trust marker, so a missing
                 // marker doesn't mean they should be skipped here
@@ -1985,9 +1989,19 @@ fn load_aliases(config_files: &ConfigMap) -> Result<AliasMap> {
 fn load_shell_aliases(config_files: &ConfigMap) -> Result<EnvWithSources> {
     let mut shell_aliases: EnvWithSources = EnvWithSources::new();
 
+    // In safe mode, shell aliases from project (non-global) config are ignored.
+    // They are emitted through `hook-env` into the interactive shell, so an
+    // untrusted config could otherwise redefine commands (e.g. `ls`, `git`) —
+    // a code-execution vector now that safe mode loads untrusted config without
+    // a trust prompt. Global/system config is operator-owned and still applies.
+    let safe_mode = Settings::safe_mode();
+
     // Iterate in reverse order (global -> local) so child directories override parent configs
     for config_file in config_files.values().rev() {
         let path = config_file.get_path().to_path_buf();
+        if safe_mode && !is_global_config(&path) {
+            continue;
+        }
         for (name, cmd) in config_file.shell_aliases()? {
             shell_aliases.insert(name, (cmd, path.clone()));
         }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 use std::{
     collections::{BTreeSet, HashSet},
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
 use super::{TOML_CONFIG_FILENAMES, load_config_paths};
@@ -231,6 +231,12 @@ impl serde::Serialize for PythonUvVenvAuto {
 pub type SettingsPartial = <Settings as Config>::Layer;
 
 static BASE_SETTINGS: RwLock<Option<Arc<Settings>>> = RwLock::new(None);
+/// Caches the resolved `safe` value from the most recent settings load so
+/// `safe_mode()` answers correctly during the config parse pass that runs before
+/// settings are (re)loaded — e.g. after `Config::reset()`. This captures `safe`
+/// set via global config, which the `MISE_SAFE` env-var fallback cannot see.
+/// 0 = false, 1 = true, 2 = never loaded (fall back to the env var).
+static LAST_SAFE: AtomicU8 = AtomicU8::new(2);
 static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
@@ -582,6 +588,7 @@ impl Settings {
             settings.experimental = true;
         }
         let settings = Arc::new(settings);
+        LAST_SAFE.store(u8::from(settings.safe), Ordering::Relaxed);
         *BASE_SETTINGS.write().unwrap() = Some(settings.clone());
         time!("try_get done");
         trace!("Settings: {:#?}", settings);
@@ -769,8 +776,15 @@ impl Settings {
     }
 
     fn all_settings_files() -> Vec<SettingsPartial> {
+        // In safe mode, ignore `[settings]` from project (non-global) config so
+        // an untrusted repo cannot change mise's behavior during resolution
+        // (e.g. disable verification, redirect a backend/registry). Global and
+        // system config is operator-owned and still applies. A specific setting
+        // could be allowlisted here later if it is safe and necessary.
+        let safe_mode = Settings::safe_mode();
         load_config_paths(&TOML_CONFIG_FILENAMES, false)
             .into_iter()
+            .filter(|p| !safe_mode || crate::config::is_global_config(p))
             .map(|p| Self::parse_settings_file(&p))
             .filter_map(|cfg| match cfg {
                 Ok(cfg) => Some(cfg),
@@ -1090,12 +1104,35 @@ impl Settings {
                     .any(|a| a == "--no-hooks")
     }
 
+    /// Whether safe mode (`MISE_SAFE=1` or the `safe` setting) is active.
+    ///
+    /// Safe to call during the config parse pass: it reads the loaded setting
+    /// when settings are available, otherwise falls back to the `MISE_SAFE`
+    /// environment variable. This avoids triggering a recursive settings load
+    /// from `trust_check` (which runs while config files are being parsed,
+    /// before settings are loaded, e.g. after `Config::reset`). `safe` is
+    /// global-only, so it can only come from the environment or global config;
+    /// the env fallback covers the common `MISE_SAFE=1` case in that window.
+    pub fn safe_mode() -> bool {
+        if is_loaded() {
+            return Settings::get().safe;
+        }
+        // Settings not loaded (e.g. the config parse pass after Config::reset).
+        // Use the value cached from the last full load, which captures `safe`
+        // set via global config; before any load, fall back to the env var.
+        match LAST_SAFE.load(Ordering::Relaxed) {
+            0 => false,
+            1 => true,
+            _ => crate::env::var_is_true("MISE_SAFE"),
+        }
+    }
+
     /// Errors when safe mode (`MISE_SAFE=1`) is enabled. Call this before any
     /// operation that would execute code controlled by project configuration.
     /// Safe mode is a security boundary: blocked operations must fail loudly,
     /// never silently fall back to something that executes.
     pub fn ensure_not_safe(operation: &str) -> Result<()> {
-        if Settings::get().safe {
+        if Settings::safe_mode() {
             bail!(
                 "{operation} is disabled in safe mode (MISE_SAFE=1)\nSee https://mise.en.dev/configuration/settings.html#safe"
             );

--- a/src/env.rs
+++ b/src/env.rs
@@ -630,7 +630,7 @@ fn var_u8(key: &str) -> u8 {
         .unwrap_or_default()
 }
 
-fn var_is_true(key: &str) -> bool {
+pub(crate) fn var_is_true(key: &str) -> bool {
     match var(key) {
         Ok(v) => {
             let v = v.to_lowercase();

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -199,11 +199,15 @@ async fn err_no_task(config: &Config, name: &str) -> Result<()> {
             use crate::config::config_file::{config_trust_root, is_trusted};
             use crate::config::{config_files_in_dir, is_tool_versions_file};
 
+            // In safe mode, config is inert and trust is not required, so there
+            // are no untrusted configs to warn about.
+            let safe_mode = config::Settings::safe_mode();
             let config_files = config_files_in_dir(cwd);
             let untrusted_configs: Vec<_> = config_files
                 .iter()
                 .filter(|p| {
-                    !is_tool_versions_file(p)
+                    !safe_mode
+                        && !is_tool_versions_file(p)
                         && !is_trusted(&config_trust_root(p))
                         && !is_trusted(p)
                 })

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -450,6 +450,9 @@ pub fn compute_settings_hash() -> String {
     // Add settings that affect env computation
     hasher.update(settings.experimental.to_string().as_bytes());
     hasher.update(settings.all_compile.to_string().as_bytes());
+    // Safe mode drops project [env]/_.path directives, so a cache entry built
+    // with a different `safe` value must not be reused.
+    hasher.update(settings.safe.to_string().as_bytes());
 
     // Add any other relevant settings
     if let Some(env_file) = &settings.env_file {


### PR DESCRIPTION
## What

Makes safe mode (`MISE_SAFE=1`) a **complete boundary** against untrusted project config, and — because of that — **removes the trust requirement in safe mode**.

Two changes:

1. **Ignore project `[env]`/`_.path`/`_.file`/`[shell_alias]`/`[settings]` in safe mode.** Safe mode already refused code execution (`exec()`/`read_file()`, `_.source`, hooks, tasks, asdf scripts, plugin installs), but it still applied project `[env]` values and `_.path`. Those flow into the host environment (`mise env`/`activate`) and into the subprocesses mise spawns during version resolution (`go list`, vfox hooks, via `dependency_env`), so an untrusted config could set `[env] LD_PRELOAD=…`, `_.path=[…]`, `NODE_OPTIONS`, etc. — indirect code execution with no `exec()` required. Now, environment directives from project (non-global) config are ignored entirely. Global/system config is operator-owned and still applies, mirroring the trust model. `_.source` is code execution rather than env injection, so it's dropped regardless of source (including global config) instead of erroring. Project `[shell_alias]` entries are also ignored — they are emitted through `hook-env` into the interactive shell, so an untrusted config could otherwise redefine commands like `ls`/`git`. Project `[settings]` are ignored too, so an untrusted repo can't change mise's behavior during resolution (disable verification, redirect a backend); specific settings can be allowlisted later if safe and necessary. The `safe` setting is folded into the env cache key so a cache built without safe mode isn't reused under it.

2. **Skip trust in safe mode.** Since a config loaded in safe mode is now inert — it can neither execute code nor inject environment — loading an untrusted config is harmless, so no trust is required. `trust_check` returns `Ok` when `safe` is set, and the discovery paths (`config/mod.rs`, `task_list.rs`) no longer skip untrusted configs. `safe` is `global_only`, so a project config cannot disable it for itself.

## Why

This is what lets automation run `mise lock` against untrusted pull-request config without a preceding `mise trust`. The [Renovate integration](https://github.com/renovatebot/renovate/pull/44749) currently runs `mise trust <config>` before `mise lock`; once this ships it can drop that step and rely on `MISE_SAFE=1` alone.

## Testing

- `e2e/config/test_safe_mode`: project `[env]` (plain, `exec()`, `LD_PRELOAD`, `_.path`) and `_.source` are applied normally but fully inert under `MISE_SAFE=1`; a global-config `_.source` is inert **and does not error** while a global `[env]` var survives.
- Full unit suite passes (1827).
- Trust-skip **manually verified** (untrusted config in a clean env: `mise env` fails with "not trusted" normally, succeeds under `MISE_SAFE=1`). Not covered by e2e because the harness auto-trusts the workdir and applies CI-implicit trust, so a genuinely untrusted config can't be simulated reliably there — noted in the test file.

## Review-feedback addressed (from the earlier revision)

- **Global `_.source` errored in safe mode** (cursor + greptile): fixed — `_.source` is now dropped in the resolver regardless of origin, and the redundant `ensure_not_safe` in `source.rs` is removed.
- **Env cache ignored safe mode** (cursor): fixed — `safe` added to `compute_settings_hash`.
- **Shell aliases bypassed the boundary** (cursor): fixed — project `[shell_alias]` entries are dropped in `load_shell_aliases` in safe mode.
- **Stale venv could skip global config** (cursor): fixed — `last_python_venv` now only considers venvs that survive the safe-mode filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the security and trust boundary for config loading and environment injection; mistakes could re-expose indirect code execution or skip needed trust checks outside safe mode.
> 
> **Overview**
> **Safe mode (`MISE_SAFE=1`)** is extended so untrusted **project** config cannot affect the host or resolution subprocesses: non-global **`[env]`**, **`_.path`**, **`_.file`**, and **`[shell_alias]`** are dropped (no errors for ignored directives). **`_.source`** is always dropped in safe mode—including global config—instead of failing. Project **`[settings]`** are excluded from the settings merge so repos cannot weaken verification or redirect backends during lock/resolution.
> 
> Because loaded config is inert under safe mode, **`trust_check`** and related discovery paths **no longer require trust** (tracked configs and task-list untrusted warnings respect this). **`Settings::safe_mode()`** resolves correctly during early config parse via a cached `safe` value and **`MISE_SAFE`** fallback; **`ensure_not_safe`** uses it. The env cache key now includes **`safe`** so entries are not reused across modes.
> 
> Docs and **`e2e/config/test_safe_mode`** cover ignored env/`_.source`, global vs project behavior, aliases, and project settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdac52b574ef623f5028d726c05991eb0621eb7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Strengthened Safe mode: non-global project environment and code-executing directives are ignored, including `exec()`/`read_file()`-style templates and `_.source` content.
  - Safe mode refuses hooks, tasks, plugin scripts, and plugin installation, and drops project-level shell aliases.
  - Settings-derived environment caches are isolated per safe mode value.

- **Documentation**
  - Expanded Safe mode documentation, including enforced boundaries and that trust checks are skipped in Safe mode.

- **Tests**
  - Updated Safe mode e2e coverage to verify inert project env behavior, global env behavior, and alias/task/plugin restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

