### PR TITLE
fix(brew): remove protected cask app backups

### DIFF
--- a/e2e/cli/test_system_install_brew_macos_slow
+++ b/e2e/cli/test_system_install_brew_macos_slow
@@ -13,7 +13,16 @@ if [[ -e $cask_app ]] || [[ -e $caskroom ]]; then
   exit 0
 fi
 
-trap 'rm -rf "$cask_app" "$caskroom"' EXIT
+cleanup() {
+  shopt -s nullglob
+  local app_work_paths=(
+    /Applications/Hidden\ Bar.mise-old-*
+    /Applications/Hidden\ Bar.mise-tmp-*
+  )
+  chmod -RN "$cask_app" "${app_work_paths[@]}" 2>/dev/null || true
+  rm -rf "$cask_app" "$caskroom" "${app_work_paths[@]}"
+}
+trap cleanup EXIT
 
 assert_contains "mise bootstrap packages brew tap --dry-run jdx/tap" "~/.config/mise/config.toml"
 mise bootstrap packages brew tap jdx/tap
@@ -31,6 +40,19 @@ mise bootstrap packages apply --yes
 assert_directory_exists "$cask_app"
 assert_directory_exists "$caskroom"
 assert_contains "mise bootstrap packages status" "installed"
+
+# Force a reinstall while the existing app contains a delete-protected
+# directory. This exercises the complete app swap and permission-recovery path
+# without downloading the much larger docker-desktop cask.
+chmod +a "everyone deny delete_child" "$cask_app/Contents"
+rm -rf "$caskroom"
+assert_contains "mise bootstrap packages status" "missing"
+mise bootstrap packages apply --yes
+
+assert_directory_exists "$cask_app"
+assert_directory_exists "$caskroom"
+assert_contains "mise bootstrap packages status" "installed"
+assert_fail "find /Applications -maxdepth 1 -name 'Hidden Bar.mise-old-*' -print -quit | grep -q ."
 
 # aube's install docs reference jdx/tap/aube. It currently lives in
 # homebrew/core and the public jdx tap does not publish aube API metadata, so

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1,5 +1,6 @@
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+use std::process::Stdio;
 
 use async_trait::async_trait;
 use eyre::{WrapErr, bail, eyre};
@@ -716,7 +717,7 @@ fn swap_app(target: &Path, tmp_target: &Path) -> Result<()> {
         "mise-old-{}",
         crate::hash::hash_to_str(&target.display().to_string())
     ));
-    file::remove_all(&old_target)?;
+    remove_app(&old_target)?;
     if target.exists() {
         file::rename(&target, &old_target)?;
     }
@@ -727,8 +728,59 @@ fn swap_app(target: &Path, tmp_target: &Path) -> Result<()> {
         }
         return Err(e);
     }
-    file::remove_all(&old_target)?;
+    remove_app(&old_target)?;
     Ok(())
+}
+
+fn remove_app(path: &Path) -> Result<()> {
+    match file::remove_all(path) {
+        Ok(()) => return Ok(()),
+        Err(err) if !is_permission_denied(&err) => return Err(err),
+        Err(_) => {}
+    }
+
+    repair_app_permissions(path);
+    match file::remove_all(path) {
+        Ok(()) => return Ok(()),
+        Err(err) if !is_permission_denied(&err) => return Err(err),
+        Err(_) => {}
+    }
+
+    let user = nix::unistd::User::from_uid(nix::unistd::geteuid())?
+        .map(|user| user.name)
+        .ok_or_else(|| eyre!("brew-cask: could not determine current user"))?;
+    sudo::run(
+        "chown",
+        &[
+            "-R".to_string(),
+            "--".to_string(),
+            user,
+            path.display().to_string(),
+        ],
+        &[],
+    )?;
+    repair_app_permissions(path);
+    file::remove_all(path)
+}
+
+fn repair_app_permissions(path: &Path) {
+    let run = |program: &str, args: &[&str]| {
+        let _ = std::process::Command::new(program)
+            .args(args)
+            .arg(path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    };
+    run("/usr/bin/chflags", &["-R", "--", "000"]);
+    run("/bin/chmod", &["-R", "--", "u+rwx"]);
+    run("/bin/chmod", &["-R", "-N"]);
+}
+
+fn is_permission_denied(err: &eyre::Report) -> bool {
+    err.downcast_ref::<std::io::Error>()
+        .is_some_and(|err| err.kind() == std::io::ErrorKind::PermissionDenied)
 }
 
 /// Copy a directory using macOS `ditto`, which preserves resource forks, extended attributes,

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -720,12 +720,12 @@ fn swap_app(target: &Path, tmp_target: &Path) -> Result<()> {
     ));
     remove_app(&old_target)?;
     if target.exists() {
-        file::rename(&target, &old_target)?;
+        file::rename(target, &old_target)?;
     }
