### PR TITLE
fix(settings): avoid panic when parent key is an inline table

### DIFF
--- a/e2e/cli/test_settings_set
+++ b/e2e/cli/test_settings_set
@@ -48,5 +48,10 @@ mise settings set status.missing_tools=always
 assert "mise settings get status.missing_tools" "always"
 assert_not_contains "cat $settings_config" "[settings]"
 
+# regression: setting a child when the parent key is an inline table must not panic
+printf '[settings]\npython = { compile = true }\n' >"$settings_config"
+mise settings set python.compile false
+assert "mise settings get python.compile" "false"
+
 # test "settings set" with no value and no = fails
 assert_fail "mise settings set all_compile"

--- a/e2e/cli/test_settings_unset
+++ b/e2e/cli/test_settings_unset
@@ -4,3 +4,9 @@ mise settings set python.compile true
 assert "mise settings get python.compile" "true"
 mise settings unset python.compile
 assert_fail "mise settings get python.compile" "mise ERROR Setting [python.compile] is not set"
+
+# regression: a parent key stored as an inline table must not panic on unset
+settings_config="$MISE_CONFIG_DIR/config.toml"
+printf '[settings]\npython = { compile = true }\n' >"$settings_config"
+mise settings unset python.compile
+assert_fail "mise settings get python.compile" "mise ERROR Setting [python.compile] is not set"

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -72,19 +72,22 @@ pub fn set(mut key: &str, value: &str, add: bool, local: bool) -> Result<()> {
         settings.set_implicit(true);
         config["settings"] = toml_edit::Item::Table(settings);
     }
-    if let Some(mut settings) = config["settings"].as_table_mut() {
-        if let Some((parent_key, child_key)) = key.split_once('.') {
-            key = child_key;
-            settings = settings
-                .entry(parent_key)
-                .or_insert({
-                    let mut t = toml_edit::Table::new();
-                    t.set_implicit(true);
-                    toml_edit::Item::Table(t)
-                })
-                .as_table_mut()
-                .unwrap();
-        }
+    if let Some(settings) = config["settings"].as_table_like_mut() {
+        let settings: &mut dyn toml_edit::TableLike =
+            if let Some((parent_key, child_key)) = key.split_once('.') {
+                key = child_key;
+                settings
+                    .entry(parent_key)
+                    .or_insert({
+                        let mut t = toml_edit::Table::new();
+                        t.set_implicit(true);
+                        toml_edit::Item::Table(t)
+                    })
+                    .as_table_like_mut()
+                    .ok_or_else(|| eyre!("Setting [{parent_key}] is not a table"))?
+            } else {
+                settings
+            };
 
         let value = match settings.get(key) {
             Some(current) if add && current.as_array().is_some() => {

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -1,4 +1,4 @@
-use eyre::Result;
+use eyre::{Result, eyre};
 use toml_edit::DocumentMut;
 
 use crate::config::settings::SettingsFile;
@@ -32,19 +32,22 @@ pub fn unset(mut key: &str, local: bool) -> Result<()> {
     };
     let raw = file::read_to_string(&path)?;
     let mut config: DocumentMut = raw.parse()?;
-    if let Some(mut settings) = config["settings"].as_table_mut() {
-        if let Some((parent_key, child_key)) = key.split_once('.') {
-            key = child_key;
-            settings = settings
-                .entry(parent_key)
-                .or_insert({
-                    let mut t = toml_edit::Table::new();
-                    t.set_implicit(true);
-                    toml_edit::Item::Table(t)
-                })
-                .as_table_mut()
-                .unwrap();
-        }
+    if let Some(settings) = config["settings"].as_table_like_mut() {
+        let settings: &mut dyn toml_edit::TableLike =
+            if let Some((parent_key, child_key)) = key.split_once('.') {
+                key = child_key;
+                settings
+                    .entry(parent_key)
+                    .or_insert({
+                        let mut t = toml_edit::Table::new();
+                        t.set_implicit(true);
+                        toml_edit::Item::Table(t)
+                    })
+                    .as_table_like_mut()
+                    .ok_or_else(|| eyre!("Setting [{parent_key}] is not a table"))?
+            } else {
+                settings
+            };
         settings.remove(key);
         // validate
         let _: SettingsFile = toml::from_str(&config.to_string())?;


### PR DESCRIPTION
## Problem

`mise settings set <parent>.<child>` and `mise settings unset <parent>.<child>` panic when the parent key already exists as an **inline table** under `[settings]`.

```toml
# ~/.config/mise/config.toml
[settings]
python = { compile = true }
```

```console
$ mise settings set python.compile false
# The application panicked (crashed).
# Message:  called `Option::unwrap()` on a `None` value
$ mise settings unset python.compile
# same panic
```

Both `src/cli/settings/set.rs` and `src/cli/settings/unset.rs` descended into the parent key with `.as_table_mut().unwrap()`. `Item::as_table_mut()` returns `None` for an inline table (`Value::InlineTable`), so the `.unwrap()` panicked. `python = { compile = true }` is a perfectly natural hand-authored form, so this is easy to hit.

## Fix

Use `as_table_like_mut()` — which handles both the `[table]` header form and the inline-table form — and return a clear error for the only remaining impossible case (a parent set to a non-table scalar) instead of panicking.

This mirrors the exact same fix already applied to `mise config set` in #11153, which replaced the same `as_table_mut().unwrap()` anti-pattern with `as_table_like_mut().ok_or_else(...)?`.

## Tests

Added regression cases to `e2e/cli/test_settings_set` and `e2e/cli/test_settings_unset` that seed an inline-table parent (`python = { compile = true }`) and verify `settings set` / `settings unset` operate on it without panicking.

---

*This PR was prepared with the help of an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `mise settings set` for dotted keys when the parent is stored as a TOML inline table.
  * Fixed `mise settings unset` for the same inline-table parent scenario.
  * Improved behavior when a dotted key’s parent isn’t table-like, returning a clear error instead of panicking.
* **Tests**
  * Added end-to-end CLI regression tests for `settings set`/`settings unset` covering dotted keys under inline-table parents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->