### PR TITLE
feat(upgrade): add global flag

### DIFF
--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -61,6 +61,13 @@ This is useful for scripts to check if tools need to be upgraded.
 
 Upgrade all tools, including installed-but-inactive tools not present in the current config
 
+### `-g --global`
+
+Only upgrade tools defined in the global config file
+
+This will only upgrade tools that are defined in the global config
+(~/.config/mise/config.toml) and will skip tools defined in local config files.
+
 ### `--local`
 
 Only upgrade tools defined in local config files
@@ -115,4 +122,7 @@ $ mise upgrade --interactive
 
 # Only upgrade tools defined in local mise.toml, not global ones
 $ mise upgrade --local
+
+# Only upgrade tools defined in the global config
+$ mise upgrade --global
 ```

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4297,6 +4297,12 @@ This is useful for scripts to check if tools need to be upgraded.
 \fB\-\-inactive\fR
 Upgrade all tools, including installed\-but\-inactive tools not present in the current config
 .TP
+\fB\-g, \-\-global\fR
+Only upgrade tools defined in the global config file
+
+This will only upgrade tools that are defined in the global config
+(~/.config/mise/config.toml) and will skip tools defined in local config files.
+.TP
 \fB\-\-local\fR
 Only upgrade tools defined in local config files
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4227,6 +4227,9 @@ Examples:
     # Only upgrade tools defined in local mise.toml, not global ones
     $ mise upgrade --local
 
+    # Only upgrade tools defined in the global config
+    $ mise upgrade --global
+
 """#
     flag "-i --interactive" help="Display multiselect menu to choose which tools to upgrade"
     flag "-j --jobs" help=#"""
@@ -4261,6 +4264,14 @@ This is useful for scripts to check if tools need to be upgraded.
 """#
     }
     flag --inactive help="Upgrade all tools, including installed-but-inactive tools not present in the current config"
+    flag "-g --global" help="Only upgrade tools defined in the global config file" {
+        long_help #"""
+Only upgrade tools defined in the global config file
+
+This will only upgrade tools that are defined in the global config
+(~/.config/mise/config.toml) and will skip tools defined in local config files.
+"""#
+    }
     flag --local help="Only upgrade tools defined in local config files" {
         long_help #"""
 Only upgrade tools defined in local config files

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -76,8 +76,19 @@ pub struct Upgrade {
     dry_run_code: bool,
 
     /// Upgrade all tools, including installed-but-inactive tools not present in the current config
-    #[clap(long, verbatim_doc_comment, conflicts_with = "local")]
+    #[clap(
+        long,
+        verbatim_doc_comment,
+        conflicts_with_all = &["global", "local"]
+    )]
     inactive: bool,
+
+    /// Only upgrade tools defined in the global config file
+    ///
+    /// This will only upgrade tools that are defined in the global config
+    /// (~/.config/mise/config.toml) and will skip tools defined in local config files.
+    #[clap(long, short, verbatim_doc_comment, conflicts_with = "local")]
+    global: bool,
 
     /// Only upgrade tools defined in local config files
     ///
@@ -112,7 +123,9 @@ impl Upgrade {
     }
 
     fn scope(&self) -> ConfigScope {
-        if self.local {
+        if self.global {
+            ConfigScope::GlobalOnly
+        } else if self.local {
             ConfigScope::LocalOnly
         } else {
             ConfigScope::All
@@ -854,6 +867,9 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
     # Only upgrade tools defined in local mise.toml, not global ones
     $ <bold>mise upgrade --local</bold>
+
+    # Only upgrade tools defined in the global config
+    $ <bold>mise upgrade --global</bold>
 "#
 );
 


### PR DESCRIPTION
## Motivation

`mise upgrade` currently considers both global and project-local tool definitions. This makes it impossible to maintain only the global toolset while working inside a project with its own mise configuration.

The new flag provides a focused counterpart to `--local`:

```shell
mise upgrade --global
```

## How did it change

- Add `-g, --global` to scope toolset construction to global config files.
- Reject combinations with `--local` and `--inactive`, which represent incompatible scopes.
- Regenerate the CLI usage documentation and manpage.

## Validation

- `cargo build`
- `cargo check --tests`
- `cargo fmt --all -- --check`
- Verified the built CLI help and conflict errors for `--global` with `--local` and `--inactive`.

The existing `e2e/cli/test_upgrade` suite was attempted, but its Unix ASDF dummy-plugin executable cannot run in the native Windows environment (`os error 193`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `-g, --global` option to `mise upgrade`.
  * Upgrade only tools defined in the global configuration while skipping project-local tools.
  * Added command examples and help text for global-only upgrades.

* **Documentation**
  * Updated the CLI documentation and manual page with details about the new option.
  * Clarified that `--global` cannot be combined with local-only or inactive upgrade modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->