### PR TITLE
fix(task): preserve user-global task precedence

### DIFF
--- a/e2e/tasks/test_task_global_config_dedup
+++ b/e2e/tasks/test_task_global_config_dedup
@@ -84,3 +84,18 @@ EOF
 assert \
   "MISE_GLOBAL_CONFIG_FILE='$HOME/global-config/include-order.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/global-config/missing.toml' mise run include-winner" \
   "$HOME/second-global-tasks/include-winner"
+
+local_include_marker="$MISE_TMP_DIR/local-include-render-count"
+: >"$local_include_marker"
+mkdir -p "$HOME/.config/mise/tasks"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+includes = ["{{ exec(command='echo .config/mise/tasks; echo rendered >> $local_include_marker') }}"]
+EOF
+
+# Detecting explicit local task context must inspect the raw include option.
+# Rendering it again would repeat effectful template functions during one load.
+MISE_GLOBAL_CONFIG_FILE="$HOME/global-config/user.toml" \
+  MISE_SYSTEM_CONFIG_FILE="$HOME/global-config/missing.toml" \
+  mise -C "$HOME" tasks >/dev/null
+assert "wc -l < '$local_include_marker' | tr -d ' '" "1"

--- a/e2e/tasks/test_task_global_config_precedence
+++ b/e2e/tasks/test_task_global_config_precedence
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.e]
+description = "system/config/e"
+env = { SYSTEM_PRECEDENCE = "applied" }
+
+[tasks.system-vs-conf-d]
+run = "echo system"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[tasks.e]
+description = "global/conf.d/01/e"
+env = { LOWER_PRECEDENCE = "applied" }
+
+[tasks.system-vs-conf-d]
+run = "echo conf-d"
+
+[tasks.conf-d-order]
+run = "echo conf-d-01"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/02-override.toml"
+[tasks.conf-d-order]
+run = "echo conf-d-02"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[tasks.e]
+description = "global/config/e"
+env = { HIGHER_PRECEDENCE = "applied" }
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/e"
+#!/usr/bin/env bash
+echo "HIGHER_PRECEDENCE=${HIGHER_PRECEDENCE:-<unset>}"
+echo "LOWER_PRECEDENCE=${LOWER_PRECEDENCE:-<unset>}"
+echo "SYSTEM_PRECEDENCE=${SYSTEM_PRECEDENCE:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/e"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise tasks --global" "e"
+assert_contains "mise run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise run e" "SYSTEM_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "HIGHER_PRECEDENCE=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "LOWER_PRECEDENCE=<unset>"
+assert_contains "mise -C '$TMPDIR/outside-home' run e" "SYSTEM_PRECEDENCE=<unset>"
+assert "mise run system-vs-conf-d" "conf-d"
+assert "mise run conf-d-order" "conf-d-02"
+
+# A system-only global config still owns the HOME task scope. Its metadata must
+# not be replaced by an undecorated copy from the local hierarchy walk.
+cat <<'EOF' >"$HOME/.config/mise/tasks/system-only-overlay"
+#!/usr/bin/env bash
+echo "SYSTEM_ONLY=${SYSTEM_ONLY:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/system-only-overlay"
+cat <<'EOF' >"$HOME/system-only.toml"
+[tasks.system-only-overlay]
+env = { SYSTEM_ONLY = "applied" }
+EOF
+assert \
+  "MISE_GLOBAL_CONFIG_FILE='$HOME/missing-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/system-only.toml' mise run system-only-overlay" \
+  "SYSTEM_ONLY=applied"
+
+# A system config is lower precedence than local HOME tasks. Replacing its own
+# includes must not remove a local default task that the system pass never saw.
+mkdir -p "$HOME/system-tasks"
+cat <<'EOF' >"$HOME/.config/mise/tasks/local-only"
+#!/usr/bin/env bash
+echo local-only
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-only"
+cat <<'EOF' >"$HOME/system-tasks/system-only"
+#!/usr/bin/env bash
+echo system-only
+EOF
+chmod +x "$HOME/system-tasks/system-only"
+cat <<'EOF' >"$HOME/system-custom-includes.toml"
+[task_config]
+includes = ["system-tasks"]
+EOF
+assert \
+  "MISE_GLOBAL_CONFIG_FILE='$HOME/missing-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/system-custom-includes.toml' mise run local-only" \
+  "local-only"