-    if let Err(e) = file::rename(&tmp_target, &target) {
+    if let Err(e) = file::rename(tmp_target, target) {
         // Restore the old app if the swap failed.
         if old_target.exists() {
-            let _ = file::rename(&old_target, &target);
+            let _ = file::rename(&old_target, target);
         }
         return Err(e);
     }

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -710,6 +710,7 @@ fn install_app(stage: &Path, caskroom: &Path, app: &AppArtifact) -> Result<()> {
     Ok(())
 }
 
+/// Atomically replace an app, restoring the previous bundle if activation fails.
 fn swap_app(target: &Path, tmp_target: &Path) -> Result<()> {
     // Atomic swap: rename existing target aside before putting the new one in place so that
     // a failure during rename leaves the old app intact rather than leaving nothing.
@@ -728,10 +729,18 @@ fn swap_app(target: &Path, tmp_target: &Path) -> Result<()> {
         }
         return Err(e);
     }
-    remove_app(&old_target)?;
+    // The replacement is already live. A cleanup failure must not report the
+    // install as failed or prevent install_app from removing quarantine.
+    if let Err(err) = remove_app(&old_target) {
+        warn!(
+            "brew-cask: failed to remove old app backup {}: {err:#}",
+            old_target.display()
+        );
+    }
     Ok(())
 }
 
