### PR TITLE
test(nix): skip macos defaults test in sandbox

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -57,6 +57,7 @@ rustPlatform.buildRustPackage {
     RUST_BACKTRACE=full cargo test --all-features -- \
       --skip cli::plugins::ls::tests::test_plugin_list_urls \
       --skip tera::tests::test_last_modified \
+      --skip system::defaults::tests::test_status_missing_keys_are_unset \
       --skip plugins::core::ruby::tests::test_list_versions_matching
   '';
 


### PR DESCRIPTION
## Summary
- Skip the macOS defaults missing-key test during the Nix package check phase.
- Avoid Nix build failures in restricted environments where the macOS defaults command is not available on PATH.

## Test plan
- Verified that `cargo test system::defaults::tests::test_status_missing_keys_are_unset -- --nocapture` passes locally.
- Verified that `nix build .#darwinConfigurations.laohome-arm64.system --override-input mise-flake path:/Volumes/Data/works/mise` completes successfully in nix-config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test configuration to skip an additional known test during the Nix build validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->