--- a/e2e/tasks/test_task_global_include_precedence
+++ b/e2e/tasks/test_task_global_include_precedence
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/global-custom-tasks" "$HOME/high-global-tasks"
+
+cat <<'EOF' >"$MISE_SYSTEM_DIR/config.toml"
+[tasks.g]
+run = "echo system-inline/g"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/conf.d/01-base.toml"
+[task_config]
+includes = ["global-custom-tasks"]
+EOF
+
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+
+[tasks.i]
+run = "echo lower-inline/i"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks", "high-global-tasks"]
+
+[tasks.f]
+run = "echo high-inline/f"
+EOF
+
+cat <<'EOF' >"$HOME/global-custom-tasks/f"
+#!/usr/bin/env bash
+echo lower-script/f
+EOF
+chmod +x "$HOME/global-custom-tasks/f"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/h"
+#!/usr/bin/env bash
+echo lower-script/h
+EOF
+chmod +x "$HOME/global-custom-tasks/h"
+
+cat <<'EOF' >"$HOME/global-custom-tasks/file-collision"
+#!/usr/bin/env bash
+echo lower-script/file-collision
+EOF
+chmod +x "$HOME/global-custom-tasks/file-collision"
+
+cat <<'EOF' >"$HOME/high-global-tasks/i"
+#!/usr/bin/env bash
+echo high-script/i
+EOF
+chmod +x "$HOME/high-global-tasks/i"
+
+cat <<'EOF' >"$HOME/high-global-tasks/file-collision"
+#!/usr/bin/env bash
+echo high-script/file-collision
+EOF
+chmod +x "$HOME/high-global-tasks/file-collision"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise -C '$TMPDIR/outside-home' run f" "high-inline/f"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run f" "lower-script/f"
+assert_contains "mise -C '$TMPDIR/outside-home' run g" "system-inline/g"
+assert_contains "mise -C '$TMPDIR/outside-home' run h" "lower-script/h"
+assert_contains "mise -C '$TMPDIR/outside-home' run i" "high-script/i"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run i" "lower-inline/i"
+assert "mise -C '$TMPDIR/outside-home' run file-collision" "high-script/file-collision"

--- a/e2e/tasks/test_task_global_source_context_precedence
+++ b/e2e/tasks/test_task_global_source_context_precedence
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p "$HOME/.config/mise/conf.d" "$HOME/.config/mise/tasks" \
+  "$HOME/high-global-dir" "$HOME/low-global-dir"
+ln -s ".config/mise/tasks" "$HOME/linked-global-tasks"
+
+cat <<EOF >"$HOME/.config/mise/conf.d/02-override.toml"
+[task_config]
+dir = "$HOME/low-global-dir"
+includes = ["linked-global-tasks"]
+shell = "$HOME/low-shell -c"
+
+[task_config.input_groups]
+rust = ["Cargo.toml"]
+
+[tasks.j]
+env = { INLINE_METADATA = "applied" }
+
+[tasks.group-overlay]
+sources = ["@group:rust"]
+
+[tasks.explicit-shell-overlay]
+shell = "$HOME/explicit-shell -c"
+EOF
+
+cat <<EOF >"$HOME/.config/mise/config.toml"
+[task_config]
+includes = [".config/mise/tasks"]
+dir = "$HOME/high-global-dir"
+shell = "$HOME/high-shell -c"
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/j"
+#!/usr/bin/env bash
+echo same-script/j
+echo "INLINE_METADATA=${INLINE_METADATA:-<unset>}"
+echo "TASK_DIR=$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/j"
+cat <<'EOF' >"$HOME/.config/mise/tasks/group-overlay"
+#!/usr/bin/env bash
+echo group-overlay
+EOF
+chmod +x "$HOME/.config/mise/tasks/group-overlay"
+cat <<'EOF' >"$HOME/.config/mise/tasks/explicit-shell-overlay"
+#!/usr/bin/env bash
+echo explicit-shell-overlay
+EOF
+chmod +x "$HOME/.config/mise/tasks/explicit-shell-overlay"
+
+mkdir -p "$TMPDIR/outside-home"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "same-script/j"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "INLINE_METADATA=applied"
+assert_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/high-global-dir"
+assert_not_contains "mise -C '$TMPDIR/outside-home' run j" "TASK_DIR=$HOME/low-global-dir"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"group-overlay\") | .sources[0]'" \
+  "$HOME/Cargo.toml"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"j\") | .shell'" \
+  "$HOME/high-shell -c"
+assert \
+  "mise -C '$TMPDIR/outside-home' tasks ls --json | jq -r '.[] | select(.name == \"explicit-shell-overlay\") | .shell'" \
+  "$HOME/explicit-shell -c"
+
+# An explicit project include of the same global scripts must retain local
+# precedence. Same-source deduplication may discard only the incidental copy
+# discovered while walking the global config root, not project task context.
+mkdir -p "$HOME/project" "$HOME/local-project-dir"
+
+cat <<'EOF' >>"$HOME/.config/mise/config.toml"
+
+[tasks.local-overlay-wins]
+env = { GLOBAL_CONTEXT = "applied" }
+EOF
+
+cat <<EOF >"$HOME/project/mise.toml"
+[task_config]
+includes = ["$HOME/.config/mise/tasks"]
+dir = "$HOME/local-project-dir"
+
+[tasks.local-overlay-wins]
+env = { LOCAL_CONTEXT = "applied" }
+EOF
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/local-overlay-wins"
+#!/usr/bin/env bash
+echo "LOCAL_CONTEXT=${LOCAL_CONTEXT:-<unset>}"
+echo "GLOBAL_CONTEXT=${GLOBAL_CONTEXT:-<unset>}"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-overlay-wins"
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/local-dir-wins"
+#!/usr/bin/env bash
+echo "TASK_DIR=$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-dir-wins"
+
+assert_contains "mise -C '$HOME/project' run local-overlay-wins" "LOCAL_CONTEXT=applied"
+assert_contains "mise -C '$HOME/project' run local-overlay-wins" "GLOBAL_CONTEXT=<unset>"
+assert_contains "mise -C '$HOME/project' run local-dir-wins" "TASK_DIR=$HOME/local-project-dir"
+assert_not_contains "mise -C '$HOME/project' run local-dir-wins" "TASK_DIR=$HOME/high-global-dir"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -72,3 +72,117 @@ assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run systemglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run relative-meta" "RELATIVE_OVERLAY=applied"
 assert "mise run templated-meta" "TEMPLATED_OVERLAY=applied"
