### PR TITLE
fix(config): improve unsupported semver range warnings

### DIFF
--- a/e2e/config/test_semver_range_warning
+++ b/e2e/config/test_semver_range_warning
@@ -6,5 +6,5 @@ node = "^20.0.0"
 "npm:prettier" = "^3.1.0"
 EOF
 
-assert_contains "mise ls 2>&1" "semver ranges are not supported: ^20.0.0"
-assert_contains "mise ls 2>&1" "semver ranges are not supported: ^3.1.0"
+assert_contains "mise ls 2>&1" 'semver range "^20.0.0" is not supported for node (source: ~/workdir/mise.toml); use a concrete version or version prefix'
+assert_contains "mise ls 2>&1" 'semver range "^3.1.0" is not supported for npm:prettier (source: ~/workdir/mise.toml); use a concrete version or version prefix'

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -70,13 +70,21 @@ impl ToolRequest {
             _ => s.to_string(),
         };
         if crate::semver::is_npm_semver_range_query(&s)
+            && !source.is_unknown()
             && !matches!(
                 &source,
                 ToolSource::IdiomaticVersionFile(path)
                     if crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
             )
         {
-            warn_once!("semver ranges are not supported: {s}");
+            let source_display = match &source {
+                ToolSource::Argument => "command argument".to_string(),
+                _ => source.to_string(),
+            };
+            warn_once!(
+                "semver range \"{s}\" is not supported for {} (source: {source_display}); use a concrete version or version prefix",
+                backend.short
+            );
         }
         Ok(match s.split_once(':') {
             Some((ref_type @ ("ref" | "tag" | "branch" | "rev"), r)) => {


### PR DESCRIPTION
## Summary

- suppress unsupported semver-range warnings for internal `ToolSource::Unknown` requests reconstructed from installed directories
- identify the affected tool and source in warnings for user-authored requests
- suggest using a concrete version or version prefix

## Root cause

The warning added in #10916 runs in the generic `ToolRequest` constructor. Installed version directories are also reconstructed through that constructor with `ToolSource::Unknown`, so an opaque directory name beginning with `~` can be mistaken for an npm-style semver range.

This produced the unrelated warning reported in [discussion #10284](https://github.com/jdx/mise/discussions/10284#discussioncomment-17710322): a stale Groovy install directory named `~-Projects-community-gocd-tmp-mise.toml` warned while the user was inspecting Ruby.

Internal reconstructed requests now skip this user-facing warning. Actual configuration, environment, idiomatic-file, tool-stub, and argument sources continue to warn, with enough context and guidance to act on the message. The existing `package.json` exemption is unchanged.

## Validation

- `mise run test:e2e e2e/config/test_semver_range_warning`
- manually verified that a `~-...` Groovy install directory does not emit the warning
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the CLI warning shown for unsupported semver ranges to be more precise about the tool and where the version request came from.
  * Updated the warning text to include the relevant context (including command-argument/source markers) and clearer guidance to use a concrete version or a version prefix.
  * The warning is now suppressed when it doesn’t apply (e.g., certain Node/npm scenarios or irrelevant/unknown sources).
* **Tests**
  * Updated end-to-end assertions to match the new semver-range warning format exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->