### PR TITLE
feat(bootstrap): support relative paths in [bootstrap.repos]

### DIFF
--- a/docs/bootstrap/repos.md
+++ b/docs/bootstrap/repos.md
@@ -12,6 +12,13 @@ mise can declare git repositories in `[bootstrap.repos]` and apply them with
 Each key is the target path. The `url` is required. The optional `ref` can be a
 branch, tag, or full commit SHA.
 
+Target paths may be absolute, start with `~/`, or be relative. Relative paths
+are resolved against the project root of the config file that declares them and
+must name a directory inside it — they cannot be empty or `.`, and cannot
+escape the root with `..` or absolute segments. Because of that, relative paths
+are only valid in a project config, not in a global config such as
+`~/.config/mise/config.toml`.
+
 Repos run after `[bootstrap.packages]` and before `[dotfiles]`, so a bootstrap
 config can install `git`, clone a dotfiles repository, and then apply dotfiles
 from that checkout.

--- a/e2e/cli/test_bootstrap_repos
+++ b/e2e/cli/test_bootstrap_repos
@@ -190,3 +190,18 @@ assert_succeed "mise bootstrap --yes --only tools"
 assert_directory_not_exists "$HOME/src/only-skipped"
 assert_fail "test -f pre_repo_hook"
 assert_fail "test -f post_repo_hook"
