### PR TITLE
fix(http): don't cap remote-fetch commands to 3s under prefer_offline

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -433,7 +433,7 @@ pub(crate) fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> 
             return Some(i);
         }
 
-        let flag_takes_value = if arg.starts_with("--") {
+        let flag_takes_separate_value = if arg.starts_with("--") {
             if arg.contains('=') {
                 false
             } else {
@@ -446,12 +446,12 @@ pub(crate) fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> 
             // malformed byte becomes a multi-byte U+FFFD and byte index 2 may not
             // be a char boundary. A short flag is always ASCII, so a non-ASCII
             // prefix simply matches no value-taking flag.
-            flags_with_values.iter().any(|f| f == flag_name)
+            arg.len() == 2 && flags_with_values.iter().any(|f| f == flag_name)
         } else {
             false
         };
 
-        if flag_takes_value && i + 1 < args.len() {
+        if flag_takes_separate_value && i + 1 < args.len() {
             i += 2;
         } else {
             i += 1;
@@ -956,6 +956,26 @@ mod tests {
         ];
 
         assert!(!uses_deprecated_backends_alias(&cmd, &args));
+    }
+
+    #[test]
+    fn test_first_non_global_arg_idx_handles_attached_short_flag_values() {
+        let cmd = Cli::command();
+        let args = |args: &[&str]| {
+            args.iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>()
+        };
+
+        for args in [
+            args(&["mise", "-C", "/tmp", "lock"]),
+            args(&["mise", "-C/tmp", "lock"]),
+            args(&["mise", "-C=/tmp", "lock"]),
+            args(&["mise", "-j8", "lock"]),
+        ] {
+            let idx = first_non_global_arg_idx(&cmd, &args).unwrap();
+            assert_eq!(args[idx], "lock");
+        }
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -419,7 +419,7 @@ fn escape_args_after_separator(args: &[String], separator_idx: usize) -> Vec<Str
     result
 }
 
-fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> Option<usize> {
+pub(crate) fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> Option<usize> {
     let (flags_with_values, _) = get_global_flags(cmd);
     let mut i = 1;
     while i < args.len() {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -913,7 +913,7 @@ impl Settings {
 
     pub fn fetch_remote_versions_timeout(&self) -> Duration {
         let timeout = self.configured_fetch_remote_versions_timeout();
-        if self.prefer_offline() {
+        if self.bound_remote_version_lookups() {
             timeout.min(Duration::from_secs(3))
         } else {
             timeout
@@ -922,6 +922,19 @@ impl Settings {
 
     pub fn configured_fetch_remote_versions_timeout(&self) -> Duration {
         duration::parse_duration(&self.fetch_remote_versions_timeout).unwrap()
+    }
+
+    /// Whether remote-version lookups should use the aggressive fast-path budget
+    /// (a single ~3s attempt with no retries). This is on under `prefer_offline`
+    /// so shims and shell activation never stall — but NOT for commands whose
+    /// whole job is to enumerate remote versions/tags (`mise lock`, `ls-remote`,
+    /// `outdated`, `upgrade`), which must honor the full configured
+    /// `fetch_remote_versions_timeout` and retry budget even when
+    /// `prefer_offline` is set.
+    ///
+    /// See <https://github.com/jdx/mise/discussions/11185>.
+    pub fn bound_remote_version_lookups(&self) -> bool {
+        self.prefer_offline() && !env::REMOTE_FETCH_COMMAND.load(Ordering::Relaxed)
     }
 
     /// duration that remote version cache is kept for
@@ -949,7 +962,7 @@ impl Settings {
     /// back to cached/local behavior. In particular, shims must not multiply a
     /// stalled resolver timeout by the configured retry count.
     pub fn http_retries(&self) -> i64 {
-        if self.prefer_offline() {
+        if self.bound_remote_version_lookups() {
             0
         } else {
             self.http_retries

--- a/src/env.rs
+++ b/src/env.rs
@@ -751,27 +751,26 @@ fn prefer_offline(args: &[String]) -> bool {
         .unwrap_or_default()
 }
 
-/// See [`REMOTE_FETCH_COMMAND`]. Mirrors the argument parsing in
-/// [`prefer_offline`]: the first non-flag argument after the binary is the
-/// subcommand.
+/// See [`REMOTE_FETCH_COMMAND`].
 fn remote_fetch_command(args: &[String]) -> bool {
-    args.iter()
-        .take_while(|a| *a != "--")
-        .filter(|a| !a.starts_with('-'))
-        .nth(1)
-        .map(|a| {
-            [
-                "lock",
-                "ls-remote",
-                "list-all",
-                "list-remote",
-                "outdated",
-                "upgrade",
-                "up",
-            ]
-            .contains(&a.as_str())
-        })
-        .unwrap_or_default()
+    crate::cli::first_non_global_arg_idx(
+        &<crate::cli::Cli as clap::CommandFactory>::command(),
+        args,
+    )
+    .and_then(|idx| args.get(idx))
+    .map(|a| {
+        [
+            "lock",
+            "ls-remote",
+            "list-all",
+            "list-remote",
+            "outdated",
+            "upgrade",
+            "up",
+        ]
+        .contains(&a.as_str())
+    })
+    .unwrap_or_default()
 }
 
 /// returns true if missing required env vars should produce warnings instead of errors
@@ -1000,6 +999,31 @@ mod tests {
         assert!(!auto_env_default_for_version(&v("2027.5.9")));
         assert!(auto_env_default_for_version(&v("2027.6.0")));
         assert!(auto_env_default_for_version(&v("2028.1.0")));
+    }
+
+    #[test]
+    fn test_remote_fetch_command_skips_global_option_values() {
+        let args = |args: &[&str]| {
+            args.iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>()
+        };
+
+        assert!(remote_fetch_command(&args(&[
+            "mise", "--cd", "/tmp", "lock"
+        ])));
+        assert!(remote_fetch_command(&args(&[
+            "mise",
+            "--profile",
+            "development",
+            "ls-remote",
+        ])));
+        assert!(remote_fetch_command(&args(&[
+            "mise",
+            "--cd=/tmp",
+            "--profile=development",
+            "outdated",
+        ])));
     }
 
     #[cfg(unix)]

--- a/src/env.rs
+++ b/src/env.rs
@@ -727,50 +727,59 @@ fn prefer_offline(args: &[String]) -> bool {
         return true;
     }
 
-    // Otherwise fall back to the original command-based logic
-    args.iter()
-        .take_while(|a| *a != "--")
-        .filter(|a| !a.starts_with('-') || *a == "--prefer-offline")
-        .nth(1)
+    let command_idx = first_non_global_arg_idx(args);
+    let settings_args_end = command_idx.unwrap_or(args.len());
+    if args[..settings_args_end]
+        .iter()
+        .any(|arg| arg == "--prefer-offline")
+    {
+        return true;
+    }
+
+    prefer_offline_command(args)
+}
+
+fn first_non_global_arg_idx(args: &[String]) -> Option<usize> {
+    crate::cli::first_non_global_arg_idx(
+        &<crate::cli::Cli as clap::CommandFactory>::command(),
+        args,
+    )
+}
+
+fn command_arg(args: &[String]) -> Option<&str> {
+    first_non_global_arg_idx(args)
+        .and_then(|idx| args.get(idx))
+        .map(String::as_str)
+}
+
+fn prefer_offline_command(args: &[String]) -> bool {
+    command_arg(args)
         .map(|a| {
             [
-                "--prefer-offline",
-                "activate",
-                "current",
-                "direnv",
-                "env",
-                "exec",
-                "hook-env",
-                "ls",
-                "where",
-                "which",
+                "activate", "current", "direnv", "env", "exec", "hook-env", "ls", "where", "which",
                 "x",
             ]
-            .contains(&a.as_str())
+            .contains(&a)
         })
         .unwrap_or_default()
 }
 
 /// See [`REMOTE_FETCH_COMMAND`].
 fn remote_fetch_command(args: &[String]) -> bool {
-    crate::cli::first_non_global_arg_idx(
-        &<crate::cli::Cli as clap::CommandFactory>::command(),
-        args,
-    )
-    .and_then(|idx| args.get(idx))
-    .map(|a| {
-        [
-            "lock",
-            "ls-remote",
-            "list-all",
-            "list-remote",
-            "outdated",
-            "upgrade",
-            "up",
-        ]
-        .contains(&a.as_str())
-    })
-    .unwrap_or_default()
+    command_arg(args)
+        .map(|a| {
+            [
+                "lock",
+                "ls-remote",
+                "list-all",
+                "list-remote",
+                "outdated",
+                "upgrade",
+                "up",
+            ]
+            .contains(&a)
+        })
+        .unwrap_or_default()
 }
 
 /// returns true if missing required env vars should produce warnings instead of errors
@@ -1023,6 +1032,36 @@ mod tests {
             "--cd=/tmp",
             "--profile=development",
             "outdated",
+        ])));
+    }
+
+    #[test]
+    fn test_prefer_offline_command_skips_global_option_values() {
+        let args = |args: &[&str]| {
+            args.iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>()
+        };
+
+        assert!(prefer_offline_command(&args(&[
+            "mise", "--cd", "/tmp", "activate"
+        ])));
+        assert!(prefer_offline_command(&args(&[
+            "mise",
+            "--profile",
+            "development",
+            "hook-env",
+        ])));
+        assert!(prefer_offline_command(&args(&["mise", "-C/tmp", "env",])));
+        assert!(!prefer_offline_command(&args(&[
+            "mise", "--cd", "/tmp", "lock"
+        ])));
+        assert!(prefer_offline(&args(&[
+            "mise",
+            "--cd",
+            "/tmp",
+            "--prefer-offline",
+            "lock",
         ])));
     }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -524,6 +524,14 @@ pub static __MISE_ZSH_PRECMD_RUN: Lazy<bool> = Lazy::new(|| !var_is_false("__MIS
 pub static LINUX_DISTRO: Lazy<Option<String>> = Lazy::new(linux_distro);
 pub static PREFER_OFFLINE: Lazy<AtomicBool> =
     Lazy::new(|| prefer_offline(&ARGS.read().unwrap()).into());
+/// Commands whose explicit purpose is to enumerate remote versions/tags. Under
+/// `prefer_offline`, remote-version lookups are otherwise capped to a single
+/// ~3s attempt with no retries so fast/interactive commands (shims, activation)
+/// never stall. These commands opt out of that cap so they honor the full
+/// configured `fetch_remote_versions_timeout` even when `prefer_offline` is set
+/// (https://github.com/jdx/mise/discussions/11185).
+pub static REMOTE_FETCH_COMMAND: Lazy<AtomicBool> =
+    Lazy::new(|| remote_fetch_command(&ARGS.read().unwrap()).into());
 pub static OFFLINE: Lazy<bool> = Lazy::new(|| offline(&ARGS.read().unwrap()));
 pub static WARN_ON_MISSING_REQUIRED_ENV: Lazy<bool> =
     Lazy::new(|| warn_on_missing_required_env(&ARGS.read().unwrap()));
@@ -737,6 +745,29 @@ fn prefer_offline(args: &[String]) -> bool {
                 "where",
                 "which",
                 "x",
+            ]
+            .contains(&a.as_str())
+        })
+        .unwrap_or_default()
+}
+
+/// See [`REMOTE_FETCH_COMMAND`]. Mirrors the argument parsing in
+/// [`prefer_offline`]: the first non-flag argument after the binary is the
+/// subcommand.
+fn remote_fetch_command(args: &[String]) -> bool {
+    args.iter()
+        .take_while(|a| *a != "--")
+        .filter(|a| !a.starts_with('-'))
+        .nth(1)
+        .map(|a| {
+            [
+                "lock",
+                "ls-remote",
+                "list-all",
+                "list-remote",
+                "outdated",
+                "upgrade",
+                "up",
             ]
             .contains(&a.as_str())
         })

--- a/src/http.rs
+++ b/src/http.rs
@@ -150,7 +150,7 @@ impl Client {
 
     fn request_timeout(&self) -> Duration {
         match self.kind {
-            ClientKind::Fetch if Settings::get().prefer_offline() => {
+            ClientKind::Fetch if Settings::get().bound_remote_version_lookups() => {
                 self.timeout.min(Duration::from_secs(3))
             }
             _ => self.timeout,
@@ -1793,6 +1793,26 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let _guard = set_test_prefer_offline(3);
 
         assert_eq!(client.request_timeout(), Duration::from_secs(3));
+    }
+
+    #[test]
+    fn test_remote_fetch_command_keeps_full_budget_under_prefer_offline() {
+        // Commands whose job is to enumerate remote versions/tags (`mise lock`,
+        // `ls-remote`, ...) must honor the configured timeout and retries even
+        // when prefer_offline is set.
+        // https://github.com/jdx/mise/discussions/11185
+        let client = Client::new(Duration::from_secs(30), ClientKind::Fetch).unwrap();
+        let _guard = set_test_prefer_offline(3);
+        let prev = crate::env::REMOTE_FETCH_COMMAND.swap(true, Ordering::SeqCst);
+
+        assert_eq!(client.request_timeout(), Duration::from_secs(30));
+        assert_eq!(
+            Settings::get().fetch_remote_versions_timeout(),
+            Settings::get().configured_fetch_remote_versions_timeout()
+        );
+        assert_eq!(Settings::get().http_retries(), 3);
+
+        crate::env::REMOTE_FETCH_COMMAND.store(prev, Ordering::SeqCst);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1358,6 +1358,22 @@ mod tests {
         SettingsGuard { _lock: lock }
     }
 
+    struct AtomicBoolGuard {
+        value: &'static std::sync::atomic::AtomicBool,
+        previous: bool,
+    }
+    impl AtomicBoolGuard {
+        fn set(value: &'static std::sync::atomic::AtomicBool, enabled: bool) -> Self {
+            let previous = value.swap(enabled, Ordering::SeqCst);
+            Self { value, previous }
+        }
+    }
+    impl Drop for AtomicBoolGuard {
+        fn drop(&mut self) {
+            self.value.store(self.previous, Ordering::SeqCst);
+        }
+    }
+
     struct UnavailableHostsGuard {
         host_keys: Vec<String>,
     }
@@ -1803,7 +1819,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         // https://github.com/jdx/mise/discussions/11185
         let client = Client::new(Duration::from_secs(30), ClientKind::Fetch).unwrap();
         let _guard = set_test_prefer_offline(3);
-        let prev = crate::env::REMOTE_FETCH_COMMAND.swap(true, Ordering::SeqCst);
+        let _remote_fetch_guard = AtomicBoolGuard::set(&crate::env::REMOTE_FETCH_COMMAND, true);
 
         assert_eq!(client.request_timeout(), Duration::from_secs(30));
         assert_eq!(
@@ -1811,8 +1827,6 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
             Settings::get().configured_fetch_remote_versions_timeout()
         );
         assert_eq!(Settings::get().http_retries(), 3);
-
-        crate::env::REMOTE_FETCH_COMMAND.store(prev, Ordering::SeqCst);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

- Stop applying the `prefer_offline` fast-path budget (a single ~3s attempt, no retries) to commands whose whole job is to enumerate remote versions/tags.
- Add `env::REMOTE_FETCH_COMMAND` (`lock`, `ls-remote`, `outdated`, `upgrade`) and `Settings::bound_remote_version_lookups()`.
- These commands now honor the full configured `fetch_remote_versions_timeout` and retry budget even when `prefer_offline` is set. Shims, shell activation, and `mise x` are unchanged.

Fixes #11185.

## Root cause

#11066 ("fail fast when network is unavailable") caps remote-version lookups at 3s and disables HTTP retries whenever `Settings::prefer_offline()` is true, so latency-sensitive fast commands (shims, activation, `mise x`) make at most one bounded attempt.

But `prefer_offline` is also a persistent user setting / `MISE_PREFER_OFFLINE` env var, and the cap was gated on `prefer_offline()` alone — with no distinction for the command being run. So with `prefer_offline` enabled, `mise lock` (whose entire purpose is to fetch remote tags/releases to build a lockfile) is forced into a single 3s no-retry attempt.

The `3.00s` in the error is only reachable through this cap — `Duration::from_secs(3)` is the sole 3s constant in the HTTP stack, and both cap sites plus `request_timeout()` are gated on `prefer_offline()`. Before #11066 the cap didn't exist, which is why reverting to v2026.7.7 works.

## User impact

With `prefer_offline` set:

```
mise WARN  [openai/codex] failed to fetch version tags for lockfile, URL may be incorrect:
HTTP timed out after 3.00s for https://api.github.com/repos/openai/codex/releases?per_page=100
(change with `fetch_remote_versions_timeout` or env `MISE_FETCH_REMOTE_VERSIONS_TIMEOUT`).
```

Raising `fetch_remote_versions_timeout` to 20s/30s has no effect — the cap silently overrides it, even though the hint tells the user to change that exact setting. After this change, `mise lock` / `ls-remote` / `outdated` / `upgrade` use the configured timeout and retries again. Fast/interactive commands keep the bounded fast-path behavior from #11066.

## Testing

- `cargo test --bin mise -- offline` — 14 passed
- `cargo test --bin mise -- http::tests` — 52 passed
- New regression test `test_remote_fetch_command_keeps_full_budget_under_prefer_offline`

*This pull request was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes early argv parsing and HTTP timeout/retry gating for prefer_offline paths; impact is scoped with new tests but affects network behavior for common CLI invocations.
> 
> **Overview**
> With **`prefer_offline`** enabled, remote version lookups were always forced through the fast-path budget (~**3s** timeout, **no retries**), so commands like **`mise lock`**, **`ls-remote`**, **`outdated`**, and **`upgrade`** could time out even when users raised **`fetch_remote_versions_timeout`**.
> 
> This change introduces **`REMOTE_FETCH_COMMAND`** and **`Settings::bound_remote_version_lookups()`** so only true fast-path usage keeps the cap; remote-enumeration commands get the full configured timeout and retry budget. HTTP fetch clients and settings now gate on **`bound_remote_version_lookups()`** instead of **`prefer_offline()`** alone.
> 
> **`prefer_offline`** / command classification no longer treats global option values as the subcommand: detection goes through shared **`first_non_global_arg_idx`**, including a fix for attached short flags (**`-C/tmp`**, **`-j8`**). Regression tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67112c190a153a74609e5aa70e3ecb7d245dd54d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote version and tag lookup behavior for commands that explicitly fetch remote data.
  * Prevented overly aggressive timeouts and retry limits during remote enumeration when offline preference is enabled.
  * Enhanced detection of remote-enumeration commands when preceded by global options, ensuring these operations keep the full configured timeout budget and retry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->