### PR TITLE
fix(bootstrap): strip "./" from relative [bootstrap.repos] paths

### DIFF
--- a/src/system/repos.rs
+++ b/src/system/repos.rs
@@ -109,7 +109,16 @@ impl RepoRequest {
                     "relative repo path `{path_raw}` must name a directory inside the project root"
                 );
             }
-            root.join(&path)
+            // Join only the Normal segments so `./foobar` resolves to
+            // `<root>/foobar` rather than `<root>/./foobar` — a `.` component
+            // survives `Path::join` and leaks into every displayed path.
+            let mut resolved = root.to_path_buf();
+            for component in path.components() {
+                if let Component::Normal(segment) = component {
+                    resolved.push(segment);
+                }
+            }
+            resolved
         };
         let Some(url) = config.url.map(|s| s.trim().to_string()) else {
             bail!("must set `url`");
@@ -898,6 +907,15 @@ mod tests {
             .expect("relative path with a project root should resolve");
         assert_eq!(request.path, Path::new("/home/u/proj/vendor/tool"));
         assert_eq!(request.path_raw, "vendor/tool");
+
+        let request = RepoRequest::from_toml("./foobar".to_string(), config(), Some(root))
+            .expect("`./`-prefixed relative path should resolve");
+        assert_eq!(
+            request.path,
+            Path::new("/home/u/proj/foobar"),
+            "a leading `./` should not leak into the resolved path"
+        );
+        assert_eq!(request.path_raw, "./foobar");
 
         assert!(
             RepoRequest::from_toml("vendor/tool".to_string(), config(), None).is_err(),


### PR DESCRIPTION
Small follow-up to #11155.

When a `[bootstrap.repos]` entry uses a `./`-prefixed relative path, the `./` was surviving into the resolved path because `Path::join` keeps `.` components. So an entry like `"./foobar"` under `~/src/myproject` rendered everywhere as:

```
~/src/myproject/./foobar
```

...in the apply confirmation prompt, in `info!`/`warn!` messages, and in dry-run output (all of which display the resolved `RepoRequest` path).

This resolves the relative path by joining only the `Normal` components, dropping any `.` segments, so it now reads:

```
~/src/myproject/foobar
```

Validation already rejected `..`, absolute, and root segments before this point, so filtering to `Normal` segments loses nothing. This is display-only — git treats `a/./b` and `a/b` as the same directory, so existing checkouts are unaffected.

Updated the `resolves_relative_repo_paths` unit test to cover the `./`-prefixed case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resolution of repository paths beginning with `./` when used with a project root.
  * Resolved paths now display cleanly without an unnecessary leading `.` component, while preserving the original path input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
