### PR TITLE
fix(link): reject selector-style link requests

### DIFF
--- a/e2e/cli/test_link
+++ b/e2e/cli/test_link
@@ -55,6 +55,42 @@ assert "test ! -f \"$MISE_CACHE_DIR/tiny/ref-feature-foo/incomplete\""
 assert "mise where tiny@ref:feature/foo" "$MISE_DATA_DIR/installs/tiny/ref-feature-foo"
 assert "readlink \"$MISE_DATA_DIR/installs/tiny/ref-feature-foo\"" "$PWD/tmp/tiny-ref"
 
+# Selector-style requests do not identify a stable install pathname and must be
+# rejected instead of creating an unreachable link.
+#
+# Snapshot link names because `tiny/latest` is already a valid runtime symlink;
+# every rejection below must leave the complete install-link set unchanged.
+find "$MISE_DATA_DIR/installs" -type l -print | sort >tmp/install-links-before
+assert_fail_contains "mise link tiny@prefix:9 tmp/tiny2" "only supports concrete versions and refs"
+assert "find \"$MISE_DATA_DIR/installs\" -type l -print | sort | diff -u tmp/install-links-before -"
+assert_fail_contains "mise link tiny@path:tmp/tiny2 tmp/tiny2" "only supports concrete versions and refs"
+assert "find \"$MISE_DATA_DIR/installs\" -type l -print | sort | diff -u tmp/install-links-before -"
+assert_fail_contains "mise link tiny@sub-0:9 tmp/tiny2" "only supports concrete versions and refs"
+assert "find \"$MISE_DATA_DIR/installs\" -type l -print | sort | diff -u tmp/install-links-before -"
+assert_fail_contains "mise link tiny@system tmp/tiny2" "only supports concrete versions and refs"
+assert "find \"$MISE_DATA_DIR/installs\" -type l -print | sort | diff -u tmp/install-links-before -"
+assert_fail_contains "mise link tiny@latest tmp/tiny2" "only supports concrete versions and refs"
+assert "find \"$MISE_DATA_DIR/installs\" -type l -print | sort | diff -u tmp/install-links-before -"
+assert_fail_contains "mise link zig@master tmp/tiny2" "only supports concrete versions and refs"
+assert "test ! -e \"$MISE_DATA_DIR/installs/zig/master\" && test ! -L \"$MISE_DATA_DIR/installs/zig/master\""
+assert "find \"$MISE_DATA_DIR/installs\" -type l -print | sort | diff -u tmp/install-links-before -"
+
+cat >mise.toml <<'EOF'
+[tool_alias]
+linked-tiny = "asdf:mise-plugins/mise-tiny"
+
+[tool_alias.tiny.versions]
+lts = "3.1.0"
+EOF
+assert_fail_contains "mise link tiny@lts tmp/tiny2" "only supports concrete versions and refs"
+assert "test ! -e \"$MISE_DATA_DIR/installs/tiny/lts\" && test ! -L \"$MISE_DATA_DIR/installs/tiny/lts\""
+assert "find \"$MISE_DATA_DIR/installs\" -type l -print | sort | diff -u tmp/install-links-before -"
+
+# Backend aliases must be loaded before validating whether their versions are
+# concrete.
+mise link linked-tiny@9.9.6 tmp/tiny2
+assert "readlink \"$MISE_DATA_DIR/installs/linked-tiny/9.9.6\"" "$PWD/tmp/tiny2"
+
 # Marker removal errors remain strict, while the marker itself is preserved.
 mkdir -p tmp/tiny3
 mkdir -p "$MISE_CACHE_DIR/tiny/9.9.7/incomplete"

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -7,9 +7,9 @@ use eyre::bail;
 use path_absolutize::Absolutize;
 
 use crate::file::{make_symlink, remove_all};
-use crate::toolset::{ToolVersion, install_state};
+use crate::toolset::{ToolRequest, ToolVersion, install_state};
+use crate::{backend, config, file};
 use crate::{cli::args::ToolArg, config::Config};
-use crate::{config, file};
 
 /// Symlinks a tool version into mise
 ///
