### PR TITLE
fix(shim): actionable error for unresolved Windows exe-shim dispatch

### DIFF
--- a/e2e-win/shim.Tests.ps1
+++ b/e2e-win/shim.Tests.ps1
@@ -57,6 +57,26 @@ Describe 'shim_mode' {
         Test-Path -Path (Join-Path -Path $shimPath -ChildPath go) -PathType Leaf | Should -Be $false
     }
 
+    It 'exe shim dispatch for an unresolvable bin gives an actionable error' {
+        # Reproduces discussion #11183: an exe-mode shim dispatches through
+        # `mise x -- <tool>` with __MISE_SHIM_PATH set. When the tool cannot be
+        # resolved (e.g. a project-scoped tool invoked from outside the project),
+        # the Windows arm used to surface the opaque `cannot find binary path`.
+        # It should now surface the same which_shim-style guidance Unix gets.
+        $fakeShim = Join-Path -Path $shimPath -ChildPath "mise-11183-not-real.exe"
+        $env:__MISE_SHIM_PATH = $fakeShim
+        try {
+            $out = mise x -- mise-11183-not-real 2>&1
+            $LASTEXITCODE | Should -Not -Be 0
+            $joined = ($out | Out-String)
+            $joined | Should -Not -Match "cannot find binary path"
+            $joined | Should -Match "not a valid shim|No version is set for shim"
+        }
+        finally {
+            Remove-Item Env:\__MISE_SHIM_PATH -ErrorAction SilentlyContinue
+        }
+    }
+
     It 'run on hardlink' {
         mise settings windows_shim_mode "hardlink"
 

--- a/e2e-win/shim.Tests.ps1
+++ b/e2e-win/shim.Tests.ps1
@@ -66,11 +66,13 @@ Describe 'shim_mode' {
         $fakeShim = Join-Path -Path $shimPath -ChildPath "mise-11183-not-real.exe"
         $env:__MISE_SHIM_PATH = $fakeShim
         try {
-            $out = mise x -- mise-11183-not-real 2>&1
+            $out = mise x -- mise-11183-not-real.exe 2>&1
             $LASTEXITCODE | Should -Not -Be 0
             $joined = ($out | Out-String)
             $joined | Should -Not -Match "cannot find binary path"
             $joined | Should -Match "not a valid shim|No version is set for shim"
+            $joined | Should -Match "mise-11183-not-real"
+            $joined | Should -Not -Match "mise-11183-not-real\.exe"
         }
         finally {
             Remove-Item Env:\__MISE_SHIM_PATH -ErrorAction SilentlyContinue

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -324,6 +324,7 @@ where
             std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
         });
         let program_name = program.to_string_lossy().into_owned();
+        let is_shim_dispatch = env::MISE_SHIM_PATH.read().unwrap().is_some();
         match which::which_in_all(&program, lookup_path, cwd) {
             Ok(mut candidates) => {
                 match candidates.find(|candidate| !crate::file::is_active_mise_shim(candidate)) {
@@ -331,15 +332,16 @@ where
                     // When invoked as a shim (`__MISE_SHIM_PATH` set), give the
                     // actionable `which_shim`-style error rather than the opaque
                     // `cannot find binary path` (discussion #11183).
-                    None if env::MISE_SHIM_PATH.read().unwrap().is_some() => {
+                    None if is_shim_dispatch => {
                         return Err(crate::shims::err_shim_not_found(&program_name).await);
                     }
                     None => program, // Fall back to original if resolution fails
                 }
             }
-            Err(_) if env::MISE_SHIM_PATH.read().unwrap().is_some() => {
+            Err(which::Error::CannotFindBinaryPath) if is_shim_dispatch => {
                 return Err(crate::shims::err_shim_not_found(&program_name).await);
             }
+            Err(err) if is_shim_dispatch => return Err(err.into()),
             Err(_) => program, // Fall back to original if resolution fails
         }
     };
@@ -428,17 +430,22 @@ where
     // Capture the requested program name before `which_in_all` consumes it, so
     // a resolution failure while dispatching a shim can name the tool.
     let program_name = program.to_string_lossy().into_owned();
-    let resolved = which::which_in_all(program, lookup_path, cwd)
-        .ok()
-        .and_then(|mut candidates| {
+    let is_shim_dispatch = env::MISE_SHIM_PATH.read().unwrap().is_some();
+    let resolved = match which::which_in_all(program, lookup_path, cwd) {
+        Ok(mut candidates) => {
             candidates.find(|candidate| !crate::file::is_active_mise_shim(candidate))
-        });
+        }
+        Err(which::Error::CannotFindBinaryPath) if is_shim_dispatch => {
+            return Err(crate::shims::err_shim_not_found(&program_name).await);
+        }
+        Err(err) => return Err(err.into()),
+    };
     let program = match resolved {
         Some(program) => program,
         // When invoked as a shim (`__MISE_SHIM_PATH` set), give the actionable
         // `which_shim`-style error instead of the opaque `cannot find binary
         // path` (discussion #11183).
-        None if env::MISE_SHIM_PATH.read().unwrap().is_some() => {
+        None if is_shim_dispatch => {
             return Err(crate::shims::err_shim_not_found(&program_name).await);
         }
         None => return Err(which::Error::CannotFindBinaryPath.into()),

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -323,17 +323,23 @@ where
                 .collect();
             std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
         });
+        let program_name = program.to_string_lossy().into_owned();
         match which::which_in_all(&program, lookup_path, cwd) {
             Ok(mut candidates) => {
                 match candidates.find(|candidate| !crate::file::is_active_mise_shim(candidate)) {
                     Some(resolved) => resolved.into_os_string(),
+                    // When invoked as a shim (`__MISE_SHIM_PATH` set), give the
+                    // actionable `which_shim`-style error rather than the opaque
+                    // `cannot find binary path` (discussion #11183).
                     None if env::MISE_SHIM_PATH.read().unwrap().is_some() => {
-                        return Err(which::Error::CannotFindBinaryPath.into());
+                        return Err(crate::shims::err_shim_not_found(&program_name).await);
                     }
                     None => program, // Fall back to original if resolution fails
                 }
             }
-            Err(err) if env::MISE_SHIM_PATH.read().unwrap().is_some() => return Err(err.into()),
+            Err(_) if env::MISE_SHIM_PATH.read().unwrap().is_some() => {
+                return Err(crate::shims::err_shim_not_found(&program_name).await);
+            }
             Err(_) => program, // Fall back to original if resolution fails
         }
     };
@@ -419,9 +425,24 @@ where
             .collect();
         std::env::join_paths(mise_added.iter().chain(original.iter())).unwrap()
     });
