### PR TITLE
fix(task): harden remote task cache lifecycle

### DIFF
--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -14,8 +14,9 @@ import socketserver
 from pathlib import Path
 
 class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
-    def __init__(self, *args, repo_dir=None, **kwargs):
+    def __init__(self, *args, repo_dir=None, request_log=None, **kwargs):
         self.repo_dir = repo_dir
+        self.request_log = request_log
         super().__init__(*args, **kwargs)
 
     def do_GET(self):
@@ -25,6 +26,10 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         self.handle_git_request()
 
     def handle_git_request(self):
+        if self.request_log:
+            with open(self.request_log, 'a') as log:
+                log.write(f'{self.command} {self.path}\n')
+
         # Set up environment for git-http-backend
         env = os.environ.copy()
         env['GIT_PROJECT_ROOT'] = str(self.repo_dir)
@@ -193,8 +198,15 @@ def start_server(port=0):
     repo_path = temp_dir / 'repo'
 
     # Create handler with repo directory
+    request_log = os.environ.get('MISE_GIT_HTTP_REQUEST_LOG')
+
     def handler(*args, **kwargs):
-        return GitHTTPHandler(*args, repo_dir=temp_dir, **kwargs)
+        return GitHTTPHandler(
+            *args,
+            repo_dir=temp_dir,
+            request_log=request_log,
+            **kwargs
+        )
 
     # Let the OS assign an available port if port=0
     # This avoids race conditions between finding and binding

--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -119,6 +119,19 @@ def create_test_repo(repo_path):
     ripgrep_file.write_text('#!/usr/bin/env bash\necho "ripgrep task executed"\n')
     ripgrep_file.chmod(0o755)
 
+    # A config-declared remote task whose script filename ends in .toml. This
+    # exercises the script-header path rather than task-include TOML parsing.
+    remote_task_dir = Path(repo_path) / 'xtasks' / 'remote'
+    remote_task_dir.mkdir(parents=True)
+    remote_metadata_file = remote_task_dir / 'remote_metadata.toml'
+    remote_metadata_file.write_text(
+        '#!/usr/bin/env bash\n'
+        '#MISE description="remote git metadata"\n'
+        '#MISE tools={dummy="1.0.0"}\n'
+        'dummy\n'
+    )
+    remote_metadata_file.chmod(0o755)
+
     # A toml task file colocated with the executable scripts. Keys are task
     # names; values are the run command (or a table). Used by tests covering
     # remote toml task includes.

--- a/e2e/helpers/scripts/git_http_backend_server.py
+++ b/e2e/helpers/scripts/git_http_backend_server.py
@@ -102,7 +102,7 @@ class GitHTTPHandler(http.server.BaseHTTPRequestHandler):
         except Exception as e:
             self.send_error(500, f"Server error: {str(e)}")
 
-def create_test_repo(repo_path):
+def create_test_repo(repo_path, server_port):
     """Create a minimal test repository"""
     # Create a regular (non-bare) repository
     subprocess.run(['git', 'init', repo_path], check=True)
@@ -128,9 +128,19 @@ def create_test_repo(repo_path):
         '#!/usr/bin/env bash\n'
         '#MISE description="remote git metadata"\n'
         '#MISE tools={dummy="1.0.0"}\n'
+        '#MISE env._.file="remote.env"\n'
+        'echo "remote path: $0"\n'
+        'echo "$REMOTE_RELATIVE_ENV"\n'
         'dummy\n'
     )
     remote_metadata_file.chmod(0o755)
+    (remote_task_dir / 'remote.env').write_text('REMOTE_RELATIVE_ENV="relative env loaded"\n')
+    nested_remote_file = remote_task_dir / 'nested'
+    nested_remote_file.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "nested remote task executed"\n'
+    )
+    nested_remote_file.chmod(0o755)
 
     # A toml task file colocated with the executable scripts. Keys are task
     # names; values are the run command (or a table). Used by tests covering
@@ -142,6 +152,9 @@ def create_test_repo(repo_path):
         '[toml_table_task]\n'
         'run = "echo toml_table_task executed"\n'
         'description = "TOML task with table form"\n'
+        '\n'
+        '[nested_remote]\n'
+        f'file = "git::http://localhost:{server_port}/repo.git//xtasks/remote/nested"\n'
     )
 
     # A standalone toml file in a sibling directory to test the
@@ -179,9 +192,6 @@ def start_server(port=0):
     temp_dir = Path(tempfile.mkdtemp(prefix='mise_git_http_'))
     repo_path = temp_dir / 'repo'
 
-    print(f"Creating test repository at {repo_path}")
-    create_test_repo(str(repo_path))
-
     # Create handler with repo directory
     def handler(*args, **kwargs):
         return GitHTTPHandler(*args, repo_dir=temp_dir, **kwargs)
@@ -190,6 +200,8 @@ def start_server(port=0):
     # This avoids race conditions between finding and binding
     with socketserver.TCPServer(("", port), handler) as httpd:
         actual_port = httpd.server_address[1]
+        print(f"Creating test repository at {repo_path}")
+        create_test_repo(str(repo_path), actual_port)
         print(f"Git HTTP server running on port {actual_port}")
         print(f"Repository URL: http://localhost:{actual_port}/repo.git")
 

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -22,6 +22,7 @@ HEADERS_LOG_DIR = None
 
 class TestFileHandler(http.server.SimpleHTTPRequestHandler):
     changing_remote_revision = 0
+    raw_help_revision = 0
 
     def do_GET(self):
         """Handle GET requests for test files"""
@@ -43,7 +44,32 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
             content = (
                 '#!/usr/bin/env bash\n'
                 '#MISE description="{{ exec(command=\'touch $MISE_REMOTE_TEMPLATE_MARKER\') }}"\n'
+                '#MISE depends=["remote_dep"]\n'
+                '#USAGE flag "--remote-flag" help="Remote usage flag"\n'
                 'echo "remote template task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-raw-help':
+            TestFileHandler.raw_help_revision += 1
+            revision = TestFileHandler.raw_help_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE raw_args=true\n'
+                f'echo "remote raw help revision {revision}"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-deferred-template':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE confirm="\\u007b\\u007b exec(command=\'touch $MISE_REMOTE_DEFERRED_MARKER\') \\u007d\\u007d"\n'
+                '#MISE env={REMOTE_DEFERRED="\\u007b\\u007b exec(command=\'touch $MISE_REMOTE_DEFERRED_MARKER\') \\u007d\\u007d"}\n'
+                'echo "remote deferred task ran"\n'
             )
             self.wfile.write(content.encode('utf-8'))
         elif self.path == '/test/remote-tools':

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -32,6 +32,26 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
             content = '#!/usr/bin/env bash\necho "running mytask"\n'
             self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-template':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE description="{{ exec(command=\'touch $MISE_REMOTE_TEMPLATE_MARKER\') }}"\n'
+                'echo "remote template task ran"\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-tools':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                '#MISE tools={dummy="1.0.0"}\n'
+                'dummy\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
         else:
             # Return 404 for other paths
             self.send_error(404, "File not found")

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -21,6 +21,8 @@ HEADERS_LOG_DIR = None
 
 
 class TestFileHandler(http.server.SimpleHTTPRequestHandler):
+    changing_remote_revision = 0
+
     def do_GET(self):
         """Handle GET requests for test files"""
         self._log_headers()
@@ -33,6 +35,8 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
             content = '#!/usr/bin/env bash\necho "running mytask"\n'
             self.wfile.write(content.encode('utf-8'))
         elif self.path == '/test/remote-template':
+            if marker := os.environ.get('MISE_HTTP_REQUEST_MARKER'):
+                Path(marker).touch()
             self.send_response(200)
             self.send_header('Content-Type', 'text/plain')
             self.end_headers()
@@ -49,7 +53,19 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
             content = (
                 '#!/usr/bin/env bash\n'
                 '#MISE tools={dummy="1.0.0"}\n'
-                'dummy\n'
+                'if command -v dummy >/dev/null 2>&1; then dummy; else echo "dummy not installed"; fi\n'
+            )
+            self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-changing':
+            TestFileHandler.changing_remote_revision += 1
+            revision = TestFileHandler.changing_remote_revision
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = (
+                '#!/usr/bin/env bash\n'
+                f'#MISE description="remote revision {revision}"\n'
+                f'echo "remote revision {revision}"\n'
             )
             self.wfile.write(content.encode('utf-8'))
         else:

--- a/e2e/helpers/scripts/http_test_server.py
+++ b/e2e/helpers/scripts/http_test_server.py
@@ -94,6 +94,12 @@ class TestFileHandler(http.server.SimpleHTTPRequestHandler):
                 f'echo "remote revision {revision}"\n'
             )
             self.wfile.write(content.encode('utf-8'))
+        elif self.path == '/test/remote-failing':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            content = '#!/usr/bin/env bash\nexit 7\n'
+            self.wfile.write(content.encode('utf-8'))
         else:
             # Return 404 for other paths
             self.send_error(404, "File not found")

--- a/e2e/tasks/test_task_remote_git_https
+++ b/e2e/tasks/test_task_remote_git_https
@@ -45,7 +45,7 @@ LOCAL_GIT_URL="http://localhost:${SERVER_PORT}/repo.git"
 # Update cache directory paths for local server
 REMOTE_TASKS_DIR="${MISE_CACHE_DIR}/remote-git-tasks-cache"
 # Hash for localhost URL will be different than GitHub URL
-LOCAL_CACHE_HASH=$(echo -n "${LOCAL_GIT_URL}v2025.1.17" | shasum -a 256 | cut -d' ' -f1)
+LOCAL_CACHE_HASH=$(printf '%s\0%s' "${LOCAL_GIT_URL}" "v2025.1.17" | shasum -a 256 | cut -d' ' -f1)
 MISE_LOCAL_CACHE_DIR="${REMOTE_TASKS_DIR}/${LOCAL_CACHE_HASH}"
 
 git init

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -67,6 +67,12 @@ includes = [
 ]
 EOF
 
+# Safe-mode config parsing must not clone an untrusted remote include before
+# enforcing the defining config's actual trust.
+: >"$REQUEST_LOG"
+assert_fail "MISE_SAFE=1 MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 mise tasks"
+assert_fail "test -s '$REQUEST_LOG'"
+
 # The xtasks/lint directory contains multiple task files
 # We should be able to see and run them
 assert_contains "mise tasks" "ripgrep"
@@ -107,7 +113,7 @@ EOF
 
 INCLUDE_ARTIFACT_TMPDIR="$TMPDIR/remote-git-include-artifacts"
 mkdir -p "$INCLUDE_ARTIFACT_TMPDIR"
-assert_succeed "TMPDIR=$INCLUDE_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run ripgrep" # Remote task should be redownloaded
+assert_succeed "TMPDIR=$INCLUDE_ARTIFACT_TMPDIR mise run --no-cache ripgrep" # CLI no-cache must also redownload includes
 assert_fail "find '$INCLUDE_ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
 assert_directory_not_exists "${REMOTE_TASKS_DIR}"
 

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -175,4 +175,17 @@ EOF
 assert_contains "mise tasks" "standalone_task"
 assert_contains "mise run standalone_task" "standalone_task executed"
 
+#################################################################################
+# Test config-declared remote git task metadata and tool installation
+#################################################################################
+
+cat <<EOF >mise.toml
+[tasks.remote_metadata]
+file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
+EOF
+
+mise trust
+assert_contains "mise tasks info remote_metadata" "remote git metadata"
+assert_contains "mise run remote_metadata" "This is Dummy 1.0.0!"
+
 echo "All tests passed!"

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -7,14 +7,16 @@
 PORT_FILE="$TMPDIR/mise_git_http_port"
 READY_FILE="$TMPDIR/mise_git_http_ready"
 INFO_FILE="$TMPDIR/mise_git_http_info"
+REQUEST_LOG="$TMPDIR/mise_git_http_requests"
 
 # Clean up any previous server files
-rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE"
+rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$REQUEST_LOG"
 
 # Start local git HTTP server with OS-assigned port to avoid race conditions
 MISE_GIT_HTTP_PORT_FILE="$PORT_FILE" \
   MISE_GIT_HTTP_READY_FILE="$READY_FILE" \
   MISE_GIT_HTTP_INFO_FILE="$INFO_FILE" \
+  MISE_GIT_HTTP_REQUEST_LOG="$REQUEST_LOG" \
   python3 "${TEST_ROOT}/helpers/scripts/git_http_backend_server.py" 0 &
 SERVER_PID=$!
 
@@ -50,7 +52,7 @@ git init
 # Ensure cleanup on exit
 cleanup() {
   kill "$SERVER_PID" 2>/dev/null || true
-  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE"
+  rm -f "$PORT_FILE" "$READY_FILE" "$INFO_FILE" "$REQUEST_LOG"
 }
 trap cleanup EXIT
 
@@ -167,7 +169,10 @@ assert_contains "mise run toml_table_task" "toml_table_task executed"
 # then be cleaned when no-cache mode bypasses the static task cache.
 NESTED_ARTIFACT_TMPDIR="$TMPDIR/nested-remote-git-artifacts"
 mkdir -p "$NESTED_ARTIFACT_TMPDIR"
+: >"$REQUEST_LOG"
 assert_contains "TMPDIR=$NESTED_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run nested_remote" "nested remote task executed"
+clone_count=$(grep -c 'GET /repo.git/info/refs?service=git-upload-pack' "$REQUEST_LOG" || true)
+[[ $clone_count -eq 2 ]] || fail "no-cache nested task used $clone_count clones instead of one outer and one inner snapshot"
 assert_fail "find '$NESTED_ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
 
 mise cache clear # Clear cache to force redownload

--- a/e2e/tasks/test_task_remote_git_includes
+++ b/e2e/tasks/test_task_remote_git_includes
@@ -103,7 +103,10 @@ includes = [
 ]
 EOF
 
-assert_succeed "MISE_TASK_REMOTE_NO_CACHE=true mise run ripgrep" # Remote task should be redownloaded
+INCLUDE_ARTIFACT_TMPDIR="$TMPDIR/remote-git-include-artifacts"
+mkdir -p "$INCLUDE_ARTIFACT_TMPDIR"
+assert_succeed "TMPDIR=$INCLUDE_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run ripgrep" # Remote task should be redownloaded
+assert_fail "find '$INCLUDE_ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
 assert_directory_not_exists "${REMOTE_TASKS_DIR}"
 
 assert_succeed "mise run ripgrep" # Cache should be used
@@ -159,6 +162,14 @@ assert_contains "mise tasks" "toml_table_task"
 assert_contains "mise run toml_task" "toml_task executed"
 assert_contains "mise run toml_table_task" "toml_table_task executed"
 
+# A remote TOML include can itself declare a remote file task. Both the outer
+# include clone and inner script clone must remain alive through execution and
+# then be cleaned when no-cache mode bypasses the static task cache.
+NESTED_ARTIFACT_TMPDIR="$TMPDIR/nested-remote-git-artifacts"
+mkdir -p "$NESTED_ARTIFACT_TMPDIR"
+assert_contains "TMPDIR=$NESTED_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run nested_remote" "nested remote task executed"
+assert_fail "find '$NESTED_ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
+
 mise cache clear # Clear cache to force redownload
 
 #################################################################################
@@ -180,12 +191,24 @@ assert_contains "mise run standalone_task" "standalone_task executed"
 #################################################################################
 
 cat <<EOF >mise.toml
-[tasks.remote_metadata]
+[tasks.remote_metadata_a]
+file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
+
+[tasks.remote_metadata_b]
 file = "git::${LOCAL_GIT_URL}//xtasks/remote/remote_metadata.toml"
 EOF
 
 mise trust
-assert_contains "mise tasks info remote_metadata" "remote git metadata"
-assert_contains "mise run remote_metadata" "This is Dummy 1.0.0!"
+assert_contains "mise tasks info remote_metadata_a" "remote git metadata"
+assert_contains "mise run remote_metadata_a" "This is Dummy 1.0.0!"
+assert_contains "mise run remote_metadata_a" "relative env loaded"
+ARTIFACT_TMPDIR="$TMPDIR/remote-git-artifacts"
+mkdir -p "$ARTIFACT_TMPDIR"
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_metadata_a ::: remote_metadata_b")
+assert_contains_text "$output" "This is Dummy 1.0.0!"
+assert_contains_text "$output" "relative env loaded"
+path_count=$(grep -o 'remote path: .*' <<<"$output" | sort -u | wc -l)
+[[ $path_count -eq 2 ]] || fail "no-cache Git tasks did not retain two distinct snapshots"
+assert_fail "find '$ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
 
 echo "All tests passed!"

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -43,6 +43,25 @@ assert_contains "$UNTRUSTED_ENV mise run remote_template --help" "--remote-flag"
 [[ -e $MARKER ]] || fail "trusted remote metadata template did not render"
 assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
 