@@ -33,12 +33,32 @@ pub struct Link {
 
 impl Link {
     pub async fn run(self) -> Result<()> {
-        let version_pathname = match self.tool.tvr {
-            Some(ref tvr) => {
-                let version = tvr.version();
-                ToolVersion::new(tvr.clone(), version).tv_pathname()
-            }
+        let tvr = match self.tool.tvr.as_ref() {
+            Some(tvr @ (ToolRequest::Version { .. } | ToolRequest::Ref { .. })) => tvr,
+            Some(tvr) => bail!(
+                "mise link only supports concrete versions and refs, not {}",
+                tvr.version()
+            ),
             None => bail!("must provide a version for {}", self.tool.style()),
+        };
+        let config = Config::get().await?;
+        let version_pathname = match tvr {
+            ToolRequest::Version { version, .. } => {
+                let backend = tvr.backend()?;
+                let resolved_alias = config.resolve_alias(&backend, version).await?;
+                if version == "latest"
+                    || resolved_alias != *version
+                    || backend.is_rolling_channel(version)
+                {
+                    bail!(
+                        "mise link only supports concrete versions and refs, not {}",
+                        tvr.version()
+                    );
+                }
+                ToolVersion::new(tvr.clone(), version.clone()).tv_pathname()
+            }
+            ToolRequest::Ref { .. } => ToolVersion::new(tvr.clone(), tvr.version()).tv_pathname(),
+            _ => unreachable!(),
         };
         let path = self.path.absolutize()?;
         if !path.exists() {
@@ -75,7 +95,7 @@ impl Link {
             }
         }
 
-        let config = Config::reset().await?;
+        backend::reset().await?;
         let ts = config.get_toolset().await?;
         config::rebuild_shims_and_runtime_symlinks(
             &config,


### PR DESCRIPTION
This breaks `mise link node@latest` or similar. It didn't work well before this PR, but if you prefer to keep them, I'll create another PR to fix it somehow (idk if we can).

## Summary

- allow `mise link` only for concrete version identities and explicit refs
- reject prefix, path, sub-tool, system, `latest`, configured version aliases, and backend-declared rolling channels before filesystem mutation
- load configuration before resolving configured backend aliases, then refresh only backend/install-state caches after linking so configuration is evaluated once
- cover rejected selectors, aliases, rolling channels, configured backend aliases, and no-link side effects in the link E2E test

## Why

A link creates a named managed install. Resolution selectors such as prefixes, paths, sub-tools, `system`, `latest`, aliases, and rolling channels do not identify a stable install pathname; accepting them can create links that later commands cannot address consistently.

Refs remain supported through their normalized ref pathname, and arbitrary literal labels such as `brew` remain supported when they are not aliases or backend-declared moving channels.

## Breaking changes

`mise link` previously accepted request-style selectors and moving names even though the resulting link did not reliably round-trip through later resolution. These commands now fail before creating or replacing a filesystem link:

```sh
mise link node@latest /opt/node
mise link tiny@prefix:9 ./tiny
mise link tiny@path:./tiny ./tiny
mise link tiny@sub-0:9 ./tiny
mise link tiny@system ./tiny
mise link zig@master ./zig       # backend-declared rolling channel
mise link tiny@lts ./tiny        # when `lts` is a configured version alias
```

For example, `latest` is also the name of mise's managed runtime symlink. Previously, forcing a link at that name could replace the pointer and then break installed-version resolution:

```sh
mise install node@22.17.0
readlink "$MISE_DATA_DIR/installs/node/latest"
# ./22.17.0

mise link --force node@latest /opt/node-dev
readlink "$MISE_DATA_DIR/installs/node/latest"
# /opt/node-dev

mise where node@latest
# error: mise interprets the target basename `node-dev` as a concrete version
# and looks for `$MISE_DATA_DIR/installs/node/node-dev` instead of `/opt/node-dev`
```

This also prevents mise from updating its normal `latest` pointer when newer concrete versions are installed.

Use a concrete version, an explicit ref, or an unconfigured stable label instead:

```sh
mise link node@22.17.0 /opt/node
mise link node@ref:my-build /opt/node
mise link node@external /opt/node
mise use node@external
```

Existing links are not removed by this change; it only rejects new `mise link` invocations that use non-concrete requests.

## Testing

- `/usr/bin/mise run test:e2e e2e/cli/test_link`
- `/usr/bin/mise run lint-fix`
- `hk check src/cli/link.rs e2e/cli/test_link`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `mise link` now rejects non-concrete selectors and unsupported version/ref requests with a clear constraint error.
  * Prevents creation of invalid install entries, including cases like `latest` that can’t resolve to a fixed target.
  * Backend-alias linking now produces the expected install symlinks for concrete versions, and existing valid links aren’t recreated unnecessarily.
* **Tests**
  * Extended CLI end-to-end coverage to verify invalid link attempts don’t change existing install-link sets and to confirm alias-based linking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->