### PR TITLE
fix(deps): scope task providers by config root

### DIFF
--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -529,50 +529,174 @@ assert_not_contains "mise deps --list" "custom_sub"
 # Clean up previous test
 rm -rf subproject root_input.txt root_output.txt mise.toml .mise
 
-# Test that monorepo subdirectory prepare steps run when using //subdir:task from root
+# Test that task-discovered providers are scoped to their monorepo config root
 export MISE_EXPERIMENTAL=1
-mkdir -p subapp
+mkdir -p apps/subapp-a apps/subapp-b apps/subapp-c
 
 cat >mise.toml <<'EOF'
 monorepo_root = true
 
 [monorepo]
-config_roots = ["subapp"]
-EOF
-
-cat >subapp/mise.toml <<'EOF'
-[deps.subapp_deps]
-auto = true
-sources = ["input.txt"]
-outputs = ["deps_marker"]
-run = "touch deps_marker"
-
-[tasks.check]
-run = "test -f deps_marker && echo SUBAPP_PREPARE_OK || echo SUBAPP_PREPARE_MISSING"
-EOF
-
-touch subapp/input.txt
-
-# Run the task from root using monorepo syntax
-assert_contains "mise run //subapp:check" "SUBAPP_PREPARE_OK"
-
-# Test that prepare steps also run when subtasks are reached via dependencies
-cat >mise.toml <<'EOF'
-monorepo_root = true
-
-[monorepo]
-config_roots = ["subapp"]
+config_roots = ["apps/subapp-*"]
 
 [tasks.check]
 depends = "//...:check"
 EOF
 
