### PR TITLE
feat(upgrade): add global tool filtering

### DIFF
--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -23,6 +23,10 @@ If not specified, all current tools will be upgraded
 
 ## Flags
 
+### `-g --global`
+
+Only upgrade tools defined in the global config file
+
 ### `-i --interactive`
 
 Display multiselect menu to choose which tools to upgrade
@@ -115,4 +119,7 @@ $ mise upgrade --interactive
 
 # Only upgrade tools defined in local mise.toml, not global ones
 $ mise upgrade --local
+
+# Only upgrade tools defined in the global config
+$ mise upgrade --global
 ```

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4266,6 +4266,9 @@ This will update mise.lock if it is enabled, see https://mise.en.dev/configurati
 \fBOptions:\fR
 .PP
 .TP
+\fB\-g, \-\-global\fR
+Only upgrade tools defined in the global config file
+.TP
 \fB\-i, \-\-interactive\fR
 Display multiselect menu to choose which tools to upgrade
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4227,7 +4227,11 @@ Examples:
     # Only upgrade tools defined in local mise.toml, not global ones
     $ mise upgrade --local
 
+    # Only upgrade tools defined in the global config
+    $ mise upgrade --global
+
 """#
+    flag "-g --global" help="Only upgrade tools defined in the global config file"
     flag "-i --interactive" help="Display multiselect menu to choose which tools to upgrade"
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -308,7 +308,10 @@ impl Upgrade {
                     .iter()
                     .map(|(n, v)| (n.as_str(), v.as_str()))
                     .collect();
-                let bumps = compute_config_bumps(config, &refs);
+                let bumps = compute_config_bumps(config, &refs)
+                    .into_iter()
+                    .filter(|bump| !self.global || config::is_global_config(&bump.config_path))
+                    .collect::<Vec<_>>();
                 for bump in &bumps {
                     miseprintln!(
                         "Would update {} from {} to {} in {}",
@@ -393,7 +396,10 @@ impl Upgrade {
                 .iter()
                 .map(|(n, v)| (n.as_str(), v.as_str()))
                 .collect();
-            let bumps = compute_config_bumps(config, &refs);
+            let bumps = compute_config_bumps(config, &refs)
+                .into_iter()
+                .filter(|bump| !self.global || config::is_global_config(&bump.config_path))
+                .collect::<Vec<_>>();
             apply_config_bumps(config, &bumps)?;
         }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -14,7 +14,7 @@ use crate::toolset::is_outdated_version;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::outdated_info::prefixed_latest_query;
 use crate::toolset::{
-    ConfigScope, InstallOptions, ResolveOptions, ToolSource, ToolVersion, ToolsetBuilder,
+    ConfigScope, InstallOptions, ResolveOptions, ToolSource, ToolVersion, Toolset, ToolsetBuilder,
     get_versions_needed_by_tracked_configs_excluding_locks, get_versions_needed_by_tracked_stubs,
 };
 use crate::ui::multi_progress_report::MultiProgressReport;
@@ -40,6 +40,10 @@ pub struct Upgrade {
     /// If not specified, all current tools will be upgraded
     #[clap(value_name = "INSTALLED_TOOL@VERSION", verbatim_doc_comment)]
     tool: Vec<ToolArg>,
+
+    /// Only upgrade tools defined in the global config file
+    #[clap(long, short, conflicts_with = "local")]
+    global: bool,
 
     /// Display multiselect menu to choose which tools to upgrade
     #[clap(long, short, verbatim_doc_comment, conflicts_with = "tool")]
@@ -76,14 +80,18 @@ pub struct Upgrade {
     dry_run_code: bool,
 
     /// Upgrade all tools, including installed-but-inactive tools not present in the current config
-    #[clap(long, verbatim_doc_comment, conflicts_with = "local")]
+    #[clap(
+        long,
+        verbatim_doc_comment,
+        conflicts_with_all = &["global", "local"]
+    )]
     inactive: bool,
 
     /// Only upgrade tools defined in local config files
     ///
     /// This will only upgrade tools that are defined in project-local mise.toml and
     /// will skip tools defined in the global config (~/.config/mise/config.toml).
-    #[clap(long, verbatim_doc_comment)]
+    #[clap(long, verbatim_doc_comment, conflicts_with = "global")]
     local: bool,
 
     /// Only upgrade to versions released before this date or older than this duration
@@ -112,11 +120,51 @@ impl Upgrade {
     }
 
     fn scope(&self) -> ConfigScope {
-        if self.local {
+        if self.global {
+            ConfigScope::GlobalOnly
+        } else if self.local {
             ConfigScope::LocalOnly
         } else {
             ConfigScope::All
         }
+    }
+
+    async fn build_toolset(&self, config: &Arc<Config>) -> Result<Toolset> {
+        if self.global {
+            return self.build_global_toolset(config).await;
+        }
+        ToolsetBuilder::new()
+            .with_args(&self.tool)
+            .with_scope(self.scope())
+            .build(config)
+            .await
+    }
+
+    async fn build_global_toolset(&self, config: &Arc<Config>) -> Result<Toolset> {
+        let mut ts = Toolset::default();
+        for cf in config.config_files.values().rev() {
+            if config::is_global_config(cf.get_path()) {
+                ts.merge(cf.to_toolset()?);
+            }
+        }
+        let mut arg_ts = Toolset::new(ToolSource::Argument);
+        for arg in &self.tool {
+            let Some(config_versions) = ts.versions.get(&arg.ba) else {
+                continue;
+            };
+            let Some(tvr) = &arg.tvr else {
+                continue;
+            };
+            let config_options = config_versions.requests.first().map(|tvr| tvr.options());
+            let mut tvr = tvr.clone();
+            tvr.set_options(arg.ba.opts_with_config(config_options));
+            arg_ts.add_version(tvr);
+        }
+        if !arg_ts.versions.is_empty() {
+            ts.merge(arg_ts);
+        }
+        ts.resolve(config).await?;
+        Ok(ts)
     }
 
     pub async fn run(self) -> Result<()> {
@@ -127,11 +175,7 @@ impl Upgrade {
         if !self.is_dry_run() {
             crate::lockfile::migrate_monorepo_lockfiles(&config)?;
         }
-        let ts = ToolsetBuilder::new()
-            .with_args(&self.tool)
-            .with_scope(self.scope())
-            .build(&config)
-            .await?;
+        let ts = self.build_toolset(&config).await?;
         // Compute before_date once to ensure consistency when using relative durations
         let before_date = self.get_before_date()?;
         let opts = ResolveOptions {
@@ -192,11 +236,7 @@ impl Upgrade {
         before_date: Option<Timestamp>,
     ) -> Result<()> {
         let mpr = MultiProgressReport::get();
-        let mut ts = ToolsetBuilder::new()
-            .with_args(&self.tool)
-            .with_scope(self.scope())
-            .build(config)
-            .await?;
+        let mut ts = self.build_toolset(config).await?;
 
         let mut outdated_with_config_files: Vec<(&OutdatedInfo, Arc<dyn config_file::ConfigFile>)> =
             vec![];
@@ -854,6 +894,9 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
     # Only upgrade tools defined in local mise.toml, not global ones
     $ <bold>mise upgrade --local</bold>
+
+    # Only upgrade tools defined in the global config
+    $ <bold>mise upgrade --global</bold>
 "#
 );
 


### PR DESCRIPTION
## Motivation

`mise upgrade --local` can limit upgrades to project-local configuration, but there is no inverse operation for users who want to update only the tools managed by their global mise configuration.

The distinction matters when a project and the global configuration select different tools or versions:

```console
$ mise upgrade --global
# upgrade the global config toolset without touching project-local tools
```

For this command, "global" follows config provenance. `config::is_global_config()` recognizes the user-global config set and system config files. Runtime requests such as `MISE_NODE_VERSION` have `ToolSource::Environment`; they are not global config entries and should not cause an environment-only tool to be upgraded by `--global`.

## How did it change?

- Add `mise upgrade -g|--global`.
- Build the global upgrade toolset from config files recognized by `config::is_global_config()`.
- Keep explicit CLI versions for tools present in that global toolset and preserve their configured options.
- Exclude project-local and environment-only tool requests from a global upgrade.
- Make `--global`, `--local`, and `--inactive` mutually exclusive because they describe incompatible sources.
- Regenerate the CLI reference, usage specification, and man page.

The filtering is intentionally local to `upgrade`. Existing `ToolsetBuilder`, `mise use --global`, and system-package plugin behavior is unchanged.

## Options considered

### Use `ConfigScope::GlobalOnly` without changing the builder

This was the smallest implementation, but it does not produce a config-only global toolset. `ToolsetBuilder` filters config files first and then overlays `MISE_<TOOL>_VERSION` requests, so environment-only tools can enter the result and environment requests can replace globally configured requests.

That behavior is useful to existing callers, but it does not satisfy `upgrade --global`, whose purpose is to select tools defined by global configuration.

### Change `ToolsetBuilder::GlobalOnly`

We explored making `ToolsetBuilder` load runtime tool-version environment variables only for `ConfigScope::All`. This creates a clean shared interpretation of scoped builders and lets `upgrade` use the normal builder path.

However, it also changes existing behavior outside this feature:

- `mise use --global` would no longer include `MISE_<TOOL>_VERSION` requests in its installation, hook, option-inheritance, and resolution context.
- System-package plugin hooks would no longer append paths resolved only through environment-sourced tool requests.

Those are breaking changes for users relying on the existing behavior. Adding `upgrade --global` should not redefine other commands, so this PR does not modify `ToolsetBuilder`.

### Build the global toolset inside `upgrade`

This is the selected approach. `build_global_toolset()` mirrors the relevant builder steps for this command: merge global/system config files, apply eligible explicit arguments with config options, and resolve the result.

The tradeoff is some duplicated toolset-construction logic and a command-specific path that must remain aligned with shared builder behavior. We accept that maintenance cost here because it confines the new semantics to the new flag and avoids unrelated behavioral changes. A broader `GlobalOnly` semantic change can still be considered separately with its own compatibility discussion.

## Validation

- `mise run lint-fix`
- `mise run render:help`
- `cargo build --all-features` (run by the render and E2E tasks)
- `mise run test:e2e e2e/cli/test_upgrade` progressed through the upgrade/local-scope assertions, then was blocked by an external `401 Unauthorized` response while downloading `bazelbuild/buildtools@7.1.2` from the GitHub API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--global` (`-g`) option to `mise upgrade` to restrict upgrades to tools defined in the global configuration.
  * Upgrades now apply the selected scope consistently across the command flow, including config bump behavior in both dry-run and real runs.

* **Documentation**
  * Updated CLI help, usage examples, and the `mise upgrade` manual page to include `mise upgrade --global` and clarify scope semantics.

* **Bug Fixes**
  * Improved validation so `--global`, `--local`, and `--inactive` can’t be combined in unsupported ways.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