+
+# relative keys resolve against the declaring config's project root
+cat <<EOF >mise.toml
+[bootstrap.repos]
+"vendor/checkout" = { url = "$SRC_URL", ref = "main" }
+EOF
+assert_contains "mise bootstrap repos status" "missing"
+assert_succeed "mise bootstrap repos apply --yes"
+assert "cat vendor/checkout/version.txt" "v5"
+assert_contains "mise bootstrap repos status" "current"
+
+# resolution is project-root-relative, not cwd-relative
+mkdir -p nested
+assert_succeed "cd nested && mise bootstrap repos status --missing"
+assert_directory_not_exists "$PWD/nested/vendor"

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -477,7 +477,7 @@ pub fn repos_from_config(config: &Config) -> Vec<RepoRequest> {
     for cf in config.config_files.values().rev() {
         if let Some(sys) = cf.bootstrap_config() {
             for (path_raw, repo) in sys.repos {
-                match RepoRequest::from_toml(path_raw.clone(), repo) {
+                match RepoRequest::from_toml(path_raw.clone(), repo, cf.project_root().as_deref()) {
                     Ok(request) => {
                         merged.insert(request.path.clone(), request);
                     }
@@ -1485,13 +1485,24 @@ mod tests {
                 url: Some("https://github.com/jdx/dotfiles.git".to_string()),
                 git_ref: Some("main".to_string()),
             },
+            None,
         )
         .unwrap();
         assert!(request.path.is_absolute());
         assert_eq!(request.path_raw, "~/src/dotfiles");
         assert_eq!(request.url, "https://github.com/jdx/dotfiles.git");
         assert_eq!(request.git_ref.as_deref(), Some("main"));
-        assert!(repos::RepoRequest::from_toml("relative".to_string(), Default::default()).is_err());
+        assert!(
+            repos::RepoRequest::from_toml(
+                "relative".to_string(),
+                repos::RepoTomlConfig {
+                    url: Some("https://github.com/jdx/dotfiles.git".to_string()),
+                    git_ref: None,
+                },
+                None,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/system/repos.rs
+++ b/src/system/repos.rs
@@ -12,7 +12,7 @@
 //! matches. Origins are compared transport-agnostically for common network
 //! forms, so an ssh origin matches its https equivalent.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use eyre::{Result, bail, eyre};
@@ -72,11 +72,45 @@ pub struct RepoStatus {
 }
 
 impl RepoRequest {
-    pub fn from_toml(path_raw: String, config: RepoTomlConfig) -> Result<Self> {
-        let path = file::replace_path(&path_raw);
-        if path.is_relative() {
-            bail!("path must be absolute or start with ~/");
+    pub fn from_toml(
+        path_raw: String,
+        config: RepoTomlConfig,
+        project_root: Option<&Path>,
+    ) -> Result<Self> {
+        if path_raw.starts_with('~') && !path_raw.starts_with("~/") {
+            bail!(
+                "repo path `{path_raw}` cannot start with `~`; use `~/` for a home-relative path"
+            );
         }
+        let path = file::replace_path(&path_raw);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            let Some(root) = project_root else {
+                bail!(
+                    "relative repo paths are only allowed in a project config; use an absolute path or a `~/` path"
+                );
+            };
+            if path.components().any(|component| {
+                matches!(
+                    component,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                )
+            }) {
+                bail!(
+                    "relative repo path `{path_raw}` must stay within the project root (no `..` or absolute segments)"
+                );
+            }
+            if !path
+                .components()
+                .any(|component| matches!(component, Component::Normal(_)))
+            {
+                bail!(
+                    "relative repo path `{path_raw}` must name a directory inside the project root"
+                );
+            }
+            root.join(&path)
+        };
         let Some(url) = config.url.map(|s| s.trim().to_string()) else {
             bail!("must set `url`");
         };
@@ -811,19 +845,20 @@ mod tests {
                 url: Some(" https://example.com/dotfiles.git ".to_string()),
                 git_ref: Some(" main ".to_string()),
             },
+            None,
         )
         .unwrap();
         assert!(request.path.is_absolute());
         assert_eq!(request.url, "https://example.com/dotfiles.git");
         assert_eq!(request.git_ref.as_deref(), Some("main"));
-        assert!(RepoRequest::from_toml("relative".to_string(), Default::default()).is_err());
         assert!(
             RepoRequest::from_toml(
                 "~/src/empty".to_string(),
                 RepoTomlConfig {
                     url: Some("".to_string()),
                     git_ref: None
-                }
+                },
+                None
             )
             .is_err()
         );
@@ -833,7 +868,8 @@ mod tests {
                 RepoTomlConfig {
                     url: Some("--upload-pack=sh".to_string()),
                     git_ref: None
-                }
+                },
+                None
             )
             .is_err()
         );
@@ -843,9 +879,69 @@ mod tests {
                 RepoTomlConfig {
                     url: Some("https://example.com/repo.git".to_string()),
                     git_ref: Some("--detach".to_string())
-                }
+                },
+                None
             )
             .is_err()
+        );
+    }
+
+    #[test]
+    fn resolves_relative_repo_paths() {
+        let root = Path::new("/home/u/proj");
+        let config = || RepoTomlConfig {
+            url: Some("https://example.com/tool.git".to_string()),
+            git_ref: None,
+        };
+
+        let request = RepoRequest::from_toml("vendor/tool".to_string(), config(), Some(root))
+            .expect("relative path with a project root should resolve");
+        assert_eq!(request.path, Path::new("/home/u/proj/vendor/tool"));
+        assert_eq!(request.path_raw, "vendor/tool");
+
+        assert!(
+            RepoRequest::from_toml("vendor/tool".to_string(), config(), None).is_err(),
+            "relative path without a project root should error"
+        );
+        assert!(
+            RepoRequest::from_toml("../evil".to_string(), config(), Some(root)).is_err(),
+            "relative path escaping the project root should error"
+        );
+        assert!(
+            RepoRequest::from_toml("".to_string(), config(), Some(root)).is_err(),
+            "empty path resolving to the project root itself should error"
+        );
+        assert!(
+            RepoRequest::from_toml(".".to_string(), config(), Some(root)).is_err(),
+            "`.` path resolving to the project root itself should error"
+        );
+        assert!(
+            RepoRequest::from_toml("~".to_string(), config(), Some(root)).is_err(),
+            "bare `~` should error instead of becoming a literal `~` directory"
+        );
+        assert!(
+            RepoRequest::from_toml("~user/x".to_string(), config(), Some(root)).is_err(),
+            "`~user/...` should error instead of becoming a literal `~user` directory"
+        );
+
+        #[cfg(unix)]
+        {
+            let request =
+                RepoRequest::from_toml("/abs/elsewhere".to_string(), config(), Some(root))
+                    .expect("absolute path should be accepted");
+            assert_eq!(
+                request.path,
+                Path::new("/abs/elsewhere"),
+                "absolute path should be used verbatim, not joined under the project root"
+            );
+        }
+
+        let request = RepoRequest::from_toml("~/src/dotfiles".to_string(), config(), Some(root))
+            .expect("~/ path should be accepted");
+        assert!(request.path.is_absolute());
+        assert!(
+            !request.path.starts_with(root),
+            "~/ path should expand to home, not be joined under the project root"
         );
     }
 


### PR DESCRIPTION
> Not sure whether keeping `[bootstrap.repos]` keys absolute/`~/`-only was a deliberate design decision or just where things landed — apologies if I'm missing context here. Either way, being able to use relative paths would be really helpful, so I took a stab at it. Very happy to adjust or drop it if this isn't a direction you want.

## What

Lets `[bootstrap.repos]` destination keys be **relative paths**, resolved against the project root of the config file that declares them. Absolute and `~/` keys behave exactly as before.

```toml
# in a project's mise.toml
[bootstrap.repos]
"vendor/some-tool" = { url = "https://github.com/acme/some-tool.git", ref = "main" }
```

## Why

Today a repo key must be absolute or `~/`-prefixed — there's no way to say "check this out **inside my project**" without hardcoding a machine-specific absolute path. Relative keys make a project's `mise.toml` portable across machines and checkout locations, matching how `_.path` / `_.source` already resolve against `config_root`. There's no templating fallback either (`[bootstrap.repos]` keys aren't Tera-rendered, only `~/`-expanded), so this needs to be handled in the resolver.

## How it's safe

Relative paths are strictly contained to the project root:

- `..`, absolute segments (`RootDir` / drive `Prefix`) are rejected, so a relative key can't escape the project tree.
- Empty and `.` keys are rejected, so a key can't resolve to the project root itself (which would otherwise make bootstrap run `fetch`/`checkout`/`pull` against the user's own checkout).
- A bare `~` (vs `~/`) is rejected with a hint, instead of silently becoming a literal `~` directory.
- Relative keys are only accepted in **project** configs. Global configs (`~/.config/mise/...`) have no project root and continue to reject relative paths — resolution keys off `ConfigFile::project_root()`, which is `None` for them.

The containment check mirrors the existing `sanitize_7z_entry_path` idiom in `src/file.rs`. Note it's a lexical guard, not a security boundary — a *trusted* bootstrap config can already write anywhere via an absolute key; this just prevents accidental escapes and keeps the merge key stable (resolved paths dedupe correctly across the config hierarchy).

## Tests

- Unit (`src/system/repos.rs`): resolve-within-root, no-project-root → err, `..` → err, empty/`.` → err, `~`/`~user` → err, absolute verbatim, `~/` verbatim.
- e2e (`e2e/cli/test_bootstrap_repos`): a relative key clones into the project tree, and running from a subdirectory still resolves against the project root (not cwd). Full e2e run passes locally.
- `cargo fmt --check`, `clippy` (no new warnings), `cargo test`, and the e2e suite all pass.

Docs updated in `docs/bootstrap/repos.md`.

Happy to adjust the semantics — e.g. if you'd prefer this expressed via a `{{config_root}}` Tera variable instead of implicit relative resolution, I can rework it. 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how bootstrap repository paths are interpreted, including absolute, home-relative, and project-relative paths.
  * Documented restrictions for relative paths and their use in project configuration.

* **Bug Fixes**
  * Bootstrap repository targets now resolve relative to the declaring project configuration rather than the current working directory.
  * Added validation to reject invalid, empty, or project-escaping paths.
  * Improved handling of home-directory path syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