-touch subapp/input.txt
-rm -f subapp/deps_marker
-assert_contains "mise run //:check" "SUBAPP_PREPARE_OK"
+# Loading a selected root's config hierarchy must not activate providers from
+# an intermediate ancestor that is not itself a selected task root.
+cat >apps/mise.toml <<'EOF'
+[deps.intermediate]
+auto = true
+sources = ["intermediate-input.txt"]
+outputs = ["intermediate-output.txt"]
+run = "cp intermediate-input.txt intermediate-output.txt"
+EOF
+echo intermediate >apps/intermediate-input.txt
+
+for subapp in subapp-a subapp-b; do
+  cat >"apps/$subapp/mise.toml" <<'EOF'
+[deps.setup]
+auto = true
+sources = ["input.txt"]
+outputs = ["prepared.txt"]
+run = "sleep 1; cp input.txt prepared.txt"
+
+[deps.build]
+auto = true
+depends = ["setup", "//:root_setup", "global_setup"]
+sources = ["prepared.txt"]
+outputs = ["built.txt"]
+run = "test -f prepared.txt && test -f ../../root-output.txt && test -f ../../global-output.txt && cp prepared.txt built.txt"
+
+[deps.disabled]
+auto = true
+sources = ["input.txt"]
+outputs = ["disabled.txt"]
+run = "cp input.txt disabled.txt"
+
+[tasks.check]
+run = "test -f built.txt && echo TASK_DEPS_OK"
+EOF
+  echo "$subapp" >"apps/$subapp/input.txt"
+done
+
+# Local tool configuration must override the base config while providing an
+# automatic provider from the same layered file.
+cat >>apps/subapp-a/mise.toml <<'EOF'
+
+[tools]
+tiny = "2"
+EOF
+
+# This configured root has no task in the resolved graph, so its provider must
+# not run when another root is selected or through //...:check.
+cat >apps/subapp-c/mise.toml <<'EOF'
+[deps.outside]
+auto = true
+sources = ["input.txt"]
+outputs = ["outside.txt"]
+run = "cp input.txt outside.txt"
+
+[deps.from_a]
+auto = true
+depends = ["//apps/subapp-a:setup"]
+outputs = ["from-a.txt"]
+run = "test -f ../subapp-a/prepared.txt && touch from-a.txt"
+
+[tasks.unrelated]
+run = "test -f from-a.txt && echo NESTED_DEPS_OK"
+EOF
+echo subapp-c >apps/subapp-c/input.txt
+
+# Disabling a provider in one root must not disable the same ID in another root.
+cat >apps/subapp-a/mise.local.toml <<'EOF'
+[tools]
+tiny = "1"
+
+[deps]
+disable = ["disabled"]
+
+[deps.layered_tool]
+auto = true
+outputs = ["layered-tool.txt"]
+run = "rtx-tiny > layered-tool.txt"
+EOF
+
+# Task-discovered providers must not bypass the deps experimental gate
+unset MISE_EXPERIMENTAL
+assert_fail "mise run //:check" "deps is experimental"
+export MISE_EXPERIMENTAL=1
+
+# Root and global providers retain their existing automatic-task behavior.
+cat >>mise.toml <<'EOF'
+
+[deps.root_setup]
+auto = true
+sources = ["root-input.txt"]
+outputs = ["root-output.txt"]
+run = "cp root-input.txt root-output.txt"
+EOF
+echo root >root-input.txt
+
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[deps.global_setup]
+auto = true
+dir = "$PWD"
+sources = ["global-input.txt"]
+outputs = ["global-output.txt"]
+run = "cp global-input.txt global-output.txt"
+EOF
+echo global >global-input.txt
+
+# A direct task invocation runs only its root (plus root/global providers).
+assert_contains "mise run //apps/subapp-a:check" "TASK_DEPS_OK"
+assert "test -f apps/subapp-a/built.txt"
+assert_fail "test -f apps/subapp-b/built.txt"
+assert_fail "test -f apps/subapp-c/outside.txt"
+assert_fail "test -f apps/intermediate-output.txt"
+assert "test -f root-output.txt"
+assert "test -f global-output.txt"
+assert_contains "cat apps/subapp-a/layered-tool.txt" "v1.1.0"
+
+rm -f apps/subapp-a/prepared.txt apps/subapp-a/built.txt \
+  apps/subapp-a/layered-tool.txt root-output.txt global-output.txt
+
+# Providers with duplicate IDs run in both roots. Unqualified dependencies
+# prefer the same root and can fall back to retained root/global providers.
+assert_contains "mise run //:check" "TASK_DEPS_OK"
+assert "test -f apps/subapp-a/built.txt"
+assert "test -f apps/subapp-b/built.txt"
+assert_fail "test -f apps/subapp-a/disabled.txt"
+assert "test -f apps/subapp-b/disabled.txt"
+assert_fail "test -f apps/subapp-c/outside.txt"
+assert_fail "test -f apps/intermediate-output.txt"
+assert "test -f root-output.txt"
+assert "test -f global-output.txt"
+assert_contains "cat apps/subapp-a/layered-tool.txt" "v1.1.0"
+
+# From a nested invocation root, absolute provider dependencies resolve only to
+# that root's qualified ID rather than treating it as the monorepo root.
+cat >apps/subapp-a/mise.local.toml <<'EOF'
+[tools]
+tiny = "1"
+
+[deps]
+disable = ["build", "disabled"]
+
+[deps.layered_tool]
+auto = true
+outputs = ["layered-tool.txt"]
+run = "rtx-tiny > layered-tool.txt"
+EOF
+rm -f apps/subapp-a/prepared.txt apps/subapp-c/from-a.txt
+assert_contains "cd apps/subapp-a && mise run //apps/subapp-c:unrelated" "NESTED_DEPS_OK"
+assert "test -f apps/subapp-a/prepared.txt"
+assert "test -f apps/subapp-c/from-a.txt"
 
 # Clean up
