### PR TITLE
fix(deps): share state across provider scopes

### DIFF
--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -845,6 +845,23 @@ assert "test -f deps-monorepo/root-output.txt"
 assert "test -f deps-monorepo/packages/a/built.txt"
 assert "test -f deps-monorepo/packages/b/built.txt"
 
+# Scoped and plain invocation share freshness state for the same provider root.
+# First verify state written by monorepo mode is visible to plain mode.
+assert_contains "cd deps-monorepo/packages/a && mise deps --only setup 2>&1" "up to date"
+
+# Then verify state written by plain mode is visible to monorepo mode.
+cat >>deps-monorepo/packages/a/mise.toml <<'EOF'
+
+[deps.state]
+sources = ["state-input.txt"]
+outputs = ["state-output.txt"]
+run = "echo run >> state-runs.txt && cp state-input.txt state-output.txt"
+EOF
+echo a >deps-monorepo/packages/a/state-input.txt
+assert "cd deps-monorepo/packages/a && mise deps --only state"
+assert_contains "cd deps-monorepo && mise deps --monorepo --only //packages/a:state 2>&1" "up to date"
+assert "test \"$(wc -l <deps-monorepo/packages/a/state-runs.txt)\" -eq 1"
+
 # Qualified names can target one provider when names repeat across config roots.
 rm -f deps-monorepo/root-output.txt \
   deps-monorepo/packages/a/output.txt \

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -603,8 +603,9 @@ impl DepsEngine {
                             .map(|p| state::relative_str(p, project_root))
                             .collect();
                         let mut st = DepsState::load(project_root);
-                        st.set_hashes(id, hashes);
-                        st.set_seen_outputs(id, seen);
+                        let provider_id = provider.base().id.as_str();
+                        st.set_hashes(provider_id, hashes);
+                        st.set_seen_outputs(provider_id, seen);
                         if let Err(e) = st.save(project_root) {
                             warn!("failed to save deps state: {e}");
                         }
@@ -873,7 +874,7 @@ impl DepsEngine {
 
         let project_root = &provider.base().project_root;
         let st = DepsState::load(project_root);
-        let provider_id = provider.id();
+        let provider_id = provider.base().id.as_str();
 
         // Session-stale check applies to any output that currently exists,
         // regardless of whether it was required or optional.


### PR DESCRIPTION
## Summary

- use each provider's existing unscoped config ID as its freshness-state key
- keep scoped provider IDs for display, selection, and dependency ordering
- share freshness hashes and optional-output state between plain and scoped invocation modes
- add regression coverage for monorepo-to-plain and plain-to-monorepo state reuse

## Root cause

Scoped dependency providers used their qualified execution ID (for example, `//packages/a:setup`) as the persistence key. Plain invocation used the unqualified ID (`setup`). Although state files are already isolated by provider project root, switching invocation modes therefore appeared to have no previous state and needlessly reran the provider. The provider's existing base ID is unscoped in both modes, so this PR uses it directly for freshness state.

## Example bug

Consider a monorepo with a `codegen` provider in `packages/api/mise.toml`:

```toml
[deps.codegen]
sources = ["schema.graphql"]
outputs = ["generated.rs"]
run = "generate-code schema.graphql > generated.rs"
```

Running it from the repository root used the qualified provider ID:

```sh
mise deps --monorepo --only //packages/api:codegen
```

Before this fix, freshness state was saved under `//packages/api:codegen`. A later plain invocation from the package looked for `codegen` instead:

```sh
cd packages/api
mise deps --only codegen
```

Even when `schema.graphql` and `generated.rs` were unchanged, mise found no state under that different key and unnecessarily ran code generation again. The reverse order had the same problem. With this PR, both invocation modes persist state under the existing unscoped `codegen` ID inside the package-root-specific state file, so the second command reports the provider as up to date.

## Upgrade behavior

Existing state written by older versions under qualified IDs is not migrated. Because this state is only a freshness cache, an affected provider may run once after upgrading; subsequent plain and scoped invocations share the new stable state.

## Stack

This PR was stacked on https://github.com/jdx/mise/pull/11180, which is now merged. This branch has been rebased onto the resulting `main` commit.

## Validation

- `cargo fmt --all -- --check`
- `mise run test:e2e e2e/cli/test_deps`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency freshness tracking consistency between standard and monorepo executions.
  * Ensured cached hashes and “seen” optional outputs are keyed consistently, improving accurate “up to date” results.
  * Prevented unnecessary reruns by correctly reusing prior run information across invocation modes.
* **Tests**
  * Extended end-to-end coverage to verify freshness sharing from a plain dependency run into a monorepo-qualified run for the same provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->