+
+# The user-global pass owns HOME's task include scope. An unrelated local HOME
+# config must not resurrect omitted defaults or let them override an explicitly
+# included global task with the same name.
+cat <<'EOF' >~/.config/mise/tasks/collision
+#!/usr/bin/env bash
+echo default-task
+EOF
+chmod +x ~/.config/mise/tasks/collision
+cat <<'EOF' >~/.config/mise/tasks/omitted-only
+#!/usr/bin/env bash
+echo omitted-task
+EOF
+chmod +x ~/.config/mise/tasks/omitted-only
+cat <<'EOF' >~/dotfiles/tasks/collision
+#!/usr/bin/env bash
+echo custom-task
+EOF
+chmod +x ~/dotfiles/tasks/collision
+cat >~/.config/mise/config.toml <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
+cat >"$HOME/mise.toml" <<'TOML'
+[env]
+UNRELATED_HOME_CONFIG = "present"
+TOML
+
+assert "mise run collision" "custom-task"
+assert_fail "mise run omitted-only"
+assert_not_contains "mise tasks --global" "omitted-only"
+
+# Cascade control alone does not supply file-task context at the HOME root, so
+# it must not resurrect defaults omitted by the user-global config.
+cat >"$HOME/mise.toml" <<'TOML'
+[task_config]
+cascade = true
+TOML
+assert_fail "mise run omitted-only"
+
+# A local ancestor config can explicitly include the global task directory even
+# when the global config replaces that default include. Source deduplication
+# must not discard a task that the independent global pass did not load.
+cat >"$HOME/mise.toml" <<'TOML'
+[task_config]
+includes = [".config/mise/tasks"]
+TOML
+cat >"$HOME/.config/mise/config.toml" <<'TOML'
+tasks.myglobal = { run = 'echo myglobal' }
+
+[task_config]
+includes = ["dotfiles/tasks"]
+TOML
+
+assert "mise run myglobalfile" "myglobalfile"
+assert_contains "mise tasks --global" "myglobalfile"
+
+# Explicit task configuration at the HOME root owns its default file tasks even
+# when the user-global config replaces those defaults.
+mkdir -p "$HOME/local-task-dir"
+cat >"$HOME/.config/mise/tasks/local-dir-context" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-dir-context"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+dir = "$HOME/local-task-dir"
+EOF
+assert "mise run local-dir-context" "$HOME/local-task-dir"
+
+cat >"$HOME/local-shell-wrapper" <<'EOF'
+#!/usr/bin/env bash
+echo LOCAL_SHELL
+exec bash "$@"
+EOF
+chmod +x "$HOME/local-shell-wrapper"
+cat >"$HOME/.config/mise/tasks/local-shell-context" <<'EOF'
+#!/usr/bin/env bash
+echo LOCAL_TASK
+EOF
+chmod +x "$HOME/.config/mise/tasks/local-shell-context"
+cat >"$HOME/mise.toml" <<EOF
+[task_config]
+shell = "$HOME/local-shell-wrapper -c"
+EOF
+assert \
+  "mise tasks ls --json | jq -r '.[] | select(.name == \"local-shell-context\") | .shell'" \
+  "$HOME/local-shell-wrapper -c"
+
+# Effective task context may cascade from an ancestor into a custom global
+# root. The HOME/global-root filter must use that effective context, not only
+# config files located directly at the root.
+custom_global_root="$HOME/nested/global-root"
+mkdir -p "$custom_global_root/.config/mise/tasks" "$HOME/nested/cascaded-dir"
+cat >"$HOME/nested/mise.toml" <<EOF
+[task_config]
+cascade = true
+dir = "$HOME/nested/cascaded-dir"
+EOF
+cat >"$custom_global_root/.config/mise/tasks/cascaded-context" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD"
+EOF
+chmod +x "$custom_global_root/.config/mise/tasks/cascaded-context"
+cat >"$HOME/custom-global.toml" <<'EOF'
+[task_config]
+includes = ["empty-global-tasks"]
+EOF
+assert \
+  "MISE_GLOBAL_CONFIG_ROOT='$custom_global_root' MISE_GLOBAL_CONFIG_FILE='$HOME/custom-global.toml' MISE_SYSTEM_CONFIG_FILE='$HOME/missing-system.toml' mise -C '$custom_global_root' run cascaded-context" \
+  "$HOME/nested/cascaded-dir"

