### PR TITLE
fix(install): serialize logical state mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5841,6 +5841,7 @@ dependencies = [
  "rmcp",
  "rmp-serde",
  "rops",
+ "same-file",
  "seccompiler",
  "self_update",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,7 @@ rops = { version = "0.1", default-features = false, features = [
   "toml",
   "age",
 ] }
+same-file = "1"
 serde = { version = "1", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1"

--- a/e2e/backend/test_aqua_failed_install_cleanup
+++ b/e2e/backend/test_aqua_failed_install_cleanup
@@ -12,6 +12,7 @@ assert_fail "mise x tilt@9999.9999.9999 -- tilt version"
 
 # The parent installs directory should be fully cleaned up, not left empty.
 assert_directory_not_exists "$MISE_DATA_DIR/installs/tilt"
+assert "test ! -e \"$MISE_CACHE_DIR/tilt/9999.9999.9999/incomplete\""
 
 # A subsequent successful install should work correctly.
 assert_contains "mise x tilt@0.36.3 -- tilt version" "v0.36.3"

--- a/e2e/cli/test_link
+++ b/e2e/cli/test_link
@@ -14,6 +14,8 @@ assert_contains "mise ls tiny" "tiny  9.8.7 (symlink)"
 mkdir -p tmp/tiny2
 mkdir -p "$MISE_CACHE_DIR/tiny/9.9.9"
 touch "$MISE_CACHE_DIR/tiny/9.9.9/incomplete"
+mkdir -p "$MISE_CACHE_DIR/tiny/9.9.8"
+touch "$MISE_CACHE_DIR/tiny/9.9.8/incomplete"
 mise link tiny@9.9.9 tmp/tiny2
 
 # `mise ls -i` only lists versions considered installed; the linked version
@@ -21,3 +23,40 @@ mise link tiny@9.9.9 tmp/tiny2
 assert_contains "mise ls -i tiny" "tiny  9.9.9 (symlink)"
 # the stale marker should have been removed by `mise link`.
 assert "test ! -f \"$MISE_CACHE_DIR/tiny/9.9.9/incomplete\""
+# a sibling version's marker must not be affected.
+assert "test -f \"$MISE_CACHE_DIR/tiny/9.9.8/incomplete\""
+
+# Re-linking the same target should repair a newly-created stale marker without
+# requiring --force.
+touch "$MISE_CACHE_DIR/tiny/9.9.9/incomplete"
+mise link tiny@9.9.9 tmp/tiny2
+assert "test ! -f \"$MISE_CACHE_DIR/tiny/9.9.9/incomplete\""
+
+# A dangling external link is not a complete install and must keep the marker.
+mise link tiny@9.9.8 tmp/missing
+assert "test -f \"$MISE_CACHE_DIR/tiny/9.9.8/incomplete\""
+
+# Path equality alone must not treat an ordinary managed install as an existing
+# external link.
+mkdir -p "$MISE_CACHE_DIR/tiny/3.1.0"
+touch "$MISE_CACHE_DIR/tiny/3.1.0/incomplete"
+assert_fail "mise link tiny@3.1.0 \"$MISE_DATA_DIR/installs/tiny/3.1.0\""
+assert_fail "mise link --force tiny@3.1.0 \"$MISE_DATA_DIR/installs/tiny/3.1.0\""
+assert_directory_exists "$MISE_DATA_DIR/installs/tiny/3.1.0"
+assert "test -f \"$MISE_CACHE_DIR/tiny/3.1.0/incomplete\""
+
+# Request-style versions use their normalized install pathname for both the
+# symlink and incomplete marker.
+mkdir -p tmp/tiny-ref
+mkdir -p "$MISE_CACHE_DIR/tiny/ref-feature-foo"
+touch "$MISE_CACHE_DIR/tiny/ref-feature-foo/incomplete"
+mise link tiny@ref:feature/foo tmp/tiny-ref
+assert "test ! -f \"$MISE_CACHE_DIR/tiny/ref-feature-foo/incomplete\""
+assert "mise where tiny@ref:feature/foo" "$MISE_DATA_DIR/installs/tiny/ref-feature-foo"
+assert "readlink \"$MISE_DATA_DIR/installs/tiny/ref-feature-foo\"" "$PWD/tmp/tiny-ref"
+
+# Marker removal errors remain strict, while the marker itself is preserved.
+mkdir -p tmp/tiny3
+mkdir -p "$MISE_CACHE_DIR/tiny/9.9.7/incomplete"
+assert_fail "mise link tiny@9.9.7 tmp/tiny3"
+assert "test -d \"$MISE_CACHE_DIR/tiny/9.9.7/incomplete\""

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -42,7 +42,7 @@ use crate::{
     cache::{CacheManager, CacheManagerBuilder},
     plugins::PluginEnum,
 };
-use crate::{dirs, env, file, hash, lock_file, versions_host};
+use crate::{dirs, env, file, hash, versions_host};
 use async_trait::async_trait;
 use backend_type::BackendType;
 use eyre::{Result, bail, eyre};
@@ -2183,6 +2183,13 @@ pub trait Backend: Debug + Send + Sync {
             tv.install_path = Some(tv.ba().installs_path.join(tv.tv_pathname()));
         }
 
+        // Incomplete markers are keyed by logical tool/version rather than by
+        // the physical install path. Use the same logical key as link and
+        // uninstall so shared and system installs cannot have their marker
+        // cleared while an install is still in progress.
+        let state_version = tv.tv_pathname();
+        let _state_lock = install_state::lock_tool_version(&tv.ba().short, &state_version)?;
+
         let will_uninstall =
             (ctx.force || rolling_reinstall) && self.is_version_installed(&ctx.config, &tv, true);
 
@@ -2196,7 +2203,7 @@ pub trait Backend: Debug + Send + Sync {
         ctx.pr.start_operations(total_ops);
 
         if will_uninstall {
-            self.uninstall_version(&ctx.config, &tv, ctx.pr.as_ref(), false)
+            self.uninstall_version_unlocked(&ctx.config, &tv, ctx.pr.as_ref(), false)
                 .await?;
             ctx.pr.next_operation();
         } else if self
@@ -2212,18 +2219,6 @@ pub trait Backend: Debug + Send + Sync {
         versions_host::track_install(tv.short(), &tv.ba().full(), &tv.version);
 
         ctx.pr.set_message("install".into());
-        let _lock = lock_file::get(&tv.install_path(), ctx.force)?;
-
-        // Double-checked (locking) that it wasn't installed while we were waiting for the lock
-        if self
-            .is_install_satisfied_or_false(&ctx.config, &tv, true)
-            .await
-            && !ctx.force
-            && !rolling_reinstall
-        {
-            return Ok(tv);
-        }
-
         self.create_install_dirs(&tv)?;
 
         let old_tv = tv.clone();
@@ -2263,17 +2258,7 @@ pub trait Backend: Debug + Send + Sync {
                 trace!("error touching config file: {:?} {:?}", path, err);
             }
         }
-        let incomplete_path = self.incomplete_file_path(&tv);
-        if let Err(err) = file::remove_file(&incomplete_path) {
-            debug!("error removing incomplete file: {:?}", err);
-        } else {
-            // Sync parent directory to ensure file removal is immediately visible
-            if let Some(parent) = incomplete_path.parent()
-                && let Err(err) = file::sync_dir(parent)
-            {
-                debug!("error syncing incomplete file parent directory: {:?}", err);
-            }
-        }
+        install_state::clear_incomplete_marker_best_effort(&tv.ba().short, &tv.tv_pathname());
         if let Some(script) = tv.request.options().get("postinstall") {
             ctx.pr
                 .finish_with_message("running custom postinstall hook".to_string());
@@ -2437,6 +2422,25 @@ pub trait Backend: Debug + Send + Sync {
         pr: &dyn SingleReport,
         dryrun: bool,
     ) -> eyre::Result<()> {
+        let state_version = tv.tv_pathname();
+        let _state_lock = if dryrun {
+            None
+        } else {
+            Some(install_state::lock_tool_version(
+                &tv.ba().short,
+                &state_version,
+            )?)
+        };
+        self.uninstall_version_unlocked(config, tv, pr, dryrun)
+            .await
+    }
+    async fn uninstall_version_unlocked(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        pr: &dyn SingleReport,
+        dryrun: bool,
+    ) -> eyre::Result<()> {
         pr.set_message("uninstall".into());
 
         if !dryrun {
@@ -2537,9 +2541,18 @@ pub trait Backend: Debug + Send + Sync {
     }
     fn cleanup_install_dirs_on_error(&self, tv: &ToolVersion) {
         if !Settings::get().always_keep_install {
-            let _ = remove_all_with_warning(tv.install_path());
-            // Clean up the incomplete marker from cache
-            let _ = file::remove_file(self.incomplete_file_path(tv));
+            let install_path = tv.install_path();
+            let install_removed = remove_all_with_warning(&install_path).is_ok()
+                && matches!(
+                    std::fs::symlink_metadata(&install_path),
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound
+                );
+            if install_removed {
+                install_state::clear_incomplete_marker_best_effort(
+                    &tv.ba().short,
+                    &tv.tv_pathname(),
+                );
+            }
             // Remove parent installs dir if it's now empty (no other versions present)
             let installs_path = &self.ba().installs_path;
             if installs_path.exists()

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -7,7 +7,7 @@ use eyre::bail;
 use path_absolutize::Absolutize;
 
 use crate::file::{make_symlink, remove_all};
-use crate::toolset::install_state;
+use crate::toolset::{ToolVersion, install_state};
 use crate::{cli::args::ToolArg, config::Config};
 use crate::{config, file};
 
@@ -33,8 +33,11 @@ pub struct Link {
 
 impl Link {
     pub async fn run(self) -> Result<()> {
-        let version = match self.tool.tvr {
-            Some(ref tvr) => tvr.version(),
+        let version_pathname = match self.tool.tvr {
+            Some(ref tvr) => {
+                let version = tvr.version();
+                ToolVersion::new(tvr.clone(), version).tv_pathname()
+            }
             None => bail!("must provide a version for {}", self.tool.style()),
         };
         let path = self.path.absolutize()?;
@@ -44,27 +47,33 @@ impl Link {
                 style(path.to_string_lossy()).cyan().for_stderr()
             );
         }
-        let target = self.tool.ba.installs_path.join(&version);
-        if target.exists() {
-            if self.force {
-                remove_all(&target)?;
-            } else {
-                return Err(eyre!(
-                    "Tool version {} already exists, use {} to overwrite",
-                    self.tool.style(),
-                    style("--force").yellow().for_stderr()
-                ));
+        let target = self.tool.ba.installs_path.join(&version_pathname);
+        if file::paths_eq(&path, &target) {
+            bail!("cannot link {} to its own install path", self.tool.style());
+        }
+        {
+            let _state_lock =
+                install_state::lock_tool_version(&self.tool.ba.short, &version_pathname)?;
+            if !file::is_symlink_to(&target, &path) {
+                if target.exists() {
+                    if self.force {
+                        remove_all(&target)?;
+                    } else {
+                        return Err(eyre!(
+                            "Tool version {} already exists, use {} to overwrite",
+                            self.tool.style(),
+                            style("--force").yellow().for_stderr()
+                        ));
+                    }
+                }
+                file::create_dir_all(target.parent().unwrap())?;
+                make_symlink(&path, &target)?;
+            }
+
+            if path.exists() {
+                install_state::clear_incomplete_marker(&self.tool.ba.short, &version_pathname)?;
             }
         }
-        file::create_dir_all(target.parent().unwrap())?;
-        make_symlink(&path, &target)?;
-
-        // A linked tool is complete by definition. Clear any stale `incomplete`
-        // marker left in the cache by a previously-interrupted install so that
-        // `mise use`/`mise doctor` don't treat the linked version as missing.
-        // See discussion #3539.
-        let incomplete = install_state::incomplete_file_path(&self.tool.ba.short, &version);
-        let _ = file::remove_file(&incomplete);
 
         let config = Config::reset().await?;
         let ts = config.get_toolset().await?;

--- a/src/file.rs
+++ b/src/file.rs
@@ -654,6 +654,20 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
     }
 }
 
+pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
+    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
+}
+
+#[cfg(unix)]
+pub fn is_symlink_or_junction(path: &Path) -> bool {
+    path.is_symlink()
+}
+
+#[cfg(windows)]
+pub fn is_symlink_or_junction(path: &Path) -> bool {
+    path.is_symlink() || junction::get_target(path).is_ok()
+}
+
 #[cfg(unix)]
 pub fn make_symlink_or_file(target: &Path, link: &Path) -> Result<()> {
     make_symlink(target, link)?;

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -2,6 +2,7 @@ use crate::backend::backend_type::BackendType;
 use crate::cli::args::BackendArg;
 use crate::file::display_path;
 use crate::git::Git;
+use crate::lock_file::LockFile;
 use crate::plugins::PluginType;
 use crate::toolset::{EPHEMERAL_OPT_KEYS, parse_tool_options};
 use crate::{dirs, env, file, runtime_symlinks};
@@ -605,6 +606,52 @@ pub fn incomplete_file_path(short: &str, v: &str) -> PathBuf {
         .join("incomplete")
 }
 
+fn tool_version_lock(short: &str, v: &str) -> LockFile {
+    LockFile::new(&incomplete_file_path(short, v))
+}
+
+/// Acquires the transaction lock for one logical tool version.
+///
+/// The incomplete marker is shared by local, shared, and system install paths,
+/// so install, uninstall, and link use this logical identity while mutating the
+/// marker and install path. The marker path is only the lock identity; the
+/// lock itself remains a separate stable file under the lockfiles cache.
+pub(crate) fn lock_tool_version(short: &str, v: &str) -> Result<fslock::LockFile> {
+    tool_version_lock(short, v)
+        .with_callback(|lock| {
+            debug!("waiting for tool-version lock on {}", display_path(lock));
+        })
+        .lock()
+}
+
+pub fn clear_incomplete_marker(short: &str, v: &str) -> Result<()> {
+    let incomplete_path = incomplete_file_path(short, v);
+    match file::remove_file(&incomplete_path) {
+        std::result::Result::Ok(()) => {
+            if let Some(parent) = incomplete_path.parent()
+                && let Err(err) = file::sync_dir(parent)
+            {
+                debug!("error syncing incomplete marker parent: {:?}", err);
+            }
+            Ok(())
+        }
+        Err(err)
+            if err
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|err| err.kind() == std::io::ErrorKind::NotFound) =>
+        {
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+pub fn clear_incomplete_marker_best_effort(short: &str, v: &str) {
+    if let Err(err) = clear_incomplete_marker(short, v) {
+        debug!("error clearing incomplete marker: {:?}", err);
+    }
+}
+
 /// Path to the checksum file for a specific tool version
 /// Used to track changes in rolling releases (like "nightly")
 fn checksum_file_path(short: &str, v: &str) -> PathBuf {
@@ -643,10 +690,45 @@ pub fn reset() {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_version_for_sort;
+    use super::{lock_tool_version, normalize_version_for_sort, tool_version_lock};
     use itertools::Itertools;
     use std::collections::BTreeMap;
+    use std::sync::mpsc;
+    use std::time::Duration;
     use versions::Versioning;
+
+    #[test]
+    fn tool_version_locks_serialize_logical_versions() {
+        let short = format!("lock_test_{}", std::process::id());
+        let first = lock_tool_version(&short, "1.0.0").unwrap();
+        let (waiting_tx, waiting_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let thread_short = short.replace('_', "-");
+        let waiter = std::thread::spawn(move || {
+            let lock = tool_version_lock(&thread_short, "1.0.0")
+                .with_callback(move |_| waiting_tx.send(()).unwrap())
+                .lock()
+                .unwrap();
+            acquired_tx.send(()).unwrap();
+            drop(lock);
+        });
+
+        // The callback proves the second lock reached the contended lock rather
+        // than merely losing a scheduling race with this assertion.
+        waiting_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(matches!(
+            acquired_rx.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+
+        // A different logical version is independent even while the first is held.
+        let other = lock_tool_version(&short, "2.0.0").unwrap();
+        drop(other);
+        drop(first);
+
+        acquired_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        waiter.join().unwrap();
+    }
 
     #[test]
     fn test_normalize_version_for_sort() {


### PR DESCRIPTION
## Summary

- serialize install, forced reinstall, uninstall, and `mise link` mutations with one logical tool-version transaction lock
- normalize backend aliases so equivalent names share one state lock
- keep incomplete-marker transitions atomic with their corresponding install-path changes
- hold the transaction lock through custom postinstall hooks so the install path cannot be mutated concurrently while a hook uses it

## Why

The existing install-path lock can be bypassed by `--force`, while incomplete markers are keyed by logical tool and version rather than physical install path. Concurrent install, uninstall, and link operations could therefore mutate the same logical state independently, leaving the install path and marker out of sync.

This replaces the install flow's bypassable physical-path lock with one non-bypassable logical transaction lock shared by install, uninstall, and link. The lock identity is derived from the existing incomplete-marker path, so local, shared, and system installs coordinate without duplicating marker normalization. Cleanup only clears an incomplete marker after confirming the failed install path was actually removed. The lock remains held through the postinstall hook because the hook may still read or mutate the newly installed path; releasing it earlier would let a concurrent link or uninstall replace that path mid-hook.

## Testing

- `cargo check --all-features`
- `cargo test tool_version_locks_serialize_logical_versions --all-features`
- `mise run test:e2e e2e/cli/test_link e2e/backend/test_aqua_failed_install_cleanup`
- `mise run test:e2e e2e/cli/test_install_postinstall_bin_path`
- `/usr/bin/mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup after failed installs by better managing version-specific incomplete markers.
  - Fixed `mise link` with stale/incomplete markers, including correct marker repair and preserving markers for dangling/invalid targets.
  - Avoided unnecessary overwrites by detecting existing symlinks and Windows junctions more reliably, and tightened failure handling when marker removal fails.
- **Reliability**
  - Reduced conflicting operations by using logical per-tool/version locking across install, link, and uninstall.
- **Tests**
  - Expanded e2e coverage for failed-install cleanup and `mise link` marker scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->