### PR TITLE
chore: release 2026.7.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## [2026.7.13](https://github.com/jdx/mise/compare/v2026.7.12..v2026.7.13) - 2026-07-24
+
+### 🚀 Features
+
+- **(backend)** support renaming multiple binaries via rename_exe table form by @jdx in [#11231](https://github.com/jdx/mise/pull/11231)
+- **(brew)** support cask shell completions by @jdx in [#11198](https://github.com/jdx/mise/pull/11198)
+- **(go)** support go.mod as idiomatic version file by @JamBalaya56562 in [#11213](https://github.com/jdx/mise/pull/11213)
+- **(task)** pass -NoProfile to PowerShell task shells by @jdx in [#11199](https://github.com/jdx/mise/pull/11199)
+
+### 🐛 Bug Fixes
+
+- **(bootstrap)** strip "./" from relative [bootstrap.repos] paths by @lilienblum in [#11214](https://github.com/jdx/mise/pull/11214)
+- **(brew)** handle cask flight steps and zap receipts by @jdx in [#11197](https://github.com/jdx/mise/pull/11197)
+- **(brew)** remove protected cask app backups by @jdx in [#11219](https://github.com/jdx/mise/pull/11219)
+- **(env)** resolve _.path/_.file/_.source directives in written order by @JamBalaya56562 in [#11163](https://github.com/jdx/mise/pull/11163)
+- **(http)** return an error instead of panicking on invalid URLs by @Marukome0743 in [#11160](https://github.com/jdx/mise/pull/11160)
+- **(install)** serialize logical state mutations by @risu729 in [#11207](https://github.com/jdx/mise/pull/11207)
+- **(install)** don't report failed installs as "installed but not activated" by @jdx in [#11227](https://github.com/jdx/mise/pull/11227)
+- **(lockfile)** don't flag already-installed upgrades as provenance regressions by @jdx in [#11230](https://github.com/jdx/mise/pull/11230)
+- **(npm)** surface aube install error chain instead of opaque message by @jdx in [#11226](https://github.com/jdx/mise/pull/11226)
+- **(python)** add python3 executable on Windows by @jdx in [#11212](https://github.com/jdx/mise/pull/11212)
+- **(python)** deprecate virtualenv tool option in favor of _.python.venv by @JamBalaya56562 in [#11234](https://github.com/jdx/mise/pull/11234)
+- **(ruby)** bypass versions host for custom precompiled releases by @risu729 in [#11154](https://github.com/jdx/mise/pull/11154)
+- **(ruby)** accept multi-digit versions in Gemfile parse by @capnregex in [#11229](https://github.com/jdx/mise/pull/11229)
+- **(settings)** avoid panic when parent key is an inline table by @Marukome0743 in [#11184](https://github.com/jdx/mise/pull/11184)
+- **(task)** preserve inline overlay precedence by @risu729 in [#11103](https://github.com/jdx/mise/pull/11103)
+- **(task)** fix source freshness for workspace-rooted patterns in subproject tasks by @rabadin in [#11202](https://github.com/jdx/mise/pull/11202)
+- align self-update TLS backend with feature activation by @bltavares in [#10834](https://github.com/jdx/mise/pull/10834)
+
+### 📚 Documentation
+
+- **(python)** clarify uv_venv_auto requires a uv.lock file by @jdx in [#11223](https://github.com/jdx/mise/pull/11223)
+- retarget dead registry_comment.yml link in contributing guide by @Bartok9 in [#11123](https://github.com/jdx/mise/pull/11123)
+- fix dead aqua-registry and pipx installation links by @Bartok9 in [#11167](https://github.com/jdx/mise/pull/11167)
+
+### 📦️ Dependency Updates
+
+- scope task providers by config root by @risu729 in [#11180](https://github.com/jdx/mise/pull/11180)
+- share state across provider scopes by @risu729 in [#11181](https://github.com/jdx/mise/pull/11181)
+- bump clx to 2.1.1 by @jdx in [#11233](https://github.com/jdx/mise/pull/11233)
+- update docker/login-action digest to 06fb636 by @renovate[bot] in [#11238](https://github.com/jdx/mise/pull/11238)
+- update ghcr.io/jdx/mise:alpine docker digest to 91ff6f4 by @renovate[bot] in [#11239](https://github.com/jdx/mise/pull/11239)
+- update ubuntu docker tag to resolute-20260707 by @renovate[bot] in [#11244](https://github.com/jdx/mise/pull/11244)
+- update rust docker digest to 1bcff4b by @renovate[bot] in [#11242](https://github.com/jdx/mise/pull/11242)
+- update zizmorcore/zizmor-action action to v0.6.0 by @renovate[bot] in [#11245](https://github.com/jdx/mise/pull/11245)
+- update ghcr.io/jdx/mise:rpm docker digest to fa31e49 by @renovate[bot] in [#11241](https://github.com/jdx/mise/pull/11241)
+- update ghcr.io/jdx/mise:deb docker digest to 99749e6 by @renovate[bot] in [#11240](https://github.com/jdx/mise/pull/11240)
+- update rust crate usage-lib to v3.5.6 by @renovate[bot] in [#11243](https://github.com/jdx/mise/pull/11243)
+- update jdx/mise-action digest to f10502f by @renovate[bot] in [#11253](https://github.com/jdx/mise/pull/11253)
+
+### Chore
+
+- **(ci)** remove redundant main push tests by @jdx in [#11210](https://github.com/jdx/mise/pull/11210)
+- **(ci)** double macos release build timeouts by @jdx in [330dd4a](https://github.com/jdx/mise/commit/330dd4a257eafe28af3a8c2ba91a7d96abe5564c)
+- **(docker)** install cmake in builder image by @jdx in [#11209](https://github.com/jdx/mise/pull/11209)
+
+### New Contributors
+
+- @capnregex made their first contribution in [#11229](https://github.com/jdx/mise/pull/11229)
+- @rabadin made their first contribution in [#11202](https://github.com/jdx/mise/pull/11202)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (1)
+
+- [`dyoshikawa/rulesync`](https://github.com/dyoshikawa/rulesync)
+
+#### Updated Packages (13)
+
+- [`colbymchenry/codegraph`](https://github.com/colbymchenry/codegraph)
+- [`ekristen/aws-nuke`](https://github.com/ekristen/aws-nuke)
+- [`eth-p/bat-extras`](https://github.com/eth-p/bat-extras)
+- [`getsops/sops`](https://github.com/getsops/sops)
+- [`jenkins-x/jx`](https://github.com/jenkins-x/jx)
+- [`jreleaser/jreleaser`](https://github.com/jreleaser/jreleaser)
+- [`nektro/zigmod`](https://github.com/nektro/zigmod)
+- [`ovh/venom`](https://github.com/ovh/venom)
+- [`sigstore/gitsign`](https://github.com/sigstore/gitsign)
+- [`smallstep/cli`](https://github.com/smallstep/cli)
+- [`suzuki-shunsuke/pinact`](https://github.com/suzuki-shunsuke/pinact)
+- [`uutils/coreutils`](https://github.com/uutils/coreutils)
+- [`version-fox/vfox`](https://github.com/version-fox/vfox)
+
 ## [2026.7.12](https://github.com/jdx/mise/compare/v2026.7.11..v2026.7.12) - 2026-07-22
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.12"
+version = "2026.7.13"
 dependencies = [
  "age",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.12"
+version = "2026.7.13"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.12 macos-arm64 (2026-07-22)
+2026.7.13 macos-arm64 (2026-07-24)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -24,7 +24,7 @@ _mise() {
       return 1
   fi
 
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_12.spec"
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_13.spec"
   if [[ ! -f "$spec_file" ]]; then
     mise usage >| "$spec_file"
   fi

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -9,7 +9,7 @@ _mise() {
 
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_12.spec"
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mise_2026_7_13.spec"
     if [[ ! -f "$spec_file" ]]; then
         mise usage >| "$spec_file"
     fi

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
-set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_12.spec"
+set -l spec_file "$tmpdir/usage__usage_spec_mise_2026_7_13.spec"
 if not test -f "$spec_file"
     mise usage | string collect > "$spec_file"
 end

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_12.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_13.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.12";
+  version = "2026.7.13";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "31k",
+      stars: "31.1k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.12
+Version: 2026.7.13
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.12"
+version: "2026.7.13"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "f5255a020e80ad66ef746094bfe80519ad4cd0e4"
+  "tag": "1639bafbf14e15d6585eed45623162a65171b432"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -27471,6 +27471,25 @@ packages:
             files:
               - name: codegraph
                 src: "{{.AssetWithoutExt}}/bin/codegraph.cmd"
+      - version_constraint: semver("< 1.5.0")
+        asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: codegraph
+            src: "{{.AssetWithoutExt}}/bin/codegraph"
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: codegraph
+                src: "{{.AssetWithoutExt}}/bin/codegraph.cmd"
       - version_constraint: "true"
         asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -27484,6 +27503,8 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: colbymchenry/codegraph/\.github/workflows/release\.yml
         overrides:
           - goos: windows
             format: zip
@@ -35933,6 +35954,74 @@ packages:
               - name: zencode-exec
                 src: zenroom-{{.OS}}/zencode-exec
   - type: github_release
+    repo_owner: dyoshikawa
+    repo_name: rulesync
+    description: A Utility CLI for AI Coding Agents
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v6.7.1"
+        no_asset: true
+      - version_constraint: semver("<= 3.14.0")
+        no_asset: true
+      - version_constraint: semver("<= 3.17.1")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 4.0.0")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 5.5.1")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: semver("<= 14.1.0")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        github_artifact_attestations:
+          signer_workflow: dyoshikawa/rulesync/.github/workflows/publish-assets.yml
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+  - type: github_release
     repo_owner: earendil-works
     repo_name: pi
     description: Interactive coding agent CLI
@@ -36109,7 +36198,7 @@ packages:
     description: Remove all the resources from an AWS account
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0"]
+      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0", "v3.53.0", "v3.62.1", "v3.63.0", "v3.64.3"]
         no_asset: true
       - version_constraint: Version == "v2.17.0-ek.1"
         asset: aws-nuke-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -36161,7 +36250,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.64.2")
         asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -36179,6 +36268,26 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/ekristen/aws-nuke/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - "https://github.com/ekristen/aws-nuke/.github/workflows/goreleaser.yml@refs/tags/{{.Version}}"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip
@@ -37022,6 +37131,7 @@ packages:
     repo_owner: eth-p
     repo_name: bat-extras
     description: Bash scripts that integrate bat with various command line tools
+    version_filter: Version matches "^v\\d{4}\\.\\d{2}\\.\\d{2}$"
     version_constraint: "false"
     supported_envs:
       - linux
@@ -37042,6 +37152,8 @@ packages:
       - name: bat-modules
         src: bin/bat-modules
     version_overrides:
+      - version_constraint: semver("<= 2020.10.05")
+        no_asset: true
       - version_constraint: semver("<= 2023.03.21")
         asset: bat-extras-{{ trimV .Version | replace "." "" }}.zip
       - version_constraint: semver("<= 2024.02.12")
@@ -40969,6 +41081,29 @@ packages:
     description: Simple and flexible tool for managing secrets
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v3.8.0-rc.1"
+        asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sops-{{.Version}}.checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
+              - --signature
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        slsa_provenance:
+          type: github_release
+          asset: provenance.intoto.jsonl
+        overrides:
+          - goos: windows
+            asset: sops-{{.Version}}
       - version_constraint: semver("<= 3.7.1")
         asset: sops-{{.Version}}.{{.OS}}
         format: raw
@@ -41008,7 +41143,7 @@ packages:
         overrides:
           - goos: windows
             asset: sops-{{.Version}}
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.12.2")
         asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
         format: raw
         checksum:
@@ -41021,6 +41156,28 @@ packages:
               - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
               - --signature
               - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        slsa_provenance:
+          type: github_release
+          asset: sops-{{.Version}}.intoto.jsonl
+        overrides:
+          - goos: windows
+            asset: sops-{{.Version}}.{{.Arch}}
+      - version_constraint: "true"
+        asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sops-{{.Version}}.checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: sops-{{.Version}}.checksums.sigstore.json
+            opts:
               - --certificate-identity-regexp
               - https://github.com/getsops
               - --certificate-oidc-issuer
@@ -52305,7 +52462,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.17.6")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -52323,6 +52480,28 @@ packages:
               - https://github.com/jenkins-x/jx/releases/download/{{.Version}}/jx-checksums.txt.sig
               - --certificate
               - https://github.com/jenkins-x/jx/releases/download/{{.Version}}/jx-checksums.txt.pem
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version in ["v3.17.7", "v3.17.8", "v3.17.9"]
+        no_asset: true
+      - version_constraint: "true"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: jx-checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/jenkins-x/jx/.github/workflows/jenkins-x-release.yaml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -53848,13 +54027,31 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.24.0")
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
         files:
           - name: jreleaser
             src: "{{.AssetWithoutExt}}/bin/jreleaser"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: osx
+        overrides:
+          - goos: windows
+            replacements: {}
+        slsa_provenance:
+          type: github_release
+          asset: jreleaser-all-{{trimV .Version}}.intoto.jsonl
+          source_tag: "-"
+      - version_constraint: "true"
+        asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/{{.AssetWithoutExt}}"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -68529,12 +68726,25 @@ packages:
     repo_name: zigmod
     description: Zig package manager
     version_prefix: "r"
-    asset: zigmod-{{.Arch}}-{{.OS}}
-    format: raw
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: macos
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 100")
+        asset: zigmod-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: "true"
+        asset: zigmod-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - linux
   - type: github_release
     repo_owner: neondatabase
     repo_name: neonctl
@@ -72859,11 +73069,15 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.2.0")
         asset: venom.{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         complete_windows_ext: false
+      - version_constraint: "true"
+        asset: venom.{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: owenlamont
     repo_name: ryl
@@ -83453,7 +83667,7 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.0.1-alpha")
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.14.0")
         asset: gitsign_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
         checksum:
@@ -83470,6 +83684,24 @@ packages:
             - https://token.actions.githubusercontent.com
             - --signature
             - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.sig
+      - version_constraint: Version == "v0.15.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: gitsign_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.bundle"
+          opts:
+            - --certificate-identity
+            - https://github.com/sigstore/gitsign/.github/workflows/release.yml@refs/tags/{{.Version}}
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
   - type: github_release
     repo_owner: sigstore
     repo_name: rekor
@@ -84533,7 +84765,7 @@ packages:
         src: step_{{.OS}}_{{.Arch}}/bin/step
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v0.15.1", "v0.27.0", "v0.28.1", "v0.28.4"]
+      - version_constraint: Version in ["v0.15.1", "v0.27.0", "v0.28.1", "v0.28.4", "v0.30.3-rc1"]
         no_asset: true
       - version_constraint: Version == "v0.0.1"
         asset: step_{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -84629,7 +84861,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.29.0")
         asset: step_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -84646,6 +84878,25 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/smallstep/cli/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: step_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/smallstep/workflows/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -89580,7 +89831,7 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
-      - version_constraint: "true"
+      - version_constraint: semver("<= 4.1.0")
         asset: pinact_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -89597,6 +89848,30 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/suzuki-shunsuke/pinact/releases/download/{{.Version}}/pinact_{{trimV .Version}}_checksums.txt.sig
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: pinact_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: pinact_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: pinact_{{trimV .Version}}_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
@@ -96564,6 +96839,21 @@ packages:
         files:
           - name: coreutils
             src: coreutils-{{.Arch}}-{{.OS}}/coreutils
+      - version_constraint: semver("<= 0.6.0")
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: "true"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -96575,6 +96865,12 @@ packages:
           windows: pc-windows-msvc
         overrides:
           - goos: windows
+            goarch: amd64
+            format: zip
+            replacements:
+              windows: pc-windows-gnu
+          - goos: windows
+            goarch: arm64
             format: zip
         files:
           - name: coreutils
@@ -97517,11 +97813,38 @@ packages:
   - type: github_release
     repo_owner: version-fox
     repo_name: vfox
-    description: A cross-platform and extendable version manager with support for Java, Node.js, Flutter, .Net & more
+    description: A cross-platform and extendable version manager with support for Java, Node.js, Golang, Python, Flutter, .NET & more
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.5"
         no_asset: true
+      - version_constraint: semver("<= 1.0.8")
+        asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: vfox
+            src: "{{.AssetWithoutExt}}/vfox"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/version-fox/vfox/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -97539,13 +97862,12 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "https://github\\.com/version-fox/vfox/\\.github/workflows/go-releaser\\.yml@.*"
+              - "^https://github\\.com/version-fox/vfox/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
-              - "https://token.actions.githubusercontent.com"
-              - --signature
-              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.sig
-              - --certificate
-              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.pem
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
### 🚀 Features

- **(backend)** support renaming multiple binaries via rename_exe table form by @jdx in [#11231](https://github.com/jdx/mise/pull/11231)
- **(brew)** support cask shell completions by @jdx in [#11198](https://github.com/jdx/mise/pull/11198)
- **(go)** support go.mod as idiomatic version file by @JamBalaya56562 in [#11213](https://github.com/jdx/mise/pull/11213)
- **(task)** pass -NoProfile to PowerShell task shells by @jdx in [#11199](https://github.com/jdx/mise/pull/11199)

### 🐛 Bug Fixes

- **(bootstrap)** strip "./" from relative [bootstrap.repos] paths by @lilienblum in [#11214](https://github.com/jdx/mise/pull/11214)
- **(brew)** handle cask flight steps and zap receipts by @jdx in [#11197](https://github.com/jdx/mise/pull/11197)
- **(brew)** remove protected cask app backups by @jdx in [#11219](https://github.com/jdx/mise/pull/11219)
- **(env)** resolve _.path/_.file/_.source directives in written order by @JamBalaya56562 in [#11163](https://github.com/jdx/mise/pull/11163)
- **(http)** return an error instead of panicking on invalid URLs by @Marukome0743 in [#11160](https://github.com/jdx/mise/pull/11160)
- **(install)** serialize logical state mutations by @risu729 in [#11207](https://github.com/jdx/mise/pull/11207)
- **(install)** don't report failed installs as "installed but not activated" by @jdx in [#11227](https://github.com/jdx/mise/pull/11227)
- **(lockfile)** don't flag already-installed upgrades as provenance regressions by @jdx in [#11230](https://github.com/jdx/mise/pull/11230)
- **(npm)** surface aube install error chain instead of opaque message by @jdx in [#11226](https://github.com/jdx/mise/pull/11226)
- **(python)** add python3 executable on Windows by @jdx in [#11212](https://github.com/jdx/mise/pull/11212)
- **(python)** deprecate virtualenv tool option in favor of _.python.venv by @JamBalaya56562 in [#11234](https://github.com/jdx/mise/pull/11234)
- **(ruby)** bypass versions host for custom precompiled releases by @risu729 in [#11154](https://github.com/jdx/mise/pull/11154)
- **(ruby)** accept multi-digit versions in Gemfile parse by @capnregex in [#11229](https://github.com/jdx/mise/pull/11229)
- **(settings)** avoid panic when parent key is an inline table by @Marukome0743 in [#11184](https://github.com/jdx/mise/pull/11184)
- **(task)** preserve inline overlay precedence by @risu729 in [#11103](https://github.com/jdx/mise/pull/11103)
- **(task)** fix source freshness for workspace-rooted patterns in subproject tasks by @rabadin in [#11202](https://github.com/jdx/mise/pull/11202)
- align self-update TLS backend with feature activation by @bltavares in [#10834](https://github.com/jdx/mise/pull/10834)

### 📚 Documentation

- **(python)** clarify uv_venv_auto requires a uv.lock file by @jdx in [#11223](https://github.com/jdx/mise/pull/11223)
- retarget dead registry_comment.yml link in contributing guide by @Bartok9 in [#11123](https://github.com/jdx/mise/pull/11123)
- fix dead aqua-registry and pipx installation links by @Bartok9 in [#11167](https://github.com/jdx/mise/pull/11167)

### 📦️ Dependency Updates

- scope task providers by config root by @risu729 in [#11180](https://github.com/jdx/mise/pull/11180)
- share state across provider scopes by @risu729 in [#11181](https://github.com/jdx/mise/pull/11181)
- bump clx to 2.1.1 by @jdx in [#11233](https://github.com/jdx/mise/pull/11233)
- update docker/login-action digest to 06fb636 by @renovate[bot] in [#11238](https://github.com/jdx/mise/pull/11238)
- update ghcr.io/jdx/mise:alpine docker digest to 91ff6f4 by @renovate[bot] in [#11239](https://github.com/jdx/mise/pull/11239)
- update ubuntu docker tag to resolute-20260707 by @renovate[bot] in [#11244](https://github.com/jdx/mise/pull/11244)
- update rust docker digest to 1bcff4b by @renovate[bot] in [#11242](https://github.com/jdx/mise/pull/11242)
- update zizmorcore/zizmor-action action to v0.6.0 by @renovate[bot] in [#11245](https://github.com/jdx/mise/pull/11245)
- update ghcr.io/jdx/mise:rpm docker digest to fa31e49 by @renovate[bot] in [#11241](https://github.com/jdx/mise/pull/11241)
- update ghcr.io/jdx/mise:deb docker digest to 99749e6 by @renovate[bot] in [#11240](https://github.com/jdx/mise/pull/11240)
- update rust crate usage-lib to v3.5.6 by @renovate[bot] in [#11243](https://github.com/jdx/mise/pull/11243)
- update jdx/mise-action digest to f10502f by @renovate[bot] in [#11253](https://github.com/jdx/mise/pull/11253)

### Chore

- **(ci)** remove redundant main push tests by @jdx in [#11210](https://github.com/jdx/mise/pull/11210)
- **(ci)** double macos release build timeouts by @jdx in [330dd4a](https://github.com/jdx/mise/commit/330dd4a257eafe28af3a8c2ba91a7d96abe5564c)
- **(docker)** install cmake in builder image by @jdx in [#11209](https://github.com/jdx/mise/pull/11209)

### New Contributors

- @capnregex made their first contribution in [#11229](https://github.com/jdx/mise/pull/11229)
- @rabadin made their first contribution in [#11202](https://github.com/jdx/mise/pull/11202)

## 📦 Aqua Registry Updates

### New Packages (1)

- [`dyoshikawa/rulesync`](https://github.com/dyoshikawa/rulesync)

### Updated Packages (13)

- [`colbymchenry/codegraph`](https://github.com/colbymchenry/codegraph)
- [`ekristen/aws-nuke`](https://github.com/ekristen/aws-nuke)
- [`eth-p/bat-extras`](https://github.com/eth-p/bat-extras)
- [`getsops/sops`](https://github.com/getsops/sops)
- [`jenkins-x/jx`](https://github.com/jenkins-x/jx)
- [`jreleaser/jreleaser`](https://github.com/jreleaser/jreleaser)
- [`nektro/zigmod`](https://github.com/nektro/zigmod)
- [`ovh/venom`](https://github.com/ovh/venom)
- [`sigstore/gitsign`](https://github.com/sigstore/gitsign)
- [`smallstep/cli`](https://github.com/smallstep/cli)
- [`suzuki-shunsuke/pinact`](https://github.com/suzuki-shunsuke/pinact)
- [`uutils/coreutils`](https://github.com/uutils/coreutils)
- [`version-fox/vfox`](https://github.com/version-fox/vfox)