### PR TITLE
fix(install): don't report failed installs as "installed but not activated"

### DIFF
--- a/e2e/cli/test_install_inactive_hint
+++ b/e2e/cli/test_install_inactive_hint
@@ -36,3 +36,11 @@ assert_not_contains "cat '$INSTALL_ENV_LOG'" "not activated"
 # in src/toolset/tool_request_set.rs; we don't repeat it here because
 # installing node in e2e is expensive and `--dry-run` returns before the
 # inactive-tool warning would fire.)
+
+# Test: a tool whose install FAILS must NOT be reported as "installed but not
+# activated". The failure is surfaced on its own; also claiming it installed
+# is misleading (discussion #11224). `dummy@other-dummy` fails on purpose.
+INSTALL_FAIL_LOG="$TMPDIR/mise-install-fail.log"
+mise install dummy@other-dummy >"$INSTALL_FAIL_LOG" 2>&1 || true
+assert_contains "cat '$INSTALL_FAIL_LOG'" "on purpose"
+assert_not_contains_text "$(cat "$INSTALL_FAIL_LOG")" "not activated"

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -308,6 +308,11 @@ impl Install {
                     .await,
             )
         };
+        // Tools that actually installed successfully. `versions` is mutated
+        // below (retained to current versions for the lockfile/shim rebuild),
+        // so capture the set now for the "installed but not activated" warning.
+        let installed_shorts: HashSet<String> =
+            versions.iter().map(|tv| tv.short().to_string()).collect();
         // In dry-run mode, check if any tools would be installed before filtering
         if self.is_dry_run() {
             if self.dry_run_code {
@@ -347,7 +352,14 @@ impl Install {
             .await?;
         }
 
-        // Warn about tools that were installed but not in any config file
+        // Warn about tools that were installed but not in any config file.
+        // Restrict to tools that actually installed — a tool whose install
+        // failed is already reported by `install_error` below, and also
+        // claiming it was "installed but not activated" would be misleading.
+        let inactive_tools: Vec<String> = inactive_tools
+            .into_iter()
+            .filter(|t| installed_shorts.contains(t))
+            .collect();
         if !inactive_tools.is_empty() {
             let tool_list = inactive_tools.join(", ");
             let use_cmds: Vec<String> = inactive_tools


### PR DESCRIPTION
## Problem

The "installed but not activated" hint is computed from the *requested* tools and printed regardless of whether each install actually succeeded, right before the real install error. So a failed install produces a confusing double message:

```
mise WARN  npm:danger installed but not activated — it is not in any config file.
To install and activate, run:
  mise use npm:danger
mise ERROR Failed to install npm:danger@13.0.10: ...
```

The tool was **not** installed, so telling the user it "installed but not activated" and then that it failed is contradictory. Surfaced by [discussion #11224](https://github.com/jdx/mise/discussions/11224).

## Fix

Restrict the warning to tools that actually installed, by intersecting the inactive set with the successful install results. The successful set is captured right after `split_install_result` (before `versions` is retained for the lockfile/shim rebuild, which can drop CLI-only tools that aren't "current").

Successful inactive installs still get the hint; failed ones no longer do.

## Testing

Added a regression case to `e2e/cli/test_install_inactive_hint` using `dummy@other-dummy` (a fixture version that fails install on purpose) — asserts the failure is reported but "not activated" is not. Full e2e test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to warning logic in `install` with an e2e regression test; no auth, data, or install-path behavior changes beyond suppressing a misleading message.
> 
> **Overview**
> Fixes a misleading **"installed but not activated"** warning when `mise install` fails for a CLI-only tool: the hint used to be based on requested tools and could appear right before the real install error.
> 
> After install, the code now records which tools actually succeeded (`installed_shorts` from the post-`split_install_result` `versions` list, before lockfile/shim retention mutates it) and only warns for inactive tools in that set. Failed installs still surface via `install_error` without the contradictory activation hint.
> 
> Regression coverage in `e2e/cli/test_install_inactive_hint` uses `dummy@other-dummy` (intentional install failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901c36b74aa4d1a740d3c454a6dcb6d0926514d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed misleading “installed but not activated” messages appearing when tool installation fails.
  * Installation output now reports failures accurately without incorrectly suggesting the tool was installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->