### PR TITLE
fix(lock): preserve os-restricted tool entries

### DIFF
--- a/e2e/lockfile/test_lockfile_prune_stale_tools
+++ b/e2e/lockfile/test_lockfile_prune_stale_tools
@@ -47,6 +47,7 @@ EOF
 
 OUTPUT=$(mise lock --platform linux-x64 2>&1)
 assert_contains "echo \"$OUTPUT\"" "Pruned 1 stale tool entry"
+assert_not_contains "echo \"$OUTPUT\"" "No tools configured to lock"
 assert_not_contains "cat mise.lock" "[[tools.tiny]]"
 assert_contains "cat mise.lock" "[[tools.cocoapods]]"
 

--- a/e2e/lockfile/test_lockfile_prune_stale_tools
+++ b/e2e/lockfile/test_lockfile_prune_stale_tools
@@ -28,6 +28,28 @@ mise lock --platform linux-x64
 assert_contains "cat mise.lock" "[[tools.tiny]]"
 assert_not_contains "cat mise.lock" "[[tools.dummy]]"
 
+echo "=== Preserve tool excluded on the current OS ==="
+if [[ $(uname -s) == Darwin ]]; then
+  INACTIVE_OS=linux
+else
+  INACTIVE_OS=macos
+fi
+cat <<EOF >mise.toml
+[tools]
+cocoapods = { version = "1.16.2", os = ["$INACTIVE_OS"] }
+EOF
+cat <<EOF >>mise.lock
+
+[[tools.cocoapods]]
+version = "1.16.2"
+backend = "gem:cocoapods"
+EOF
+
+OUTPUT=$(mise lock --platform linux-x64 2>&1)
+assert_contains "echo \"$OUTPUT\"" "Pruned 1 stale tool entry"
+assert_not_contains "cat mise.lock" "[[tools.tiny]]"
+assert_contains "cat mise.lock" "[[tools.cocoapods]]"
+
 echo "=== Remove all tools and relock ==="
 cat <<EOF >mise.toml
 [tools]
@@ -36,7 +58,7 @@ EOF
 assert_contains \
   "mise lock --dry-run --platform linux-x64" \
   "Dry run - would prune 1 stale tool entry"
-assert_contains "cat mise.lock" "[[tools.tiny]]"
+assert_contains "cat mise.lock" "[[tools.cocoapods]]"
 
 OUTPUT=$(mise lock --platform linux-x64 2>&1)
 assert_contains "echo \"$OUTPUT\"" "Pruned 1 stale tool entry"

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -18,6 +18,7 @@ use tokio::task::JoinSet;
 
 /// A tool to lock for a specific lockfile target.
 type LockTool = (crate::cli::args::BackendArg, crate::toolset::ToolVersion);
+type ToolSelectors = (BTreeSet<String>, BTreeSet<String>);
 
 fn request_matches(a: &ToolRequest, b: &ToolRequest) -> bool {
     a.version() == b.version() && a.options() == b.options()
@@ -178,14 +179,19 @@ impl Lock {
                     &lock_resolve_options,
                 )
                 .await?;
-            let (configured_tools, configured_backends) = self
-                .configured_tool_selectors_for_target(
-                    &config,
-                    &tools,
-                    lockfile_path,
-                    config_paths,
-                    effective_config_files,
-                )?;
+            let configured_selectors = self.configured_tool_selectors_for_target(
+                &config,
+                &tools,
+                lockfile_path,
+                config_paths,
+                effective_config_files,
+            );
+            if configured_selectors
+                .as_ref()
+                .is_some_and(|(configured_tools, _)| !configured_tools.is_empty())
+            {
+                has_lock_targets = true;
+            }
 
             if tools.is_empty() {
                 // `tools` can be empty either because config has no tools, or because a filter excludes all.
@@ -199,11 +205,8 @@ impl Lock {
                             lockfile_path,
                         ));
                     }
