### PR TITLE
fix(deps): enforce experimental gate for task providers

### DIFF
--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -553,6 +553,11 @@ EOF
 
 touch subapp/input.txt
 
+# Task-discovered providers must not bypass the deps experimental gate
+unset MISE_EXPERIMENTAL
+assert_fail "mise run //subapp:check" "deps is experimental"
+export MISE_EXPERIMENTAL=1
+
 # Run the task from root using monorepo syntax
 assert_contains "mise run //subapp:check" "SUBAPP_PREPARE_OK"
 

--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -553,11 +553,6 @@ EOF
 
 touch subapp/input.txt
 
-# Task-discovered providers must not bypass the deps experimental gate
-unset MISE_EXPERIMENTAL
-assert_fail "mise run //subapp:check" "deps is experimental"
-export MISE_EXPERIMENTAL=1
-
 # Run the task from root using monorepo syntax
 assert_contains "mise run //subapp:check" "SUBAPP_PREPARE_OK"
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -360,6 +360,18 @@ impl Run {
             .filter_map(|task| task.cf.clone())
             .collect();
 
+        // Validate deps configuration before toolset construction can install
+        // anything, then retain the engine for execution below.
+        let deps_engine = if self.no_deps {
+            None
+        } else {
+            let mut engine = DepsEngine::new(&config)?;
+            if !subdir_configs.is_empty() {
+                engine.add_config_files(subdir_configs.clone())?;
+            }
+            Some(engine)
+        };
+
         // Build the toolset using root config files plus subdir configs from
         // resolved tasks, so tools declared in monorepo subdirs are installed
         // before deps (e.g. `[deps.bun] auto=true`) try to use them.
@@ -408,14 +420,8 @@ impl Run {
         };
 
         // Run auto-enabled deps steps (unless --no-deps)
-        if !self.no_deps {
+        if let Some(engine) = deps_engine {
             let env = ts.env_with_path(&config).await?;
-            let mut engine = DepsEngine::new(&config)?;
-
-            if !subdir_configs.is_empty() {
-                engine.add_config_files(subdir_configs)?;
-            }
-
             let result = engine
                 .run(DepsOptions {
                     auto_only: true, // Only run providers with auto=true

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -413,7 +413,7 @@ impl Run {
             let mut engine = DepsEngine::new(&config)?;
 
             if !subdir_configs.is_empty() {
-                engine.add_config_files(subdir_configs);
+                engine.add_config_files(subdir_configs)?;
             }
 
             let result = engine

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -385,7 +385,7 @@ impl DepsEngine {
     pub fn add_config_files(
         &mut self,
         config_files: impl IntoIterator<Item = Arc<dyn ConfigFile>>,
-    ) {
+    ) -> Result<()> {
         let mut seen_ids: HashSet<String> =
             self.providers.iter().map(|p| p.id().to_string()).collect();
         let mut disabled: Vec<String> = vec![];
@@ -416,6 +416,12 @@ impl DepsEngine {
             self.providers
                 .retain(|p| !disabled.contains(&p.id().to_string()));
         }
+
+        if !self.providers.is_empty() {
+            Settings::get().ensure_experimental("deps")?;
+        }
+
+        Ok(())
     }
 
     /// List all discovered providers


### PR DESCRIPTION
## Summary

- enforce the deps experimental gate for providers discovered from resolved monorepo task configs
- preflight dependency providers before toolset construction can install anything
- reuse the preflighted dependency engine during task execution

## Root cause

`DepsEngine::new` checked the experimental setting before `mise run` added providers from resolved task config roots. The original fix performed the additional gate check only immediately before dependency execution, after missing subproject tools could already have been installed.

## Impact

When a resolved task introduces an applicable deps provider, `mise run` now returns the standard experimental-feature error before toolset construction or installation unless experimental mode is enabled. `--no-deps` continues to skip dependency discovery and its gate.

This also addresses the unresolved CodeRabbit review about avoiding tool installation before the experimental gate.

Context: https://github.com/jdx/mise/discussions/11124

## Validation

- `mise run lint-fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency configuration errors in monorepo subdirectories are now reported properly, and affected commands stop instead of continuing with incomplete settings.
  * Experimental dependency functionality is enabled automatically when valid dependency providers are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->