### PR TITLE
docs: retarget dead clap.rs link to docs.rs/clap

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ These three pillars work together to provide a unified development environment m
 The CLI layer provides the user interface and delegates to core functionality:
 
 - **Modular Commands**: Each command is a separate module ([`install.rs`](https://github.com/jdx/mise/blob/main/src/cli/install.rs), [`use.rs`](https://github.com/jdx/mise/blob/main/src/cli/use.rs), [`run.rs`](https://github.com/jdx/mise/blob/main/src/cli/run.rs), etc.)
-- **Argument Parsing**: Leverages [`clap`](https://clap.rs) for robust CLI parsing and validation
+- **Argument Parsing**: Leverages [`clap`](https://docs.rs/clap) for robust CLI parsing and validation
 - **Async Command Execution**: All commands support concurrent operations
 - **Unified Error Handling**: Consistent error reporting across all commands
 


### PR DESCRIPTION
## Summary

- Replace the dead `https://clap.rs` link on the architecture page (TLS handshake fails / host no longer serves).
- Point clap at the live official docs: `https://docs.rs/clap`.

## Motivation

Readers on the architecture overview following the Argument Parsing bullet hit an unreachable host. CLI docs for clap live on docs.rs; that destination returns HTTP 200.

## Verification

- `curl -sI -L -A Mozilla/5.0 https://clap.rs` → **connection/TLS failure** (exit 35 / http_code 000)
- `curl -sI -L -A Mozilla/5.0 https://docs.rs/clap` → **200** → `https://docs.rs/clap/latest/clap/`
- Dup search: no open/closed PRs retargeting `clap.rs` on jdx/mise
- Docs-only; single line in `docs/architecture.md`; no runtime change

## Notes

- Left example/placeholder URLs (example.com, my-org, demo plugins) untouched.
- Preferred `docs.rs/clap` over the GitHub repo so the architecture bullet still lands on API docs.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 24h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI argument parsing reference link in the architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->