+# A trusted config vouches for an explicitly included task file even when that
+# file is outside the config's trust root. Preserve that provenance when the
+# include declares a remote task, including for temporary no-cache snapshots.
+INCLUDED_TASK_DIR="$TMPDIR/included-remote-tasks"
+mkdir -p "$INCLUDED_TASK_DIR"
+cat <<EOF >"$INCLUDED_TASK_DIR/tasks.toml"
+[included_remote_template]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+EOF
+cat <<EOF >mise.toml
+[task_config]
+includes = ["$INCLUDED_TASK_DIR/tasks.toml"]
+EOF
+
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV mise tasks info included_remote_template" "remote_dep"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_REMOTE_NO_CACHE=true mise tasks info included_remote_template" "remote_dep"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
 # Deferred metadata (confirmation and task env) can render after initial task
 # discovery, so decoded header templates must still require the defining
 # config's trust before either path gets a chance to execute.

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -30,6 +30,11 @@ file = "http://localhost:${HTTP_PORT}/test/remote-template"
 run = "echo remote dependency"
 EOF
 
+# Safe mode makes config parsing inert, but it must not turn remote discovery
+# into an SSRF-capable trust bypass.
+assert_fail "$UNTRUSTED_ENV MISE_SAFE=1 mise tasks ls" "not trusted"
+[[ ! -e $REQUEST_MARKER ]] || fail "safe-mode discovery fetched an untrusted remote task"
+
 assert_fail "$UNTRUSTED_ENV mise tasks ls" "not trusted"
 assert_fail "$UNTRUSTED_ENV mise tasks deps remote_template" "not trusted"
 assert_fail "$UNTRUSTED_ENV mise run remote_template --help" "not trusted"
@@ -122,3 +127,17 @@ output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE
 assert_contains_text "$output" "remote revision 1"
 assert_contains_text "$output" "remote revision 2"
 assert_fail "find '$ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."
