### PR TITLE
chore(ci): remove redundant main push tests

### DIFF
--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -52,21 +52,8 @@ jobs:
       - run: echo "$HOME/bin" >> "$GITHUB_PATH"
       - id: versions
         run: |
-          #echo "main=$(git rev-parse --short origin/main)" >> "$GITHUB_OUTPUT"
           echo "release=$(mise-release v | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-      #- uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-      #  with:
-      #    path: ~/bin/mise-${{ steps.versions.outputs.main }}
-      #    key: mise-hyperfine-main-${{ steps.versions.outputs.main }}-${{ runner.os }}-${{ runner.arch }}
-      #- name: build main
-      #  run: |
-      #    if [ ! -f "$HOME/bin/mise-${{ steps.versions.outputs.main }}" ]; then
-      #      git checkout main
-      #      cargo build --profile serious && mv target/serious/mise "$HOME/bin/mise-${{ steps.versions.outputs.main }}"
-      #      git checkout -
-      #    fi
       - run: mv "$HOME/bin/mise-release" "$HOME/bin/mise-${{ steps.versions.outputs.release }}"
-      #- run: cp "$HOME/bin/mise-${{ steps.versions.outputs.main }}" "$HOME/bin/mise-main"
       - run: cargo build --profile serious && mv target/serious/mise "$HOME/bin"
       - uses: ./.github/actions/mise-tools
       - run: |

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "crates/vfox/**"
   push:
-    branches: [main, release]
+    branches: [release]
 
 concurrency:
   group: test-vfox-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on:
   push:
     tags: ["v*"]
-    branches: ["main", "mise", "release"]
+    branches: ["mise", "release"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,7 +1,5 @@
 name: zizmor
 on:
-  push:
-    branches: [main]
   pull_request:
     paths: [".github/workflows/**"]
 


### PR DESCRIPTION
## Summary

- stop running the full test workflow on pushes to `main`
- stop running vfox tests on pushes to `main`
- stop running zizmor on pushes to `main`
- remove the stale commented-out `origin/main` hyperfine comparison
- retain pull request validation, release/tag testing, docs deployment, and release automation

## Why

These verification jobs already run before merge on pull requests, so rerunning them after every push to `main` duplicates CI work without adding coverage to the current workflow.

## Validation

- `actionlint .github/workflows/test.yml .github/workflows/test-vfox.yml .github/workflows/zizmor.yml .github/workflows/hyperfine.yml`
- `git diff --check origin/main...HEAD`

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger-only changes; PR validation and release/tag CI are unchanged, so merge gates remain but post-merge `main` push coverage is reduced.
> 
> **Overview**
> **Stops re-running heavy CI on every push to `main`** by narrowing workflow triggers while keeping PR checks and release/tag paths.
> 
> `test.yml` no longer runs on `main` pushes (still on PRs to `main`, tags `v*`, and `mise`/`release` branches). `test-vfox.yml` drops `main` from push triggers, leaving `release` only. `zizmor.yml` now runs only on pull requests that touch `.github/workflows/**`, not on `main` pushes.
> 
> In `hyperfine.yml`, removes dead commented steps that compared benchmarks against a built `origin/main` binary and related cache setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51860f3cfe0d82416dfad318208b2e3486ada4b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers to run only for relevant branches and pull request changes.
  * Reduced unnecessary workflow executions on the default branch.
  * Applied minor formatting cleanup to the release benchmarking workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->