-    let program = which::which_in_all(program, lookup_path, cwd)?
-        .find(|candidate| !crate::file::is_active_mise_shim(candidate))
-        .ok_or(which::Error::CannotFindBinaryPath)?;
+    // Capture the requested program name before `which_in_all` consumes it, so
+    // a resolution failure while dispatching a shim can name the tool.
+    let program_name = program.to_string_lossy().into_owned();
+    let resolved = which::which_in_all(program, lookup_path, cwd)
+        .ok()
+        .and_then(|mut candidates| {
+            candidates.find(|candidate| !crate::file::is_active_mise_shim(candidate))
+        });
+    let program = match resolved {
+        Some(program) => program,
+        // When invoked as a shim (`__MISE_SHIM_PATH` set), give the actionable
+        // `which_shim`-style error instead of the opaque `cannot find binary
+        // path` (discussion #11183).
+        None if env::MISE_SHIM_PATH.read().unwrap().is_some() => {
+            return Err(crate::shims::err_shim_not_found(&program_name).await);
+        }
+        None => return Err(which::Error::CannotFindBinaryPath.into()),
+    };
     env::remove_var(env::MISE_SHIM_PATH_ENV);
     let args: Vec<OsString> = args.into_iter().map(Into::into).collect();
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -176,6 +176,7 @@ async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -
 /// on Windows, invoked with `__MISE_SHIM_PATH` set). Without this, that path
 /// surfaces the opaque `cannot find binary path`; symlink shims already get
 /// this message directly from `which_shim`. See discussion #11183.
+#[cfg(not(test))]
 pub async fn err_shim_not_found(bin_name: &str) -> color_eyre::Report {
     // Windows exe shims are invoked as `<tool>.exe`; name `<tool>` in the message.
     let bin_stem = bin_name

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -171,6 +171,30 @@ async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -
     err_no_version_set(config, ts, bin_name, tvs).await
 }
 
