### PR TITLE
fix(python): add python3 executable on Windows

### DIFF
--- a/e2e-win/python.Tests.ps1
+++ b/e2e-win/python.Tests.ps1
@@ -12,7 +12,8 @@ Describe 'python' {
 
         mise x python@3.12.0 -- where python
         mise x python@3.12.0 -- python --version | Should -Be "Python 3.12.0"
-        mise x python@3.12.0 -- where python3
+        $python3Path = (mise x python@3.12.0 -- where python3).Trim()
+        $python3Path | Should -Be (Join-Path $installPath 'python3.exe')
         mise x python@3.12.0 -- python3 --version | Should -Be "Python 3.12.0"
     }
 }

--- a/e2e-win/python.Tests.ps1
+++ b/e2e-win/python.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'python' {
 
         mise x python@3.12.0 -- where python
         mise x python@3.12.0 -- python --version | Should -Be "Python 3.12.0"
-        $python3Path = (mise x python@3.12.0 -- where python3).Trim()
+        $python3Path = (mise x python@3.12.0 -- where python3 | Select-Object -First 1).Trim()
         $python3Path | Should -Be (Join-Path $installPath 'python3.exe')
         mise x python@3.12.0 -- python3 --version | Should -Be "Python 3.12.0"
     }

--- a/e2e-win/python.Tests.ps1
+++ b/e2e-win/python.Tests.ps1
@@ -4,8 +4,15 @@ Describe 'python' {
         $env:MISE_PYTHON_GITHUB_ATTESTATIONS = "0"
     }
 
-    It 'executes python 3.12.0' {
+    It 'executes python and python3 for 3.12.0' {
+        mise install python@3.12.0 --force | Out-Null
+
+        $installPath = (mise where python@3.12.0).Trim()
+        (Join-Path $installPath 'python3.exe') | Should -Exist
+
         mise x python@3.12.0 -- where python
         mise x python@3.12.0 -- python --version | Should -Be "Python 3.12.0"
+        mise x python@3.12.0 -- where python3
+        mise x python@3.12.0 -- python3 --version | Should -Be "Python 3.12.0"
     }
 }

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -91,9 +91,9 @@ fn install_python3_windows(tv: &ToolVersion) -> Result<()> {
         Ok(()) => Ok(()),
         Err(e) => {
             debug!(
-                "python: hardlink {python3_exe} -> {python_exe} failed ({e}); copying executable",
-                python3_exe = python3_exe.display(),
+                "python: hardlink {python_exe} as {python3_exe} failed ({e}); copying executable",
                 python_exe = python_exe.display(),
+                python3_exe = python3_exe.display(),
             );
             std::fs::copy(&python_exe, &python3_exe)?;
             Ok(())

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -75,6 +75,32 @@ pub fn python_path(tv: &ToolVersion) -> PathBuf {
     }
 }
 
+/// Create the conventional `python3` entry next to `python.exe` on Windows.
+///
+/// The python-build-standalone Windows archives only ship `python.exe`, while
+/// cross-platform scripts commonly invoke `python3`. Keeping the alias inside
+/// the install directory lets normal PATH and shim discovery handle it just
+/// like an upstream executable.
+#[cfg(windows)]
+fn install_python3_windows(tv: &ToolVersion) -> Result<()> {
+    let python_exe = tv.install_path().join("python.exe");
+    let python3_exe = tv.install_path().join("python3.exe");
+
+    file::remove_all(&python3_exe)?;
+    match std::fs::hard_link(&python_exe, &python3_exe) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            debug!(
+                "python: hardlink {python3_exe} -> {python_exe} failed ({e}); copying executable",
+                python3_exe = python3_exe.display(),
+                python_exe = python_exe.display(),
+            );
+            std::fs::copy(&python_exe, &python3_exe)?;
+            Ok(())
+        }
+    }
+}
+
 /// Sort key for Python versions that handles miniconda's two versioning schemes correctly.
 ///
 /// Miniconda has two formats:
@@ -416,6 +442,9 @@ impl PythonPlugin {
             #[cfg(unix)]
             file::make_symlink(&install.join("bin/python3"), &install.join("bin/python"))?;
         }
+
+        #[cfg(windows)]
+        install_python3_windows(tv)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- create `python3.exe` alongside `python.exe` after extracting core Python on Windows
- prefer a hardlink and fall back to copying the executable when hardlinks are unavailable
- extend the Windows Python e2e test to verify `python3` discovery and execution

## Motivation

The python-build-standalone Windows archives only provide `python.exe`. As a result, mise cannot generate a functional `python3` shim, and Windows may instead resolve `python3` to the Microsoft Store app execution alias. Keeping the compatibility alias inside the managed Python installation allows mise's existing PATH and shim discovery to handle it normally.

This intentionally adds only `python3`; it does not emulate the `py` launcher or create a misleading `python2` alias.

Related: https://github.com/jdx/mise/discussions/7465

## Testing

- `cargo test plugins::core::python::tests`
- `mise run lint-fix`
- added Windows Pester coverage in `e2e-win/python.Tests.ps1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only post-install file alias in the Python plugin; no auth, data, or shared install-path logic changes beyond adding `python3.exe`.
> 
> **Overview**
> **Windows precompiled Python installs now get a `python3.exe` next to `python.exe`**, so scripts and mise PATH/shim resolution can use `python3` instead of hitting the Store alias or missing shims.
> 
> After extracting python-build-standalone archives, mise calls **`install_python3_windows`**: remove any stale `python3.exe`, **hardlink** from `python.exe`, and **copy** the executable if hardlinks fail. Scope is **`python3` only** (no `py` launcher or `python2`).
> 
> **Windows e2e** (`e2e-win/python.Tests.ps1`) now forces install, asserts `python3.exe` exists under the install path, and checks `where python3` and `python3 --version` via `mise x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ba7986b02c9532861f0e8bc7b17bfa0bd2e21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Windows installation so `python3` is available and resolves to the installed Python.
* **Bug Fixes**
  * Ensures `python3.exe` exists on Windows and matches the `python.exe` installation (via aliasing behavior), providing consistent version reporting.
* **Tests**
  * Expanded the Windows end-to-end test to verify both `python` and `python3` executable paths and confirm `python3 --version` reports Python 3.12.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->