### PR TITLE
fix(config): avoid panic when config set descends into a non-table value

### DIFF
--- a/e2e/cli/test_config_set
+++ b/e2e/cli/test_config_set
@@ -35,3 +35,16 @@ assert "mise config get env._.python.venv.path" ".venv2"
 
 # test "config set" with no value and no = fails
 assert_fail "mise config set tools.node"
+
+# regression test for https://github.com/jdx/mise/discussions/3820:
+# descending into a key whose value is already a non-table scalar must fail
+# cleanly instead of panicking (>=2 levels) or silently doing nothing (1 level).
+printf '[env]\nFOO = "bar"\n' >mise.toml
+assert_fail "mise config set env.FOO.BAZ.QUX hello" "non-table value"
+assert_fail "mise config set env.FOO.BAZ hello" "non-table value"
+
+# descending into a pre-existing inline table updates the field and keeps siblings.
+printf '[env]\n_.python.venv = { path = ".venv", create = true }\n' >mise.toml
+mise config set env._.python.venv.path .venv2
+assert "mise config get env._.python.venv.path" ".venv2"
+assert "mise config get env._.python.venv.create" "true"

--- a/src/cli/config/set.rs
+++ b/src/cli/config/set.rs
@@ -71,7 +71,12 @@ impl ConfigSet {
         for (idx, part) in parts.iter().take(parts.len() - 1).enumerate() {
             container = container
                 .as_table_like_mut()
-                .unwrap()
+                .ok_or_else(|| {
+                    eyre::eyre!(
+                        "cannot set '{full_key}': '{}' is already set to a non-table value",
+                        parts[..idx].join(".")
+                    )
+                })?
                 .entry(part)
                 .or_insert({
                     let mut t = toml_edit::Table::new();
@@ -143,12 +148,14 @@ impl ConfigSet {
             TomlValueTypes::Infer => bail!("Type not found"),
         };
 
-        let mut t = toml_edit::Table::new();
-        t.set_implicit(true);
-        let mut table = toml_edit::Item::Table(t);
         container
             .as_table_like_mut()
-            .unwrap_or_else(|| table.as_table_like_mut().unwrap())
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "cannot set '{full_key}': '{}' is already set to a non-table value",
+                    parts[..parts.len() - 1].join(".")
+                )
+            })?
             .insert(last_key, value);
 
         let raw = config.to_string();


### PR DESCRIPTION
## Summary

`mise config set` had two remaining unsafe paths when a key segment collided with an existing non-table (scalar) value:

- **Panic** when descending ≥2 levels through a scalar, e.g. with `env.FOO = "bar"`, `mise config set env.FOO.BAZ.QUX hello` hit `container.as_table_like_mut().unwrap()` on the string → `Option::unwrap() on a None value`.
- **Silent no-op** when the final parent was a scalar, e.g. `mise config set env.FOO.BAZ hello`: the final insert used `unwrap_or_else(|| table.as_table_like_mut().unwrap())`, writing into a throwaway table that was never persisted — the command exited 0 but changed nothing.

PR #3823 already handled the original report (converting a `tools.<x>` simple version string into an inline table). This change replaces the two remaining `.unwrap()`/throwaway sites — in the key-descent loop and the final insert — with a clear error, so `config set` never panics and never silently discards a write on a non-table collision. We intentionally do not clobber an existing scalar into a table (that would lose the user's value).

## Testing

Extends `e2e/cli/test_config_set`:
- `env.FOO.BAZ.QUX` / `env.FOO.BAZ` against `env.FOO = "bar"` now fail cleanly with a `non-table value` error (previously panicked / silently no-oped).
- Descending into a pre-existing inline table (`_.python.venv = { path = ".venv", create = true }` → `config set env._.python.venv.path`) still updates the field and preserves siblings.

Fixes https://github.com/jdx/mise/discussions/3820

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mise config set` validation for nested configuration paths.
  * Added clear errors when attempting to set values beneath an existing non-table value.
  * Preserved existing sibling fields when updating values in inline tables.
  * Added regression coverage for invalid nested paths and inline-table updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->