### PR TITLE
fix(env): expand cross-file references in _.file env files

### DIFF
--- a/e2e/env/test_env_file_expand
+++ b/e2e/env/test_env_file_expand
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Regression test for https://github.com/jdx/mise/discussions/3897:
+# env vars loaded from `_.file` should be able to reference vars defined in an
+# earlier file or `[env]` block, instead of collapsing to an empty string.
+
+# dotenv cross-file reference within a single `_.file` array
+cat >mise.toml <<'EOF'
+[env]
+_.file = ['.postgres', '.local']
+EOF
+printf 'PGHOST=postgres\n' >.postgres
+printf 'PGTEST="${PGHOST}"\nPGTESTING=$PGHOST\n' >.local
+assert "mise env | grep '^export PGTEST='" "export PGTEST=postgres"
+assert "mise env | grep '^export PGTESTING='" "export PGTESTING=postgres"
+
+# same result via separate `[[env]]` blocks
+cat >mise.toml <<'EOF'
+[[env]]
+_.file = '.postgres'
+[[env]]
+_.file = '.local'
+EOF
+assert "mise env | grep '^export PGTEST='" "export PGTEST=postgres"
+
+# a dotenv file can reference a var defined in `[env]` (not a file)
+cat >mise.toml <<'EOF'
+[env]
+BASE = "base"
+_.file = '.child'
+EOF
+printf 'CHILD="${BASE}/child"\n' >.child
+assert "mise env | grep '^export CHILD='" "export CHILD=base/child"
+
+# structured (json) file referencing an earlier `[env]` var
+cat >mise.toml <<'EOF'
+[env]
+FIRST = "one"
+_.file = 'vals.json'
+EOF
+echo '{"SECOND": "${FIRST}/two"}' >vals.json
+assert "mise env | grep '^export SECOND='" "export SECOND=one/two"
+
+# a structured file value can reference an earlier key from the same file
+cat >mise.toml <<'EOF'
+[env]
+_.file = 'chain.json'
+EOF
+echo '{"BASE": "/opt", "BIN": "${BASE}/bin"}' >chain.json
+assert "mise env | grep '^export BIN='" "export BIN=/opt/bin"
+
+# with env_shell_expand disabled the seeding is skipped: the cross-file ref is
+# not resolved (falls back to plain dotenvy behavior against the process env).
+cat >mise.toml <<'EOF'
+[env]
+_.file = ['.postgres', '.local']
+EOF
+assert_not_contains "MISE_ENV_SHELL_EXPAND=false mise env" "export PGTEST=postgres"

