### PR TITLE
fix(activate): avoid zsh/parameter autoload during zsh activation

### DIFF
--- a/e2e/env/test_zsh_consecutive_precmd_runs
+++ b/e2e/env/test_zsh_consecutive_precmd_runs
@@ -25,6 +25,14 @@ if [[ ${__MISE_ZSH_CHPWD_RAN:-unset} != "0" ]]; then
   exit 1
 fi
 
+# activation must not autoload zsh/parameter: the dlopen it triggers can
+# deadlock under Rosetta in login shells (discussion #11187)
+_mise_hook_env_state >/dev/null
+if zmodload | grep -q "zsh/parameter"; then
+  echo "expected activation to not autoload the zsh/parameter module"
+  exit 1
+fi
+
 _mise_hook_precmd
 
 if [[ ${__MISE_ZSH_PRECMD_RUN:-unset} != "1" ]]; then

--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -35,7 +35,11 @@ _mise_hook() {
   eval "$(/some/dir/mise hook-env --status -s zsh "$@")";
 }
 _mise_hook_env_state() {
-  local -a keys=(${(ok)parameters[(I)MISE_*]})
+  # enumerate MISE_* vars with the typeset builtin rather than
+  # ${parameters}: referencing that special array autoloads the
+  # zsh/parameter module via dlopen, which can deadlock under
+  # Rosetta in login shells (https://github.com/jdx/mise/discussions/11187)
+  local -a keys=(${(o)${(f)"$(typeset +m 'MISE_*' 2>/dev/null)"}##* })
   if (( $#keys > 0 )); then
     typeset -p "${keys[@]}" 2>/dev/null
   fi

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -66,7 +66,11 @@ impl Shell for Zsh {
               eval "$({exe} hook-env{flags} -s zsh "$@")";
             }}
             _mise_hook_env_state() {{
-              local -a keys=(${{(ok)parameters[(I)MISE_*]}})
+              # enumerate MISE_* vars with the typeset builtin rather than
+              # ${{parameters}}: referencing that special array autoloads the
+              # zsh/parameter module via dlopen, which can deadlock under
+              # Rosetta in login shells (https://github.com/jdx/mise/discussions/11187)
+              local -a keys=(${{(o)${{(f)"$(typeset +m 'MISE_*' 2>/dev/null)"}}##* }})
               if (( $#keys > 0 )); then
                 typeset -p "${{keys[@]}}" 2>/dev/null
               fi


### PR DESCRIPTION
## Summary

Fixes the v2026.7.11 regression reported in https://github.com/jdx/mise/discussions/11187: `mise activate zsh` could hang a non-interactive login shell under Rosetta.

The `_mise_hook_env_state` helper added in #11134 referenced the special `${parameters}` associative array, which autoloads the `zsh/parameter` module via `dlopen`. Because activation snapshots the env state eagerly (`export __MISE_ZSH_ACTIVATE_ENV="$(_mise_hook_env_state)"`), every shell startup — including non-interactive login shells that never run `precmd` — triggered that `dlopen`. The reporter's stack sample shows a translated x86_64 zsh deadlocked in dyld/Rosetta while loading `/usr/lib/zsh/5.9/zsh/parameter.so`, blocking the shell before it could `exec` its target command.

## Fix

Enumerate `MISE_*` variables with the `typeset` builtin instead, which requires no module:

```zsh
local -a keys=(${(o)${(f)"$(typeset +m 'MISE_*' 2>/dev/null)"}##* })
```

`typeset +m` prints one matching parameter name per line (prefixed with attributes like `array`/`integer`, hence the `##* ` strip); the result is sorted with `(o)` exactly like the previous `${(ok)parameters[...]}` lookup, so the snapshot comparison semantics from #11134 are unchanged. Verified in a fresh `zsh -f` that a full activation plus `_mise_hook_env_state` calls leave only `zsh/main` loaded, whereas the previous code loads `zsh/parameter` on first reference.

The pre-existing `${+functions[...]}` references in the deactivation script also touch `zsh/parameter`, but that block is only emitted when re-activating an already-activated shell and predates this regression, so it's left alone.

## Validation

- `cargo insta test -- shell::zsh` (activate snapshot updated)
- `mise run test:e2e env/test_zsh_consecutive_precmd_runs cli/test_zsh_precmd_runs_once`
- new e2e assertion: activation + `_mise_hook_env_state` must not autoload `zsh/parameter`
- `mise run lint-fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted shell-hook change with snapshot and e2e coverage; behavior is intended to match prior env snapshot semantics without module autoload.
> 
> **Overview**
> Fixes a **v2026.7.11 regression** where `mise activate zsh` could hang non-interactive login shells under Rosetta. Eager activation snapshots call `_mise_hook_env_state`, which previously used `${parameters}` to list `MISE_*` vars; that reference **autoloads `zsh/parameter` via `dlopen`**, which can deadlock in that environment.
> 
> **`_mise_hook_env_state`** now discovers `MISE_*` names with **`typeset +m 'MISE_*'`** (sorted with `(o)` like before) and still emits definitions via `typeset -p`, so precmd skip logic comparing `__MISE_ZSH_ACTIVATE_ENV` is unchanged without loading the module.
> 
> An **e2e check** asserts activation plus `_mise_hook_env_state` does not load `zsh/parameter`; the **activate snapshot** is updated to match generated shell code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b4813b4d3ad0954a515427bc9d7d2d7f825b92e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zsh environment activation to avoid unintentionally loading the `zsh/parameter` module.
  * Enhanced detection and reporting of `MISE_*` environment variables during shell hook execution.
  * Added verification to ensure activation behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->