### PR TITLE
docs: fix dead aqua-registry and pipx installation links

### DIFF
--- a/docs/asdf-legacy-plugins.md
+++ b/docs/asdf-legacy-plugins.md
@@ -328,7 +328,7 @@ chmod +x "$ASDF_INSTALL_PATH/bin/tool"
 
 Consider migrating from asdf plugins to modern alternatives:
 
-1. **Check if tool is available in [aqua registry](https://aquaproj.github.io/aqua-registry/)**
+1. **Check if tool is available in [aqua registry](https://github.com/aquaproj/aqua-registry)**
 2. **Use [github backend](dev-tools/backends/github.md) for simple GitHub releases**
 3. **Create a [mise plugin](tool-plugin-development.md) for complex tools** - use the [mise-tool-plugin-template](https://github.com/jdx/mise-tool-plugin-template) for a quick start
 4. **Use language-specific package managers** (npm, pipx, cargo, gem)

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -40,7 +40,7 @@ mise use -g python
 pip install --user pipx
 ```
 
-[Other installation instructions](https://pipx.pypa.io/latest/installation/)
+[Other installation instructions](https://pipx.pypa.io/stable/how-to/install-pipx.html)
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Replace a dead aqua-registry docs URL on the asdf migration page (`aquaproj.github.io/aqua-registry/` → 404).
- Retarget the pipx backend docs “other installation instructions” link after pypa moved install docs off `/latest/installation/`.

## Motivation

Contributors following asdf→mise migration guidance hit a broken aqua registry link. Other mise docs already point at the live GitHub registry (`github.com/aquaproj/aqua-registry`). Separately, the pipx backend page linked a retired pipx.pypa.io path.

## Verification

- `curl -sI -L -A Mozilla/5.0 https://aquaproj.github.io/aqua-registry/` → **404**
- `curl -sI -L -A Mozilla/5.0 https://github.com/aquaproj/aqua-registry` → **200**
- Consistent with existing aqua links in `docs/dev-tools/backends/aqua.md` and `docs/contributing.md`
- `curl -sI -L -A Mozilla/5.0 https://pipx.pypa.io/latest/installation/` → **404**
- `curl -sI -L -A Mozilla/5.0 https://pipx.pypa.io/stable/how-to/install-pipx.html` → **200**
- Dup search: no open PR retargeting these URLs
- Docs-only; no runtime change

## Notes

- Does not change aqua/pipx install behavior — documentation links only.
- Left example/placeholder URLs (example.com, my-org registries) untouched.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 24h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the legacy plugin migration guide to link to the current aqua-registry repository.
  - Updated pipx installation guidance to reference the current official installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->