### PR TITLE
chore(docker): install cmake in builder image

### DIFF
--- a/packaging/mise/Dockerfile
+++ b/packaging/mise/Dockerfile
@@ -7,6 +7,8 @@ LABEL org.opencontainers.image.licenses=MIT
 
 WORKDIR /usr/src/mise
 COPY . /usr/src/mise/
+RUN apt-get update && apt-get install -y --no-install-recommends cmake \
+    && rm -rf /var/lib/apt/lists/*
 RUN cargo build --release
 
 FROM rust@sha256:9a2cd304a852f05d3352f75bc2775242371c0169a72dbb40d5d881379d571989 AS runtime


### PR DESCRIPTION
## Summary

- install CMake in the mise Docker builder stage
- keep the runtime image unchanged

## Root cause

The `v2026.7.12` Docker workflow failed for both amd64 and arm64 while building `libz-ng-sys v1.1.29`. That crate now invokes CMake, but the Rust builder image did not include it.

## Impact

Docker Hub and GHCR multi-architecture release images can build successfully again.

## Validation

- `git diff --check`
- `docker build --target builder -t mise-ci-fix-test .`

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only change to the Docker builder stage; no runtime behavior, auth, or application logic is affected.
> 
> **Overview**
> Fixes **multi-arch Docker release builds** that started failing when `libz-ng-sys` began requiring CMake during `cargo build --release`.
> 
> The **builder** stage in `packaging/mise/Dockerfile` now runs `apt-get install cmake` (with list cleanup) **before** `cargo build`. The **runtime** stage is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a962ee0c9f19c8e6a8a061c9d82f0a498054a9e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to support projects requiring CMake.
  * Reduced leftover package metadata to help keep build images smaller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->