-                    let stale_tools = self.stale_entries_if_pruned(
-                        &lockfile,
-                        &configured_tools,
-                        &configured_backends,
-                    );
+                    let stale_tools =
+                        self.stale_entries_if_pruned(&lockfile, configured_selectors.as_ref());
                     self.show_stale_prune_message(lockfile_path, &stale_tools, true)?;
                     if !stale_tools.is_empty() {
                         has_lock_targets = true;
@@ -222,8 +225,7 @@ impl Lock {
                     }
                     let pruned_tools = self.prune_stale_entries_if_needed(
                         &mut lockfile,
-                        &configured_tools,
-                        &configured_backends,
+                        configured_selectors.as_ref(),
                     );
                     if !pruned_tools.is_empty() {
                         lockfile.write(lockfile_path)?;
@@ -273,11 +275,8 @@ impl Lock {
                     ));
                 }
                 if self.is_unfiltered_lock_run() {
-                    let stale_tools = self.stale_entries_if_pruned(
-                        &lockfile,
-                        &configured_tools,
-                        &configured_backends,
-                    );
+                    let stale_tools =
+                        self.stale_entries_if_pruned(&lockfile, configured_selectors.as_ref());
                     self.show_stale_prune_message(lockfile_path, &stale_tools, true)?;
                 }
                 let stale_versions = self.stale_versions_if_pruned(&lockfile, &tools);
