### PR TITLE
fix(ruby): bypass versions host for custom precompiled releases

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -305,12 +305,20 @@ async fn list_tags_with_dates_(api_url: &str, repo: &str) -> Result<Vec<GithubTa
 }
 
 pub async fn get_release(repo: &str, tag: &str) -> Result<GithubRelease> {
-    let key = release_cache_key(API_URL, repo, tag, true);
+    get_release_with_versions_host(repo, tag, true).await
+}
+
+pub async fn get_release_with_versions_host(
+    repo: &str,
+    tag: &str,
+    use_versions_host: bool,
+) -> Result<GithubRelease> {
+    let key = release_cache_key(API_URL, repo, tag, use_versions_host);
     let cache = get_release_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     cache
         .get_or_try_init_async_if(
-            async || get_release_with_options(API_URL, repo, tag, true).await,
+            async || get_release_with_options(API_URL, repo, tag, use_versions_host).await,
             should_cache_release,
         )
         .await
@@ -363,13 +371,17 @@ fn should_cache_release(release: &GithubRelease) -> bool {
 pub async fn get_release_with_build_revision_status(
     repo: &str,
     version: &str,
+    use_versions_host: bool,
 ) -> Result<(GithubRelease, bool)> {
     let releases = list_releases(repo).await?;
     match pick_best_numeric_build_revision(releases.clone(), version) {
         Some(release) => Ok((release, true)),
         None => match pick_best_build_revision(releases, version) {
             Some(release) => Ok((release, false)),
-            None => Ok((get_release(repo, version).await?, false)),
+            None => Ok((
+                get_release_with_versions_host(repo, version, use_versions_host).await?,
+                false,
+            )),
         },
     }
 }

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -441,7 +441,7 @@ impl RubyPlugin {
         source == DEFAULT_RUBY_PRECOMPILED_URL
     }
 
-    fn use_versions_host_for_precompiled_attestations(source: &str) -> bool {
+    fn use_versions_host_for_precompiled_source(source: &str) -> bool {
         Self::is_default_ruby_source(source)
     }
 
@@ -580,14 +580,23 @@ impl RubyPlugin {
         locked_build_revision: Option<&str>,
     ) -> Result<Option<(String, Option<String>)>> {
         let requires_build_revision = Self::source_requires_build_revision(repo);
+        // The default precompiled repo is explicitly allowlisted by mise-versions.
+        // Custom repositories must fetch their release metadata directly from GitHub.
+        let use_versions_host = Self::use_versions_host_for_precompiled_source(repo);
         let release = if let Some(tag) = locked_build_revision {
             // Use the exact build revision from the lockfile
             debug!("using locked build revision {tag} for ruby {version}");
-            match github::get_release(repo, tag).await {
+            match github::get_release_with_versions_host(repo, tag, use_versions_host).await {
                 Ok(r) => r,
                 Err(err) => {
                     debug!("locked build revision {tag} not found, finding latest: {err}");
-                    match github::get_release_with_build_revision_status(repo, version).await {
+                    match github::get_release_with_build_revision_status(
+                        repo,
+                        version,
+                        use_versions_host,
+                    )
+                    .await
+                    {
                         Ok((r, found_build_revision)) => {
                             if requires_build_revision && !found_build_revision {
                                 debug!("no build revision release found for ruby {version}");
@@ -603,7 +612,9 @@ impl RubyPlugin {
                 }
             }
         } else {
-            match github::get_release_with_build_revision_status(repo, version).await {
+            match github::get_release_with_build_revision_status(repo, version, use_versions_host)
+                .await
+            {
                 Ok((r, found_build_revision)) => {
                     if requires_build_revision && !found_build_revision {
                         debug!("no build revision release found for ruby {version}");
@@ -837,7 +848,7 @@ impl RubyPlugin {
             repo,
             None, // Accept any workflow from repo
             None,
-            Self::use_versions_host_for_precompiled_attestations(source),
+            Self::use_versions_host_for_precompiled_source(source),
         )
         .await
         {
@@ -1273,10 +1284,10 @@ mod tests {
 
     #[test]
     fn test_ruby_precompiled_versions_host_only_for_default_source() {
-        assert!(RubyPlugin::use_versions_host_for_precompiled_attestations(
+        assert!(RubyPlugin::use_versions_host_for_precompiled_source(
             DEFAULT_RUBY_PRECOMPILED_URL
         ));
-        assert!(!RubyPlugin::use_versions_host_for_precompiled_attestations(
+        assert!(!RubyPlugin::use_versions_host_for_precompiled_source(
             "acme/ruby"
         ));
     }


### PR DESCRIPTION
## Summary

- let callers of the shared GitHub release helper opt out of `mise-versions`
- keep `mise-versions` release and attestation lookups for the default `jdx/ruby` precompiled source
- fetch release metadata directly from GitHub for custom `ruby.precompiled_url = "owner/repo"` sources
- keep hosted and direct release responses in separate cache entries

## Root cause

Ruby's precompiled installer treated an arbitrary `ruby.precompiled_url = "owner/repo"` as though it were a registry-backed release source. Exact-tag and fallback lookups therefore queried the restricted `mise-versions` endpoint first, producing a 403 warning for custom repositories the service cannot allowlist.

The default `jdx/ruby` source is known and intentionally supported by `mise-versions`. With jdx/mise-versions#273 allowing its release metadata, this PR now branches by source instead of bypassing the service for every precompiled repository.

## Routing after this change

- default `jdx/ruby`: use `mise-versions` first for release metadata and attestations, with the existing GitHub fallback
- custom `owner/repo`: query GitHub directly for release metadata and attestations
- `oneclick/rubyinstaller2`: unchanged; its separate Windows path continues using `mise-versions`

The source-aware flag is propagated through locked build-revision lookups and exact-release fallbacks, so custom repositories avoid the rejected service request on every path.

## Validation

- `mise run lint-fix`
- `cargo test --all-features test_versions_host_flag_splits_release_cache`
- `cargo test --all-features test_ruby_precompiled_versions_host_only_for_default_source`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release lookup reliability across supported release sources, including cases where different “versions host” handling applies.
  * Fixed fallback behavior when matching build revisions are unavailable, ensuring the correct release metadata is used.
  * Improved detection and retrieval of precompiled Ruby assets for both locked and unlocked builds.
  * Ensured consistent release information usage and improved verification behavior for precompiled artifact attestations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->