### PR TITLE
feat(deps): explain inactive providers

### DIFF
--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -37,6 +37,21 @@ assert_fail "mise deps npm" "is inactive: missing package-lock.json"
 assert_fail "mise deps --only npm" "is inactive: missing package-lock.json"
 assert_not_contains "mise deps --force 2>&1" "npm install"
 
+# Inactive-only automatic providers do not trigger the experimental feature
+# gate for otherwise unrelated commands.
+assert "env -u MISE_EXPERIMENTAL mise exec -- echo INACTIVE_DEPS_OK" "INACTIVE_DEPS_OK"
+
+# Explicit inactive selection fails before unrelated project tools are installed.
+mkdir inactive-before-tools
+cat >inactive-before-tools/mise.toml <<'EOF'
+[tools]
+tiny = "1"
+
+[deps.npm]
+EOF
+assert_fail "cd inactive-before-tools && MISE_DATA_DIR='$PWD/inactive-data' mise deps npm" "is inactive: missing package-lock.json"
+assert_fail "test -d inactive-data/installs/tiny"
+
 # A directory with the expected name is not a valid applicability file.
 mkdir package-lock.json
 assert_contains "mise deps --list" "status: inactive (missing package-lock.json)"
@@ -61,7 +76,14 @@ cat >mise.toml <<'EOF'
 depends = ["missing_run"]
 sources = ["schema.graphql"]
 outputs = ["generated/"]
-run = "echo codegen"
+run = "touch blocked-output; echo codegen"
+
+[deps.downstream]
+depends = ["codegen"]
+run = "touch downstream-output"
+
+[deps.unrelated]
+run = "touch unrelated-output"
 EOF
 
 # Create source file
@@ -81,6 +103,18 @@ EOF
 assert_contains "mise deps --list" "missing_run"
 assert_contains "mise deps --list" "status: inactive (missing run command)"
 assert_fail "mise deps missing_run --explain" "is inactive: missing run command"
+
+# Broad runs block the inactive provider's dependent chain but continue
+# unrelated providers.
+assert_contains "mise deps --force --skip npm 2>&1" "dependency 'missing_run' is inactive: missing run command"
+assert_fail "test -f blocked-output"
+assert_fail "test -f downstream-output"
+assert "test -f unrelated-output"
+
+# Dry-run uses the same blocked-dependency plan as execution.
+assert_not_contains "mise deps --dry-run --skip npm 2>&1" "Would install: codegen"
+assert_not_contains "mise deps --dry-run --skip npm 2>&1" "Would install: downstream"
+assert_contains "mise deps --dry-run --skip npm 2>&1" "Would install: unrelated"
 
 # Test --only flag
 assert_contains "mise deps --dry-run --only codegen 2>&1" "codegen"

--- a/e2e/cli/test_deps
+++ b/e2e/cli/test_deps
@@ -24,8 +24,27 @@ EOF
 
 # Now npm provider should be detected
 assert_contains "mise deps --list" "npm"
+assert_contains "mise deps --list" "status: active"
 assert_contains "mise deps --list" "package-lock.json"
 assert_contains "mise deps --list" "node_modules"
+
+# Explicitly configured providers remain visible when their applicability file
+# is missing, but explain why they cannot run.
+rm package-lock.json
+assert_contains "mise deps --list" "status: inactive (missing package-lock.json)"
+assert_fail "mise deps npm --explain" "is inactive: missing package-lock.json"
+assert_fail "mise deps npm" "is inactive: missing package-lock.json"
+assert_fail "mise deps --only npm" "is inactive: missing package-lock.json"
+assert_not_contains "mise deps --force 2>&1" "npm install"
+
+# A directory with the expected name is not a valid applicability file.
+mkdir package-lock.json
+assert_contains "mise deps --list" "status: inactive (missing package-lock.json)"
+rmdir package-lock.json
+
+# Creating the applicability file transitions the same provider to active.
+touch package-lock.json
+assert_contains "mise deps --list" "status: active"
 
 # Test --dry-run shows what would run
 assert_contains "mise deps --dry-run 2>&1" "npm"
@@ -39,6 +58,7 @@ cat >mise.toml <<'EOF'
 [deps.npm]
 
 [deps.codegen]
+depends = ["missing_run"]
 sources = ["schema.graphql"]
 outputs = ["generated/"]
 run = "echo codegen"
@@ -50,10 +70,23 @@ touch schema.graphql
 assert_contains "mise deps --list" "codegen"
 assert_contains "mise deps --list" "schema.graphql"
 
+# Custom providers without a run command are retained for diagnostics and
+# cannot be executed.
+cat >>mise.toml <<'EOF'
+
+[deps.missing_run]
+sources = ["schema.graphql"]
+outputs = ["generated-missing/"]
+EOF
+assert_contains "mise deps --list" "missing_run"
+assert_contains "mise deps --list" "status: inactive (missing run command)"
+assert_fail "mise deps missing_run --explain" "is inactive: missing run command"
+
 # Test --only flag
 assert_contains "mise deps --dry-run --only codegen 2>&1" "codegen"
 assert_not_contains "mise deps --dry-run --only codegen 2>&1" "npm"
 assert_contains "mise deps --force --only codegen 2>&1" "[deps.codegen] codegen"
+assert_not_contains "mise deps --force --only codegen 2>&1" "depends on 'missing_run' which is not configured"
 
 # Test -q/--quiet suppresses provider stream output and status messages.
 # Without -q the previous assertion proved "[deps.codegen] codegen" appears;
@@ -145,8 +178,18 @@ EOF
 assert_contains "mise deps --list" "bun"
 assert_contains "mise deps --list" "bun.lock"
 
+rm bun.lock
+assert_contains "mise deps --list" "inactive (missing bun.lockb or bun.lock)"
+
+# A directory named bun.lockb must not take precedence over a valid bun.lock.
+mkdir bun.lockb
+touch bun.lock
+assert_contains "mise deps --list" "status: active"
+assert_not_contains "mise deps --list" "bun.lockb"
+rmdir bun.lockb
+rm bun.lock
+
 # Test aube provider
-rm -f bun.lock
 cat >aube-lock.yaml <<'EOF'
 lockfileVersion: 1
 EOF
@@ -190,6 +233,9 @@ EOF
 assert_contains "mise deps --list" "go"
 assert_contains "mise deps --list" "go.mod"
 assert_contains "mise deps --dry-run 2>&1" "go"
+
+rm go.mod
+assert_contains "mise deps --list" "inactive (missing go.mod)"
 
 # Test pip provider
 rm -f go.sum go.mod
@@ -564,16 +610,19 @@ run = "sleep 1; cp input.txt prepared.txt"
 
 [deps.build]
 auto = true
