### PR TITLE
feat(task): pass -NoProfile to PowerShell task shells

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -454,6 +454,12 @@ The shell to use to run the task. This is useful if you want to run a task with 
 the default such as `fish`, `zsh`, or `pwsh`. Generally though, it's recommended to use a [shebang](./toml-tasks#shell-shebang) instead
 because that will allow IDEs with mise support to show syntax highlighting and linting for the script.
 
+When the shell is PowerShell (`pwsh` or `powershell`), mise passes `-NoProfile` so your PowerShell
+profile is not loaded, matching the non-interactive behavior of `sh -c`/`zsh -c`. This avoids profiles
+that mutate `PATH` (for example a mise activation snippet) shadowing a task's own installed tools. Set
+[`windows_powershell_no_profile`](/configuration/settings.html#windows_powershell_no_profile) to `false`
+if your tasks depend on side effects from your profile.
+
 ```mise-toml
 [tasks.hello]
 run = '''

--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -73,7 +73,7 @@ echo "from-bash"
         # Repro for the per-task `tools = {...}` + `shell = "bash -c"` case.
         # When mise on Windows spawns bash for a task, PATH must be `:`-separated
         # `/c/...` form, not `;`-separated `C:\...` form, or bash cannot resolve
-        # any command — including the one mise just installed for the task.
+        # any command, including the one mise just installed for the task.
         #
         # We assert on the PATH the task observes, not on a tool install, so the
         # test runs without depending on rust/cargo or any toolchain backend.
@@ -176,7 +176,7 @@ esac
         # shell = "bash -c", a forwarded arg used to be passed as a separate argv
         # to `bash -c`, so the user's first arg became $0. Inline TOML scripts
         # append args to the command (like Unix), so $0 stays the shell (bash) and
-        # the arg is appended after it — not `using shell myarg`, where the arg had
+        # the arg is appended after it, not `using shell myarg`, where the arg had
         # been swallowed into $0.
         if (-not (Get-Command bash.exe -ErrorAction SilentlyContinue)) {
             Set-ItResult -Skipped -Because "bash.exe (Git Bash / MSYS) not on PATH"
@@ -194,7 +194,7 @@ run = 'echo "using shell $0"'
         try {
             # $0 is the shell bash was invoked as: "bash" on some setups, a full
             # path like "/usr/bin/bash" on Git Bash. Assert on the shape that
-            # proves the fix regardless of that form — $0 still names bash (not
+            # proves the fix regardless of that form: $0 still names bash (not
             # the forwarded arg) and "myarg" is appended as the trailing token,
             # rather than being swallowed into $0 (the old bug printed
             # "using shell myarg").
@@ -218,29 +218,58 @@ run = 'echo "using shell $0"'
         # discussion #10956. The task prints its own process argv so we can
         # assert on how pwsh was actually invoked.
         BeforeEach {
+            $script:noProfileTestEnv = @{}
+            foreach ($name in @('MISE_CONFIG_FILE', 'MISE_WINDOWS_POWERSHELL_NO_PROFILE')) {
+                $script:noProfileTestEnv[$name] = @{
+                    Exists = Test-Path "Env:\$name"
+                    Value = [Environment]::GetEnvironmentVariable($name, 'Process')
+                }
+            }
             @'
 [tasks.probe_argv]
 shell = "pwsh -c"
 run = 'Write-Output ([Environment]::GetCommandLineArgs() -join " ")'
+
+[tasks.probe_file_argv]
+file = "probe_file_argv.ps1"
 '@ | Out-File -FilePath "$TestDrive\mise.noprofile.toml" -Encoding utf8NoBOM
+            @'
+Write-Output ([Environment]::GetCommandLineArgs() -join " ")
+'@ | Out-File -FilePath "$TestDrive\probe_file_argv.ps1" -Encoding utf8NoBOM
             $env:MISE_CONFIG_FILE = "$TestDrive\mise.noprofile.toml"
         }
 
         AfterEach {
-            Remove-Item -Path Env:\MISE_CONFIG_FILE -ErrorAction SilentlyContinue
-            Remove-Item -Path Env:\MISE_WINDOWS_POWERSHELL_NO_PROFILE -ErrorAction SilentlyContinue
+            foreach ($name in @('MISE_CONFIG_FILE', 'MISE_WINDOWS_POWERSHELL_NO_PROFILE')) {
+                $original = $script:noProfileTestEnv[$name]
+                if ($original.Exists) {
+                    [Environment]::SetEnvironmentVariable($name, $original.Value, 'Process')
+                } else {
+                    [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+                }
+            }
+            $script:noProfileTestEnv = $null
             Remove-Item -Path "$TestDrive\mise.noprofile.toml" -ErrorAction SilentlyContinue
+            Remove-Item -Path "$TestDrive\probe_file_argv.ps1" -ErrorAction SilentlyContinue
         }
 
         It 'injects -NoProfile into a pwsh task shell by default' {
             $output = mise run probe_argv 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
             $output | Should -BeLike '*-NoProfile*'
         }
 
         It 'omits -NoProfile when windows_powershell_no_profile is disabled' {
             $env:MISE_WINDOWS_POWERSHELL_NO_PROFILE = "false"
             $output = mise run probe_argv 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
             $output | Should -Not -BeLike '*-NoProfile*'
+        }
+
+        It 'injects -NoProfile into a PowerShell file task' {
+            $output = mise run probe_file_argv 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            $output | Should -BeLike '*-NoProfile*'
         }
     }
 }

--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -210,4 +210,37 @@ run = 'echo "using shell $0"'
             Remove-Item -Path "$TestDrive\mise.args_repro.toml" -ErrorAction SilentlyContinue
         }
     }
+
+    Context 'pwsh -NoProfile injection' {
+        # A pwsh inline shell should be spawned with -NoProfile so startup
+        # profiles (which can mutate PATH and shadow task tools) are skipped,
+        # matching the non-interactive behavior of `sh -c`/`zsh -c`. See
+        # discussion #10956. The task prints its own process argv so we can
+        # assert on how pwsh was actually invoked.
+        BeforeEach {
+            @'
+[tasks.probe_argv]
+shell = "pwsh -c"
+run = 'Write-Output ([Environment]::GetCommandLineArgs() -join " ")'
+'@ | Out-File -FilePath "$TestDrive\mise.noprofile.toml" -Encoding utf8NoBOM
+            $env:MISE_CONFIG_FILE = "$TestDrive\mise.noprofile.toml"
+        }
+
+        AfterEach {
+            Remove-Item -Path Env:\MISE_CONFIG_FILE -ErrorAction SilentlyContinue
+            Remove-Item -Path Env:\MISE_WINDOWS_POWERSHELL_NO_PROFILE -ErrorAction SilentlyContinue
+            Remove-Item -Path "$TestDrive\mise.noprofile.toml" -ErrorAction SilentlyContinue
+        }
+
+        It 'injects -NoProfile into a pwsh task shell by default' {
+            $output = mise run probe_argv 2>&1 | Out-String
+            $output | Should -BeLike '*-NoProfile*'
+        }
+
+        It 'omits -NoProfile when windows_powershell_no_profile is disabled' {
+            $env:MISE_WINDOWS_POWERSHELL_NO_PROFILE = "false"
+            $output = mise run probe_argv 2>&1 | Out-String
+            $output | Should -Not -BeLike '*-NoProfile*'
+        }
+    }
 }

--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -226,16 +226,16 @@ run = 'echo "using shell $0"'
                 }
             }
             @'
+[task_config]
+includes = ["tasks"]
+
 [tasks.probe_argv]
 shell = "pwsh -c"
 run = 'Write-Output ([Environment]::GetCommandLineArgs() -join " ")'
-
-[tasks.probe_file_argv]
-file = "probe_file_argv.ps1"
 '@ | Out-File -FilePath "$TestDrive\mise.noprofile.toml" -Encoding utf8NoBOM
             @'
 Write-Output ([Environment]::GetCommandLineArgs() -join " ")
-'@ | Out-File -FilePath "$TestDrive\probe_file_argv.ps1" -Encoding utf8NoBOM
+'@ | Out-File -FilePath "$TestDrive\tasks\probe_file_argv.ps1" -Encoding utf8NoBOM
             $env:MISE_CONFIG_FILE = "$TestDrive\mise.noprofile.toml"
         }
 
@@ -250,7 +250,7 @@ Write-Output ([Environment]::GetCommandLineArgs() -join " ")
             }
             $script:noProfileTestEnv = $null
             Remove-Item -Path "$TestDrive\mise.noprofile.toml" -ErrorAction SilentlyContinue
-            Remove-Item -Path "$TestDrive\probe_file_argv.ps1" -ErrorAction SilentlyContinue
+            Remove-Item -Path "$TestDrive\tasks\probe_file_argv.ps1" -ErrorAction SilentlyContinue
         }
 
         It 'injects -NoProfile into a pwsh task shell by default' {

--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -225,6 +225,7 @@ run = 'echo "using shell $0"'
                     Value = [Environment]::GetEnvironmentVariable($name, 'Process')
                 }
             }
+            Remove-Item -Path Env:\MISE_WINDOWS_POWERSHELL_NO_PROFILE -ErrorAction SilentlyContinue
             @'
 [task_config]
 includes = ["tasks"]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1977,11 +1977,6 @@
           "description": "Default shell arguments for Windows to be used for inline commands. For example, `cmd /c` for cmd.exe.",
           "type": "string"
         },
-        "windows_powershell_no_profile": {
-          "default": true,
-          "description": "Pass `-NoProfile` to PowerShell (`pwsh`/`powershell`) shells that mise spawns for tasks and inline commands, so startup profiles are skipped.",
-          "type": "boolean"
-        },
         "windows_executable_extensions": {
           "default": ["exe", "bat", "cmd", "com", "ps1", "vbs"],
           "description": "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on.",
@@ -1989,6 +1984,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "windows_powershell_no_profile": {
+          "default": true,
+          "description": "Pass `-NoProfile` to PowerShell (`pwsh`/`powershell`) shells that mise spawns for tasks and inline commands, so startup profiles are skipped.",
+          "type": "boolean"
         },
         "windows_shim_mode": {
           "default": "exe",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1977,6 +1977,11 @@
           "description": "Default shell arguments for Windows to be used for inline commands. For example, `cmd /c` for cmd.exe.",
           "type": "string"
         },
+        "windows_powershell_no_profile": {
+          "default": true,
+          "description": "Pass `-NoProfile` to PowerShell (`pwsh`/`powershell`) shells that mise spawns for tasks and inline commands, so startup profiles are skipped.",
+          "type": "boolean"
+        },
         "windows_executable_extensions": {
           "default": ["exe", "bat", "cmd", "com", "ps1", "vbs"],
           "description": "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on.",

--- a/settings.toml
+++ b/settings.toml
@@ -3013,6 +3013,14 @@ description = "Default shell arguments for Windows to be used for inline command
 env = "MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS"
 type = "String"
 
+[windows_executable_extensions]
+default = ["exe", "bat", "cmd", "com", "ps1", "vbs"]
+description = "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on."
+env = "MISE_WINDOWS_EXECUTABLE_EXTENSIONS"
+parse_env = "list_by_comma"
+rust_type = "Vec<String>"
+type = "ListString"
+
 [windows_powershell_no_profile]
 default = true
 description = "Pass `-NoProfile` to PowerShell (`pwsh`/`powershell`) shells that mise spawns for tasks and inline commands, so startup profiles are skipped."
@@ -3032,14 +3040,6 @@ Set to `false` if your tasks rely on side effects from your PowerShell profile
 """
 env = "MISE_WINDOWS_POWERSHELL_NO_PROFILE"
 type = "Bool"
-
-[windows_executable_extensions]
-default = ["exe", "bat", "cmd", "com", "ps1", "vbs"]
-description = "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on."
-env = "MISE_WINDOWS_EXECUTABLE_EXTENSIONS"
-parse_env = "list_by_comma"
-rust_type = "Vec<String>"
-type = "ListString"
 
 [windows_shim_mode]
 default = "exe"

--- a/settings.toml
+++ b/settings.toml
@@ -3013,6 +3013,26 @@ description = "Default shell arguments for Windows to be used for inline command
 env = "MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS"
 type = "String"
 
+[windows_powershell_no_profile]
+default = true
+description = "Pass `-NoProfile` to PowerShell (`pwsh`/`powershell`) shells that mise spawns for tasks and inline commands, so startup profiles are skipped."
+docs = """
+When mise runs a task or inline command through PowerShell, it passes
+`-NoProfile` so the shell does not load the user's PowerShell profile. This
+matches the non-interactive behavior of `sh -c` / `zsh -c` on Unix, which do not
+source interactive startup files.
+
+Profiles that mutate `PATH` — for example a mise activation snippet that prepends
+the shims directory — can otherwise shadow a task's own installed tools and
+produce confusing `cannot find binary path` errors.
+
+Set to `false` if your tasks rely on side effects from your PowerShell profile
+(environment variables, functions, aliases). This only affects `pwsh` and
+`powershell`; it has no effect on `cmd` or on non-Windows shells.
+"""
+env = "MISE_WINDOWS_POWERSHELL_NO_PROFILE"
+type = "Bool"
+
 [windows_executable_extensions]
 default = ["exe", "bat", "cmd", "com", "ps1", "vbs"]
 description = "List of executable extensions for Windows. For example, `exe` for .exe files, `bat` for .bat files, and so on."

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1041,7 +1041,9 @@ impl Settings {
                 Self::UNIX_DEFAULT_INLINE_SHELL_ARGS,
             )
         };
-        split_default_shell_or_fallback(sa, fallback)
+        let mut shell = split_default_shell_or_fallback(sa, fallback)?;
+        self.maybe_no_profile(&mut shell);
+        Ok(shell)
     }
 
     pub fn default_file_shell(&self) -> Result<Vec<String>> {
@@ -1056,7 +1058,17 @@ impl Settings {
                 Self::UNIX_DEFAULT_FILE_SHELL_ARGS,
             )
         };
-        split_default_shell_or_fallback(sa, fallback)
+        let mut shell = split_default_shell_or_fallback(sa, fallback)?;
+        self.maybe_no_profile(&mut shell);
+        Ok(shell)
+    }
+
+    /// Inject `-NoProfile` into a PowerShell shell command when
+    /// `windows_powershell_no_profile` is enabled. No-op for other shells.
+    pub fn maybe_no_profile(&self, shell: &mut Vec<String>) {
+        if self.windows_powershell_no_profile {
+            crate::path::inject_powershell_no_profile(shell);
+        }
     }
 
     pub fn os(&self) -> &str {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -533,11 +533,12 @@ fn preview_matched_hook(root: &Path, hook: &Hook) -> Result<()> {
             };
             // Do not render the command again here: template functions such as
             // exec() may have side effects. Preview the command as currently loaded.
-            let shell = shell
+            let mut shell = shell
                 .as_ref()
                 .map(|shell| crate::path::split_shell_command(shell))
                 .transpose()?
                 .unwrap_or(Settings::get().default_inline_shell()?);
+            Settings::get().maybe_no_profile(&mut shell);
             display_inline_command(&shell, run)
         }
     };
@@ -595,11 +596,12 @@ async fn execute(
     let Some(run) = hook.action.run_for_current_platform() else {
         return Ok(());
     };
-    let shell = shell
+    let mut shell = shell
         .as_ref()
         .map(|shell| crate::path::split_shell_command(shell))
         .transpose()?
         .unwrap_or(Settings::get().default_inline_shell()?);
+    Settings::get().maybe_no_profile(&mut shell);
 
     // Preinstall hooks skip `tools=true` env directives since the tools
     // providing those env vars aren't installed yet (fixes #6162)

--- a/src/path.rs
+++ b/src/path.rs
@@ -198,13 +198,25 @@ pub fn inject_powershell_no_profile(shell: &mut Vec<String>) {
     if !is_powershell_program(Path::new(program)) {
         return;
     }
-    let already_present = shell[1..].iter().any(|arg| {
-        let token = arg.trim_start_matches(['-', '/']).to_ascii_lowercase();
-        // `-nop`, `-nopro`, …, `-noprofile` are all abbreviations of NoProfile.
-        // Require at least "nop" to avoid matching unrelated `-no*` flags, and
-        // stop at "noprofile" so longer names like NoProfileLoadTime don't match.
-        token.len() >= 3 && "noprofile".starts_with(&token)
-    });
+    let already_present = shell[1..]
+        .iter()
+        .take_while(|arg| {
+            let token = arg.trim_start_matches(['-', '/']).to_ascii_lowercase();
+            // PowerShell treats everything after -Command/-File (and their
+            // abbreviations) as payload, so a payload argument such as `-nop`
+            // must not suppress injection.
+            !(!token.is_empty()
+                && ("command".starts_with(&token)
+                    || "commandwithargs".starts_with(&token)
+                    || "file".starts_with(&token)))
+        })
+        .any(|arg| {
+            let token = arg.trim_start_matches(['-', '/']).to_ascii_lowercase();
+            // `-nop`, `-nopro`, …, `-noprofile` are all abbreviations of NoProfile.
+            // Require at least "nop" to avoid matching unrelated `-no*` flags, and
+            // stop at "noprofile" so longer names like NoProfileLoadTime don't match.
+            token.len() >= 3 && "noprofile".starts_with(&token)
+        });
     if !already_present {
         shell.insert(1, "-NoProfile".to_string());
     }
@@ -871,6 +883,17 @@ mod tests {
         assert_eq!(
             inject(&["pwsh", "/NoProfile", "-c"]),
             sv(&["pwsh", "/NoProfile", "-c"])
+        );
+
+        // NoProfile-like payload arguments after -Command/-File are not shell
+        // options and must not prevent injection.
+        assert_eq!(
+            inject(&["pwsh", "-Command", "-nop"]),
+            sv(&["pwsh", "-NoProfile", "-Command", "-nop"])
+        );
+        assert_eq!(
+            inject(&["pwsh", "-File", "script.ps1", "-nop"]),
+            sv(&["pwsh", "-NoProfile", "-File", "script.ps1", "-nop"])
         );
 
         // -NoProfileLoadTime does not suppress the profile, so still injected.

--- a/src/path.rs
+++ b/src/path.rs
@@ -163,6 +163,53 @@ pub fn is_cmd_shell_program(program: &Path) -> bool {
     program_stem(program).as_deref() == Some("cmd")
 }
 
+/// Returns true if `program` is PowerShell (`pwsh` / PowerShell Core) or Windows
+/// PowerShell (`powershell`), with or without a directory prefix or `.exe`
+/// extension.
+pub fn is_powershell_program(program: &Path) -> bool {
+    matches!(
+        program_stem(program).as_deref(),
+        Some("pwsh" | "powershell")
+    )
+}
+
+/// If `shell` invokes PowerShell and does not already suppress startup profiles,
+/// insert `-NoProfile` immediately after the program.
+///
+/// Unlike `zsh -c` / `sh -c`, `pwsh -Command` loads the user's PowerShell
+/// profile even for a non-interactive one-liner. A profile that mutates `PATH`
+/// (e.g. mise activation prepending the shims dir) can shadow a task's own
+/// installed tools, producing confusing "cannot find binary path" failures
+/// (discussion #10956). Skipping the profile makes mise-spawned PowerShell
+/// behave like the POSIX shells it spawns elsewhere.
+///
+/// `-NoProfile` must precede `-Command`/`-File`, since everything after those is
+/// treated as the script/args rather than as pwsh options — hence insertion at
+/// index 1, right after the program.
+///
+/// Detection is idempotent and covers PowerShell's case-insensitive prefix
+/// abbreviations (`-nop`, `-NoProfile`, `/noprofile`, …). `-NoProfileLoadTime`
+/// is deliberately *not* treated as suppressing the profile — it only affects
+/// startup timing output — so it does not block injection.
+pub fn inject_powershell_no_profile(shell: &mut Vec<String>) {
+    let Some(program) = shell.first() else {
+        return;
+    };
+    if !is_powershell_program(Path::new(program)) {
+        return;
+    }
+    let already_present = shell[1..].iter().any(|arg| {
+        let token = arg.trim_start_matches(['-', '/']).to_ascii_lowercase();
+        // `-nop`, `-nopro`, …, `-noprofile` are all abbreviations of NoProfile.
+        // Require at least "nop" to avoid matching unrelated `-no*` flags, and
+        // stop at "noprofile" so longer names like NoProfileLoadTime don't match.
+        token.len() >= 3 && "noprofile".starts_with(&token)
+    });
+    if !already_present {
+        shell.insert(1, "-NoProfile".to_string());
+    }
+}
+
 /// Assemble the args (everything after the `cmd.exe` program) for running
 /// `script` — plus any forwarded `args` — through cmd.exe *verbatim*.
 ///
@@ -766,6 +813,77 @@ mod tests {
         // `cmd.com` is not the modern interpreter we target.
         assert!(!is_cmd_shell_program(Path::new("cmd.com")));
         assert!(!is_cmd_shell_program(Path::new("")));
+    }
+
+    #[test]
+    fn test_is_powershell_program() {
+        assert!(is_powershell_program(Path::new("pwsh")));
+        assert!(is_powershell_program(Path::new("pwsh.exe")));
+        assert!(is_powershell_program(Path::new("PWSH.EXE")));
+        assert!(is_powershell_program(Path::new("powershell")));
+        assert!(is_powershell_program(Path::new("powershell.exe")));
+        assert!(is_powershell_program(Path::new(
+            r"C:\Program Files\PowerShell\7\pwsh.exe"
+        )));
+
+        assert!(!is_powershell_program(Path::new("cmd")));
+        assert!(!is_powershell_program(Path::new("bash")));
+        assert!(!is_powershell_program(Path::new("")));
+    }
+
+    #[test]
+    fn test_inject_powershell_no_profile() {
+        let inject = |args: &[&str]| {
+            let mut v = sv(args);
+            inject_powershell_no_profile(&mut v);
+            v
+        };
+
+        // Injected right after the program, before -Command.
+        assert_eq!(
+            inject(&["pwsh", "-Command"]),
+            sv(&["pwsh", "-NoProfile", "-Command"])
+        );
+        assert_eq!(
+            inject(&["powershell", "-c"]),
+            sv(&["powershell", "-NoProfile", "-c"])
+        );
+        assert_eq!(
+            inject(&["pwsh.exe", "-NoLogo", "-Command"]),
+            sv(&["pwsh.exe", "-NoProfile", "-NoLogo", "-Command"])
+        );
+
+        // Non-PowerShell shells are untouched.
+        assert_eq!(inject(&["cmd", "/c"]), sv(&["cmd", "/c"]));
+        assert_eq!(inject(&["bash", "-c"]), sv(&["bash", "-c"]));
+        assert_eq!(inject(&[]), sv(&[]));
+
+        // Idempotent — already present in any accepted spelling/abbreviation.
+        assert_eq!(
+            inject(&["pwsh", "-NoProfile", "-Command"]),
+            sv(&["pwsh", "-NoProfile", "-Command"])
+        );
+        assert_eq!(
+            inject(&["pwsh", "-noprofile", "-c"]),
+            sv(&["pwsh", "-noprofile", "-c"])
+        );
+        assert_eq!(inject(&["pwsh", "-nop", "-c"]), sv(&["pwsh", "-nop", "-c"]));
+        assert_eq!(
+            inject(&["pwsh", "/NoProfile", "-c"]),
+            sv(&["pwsh", "/NoProfile", "-c"])
+        );
+
+        // -NoProfileLoadTime does not suppress the profile, so still injected.
+        assert_eq!(
+            inject(&["pwsh", "-NoProfileLoadTime", "-c"]),
+            sv(&["pwsh", "-NoProfile", "-NoProfileLoadTime", "-c"])
+        );
+
+        // -NoLogo starts with "-no" but is not a NoProfile abbreviation.
+        assert_eq!(
+            inject(&["pwsh", "-NoLogo", "-c"]),
+            sv(&["pwsh", "-NoProfile", "-NoLogo", "-c"])
+        );
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1744,11 +1744,12 @@ impl Task {
         // A malformed explicit shell (e.g. an unbalanced quote in a path with
         // spaces) must fail loudly rather than silently falling back to the
         // default shell and running the task under the wrong interpreter.
-        let shell_cmd = crate::path::split_shell_command(shell)?;
+        let mut shell_cmd = crate::path::split_shell_command(shell)?;
         if shell_cmd.is_empty() || shell_cmd[0].trim().is_empty() {
             warn!("invalid shell '{shell}', expected '<program> <argument>' (e.g. sh -c)");
             Ok(None)
         } else {
+            config::Settings::get().maybe_no_profile(&mut shell_cmd);
             Ok(Some(shell_cmd))
         }
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -909,11 +909,12 @@ impl TaskExecutor {
         if !Settings::get().use_file_shell_for_executable_tasks && can_execute_directly(file) {
             return Ok((display, args.to_vec()));
         }
-        let shell = task
+        let mut shell = task
             .shell()?
             .or_else(|| shell_from_shebang(file))
             .or_else(|| shell_from_extension(file))
             .unwrap_or(Settings::get().default_file_shell()?);
+        Settings::get().maybe_no_profile(&mut shell);
         let (program, _) = task_shell_parts(&shell, "file shell")?;
         trace!("using shell: {}", shell.join(" "));
         let mut full_args = shell.to_vec();

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -985,7 +985,9 @@ impl TaskExecutor {
 
     fn clone_default_inline_shell(&self) -> Result<Vec<String>> {
         if let Some(shell) = &self.shell {
-            crate::path::split_shell_command(shell)
+            let mut shell = crate::path::split_shell_command(shell)?;
+            Settings::get().maybe_no_profile(&mut shell);
+            Ok(shell)
         } else {
             Settings::get().default_inline_shell()
         }

--- a/src/watch_files.rs
+++ b/src/watch_files.rs
@@ -81,10 +81,11 @@ async fn execute(
         .iter()
         .map(|f| f.to_string_lossy().replace(':', "\\:"))
         .join(":");
-    let shell = match shell {
+    let mut shell = match shell {
         Some(shell) => crate::path::split_shell_command(shell)?,
         None => Settings::get().default_inline_shell()?,
     };
+    Settings::get().maybe_no_profile(&mut shell);
     let (program, shell_args) = shell.split_first().ok_or_else(|| {
         eyre::eyre!(
             "inline shell is empty; check watch_files.shell or unix_default_inline_shell_args / windows_default_inline_shell_args"


### PR DESCRIPTION
## Summary

`pwsh -c` / `pwsh -Command` loads the user's PowerShell profile even for a non-interactive one-liner — unlike `sh -c` / `zsh -c` on Unix, which do not source interactive startup files. A profile that mutates `PATH` (for example a mise activation snippet that prepends the shims dir) can shadow a task's own installed tools, producing the confusing `cannot find binary path` failure reported in [discussion #10956](https://github.com/jdx/mise/discussions/10956).

This makes mise-spawned PowerShell behave like the POSIX shells mise already spawns elsewhere: when the shell program is `pwsh` or `powershell`, mise inserts `-NoProfile` right after the program (before `-Command`/`-File`).

## Details

- New helpers in `src/path.rs`: `is_powershell_program` and `inject_powershell_no_profile`. Injection is idempotent and recognizes PowerShell's case-insensitive prefix abbreviations (`-nop`, `-NoProfile`, `/noprofile`, …). `-NoProfileLoadTime` is deliberately *not* treated as suppressing the profile, so it doesn't block injection.
- Applied at every point mise resolves a shell: inline/file task shells, `--shell`, explicit task `shell =`, hooks, and `watch_files`.
- Gated by a new setting **`windows_powershell_no_profile`** (default `true`). This is the opt-out — because PowerShell has no "load profile" counter-flag, a user who relies on profile side effects (env vars, functions) can set this to `false`. Doing this via the shell-args config alone isn't possible, which is why a dedicated setting is warranted.

## Why a setting rather than just editing the default

mise's Windows default shell is `cmd /c`; the user in #10956 opted into `pwsh -c` themselves. Fixing the reported bug therefore requires rewriting *user-specified* args, and once we do that there's no PowerShell flag a user could add to re-enable the profile — hence the boolean escape hatch.

## Scope note

This makes the common case deterministic but does not fix the whole class: a wrapper script or a manually-prepended shims dir can still shadow a task tool, and nested shim dispatch still cannot see `tasks.<name>.tools`. Those are worth a follow-up (propagating resolved task tools into shim/`mise x` resolution).

## Tests

- Unit tests for `is_powershell_program` and `inject_powershell_no_profile` (detection, ordering, idempotency, abbreviations, opt-out edge cases) in `src/path.rs`.
- Windows e2e tests in `e2e-win/task.Tests.ps1` asserting `-NoProfile` reaches the pwsh invocation by default and is omitted when the setting is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every mise-spawned PowerShell task runs on Windows (profiles skipped by default), which can break tasks that relied on profile-defined env/functions unless they opt out via the new setting.
> 
> **Overview**
> PowerShell tasks and inline commands now spawn **`pwsh`/`powershell` with `-NoProfile`** by default, so startup profiles (often mise activation that prepends shims to `PATH`) do not shadow per-task `tools` and cause misleading “cannot find binary” failures.
> 
> Injection is centralized in **`inject_powershell_no_profile`** (idempotent, respects existing `-NoProfile` abbreviations, ignores `-nop` in script payload after `-Command`/`-File`) and applied wherever mise resolves a shell: default inline/file shells, explicit task `shell`, hooks, `watch_files`, and file-task execution.
> 
> A new setting **`windows_powershell_no_profile`** (default `true`, env `MISE_WINDOWS_POWERSHELL_NO_PROFILE`) opts out when tasks need profile side effects. Docs/schema and Windows e2e tests assert `-NoProfile` on the real process argv for inline and file PowerShell tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd26af890e0c98507a110a00302b70b852a7bb4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PowerShell (`pwsh`/`powershell`) task shells and inline `pwsh` commands now skip loading user profiles by default via `-NoProfile`, improving consistent PATH/tool resolution.
  * Added the Windows-only `windows_powershell_no_profile` setting (default: `true`); set it to `false` to allow profile loading and side effects.
* **Documentation**
  * Updated task/shell and configuration documentation to describe the new `-NoProfile` behavior and setting.
* **Tests**
  * Added end-to-end coverage verifying `-NoProfile` is injected by default, omitted when disabled, and applied consistently to both inline and file-based PowerShell tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->