### PR TITLE
chore(ci): bump release linux runner to xlarge

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,7 @@ self-hosted-runner:
     - namespace-profile-endev-macos-arm64-large;overrides.cache-tag=mise-release-rust-macos
     - namespace-profile-endev-linux-amd64
     - namespace-profile-endev-linux-amd64-large
+    - namespace-profile-endev-linux-amd64-xlarge
     - namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     - namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux-nightly
     - namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-release-plz-rust-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   build-tarball-linux:
     if: github.event_name != 'pull_request' || github.head_ref == 'release'
     name: build-tarball-${{matrix.name}}
-    runs-on: namespace-profile-endev-linux-amd64-large
+    runs-on: namespace-profile-endev-linux-amd64-xlarge
     # PGO rows build the serious profile twice (instrument + optimize),
     # so they need roughly double the old 45-minute budget.
     timeout-minutes: 80


### PR DESCRIPTION
## Summary
- run release Linux tarball builds on `namespace-profile-endev-linux-amd64-xlarge`
- allow the new self-hosted runner label in `actionlint`

## Why
The release Linux tarball jobs now run PGO builds and were getting killed on the current `16x32` runner. The available `xlarge` profile gives those jobs a `32x64` machine instead.

## Checks
- `git diff --check`
- `actionlint .github/workflows/release.yml`

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner sizing and actionlint allowlist; no application, auth, or release artifact logic changes.
> 
> **Overview**
> Moves **release Linux tarball** jobs from `namespace-profile-endev-linux-amd64-large` to **`namespace-profile-endev-linux-amd64-xlarge`** so PGO builds (instrument + optimize) have enough CPU/RAM and stop getting killed on the smaller `16x32` runners.
> 
> Registers the new **`namespace-profile-endev-linux-amd64-xlarge`** label in **actionlint** so workflow linting accepts the updated `runs-on` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 615e59bca4cbf449e748e41977bd7e9137e6c0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux release build to use a larger-capacity build environment.
  * Added support for recognizing the new runner configuration in workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->