-depends = ["setup", "//:root_setup", "global_setup"]
+depends = ["setup", "//:root_setup", "global_setup", "root_fallback"]
 sources = ["prepared.txt"]
 outputs = ["built.txt"]
-run = "test -f prepared.txt && test -f ../../root-output.txt && test -f ../../global-output.txt && cp prepared.txt built.txt"
+run = "test -f prepared.txt && test -f ../../root-output.txt && test -f ../../global-output.txt && test -f ../../root-fallback-output.txt && cp prepared.txt built.txt"
 
 [deps.disabled]
 auto = true
 sources = ["input.txt"]
 outputs = ["disabled.txt"]
 run = "cp input.txt disabled.txt"
+
+[deps.root_fallback]
+auto = true
 
 [tasks.check]
 run = "test -f built.txt && echo TASK_DEPS_OK"
@@ -636,6 +685,11 @@ auto = true
 sources = ["root-input.txt"]
 outputs = ["root-output.txt"]
 run = "cp root-input.txt root-output.txt"
+
+[deps.root_fallback]
+auto = true
+outputs = ["root-fallback-output.txt"]
+run = "sleep 2; touch root-fallback-output.txt"
 EOF
 echo root >root-input.txt
 
@@ -717,12 +771,13 @@ assert_contains "mise deps --list" ".gitmodules"
 assert_contains "mise deps --list" "libs/foo"
 assert_contains "mise deps --list" "libs/bar"
 
-# Test that empty .gitmodules is not applicable
+# Empty .gitmodules remains visible with its inapplicability reason.
 echo -n "" >.gitmodules
 cat >mise.toml <<'EOF'
 [deps.git-submodule]
 EOF
-assert_not_contains "mise deps --list" "git-submodule"
+assert_contains "mise deps --list" "git-submodule"
+assert_contains "mise deps --list" "status: inactive (empty .gitmodules)"
 
 # Clean up
 rm -f .gitmodules mise.toml .mise
@@ -820,14 +875,30 @@ run = "cp output.txt built.txt"
 sources = ["input.txt"]
 outputs = ["disabled.txt"]
 run = "cp input.txt disabled.txt"
+
+[deps.layered_active]
+sources = ["input.txt"]
+outputs = ["layered-active.txt"]
+run = "cp input.txt layered-active.txt"
 EOF
   echo "$package" >"deps-monorepo/packages/$package/input.txt"
 done
+
+# Keep an inapplicable provider in one root to verify scoped diagnostics.
+cat >>deps-monorepo/packages/a/mise.toml <<'EOF'
+
+[deps.npm]
+EOF
 
 # A layered disable applies to providers from the same config root.
 cat >deps-monorepo/packages/a/mise.local.toml <<'EOF'
 [deps]
 disable = ["disabled"]
+
+# An inactive higher-precedence definition must not suppress the applicable
+# lower-precedence provider that discovery selected before inactive providers
+# were retained for diagnostics.
+[deps.layered_active]
 EOF
 
 # Plain deps remains scoped to the root config, while monorepo mode qualifies it.
@@ -838,12 +909,18 @@ assert_contains "cd deps-monorepo && mise deps --monorepo --list" "//:root"
 # --monorepo loads every explicit config root and qualifies duplicate IDs.
 assert_contains "cd deps-monorepo && mise deps --monorepo --list" "//packages/a:setup"
 assert_contains "cd deps-monorepo && mise deps --monorepo --list" "//packages/b:setup"
+assert_contains "cd deps-monorepo && mise deps --monorepo --list" "//packages/a:npm"
+assert_contains "cd deps-monorepo && mise deps --monorepo --list" "inactive (missing package-lock.json)"
+assert_fail "cd deps-monorepo && mise deps --monorepo //packages/a:npm --explain" "is inactive: missing package-lock.json"
+assert_fail "cd deps-monorepo && mise deps --monorepo //packages/a:npm" "is inactive: missing package-lock.json"
 assert_not_contains "cd deps-monorepo && mise deps --monorepo --list" "//packages/a:disabled"
 assert_contains "cd deps-monorepo && mise deps --monorepo --list" "//packages/b:disabled"
 assert "cd deps-monorepo && mise deps --monorepo --force"
 assert "test -f deps-monorepo/root-output.txt"
 assert "test -f deps-monorepo/packages/a/built.txt"
 assert "test -f deps-monorepo/packages/b/built.txt"
+assert "test -f deps-monorepo/packages/a/layered-active.txt"
+assert "test -f deps-monorepo/packages/b/layered-active.txt"
 
 # Scoped and plain invocation share freshness state for the same provider root.
 # First verify state written by monorepo mode is visible to plain mode.

--- a/src/cli/deps/install.rs
+++ b/src/cli/deps/install.rs
@@ -1,7 +1,7 @@
 use eyre::{Result, bail};
 
 use crate::config::Config;
-use crate::deps::{DepsEngine, DepsOptions, DepsStepResult};
+use crate::deps::{DepsEngine, DepsOptions, DepsProviderApplicability, DepsStepResult};
 use crate::toolset::{InstallOptions, Toolset, ToolsetBuilder};
 
 /// Install all project dependencies
@@ -167,7 +167,7 @@ impl DepsInstall {
             bail!("Provider '{provider_id}' not found.\n\nAvailable providers:\n{available}");
         };
 
-        let freshness = engine.check_provider_freshness(provider)?;
+        let applicability = provider.applicability();
 
         // Header
         miseprintln!("Provider: {}", provider.id());
