### PR TITLE
fix(ruby): accept multi-digit versions in Gemfile parse

### DIFF
--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -1152,8 +1152,9 @@ fn parse_gemfile(body: &str) -> String {
     let v = regex!(r#"(.*)__ENGINE__(.*)"#)
         .replace_all(&v, "$2-$1")
         .to_string();
-    // make sure it's like "ruby-3.0.0" or "3.0.0"
-    if !regex!(r"^(\w+-)?([0-9])(\.[0-9])*$").is_match(&v) {
+    // make sure it's a version string like "3.0.0", "3.4.10", "ruby-3.0.0",
+    // or "jruby-9.4.12.0" (optional engine prefix, one or more numeric segments)
+    if !regex!(r"^(\w+-)?\d+(\.\d+)*$").is_match(&v) {
         return "".to_string();
     }
     v
@@ -1255,6 +1256,19 @@ mod tests {
         "#}),
             "2.7.2"
         );
+        // Each numeric segment may be more than one digit (e.g. 3.4.10, 4.0.6)
+        assert_eq!(
+            parse_gemfile(indoc! {r#"
+            ruby "3.4.10"
+        "#}),
+            "3.4.10"
+        );
+        assert_eq!(
+            parse_gemfile(indoc! {r#"
+            ruby "4.0.6"
+        "#}),
+            "4.0.6"
+        );
         assert_eq!(
             parse_gemfile(indoc! {r#"
             ruby '1.9.3', engine: 'jruby', engine_version: "1.6.7"
@@ -1272,6 +1286,12 @@ mod tests {
             ruby '1.9.3', :engine_version => '1.6.7', :engine => 'jruby'
         "#}),
             "jruby-1.6.7"
+        );
+        assert_eq!(
+            parse_gemfile(indoc! {r#"
+            ruby "3.3.0", engine: "jruby", engine_version: "9.4.12.0"
+        "#}),
+            "jruby-9.4.12.0"
         );
         assert_eq!(
             parse_gemfile(indoc! {r#"


### PR DESCRIPTION
### Problem

With idiomatic version files enabled for Ruby, Gemfile pins that use multi-digit version segments (e.g. `ruby "3.4.10"`) were ignored. `mise config ls` showed the Gemfile as `(none)`, and Ruby fell through to a parent/global pin. Single-digit-per-segment pins like `2.7.2` still worked; `.ruby-version` with `3.4.10` also worked.

### Cause

`parse_gemfile` validated the extracted version with a pattern that only allowed one digit per numeric segment (`([0-9])(\.[0-9])*`). Multi-digit segments failed the match and returned an empty string.

### Fix

Accept one or more digits per segment (`\d+(\.\d+)*`), still allowing an optional engine prefix (e.g. `jruby-9.4.12.0`).

### Tests

Extended `test_parse_gemfile` for `3.4.10`, `4.0.6`, and multi-digit jruby engine versions.

```bash
cargo test test_parse_gemfile --all-features
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ruby version parsing now supports multi-digit version segments, such as `3.4.10` and `4.0.6`.
  * Improved handling of engine-prefixed Ruby versions and Ruby configuration values using double quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->