### PR TITLE
fix(sync): clear stale incomplete markers for external links

### DIFF
--- a/e2e/sync/test_sync_python_uv
+++ b/e2e/sync/test_sync_python_uv
@@ -5,7 +5,11 @@ export MISE_PYTHON_GITHUB_ATTESTATIONS=0
 # (astral-sh/uv#19278). Bump once 0.11.10 ships with attestations restored.
 assert "mise use -g uv@0.11.8 python@3.11.3"
 assert "mise x -- uv python install 3.11.1"
+mkdir -p "$MISE_CACHE_DIR/python/3.11.1"
+touch "$MISE_CACHE_DIR/python/3.11.1/incomplete"
 export UV_PYTHON_DOWNLOADS=never
 assert "mise sync python --uv"
+assert "test ! -f \"$MISE_CACHE_DIR/python/3.11.1/incomplete\""
+assert "mise where python@3.11.1"
 assert "mise x python@3.11.1 -- python -V" "Python 3.11.1"
 assert "mise x -- uv run -p 3.11.3 -- python -V" "Python 3.11.3"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2193,12 +2193,19 @@ pub trait Backend: Debug + Send + Sync {
         None
     }
     fn create_symlink(&self, version: &str, target: &Path) -> Result<Option<(PathBuf, PathBuf)>> {
+        let _state_lock = install_state::lock_tool_version(&self.ba().short, version)?;
         let link = self.ba().installs_path.join(version);
         if link.exists() {
+            if target.exists() && file::is_symlink_to(&link, target) {
+                install_state::clear_incomplete_marker(&self.ba().short, version)?;
+            }
             return Ok(None);
         }
         file::create_dir_all(link.parent().unwrap())?;
         let link = file::make_symlink(target, &link)?;
+        if target.exists() {
+            install_state::clear_incomplete_marker(&self.ba().short, version)?;
+        }
         Ok(Some(link))
     }
     fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {


### PR DESCRIPTION
## Summary

- serialize external-link state updates with the tool-version install lock
- clear a stale incomplete marker when an existing external link is verified healthy
- clear the marker after creating a healthy external link
- cover the uv-to-mise sync path with an end-to-end regression test

## Bug

An interrupted or failed mise install can leave an `incomplete` marker for a version. If that version is later provided by uv, nvm, pyenv, nodenv, or Homebrew, sync creates or confirms the external link but leaves the stale marker behind. Mise therefore continues treating the healthy external version as incomplete.

For example:

```sh
uv python install 3.11.1
mkdir -p "$MISE_CACHE_DIR/python/3.11.1"
touch "$MISE_CACHE_DIR/python/3.11.1/incomplete"
mise sync python --uv
mise where python@3.11.1
```

Before this fix, the final command fails even though the uv installation exists and mise linked it. After this fix, sync clears the marker once it confirms the external target exists, and `mise where` returns the linked installation.

## Split follow-ups

- #11682 reconciles links by provider ownership and preserves managed installs, runtime aliases, and other providers' links
- #11683 treats Windows junctions like symlinks when syncing mise Python installs to uv
- #11686 serializes provider reconciliation with install, uninstall, and link operations one version at a time
- #11687 continues reconciliation after marker cleanup failures and reports the errors after rebuilding runtime links

## Testing

- `mise run lint-fix`
- `mise run test:e2e e2e/sync/test_sync_python_uv`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*
