### PR TITLE
fix(backend): detect qualified prerelease suffixes

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -997,6 +997,18 @@ mod tests {
         });
         assert!(php_rc.prerelease);
 
+        let php_unnumbered_rc = mark_prerelease(VersionInfo {
+            version: "4.0.1RC".into(),
+            ..Default::default()
+        });
+        assert!(php_unnumbered_rc.prerelease);
+
+        let php_qualified_rc = mark_prerelease(VersionInfo {
+            version: "8.3.1RC1-clean".into(),
+            ..Default::default()
+        });
+        assert!(php_qualified_rc.prerelease);
+
         let already_flagged = mark_prerelease(VersionInfo {
             version: "2.0.0".into(),
             prerelease: true,

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -266,7 +266,7 @@ pub fn warn_if_env_plugin_shadows_registry(name: &str, plugin_path: &Path) {
 
 pub static VERSION_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
     Regex::new(
-        r"(?i)(^Available versions:|-src|[-\\.]dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|-test|-nightly|-canary|-experimental|-insider|-edge|snapshot|SNAPSHOT|master|\d(?:alpha|beta|rc)\d+$)"
+        r"(?i)(^Available versions:|-src|[-\\.]dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|-test|-nightly|-canary|-experimental|-insider|-edge|snapshot|SNAPSHOT|master|\d(?:alpha|beta|rc)\d*\b)"
     )
         .unwrap()
 });
@@ -745,6 +745,8 @@ mod tests {
         assert!(VERSION_REGEX.is_match("8.5.9alpha1"));
         assert!(VERSION_REGEX.is_match("8.5.9beta2"));
         assert!(VERSION_REGEX.is_match("8.5.9RC1"));
+        assert!(VERSION_REGEX.is_match("4.0.1RC"));
+        assert!(VERSION_REGEX.is_match("8.3.1RC1-clean"));
 
         // PEP 440 dot-separated dev versions (GitHub discussion #8784)
         assert!(
@@ -784,6 +786,8 @@ mod tests {
         assert!(!VERSION_REGEX.is_match("1.0.0"));
         assert!(!VERSION_REGEX.is_match("2026.3.3"));
         assert!(!VERSION_REGEX.is_match("22.6.0"));
+        assert!(!VERSION_REGEX.is_match("4.0.1pl1"));
+        assert!(!VERSION_REGEX.is_match("4.0.4REL"));
 
         // PEP 440 separator-less suffixes (`3.12.0a1`, `1.2.3c1`) live in
         // PEP440_PRERELEASE_REGEX, not the general regex — see that test below.


### PR DESCRIPTION
## Summary

- detect separatorless prerelease markers without a numeric counter, such as `4.0.1RC`
- detect prerelease markers followed by a qualifier, such as `8.3.1RC1-clean`
- preserve stable PHP patch-level and release tags such as `4.0.1pl1` and `4.0.4REL`

## Root cause

The separatorless prerelease matcher added in #11032 required one or more digits after `alpha`, `beta`, or `rc`, and required those digits to end the version string. That excluded genuine PHP prerelease tags with an unnumbered marker or a trailing qualifier.

This replaces the numeric/end anchor with an optional counter and word boundary, following the report in https://github.com/jdx/mise/pull/11032#issuecomment-5029476939.

## Impact

Metadata-free backends now mark these PHP RC forms as prereleases so default remote-version listing and stable resolution can filter them. Users can still include them with prerelease opt-in.

## Validation

- `cargo test prerelease`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prerelease version detection for additional PHP formats, including RC versions without separators and versions with trailing qualifiers.
  * Continued filtering invalid prerelease-like suffixes to prevent incorrect version classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->