### PR TITLE
fix(config): honor trusted_config_paths over previously-ignored configs

### DIFF
--- a/e2e/cli/test_trusted_config_paths_override_ignore
+++ b/e2e/cli/test_trusted_config_paths_override_ignore
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/jdx/mise/discussions/3544
+#
+# `trusted_config_paths` (MISE_TRUSTED_CONFIG_PATHS) must take effect even when
+# a config was previously ignored — either by answering "No" to the trust
+# prompt or by running `mise trust --ignore`. Before the fix the persisted
+# ignore list was consulted before `trusted_config_paths`, so the setting was
+# silently ignored for any config the user had once dismissed.
+
+# Override the blanket trust the e2e harness sets so trust is enforced.
+export MISE_TRUSTED_CONFIG_PATHS=""
+
+mkdir -p project
+cat <<EOF >project/.mise.toml
+[env]
+PROJECT = "trusted-via-settings"
+EOF
+
+cd project
+DIR="$(pwd)"
+
+# Simulate the user dismissing the trust prompt: the config is added to the
+# persisted ignore list. (The "ignored" message is written to stderr.)
+assert_contains "mise trust --ignore 2>&1" "ignored"
+
+# While ignored and without trusted_config_paths, the config is not loaded.
+assert_not_contains "mise env" "PROJECT=trusted-via-settings"
+
+# trusted_config_paths must override the persisted ignore and load the config.
+assert_contains "MISE_TRUSTED_CONFIG_PATHS=$DIR mise env" "PROJECT=trusted-via-settings"
+
+# `mise trust --show` should reflect that the config is trusted via settings.
+# `--show` lists the config's trust root (the directory), so match
+# "project: trusted"; note "project: untrusted" does not contain this substring.
+assert_contains "MISE_TRUSTED_CONFIG_PATHS=$DIR mise trust --show" "project: trusted"

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -352,7 +352,10 @@ pub fn is_trusted(path: &Path) -> bool {
             return false;
         }
     };
