### PR TITLE
docs: replace dead taobao node mirror example with npmmirror

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -65,6 +65,6 @@ $ mise settings always_keep_download
 # set the value of the setting "always_keep_download" to "true"
 $ mise settings always_keep_download=true
 
-# set the value of the setting "node.mirror_url" to "https://npm.taobao.org/mirrors/node"
-$ mise settings node.mirror_url https://npm.taobao.org/mirrors/node
+# set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node"
+$ mise settings node.mirror_url https://npmmirror.com/mirrors/node
 ```

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3231,8 +3231,8 @@ Examples:
     # set the value of the setting "always_keep_download" to "true"
     $ mise settings always_keep_download=true
 
-    # set the value of the setting "node.mirror_url" to "https://npm.taobao.org/mirrors/node"
-    $ mise settings node.mirror_url https://npm.taobao.org/mirrors/node
+    # set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node"
+    $ mise settings node.mirror_url https://npmmirror.com/mirrors/node
 
 """#
     flag "-a --all" help="List all settings"

--- a/src/cli/settings/mod.rs
+++ b/src/cli/settings/mod.rs
@@ -85,7 +85,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     # set the value of the setting "always_keep_download" to "true"
     $ <bold>mise settings always_keep_download=true</bold>
 
-    # set the value of the setting "node.mirror_url" to "https://npm.taobao.org/mirrors/node"
-    $ <bold>mise settings node.mirror_url https://npm.taobao.org/mirrors/node</bold>
+    # set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node"
+    $ <bold>mise settings node.mirror_url https://npmmirror.com/mirrors/node</bold>
 "#
 );


### PR DESCRIPTION
## Summary

- Replace the `mise settings` help example that still demonstrates `node.mirror_url` with the dead `https://npm.taobao.org/mirrors/node` host.
- Point the example at `https://npmmirror.com/mirrors/node`, which hosts the same `nodejs.org/dist`-compatible layout.

## Motivation

Copy-pasting the long-help example fails because `npm.taobao.org` no longer resolves. The CN community mirror moved to npmmirror years ago; mise expects a base URL that serves `v{version}/…` tarballs and `SHASUMS256.txt`.

## Verification

```text
# old host fails to resolve
curl -sS -o /dev/null -w "%{http_code}\n" -L --max-time 15 https://npm.taobao.org/mirrors/node
# → 000 / connection error

# new host serves dist layout mise joins against
curl -sS -o /dev/null -w "%{http_code}\n" -L --max-time 15   https://npmmirror.com/mirrors/node/v22.17.1/SHASUMS256.txt
# → 200

curl -sS -o /dev/null -w "%{http_code}\n" -L --max-time 15   https://npmmirror.com/mirrors/node/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
# → 200 (after CDN redirect)
```

Also updated the generated companions that mirror this help text (`mise.usage.kdl`, `docs/cli/settings.md`) so `render`/docs stay consistent with `src/cli/settings/mod.rs`.

Did NOT change: default `DEFAULT_NODE_MIRROR_URL` (`https://nodejs.org/dist/`), only the docs/help example.

## Duplicates

No open/closed PRs turned up for taobao/npmmirror `node.mirror_url` example replacement.

---

<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated CLI settings examples to use the current `npmmirror.com` Node mirror URL.
  - Synchronized the example across command help and user documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->