### PR TITLE
fix(brew): allow cask binaries to symlink into /usr/local on arm64

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -859,13 +859,17 @@ fn link_binary(caskroom: &Path, binary: &BinaryArtifact) -> Result<()> {
 
 fn caskroom_binary_path(caskroom: &Path, binary: &BinaryArtifact) -> Result<PathBuf> {
     let target = binary.target_path()?;
-    let relative = target.strip_prefix(prefix::prefix()).wrap_err_with(|| {
-        format!(
-            "brew-cask: binary target '{}' must be under {}",
-            target.display(),
-            prefix::prefix().display()
-        )
-    })?;
+    let roots = allowed_binary_target_roots();
+    let relative = roots
+        .iter()
+        .find_map(|root| target.strip_prefix(root).ok())
+        .ok_or_else(|| {
+            eyre!(
+                "brew-cask: binary target '{}' must be under {}",
+                target.display(),
+                allowed_binary_target_roots_display(&roots)
+            )
+        })?;
     if relative.components().next().is_none() {
         bail!(
             "brew-cask: invalid binary target '{}'",
@@ -1082,6 +1086,31 @@ fn app_bundle_name(target_name: &str) -> Result<&str> {
         .ok_or_else(|| eyre!("brew-cask: invalid app target '{target_name}'"))
 }
 
+/// Roots that a cask's `binary` artifact may legitimately symlink into.
+///
+/// The Homebrew prefix (`/opt/homebrew` on arm64, `/usr/local` on Intel) is
+/// always allowed. `/usr/local` is additionally allowed even on arm64 because
+/// some casks (e.g. docker-desktop) hardcode absolute `/usr/local/bin` targets
+/// so their CLIs land on PATH regardless of architecture. Homebrew honors those
+/// targets, so mise does too.
+fn allowed_binary_target_roots() -> Vec<PathBuf> {
+    let prefix = prefix::prefix();
+    let mut roots = vec![prefix.clone()];
+    let usr_local = PathBuf::from("/usr/local");
+    if prefix != usr_local {
+        roots.push(usr_local);
+    }
+    roots
+}
+
+fn allowed_binary_target_roots_display(roots: &[PathBuf]) -> String {
+    roots
+        .iter()
+        .map(|root| root.display().to_string())
+        .collect::<Vec<_>>()
+        .join(" or ")
+}
+
 fn binary_target_path(target_name: &str) -> Result<PathBuf> {
     let prefix = prefix::prefix();
     let prefix_str = prefix.to_string_lossy();
@@ -1103,11 +1132,12 @@ fn binary_target_path(target_name: &str) -> Result<PathBuf> {
             target.display()
         );
     }
-    if !target.starts_with(&prefix) {
+    let roots = allowed_binary_target_roots();
+    if !roots.iter().any(|root| target.starts_with(root)) {
         bail!(
             "brew-cask: binary target '{}' must be under {}",
             target.display(),
-            prefix.display()
+            allowed_binary_target_roots_display(&roots)
         );
     }
     Ok(target)
@@ -2016,17 +2046,37 @@ end
     }
 
     #[test]
-    fn binary_targets_must_stay_under_prefix() -> Result<()> {
+    fn binary_targets_must_stay_under_an_allowed_root() -> Result<()> {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
 
-        let err = binary_target_path("/usr/local/bin/op")
+        // Targets outside both the prefix and /usr/local are rejected.
+        let err = binary_target_path("/opt/elsewhere/bin/op")
             .unwrap_err()
             .to_string();
         assert!(err.contains("must be under"));
         let err = binary_target_path("../op").unwrap_err().to_string();
         assert!(err.contains("must not contain '..'"));
+        Ok(())
+    }
+
+    #[test]
+    fn binary_targets_allow_absolute_usr_local() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+
+        // Casks like docker-desktop hardcode absolute /usr/local targets; these
+        // are honored even when the prefix is elsewhere (arm64 /opt/homebrew).
+        assert_eq!(
+            binary_target_path("/usr/local/bin/docker")?,
+            PathBuf::from("/usr/local/bin/docker")
+        );
+        assert_eq!(
+            binary_target_path("/usr/local/cli-plugins/docker-compose")?,
+            PathBuf::from("/usr/local/cli-plugins/docker-compose")
+        );
         Ok(())
     }
 
@@ -2044,6 +2094,24 @@ end
         assert_eq!(
             caskroom_binary_path(&caskroom, &binary)?,
             caskroom.join("sbin/op")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn caskroom_binary_paths_strip_usr_local_root() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let caskroom = tmp.path().join("Caskroom/docker-desktop/1.0.0");
+        let binary = BinaryArtifact {
+            source: "$APPDIR/Docker.app/Contents/Resources/bin/docker".to_string(),
+            target: Some("/usr/local/bin/docker".to_string()),
+        };
+
+        assert_eq!(
+            caskroom_binary_path(&caskroom, &binary)?,
+            caskroom.join("bin/docker")
         );
         Ok(())
     }


### PR DESCRIPTION
## Problem

Reported in #11168. Installing the `docker-desktop` cask via mise's brew-cask backend fails on Apple Silicon with:

```
mise ERROR brew-cask: binary target '/usr/local/bin/docker-credential-ecr-login' must be under /opt/homebrew
```

## Root cause

mise reimplements Homebrew cask installation in [`src/system/packages/brew/cask.rs`](src/system/packages/brew/cask.rs) rather than shelling out to `brew`. When linking a cask's `binary` artifacts, it required every symlink target to live under the Homebrew prefix (`/opt/homebrew` on arm64).

Most casks specify bare filenames (which mise places under `$HOMEBREW_PREFIX/bin`), but a few—most notably `docker-desktop`—hardcode absolute `/usr/local` targets so their CLIs stay on PATH regardless of architecture:

- `docker`, `docker-credential-ecr-login`, `docker-credential-desktop`, `docker-credential-osxkeychain`, `kubectl.docker` → `/usr/local/bin/...`
- `docker-compose` → `/usr/local/cli-plugins/docker-compose`

Homebrew honors these absolute targets; mise rejected them outright.

## Fix

Allow `/usr/local` as an additional valid symlink root alongside the Homebrew prefix, and strip whichever matching root applies when computing the caskroom staging path. On Intel Macs the prefix already *is* `/usr/local`, so the roots dedupe to one. Path traversal (`..`) and targets outside both roots are still rejected.

## Tests

- Added `binary_targets_allow_absolute_usr_local` and `caskroom_binary_paths_strip_usr_local_root`.
- Updated `binary_targets_must_stay_under_prefix` → `binary_targets_must_stay_under_an_allowed_root` to assert a genuinely out-of-bounds path (`/opt/elsewhere/...`) is still rejected.
- All 52 `brew::cask` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to macOS brew-cask binary path validation and staging; expands allowed symlink roots without loosening traversal checks.
> 
> **Overview**
> Fixes brew-cask installs that fail on Apple Silicon when a cask declares **absolute `/usr/local` binary targets** (e.g. `docker-desktop`), which mise previously rejected because only paths under `$HOMEBREW_PREFIX` (e.g. `/opt/homebrew`) were allowed.
> 
> **`binary_target_path`** and **`caskroom_binary_path`** now treat symlink roots as the Homebrew prefix **or** `/usr/local` (deduped when the prefix is already `/usr/local`). Caskroom staging strips whichever root matches so targets like `/usr/local/bin/docker` stage as `bin/docker` under the version directory. **`..`** and paths outside those roots are still rejected.
> 
> Unit tests cover `/usr/local` acceptance, caskroom path stripping, and out-of-bounds rejection (`/opt/elsewhere/...`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2445c4611ae7d83eed91388c4157041fa0c45b56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Homebrew cask binary path handling for installations using symlinks.
  - Binary targets within the active Homebrew prefix or `/usr/local` are now recognized as valid.
  - Paths outside approved Homebrew locations continue to be rejected with clearer errors.
  - Corrected staged path calculation for binaries targeting `/usr/local`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->