### PR TITLE
docs(python): clarify uv_venv_auto requires a uv.lock file

### DIFF
--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -80,7 +80,7 @@ mise has two ways to manage Python virtualenvs:
 | `python.uv_venv_auto` | uv projects (with `uv.lock`) | `[settings]` section |
 | `_.python.venv`       | Projects not using uv        | `[env]` section      |
 
-**`python.uv_venv_auto`** detects and sources the `.venv` managed by `uv`. Use `"source"` to only activate existing venvs, or `"create|source"` to create if missing. See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for full examples.
+**`python.uv_venv_auto`** detects and sources the `.venv` managed by `uv`. Use `"source"` to only activate existing venvs, or `"create|source"` to create if missing. mise locates the uv project by walking up for a `uv.lock` file, so a `uv.lock` must be present — without one the setting does nothing. See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for full examples.
 
 **`_.python.venv`** creates/activates a venv and adds it to PATH. It works with both `mise activate` and `mise exec`. Use this for projects that don't use uv.
 
@@ -123,7 +123,7 @@ Virtualenv activation requires `mise activate` or `mise exec`. When using [shims
 
 ### `python.uv_venv_auto` setting
 
-For uv-managed projects (those with a `uv.lock` file), you can use the `python.uv_venv_auto` setting to automatically source or create the `.venv` that uv manages. See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for full examples.
+For uv-managed projects (those with a `uv.lock` file), you can use the `python.uv_venv_auto` setting to automatically source or create the `.venv` that uv manages. mise finds the project root by walking up for a `uv.lock`; the presence of that lockfile is how mise knows the project uses uv, so a `uv.lock` must be present. If no `uv.lock` is found the setting is a no-op — run `uv sync` (or `uv lock`) to generate one first. See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for full examples.
 
 ```toml [mise.toml]
 [settings]

--- a/docs/mise-cookbook/python.md
+++ b/docs/mise-cookbook/python.md
@@ -77,6 +77,10 @@ If you want `mise` to use the virtual environment created by `uv`, you can set t
 Use `"source"` to only source an existing `.venv`, or `"create|source"` to create it if missing and then source it.
 If you prefer `mise deps` to create the venv, keep it at `"source"`, enable `[deps.uv]`, and run `mise deps`.
 
+::: tip
+`mise` locates the uv project by walking up for a `uv.lock` file — that lockfile is how `mise` knows the project uses uv. A `uv.lock` must therefore be present: if none is found (for example a fresh project that hasn't been `uv sync`'d yet), the setting does nothing. Run `uv sync` (or `uv lock`) to generate one.
+:::
+
 ```toml [mise.toml]
 [settings]
 python.uv_venv_auto = "source"


### PR DESCRIPTION
## Problem

Reported in #11221. `python.uv_venv_auto` (both `"source"` and `"create|source"`) is a silent no-op unless a `uv.lock` file is present. A user with only a `pyproject.toml` got no venv, no PATH change, and no warning, and had to discover the `uv.lock` requirement by trial and error — the cookbook doesn't mention it.

## Why it works this way (intentional)

mise locates the uv project by walking up for a `uv.lock` file in `uv_root()`. **The presence of that lockfile is the signal that the project is committed to uv** — a bare `pyproject.toml` could just as easily be a poetry/pdm/hatch/setuptools project, so anchoring on it (especially with a global `uv_venv_auto` setting) would make mise create uv venvs in projects that don't use uv. The lockfile guard is deliberate.

So this is a **docs** fix, not a behavior change: document the `uv.lock` requirement where users actually look.

## Changes

- `docs/mise-cookbook/python.md` — add a tip explaining a committed `uv.lock` is required (run `uv sync`/`uv lock` to generate one)
- `docs/lang/python.md` — same clarification in the setting reference

This is essentially the reporter's suggested doc addition.

Closes #11221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no effect on mise behavior or user configuration parsing.
> 
> **Overview**
> Documents that **`python.uv_venv_auto`** only applies when mise can find a **`uv.lock`** by walking up from the current directory; without that lockfile the setting is a silent no-op.
> 
> Updates **`docs/lang/python.md`** (overview table blurb and the `python.uv_venv_auto` section) and **`docs/mise-cookbook/python.md`** (new tip before the example `mise.toml`) to explain why the lockfile is required and to tell users to run **`uv sync`** or **`uv lock`** if it is missing. No runtime or config behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec06e33f9403bad501462f2388c54c1c9e5f1d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that automatic Python virtual environment activation locates the project by walking up the directory tree to find a committed `uv.lock`.
  * Documented that the setting becomes a no-op when `uv.lock` is missing.
  * Added guidance to run `uv sync` or `uv lock` to generate `uv.lock`.
  * Added a tip in the `mise + uv` cookbook reinforcing the same `uv.lock`-based detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->