### PR TITLE
fix(github): clarify versions host fallback warnings

### DIFF
--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -312,7 +312,11 @@ pub async fn github_release(repo: &str, tag: &str) -> eyre::Result<Option<Github
         return Ok(None);
     };
     if !valid_github_release_asset_urls(&release, owner, repo_name) {
-        log_versions_host_warn(ctx, "invalid_asset_urls", "fallback=true");
+        log_versions_host_warn(
+            ctx,
+            "invalid_asset_urls",
+            "fallback=true message=\"falling back to GitHub directly\"",
+        );
         return Ok(None);
     }
     if !valid_github_release_tag(&release, tag) {
@@ -320,7 +324,7 @@ pub async fn github_release(repo: &str, tag: &str) -> eyre::Result<Option<Github
             ctx,
             "tag_mismatch",
             &format!(
-                "returned_tag={} fallback=true",
+                "returned_tag={} fallback=true message=\"falling back to GitHub directly\"",
                 log_value(&release.tag_name)
             ),
         );
@@ -394,7 +398,11 @@ where
                     Ok(None)
                 }
                 429 => {
-                    log_versions_host_warn(ctx, "rate_limited", "status=429 fallback=true");
+                    log_versions_host_warn(
+                        ctx,
+                        "rate_limited",
+                        "status=429 fallback=true message=\"falling back to GitHub directly\"",
+                    );
                     Ok(None)
                 }
                 status => {
@@ -402,7 +410,7 @@ where
                         ctx,
                         "failed",
                         &format!(
-                            "status={status} fallback=true error={}",
+                            "status={status} fallback=true error={} message=\"falling back to GitHub directly\"",
                             log_value(&versions_host_error_message(status, &body))
                         ),
                     );
@@ -415,7 +423,7 @@ where
                 ctx,
                 "failed",
                 &format!(
-                    "status={} fallback=true error={}",
+                    "status={} fallback=true error={} message=\"falling back to GitHub directly\"",
                     http::error_code(&err).unwrap_or(0),
                     log_value(&err.to_string())
                 ),


### PR DESCRIPTION
## Summary

- preserve the structured `fallback=true` field and add `message="falling back to GitHub directly"` to GitHub metadata warnings
- cover release and attestation metadata failures, rate limits, and invalid mirrored release responses
- leave non-GitHub versions-host fallback diagnostics unchanged

## Root cause

The warning discussed in [#10284](https://github.com/jdx/mise/discussions/10284) said only that a fallback existed. It did not tell users that mise would continue by querying GitHub directly, making the impact of a `mise-versions` failure unclear.

The warning now identifies the fallback destination without changing the existing boolean field or fallback behavior.

## Validation

- `cargo test --all-features versions_host_error_message`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning messages for invalid release data, rate limits, and other request failures.
  * Warnings now explicitly state when the app is “falling back to GitHub directly,” while preserving the existing fallback behavior (including returning no data when applicable).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->