### PR TITLE
fix(http): return an error instead of panicking on invalid URLs

### DIFF
--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -162,7 +162,11 @@ fn cache_dir() -> PathBuf {
 
 pub fn get_headers<U: IntoUrl>(url: U) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    let url = url.into_url().unwrap();
+    // An invalid URL just means no auth headers; the real error surfaces when the
+    // request is made. Avoid panicking here. See #3547.
+    let Ok(url) = url.into_url() else {
+        return headers;
+    };
 
     if let Some((token, _source)) = resolve_token(url.host_str().unwrap_or("codeberg.org")) {
         headers.insert(

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -243,7 +243,11 @@ fn cache_dir() -> PathBuf {
 
 pub fn get_headers<U: IntoUrl>(url: U) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    let url = url.into_url().unwrap();
+    // An invalid URL just means no auth headers; the real error surfaces when the
+    // request is made. Avoid panicking here. See #3547.
+    let Ok(url) = url.into_url() else {
+        return headers;
+    };
     let lookup_host = url.host_str().unwrap_or("gitlab.com");
 
     if let Some((token, _source)) = resolve_token(lookup_host) {

--- a/src/http.rs
+++ b/src/http.rs
@@ -158,7 +158,7 @@ impl Client {
     }
 
     pub async fn get_bytes<U: IntoUrl>(&self, url: U) -> Result<impl AsRef<[u8]>> {
-        let url = url.into_url().unwrap();
+        let url = url.into_url()?;
         let resp = self.get_async(url.clone()).await?;
         Ok(resp.bytes().await?)
     }
@@ -175,7 +175,7 @@ impl Client {
         headers: &HeaderMap,
     ) -> Result<Response> {
         ensure!(!Settings::get().offline(), "offline mode is enabled");
-        let url = url.into_url().unwrap();
+        let url = url.into_url()?;
         let resp = self
             .send_with_https_fallback(Method::GET, url, headers, "GET")
             .await?;
@@ -189,7 +189,7 @@ impl Client {
         headers: &HeaderMap,
     ) -> Result<Response> {
         ensure!(!Settings::get().offline(), "offline mode is enabled");
-        let url = url.into_url().unwrap();
+        let url = url.into_url()?;
         self.send_with_https_fallback_allow_error_status(Method::GET, url, headers, "GET")
             .await
     }
@@ -206,7 +206,7 @@ impl Client {
         headers: &HeaderMap,
     ) -> Result<Response> {
         ensure!(!Settings::get().offline(), "offline mode is enabled");
-        let url = url.into_url().unwrap();
+        let url = url.into_url()?;
         let resp = self
             .send_with_https_fallback(Method::HEAD, url, headers, "HEAD")
             .await?;
@@ -219,9 +219,11 @@ impl Client {
     }
 
     pub fn get_text_request<U: IntoUrl>(&self, url: U) -> TextRequest<'_> {
+        // Defer surfacing an invalid URL to `send()` (which returns `Result`) so a
+        // bad URL is reported as an error instead of panicking here. See #3547.
         TextRequest {
             client: self,
-            url: url.into_url().unwrap(),
+            url: url.into_url().map_err(|e| e.to_string()),
             extra_headers: HeaderMap::new(),
             retries: Settings::get().http_retries(),
         }
@@ -232,7 +234,7 @@ impl Client {
     /// when locking multiple platforms). Concurrent requests for the same URL will
     /// wait for the first fetch to complete.
     pub async fn get_text_cached<U: IntoUrl>(&self, url: U) -> Result<String> {
-        let url = url.into_url().unwrap();
+        let url = url.into_url()?;
         let key = url.to_string();
 
         // Get or create the OnceCell for this URL
@@ -261,7 +263,7 @@ impl Client {
     }
 
     pub async fn get_html<U: IntoUrl>(&self, url: U) -> Result<String> {
-        let url = url.into_url().unwrap();
+        let url = url.into_url()?;
         let resp = self.get_async(url.clone()).await?;
         let is_html = resp
             .headers()
@@ -285,7 +287,7 @@ impl Client {
     where
         T: serde::de::DeserializeOwned,
     {
-        let url = url.into_url().unwrap();
+        let url = url.into_url()?;
         let resp = self.get_async(url).await?;
         let headers = resp.headers().clone();
         let json = resp.json().await?;
@@ -300,7 +302,7 @@ impl Client {
     where
         T: serde::de::DeserializeOwned,
     {
-        let url = url.into_url().unwrap();
+        let url = url.into_url()?;
         let resp = self.get_async_with_headers(url, headers).await?;
         let headers = resp.headers().clone();
         let json = resp.json().await?;
@@ -793,7 +795,9 @@ impl Client {
 
 pub struct TextRequest<'a> {
     client: &'a Client,
-    url: Url,
+    // Parsed lazily by `get_text_request`; an invalid URL surfaces as an error in
+    // `send()` rather than a panic. See #3547.
+    url: Result<Url, String>,
     extra_headers: HeaderMap,
     retries: i64,
 }
@@ -811,14 +815,15 @@ impl TextRequest<'_> {
 
     pub async fn send(mut self) -> Result<String> {
         ensure!(!Settings::get().offline(), "offline mode is enabled");
+        let mut url = self.url.clone().map_err(|e| eyre!(e))?;
         // Merge GitHub headers with any extra headers provided
-        let mut headers = host_auth_headers(&self.url)?;
+        let mut headers = host_auth_headers(&url)?;
         headers.extend(self.extra_headers.clone());
         let resp = self
             .client
             .send_with_https_fallback_with_retries(
                 Method::GET,
-                self.url.clone(),
+                url.clone(),
                 &headers,
                 "GET",
                 self.retries,
@@ -827,12 +832,13 @@ impl TextRequest<'_> {
             .await?;
         let text = resp.text().await?;
         if text.starts_with("<!DOCTYPE html>") {
-            if self.url.scheme() == "http" {
+            if url.scheme() == "http" {
                 // try with https since http may be blocked
-                self.url.set_scheme("https").unwrap();
+                url.set_scheme("https").unwrap();
+                self.url = Ok(url);
                 return Box::pin(self.send()).await;
             }
-            bail!("Got HTML instead of text from {}", self.url);
+            bail!("Got HTML instead of text from {}", url);
         }
         Ok(text)
     }
@@ -1277,6 +1283,17 @@ mod tests {
         crate::config::Settings::reset(None);
 
         result
+    }
+
+    #[tokio::test]
+    async fn test_invalid_url_returns_error_not_panic() {
+        // A relative/invalid URL must return an error rather than panicking
+        // (previously `into_url().unwrap()` crashed the process). See #3547.
+        let client = Client::new(Duration::from_secs(1), ClientKind::Http).unwrap();
+        assert!(client.get_bytes("").await.is_err());
+        assert!(client.head("").await.is_err());
+        assert!(client.get_text("").await.is_err());
+        assert!(client.get_text_request("").send().await.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
> **Draft:** opened as a draft because #11158 is still open; will mark ready once that lands.

## Summary

Several `url.into_url().unwrap()` sites in the HTTP layer panicked the whole process with `RelativeUrlWithoutBase` (and similar) when a backend handed a relative/invalid URL to the client — the crash reported in discussion #3547 (`mise use aqua:gitlab.com/...`). The reporter's specific tool (glab) already works via the native `gitlab:` backend, but the panic *class* remained: any bad URL still crashed instead of returning an error.

This turns those panics into graceful errors:

- **Eight `Result`-returning `Client` methods** (`get_bytes`, `get_async_with_headers`, `get_async_with_headers_allow_error_status`, `head_async_with_headers`, `get_text_cached`, `get_html`, `json_headers`, `json_headers_with_headers`) now use `into_url()?` (the pattern already used elsewhere in the file).
- **`get_text_request`** returns a `TextRequest`, not a `Result`, and has several callers (incl. the aqua registry path). Instead of rippling a `Result` return through them, `TextRequest.url` becomes `Result<Url, String>` and `send()` surfaces the error — **no caller changes**.
- **`forgejo::get_headers` / `gitlab::get_headers`** return a `HeaderMap` (not a `Result`); they only use the URL host to look up an auth token and already default the host, so an invalid URL now yields no auth headers and the real error surfaces when the request is made.

## Testing

- New unit test `test_invalid_url_returns_error_not_panic`: asserts `get_bytes`/`head`/`get_text`/`get_text_request(...).send()` all return `Err` (not panic) for an invalid URL.
- rustfmt-checked locally; `cargo build`/clippy/tests deferred to CI (local compile skipped for memory).

Refs https://github.com/jdx/mise/discussions/3547

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid URLs now return clear errors instead of causing application crashes.
  * Improved reliability across HTTP requests, including downloads, headers, text, HTML, JSON, and HEAD requests.
  * Invalid URLs in deferred text requests are now reported when the request is sent.
  * Preserved authorization behavior for valid Forgejo and GitLab URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->