### PR TITLE
feat(go): support go.mod as idiomatic version file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -420,7 +420,7 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | yarn       | `.yvmrc`, `package.json`                  |
 
 For `go.mod`, the `toolchain goX.Y.Z` directive (an exact toolchain pin) is used when present.
-Otherwise the `go X.Y` directive is used; because it declares only the *minimum* required Go
+Otherwise the `go X.Y` directive is used; because it declares only the _minimum_ required Go
 version, mise resolves it to the latest matching patch (e.g. `go 1.22` → latest `1.22.x`).
 
 In mise, these are disabled by default, see <https://github.com/jdx/mise/discussions/4345> for rationale.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -403,7 +403,7 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | deno       | `.deno-version`, `package.json`           |
 | dotnet     | `global.json`                             |
 | elixir     | `.exenv-version`                          |
-| go         | `.go-version`                             |
+| go         | `.go-version`, `go.mod`                   |
 | java       | `.java-version`, `.sdkmanrc`              |
 | node       | `.nvmrc`, `.node-version`, `package.json` |
 | npm        | `package.json`                            |
@@ -418,6 +418,10 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | terragrunt | `.terragrunt-version`                     |
 | terramate  | `.terramate-version`                      |
 | yarn       | `.yvmrc`, `package.json`                  |
+
+For `go.mod`, the `toolchain goX.Y.Z` directive (an exact toolchain pin) is used when present.
+Otherwise the `go X.Y` directive is used; because it declares only the *minimum* required Go
+version, mise resolves it to the latest matching patch (e.g. `go 1.22` → latest `1.22.x`).
 
 In mise, these are disabled by default, see <https://github.com/jdx/mise/discussions/4345> for rationale.
 

--- a/e2e/core/test_go_from_gomod
+++ b/e2e/core/test_go_from_gomod
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Read go version from go.mod (idiomatic version file, opt-in)
+# The "ignored without opt-in" case is covered by e2e/core/test_go_slow.
+
+# Enable idiomatic version files for go
+mise settings set idiomatic_version_file_enable_tools go
+
+# the `toolchain` directive is an exact pin and takes precedence over the
+# `go` directive (which is only a minimum version)
+cat >go.mod <<EOF
+module example.com/m
+
+go 1.21
+toolchain go1.21.4
+EOF
+assert "mise current go" "1.21.4"
+
+# `toolchain default` is ignored; the `go` directive is used, resolved to the
+# latest matching patch (a minimum version -> latest 1.21.x)
+cat >go.mod <<EOF
+module example.com/m
+
+go 1.21
+toolchain default
+EOF
+assert_contains "mise current go" "1.21"

--- a/e2e/core/test_go_from_gomod
+++ b/e2e/core/test_go_from_gomod
@@ -16,11 +16,13 @@ EOF
 assert "mise current go" "1.21.4"
 
 # `toolchain default` is ignored; the `go` directive is used, resolved to the
-# latest matching patch (a minimum version -> latest 1.21.x)
+# latest matching patch (a minimum version -> latest 1.21.x). Derive the expected
+# patch the same way resolution does, so the assertion tracks "latest matching".
 cat >go.mod <<EOF
 module example.com/m
 
 go 1.21
 toolchain default
 EOF
-assert_contains "mise current go" "1.21"
+latest_121="$(mise ls-remote go@1.21 | tail -1)"
+assert "mise current go" "$latest_121"

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -410,11 +410,19 @@ impl Backend for GoPlugin {
     }
 }
 
-/// Returns true if `v` is a plain numeric-dotted version like `1.22` or `1.22.5`.
-/// Pre-releases (`1.22rc1`), `default`, and other non-numeric forms are rejected so
-/// they never mis-resolve.
-fn is_go_version(v: &str) -> bool {
-    regex!(r"^[0-9]+(\.[0-9]+)*$").is_match(v)
+/// A `go` directive version: the minimum language version, `major.minor` with an
+/// optional patch (e.g. `1.22` or `1.22.5`). A bare `1` is rejected so it can't be
+/// mistaken for a version prefix that resolves to the newest Go release.
+fn is_go_directive_version(v: &str) -> bool {
+    regex!(r"^[0-9]+\.[0-9]+(\.[0-9]+)?$").is_match(v)
+}
+
+/// A `toolchain` version: a fully-qualified Go release `major.minor.patch` (e.g.
+/// `1.22.5`). Go toolchain names always carry the patch (`go1.22.5`, never `go1.22`),
+/// and pre-releases are excluded from resolution, so anything else falls back to the
+/// `go` directive rather than being used as an exact pin.
+fn is_go_toolchain_version(v: &str) -> bool {
+    regex!(r"^[0-9]+\.[0-9]+\.[0-9]+$").is_match(v)
 }
 
 /// Parse a `go.mod` file into a Go version request for idiomatic version resolution.
@@ -444,13 +452,14 @@ fn parse_gomod(body: &str) -> String {
         })
     };
 