+
+# Task failures exit through mise's explicit exit path. That path must clean
+# live no-cache snapshots even though process::exit does not run destructors.
+cat <<EOF >mise.toml
+[tasks.remote_failing]
+file = "http://localhost:${HTTP_PORT}/test/remote-failing"
+EOF
+
+FAILING_ARTIFACT_TMPDIR="$TMPDIR/remote-failing-artifacts"
+mkdir -p "$FAILING_ARTIFACT_TMPDIR"
+assert_fail "TMPDIR=$FAILING_ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_failing"
+# The run command's own TempDir cannot destruct on process::exit and may leave
+# an empty directory; the downloaded remote task file itself must be gone.
+assert_fail "find '$FAILING_ARTIFACT_TMPDIR' -type f -print -quit | grep -q ."

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Remote task metadata can render Tera templates during discovery and install
+# tools before execution. Both actions must respect the defining config's trust.
+
+HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
+MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 &
+HTTP_SERVER_PID=$!
+
+cleanup() {
+  kill "$HTTP_SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
+HTTP_PORT=$(cat "$HTTP_PORT_FILE")
+
+MARKER="$TMPDIR/remote-template-executed"
+UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER"
+
+cat <<EOF >mise.toml
+[tasks.remote_template]
+file = "http://localhost:${HTTP_PORT}/test/remote-template"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise tasks ls" "not trusted"
+[[ ! -e $MARKER ]] || fail "remote metadata template executed before trust"
+
+# Tool metadata is inert when installation is disabled, but normal task auto-
+# installation must require trust. Preinstall the fixture so the disabled paths
+# can still execute the task and prove they do not trip the trust gate.
+mise install dummy@1.0.0
+cat <<EOF >mise.toml
+[tasks.remote_tools]
+file = "http://localhost:${HTTP_PORT}/test/remote-tools"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run remote_tools" "not trusted"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_tools" "This is Dummy 1.0.0!"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "This is Dummy 1.0.0!"
+assert_contains "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "This is Dummy 1.0.0!"
+
+mise uninstall dummy@1.0.0
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV mise run remote_tools" "This is Dummy 1.0.0!"

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -5,6 +5,7 @@
 
 HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
 MARKER="$TMPDIR/remote-template-executed"
+DEFERRED_MARKER="$TMPDIR/remote-deferred-template-executed"
 REQUEST_MARKER="$TMPDIR/remote-template-requested"
 MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" \
   MISE_HTTP_REQUEST_MARKER="$REQUEST_MARKER" \
@@ -19,20 +20,42 @@ trap cleanup EXIT
 wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
 HTTP_PORT=$(cat "$HTTP_PORT_FILE")
 
-UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER"
+UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER MISE_REMOTE_DEFERRED_MARKER=$DEFERRED_MARKER"
 
 cat <<EOF >mise.toml
 [tasks.remote_template]
 file = "http://localhost:${HTTP_PORT}/test/remote-template"
+
+[tasks.remote_dep]
+run = "echo remote dependency"
 EOF
 
 assert_fail "$UNTRUSTED_ENV mise tasks ls" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise tasks deps remote_template" "not trusted"
+assert_fail "$UNTRUSTED_ENV mise run remote_template --help" "not trusted"
 [[ ! -e $REQUEST_MARKER ]] || fail "remote task was fetched during untrusted passive discovery"
 [[ ! -e $MARKER ]] || fail "remote metadata template executed before trust"
 assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
 assert_succeed "$UNTRUSTED_ENV mise tasks ls"
+assert_contains "$UNTRUSTED_ENV mise tasks deps remote_template" "remote_dep"
+assert_contains "$UNTRUSTED_ENV mise run remote_template --help" "--remote-flag"
 [[ -e $REQUEST_MARKER ]] || fail "trusted passive discovery did not fetch the remote task"
 [[ -e $MARKER ]] || fail "trusted remote metadata template did not render"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
+
+# Deferred metadata (confirmation and task env) can render after initial task
+# discovery, so decoded header templates must still require the defining
+# config's trust before either path gets a chance to execute.
+cat <<EOF >mise.toml
+[tasks.remote_deferred]
+file = "http://localhost:${HTTP_PORT}/test/remote-deferred-template"
+EOF
+
+assert_fail "$UNTRUSTED_ENV mise run remote_deferred" "not trusted"
+[[ ! -e $DEFERRED_MARKER ]] || fail "deferred remote metadata template executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_contains "$UNTRUSTED_ENV MISE_YES=1 mise run remote_deferred" "remote deferred task ran"
+[[ -e $DEFERRED_MARKER ]] || fail "trusted remote task env template did not render"
 assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
 
 # Tool metadata is inert when installation is disabled, but normal task auto-
@@ -55,6 +78,15 @@ assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
 assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
 assert_contains "$UNTRUSTED_ENV mise run remote_tools" "This is Dummy 1.0.0!"
 
+# A remote raw-args task must execute the same snapshot used to decide that
+# --help should pass through, rather than fetching a mutable source twice.
+cat <<EOF >mise.toml
+[tasks.remote_raw_help]
+file = "http://localhost:${HTTP_PORT}/test/remote-raw-help"
+EOF
+
+assert_contains "MISE_TASK_REMOTE_NO_CACHE=true mise run remote_raw_help --help" "remote raw help revision 1"
+
 # Two no-cache tasks using the same mutable URL must retain the exact body that
 # was parsed for each Task instead of both executing the final download path.
 cat <<EOF >mise.toml
@@ -65,6 +97,9 @@ file = "http://localhost:${HTTP_PORT}/test/remote-changing"
 file = "http://localhost:${HTTP_PORT}/test/remote-changing"
 EOF
 
-output=$(quiet_assert_succeed "MISE_TASK_REMOTE_NO_CACHE=true mise run remote_revision_a ::: remote_revision_b")
+ARTIFACT_TMPDIR="$TMPDIR/remote-artifacts"
+mkdir -p "$ARTIFACT_TMPDIR"
+output=$(quiet_assert_succeed "TMPDIR=$ARTIFACT_TMPDIR MISE_TASK_REMOTE_NO_CACHE=true mise run remote_revision_a ::: remote_revision_b")
 assert_contains_text "$output" "remote revision 1"
 assert_contains_text "$output" "remote revision 2"
+assert_fail "find '$ARTIFACT_TMPDIR' -mindepth 1 -print -quit | grep -q ."

--- a/e2e/tasks/test_task_remote_metadata_trust
+++ b/e2e/tasks/test_task_remote_metadata_trust
@@ -4,7 +4,11 @@
 # tools before execution. Both actions must respect the defining config's trust.
 
 HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
-MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 &
+MARKER="$TMPDIR/remote-template-executed"
+REQUEST_MARKER="$TMPDIR/remote-template-requested"
+MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" \
+  MISE_HTTP_REQUEST_MARKER="$REQUEST_MARKER" \
+  python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 &
 HTTP_SERVER_PID=$!
 
 cleanup() {
@@ -15,7 +19,6 @@ trap cleanup EXIT
 wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
 HTTP_PORT=$(cat "$HTTP_PORT_FILE")
 
-MARKER="$TMPDIR/remote-template-executed"
 UNTRUSTED_ENV="env -u CI -u GITHUB_ACTION -u GITHUB_ACTIONS MISE_TRUSTED_CONFIG_PATHS=$TMPDIR/not-trusted MISE_YES=0 MISE_REMOTE_TEMPLATE_MARKER=$MARKER"
 
 cat <<EOF >mise.toml
@@ -24,22 +27,44 @@ file = "http://localhost:${HTTP_PORT}/test/remote-template"
 EOF
 
 assert_fail "$UNTRUSTED_ENV mise tasks ls" "not trusted"
+[[ ! -e $REQUEST_MARKER ]] || fail "remote task was fetched during untrusted passive discovery"
 [[ ! -e $MARKER ]] || fail "remote metadata template executed before trust"
+assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
+assert_succeed "$UNTRUSTED_ENV mise tasks ls"
+[[ -e $REQUEST_MARKER ]] || fail "trusted passive discovery did not fetch the remote task"
+[[ -e $MARKER ]] || fail "trusted remote metadata template did not render"
+assert_succeed "$UNTRUSTED_ENV mise untrust mise.toml"
 
 # Tool metadata is inert when installation is disabled, but normal task auto-
-# installation must require trust. Preinstall the fixture so the disabled paths
-# can still execute the task and prove they do not trip the trust gate.
-mise install dummy@1.0.0
+# installation must require trust. Each disabled path must execute without
+# installing the missing fixture tool.
 cat <<EOF >mise.toml
 [tasks.remote_tools]
 file = "http://localhost:${HTTP_PORT}/test/remote-tools"
 EOF
 
 assert_fail "$UNTRUSTED_ENV mise run remote_tools" "not trusted"
-assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_tools" "This is Dummy 1.0.0!"
-assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "This is Dummy 1.0.0!"
-assert_contains "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "This is Dummy 1.0.0!"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_contains "$UNTRUSTED_ENV mise run --skip-tools remote_tools" "dummy not installed"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_contains "$UNTRUSTED_ENV MISE_TASK_RUN_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
+assert_contains "$UNTRUSTED_ENV MISE_AUTO_INSTALL=0 mise run remote_tools" "dummy not installed"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
 
-mise uninstall dummy@1.0.0
 assert_succeed "$UNTRUSTED_ENV mise trust mise.toml"
 assert_contains "$UNTRUSTED_ENV mise run remote_tools" "This is Dummy 1.0.0!"
+
+# Two no-cache tasks using the same mutable URL must retain the exact body that
+# was parsed for each Task instead of both executing the final download path.
+cat <<EOF >mise.toml
+[tasks.remote_revision_a]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing"
+
+[tasks.remote_revision_b]
+file = "http://localhost:${HTTP_PORT}/test/remote-changing"
+EOF
+
+output=$(quiet_assert_succeed "MISE_TASK_REMOTE_NO_CACHE=true mise run remote_revision_a ::: remote_revision_b")
+assert_contains_text "$output" "remote revision 1"
+assert_contains_text "$output" "remote revision 2"

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use crate::config::Config;
+use crate::config::{Config, Settings};
 use clap::Parser;
 use rmcp::{
     RoleServer, ServiceExt,
@@ -300,7 +300,17 @@ impl ServerHandler for MiseServer {
                     data: None,
                 })?;
 
-                let tasks = config.tasks().await.map_err(|e| ErrorData {
+                // MCP is a long-lived process. In remote no-cache mode each
+                // resource read is its own logical command and must receive a
+                // fresh snapshot rather than retaining the first one forever.
+                let remote_no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
+                let task_config = if remote_no_cache {
+                    config.with_config_files(config.config_files.clone())
+                } else {
+                    config
+                };
+
+                let tasks = task_config.tasks().await.map_err(|e| ErrorData {
                     code: ErrorCode::INTERNAL_ERROR,
                     message: Cow::Owned(format!("Failed to load tasks: {e}")),
                     data: None,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -257,20 +257,24 @@ impl Run {
             self.args.contains(&"--help".to_string()) || self.args.contains(&"-h".to_string());
 
         let mut config = Config::get().await?;
+        let mut prefetched_task_list = None;
 
         // Handle task help early to avoid unnecessary toolset/deps work
         if has_help_in_task_args {
-            // Build args list to get the task (filter out --help/-h for task lookup)
+            // Build the same task list normal execution would use so raw-args
+            // tasks can reuse this exact fetched snapshot.
             let args = once(self.task.clone())
-                .chain(
-                    self.args
-                        .iter()
-                        .filter(|a| *a != "--help" && *a != "-h")
-                        .cloned(),
-                )
+                .chain(self.args.iter().cloned())
                 .collect_vec();
 
-            let task_list = get_task_lists(&config, &args, false, false).await?;
+            let mut task_list = get_task_lists(&config, &args, false, false).await?;
+
+            // Help is passive discovery, but remote #USAGE and #MISE headers
+            // still need to be fetched before they can be displayed. Require
+            // trust before that fetch, just like `mise tasks info`.
+            let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache)
+                .require_trust_before_fetch();
+            fetcher.fetch_tasks(&config, &mut task_list).await?;
 
             if let Some(task) = task_list.first() {
                 // raw_args tasks act as proxies for tools that handle their
@@ -289,6 +293,7 @@ impl Run {
                     }
                     return Ok(());
                 }
+                prefetched_task_list = Some(task_list);
             } else {
                 // No task found, show run command help
                 self.get_clap_command().print_long_help()?;
@@ -309,7 +314,21 @@ impl Run {
             .chain(self.args.clone())
             .collect_vec();
 
-        let mut task_list = get_task_lists(&config, &args, true, self.skip_deps).await?;
+        let (mut task_list, tasks_already_fetched) = if let Some(mut tasks) = prefetched_task_list {
+            if self.skip_deps {
+                for task in &mut tasks {
+                    task.depends.clear();
+                    task.depends_post.clear();
+                    task.wait_for.clear();
+                }
+            }
+            (tasks, true)
+        } else {
+            (
+                get_task_lists(&config, &args, true, self.skip_deps).await?,
+                false,
+            )
+        };
 
         // Args after -- go directly to tasks (no prefix). They are also
         // recorded on `trailing_args` so the task renderer can detect
@@ -323,8 +342,10 @@ impl Run {
 
         // Fetch remote task files before parsing usage specs, so that
         // file-based remote tasks have their files resolved to local cache.
-        let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
-        fetcher.fetch_tasks(&config, &mut task_list).await?;
+        if !tasks_already_fetched {
+            let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
+            fetcher.fetch_tasks(&config, &mut task_list).await?;
+        }
 
         // Re-render dependency templates with parent task's usage arg/flag values.
         // This enables patterns like: depends = ["child {{usage.app}}"]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -14,7 +14,7 @@ use crate::env;
 use crate::file::display_path;
 use crate::task::has_any_usage_spec;
 use crate::task::task_helpers::task_needs_permit;
-use crate::task::task_list::{get_task_lists, resolve_depends};
+use crate::task::task_list::{get_task_lists_with_no_cache, resolve_depends_with_no_cache};
 use crate::task::task_output::TaskOutput;
 use crate::task::task_output_handler::OutputHandler;
 use crate::task::{Deps, Task};
@@ -267,7 +267,8 @@ impl Run {
                 .chain(self.args.iter().cloned())
                 .collect_vec();
 
-            let mut task_list = get_task_lists(&config, &args, false, false).await?;
+            let mut task_list =
+                get_task_lists_with_no_cache(&config, &args, false, false, self.no_cache).await?;
 
             // Help is passive discovery, but remote #USAGE and #MISE headers
             // still need to be fetched before they can be displayed. Require
@@ -325,7 +326,8 @@ impl Run {
             (tasks, true)
         } else {
             (
-                get_task_lists(&config, &args, true, self.skip_deps).await?,
+                get_task_lists_with_no_cache(&config, &args, true, self.skip_deps, self.no_cache)
+                    .await?,
                 false,
             )
         };
@@ -371,7 +373,8 @@ impl Run {
         // 1. Discover deps providers from monorepo subdirectory configs
         // 2. Include monorepo subdirectory tools in the toolset before installing
         // 3. Reuse the resolved list for execution (avoiding duplicate work)
-        let resolved_tasks = resolve_depends(&config, task_list).await?;
+        let resolved_tasks =
+            resolve_depends_with_no_cache(&config, task_list, self.no_cache).await?;
 
         // Collect subdirectory config files from all resolved tasks. In
         // monorepos these come from sub mise.toml files referenced via the
@@ -780,6 +783,7 @@ impl Run {
             continue_on_error: self.continue_on_error,
             dry_run: self.dry_run,
             skip_deps: self.skip_deps,
+            no_cache: self.no_cache,
             sandbox: crate::sandbox::SandboxConfig::from_settings_and_cli(
                 &Settings::get().sandbox,
                 self.deny_all,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -712,7 +712,7 @@ impl Run {
     async fn prepare_tasks(&mut self, config: &Arc<Config>, mut tasks: Vec<Task>) -> Result<Deps> {
         let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
         fetcher.fetch_tasks(config, &mut tasks).await?;
-        let mut tasks = Deps::new(config, tasks).await?;
+        let mut tasks = Deps::new_with_no_cache(config, tasks, self.no_cache).await?;
         tasks.mark_ambiguous_prefixes();
         self.is_linear = tasks.is_linear();
         Ok(tasks)

--- a/src/cli/tasks/deps.rs
+++ b/src/cli/tasks/deps.rs
@@ -138,7 +138,7 @@ impl TasksDeps {
     /// ```
     ///
     async fn print_deps_tree(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
-        let deps = Deps::new(config, tasks.clone()).await?;
+        let deps = Deps::new_for_display(config, tasks.clone()).await?;
         // filter out nodes that are not selected
         let start_indexes = deps.graph.node_indices().filter(|&idx| {
             let task = &deps.graph[idx];
@@ -169,7 +169,7 @@ impl TasksDeps {
     /// ```
     //
     async fn print_deps_dot(&self, config: &Arc<Config>, tasks: Vec<Task>) -> Result<()> {
-        let deps = Deps::new(config, tasks).await?;
+        let deps = Deps::new_for_display(config, tasks).await?;
         miseprintln!(
             "{:?}",
             Dot::with_attr_getters(

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -48,6 +48,7 @@ impl TasksInfo {
             // always pass no_cache=false as the command doesn't take no-cache argument
             // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
             TaskFetcher::new(false)
+                .require_trust_before_fetch()
                 .fetch_tasks(&config, &mut tasks)
                 .await?;
             let task = &tasks[0];

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -132,6 +132,7 @@ impl TasksLs {
         // always pass no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
+            .require_trust_before_fetch()
             .fetch_tasks(&config, &mut tasks)
             .await?;
 

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -68,6 +68,7 @@ impl TasksValidate {
         // always no_cache=false as the command doesn't take no-cache argument
         // MISE_TASK_REMOTE_NO_CACHE env var is still respected if set
         TaskFetcher::new(false)
+            .require_trust_before_fetch()
             .fetch_tasks(&config, &mut resolved_tasks)
             .await?;
         let all_tasks: BTreeMap<String, Task> = resolved_tasks

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -351,6 +351,23 @@ pub fn trust_check(path: &Path) -> eyre::Result<()> {
     Err(UntrustedConfig(path.into()))?
 }
 
+/// Require trust before configuration can cause remote network or Git work.
+///
+/// Safe mode makes ordinary config parsing trust-exempt because its executable
+/// features are disabled. A remote fetch is still an external side effect,
+/// though, so safe mode only permits it when the owner was already trusted.
+/// Outside safe mode this preserves the normal interactive trust prompt.
+pub fn trust_check_remote_fetch(path: &Path) -> eyre::Result<()> {
+    if !remote_fetch_trust_allows(Settings::safe_mode(), is_path_trusted(path)) {
+        Err(UntrustedConfig(path.into()))?
+    }
+    trust_check(path)
+}
+
+fn remote_fetch_trust_allows(safe_mode: bool, is_trusted: bool) -> bool {
+    !safe_mode || is_trusted
+}
+
 pub fn is_trusted(path: &Path) -> bool {
     let canonicalized_path = match path.canonicalize() {
         Ok(p) => p,
@@ -762,5 +779,13 @@ mod tests {
             result2,
             Path::new("/tmp/trusted/infra-mise.toml-a1b2c3d4e5f67890.monorepo")
         );
+    }
+
+    #[test]
+    fn test_remote_fetch_trust_policy() {
+        assert!(!remote_fetch_trust_allows(true, false));
+        assert!(remote_fetch_trust_allows(true, true));
+        assert!(remote_fetch_trust_allows(false, false));
+        assert!(remote_fetch_trust_allows(false, true));
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -323,6 +323,7 @@ pub struct EnvResults {
     pub watch_files: Vec<PathBuf>,
     /// True if any directive declared cacheable=false or is a dynamic module
     pub has_uncacheable: bool,
+    pub(crate) template_trust_source: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -348,17 +349,35 @@ pub struct EnvResolveOptions {
 impl EnvResults {
     pub async fn resolve(
         config: &Arc<Config>,
+        ctx: tera::Context,
+        initial: &EnvMap,
+        input: Vec<(EnvDirective, PathBuf)>,
+        resolve_opts: EnvResolveOptions,
+    ) -> eyre::Result<Self> {
+        Self::resolve_with_trust_source(config, ctx, initial, input, resolve_opts, None).await
+    }
+
+    /// Resolve directives relative to their source paths while checking Tera
+    /// trust against a separate provenance path. Remote task headers need this:
+    /// relative files belong to the fetched script, but trust belongs to the
+    /// local config that declared the remote task.
+    pub async fn resolve_with_trust_source(
+        config: &Arc<Config>,
         mut ctx: tera::Context,
         initial: &EnvMap,
         input: Vec<(EnvDirective, PathBuf)>,
         resolve_opts: EnvResolveOptions,
+        trust_source: Option<&Path>,
     ) -> eyre::Result<Self> {
         // trace!("resolve: input: {:#?}", &input);
         let mut env = initial
             .iter()
             .map(|(k, v)| (k.clone(), (v.clone(), None)))
             .collect::<IndexMap<_, _>>();
-        let mut r = Self::default();
+        let mut r = Self {
+            template_trust_source: trust_source.map(Path::to_path_buf),
+            ..Default::default()
+        };
         let normalize_path = |config_root: &Path, p: PathBuf| {
             let p = p.strip_prefix("./").unwrap_or(&p);
             match p.strip_prefix("~/") {
@@ -878,7 +897,7 @@ impl EnvResults {
 
         // Step 1: Tera template expansion
         if contains_template_syntax(input) {
-            trust_check(path)?;
+            trust_check(self.template_trust_source.as_deref().unwrap_or(path))?;
             let tera = tera.get_or_insert_with(|| {
                 let mut tera = get_tera(path.parent());
                 // Re-bind exec() to the accumulated env vars — but never in safe

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,6 +62,12 @@ pub(crate) struct MonorepoUnion {
     pub repo_urls: HashMap<String, String>,
 }
 
+#[derive(Clone, Hash, Eq, PartialEq)]
+struct TasksCacheKey {
+    context: crate::task::TaskLoadContext,
+    remote_no_cache: bool,
+}
+
 pub struct Config {
     pub config_files: ConfigMap,
     pub project_root: Option<PathBuf>,
@@ -78,7 +84,7 @@ pub struct Config {
     env: OnceCell<EnvResults>,
     env_with_sources: OnceCell<EnvWithSources>,
     hooks: OnceCell<Vec<(PathBuf, Hook)>>,
-    tasks_cache: Arc<DashMap<crate::task::TaskLoadContext, Arc<BTreeMap<String, Task>>>>,
+    tasks_cache: Arc<DashMap<TasksCacheKey, Arc<BTreeMap<String, Task>>>>,
     tool_request_set: OnceCell<ToolRequestSet>,
     toolset: OnceCell<Toolset>,
     vars_results: OnceCell<EnvResults>,
@@ -593,16 +599,15 @@ impl Config {
         &self,
         ctx: Option<&crate::task::TaskLoadContext>,
     ) -> Result<Arc<BTreeMap<String, Task>>> {
-        // Use the entire context as cache key
-        // Default context (None) becomes TaskLoadContext::default()
-        let cache_key = ctx.cloned().unwrap_or_default();
+        let cache_key = TasksCacheKey {
+            context: ctx.cloned().unwrap_or_default(),
+            remote_no_cache: Settings::get().task.remote_no_cache.unwrap_or(false),
+        };
 
-        // No-cache remote includes own temporary snapshots through their Tasks.
-        // The global Config cache is static and would keep those cleanup guards
-        // alive until process teardown (static destructors do not run), so skip
-        // both cache reads and writes in this mode.
-        let use_cache = !Settings::get().task.remote_no_cache.unwrap_or(false);
-        if use_cache && let Some(cached) = self.tasks_cache.get(&cache_key) {
+        // No-cache remote includes still need one immutable snapshot for the
+        // duration of a command. Re-loading here can mix revisions when task
+        // selection and dependency resolution ask for the same task set.
+        if let Some(cached) = self.tasks_cache.get(&cache_key) {
             return Ok(cached.value().clone());
         }
 
@@ -612,11 +617,13 @@ impl Config {
         });
         let tasks_arc = Arc::new(tasks);
 
-        if use_cache {
-            self.tasks_cache.insert(cache_key, tasks_arc.clone());
-        }
+        self.tasks_cache.insert(cache_key, tasks_arc.clone());
 
         Ok(tasks_arc)
+    }
+
+    pub(crate) fn clear_tasks_cache(&self) {
+        self.tasks_cache.clear();
     }
 
     pub async fn tasks_with_aliases(&self) -> Result<BTreeMap<String, Task>> {
@@ -2104,8 +2111,11 @@ impl Debug for Config {
         s.field("Config Files", &config_files);
         // Note: tasks are now lazily loaded and cached, so we can't access them synchronously here
         // Try to get the default (current hierarchy) cache entry
-        let default_ctx = crate::task::TaskLoadContext::default();
-        if let Some(tasks) = self.tasks_cache.get(&default_ctx) {
+        let default_key = TasksCacheKey {
+            context: crate::task::TaskLoadContext::default(),
+            remote_no_cache: Settings::get().task.remote_no_cache.unwrap_or(false),
+        };
+        if let Some(tasks) = self.tasks_cache.get(&default_key) {
             s.field(
                 "Tasks",
                 &tasks.values().map(|t| t.to_string()).collect_vec(),
@@ -3000,6 +3010,18 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
     }
 }
 
+fn preserve_remote_task_trust_source(tasks: &mut [Task], source: &Path) {
+    for task in tasks {
+        if task.file.as_ref().is_some_and(|file| {
+            let file = file.to_string_lossy();
+            file.starts_with("git::") || file.starts_with("http://") || file.starts_with("https://")
+        }) {
+            task.remote_config_source
+                .get_or_insert_with(|| source.to_path_buf());
+        }
+    }
+}
+
 /// Check if a pattern contains glob metacharacters
 fn is_glob_pattern(pattern: &str) -> bool {
     // Check for unescaped glob metacharacters: *, ?, [, ], {, }
@@ -3087,6 +3109,9 @@ async fn load_file_tasks(
                 require_task_include_trust,
             )
             .await?;
+            if !require_task_include_trust || is_global {
+                preserve_remote_task_trust_source(&mut loaded, cf.get_path());
+            }
             if let Some(cleanup) = artifact.cleanup {
                 for task in &mut loaded {
                     task.remote_artifact_cleanups.push(cleanup.clone());
@@ -3181,6 +3206,10 @@ pub async fn load_tasks_in_dir(
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
+    let vouching_config_source = configs
+        .iter()
+        .find(|cf| is_path_trusted(cf.get_path()))
+        .map(|cf| cf.get_path().to_path_buf());
 
     let (includes, resolve_dir) = configs
         .iter()
@@ -3223,6 +3252,9 @@ pub async fn load_tasks_in_dir(
                 require_task_include_trust,
             )
             .await?;
+            if let Some(source) = &vouching_config_source {
+                preserve_remote_task_trust_source(&mut loaded, source);
+            }
             if let Some(cleanup) = artifact.cleanup {
                 for task in &mut loaded {
                     task.remote_artifact_cleanups.push(cleanup.clone());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,7 +84,7 @@ pub struct Config {
     env: OnceCell<EnvResults>,
     env_with_sources: OnceCell<EnvWithSources>,
     hooks: OnceCell<Vec<(PathBuf, Hook)>>,
-    tasks_cache: Arc<DashMap<TasksCacheKey, Arc<BTreeMap<String, Task>>>>,
+    tasks_cache: Arc<DashMap<TasksCacheKey, Arc<OnceCell<Arc<BTreeMap<String, Task>>>>>>,
     tool_request_set: OnceCell<ToolRequestSet>,
     toolset: OnceCell<Toolset>,
     vars_results: OnceCell<EnvResults>,
@@ -599,27 +599,40 @@ impl Config {
         &self,
         ctx: Option<&crate::task::TaskLoadContext>,
     ) -> Result<Arc<BTreeMap<String, Task>>> {
+        self.tasks_with_context_no_cache(ctx, false).await
+    }
+
+    pub async fn tasks_with_context_no_cache(
+        &self,
+        ctx: Option<&crate::task::TaskLoadContext>,
+        no_cache: bool,
+    ) -> Result<Arc<BTreeMap<String, Task>>> {
+        let remote_no_cache = no_cache || Settings::get().task.remote_no_cache.unwrap_or(false);
         let cache_key = TasksCacheKey {
             context: ctx.cloned().unwrap_or_default(),
-            remote_no_cache: Settings::get().task.remote_no_cache.unwrap_or(false),
+            remote_no_cache,
         };
 
         // No-cache remote includes still need one immutable snapshot for the
         // duration of a command. Re-loading here can mix revisions when task
         // selection and dependency resolution ask for the same task set.
-        if let Some(cached) = self.tasks_cache.get(&cache_key) {
-            return Ok(cached.value().clone());
-        }
-
-        // Not cached, load tasks
-        let tasks = measure!("config::load_all_tasks_with_context", {
-            self.load_all_tasks_with_context(ctx).await?
-        });
-        let tasks_arc = Arc::new(tasks);
-
-        self.tasks_cache.insert(cache_key, tasks_arc.clone());
-
-        Ok(tasks_arc)
+        // Store an async cell before loading so concurrent callers share the
+        // same fetch rather than returning different mutable-source revisions.
+        let cell = self
+            .tasks_cache
+            .entry(cache_key)
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone();
+        let tasks = cell
+            .get_or_try_init(|| async {
+                let tasks = measure!("config::load_all_tasks_with_context", {
+                    self.load_all_tasks_with_context(ctx, remote_no_cache)
+                        .await?
+                });
+                Ok::<_, eyre::Report>(Arc::new(tasks))
+            })
+            .await?;
+        Ok(tasks.clone())
     }
 
     pub(crate) fn clear_tasks_cache(&self) {
@@ -690,14 +703,16 @@ impl Config {
     async fn load_all_tasks_with_context(
         &self,
         ctx: Option<&crate::task::TaskLoadContext>,
+        remote_no_cache: bool,
     ) -> Result<BTreeMap<String, Task>> {
         let config = Config::get().await?;
         time!("load_all_tasks");
 
         let templates = collect_task_templates(&config.config_files);
 
-        let local_tasks = load_local_tasks_with_context(&config, ctx, &templates).await?;
-        let global_tasks = load_global_tasks(&config, &templates).await?;
+        let local_tasks =
+            load_local_tasks_with_context(&config, ctx, &templates, remote_no_cache).await?;
+        let global_tasks = load_global_tasks(&config, &templates, remote_no_cache).await?;
         let mut tasks: BTreeMap<String, Task> = local_tasks
             .into_iter()
             .chain(global_tasks)
@@ -2115,7 +2130,11 @@ impl Debug for Config {
             context: crate::task::TaskLoadContext::default(),
             remote_no_cache: Settings::get().task.remote_no_cache.unwrap_or(false),
         };
-        if let Some(tasks) = self.tasks_cache.get(&default_key) {
+        if let Some(tasks) = self
+            .tasks_cache
+            .get(&default_key)
+            .and_then(|cell| cell.get().cloned())
+        {
             s.field(
                 "Tasks",
                 &tasks.values().map(|t| t.to_string()).collect_vec(),
@@ -2269,6 +2288,7 @@ async fn load_local_tasks_with_context(
     config: &Arc<Config>,
     ctx: Option<&crate::task::TaskLoadContext>,
     templates: &IndexMap<String, TaskTemplate>,
+    remote_no_cache: bool,
 ) -> Result<Vec<Task>> {
     let mut tasks = vec![];
     let monorepo_config = find_monorepo_config(&config.config_files);
@@ -2286,7 +2306,14 @@ async fn load_local_tasks_with_context(
         if cfg!(test) && !d.starts_with(*dirs::HOME) {
             continue;
         }
-        let mut dir_tasks = load_tasks_in_dir(config, &d, &local_config_files, templates).await?;
+        let mut dir_tasks = load_tasks_in_dir_with_policy(
+            config,
+            &d,
+            &local_config_files,
+            templates,
+            remote_no_cache,
+        )
+        .await?;
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
@@ -2344,6 +2371,7 @@ async fn load_local_tasks_with_context(
                                     cf.clone(),
                                     &templates,
                                     Some(&cf),
+                                    remote_no_cache,
                                 )
                                 .await?;
 
@@ -2690,6 +2718,7 @@ fn discover_monorepo_subdirs(
 async fn load_global_tasks(
     config: &Arc<Config>,
     templates: &IndexMap<String, TaskTemplate>,
+    remote_no_cache: bool,
 ) -> Result<Vec<Task>> {
     let config_files = config
         .config_files
@@ -2698,7 +2727,10 @@ async fn load_global_tasks(
         .collect::<Vec<_>>();
     let mut tasks = vec![];
     for cf in config_files {
-        tasks.extend(load_config_and_file_tasks(config, cf.clone(), templates, None).await?);
+        tasks.extend(
+            load_config_and_file_tasks(config, cf.clone(), templates, None, remote_no_cache)
+                .await?,
+        );
     }
     Ok(tasks)
 }
@@ -2713,12 +2745,20 @@ async fn load_config_and_file_tasks(
     cf: Arc<dyn ConfigFile>,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
+    remote_no_cache: bool,
 ) -> Result<Vec<Task>> {
     let config_root = cf.config_root();
     let config_tasks =
         load_config_tasks(config, cf.clone(), &config_root, templates, monorepo_cf).await?;
-    let file_tasks =
-        load_file_tasks(config, cf.clone(), &config_root, templates, monorepo_cf).await?;
+    let file_tasks = load_file_tasks(
+        config,
+        cf.clone(),
+        &config_root,
+        templates,
+        monorepo_cf,
+        remote_no_cache,
+    )
+    .await?;
     Ok(merge_file_and_config_tasks(file_tasks, config_tasks))
 }
 
@@ -2998,16 +3038,24 @@ fn is_mise_config_file_in_task_include(root: &Path, path: &Path) -> bool {
     })
 }
 
-async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
-    let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
+async fn resolve_git_url_to_path(git_url: &str, remote_no_cache: bool) -> Result<TaskFileArtifact> {
     let task_file_providers = TaskFileProvidersBuilder::new()
-        .with_cache(!no_cache)
+        .with_cache(!remote_no_cache)
         .build();
 
     match task_file_providers.get_provider(git_url) {
         Some(provider) => provider.get_local_artifact(git_url).await,
         None => bail!("No provider found for git URL: {}", git_url),
     }
+}
+
+fn trust_check_remote_task_include(owner: &Path, include: &str) -> Result<()> {
+    config_file::trust_check_remote_fetch(owner).wrap_err_with(|| {
+        format!(
+            "fetching remote task include {include} requires its defining config {} to be trusted",
+            display_path(owner)
+        )
+    })
 }
 
 fn preserve_remote_task_trust_source(tasks: &mut [Task], source: &Path) {
@@ -3074,6 +3122,7 @@ async fn load_file_tasks(
     config_root: &Path,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
+    remote_no_cache: bool,
 ) -> Result<Vec<Task>> {
     let is_global = is_global_config(cf.get_path());
     let includes = cf
@@ -3090,7 +3139,8 @@ async fn load_file_tasks(
 
     for include in includes {
         let artifacts = if include.starts_with("git::") {
-            vec![resolve_git_url_to_path(&include).await?]
+            trust_check_remote_task_include(cf.get_path(), &include)?;
+            vec![resolve_git_url_to_path(&include, remote_no_cache).await?]
         } else {
             expand_task_include(&cf_root, &include)
                 .into_iter()
@@ -3202,24 +3252,50 @@ pub async fn load_tasks_in_dir(
     config_files: &ConfigMap,
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
-    let configs = configs_at_root(dir, config_files);
-    // a config can only vouch for task include files when it was actually
-    // trusted — safe configs load without trust and cannot vouch for anything
-    let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
-    let vouching_config_source = configs
-        .iter()
-        .find(|cf| is_path_trusted(cf.get_path()))
-        .map(|cf| cf.get_path().to_path_buf());
+    let remote_no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
+    load_tasks_in_dir_with_policy(config, dir, config_files, templates, remote_no_cache).await
+}
 
-    let (includes, resolve_dir) = configs
+async fn load_tasks_in_dir_with_policy(
+    config: &Arc<Config>,
+    dir: &Path,
+    config_files: &ConfigMap,
+    templates: &IndexMap<String, TaskTemplate>,
+    remote_no_cache: bool,
+) -> Result<Vec<Task>> {
+    let configs = configs_at_root(dir, config_files);
+    let (includes, resolve_dir, include_owner) = configs
         .iter()
         .find_map(|cf| match cf.task_config_includes() {
-            Ok(Some(includes)) => Some(Ok((includes, cf.config_root()))),
+            Ok(Some(includes)) => Some(Ok((
+                includes,
+                cf.config_root(),
+                Some(cf.get_path().to_path_buf()),
+            ))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         })
         .transpose()?
-        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf()));
+        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), None));
+
+    // An explicit include is vouched for only by the config that declared it.
+    // For implicit default includes, retain the existing directory-level rule:
+    // any trusted config at that root can vouch for the conventional task dir.
+    let vouching_config_source = include_owner
+        .as_ref()
+        .filter(|owner| is_path_trusted(owner))
+        .cloned()
+        .or_else(|| {
+            if include_owner.is_some() {
+                return None;
+            }
+            configs
+                .iter()
+                .find(|cf| is_path_trusted(cf.get_path()))
+                .map(|cf| cf.get_path().to_path_buf())
+        });
+    // Safe configs load without trust and cannot vouch for task include files.
+    let require_task_include_trust = vouching_config_source.is_none();
 
     let mut config_tasks = vec![];
     for cf in &configs {
@@ -3233,7 +3309,11 @@ pub async fn load_tasks_in_dir(
     let mut file_tasks = vec![];
     for include in &includes {
         let artifacts = if include.starts_with("git::") {
-            vec![resolve_git_url_to_path(include).await?]
+            let owner = include_owner.as_deref().ok_or_else(|| {
+                eyre!("remote task include {include} has no defining config provenance")
+            })?;
+            trust_check_remote_task_include(owner, include)?;
+            vec![resolve_git_url_to_path(include, remote_no_cache).await?]
         } else {
             expand_task_include(&resolve_dir, include)
                 .into_iter()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3238,7 +3238,7 @@ fn trust_check_task_include(path: &Path, require_trust: bool) -> Result<()> {
 /// `mise run`. Templates are what can execute code while tasks load (via
 /// exec() etc. when task fields render), so only files containing template
 /// syntax need trust. Paranoid mode keeps requiring trust for everything.
-fn task_include_requires_trust(path: &Path) -> bool {
+pub(crate) fn task_include_requires_trust(path: &Path) -> bool {
     if Settings::try_get().is_ok_and(|settings| settings.paranoid) {
         return true;
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -68,6 +68,8 @@ struct TasksCacheKey {
     remote_no_cache: bool,
 }
 
+type TasksCache = DashMap<TasksCacheKey, Arc<OnceCell<Arc<BTreeMap<String, Task>>>>>;
+
 pub struct Config {
     pub config_files: ConfigMap,
     pub project_root: Option<PathBuf>,
@@ -84,7 +86,7 @@ pub struct Config {
     env: OnceCell<EnvResults>,
     env_with_sources: OnceCell<EnvWithSources>,
     hooks: OnceCell<Vec<(PathBuf, Hook)>>,
-    tasks_cache: Arc<DashMap<TasksCacheKey, Arc<OnceCell<Arc<BTreeMap<String, Task>>>>>>,
+    tasks_cache: Arc<TasksCache>,
     tool_request_set: OnceCell<ToolRequestSet>,
     toolset: OnceCell<Toolset>,
     vars_results: OnceCell<EnvResults>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,7 +26,7 @@ use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
 use crate::file::display_path;
 use crate::shorthands::{Shorthands, get_shorthands};
-use crate::task::task_file_providers::TaskFileProvidersBuilder;
+use crate::task::task_file_providers::{TaskFileArtifact, TaskFileProvidersBuilder};
 use crate::task::{Task, TaskTemplate, strip_extension};
 use crate::tera::{contains_template_syntax, render_str, take_tera_accessed_files};
 use crate::toolset::env_cache::{CachedNonToolEnv, compute_settings_hash, get_file_mtime};
@@ -597,8 +597,12 @@ impl Config {
         // Default context (None) becomes TaskLoadContext::default()
         let cache_key = ctx.cloned().unwrap_or_default();
 
-        // Check if already cached
-        if let Some(cached) = self.tasks_cache.get(&cache_key) {
+        // No-cache remote includes own temporary snapshots through their Tasks.
+        // The global Config cache is static and would keep those cleanup guards
+        // alive until process teardown (static destructors do not run), so skip
+        // both cache reads and writes in this mode.
+        let use_cache = !Settings::get().task.remote_no_cache.unwrap_or(false);
+        if use_cache && let Some(cached) = self.tasks_cache.get(&cache_key) {
             return Ok(cached.value().clone());
         }
 
@@ -608,8 +612,9 @@ impl Config {
         });
         let tasks_arc = Arc::new(tasks);
 
-        // Insert into cache
-        self.tasks_cache.insert(cache_key, tasks_arc.clone());
+        if use_cache {
+            self.tasks_cache.insert(cache_key, tasks_arc.clone());
+        }
 
         Ok(tasks_arc)
     }
@@ -830,6 +835,7 @@ impl Config {
                 tool_add_paths: Vec::new(),
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
+                template_trust_source: None,
             };
             let redact_keys = self
                 .redaction_keys()
@@ -2982,14 +2988,14 @@ fn is_mise_config_file_in_task_include(root: &Path, path: &Path) -> bool {
     })
 }
 
-async fn resolve_git_url_to_path(git_url: &str) -> Result<PathBuf> {
+async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
     let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
     let task_file_providers = TaskFileProvidersBuilder::new()
         .with_cache(!no_cache)
         .build();
 
     match task_file_providers.get_provider(git_url) {
-        Some(provider) => provider.get_local_path(git_url).await,
+        Some(provider) => provider.get_local_artifact(git_url).await,
         None => bail!("No provider found for git URL: {}", git_url),
     }
 }
@@ -3061,12 +3067,16 @@ async fn load_file_tasks(
     let require_task_include_trust = !is_path_trusted(cf.get_path());
 
     for include in includes {
-        let paths = if include.starts_with("git::") {
+        let artifacts = if include.starts_with("git::") {
             vec![resolve_git_url_to_path(&include).await?]
         } else {
             expand_task_include(&cf_root, &include)
+                .into_iter()
+                .map(TaskFileArtifact::persistent)
+                .collect()
         };
-        for path in paths {
+        for artifact in artifacts {
+            let path = artifact.path;
             let mut loaded = load_tasks_includes(
                 config,
                 &path,
@@ -3077,6 +3087,11 @@ async fn load_file_tasks(
                 require_task_include_trust,
             )
             .await?;
+            if let Some(cleanup) = artifact.cleanup {
+                for task in &mut loaded {
+                    task.remote_artifact_cleanups.push(cleanup.clone());
+                }
+            }
             if is_global || is_global_task_include_path(&path) {
                 mark_tasks_as_global(&mut loaded);
             }
@@ -3188,12 +3203,16 @@ pub async fn load_tasks_in_dir(
 
     let mut file_tasks = vec![];
     for include in &includes {
-        let paths = if include.starts_with("git::") {
+        let artifacts = if include.starts_with("git::") {
             vec![resolve_git_url_to_path(include).await?]
         } else {
             expand_task_include(&resolve_dir, include)
+                .into_iter()
+                .map(TaskFileArtifact::persistent)
+                .collect()
         };
-        for p in paths {
+        for artifact in artifacts {
+            let p = artifact.path;
             let mut loaded = load_tasks_includes(
                 config,
                 &p,
@@ -3204,6 +3223,11 @@ pub async fn load_tasks_in_dir(
                 require_task_include_trust,
             )
             .await?;
+            if let Some(cleanup) = artifact.cleanup {
+                for task in &mut loaded {
+                    task.remote_artifact_cleanups.push(cleanup.clone());
+                }
+            }
             if is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3238,7 +3238,7 @@ fn trust_check_task_include(path: &Path, require_trust: bool) -> Result<()> {
 /// `mise run`. Templates are what can execute code while tasks load (via
 /// exec() etc. when task fields render), so only files containing template
 /// syntax need trust. Paranoid mode keeps requiring trust for everything.
-pub(crate) fn task_include_requires_trust(path: &Path) -> bool {
+fn task_include_requires_trust(path: &Path) -> bool {
     if Settings::try_get().is_ok_and(|settings| settings.paranoid) {
         return true;
     }

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -9,6 +9,7 @@ pub fn exit(code: i32) -> ! {
     #[cfg(windows)]
     CmdLineRunner::kill_all();
 
+    crate::task::task_file_providers::cleanup_temporary_artifacts();
     debug!("exiting with code: {code}");
     std::process::exit(code)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,10 +142,16 @@ async fn main_() -> eyre::Result<()> {
     }
     measure!("main", {
         let args = env::args_safe();
-        match Cli::run(&args)
+        let result = Cli::run(&args)
             .await
-            .with_section(|| VERSION.to_string().header("Version:"))
-        {
+            .with_section(|| VERSION.to_string().header("Version:"));
+        // Command-scoped no-cache task snapshots can own temporary remote
+        // artifacts. Release the Config cache before normal process teardown,
+        // since statics do not run destructors.
+        if let Some(config) = config::Config::maybe_get() {
+            config.clear_tasks_cache();
+        }
+        match result {
             Ok(()) => Ok(()),
             Err(err) => handle_err(err),
         }?;

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -48,6 +48,20 @@ pub fn task_key(task: &Task) -> TaskKey {
 /// manages a dependency graph of tasks so `mise run` knows what to run next
 impl Deps {
     pub async fn new(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
+        Self::new_with_fetch_policy(config, tasks, false).await
+    }
+
+    /// Build a dependency graph for passive display without allowing remote
+    /// providers to perform network or Git work from an untrusted config.
+    pub async fn new_for_display(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
+        Self::new_with_fetch_policy(config, tasks, true).await
+    }
+
+    async fn new_with_fetch_policy(
+        config: &Arc<Config>,
+        tasks: Vec<Task>,
+        trust_before_fetch: bool,
+    ) -> eyre::Result<Self> {
         let mut graph = DiGraph::new();
         let mut indexes = HashMap::new();
         let mut stack = vec![];
@@ -69,7 +83,11 @@ impl Deps {
         }
         let all_tasks_to_run = resolve_depends(config, tasks).await?;
         let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
-        let fetcher = TaskFetcher::new(no_cache);
+        let fetcher = if trust_before_fetch {
+            TaskFetcher::new(no_cache).require_trust_before_fetch()
+        } else {
+            TaskFetcher::new(no_cache)
+        };
         while let Some(mut a) = stack.pop() {
             if seen.contains(&a) {
                 // prevent infinite loop

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -1,7 +1,7 @@
 use crate::config::env_directive::EnvDirective;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Task, dep_has_usage_ref, parse_usage_values_from_task};
-use crate::{config::Config, task::task_list::resolve_depends};
+use crate::{config::Config, task::task_list::resolve_depends_with_no_cache};
 use itertools::Itertools;
 use petgraph::Direction;
 use petgraph::graph::DiGraph;
@@ -89,7 +89,7 @@ impl Deps {
             stack.push(t.clone());
             add_idx(t, &mut graph);
         }
-        let all_tasks_to_run = resolve_depends(config, tasks).await?;
+        let all_tasks_to_run = resolve_depends_with_no_cache(config, tasks, no_cache).await?;
         let fetcher = if trust_before_fetch {
             TaskFetcher::new(no_cache).require_trust_before_fetch()
         } else {
@@ -129,7 +129,9 @@ impl Deps {
             // Update the graph node with the fetched version of the task
             // (add_idx may have returned an existing index with an unfetched task)
             graph[a_idx] = a.clone();
-            let (pre, post) = a.resolve_depends(config, &all_tasks_to_run).await?;
+            let (pre, post) = a
+                .resolve_depends(config, &all_tasks_to_run, no_cache)
+                .await?;
             for b in pre {
                 let b_idx = add_idx(&b, &mut graph);
                 graph.update_edge(a_idx, b_idx, ());
@@ -170,12 +172,13 @@ impl Deps {
     /// Create a sub-graph that prunes tasks already completed by the caller.
     /// `completed` is a snapshot of task keys that have finished in the parent
     /// graph — these are removed from the sub-graph so they don't run again.
-    pub async fn new_pruned(
+    pub async fn new_pruned_with_no_cache(
         config: &Arc<Config>,
         tasks: Vec<Task>,
         completed: &HashSet<TaskKey>,
+        no_cache: bool,
     ) -> eyre::Result<Self> {
-        let mut deps = Self::new(config, tasks).await?;
+        let mut deps = Self::new_with_no_cache(config, tasks, no_cache).await?;
         let mut to_remove = vec![];
         for idx in deps.graph.node_indices() {
             let key = task_key(&deps.graph[idx]);
@@ -356,4 +359,46 @@ fn leaves(graph: &DiGraph<Task, ()>) -> Vec<Task> {
         .externals(Direction::Outgoing)
         .map(|idx| graph[idx].clone())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_new_pruned_with_no_cache_keeps_remote_fetches_uncached() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/task")
+            .with_status(200)
+            .with_body("#!/usr/bin/env bash\necho ok\n")
+            .expect(2)
+            .create_async()
+            .await;
+        let config = Config::get().await.unwrap();
+        let config_root = tempfile::tempdir().unwrap();
+        let source = format!("{}/task", server.url());
+        let task = Task {
+            name: "remote".into(),
+            display_name: "remote".into(),
+            config_source: config_root.path().join("mise.toml"),
+            config_root: Some(config_root.path().to_path_buf()),
+            file: Some(PathBuf::from(source)),
+            ..Default::default()
+        };
+        let completed = HashSet::new();
+
+        let first = Deps::new_pruned_with_no_cache(&config, vec![task.clone()], &completed, true)
+            .await
+            .unwrap();
+        let second = Deps::new_pruned_with_no_cache(&config, vec![task], &completed, true)
+            .await
+            .unwrap();
+
+        let first_path = first.all().next().unwrap().file.clone().unwrap();
+        let second_path = second.all().next().unwrap().file.clone().unwrap();
+        assert_ne!(first_path, second_path);
+        remote.assert_async().await;
+    }
 }

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -1,4 +1,3 @@
-use crate::config::Settings;
 use crate::config::env_directive::EnvDirective;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Task, dep_has_usage_ref, parse_usage_values_from_task};
@@ -48,19 +47,28 @@ pub fn task_key(task: &Task) -> TaskKey {
 /// manages a dependency graph of tasks so `mise run` knows what to run next
 impl Deps {
     pub async fn new(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
-        Self::new_with_fetch_policy(config, tasks, false).await
+        Self::new_with_fetch_policy(config, tasks, false, false).await
+    }
+
+    pub async fn new_with_no_cache(
+        config: &Arc<Config>,
+        tasks: Vec<Task>,
+        no_cache: bool,
+    ) -> eyre::Result<Self> {
+        Self::new_with_fetch_policy(config, tasks, false, no_cache).await
     }
 
     /// Build a dependency graph for passive display without allowing remote
     /// providers to perform network or Git work from an untrusted config.
     pub async fn new_for_display(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
-        Self::new_with_fetch_policy(config, tasks, true).await
+        Self::new_with_fetch_policy(config, tasks, true, false).await
     }
 
     async fn new_with_fetch_policy(
         config: &Arc<Config>,
         tasks: Vec<Task>,
         trust_before_fetch: bool,
+        no_cache: bool,
     ) -> eyre::Result<Self> {
         let mut graph = DiGraph::new();
         let mut indexes = HashMap::new();
@@ -82,7 +90,6 @@ impl Deps {
             add_idx(t, &mut graph);
         }
         let all_tasks_to_run = resolve_depends(config, tasks).await?;
-        let no_cache = Settings::get().task.remote_no_cache.unwrap_or(false);
         let fetcher = if trust_before_fetch {
             TaskFetcher::new(no_cache).require_trust_before_fetch()
         } else {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -605,6 +605,18 @@ pub struct Task {
     #[serde(skip)]
     pub remote_file_source: Option<String>,
 
+    /// Config file that declared a remote task. The fetched task's
+    /// `config_source` is its cache path, so retain the defining config path for
+    /// trust checks that must happen after fetching.
+    #[serde(skip)]
+    pub remote_config_source: Option<PathBuf>,
+
+    /// Whether the fetched remote header contributed tool requirements.
+    /// Remote metadata is parsed during discovery, but these requirements must
+    /// not trigger installation until the defining config is trusted.
+    #[serde(skip)]
+    pub remote_metadata_has_tools: bool,
+
     /// Block reads, writes, network, and env vars
     #[serde(default)]
     pub deny_all: bool,
@@ -2395,6 +2407,8 @@ impl Default for Task {
             usage: "".to_string(),
             timeout: None,
             remote_file_source: None,
+            remote_config_source: None,
+            remote_metadata_has_tools: false,
             deny_all: false,
             deny_read: false,
             deny_write: false,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1195,6 +1195,7 @@ impl Task {
         &self,
         config: &Arc<Config>,
         tasks_to_run: &[Task],
+        no_cache: bool,
     ) -> Result<(Vec<Task>, Vec<Task>)> {
         use crate::task::TaskLoadContext;
 
@@ -1225,7 +1226,9 @@ impl Task {
             None
         };
 
-        let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
+        let all_tasks = config
+            .tasks_with_context_no_cache(ctx.as_ref(), no_cache)
+            .await?;
         let tasks = build_task_ref_map(all_tasks.iter());
         // Skip deps with unresolved {{usage.*}} references — they'll be resolved
         // later when render_depends_with_usage() is called with actual arg values.

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1896,7 +1896,7 @@ impl Task {
         self.allow_env.extend(other.allow_env);
     }
 
-    fn has_render_templates(&self) -> bool {
+    pub(crate) fn has_render_templates(&self) -> bool {
         fn path_contains_template(path: &Path) -> bool {
             path.to_str().is_some_and(contains_template_syntax)
         }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -617,6 +617,11 @@ pub struct Task {
     #[serde(skip)]
     pub remote_metadata_has_tools: bool,
 
+    /// Keeps a no-cache remote snapshot alive while this Task (and any clones)
+    /// may still execute it. The final clone removes the temporary file/repo.
+    #[serde(skip)]
+    pub(crate) remote_artifact_cleanups: Vec<Arc<task_file_providers::TaskFileArtifactCleanup>>,
+
     /// Block reads, writes, network, and env vars
     #[serde(default)]
     pub deny_all: bool,
@@ -704,6 +709,17 @@ pub(crate) fn file_has_decoded_template(path: &Path, body: &str) -> bool {
             .iter()
             .any(toml_value_has_template)
     }
+}
+
+/// Check decoded `#MISE` header values regardless of the script filename.
+/// Remote file tasks are always scripts, even when their URL/path ends in
+/// `.toml`, so extension-based dispatch is not appropriate for them.
+pub(crate) fn script_header_has_decoded_template(body: &str) -> bool {
+    use crate::config::config_file::mise_toml::toml_value_has_template;
+    parse_mise_header_toml(body)
+        .unwrap_or_default()
+        .iter()
+        .any(toml_value_has_template)
 }
 
 fn parse_task_script_usage(file: &Path) -> usage::Result<usage::Spec> {
@@ -1896,7 +1912,7 @@ impl Task {
         self.allow_env.extend(other.allow_env);
     }
 
-    pub(crate) fn has_render_templates(&self) -> bool {
+    fn has_render_templates(&self) -> bool {
         fn path_contains_template(path: &Path) -> bool {
             path.to_str().is_some_and(contains_template_syntax)
         }
@@ -2117,7 +2133,7 @@ impl Task {
         env_directives.extend(self.overlay_env.iter().cloned());
 
         // Resolve environment directives using the same system as global env
-        let env_results = EnvResults::resolve(
+        let env_results = EnvResults::resolve_with_trust_source(
             config,
             tera_ctx.clone(),
             &env,
@@ -2127,6 +2143,7 @@ impl Task {
                 tools: ToolsFilter::Both,
                 warn_on_missing_required: false,
             },
+            self.remote_config_source.as_deref(),
         )
         .await?;
         // Register task-specific redactions with the global redactor
@@ -2409,6 +2426,7 @@ impl Default for Task {
             remote_file_source: None,
             remote_config_source: None,
             remote_metadata_has_tools: false,
+            remote_artifact_cleanups: vec![],
             deny_all: false,
             deny_read: false,
             deny_write: false,

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -9,7 +9,7 @@ use crate::toolset::{Toolset, ToolsetBuilder};
 use eyre::Result;
 use indexmap::IndexMap;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 type EnvResolutionResult = (
@@ -252,7 +252,7 @@ impl TaskContextBuilder {
 
         // Resolve config-level env from ALL config files, not just task_cf
         let config_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries)
+            .resolve_env_directives(config, &tera_ctx, &env, all_config_env_entries, None)
             .await?;
         Self::apply_env_results(&mut env, &config_env_results);
 
@@ -263,7 +263,13 @@ impl TaskContextBuilder {
 
         let task_env_directives = self.build_task_env_directives(task);
         let task_env_results = self
-            .resolve_env_directives(config, &tera_ctx, &env, task_env_directives)
+            .resolve_env_directives(
+                config,
+                &tera_ctx,
+                &env,
+                task_env_directives,
+                task.remote_config_source.as_deref(),
+            )
             .await?;
 
         let task_env = self.extract_task_env(&task_env_results);
@@ -408,8 +414,9 @@ impl TaskContextBuilder {
         tera_ctx: &tera::Context,
         env: &BTreeMap<String, String>,
         directives: Vec<(EnvDirective, PathBuf)>,
+        trust_source: Option<&Path>,
     ) -> Result<EnvResults> {
-        EnvResults::resolve(
+        EnvResults::resolve_with_trust_source(
             config,
             tera_ctx.clone(),
             env,
@@ -419,6 +426,7 @@ impl TaskContextBuilder {
                 tools: ToolsFilter::Both,
                 warn_on_missing_required: false,
             },
+            trust_source,
         )
         .await
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -120,6 +120,7 @@ pub struct TaskExecutorConfig {
     pub continue_on_error: bool,
     pub dry_run: bool,
     pub skip_deps: bool,
+    pub no_cache: bool,
     /// CLI-level sandbox overrides (merged with task-level sandbox config)
     pub sandbox: crate::sandbox::SandboxConfig,
 }
@@ -139,6 +140,7 @@ pub struct TaskExecutor {
     pub continue_on_error: bool,
     pub dry_run: bool,
     pub skip_deps: bool,
+    pub no_cache: bool,
     pub sandbox: crate::sandbox::SandboxConfig,
 }
 
@@ -160,6 +162,7 @@ impl TaskExecutor {
             continue_on_error: config.continue_on_error,
             dry_run: config.dry_run,
             skip_deps: config.skip_deps,
+            no_cache: config.no_cache,
             sandbox: config.sandbox,
         }
     }
@@ -695,7 +698,9 @@ impl TaskExecutor {
             let (name, _) = split_task_spec(s);
             name
         }));
-        let tasks = config.tasks_with_context(Some(&ctx)).await?;
+        let tasks = config
+            .tasks_with_context_no_cache(Some(&ctx), self.no_cache)
+            .await?;
         let tasks_map: BTreeMap<String, Task> = tasks
             .values()
             .flat_map(|t| {
@@ -747,7 +752,8 @@ impl TaskExecutor {
                 to_run.push(t);
             }
         }
-        let sub_deps = Deps::new_pruned(config, to_run, completed_tasks).await?;
+        let sub_deps =
+            Deps::new_pruned_with_no_cache(config, to_run, completed_tasks, self.no_cache).await?;
         let sub_deps = Arc::new(Mutex::new(sub_deps));
 
         // Pump subgraph into scheduler and signal completion via oneshot when done

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -1,4 +1,4 @@
-use crate::config::config_file::trust_check;
+use crate::config::config_file::{trust_check, trust_check_remote_fetch};
 use crate::config::{Config, Settings};
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
 use crate::task::{Task, script_header_has_decoded_template};
@@ -55,7 +55,7 @@ impl TaskFetcher {
                     .unwrap_or_else(|| original.config_source.clone());
 
                 if self.trust_before_fetch {
-                    trust_check(&defining_config_source).wrap_err_with(|| {
+                    trust_check_remote_fetch(&defining_config_source).wrap_err_with(|| {
                         format!(
                             "fetching remote task {source} requires its defining config to be trusted"
                         )

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -1,7 +1,8 @@
-use crate::config::{Config, Settings};
+use crate::config::config_file::trust_check;
+use crate::config::{self, Config, Settings};
 use crate::task::Task;
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
-use eyre::{Result, bail};
+use eyre::{Result, WrapErr, bail};
 use std::sync::Arc;
 
 /// Handles fetching remote task files and converting them to local paths
@@ -36,8 +37,20 @@ impl TaskFetcher {
                     bail!("No provider found for file: {}", source);
                 }
 
-                let local_path = provider.unwrap().get_local_path(&source).await?;
+                let local_path = provider
+                    .unwrap()
+                    .get_local_path(&source)
+                    .await
+                    .wrap_err_with(|| format!("failed to fetch remote task {source}"))?;
                 let original = t.clone();
+                let defining_cf = original
+                    .cf
+                    .clone()
+                    .or_else(|| config.config_files.get(&original.config_source).cloned());
+                let defining_config_source = defining_cf
+                    .as_ref()
+                    .map(|cf| cf.get_path().to_path_buf())
+                    .unwrap_or_else(|| original.config_source.clone());
                 let config_root = original
                     .config_root
                     .clone()
@@ -48,12 +61,24 @@ impl TaskFetcher {
                 // Parse the downloaded script as a regular file task so all #MISE
                 // metadata is honored. The inline TOML task remains the higher-
                 // precedence overlay, matching local file-task behavior.
+                // Apply the same trust boundary as local task includes before
+                // rendering templates such as `exec()`, but trust the config that
+                // declared the URL rather than the mutable cache path.
+                if config::task_include_requires_trust(&local_path) {
+                    trust_check(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "remote task metadata from {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
                 let mut remote = Task::from_path_unrendered_with_cf(
                     &local_path,
                     prefix,
                     &config_root,
-                    original.cf.clone(),
-                )?;
+                    defining_cf,
+                )
+                .wrap_err_with(|| format!("failed to parse remote task metadata from {source}"))?;
+                let remote_metadata_has_tools = !remote.tools.is_empty();
                 remote.name.clone_from(&original.name);
                 remote.display_name.clone_from(&original.display_name);
 
@@ -66,13 +91,20 @@ impl TaskFetcher {
                 remote.inherited_env.clone_from(&original.inherited_env);
                 remote.overlay_env.clone_from(&original.overlay_env);
                 remote.overlay_vars.clone_from(&original.overlay_vars);
-                remote.render(config, &config_root).await?;
+                remote
+                    .render(config, &config_root)
+                    .await
+                    .wrap_err_with(|| {
+                        format!("failed to render remote task metadata from {source}")
+                    })?;
                 remote.merge_toml_overlay(original.clone());
 
                 // Preserve runtime state that is not task metadata and therefore is
                 // intentionally not handled by merge_toml_overlay().
                 remote.global = original.global;
                 remote.remote_file_source = Some(source);
+                remote.remote_config_source = Some(defining_config_source);
+                remote.remote_metadata_has_tools = remote_metadata_has_tools;
                 *t = remote;
             }
         }
@@ -147,6 +179,11 @@ echo ok
         assert_eq!(task.args, ["--fix"]);
         assert_eq!(task.config_root.as_deref(), Some(config_root.path()));
         assert_eq!(task.remote_file_source.as_deref(), Some(source.as_str()));
+        assert_eq!(
+            task.remote_config_source.as_deref(),
+            Some(config_root.path().join("mise.toml").as_path())
+        );
+        assert!(task.remote_metadata_has_tools);
         assert!(task.is_remote());
         assert_eq!(
             task.tools.get("node"),
@@ -232,5 +269,41 @@ echo ok
 
         remote.assert_async().await;
         assert_eq!(tasks[0].description, "rendered from runtime context");
+    }
+
+    #[tokio::test]
+    async fn test_remote_header_error_identifies_source_url() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/invalid-task")
+            .with_status(200)
+            .with_body("#!/usr/bin/env bash\n#MISE unsupported_remote_field=true\necho ok\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let config = Config::get().await.unwrap();
+        let config_root = tempfile::tempdir().unwrap();
+        let source = format!("{}/invalid-task", server.url());
+        let mut tasks = vec![Task {
+            name: "invalid".into(),
+            config_source: config_root.path().join("mise.toml"),
+            config_root: Some(config_root.path().to_path_buf()),
+            file: Some(PathBuf::from(&source)),
+            ..Default::default()
+        }];
+
+        let error = TaskFetcher::new(true)
+            .fetch_tasks(&config, &mut tasks)
+            .await
+            .unwrap_err();
+
+        remote.assert_async().await;
+        assert!(error.to_string().contains(&source));
+        assert!(
+            error
+                .to_string()
+                .contains("failed to parse remote task metadata")
+        );
     }
 }

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -1,7 +1,7 @@
 use crate::config::config_file::trust_check;
 use crate::config::{Config, Settings};
-use crate::task::Task;
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
+use crate::task::{Task, script_header_has_decoded_template};
 use eyre::{Result, WrapErr, bail};
 use std::sync::Arc;
 
@@ -67,11 +67,12 @@ impl TaskFetcher {
                     bail!("No provider found for file: {}", source);
                 }
 
-                let local_path = provider
+                let artifact = provider
                     .unwrap()
-                    .get_local_path(&source)
+                    .get_local_artifact(&source)
                     .await
                     .wrap_err_with(|| format!("failed to fetch remote task {source}"))?;
+                let local_path = artifact.path;
                 let config_root = original
                     .config_root
                     .clone()
@@ -82,6 +83,10 @@ impl TaskFetcher {
                 // Parse the downloaded script as a regular file task so all #MISE
                 // metadata is honored. The inline TOML task remains the higher-
                 // precedence overlay, matching local file-task behavior.
+                let body = crate::file::read_to_string(&local_path).wrap_err_with(|| {
+                    format!("failed to read remote task metadata from {source}")
+                })?;
+                let header_has_templates = script_header_has_decoded_template(&body);
                 let mut remote = Task::from_path_unrendered_with_cf(
                     &local_path,
                     prefix,
@@ -93,7 +98,7 @@ impl TaskFetcher {
                 // guessing its format from the fetched filename: Git task scripts
                 // may legitimately end in `.toml`, and escaped TOML delimiters
                 // only become visible after header parsing.
-                if remote.has_render_templates() {
+                if header_has_templates {
                     trust_check(&defining_config_source).wrap_err_with(|| {
                         format!(
                             "remote task metadata from {source} requires its defining config to be trusted"
@@ -127,6 +132,12 @@ impl TaskFetcher {
                 remote.remote_file_source = Some(source);
                 remote.remote_config_source = Some(defining_config_source);
                 remote.remote_metadata_has_tools = remote_metadata_has_tools;
+                remote
+                    .remote_artifact_cleanups
+                    .extend(original.remote_artifact_cleanups);
+                if let Some(cleanup) = artifact.cleanup {
+                    remote.remote_artifact_cleanups.push(cleanup);
+                }
                 *t = remote;
             }
         }
@@ -166,6 +177,24 @@ echo ok
             Task::from_path_unrendered_with_cf(&path, root.path(), root.path(), None).unwrap();
 
         assert!(task.has_render_templates());
+        assert!(script_header_has_decoded_template(
+            &fs::read_to_string(path).unwrap()
+        ));
+    }
+
+    #[test]
+    fn test_remote_script_detects_deferred_header_templates() {
+        let confirm = r#"#!/usr/bin/env bash
+#MISE confirm="\u007b\u007b exec(command='echo unsafe') \u007d\u007d"
+echo ok
+"#;
+        let env = r#"#!/usr/bin/env bash
+#MISE env={MARKER="{{ exec(command='echo unsafe') }}"}
+echo ok
+"#;
+
+        assert!(script_header_has_decoded_template(confirm));
+        assert!(script_header_has_decoded_template(env));
     }
 
     #[tokio::test]

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -1,5 +1,5 @@
 use crate::config::config_file::trust_check;
-use crate::config::{self, Config, Settings};
+use crate::config::{Config, Settings};
 use crate::task::Task;
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
 use eyre::{Result, WrapErr, bail};
@@ -8,11 +8,23 @@ use std::sync::Arc;
 /// Handles fetching remote task files and converting them to local paths
 pub struct TaskFetcher {
     no_cache: bool,
+    trust_before_fetch: bool,
 }
 
 impl TaskFetcher {
     pub fn new(no_cache: bool) -> Self {
-        Self { no_cache }
+        Self {
+            no_cache,
+            trust_before_fetch: false,
+        }
+    }
+
+    /// Require trust before a remote provider performs network or Git work.
+    /// Passive discovery commands use this because merely listing tasks is not
+    /// an explicit request to execute a configured remote task.
+    pub fn require_trust_before_fetch(mut self) -> Self {
+        self.trust_before_fetch = true;
+        self
     }
 
     /// Fetch remote task files, converting remote paths to local cached paths
@@ -31,6 +43,24 @@ impl TaskFetcher {
                     continue;
                 }
 
+                let original = t.clone();
+                let defining_cf = original
+                    .cf
+                    .clone()
+                    .or_else(|| config.config_files.get(&original.config_source).cloned());
+                let defining_config_source = defining_cf
+                    .as_ref()
+                    .map(|cf| cf.get_path().to_path_buf())
+                    .unwrap_or_else(|| original.config_source.clone());
+
+                if self.trust_before_fetch {
+                    trust_check(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "fetching remote task {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
+
                 let provider = task_file_providers.get_provider(&source);
 
                 if provider.is_none() {
@@ -42,15 +72,6 @@ impl TaskFetcher {
                     .get_local_path(&source)
                     .await
                     .wrap_err_with(|| format!("failed to fetch remote task {source}"))?;
-                let original = t.clone();
-                let defining_cf = original
-                    .cf
-                    .clone()
-                    .or_else(|| config.config_files.get(&original.config_source).cloned());
-                let defining_config_source = defining_cf
-                    .as_ref()
-                    .map(|cf| cf.get_path().to_path_buf())
-                    .unwrap_or_else(|| original.config_source.clone());
                 let config_root = original
                     .config_root
                     .clone()
@@ -61,16 +82,6 @@ impl TaskFetcher {
                 // Parse the downloaded script as a regular file task so all #MISE
                 // metadata is honored. The inline TOML task remains the higher-
                 // precedence overlay, matching local file-task behavior.
-                // Apply the same trust boundary as local task includes before
-                // rendering templates such as `exec()`, but trust the config that
-                // declared the URL rather than the mutable cache path.
-                if config::task_include_requires_trust(&local_path) {
-                    trust_check(&defining_config_source).wrap_err_with(|| {
-                        format!(
-                            "remote task metadata from {source} requires its defining config to be trusted"
-                        )
-                    })?;
-                }
                 let mut remote = Task::from_path_unrendered_with_cf(
                     &local_path,
                     prefix,
@@ -78,6 +89,17 @@ impl TaskFetcher {
                     defining_cf,
                 )
                 .wrap_err_with(|| format!("failed to parse remote task metadata from {source}"))?;
+                // Parsing headers is inert. Check the decoded Task instead of
+                // guessing its format from the fetched filename: Git task scripts
+                // may legitimately end in `.toml`, and escaped TOML delimiters
+                // only become visible after header parsing.
+                if remote.has_render_templates() {
+                    trust_check(&defining_config_source).wrap_err_with(|| {
+                        format!(
+                            "remote task metadata from {source} requires its defining config to be trusted"
+                        )
+                    })?;
+                }
                 let remote_metadata_has_tools = !remote.tools.is_empty();
                 remote.name.clone_from(&original.name);
                 remote.display_name.clone_from(&original.display_name);
@@ -125,7 +147,26 @@ mod tests {
     use super::*;
     use crate::config::env_directive::EnvDirective;
     use crate::task::TaskToolValue;
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf};
+
+    #[test]
+    fn test_remote_script_template_detection_ignores_toml_extension() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("remote-task.toml");
+        fs::write(
+            &path,
+            r#"#!/usr/bin/env bash
+#MISE description="\u007b\u007b exec(command='echo unsafe') \u007d\u007d"
+echo ok
+"#,
+        )
+        .unwrap();
+
+        let task =
+            Task::from_path_unrendered_with_cf(&path, root.path(), root.path(), None).unwrap();
+
+        assert!(task.has_render_templates());
+    }
 
     #[tokio::test]
     async fn test_fetch_remote_task_parses_headers_and_applies_toml_overlay() {

--- a/src/task/task_fetcher.rs
+++ b/src/task/task_fetcher.rs
@@ -48,9 +48,10 @@ impl TaskFetcher {
                     .cf
                     .clone()
                     .or_else(|| config.config_files.get(&original.config_source).cloned());
-                let defining_config_source = defining_cf
-                    .as_ref()
-                    .map(|cf| cf.get_path().to_path_buf())
+                let defining_config_source = original
+                    .remote_config_source
+                    .clone()
+                    .or_else(|| defining_cf.as_ref().map(|cf| cf.get_path().to_path_buf()))
                     .unwrap_or_else(|| original.config_source.clone());
 
                 if self.trust_before_fetch {

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -1,4 +1,9 @@
-use std::{fmt::Debug, path::PathBuf, sync::Arc};
+use std::{
+    collections::HashSet,
+    fmt::Debug,
+    path::{Path, PathBuf},
+    sync::{Arc, LazyLock, Mutex},
+};
 
 mod local_task;
 mod remote_task_git;
@@ -26,14 +31,42 @@ pub(crate) struct TaskFileArtifactCleanup {
     path: PathBuf,
 }
 
-impl Drop for TaskFileArtifactCleanup {
-    fn drop(&mut self) {
-        if let Err(err) = crate::file::remove_all(&self.path) {
+static TEMPORARY_ARTIFACTS: LazyLock<Mutex<HashSet<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+impl TaskFileArtifactCleanup {
+    fn new(path: PathBuf) -> Self {
+        TEMPORARY_ARTIFACTS.lock().unwrap().insert(path.clone());
+        Self { path }
+    }
+
+    fn remove(path: &Path) {
+        if let Err(err) = crate::file::remove_all(path) {
             warn!(
                 "failed to clean up remote task artifact {}: {err:#}",
-                crate::file::display_path(&self.path)
+                crate::file::display_path(path)
             );
         }
+    }
+}
+
+impl Drop for TaskFileArtifactCleanup {
+    fn drop(&mut self) {
+        TEMPORARY_ARTIFACTS.lock().unwrap().remove(&self.path);
+        Self::remove(&self.path);
+    }
+}
+
+/// Remove temporary remote task snapshots even when an explicit process exit
+/// bypasses Rust destructors (for example after a task returns a non-zero code).
+pub(crate) fn cleanup_temporary_artifacts() {
+    let paths = TEMPORARY_ARTIFACTS
+        .lock()
+        .unwrap()
+        .drain()
+        .collect::<Vec<_>>();
+    for path in paths {
+        TaskFileArtifactCleanup::remove(&path);
     }
 }
 
@@ -54,7 +87,7 @@ impl TaskFileArtifact {
     pub(crate) fn temporary(path: PathBuf, cleanup_path: PathBuf) -> Self {
         Self {
             path,
-            cleanup: Some(Arc::new(TaskFileArtifactCleanup { path: cleanup_path })),
+            cleanup: Some(Arc::new(TaskFileArtifactCleanup::new(cleanup_path))),
         }
     }
 }

--- a/src/task/task_file_providers/mod.rs
+++ b/src/task/task_file_providers/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, path::PathBuf};
+use std::{fmt::Debug, path::PathBuf, sync::Arc};
 
 mod local_task;
 mod remote_task_git;
@@ -13,6 +13,50 @@ use remote_task_http::RemoteTaskHttpBuilder;
 pub trait TaskFileProvider: Debug + Send + Sync {
     fn is_match(&self, file: &str) -> bool;
     async fn get_local_path(&self, file: &str) -> Result<PathBuf>;
+
+    async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
+        Ok(TaskFileArtifact::persistent(
+            self.get_local_path(file).await?,
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TaskFileArtifactCleanup {
+    path: PathBuf,
+}
+
+impl Drop for TaskFileArtifactCleanup {
+    fn drop(&mut self) {
+        if let Err(err) = crate::file::remove_all(&self.path) {
+            warn!(
+                "failed to clean up remote task artifact {}: {err:#}",
+                crate::file::display_path(&self.path)
+            );
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TaskFileArtifact {
+    pub path: PathBuf,
+    pub(crate) cleanup: Option<Arc<TaskFileArtifactCleanup>>,
+}
+
+impl TaskFileArtifact {
+    pub(crate) fn persistent(path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup: None,
+        }
+    }
+
+    pub(crate) fn temporary(path: PathBuf, cleanup_path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup: Some(Arc::new(TaskFileArtifactCleanup { path: cleanup_path })),
+        }
+    }
 }
 
 pub struct TaskFileProvidersBuilder {

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -108,12 +108,18 @@ impl RemoteTaskGit {
         Ok(destination)
     }
 
+    fn path_cache_destination(&self, cache_key: &str, repo_path: &str) -> PathBuf {
+        let path_key = hash::hash_sha256_to_str(repo_path);
+        self.storage_path
+            .join(format!("{cache_key}.path-{path_key}"))
+    }
+
     fn fetch_to_destination(
         &self,
         repo_structure: &GitRepoStructure,
         destination: &PathBuf,
         reuse_existing: bool,
-    ) -> Result<PathBuf> {
+    ) -> Result<Option<PathBuf>> {
         let repo_file_path = repo_structure.path.clone();
         let full_path = destination.join(&repo_file_path);
 
@@ -128,10 +134,22 @@ impl RemoteTaskGit {
             })
             .lock()?;
 
-        if reuse_existing && full_path.exists() {
+        let destination_metadata = destination.symlink_metadata().ok();
+        let published_directory = destination_metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.file_type().is_dir());
+        if reuse_existing && published_directory && full_path.exists() {
             debug!("Using cached file: {:?}", full_path);
             Self::prepare_remote_path(&full_path)?;
-            return Ok(full_path);
+            return Ok(Some(full_path));
+        }
+
+        // Published cache trees are immutable. A path may be absent when a
+        // mutable branch gained that path after the shared repo snapshot was
+        // cached. Signal the caller to use a path-specific snapshot instead of
+        // replacing a tree that another process may still be reading.
+        if reuse_existing && destination_metadata.is_some() {
+            return Ok(None);
         }
 
         let mut tmp_destination = destination.as_os_str().to_os_string();
@@ -148,30 +166,66 @@ impl RemoteTaskGit {
             clone_options = clone_options.branch(branch);
         }
 
-        match git_repo.clone(repo_structure.url_without_path.as_str(), clone_options) {
-            Ok(()) => {
-                if destination.exists()
-                    && let Err(e) = crate::file::remove_all(destination)
-                {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(e);
-                }
-                if let Err(e) = std::fs::rename(&tmp_destination, destination) {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(eyre::eyre!(
-                        "failed to move cloned repo into cache at {}: {e}",
-                        display_path(destination)
-                    ));
-                }
-            }
-            Err(e) => {
-                let _ = crate::file::remove_all(&tmp_destination);
-                return Err(e);
-            }
+        if let Err(err) = git_repo.clone(repo_structure.url_without_path.as_str(), clone_options) {
+            let _ = crate::file::remove_all(&tmp_destination);
+            return Err(err);
         }
 
-        Self::prepare_remote_path(&full_path)?;
-        Ok(full_path)
+        // Validate and prepare the requested path before publishing the clone.
+        // A failed/missing path must never leave behind a cache tree that every
+        // later lookup has to replace.
+        let tmp_full_path = tmp_destination.join(&repo_file_path);
+        if let Err(err) = Self::prepare_remote_path(&tmp_full_path) {
+            let _ = crate::file::remove_all(&tmp_destination);
+            return Err(err);
+        }
+
+        // The lock coordinates all mise writers for this destination. Keep the
+        // existence check anyway so an out-of-band creator cannot make rename
+        // replace a published tree on platforms where rename permits it.
+        let destination_metadata = destination.symlink_metadata().ok();
+        let published_directory = destination_metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.file_type().is_dir());
+        if destination_metadata.is_some() {
+            let _ = crate::file::remove_all(&tmp_destination);
+            if reuse_existing && published_directory && full_path.exists() {
+                Self::prepare_remote_path(&full_path)?;
+                return Ok(Some(full_path));
+            }
+            return Ok(None);
+        }
+
+        if let Err(e) = file::rename(&tmp_destination, destination) {
+            let _ = crate::file::remove_all(&tmp_destination);
+            return Err(eyre::eyre!(
+                "failed to move cloned repo into cache at {}: {e}",
+                display_path(destination)
+            ));
+        }
+
+        Ok(Some(full_path))
+    }
+
+    fn get_cached_path(&self, repo_structure: &GitRepoStructure) -> Result<PathBuf> {
+        let cache_key = self.get_cache_key(repo_structure);
+        let destination = self.storage_path.join(&cache_key);
+        if let Some(path) = self.fetch_to_destination(repo_structure, &destination, true)? {
+            return Ok(path);
+        }
+
+        // Preserve the original repo-wide snapshot for live readers. A
+        // deterministic path-specific clone gives newly-added paths persistent
+        // cache behavior without ever deleting or replacing that snapshot.
+        let destination = self.path_cache_destination(&cache_key, &repo_structure.path);
+        self.fetch_to_destination(repo_structure, &destination, true)?
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "remote git task cache at {} does not contain {}",
+                    display_path(&destination),
+                    repo_structure.path
+                )
+            })
     }
 
     #[cfg(test)]
@@ -199,9 +253,13 @@ impl TaskFileProvider for RemoteTaskGit {
 
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {
         let repo_structure = self.get_repo_structure(file);
+        if self.is_cached {
+            return self.get_cached_path(&repo_structure);
+        }
         let cache_key = self.get_cache_key(&repo_structure);
-        let destination = self.storage_path.join(&cache_key);
-        self.fetch_to_destination(&repo_structure, &destination, self.is_cached)
+        let destination = self.unique_destination(&cache_key)?;
+        self.fetch_to_destination(&repo_structure, &destination, false)?
+            .ok_or_else(|| eyre::eyre!("failed to publish remote git task snapshot"))
     }
 
     async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
@@ -214,7 +272,11 @@ impl TaskFileProvider for RemoteTaskGit {
         let cache_key = self.get_cache_key(&repo_structure);
         let destination = self.unique_destination(&cache_key)?;
         let path = match self.fetch_to_destination(&repo_structure, &destination, false) {
-            Ok(path) => path,
+            Ok(Some(path)) => path,
+            Ok(None) => {
+                let _ = crate::file::remove_all(&destination);
+                eyre::bail!("failed to publish remote git task snapshot");
+            }
             Err(err) => {
                 let _ = crate::file::remove_all(&destination);
                 return Err(err);
@@ -228,6 +290,112 @@ impl TaskFileProvider for RemoteTaskGit {
 mod tests {
 
     use super::*;
+    use std::process::Command;
+
+    fn run_git(repo: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn test_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().unwrap();
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["config", "user.name", "Mise Test"]);
+        run_git(
+            repo.path(),
+            &["config", "user.email", "mise-test@example.com"],
+        );
+        repo
+    }
+
+    fn commit_file(repo: &std::path::Path, path: &str, body: &str) {
+        let path = repo.join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, body).unwrap();
+        run_git(repo, &["add", "."]);
+        run_git(repo, &["commit", "-m", "update task fixture"]);
+    }
+
+    #[test]
+    fn test_cached_missing_path_preserves_published_repo_tree() {
+        let source = test_repo();
+        commit_file(source.path(), "tasks/first", "first revision\n");
+        let source_url = url::Url::from_directory_path(source.path())
+            .unwrap()
+            .to_string();
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskGit {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: true,
+        };
+
+        let first_repo = GitRepoStructure::new(&source_url, "tasks/first", None);
+        let first_path = provider.get_cached_path(&first_repo).unwrap();
+        let cache_key = provider.get_cache_key(&first_repo);
+        let published_repo = storage.path().join(&cache_key);
+        let reader_marker = published_repo.join("reader-marker");
+        std::fs::write(&reader_marker, "live reader state\n").unwrap();
+
+        // Simulate a mutable branch gaining a task after its shared snapshot
+        // was published. Looking up the new path must not replace that tree.
+        commit_file(source.path(), "tasks/second", "second revision\n");
+        let second_repo = GitRepoStructure::new(&source_url, "tasks/second", None);
+        let second_path = provider.get_cached_path(&second_repo).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&first_path).unwrap(),
+            "first revision\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&reader_marker).unwrap(),
+            "live reader state\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&second_path).unwrap(),
+            "second revision\n"
+        );
+        assert!(first_path.starts_with(&published_repo));
+        assert!(!second_path.starts_with(&published_repo));
+
+        // The path-specific fallback is persistent too; later source changes
+        // do not mutate or replace its published snapshot.
+        commit_file(source.path(), "tasks/second", "third revision\n");
+        let cached_second_path = provider.get_cached_path(&second_repo).unwrap();
+        assert_eq!(cached_second_path, second_path);
+        assert_eq!(
+            std::fs::read_to_string(cached_second_path).unwrap(),
+            "second revision\n"
+        );
+    }
+
+    #[test]
+    fn test_missing_path_does_not_publish_invalid_cache_tree() {
+        let source = test_repo();
+        commit_file(source.path(), "tasks/first", "first revision\n");
+        let source_url = url::Url::from_directory_path(source.path())
+            .unwrap()
+            .to_string();
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskGit {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: true,
+        };
+        let missing_repo = GitRepoStructure::new(&source_url, "tasks/missing", None);
+        let destination = storage.path().join(provider.get_cache_key(&missing_repo));
+
+        assert!(provider.get_cached_path(&missing_repo).is_err());
+        assert!(!destination.exists());
+    }
 
     #[test]
     #[cfg(unix)]

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -124,7 +124,20 @@ impl TaskFileProvider for RemoteTaskGit {
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {
         let repo_structure = self.get_repo_structure(file);
         let cache_key = self.get_cache_key(&repo_structure);
-        let destination = self.storage_path.join(&cache_key);
+        let destination = if self.is_cached {
+            self.storage_path.join(&cache_key)
+        } else {
+            // No-cache clones must remain available until their owning Task
+            // executes. A unique destination prevents a later fetch of the same
+            // URL/ref from replacing the first task's checked-out contents.
+            file::create_dir_all(&self.storage_path)?;
+            let temp_dir = tempfile::Builder::new()
+                .prefix(&format!("{cache_key}-"))
+                .tempdir_in(&self.storage_path)?;
+            let destination = temp_dir.path().to_path_buf();
+            temp_dir.close()?;
+            destination
+        };
         let repo_file_path = repo_structure.path.clone();
         let full_path = destination.join(&repo_file_path);
 

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -109,9 +109,11 @@ impl RemoteTaskGit {
     }
 
     fn path_cache_destination(&self, cache_key: &str, repo_path: &str) -> PathBuf {
-        let path_key = hash::hash_sha256_to_str(repo_path);
-        self.storage_path
-            .join(format!("{cache_key}.path-{path_key}"))
+        // Hash the complete identity into a single component. Concatenating
+        // both SHA-256 strings makes gix's temporary pack paths exceed the
+        // legacy Windows path limit in otherwise ordinary temp directories.
+        let path_key = hash::hash_sha256_to_str(&format!("{cache_key}\0{repo_path}"));
+        self.storage_path.join(format!("path-{path_key}"))
     }
 
     fn fetch_to_destination(

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -355,7 +355,9 @@ mod tests {
         let second_path = provider.get_cached_path(&second_repo).unwrap();
 
         assert_eq!(
-            std::fs::read_to_string(&first_path).unwrap(),
+            std::fs::read_to_string(&first_path)
+                .unwrap()
+                .replace("\r\n", "\n"),
             "first revision\n"
         );
         assert_eq!(
@@ -363,7 +365,9 @@ mod tests {
             "live reader state\n"
         );
         assert_eq!(
-            std::fs::read_to_string(&second_path).unwrap(),
+            std::fs::read_to_string(&second_path)
+                .unwrap()
+                .replace("\r\n", "\n"),
             "second revision\n"
         );
         assert!(first_path.starts_with(&published_repo));
@@ -375,7 +379,9 @@ mod tests {
         let cached_second_path = provider.get_cached_path(&second_repo).unwrap();
         assert_eq!(cached_second_path, second_path);
         assert_eq!(
-            std::fs::read_to_string(cached_second_path).unwrap(),
+            std::fs::read_to_string(cached_second_path)
+                .unwrap()
+                .replace("\r\n", "\n"),
             "second revision\n"
         );
     }

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -85,7 +85,7 @@ impl RemoteTaskGit {
 
     fn get_cache_key(&self, repo_structure: &GitRepoStructure) -> String {
         let key = format!(
-            "{}{}",
+            "{}\0{}",
             &repo_structure.url_without_path,
             &repo_structure.branch.to_owned().unwrap_or("".to_string())
         );
@@ -640,6 +640,13 @@ mod tests {
                 "git::https://github.com/example.git//myfile?ref=v1.0.0",
                 "git::https://github.com/example.git//subfolder/myfile?ref=v1.0.0",
                 true,
+            ),
+            // URL and ref must have an explicit identity boundary. Without
+            // one, these both concatenate to `.../example.gitnext.gitmain`.
+            (
+                "git::https://github.com/example.git//myfile?ref=next.gitmain",
+                "git::https://github.com/example.gitnext.git//myfile?ref=main",
+                false,
             ),
         ];
 

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -12,7 +12,7 @@ use crate::{
     remote_source::{RemoteGitSource, RemoteSource},
 };
 
-use super::TaskFileProvider;
+use super::{TaskFileArtifact, TaskFileProvider};
 
 #[derive(Debug)]
 pub struct RemoteTaskGitBuilder {
@@ -98,6 +98,82 @@ impl RemoteTaskGit {
             .unwrap()
     }
 
+    fn unique_destination(&self, cache_key: &str) -> Result<PathBuf> {
+        file::create_dir_all(&self.storage_path)?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix(&format!("{cache_key}-"))
+            .tempdir_in(&self.storage_path)?;
+        let destination = temp_dir.path().to_path_buf();
+        temp_dir.close()?;
+        Ok(destination)
+    }
+
+    fn fetch_to_destination(
+        &self,
+        repo_structure: &GitRepoStructure,
+        destination: &PathBuf,
+        reuse_existing: bool,
+    ) -> Result<PathBuf> {
+        let repo_file_path = repo_structure.path.clone();
+        let full_path = destination.join(&repo_file_path);
+
+        debug!("Repo structure: {:?}", repo_structure);
+
+        let _lock = LockFile::new(destination)
+            .with_callback(|l| {
+                debug!(
+                    "waiting for lock on remote git task cache: {}",
+                    display_path(l)
+                );
+            })
+            .lock()?;
+
+        if reuse_existing && full_path.exists() {
+            debug!("Using cached file: {:?}", full_path);
+            Self::prepare_remote_path(&full_path)?;
+            return Ok(full_path);
+        }
+
+        let mut tmp_destination = destination.as_os_str().to_os_string();
+        tmp_destination.push(".clone-tmp");
+        let tmp_destination = PathBuf::from(tmp_destination);
+        if tmp_destination.exists() {
+            crate::file::remove_all(&tmp_destination)?;
+        }
+
+        let git_repo = git::Git::new(&tmp_destination);
+        let mut clone_options = CloneOptions::default();
+        if let Some(branch) = &repo_structure.branch {
+            trace!("Use specific branch {}", branch);
+            clone_options = clone_options.branch(branch);
+        }
+
+        match git_repo.clone(repo_structure.url_without_path.as_str(), clone_options) {
+            Ok(()) => {
+                if destination.exists()
+                    && let Err(e) = crate::file::remove_all(destination)
+                {
+                    let _ = crate::file::remove_all(&tmp_destination);
+                    return Err(e);
+                }
+                if let Err(e) = std::fs::rename(&tmp_destination, destination) {
+                    let _ = crate::file::remove_all(&tmp_destination);
+                    return Err(eyre::eyre!(
+                        "failed to move cloned repo into cache at {}: {e}",
+                        display_path(destination)
+                    ));
+                }
+            }
+            Err(e) => {
+                let _ = crate::file::remove_all(&tmp_destination);
+                return Err(e);
+            }
+        }
+
+        Self::prepare_remote_path(&full_path)?;
+        Ok(full_path)
+    }
+
     #[cfg(test)]
     fn parse_ssh(file: &str) -> Option<GitRepoStructure> {
         RemoteSource::parse_git_ssh(file).map(|source| source.into())
@@ -124,83 +200,27 @@ impl TaskFileProvider for RemoteTaskGit {
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {
         let repo_structure = self.get_repo_structure(file);
         let cache_key = self.get_cache_key(&repo_structure);
-        let destination = if self.is_cached {
-            self.storage_path.join(&cache_key)
-        } else {
-            // No-cache clones must remain available until their owning Task
-            // executes. A unique destination prevents a later fetch of the same
-            // URL/ref from replacing the first task's checked-out contents.
-            file::create_dir_all(&self.storage_path)?;
-            let temp_dir = tempfile::Builder::new()
-                .prefix(&format!("{cache_key}-"))
-                .tempdir_in(&self.storage_path)?;
-            let destination = temp_dir.path().to_path_buf();
-            temp_dir.close()?;
-            destination
-        };
-        let repo_file_path = repo_structure.path.clone();
-        let full_path = destination.join(&repo_file_path);
+        let destination = self.storage_path.join(&cache_key);
+        self.fetch_to_destination(&repo_structure, &destination, self.is_cached)
+    }
 
-        debug!("Repo structure: {:?}", repo_structure);
-
-        let _lock = LockFile::new(&destination)
-            .with_callback(|l| {
-                debug!(
-                    "waiting for lock on remote git task cache: {}",
-                    display_path(l)
-                );
-            })
-            .lock()?;
-
+    async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
         if self.is_cached {
-            trace!("Cache mode enabled");
-            if full_path.exists() {
-                debug!("Using cached file: {:?}", full_path);
-                Self::prepare_remote_path(&full_path)?;
-                return Ok(full_path);
+            return Ok(TaskFileArtifact::persistent(
+                self.get_local_path(file).await?,
+            ));
+        }
+        let repo_structure = self.get_repo_structure(file);
+        let cache_key = self.get_cache_key(&repo_structure);
+        let destination = self.unique_destination(&cache_key)?;
+        let path = match self.fetch_to_destination(&repo_structure, &destination, false) {
+            Ok(path) => path,
+            Err(err) => {
+                let _ = crate::file::remove_all(&destination);
+                return Err(err);
             }
-        } else {
-            trace!("Cache mode disabled");
-        }
-
-        let tmp_destination = self.storage_path.join(format!("{}.clone-tmp", &cache_key));
-        if tmp_destination.exists() {
-            crate::file::remove_all(&tmp_destination)?;
-        }
-
-        let git_repo = git::Git::new(&tmp_destination);
-
-        let mut clone_options = CloneOptions::default();
-
-        if let Some(branch) = &repo_structure.branch {
-            trace!("Use specific branch {}", branch);
-            clone_options = clone_options.branch(branch);
-        }
-
-        match git_repo.clone(repo_structure.url_without_path.as_str(), clone_options) {
-            Ok(()) => {
-                if destination.exists()
-                    && let Err(e) = crate::file::remove_all(&destination)
-                {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(e);
-                }
-                if let Err(e) = std::fs::rename(&tmp_destination, &destination) {
-                    let _ = crate::file::remove_all(&tmp_destination);
-                    return Err(eyre::eyre!(
-                        "failed to move cloned repo into cache at {}: {e}",
-                        display_path(&destination)
-                    ));
-                }
-            }
-            Err(e) => {
-                let _ = crate::file::remove_all(&tmp_destination);
-                return Err(e);
-            }
-        }
-
-        Self::prepare_remote_path(&full_path)?;
-        Ok(full_path)
+        };
+        Ok(TaskFileArtifact::temporary(path, destination))
     }
 }
 

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -6,7 +6,7 @@ use crate::{
     Result, dirs, env, file, hash, http::HTTP, lock_file::LockFile, remote_source::RemoteSource,
 };
 
-use super::TaskFileProvider;
+use super::{TaskFileArtifact, TaskFileProvider};
 
 #[derive(Debug)]
 pub struct RemoteTaskHttpBuilder {
@@ -55,6 +55,23 @@ impl RemoteTaskHttp {
         file::make_executable(destination)?;
         Ok(())
     }
+
+    async fn get_unique_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
+        let cache_key = self.get_cache_key(file);
+        file::create_dir_all(&self.storage_path)?;
+        let temp_file =
+            tempfile::NamedTempFile::with_prefix_in(format!("{cache_key}-"), &self.storage_path)?;
+        let (_, destination) = temp_file.keep()?;
+        file::remove_file(&destination)?;
+        if let Err(error) = self.download_file(file, &destination).await {
+            let _ = file::remove_file(&destination);
+            return Err(error);
+        }
+        Ok(TaskFileArtifact::temporary(
+            destination.clone(),
+            destination,
+        ))
+    }
 }
 
 #[async_trait]
@@ -65,9 +82,9 @@ impl TaskFileProvider for RemoteTaskHttp {
 
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {
         let cache_key = self.get_cache_key(file);
+        let destination = self.storage_path.join(&cache_key);
         if self.is_cached {
             trace!("Cache mode enabled");
-            let destination = self.storage_path.join(&cache_key);
             let _lock = LockFile::new(&destination).lock()?;
             if destination.exists() {
                 debug!("Using cached file: {:?}", destination);
@@ -79,17 +96,18 @@ impl TaskFileProvider for RemoteTaskHttp {
 
         trace!("Cache mode disabled");
         file::create_dir_all(&self.storage_path)?;
-        // A no-cache fetch must not replace a path already retained by another
-        // Task. Keep each response at a unique location until that task runs.
-        let temp_file =
-            tempfile::NamedTempFile::with_prefix_in(format!("{cache_key}-"), &self.storage_path)?;
-        let (_, destination) = temp_file.keep()?;
-        file::remove_file(&destination)?;
-        if let Err(error) = self.download_file(file, &destination).await {
-            let _ = file::remove_file(&destination);
-            return Err(error);
-        }
+        let _lock = LockFile::new(&destination).lock()?;
+        self.download_file(file, &destination).await?;
         Ok(destination)
+    }
+
+    async fn get_local_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
+        if self.is_cached {
+            return Ok(TaskFileArtifact::persistent(
+                self.get_local_path(file).await?,
+            ));
+        }
+        self.get_unique_artifact(file).await
     }
 }
 
@@ -139,7 +157,8 @@ mod tests {
 
             let mut local_paths = vec![];
             for _ in 0..2 {
-                let local_path = provider.get_local_path(&request_url).await.unwrap();
+                let artifact = provider.get_local_artifact(&request_url).await.unwrap();
+                let local_path = artifact.path.clone();
                 assert!(local_path.exists());
                 assert!(local_path.is_file());
                 assert!(
@@ -149,9 +168,15 @@ mod tests {
                         .to_string_lossy()
                         .starts_with(&cache_key)
                 );
-                local_paths.push(local_path);
+                local_paths.push((local_path, artifact));
             }
-            assert_ne!(local_paths[0], local_paths[1]);
+            assert_ne!(local_paths[0].0, local_paths[1].0);
+            let retained_paths = local_paths
+                .iter()
+                .map(|(path, _)| path.clone())
+                .collect::<Vec<_>>();
+            drop(local_paths);
+            assert!(retained_paths.iter().all(|path| !path.exists()));
 
             mocked_server.assert();
         }

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -254,10 +254,12 @@ mod tests {
         };
         let request_url = format!("{}/task", server.url());
         let destination = storage.path().join(provider.get_cache_key(&request_url));
+        let temp_destination = RemoteTaskHttp::temp_download_path(&destination);
+        std::fs::write(&temp_destination, b"partial download").unwrap();
 
         assert!(provider.get_local_path(&request_url).await.is_err());
         assert!(!destination.exists());
-        assert!(!RemoteTaskHttp::temp_download_path(&destination).exists());
+        assert!(!temp_destination.exists());
         remote.assert_async().await;
     }
 }

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -56,6 +56,28 @@ impl RemoteTaskHttp {
         Ok(())
     }
 
+    fn temp_download_path(destination: &PathBuf) -> PathBuf {
+        let mut path = destination.as_os_str().to_os_string();
+        path.push(".download-tmp");
+        path.into()
+    }
+
+    async fn download_file_atomically(&self, file: &str, destination: &PathBuf) -> Result<()> {
+        let temp = Self::temp_download_path(destination);
+        if temp.exists() {
+            file::remove_file(&temp)?;
+        }
+        if let Err(error) = self.download_file(file, &temp).await {
+            let _ = file::remove_file(&temp);
+            return Err(error);
+        }
+        if let Err(error) = file::rename(&temp, destination) {
+            let _ = file::remove_file(&temp);
+            return Err(error);
+        }
+        Ok(())
+    }
+
     async fn get_unique_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
         let cache_key = self.get_cache_key(file);
         file::create_dir_all(&self.storage_path)?;
@@ -85,12 +107,13 @@ impl TaskFileProvider for RemoteTaskHttp {
         let destination = self.storage_path.join(&cache_key);
         if self.is_cached {
             trace!("Cache mode enabled");
+            file::create_dir_all(&self.storage_path)?;
             let _lock = LockFile::new(&destination).lock()?;
             if destination.exists() {
                 debug!("Using cached file: {:?}", destination);
                 return Ok(destination);
             }
-            self.download_file(file, &destination).await?;
+            self.download_file_atomically(file, &destination).await?;
             return Ok(destination);
         }
 
@@ -213,5 +236,28 @@ mod tests {
 
             mocked_server.assert();
         }
+    }
+
+    #[tokio::test]
+    async fn test_cached_download_failure_leaves_no_partial_file() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/task")
+            .with_status(500)
+            .expect(4)
+            .create_async()
+            .await;
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskHttp {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: true,
+        };
+        let request_url = format!("{}/task", server.url());
+        let destination = storage.path().join(provider.get_cache_key(&request_url));
+
+        assert!(provider.get_local_path(&request_url).await.is_err());
+        assert!(!destination.exists());
+        assert!(!RemoteTaskHttp::temp_download_path(&destination).exists());
+        remote.assert_async().await;
     }
 }

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 
-use crate::{Result, dirs, env, file, hash, http::HTTP, remote_source::RemoteSource};
+use crate::{
+    Result, dirs, env, file, hash, http::HTTP, lock_file::LockFile, remote_source::RemoteSource,
+};
 
 use super::TaskFileProvider;
 
@@ -63,27 +65,30 @@ impl TaskFileProvider for RemoteTaskHttp {
 
     async fn get_local_path(&self, file: &str) -> Result<PathBuf> {
         let cache_key = self.get_cache_key(file);
-        let destination = self.storage_path.join(&cache_key);
-
-        match self.is_cached {
-            true => {
-                trace!("Cache mode enabled");
-
-                if destination.exists() {
-                    debug!("Using cached file: {:?}", destination);
-                    return Ok(destination);
-                }
+        if self.is_cached {
+            trace!("Cache mode enabled");
+            let destination = self.storage_path.join(&cache_key);
+            let _lock = LockFile::new(&destination).lock()?;
+            if destination.exists() {
+                debug!("Using cached file: {:?}", destination);
+                return Ok(destination);
             }
-            false => {
-                trace!("Cache mode disabled");
-
-                if destination.exists() {
-                    file::remove_file(&destination)?;
-                }
-            }
+            self.download_file(file, &destination).await?;
+            return Ok(destination);
         }
 
-        self.download_file(file, &destination).await?;
+        trace!("Cache mode disabled");
+        file::create_dir_all(&self.storage_path)?;
+        // A no-cache fetch must not replace a path already retained by another
+        // Task. Keep each response at a unique location until that task runs.
+        let temp_file =
+            tempfile::NamedTempFile::with_prefix_in(format!("{cache_key}-"), &self.storage_path)?;
+        let (_, destination) = temp_file.keep()?;
+        file::remove_file(&destination)?;
+        if let Err(error) = self.download_file(file, &destination).await {
+            let _ = file::remove_file(&destination);
+            return Err(error);
+        }
         Ok(destination)
     }
 }
@@ -132,12 +137,21 @@ mod tests {
             let request_url = format!("{}{}", server.url(), request_path);
             let cache_key = provider.get_cache_key(&request_url);
 
+            let mut local_paths = vec![];
             for _ in 0..2 {
                 let local_path = provider.get_local_path(&request_url).await.unwrap();
                 assert!(local_path.exists());
                 assert!(local_path.is_file());
-                assert!(local_path.ends_with(&cache_key));
+                assert!(
+                    local_path
+                        .file_name()
+                        .unwrap()
+                        .to_string_lossy()
+                        .starts_with(&cache_key)
+                );
+                local_paths.push(local_path);
             }
+            assert_ne!(local_paths[0], local_paths[1]);
 
             mocked_server.assert();
         }

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -49,20 +49,20 @@ impl RemoteTaskHttp {
         hash::hash_sha256_to_str(file)
     }
 
-    async fn download_file(&self, file: &str, destination: &PathBuf) -> Result<()> {
+    async fn download_file(&self, file: &str, destination: &Path) -> Result<()> {
         trace!("Downloading file: {}", file);
         HTTP.download_file(file, destination, None).await?;
         file::make_executable(destination)?;
         Ok(())
     }
 
-    fn temp_download_path(destination: &PathBuf) -> PathBuf {
+    fn temp_download_path(destination: &Path) -> PathBuf {
         let mut path = destination.as_os_str().to_os_string();
         path.push(".download-tmp");
         path.into()
     }
 
-    async fn download_file_atomically(&self, file: &str, destination: &PathBuf) -> Result<()> {
+    async fn download_file_atomically(&self, file: &str, destination: &Path) -> Result<()> {
         let temp = Self::temp_download_path(destination);
         if temp.exists() {
             file::remove_file(&temp)?;
@@ -84,7 +84,6 @@ impl RemoteTaskHttp {
         let temp_file =
             tempfile::NamedTempFile::with_prefix_in(format!("{cache_key}-"), &self.storage_path)?;
         let (_, destination) = temp_file.keep()?;
-        file::remove_file(&destination)?;
         if let Err(error) = self.download_file(file, &destination).await {
             let _ = file::remove_file(&destination);
             return Err(error);
@@ -120,7 +119,7 @@ impl TaskFileProvider for RemoteTaskHttp {
         trace!("Cache mode disabled");
         file::create_dir_all(&self.storage_path)?;
         let _lock = LockFile::new(&destination).lock()?;
-        self.download_file(file, &destination).await?;
+        self.download_file_atomically(file, &destination).await?;
         Ok(destination)
     }
 
@@ -157,7 +156,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_http_remote_task_get_local_path_without_cache() {
+    async fn test_http_remote_task_get_local_artifact_without_cache() {
         let paths = vec![
             "/myfile.py",
             "/subpath/myfile.sh",

--- a/src/task/task_file_providers/remote_task_http.rs
+++ b/src/task/task_file_providers/remote_task_http.rs
@@ -56,28 +56,6 @@ impl RemoteTaskHttp {
         Ok(())
     }
 
-    fn temp_download_path(destination: &Path) -> PathBuf {
-        let mut path = destination.as_os_str().to_os_string();
-        path.push(".download-tmp");
-        path.into()
-    }
-
-    async fn download_file_atomically(&self, file: &str, destination: &Path) -> Result<()> {
-        let temp = Self::temp_download_path(destination);
-        if temp.exists() {
-            file::remove_file(&temp)?;
-        }
-        if let Err(error) = self.download_file(file, &temp).await {
-            let _ = file::remove_file(&temp);
-            return Err(error);
-        }
-        if let Err(error) = file::rename(&temp, destination) {
-            let _ = file::remove_file(&temp);
-            return Err(error);
-        }
-        Ok(())
-    }
-
     async fn get_unique_artifact(&self, file: &str) -> Result<TaskFileArtifact> {
         let cache_key = self.get_cache_key(file);
         file::create_dir_all(&self.storage_path)?;
@@ -112,14 +90,14 @@ impl TaskFileProvider for RemoteTaskHttp {
                 debug!("Using cached file: {:?}", destination);
                 return Ok(destination);
             }
-            self.download_file_atomically(file, &destination).await?;
+            self.download_file(file, &destination).await?;
             return Ok(destination);
         }
 
         trace!("Cache mode disabled");
         file::create_dir_all(&self.storage_path)?;
         let _lock = LockFile::new(&destination).lock()?;
-        self.download_file_atomically(file, &destination).await?;
+        self.download_file(file, &destination).await?;
         Ok(destination)
     }
 
@@ -253,12 +231,37 @@ mod tests {
         };
         let request_url = format!("{}/task", server.url());
         let destination = storage.path().join(provider.get_cache_key(&request_url));
-        let temp_destination = RemoteTaskHttp::temp_download_path(&destination);
-        std::fs::write(&temp_destination, b"partial download").unwrap();
 
         assert!(provider.get_local_path(&request_url).await.is_err());
         assert!(!destination.exists());
-        assert!(!temp_destination.exists());
+        remote.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_uncached_get_local_path_replaces_existing_file() {
+        let mut server = mockito::Server::new_async().await;
+        let remote = server
+            .mock("GET", "/task")
+            .with_status(200)
+            .with_body("#!/bin/sh\necho ok\n")
+            .expect(2)
+            .create_async()
+            .await;
+        let storage = tempfile::tempdir().unwrap();
+        let provider = RemoteTaskHttp {
+            storage_path: storage.path().to_path_buf(),
+            is_cached: false,
+        };
+        let request_url = format!("{}/task", server.url());
+
+        let first = provider.get_local_path(&request_url).await.unwrap();
+        let second = provider.get_local_path(&request_url).await.unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(
+            std::fs::read_to_string(second).unwrap(),
+            "#!/bin/sh\necho ok\n"
+        );
         remote.assert_async().await;
     }
 }

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -352,6 +352,16 @@ pub async fn get_task_lists(
     prompt: bool,
     only: bool,
 ) -> Result<Vec<Task>> {
+    get_task_lists_with_no_cache(config, args, prompt, only, false).await
+}
+
+pub async fn get_task_lists_with_no_cache(
+    config: &Arc<Config>,
+    args: &[String],
+    prompt: bool,
+    only: bool,
+    no_cache: bool,
+) -> Result<Vec<Task>> {
     let args = args
         .iter()
         .map(|s| vec![s.to_string()])
@@ -445,9 +455,11 @@ pub async fn get_task_lists(
         };
 
         let all_tasks = if let Some(ref ctx) = effective_context {
-            config.tasks_with_context(Some(ctx)).await?
+            config
+                .tasks_with_context_no_cache(Some(ctx), no_cache)
+                .await?
         } else {
-            config.tasks().await?
+            config.tasks_with_context_no_cache(None, no_cache).await?
         };
 
         let tasks_with_aliases = crate::task::build_task_ref_map(all_tasks.iter());
@@ -500,7 +512,11 @@ pub async fn get_task_lists(
 
 /// Resolve all dependencies for a list of tasks
 /// Iteratively discovers path hints by loading tasks and their dependencies
-pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<Vec<Task>> {
+pub async fn resolve_depends_with_no_cache(
+    config: &Arc<Config>,
+    tasks: Vec<Task>,
+    no_cache: bool,
+) -> Result<Vec<Task>> {
     // Iteratively discover all path hints by loading tasks and their dependencies
     // This handles chains like: //A:B -> :C -> :D -> //E:F where we need to discover E
     let mut all_path_hints = HashSet::new();
@@ -540,7 +556,9 @@ pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<V
             load_all: false,
         });
 
-        let loaded_tasks = config.tasks_with_context(ctx.as_ref()).await?;
+        let loaded_tasks = config
+            .tasks_with_context_no_cache(ctx.as_ref(), no_cache)
+            .await?;
 
         // Find new tasks that haven't been processed yet
         tasks_to_process = loaded_tasks
@@ -560,7 +578,9 @@ pub async fn resolve_depends(config: &Arc<Config>, tasks: Vec<Task>) -> Result<V
         None
     };
 
-    let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
+    let all_tasks = config
+        .tasks_with_context_no_cache(ctx.as_ref(), no_cache)
+        .await?;
 
     tasks
         .into_iter()

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -1,10 +1,12 @@
 use crate::cli::args::ToolArg;
+use crate::config::config_file::trust_check;
 use crate::config::{Config, Settings};
+use crate::file::display_path;
 use crate::task::Deps;
 use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_helpers::canonicalize_path;
 use crate::toolset::{InstallOptions, ToolSource, ToolVersion, Toolset};
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
@@ -34,6 +36,29 @@ impl<'a> TaskToolInstaller<'a> {
         let mut all_tools = self.cli_tools.to_vec();
         let mut all_tool_requests = vec![];
         let all_tasks: Vec<_> = tasks.all().collect();
+
+        // A template-free remote header is safe to inspect during task
+        // discovery, but its tool requirements can cause downloads and install
+        // hooks when a task runs. Require trust at that action boundary. The
+        // caller skips this installer entirely for --skip-tools, and disabled
+        // auto-install settings remain authoritative here as well.
+        if Settings::get().task.run_auto_install && Settings::get().auto_install {
+            for task in &all_tasks {
+                if !task.remote_metadata_has_tools {
+                    continue;
+                }
+                let Some(config_source) = task.remote_config_source.as_deref() else {
+                    continue;
+                };
+                trust_check(config_source).wrap_err_with(|| {
+                    format!(
+                        "tool metadata from remote task {} requires its defining config {} to be trusted",
+                        task.remote_file_source.as_deref().unwrap_or(&task.name),
+                        display_path(config_source)
+                    )
+                })?;
+            }
+        }
 
         trace!("Collecting tools from {} tasks", all_tasks.len());
 

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -2,11 +2,11 @@ use crate::cli::args::ToolArg;
 use crate::config::config_file::trust_check;
 use crate::config::{Config, Settings};
 use crate::file::display_path;
-use crate::task::Deps;
 use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_helpers::canonicalize_path;
+use crate::task::{Deps, Task};
 use crate::toolset::{InstallOptions, ToolSource, ToolVersion, Toolset};
-use eyre::{Result, WrapErr};
+use eyre::{Result, WrapErr, eyre};
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
@@ -43,21 +43,7 @@ impl<'a> TaskToolInstaller<'a> {
         // caller skips this installer entirely for --skip-tools, and disabled
         // auto-install settings remain authoritative here as well.
         if Settings::get().task.run_auto_install && Settings::get().auto_install {
-            for task in &all_tasks {
-                if !task.remote_metadata_has_tools {
-                    continue;
-                }
-                let Some(config_source) = task.remote_config_source.as_deref() else {
-                    continue;
-                };
-                trust_check(config_source).wrap_err_with(|| {
-                    format!(
-                        "tool metadata from remote task {} requires its defining config {} to be trusted",
-                        task.remote_file_source.as_deref().unwrap_or(&task.name),
-                        display_path(config_source)
-                    )
-                })?;
-            }
+            Self::trust_remote_tool_metadata(&all_tasks)?;
         }
 
         trace!("Collecting tools from {} tasks", all_tasks.len());
@@ -88,6 +74,28 @@ impl<'a> TaskToolInstaller<'a> {
         self.install_toolset(config, toolset, dry_run, previewed_tools)
             .await?;
 
+        Ok(())
+    }
+
+    fn trust_remote_tool_metadata(tasks: &[&Task]) -> Result<()> {
+        for task in tasks {
+            if !task.remote_metadata_has_tools {
+                continue;
+            }
+            let remote_source = task.remote_file_source.as_deref().unwrap_or(&task.name);
+            let config_source = task.remote_config_source.as_deref().ok_or_else(|| {
+                eyre!(
+                    "remote task {remote_source} has tool metadata without defining config provenance"
+                )
+            })?;
+            trust_check(config_source).wrap_err_with(|| {
+                format!(
+                    "tool metadata from remote task {} requires its defining config {} to be trusted",
+                    remote_source,
+                    display_path(config_source)
+                )
+            })?;
+        }
         Ok(())
     }
 
@@ -252,5 +260,23 @@ mod tests {
         let cli_tools: Vec<ToolArg> = vec![];
         let installer = TaskToolInstaller::new(&context_builder, &cli_tools);
         assert_eq!(installer.cli_tools.len(), 0);
+    }
+
+    #[test]
+    fn test_remote_tool_metadata_without_provenance_fails_closed() {
+        let task = Task {
+            name: "remote".into(),
+            remote_file_source: Some("https://example.com/task".into()),
+            remote_metadata_has_tools: true,
+            ..Default::default()
+        };
+
+        let error = TaskToolInstaller::trust_remote_tool_metadata(&[&task]).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("tool metadata without defining config provenance")
+        );
     }
 }


### PR DESCRIPTION
## Work order

1. #12000 — preserve Git task snapshots and establish the Git artifact lifecycle layer
2. #11113 — enforce remote-task trust and metadata provenance on that foundation
3. #11203 — audit and extract the remaining cache lifecycle hardening into focused follow-ups

Prerequisite #11222 is merged.

## Summary

- preserve the remote task cache, no-cache propagation, artifact lifecycle, concurrency, and platform hardening extracted from #11113
- keep the cleanup work available while #11113 is reduced to the focused security follow-up for #11111

## Stack

- Stacked on #11113. This draft currently includes the source diff and should be rebased onto main after #11113 merges.
- Deferred for later cleanup; not ready for review.

## Validation

- The combined head passed the complete GitHub Actions matrix before extraction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger trust controls for remote task discovery, metadata, templates, includes, and tool installation.
  * Remote tasks now support safer nested includes and more consistent no-cache execution.
* **Bug Fixes**
  * Improved remote task snapshot handling to prevent stale or mixed content.
  * Temporary files and no-cache artifacts are cleaned up reliably, including after failures.
  * Task listings, validation, help, and task information now avoid untrusted remote fetches.
* **Tests**
  * Expanded coverage for remote task trust, caching, nested includes, templates, tools, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*