--- a/e2e/tasks/test_task_monorepo_config_dedup
+++ b/e2e/tasks/test_task_monorepo_config_dedup
@@ -3,6 +3,7 @@
 export MISE_EXPERIMENTAL=1
 
 marker="$MISE_TMP_DIR/monorepo-config-render-count"
+: >"$marker"
 mkdir -p apps/example
 
 cat <<'EOF' >mise.toml

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,7 +3,7 @@ use eyre::{Context, Result, bail, eyre};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 pub use settings::Settings;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env::join_paths;
 use std::fmt::{Debug, Formatter};
 use std::iter::once;
@@ -720,12 +720,14 @@ impl Config {
         let mut local_tasks = load_local_tasks_with_context(&config, ctx, &templates).await?;
         let global_tasks = load_global_tasks(&config, &templates).await?;
         local_tasks.retain(|local| {
-            !global_tasks
-                .iter()
-                .any(|global| tasks_have_same_source(local, global))
+            !local.suppress_if_global_duplicate
+                || !global_tasks
+                    .iter()
+                    .any(|global| tasks_have_same_source(&local.task, global))
         });
         let mut tasks: BTreeMap<String, Task> = local_tasks
             .into_iter()
+            .map(|local| local.task)
             .chain(global_tasks)
             .rev()
             .inspect(|t| {
@@ -2478,17 +2480,17 @@ fn render_task_input_entries(
         .collect()
 }
 
-async fn apply_task_config_inputs(
-    task: &mut Task,
+async fn resolve_task_config_inputs(
+    task: &Task,
     config: &Arc<Config>,
     task_inputs: &ResolvedTaskInputs,
-) -> Result<()> {
+) -> Result<Option<ResolvedTaskInputs>> {
     let has_group_references = task
         .sources
         .iter()
         .any(|source| source.starts_with(TASK_INPUT_GROUP_PREFIX));
     if task_inputs.is_empty() && !has_group_references {
-        return Ok(());
+        return Ok(None);
     }
     Settings::get().ensure_experimental("task input groups")?;
 
@@ -2515,23 +2517,33 @@ async fn apply_task_config_inputs(
         )),
         None => None,
     };
-    let task_inputs = ResolvedTaskInputs {
+    Ok(Some(ResolvedTaskInputs {
         global_inputs,
         input_groups,
-    };
-    let had_sources = !task.sources.is_empty();
-    let mut sources = expand_task_inputs(
+    }))
+}
+
+fn apply_task_input_groups(task: &mut Task, task_inputs: &ResolvedTaskInputs) -> Result<()> {
+    task.sources = expand_task_inputs(
         &task.sources,
-        &task_inputs,
+        task_inputs,
         Path::new(""),
         &task.name,
         &mut vec![],
         false,
     )?;
+    Ok(())
+}
+
+fn apply_task_global_inputs(
+    task: &mut Task,
+    task_inputs: &ResolvedTaskInputs,
+    had_sources: bool,
+) -> Result<()> {
     if let Some((global_inputs, root)) = &task_inputs.global_inputs {
-        sources.extend(expand_task_inputs(
+        task.sources.extend(expand_task_inputs(
             global_inputs,
-            &task_inputs,
+            task_inputs,
             root,
             &task.name,
             &mut vec![],
@@ -2539,9 +2551,21 @@ async fn apply_task_config_inputs(
         )?);
     }
 
-    task.sources = sources;
     if !had_sources && !task.sources.is_empty() && task.outputs.is_empty() {
         task.outputs = TaskOutputs::Auto;
+    }
+    Ok(())
+}
+
+async fn apply_task_config_inputs(
+    task: &mut Task,
+    config: &Arc<Config>,
+    task_inputs: &ResolvedTaskInputs,
+) -> Result<()> {
+    let had_sources = !task.sources.is_empty();
+    if let Some(task_inputs) = resolve_task_config_inputs(task, config, task_inputs).await? {
+        apply_task_input_groups(task, &task_inputs)?;
+        apply_task_global_inputs(task, &task_inputs, had_sources)?;
     }
     Ok(())
 }
@@ -2667,11 +2691,27 @@ fn dir_is_in_enclosing_monorepo(
         && !file::path_starts_with_resolved(dir, selected_root)
 }
 
+struct LoadedLocalTask {
+    task: Task,
+    suppress_if_global_duplicate: bool,
+}
+
+fn task_config_has_file_context(task_config: &TaskConfig) -> bool {
+    task_config.includes.is_some()
+        || task_config.dir.is_some()
+        || task_config.shell.is_some()
+        || task_config.cache.is_some()
+        || !task_config.global_env.is_empty()
+        || !task_config.global_pass_through_env.is_empty()
+        || !task_config.global_inputs.is_empty()
+        || !task_config.input_groups.is_empty()
+}
+
 async fn load_local_tasks_with_context(
     config: &Arc<Config>,
     ctx: Option<&crate::task::TaskLoadContext>,
     templates: &IndexMap<String, TaskTemplate>,
-) -> Result<Vec<Task>> {
+) -> Result<Vec<LoadedLocalTask>> {
     let mut tasks = vec![];
     let monorepo_config = find_monorepo_config(&config.config_files);
     let monorepo_root = monorepo_config.and_then(|cf| cf.project_root().map(|p| p.to_path_buf()));
@@ -2688,6 +2728,16 @@ async fn load_local_tasks_with_context(
         .as_deref()
         .map(|root| enclosing_monorepo_roots(&config.config_files, root))
         .unwrap_or_default();
+    let user_global_config_paths = global_config_files();
+    let has_user_global_config = config
+        .config_files
+        .values()
+        .any(|cf| config_set_contains(&user_global_config_paths, cf.get_path()));
+    let system_config_paths = system_config_files();
+    let has_system_config = config
+        .config_files
+        .values()
+        .any(|cf| config_set_contains(&system_config_paths, cf.get_path()));
     for d in all_dirs()? {
         if cfg!(test) && !d.starts_with(*dirs::HOME) {
             continue;
@@ -2702,13 +2752,58 @@ async fn load_local_tasks_with_context(
             );
             continue;
         }
-        let mut dir_tasks = load_tasks_in_dir(config, &d, &local_config_files, templates).await?;
+        let local_configs = configs_at_root(&d, &local_config_files);
+        let cascaded_task_config = cascaded_task_config_for_dir(&d, &local_config_files)?;
+        let mut dir_tasks = load_tasks_from_configs(
+            config,
+            &d,
+            local_configs.clone(),
+            templates,
+            false,
+            cascaded_task_config.as_ref(),
+        )
+        .await?;
+
+        let mut suppress_if_global_duplicate = false;
+        let mut local_inline_task_names = HashSet::new();
+        if (has_user_global_config || has_system_config)
+            && file::same_file(&d, &env::MISE_GLOBAL_CONFIG_ROOT)
+        {
+            let local_file_context = local_configs
+                .iter()
+                .any(|cf| task_config_has_file_context(cf.task_config()))
+                || cascaded_task_config
+                    .as_ref()
+                    .is_some_and(|tc| task_config_has_file_context(&tc.task_config));
+            if !local_file_context {
+                local_inline_task_names = local_configs
+                    .iter()
+                    .flat_map(|cf| cf.tasks())
+                    .map(|task| task.name.clone())
+                    .collect();
+                if has_user_global_config {
+                    // A user-global config owns the HOME include decision, so
+                    // omitted defaults must not be resurrected by the local
+                    // hierarchy walk.
+                    dir_tasks.retain(|task| local_inline_task_names.contains(&task.name));
+                } else {
+                    // A system config is lower precedence than local HOME
+                    // tasks. Suppress only incidental copies of sources that
+                    // the system pass actually loaded.
+                    suppress_if_global_duplicate = true;
+                }
+            }
+        }
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
         }
 
-        tasks.extend(dir_tasks);
+        tasks.extend(dir_tasks.into_iter().map(|task| LoadedLocalTask {
+            suppress_if_global_duplicate: suppress_if_global_duplicate
+                && !local_inline_task_names.contains(&task.name),
+            task,
+        }));
     }
 
     // Determine if we should load monorepo tasks from subdirectories
@@ -2834,7 +2929,10 @@ async fn load_local_tasks_with_context(
         }
 
         while let Some(result) = join_set.join_next().await {
-            tasks.extend(result??);
+            tasks.extend(result??.into_iter().map(|task| LoadedLocalTask {
+                task,
+                suppress_if_global_duplicate: false,
+            }));
         }
     }
 
@@ -3170,7 +3268,7 @@ async fn load_global_tasks(
         .await?;
         rendered_file_tasks.finish_config();
         let mut inline_tasks = IndexMap::new();
-        for task in &sources.config_tasks {
+        for task in &sources.config_task_overlays {
             inline_tasks
                 .entry(task.name.clone())
                 .or_insert_with(|| task.clone());
@@ -3322,10 +3420,11 @@ async fn load_config_tasks(
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     task_config: &ResolvedTaskConfig,
-) -> Result<Vec<Task>> {
+) -> Result<LoadedConfigTasks> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
     let mut tasks = vec![];
+    let mut overlays = vec![];
     for t in cf.tasks().into_iter() {
         let config_root = config_root.clone();
         let config = config.clone();
@@ -3341,6 +3440,8 @@ async fn load_config_tasks(
         }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
+        let has_explicit_dir = t.dir.is_some();
+        let has_explicit_shell = t.shell.is_some();
         if t.dir.is_none() {
             t.dir = task_config.dir.clone();
         }
@@ -3349,7 +3450,25 @@ async fn load_config_tasks(
         }
         match t.render(&config, &config_root).await {
             Ok(()) => {
-                apply_task_config_inputs(&mut t, &config, &task_config.inputs).await?;
+                let had_sources = !t.sources.is_empty();
+                let resolved_task_inputs =
+                    resolve_task_config_inputs(&t, &config, &task_config.inputs).await?;
+                if let Some(task_inputs) = &resolved_task_inputs {
+                    apply_task_input_groups(&mut t, task_inputs)?;
+                }
+                if is_global {
+                    let mut overlay = t.clone();
+                    if !has_explicit_dir {
+                        overlay.dir = None;
+                    }
+                    if !has_explicit_shell {
+                        overlay.shell = None;
+                    }
+                    overlays.push(overlay);
+                }
+                if let Some(task_inputs) = &resolved_task_inputs {
+                    apply_task_global_inputs(&mut t, task_inputs, had_sources)?;
+                }
                 apply_task_config_cache_default(&mut t, &task_config.cache);
                 task_config.environment.apply(&mut t)?;
                 tasks.push(t);
@@ -3367,7 +3486,7 @@ async fn load_config_tasks(
             }
         }
     }
-    Ok(tasks)
+    Ok(LoadedConfigTasks { tasks, overlays })
 }
 
 struct LoadTaskIncludesOptions<'a> {
@@ -3677,6 +3796,12 @@ pub async fn load_tasks_in_dir(
 struct TaskSources {
     file_tasks: Vec<Task>,
     config_tasks: Vec<Task>,
+    config_task_overlays: Vec<Task>,
+}
+
+struct LoadedConfigTasks {
+    tasks: Vec<Task>,
+    overlays: Vec<Task>,
 }
 
 #[derive(Clone)]
@@ -3896,20 +4021,21 @@ async fn load_task_sources_from_configs(
     };
 
     let mut config_tasks = vec![];
+    let mut config_task_overlays = vec![];
     for cf in &configs {
         let dir = dir.to_path_buf();
         let monorepo_cf = monorepo_context.then_some(*cf);
-        config_tasks.extend(
-            load_config_tasks(
-                config,
-                (*cf).clone(),
-                &dir,
-                templates,
-                monorepo_cf,
-                &task_config,
-            )
-            .await?,
-        );
+        let loaded = load_config_tasks(
+            config,
+            (*cf).clone(),
+            &dir,
+            templates,
+            monorepo_cf,
+            &task_config,
+        )
+        .await?;
+        config_tasks.extend(loaded.tasks);
+        config_task_overlays.extend(loaded.overlays);
     }
 
     let mut file_tasks = vec![];
@@ -3953,6 +4079,7 @@ async fn load_task_sources_from_configs(
     Ok(TaskSources {
         file_tasks,
         config_tasks,
+        config_task_overlays,
     })
 }
 


### PR DESCRIPTION
## Summary

- preserve first-wins task precedence across user-global config files and `conf.d` fragments
- keep independently declared global include sets without replacing the selected script context
- let the user-global pass own its default HOME task scope
- retain explicit project includes and task directories as local context

## Bugs fixed

### Lower global configs could replace higher script context

Global config files have independent task include sets. A lower config could rediscover a script selected by a higher config and provide the first inline metadata for that name. The previous aggregation replaced the selected task with the lower config's fully merged result, which also replaced higher-precedence template variables and `task_config.dir`.

### Distinct global sources could merge in the wrong direction

When one global config supplied an inline task and another supplied a different same-named script, loader-by-loader merging could allow the lower source to win or leak metadata into the higher source. User-global, `conf.d`, and system definitions did not consistently follow the same first-wins rule.

### The local HOME walk could resurrect omitted global defaults

Task discovery also walks HOME as part of the local hierarchy. If a user-global config replaced the default task include list, the local pass still discovered those omitted default scripts. They could override an explicitly included global script or appear even though the global config intentionally excluded them.

### Blanket source deduplication removed explicit local ownership

A project may explicitly include a directory that is also visible to the global pass and assign its own metadata or task directory. Removing every local/global source match discarded that intentional project context.

## Fix

- aggregate global configs in explicit high-to-low order while retaining each config's include set
- overlay only the raw winning inline definition when two global results resolve to the same script
- preserve the selected script's config root, variables, and task directory
- make the user-global pass authoritative for incidental default discovery at the global root
- retain file sources supplied through an explicit local include or task directory

## Impact

User-global tasks behave consistently from inside and outside HOME. Replacing global includes no longer leaks omitted defaults, while projects can still intentionally reuse a global script with local metadata and execution context.

## Stack

Stacked on #11204, which provides safe source identity and deduplication. That PR is stacked on #11103.

## Tests

- `mise run test:e2e e2e/tasks/test_task_global_config_precedence`
- `mise run test:e2e e2e/tasks/test_task_global_include_precedence`
- `mise run test:e2e e2e/tasks/test_task_global_source_context_precedence`
- `mise run test:e2e e2e/tasks/test_task_ls_global`
- `cargo check --all-features`
- `mise run lint-fix`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task precedence across system, global includes, and project overlays, including symlinked config paths and runs from non-home directories.
  - Fixed duplicate template/script evaluations by deduplicating task/config sources deterministically (including monorepo and global include edge cases).
  - Prevented deferred template `exec` side effects during source comparison and corrected which variable context is used.
  - Improved handling of broken/relative symlink targets during path resolution.
- **Testing**
  - Added end-to-end coverage for global config/include precedence and deduplication scenarios.
- **Compatibility**
  - Ensured template rendering behavior remains consistent during source comparison via the configured Tera engine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->