### PR TITLE
fix(task): fix source freshness for workspace-rooted patterns in subproject tasks

### DIFF
--- a/e2e/tasks/test_task_source_freshness_subproject
+++ b/e2e/tasks/test_task_source_freshness_subproject
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Bug: when a task in a subproject uses a workspace-rooted source glob, edits
+# to files inside the subproject directory do not trigger a rebuild.
+#
+# Setup: workspace root with a task defined in lib/worker/ (a subproject).
+# The task watches lib/**/* — a pattern rooted at the workspace, not at lib/worker/.
+# Editing worker.go (inside lib/worker/) should trigger a rebuild, but doesn't.
+
+WORKSPACE="$PWD"
+
+# Workspace root: defines workspace_root var so subproject can reference it.
+cat <<EOF >mise.toml
+[vars]
+workspace_root = "{{ config_root }}"
+
+[settings.task]
+source_freshness_hash_contents = true
+EOF
+
+# Subproject: task watches all files under workspace lib/ — including its own files.
+mkdir -p lib/worker
+cat <<EOF >lib/worker/mise.toml
+[tasks.build]
+run = "echo built"
+sources = ["{{ vars.workspace_root }}/lib/**/*"]
+outputs = { auto = true }
+EOF
+
+echo "initial" >lib/worker/worker.go
+echo "initial" >lib/shared.go
+
+cd "$WORKSPACE/lib/worker"
+
+# First run: no prior state, task must run.
+assert "mise run -q build" "built"
+
+# Second run: nothing changed, task must be skipped.
+assert_empty "mise run -q build"
+
+# Edit a file inside the subproject (covered by lib/**/*) — must trigger a rebuild.
+echo "changed" >worker.go
+assert "mise run -q build" "built"
+
+# Edit the shared file outside the subproject — must also trigger a rebuild.
+echo "changed" >"$WORKSPACE/lib/shared.go"
+assert "mise run -q build" "built"

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -172,6 +172,7 @@ impl TaskScriptParser {
                 .unwrap_or_else(|| std::path::PathBuf::from("."));
             let matcher = Arc::new(crate::task::task_source_checker::build_source_matcher(
                 &root,
+                &root,
                 &task.sources,
             ));
 

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -46,20 +46,24 @@ pub fn is_glob_pattern(path: &str) -> bool {
 
 /// Build an [`Override`] matcher for a task's `sources` patterns.
 ///
-/// Patterns use gitignore syntax with `!` inverted (the [`Override`] convention,
-/// see `ignore::overrides`): a non-negated entry marks a file as a *source*,
-/// and a `!`-prefixed entry *excludes* it. `\!` escapes a literal leading `!`,
-/// and order matters — a later non-negated entry can re-include a file an
-/// earlier `!` excluded.
+/// `match_root` is the directory the [`Override`] is anchored at (the workspace
+/// root in workspace setups, otherwise the task CWD). `task_cwd` is the
+/// directory the task actually runs from. When they differ — a subproject task
+/// inside a workspace — relative patterns are prefixed with the
+/// `task_cwd`-relative-to-`match_root` path so they remain correctly anchored.
+/// Absolute patterns are stripped of the `match_root` prefix as before.
 ///
-/// Patterns that are absolute paths under `root` are rewritten to be relative,
-/// matching the convention used by `Override` itself (see its tests) and the
-/// `ignore::WalkBuilder`: matchers receive root-relative patterns and let
-/// `matched()` strip the root from incoming paths automatically.
-pub(crate) fn build_source_matcher(root: &Path, sources: &[String]) -> Override {
-    let mut builder = OverrideBuilder::new(root);
+/// Patterns use gitignore syntax with `!` inverted (the [`Override`] convention):
+/// a non-negated entry marks a file as a *source*, `!`-prefixed excludes it,
+/// `\!` escapes a literal `!`, and order matters.
+pub(crate) fn build_source_matcher(
+    match_root: &Path,
+    task_cwd: &Path,
+    sources: &[String],
+) -> Override {
+    let mut builder = OverrideBuilder::new(match_root);
     for s in sources {
-        let normalized = relativize_pattern(root, s);
+        let normalized = normalize_pattern(match_root, task_cwd, s);
         if let Err(e) = builder.add(&normalized) {
             warn!("invalid source pattern {s:?}: {e}");
         }
@@ -70,13 +74,17 @@ pub(crate) fn build_source_matcher(root: &Path, sources: &[String]) -> Override 
     })
 }
 
-/// If `pattern`'s body is an absolute path under `root`, rewrite it as a
-/// root-relative path so the matcher can use gitignore's relative-path
-/// semantics. The `!` / `\!` prefix is preserved as-is.
-fn relativize_pattern(root: &Path, pattern: &str) -> String {
+/// Normalise `pattern` so it is always expressed relative to `match_root`.
+///
+/// - **Absolute** body under `match_root`: strip the prefix.
+/// - **Relative** body when `task_cwd` is a subdirectory of `match_root`:
+///   prefix with `task_cwd`-relative-to-`match_root` so the pattern is
+///   anchored at the workspace root rather than the subproject CWD.
+///   E.g. `match_root=/ws`, `task_cwd=/ws/lib/worker`, `src/**/*.go`
+///   → `lib/worker/src/**/*.go`.
+/// - Everything else: returned unchanged.
+fn normalize_pattern(match_root: &Path, task_cwd: &Path, pattern: &str) -> String {
     let (prefix, body) = if pattern.starts_with("\\!") {
-        // `\!body` is a literal include of a path beginning with `!`. Don't
-        // peek past the escape — `OverrideBuilder::add` handles it.
         return pattern.to_string();
     } else if let Some(rest) = pattern.strip_prefix('!') {
         ("!", rest)
@@ -84,11 +92,20 @@ fn relativize_pattern(root: &Path, pattern: &str) -> String {
         ("", pattern)
     };
     let body_path = Path::new(body);
-    if body_path.is_absolute()
-        && let Ok(rel) = body_path.strip_prefix(root)
-        && let Some(rel_str) = rel.to_str()
+    if body_path.is_absolute() {
+        if let Ok(rel) = body_path.strip_prefix(match_root)
+            && let Some(rel_str) = rel.to_str()
+        {
+            return format!("{prefix}{rel_str}");
+        }
+        return pattern.to_string();
+    }
+    // Relative pattern: anchor it at match_root by prepending the subproject path.
+    if let Ok(cwd_rel) = task_cwd.strip_prefix(match_root)
+        && let Some(cwd_rel_str) = cwd_rel.to_str()
+        && !cwd_rel_str.is_empty()
     {
-        return format!("{prefix}{rel_str}");
+        return format!("{prefix}{cwd_rel_str}/{body}");
     }
     pattern.to_string()
 }
@@ -101,8 +118,7 @@ fn relativize_pattern(root: &Path, pattern: &str) -> String {
 /// gitignore's domain — `Override::matched` would return `Match::None` and,
 /// when positive patterns are present, promote that to `Match::Ignore`,
 /// silently dropping a file the glob legitimately included. Trust the glob
-/// in that case (matching pre-PR behavior for workspace-root paths
-/// referenced from sub-package tasks, etc.).
+/// in that case.
 pub(crate) fn is_source(matcher: &Override, path: &Path) -> bool {
     if path.is_absolute() && !path.starts_with(matcher.path()) {
         return true;
@@ -218,7 +234,25 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
 
     let run = async || -> Result<bool> {
         let root = task_cwd(task, config).await?;
-        let matcher = build_source_matcher(&root, &task.sources);
+        // Anchor the Override matcher at the outermost config root that is an
+        // ancestor of the task CWD (i.e. the workspace root). This allows
+        // workspace-rooted patterns like `{{ config_root }}/lib/**/*` to be
+        // correctly relativized so that files inside a subproject directory are
+        // not silently dropped.
+        //
+        // config.project_root cannot be used directly: BTreeMap iterates by
+        // lexicographic path order, so a subproject config may be returned
+        // before the workspace root config (mise.toml) even though
+        // the workspace root has a shorter path.
+        let match_root_owned = config
+            .config_files
+            .values()
+            .filter_map(|cf| cf.project_root())
+            .filter(|pr| root.starts_with(pr) || *pr == root)
+            .min_by_key(|p| p.components().count())
+            .unwrap_or_else(|| root.clone());
+        let match_root = match_root_owned.as_path();
+        let matcher = build_source_matcher(match_root, &root, &task.sources);
         let glob_patterns = source_glob_patterns(&task.sources);
         let mut source_metadatas = get_file_metadatas(&root, &glob_patterns, &matcher)?;
         // Always include every file that contributed to the task definition,
@@ -562,7 +596,8 @@ mod tests {
 
     fn matches(sources: &[&str], path: &str) -> bool {
         let sources: Vec<String> = sources.iter().map(|s| s.to_string()).collect();
-        let matcher = build_source_matcher(Path::new("."), &sources);
+        let root = Path::new(".");
+        let matcher = build_source_matcher(root, root, &sources);
         is_source(&matcher, Path::new(path))
     }
 
@@ -637,7 +672,7 @@ mod tests {
         // `Path::is_absolute` returns false for `/proj` there.
         let root = Path::new("/proj");
         let sources = vec!["/proj/input".to_string()];
-        let matcher = build_source_matcher(root, &sources);
+        let matcher = build_source_matcher(root, root, &sources);
         assert!(is_source(&matcher, Path::new("/proj/input")));
         assert!(!is_source(&matcher, Path::new("/proj/other")));
     }
@@ -650,7 +685,7 @@ mod tests {
             "/proj/src/**/*.ts".to_string(),
             "!/proj/src/**/*.test.ts".to_string(),
         ];
-        let matcher = build_source_matcher(root, &sources);
+        let matcher = build_source_matcher(root, root, &sources);
         assert!(is_source(&matcher, Path::new("/proj/src/foo.ts")));
         assert!(!is_source(&matcher, Path::new("/proj/src/foo.test.ts")));
     }
@@ -665,8 +700,41 @@ mod tests {
     fn matcher_absolute_path_outside_root_passes_through() {
         let root = Path::new("/proj");
         let sources = vec!["/elsewhere/Cargo.toml".to_string()];
-        let matcher = build_source_matcher(root, &sources);
+        let matcher = build_source_matcher(root, root, &sources);
         assert!(is_source(&matcher, Path::new("/elsewhere/Cargo.toml")));
+    }
+
+    /// Workspace-rooted absolute pattern in a subproject task must match files
+    /// both inside and outside the subproject CWD.
+    #[test]
+    #[cfg(unix)]
+    fn matcher_subproject_absolute_workspace_pattern() {
+        let match_root = Path::new("/workspace");
+        let task_cwd = Path::new("/workspace/lib/worker");
+        let sources = vec!["/workspace/lib/**/*".to_string()];
+        let matcher = build_source_matcher(match_root, task_cwd, &sources);
+        assert!(is_source(
+            &matcher,
+            Path::new("/workspace/lib/worker/worker.go")
+        ));
+        assert!(is_source(&matcher, Path::new("/workspace/lib/shared.go")));
+        assert!(!is_source(&matcher, Path::new("/workspace/other/file.go")));
+    }
+
+    /// Relative pattern in a subproject task must be anchored at the task CWD,
+    /// not the workspace root.
+    #[test]
+    #[cfg(unix)]
+    fn matcher_subproject_relative_pattern() {
+        let match_root = Path::new("/workspace");
+        let task_cwd = Path::new("/workspace/lib/worker");
+        let sources = vec!["src/**/*.go".to_string()];
+        let matcher = build_source_matcher(match_root, task_cwd, &sources);
+        assert!(is_source(
+            &matcher,
+            Path::new("/workspace/lib/worker/src/main.go")
+        ));
+        assert!(!is_source(&matcher, Path::new("/workspace/src/other.go")));
     }
 
     #[test]


### PR DESCRIPTION
In a monorepo setup where a subproject has its own mise.toml nested
inside a workspace, tasks that use source patterns rooted at the
workspace root do not correctly track files inside the subproject
directory — edits there do not trigger a rebuild.

Example:

```toml
# /workspace/mise.toml
[vars]
workspace_root = "{{ config_root }}"

[settings.task]
source_freshness_hash_contents = true

# /workspace/lib/worker/mise.toml
[tasks.build]
run = "echo built"
sources = ["{{ vars.workspace_root }}/lib/**/*"]
outputs = { auto = true }
```

Running from `lib/worker/`, the second `mise run build` after editing
`worker.go` (inside `lib/worker/`) is incorrectly skipped — the task
reports fresh despite the change.

**Root cause:** `build_source_matcher` was anchored at the task CWD
(`lib/worker/`). Source patterns are template-expanded to absolute paths
like `/workspace/lib/**/*`. The matcher's `relativize_pattern` tries to
strip the task CWD as a prefix from this path, fails (since `lib/**/*`
is not under `lib/worker/`), and leaves the pattern as a raw absolute
string. The Override matcher then can't match files against it, returning
`Match::Ignore` for everything inside the subproject — silently dropping
them from source tracking.

**Fix:** replace `relativize_pattern` with `normalize_pattern(match_root, task_cwd, pattern)`. The matcher is now anchored at the outermost config root that is an ancestor of the task CWD (the workspace root). Absolute patterns are stripped of that prefix as before. Relative patterns are prefixed with the task-CWD-relative-to-workspace path so they remain anchored at the subproject, not the workspace root.

Note: the fix was mostly created by Claude since I'm not that familiar with Rust... and I'm not too sure about the fix... but the e2e test should make it clear what the problem is at least.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task source freshness checks for tasks in subprojects.
  * Changes to files within a subproject or shared workspace files now correctly trigger task reruns.
  * Improved handling of relative and workspace-rooted source patterns, while preserving skip behavior when no sources have changed.

* **Tests**
  * Added end-to-end coverage for initial runs, unchanged-source skips, and rebuilds after modifying local or shared files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->