### PR TITLE
feat(brew): support cask shell completions

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -68,22 +68,20 @@ installs app bundles into `/Applications` while recording the version under
 ```
 
 `brew-cask` currently supports app-bundle casks (`app` artifacts), binary casks
-(`binary` artifacts), and simple macOS installer packages (`pkg` artifacts)
-from dmg and common archive formats. Binary artifacts are staged in the Caskroom
-and linked into the Homebrew prefix, usually under `<prefix>/bin`. Package
-installers run through mise's normal system-package sudo path, so non-interactive
-runs never hang waiting for a password. Pkg casks must include `pkgutil` receipt
-IDs in their `uninstall` metadata so mise can verify installed state after the
-installer writes files outside the Caskroom. `zap` `pkgutil` IDs are treated as
-cleanup metadata, not install receipts. For casks with lifecycle hooks, mise
-fetches the sha256-verified cask Ruby source pinned by the API metadata and runs
-supported `preflight`/`postflight` hooks through its own Cask DSL shim, without
-delegating to Homebrew. mise also supports structured `preflight_steps` and
-`postflight_steps` for `move`/`remove` operations against `staged_path`. Casks
-that require custom installer choices, services, unsupported hook DSL, unsupported
-structured lifecycle steps, or other cask artifact types fail with a clear
-unsupported artifact error instead of delegating to Homebrew. Generated shell
-completions are not installed.
+(`binary` artifacts), simple macOS installer packages (`pkg` artifacts), and
+shell completions (`bash_completion`, `fish_completion`, `zsh_completion`, and
+`generate_completions_from_executable`) from dmg and common archive formats.
+Binary artifacts are staged in the Caskroom and linked into the Homebrew prefix,
+usually under `<prefix>/bin`. Package installers run through mise's normal
+system-package sudo path, so non-interactive runs never hang waiting for a
+password. Pkg casks must include `pkgutil` receipt IDs in their `uninstall` or
+`zap` metadata so mise can verify installed state after the installer writes
+files outside the Caskroom. For casks with lifecycle hooks, mise fetches the
+sha256-verified cask Ruby source pinned by the API metadata and runs supported
+`preflight`/`postflight` hooks through its own Cask DSL shim, without delegating
+to Homebrew. Casks that require custom installer choices, services, unsupported
+hook DSL, or other cask artifact types fail with a clear unsupported artifact
+error instead of delegating to Homebrew.
 
 This exists because shared-library packages — postgres, ffmpeg, imagemagick,
 php — fundamentally can't be served by mise's per-project backends like

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -71,17 +71,20 @@ installs app bundles into `/Applications` while recording the version under
 (`binary` artifacts), simple macOS installer packages (`pkg` artifacts), and
 shell completions (`bash_completion`, `fish_completion`, `zsh_completion`, and
 `generate_completions_from_executable`) from dmg and common archive formats.
-Binary artifacts are staged in the Caskroom and linked into the Homebrew prefix,
-usually under `<prefix>/bin`. Package installers run through mise's normal
-system-package sudo path, so non-interactive runs never hang waiting for a
-password. Pkg casks must include `pkgutil` receipt IDs in their `uninstall` or
-`zap` metadata so mise can verify installed state after the installer writes
-files outside the Caskroom. For casks with lifecycle hooks, mise fetches the
-sha256-verified cask Ruby source pinned by the API metadata and runs supported
-`preflight`/`postflight` hooks through its own Cask DSL shim, without delegating
-to Homebrew. Casks that require custom installer choices, services, unsupported
-hook DSL, or other cask artifact types fail with a clear unsupported artifact
-error instead of delegating to Homebrew.
+Binary artifacts are staged in the Caskroom
+and linked into the Homebrew prefix, usually under `<prefix>/bin`. Package
+installers run through mise's normal system-package sudo path, so non-interactive
+runs never hang waiting for a password. Pkg casks must include `pkgutil` receipt
+IDs in their `uninstall` metadata so mise can verify installed state after the
+installer writes files outside the Caskroom. `zap` `pkgutil` IDs are treated as
+cleanup metadata, not install receipts. For casks with lifecycle hooks, mise
+fetches the sha256-verified cask Ruby source pinned by the API metadata and runs
+supported `preflight`/`postflight` hooks through its own Cask DSL shim, without
+delegating to Homebrew. mise also supports structured `preflight_steps` and
+`postflight_steps` for `move`/`remove` operations against `staged_path`. Casks
+that require custom installer choices, services, unsupported hook DSL, unsupported
+structured lifecycle steps, or other cask artifact types fail with a clear
+unsupported artifact error instead of delegating to Homebrew.
 
 This exists because shared-library packages — postgres, ffmpeg, imagemagick,
 php — fundamentally can't be served by mise's per-project backends like

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -187,30 +187,33 @@ impl BrewCaskManager {
         }
         execute_lifecycle_hook(&cask, &tmp_caskroom, &appdir, "postflight", pr).await?;
         for binary in &artifacts.binaries {
-            stage_binary(&stage, &tmp_caskroom, &cask, binary)?;
+            stage_binary(&stage, &tmp_caskroom, &cask, &appdir, binary)?;
         }
         for completion in &artifacts.completions {
-            stage_completion(&stage, &tmp_caskroom, &cask, completion)?;
+            stage_completion(&stage, &tmp_caskroom, &cask, &appdir, completion)?;
         }
         for generated in &artifacts.generated_completions {
-            stage_generated_completions(&stage, &tmp_caskroom, &cask, generated)?;
+            stage_generated_completions(&stage, &tmp_caskroom, &cask, &appdir, generated)?;
         }
         write_receipt(&tmp_caskroom, &cask, &artifacts)?;
-        file::remove_all(&caskroom)?;
-        file::rename(&tmp_caskroom, &caskroom)?;
-        for binary in &artifacts.binaries {
-            link_binary(&caskroom, binary)?;
-        }
-        remove_obsolete_binary_links(&cask, &previous_binaries, &binary_targets(&artifacts)?)?;
+        let current_binaries = binary_targets(&artifacts)?;
         let current_completions = completion_target_paths(&cask, &artifacts)?;
-        for target in &current_completions {
-            link_completion(&cask, &caskroom, target)?;
-        }
+        let current_fonts = font_target_paths(&artifacts)?;
+        replace_caskroom(&cask, &tmp_caskroom, &caskroom, || {
+            for binary in &artifacts.binaries {
+                link_binary(&caskroom, binary)?;
+            }
+            for target in &current_completions {
+                link_completion(&cask, &caskroom, target)?;
+            }
+            for font in &artifacts.fonts {
+                link_font(&caskroom, font)?;
+            }
+            Ok(())
+        })?;
+        remove_obsolete_binary_links(&cask, &previous_binaries, &current_binaries)?;
         remove_obsolete_completions(&cask, &previous_completions, &current_completions)?;
-        for font in &artifacts.fonts {
-            link_font(&caskroom, font)?;
-        }
-        remove_obsolete_fonts(&cask, &previous_fonts, &font_target_paths(&artifacts)?)?;
+        remove_obsolete_fonts(&cask, &previous_fonts, &current_fonts)?;
         remove_stale_versions(&caskroom_token, &cask.version)?;
         file::remove_all(stage)?;
         Ok(cask.version)
@@ -858,12 +861,13 @@ fn stage_completion(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
+    appdir: &Path,
     completion: &CompletionArtifact,
 ) -> Result<()> {
     let target = completion.target_path()?;
     let caskroom_completion = caskroom_completion_path(caskroom, &target)?;
-    let source =
-        find_completion_source(stage, caskroom, cask, &completion.source).ok_or_else(|| {
+    let source = find_completion_source(stage, caskroom, cask, appdir, &completion.source)
+        .ok_or_else(|| {
             eyre!(
                 "brew-cask: {} completion artifact '{}' was not found",
                 completion.shell.name(),
@@ -884,9 +888,11 @@ fn stage_generated_completions(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
+    appdir: &Path,
     completion: &GeneratedCompletionArtifact,
 ) -> Result<()> {
-    let executable = find_generated_completion_executable(stage, caskroom, cask, completion)?;
+    let executable =
+        find_generated_completion_executable(stage, caskroom, cask, appdir, completion)?;
     if executable.starts_with(stage) || executable.starts_with(caskroom) {
         file::make_executable(&executable)?;
     }
@@ -948,6 +954,7 @@ fn find_completion_source(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
+    appdir: &Path,
     source: &str,
 ) -> Option<PathBuf> {
     for root in [caskroom, stage] {
@@ -957,7 +964,7 @@ fn find_completion_source(
             return Some(source);
         }
     }
-    if let Some(source) = appdir_artifact_source(source) {
+    if let Some(source) = appdir_artifact_source(source, appdir) {
         return Some(source);
     }
     absolute_prefixed_source(source)
@@ -970,6 +977,7 @@ fn find_generated_completion_executable(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
+    appdir: &Path,
     completion: &GeneratedCompletionArtifact,
 ) -> Result<PathBuf> {
     let executable = &completion.executable;
@@ -983,7 +991,7 @@ fn find_generated_completion_executable(
     {
         return Ok(source);
     }
-    if let Some(source) = appdir_artifact_source(executable) {
+    if let Some(source) = appdir_artifact_source(executable, appdir) {
         return Ok(source);
     }
     if let Some(source) = absolute_prefixed_source(executable) {
@@ -1009,24 +1017,16 @@ fn find_generated_completion_executable(
     ))
 }
 
-fn appdir_artifact_source(source: &str) -> Option<PathBuf> {
+fn appdir_artifact_source(source: &str, appdir: &Path) -> Option<PathBuf> {
     if !source.contains("$APPDIR") {
         return None;
     }
-    [
-        PathBuf::from("/Applications"),
-        prefix::prefix().join("Applications"),
-    ]
-    .iter()
-    .map(|appdir| PathBuf::from(source.replace("$APPDIR", &appdir.to_string_lossy())))
-    .find(|path| path.is_file())
+    let path = PathBuf::from(source.replace("$APPDIR", &appdir.to_string_lossy()));
+    path.is_file().then_some(path)
 }
 
 fn find_generated_completion_file(root: &Path, executable: &str) -> Result<Option<PathBuf>> {
     let executable_path = Path::new(executable);
-    if executable_path.components().count() != 1 {
-        return Ok(find_file_artifact(root, executable));
-    }
     let direct = root.join(executable_path);
     if direct.is_file() {
         return Ok(Some(direct));
@@ -1305,7 +1305,13 @@ fn remove_obsolete_completions(
     Ok(())
 }
 
-fn stage_binary(stage: &Path, caskroom: &Path, cask: &Cask, binary: &BinaryArtifact) -> Result<()> {
+fn stage_binary(
+    stage: &Path,
+    caskroom: &Path,
+    cask: &Cask,
+    appdir: &Path,
+    binary: &BinaryArtifact,
+) -> Result<()> {
     let caskroom_binary = caskroom_binary_path(caskroom, binary)?;
     file::remove_all(&caskroom_binary)?;
     if let Some(parent) = caskroom_binary.parent() {
@@ -1314,8 +1320,7 @@ fn stage_binary(stage: &Path, caskroom: &Path, cask: &Cask, binary: &BinaryArtif
     if binary.source.contains("$APPDIR") {
         // $APPDIR is the Applications directory where install_app placed the bundle.
         // Symlink into the installed app so the CLI wrapper can trace back to find the app.
-        // Check both /Applications and $HOMEBREW_PREFIX/Applications per app_target_path().
-        let app_binary = appdir_artifact_source(&binary.source).ok_or_else(|| {
+        let app_binary = appdir_artifact_source(&binary.source, appdir).ok_or_else(|| {
             eyre!(
                 "brew-cask: binary artifact '{}' was not found",
                 binary.source
@@ -1729,6 +1734,9 @@ fn parse_generated_completion_artifact(
         })
         .transpose()?
         .unwrap_or_else(|| default_generated_completion_shells(shell_parameter_format.as_deref()));
+    if shells.is_empty() {
+        bail!("brew-cask: generate_completions_from_executable requires at least one shell");
+    }
     Ok(Some(GeneratedCompletionArtifact {
         executable,
         args,
@@ -2155,6 +2163,48 @@ fn caskroom_version_dir(token: &str, version: &str) -> PathBuf {
 fn caskroom_tmp_dir(cask: &Cask) -> PathBuf {
     let key = format!("{}-{}", cask.token, cask.version);
     caskroom_token_dir(&cask.token).join(format!(".mise-tmp-{}", hash::hash_to_str(&key)))
+}
+
+fn caskroom_backup_dir(cask: &Cask) -> PathBuf {
+    let key = format!("{}-{}", cask.token, cask.version);
+    caskroom_token_dir(&cask.token).join(format!(".mise-backup-{}", hash::hash_to_str(&key)))
+}
+
+fn replace_caskroom(
+    cask: &Cask,
+    staged: &Path,
+    destination: &Path,
+    link_artifacts: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    let backup = caskroom_backup_dir(cask);
+    file::remove_all(&backup)?;
+    let had_previous = destination.symlink_metadata().is_ok();
+    if had_previous {
+        file::rename(destination, &backup)?;
+    }
+    if let Err(err) = file::rename(staged, destination) {
+        if had_previous {
+            file::rename(&backup, destination)?;
+        }
+        return Err(err);
+    }
+    if let Err(err) = link_artifacts() {
+        let rollback = (|| -> Result<()> {
+            file::remove_all(destination)?;
+            if had_previous {
+                file::rename(&backup, destination)?;
+            }
+            Ok(())
+        })();
+        if let Err(rollback_err) = rollback {
+            return Err(err.wrap_err(format!(
+                "failed to restore previous cask after activation failed: {rollback_err:#}"
+            )));
+        }
+        return Err(err);
+    }
+    file::remove_all(backup)?;
+    Ok(())
 }
 
 fn remove_stale_versions(token_dir: &Path, current_version: &str) -> Result<()> {
@@ -2627,6 +2677,19 @@ end
     }
 
     #[test]
+    fn rejects_generated_completions_with_no_shells() {
+        let value = serde_json::json!({
+            "generate_completions_from_executable": ["op", {"shells": []}]
+        });
+
+        let err = parse_generated_completion_artifact(&value)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("requires at least one shell"));
+    }
+
+    #[test]
     fn parses_declared_completion_artifacts() -> Result<()> {
         let mut cask = test_cask("ghostty", "1.2.0");
         cask.artifacts = vec![
@@ -2724,7 +2787,13 @@ end
         };
         let target = completion.target_path()?;
 
-        stage_completion(&stage, &caskroom, &cask, &completion)?;
+        stage_completion(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &completion,
+        )?;
         link_completion(&cask, &caskroom, &target)?;
 
         assert_eq!(
@@ -2756,7 +2825,13 @@ end
             target: Some("$HOMEBREW_PREFIX/etc/bash_completion.d/foo".to_string()),
         };
 
-        stage_completion(&stage, &caskroom, &cask, &completion)?;
+        stage_completion(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &completion,
+        )?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/foo"))?,
@@ -2782,7 +2857,13 @@ end
             target: Some("$HOMEBREW_PREFIX/etc/bash_completion.d/foo".to_string()),
         };
 
-        stage_completion(&stage, &caskroom, &cask, &completion)?;
+        stage_completion(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &completion,
+        )?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/foo"))?,
@@ -2842,7 +2923,13 @@ end
             shells: vec![CompletionShell::Bash],
         };
 
-        stage_generated_completions(&stage, &caskroom, &cask, &completion)?;
+        stage_generated_completions(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &completion,
+        )?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/op"))?,
@@ -2873,8 +2960,32 @@ end
         };
 
         assert_eq!(
-            find_generated_completion_executable(&stage, &caskroom, &cask, &completion)?,
+            find_generated_completion_executable(
+                &stage,
+                &caskroom,
+                &cask,
+                &tmp.path().join("Applications"),
+                &completion,
+            )?,
             app_executable
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn appdir_artifact_source_uses_selected_appdir() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let system_appdir = tmp.path().join("system-applications");
+        let prefix_appdir = tmp.path().join("prefix-applications");
+        let relative = "Foo.app/Contents/MacOS/foo";
+        file::create_dir_all(system_appdir.join(relative).parent().unwrap())?;
+        file::create_dir_all(prefix_appdir.join(relative).parent().unwrap())?;
+        crate::file::write(system_appdir.join(relative), "system")?;
+        crate::file::write(prefix_appdir.join(relative), "prefix")?;
+
+        assert_eq!(
+            appdir_artifact_source("$APPDIR/Foo.app/Contents/MacOS/foo", &prefix_appdir),
+            Some(prefix_appdir.join(relative))
         );
         Ok(())
     }
@@ -2900,7 +3011,13 @@ end
         };
 
         assert_eq!(
-            find_generated_completion_executable(&stage, &caskroom, &cask, &completion)?,
+            find_generated_completion_executable(
+                &stage,
+                &caskroom,
+                &cask,
+                Path::new("/Applications"),
+                &completion,
+            )?,
             caskroom.join("bin/op")
         );
         Ok(())
@@ -2927,11 +3044,52 @@ end
             shells: vec![CompletionShell::Bash],
         };
 
-        let err = find_generated_completion_executable(&stage, &caskroom, &cask, &completion)
-            .unwrap_err();
+        let err = find_generated_completion_executable(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &completion,
+        )
+        .unwrap_err();
         assert!(
             err.to_string()
                 .contains("completion executable 'tool' is ambiguous")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_ambiguous_generated_completion_nested_executable() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("caskroom");
+        file::create_dir_all(stage.join("a/bin"))?;
+        file::create_dir_all(stage.join("b/bin"))?;
+        file::create_dir_all(&caskroom)?;
+        crate::file::write(stage.join("a/bin/tool"), "a")?;
+        crate::file::write(stage.join("b/bin/tool"), "b")?;
+        let cask = test_cask("tool", "1.0.0");
+        let completion = GeneratedCompletionArtifact {
+            executable: "bin/tool".to_string(),
+            args: vec![],
+            base_name: None,
+            shell_parameter_format: None,
+            shells: vec![CompletionShell::Bash],
+        };
+
+        let err = find_generated_completion_executable(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &completion,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("completion executable 'bin/tool' is ambiguous")
         );
         Ok(())
     }
@@ -3559,7 +3717,13 @@ end
             target: Some("$HOMEBREW_PREFIX/bin/op".to_string()),
         };
 
-        stage_binary(&stage, &caskroom, &cask, &binary)?;
+        stage_binary(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &binary,
+        )?;
         link_binary(&caskroom, &binary)?;
 
         let target = binary.target_path()?;
@@ -3591,8 +3755,8 @@ end
             target: Some("$HOMEBREW_PREFIX/sbin/op".to_string()),
         };
 
-        stage_binary(&stage, &caskroom, &cask, &bin)?;
-        stage_binary(&stage, &caskroom, &cask, &sbin)?;
+        stage_binary(&stage, &caskroom, &cask, Path::new("/Applications"), &bin)?;
+        stage_binary(&stage, &caskroom, &cask, Path::new("/Applications"), &sbin)?;
         link_binary(&caskroom, &bin)?;
         link_binary(&caskroom, &sbin)?;
 
@@ -3619,7 +3783,13 @@ end
             target: Some("$HOMEBREW_PREFIX/bin/op".to_string()),
         };
 
-        stage_binary(&stage, &caskroom, &cask, &binary)?;
+        stage_binary(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &binary,
+        )?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("bin/op"))?,
@@ -3651,7 +3821,13 @@ end
             target: Some("$HOMEBREW_PREFIX/bin/karabiner_cli".to_string()),
         };
 
-        stage_binary(&stage, &caskroom, &cask, &binary)?;
+        stage_binary(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &binary,
+        )?;
         link_binary(&caskroom, &binary)?;
 
         let staged = caskroom.join("bin/karabiner_cli");
@@ -3685,7 +3861,13 @@ end
             target: Some("$HOMEBREW_PREFIX/bin/karabiner_cli".to_string()),
         };
 
-        stage_binary(&stage, &caskroom, &cask, &binary)?;
+        stage_binary(
+            &stage,
+            &caskroom,
+            &cask,
+            Path::new("/Applications"),
+            &binary,
+        )?;
         file::remove_file(&pkg_binary)?;
         let err = link_binary(&caskroom, &binary).unwrap_err().to_string();
 
@@ -3897,6 +4079,33 @@ end
         file::create_dir_all(token_dir.join(".mise-tmp-interrupted"))?;
 
         assert_eq!(installed_version("actual-token"), Some("2.0.0".to_string()));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replace_caskroom_restores_previous_files_when_linking_fails() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let cask = test_cask("completion-only", "1.0.0");
+        let destination = caskroom_version_dir(&cask.token, &cask.version);
+        let staged = caskroom_tmp_dir(&cask);
+        let relative = Path::new("etc/bash_completion.d/tool");
+        file::create_dir_all(destination.join(relative).parent().unwrap())?;
+        file::create_dir_all(staged.join(relative).parent().unwrap())?;
+        crate::file::write(destination.join(relative), "previous")?;
+        crate::file::write(staged.join(relative), "replacement")?;
+        let target = tmp.path().join(relative);
+        file::create_dir_all(target.parent().unwrap())?;
+        file::make_symlink(&destination.join(relative), &target)?;
+
+        let err = replace_caskroom(&cask, &staged, &destination, || Err(eyre!("link failed")))
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "link failed");
+        assert_eq!(crate::file::read_to_string(&target)?, "previous");
+        assert!(!caskroom_backup_dir(&cask).exists());
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1250,16 +1250,16 @@ fn appdir_artifact_source(source: &str, apps: &[AppArtifact]) -> Result<Option<P
         return Ok(None);
     };
     let relative = Path::new(relative);
-    let Some(bundle) = relative.components().next() else {
+    let Some(Component::Normal(bundle)) = relative.components().next() else {
         return Ok(None);
     };
     let suffix = relative.components().skip(1).collect::<PathBuf>();
     let mut matches = Vec::new();
     for app in apps {
         let target = app_target_path(app.target_name())?;
-        let source_bundle = Path::new(&app.source).file_name();
-        let target_bundle = target.file_name();
-        if !matches!(bundle, Component::Normal(name) if Some(name) == source_bundle || Some(name) == target_bundle)
+        let bundle = Path::new(bundle);
+        if !path_ends_with_ignore_ascii_case(Path::new(&app.source), bundle)
+            && !path_ends_with_ignore_ascii_case(&target, bundle)
         {
             continue;
         }
@@ -3654,12 +3654,12 @@ end
     }
 
     #[test]
-    fn appdir_artifact_source_uses_matching_app_location() -> Result<()> {
+    fn appdir_artifact_source_matches_app_case_insensitively() -> Result<()> {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let prefix_appdir = tmp.path().join("Applications");
-        let relative = "Foo.app/Contents/MacOS/foo";
+        let relative = "foo.app/Contents/MacOS/foo";
         file::create_dir_all(prefix_appdir.join(relative).parent().unwrap())?;
         crate::file::write(prefix_appdir.join(relative), "prefix")?;
         let apps = [
@@ -3668,8 +3668,8 @@ end
                 target: None,
             },
             AppArtifact {
-                source: "Foo.app".to_string(),
-                target: Some("$HOMEBREW_PREFIX/Applications/Foo.app".to_string()),
+                source: "foo.app".to_string(),
+                target: Some("$HOMEBREW_PREFIX/Applications/foo.app".to_string()),
             },
         ];
 
@@ -4775,7 +4775,7 @@ end
 
         assert_eq!(err.to_string(), "link failed");
         assert_eq!(crate::file::read_to_string(&target)?, "previous");
-        assert!(!new_target.symlink_metadata().is_ok());
+        assert!(new_target.symlink_metadata().is_err());
         assert!(!caskroom_backup_dir(&cask).exists());
         Ok(())
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -906,7 +906,7 @@ fn link_completion(caskroom: &Path, target: &Path) -> Result<()> {
     if let Some(parent) = target.parent() {
         file::create_dir_all(parent)?;
     }
-    replace_completion(&caskroom_completion, target)?;
+    file::make_symlink(&caskroom_completion, target)?;
     Ok(())
 }
 
@@ -961,32 +961,6 @@ fn find_generated_completion_executable(
         "brew-cask: completion executable '{}' was not found",
         executable
     ))
-}
-
-fn replace_completion(source: &Path, target: &Path) -> Result<()> {
-    if target.exists() && !target.is_file() {
-        bail!(
-            "brew-cask: completion target '{}' exists and is not a file",
-            target.display()
-        );
-    }
-    let old_target = target.with_extension(format!(
-        "mise-old-{}",
-        crate::hash::hash_to_str(&target.display().to_string())
-    ));
-    file::remove_all(&old_target)?;
-    if target.exists() {
-        file::rename(target, &old_target)?;
-    }
-    if let Err(e) = file::copy(source, target) {
-        if old_target.exists() {
-            let _ = file::remove_all(target);
-            let _ = file::rename(&old_target, target);
-        }
-        return Err(e);
-    }
-    file::remove_all(&old_target)?;
-    Ok(())
 }
 
 fn appdir_artifact_source(source: &str) -> Option<PathBuf> {
@@ -1114,7 +1088,7 @@ fn completion_shell_parameter(
                 "1".to_string(),
             )],
         ),
-        Some(format) => (vec![format!("{format}{}", shell.name())], Vec::new()),
+        Some(format) => (vec![format!("{format}{shell_parameter}")], Vec::new()),
     }
 }
 
@@ -1268,32 +1242,28 @@ fn remove_obsolete_completions(
         if current_targets.contains(target) || !target.is_file() || !target.starts_with(&prefix) {
             continue;
         }
-        let Ok(relative) = target.strip_prefix(&prefix) else {
+        let Ok(metadata) = target.symlink_metadata() else {
             continue;
         };
-        let staged_copy = std::fs::read_dir(&token_dir)
-            .ok()
-            .into_iter()
-            .flatten()
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| entry.file_type().is_ok_and(|ft| ft.is_dir()))
-            .map(|entry| entry.path().join(relative))
-            .find(|path| path.is_file());
-        if staged_copy
-            .as_deref()
-            .is_some_and(|staged_copy| same_file_contents(target, staged_copy))
-        {
+        if !metadata.file_type().is_symlink() {
+            continue;
+        }
+        let Ok(link_target) = std::fs::read_link(target) else {
+            continue;
+        };
+        let resolved = if link_target.is_absolute() {
+            link_target
+        } else {
+            target
+                .parent()
+                .map(|parent| parent.join(&link_target))
+                .unwrap_or(link_target)
+        };
+        if file::desymlink_path(&resolved).starts_with(&token_dir) {
             file::remove_file(target)?;
         }
     }
     Ok(())
-}
-
-fn same_file_contents(a: &Path, b: &Path) -> bool {
-    match (std::fs::read(a), std::fs::read(b)) {
-        (Ok(a), Ok(b)) => a == b,
-        _ => false,
-    }
 }
 
 fn stage_binary(stage: &Path, caskroom: &Path, cask: &Cask, binary: &BinaryArtifact) -> Result<()> {
@@ -2689,6 +2659,10 @@ end
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/ghostty"))?,
             "complete"
         );
+        assert_eq!(
+            std::fs::read_link(&target)?,
+            caskroom.join("etc/bash_completion.d/ghostty")
+        );
         assert_eq!(crate::file::read_to_string(target)?, "complete");
         Ok(())
     }
@@ -2784,53 +2758,36 @@ end
         Ok(())
     }
 
-    #[cfg(unix)]
     #[test]
-    fn link_completion_restores_existing_target_when_copy_fails() -> Result<()> {
-        use std::os::unix::fs::PermissionsExt;
-
-        let _lock = ENV_LOCK.lock().unwrap();
-        let tmp = tempfile::tempdir()?;
-        let _guard = BrewPrefixGuard::set(tmp.path());
-        let caskroom = tmp.path().join("caskroom");
-        let target = tmp.path().join("etc/bash_completion.d/foo");
-        let staged = caskroom.join("etc/bash_completion.d/foo");
-        file::create_dir_all(staged.parent().unwrap())?;
-        file::create_dir_all(target.parent().unwrap())?;
-        crate::file::write(&staged, "new")?;
-        crate::file::write(&target, "old")?;
-        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o000))?;
-
-        let err = link_completion(&caskroom, &target).unwrap_err();
-
-        assert!(err.to_string().contains("failed copy"));
-        assert_eq!(crate::file::read_to_string(&target)?, "old");
-        std::fs::set_permissions(staged, std::fs::Permissions::from_mode(0o644))?;
-        Ok(())
-    }
-
-    #[test]
-    fn remove_obsolete_completions_keeps_replaced_targets() -> Result<()> {
+    fn remove_obsolete_completions_removes_only_caskroom_symlinks() -> Result<()> {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
         let cask = test_cask("foo", "2.0.0");
         let old_caskroom = caskroom_version_dir(&cask.token, "1.0.0");
+        let other_caskroom = caskroom_version_dir("other", "1.0.0");
         let relative = Path::new("etc/bash_completion.d/foo");
         let target = tmp.path().join(relative);
+        let other_target = tmp.path().join("etc/bash_completion.d/other-foo");
+        let regular_target = tmp.path().join("etc/bash_completion.d/regular-foo");
         file::create_dir_all(old_caskroom.join("etc/bash_completion.d"))?;
+        file::create_dir_all(other_caskroom.join("etc/bash_completion.d"))?;
         file::create_dir_all(target.parent().unwrap())?;
         crate::file::write(old_caskroom.join(relative), "old")?;
-        crate::file::write(&target, "other cask")?;
+        crate::file::write(other_caskroom.join(relative), "old")?;
+        crate::file::write(&regular_target, "old")?;
+        file::make_symlink(&old_caskroom.join(relative), &target)?;
+        file::make_symlink(&other_caskroom.join(relative), &other_target)?;
 
-        remove_obsolete_completions(&cask, std::slice::from_ref(&target), &[])?;
+        remove_obsolete_completions(
+            &cask,
+            &[target.clone(), other_target.clone(), regular_target.clone()],
+            &[],
+        )?;
 
-        assert_eq!(crate::file::read_to_string(&target)?, "other cask");
-
-        crate::file::write(&target, "old")?;
-        remove_obsolete_completions(&cask, std::slice::from_ref(&target), &[])?;
-
-        assert!(!target.exists());
+        assert!(target.symlink_metadata().is_err());
+        assert!(other_target.symlink_metadata().is_ok());
+        assert!(regular_target.symlink_metadata().is_ok());
         Ok(())
     }
 
@@ -2853,6 +2810,14 @@ end
             completion_shell_parameter(Some("clap"), CompletionShell::Bash, Path::new("tool"));
         assert!(args.is_empty());
         assert_eq!(env, vec![("COMPLETE".to_string(), "bash".to_string())]);
+
+        let (args, env) = completion_shell_parameter(
+            Some("--autocomplete=init:"),
+            CompletionShell::Pwsh,
+            Path::new("tool"),
+        );
+        assert_eq!(args, vec!["--autocomplete=init:powershell".to_string()]);
+        assert_eq!(env, Vec::<(String, String)>::new());
     }
 
     #[test]

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -987,14 +987,14 @@ fn find_generated_completion_executable(
         return Ok(source);
     }
     if let Some(source) = absolute_prefixed_source(executable) {
-        if source.is_file() {
-            return Ok(source);
-        }
         if let Ok(relative) = source.strip_prefix(prefix::prefix()) {
             let caskroom_source = caskroom.join(relative);
             if caskroom_source.is_file() {
                 return Ok(caskroom_source);
             }
+        }
+        if source.is_file() {
+            return Ok(source);
         }
     }
     if let Some(source) = find_generated_completion_file(caskroom, executable)? {
@@ -2853,6 +2853,33 @@ end
         assert_eq!(
             find_generated_completion_executable(&stage, &caskroom, &cask, &completion)?,
             app_executable
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn generated_completion_executable_prefers_staged_prefix_binary() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("caskroom");
+        file::create_dir_all(tmp.path().join("bin"))?;
+        file::create_dir_all(caskroom.join("bin"))?;
+        crate::file::write(tmp.path().join("bin/op"), "old")?;
+        crate::file::write(caskroom.join("bin/op"), "new")?;
+        let cask = test_cask("1password-cli", "2.34.1");
+        let completion = GeneratedCompletionArtifact {
+            executable: "$HOMEBREW_PREFIX/bin/op".to_string(),
+            args: vec![],
+            base_name: None,
+            shell_parameter_format: None,
+            shells: vec![CompletionShell::Bash],
+        };
+
+        assert_eq!(
+            find_generated_completion_executable(&stage, &caskroom, &cask, &completion)?,
+            caskroom.join("bin/op")
         );
         Ok(())
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -70,28 +70,28 @@ struct FontArtifact {
     target: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum FlightStep {
-    Move {
-        source: FlightPath,
-        target: FlightPath,
-        source_glob: bool,
-    },
-    Remove {
-        paths: Vec<FlightPath>,
-        recursive: bool,
-    },
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FlightPathBase {
-    StagedPath,
+enum CompletionShell {
+    Bash,
+    Fish,
+    Zsh,
+    Pwsh,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct FlightPath {
-    base: FlightPathBase,
-    path: String,
+struct CompletionArtifact {
+    shell: CompletionShell,
+    source: String,
+    target: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GeneratedCompletionArtifact {
+    executable: String,
+    args: Vec<String>,
+    base_name: Option<String>,
+    shell_parameter_format: Option<String>,
+    shells: Vec<CompletionShell>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -100,8 +100,8 @@ struct CaskArtifacts {
     binaries: Vec<BinaryArtifact>,
     pkgs: Vec<PkgArtifact>,
     fonts: Vec<FontArtifact>,
-    preflight_steps: Vec<FlightStep>,
-    postflight_steps: Vec<FlightStep>,
+    completions: Vec<CompletionArtifact>,
+    generated_completions: Vec<GeneratedCompletionArtifact>,
     pkg_ids: Vec<String>,
 }
 
@@ -114,6 +114,8 @@ struct CaskReceipt {
     binaries: Vec<PathBuf>,
     #[serde(default)]
     fonts: Vec<PathBuf>,
+    #[serde(default)]
+    completions: Vec<PathBuf>,
     #[serde(default)]
     pkg_ids: Vec<String>,
 }
@@ -149,11 +151,22 @@ impl BrewCaskManager {
             for font in &artifacts.fonts {
                 miseprintln!("install font {}", font.source);
             }
+            for completion in &artifacts.completions {
+                miseprintln!(
+                    "install {} completion {}",
+                    completion.shell.name(),
+                    completion.source
+                );
+            }
+            for generated in &artifacts.generated_completions {
+                miseprintln!("generate completions from {}", generated.executable);
+            }
             return Ok(cask.version);
         }
         prefix::bootstrap(false)?;
         let previous_binaries = previous_binary_targets(&cask)?;
         let previous_fonts = previous_font_targets(&cask)?;
+        let previous_completions = previous_completion_targets(&cask)?;
         let archive = fetch_archive(&cask, pr).await?;
         let stage = extract_archive(&cask, &archive, pr)?;
         let caskroom_token = caskroom_token_dir(&cask.token);
@@ -162,7 +175,6 @@ impl BrewCaskManager {
         file::remove_all(&tmp_caskroom)?;
         file::create_dir_all(&tmp_caskroom)?;
         let appdir = cask_appdir(&artifacts.apps)?;
-        execute_flight_steps(&cask, &artifacts.preflight_steps, &stage, "preflight_steps")?;
         execute_lifecycle_hook(&cask, &stage, &appdir, "preflight", pr).await?;
         for app in &artifacts.apps {
             install_app(&stage, &tmp_caskroom, app)?;
@@ -173,15 +185,15 @@ impl BrewCaskManager {
         for font in &artifacts.fonts {
             stage_font(&stage, &tmp_caskroom, font)?;
         }
-        execute_flight_steps(
-            &cask,
-            &artifacts.postflight_steps,
-            &tmp_caskroom,
-            "postflight_steps",
-        )?;
         execute_lifecycle_hook(&cask, &tmp_caskroom, &appdir, "postflight", pr).await?;
         for binary in &artifacts.binaries {
             stage_binary(&stage, &tmp_caskroom, &cask, binary)?;
+        }
+        for completion in &artifacts.completions {
+            stage_completion(&stage, &tmp_caskroom, completion)?;
+        }
+        for generated in &artifacts.generated_completions {
+            stage_generated_completions(&stage, &tmp_caskroom, &cask, generated)?;
         }
         write_receipt(&tmp_caskroom, &cask, &artifacts)?;
         file::remove_all(&caskroom)?;
@@ -190,6 +202,11 @@ impl BrewCaskManager {
             link_binary(&caskroom, binary)?;
         }
         remove_obsolete_binary_links(&cask, &previous_binaries, &binary_targets(&artifacts)?)?;
+        let current_completions = completion_target_paths(&cask, &artifacts)?;
+        for target in &current_completions {
+            link_completion(&caskroom, target)?;
+        }
+        remove_obsolete_completions(&cask, &previous_completions, &current_completions)?;
         for font in &artifacts.fonts {
             link_font(&caskroom, font)?;
         }
@@ -220,6 +237,76 @@ impl BinaryArtifact {
 
     fn target_path(&self) -> Result<PathBuf> {
         binary_target_path(&self.target_name()?)
+    }
+}
+
+impl CompletionShell {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "bash" => Some(Self::Bash),
+            "fish" => Some(Self::Fish),
+            "zsh" => Some(Self::Zsh),
+            "pwsh" => Some(Self::Pwsh),
+            _ => None,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Bash => "bash",
+            Self::Fish => "fish",
+            Self::Zsh => "zsh",
+            Self::Pwsh => "pwsh",
+        }
+    }
+
+    fn parameter_name(self) -> &'static str {
+        match self {
+            Self::Pwsh => "powershell",
+            _ => self.name(),
+        }
+    }
+}
+
+impl CompletionArtifact {
+    fn target_name(&self) -> Result<String> {
+        match &self.target {
+            Some(target) => Ok(target.clone()),
+            None => Path::new(&self.source)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+                .ok_or_else(|| eyre!("brew-cask: invalid completion source '{}'", self.source)),
+        }
+    }
+
+    fn target_path(&self) -> Result<PathBuf> {
+        completion_target_path(self.shell, &self.target_name()?)
+    }
+}
+
+impl GeneratedCompletionArtifact {
+    fn resolved_base_name(&self, cask: &Cask) -> String {
+        let name = self.base_name.clone().unwrap_or_else(|| {
+            Path::new(&self.executable)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(&cask.token)
+                .to_string()
+        });
+        if name.is_empty() {
+            cask.token.clone()
+        } else {
+            name
+        }
+    }
+
+    fn target_paths(&self, cask: &Cask) -> Result<Vec<PathBuf>> {
+        let base_name = self.resolved_base_name(cask);
+        self.shells
+            .iter()
+            .map(|shell| generated_completion_target_path(*shell, &base_name))
+            .collect()
     }
 }
 
@@ -767,184 +854,353 @@ fn font_target_path(font: &FontArtifact) -> Result<PathBuf> {
         .join(name_path))
 }
 
-fn execute_flight_steps(
+fn stage_completion(stage: &Path, caskroom: &Path, completion: &CompletionArtifact) -> Result<()> {
+    let target = completion.target_path()?;
+    let caskroom_completion = caskroom_completion_path(caskroom, &target)?;
+    file::remove_all(&caskroom_completion)?;
+    if let Some(parent) = caskroom_completion.parent() {
+        file::create_dir_all(parent)?;
+    }
+    let source = find_completion_source(stage, caskroom, &completion.source).ok_or_else(|| {
+        eyre!(
+            "brew-cask: {} completion artifact '{}' was not found",
+            completion.shell.name(),
+            completion.source
+        )
+    })?;
+    file::copy(&source, &caskroom_completion)?;
+    Ok(())
+}
+
+fn stage_generated_completions(
+    stage: &Path,
+    caskroom: &Path,
     cask: &Cask,
-    steps: &[FlightStep],
-    staged_path: &Path,
-    kind: &str,
+    completion: &GeneratedCompletionArtifact,
 ) -> Result<()> {
-    for step in steps {
-        execute_flight_step(step, staged_path).wrap_err_with(|| {
-            format!("brew-cask:{}: failed to run structured {kind}", cask.token)
-        })?;
+    let executable = find_generated_completion_executable(stage, caskroom, cask, completion)?;
+    let base_name = completion.resolved_base_name(cask);
+    for shell in &completion.shells {
+        let target = generated_completion_target_path(*shell, &base_name)?;
+        let caskroom_completion = caskroom_completion_path(caskroom, &target)?;
+        if let Some(parent) = caskroom_completion.parent() {
+            file::create_dir_all(parent)?;
+        }
+        let output = generate_completion_output(&executable, completion, *shell)?;
+        crate::file::write(caskroom_completion, output)?;
     }
     Ok(())
 }
 
-fn execute_flight_step(step: &FlightStep, staged_path: &Path) -> Result<()> {
-    match step {
-        FlightStep::Move {
-            source,
-            target,
-            source_glob,
-        } => {
-            let sources = flight_sources(staged_path, source, *source_glob)?;
-            let target = resolve_flight_path(staged_path, target)?;
-            if sources.len() > 1 && !target.is_dir() {
-                bail!(
-                    "brew-cask: structured move with multiple sources requires a directory target"
-                );
-            }
-            for source in sources {
-                let target = if target.is_dir() {
-                    target.join(source.file_name().ok_or_else(|| {
-                        eyre!(
-                            "brew-cask: structured move source '{}' has no file name",
-                            source.display()
-                        )
-                    })?)
-                } else {
-                    target.clone()
-                };
-                if let Some(parent) = target.parent()
-                    && !parent.as_os_str().is_empty()
-                {
-                    file::create_dir_all(parent)?;
-                }
-                file::remove_all(&target)?;
-                file::rename(&source, &target)?;
-            }
-        }
-        FlightStep::Remove { paths, recursive } => {
-            for path in paths {
-                for path in flight_paths(staged_path, path)? {
-                    if *recursive {
-                        file::remove_all(&path)?;
-                    } else if path.symlink_metadata().is_ok() {
-                        file::remove_file_or_dir(&path)?;
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn flight_sources(
-    staged_path: &Path,
-    source: &FlightPath,
-    source_glob: bool,
-) -> Result<Vec<PathBuf>> {
-    if !source_glob {
-        let source = resolve_flight_path(staged_path, source)?;
-        if !source.exists() {
-            bail!(
-                "brew-cask: structured move source '{}' was not found",
-                source.display()
-            );
-        }
-        return Ok(vec![source]);
-    }
-    // Homebrew marks move sources as globs explicitly; non-glob move sources
-    // may contain literal glob-like characters and should be resolved literally.
-    let sources = expand_staged_glob(staged_path, &source.path)?;
-    if sources.is_empty() {
+fn link_completion(caskroom: &Path, target: &Path) -> Result<()> {
+    let caskroom_completion = caskroom_completion_path(caskroom, target)?;
+    if !caskroom_completion.is_file() {
         bail!(
-            "brew-cask: structured move source '{}' was not found",
-            source.path
+            "brew-cask: completion artifact '{}' was not staged",
+            target.display()
         );
     }
-    Ok(sources)
-}
-
-fn flight_paths(staged_path: &Path, path: &FlightPath) -> Result<Vec<PathBuf>> {
-    if !is_flight_glob(&path.path) {
-        return Ok(vec![resolve_flight_path(staged_path, path)?]);
+    if let Some(parent) = target.parent() {
+        file::create_dir_all(parent)?;
     }
-    // Remove steps do not have a `source_glob` flag, so path globs are detected
-    // from the path syntax instead.
-    expand_staged_glob(staged_path, &path.path)
+    file::remove_all(target)?;
+    file::copy(&caskroom_completion, target)?;
+    Ok(())
 }
 
-fn expand_staged_glob(staged_path: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
-    let mut matches = Vec::new();
-    let escaped_root = glob::Pattern::escape(staged_path.to_string_lossy().as_ref());
-    for pattern in expand_braces(pattern) {
-        validate_flight_relative_path(&pattern)?;
-        let rooted_pattern = Path::new(&escaped_root)
-            .join(Path::new(&pattern))
-            .to_string_lossy()
-            .to_string();
-        for path in glob::glob_with(
-            &rooted_pattern,
-            glob::MatchOptions {
-                require_literal_separator: true,
-                ..Default::default()
-            },
-        )
-        .wrap_err_with(|| format!("brew-cask: invalid structured flight glob '{pattern}'"))?
-        {
-            let path = path?;
-            if !path.starts_with(staged_path) {
-                bail!(
-                    "brew-cask: structured flight glob '{}' matched outside staged path",
-                    pattern
-                );
+fn find_completion_source(stage: &Path, caskroom: &Path, source: &str) -> Option<PathBuf> {
+    if source.contains("$APPDIR") {
+        return [
+            PathBuf::from("/Applications"),
+            prefix::prefix().join("Applications"),
+        ]
+        .iter()
+        .map(|appdir| PathBuf::from(source.replace("$APPDIR", &appdir.to_string_lossy())))
+        .find(|path| path.is_file());
+    }
+    absolute_prefixed_source(source)
+        .filter(|source| source.is_file())
+        .or_else(|| find_file_artifact(caskroom, source))
+        .or_else(|| find_file_artifact(stage, source))
+}
+
+fn find_generated_completion_executable(
+    stage: &Path,
+    caskroom: &Path,
+    cask: &Cask,
+    completion: &GeneratedCompletionArtifact,
+) -> Result<PathBuf> {
+    let executable = &completion.executable;
+    if let Some(source) = generated_caskroom_artifact(caskroom, cask, executable)
+        && source.is_file()
+    {
+        return Ok(source);
+    }
+    if let Some(source) = generated_caskroom_artifact(stage, cask, executable)
+        && source.is_file()
+    {
+        return Ok(source);
+    }
+    if let Some(source) = absolute_prefixed_source(executable) {
+        if source.is_file() {
+            return Ok(source);
+        }
+        if let Ok(relative) = source.strip_prefix(prefix::prefix()) {
+            let caskroom_source = caskroom.join(relative);
+            if caskroom_source.is_file() {
+                return Ok(caskroom_source);
             }
-            matches.push(path);
         }
     }
-    matches.sort();
-    matches.dedup();
-    Ok(matches)
+    find_file_artifact(caskroom, executable)
+        .or_else(|| find_file_artifact(stage, executable))
+        .ok_or_else(|| {
+            eyre!(
+                "brew-cask: completion executable '{}' was not found",
+                executable
+            )
+        })
 }
 
-fn is_flight_glob(path: &str) -> bool {
-    path.chars()
-        .any(|c| matches!(c, '*' | '?' | '[' | ']' | '{' | '}'))
-}
-
-fn resolve_flight_path(staged_path: &Path, path: &FlightPath) -> Result<PathBuf> {
-    match path.base {
-        FlightPathBase::StagedPath => {}
+fn generate_completion_output(
+    executable: &Path,
+    completion: &GeneratedCompletionArtifact,
+    shell: CompletionShell,
+) -> Result<String> {
+    let mut command = std::process::Command::new(executable);
+    command.args(&completion.args);
+    command.env("SHELL", shell.name());
+    let (shell_args, shell_env) = completion_shell_parameter(
+        completion.shell_parameter_format.as_deref(),
+        shell,
+        executable,
+    );
+    command.args(shell_args);
+    for (key, value) in shell_env {
+        command.env(key, value);
     }
-    let relative = Path::new(&path.path);
-    validate_flight_relative_path(&path.path)?;
-    Ok(staged_path.join(relative))
+    let output = command.output().wrap_err_with(|| {
+        format!(
+            "failed to generate {} completions from {}",
+            shell.name(),
+            executable.display()
+        )
+    })?;
+    if !output.status.success() {
+        bail!(
+            "brew-cask: failed to generate {} completions from {}: {}",
+            shell.name(),
+            executable.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-fn validate_flight_relative_path(path: &str) -> Result<()> {
-    let path = Path::new(path);
-    if path.is_absolute()
-        || path
-            .components()
-            .any(|component| matches!(component, Component::ParentDir))
+fn completion_shell_parameter(
+    format: Option<&str>,
+    shell: CompletionShell,
+    executable: &Path,
+) -> (Vec<String>, Vec<(String, String)>) {
+    let shell_parameter = shell.parameter_name().to_string();
+    match format {
+        None => (vec![shell_parameter], Vec::new()),
+        Some("arg") => (vec![format!("--shell={shell_parameter}")], Vec::new()),
+        Some("clap") => (Vec::new(), vec![("COMPLETE".to_string(), shell_parameter)]),
+        Some("click") => {
+            let program = executable
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_uppercase()
+                .replace('-', "_");
+            (
+                Vec::new(),
+                vec![(
+                    format!("_{program}_COMPLETE"),
+                    format!("{shell_parameter}_source"),
+                )],
+            )
+        }
+        Some("cobra") => (vec!["completion".to_string(), shell_parameter], Vec::new()),
+        Some("flag") => (vec![format!("--{shell_parameter}")], Vec::new()),
+        Some("none") => (Vec::new(), Vec::new()),
+        Some("typer") => (
+            vec!["--show-completion".to_string(), shell_parameter],
+            vec![(
+                "_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION".to_string(),
+                "1".to_string(),
+            )],
+        ),
+        Some(format) => (vec![format!("{format}{}", shell.name())], Vec::new()),
+    }
+}
+
+fn absolute_prefixed_source(source: &str) -> Option<PathBuf> {
+    let prefix = prefix::prefix();
+    let source = source.replace("$HOMEBREW_PREFIX", &prefix.to_string_lossy());
+    let source = PathBuf::from(source);
+    source.is_absolute().then_some(source)
+}
+
+fn completion_target_path(shell: CompletionShell, target_name: &str) -> Result<PathBuf> {
+    let prefix = prefix::prefix();
+    let prefix_str = prefix.to_string_lossy();
+    let target_name = target_name.replace("$HOMEBREW_PREFIX", prefix_str.as_ref());
+    let path = PathBuf::from(&target_name);
+    let target = if path.is_absolute() {
+        path
+    } else if target_name.contains('/') {
+        prefix.join(path)
+    } else {
+        default_completion_dir(shell).join(completion_filename(shell, &target_name)?)
+    };
+    if target
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
     {
         bail!(
-            "brew-cask: invalid structured flight path '{}'",
-            path.display()
+            "brew-cask: completion target '{}' must not contain '..'",
+            target.display()
         );
     }
-    Ok(())
+    if !target.starts_with(&prefix) {
+        bail!(
+            "brew-cask: completion target '{}' must be under {}",
+            target.display(),
+            prefix.display()
+        );
+    }
+    Ok(target)
 }
 
-fn expand_braces(pattern: &str) -> Vec<String> {
-    let Some(start) = pattern.find('{') else {
-        return vec![pattern.to_string()];
+fn generated_completion_target_path(shell: CompletionShell, base_name: &str) -> Result<PathBuf> {
+    match shell {
+        CompletionShell::Pwsh => {
+            let name = format!("_{}.ps1", base_name);
+            completion_target_path(shell, &name)
+        }
+        _ => completion_target_path(shell, base_name),
+    }
+}
+
+fn default_completion_dir(shell: CompletionShell) -> PathBuf {
+    let prefix = prefix::prefix();
+    match shell {
+        CompletionShell::Bash => prefix.join("etc/bash_completion.d"),
+        CompletionShell::Fish => prefix.join("share/fish/vendor_completions.d"),
+        CompletionShell::Zsh => prefix.join("share/zsh/site-functions"),
+        CompletionShell::Pwsh => prefix.join("share/pwsh/completions"),
+    }
+}
+
+fn completion_filename(shell: CompletionShell, target_name: &str) -> Result<String> {
+    let filename = Path::new(target_name)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| eyre!("brew-cask: invalid completion target '{target_name}'"))?;
+    let stem = Path::new(filename)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or(filename);
+    let normalized = match shell {
+        CompletionShell::Bash => stem.to_string(),
+        CompletionShell::Fish => {
+            if filename.ends_with(".fish") {
+                filename.to_string()
+            } else {
+                format!("{stem}.fish")
+            }
+        }
+        CompletionShell::Zsh => {
+            if filename.starts_with('_') {
+                filename.to_string()
+            } else {
+                format!("_{stem}")
+            }
+        }
+        CompletionShell::Pwsh => {
+            if filename.ends_with(".ps1") {
+                filename.to_string()
+            } else {
+                format!("{stem}.ps1")
+            }
+        }
     };
-    let Some(end_offset) = pattern[start + 1..].find('}') else {
-        return vec![pattern.to_string()];
+    if normalized.is_empty() {
+        bail!("brew-cask: invalid completion target '{target_name}'");
+    }
+    Ok(normalized)
+}
+
+fn caskroom_completion_path(caskroom: &Path, target: &Path) -> Result<PathBuf> {
+    let prefix = prefix::prefix();
+    let relative = target.strip_prefix(&prefix).map_err(|_| {
+        eyre!(
+            "brew-cask: completion target '{}' must be under {}",
+            target.display(),
+            prefix.display()
+        )
+    })?;
+    if relative.components().next().is_none() {
+        bail!(
+            "brew-cask: invalid completion target '{}'",
+            target.display()
+        );
+    }
+    Ok(caskroom.join(relative))
+}
+
+fn completion_target_paths(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Vec<PathBuf>> {
+    let mut targets = artifacts
+        .completions
+        .iter()
+        .map(CompletionArtifact::target_path)
+        .collect::<Result<Vec<_>>>()?;
+    for generated in &artifacts.generated_completions {
+        targets.extend(generated.target_paths(cask)?);
+    }
+    targets.sort();
+    targets.dedup();
+    Ok(targets)
+}
+
+fn previous_completion_targets(cask: &Cask) -> Result<Vec<PathBuf>> {
+    let Some(version) = installed_version(&cask.token) else {
+        return Ok(Vec::new());
     };
-    let end = start + 1 + end_offset;
-    let prefix = &pattern[..start];
-    let suffix = &pattern[end + 1..];
-    let mut expanded = Vec::new();
-    for alternative in pattern[start + 1..end].split(',') {
-        for suffix in expand_braces(suffix) {
-            expanded.push(format!("{prefix}{alternative}{suffix}"));
+    let version_dir = caskroom_version_dir(&cask.token, &version);
+    Ok(read_receipt(&version_dir)?
+        .map(|receipt| receipt.completions)
+        .unwrap_or_default())
+}
+
+fn remove_obsolete_completions(
+    cask: &Cask,
+    previous_targets: &[PathBuf],
+    current_targets: &[PathBuf],
+) -> Result<()> {
+    let token_dir = file::desymlink_path(&caskroom_token_dir(&cask.token));
+    let prefix = prefix::prefix();
+    for target in previous_targets {
+        if current_targets.contains(target) || !target.is_file() || !target.starts_with(&prefix) {
+            continue;
+        }
+        let Ok(relative) = target.strip_prefix(&prefix) else {
+            continue;
+        };
+        let has_staged_copy = std::fs::read_dir(&token_dir)
+            .ok()
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_type().is_ok_and(|ft| ft.is_dir()))
+            .any(|entry| entry.path().join(relative).is_file());
+        if has_staged_copy {
+            file::remove_file(target)?;
         }
     }
-    expanded
+    Ok(())
 }
 
 fn stage_binary(stage: &Path, caskroom: &Path, cask: &Cask, binary: &BinaryArtifact) -> Result<()> {
@@ -1101,16 +1357,8 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
     let mut artifacts = CaskArtifacts::default();
     for artifact in &cask.artifacts {
         let artifact_type = artifact_type(artifact);
-        if let Some(steps) = parse_flight_steps(cask, artifact, "preflight_steps")? {
-            artifacts.preflight_steps.extend(steps);
-            continue;
-        }
-        if let Some(steps) = parse_flight_steps(cask, artifact, "postflight_steps")? {
-            artifacts.postflight_steps.extend(steps);
-            continue;
-        }
         if is_non_install_artifact(&artifact_type) {
-            collect_pkg_receipt_ids(artifact, &mut artifacts.pkg_ids);
+            collect_uninstall_pkg_ids(artifact, &mut artifacts.pkg_ids);
             continue;
         }
         if let Some(app) = parse_app_artifact(artifact) {
@@ -1129,6 +1377,14 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
             artifacts.fonts.push(font);
             continue;
         }
+        if let Some(completion) = parse_completion_artifact(artifact)? {
+            artifacts.completions.push(completion);
+            continue;
+        }
+        if let Some(generated) = parse_generated_completion_artifact(artifact)? {
+            artifacts.generated_completions.push(generated);
+            continue;
+        }
         bail!(
             "brew-cask:{}: unsupported artifact type {}",
             cask.token,
@@ -1139,9 +1395,11 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
         && artifacts.binaries.is_empty()
         && artifacts.pkgs.is_empty()
         && artifacts.fonts.is_empty()
+        && artifacts.completions.is_empty()
+        && artifacts.generated_completions.is_empty()
     {
         bail!(
-            "brew-cask:{}: no app, binary, pkg, or font artifact found; only app-bundle, binary, pkg, and font casks are supported",
+            "brew-cask:{}: no app, binary, pkg, font, or completion artifact found; only app-bundle, binary, pkg, font, and completion casks are supported",
             cask.token
         );
     }
@@ -1151,7 +1409,7 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
         artifacts.pkg_ids.clear();
     } else if artifacts.pkg_ids.is_empty() {
         bail!(
-            "brew-cask:{}: pkg artifacts require pkgutil ids in uninstall metadata",
+            "brew-cask:{}: pkg artifacts require pkgutil ids in uninstall or zap metadata",
             cask.token
         );
     }
@@ -1243,190 +1501,158 @@ fn parse_font_artifact(value: &Value) -> Option<FontArtifact> {
     }
 }
 
-fn parse_flight_steps(cask: &Cask, value: &Value, kind: &str) -> Result<Option<Vec<FlightStep>>> {
-    let Some(metadata) = value.as_object().and_then(|o| o.get(kind)) else {
+fn parse_completion_artifact(value: &Value) -> Result<Option<CompletionArtifact>> {
+    for (key, shell) in [
+        ("bash_completion", CompletionShell::Bash),
+        ("fish_completion", CompletionShell::Fish),
+        ("zsh_completion", CompletionShell::Zsh),
+    ] {
+        let Some(completion) = value.as_object().and_then(|o| o.get(key)) else {
+            continue;
+        };
+        return parse_declared_completion_artifact(value, completion, shell);
+    }
+    Ok(None)
+}
+
+fn parse_declared_completion_artifact(
+    value: &Value,
+    completion: &Value,
+    shell: CompletionShell,
+) -> Result<Option<CompletionArtifact>> {
+    match completion {
+        Value::String(source) => Ok(Some(CompletionArtifact {
+            shell,
+            source: source.clone(),
+            target: value
+                .as_object()
+                .and_then(|o| o.get("target"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        })),
+        Value::Array(values) => {
+            let Some(source) = values.first().and_then(Value::as_str) else {
+                return Ok(None);
+            };
+            Ok(Some(CompletionArtifact {
+                shell,
+                source: source.to_string(),
+                target: artifact_target(value, values),
+            }))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn parse_generated_completion_artifact(
+    value: &Value,
+) -> Result<Option<GeneratedCompletionArtifact>> {
+    let Some(generated) = value
+        .as_object()
+        .and_then(|o| o.get("generate_completions_from_executable"))
+    else {
         return Ok(None);
     };
-    let groups = metadata.as_array().ok_or_else(|| {
-        eyre!(
-            "brew-cask:{}: unsupported {kind} metadata format",
-            cask.token
-        )
-    })?;
-    let mut steps = Vec::new();
-    for group in groups {
-        let group = group.as_object().ok_or_else(|| {
-            eyre!(
-                "brew-cask:{}: unsupported {kind} metadata format",
-                cask.token
-            )
-        })?;
-        reject_unsupported_flight_fields(cask, kind, "step group", group, &["steps"])?;
-        let group_steps = group
-            .get("steps")
-            .and_then(Value::as_array)
-            .ok_or_else(|| {
-                eyre!(
-                    "brew-cask:{}: unsupported {kind} metadata format",
-                    cask.token
-                )
-            })?;
-        for step in group_steps {
-            steps.push(parse_flight_step(cask, kind, step)?);
-        }
-    }
-    Ok(Some(steps))
-}
-
-fn parse_flight_step(cask: &Cask, kind: &str, value: &Value) -> Result<FlightStep> {
-    let object = value.as_object().ok_or_else(|| {
-        eyre!(
-            "brew-cask:{}: unsupported {kind} step metadata format",
-            cask.token
-        )
-    })?;
-    let step_type = object.get("type").and_then(Value::as_str).ok_or_else(|| {
-        eyre!(
-            "brew-cask:{}: unsupported {kind} step metadata format",
-            cask.token
-        )
-    })?;
-    match step_type {
-        "move" => {
-            reject_unsupported_flight_fields(
-                cask,
-                kind,
-                "move step",
-                object,
-                &["type", "source", "target", "source_glob"],
-            )?;
-            Ok(FlightStep::Move {
-                source: parse_flight_path(cask, kind, "source", object.get("source"))?,
-                target: parse_flight_path(cask, kind, "target", object.get("target"))?,
-                source_glob: object
-                    .get("source_glob")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false),
-            })
-        }
-        "remove" => {
-            reject_unsupported_flight_fields(
-                cask,
-                kind,
-                "remove step",
-                object,
-                &["type", "paths", "recursive"],
-            )?;
-            let paths = object
-                .get("paths")
-                .and_then(Value::as_array)
-                .ok_or_else(|| {
-                    eyre!(
-                        "brew-cask:{}: unsupported {kind} remove step metadata format",
-                        cask.token
-                    )
-                })?
-                .iter()
-                .map(|path| parse_flight_path(cask, kind, "paths", Some(path)))
-                .collect::<Result<Vec<_>>>()?;
-            Ok(FlightStep::Remove {
-                paths,
-                recursive: object
-                    .get("recursive")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false),
-            })
-        }
-        _ => bail!(
-            "brew-cask:{}: unsupported {kind} step type {}",
-            cask.token,
-            step_type
-        ),
-    }
-}
-
-fn reject_unsupported_flight_fields(
-    cask: &Cask,
-    kind: &str,
-    context: &str,
-    object: &serde_json::Map<String, Value>,
-    allowed: &[&str],
-) -> Result<()> {
-    let mut unsupported = object
-        .keys()
-        .filter(|key| !allowed.contains(&key.as_str()))
-        .cloned()
-        .collect::<Vec<_>>();
-    unsupported.sort();
-    if !unsupported.is_empty() {
-        bail!(
-            "brew-cask:{}: unsupported {kind} {context} field {}",
-            cask.token,
-            unsupported.join(", ")
-        );
-    }
-    Ok(())
-}
-
-fn parse_flight_path(
-    cask: &Cask,
-    kind: &str,
-    field: &str,
-    value: Option<&Value>,
-) -> Result<FlightPath> {
-    let object = value.and_then(Value::as_object).ok_or_else(|| {
-        eyre!(
-            "brew-cask:{}: unsupported {kind} {field} metadata format",
-            cask.token
-        )
-    })?;
-    let base = match object.get("base").and_then(Value::as_str) {
-        Some("staged_path") => FlightPathBase::StagedPath,
-        Some(base) => bail!(
-            "brew-cask:{}: unsupported {kind} {field} base {}",
-            cask.token,
-            base
-        ),
-        None => bail!("brew-cask:{}: unsupported {kind} {field} base", cask.token),
+    let Value::Array(values) = generated else {
+        return Ok(None);
     };
-    let path = object
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| eyre!("brew-cask:{}: unsupported {kind} {field} path", cask.token))?;
-    if validate_flight_relative_path(path).is_err() {
-        bail!(
-            "brew-cask:{}: invalid {kind} {field} path {}",
-            cask.token,
-            path
-        )
+    if values.is_empty() {
+        bail!("brew-cask: generate_completions_from_executable requires an executable");
     }
-    Ok(FlightPath {
-        base,
-        path: path.to_string(),
-    })
+    let options = values.last().and_then(Value::as_object);
+    let command_values = if options.is_some() {
+        &values[..values.len() - 1]
+    } else {
+        values.as_slice()
+    };
+    let executable = command_values
+        .first()
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            eyre!("brew-cask: generate_completions_from_executable requires an executable")
+        })?
+        .to_string();
+    let args = command_values
+        .iter()
+        .skip(1)
+        .map(|value| {
+            value.as_str().map(str::to_string).ok_or_else(|| {
+                eyre!("brew-cask: generate_completions_from_executable arguments must be strings")
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let shell_parameter_format = options
+        .and_then(|o| o.get("shell_parameter_format"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let shells = options
+        .and_then(|o| o.get("shells"))
+        .and_then(Value::as_array)
+        .map(|shells| {
+            shells
+                .iter()
+                .map(|shell| {
+                    let shell = shell.as_str().ok_or_else(|| {
+                        eyre!("brew-cask: completion shell names must be strings")
+                    })?;
+                    CompletionShell::parse(shell)
+                        .ok_or_else(|| eyre!("brew-cask: unsupported completion shell '{shell}'"))
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()?
+        .unwrap_or_else(|| default_generated_completion_shells(shell_parameter_format.as_deref()));
+    Ok(Some(GeneratedCompletionArtifact {
+        executable,
+        args,
+        base_name: options
+            .and_then(|o| o.get("base_name"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        shell_parameter_format,
+        shells,
+    }))
 }
 
-fn collect_pkg_receipt_ids(value: &Value, pkg_ids: &mut Vec<String>) {
+fn default_generated_completion_shells(format: Option<&str>) -> Vec<CompletionShell> {
+    match format {
+        Some("cobra") | Some("typer") => vec![
+            CompletionShell::Bash,
+            CompletionShell::Zsh,
+            CompletionShell::Fish,
+            CompletionShell::Pwsh,
+        ],
+        _ => vec![
+            CompletionShell::Bash,
+            CompletionShell::Zsh,
+            CompletionShell::Fish,
+        ],
+    }
+}
+
+fn collect_uninstall_pkg_ids(value: &Value, pkg_ids: &mut Vec<String>) {
     let Some(object) = value.as_object() else {
         return;
     };
-    let Some(metadata) = object.get("uninstall") else {
-        return;
-    };
-    let values: Vec<&Value> = match metadata {
-        Value::Array(values) => values.iter().collect(),
-        value => vec![value],
-    };
-    for value in values {
-        let Some(pkgutil) = value.as_object().and_then(|o| o.get("pkgutil")) else {
+    for key in ["uninstall", "zap"] {
+        let Some(metadata) = object.get(key) else {
             continue;
         };
-        match pkgutil {
-            Value::String(id) => pkg_ids.push(id.clone()),
-            Value::Array(ids) => {
-                pkg_ids.extend(ids.iter().filter_map(Value::as_str).map(str::to_string))
+        let values: Vec<&Value> = match metadata {
+            Value::Array(values) => values.iter().collect(),
+            value => vec![value],
+        };
+        for value in values {
+            let Some(pkgutil) = value.as_object().and_then(|o| o.get("pkgutil")) else {
+                continue;
+            };
+            match pkgutil {
+                Value::String(id) => pkg_ids.push(id.clone()),
+                Value::Array(ids) => {
+                    pkg_ids.extend(ids.iter().filter_map(Value::as_str).map(str::to_string))
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
 }
@@ -1711,10 +1937,18 @@ fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Opti
             } else {
                 receipt.fonts
             };
+            let completion_targets = if receipt.completions.is_empty() {
+                completion_target_paths(cask, artifacts)?
+            } else {
+                receipt.completions
+            };
             if app_targets.iter().all(|app| app.exists())
                 && binary_targets.iter().all(|binary| binary.exists())
                 && pkgs_installed
                 && font_targets.iter().all(|font| font.exists())
+                && completion_targets
+                    .iter()
+                    .all(|completion| completion.exists())
             {
                 Ok(Some(receipt.version))
             } else {
@@ -1740,6 +1974,11 @@ fn installed_cask_version(cask: &Cask, artifacts: &CaskArtifacts) -> Result<Opti
                     return Ok(None);
                 }
             }
+            for completion in completion_target_paths(cask, artifacts)? {
+                if !completion.exists() {
+                    return Ok(None);
+                }
+            }
             Ok(Some(version))
         }
     }
@@ -1759,6 +1998,7 @@ fn write_receipt(caskroom: &Path, cask: &Cask, artifacts: &CaskArtifacts) -> Res
             .iter()
             .map(font_target_path)
             .collect::<Result<Vec<_>>>()?,
+        completions: completion_target_paths(cask, artifacts)?,
         pkg_ids: artifacts.pkg_ids.clone(),
     };
     let body = toml::to_string_pretty(&receipt)?;
@@ -1826,22 +2066,16 @@ fn artifact_type(value: &Value) -> String {
 fn is_non_install_artifact(kind: &str) -> bool {
     matches!(
         kind,
-        "bash_completion"
-            | "caveats"
+        "caveats"
             | "conflicts_with"
             | "depends_on"
-            | "fish_completion"
-            | "generate_completions_from_executable"
             | "manpage"
             | "postflight"
             | "preflight"
-            | "uninstall_postflight_steps"
-            | "uninstall_preflight_steps"
             | "uninstall"
             | "uninstall_postflight"
             | "uninstall_preflight"
             | "zap"
-            | "zsh_completion"
     )
 }
 
@@ -1911,185 +2145,6 @@ mod tests {
             tap_git_head: None,
             raw_base: None,
         }
-    }
-
-    #[test]
-    fn parses_structured_flight_steps() -> Result<()> {
-        let mut cask = test_cask("wezterm@nightly", "latest");
-        cask.artifacts = vec![
-            serde_json::json!({
-                "preflight_steps": [{
-                    "steps": [
-                        {
-                            "type": "move",
-                            "source_glob": true,
-                            "source": {
-                                "base": "staged_path",
-                                "path": "{WezTerm-*,wezterm-*}/WezTerm.app"
-                            },
-                            "target": {
-                                "base": "staged_path",
-                                "path": "."
-                            }
-                        },
-                        {
-                            "type": "remove",
-                            "recursive": true,
-                            "paths": [
-                                {"base": "staged_path", "path": "WezTerm-*"},
-                                {"base": "staged_path", "path": "wezterm-*"}
-                            ]
-                        }
-                    ]
-                }]
-            }),
-            serde_json::json!({"app": "WezTerm.app"}),
-        ];
-
-        assert_eq!(
-            cask_artifacts(&cask)?,
-            CaskArtifacts {
-                apps: vec![AppArtifact {
-                    source: "WezTerm.app".to_string(),
-                    target: None,
-                }],
-                preflight_steps: vec![
-                    FlightStep::Move {
-                        source: FlightPath {
-                            base: FlightPathBase::StagedPath,
-                            path: "{WezTerm-*,wezterm-*}/WezTerm.app".to_string(),
-                        },
-                        target: FlightPath {
-                            base: FlightPathBase::StagedPath,
-                            path: ".".to_string(),
-                        },
-                        source_glob: true,
-                    },
-                    FlightStep::Remove {
-                        paths: vec![
-                            FlightPath {
-                                base: FlightPathBase::StagedPath,
-                                path: "WezTerm-*".to_string(),
-                            },
-                            FlightPath {
-                                base: FlightPathBase::StagedPath,
-                                path: "wezterm-*".to_string(),
-                            }
-                        ],
-                        recursive: true,
-                    }
-                ],
-                ..Default::default()
-            }
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn structured_flight_steps_move_and_remove_staged_paths() -> Result<()> {
-        let tmp = tempfile::tempdir()?;
-        let staged = tmp.path();
-        let bundle_dir = staged.join("WezTerm-nightly");
-        let app = bundle_dir.join("WezTerm.app");
-        file::create_dir_all(&app)?;
-
-        execute_flight_steps(
-            &test_cask("wezterm@nightly", "latest"),
-            &[
-                FlightStep::Move {
-                    source: FlightPath {
-                        base: FlightPathBase::StagedPath,
-                        path: "{WezTerm-*,wezterm-*}/WezTerm.app".to_string(),
-                    },
-                    target: FlightPath {
-                        base: FlightPathBase::StagedPath,
-                        path: ".".to_string(),
-                    },
-                    source_glob: true,
-                },
-                FlightStep::Remove {
-                    paths: vec![
-                        FlightPath {
-                            base: FlightPathBase::StagedPath,
-                            path: "WezTerm-*".to_string(),
-                        },
-                        FlightPath {
-                            base: FlightPathBase::StagedPath,
-                            path: "wezterm-*".to_string(),
-                        },
-                    ],
-                    recursive: true,
-                },
-            ],
-            staged,
-            "preflight_steps",
-        )?;
-
-        assert!(staged.join("WezTerm.app").is_dir());
-        assert!(!bundle_dir.exists());
-        Ok(())
-    }
-
-    #[test]
-    fn rejects_unsupported_structured_flight_steps() {
-        let mut cask = test_cask("battle-net", "1.0.0");
-        cask.artifacts = vec![
-            serde_json::json!({
-                "preflight_steps": [{
-                    "steps": [{
-                        "type": "set_permissions",
-                        "paths": [{"base": "staged_path", "path": "Battle.net-Setup.app"}],
-                        "permissions": "a+x"
-                    }]
-                }]
-            }),
-            serde_json::json!({"app": "Battle.net.app"}),
-        ];
-
-        let err = cask_artifacts(&cask).unwrap_err().to_string();
-        assert!(err.contains("unsupported preflight_steps step type set_permissions"));
-    }
-
-    #[test]
-    fn rejects_structured_flight_step_group_controls() {
-        let mut cask = test_cask("example", "1.0.0");
-        cask.artifacts = vec![
-            serde_json::json!({
-                "preflight_steps": [{
-                    "if": {"arch": "arm64"},
-                    "steps": [{
-                        "type": "remove",
-                        "paths": [{"base": "staged_path", "path": "old"}]
-                    }]
-                }]
-            }),
-            serde_json::json!({"app": "Example.app"}),
-        ];
-
-        let err = cask_artifacts(&cask).unwrap_err().to_string();
-        assert!(err.contains("unsupported preflight_steps step group field if"));
-    }
-
-    #[test]
-    fn rejects_structured_flight_step_controls() {
-        let mut cask = test_cask("miniconda", "25.5.1-1");
-        cask.artifacts = vec![
-            serde_json::json!({
-                "postflight_steps": [{
-                    "steps": [{
-                        "type": "remove",
-                        "paths": [{"base": "staged_path", "path": "base/envs"}],
-                        "recursive": true,
-                        "guards": [{"condition": "if_exists", "path": "{{temp}}/miniconda-envs"}]
-                    }]
-                }]
-            }),
-            serde_json::json!({"pkg": ["Miniconda.pkg"]}),
-            serde_json::json!({"uninstall": [{"pkgutil": "com.anaconda.pkg"}]}),
-        ];
-
-        let err = cask_artifacts(&cask).unwrap_err().to_string();
-        assert!(err.contains("unsupported postflight_steps remove step field guards"));
     }
 
     #[test]
@@ -2406,7 +2461,7 @@ end
     }
 
     #[test]
-    fn parses_binary_artifacts_and_ignores_completion_generation() -> Result<()> {
+    fn parses_binary_artifacts_and_generated_completions() -> Result<()> {
         let mut cask = test_cask("1password-cli", "2.34.1");
         cask.artifacts = vec![
             serde_json::json!({"binary": ["op"], "target": "$HOMEBREW_PREFIX/bin/op"}),
@@ -2427,10 +2482,184 @@ end
                     source: "op".to_string(),
                     target: Some("$HOMEBREW_PREFIX/bin/op".to_string())
                 }],
+                generated_completions: vec![GeneratedCompletionArtifact {
+                    executable: "op".to_string(),
+                    args: vec!["completion".to_string()],
+                    base_name: None,
+                    shell_parameter_format: None,
+                    shells: vec![
+                        CompletionShell::Bash,
+                        CompletionShell::Zsh,
+                        CompletionShell::Fish,
+                    ],
+                }],
                 ..Default::default()
             }
         );
         Ok(())
+    }
+
+    #[test]
+    fn parses_declared_completion_artifacts() -> Result<()> {
+        let mut cask = test_cask("ghostty", "1.2.0");
+        cask.artifacts = vec![
+            serde_json::json!({"app": "Ghostty.app"}),
+            serde_json::json!({
+                "bash_completion": [
+                    "$APPDIR/Ghostty.app/Contents/Resources/bash-completion/completions/ghostty.bash"
+                ],
+                "target": "$HOMEBREW_PREFIX/etc/bash_completion.d/ghostty"
+            }),
+            serde_json::json!({
+                "fish_completion": [
+                    "$APPDIR/Ghostty.app/Contents/Resources/fish/vendor_completions.d/ghostty.fish"
+                ],
+                "target": "$HOMEBREW_PREFIX/share/fish/vendor_completions.d/ghostty.fish"
+            }),
+            serde_json::json!({
+                "zsh_completion": [
+                    "$APPDIR/Ghostty.app/Contents/Resources/zsh/site-functions/_ghostty"
+                ],
+                "target": "$HOMEBREW_PREFIX/share/zsh/site-functions/_ghostty"
+            }),
+        ];
+
+        assert_eq!(
+            cask_artifacts(&cask)?.completions,
+            vec![
+                CompletionArtifact {
+                    shell: CompletionShell::Bash,
+                    source: "$APPDIR/Ghostty.app/Contents/Resources/bash-completion/completions/ghostty.bash"
+                        .to_string(),
+                    target: Some("$HOMEBREW_PREFIX/etc/bash_completion.d/ghostty".to_string()),
+                },
+                CompletionArtifact {
+                    shell: CompletionShell::Fish,
+                    source: "$APPDIR/Ghostty.app/Contents/Resources/fish/vendor_completions.d/ghostty.fish"
+                        .to_string(),
+                    target: Some(
+                        "$HOMEBREW_PREFIX/share/fish/vendor_completions.d/ghostty.fish"
+                            .to_string()
+                    ),
+                },
+                CompletionArtifact {
+                    shell: CompletionShell::Zsh,
+                    source: "$APPDIR/Ghostty.app/Contents/Resources/zsh/site-functions/_ghostty"
+                        .to_string(),
+                    target: Some("$HOMEBREW_PREFIX/share/zsh/site-functions/_ghostty".to_string()),
+                },
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn completion_target_paths_match_homebrew_names() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+
+        assert_eq!(
+            completion_target_path(CompletionShell::Bash, "ghostty.bash")?,
+            tmp.path().join("etc/bash_completion.d/ghostty")
+        );
+        assert_eq!(
+            completion_target_path(CompletionShell::Fish, "ghostty")?,
+            tmp.path()
+                .join("share/fish/vendor_completions.d/ghostty.fish")
+        );
+        assert_eq!(
+            completion_target_path(CompletionShell::Zsh, "ghostty")?,
+            tmp.path().join("share/zsh/site-functions/_ghostty")
+        );
+        assert_eq!(
+            generated_completion_target_path(CompletionShell::Pwsh, "ghostty")?,
+            tmp.path().join("share/pwsh/completions/_ghostty.ps1")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stages_and_links_declared_completion() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("caskroom");
+        file::create_dir_all(stage.join("completions"))?;
+        file::create_dir_all(&caskroom)?;
+        crate::file::write(stage.join("completions/ghostty.bash"), "complete")?;
+        let completion = CompletionArtifact {
+            shell: CompletionShell::Bash,
+            source: "completions/ghostty.bash".to_string(),
+            target: None,
+        };
+        let target = completion.target_path()?;
+
+        stage_completion(&stage, &caskroom, &completion)?;
+        link_completion(&caskroom, &target)?;
+
+        assert_eq!(
+            crate::file::read_to_string(caskroom.join("etc/bash_completion.d/ghostty"))?,
+            "complete"
+        );
+        assert_eq!(crate::file::read_to_string(target)?, "complete");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stages_generated_completion_output() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("caskroom");
+        file::create_dir_all(&stage)?;
+        file::create_dir_all(&caskroom)?;
+        let executable = stage.join("op");
+        crate::file::write(
+            &executable,
+            "#!/bin/sh\nprintf '%s|%s|%s' \"$1\" \"$2\" \"$SHELL\"\n",
+        )?;
+        file::make_executable(&executable)?;
+        let cask = test_cask("1password-cli", "2.34.1");
+        let completion = GeneratedCompletionArtifact {
+            executable: "op".to_string(),
+            args: vec!["completion".to_string()],
+            base_name: None,
+            shell_parameter_format: None,
+            shells: vec![CompletionShell::Bash],
+        };
+
+        stage_generated_completions(&stage, &caskroom, &cask, &completion)?;
+
+        assert_eq!(
+            crate::file::read_to_string(caskroom.join("etc/bash_completion.d/op"))?,
+            "completion|bash|bash"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn completion_shell_parameter_formats_match_homebrew() {
+        let (args, env) =
+            completion_shell_parameter(Some("cobra"), CompletionShell::Zsh, Path::new("tool"));
+        assert_eq!(args, vec!["completion".to_string(), "zsh".to_string()]);
+        assert_eq!(env, Vec::<(String, String)>::new());
+
+        let (args, env) =
+            completion_shell_parameter(Some("click"), CompletionShell::Fish, Path::new("my-tool"));
+        assert!(args.is_empty());
+        assert_eq!(
+            env,
+            vec![("_MY_TOOL_COMPLETE".to_string(), "fish_source".to_string())]
+        );
+
+        let (args, env) =
+            completion_shell_parameter(Some("clap"), CompletionShell::Bash, Path::new("tool"));
+        assert!(args.is_empty());
+        assert_eq!(env, vec![("COMPLETE".to_string(), "bash".to_string())]);
     }
 
     #[test]
@@ -2527,21 +2756,20 @@ end
     }
 
     #[test]
-    fn ignores_zap_pkgutil_ids_for_pkg_receipts() -> Result<()> {
-        let mut cask = test_cask("google-japanese-ime", "3.33.6130");
+    fn parses_zap_pkgutil_ids() -> Result<()> {
+        let mut cask = test_cask("example", "1.0.0");
         cask.artifacts = vec![
-            serde_json::json!({"uninstall": [{"pkgutil": "com.google.pkg.GoogleJapaneseInput"}]}),
-            serde_json::json!({"pkg": ["GoogleJapaneseInput.pkg"]}),
-            serde_json::json!({"zap": [{"pkgutil": "com.google.pkg.Keystone"}]}),
+            serde_json::json!({"zap": [{"pkgutil": ["com.example.pkg"]}]}),
+            serde_json::json!({"pkg": ["Example.pkg"]}),
         ];
 
         assert_eq!(
             cask_artifacts(&cask)?,
             CaskArtifacts {
                 pkgs: vec![PkgArtifact {
-                    source: "GoogleJapaneseInput.pkg".to_string()
+                    source: "Example.pkg".to_string()
                 }],
-                pkg_ids: vec!["com.google.pkg.GoogleJapaneseInput".to_string()],
+                pkg_ids: vec!["com.example.pkg".to_string()],
                 ..Default::default()
             }
         );
@@ -2555,18 +2783,6 @@ end
 
         let err = cask_artifacts(&cask).unwrap_err().to_string();
         assert!(err.contains("pkg artifacts require pkgutil ids"));
-    }
-
-    #[test]
-    fn rejects_pkg_artifacts_with_only_zap_pkgutil_ids() {
-        let mut cask = test_cask("example", "1.0.0");
-        cask.artifacts = vec![
-            serde_json::json!({"pkg": ["Example.pkg"]}),
-            serde_json::json!({"zap": [{"pkgutil": "com.example.cleanup"}]}),
-        ];
-
-        let err = cask_artifacts(&cask).unwrap_err().to_string();
-        assert!(err.contains("pkg artifacts require pkgutil ids in uninstall metadata"));
     }
 
     #[test]
@@ -2621,7 +2837,7 @@ end
     }
 
     #[test]
-    fn skips_bash_completion_and_manpage_artifacts() -> Result<()> {
+    fn parses_completion_artifacts_and_skips_manpage_artifacts() -> Result<()> {
         let mut cask = test_cask("ghostty", "1.2.0");
         cask.artifacts = vec![
             serde_json::json!({"app": "Ghostty.app"}),
@@ -2633,6 +2849,7 @@ end
 
         let artifacts = cask_artifacts(&cask)?;
         assert_eq!(artifacts.apps.len(), 1);
+        assert_eq!(artifacts.completions.len(), 3);
         assert_eq!(artifacts.fonts.len(), 0);
         Ok(())
     }
@@ -2893,6 +3110,7 @@ end
             apps: vec![app_target_path(app.target_name())?],
             binaries: vec![],
             fonts: vec![],
+            completions: vec![],
             pkg_ids: vec!["com.example.helper".to_string()],
         };
         crate::file::write(
@@ -3166,6 +3384,7 @@ end
             apps: vec![],
             binaries: vec![],
             fonts: vec![],
+            completions: vec![],
             pkg_ids: vec![],
         };
         crate::file::write(
@@ -3221,6 +3440,35 @@ end
                     ..Default::default()
                 }
             )?,
+            Some("1.0.0".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn installed_cask_version_checks_completions_without_receipt() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let cask = test_cask("completion-only", "1.0.0");
+        let completion = CompletionArtifact {
+            shell: CompletionShell::Zsh,
+            source: "ghostty".to_string(),
+            target: None,
+        };
+        file::create_dir_all(caskroom_version_dir(&cask.token, &cask.version))?;
+        let artifacts = CaskArtifacts {
+            completions: vec![completion.clone()],
+            ..Default::default()
+        };
+
+        assert_eq!(installed_cask_version(&cask, &artifacts)?, None);
+
+        let target = completion.target_path()?;
+        file::create_dir_all(target.parent().unwrap())?;
+        crate::file::write(target, "complete")?;
+        assert_eq!(
+            installed_cask_version(&cask, &artifacts)?,
             Some("1.0.0".to_string())
         );
         Ok(())

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -190,7 +190,7 @@ impl BrewCaskManager {
             stage_binary(&stage, &tmp_caskroom, &cask, binary)?;
         }
         for completion in &artifacts.completions {
-            stage_completion(&stage, &tmp_caskroom, completion)?;
+            stage_completion(&stage, &tmp_caskroom, &cask, completion)?;
         }
         for generated in &artifacts.generated_completions {
             stage_generated_completions(&stage, &tmp_caskroom, &cask, generated)?;
@@ -204,7 +204,7 @@ impl BrewCaskManager {
         remove_obsolete_binary_links(&cask, &previous_binaries, &binary_targets(&artifacts)?)?;
         let current_completions = completion_target_paths(&cask, &artifacts)?;
         for target in &current_completions {
-            link_completion(&caskroom, target)?;
+            link_completion(&cask, &caskroom, target)?;
         }
         remove_obsolete_completions(&cask, &previous_completions, &current_completions)?;
         for font in &artifacts.fonts {
@@ -854,21 +854,29 @@ fn font_target_path(font: &FontArtifact) -> Result<PathBuf> {
         .join(name_path))
 }
 
-fn stage_completion(stage: &Path, caskroom: &Path, completion: &CompletionArtifact) -> Result<()> {
+fn stage_completion(
+    stage: &Path,
+    caskroom: &Path,
+    cask: &Cask,
+    completion: &CompletionArtifact,
+) -> Result<()> {
     let target = completion.target_path()?;
     let caskroom_completion = caskroom_completion_path(caskroom, &target)?;
-    file::remove_all(&caskroom_completion)?;
-    if let Some(parent) = caskroom_completion.parent() {
-        file::create_dir_all(parent)?;
+    let source =
+        find_completion_source(stage, caskroom, cask, &completion.source).ok_or_else(|| {
+            eyre!(
+                "brew-cask: {} completion artifact '{}' was not found",
+                completion.shell.name(),
+                completion.source
+            )
+        })?;
+    if !file::same_file(&source, &caskroom_completion) {
+        file::remove_all(&caskroom_completion)?;
+        if let Some(parent) = caskroom_completion.parent() {
+            file::create_dir_all(parent)?;
+        }
+        file::copy(&source, &caskroom_completion)?;
     }
-    let source = find_completion_source(stage, caskroom, &completion.source).ok_or_else(|| {
-        eyre!(
-            "brew-cask: {} completion artifact '{}' was not found",
-            completion.shell.name(),
-            completion.source
-        )
-    })?;
-    file::copy(&source, &caskroom_completion)?;
     Ok(())
 }
 
@@ -895,7 +903,7 @@ fn stage_generated_completions(
     Ok(())
 }
 
-fn link_completion(caskroom: &Path, target: &Path) -> Result<()> {
+fn link_completion(cask: &Cask, caskroom: &Path, target: &Path) -> Result<()> {
     let caskroom_completion = caskroom_completion_path(caskroom, target)?;
     if !caskroom_completion.is_file() {
         bail!(
@@ -906,11 +914,49 @@ fn link_completion(caskroom: &Path, target: &Path) -> Result<()> {
     if let Some(parent) = target.parent() {
         file::create_dir_all(parent)?;
     }
+    ensure_completion_target_replaceable(cask, target)?;
     file::make_symlink(&caskroom_completion, target)?;
     Ok(())
 }
 
-fn find_completion_source(stage: &Path, caskroom: &Path, source: &str) -> Option<PathBuf> {
+fn ensure_completion_target_replaceable(cask: &Cask, target: &Path) -> Result<()> {
+    let Ok(metadata) = target.symlink_metadata() else {
+        return Ok(());
+    };
+    if !metadata.file_type().is_symlink() {
+        bail!(
+            "brew-cask: completion target '{}' already exists and is not owned by cask '{}'",
+            target.display(),
+            cask.token
+        );
+    }
+    let link_target = std::fs::read_link(target)?;
+    let resolved = resolve_symlink_target(target, link_target);
+    let token_dir = file::desymlink_path(&caskroom_token_dir(&cask.token));
+    if file::desymlink_path(&resolved).starts_with(&token_dir) {
+        return Ok(());
+    }
+    bail!(
+        "brew-cask: completion target '{}' already points to '{}' and is not owned by cask '{}'",
+        target.display(),
+        resolved.display(),
+        cask.token
+    )
+}
+
+fn find_completion_source(
+    stage: &Path,
+    caskroom: &Path,
+    cask: &Cask,
+    source: &str,
+) -> Option<PathBuf> {
+    for root in [caskroom, stage] {
+        if let Some(source) = generated_caskroom_artifact(root, cask, source)
+            && source.is_file()
+        {
+            return Some(source);
+        }
+    }
     if let Some(source) = appdir_artifact_source(source) {
         return Some(source);
     }
@@ -1348,6 +1394,16 @@ fn generated_caskroom_artifact(root: &Path, cask: &Cask, source: &str) -> Option
         return None;
     }
     Some(root.join(relative))
+}
+
+fn resolve_symlink_target(link: &Path, target: PathBuf) -> PathBuf {
+    if target.is_absolute() {
+        target
+    } else {
+        link.parent()
+            .map(|parent| parent.join(&target))
+            .unwrap_or(target)
+    }
 }
 
 fn cask_appdir(apps: &[AppArtifact]) -> Result<PathBuf> {
@@ -2645,6 +2701,7 @@ end
         file::create_dir_all(stage.join("completions"))?;
         file::create_dir_all(&caskroom)?;
         crate::file::write(stage.join("completions/ghostty.bash"), "complete")?;
+        let cask = test_cask("ghostty", "1.0.0");
         let completion = CompletionArtifact {
             shell: CompletionShell::Bash,
             source: "completions/ghostty.bash".to_string(),
@@ -2652,8 +2709,8 @@ end
         };
         let target = completion.target_path()?;
 
-        stage_completion(&stage, &caskroom, &completion)?;
-        link_completion(&caskroom, &target)?;
+        stage_completion(&stage, &caskroom, &cask, &completion)?;
+        link_completion(&cask, &caskroom, &target)?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/ghostty"))?,
@@ -2664,6 +2721,85 @@ end
             caskroom.join("etc/bash_completion.d/ghostty")
         );
         assert_eq!(crate::file::read_to_string(target)?, "complete");
+        Ok(())
+    }
+
+    #[test]
+    fn declared_completion_source_maps_caskroom_path_to_temp_caskroom() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("tmp-caskroom");
+        let cask = test_cask("foo", "1.0.0");
+        file::create_dir_all(&stage)?;
+        file::create_dir_all(caskroom.join("etc/bash_completion.d"))?;
+        crate::file::write(caskroom.join("etc/bash_completion.d/foo"), "complete")?;
+        let completion = CompletionArtifact {
+            shell: CompletionShell::Bash,
+            source: "$HOMEBREW_PREFIX/Caskroom/foo/1.0.0/etc/bash_completion.d/foo".to_string(),
+            target: Some("$HOMEBREW_PREFIX/etc/bash_completion.d/foo".to_string()),
+        };
+
+        stage_completion(&stage, &caskroom, &cask, &completion)?;
+
+        assert_eq!(
+            crate::file::read_to_string(caskroom.join("etc/bash_completion.d/foo"))?,
+            "complete"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn declared_completion_source_maps_caskroom_path_to_extract_stage() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("tmp-caskroom");
+        let cask = test_cask("foo", "1.0.0");
+        file::create_dir_all(stage.join("share/completions"))?;
+        file::create_dir_all(&caskroom)?;
+        crate::file::write(stage.join("share/completions/foo.bash"), "complete")?;
+        let completion = CompletionArtifact {
+            shell: CompletionShell::Bash,
+            source: "$HOMEBREW_PREFIX/Caskroom/foo/1.0.0/share/completions/foo.bash".to_string(),
+            target: Some("$HOMEBREW_PREFIX/etc/bash_completion.d/foo".to_string()),
+        };
+
+        stage_completion(&stage, &caskroom, &cask, &completion)?;
+
+        assert_eq!(
+            crate::file::read_to_string(caskroom.join("etc/bash_completion.d/foo"))?,
+            "complete"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn link_completion_rejects_target_owned_by_another_cask() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let cask = test_cask("foo", "2.0.0");
+        let caskroom = caskroom_version_dir(&cask.token, &cask.version);
+        let other_caskroom = caskroom_version_dir("other", "1.0.0");
+        let relative = Path::new("etc/bash_completion.d/foo");
+        let target = tmp.path().join(relative);
+        file::create_dir_all(caskroom.join("etc/bash_completion.d"))?;
+        file::create_dir_all(other_caskroom.join("etc/bash_completion.d"))?;
+        file::create_dir_all(target.parent().unwrap())?;
+        crate::file::write(caskroom.join(relative), "new")?;
+        crate::file::write(other_caskroom.join(relative), "other")?;
+        file::make_symlink(&other_caskroom.join(relative), &target)?;
+
+        let err = link_completion(&cask, &caskroom, &target)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("is not owned by cask 'foo'"));
+        assert_eq!(std::fs::read_link(&target)?, other_caskroom.join(relative));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -2998,7 +2998,7 @@ end
         file::create_dir_all(target.parent().unwrap())?;
         file::make_symlink(&old_caskroom.join(relative), &target)?;
 
-        remove_obsolete_completions(&cask, &[target.clone()], &[])?;
+        remove_obsolete_completions(&cask, std::slice::from_ref(&target), &[])?;
 
         assert!(target.symlink_metadata().is_err());
         Ok(())

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -220,19 +220,26 @@ impl BrewCaskManager {
         )?;
         execute_lifecycle_hook(&cask, &tmp_caskroom, &appdir, "postflight", pr).await?;
         for binary in &artifacts.binaries {
-            stage_binary(&stage, &tmp_caskroom, &cask, &appdir, binary)?;
+            stage_binary(&stage, &tmp_caskroom, &cask, &artifacts.apps, binary)?;
         }
         for completion in &artifacts.completions {
-            stage_completion(&stage, &tmp_caskroom, &cask, &appdir, completion)?;
+            stage_completion(&stage, &tmp_caskroom, &cask, &artifacts.apps, completion)?;
         }
         for generated in &artifacts.generated_completions {
-            stage_generated_completions(&stage, &tmp_caskroom, &cask, &appdir, generated)?;
+            stage_generated_completions(&stage, &tmp_caskroom, &cask, &artifacts.apps, generated)?;
         }
         write_receipt(&tmp_caskroom, &cask, &artifacts)?;
         let current_binaries = binary_targets(&artifacts)?;
         let current_completions = completion_target_paths(&cask, &artifacts)?;
         let current_fonts = font_target_paths(&artifacts)?;
-        replace_caskroom(&cask, &tmp_caskroom, &caskroom, || {
+        for target in &current_completions {
+            ensure_completion_target_replaceable(&cask, target)?;
+        }
+        let mut current_targets = current_binaries.clone();
+        current_targets.extend(current_completions.iter().cloned());
+        current_targets.extend(current_fonts.iter().cloned());
+        let mut link_transaction = ArtifactLinkTransaction::begin(current_targets)?;
+        let activation = replace_caskroom(&cask, &tmp_caskroom, &caskroom, || {
             for binary in &artifacts.binaries {
                 link_binary(&caskroom, binary)?;
             }
@@ -243,7 +250,16 @@ impl BrewCaskManager {
                 link_font(&caskroom, font)?;
             }
             Ok(())
-        })?;
+        });
+        if let Err(err) = activation {
+            if let Err(rollback_err) = link_transaction.rollback() {
+                return Err(err.wrap_err(format!(
+                    "failed to restore external cask artifacts: {rollback_err:#}"
+                )));
+            }
+            return Err(err);
+        }
+        link_transaction.commit()?;
         remove_obsolete_binary_links(&cask, &previous_binaries, &current_binaries)?;
         remove_obsolete_completions(&cask, &previous_completions, &current_completions)?;
         remove_obsolete_fonts(&cask, &previous_fonts, &current_fonts)?;
@@ -1074,12 +1090,12 @@ fn stage_completion(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
-    appdir: &Path,
+    apps: &[AppArtifact],
     completion: &CompletionArtifact,
 ) -> Result<()> {
     let target = completion.target_path()?;
     let caskroom_completion = caskroom_completion_path(caskroom, &target)?;
-    let source = find_completion_source(stage, caskroom, cask, appdir, &completion.source)
+    let source = find_completion_source(stage, caskroom, cask, apps, &completion.source)?
         .ok_or_else(|| {
             eyre!(
                 "brew-cask: {} completion artifact '{}' was not found",
@@ -1101,11 +1117,10 @@ fn stage_generated_completions(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
-    appdir: &Path,
+    apps: &[AppArtifact],
     completion: &GeneratedCompletionArtifact,
 ) -> Result<()> {
-    let executable =
-        find_generated_completion_executable(stage, caskroom, cask, appdir, completion)?;
+    let executable = find_generated_completion_executable(stage, caskroom, cask, apps, completion)?;
     if executable.starts_with(stage) || executable.starts_with(caskroom) {
         file::make_executable(&executable)?;
     }
@@ -1167,30 +1182,30 @@ fn find_completion_source(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
-    appdir: &Path,
+    apps: &[AppArtifact],
     source: &str,
-) -> Option<PathBuf> {
+) -> Result<Option<PathBuf>> {
     for root in [caskroom, stage] {
         if let Some(source) = generated_caskroom_artifact(root, cask, source)
             && source.is_file()
         {
-            return Some(source);
+            return Ok(Some(source));
         }
     }
-    if let Some(source) = appdir_artifact_source(source, appdir) {
-        return Some(source);
+    if let Some(source) = appdir_artifact_source(source, apps)? {
+        return Ok(Some(source));
     }
-    absolute_prefixed_source(source)
+    Ok(absolute_prefixed_source(source)
         .filter(|source| source.is_file())
         .or_else(|| find_file_artifact(caskroom, source))
-        .or_else(|| find_file_artifact(stage, source))
+        .or_else(|| find_file_artifact(stage, source)))
 }
 
 fn find_generated_completion_executable(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
-    appdir: &Path,
+    apps: &[AppArtifact],
     completion: &GeneratedCompletionArtifact,
 ) -> Result<PathBuf> {
     let executable = &completion.executable;
@@ -1204,7 +1219,7 @@ fn find_generated_completion_executable(
     {
         return Ok(source);
     }
-    if let Some(source) = appdir_artifact_source(executable, appdir) {
+    if let Some(source) = appdir_artifact_source(executable, apps)? {
         return Ok(source);
     }
     if let Some(source) = absolute_prefixed_source(executable) {
@@ -1230,12 +1245,44 @@ fn find_generated_completion_executable(
     ))
 }
 
-fn appdir_artifact_source(source: &str, appdir: &Path) -> Option<PathBuf> {
-    if !source.contains("$APPDIR") {
-        return None;
+fn appdir_artifact_source(source: &str, apps: &[AppArtifact]) -> Result<Option<PathBuf>> {
+    let Some(relative) = source.strip_prefix("$APPDIR/") else {
+        return Ok(None);
+    };
+    let relative = Path::new(relative);
+    let Some(bundle) = relative.components().next() else {
+        return Ok(None);
+    };
+    let suffix = relative.components().skip(1).collect::<PathBuf>();
+    let mut matches = Vec::new();
+    for app in apps {
+        let target = app_target_path(app.target_name())?;
+        let source_bundle = Path::new(&app.source).file_name();
+        let target_bundle = target.file_name();
+        if !matches!(bundle, Component::Normal(name) if Some(name) == source_bundle || Some(name) == target_bundle)
+        {
+            continue;
+        }
+        let path = target.join(&suffix);
+        if path.is_file() {
+            matches.push(path);
+        }
     }
-    let path = PathBuf::from(source.replace("$APPDIR", &appdir.to_string_lossy()));
-    path.is_file().then_some(path)
+    matches.sort();
+    matches.dedup();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [path] => Ok(Some(path.clone())),
+        _ => bail!(
+            "brew-cask: APPDIR artifact '{}' is ambiguous: {}",
+            source,
+            matches
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
 }
 
 fn find_generated_completion_file(root: &Path, executable: &str) -> Result<Option<PathBuf>> {
@@ -1522,7 +1569,7 @@ fn stage_binary(
     stage: &Path,
     caskroom: &Path,
     cask: &Cask,
-    appdir: &Path,
+    apps: &[AppArtifact],
     binary: &BinaryArtifact,
 ) -> Result<()> {
     let caskroom_binary = caskroom_binary_path(caskroom, binary)?;
@@ -1533,7 +1580,7 @@ fn stage_binary(
     if binary.source.contains("$APPDIR") {
         // $APPDIR is the Applications directory where install_app placed the bundle.
         // Symlink into the installed app so the CLI wrapper can trace back to find the app.
-        let app_binary = appdir_artifact_source(&binary.source, appdir).ok_or_else(|| {
+        let app_binary = appdir_artifact_source(&binary.source, apps)?.ok_or_else(|| {
             eyre!(
                 "brew-cask: binary artifact '{}' was not found",
                 binary.source
@@ -2552,6 +2599,103 @@ fn caskroom_backup_dir(cask: &Cask) -> PathBuf {
     caskroom_token_dir(&cask.token).join(format!(".mise-backup-{}", hash::hash_to_str(&key)))
 }
 
+#[derive(Debug)]
+struct ArtifactLinkBackup {
+    target: PathBuf,
+    backup: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+struct ArtifactLinkTransaction {
+    backups: Vec<ArtifactLinkBackup>,
+}
+
+impl ArtifactLinkTransaction {
+    fn begin(mut targets: Vec<PathBuf>) -> Result<Self> {
+        targets.sort();
+        targets.dedup();
+        let mut transaction = Self {
+            backups: Vec::with_capacity(targets.len()),
+        };
+        for target in targets {
+            let entry = (|| -> Result<ArtifactLinkBackup> {
+                let backup = if target.symlink_metadata().is_ok() {
+                    let parent = target
+                        .parent()
+                        .ok_or_else(|| eyre!("brew-cask: artifact target has no parent"))?;
+                    let backup = parent.join(format!(
+                        ".mise-link-backup-{}",
+                        hash::hash_to_str(&target.display().to_string())
+                    ));
+                    remove_artifact_target(&backup)?;
+                    file::rename(&target, &backup)?;
+                    Some(backup)
+                } else {
+                    None
+                };
+                Ok(ArtifactLinkBackup { target, backup })
+            })();
+            match entry {
+                Ok(entry) => transaction.backups.push(entry),
+                Err(err) => {
+                    if let Err(rollback_err) = transaction.rollback() {
+                        return Err(err.wrap_err(format!(
+                            "failed to restore artifact targets after backup failed: {rollback_err:#}"
+                        )));
+                    }
+                    return Err(err);
+                }
+            }
+        }
+        Ok(transaction)
+    }
+
+    fn rollback(&mut self) -> Result<()> {
+        let mut first_error = None;
+        for entry in self.backups.iter().rev() {
+            match remove_artifact_target(&entry.target) {
+                Ok(()) => {
+                    if let Some(backup) = &entry.backup
+                        && let Err(err) = file::rename(backup, &entry.target)
+                    {
+                        first_error.get_or_insert(err);
+                    }
+                }
+                Err(err) => {
+                    first_error.get_or_insert(err);
+                }
+            }
+        }
+        if let Some(err) = first_error {
+            Err(err)
+        } else {
+            self.backups.clear();
+            Ok(())
+        }
+    }
+
+    fn commit(&mut self) -> Result<()> {
+        for entry in &self.backups {
+            if let Some(backup) = &entry.backup {
+                remove_artifact_target(backup)?;
+            }
+        }
+        self.backups.clear();
+        Ok(())
+    }
+}
+
+fn remove_artifact_target(path: &Path) -> Result<()> {
+    let Ok(metadata) = path.symlink_metadata() else {
+        return Ok(());
+    };
+    if metadata.file_type().is_symlink() {
+        file::remove_file(path)
+    } else {
+        file::remove_all(path)
+    }
+}
+
 fn replace_caskroom(
     cask: &Cask,
     staged: &Path,
@@ -3350,13 +3494,7 @@ end
         };
         let target = completion.target_path()?;
 
-        stage_completion(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &completion,
-        )?;
+        stage_completion(&stage, &caskroom, &cask, &[], &completion)?;
         link_completion(&cask, &caskroom, &target)?;
 
         assert_eq!(
@@ -3388,13 +3526,7 @@ end
             target: Some("$HOMEBREW_PREFIX/etc/bash_completion.d/foo".to_string()),
         };
 
-        stage_completion(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &completion,
-        )?;
+        stage_completion(&stage, &caskroom, &cask, &[], &completion)?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/foo"))?,
@@ -3420,13 +3552,7 @@ end
             target: Some("$HOMEBREW_PREFIX/etc/bash_completion.d/foo".to_string()),
         };
 
-        stage_completion(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &completion,
-        )?;
+        stage_completion(&stage, &caskroom, &cask, &[], &completion)?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/foo"))?,
@@ -3486,13 +3612,7 @@ end
             shells: vec![CompletionShell::Bash],
         };
 
-        stage_generated_completions(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &completion,
-        )?;
+        stage_generated_completions(&stage, &caskroom, &cask, &[], &completion)?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/op"))?,
@@ -3521,34 +3641,41 @@ end
             shell_parameter_format: None,
             shells: vec![CompletionShell::Bash],
         };
+        let apps = [AppArtifact {
+            source: "Foo.app".to_string(),
+            target: Some("$HOMEBREW_PREFIX/Applications/Foo.app".to_string()),
+        }];
 
         assert_eq!(
-            find_generated_completion_executable(
-                &stage,
-                &caskroom,
-                &cask,
-                &tmp.path().join("Applications"),
-                &completion,
-            )?,
+            find_generated_completion_executable(&stage, &caskroom, &cask, &apps, &completion,)?,
             app_executable
         );
         Ok(())
     }
 
     #[test]
-    fn appdir_artifact_source_uses_selected_appdir() -> Result<()> {
+    fn appdir_artifact_source_uses_matching_app_location() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
-        let system_appdir = tmp.path().join("system-applications");
-        let prefix_appdir = tmp.path().join("prefix-applications");
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let prefix_appdir = tmp.path().join("Applications");
         let relative = "Foo.app/Contents/MacOS/foo";
-        file::create_dir_all(system_appdir.join(relative).parent().unwrap())?;
         file::create_dir_all(prefix_appdir.join(relative).parent().unwrap())?;
-        crate::file::write(system_appdir.join(relative), "system")?;
         crate::file::write(prefix_appdir.join(relative), "prefix")?;
+        let apps = [
+            AppArtifact {
+                source: "Other.app".to_string(),
+                target: None,
+            },
+            AppArtifact {
+                source: "Foo.app".to_string(),
+                target: Some("$HOMEBREW_PREFIX/Applications/Foo.app".to_string()),
+            },
+        ];
 
         assert_eq!(
-            appdir_artifact_source("$APPDIR/Foo.app/Contents/MacOS/foo", &prefix_appdir),
-            Some(prefix_appdir.join(relative))
+            appdir_artifact_source("$APPDIR/Foo.app/Contents/MacOS/foo", &apps)?,
+            Some(prefix_appdir.join(relative)),
         );
         Ok(())
     }
@@ -3574,13 +3701,7 @@ end
         };
 
         assert_eq!(
-            find_generated_completion_executable(
-                &stage,
-                &caskroom,
-                &cask,
-                Path::new("/Applications"),
-                &completion,
-            )?,
+            find_generated_completion_executable(&stage, &caskroom, &cask, &[], &completion,)?,
             caskroom.join("bin/op")
         );
         Ok(())
@@ -3607,14 +3728,8 @@ end
             shells: vec![CompletionShell::Bash],
         };
 
-        let err = find_generated_completion_executable(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &completion,
-        )
-        .unwrap_err();
+        let err = find_generated_completion_executable(&stage, &caskroom, &cask, &[], &completion)
+            .unwrap_err();
         assert!(
             err.to_string()
                 .contains("completion executable 'tool' is ambiguous")
@@ -3641,14 +3756,8 @@ end
             shells: vec![CompletionShell::Bash],
         };
 
-        let err = find_generated_completion_executable(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &completion,
-        )
-        .unwrap_err();
+        let err = find_generated_completion_executable(&stage, &caskroom, &cask, &[], &completion)
+            .unwrap_err();
 
         assert!(
             err.to_string()
@@ -4293,13 +4402,7 @@ end
             target: Some("$HOMEBREW_PREFIX/bin/op".to_string()),
         };
 
-        stage_binary(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &binary,
-        )?;
+        stage_binary(&stage, &caskroom, &cask, &[], &binary)?;
         link_binary(&caskroom, &binary)?;
 
         let target = binary.target_path()?;
@@ -4331,8 +4434,8 @@ end
             target: Some("$HOMEBREW_PREFIX/sbin/op".to_string()),
         };
 
-        stage_binary(&stage, &caskroom, &cask, Path::new("/Applications"), &bin)?;
-        stage_binary(&stage, &caskroom, &cask, Path::new("/Applications"), &sbin)?;
+        stage_binary(&stage, &caskroom, &cask, &[], &bin)?;
+        stage_binary(&stage, &caskroom, &cask, &[], &sbin)?;
         link_binary(&caskroom, &bin)?;
         link_binary(&caskroom, &sbin)?;
 
@@ -4359,13 +4462,7 @@ end
             target: Some("$HOMEBREW_PREFIX/bin/op".to_string()),
         };
 
-        stage_binary(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &binary,
-        )?;
+        stage_binary(&stage, &caskroom, &cask, &[], &binary)?;
 
         assert_eq!(
             crate::file::read_to_string(caskroom.join("bin/op"))?,
@@ -4397,13 +4494,7 @@ end
             target: Some("$HOMEBREW_PREFIX/bin/karabiner_cli".to_string()),
         };
 
-        stage_binary(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &binary,
-        )?;
+        stage_binary(&stage, &caskroom, &cask, &[], &binary)?;
         link_binary(&caskroom, &binary)?;
 
         let staged = caskroom.join("bin/karabiner_cli");
@@ -4437,13 +4528,7 @@ end
             target: Some("$HOMEBREW_PREFIX/bin/karabiner_cli".to_string()),
         };
 
-        stage_binary(
-            &stage,
-            &caskroom,
-            &cask,
-            Path::new("/Applications"),
-            &binary,
-        )?;
+        stage_binary(&stage, &caskroom, &cask, &[], &binary)?;
         file::remove_file(&pkg_binary)?;
         let err = link_binary(&caskroom, &binary).unwrap_err().to_string();
 
@@ -4660,7 +4745,7 @@ end
 
     #[cfg(unix)]
     #[test]
-    fn replace_caskroom_restores_previous_files_when_linking_fails() -> Result<()> {
+    fn failed_activation_restores_caskroom_and_external_links() -> Result<()> {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir()?;
         let _guard = BrewPrefixGuard::set(tmp.path());
@@ -4673,14 +4758,24 @@ end
         crate::file::write(destination.join(relative), "previous")?;
         crate::file::write(staged.join(relative), "replacement")?;
         let target = tmp.path().join(relative);
+        let new_target = tmp.path().join("bin/new-tool");
         file::create_dir_all(target.parent().unwrap())?;
+        file::create_dir_all(new_target.parent().unwrap())?;
         file::make_symlink(&destination.join(relative), &target)?;
+        let mut link_transaction =
+            ArtifactLinkTransaction::begin(vec![target.clone(), new_target.clone()])?;
 
-        let err = replace_caskroom(&cask, &staged, &destination, || Err(eyre!("link failed")))
-            .unwrap_err();
+        let err = replace_caskroom(&cask, &staged, &destination, || {
+            file::make_symlink(&destination.join(relative), &target)?;
+            file::make_symlink(&destination.join("bin/new-tool"), &new_target)?;
+            Err(eyre!("link failed"))
+        })
+        .unwrap_err();
+        link_transaction.rollback()?;
 
         assert_eq!(err.to_string(), "link failed");
         assert_eq!(crate::file::read_to_string(&target)?, "previous");
+        assert!(!new_target.symlink_metadata().is_ok());
         assert!(!caskroom_backup_dir(&cask).exists());
         Ok(())
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -932,8 +932,8 @@ fn ensure_completion_target_replaceable(cask: &Cask, target: &Path) -> Result<()
     }
     let link_target = std::fs::read_link(target)?;
     let resolved = resolve_symlink_target(target, link_target);
-    let token_dir = file::desymlink_path(&caskroom_token_dir(&cask.token));
-    if file::desymlink_path(&resolved).starts_with(&token_dir) {
+    let token_dir = caskroom_token_dir(&cask.token);
+    if path_starts_with_resolved_root(&resolved, &token_dir) {
         return Ok(());
     }
     bail!(
@@ -1282,7 +1282,7 @@ fn remove_obsolete_completions(
     previous_targets: &[PathBuf],
     current_targets: &[PathBuf],
 ) -> Result<()> {
-    let token_dir = file::desymlink_path(&caskroom_token_dir(&cask.token));
+    let token_dir = caskroom_token_dir(&cask.token);
     let prefix = prefix::prefix();
     for target in previous_targets {
         if current_targets.contains(target) || !target.starts_with(&prefix) {
@@ -1298,7 +1298,7 @@ fn remove_obsolete_completions(
             continue;
         };
         let resolved = resolve_symlink_target(target, link_target);
-        if file::desymlink_path(&resolved).starts_with(&token_dir) {
+        if path_starts_with_resolved_root(&resolved, &token_dir) {
             file::remove_file(target)?;
         }
     }
@@ -1396,6 +1396,28 @@ fn resolve_symlink_target(link: &Path, target: PathBuf) -> PathBuf {
         link.parent()
             .map(|parent| parent.join(&target))
             .unwrap_or(target)
+    }
+}
+
+fn path_starts_with_resolved_root(path: &Path, root: &Path) -> bool {
+    path_with_resolved_existing_ancestor(path).starts_with(&file::desymlink_path(root))
+}
+
+fn path_with_resolved_existing_ancestor(path: &Path) -> PathBuf {
+    let mut base = path;
+    let mut suffix = PathBuf::new();
+    loop {
+        if base.symlink_metadata().is_ok() {
+            return file::desymlink_path(base).join(suffix);
+        }
+        let Some(name) = base.file_name() else {
+            return path.to_path_buf();
+        };
+        suffix = Path::new(name).join(suffix);
+        let Some(parent) = base.parent() else {
+            return path.to_path_buf();
+        };
+        base = parent;
     }
 }
 
@@ -2955,6 +2977,30 @@ end
         assert!(dangling_target.symlink_metadata().is_err());
         assert!(other_target.symlink_metadata().is_ok());
         assert!(regular_target.symlink_metadata().is_ok());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_obsolete_completions_removes_dangling_symlinks_with_symlinked_prefix() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let real_prefix = tmp.path().join("homebrew-real");
+        let prefix = tmp.path().join("homebrew");
+        file::create_dir_all(&real_prefix)?;
+        file::make_symlink(&real_prefix, &prefix)?;
+        let _guard = BrewPrefixGuard::set(&prefix);
+        let cask = test_cask("foo", "2.0.0");
+        let old_caskroom = caskroom_version_dir(&cask.token, "1.0.0");
+        let relative = Path::new("etc/bash_completion.d/dangling");
+        let target = prefix.join("etc/bash_completion.d/foo");
+        file::create_dir_all(old_caskroom.join("etc/bash_completion.d"))?;
+        file::create_dir_all(target.parent().unwrap())?;
+        file::make_symlink(&old_caskroom.join(relative), &target)?;
+
+        remove_obsolete_completions(&cask, &[target.clone()], &[])?;
+
+        assert!(target.symlink_metadata().is_err());
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -94,6 +94,30 @@ struct GeneratedCompletionArtifact {
     shells: Vec<CompletionShell>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FlightStep {
+    Move {
+        source: FlightPath,
+        target: FlightPath,
+        source_glob: bool,
+    },
+    Remove {
+        paths: Vec<FlightPath>,
+        recursive: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FlightPathBase {
+    StagedPath,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FlightPath {
+    base: FlightPathBase,
+    path: String,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct CaskArtifacts {
     apps: Vec<AppArtifact>,
@@ -102,6 +126,8 @@ struct CaskArtifacts {
     fonts: Vec<FontArtifact>,
     completions: Vec<CompletionArtifact>,
     generated_completions: Vec<GeneratedCompletionArtifact>,
+    preflight_steps: Vec<FlightStep>,
+    postflight_steps: Vec<FlightStep>,
     pkg_ids: Vec<String>,
 }
 
@@ -175,6 +201,7 @@ impl BrewCaskManager {
         file::remove_all(&tmp_caskroom)?;
         file::create_dir_all(&tmp_caskroom)?;
         let appdir = cask_appdir(&artifacts.apps)?;
+        execute_flight_steps(&cask, &artifacts.preflight_steps, &stage, "preflight_steps")?;
         execute_lifecycle_hook(&cask, &stage, &appdir, "preflight", pr).await?;
         for app in &artifacts.apps {
             install_app(&stage, &tmp_caskroom, app)?;
@@ -185,6 +212,12 @@ impl BrewCaskManager {
         for font in &artifacts.fonts {
             stage_font(&stage, &tmp_caskroom, font)?;
         }
+        execute_flight_steps(
+            &cask,
+            &artifacts.postflight_steps,
+            &tmp_caskroom,
+            "postflight_steps",
+        )?;
         execute_lifecycle_hook(&cask, &tmp_caskroom, &appdir, "postflight", pr).await?;
         for binary in &artifacts.binaries {
             stage_binary(&stage, &tmp_caskroom, &cask, &appdir, binary)?;
@@ -857,6 +890,186 @@ fn font_target_path(font: &FontArtifact) -> Result<PathBuf> {
         .join(name_path))
 }
 
+fn execute_flight_steps(
+    cask: &Cask,
+    steps: &[FlightStep],
+    staged_path: &Path,
+    kind: &str,
+) -> Result<()> {
+    for step in steps {
+        execute_flight_step(step, staged_path).wrap_err_with(|| {
+            format!("brew-cask:{}: failed to run structured {kind}", cask.token)
+        })?;
+    }
+    Ok(())
+}
+
+fn execute_flight_step(step: &FlightStep, staged_path: &Path) -> Result<()> {
+    match step {
+        FlightStep::Move {
+            source,
+            target,
+            source_glob,
+        } => {
+            let sources = flight_sources(staged_path, source, *source_glob)?;
+            let target = resolve_flight_path(staged_path, target)?;
+            if sources.len() > 1 && !target.is_dir() {
+                bail!(
+                    "brew-cask: structured move with multiple sources requires a directory target"
+                );
+            }
+            for source in sources {
+                let target = if target.is_dir() {
+                    target.join(source.file_name().ok_or_else(|| {
+                        eyre!(
+                            "brew-cask: structured move source '{}' has no file name",
+                            source.display()
+                        )
+                    })?)
+                } else {
+                    target.clone()
+                };
+                if let Some(parent) = target.parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    file::create_dir_all(parent)?;
+                }
+                file::remove_all(&target)?;
+                file::rename(&source, &target)?;
+            }
+        }
+        FlightStep::Remove { paths, recursive } => {
+            for path in paths {
+                for path in flight_paths(staged_path, path)? {
+                    if *recursive {
+                        file::remove_all(&path)?;
+                    } else if path.symlink_metadata().is_ok() {
+                        file::remove_file_or_dir(&path)?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn flight_sources(
+    staged_path: &Path,
+    source: &FlightPath,
+    source_glob: bool,
+) -> Result<Vec<PathBuf>> {
+    if !source_glob {
+        let source = resolve_flight_path(staged_path, source)?;
+        if !source.exists() {
+            bail!(
+                "brew-cask: structured move source '{}' was not found",
+                source.display()
+            );
+        }
+        return Ok(vec![source]);
+    }
+    // Homebrew marks move sources as globs explicitly; non-glob move sources
+    // may contain literal glob-like characters and should be resolved literally.
+    let sources = expand_staged_glob(staged_path, &source.path)?;
+    if sources.is_empty() {
+        bail!(
+            "brew-cask: structured move source '{}' was not found",
+            source.path
+        );
+    }
+    Ok(sources)
+}
+
+fn flight_paths(staged_path: &Path, path: &FlightPath) -> Result<Vec<PathBuf>> {
+    if !is_flight_glob(&path.path) {
+        return Ok(vec![resolve_flight_path(staged_path, path)?]);
+    }
+    // Remove steps do not have a `source_glob` flag, so path globs are detected
+    // from the path syntax instead.
+    expand_staged_glob(staged_path, &path.path)
+}
+
+fn expand_staged_glob(staged_path: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
+    let mut matches = Vec::new();
+    let escaped_root = glob::Pattern::escape(staged_path.to_string_lossy().as_ref());
+    for pattern in expand_braces(pattern) {
+        validate_flight_relative_path(&pattern)?;
+        let rooted_pattern = Path::new(&escaped_root)
+            .join(Path::new(&pattern))
+            .to_string_lossy()
+            .to_string();
+        for path in glob::glob_with(
+            &rooted_pattern,
+            glob::MatchOptions {
+                require_literal_separator: true,
+                ..Default::default()
+            },
+        )
+        .wrap_err_with(|| format!("brew-cask: invalid structured flight glob '{pattern}'"))?
+        {
+            let path = path?;
+            if !path.starts_with(staged_path) {
+                bail!(
+                    "brew-cask: structured flight glob '{}' matched outside staged path",
+                    pattern
+                );
+            }
+            matches.push(path);
+        }
+    }
+    matches.sort();
+    matches.dedup();
+    Ok(matches)
+}
+
+fn is_flight_glob(path: &str) -> bool {
+    path.chars()
+        .any(|c| matches!(c, '*' | '?' | '[' | ']' | '{' | '}'))
+}
+
+fn resolve_flight_path(staged_path: &Path, path: &FlightPath) -> Result<PathBuf> {
+    match path.base {
+        FlightPathBase::StagedPath => {}
+    }
+    let relative = Path::new(&path.path);
+    validate_flight_relative_path(&path.path)?;
+    Ok(staged_path.join(relative))
+}
+
+fn validate_flight_relative_path(path: &str) -> Result<()> {
+    let path = Path::new(path);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        bail!(
+            "brew-cask: invalid structured flight path '{}'",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn expand_braces(pattern: &str) -> Vec<String> {
+    let Some(start) = pattern.find('{') else {
+        return vec![pattern.to_string()];
+    };
+    let Some(end_offset) = pattern[start + 1..].find('}') else {
+        return vec![pattern.to_string()];
+    };
+    let end = start + 1 + end_offset;
+    let prefix = &pattern[..start];
+    let suffix = &pattern[end + 1..];
+    let mut expanded = Vec::new();
+    for alternative in pattern[start + 1..end].split(',') {
+        for suffix in expand_braces(suffix) {
+            expanded.push(format!("{prefix}{alternative}{suffix}"));
+        }
+    }
+    expanded
+}
+
 fn stage_completion(
     stage: &Path,
     caskroom: &Path,
@@ -1489,8 +1702,16 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
     let mut artifacts = CaskArtifacts::default();
     for artifact in &cask.artifacts {
         let artifact_type = artifact_type(artifact);
+        if let Some(steps) = parse_flight_steps(cask, artifact, "preflight_steps")? {
+            artifacts.preflight_steps.extend(steps);
+            continue;
+        }
+        if let Some(steps) = parse_flight_steps(cask, artifact, "postflight_steps")? {
+            artifacts.postflight_steps.extend(steps);
+            continue;
+        }
         if is_non_install_artifact(&artifact_type) {
-            collect_uninstall_pkg_ids(artifact, &mut artifacts.pkg_ids);
+            collect_pkg_receipt_ids(artifact, &mut artifacts.pkg_ids);
             continue;
         }
         if let Some(app) = parse_app_artifact(artifact) {
@@ -1541,7 +1762,7 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
         artifacts.pkg_ids.clear();
     } else if artifacts.pkg_ids.is_empty() {
         bail!(
-            "brew-cask:{}: pkg artifacts require pkgutil ids in uninstall or zap metadata",
+            "brew-cask:{}: pkg artifacts require pkgutil ids in uninstall metadata",
             cask.token
         );
     }
@@ -1765,29 +1986,190 @@ fn default_generated_completion_shells(format: Option<&str>) -> Vec<CompletionSh
     }
 }
 
-fn collect_uninstall_pkg_ids(value: &Value, pkg_ids: &mut Vec<String>) {
+fn parse_flight_steps(cask: &Cask, value: &Value, kind: &str) -> Result<Option<Vec<FlightStep>>> {
+    let Some(metadata) = value.as_object().and_then(|o| o.get(kind)) else {
+        return Ok(None);
+    };
+    let groups = metadata.as_array().ok_or_else(|| {
+        eyre!(
+            "brew-cask:{}: unsupported {kind} metadata format",
+            cask.token
+        )
+    })?;
+    let mut steps = Vec::new();
+    for group in groups {
+        let group = group.as_object().ok_or_else(|| {
+            eyre!(
+                "brew-cask:{}: unsupported {kind} metadata format",
+                cask.token
+            )
+        })?;
+        reject_unsupported_flight_fields(cask, kind, "step group", group, &["steps"])?;
+        let group_steps = group
+            .get("steps")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                eyre!(
+                    "brew-cask:{}: unsupported {kind} metadata format",
+                    cask.token
+                )
+            })?;
+        for step in group_steps {
+            steps.push(parse_flight_step(cask, kind, step)?);
+        }
+    }
+    Ok(Some(steps))
+}
+
+fn parse_flight_step(cask: &Cask, kind: &str, value: &Value) -> Result<FlightStep> {
+    let object = value.as_object().ok_or_else(|| {
+        eyre!(
+            "brew-cask:{}: unsupported {kind} step metadata format",
+            cask.token
+        )
+    })?;
+    let step_type = object.get("type").and_then(Value::as_str).ok_or_else(|| {
+        eyre!(
+            "brew-cask:{}: unsupported {kind} step metadata format",
+            cask.token
+        )
+    })?;
+    match step_type {
+        "move" => {
+            reject_unsupported_flight_fields(
+                cask,
+                kind,
+                "move step",
+                object,
+                &["type", "source", "target", "source_glob"],
+            )?;
+            Ok(FlightStep::Move {
+                source: parse_flight_path(cask, kind, "source", object.get("source"))?,
+                target: parse_flight_path(cask, kind, "target", object.get("target"))?,
+                source_glob: object
+                    .get("source_glob")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            })
+        }
+        "remove" => {
+            reject_unsupported_flight_fields(
+                cask,
+                kind,
+                "remove step",
+                object,
+                &["type", "paths", "recursive"],
+            )?;
+            let paths = object
+                .get("paths")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    eyre!(
+                        "brew-cask:{}: unsupported {kind} remove step metadata format",
+                        cask.token
+                    )
+                })?
+                .iter()
+                .map(|path| parse_flight_path(cask, kind, "paths", Some(path)))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(FlightStep::Remove {
+                paths,
+                recursive: object
+                    .get("recursive")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            })
+        }
+        _ => bail!(
+            "brew-cask:{}: unsupported {kind} step type {}",
+            cask.token,
+            step_type
+        ),
+    }
+}
+
+fn reject_unsupported_flight_fields(
+    cask: &Cask,
+    kind: &str,
+    context: &str,
+    object: &serde_json::Map<String, Value>,
+    allowed: &[&str],
+) -> Result<()> {
+    let mut unsupported = object
+        .keys()
+        .filter(|key| !allowed.contains(&key.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    unsupported.sort();
+    if !unsupported.is_empty() {
+        bail!(
+            "brew-cask:{}: unsupported {kind} {context} field {}",
+            cask.token,
+            unsupported.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn parse_flight_path(
+    cask: &Cask,
+    kind: &str,
+    field: &str,
+    value: Option<&Value>,
+) -> Result<FlightPath> {
+    let object = value.and_then(Value::as_object).ok_or_else(|| {
+        eyre!(
+            "brew-cask:{}: unsupported {kind} {field} metadata format",
+            cask.token
+        )
+    })?;
+    let base = match object.get("base").and_then(Value::as_str) {
+        Some("staged_path") => FlightPathBase::StagedPath,
+        Some(base) => bail!(
+            "brew-cask:{}: unsupported {kind} {field} base {}",
+            cask.token,
+            base
+        ),
+        None => bail!("brew-cask:{}: unsupported {kind} {field} base", cask.token),
+    };
+    let path = object
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| eyre!("brew-cask:{}: unsupported {kind} {field} path", cask.token))?;
+    if validate_flight_relative_path(path).is_err() {
+        bail!(
+            "brew-cask:{}: invalid {kind} {field} path {}",
+            cask.token,
+            path
+        )
+    }
+    Ok(FlightPath {
+        base,
+        path: path.to_string(),
+    })
+}
+
+fn collect_pkg_receipt_ids(value: &Value, pkg_ids: &mut Vec<String>) {
     let Some(object) = value.as_object() else {
         return;
     };
-    for key in ["uninstall", "zap"] {
-        let Some(metadata) = object.get(key) else {
+    let Some(metadata) = object.get("uninstall") else {
+        return;
+    };
+    let values: Vec<&Value> = match metadata {
+        Value::Array(values) => values.iter().collect(),
+        value => vec![value],
+    };
+    for value in values {
+        let Some(pkgutil) = value.as_object().and_then(|o| o.get("pkgutil")) else {
             continue;
         };
-        let values: Vec<&Value> = match metadata {
-            Value::Array(values) => values.iter().collect(),
-            value => vec![value],
-        };
-        for value in values {
-            let Some(pkgutil) = value.as_object().and_then(|o| o.get("pkgutil")) else {
-                continue;
-            };
-            match pkgutil {
-                Value::String(id) => pkg_ids.push(id.clone()),
-                Value::Array(ids) => {
-                    pkg_ids.extend(ids.iter().filter_map(Value::as_str).map(str::to_string))
-                }
-                _ => {}
+        match pkgutil {
+            Value::String(id) => pkg_ids.push(id.clone()),
+            Value::Array(ids) => {
+                pkg_ids.extend(ids.iter().filter_map(Value::as_str).map(str::to_string))
             }
+            _ => {}
         }
     }
 }
@@ -2249,6 +2631,8 @@ fn is_non_install_artifact(kind: &str) -> bool {
             | "manpage"
             | "postflight"
             | "preflight"
+            | "uninstall_postflight_steps"
+            | "uninstall_preflight_steps"
             | "uninstall"
             | "uninstall_postflight"
             | "uninstall_preflight"
@@ -2322,6 +2706,185 @@ mod tests {
             tap_git_head: None,
             raw_base: None,
         }
+    }
+
+    #[test]
+    fn parses_structured_flight_steps() -> Result<()> {
+        let mut cask = test_cask("wezterm@nightly", "latest");
+        cask.artifacts = vec![
+            serde_json::json!({
+                "preflight_steps": [{
+                    "steps": [
+                        {
+                            "type": "move",
+                            "source_glob": true,
+                            "source": {
+                                "base": "staged_path",
+                                "path": "{WezTerm-*,wezterm-*}/WezTerm.app"
+                            },
+                            "target": {
+                                "base": "staged_path",
+                                "path": "."
+                            }
+                        },
+                        {
+                            "type": "remove",
+                            "recursive": true,
+                            "paths": [
+                                {"base": "staged_path", "path": "WezTerm-*"},
+                                {"base": "staged_path", "path": "wezterm-*"}
+                            ]
+                        }
+                    ]
+                }]
+            }),
+            serde_json::json!({"app": "WezTerm.app"}),
+        ];
+
+        assert_eq!(
+            cask_artifacts(&cask)?,
+            CaskArtifacts {
+                apps: vec![AppArtifact {
+                    source: "WezTerm.app".to_string(),
+                    target: None,
+                }],
+                preflight_steps: vec![
+                    FlightStep::Move {
+                        source: FlightPath {
+                            base: FlightPathBase::StagedPath,
+                            path: "{WezTerm-*,wezterm-*}/WezTerm.app".to_string(),
+                        },
+                        target: FlightPath {
+                            base: FlightPathBase::StagedPath,
+                            path: ".".to_string(),
+                        },
+                        source_glob: true,
+                    },
+                    FlightStep::Remove {
+                        paths: vec![
+                            FlightPath {
+                                base: FlightPathBase::StagedPath,
+                                path: "WezTerm-*".to_string(),
+                            },
+                            FlightPath {
+                                base: FlightPathBase::StagedPath,
+                                path: "wezterm-*".to_string(),
+                            }
+                        ],
+                        recursive: true,
+                    }
+                ],
+                ..Default::default()
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn structured_flight_steps_move_and_remove_staged_paths() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let staged = tmp.path();
+        let bundle_dir = staged.join("WezTerm-nightly");
+        let app = bundle_dir.join("WezTerm.app");
+        file::create_dir_all(&app)?;
+
+        execute_flight_steps(
+            &test_cask("wezterm@nightly", "latest"),
+            &[
+                FlightStep::Move {
+                    source: FlightPath {
+                        base: FlightPathBase::StagedPath,
+                        path: "{WezTerm-*,wezterm-*}/WezTerm.app".to_string(),
+                    },
+                    target: FlightPath {
+                        base: FlightPathBase::StagedPath,
+                        path: ".".to_string(),
+                    },
+                    source_glob: true,
+                },
+                FlightStep::Remove {
+                    paths: vec![
+                        FlightPath {
+                            base: FlightPathBase::StagedPath,
+                            path: "WezTerm-*".to_string(),
+                        },
+                        FlightPath {
+                            base: FlightPathBase::StagedPath,
+                            path: "wezterm-*".to_string(),
+                        },
+                    ],
+                    recursive: true,
+                },
+            ],
+            staged,
+            "preflight_steps",
+        )?;
+
+        assert!(staged.join("WezTerm.app").is_dir());
+        assert!(!bundle_dir.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_unsupported_structured_flight_steps() {
+        let mut cask = test_cask("battle-net", "1.0.0");
+        cask.artifacts = vec![
+            serde_json::json!({
+                "preflight_steps": [{
+                    "steps": [{
+                        "type": "set_permissions",
+                        "paths": [{"base": "staged_path", "path": "Battle.net-Setup.app"}],
+                        "permissions": "a+x"
+                    }]
+                }]
+            }),
+            serde_json::json!({"app": "Battle.net.app"}),
+        ];
+
+        let err = cask_artifacts(&cask).unwrap_err().to_string();
+        assert!(err.contains("unsupported preflight_steps step type set_permissions"));
+    }
+
+    #[test]
+    fn rejects_structured_flight_step_group_controls() {
+        let mut cask = test_cask("example", "1.0.0");
+        cask.artifacts = vec![
+            serde_json::json!({
+                "preflight_steps": [{
+                    "if": {"arch": "arm64"},
+                    "steps": [{
+                        "type": "remove",
+                        "paths": [{"base": "staged_path", "path": "old"}]
+                    }]
+                }]
+            }),
+            serde_json::json!({"app": "Example.app"}),
+        ];
+
+        let err = cask_artifacts(&cask).unwrap_err().to_string();
+        assert!(err.contains("unsupported preflight_steps step group field if"));
+    }
+
+    #[test]
+    fn rejects_structured_flight_step_controls() {
+        let mut cask = test_cask("miniconda", "25.5.1-1");
+        cask.artifacts = vec![
+            serde_json::json!({
+                "postflight_steps": [{
+                    "steps": [{
+                        "type": "remove",
+                        "paths": [{"base": "staged_path", "path": "base/envs"}],
+                        "recursive": true,
+                        "guards": [{"condition": "if_exists", "path": "{{temp}}/miniconda-envs"}]
+                    }]
+                }]
+            }),
+            serde_json::json!({"pkg": ["Miniconda.pkg"]}),
+            serde_json::json!({"uninstall": [{"pkgutil": "com.anaconda.pkg"}]}),
+        ];
+
+        let err = cask_artifacts(&cask).unwrap_err().to_string();
+        assert!(err.contains("unsupported postflight_steps remove step field guards"));
     }
 
     #[test]
@@ -3285,20 +3848,21 @@ end
     }
 
     #[test]
-    fn parses_zap_pkgutil_ids() -> Result<()> {
-        let mut cask = test_cask("example", "1.0.0");
+    fn ignores_zap_pkgutil_ids_for_pkg_receipts() -> Result<()> {
+        let mut cask = test_cask("google-japanese-ime", "3.33.6130");
         cask.artifacts = vec![
-            serde_json::json!({"zap": [{"pkgutil": ["com.example.pkg"]}]}),
-            serde_json::json!({"pkg": ["Example.pkg"]}),
+            serde_json::json!({"uninstall": [{"pkgutil": "com.google.pkg.GoogleJapaneseInput"}]}),
+            serde_json::json!({"pkg": ["GoogleJapaneseInput.pkg"]}),
+            serde_json::json!({"zap": [{"pkgutil": "com.google.pkg.Keystone"}]}),
         ];
 
         assert_eq!(
             cask_artifacts(&cask)?,
             CaskArtifacts {
                 pkgs: vec![PkgArtifact {
-                    source: "Example.pkg".to_string()
+                    source: "GoogleJapaneseInput.pkg".to_string()
                 }],
-                pkg_ids: vec!["com.example.pkg".to_string()],
+                pkg_ids: vec!["com.google.pkg.GoogleJapaneseInput".to_string()],
                 ..Default::default()
             }
         );
@@ -3312,6 +3876,18 @@ end
 
         let err = cask_artifacts(&cask).unwrap_err().to_string();
         assert!(err.contains("pkg artifacts require pkgutil ids"));
+    }
+
+    #[test]
+    fn rejects_pkg_artifacts_with_only_zap_pkgutil_ids() {
+        let mut cask = test_cask("example", "1.0.0");
+        cask.artifacts = vec![
+            serde_json::json!({"pkg": ["Example.pkg"]}),
+            serde_json::json!({"zap": [{"pkgutil": "com.example.cleanup"}]}),
+        ];
+
+        let err = cask_artifacts(&cask).unwrap_err().to_string();
+        assert!(err.contains("pkg artifacts require pkgutil ids in uninstall metadata"));
     }
 
     #[test]

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -879,6 +879,9 @@ fn stage_generated_completions(
     completion: &GeneratedCompletionArtifact,
 ) -> Result<()> {
     let executable = find_generated_completion_executable(stage, caskroom, cask, completion)?;
+    if executable.starts_with(stage) || executable.starts_with(caskroom) {
+        file::make_executable(&executable)?;
+    }
     let base_name = completion.resolved_base_name(cask);
     for shell in &completion.shells {
         let target = generated_completion_target_path(*shell, &base_name)?;
@@ -903,20 +906,13 @@ fn link_completion(caskroom: &Path, target: &Path) -> Result<()> {
     if let Some(parent) = target.parent() {
         file::create_dir_all(parent)?;
     }
-    file::remove_all(target)?;
-    file::copy(&caskroom_completion, target)?;
+    replace_completion(&caskroom_completion, target)?;
     Ok(())
 }
 
 fn find_completion_source(stage: &Path, caskroom: &Path, source: &str) -> Option<PathBuf> {
-    if source.contains("$APPDIR") {
-        return [
-            PathBuf::from("/Applications"),
-            prefix::prefix().join("Applications"),
-        ]
-        .iter()
-        .map(|appdir| PathBuf::from(source.replace("$APPDIR", &appdir.to_string_lossy())))
-        .find(|path| path.is_file());
+    if let Some(source) = appdir_artifact_source(source) {
+        return Some(source);
     }
     absolute_prefixed_source(source)
         .filter(|source| source.is_file())
@@ -941,6 +937,9 @@ fn find_generated_completion_executable(
     {
         return Ok(source);
     }
+    if let Some(source) = appdir_artifact_source(executable) {
+        return Ok(source);
+    }
     if let Some(source) = absolute_prefixed_source(executable) {
         if source.is_file() {
             return Ok(source);
@@ -952,14 +951,97 @@ fn find_generated_completion_executable(
             }
         }
     }
-    find_file_artifact(caskroom, executable)
-        .or_else(|| find_file_artifact(stage, executable))
-        .ok_or_else(|| {
-            eyre!(
-                "brew-cask: completion executable '{}' was not found",
-                executable
-            )
+    if let Some(source) = find_generated_completion_file(caskroom, executable)? {
+        return Ok(source);
+    }
+    if let Some(source) = find_generated_completion_file(stage, executable)? {
+        return Ok(source);
+    }
+    Err(eyre!(
+        "brew-cask: completion executable '{}' was not found",
+        executable
+    ))
+}
+
+fn replace_completion(source: &Path, target: &Path) -> Result<()> {
+    if target.exists() && !target.is_file() {
+        bail!(
+            "brew-cask: completion target '{}' exists and is not a file",
+            target.display()
+        );
+    }
+    let old_target = target.with_extension(format!(
+        "mise-old-{}",
+        crate::hash::hash_to_str(&target.display().to_string())
+    ));
+    file::remove_all(&old_target)?;
+    if target.exists() {
+        file::rename(target, &old_target)?;
+    }
+    if let Err(e) = file::copy(source, target) {
+        if old_target.exists() {
+            let _ = file::remove_all(target);
+            let _ = file::rename(&old_target, target);
+        }
+        return Err(e);
+    }
+    file::remove_all(&old_target)?;
+    Ok(())
+}
+
+fn appdir_artifact_source(source: &str) -> Option<PathBuf> {
+    if !source.contains("$APPDIR") {
+        return None;
+    }
+    [
+        PathBuf::from("/Applications"),
+        prefix::prefix().join("Applications"),
+    ]
+    .iter()
+    .map(|appdir| PathBuf::from(source.replace("$APPDIR", &appdir.to_string_lossy())))
+    .find(|path| path.is_file())
+}
+
+fn find_generated_completion_file(root: &Path, executable: &str) -> Result<Option<PathBuf>> {
+    let executable_path = Path::new(executable);
+    if executable_path.components().count() != 1 {
+        return Ok(find_file_artifact(root, executable));
+    }
+    let direct = root.join(executable_path);
+    if direct.is_file() {
+        return Ok(Some(direct));
+    }
+    let matches = find_file_artifacts(root, executable_path);
+    match matches.as_slice() {
+        [] => Ok(None),
+        [path] => Ok(Some(path.clone())),
+        _ => bail!(
+            "brew-cask: completion executable '{}' is ambiguous: {}",
+            executable,
+            matches
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn find_file_artifacts(root: &Path, name: &Path) -> Vec<PathBuf> {
+    let mut matches = WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|entry| entry.file_name() != "__MACOSX")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.into_path())
+        .filter(|path| {
+            path.strip_prefix(root)
+                .is_ok_and(|relative| relative.ends_with(name))
+                && path.is_file()
         })
+        .collect::<Vec<_>>();
+    matches.sort();
+    matches.dedup();
+    matches
 }
 
 fn generate_completion_output(
@@ -1189,18 +1271,29 @@ fn remove_obsolete_completions(
         let Ok(relative) = target.strip_prefix(&prefix) else {
             continue;
         };
-        let has_staged_copy = std::fs::read_dir(&token_dir)
+        let staged_copy = std::fs::read_dir(&token_dir)
             .ok()
             .into_iter()
             .flatten()
             .filter_map(|entry| entry.ok())
             .filter(|entry| entry.file_type().is_ok_and(|ft| ft.is_dir()))
-            .any(|entry| entry.path().join(relative).is_file());
-        if has_staged_copy {
+            .map(|entry| entry.path().join(relative))
+            .find(|path| path.is_file());
+        if staged_copy
+            .as_deref()
+            .is_some_and(|staged_copy| same_file_contents(target, staged_copy))
+        {
             file::remove_file(target)?;
         }
     }
     Ok(())
+}
+
+fn same_file_contents(a: &Path, b: &Path) -> bool {
+    match (std::fs::read(a), std::fs::read(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }
 
 fn stage_binary(stage: &Path, caskroom: &Path, cask: &Cask, binary: &BinaryArtifact) -> Result<()> {
@@ -1213,14 +1306,7 @@ fn stage_binary(stage: &Path, caskroom: &Path, cask: &Cask, binary: &BinaryArtif
         // $APPDIR is the Applications directory where install_app placed the bundle.
         // Symlink into the installed app so the CLI wrapper can trace back to find the app.
         // Check both /Applications and $HOMEBREW_PREFIX/Applications per app_target_path().
-        let app_binary = [
-            PathBuf::from("/Applications"),
-            prefix::prefix().join("Applications"),
-        ]
-        .iter()
-        .map(|appdir| PathBuf::from(binary.source.replace("$APPDIR", &appdir.to_string_lossy())))
-        .find(|p| p.is_file())
-        .ok_or_else(|| {
+        let app_binary = appdir_artifact_source(&binary.source).ok_or_else(|| {
             eyre!(
                 "brew-cask: binary artifact '{}' was not found",
                 binary.source
@@ -2622,7 +2708,6 @@ end
             &executable,
             "#!/bin/sh\nprintf '%s|%s|%s' \"$1\" \"$2\" \"$SHELL\"\n",
         )?;
-        file::make_executable(&executable)?;
         let cask = test_cask("1password-cli", "2.34.1");
         let completion = GeneratedCompletionArtifact {
             executable: "op".to_string(),
@@ -2638,6 +2723,114 @@ end
             crate::file::read_to_string(caskroom.join("etc/bash_completion.d/op"))?,
             "completion|bash|bash"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn generated_completion_executable_expands_appdir() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("caskroom");
+        file::create_dir_all(&stage)?;
+        file::create_dir_all(&caskroom)?;
+        let app_executable = tmp.path().join("Applications/Foo.app/Contents/MacOS/foo");
+        file::create_dir_all(app_executable.parent().unwrap())?;
+        crate::file::write(&app_executable, "app cli")?;
+        let cask = test_cask("foo", "1.0.0");
+        let completion = GeneratedCompletionArtifact {
+            executable: "$APPDIR/Foo.app/Contents/MacOS/foo".to_string(),
+            args: vec![],
+            base_name: None,
+            shell_parameter_format: None,
+            shells: vec![CompletionShell::Bash],
+        };
+
+        assert_eq!(
+            find_generated_completion_executable(&stage, &caskroom, &cask, &completion)?,
+            app_executable
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_ambiguous_generated_completion_bare_executable() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let stage = tmp.path().join("stage");
+        let caskroom = tmp.path().join("caskroom");
+        file::create_dir_all(stage.join("a"))?;
+        file::create_dir_all(stage.join("b"))?;
+        file::create_dir_all(&caskroom)?;
+        crate::file::write(stage.join("a/tool"), "a")?;
+        crate::file::write(stage.join("b/tool"), "b")?;
+        let cask = test_cask("tool", "1.0.0");
+        let completion = GeneratedCompletionArtifact {
+            executable: "tool".to_string(),
+            args: vec![],
+            base_name: None,
+            shell_parameter_format: None,
+            shells: vec![CompletionShell::Bash],
+        };
+
+        let err = find_generated_completion_executable(&stage, &caskroom, &cask, &completion)
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("completion executable 'tool' is ambiguous")
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn link_completion_restores_existing_target_when_copy_fails() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let caskroom = tmp.path().join("caskroom");
+        let target = tmp.path().join("etc/bash_completion.d/foo");
+        let staged = caskroom.join("etc/bash_completion.d/foo");
+        file::create_dir_all(staged.parent().unwrap())?;
+        file::create_dir_all(target.parent().unwrap())?;
+        crate::file::write(&staged, "new")?;
+        crate::file::write(&target, "old")?;
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o000))?;
+
+        let err = link_completion(&caskroom, &target).unwrap_err();
+
+        assert!(err.to_string().contains("failed copy"));
+        assert_eq!(crate::file::read_to_string(&target)?, "old");
+        std::fs::set_permissions(staged, std::fs::Permissions::from_mode(0o644))?;
+        Ok(())
+    }
+
+    #[test]
+    fn remove_obsolete_completions_keeps_replaced_targets() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let cask = test_cask("foo", "2.0.0");
+        let old_caskroom = caskroom_version_dir(&cask.token, "1.0.0");
+        let relative = Path::new("etc/bash_completion.d/foo");
+        let target = tmp.path().join(relative);
+        file::create_dir_all(old_caskroom.join("etc/bash_completion.d"))?;
+        file::create_dir_all(target.parent().unwrap())?;
+        crate::file::write(old_caskroom.join(relative), "old")?;
+        crate::file::write(&target, "other cask")?;
+
+        remove_obsolete_completions(&cask, std::slice::from_ref(&target), &[])?;
+
+        assert_eq!(crate::file::read_to_string(&target)?, "other cask");
+
+        crate::file::write(&target, "old")?;
+        remove_obsolete_completions(&cask, std::slice::from_ref(&target), &[])?;
+
+        assert!(!target.exists());
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1400,7 +1400,7 @@ fn resolve_symlink_target(link: &Path, target: PathBuf) -> PathBuf {
 }
 
 fn path_starts_with_resolved_root(path: &Path, root: &Path) -> bool {
-    path_with_resolved_existing_ancestor(path).starts_with(&file::desymlink_path(root))
+    path_with_resolved_existing_ancestor(path).starts_with(file::desymlink_path(root))
 }
 
 fn path_with_resolved_existing_ancestor(path: &Path) -> PathBuf {

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1285,7 +1285,7 @@ fn remove_obsolete_completions(
     let token_dir = file::desymlink_path(&caskroom_token_dir(&cask.token));
     let prefix = prefix::prefix();
     for target in previous_targets {
-        if current_targets.contains(target) || !target.is_file() || !target.starts_with(&prefix) {
+        if current_targets.contains(target) || !target.starts_with(&prefix) {
             continue;
         }
         let Ok(metadata) = target.symlink_metadata() else {
@@ -1297,14 +1297,7 @@ fn remove_obsolete_completions(
         let Ok(link_target) = std::fs::read_link(target) else {
             continue;
         };
-        let resolved = if link_target.is_absolute() {
-            link_target
-        } else {
-            target
-                .parent()
-                .map(|parent| parent.join(&link_target))
-                .unwrap_or(link_target)
-        };
+        let resolved = resolve_symlink_target(target, link_target);
         if file::desymlink_path(&resolved).starts_with(&token_dir) {
             file::remove_file(target)?;
         }
@@ -2904,6 +2897,7 @@ end
         let other_caskroom = caskroom_version_dir("other", "1.0.0");
         let relative = Path::new("etc/bash_completion.d/foo");
         let target = tmp.path().join(relative);
+        let dangling_target = tmp.path().join("etc/bash_completion.d/dangling-foo");
         let other_target = tmp.path().join("etc/bash_completion.d/other-foo");
         let regular_target = tmp.path().join("etc/bash_completion.d/regular-foo");
         file::create_dir_all(old_caskroom.join("etc/bash_completion.d"))?;
@@ -2913,15 +2907,25 @@ end
         crate::file::write(other_caskroom.join(relative), "old")?;
         crate::file::write(&regular_target, "old")?;
         file::make_symlink(&old_caskroom.join(relative), &target)?;
+        file::make_symlink(
+            &old_caskroom.join("etc/bash_completion.d/dangling"),
+            &dangling_target,
+        )?;
         file::make_symlink(&other_caskroom.join(relative), &other_target)?;
 
         remove_obsolete_completions(
             &cask,
-            &[target.clone(), other_target.clone(), regular_target.clone()],
+            &[
+                target.clone(),
+                dangling_target.clone(),
+                other_target.clone(),
+                regular_target.clone(),
+            ],
             &[],
         )?;
 
         assert!(target.symlink_metadata().is_err());
+        assert!(dangling_target.symlink_metadata().is_err());
         assert!(other_target.symlink_metadata().is_ok());
         assert!(regular_target.symlink_metadata().is_ok());
         Ok(())


### PR DESCRIPTION
## Summary
- Add brew-cask support for declared bash/fish/zsh completion artifacts.
- Add `generate_completions_from_executable` support for bash, zsh, fish, and pwsh, including Homebrew's shell parameter formats.
- Track installed completion files in cask receipts/status checks and update brew bootstrap docs.

## Validation
- `cargo check --bin mise`
- `cargo test --bin mise system::packages::brew::cask::tests -- --test-threads=1` (65 passed)
- `git diff --check`

## Notes
- Checked the live Homebrew cask API for generated completion usage: current shapes use nil/custom shell parameter formats and bash/zsh/fish/pwsh shells.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the cask install/upgrade path (symlinks under the Homebrew prefix) and runs cask binaries to generate completions; behavior is heavily unit-tested but failures could leave partial links without rollback in edge cases.
> 
> **Overview**
> **brew-cask** now installs **shell completions** instead of skipping them: declared `bash_completion` / `fish_completion` / `zsh_completion` files and `generate_completions_from_executable` (bash, zsh, fish, pwsh), including Homebrew’s `shell_parameter_format` variants. Completions are staged under the Caskroom, symlinked into the Homebrew prefix, recorded in `.mise-cask.toml`, and included in installed-state checks; obsolete completion symlinks owned by the cask are removed on upgrade.
> 
> Cask activation is **more atomic**: external artifact links (binaries, fonts, completions) are backed up via `ArtifactLinkTransaction`, the version directory is swapped with `replace_caskroom`, and failed linking rolls back both the caskroom and prior symlinks. Completion targets refuse to overwrite non–cask-owned paths.
> 
> **$APPDIR** resolution for binaries and completion sources now goes through shared `appdir_artifact_source` (case-insensitive app bundle matching). Bootstrap docs state that completion artifacts are supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9e457aca6b20ca3c13ea762c33406a7cd83ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full Homebrew cask shell-completion support for Bash, Fish, and Zsh, including completions generated from cask-provided executables.
  * Completion files are now staged and linked, with obsolete completion targets removed to keep installs in sync.
* **Documentation**
  * Updated `brew-cask` documentation to clarify supported completion artifact types, including generated completions.
* **Bug Fixes**
  * Improved installed-state detection to include the presence of completion target files, and updated receipts so uninstall/zap validation reflects completion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->