@@ -293,11 +292,8 @@ impl Lock {
             if self.json {
                 all_changes.extend(self.compute_version_changes(&lockfile, &tools, lockfile_path));
             }
-            let stale_tools = self.prune_stale_entries_if_needed(
-                &mut lockfile,
-                &configured_tools,
-                &configured_backends,
-            );
+            let stale_tools =
+                self.prune_stale_entries_if_needed(&mut lockfile, configured_selectors.as_ref());
             self.show_stale_prune_message(lockfile_path, &stale_tools, false)?;
 
             // Compute stale versions BEFORE process_tools so provenance checks can
@@ -465,9 +461,11 @@ impl Lock {
     fn prune_stale_entries_if_needed(
         &self,
         lockfile: &mut Lockfile,
-        configured_tools: &BTreeSet<String>,
-        configured_backends: &BTreeSet<String>,
+        configured_selectors: Option<&ToolSelectors>,
     ) -> BTreeSet<String> {
+        let Some((configured_tools, configured_backends)) = configured_selectors else {
+            return BTreeSet::new();
+        };
         if !self.is_unfiltered_lock_run() {
             return BTreeSet::new();
         }
@@ -495,9 +493,11 @@ impl Lock {
     fn stale_entries_if_pruned(
         &self,
         lockfile: &Lockfile,
-        configured_tools: &BTreeSet<String>,
-        configured_backends: &BTreeSet<String>,
+        configured_selectors: Option<&ToolSelectors>,
     ) -> BTreeSet<String> {
+        let Some((configured_tools, configured_backends)) = configured_selectors else {
+            return BTreeSet::new();
+        };
         if !self.is_unfiltered_lock_run() {
             return BTreeSet::new();
         }
@@ -563,7 +563,7 @@ impl Lock {
     fn configured_tool_selectors(
         &self,
         tools: &[(crate::cli::args::BackendArg, crate::toolset::ToolVersion)],
-    ) -> (BTreeSet<String>, BTreeSet<String>) {
+    ) -> ToolSelectors {
         let configured_tools: BTreeSet<String> =
             tools.iter().map(|(ba, _)| ba.short.clone()).collect();
         let configured_backends: BTreeSet<String> = tools.iter().map(|(ba, _)| ba.full()).collect();
@@ -577,7 +577,7 @@ impl Lock {
         target_lockfile_path: &Path,
         config_paths: &[PathBuf],
         effective_config_files: &ConfigMap,
-    ) -> Result<(BTreeSet<String>, BTreeSet<String>)> {
+    ) -> Option<ToolSelectors> {
         let (mut configured_tools, mut configured_backends) = self.configured_tool_selectors(tools);
         let config_paths: BTreeSet<&PathBuf> = config_paths.iter().collect();
 
@@ -590,7 +590,17 @@ impl Lock {
             {
                 continue;
             }
-            let trs = cf.to_tool_request_set()?;
+            let trs = match cf.to_tool_request_set() {
+                Ok(trs) => trs,
+                Err(err) => {
+                    debug!(
+                        "skipping stale-tool pruning for {} because {} could not be parsed: {err}",
+                        display_path(target_lockfile_path),
+                        display_path(path)
+                    );
+                    return None;
+                }
+            };
             for (ba, _, _) in trs.iter() {
                 // Pruning answers whether the tool is still declared, not whether its
                 // backend can resolve on this machine. In particular, OS-restricted
@@ -600,7 +610,7 @@ impl Lock {
             }
         }
 
-        Ok((configured_tools, configured_backends))
+        Some((configured_tools, configured_backends))
     }
 
     fn current_tool_versions(&self, tools: &[LockTool]) -> BTreeMap<String, BTreeSet<String>> {
@@ -1162,11 +1172,11 @@ mod tests {
     fn test_prune_stale_entries_with_empty_tools_prunes_all_entries() {
         let cmd = lock_cmd(&[]);
         let mut lockfile = lockfile_with_dummy();
-        let pruned = cmd.prune_stale_entries_if_needed(
-            &mut lockfile,
-            &std::collections::BTreeSet::new(),
-            &std::collections::BTreeSet::new(),
+        let configured_selectors = (
+            std::collections::BTreeSet::new(),
+            std::collections::BTreeSet::new(),
         );
+        let pruned = cmd.prune_stale_entries_if_needed(&mut lockfile, Some(&configured_selectors));
         assert_eq!(
             pruned,
             std::collections::BTreeSet::from(["dummy".to_string()])
@@ -1178,11 +1188,25 @@ mod tests {
     fn test_prune_stale_entries_with_filter_keeps_existing_entries() {
         let cmd = lock_cmd(&["tiny"]);
         let mut lockfile = lockfile_with_dummy();
-        let pruned = cmd.prune_stale_entries_if_needed(
-            &mut lockfile,
-            &std::collections::BTreeSet::new(),
-            &std::collections::BTreeSet::new(),
+        let configured_selectors = (
+            std::collections::BTreeSet::new(),
+            std::collections::BTreeSet::new(),
         );
+        let pruned = cmd.prune_stale_entries_if_needed(&mut lockfile, Some(&configured_selectors));
+        assert!(pruned.is_empty());
+        assert_eq!(
+            lockfile.all_platform_keys(),
+            std::collections::BTreeSet::from(["linux-x64".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_prune_stale_entries_without_selectors_keeps_existing_entries() {
+        let cmd = lock_cmd(&[]);
+        let mut lockfile = lockfile_with_dummy();
+
+        let pruned = cmd.prune_stale_entries_if_needed(&mut lockfile, None);
+
         assert!(pruned.is_empty());
         assert_eq!(
             lockfile.all_platform_keys(),
@@ -1195,13 +1219,9 @@ mod tests {
         let cmd = lock_cmd(&[]);
         let mut lockfile = lockfile_with_legacy_aqua_jq();
         let tools = vec![configured_tool("aqua:jqlang/jq", "1.7.1")];
-        let (configured_tools, configured_backends) = cmd.configured_tool_selectors(&tools);
+        let configured_selectors = cmd.configured_tool_selectors(&tools);
 
-        let pruned = cmd.prune_stale_entries_if_needed(
-            &mut lockfile,
-            &configured_tools,
-            &configured_backends,
-        );
+        let pruned = cmd.prune_stale_entries_if_needed(&mut lockfile, Some(&configured_selectors));
         assert!(pruned.is_empty());
 
         assert_eq!(

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -178,6 +178,14 @@ impl Lock {
                     &lock_resolve_options,
                 )
                 .await?;
+            let (configured_tools, configured_backends) = self
+                .configured_tool_selectors_for_target(
+                    &config,
+                    &tools,
+                    lockfile_path,
+                    config_paths,
+                    effective_config_files,
+                );
 
             if tools.is_empty() {
                 // `tools` can be empty either because config has no tools, or because a filter excludes all.
@@ -191,7 +199,11 @@ impl Lock {
                             lockfile_path,
                         ));
                     }
-                    let stale_tools = self.stale_entries_if_pruned(&lockfile, &tools);
+                    let stale_tools = self.stale_entries_if_pruned(
+                        &lockfile,
+                        &configured_tools,
+                        &configured_backends,
+                    );
                     self.show_stale_prune_message(lockfile_path, &stale_tools, true)?;
                     if !stale_tools.is_empty() {
                         has_lock_targets = true;
@@ -208,7 +220,11 @@ impl Lock {
                             lockfile_path,
                         ));
                     }
-                    let pruned_tools = self.prune_stale_entries_if_needed(&mut lockfile, &tools);
+                    let pruned_tools = self.prune_stale_entries_if_needed(
+                        &mut lockfile,
+                        &configured_tools,
+                        &configured_backends,
+                    );
                     if !pruned_tools.is_empty() {
                         lockfile.write(lockfile_path)?;
                         self.show_stale_prune_message(lockfile_path, &pruned_tools, false)?;
@@ -257,7 +273,11 @@ impl Lock {
                     ));
                 }
                 if self.is_unfiltered_lock_run() {
-                    let stale_tools = self.stale_entries_if_pruned(&lockfile, &tools);
+                    let stale_tools = self.stale_entries_if_pruned(
+                        &lockfile,
+                        &configured_tools,
+                        &configured_backends,
+                    );
                     self.show_stale_prune_message(lockfile_path, &stale_tools, true)?;
                 }
                 let stale_versions = self.stale_versions_if_pruned(&lockfile, &tools);
@@ -273,7 +293,11 @@ impl Lock {
             if self.json {
                 all_changes.extend(self.compute_version_changes(&lockfile, &tools, lockfile_path));
             }
-            let stale_tools = self.prune_stale_entries_if_needed(&mut lockfile, &tools);
+            let stale_tools = self.prune_stale_entries_if_needed(
+                &mut lockfile,
+                &configured_tools,
+                &configured_backends,
+            );
             self.show_stale_prune_message(lockfile_path, &stale_tools, false)?;
 
             // Compute stale versions BEFORE process_tools so provenance checks can
@@ -441,16 +465,16 @@ impl Lock {
     fn prune_stale_entries_if_needed(
         &self,
         lockfile: &mut Lockfile,
-        tools: &[(crate::cli::args::BackendArg, crate::toolset::ToolVersion)],
+        configured_tools: &BTreeSet<String>,
+        configured_backends: &BTreeSet<String>,
     ) -> BTreeSet<String> {
         if !self.is_unfiltered_lock_run() {
             return BTreeSet::new();
         }
-        let (configured_tools, configured_backends) = self.configured_tool_selectors(tools);
         let stale_tools =
-            self.stale_entries_for_selectors(lockfile, &configured_tools, &configured_backends);
+            self.stale_entries_for_selectors(lockfile, configured_tools, configured_backends);
         if !stale_tools.is_empty() {
-            lockfile.retain_tools_by_short_or_backend(&configured_tools, &configured_backends);
+            lockfile.retain_tools_by_short_or_backend(configured_tools, configured_backends);
         }
         stale_tools
     }
@@ -471,13 +495,13 @@ impl Lock {
     fn stale_entries_if_pruned(
         &self,
         lockfile: &Lockfile,
-        tools: &[(crate::cli::args::BackendArg, crate::toolset::ToolVersion)],
+        configured_tools: &BTreeSet<String>,
+        configured_backends: &BTreeSet<String>,
     ) -> BTreeSet<String> {
         if !self.is_unfiltered_lock_run() {
             return BTreeSet::new();
         }
-        let (configured_tools, configured_backends) = self.configured_tool_selectors(tools);
-        self.stale_entries_for_selectors(lockfile, &configured_tools, &configured_backends)
+        self.stale_entries_for_selectors(lockfile, configured_tools, configured_backends)
     }
 
     fn stale_versions_if_pruned(
@@ -543,6 +567,41 @@ impl Lock {
         let configured_tools: BTreeSet<String> =
             tools.iter().map(|(ba, _)| ba.short.clone()).collect();
         let configured_backends: BTreeSet<String> = tools.iter().map(|(ba, _)| ba.full()).collect();
+        (configured_tools, configured_backends)
+    }
+
+    fn configured_tool_selectors_for_target(
+        &self,
+        config: &Config,
+        tools: &[LockTool],
+        target_lockfile_path: &Path,
+        config_paths: &[PathBuf],
+        effective_config_files: &ConfigMap,
+    ) -> (BTreeSet<String>, BTreeSet<String>) {
+        let (mut configured_tools, mut configured_backends) = self.configured_tool_selectors(tools);
+        let config_paths: BTreeSet<&PathBuf> = config_paths.iter().collect();
+
+        for (path, cf) in effective_config_files {
+            let source = cf.source();
+            let source_lockfile_matches = lockfile::lockfile_path_for_tool_source(config, &source)
+                .is_some_and(|(source_lockfile, _)| source_lockfile == target_lockfile_path);
+            if !(config_paths.contains(path)
+                || source.is_idiomatic_version_file() && source_lockfile_matches)
+            {
+                continue;
+            }
+            let Ok(trs) = cf.to_tool_request_set() else {
+                continue;
+            };
+            for (ba, _, _) in trs.iter() {
+                // Pruning answers whether the tool is still declared, not whether its
+                // backend can resolve on this machine. In particular, OS-restricted
+                // tools may be intentionally unavailable on the current platform.
+                configured_tools.insert(ba.short.clone());
+                configured_backends.insert(ba.full());
+            }
+        }
+
         (configured_tools, configured_backends)
     }
 
@@ -1105,7 +1164,11 @@ mod tests {
     fn test_prune_stale_entries_with_empty_tools_prunes_all_entries() {
         let cmd = lock_cmd(&[]);
         let mut lockfile = lockfile_with_dummy();
-        let pruned = cmd.prune_stale_entries_if_needed(&mut lockfile, &[]);
+        let pruned = cmd.prune_stale_entries_if_needed(
+            &mut lockfile,
+            &std::collections::BTreeSet::new(),
+            &std::collections::BTreeSet::new(),
+        );
         assert_eq!(
             pruned,
             std::collections::BTreeSet::from(["dummy".to_string()])
@@ -1117,7 +1180,11 @@ mod tests {
     fn test_prune_stale_entries_with_filter_keeps_existing_entries() {
         let cmd = lock_cmd(&["tiny"]);
         let mut lockfile = lockfile_with_dummy();
-        let pruned = cmd.prune_stale_entries_if_needed(&mut lockfile, &[]);
+        let pruned = cmd.prune_stale_entries_if_needed(
+            &mut lockfile,
+            &std::collections::BTreeSet::new(),
+            &std::collections::BTreeSet::new(),
+        );
         assert!(pruned.is_empty());
         assert_eq!(
             lockfile.all_platform_keys(),
@@ -1130,8 +1197,13 @@ mod tests {
         let cmd = lock_cmd(&[]);
         let mut lockfile = lockfile_with_legacy_aqua_jq();
         let tools = vec![configured_tool("aqua:jqlang/jq", "1.7.1")];
+        let (configured_tools, configured_backends) = cmd.configured_tool_selectors(&tools);
 
-        let pruned = cmd.prune_stale_entries_if_needed(&mut lockfile, &tools);
+        let pruned = cmd.prune_stale_entries_if_needed(
+            &mut lockfile,
+            &configured_tools,
+            &configured_backends,
+        );
         assert!(pruned.is_empty());
 
         assert_eq!(

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -185,7 +185,7 @@ impl Lock {
                     lockfile_path,
                     config_paths,
                     effective_config_files,
-                );
+                )?;
 
             if tools.is_empty() {
                 // `tools` can be empty either because config has no tools, or because a filter excludes all.
@@ -577,7 +577,7 @@ impl Lock {
         target_lockfile_path: &Path,
         config_paths: &[PathBuf],
         effective_config_files: &ConfigMap,
-    ) -> (BTreeSet<String>, BTreeSet<String>) {
+    ) -> Result<(BTreeSet<String>, BTreeSet<String>)> {
         let (mut configured_tools, mut configured_backends) = self.configured_tool_selectors(tools);
         let config_paths: BTreeSet<&PathBuf> = config_paths.iter().collect();
 
@@ -590,9 +590,7 @@ impl Lock {
             {
                 continue;
             }
-            let Ok(trs) = cf.to_tool_request_set() else {
-                continue;
-            };
+            let trs = cf.to_tool_request_set()?;
             for (ba, _, _) in trs.iter() {
                 // Pruning answers whether the tool is still declared, not whether its
                 // backend can resolve on this machine. In particular, OS-restricted
@@ -602,7 +600,7 @@ impl Lock {
             }
         }
 
-        (configured_tools, configured_backends)
+        Ok((configured_tools, configured_backends))
     }
 
     fn current_tool_versions(&self, tools: &[LockTool]) -> BTreeMap<String, BTreeSet<String>> {


### PR DESCRIPTION
## Summary

- derive stale-tool pruning selectors from every tool declaration contributing to the target lockfile
- keep OS-restricted entries even when their backend is unavailable or unresolved on the current machine
- retain normal pruning for tools actually removed from configuration
- add a cross-platform regression case based on discussion #11171

## Root cause

Unfiltered `mise lock` derived the set of configured tools only from the current platform's resolved toolset. A tool excluded by its `os` option could therefore be mistaken for a removed tool and pruned from `mise.lock`.

## User impact

A shared lockfile now remains stable when `mise lock` runs on a platform that does not target every configured tool.

## Validation

- `cargo test -q cli::lock::tests`
- `mise run test:e2e e2e/lockfile/test_lockfile_prune_stale_tools`
- `mise run lint-fix`
- pre-commit `mise run lint`

Fixes the behavior reported in https://github.com/jdx/mise/discussions/11171

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile mutation logic for unfiltered `mise lock`; incorrect selector logic could prune valid entries or retain stale ones, though unit and e2e tests cover the main paths.
> 
> **Overview**
> **Unfiltered `mise lock` no longer drops lockfile entries for tools that are still in config but excluded on the current OS** (e.g. `os = ["macos"]` while locking on Linux).
> 
> Stale **tool** pruning now builds keep-lists from every tool declaration that contributes to the target lockfile via `configured_tool_selectors_for_target`, not only from tools that resolved on this machine. OS-restricted tools stay protected even when their backend cannot run here; tools actually removed from config are still pruned as before.
> 
> If a contributing config file fails to parse, pruning is skipped for that target (`None` selectors) so entries are not wiped by mistake. Dry-run and normal lock paths share the same selector logic.
> 
> E2E coverage adds a cross-platform case: after swapping to an OS-inactive `cocoapods` pin, `mise lock` prunes the previous tool (`tiny`) but keeps `[[tools.cocoapods]]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6783e74cee4b7c43dbbac4cab462eda5d017de27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockfile stale-tool pruning to preserve tools excluded for the current operating system.
  * Fixed stale-entry pruning to operate correctly per lockfile target, including consistent behavior between dry-run and normal lock runs.
* **Tests**
  * Added end-to-end coverage for lockfile pruning where an OS-excluded tool remains while only stale entries are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->