-rm -rf subapp mise.toml .mise
+rm -rf apps mise.toml .mise root-input.txt root-output.txt \
+  global-input.txt global-output.txt "$MISE_CONFIG_DIR/config.toml"
 
 # Test git-submodule provider
 cat >.gitmodules <<'EOF'

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -362,20 +362,51 @@ impl Run {
 
         // Validate deps configuration before toolset construction can install
         // anything, then retain the engine for execution below.
+        let mut layered_subdir_configs = vec![];
         let deps_engine = if self.no_deps {
             None
+        } else if subdir_configs.is_empty() {
+            Some(DepsEngine::new(&config)?)
         } else {
-            let mut engine = DepsEngine::new(&config)?;
-            if !subdir_configs.is_empty() {
-                engine.add_config_files(subdir_configs.clone())?;
+            let mut deps_config_files = config.config_files.clone();
+            let selected_config_roots: HashSet<_> =
+                subdir_configs.iter().map(|cf| cf.config_root()).collect();
+            for config_root in subdir_configs.iter().map(|cf| cf.config_root()).unique() {
+                let (config_paths, idiomatic_filenames) =
+                    crate::config::load_config_hierarchy_from_dir(&config_root).await?;
+                deps_config_files.extend(
+                    crate::config::load_config_files_from_paths(
+                        &config_paths,
+                        &idiomatic_filenames,
+                    )
+                    .await?,
+                );
             }
-            Some(engine)
+            deps_config_files.retain(|_, cf| {
+                let config_root = cf.config_root();
+                cf.project_root().is_some()
+                    && selected_config_roots.contains(&config_root)
+                    && config.project_root.as_ref() != Some(&config_root)
+            });
+            layered_subdir_configs.extend(deps_config_files.values().cloned());
+            Some(DepsEngine::new_task_monorepo(
+                &config,
+                deps_config_files.into_values(),
+            )?)
         };
 
         // Build the toolset using root config files plus subdir configs from
         // resolved tasks, so tools declared in monorepo subdirs are installed
         // before deps (e.g. `[deps.bun] auto=true`) try to use them.
         let mut combined_configs = config.config_files.clone();
+        // The hierarchy loader returns higher-precedence files first. Preserve
+        // that order so local overlays still win when ToolsetBuilder reverses
+        // the map for low-to-high merging.
+        for cf in layered_subdir_configs {
+            combined_configs
+                .entry(cf.get_path().to_path_buf())
+                .or_insert(cf);
+        }
         for cf in &subdir_configs {
             combined_configs
                 .entry(cf.get_path().to_path_buf())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,7 +27,7 @@ use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENA
 use crate::file::display_path;
 use crate::shorthands::{Shorthands, get_shorthands};
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
-use crate::task::{Task, TaskTemplate, strip_extension};
+use crate::task::{Task, TaskTemplate, monorepo_scope, strip_extension};
 use crate::tera::{contains_template_syntax, render_str, take_tera_accessed_files};
 use crate::toolset::env_cache::{CachedNonToolEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::{
@@ -2233,18 +2233,9 @@ pub async fn rebuild_shims_and_runtime_symlinks(
 }
 
 fn prefix_monorepo_task_names(tasks: &mut [Task], dir: &Path, monorepo_root: &Path) {
-    const MONOREPO_PATH_PREFIX: &str = "//";
-    const MONOREPO_TASK_SEPARATOR: &str = ":";
-
-    if let Ok(rel_path) = dir.strip_prefix(monorepo_root) {
-        let prefix = rel_path
-            .to_string_lossy()
-            .replace(std::path::MAIN_SEPARATOR, "/");
+    if let Some(scope) = monorepo_scope(monorepo_root, dir) {
         for task in tasks.iter_mut() {
-            task.name = format!(
-                "{}{}{}{}",
-                MONOREPO_PATH_PREFIX, prefix, MONOREPO_TASK_SEPARATOR, task.name
-            );
+            task.name = format!("{scope}:{}", task.name);
         }
     }
 }

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -9,6 +9,7 @@ use tokio::task::JoinSet;
 use crate::cmd::CmdLineRunner;
 use crate::config::config_file::ConfigFile;
 use crate::config::{Config, Settings};
+use crate::task::monorepo_scope;
 use crate::tera::{BASE_CONTEXT, contains_template_syntax, get_tera, render_str};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
@@ -25,15 +26,33 @@ struct ScopedDepsProvider {
 }
 
 impl ScopedDepsProvider {
-    fn new(inner: Box<dyn DepsProvider>, id: String, scope: &str) -> Self {
+    fn new(
+        inner: Box<dyn DepsProvider>,
+        id: String,
+        scope: &str,
+        scoped_ids: &HashSet<String>,
+        fallback_ids: &HashSet<String>,
+        qualified_fallback_ids: &HashMap<String, String>,
+    ) -> Self {
         let depends = inner
             .depends()
             .into_iter()
             .map(|dep| {
                 if dep.starts_with("//") {
-                    dep
+                    if scoped_ids.contains(&dep) {
+                        dep
+                    } else if let Some(fallback_id) = qualified_fallback_ids.get(&dep) {
+                        fallback_id.clone()
+                    } else {
+                        dep
+                    }
                 } else {
-                    format!("{scope}:{dep}")
+                    let scoped_dep = format!("{scope}:{dep}");
+                    if scoped_ids.contains(&scoped_dep) || !fallback_ids.contains(&dep) {
+                        scoped_dep
+                    } else {
+                        dep
+                    }
                 }
             })
             .collect();
@@ -178,10 +197,19 @@ impl DepsEngine {
         config: &Config,
         config_files: impl IntoIterator<Item = Arc<dyn ConfigFile>>,
     ) -> Result<Self> {
+        Self::new_monorepo_with_fallback(config, config_files, &HashSet::new(), &HashMap::new())
+    }
+
+    fn new_monorepo_with_fallback(
+        config: &Config,
+        config_files: impl IntoIterator<Item = Arc<dyn ConfigFile>>,
+        fallback_ids: &HashSet<String>,
+        qualified_fallback_ids: &HashMap<String, String>,
+    ) -> Result<Self> {
         let monorepo_root = config
             .monorepo_root()
             .ok_or_else(|| eyre::eyre!("no config file in scope sets monorepo_root = true"))?;
-        let mut providers: Vec<Box<dyn DepsProvider>> = vec![];
+        let mut scoped_providers: Vec<(Box<dyn DepsProvider>, String, String)> = vec![];
         let mut seen_ids = HashSet::new();
         let config_files: Vec<_> = config_files.into_iter().collect();
         let mut disabled_by_root: HashMap<PathBuf, HashSet<String>> = HashMap::new();
@@ -215,15 +243,8 @@ impl DepsEngine {
             };
 
             let config_root = cf.config_root();
-            let relative_root = config_root
-                .strip_prefix(&monorepo_root)
-                .unwrap_or(&config_root)
-                .to_string_lossy()
-                .replace('\\', "/");
-            let scope = if relative_root.is_empty() {
-                "//".to_string()
-            } else {
-                format!("//{relative_root}")
+            let Some(scope) = monorepo_scope(&monorepo_root, &config_root) else {
+                continue;
             };
 
             for (id, provider_config) in &deps_config.providers {
@@ -240,13 +261,70 @@ impl DepsEngine {
                     && provider.is_applicable()
                     && seen_ids.insert(scoped_id.clone())
                 {
-                    providers.push(Box::new(ScopedDepsProvider::new(
-                        provider, scoped_id, &scope,
-                    )));
+                    scoped_providers.push((provider, scoped_id, scope.clone()));
                 }
             }
         }
 
+        let providers: Vec<Box<dyn DepsProvider>> = scoped_providers
+            .into_iter()
+            .map(|(provider, scoped_id, scope)| {
+                Box::new(ScopedDepsProvider::new(
+                    provider,
+                    scoped_id,
+                    &scope,
+                    &seen_ids,
+                    fallback_ids,
+                    qualified_fallback_ids,
+                )) as Box<dyn DepsProvider>
+            })
+            .collect();
+        if !providers.is_empty() {
+            Settings::get().ensure_experimental("deps")?;
+        }
+        Ok(Self { providers })
+    }
+
+    /// Create a monorepo engine for task execution while preserving providers
+    /// from the current project plus global and system configuration.
+    pub fn new_task_monorepo(
+        config: &Config,
+        config_files: impl IntoIterator<Item = Arc<dyn ConfigFile>>,
+    ) -> Result<Self> {
+        let mut providers = Self::discover_providers(config)?;
+        let fallback_ids = providers
+            .iter()
+            .map(|provider| provider.id().to_string())
+            .collect();
+        let monorepo_root = config
+            .monorepo_root()
+            .ok_or_else(|| eyre::eyre!("no config file in scope sets monorepo_root = true"))?;
+        let qualified_fallback_ids = config
+            .project_root
+            .as_deref()
+            .and_then(|project_root| {
+                let scope = monorepo_scope(&monorepo_root, project_root)?;
+                Some(
+                    providers
+                        .iter()
+                        .filter(|provider| provider.base().project_root.as_path() == project_root)
+                        .map(|provider| {
+                            (
+                                format!("{scope}:{}", provider.id()),
+                                provider.id().to_string(),
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .unwrap_or_default();
+        let mut engine = Self::new_monorepo_with_fallback(
+            config,
+            config_files,
+            &fallback_ids,
+            &qualified_fallback_ids,
+        )?;
+        providers.append(&mut engine.providers);
         if !providers.is_empty() {
             Settings::get().ensure_experimental("deps")?;
         }
@@ -263,7 +341,6 @@ impl DepsEngine {
             .project_root
             .clone()
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-
         let mut providers: Vec<Box<dyn DepsProvider>> = vec![];
         let mut seen_ids: HashSet<String> = HashSet::new();
         let mut disabled: Vec<String> = vec![];
@@ -376,52 +453,6 @@ impl DepsEngine {
                 config_root,
             )))
         }
-    }
-
-    /// Add providers from additional config files (e.g., monorepo subdirectory configs).
-    ///
-    /// Unlike `discover_providers`, this does NOT filter by project root, since these
-    /// configs are intentionally from different directories (monorepo subdirectories).
-    pub fn add_config_files(
-        &mut self,
-        config_files: impl IntoIterator<Item = Arc<dyn ConfigFile>>,
-    ) -> Result<()> {
-        let mut seen_ids: HashSet<String> =
-            self.providers.iter().map(|p| p.id().to_string()).collect();
-        let mut disabled: Vec<String> = vec![];
-
-        for cf in config_files {
-            let Some(deps_config) = cf.deps_config() else {
-                continue;
-            };
-
-            disabled.extend(deps_config.disable.iter().cloned());
-            let config_root = cf.config_root();
-
-            for (id, provider_config) in &deps_config.providers {
-                if !seen_ids.insert(id.clone()) {
-                    continue;
-                }
-
-                if let Some(provider) =
-                    Self::build_provider(id, &config_root, provider_config.clone())
-                    && provider.is_applicable()
-                {
-                    self.providers.push(provider);
-                }
-            }
-        }
-
-        if !disabled.is_empty() {
-            self.providers
-                .retain(|p| !disabled.contains(&p.id().to_string()));
-        }
-
-        if !self.providers.is_empty() {
-            Settings::get().ensure_experimental("deps")?;
-        }
-
-        Ok(())
     }
 
     /// List all discovered providers

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -63,6 +63,7 @@ pub mod task_template;
 pub mod task_tool_installer;
 
 pub use task_confirm::TaskConfirm;
+pub(crate) use task_load_context::monorepo_scope;
 pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax};
 pub use task_output::TaskOutput;
 pub use task_script_parser::{has_any_args_defined, has_any_usage_spec};

--- a/src/task/task_load_context.rs
+++ b/src/task/task_load_context.rs
@@ -1,4 +1,18 @@
 use eyre::bail;
+use std::path::Path;
+
+/// Return the absolute `//path` scope for a directory within a monorepo.
+pub(crate) fn monorepo_scope(monorepo_root: &Path, dir: &Path) -> Option<String> {
+    let relative_path = dir.strip_prefix(monorepo_root).ok()?;
+    let path = relative_path
+        .to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, "/");
+    if path.is_empty() {
+        Some("//".to_string())
+    } else {
+        Some(format!("//{path}"))
+    }
+}
 
 /// Context for loading tasks with optional filtering hints
 #[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
@@ -193,33 +207,14 @@ pub fn expand_colon_task_syntax(
 
     // Determine the current directory relative to monorepo root
     if let Some(cwd) = &*crate::dirs::CWD {
-        if let Ok(rel_path) = cwd.strip_prefix(monorepo_root) {
+        if let Some(scope) = monorepo_scope(&monorepo_root, cwd) {
             // For bare task names, only expand if we're actually in the monorepo
             // For colon patterns, always expand (and error if outside monorepo)
 
-            // Convert relative path to monorepo path format
-            let path_str = rel_path
-                .to_string_lossy()
-                .replace(std::path::MAIN_SEPARATOR, "/");
-
-            if path_str.is_empty() {
-                // We're at the root
-                if is_colon_pattern {
-                    // :task -> //:task (task already has colon)
-                    Ok(format!("//{}", task))
-                } else {
-                    // bare task -> //:task (add colon)
-                    Ok(format!("//:{}", task))
-                }
+            if is_colon_pattern {
+                Ok(format!("{scope}{task}"))
             } else {
-                // We're in a subdirectory
-                if is_colon_pattern {
-                    // :task -> //path:task
-                    Ok(format!("//{}{}", path_str, task))
-                } else {
-                    // bare name -> //path:task
-                    Ok(format!("//{}:{}", path_str, task))
-                }
+                Ok(format!("{scope}:{task}"))
             }
         } else {
             if is_colon_pattern {
@@ -239,6 +234,17 @@ pub fn expand_colon_task_syntax(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_monorepo_scope() {
+        let root = Path::new("repo");
+        assert_eq!(monorepo_scope(root, root), Some("//".to_string()));
+        assert_eq!(
+            monorepo_scope(root, &root.join("apps").join("api")),
+            Some("//apps/api".to_string())
+        );
+        assert_eq!(monorepo_scope(root, Path::new("other")), None);
+    }
 
     #[test]
     fn test_extract_path_hint() {


### PR DESCRIPTION
## Summary

- keep the existing invocation-root/global dependency providers, while adding only providers from config roots represented by the resolved task graph
- qualify selected subproject providers by config root and resolve dependencies locally, with the existing invocation-root/global namespace as a fallback
- use the selected roots' layered configs for both provider discovery and toolset construction while preserving local-over-base precedence
- apply layered disables without activating providers from intermediate ancestors or unrelated monorepo roots
- share canonical `//path` scope generation with task prefixing and `:task` expansion
- cover direct and transitive selection, duplicate IDs, ordering, scoped disables, excluded roots, layered tools, nested invocation roots, and root/global compatibility

## Bug

Automatic dependency discovery for `mise run` used one flat provider namespace after resolving monorepo tasks. For example, if both `apps/api` and `apps/web` declared `[deps.setup]`, only the first `setup` provider survived ID deduplication. A `build` provider in the other project could therefore lose its local prerequisite or bind to the wrong project. Likewise, `disable = ["setup"]` in one project was collected into a global disable list and could remove the matching provider from every selected project.

The failure was observable when a root task depended on tasks from multiple config roots: one subproject's automatic dependency output could be missing even though its task ran, and a local disable could suppress work in a sibling project.

## Fix

Selected subproject providers now use execution IDs such as `//apps/api:setup` and `//apps/web:setup`. An unqualified dependency such as `depends = ["setup"]` first resolves inside the provider's own config root; if that root does not define it, resolution falls back to the pre-existing invocation-root/global provider namespace.

Explicit qualified dependencies are translated to retained invocation-root providers only when their absolute scope matches that root. For example, `//:setup` maps to the retained `setup` provider when invoked from the monorepo root, while an invocation from `apps/api` maps `//apps/api:setup` instead. This preserves ordering without accidentally rebinding `//:setup` to a same-named provider in a nested working directory.

Provider discovery is restricted to the invocation root plus config roots present in the resolved task graph. The full hierarchy is still loaded for each selected root so files such as `mise.local.toml` can disable a provider locally. Those same filtered config files now feed toolset construction in their original precedence order, so a local tool override wins over the base config and is installed before an automatic provider uses it. Configs from intermediate ancestors and unresolved sibling roots are filtered out and cannot run automatic commands accidentally.

Root, global, and system providers retain their previous behavior and disable semantics. The dependency engine is still constructed before toolset installation, preserving the experimental-feature preflight added by #11177.

## Impact

`mise run` now executes automatic dependency providers for every selected subproject without cross-project ID collisions. Provider dependencies and disables stay local to their config root, qualified fallback dependencies remain correctly ordered from root or nested invocations, layered provider tools honor normal config precedence, unrelated roots do not run, and existing invocation-root/global providers continue to participate.

## Validation

- `cargo test --all-features task::task_load_context::tests::test_monorepo_scope`
- `mise run test:e2e e2e/cli/test_deps e2e/tasks/test_task_colon_syntax e2e/tasks/test_task_monorepo_syntax`
- `mise run lint-fix`
- `cargo check --all-features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task dependency auto-run in monorepos so providers execute only within the selected `monorepo_root` configuration root(s).
  * Suppresses disabled or unrelated providers outside the intended scope, and handles per-root provider ID collisions independently.
  * Scoped task naming/pattern expansion now reflects monorepo scope for colon syntax.

* **New Features**
  * Experimental monorepo-scoped dependency execution with fallback behavior when scoped providers are unavailable.

* **Tests**
  * Updated end-to-end coverage for experimental gating, root scoping, fallback behavior, and boundary enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
