### PR TITLE
fix(brew-cask): case-insensitive app lookup + preflight-generated wrappers

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1660,7 +1660,8 @@ end
     #[test]
     fn artifact_lookup_matches_app_bundle_case_insensitively() -> Result<()> {
         // Homebrew cask `yaak` declares `app "yaak.app"` but the DMG ships
-        // `Yaak.app`. APFS is case-insensitive; exact match must not be required.
+        // `Yaak.app`. Default macOS APFS is case-insensitive; exact match must
+        // not be required.
         let tmp = tempfile::tempdir()?;
         let app = tmp.path().join("Yaak.app");
         file::create_dir_all(&app)?;

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -777,10 +777,17 @@ fn find_binary_source(
     cask: &Cask,
     binary: &BinaryArtifact,
 ) -> Result<PathBuf> {
-    if let Some(source) = generated_caskroom_artifact(caskroom, cask, &binary.source)
-        && source.is_file()
-    {
-        return Ok(source);
+    // Homebrew API often records preflight/postflight wrappers as
+    // `$HOMEBREW_PREFIX/Caskroom/<token>/<version>/<name>`. Map that final
+    // path onto:
+    //   1) temp caskroom (postflight, or preflight if staged there)
+    //   2) extract stage (preflight runs with staged_path = stage; e.g. VLC)
+    for root in [caskroom, stage] {
+        if let Some(source) = generated_caskroom_artifact(root, cask, &binary.source)
+            && source.is_file()
+        {
+            return Ok(source);
+        }
     }
     if let Some(source) = absolute_binary_source(&binary.source)
         && source.is_file()
@@ -1046,7 +1053,8 @@ fn find_app(root: &Path, name: &str) -> Option<PathBuf> {
 
 fn find_artifact(root: &Path, name: &str) -> Option<PathBuf> {
     let name_path = Path::new(name);
-    WalkDir::new(root)
+    // Prefer exact path match (preserves Homebrew's declared casing).
+    if let Some(path) = WalkDir::new(root)
         .into_iter()
         .filter_entry(|entry| entry.file_name() != "__MACOSX")
         .filter_map(|entry| entry.ok())
@@ -1057,6 +1065,43 @@ fn find_artifact(root: &Path, name: &str) -> Option<PathBuf> {
                 .is_ok_and(|relative| relative.ends_with(name_path))
         })
         .map(|entry| entry.into_path())
+    {
+        return Some(path);
+    }
+    // macOS APFS is usually case-insensitive; Homebrew succeeds when the
+    // cask declares `app "yaak.app"` but the DMG ships `Yaak.app`.
+    // Match case-insensitively only as a fallback so we do not change
+    // case-sensitive filesystems' exact-match preference.
+    WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|entry| entry.file_name() != "__MACOSX")
+        .filter_map(|entry| entry.ok())
+        .find(|entry| {
+            entry
+                .path()
+                .strip_prefix(root)
+                .is_ok_and(|relative| path_ends_with_ignore_ascii_case(relative, name_path))
+        })
+        .map(|entry| entry.into_path())
+}
+
+/// True when `path`'s trailing components match `suffix` with ASCII
+/// case-insensitive comparison of normal path components.
+fn path_ends_with_ignore_ascii_case(path: &Path, suffix: &Path) -> bool {
+    let path: Vec<_> = path.components().collect();
+    let suffix: Vec<_> = suffix.components().collect();
+    if suffix.is_empty() || suffix.len() > path.len() {
+        return false;
+    }
+    path[path.len() - suffix.len()..]
+        .iter()
+        .zip(suffix.iter())
+        .all(|(a, b)| match (a, b) {
+            (std::path::Component::Normal(a), std::path::Component::Normal(b)) => a
+                .to_string_lossy()
+                .eq_ignore_ascii_case(&b.to_string_lossy()),
+            _ => a == b,
+        })
 }
 
 fn app_target_path(target_name: &str) -> Result<PathBuf> {
@@ -1600,6 +1645,49 @@ end
         file::create_dir_all(&app)?;
 
         assert_eq!(find_app(tmp.path(), "Pearcleaner.app"), Some(app));
+        Ok(())
+    }
+
+    #[test]
+    fn artifact_lookup_matches_app_bundle_case_insensitively() -> Result<()> {
+        // Homebrew cask `yaak` declares `app "yaak.app"` but the DMG ships
+        // `Yaak.app`. APFS is case-insensitive; exact match must not be required.
+        let tmp = tempfile::tempdir()?;
+        let app = tmp.path().join("Yaak.app");
+        file::create_dir_all(&app)?;
+
+        assert_eq!(find_app(tmp.path(), "yaak.app"), Some(app.clone()));
+        assert_eq!(find_app(tmp.path(), "Yaak.app"), Some(app));
+        assert_eq!(find_app(tmp.path(), "Other.app"), None);
+        Ok(())
+    }
+
+    #[test]
+    fn maps_preflight_generated_wrapper_from_extract_stage() -> Result<()> {
+        // VLC: preflight writes `#{staged_path}/vlc.wrapper.sh` while preflight
+        // staged_path is the extract stage, not the temp Caskroom. API binary
+        // source is `$HOMEBREW_PREFIX/Caskroom/vlc/<ver>/vlc.wrapper.sh`.
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let prefix = tmp.path().join("homebrew");
+        let _guard = BrewPrefixGuard::set(&prefix);
+        let cask = test_cask("vlc", "3.0.23");
+        let stage = tmp.path().join("extract");
+        let tmp_caskroom = tmp.path().join("tmp-caskroom");
+        file::create_dir_all(&stage)?;
+        file::create_dir_all(&tmp_caskroom)?;
+        let wrapper = stage.join("vlc.wrapper.sh");
+        std::fs::write(&wrapper, "#!/bin/sh\n")?;
+
+        let binary = BinaryArtifact {
+            source: "$HOMEBREW_PREFIX/Caskroom/vlc/3.0.23/vlc.wrapper.sh".to_string(),
+            target: Some("vlc".to_string()),
+        };
+
+        assert_eq!(
+            find_binary_source(&stage, &tmp_caskroom, &cask, &binary)?,
+            wrapper
+        );
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -573,7 +573,7 @@ fn ditto(from: &Path, to: &Path) -> Result<()> {
 }
 
 fn install_pkg(stage: &Path, pkg: &PkgArtifact) -> Result<()> {
-    let source = find_artifact(stage, &pkg.source)
+    let source = find_file_artifact(stage, &pkg.source)
         .ok_or_else(|| eyre!("brew-cask: pkg artifact '{}' was not found", pkg.source))?;
     let args = vec![
         "-pkg".to_string(),
@@ -1046,27 +1046,16 @@ fn collect_uninstall_pkg_ids(value: &Value, pkg_ids: &mut Vec<String>) {
 }
 
 fn find_app(root: &Path, name: &str) -> Option<PathBuf> {
-    // `.app` bundles are directories; keep the type predicate inside the walk so a
-    // same-named file cannot shadow a later directory match.
+    // Directory predicate inside the walk so a same-named file cannot shadow.
     find_artifact_matching(root, name, |path| path.is_dir())
-}
-
-fn find_artifact(root: &Path, name: &str) -> Option<PathBuf> {
-    find_artifact_matching(root, name, |_| true)
 }
 
 fn find_file_artifact(root: &Path, name: &str) -> Option<PathBuf> {
     find_artifact_matching(root, name, |path| path.is_file())
 }
 
-/// Locate `name` under `root`, preferring exact path suffix match then ASCII
-/// case-insensitive suffix match (Homebrew/macOS APFS: cask may declare
-/// `yaak.app` while the DMG ships `Yaak.app`).
-///
-/// Exact match always wins when present. Case-insensitive fallback only runs
-/// when no exact match exists among entries satisfying `pred`. On case-sensitive
-/// volumes with multiple case variants and no exact hit, WalkDir order decides
-/// which fallback wins (pathological; rare for real casks).
+/// Exact path suffix match first, then ASCII case-insensitive suffix (e.g. cask
+/// `yaak.app` vs DMG `Yaak.app`). `pred` runs only after a name hit.
 fn find_artifact_matching(
     root: &Path,
     name: &str,

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -590,8 +590,7 @@ fn stage_font(stage: &Path, caskroom: &Path, font: &FontArtifact) -> Result<()> 
     if let Some(parent) = caskroom_font.parent() {
         file::create_dir_all(parent)?;
     }
-    let source = find_artifact(stage, &font.source)
-        .filter(|path| path.is_file())
+    let source = find_file_artifact(stage, &font.source)
         .ok_or_else(|| eyre!("brew-cask: font artifact '{}' was not found", font.source))?;
     ditto(&source, &caskroom_font)?;
     Ok(())
@@ -794,9 +793,8 @@ fn find_binary_source(
     {
         return Ok(source);
     }
-    find_artifact(caskroom, &binary.source)
-        .or_else(|| find_artifact(stage, &binary.source))
-        .filter(|path| path.is_file())
+    find_file_artifact(caskroom, &binary.source)
+        .or_else(|| find_file_artifact(stage, &binary.source))
         .ok_or_else(|| {
             eyre!(
                 "brew-cask: binary artifact '{}' was not found",
@@ -1048,41 +1046,54 @@ fn collect_uninstall_pkg_ids(value: &Value, pkg_ids: &mut Vec<String>) {
 }
 
 fn find_app(root: &Path, name: &str) -> Option<PathBuf> {
-    find_artifact(root, name).filter(|path| path.is_dir())
+    // `.app` bundles are directories; keep the type predicate inside the walk so a
+    // same-named file cannot shadow a later directory match.
+    find_artifact_matching(root, name, |path| path.is_dir())
 }
 
 fn find_artifact(root: &Path, name: &str) -> Option<PathBuf> {
+    find_artifact_matching(root, name, |_| true)
+}
+
+fn find_file_artifact(root: &Path, name: &str) -> Option<PathBuf> {
+    find_artifact_matching(root, name, |path| path.is_file())
+}
+
+/// Locate `name` under `root`, preferring exact path suffix match then ASCII
+/// case-insensitive suffix match (Homebrew/macOS APFS: cask may declare
+/// `yaak.app` while the DMG ships `Yaak.app`).
+///
+/// Exact match always wins when present. Case-insensitive fallback only runs
+/// when no exact match exists among entries satisfying `pred`. On case-sensitive
+/// volumes with multiple case variants and no exact hit, WalkDir order decides
+/// which fallback wins (pathological; rare for real casks).
+fn find_artifact_matching(
+    root: &Path,
+    name: &str,
+    pred: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
     let name_path = Path::new(name);
-    // Prefer exact path match (preserves Homebrew's declared casing).
-    if let Some(path) = WalkDir::new(root)
+    let mut case_insensitive = None;
+    for entry in WalkDir::new(root)
         .into_iter()
         .filter_entry(|entry| entry.file_name() != "__MACOSX")
         .filter_map(|entry| entry.ok())
-        .find(|entry| {
-            entry
-                .path()
-                .strip_prefix(root)
-                .is_ok_and(|relative| relative.ends_with(name_path))
-        })
-        .map(|entry| entry.into_path())
     {
-        return Some(path);
+        let path = entry.path();
+        if !pred(path) {
+            continue;
+        }
+        let Ok(relative) = path.strip_prefix(root) else {
+            continue;
+        };
+        if relative.ends_with(name_path) {
+            return Some(entry.into_path());
+        }
+        if case_insensitive.is_none() && path_ends_with_ignore_ascii_case(relative, name_path) {
+            case_insensitive = Some(entry.into_path());
+        }
     }
-    // macOS APFS is usually case-insensitive; Homebrew succeeds when the
-    // cask declares `app "yaak.app"` but the DMG ships `Yaak.app`.
-    // Match case-insensitively only as a fallback so we do not change
-    // case-sensitive filesystems' exact-match preference.
-    WalkDir::new(root)
-        .into_iter()
-        .filter_entry(|entry| entry.file_name() != "__MACOSX")
-        .filter_map(|entry| entry.ok())
-        .find(|entry| {
-            entry
-                .path()
-                .strip_prefix(root)
-                .is_ok_and(|relative| path_ends_with_ignore_ascii_case(relative, name_path))
-        })
-        .map(|entry| entry.into_path())
+    case_insensitive
 }
 
 /// True when `path`'s trailing components match `suffix` with ASCII
@@ -1097,9 +1108,10 @@ fn path_ends_with_ignore_ascii_case(path: &Path, suffix: &Path) -> bool {
         .iter()
         .zip(suffix.iter())
         .all(|(a, b)| match (a, b) {
-            (std::path::Component::Normal(a), std::path::Component::Normal(b)) => a
-                .to_string_lossy()
-                .eq_ignore_ascii_case(&b.to_string_lossy()),
+            (Component::Normal(a), Component::Normal(b)) => match (a.to_str(), b.to_str()) {
+                (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+                _ => *a == *b,
+            },
             _ => a == b,
         })
 }
@@ -1663,6 +1675,53 @@ end
     }
 
     #[test]
+    fn artifact_lookup_skips_macos_metadata_for_case_insensitive_match() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        file::create_dir_all(tmp.path().join("__MACOSX/Yaak.app"))?;
+        let app = tmp.path().join("Yaak.app");
+        file::create_dir_all(&app)?;
+
+        assert_eq!(find_app(tmp.path(), "yaak.app"), Some(app));
+        Ok(())
+    }
+
+    #[test]
+    fn find_app_ignores_file_that_matches_app_name() -> Result<()> {
+        // A same-named regular file must not shadow a later .app directory.
+        let tmp = tempfile::tempdir()?;
+        std::fs::write(tmp.path().join("yaak.app"), b"not a bundle")?;
+        let app = tmp.path().join("nested/Yaak.app");
+        file::create_dir_all(&app)?;
+
+        assert_eq!(find_app(tmp.path(), "yaak.app"), Some(app));
+        Ok(())
+    }
+
+    #[test]
+    fn path_ends_with_ignore_ascii_case_matches_components() {
+        assert!(path_ends_with_ignore_ascii_case(
+            Path::new("payload/Yaak.app"),
+            Path::new("yaak.app")
+        ));
+        assert!(path_ends_with_ignore_ascii_case(
+            Path::new("Yaak.app"),
+            Path::new("yaak.app")
+        ));
+        assert!(!path_ends_with_ignore_ascii_case(
+            Path::new("Yaak.app"),
+            Path::new("Other.app")
+        ));
+        assert!(!path_ends_with_ignore_ascii_case(
+            Path::new("Yaak.app"),
+            Path::new("")
+        ));
+        assert!(!path_ends_with_ignore_ascii_case(
+            Path::new("Yaak.app"),
+            Path::new("/Yaak.app")
+        ));
+    }
+
+    #[test]
     fn maps_preflight_generated_wrapper_from_extract_stage() -> Result<()> {
         // VLC: preflight writes `#{staged_path}/vlc.wrapper.sh` while preflight
         // staged_path is the extract stage, not the temp Caskroom. API binary
@@ -1687,6 +1746,33 @@ end
         assert_eq!(
             find_binary_source(&stage, &tmp_caskroom, &cask, &binary)?,
             wrapper
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn prefers_temp_caskroom_wrapper_over_extract_stage() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let prefix = tmp.path().join("homebrew");
+        let _guard = BrewPrefixGuard::set(&prefix);
+        let cask = test_cask("vlc", "3.0.23");
+        let stage = tmp.path().join("extract");
+        let tmp_caskroom = tmp.path().join("tmp-caskroom");
+        file::create_dir_all(&stage)?;
+        file::create_dir_all(&tmp_caskroom)?;
+        std::fs::write(stage.join("vlc.wrapper.sh"), "#!/bin/sh\necho stage\n")?;
+        let preferred = tmp_caskroom.join("vlc.wrapper.sh");
+        std::fs::write(&preferred, "#!/bin/sh\necho caskroom\n")?;
+
+        let binary = BinaryArtifact {
+            source: "$HOMEBREW_PREFIX/Caskroom/vlc/3.0.23/vlc.wrapper.sh".to_string(),
+            target: Some("vlc".to_string()),
+        };
+
+        assert_eq!(
+            find_binary_source(&stage, &tmp_caskroom, &cask, &binary)?,
+            preferred
         );
         Ok(())
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -779,8 +779,8 @@ fn find_binary_source(
     // Homebrew API often records preflight/postflight wrappers as
     // `$HOMEBREW_PREFIX/Caskroom/<token>/<version>/<name>`. Map that final
     // path onto:
-    //   1) temp caskroom (postflight, or preflight if staged there)
-    //   2) extract stage (preflight runs with staged_path = stage; e.g. VLC)
+    //   1) temp caskroom (postflight runs with staged_path = temp caskroom)
+    //   2) extract stage (preflight runs with staged_path = extract stage; e.g. VLC)
     for root in [caskroom, stage] {
         if let Some(source) = generated_caskroom_artifact(root, cask, &binary.source)
             && source.is_file()
@@ -810,7 +810,7 @@ fn absolute_binary_source(source: &str) -> Option<PathBuf> {
     source.is_absolute().then_some(source)
 }
 
-fn generated_caskroom_artifact(caskroom: &Path, cask: &Cask, source: &str) -> Option<PathBuf> {
+fn generated_caskroom_artifact(root: &Path, cask: &Cask, source: &str) -> Option<PathBuf> {
     let prefix = prefix::prefix();
     let source = source.replace("$HOMEBREW_PREFIX", &prefix.to_string_lossy());
     let source = PathBuf::from(source);
@@ -822,7 +822,7 @@ fn generated_caskroom_artifact(caskroom: &Path, cask: &Cask, source: &str) -> Op
     {
         return None;
     }
-    Some(caskroom.join(relative))
+    Some(root.join(relative))
 }
 
 fn cask_appdir(apps: &[AppArtifact]) -> Result<PathBuf> {

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -347,8 +347,8 @@ fn extract_archive(cask: &Cask, archive: &Path, pr: Option<&dyn SingleReport>) -
     } else {
         let format = cask_extraction_format(archive, filename)?;
         if format == ExtractionFormat::Raw {
-            // Raw executable binary — copy it using the original URL filename so find_artifact
-            // can match against the binary stanza source name (e.g. "claude").
+            // Raw executable binary — copy it using the original URL filename so
+            // find_file_artifact can match against the binary stanza source name (e.g. "claude").
             let url_filename = archive_filename(&cask.url).unwrap_or_else(|| filename.to_string());
             let dest = extract_dir.join(&url_filename);
             file::copy(archive, &dest)?;

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1672,6 +1672,17 @@ end
     }
 
     #[test]
+    fn artifact_lookup_prefers_exact_case_over_earlier_fallback() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let fallback = tmp.path().join("Yaak.app");
+        let exact = fallback.join("Contents/yaak.app");
+        file::create_dir_all(&exact)?;
+
+        assert_eq!(find_app(tmp.path(), "yaak.app"), Some(exact));
+        Ok(())
+    }
+
+    #[test]
     fn artifact_lookup_skips_macos_metadata_for_case_insensitive_match() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         file::create_dir_all(tmp.path().join("__MACOSX/Yaak.app"))?;

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1080,16 +1080,19 @@ fn find_artifact_matching(
         .filter_map(|entry| entry.ok())
     {
         let path = entry.path();
-        if !pred(path) {
-            continue;
-        }
         let Ok(relative) = path.strip_prefix(root) else {
             continue;
         };
+        // Cheap path-string checks first; only `stat` via `pred` on name hits
+        // (large .app trees have thousands of non-matching entries).
         if relative.ends_with(name_path) {
-            return Some(entry.into_path());
-        }
-        if case_insensitive.is_none() && path_ends_with_ignore_ascii_case(relative, name_path) {
+            if pred(path) {
+                return Some(entry.into_path());
+            }
+        } else if case_insensitive.is_none()
+            && path_ends_with_ignore_ascii_case(relative, name_path)
+            && pred(path)
+        {
             case_insensitive = Some(entry.into_path());
         }
     }
@@ -1099,21 +1102,26 @@ fn find_artifact_matching(
 /// True when `path`'s trailing components match `suffix` with ASCII
 /// case-insensitive comparison of normal path components.
 fn path_ends_with_ignore_ascii_case(path: &Path, suffix: &Path) -> bool {
-    let path: Vec<_> = path.components().collect();
-    let suffix: Vec<_> = suffix.components().collect();
-    if suffix.is_empty() || suffix.len() > path.len() {
+    if suffix.as_os_str().is_empty() {
         return false;
     }
-    path[path.len() - suffix.len()..]
-        .iter()
-        .zip(suffix.iter())
-        .all(|(a, b)| match (a, b) {
+    let mut path_iter = path.components().rev();
+    for b in suffix.components().rev() {
+        let Some(a) = path_iter.next() else {
+            return false;
+        };
+        let matches = match (a, b) {
             (Component::Normal(a), Component::Normal(b)) => match (a.to_str(), b.to_str()) {
                 (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
-                _ => *a == *b,
+                _ => a == b,
             },
             _ => a == b,
-        })
+        };
+        if !matches {
+            return false;
+        }
+    }
+    true
 }
 
 fn app_target_path(target_name: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary

Two related `brew-cask` install failures found while bootstrapping a machine with real Homebrew casks after mise 2026.7.11:

1. **Case-insensitive app artifact lookup** ([discussion #11156](https://github.com/jdx/mise/discussions/11156)) — `yaak`
2. **Preflight-generated binary wrappers under extract stage** ([discussion #11157](https://github.com/jdx/mise/discussions/11157)) — `vlc`

## Root causes

### 1. `yaak` — exact path suffix match only

`find_artifact` used `relative.ends_with(name_path)` (case-sensitive). Homebrew API / cask Ruby declare `app "yaak.app"` while the DMG ships `Yaak.app`. Homebrew succeeds on default APFS (case-insensitive); mise did not.

### 2. `vlc` — preflight `staged_path` ≠ binary resolution root

Install order:

```text
preflight(staged_path = extract stage)
→ install apps into tmp Caskroom
→ postflight(staged_path = tmp Caskroom)
→ stage_binary(stage, tmp_caskroom, …)
```

VLC preflight writes `#{staged_path}/vlc.wrapper.sh`. API binary source is:

```text
$HOMEBREW_PREFIX/Caskroom/vlc/3.0.23/vlc.wrapper.sh
```

`generated_caskroom_artifact` only remapped that path onto the **temp Caskroom**. The wrapper lives on the **extract stage**, so `find_binary_source` failed.

## Fix

- Single-pass exact-then-ASCII case-insensitive artifact match (type predicates inside the walk: apps=`is_dir`, files=`is_file`; still skips `__MACOSX`)
- When resolving `$HOMEBREW_PREFIX/Caskroom/<token>/<ver>/…` binaries, check **both** temp Caskroom and extract stage

## Tests

```bash
cargo test system::packages::brew::cask::tests -- --test-threads=1
# 56 passed
```

Includes regressions for yaak casing, VLC wrapper mapping, `__MACOSX` + case-insensitive, file-vs-dir shadowing, and temp-caskroom preferred over extract stage.

## Validation

- `cargo test system::packages::brew::cask::tests -- --test-threads=1`
- CI: lint / unit-macos on the PR

## How to test

1. On macOS with mise built from this branch:
   - `brew uninstall --cask yaak` (if installed), then `mise bootstrap packages apply` with `"brew-cask:yaak" = "latest"`
   - Same for `vlc`
2. Or run the unit tests above.

## AI Disclosure

**AI Disclosure:** This contribution was prepared end-to-end by Grok (xAI coding agent) under the direction of Alexey Zhokhov, who verified and approved the approach, reproduction, code, tests, discussions, and PR before considering them final. Root causes were reproduced on the contributor's machine (mise 2026.7.11, macOS arm64, real `yaak`/`vlc` Homebrew casks). Unit tests: `cargo test system::packages::brew::cask::tests` (56 passed); CI also run on the PR.

Refs: https://github.com/jdx/mise/discussions/11156  
Refs: https://github.com/jdx/mise/discussions/11157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when locating Homebrew cask artifacts such as application bundles, fonts, and generated wrapper scripts.
  - Application bundles are now selected correctly even when path capitalization differs.
  - macOS metadata folders (such as `__MACOSX`) are ignored during artifact searches.
  - Ensured `.app` bundles aren’t overridden by same-name regular files.
  - Wrapper script resolution now correctly prefers the appropriate generated wrapper from temporary or extracted locations.

- **Tests**
  - Expanded unit test coverage for case-insensitive `.app` selection, `__MACOSX` skipping, non-directory non-shadowing, and wrapper mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->