### PR TITLE
fix(completions): avoid network lookup during usage completion

### DIFF
--- a/e2e/cli/test_usage_completion_shim_offline
+++ b/e2e/cli/test_usage_completion_shim_offline
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# `usage complete-word` is invoked by the generated shell completion script.
+# Resolving its mise shim must not consult GitHub for a configured `usage@latest`.
+credential_marker="$HOME/github-credential-command-called"
+credential_command="$HOME/fake-github-credential-command"
+cat >"$credential_command" <<'EOF'
+#!/usr/bin/env bash
+touch "$HOME/github-credential-command-called"
+echo fake-token
+EOF
+chmod +x "$credential_command"
+
+mkdir -p "$MISE_CONFIG_DIR" "$MISE_DATA_DIR/shims"
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[settings]
+github.credential_command = "$credential_command"
+EOF
+cat >mise.toml <<'EOF'
+[tools]
+usage = "latest"
+EOF
+
+ln -s "$(which mise)" "$MISE_DATA_DIR/shims/usage"
+export PATH="$MISE_DATA_DIR/shims:$PATH"
+
+assert_fail "usage complete-word --shell zsh -- mise activate"
+assert_fail "test -f '$credential_marker'"

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -101,15 +101,24 @@ fn invoked_shim_path() -> PathBuf {
 async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -> Result<PathBuf> {
     // Shell completion invokes `usage complete-word` through the `usage` shim.
     // It should use the installed CLI or fail locally, never resolve a floating
-    // tool version through the network while the user is pressing tab.
-    let resolve_options = (bin_name == "usage"
-        && args.get(1).is_some_and(|arg| arg == "complete-word"))
-    .then_some(ResolveOptions {
-        offline: true,
-        ..Default::default()
-    });
+    // tool version or auto-install over the network while the user is pressing
+    // tab. On Windows the shim is invoked as `usage.exe`, so strip the platform
+    // executable suffix before comparing.
+    let bin_stem = bin_name
+        .strip_suffix(std::env::consts::EXE_SUFFIX)
+        .unwrap_or(bin_name);
+    let completion_offline =
+        bin_stem == "usage" && args.get(1).is_some_and(|arg| arg == "complete-word");
+    let resolve_options = if completion_offline {
+        ResolveOptions {
+            offline: true,
+            ..Default::default()
+        }
+    } else {
+        ResolveOptions::default()
+    };
     let mut ts = ToolsetBuilder::new()
-        .with_resolve_options(resolve_options.unwrap_or_default())
+        .with_resolve_options(resolve_options)
         .build(config)
         .await?;
     if let Some((p, tv)) = ts.which(config, bin_name).await
@@ -121,7 +130,9 @@ async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -
         );
         return Ok(bin);
     }
-    if Settings::get().not_found_auto_install {
+    // Auto-installing here would download a tool over the network; skip it for
+    // offline completion so `usage complete-word` fails locally instead.
+    if !completion_offline && Settings::get().not_found_auto_install {
         for tv in ts
             .install_missing_bin(config, bin_name)
             .await?

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -12,7 +12,7 @@ use crate::cli::exec::Exec;
 use crate::config::{Config, Settings};
 use crate::file::display_path;
 use crate::lock_file::LockFile;
-use crate::toolset::{ToolVersion, Toolset, ToolsetBuilder};
+use crate::toolset::{ResolveOptions, ToolVersion, Toolset, ToolsetBuilder};
 use crate::{backend, dirs, env, fake_asdf, file};
 use color_eyre::eyre::{Result, bail, eyre};
 use eyre::WrapErr;
@@ -52,7 +52,7 @@ pub async fn handle_shim() -> Result<()> {
     let mut args = env::ARGS.read().unwrap().clone();
     env::PREFER_OFFLINE.store(true, Ordering::Relaxed);
     trace!("shim[{bin_name}] args: {}", args.join(" "));
-    args[0] = which_shim(&mut config, &env::MISE_BIN_NAME)
+    args[0] = which_shim(&mut config, &env::MISE_BIN_NAME, &args)
         .await?
         .to_string_lossy()
         .to_string();
@@ -98,8 +98,20 @@ fn invoked_shim_path() -> PathBuf {
         .unwrap_or(argv0)
 }
 
-async fn which_shim(config: &mut Arc<Config>, bin_name: &str) -> Result<PathBuf> {
-    let mut ts = ToolsetBuilder::new().build(config).await?;
+async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -> Result<PathBuf> {
+    // Shell completion invokes `usage complete-word` through the `usage` shim.
+    // It should use the installed CLI or fail locally, never resolve a floating
+    // tool version through the network while the user is pressing tab.
+    let resolve_options = (bin_name == "usage"
+        && args.get(1).is_some_and(|arg| arg == "complete-word"))
+    .then_some(ResolveOptions {
+        offline: true,
+        ..Default::default()
+    });
+    let mut ts = ToolsetBuilder::new()
+        .with_resolve_options(resolve_options.unwrap_or_default())
+        .build(config)
+        .await?;
     if let Some((p, tv)) = ts.which(config, bin_name).await
         && let Some(bin) = p.which(config, &tv, bin_name).await?
     {


### PR DESCRIPTION
## Summary

- resolve the `usage complete-word` shim invocation offline
- add regression coverage that verifies completion does not invoke a GitHub credential command for `usage@latest`

## Root cause

Generated shell completions invoke `usage complete-word`. When `usage` resolved to a mise shim, the shim’s prefer-offline mode still fetched a remote version for an uninstalled `latest` request.

## Verification

- `mise run test:e2e e2e/cli/test_usage_completion_shim_offline`
- `mise run test:e2e e2e/tasks/test_task_completion`
- pre-commit `hk` checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `usage complete-word` shell completion by resolving the correct tool versions in offline mode.
  * Prevented completion from triggering external credential commands and avoided network-dependent behavior during completion.

* **Tests**
  * Added end-to-end coverage to verify that offline shell completion does not invoke the external credential command and fails/behaves correctly when resolution is offline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow shim-path change for a specific `usage complete-word` invocation; other shim behavior is unchanged.
> 
> **Overview**
> **Shell completion** no longer triggers remote version resolution or auto-install when tab completion runs **`usage complete-word`** through the **`usage`** mise shim.
> 
> `which_shim` now treats that invocation as **completion-offline**: it builds the toolset with **`ResolveOptions { offline: true }`** and **skips** `not_found_auto_install`, so an unconfigured **`usage@latest`** fails locally instead of hitting GitHub (e.g. via **`github.credential_command`**). Windows **`usage.exe`** is handled by stripping the executable suffix before matching.
> 
> An **e2e** test asserts **`usage complete-word`** fails without calling a fake GitHub credential command when **`usage = "latest"`** is configured but not installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c9b1ed335e0c1421536427ebbe1cd45782ea26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->