-    if is_ignored(canonicalized_path.as_path()) {
+    // The `ignored_config_paths` setting is an explicit "never load this
+    // config" instruction and is a hard block that takes precedence over
+    // everything, including `trusted_config_paths`.
+    if is_ignored_via_setting(canonicalized_path.as_path()) {
         return false;
     }
     if IS_TRUSTED
@@ -362,16 +365,22 @@ pub fn is_trusted(path: &Path) -> bool {
     {
         return true;
     }
-    if config::is_global_config(path) {
+    // `trusted_config_paths` is trusted by configuration and overrides the
+    // persisted ignore list (a dismissed trust prompt or `mise trust
+    // --ignore`), matching the "still trusted via settings" warnings emitted by
+    // `mise trust`. It is therefore checked *before* the persisted ignore list.
+    if trusted_config_path_matches(canonicalized_path.as_path()) {
         add_trusted(canonicalized_path.to_path_buf());
         return true;
     }
-    let settings = Settings::get();
-    for p in settings.trusted_config_paths() {
-        if canonicalized_path.starts_with(p) {
-            add_trusted(canonicalized_path.to_path_buf());
-            return true;
-        }
+    // The persisted ignore list blocks trust only when the path is not trusted
+    // via `trusted_config_paths` above.
+    if is_persisted_ignored(canonicalized_path.as_path()) {
+        return false;
+    }
+    if config::is_global_config(path) {
+        add_trusted(canonicalized_path.to_path_buf());
+        return true;
     }
 
     // Check if this path is within a trusted monorepo root
@@ -387,6 +396,7 @@ pub fn is_trusted(path: &Path) -> bool {
             current = dir;
         }
     }
+    let settings = Settings::get();
     if settings.paranoid {
         let trusted = trust_file_hash(path).unwrap_or_else(|e| {
             warn!("trust_file_hash: {e}");
@@ -437,7 +447,59 @@ pub fn rm_ignored(path: PathBuf) -> Result<()> {
     IS_IGNORED.lock().unwrap().remove(&path);
     Ok(())
 }
-pub fn is_ignored(path: &Path) -> bool {
+/// Whether an already-canonicalized path lives under a `trusted_config_paths`
+/// entry. Callers with a raw path use [`is_trusted_via_config_paths`], which
+/// canonicalizes first.
+fn trusted_config_path_matches(canonicalized_path: &Path) -> bool {
+    Settings::get()
+        .trusted_config_paths()
+        .any(|p| canonicalized_path.starts_with(p))
+}
+
+/// Whether `path` is trusted purely via the `trusted_config_paths` setting.
+///
+/// This is the signal that overrides the persisted ignore list (a dismissed
+/// trust prompt or `mise trust --ignore`) in both [`is_trusted`] and config
+/// discovery. It does not consider global config or per-file trust records.
+pub fn is_trusted_via_config_paths(path: &Path) -> bool {
+    // Config discovery calls this, and the initial `Settings` load itself runs
+    // config discovery (`load_config_paths`). Reading `trusted_config_paths`
+    // before settings are loaded would re-enter `Settings::get()` and recurse,
+    // so treat the path as not-yet-trusted until settings exist; discovery runs
+    // again once they do.
+    if !settings::is_loaded() {
+        return false;
+    }
+    match path.canonicalize() {
+        Ok(canonicalized_path) => trusted_config_path_matches(&canonicalized_path),
+        Err(_) => false,
+    }
+}
+
+/// Whether `path` is under an explicitly-configured `ignored_config_paths`
+/// (`MISE_IGNORED_CONFIG_PATHS`) entry.
+///
+/// This is an explicit "never load this config" instruction and is a hard
+/// block: it takes precedence over `trusted_config_paths`.
+pub fn is_ignored_via_setting(path: &Path) -> bool {
+    match path.canonicalize() {
+        Ok(path) => env::MISE_IGNORED_CONFIG_PATHS
+            .iter()
+            .any(|p| path.starts_with(p)),
+        Err(_) => {
+            debug!("is_ignored_via_setting: path canonicalize failed");
+            false
+        }
+    }
+}
+
+/// Whether `path` is in the persisted ignore list.
+///
+/// Entries are recorded when the user answers "No" to a trust prompt or runs
+/// `mise trust --ignore`. Unlike [`is_ignored_via_setting`], this only records
+/// a dismissed prompt, so it is overridden by `trusted_config_paths` (see
+/// [`is_trusted_via_config_paths`]).
+pub fn is_persisted_ignored(path: &Path) -> bool {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
         if !dirs::IGNORED_CONFIGS.exists() {
@@ -450,15 +512,20 @@ pub fn is_ignored(path: &Path) -> bool {
             }
         }
     });
-    if let Ok(path) = path.canonicalize() {
-        env::MISE_IGNORED_CONFIG_PATHS
-            .iter()
-            .any(|p| path.starts_with(p))
-            || IS_IGNORED.lock().unwrap().contains(&path)
-    } else {
-        debug!("is_ignored: path canonicalize failed");
-        true
+    match path.canonicalize() {
+        Ok(path) => IS_IGNORED.lock().unwrap().contains(&path),
+        Err(_) => {
+            debug!("is_persisted_ignored: path canonicalize failed");
+            true
+        }
     }
+}
+
+/// Whether `path` is ignored, by either the `ignored_config_paths` setting or
+/// the persisted ignore list. Callers that need to respect the
+/// `trusted_config_paths` override use the finer-grained variants directly.
+pub fn is_ignored(path: &Path) -> bool {
+    is_ignored_via_setting(path) || is_persisted_ignored(path)
 }
 
 pub fn trust(path: &Path) -> Result<()> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1258,7 +1258,17 @@ pub static ALL_CONFIG_FILES: Lazy<IndexSet<PathBuf>> = Lazy::new(|| {
 pub static IGNORED_CONFIG_FILES: Lazy<IndexSet<PathBuf>> = Lazy::new(|| {
     load_config_paths(&DEFAULT_CONFIG_FILENAMES, true)
         .into_iter()
-        .filter(|p| config_file::is_ignored(&config_trust_root(p)) || config_file::is_ignored(p))
+        .filter(|p| {
+            let ctr = config_trust_root(p);
+            // The `ignored_config_paths` setting is a hard block; the persisted
+            // ignore list is overridden by `trusted_config_paths`, matching
+            // is_trusted so a settings-trusted config is not reported as ignored.
+            if config_file::is_ignored_via_setting(&ctr) || config_file::is_ignored_via_setting(p) {
+                return true;
+            }
+            (config_file::is_persisted_ignored(&ctr) || config_file::is_persisted_ignored(p))
+                && !config_file::is_trusted_via_config_paths(p)
+        })
         .collect()
 });
 // pub static LOCAL_CONFIG_FILES: Lazy<Vec<PathBuf>> = Lazy::new(|| {
@@ -1684,8 +1694,21 @@ fn config_path_is_ignored(path: &Path, include_ignored: bool) -> bool {
     if is_default_config_dir_override_filtered(path) {
         return true;
     }
-    !include_ignored
-        && (config_file::is_ignored(&config_trust_root(path)) || config_file::is_ignored(path))
+    if include_ignored {
+        return false;
+    }
+    let ctr = config_trust_root(path);
+    // The `ignored_config_paths` setting is a hard filter.
+    if config_file::is_ignored_via_setting(&ctr) || config_file::is_ignored_via_setting(path) {
+        return true;
+    }
+    // The persisted ignore list (dismissed prompt / `mise trust --ignore`) is
+    // overridden by `trusted_config_paths`, matching is_trusted's precedence so
+    // a settings-trusted config is still discovered and loaded.
+    if config_file::is_persisted_ignored(&ctr) || config_file::is_persisted_ignored(path) {
+        return !config_file::is_trusted_via_config_paths(path);
+    }
+    false
 }
 
 static GLOBAL_CONFIG_FILES: Lazy<Mutex<Option<IndexSet<PathBuf>>>> = Lazy::new(Default::default);


### PR DESCRIPTION

`trusted_config_paths` (MISE_TRUSTED_CONFIG_PATHS) had no effect for any config
that had been added to the persisted ignore list — by answering "No" to the
trust prompt or running `mise trust --ignore`. `is_trusted()` consulted the
ignore list before `trusted_config_paths`, so the setting never took effect,
which also contradicted the `mise trust` warnings that a settings-trusted path
"will still be trusted".

Precedence is now:

1. `ignored_config_paths` setting — explicit hard block (unchanged)
2. `trusted_config_paths` / global config — overrides the persisted ignore list
3. persisted ignore list (dismissed prompt / `mise trust --ignore`)

The override is applied in both the trust check (`is_trusted`) and config
discovery (`config_path_is_ignored`), so a settings-trusted config is actually
discovered and loaded, and `mise doctor`'s ignored-config list reflects it.
Adds an e2e regression test.

Addresses https://github.com/jdx/mise/discussions/3544

*This PR was prepared by an AI coding assistant.*

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trusted configuration paths now correctly override previously persisted “ignored” configuration entries.
  * When `MISE_TRUSTED_CONFIG_PATHS` is set, corresponding configurations are now discovered and loaded as trusted (including their environment variables).
  * Trust reporting (`mise trust --show`, and related environment output) more accurately reflects the active trusted-path rules.
* **Tests**
  * Added an end-to-end regression test covering `MISE_TRUSTED_CONFIG_PATHS` overriding persisted ignore behavior and validating trust status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->