-    // Prefer a concrete `toolchain goX.Y.Z` pin; otherwise fall back to the `go` minimum.
-    // An invalid toolchain value (e.g. `toolchain default`, a pre-release) falls through
-    // to a usable `go` directive rather than discarding the file.
+    // Prefer a fully-qualified `toolchain goX.Y.Z` pin; otherwise fall back to the `go`
+    // minimum. A malformed/partial/pre-release toolchain (e.g. `toolchain default`,
+    // `toolchain go1.22`, `toolchain go1.22rc1`) falls through to the `go` directive
+    // rather than discarding the file.
     directive_value("toolchain")
         .and_then(|v| v.strip_prefix("go").map(|s| s.to_string()))
-        .filter(|v| is_go_version(v))
-        .or_else(|| directive_value("go").filter(|v| is_go_version(v)))
+        .filter(|v| is_go_toolchain_version(v))
+        .or_else(|| directive_value("go").filter(|v| is_go_directive_version(v)))
         .unwrap_or_default()
 }
 
@@ -498,6 +507,13 @@ mod tests {
         assert_eq!(parse_gomod("go 1.22rc1\n"), "");
         // an invalid pre-release toolchain falls back to a valid `go` line
         assert_eq!(parse_gomod("go 1.21\ntoolchain go1.21rc1\n"), "1.21");
+        // a partial (not fully-qualified) toolchain is not a real toolchain name;
+        // fall back to the `go` directive
+        assert_eq!(parse_gomod("go 1.22\ntoolchain go1.22\n"), "1.22");
+        // a fully-qualified toolchain with no `go` directive is still usable
+        assert_eq!(parse_gomod("toolchain go1.22.0\n"), "1.22.0");
+        // a bare major-only directive is rejected (would resolve to the newest Go)
+        assert_eq!(parse_gomod("go 1\n"), "");
         // no version directive -> empty (file skipped)
         assert_eq!(parse_gomod("module example.com/m\n"), "");
     }

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use crate::Result;
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::static_helpers::fetch_checksum_from_file;
-use crate::backend::{Backend, VersionInfo};
+use crate::backend::{Backend, VersionInfo, normalize_idiomatic_contents};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
@@ -281,7 +281,22 @@ impl Backend for GoPlugin {
         Ok(versions)
     }
     async fn _idiomatic_filenames(&self) -> eyre::Result<Vec<String>> {
-        Ok(vec![".go-version".into()])
+        Ok(vec![".go-version".into(), "go.mod".into()])
+    }
+
+    async fn _parse_idiomatic_file(&self, path: &Path) -> eyre::Result<Vec<String>> {
+        let v = match path.file_name() {
+            Some(name) if name == "go.mod" => parse_gomod(&file::read_to_string(path)?),
+            _ => {
+                // .go-version
+                let body = normalize_idiomatic_contents(&file::read_to_string(path)?);
+                body.trim().trim_start_matches('v').to_string()
+            }
+        };
+        if v.is_empty() {
+            return Ok(vec![]);
+        }
+        Ok(vec![v])
     }
 
     async fn install_version_(
@@ -392,5 +407,98 @@ impl Backend for GoPlugin {
             conda_deps: None,
             ..Default::default()
         })