@@ -209,6 +209,12 @@ impl DepsInstall {
 
         // Verdict
         miseprintln!("");
+        if let DepsProviderApplicability::Inactive(reason) = applicability {
+            miseprintln!("Status: inactive ({reason})");
+            bail!("provider '{}' is inactive: {reason}", provider.id());
+        }
+
+        let freshness = engine.check_provider_freshness(provider)?;
         if freshness.is_fresh() {
             miseprintln!("Status: fresh ({})", freshness.reason());
         } else {
@@ -247,6 +253,14 @@ impl DepsInstall {
                 .join(", ");
 
             miseprintln!("  {}", provider.id());
+            match provider.applicability() {
+                DepsProviderApplicability::Applicable => {
+                    miseprintln!("    status: active");
+                }
+                DepsProviderApplicability::Inactive(reason) => {
+                    miseprintln!("    status: inactive ({reason})");
+                }
+            }
             miseprintln!("    sources: {}", sources);
             miseprintln!("    outputs: {}", outputs);
         }

--- a/src/cli/deps/install.rs
+++ b/src/cli/deps/install.rs
@@ -73,6 +73,24 @@ impl DepsInstall {
             return self.explain_provider(&engine, provider_id);
         }
 
+        // If a provider is specified as a positional arg, treat it like --only.
+        let only = match (&self.provider, &self.only) {
+            (Some(p), None) => Some(vec![p.clone()]),
+            (Some(p), Some(list)) => {
+                let mut combined = list.clone();
+                if !combined.contains(p) {
+                    combined.push(p.clone());
+                }
+                Some(combined)
+            }
+            (None, only) => only.clone(),
+        };
+        let skip = self.skip.unwrap_or_default();
+
+        // Report an explicitly selected inactive provider before resolving or
+        // installing unrelated tools from the project toolset.
+        engine.validate_selection(only.as_deref(), &skip)?;
+
         // Build and install the effective toolset so package managers declared
         // in monorepo config roots are available to their deps providers.
         let mut install_config = match &monorepo_union {
@@ -104,24 +122,11 @@ impl DepsInstall {
         // Get toolset environment with PATH
         let env = ts.env_with_path(&install_config).await?;
 
-        // If a provider is specified as a positional arg, treat it like --only
-        let only = match (&self.provider, &self.only) {
-            (Some(p), None) => Some(vec![p.clone()]),
-            (Some(p), Some(list)) => {
-                let mut combined = list.clone();
-                if !combined.contains(p) {
-                    combined.push(p.clone());
-                }
-                Some(combined)
-            }
-            (None, only) => only.clone(),
-        };
-
         let opts = DepsOptions {
             dry_run: self.dry_run,
             force: self.force,
             only,
-            skip: self.skip.unwrap_or_default(),
+            skip,
             env,
             ..Default::default()
         };

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -182,8 +182,8 @@ impl DepsEngine {
     /// Create a new DepsEngine, discovering all configured providers.
     pub fn new(config: &Config) -> Result<Self> {
         let providers = Self::discover_providers(config)?;
-        // Only require experimental when deps is actually configured
-        if !providers.is_empty() {
+        // Inactive-only config is diagnostic state and cannot run.
+        if providers.iter().any(|provider| provider.is_applicable()) {
             Settings::get().ensure_experimental("deps")?;
         }
         Ok(Self { providers })
@@ -294,7 +294,7 @@ impl DepsEngine {
                 )) as Box<dyn DepsProvider>
             })
             .collect();
-        if !providers.is_empty() {
+        if providers.iter().any(|provider| provider.is_applicable()) {
             Settings::get().ensure_experimental("deps")?;
         }
         Ok(Self { providers })
@@ -342,7 +342,7 @@ impl DepsEngine {
             &qualified_fallback_ids,
         )?;
         providers.append(&mut engine.providers);
-        if !providers.is_empty() {
+        if providers.iter().any(|provider| provider.is_applicable()) {
             Settings::get().ensure_experimental("deps")?;
         }
         Ok(Self { providers })
@@ -506,39 +506,59 @@ impl DepsEngine {
             .collect()
     }
 
+    /// Reject explicitly selected providers that cannot run.
+    pub fn validate_selection(&self, only: Option<&[String]>, skip: &[String]) -> Result<()> {
+        let Some(only) = only else {
+            return Ok(());
+        };
+        for id in only {
+            if skip.contains(id) {
+                continue;
+            }
+            let Some(provider) = self.providers.iter().find(|provider| provider.id() == id) else {
+                continue;
+            };
+            if let DepsProviderApplicability::Inactive(reason) = provider.applicability() {
+                bail!("provider '{}' is inactive: {reason}", provider.id());
+            }
+        }
+        Ok(())
+    }
+
     /// Run all stale deps steps, respecting dependency ordering
     pub async fn run(&self, opts: DepsOptions) -> Result<DepsResult> {
         let mut results = vec![];
 
-        if let Some(only) = &opts.only {
-            for id in only {
-                if opts.skip.contains(id) {
-                    continue;
-                }
-                let Some(provider) = self.providers.iter().find(|provider| provider.id() == id)
-                else {
-                    continue;
-                };
-                if let DepsProviderApplicability::Inactive(reason) = provider.applicability() {
-                    bail!("provider '{}' is inactive: {reason}", provider.id());
-                }
-            }
-        }
+        self.validate_selection(opts.only.as_deref(), &opts.skip)?;
 
-        // Collect providers that need to run
-        let mut to_run: Vec<DepsJob> = vec![];
+        let is_selected = |provider: &dyn DepsProvider| {
+            (!opts.auto_only || provider.is_auto())
+                && !opts.skip.iter().any(|id| id == provider.id())
+                && opts
+                    .only
+                    .as_ref()
+                    .is_none_or(|only| only.iter().any(|id| id == provider.id()))
+        };
+        let inactive_ids: HashMap<String, String> = self
+            .providers
+            .iter()
+            .filter(|provider| is_selected(provider.as_ref()))
+            .filter_map(|provider| match provider.applicability() {
+                DepsProviderApplicability::Applicable => None,
+                DepsProviderApplicability::Inactive(reason) => {
+                    Some((provider.id().to_string(), reason))
+                }
+            })
+            .collect();
+
+        // Collect stale providers before applying dependency blocking so a
+        // fresh provider remains satisfied even if one of its deps is inactive.
+        let mut candidates: Vec<(DepsJob, String)> = vec![];
         // Track IDs of providers that are fresh/skipped (treated as already satisfied for deps)
         let mut satisfied_ids: HashSet<String> = HashSet::new();
 
         for provider in &self.providers {
             let id = provider.id().to_string();
-
-            if !provider.is_applicable() {
-                trace!("deps step {} is inactive, skipping", id);
-                results.push(DepsStepResult::Skipped(id.clone()));
-                satisfied_ids.insert(id);
-                continue;
-            }
 
             // Check auto_only filter
             if opts.auto_only && !provider.is_auto() {
@@ -564,6 +584,12 @@ impl DepsEngine {
                 continue;
             }
 
+            if let DepsProviderApplicability::Inactive(_) = provider.applicability() {
+                trace!("deps step {} is inactive, skipping", id);
+                results.push(DepsStepResult::Skipped(id.clone()));
+                continue;
+            }
+
             let freshness = if opts.force {
                 FreshnessResult::Forced
             } else {
@@ -583,21 +609,63 @@ impl DepsEngine {
                 let timeout = provider.timeout();
                 let reason = freshness.reason().to_string();
 
-                if opts.dry_run {
-                    results.push(DepsStepResult::WouldRun(id, reason));
-                } else {
-                    to_run.push(DepsJob {
+                candidates.push((
+                    DepsJob {
                         id,
                         cmd,
                         outputs,
                         depends,
                         timeout,
-                    });
-                }
+                    },
+                    reason,
+                ));
             } else {
                 trace!("deps step {} is fresh, skipping", id);
                 results.push(DepsStepResult::Fresh(id.clone()));
                 satisfied_ids.insert(id);
+            }
+        }
+
+        let mut inactive_blocked_ids: HashSet<String> = inactive_ids.keys().cloned().collect();
+        loop {
+            let previous_len = inactive_blocked_ids.len();
+            for (job, _) in &candidates {
+                if job
+                    .depends
+                    .iter()
+                    .any(|dependency| inactive_blocked_ids.contains(dependency))
+                {
+                    inactive_blocked_ids.insert(job.id.clone());
+                }
+            }
+            if inactive_blocked_ids.len() == previous_len {
+                break;
+            }
+        }
+
+        let mut to_run: Vec<DepsJob> = vec![];
+        for (job, reason) in candidates {
+            if inactive_blocked_ids.contains(&job.id) {
+                if let Some((dependency, reason)) = job
+                    .depends
+                    .iter()
+                    .find_map(|dependency| inactive_ids.get(dependency).map(|r| (dependency, r)))
+                {
+                    warn!(
+                        "deps provider '{}' skipped because dependency '{}' is inactive: {}",
+                        job.id, dependency, reason
+                    );
+                } else {
+                    warn!(
+                        "deps provider '{}' skipped due to inactive dependency",
+                        job.id
+                    );
+                }
+                results.push(DepsStepResult::Skipped(job.id));
+            } else if opts.dry_run {
+                results.push(DepsStepResult::WouldRun(job.id, reason));
+            } else {
+                to_run.push(job);
             }
         }
 

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use eyre::Result;
+use eyre::{Result, bail};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
@@ -85,8 +85,8 @@ impl DepsProvider for ScopedDepsProvider {
         self.inner.install_command()
     }
 
-    fn is_applicable(&self) -> bool {
-        self.inner.is_applicable()
+    fn applicability(&self) -> super::DepsProviderApplicability {
+        self.inner.applicability()
     }
 
     fn is_auto(&self) -> bool {
@@ -115,7 +115,7 @@ use super::providers::{
 };
 use super::rule::BUILTIN_PROVIDERS;
 use super::state::{self, DepsState};
-use super::{DepsProvider, FreshnessResult};
+use super::{DepsProvider, DepsProviderApplicability, FreshnessResult};
 
 /// Options for running deps steps
 #[derive(Debug, Default)]
@@ -179,7 +179,7 @@ pub struct DepsEngine {
 }
 
 impl DepsEngine {
-    /// Create a new DepsEngine, discovering all applicable providers
+    /// Create a new DepsEngine, discovering all configured providers.
     pub fn new(config: &Config) -> Result<Self> {
         let providers = Self::discover_providers(config)?;
         // Only require experimental when deps is actually configured
@@ -210,7 +210,7 @@ impl DepsEngine {
             .monorepo_root()
             .ok_or_else(|| eyre::eyre!("no config file in scope sets monorepo_root = true"))?;
         let mut scoped_providers: Vec<(Box<dyn DepsProvider>, String, String)> = vec![];
-        let mut seen_ids = HashSet::new();
+        let mut provider_indices: HashMap<String, usize> = HashMap::new();
         let config_files: Vec<_> = config_files.into_iter().collect();
         let mut disabled_by_root: HashMap<PathBuf, HashSet<String>> = HashMap::new();
 
@@ -258,14 +258,29 @@ impl DepsEngine {
                 let scoped_id = format!("{scope}:{id}");
                 if let Some(provider) =
                     Self::build_provider(id, &config_root, provider_config.clone())
-                    && provider.is_applicable()
-                    && seen_ids.insert(scoped_id.clone())
                 {
-                    scoped_providers.push((provider, scoped_id, scope.clone()));
+                    if let Some(index) = provider_indices.get(&scoped_id).copied() {
+                        // Before inactive providers were retained, layered
+                        // discovery selected the first applicable definition.
+                        // Preserve that precedence while retaining the
+                        // highest-precedence inactive definition only when no
+                        // applicable definition exists.
+                        if !scoped_providers[index].0.is_applicable() && provider.is_applicable() {
+                            scoped_providers[index] = (provider, scoped_id, scope.clone());
+                        }
+                    } else {
+                        provider_indices.insert(scoped_id.clone(), scoped_providers.len());
+                        scoped_providers.push((provider, scoped_id, scope.clone()));
+                    }
                 }
             }
         }
 
+        let applicable_ids = scoped_providers
+            .iter()
+            .filter(|(provider, _, _)| provider.is_applicable())
+            .map(|(_, scoped_id, _)| scoped_id.clone())
+            .collect();
         let providers: Vec<Box<dyn DepsProvider>> = scoped_providers
             .into_iter()
             .map(|(provider, scoped_id, scope)| {
@@ -273,7 +288,7 @@ impl DepsEngine {
                     provider,
                     scoped_id,
                     &scope,
-                    &seen_ids,
+                    &applicable_ids,
                     fallback_ids,
                     qualified_fallback_ids,
                 )) as Box<dyn DepsProvider>
@@ -294,6 +309,7 @@ impl DepsEngine {
         let mut providers = Self::discover_providers(config)?;
         let fallback_ids = providers
             .iter()
+            .filter(|provider| provider.is_applicable())
             .map(|provider| provider.id().to_string())
             .collect();
         let monorepo_root = config
@@ -307,6 +323,7 @@ impl DepsEngine {
                 Some(
                     providers
                         .iter()
+                        .filter(|provider| provider.is_applicable())
                         .filter(|provider| provider.base().project_root.as_path() == project_root)
                         .map(|provider| {
                             (
@@ -331,7 +348,7 @@ impl DepsEngine {
         Ok(Self { providers })
     }
 
-    /// Discover all applicable deps providers for the current project
+    /// Discover all configured deps providers for the current project.
     ///
     /// Each config file's deps providers are scoped to that config file's directory.
     /// For example, a `[deps.pnpm]` defined in the root `mise.toml` only applies when
@@ -376,7 +393,6 @@ impl DepsEngine {
 
                 if let Some(provider) =
                     Self::build_provider(id, &config_root, provider_config.clone())
-                    && provider.is_applicable()
                 {
                     providers.push(provider);
                 }
@@ -455,7 +471,7 @@ impl DepsEngine {
         }
     }
 
-    /// List all discovered providers
+    /// List all discovered providers, including inactive providers.
     pub fn list_providers(&self) -> Vec<&dyn DepsProvider> {
         self.providers.iter().map(|p| p.as_ref()).collect()
     }
@@ -479,6 +495,7 @@ impl DepsEngine {
         self.providers
             .iter()
             .filter(|p| p.is_auto())
+            .filter(|p| p.is_applicable())
             .filter_map(|p| {
                 let result = self.check_freshness(p.as_ref());
                 match result {
@@ -493,6 +510,21 @@ impl DepsEngine {
     pub async fn run(&self, opts: DepsOptions) -> Result<DepsResult> {
         let mut results = vec![];
 
+        if let Some(only) = &opts.only {
+            for id in only {
+                if opts.skip.contains(id) {
+                    continue;
+                }
+                let Some(provider) = self.providers.iter().find(|provider| provider.id() == id)
+                else {
+                    continue;
+                };
+                if let DepsProviderApplicability::Inactive(reason) = provider.applicability() {
+                    bail!("provider '{}' is inactive: {reason}", provider.id());
+                }
+            }
+        }
+
         // Collect providers that need to run
         let mut to_run: Vec<DepsJob> = vec![];
         // Track IDs of providers that are fresh/skipped (treated as already satisfied for deps)
@@ -500,6 +532,13 @@ impl DepsEngine {
 
         for provider in &self.providers {
             let id = provider.id().to_string();
+
+            if !provider.is_applicable() {
+                trace!("deps step {} is inactive, skipping", id);
+                results.push(DepsStepResult::Skipped(id.clone()));
+                satisfied_ids.insert(id);
+                continue;
+            }
 
             // Check auto_only filter
             if opts.auto_only && !provider.is_auto() {
@@ -868,6 +907,13 @@ impl DepsEngine {
     /// Uses blake3 content hashing with persistent state. On first run (no
     /// stored hashes), the provider is always considered stale.
     pub fn check_freshness(&self, provider: &dyn DepsProvider) -> Result<FreshnessResult> {
+        if let DepsProviderApplicability::Inactive(reason) = provider.applicability() {
+            return Err(eyre::eyre!(
+                "deps provider '{}' is inactive: {reason}",
+                provider.id()
+            ));
+        }
+
         let sources = provider.sources();
         let outputs = provider.outputs();
         let optional_outputs = provider.optional_outputs();

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -106,6 +106,7 @@ impl DepsProvider for ScopedDepsProvider {
     }
 }
 
+use super::DepsProviderApplicability::Applicable;
 use super::deps_ordering::DepsOrdering;
 use super::providers::{
     AubeDepsProvider, BunDepsProvider, BundlerDepsProvider, ComposerDepsProvider,
@@ -183,7 +184,10 @@ impl DepsEngine {
     pub fn new(config: &Config) -> Result<Self> {
         let providers = Self::discover_providers(config)?;
         // Inactive-only config is diagnostic state and cannot run.
-        if providers.iter().any(|provider| provider.is_applicable()) {
+        if providers
+            .iter()
+            .any(|provider| matches!(provider.applicability(), Applicable))
+        {
             Settings::get().ensure_experimental("deps")?;
         }
         Ok(Self { providers })
@@ -265,7 +269,9 @@ impl DepsEngine {
                         // Preserve that precedence while retaining the
                         // highest-precedence inactive definition only when no
                         // applicable definition exists.
-                        if !scoped_providers[index].0.is_applicable() && provider.is_applicable() {
+                        if !matches!(scoped_providers[index].0.applicability(), Applicable)
+                            && matches!(provider.applicability(), Applicable)
+                        {
                             scoped_providers[index] = (provider, scoped_id, scope.clone());
                         }
                     } else {
@@ -278,7 +284,7 @@ impl DepsEngine {
 
         let applicable_ids = scoped_providers
             .iter()
-            .filter(|(provider, _, _)| provider.is_applicable())
+            .filter(|(provider, _, _)| matches!(provider.applicability(), Applicable))
             .map(|(_, scoped_id, _)| scoped_id.clone())
             .collect();
         let providers: Vec<Box<dyn DepsProvider>> = scoped_providers
@@ -294,7 +300,10 @@ impl DepsEngine {
                 )) as Box<dyn DepsProvider>
             })
             .collect();
-        if providers.iter().any(|provider| provider.is_applicable()) {
+        if providers
+            .iter()
+            .any(|provider| matches!(provider.applicability(), Applicable))
+        {
             Settings::get().ensure_experimental("deps")?;
         }
         Ok(Self { providers })
@@ -309,7 +318,7 @@ impl DepsEngine {
         let mut providers = Self::discover_providers(config)?;
         let fallback_ids = providers
             .iter()
-            .filter(|provider| provider.is_applicable())
+            .filter(|provider| matches!(provider.applicability(), Applicable))
             .map(|provider| provider.id().to_string())
             .collect();
         let monorepo_root = config
@@ -323,7 +332,7 @@ impl DepsEngine {
                 Some(
                     providers
                         .iter()
-                        .filter(|provider| provider.is_applicable())
+                        .filter(|provider| matches!(provider.applicability(), Applicable))
                         .filter(|provider| provider.base().project_root.as_path() == project_root)
                         .map(|provider| {
                             (
@@ -342,7 +351,10 @@ impl DepsEngine {
             &qualified_fallback_ids,
         )?;
         providers.append(&mut engine.providers);
-        if providers.iter().any(|provider| provider.is_applicable()) {
+        if providers
+            .iter()
+            .any(|provider| matches!(provider.applicability(), Applicable))
+        {
             Settings::get().ensure_experimental("deps")?;
         }
         Ok(Self { providers })
@@ -495,7 +507,7 @@ impl DepsEngine {
         self.providers
             .iter()
             .filter(|p| p.is_auto())
-            .filter(|p| p.is_applicable())
+            .filter(|p| matches!(p.applicability(), Applicable))
             .filter_map(|p| {
                 let result = self.check_freshness(p.as_ref());
                 match result {
@@ -544,7 +556,7 @@ impl DepsEngine {
             .iter()
             .filter(|provider| is_selected(provider.as_ref()))
             .filter_map(|provider| match provider.applicability() {
-                DepsProviderApplicability::Applicable => None,
+                Applicable => None,
                 DepsProviderApplicability::Inactive(reason) => {
                     Some((provider.id().to_string(), reason))
                 }

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -7,6 +7,7 @@ use eyre::{Result, bail};
 
 use crate::config::{Config, Settings};
 use crate::env;
+use crate::file::display_filename;
 
 pub use engine::{DepsEngine, DepsOptions, DepsStepResult};
 pub use rule::DepsConfig;
@@ -40,19 +41,12 @@ pub enum DepsProviderApplicability {
 }
 
 impl DepsProviderApplicability {
-    fn filename(path: &Path) -> String {
-        path.file_name()
-            .unwrap_or(path.as_os_str())
-            .to_string_lossy()
-            .into_owned()
-    }
-
     /// Require a provider-specific file to exist.
     pub fn require_file(path: &Path) -> Self {
         if path.is_file() {
             Self::Applicable
         } else {
-            let name = Self::filename(path);
+            let name = display_filename(path);
             Self::Inactive(format!("missing {name}"))
         }
     }
@@ -64,7 +58,7 @@ impl DepsProviderApplicability {
         } else {
             let names = paths
                 .iter()
-                .map(|path| Self::filename(path))
+                .map(display_filename)
                 .collect::<Vec<_>>()
                 .join(" or ");
             Self::Inactive(format!("missing {names}"))
@@ -73,7 +67,7 @@ impl DepsProviderApplicability {
 
     /// Require a file to exist and contain data.
     pub fn require_nonempty_file(path: &Path) -> Self {
-        let name = Self::filename(path);
+        let name = display_filename(path);
         if !path.is_file() {
             return Self::Inactive(format!("missing {name}"));
         }

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -40,23 +40,31 @@ pub enum DepsProviderApplicability {
 }
 
 impl DepsProviderApplicability {
+    fn filename(path: &Path) -> String {
+        path.file_name()
+            .unwrap_or(path.as_os_str())
+            .to_string_lossy()
+            .into_owned()
+    }
+
     /// Require a provider-specific file to exist.
-    pub fn require_file(path: &Path, name: &str) -> Self {
+    pub fn require_file(path: &Path) -> Self {
         if path.is_file() {
             Self::Applicable
         } else {
+            let name = Self::filename(path);
             Self::Inactive(format!("missing {name}"))
         }
     }
 
     /// Require one of several provider-specific files to exist.
-    pub fn require_any_file(paths: &[(&Path, &str)]) -> Self {
-        if paths.iter().any(|(path, _)| path.is_file()) {
+    pub fn require_any_file(paths: &[&Path]) -> Self {
+        if paths.iter().any(|path| path.is_file()) {
             Self::Applicable
         } else {
             let names = paths
                 .iter()
-                .map(|(_, name)| *name)
+                .map(|path| Self::filename(path))
                 .collect::<Vec<_>>()
                 .join(" or ");
             Self::Inactive(format!("missing {names}"))
@@ -64,7 +72,8 @@ impl DepsProviderApplicability {
     }
 
     /// Require a file to exist and contain data.
-    pub fn require_nonempty_file(path: &Path, name: &str) -> Self {
+    pub fn require_nonempty_file(path: &Path) -> Self {
+        let name = Self::filename(path);
         if !path.is_file() {
             return Self::Inactive(format!("missing {name}"));
         }

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -86,10 +86,6 @@ impl DepsProviderApplicability {
             None => Self::Inactive("missing run command".to_string()),
         }
     }
-
-    pub fn is_applicable(&self) -> bool {
-        matches!(self, Self::Applicable)
-    }
 }
 
 impl FreshnessResult {
@@ -206,11 +202,6 @@ pub trait DepsProvider: Debug + Send + Sync {
     /// Whether this provider is applicable, with an actionable reason if not.
     fn applicability(&self) -> DepsProviderApplicability;
 
-    /// Whether this provider is applicable (e.g., lockfile exists)
-    fn is_applicable(&self) -> bool {
-        self.applicability().is_applicable()
-    }
-
     /// Whether this provider should auto-run before mise x/run
     fn is_auto(&self) -> bool {
         self.base().is_auto()
@@ -306,6 +297,8 @@ pub fn clear_output_stale(path: &PathBuf) {
 ///
 /// This checks if the lockfiles/config files for each provider exist.
 pub fn detect_applicable_providers(project_root: &Path) -> Vec<String> {
+    use DepsProviderApplicability::Applicable;
+
     use providers::*;
     use rule::DepsProviderConfig;
 
@@ -381,7 +374,7 @@ pub fn detect_applicable_providers(project_root: &Path) -> Vec<String> {
     ];
 
     for (name, provider) in checks {
-        if provider.is_applicable() {
+        if matches!(provider.applicability(), Applicable) {
             applicable.push(name.to_string());
         }
     }

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -32,6 +32,63 @@ pub enum FreshnessResult {
     Forced,
 }
 
+/// Whether a configured deps provider can run in its current project.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DepsProviderApplicability {
+    Applicable,
+    Inactive(String),
+}
+
+impl DepsProviderApplicability {
+    /// Require a provider-specific file to exist.
+    pub fn require_file(path: &Path, name: &str) -> Self {
+        if path.is_file() {
+            Self::Applicable
+        } else {
+            Self::Inactive(format!("missing {name}"))
+        }
+    }
+
+    /// Require one of several provider-specific files to exist.
+    pub fn require_any_file(paths: &[(&Path, &str)]) -> Self {
+        if paths.iter().any(|(path, _)| path.is_file()) {
+            Self::Applicable
+        } else {
+            let names = paths
+                .iter()
+                .map(|(_, name)| *name)
+                .collect::<Vec<_>>()
+                .join(" or ");
+            Self::Inactive(format!("missing {names}"))
+        }
+    }
+
+    /// Require a file to exist and contain data.
+    pub fn require_nonempty_file(path: &Path, name: &str) -> Self {
+        if !path.is_file() {
+            return Self::Inactive(format!("missing {name}"));
+        }
+        if path.metadata().map(|m| m.len() > 0).unwrap_or(false) {
+            Self::Applicable
+        } else {
+            Self::Inactive(format!("empty {name}"))
+        }
+    }
+
+    /// Require a custom provider to define a non-empty run command.
+    pub fn require_run(run: Option<&str>) -> Self {
+        match run {
+            Some(run) if !run.trim().is_empty() => Self::Applicable,
+            Some(_) => Self::Inactive("run command is empty".to_string()),
+            None => Self::Inactive("missing run command".to_string()),
+        }
+    }
+
+    pub fn is_applicable(&self) -> bool {
+        matches!(self, Self::Applicable)
+    }
+}
+
 impl FreshnessResult {
     /// Returns true if the provider should be considered fresh (no work needed)
     pub fn is_fresh(&self) -> bool {
@@ -143,8 +200,13 @@ pub trait DepsProvider: Debug + Send + Sync {
     /// The command to run when outputs are stale relative to sources
     fn install_command(&self) -> Result<DepsCommand>;
 
+    /// Whether this provider is applicable, with an actionable reason if not.
+    fn applicability(&self) -> DepsProviderApplicability;
+
     /// Whether this provider is applicable (e.g., lockfile exists)
-    fn is_applicable(&self) -> bool;
+    fn is_applicable(&self) -> bool {
+        self.applicability().is_applicable()
+    }
 
     /// Whether this provider should auto-run before mise x/run
     fn is_auto(&self) -> bool {

--- a/src/deps/providers/aube.rs
+++ b/src/deps/providers/aube.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -54,8 +54,11 @@ impl DepsProvider for AubeDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("aube-lock.yaml").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("aube-lock.yaml"),
+            "aube-lock.yaml",
+        )
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/aube.rs
+++ b/src/deps/providers/aube.rs
@@ -55,10 +55,7 @@ impl DepsProvider for AubeDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("aube-lock.yaml"),
-            "aube-lock.yaml",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("aube-lock.yaml"))
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/bun.rs
+++ b/src/deps/providers/bun.rs
@@ -76,10 +76,7 @@ impl DepsProvider for BunDepsProvider {
         let root = self.base.config_root();
         let binary_lock = root.join("bun.lockb");
         let text_lock = root.join("bun.lock");
-        DepsProviderApplicability::require_any_file(&[
-            (&binary_lock, "bun.lockb"),
-            (&text_lock, "bun.lock"),
-        ])
+        DepsProviderApplicability::require_any_file(&[&binary_lock, &text_lock])
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/bun.rs
+++ b/src/deps/providers/bun.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -24,11 +24,11 @@ impl BunDepsProvider {
         let root = self.base.config_root();
         // Bun supports both bun.lockb (binary) and bun.lock (text)
         let binary_lock = root.join("bun.lockb");
-        if binary_lock.exists() {
+        if binary_lock.is_file() {
             return Some(binary_lock);
         }
         let text_lock = root.join("bun.lock");
-        if text_lock.exists() {
+        if text_lock.is_file() {
             return Some(text_lock);
         }
         None
@@ -72,8 +72,14 @@ impl DepsProvider for BunDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.lockfile_path().is_some()
+    fn applicability(&self) -> DepsProviderApplicability {
+        let root = self.base.config_root();
+        let binary_lock = root.join("bun.lockb");
+        let text_lock = root.join("bun.lock");
+        DepsProviderApplicability::require_any_file(&[
+            (&binary_lock, "bun.lockb"),
+            (&text_lock, "bun.lock"),
+        ])
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/bundler.rs
+++ b/src/deps/providers/bundler.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -62,7 +62,10 @@ impl DepsProvider for BundlerDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("Gemfile.lock").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("Gemfile.lock"),
+            "Gemfile.lock",
+        )
     }
 }

--- a/src/deps/providers/bundler.rs
+++ b/src/deps/providers/bundler.rs
@@ -63,9 +63,6 @@ impl DepsProvider for BundlerDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("Gemfile.lock"),
-            "Gemfile.lock",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("Gemfile.lock"))
     }
 }

--- a/src/deps/providers/composer.rs
+++ b/src/deps/providers/composer.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -54,7 +54,10 @@ impl DepsProvider for ComposerDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("composer.lock").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("composer.lock"),
+            "composer.lock",
+        )
     }
 }

--- a/src/deps/providers/composer.rs
+++ b/src/deps/providers/composer.rs
@@ -55,9 +55,6 @@ impl DepsProvider for ComposerDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("composer.lock"),
-            "composer.lock",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("composer.lock"))
     }
 }

--- a/src/deps/providers/custom.rs
+++ b/src/deps/providers/custom.rs
@@ -4,7 +4,7 @@ use eyre::Result;
 use glob::glob;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -76,8 +76,7 @@ impl DepsProvider for CustomDepsProvider {
         DepsCommand::from_string(run, &self.base.project_root, &self.base.config)
     }
 
-    fn is_applicable(&self) -> bool {
-        // Custom providers require a run command to be applicable
-        self.base.config.run.is_some()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_run(self.base.config.run.as_deref())
     }
 }

--- a/src/deps/providers/dart.rs
+++ b/src/deps/providers/dart.rs
@@ -4,7 +4,7 @@ use eyre::Result;
 use path_absolutize::Absolutize;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -68,8 +68,11 @@ impl DepsProvider for DartDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("pubspec.yaml").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("pubspec.yaml"),
+            "pubspec.yaml",
+        )
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/dart.rs
+++ b/src/deps/providers/dart.rs
@@ -69,10 +69,7 @@ impl DepsProvider for DartDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("pubspec.yaml"),
-            "pubspec.yaml",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("pubspec.yaml"))
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/deno.rs
+++ b/src/deps/providers/deno.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -64,8 +64,11 @@ impl DepsProvider for DenoDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("deno.lock").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("deno.lock"),
+            "deno.lock",
+        )
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/deno.rs
+++ b/src/deps/providers/deno.rs
@@ -65,10 +65,7 @@ impl DepsProvider for DenoDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("deno.lock"),
-            "deno.lock",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("deno.lock"))
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/git_submodule.rs
+++ b/src/deps/providers/git_submodule.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -99,8 +99,8 @@ impl DepsProvider for GitSubmoduleDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
+    fn applicability(&self) -> DepsProviderApplicability {
         let gitmodules = self.base.config_root().join(".gitmodules");
-        gitmodules.exists() && gitmodules.metadata().map(|m| m.len() > 0).unwrap_or(false)
+        DepsProviderApplicability::require_nonempty_file(&gitmodules, ".gitmodules")
     }
 }

--- a/src/deps/providers/git_submodule.rs
+++ b/src/deps/providers/git_submodule.rs
@@ -101,6 +101,6 @@ impl DepsProvider for GitSubmoduleDepsProvider {
 
     fn applicability(&self) -> DepsProviderApplicability {
         let gitmodules = self.base.config_root().join(".gitmodules");
-        DepsProviderApplicability::require_nonempty_file(&gitmodules, ".gitmodules")
+        DepsProviderApplicability::require_nonempty_file(&gitmodules)
     }
 }

--- a/src/deps/providers/go.rs
+++ b/src/deps/providers/go.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -78,8 +78,8 @@ impl DepsProvider for GoDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
+    fn applicability(&self) -> DepsProviderApplicability {
         // Check for go.mod (the source/lockfile), not go.sum (which may be an output)
-        self.base.config_root().join("go.mod").exists()
+        DepsProviderApplicability::require_file(&self.base.config_root().join("go.mod"), "go.mod")
     }
 }

--- a/src/deps/providers/go.rs
+++ b/src/deps/providers/go.rs
@@ -80,6 +80,6 @@ impl DepsProvider for GoDepsProvider {
 
     fn applicability(&self) -> DepsProviderApplicability {
         // Check for go.mod (the source/lockfile), not go.sum (which may be an output)
-        DepsProviderApplicability::require_file(&self.base.config_root().join("go.mod"), "go.mod")
+        DepsProviderApplicability::require_file(&self.base.config_root().join("go.mod"))
     }
 }

--- a/src/deps/providers/npm.rs
+++ b/src/deps/providers/npm.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -54,8 +54,11 @@ impl DepsProvider for NpmDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("package-lock.json").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("package-lock.json"),
+            "package-lock.json",
+        )
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/npm.rs
+++ b/src/deps/providers/npm.rs
@@ -55,10 +55,7 @@ impl DepsProvider for NpmDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("package-lock.json"),
-            "package-lock.json",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("package-lock.json"))
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/pip.rs
+++ b/src/deps/providers/pip.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -65,7 +65,10 @@ impl DepsProvider for PipDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("requirements.txt").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("requirements.txt"),
+            "requirements.txt",
+        )
     }
 }

--- a/src/deps/providers/pip.rs
+++ b/src/deps/providers/pip.rs
@@ -66,9 +66,6 @@ impl DepsProvider for PipDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("requirements.txt"),
-            "requirements.txt",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("requirements.txt"))
     }
 }

--- a/src/deps/providers/pnpm.rs
+++ b/src/deps/providers/pnpm.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -54,8 +54,11 @@ impl DepsProvider for PnpmDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("pnpm-lock.yaml").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("pnpm-lock.yaml"),
+            "pnpm-lock.yaml",
+        )
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/pnpm.rs
+++ b/src/deps/providers/pnpm.rs
@@ -55,10 +55,7 @@ impl DepsProvider for PnpmDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("pnpm-lock.yaml"),
-            "pnpm-lock.yaml",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("pnpm-lock.yaml"))
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/poetry.rs
+++ b/src/deps/providers/poetry.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -61,7 +61,10 @@ impl DepsProvider for PoetryDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("poetry.lock").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("poetry.lock"),
+            "poetry.lock",
+        )
     }
 }

--- a/src/deps/providers/poetry.rs
+++ b/src/deps/providers/poetry.rs
@@ -62,9 +62,6 @@ impl DepsProvider for PoetryDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("poetry.lock"),
-            "poetry.lock",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("poetry.lock"))
     }
 }

--- a/src/deps/providers/uv.rs
+++ b/src/deps/providers/uv.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -62,7 +62,7 @@ impl DepsProvider for UvDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("uv.lock").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(&self.base.config_root().join("uv.lock"), "uv.lock")
     }
 }

--- a/src/deps/providers/uv.rs
+++ b/src/deps/providers/uv.rs
@@ -63,6 +63,6 @@ impl DepsProvider for UvDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(&self.base.config_root().join("uv.lock"), "uv.lock")
+        DepsProviderApplicability::require_file(&self.base.config_root().join("uv.lock"))
     }
 }

--- a/src/deps/providers/yarn.rs
+++ b/src/deps/providers/yarn.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use eyre::Result;
 
 use crate::deps::rule::DepsProviderConfig;
-use crate::deps::{DepsCommand, DepsProvider};
+use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
 
 use super::ProviderBase;
 
@@ -54,8 +54,11 @@ impl DepsProvider for YarnDepsProvider {
         })
     }
 
-    fn is_applicable(&self) -> bool {
-        self.base.config_root().join("yarn.lock").exists()
+    fn applicability(&self) -> DepsProviderApplicability {
+        DepsProviderApplicability::require_file(
+            &self.base.config_root().join("yarn.lock"),
+            "yarn.lock",
+        )
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/deps/providers/yarn.rs
+++ b/src/deps/providers/yarn.rs
@@ -55,10 +55,7 @@ impl DepsProvider for YarnDepsProvider {
     }
 
     fn applicability(&self) -> DepsProviderApplicability {
-        DepsProviderApplicability::require_file(
-            &self.base.config_root().join("yarn.lock"),
-            "yarn.lock",
-        )
+        DepsProviderApplicability::require_file(&self.base.config_root().join("yarn.lock"))
     }
 
     fn add_command(&self, packages: &[&str], dev: bool) -> Result<DepsCommand> {

--- a/src/file.rs
+++ b/src/file.rs
@@ -362,6 +362,14 @@ pub fn display_path<P: AsRef<Path>>(path: P) -> String {
     path.as_ref().display_user()
 }
 
+pub fn display_filename<P: AsRef<Path>>(path: P) -> String {
+    let path = path.as_ref();
+    path.file_name()
+        .unwrap_or(path.as_os_str())
+        .to_string_lossy()
+        .into_owned()
+}
+
 pub fn display_rel_path<P: AsRef<Path>>(path: P) -> String {
     let path = path.as_ref();
     match path.strip_prefix(dirs::CWD.as_ref().unwrap()) {
@@ -2166,6 +2174,12 @@ mod tests {
             .join(dirs::HOME.deref().strip_prefix("/").unwrap())
             .join("cwd");
         assert_eq!(display_path(&path), path.display().to_string());
+    }
+
+    #[test]
+    fn test_display_filename() {
+        assert_eq!(display_filename("/tmp/mise.toml"), "mise.toml");
+        assert_eq!(display_filename("/"), "/");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- retain explicitly configured deps providers when they are currently inapplicable
- model applicability as a structured active/inactive result with provider-specific reasons
- show active/inactive status in `mise deps --list`
- make `mise deps <provider> --explain` and explicit attempts to run an inactive provider fail with the reason
- skip inactive providers during broad automatic runs and stale checks
- block stale dependents of inactive providers, including transitive dependents, while unrelated providers continue
- keep dry-run planning consistent with real execution
- preserve existing monorepo precedence, dependency fallback, and scoped provider behavior

## Example

Given this configuration:

```toml
[deps.npm]
```

if `package-lock.json` is deleted, the npm provider previously disappeared from `mise deps --list`. That made the configuration look absent and gave the user no way to tell why npm would not run.

After this change, `mise deps --list` keeps the provider visible as:

```text
status: inactive (missing package-lock.json)
```

`mise deps npm --explain` and `mise deps npm` report the same actionable reason and exit nonzero. The explicit error is reported before mise resolves or installs unrelated tools from the project toolset.

Broad commands skip the inactive provider. If a stale `codegen` provider depends on that inactive npm provider, `codegen` and its stale downstream dependents are skipped rather than run with an unsatisfied prerequisite. Unrelated providers still run, and `--dry-run` reports the same plan. Fresh dependents remain satisfied and do not need to be blocked.

## Correctness details

- applicability paths must be regular files, so directories named like lockfiles are not accepted
- inactive dependencies are recognized as configured and block only stale dependent chains
- inactive-only automatic configuration does not trigger the experimental gate for unrelated commands
- an inactive scoped provider does not shadow an active root/global fallback with the same ID
- layered monorepo discovery still selects the first applicable definition, retaining an inactive definition only when no applicable one exists
- Bun selects an actual `bun.lockb` or `bun.lock` file consistently for both applicability and freshness

## Stack

This PR follows https://github.com/jdx/mise/pull/11181, which is now merged. This branch has been rebased onto the latest `main`.

## Validation

- `mise run test:e2e test_deps`
- `mise run lint-fix`
- `cargo check --all-features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise deps --list` now includes per-provider **active/inactive** status with an explanation.
  * `mise deps --explain` shows why a provider is inactive and exits early.
  * Explicitly selecting an inactive provider fails fast; jobs depending on it are skipped (or shown as would-run in dry-run).
* **Bug Fixes**
  * Improved applicability detection for lockfiles (including missing/empty placeholders) and correct layered monorepo scoping/precedence across providers.
  * Git submodule and custom provider inactivity are handled consistently.
* **Tests**
  * Expanded end-to-end coverage for applicability, layered monorepo behavior, and `--only`/`--force` execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