--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -36,19 +36,49 @@ impl EnvResults {
     ) -> Result<IndexMap<PathBuf, EnvMap>> {
         let mut out = IndexMap::new();
         let s = r.parse_template(ctx, tera, source, exec_env, &input)?;
+        let shell_expand = crate::config::Settings::get().env_shell_expand;
+        // Accumulate loaded vars so a later file in the same `_.file` directive can
+        // reference vars defined by an earlier one (matching how separate `[[env]]`
+        // blocks accumulate through `resolve`). See discussion #3897.
+        let mut acc: TeraEnvMap = exec_env.clone();
         for p in xx::file::glob(normalize_path(config_root, s.into())).unwrap_or_default() {
-            let env = out.entry(p.clone()).or_insert_with(IndexMap::new);
             let parse_template = |s: String| r.parse_template(ctx, tera, source, exec_env, &s);
             let ext = p
                 .extension()
                 .map(|e| e.to_string_lossy().to_string())
                 .unwrap_or_default();
-            *env = match ext.as_str() {
+            let mut loaded = match ext.as_str() {
                 "json" => Self::json(config, exec_env, &p, parse_template).await?,
                 "yaml" => Self::yaml(config, exec_env, &p, parse_template).await?,
                 "toml" => Self::toml(config, exec_env, &p, parse_template).await?,
-                _ => Self::dotenv(&p).await?,
+                _ => Self::dotenv(&p, &acc, shell_expand).await?,
             };
+            // Structured files keep `${VAR}` intact (serde doesn't expand), so run
+            // their values through the same `$VAR` engine used for `KEY = value`
+            // vars. Expand and accumulate key-by-key so a later value in the same
+            // file can reference an earlier one (e.g. `BIN = "${BASE}/bin"`), and
+            // warn on undefined refs like the normal expansion path does. dotenv is
+            // expanded inside `Self::dotenv` via dotenvy itself.
+            if shell_expand && matches!(ext.as_str(), "json" | "yaml" | "toml") {
+                for (k, v) in loaded.iter_mut() {
+                    let mut missing = Vec::new();
+                    let expanded = super::shell_expand_env(&*v, &acc, &mut missing);
+                    for var in missing {
+                        warn_once!(
+                            "env var '{var}' is not defined and will be left unexpanded. \
+                             Use ${{{var}:-}} to default to an empty string and suppress \
+                             this warning."
+                        );
+                    }
+                    *v = expanded;
+                    acc.insert(k.clone(), v.clone());
+                }
+            } else {
+                for (k, v) in &loaded {
+                    acc.insert(k.clone(), v.clone());
+                }
+            }
+            out.insert(p, loaded);
         }
         Ok(out)
     }
@@ -191,17 +221,92 @@ impl EnvResults {
         }
     }
 
