### PR TITLE
registry: add kotlintoolchain 

### DIFF
--- a/registry/kotlintoolchain.toml
+++ b/registry/kotlintoolchain.toml
@@ -1,0 +1,13 @@
+description = "A unified entry point into Kotlin"
+os = ["linux", "macos"]
+test = { cmd = "KOTLIN_CLI_WRAPPER_ALWAYS_USE_INTRINSIC_VERSION=1 kotlin --version", expected = "{{version}}" }
+
+[[backends]]
+full = "http:kotlintoolchain"
+
+[backends.options]
+bin = "kotlin"
+checksum_url = "https://packages.jetbrains.team/maven/p/amper/amper/org/jetbrains/kotlin/kotlin-cli/{{ version }}/kotlin-cli-{{version }}-wrapper.sha256"
+url = "https://packages.jetbrains.team/maven/p/amper/amper/org/jetbrains/kotlin/kotlin-cli/{{ version }}/kotlin-cli-{{ version}}-wrapper"
+version_json_path = ".tag_name"
+version_list_url = "https://api.github.com/repos/JetBrains/kotlin-toolchain/releases/latest"


### PR DESCRIPTION
• ## Summary

  Adds [`kotlintoolchain`](https://kotlin-toolchain.org/dev/) to the registry using the HTTP backend.


  ## Popularity

  - GitHub: 328 stars and 15 forks.
  - Maintained by JetBrains.
  - Latest release: [v0.11.1](https://github.com/JetBrains/kotlin-toolchain/releases/tag/v0.11.1), published June 5, 2026.

  ## Testing

  ```console
  $ target/debug/mise test-tool --raw kotlintoolchain
  mise kotlintoolchain@0.11.1 ✓ installed
  mise $ KOTLIN_CLI_WRAPPER_ALWAYS_USE_INTRINSIC_VERSION=1 kotlin --version
  Kotlin Toolchain version 0.11.1 (801e9d4, 2026-06-05)
  mise kotlintoolchain: OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kotlin toolchain support with unified entry-point configuration.
  * Added version detection and validation for Kotlin installations.
  * Added automatic discovery and download configuration for Kotlin releases across supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->