### PR TITLE
registry: add remotecli

### DIFF
--- a/registry/remotecli.toml
+++ b/registry/remotecli.toml
@@ -1,0 +1,4 @@
+backends = ["github:remoteoss/remote-cli"]
+description = "Interact with the Remote.com API to manage your company and employees directly from your terminal"
+os = ["linux", "macos"]
+test = { cmd = "remotecli --version", expected = "remote version v{{version}}" }


### PR DESCRIPTION
Official CLI for the Remote.com API.

Repo: https://github.com/remoteoss/remote-cli
Docs: https://developer.remote.com/docs/remote-cli-quick-start

Popularity: 3 stars, 0 forks. First-party vendor CLI published under Remote's org; newly released (v0.1.3, 2026-07-20).

Verified: `mise use github:remoteoss/remote-cli` installs the binary as `remotecli` and `remotecli --version` prints `remote version v0.1.3` (linux-amd64, darwin-arm64). The github backend also verifies SHA256 + SLSA provenance.