-    async fn dotenv(p: &Path) -> Result<EnvMap> {
+    async fn dotenv(p: &Path, acc: &TeraEnvMap, seed: bool) -> Result<EnvMap> {
         let errfn = || eyre!("failed to parse dotenv file: {}", display_path(p));
+        if !seed {
+            // env_shell_expand disabled: preserve the original behavior exactly
+            // (dotenvy substitutes against the process env + same-file vars only).
+            let mut env = EnvMap::new();
+            if let Ok(dotenv) = dotenvy::from_path_iter(p) {
+                for item in dotenv {
+                    let (k, v) = item.wrap_err_with(errfn)?;
+                    env.insert(k, v);
+                }
+            }
+            return Ok(env);
+        }
+        // dotenvy substitutes `${VAR}` only against the process env + vars defined
+        // earlier in the *same* file, collapsing anything else to "" — and 0.15 has
+        // no API to disable substitution or supply a custom map. To make cross-file
+        // references resolve (discussion #3897) we reuse dotenvy's own parser by
+        // prepending the accumulated env as escaped `KEY="..."` lines, then keep
+        // only the keys the file itself defines.
+        let Ok(content) = file::read_to_string(p) else {
+            return Ok(EnvMap::new());
+        };
+        // Keys the file itself defines (values here may be collapsed; we only need
+        // the key set to filter the seeded parse below).
+        let mut own_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for item in dotenvy::from_read_iter(content.as_bytes()) {
+            let (k, _v) = item.wrap_err_with(errfn)?;
+            own_keys.insert(k);
+        }
+        if own_keys.is_empty() {
+            return Ok(EnvMap::new());
+        }
+        // Seed lines for cross-file vars. dotenvy resolves `${VAR}` against the
+        // process env first and only then this prepended (same-file) data, so the
+        // seed fills genuinely-missing refs. This intentionally preserves dotenv's
+        // own substitution semantics; the one gap is that an ambient export still
+        // wins over a mise override of the same name for dotenv values (there is no
+        // dotenvy API to supply a custom substitution map).
+        let mut prefix = String::new();
+        for (k, v) in acc {
+            if own_keys.contains(k) || !is_env_key(k) {
+                continue;
+            }
+            prefix.push_str(k);
+            prefix.push_str("=\"");
+            prefix.push_str(&escape_dotenv_double_quoted(v));
+            prefix.push_str("\"\n");
+        }
+        let augmented = format!("{prefix}{content}");
         let mut env = EnvMap::new();
-        if let Ok(dotenv) = dotenvy::from_path_iter(p) {
-            for item in dotenv {
-                let (k, v) = item.wrap_err_with(errfn)?;
+        for item in dotenvy::from_read_iter(augmented.as_bytes()) {
+            let (k, v) = item.wrap_err_with(errfn)?;
+            if own_keys.contains(&k) {
                 env.insert(k, v);
             }
         }
         Ok(env)
     }
+}
+
+/// Whether `k` is a valid env var name we can safely emit as a dotenv key.
+fn is_env_key(k: &str) -> bool {
+    let mut chars = k.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Escape a value for a dotenv double-quoted context so dotenvy stores it
+/// verbatim (no re-substitution). dotenvy 0.15 only supports the `\\ \" \$ \n`
+/// escapes inside double quotes — emitting any other backslash escape is a parse
+/// error — so we escape exactly those and leave everything else literal.
+fn escape_dotenv_double_quoted(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '$' => out.push_str("\\$"),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -349,5 +454,21 @@ mod tests {
         restore_env_var("MISE_SOPS_AGE_KEY", prev_age_key);
         restore_env_var("MISE_SOPS_ROPS", prev_rops);
         Settings::reset(None);
+    }
+
+    #[test]
+    fn test_escape_dotenv_double_quoted() {
+        assert_eq!(escape_dotenv_double_quoted("plain"), "plain");
+        assert_eq!(escape_dotenv_double_quoted(r#"a$b"c\d"#), r#"a\$b\"c\\d"#);
+        assert_eq!(escape_dotenv_double_quoted("l1\nl2"), "l1\\nl2");
+    }
+
+    #[test]
+    fn test_is_env_key() {
+        assert!(is_env_key("PGHOST"));
+        assert!(is_env_key("_FOO123"));
+        assert!(!is_env_key("1FOO"));
+        assert!(!is_env_key("FOO-BAR"));
+        assert!(!is_env_key(""));
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -914,7 +914,7 @@ impl EnvResults {
     }
 }
 
-fn shell_expand_env(
+pub(crate) fn shell_expand_env(
     input: &str,
     env_vars: &BTreeMap<String, String>,
     missing_vars: &mut Vec<String>,


### PR DESCRIPTION

Env vars loaded from `_.file` were inserted verbatim, so a value that
referenced a var defined in an earlier file or `[env]` block resolved to
empty. dotenv files were especially affected: dotenvy substitutes
`${VAR}` only against the process env + same-file vars, collapsing an
undefined reference to "" (and it has no API to disable substitution or
supply a custom map), which also made the result depend on whatever was
ambiently exported — hence the flaky "mise env shows it but the shell is
blank" behavior.

Now, when `env_shell_expand` is enabled (the default):
- values within a single `_.file` array accumulate, so a later file sees
  vars from an earlier one (matching separate `[[env]]` blocks);
- structured files (json/yaml/toml) keep `${VAR}` intact and are run
  through the same `$VAR` engine used for `KEY = value` vars;
- dotenv files are parsed by dotenvy seeded with the accumulated env
  (prepended as escaped `KEY="..."` lines, then filtered back to the
  file's own keys) so cross-file references resolve deterministically.

When `env_shell_expand` is disabled, dotenv keeps its previous behavior.

Fixes https://github.com/jdx/mise/discussions/3897

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment files loaded via `_.file` can now reference variables defined in earlier loaded files.
  * Structured environment files (JSON/YAML/TOML) support shell-style `$VAR` expansion when enabled.
  * Cross-file expansion is supported for JSON-formatted dotenv content.
* **Bug Fixes**
  * When shell expansion is disabled (`MISE_ENV_SHELL_EXPAND=false`), cross-file/seed expansion is skipped to prevent unintended exported values.
* **Tests**
  * Added end-to-end coverage for cross-file expansion and structured dotenv behavior, plus unit tests for escaping and environment key validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->