+/// Remove an app bundle, repairing protected contents before escalating ownership.
 fn remove_app(path: &Path) -> Result<()> {
     match file::remove_all(path) {
         Ok(()) => return Ok(()),
@@ -749,6 +758,8 @@ fn remove_app(path: &Path) -> Result<()> {
     let user = nix::unistd::User::from_uid(nix::unistd::geteuid())?
         .map(|user| user.name)
         .ok_or_else(|| eyre!("brew-cask: could not determine current user"))?;
+    // Match Homebrew's final ownership-recovery step. sudo::run applies the
+    // system_packages.sudo setting and refuses to prompt without a TTY.
     sudo::run(
         "chown",
         &[
@@ -763,6 +774,7 @@ fn remove_app(path: &Path) -> Result<()> {
     file::remove_all(path)
 }
 
+/// Clear flags, restore owner permissions, and remove ACLs from an app bundle.
 fn repair_app_permissions(path: &Path) {
     let run = |program: &str, args: &[&str]| {
         let _ = std::process::Command::new(program)
@@ -778,6 +790,7 @@ fn repair_app_permissions(path: &Path) {
     run("/bin/chmod", &["-R", "-N"]);
 }
 
+/// Return whether an eyre chain originated from an I/O permission error.
 fn is_permission_denied(err: &eyre::Report) -> bool {
     err.downcast_ref::<std::io::Error>()
         .is_some_and(|err| err.kind() == std::io::ErrorKind::PermissionDenied)

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -698,6 +698,18 @@ fn install_app(stage: &Path, caskroom: &Path, app: &AppArtifact) -> Result<()> {
     ));
     file::remove_all(&tmp_target)?;
     ditto(&caskroom_app, &tmp_target)?;
+    swap_app(&target, &tmp_target)?;
+    // Remove macOS quarantine attribute so Gatekeeper doesn't block the app.
+    let _ = std::process::Command::new("xattr")
+        .args(["-r", "-d", "com.apple.quarantine"])
+        .arg(&target)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    Ok(())
+}
+
+fn swap_app(target: &Path, tmp_target: &Path) -> Result<()> {
     // Atomic swap: rename existing target aside before putting the new one in place so that
     // a failure during rename leaves the old app intact rather than leaving nothing.
     let old_target = target.with_extension(format!(
@@ -716,13 +728,6 @@ fn install_app(stage: &Path, caskroom: &Path, app: &AppArtifact) -> Result<()> {
         return Err(e);
     }
     file::remove_all(&old_target)?;
-    // Remove macOS quarantine attribute so Gatekeeper doesn't block the app.
-    let _ = std::process::Command::new("xattr")
-        .args(["-r", "-d", "com.apple.quarantine"])
-        .arg(&target)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
     Ok(())
 }
 
@@ -4548,6 +4553,45 @@ end
         };
 
         assert_eq!(cask_appdir(&[app])?, tmp.path().join("Applications"));
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn upgrades_app_with_protected_existing_contents() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let target = tmp.path().join("Docker.app");
+        let protected_dir = target.join("Contents/Resources");
+        file::create_dir_all(&protected_dir)?;
+        crate::file::write(protected_dir.join("docker"), "old")?;
+        let status = std::process::Command::new("chmod")
+            .args(["+a", "everyone deny delete_child"])
+            .arg(&protected_dir)
+            .status()?;
+        assert!(status.success());
+
+        let tmp_target = tmp.path().join("Docker.mise-tmp-test");
+        file::create_dir_all(&tmp_target)?;
+        crate::file::write(tmp_target.join("version"), "new")?;
+
+        let result = swap_app(&target, &tmp_target);
+
+        // Remove the ACL so tempfile can clean up even when the repro fails.
+        let old_target = target.with_extension(format!(
+            "mise-old-{}",
+            crate::hash::hash_to_str(&target.display().to_string())
+        ));
+        if old_target.exists() {
+            let status = std::process::Command::new("chmod")
+                .arg("-RN")
+                .arg(&old_target)
+                .status()?;
+            assert!(status.success());
+        }
+
+        result?;
+        assert_eq!(crate::file::read_to_string(target.join("version"))?, "new");
+        assert!(!old_target.exists());
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

Follow-up to discussion #11168. After the `/usr/local` binary-target fix, upgrading an existing `docker-desktop` cask could fail while deleting the app backup:

```text
failed rm -rf: /Applications/Docker.mise-old-...
Permission denied (os error 13)
```

## Root cause

The cask app swap renames the existing bundle to `.mise-old-*`, installs the new bundle, and then recursively removes the backup. Docker app bundles can contain ownership-, ACL-, or flag-protected descendants, so an ordinary unprivileged `remove_dir_all` can fail even though renaming the top-level bundle succeeded.

## Fix

Match Homebrew's permission-recovery approach when app-backup removal returns `PermissionDenied`:

1. clear file flags
2. restore owner read/write/execute permissions
3. remove ACLs
4. retry deletion
5. if ownership still blocks cleanup, use the existing controlled sudo path to take ownership, repair permissions again, and retry

Ordinary deletion remains the fast path. Permission repair and elevation are only attempted after `EACCES`.

The same cleanup is used for stale `.mise-old-*` bundles left by an interrupted or failed prior upgrade.

## Tests

- Added a macOS unit regression test with a delete-deny ACL inside an existing `Docker.app`. Before the fix it reproduced the reported `Permission denied` error; after the fix it passes.
- Extended the existing macOS CI E2E test to install the small `hiddenbar` cask, protect its installed app contents with a delete-deny ACL, force a full reinstall, and verify the app is installed without a stale `.mise-old-*` backup.
- `cargo test system::packages::brew::cask::tests -- --nocapture` — 84 passed
- `mise run test:e2e e2e/cli/test_system_install_brew_macos_slow` — local harness passes and safely skips the CI-only `/Applications` mutation; `unit-macos` exercises it on the ephemeral runner
- `mise run lint-fix`
- pre-commit `mise run lint`

*This PR was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS app upgrades by atomically swapping upgraded bundles, with safer rollback if the swap fails.
  * Enhanced cleanup of old/temporary app bundles on macOS, including handling permission/ACL restrictions that previously blocked deletion.
  * Improved macOS install reliability by removing quarantine after the swap completes.

* **Tests**
  * Added a macOS test for upgrades when the existing app’s contents deny child deletion.
  * Expanded the macOS slow Homebrew/brew-cask end-to-end test to cover forced reinstall recovery and confirm “mise-old-*”/“mise-tmp-*” leftovers are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS cask install/upgrade paths and may invoke sudo chown when deleting protected app bundles; behavior change is scoped to permission-denied removal with tests covering the swap path.
> 
> **Overview**
> Fixes **brew-cask** upgrades that could fail after the new app was already in place when deleting the `.mise-old-*` backup hit `Permission denied` (e.g. **docker-desktop** with ACL/flag-protected bundle contents).
> 
> **`install_app`** now delegates the atomic rename to **`swap_app`**, which uses **`remove_app`** for stale backups and post-swap cleanup. **`remove_app`** retries like Homebrew: clear flags, restore owner perms, strip ACLs, then optional **`sudo chown`** before another delete. If backup removal still fails after a successful swap, the install **warns** instead of failing so quarantine stripping still runs.
> 
> **Tests:** macOS unit test with a delete-deny ACL on an existing app; slow CI E2E reinstalls **hiddenbar** with protected `Contents` and asserts no leftover `.mise-old-*`; E2E **cleanup** clears ACLs on temp/old app paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41fc234cee99f5140ccd5e434dcc0580ba87d606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->