+/// Build the actionable, `which_shim`-style resolution error for a bin that a
+/// shim failed to resolve while dispatching through `mise x` (the exe-mode shim
+/// on Windows, invoked with `__MISE_SHIM_PATH` set). Without this, that path
+/// surfaces the opaque `cannot find binary path`; symlink shims already get
+/// this message directly from `which_shim`. See discussion #11183.
+pub async fn err_shim_not_found(bin_name: &str) -> color_eyre::Report {
+    // Windows exe shims are invoked as `<tool>.exe`; name `<tool>` in the message.
+    let bin_stem = bin_name
+        .strip_suffix(std::env::consts::EXE_SUFFIX)
+        .unwrap_or(bin_name);
+    let build = async {
+        let config = Config::get().await?;
+        let ts = ToolsetBuilder::new().build(&config).await?;
+        let tvs = ts.list_rtvs_with_bin(&config, bin_stem).await?;
+        // err_no_version_set always returns Err; map its Ok arm defensively.
+        err_no_version_set(&config, ts, bin_stem, tvs)
+            .await
+            .map(|_| eyre!("cannot find binary path: {bin_stem}"))
+    };
+    match build.await {
+        Ok(report) | Err(report) => report,
+    }
+}
+
 pub async fn reshim(config: &Arc<Config>, ts: &Toolset, force: bool) -> Result<()> {
     let _lock = LockFile::new(&dirs::SHIMS)
         .with_callback(|l| {


### PR DESCRIPTION
## Problem

On Windows, the default `windows_shim_mode = "exe"` shim dispatches through `mise x -- <tool>` with `__MISE_SHIM_PATH` set (see [`crates/mise-shim/src/main.rs`](crates/mise-shim/src/main.rs)). When the tool can't be resolved — e.g. a **project-scoped** tool invoked from a directory **outside** the project — the Windows arm of `exec_program` hard-propagated `which::Error::CannotFindBinaryPath`:

```
mise ERROR cannot find binary path
```

Unix doesn't hit this: symlink shims route through `which_shim`, which has a system-PATH fallback and fails with the actionable **`No version is set for shim: <bin> … mise use -g <tool>@<version>`**. So the Windows exe-shim path lost the helpful diagnostic that the equivalent Unix situation gets.

Reported in discussion #11183 (with a clean diagnosis). Related: #10522 (better message / `mise doctor` for this string — this is one concrete producer); distinct from #9528 (stripped `PATHEXT`, same string, different cause).

## Fix

- Add `shims::err_shim_not_found(bin_name)`, which rebuilds the toolset and reuses the existing `err_no_version_set` to produce the same `which_shim`-style message (stripping the `.exe` suffix so it names `<tool>`, not `<tool>.exe`).
- Call it from **both** `exec_program` arms when program resolution fails **and** the invocation is a shim dispatch (`__MISE_SHIM_PATH` set). Non-shim invocations are unchanged (still fall back to the bare program name / `CannotFindBinaryPath`).

The report also asked for the system-PATH fallback. That's already covered on Windows: `which_in_all` searches the full reordered PATH (mise-added + original system paths, minus the shims dir), so a bin present on the system PATH is still found and executed — only the genuinely-unresolvable case now yields the actionable error.

### Note on the Unix arm

The Unix `exec_program` arm also hard-returned `CannotFindBinaryPath` under a shim dispatch (it's just rarely reached, since Unix defaults to symlink shims that go through `which_shim`). This change routes that arm through the same helper too, for cross-platform consistency. Gated on `__MISE_SHIM_PATH`, so normal `mise exec` behavior is untouched.

## Test

Added a Windows e2e case in [`e2e-win/shim.Tests.ps1`](e2e-win/shim.Tests.ps1) that drives the exact path — `mise x -- <bin>` with `__MISE_SHIM_PATH` set for an unresolvable bin — and asserts the output is the actionable guidance, not `cannot find binary path`. (`go` can't be used here: it's preinstalled on `windows-latest` and resolves via the system-PATH fallback, which is why the original repro used a niche tool.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is gated on `__MISE_SHIM_PATH` during failed resolution only; normal exec and successful shim paths are unchanged.
> 
> **Overview**
> Fixes the opaque **`cannot find binary path`** error when Windows **exe-mode** shims dispatch through `mise x` with `__MISE_SHIM_PATH` set and the tool cannot be resolved (e.g. project-scoped tools run outside the project), matching the actionable messages Unix symlink shims already get from `which_shim`.
> 
> Adds **`shims::err_shim_not_found`**, which rebuilds the toolset and reuses **`err_no_version_set`** (stripping `.exe` from the tool name in messages). **`exec_program`** on Unix and Windows now routes shim-dispatch resolution failures through that helper; ordinary `mise exec` behavior is unchanged.
> 
> Adds a Windows e2e test that simulates exe-shim dispatch for a fake tool and asserts the output mentions the tool stem and avoids the old error string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b56d27f2368b4559385f6409b9f39871b25fd5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shim-dispatch failures by preserving the originally requested program name for more accurate guidance.
  * Replaced opaque “cannot find binary path” output with actionable “not a valid shim” / “no version is set” style messaging.
  * Standardized behavior across Unix and Windows, including handling `.exe` tool names consistently.
* **Tests**
  * Added an end-to-end test covering Windows shim dispatch when `__MISE_SHIM_PATH` points to a missing `.exe` shim, validating exit code and expected message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->