+    }
+}
+
+/// Returns true if `v` is a plain numeric-dotted version like `1.22` or `1.22.5`.
+/// Pre-releases (`1.22rc1`), `default`, and other non-numeric forms are rejected so
+/// they never mis-resolve.
+fn is_go_version(v: &str) -> bool {
+    regex!(r"^[0-9]+(\.[0-9]+)*$").is_match(v)
+}
+
+/// Parse a `go.mod` file into a Go version request for idiomatic version resolution.
+///
+/// go.mod carries two relevant directives with different semantics:
+/// - `toolchain goX.Y.Z` is the *exact* toolchain the module builds/tests with (what
+///   `go version` reports in the repo), so it takes precedence and resolves exactly.
+/// - `go X.Y` is the *minimum* required Go version. mise materializes it as a prefix,
+///   resolving to the latest matching patch (e.g. `go 1.22` -> latest `1.22.x`), which
+///   is consistent with how every other idiomatic version file (`.go-version`, etc.) is
+///   resolved and picks up patch/security updates.
+///
+/// Returns an empty string when no usable version is found (malformed, pre-release, or
+/// missing directive) so the caller skips the file rather than erroring or pinning a
+/// wrong version.
+fn parse_gomod(body: &str) -> String {
+    // Value of the first `<keyword> <value>` directive, ignoring `//` line comments.
+    let directive_value = |keyword: &str| -> Option<String> {
+        body.lines().find_map(|line| {
+            let line = line.split("//").next().unwrap_or("");
+            let mut parts = line.split_whitespace();
+            if parts.next() == Some(keyword) {
+                parts.next().map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+    };
+
+    // Prefer a concrete `toolchain goX.Y.Z` pin; otherwise fall back to the `go` minimum.
+    // An invalid toolchain value (e.g. `toolchain default`, a pre-release) falls through
+    // to a usable `go` directive rather than discarding the file.
+    directive_value("toolchain")
+        .and_then(|v| v.strip_prefix("go").map(|s| s.to_string()))
+        .filter(|v| is_go_version(v))
+        .or_else(|| directive_value("go").filter(|v| is_go_version(v)))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_gomod() {
+        // bare `go` directive -> minor version (mise resolves to the latest patch)
+        assert_eq!(
+            parse_gomod(indoc! {r#"
+                module example.com/mymodule
+                go 1.14
+                require (
+                    example.com/othermodule v1.2.3
+                )
+            "#}),
+            "1.14"
+        );
+        // `toolchain` (exact pin) takes precedence over `go` (minimum)
+        assert_eq!(
+            parse_gomod(indoc! {r#"
+                module example.com/m
+                go 1.22
+                toolchain go1.22.5
+            "#}),
+            "1.22.5"
+        );
+        // `toolchain default` is ignored -> fall back to the `go` directive
+        assert_eq!(
+            parse_gomod(indoc! {r#"
+                go 1.22
+                toolchain default
+            "#}),
+            "1.22"
+        );
+        // full patch version in the `go` directive is used as-is (resolves exactly)
+        assert_eq!(parse_gomod("go 1.21.4\n"), "1.21.4");
+        // inline `//` comments and extra whitespace are ignored
+        assert_eq!(parse_gomod("go   1.20   // set by go mod tidy\n"), "1.20");
+        // pre-releases are not resolvable -> skip the file
+        assert_eq!(parse_gomod("go 1.22rc1\n"), "");
+        // an invalid pre-release toolchain falls back to a valid `go` line
+        assert_eq!(parse_gomod("go 1.21\ntoolchain go1.21rc1\n"), "1.21");
+        // no version directive -> empty (file skipped)
+        assert_eq!(parse_gomod("module example.com/m\n"), "");
     }
 }


### PR DESCRIPTION
## Summary

Reads the Go version from `go.mod` as an idiomatic version file, addressing
discussion [#4136](https://github.com/jdx/mise/discussions/4136).

This was first added in #4312 and **reverted 4 days later** (`842d051` → `7fc9beb`). This PR re-implements it in a way that resolves both root causes of that revert.

## Why it was reverted before (and why this is different)

1. **The `go` directive is a *minimum* version, not a pin.** #4312 used `go 1.14` verbatim as the version to select, so mise forced users onto the module's floor version instead of their intended/latest one ([confirmed by a user on the revert day](https://github.com/jdx/mise/discussions/4136)).
2. **Idiomatic version files were enabled by default then**, so the change silently affected *every* Go user with a `go.mod` — a widespread regression, hence the fast revert.

Both are addressed:

- **Opt-in.** Idiomatic version files are disabled by default (#6501) and enabled per-tool (#4902). `go.mod` is only read when the user runs `mise settings add idiomatic_version_file_enable_tools go`, so unlike #4312 it cannot silently change behavior for everyone.
- **Correct version semantics.** The `toolchain goX.Y.Z` directive (an exact pin — what `go version` reports in the repo) takes precedence when present and resolves exactly. Otherwise the `go X.Y` minimum resolves as a **prefix to the latest matching patch** (e.g. `go 1.22` → latest `1.22.x`), consistent with how every other idiomatic version file is resolved (no self-sorting; the backend resolves the request string). Pre-releases and malformed values fail safe (the file is skipped).

## Changes

- `src/plugins/core/go.rs`: add `go.mod` to `_idiomatic_filenames`, override `_parse_idiomatic_file`, add `parse_gomod`/`is_go_version`, and a `#[cfg(test)]` unit test covering `toolchain` precedence, `toolchain default` fallback, full-patch `go`, comments/whitespace, pre-releases, and malformed input. Modeled on the Ruby `Gemfile` plugin as suggested in the discussion.
- `e2e/core/test_go_from_gomod`: opt-in e2e test (toolchain precedence + minimum→latest-patch). The "ignored without opt-in" case remains covered by `test_go_slow`.
- `docs/configuration.md`: add `go.mod` to the idiomatic files table and document the minimum-version semantics.

## Notes

- Behavior is unchanged unless a user explicitly opts in for `go`.
- Full build / clippy / e2e validated in CI.

*This PR was prepared by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Go projects can now use `go.mod` as an idiomatic version source alongside existing idiomatic version files.
  * `toolchain goX.Y.Z` takes priority when determining the Go version.
  * If only `go X.Y` is present (or `toolchain default` is used), it resolves to the latest matching patch release.
  * Invalid or unsupported directives are ignored.
* **Documentation**
  * Updated configuration guidance to explain `go.mod` directive interpretation and pin vs minimum behavior.
* **Tests**
  * Added end-to-end and unit test coverage for precedence, fallback behavior, and comment/whitespace and invalid-format handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->