### PR TITLE
feat(backend): support renaming multiple binaries via rename_exe table form

### DIFF
--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -271,6 +271,17 @@ asset_pattern = "yt-dlp_linux.zip"
 rename_exe = "yt-dlp"  # Rename the extracted binary to yt-dlp
 ```
 
+The string form renames the tool's primary binary (matched against the repo name). When an archive ships **multiple** binaries that you want to expose under clean names, use the table form instead — each key is a source name (an exact file name or a glob), and each value is the new name:
+
+```toml
+[tools."github:DanielGavin/ols"]
+version = "latest"
+# archive contains ols-x86_64-unknown-linux-gnu and odinfmt-x86_64-unknown-linux-gnu
+rename_exe = { "ols-*" = "ols", "odinfmt-*" = "odinfmt" }
+```
+
+Both binaries are renamed and become available on PATH. Missing sources are skipped with a warning, and the executable bit is restored for archives (such as ZIPs) that drop it.
+
 ::: tip
 Use `rename_exe` for archives where the binary inside has a different name than desired. Use `bin` for single binary downloads (non-archives).
 :::

--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -270,6 +270,15 @@ rename_exe = "kubectl-openunison-cli"  # Rename extracted binary for kubectl plu
 
 This works by searching for the first executable in the extracted directory (or `bin_path` if specified) and renaming it to the specified name.
 
+To rename **multiple** binaries from one archive, use the table form — each key is a source name (an exact file name or a glob) and each value is the new name:
+
+```toml
+[tools."http:mytool"]
+version = "1.0.0"
+url = "https://example.com/mytool-v{{version}}-linux.zip"
+rename_exe = { "mytool-*" = "mytool", "myhelper-*" = "myhelper" }
+```
+
 ::: tip
 Use `bin` for renaming single binary downloads, and `rename_exe` for renaming executables inside archives.
 :::

--- a/e2e/backend/test_github_rename_exe_multi_bin_table
+++ b/e2e/backend/test_github_rename_exe_multi_bin_table
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Test the table form of rename_exe: renaming multiple binaries from one archive.
+# Regression test for https://github.com/jdx/mise/discussions/8632
+# The ols zip ships two platform-suffixed binaries (ols-* and odinfmt-*) that both
+# need clean names. The string form of rename_exe can only rename one; the table
+# form renames both.
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "Skipping Linux-specific test on non-Linux OS"
+  exit 0
+fi
+
+export MISE_EXPERIMENTAL=1
+export MISE_GPG_VERIFY=false
+
+cat <<EOF >mise.toml
+[tools."github:DanielGavin/ols"]
+version = "dev-2026-05"
+asset_pattern = "ols-x86_64-unknown-linux-gnu.zip"
+rename_exe = { "ols-*" = "ols", "odinfmt-*" = "odinfmt" }
+EOF
+
+mise install
+
+install_path="$(mise where github:DanielGavin/ols)"
+
+# Both binaries should be renamed to their clean names...
+assert_directory_exists "$install_path"
+assert "test -x '$install_path/ols' && echo ok" "ok"
+assert "test -x '$install_path/odinfmt' && echo ok" "ok"
+
+# ...and the original platform-suffixed names should be gone.
+assert "test ! -e '$install_path/ols-x86_64-unknown-linux-gnu' && echo ok" "ok"
+assert "test ! -e '$install_path/odinfmt-x86_64-unknown-linux-gnu' && echo ok" "ok"
+
+# Both should be exposed on PATH.
+assert_contains "mise which ols" "/ols"
+assert_contains "mise which odinfmt" "/odinfmt"

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1727,6 +1727,15 @@ impl UnifiedGitBackend {
         }
 
         for bin_name in bins {
+            // A name with separators or parent components would resolve outside
+            // the install directories and symlink an arbitrary file onto PATH.
+            if !file::is_plain_file_name(&bin_name) {
+                warn!(
+                    "filter_bins: '{}' must be a plain file name, skipping",
+                    bin_name
+                );
+                continue;
+            }
             // Find the binary in any of the source directories
             let mut found = false;
             for dir in &src_dirs {

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -285,9 +285,16 @@ impl HttpBackend {
 
         // Include rename_exe in cache key since it modifies the extracted content.
         // Use the raw value so the table form (multi-binary rename) is captured too;
-        // `opts.rename_exe()` only stringifies the scalar form.
+        // `opts.rename_exe()` only stringifies the scalar form. Keep the readable
+        // unquoted name for the scalar form, but hash the table form so glob/quote
+        // characters (`*`, `"`, `{`, `}`) never leak into the cache directory name —
+        // those are illegal in Windows paths.
         if let Some(rename) = lookup_value_with_fallback(opts.raw(), "rename_exe") {
-            parts.push(format!("rename_{rename}"));
+            let rename_key = match rename.as_str() {
+                Some(name) => name.to_string(),
+                None => hash::hash_blake3_to_str(&rename.to_string()),
+            };
+            parts.push(format!("rename_{rename_key}"));
             // When rename_exe is used, bin_path affects where the rename happens,
             // so different bin_path values result in different cached content
             if let Some(bin_path) = opts.bin_path() {
@@ -1321,5 +1328,53 @@ mod tests {
             backend.dest_filename(file_path, &file_info, &opts),
             "code2prompt.exe"
         );
+    }
+
+    #[test]
+    fn cache_key_is_path_safe_for_scalar_and_table_rename_exe() {
+        let backend = HttpBackend {
+            ba: Arc::new(BackendArg::new_raw(
+                "http-mytool".to_string(),
+                Some("http:mytool".to_string()),
+                "mytool".to_string(),
+                None,
+                BackendResolution::new(true),
+            )),
+        };
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"archive-contents").unwrap();
+
+        // Characters that are illegal in Windows path components and must never
+        // appear in a cache directory name derived from rename_exe.
+        let illegal = ['*', '"', '{', '}', '<', '>', ':', '|', '?', '\\', ' '];
+
+        // Scalar form stays readable and path-safe.
+        let scalar_opts = crate::toolset::parse_tool_options("rename_exe=plz");
+        let scalar_key = backend
+            .cache_key(tmp.path(), &HttpOptions::new(&scalar_opts), 0)
+            .unwrap();
+        assert!(scalar_key.contains("rename_plz"), "key: {scalar_key}");
+        assert!(!scalar_key.contains(illegal), "key: {scalar_key}");
+
+        // Table form is hashed, so globs/quotes/braces never reach the path.
+        let table_opts = crate::toolset::parse_tool_options(
+            r#"rename_exe={ "ols-*" = "ols", "odinfmt-*" = "odinfmt" }"#,
+        );
+        let table_key = backend
+            .cache_key(tmp.path(), &HttpOptions::new(&table_opts), 0)
+            .unwrap();
+        assert!(
+            !table_key.contains(illegal),
+            "table cache key must be path-safe, got: {table_key}"
+        );
+
+        // Different table values must still produce different keys.
+        let other_opts =
+            crate::toolset::parse_tool_options(r#"rename_exe={ "ols-*" = "renamed" }"#);
+        let other_key = backend
+            .cache_key(tmp.path(), &HttpOptions::new(&other_opts), 0)
+            .unwrap();
+        assert_ne!(table_key, other_key);
     }
 }

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -5,10 +5,10 @@ use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
-    apply_rename_exe, clean_binary_name, ensure_plain_bin_name, eval_checksum_expr,
-    fetch_checksum_from_file, fetch_checksum_from_shasums, get_filename_from_url,
-    lookup_value_with_fallback, rename_binary_name, shasums_has_entries, template_string,
-    template_string_for_target, verify_artifact,
+    apply_rename_exe, clean_binary_name, ensure_plain_bin_name, ensure_safe_relative_bin_path,
+    eval_checksum_expr, fetch_checksum_from_file, fetch_checksum_from_shasums,
+    get_filename_from_url, lookup_value_with_fallback, rename_binary_name, shasums_has_entries,
+    template_string, template_string_for_target, verify_artifact,
 };
 use crate::backend::version_list;
 use crate::cli::args::BackendArg;
@@ -358,7 +358,7 @@ impl HttpBackend {
     ) -> Result<String> {
         // Check for explicit bin name first
         if let Some(bin_name) = opts.bin() {
-            ensure_plain_bin_name("bin", &bin_name)?;
+            ensure_safe_relative_bin_path("bin", &bin_name)?;
             return Ok(bin_name);
         }
         if let Some(rename_to) = opts.rename_exe() {
@@ -1354,7 +1354,10 @@ mod tests {
         };
         let file_path = Path::new("mytool-linux-x64");
 
-        for opt in [r#"bin="../evil""#, r#"rename_exe="a/b""#] {
+        for (opt, expected) in [
+            (r#"bin="../evil""#, "safe relative path"),
+            (r#"rename_exe="a/b""#, "plain file name"),
+        ] {
             let raw_opts = crate::toolset::parse_tool_options(opt);
             let opts = HttpOptions::new(&raw_opts);
             let file_info = FileInfo::new(file_path, &opts);
@@ -1362,10 +1365,18 @@ mod tests {
                 .dest_filename(file_path, &file_info, &opts)
                 .unwrap_err();
             assert!(
-                err.to_string().contains("plain file name"),
+                err.to_string().contains(expected),
                 "unexpected error for {opt}: {err}"
             );
         }
+
+        let raw_opts = crate::toolset::parse_tool_options(r#"bin="bin/mytool""#);
+        let opts = HttpOptions::new(&raw_opts);
+        let file_info = FileInfo::new(file_path, &opts);
+        assert_eq!(
+            backend.dest_filename(file_path, &file_info, &opts).unwrap(),
+            "bin/mytool"
+        );
     }
 
     #[test]

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -5,10 +5,10 @@ use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
-    apply_rename_exe, clean_binary_name, eval_checksum_expr, fetch_checksum_from_file,
-    fetch_checksum_from_shasums, get_filename_from_url, lookup_value_with_fallback,
-    rename_binary_name, shasums_has_entries, template_string, template_string_for_target,
-    verify_artifact,
+    apply_rename_exe, clean_binary_name, ensure_plain_bin_name, eval_checksum_expr,
+    fetch_checksum_from_file, fetch_checksum_from_shasums, get_filename_from_url,
+    lookup_value_with_fallback, rename_binary_name, shasums_has_entries, template_string,
+    template_string_for_target, verify_artifact,
 };
 use crate::backend::version_list;
 use crate::cli::args::BackendArg;
@@ -347,24 +347,28 @@ impl HttpBackend {
     // Filename determination
     // -------------------------------------------------------------------------
 
-    /// Determine the destination filename for a raw file or compressed binary
+    /// Determine the destination filename for a raw file or compressed binary.
+    /// `bin`/`rename_exe` values are joined onto the extraction directory, so a
+    /// path in either (`../evil`, `a/b`) would escape it and is rejected.
     fn dest_filename(
         &self,
         file_path: &Path,
         file_info: &FileInfo,
         opts: &HttpOptions<'_>,
-    ) -> String {
+    ) -> Result<String> {
         // Check for explicit bin name first
         if let Some(bin_name) = opts.bin() {
-            return bin_name;
+            ensure_plain_bin_name("bin", &bin_name)?;
+            return Ok(bin_name);
         }
         if let Some(rename_to) = opts.rename_exe() {
+            ensure_plain_bin_name("rename_exe", &rename_to)?;
             let source_name = if file_info.is_compressed_binary {
                 file_info.decompressed_name()
             } else {
                 file_path.file_name().unwrap().to_string_lossy().to_string()
             };
-            return rename_binary_name(&source_name, &rename_to);
+            return Ok(rename_binary_name(&source_name, &rename_to));
         }
 
         // Auto-clean the binary name
@@ -374,7 +378,7 @@ impl HttpBackend {
             file_path.file_name().unwrap().to_string_lossy().to_string()
         };
 
-        clean_binary_name(&raw_name, Some(&self.ba.tool_name))
+        Ok(clean_binary_name(&raw_name, Some(&self.ba.tool_name)))
     }
 
     // -------------------------------------------------------------------------
@@ -485,7 +489,7 @@ impl HttpBackend {
         opts: &HttpOptions<'_>,
         pr: Option<&dyn SingleReport>,
     ) -> Result<ExtractionType> {
-        let filename = self.dest_filename(file_path, file_info, opts);
+        let filename = self.dest_filename(file_path, file_info, opts)?;
         let dest_file = dest.join(&filename);
 
         // Report extraction progress (no bytes - we don't know total for extraction)
@@ -508,7 +512,7 @@ impl HttpBackend {
         opts: &HttpOptions<'_>,
         pr: Option<&dyn SingleReport>,
     ) -> Result<ExtractionType> {
-        let filename = self.dest_filename(file_path, file_info, opts);
+        let filename = self.dest_filename(file_path, file_info, opts)?;
         let dest_file = dest.join(&filename);
 
         // Report extraction progress (no bytes - we don't know total for extraction)
@@ -1332,9 +1336,36 @@ mod tests {
 
         assert!(file_info.is_compressed_binary);
         assert_eq!(
-            backend.dest_filename(file_path, &file_info, &opts),
+            backend.dest_filename(file_path, &file_info, &opts).unwrap(),
             "code2prompt.exe"
         );
+    }
+
+    #[test]
+    fn dest_filename_rejects_path_traversal_in_bin_and_rename_exe() {
+        let backend = HttpBackend {
+            ba: Arc::new(BackendArg::new_raw(
+                "http-mytool".to_string(),
+                Some("http:mytool".to_string()),
+                "mytool".to_string(),
+                None,
+                BackendResolution::new(true),
+            )),
+        };
+        let file_path = Path::new("mytool-linux-x64");
+
+        for opt in [r#"bin="../evil""#, r#"rename_exe="a/b""#] {
+            let raw_opts = crate::toolset::parse_tool_options(opt);
+            let opts = HttpOptions::new(&raw_opts);
+            let file_info = FileInfo::new(file_path, &opts);
+            let err = backend
+                .dest_filename(file_path, &file_info, &opts)
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("plain file name"),
+                "unexpected error for {opt}: {err}"
+            );
+        }
     }
 
     #[test]

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -5,9 +5,10 @@ use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::runtime_path_for_install_path;
 use crate::backend::static_helpers::{
-    clean_binary_name, eval_checksum_expr, fetch_checksum_from_file, fetch_checksum_from_shasums,
-    get_filename_from_url, rename_binary_name, rename_executable_in_dir, shasums_has_entries,
-    template_string, template_string_for_target, verify_artifact,
+    apply_rename_exe, clean_binary_name, eval_checksum_expr, fetch_checksum_from_file,
+    fetch_checksum_from_shasums, get_filename_from_url, lookup_value_with_fallback,
+    rename_binary_name, shasums_has_entries, template_string, template_string_for_target,
+    verify_artifact,
 };
 use crate::backend::version_list;
 use crate::cli::args::BackendArg;
@@ -282,8 +283,10 @@ impl HttpBackend {
             parts.push(format!("strip_{strip_components}"));
         }
 
-        // Include rename_exe in cache key since it modifies the extracted content
-        if let Some(rename) = opts.rename_exe() {
+        // Include rename_exe in cache key since it modifies the extracted content.
+        // Use the raw value so the table form (multi-binary rename) is captured too;
+        // `opts.rename_exe()` only stringifies the scalar form.
+        if let Some(rename) = lookup_value_with_fallback(opts.raw(), "rename_exe") {
             parts.push(format!("rename_{rename}"));
             // When rename_exe is used, bin_path affects where the rename happens,
             // so different bin_path values result in different cached content
@@ -535,7 +538,7 @@ impl HttpBackend {
         file::extract_archive(file_path, dest, cache_plan.file_info.format, &extract_opts)?;
 
         // Handle rename_exe option for archives
-        if let Some(rename_to) = opts.rename_exe() {
+        if let Some(rename_value) = lookup_value_with_fallback(opts.raw(), "rename_exe") {
             // When bin_path is not explicitly set, auto-detect bin/ subdirectory to match
             // the same logic used by discover_bin_paths() for PATH construction
             let search_dir = if let Some(bin_path_template) = opts.bin_path() {
@@ -551,7 +554,7 @@ impl HttpBackend {
             };
             // rsplit('/') always yields at least one element (the full string if no delimiter)
             let tool_name = self.ba.tool_name.rsplit('/').next().unwrap();
-            rename_executable_in_dir(&search_dir, &rename_to, Some(tool_name))?;
+            apply_rename_exe(&search_dir, rename_value, Some(tool_name))?;
         }
 
         Ok(ExtractionType::Archive)

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -1149,28 +1149,15 @@ impl Backend for HttpBackend {
     }
 }
 
-/// Produce a path-safe cache-key token for a `rename_exe` value. A scalar name is
-/// kept verbatim when it is safe to use as a single path component (the common
-/// case, e.g. `plz`), so cache keys stay readable and stable. Anything else — the
-/// table form, or a scalar containing path separators or Windows-invalid
-/// characters — is hashed, so nothing unsafe reaches the cache directory name.
+/// Produce a cache-key token for a `rename_exe` value. The value is always hashed
+/// rather than embedded, so nothing can leak into or alias the cache directory
+/// name — not the table form's glob/brace syntax, not path separators or
+/// Windows-invalid characters, and not trailing dots/spaces that Windows strips
+/// (which would otherwise make `tool.` and `tool` share a cache entry). The key
+/// still differs whenever the rename config differs, which is all it needs to do;
+/// the human-readable part of the cache key is the file checksum, not this token.
 fn rename_cache_token(rename: &toml::Value) -> String {
-    if let Some(name) = rename.as_str()
-        && is_path_safe_component(name)
-    {
-        return name.to_string();
-    }
     hash::hash_blake3_to_str(&rename.to_string())
-}
-
-/// Whether `s` is safe to use as a single filesystem path component on all
-/// platforms: non-empty, no path separators, and none of the characters Windows
-/// forbids in file names.
-fn is_path_safe_component(s: &str) -> bool {
-    !s.is_empty()
-        && !s.chars().any(|c| {
-            matches!(c, '/' | '\\' | '<' | '>' | ':' | '"' | '|' | '?' | '*') || c.is_control()
-        })
 }
 
 #[cfg(test)]
@@ -1365,45 +1352,38 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(tmp.path(), b"archive-contents").unwrap();
 
-        // Characters that are illegal in Windows path components and must never
-        // appear in a cache directory name derived from rename_exe.
-        let illegal = ['*', '"', '{', '}', '<', '>', ':', '|', '?', '\\', ' '];
+        // Characters that are illegal or unsafe in Windows path components and
+        // must never appear in a cache directory name derived from rename_exe.
+        let illegal = ['*', '"', '{', '}', '<', '>', ':', '|', '?', '\\', '/', ' '];
 
-        // Scalar form stays readable and path-safe.
-        let scalar_opts = crate::toolset::parse_tool_options("rename_exe=plz");
-        let scalar_key = backend
-            .cache_key(tmp.path(), &HttpOptions::new(&scalar_opts), 0)
-            .unwrap();
-        assert!(scalar_key.contains("rename_plz"), "key: {scalar_key}");
-        assert!(!scalar_key.contains(illegal), "key: {scalar_key}");
+        let key_for = |opt: &str| {
+            let opts = crate::toolset::parse_tool_options(opt);
+            backend
+                .cache_key(tmp.path(), &HttpOptions::new(&opts), 0)
+                .unwrap()
+        };
 
-        // A scalar containing path separators / illegal characters is hashed,
-        // so it never produces a nested path or a Windows-invalid component.
-        let unsafe_opts = crate::toolset::parse_tool_options(r#"rename_exe="foo/bar:baz""#);
-        let unsafe_key = backend
-            .cache_key(tmp.path(), &HttpOptions::new(&unsafe_opts), 0)
-            .unwrap();
-        assert!(!unsafe_key.contains(illegal), "key: {unsafe_key}");
-        assert!(!unsafe_key.contains('/'), "key: {unsafe_key}");
-
-        // Table form is hashed, so globs/quotes/braces never reach the path.
-        let table_opts = crate::toolset::parse_tool_options(
+        // Scalar, table, and adversarial values all yield path-safe keys.
+        for opt in [
+            "rename_exe=plz",
+            r#"rename_exe="foo/bar:baz""#,
             r#"rename_exe={ "ols-*" = "ols", "odinfmt-*" = "odinfmt" }"#,
-        );
-        let table_key = backend
-            .cache_key(tmp.path(), &HttpOptions::new(&table_opts), 0)
-            .unwrap();
-        assert!(
-            !table_key.contains(illegal),
-            "table cache key must be path-safe, got: {table_key}"
+        ] {
+            let key = key_for(opt);
+            assert!(key.contains("rename_"), "key: {key}");
+            assert!(!key.contains(illegal), "unsafe cache key for {opt}: {key}");
+        }
+
+        // Different rename configs must produce different keys...
+        assert_ne!(key_for("rename_exe=plz"), key_for("rename_exe=other"));
+        assert_ne!(
+            key_for(r#"rename_exe={ "ols-*" = "ols" }"#),
+            key_for(r#"rename_exe={ "ols-*" = "renamed" }"#)
         );
 
-        // Different table values must still produce different keys.
-        let other_opts =
-            crate::toolset::parse_tool_options(r#"rename_exe={ "ols-*" = "renamed" }"#);
-        let other_key = backend
-            .cache_key(tmp.path(), &HttpOptions::new(&other_opts), 0)
-            .unwrap();
-        assert_ne!(table_key, other_key);
+        // ...including values that only differ by a trailing dot or space, which
+        // Windows would otherwise collapse to the same path component.
+        assert_ne!(key_for("rename_exe=tool"), key_for(r#"rename_exe="tool.""#));
+        assert_ne!(key_for("rename_exe=tool"), key_for(r#"rename_exe="tool ""#));
     }
 }

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -285,16 +285,12 @@ impl HttpBackend {
 
         // Include rename_exe in cache key since it modifies the extracted content.
         // Use the raw value so the table form (multi-binary rename) is captured too;
-        // `opts.rename_exe()` only stringifies the scalar form. Keep the readable
-        // unquoted name for the scalar form, but hash the table form so glob/quote
-        // characters (`*`, `"`, `{`, `}`) never leak into the cache directory name —
-        // those are illegal in Windows paths.
+        // `opts.rename_exe()` only stringifies the scalar form. `rename_cache_token`
+        // keeps a readable name when it is path-safe and hashes anything else (the
+        // table form, or a scalar with path separators / Windows-invalid characters)
+        // so nothing unsafe reaches the cache directory name.
         if let Some(rename) = lookup_value_with_fallback(opts.raw(), "rename_exe") {
-            let rename_key = match rename.as_str() {
-                Some(name) => name.to_string(),
-                None => hash::hash_blake3_to_str(&rename.to_string()),
-            };
-            parts.push(format!("rename_{rename_key}"));
+            parts.push(format!("rename_{}", rename_cache_token(rename)));
             // When rename_exe is used, bin_path affects where the rename happens,
             // so different bin_path values result in different cached content
             if let Some(bin_path) = opts.bin_path() {
@@ -1153,6 +1149,30 @@ impl Backend for HttpBackend {
     }
 }
 
+/// Produce a path-safe cache-key token for a `rename_exe` value. A scalar name is
+/// kept verbatim when it is safe to use as a single path component (the common
+/// case, e.g. `plz`), so cache keys stay readable and stable. Anything else — the
+/// table form, or a scalar containing path separators or Windows-invalid
+/// characters — is hashed, so nothing unsafe reaches the cache directory name.
+fn rename_cache_token(rename: &toml::Value) -> String {
+    if let Some(name) = rename.as_str()
+        && is_path_safe_component(name)
+    {
+        return name.to_string();
+    }
+    hash::hash_blake3_to_str(&rename.to_string())
+}
+
+/// Whether `s` is safe to use as a single filesystem path component on all
+/// platforms: non-empty, no path separators, and none of the characters Windows
+/// forbids in file names.
+fn is_path_safe_component(s: &str) -> bool {
+    !s.is_empty()
+        && !s.chars().any(|c| {
+            matches!(c, '/' | '\\' | '<' | '>' | ':' | '"' | '|' | '?' | '*') || c.is_control()
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1356,6 +1376,15 @@ mod tests {
             .unwrap();
         assert!(scalar_key.contains("rename_plz"), "key: {scalar_key}");
         assert!(!scalar_key.contains(illegal), "key: {scalar_key}");
+
+        // A scalar containing path separators / illegal characters is hashed,
+        // so it never produces a nested path or a Windows-invalid component.
+        let unsafe_opts = crate::toolset::parse_tool_options(r#"rename_exe="foo/bar:baz""#);
+        let unsafe_key = backend
+            .cache_key(tmp.path(), &HttpOptions::new(&unsafe_opts), 0)
+            .unwrap();
+        assert!(!unsafe_key.contains(illegal), "key: {unsafe_key}");
+        assert!(!unsafe_key.contains('/'), "key: {unsafe_key}");
 
         // Table form is hashed, so globs/quotes/braces never reach the path.
         let table_opts = crate::toolset::parse_tool_options(

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -1007,20 +1007,22 @@ fn take_matching(available: &mut Vec<PathBuf>, pattern: &str) -> eyre::Result<Op
 }
 
 /// Renames `path` (named `file_name`) to `target` within `dir`, preserving any
-/// required extension and ensuring the result is executable. Refuses to clobber
-/// an existing different file so overlapping mappings can't silently drop a binary.
+/// required extension and ensuring the result is executable. A collision on the
+/// target (two mappings pointing at the same name, or the archive already
+/// containing that name) is unsatisfiable, so it fails the install loudly rather
+/// than silently dropping a binary and reporting success.
 fn finish_rename(dir: &Path, path: &Path, file_name: &str, target: &str) -> eyre::Result<()> {
     let target_path = keep_required_extensions(dir, file_name, target, dir.join(target));
     if path == target_path {
         return Ok(());
     }
     if target_path.exists() {
-        warn!(
-            "rename_exe: refusing to overwrite existing '{}' while renaming '{}'",
-            target_path.display(),
-            path.display()
+        bail!(
+            "rename_exe: cannot rename '{}' to '{}': target already exists. \
+             Check for duplicate or overlapping rename_exe mappings.",
+            path.display(),
+            target_path.display()
         );
-        return Ok(());
     }
     if !file::is_executable(path) {
         file::make_executable(path)?;
@@ -2146,9 +2148,9 @@ bin = "tool.exe"
 
     #[cfg(unix)]
     #[test]
-    fn test_apply_rename_exe_table_refuses_to_clobber_shared_target() {
-        // Two sources mapped to the same target: the first rename wins, the
-        // second is refused rather than silently replacing the first binary.
+    fn test_apply_rename_exe_table_errors_on_shared_target() {
+        // Two sources mapped to the same target is unsatisfiable: the install
+        // must fail loudly rather than silently drop one binary and report success.
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("a-bin"), b"aaa").unwrap();
         std::fs::write(tmp.path().join("b-bin"), b"bbb").unwrap();
@@ -2166,10 +2168,10 @@ bin = "tool.exe"
             t
         });
 
-        apply_rename_exe(tmp.path(), &value, None).unwrap();
-
-        // `a-bin` renamed to `common`; `b-bin` left in place (not dropped).
-        assert_eq!(std::fs::read(tmp.path().join("common")).unwrap(), b"aaa");
-        assert!(tmp.path().join("b-bin").is_file());
+        let err = apply_rename_exe(tmp.path(), &value, None).unwrap_err();
+        assert!(
+            err.to_string().contains("target already exists"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -988,16 +988,24 @@ pub fn apply_rename_exe(
 /// keeps one file from satisfying two mappings and keeps a rename output from
 /// being re-matched by a later pattern.
 fn take_matching(available: &mut Vec<PathBuf>, pattern: &str) -> eyre::Result<Option<PathBuf>> {
+    // An exact file name honors the user's explicit choice, even for files a glob
+    // heuristic would skip.
     let exact = std::ffi::OsStr::new(pattern);
     if let Some(idx) = available.iter().position(|p| p.file_name() == Some(exact)) {
         return Ok(Some(available.remove(idx)));
     }
 
+    // For a glob, skip obvious non-binary collateral (LICENSE, README, *.txt/.md,
+    // …) the same way the string-form rename path does, so e.g. `ols-*` grabs the
+    // real binary rather than `ols-license.txt`, which would sort first.
     let glob = glob::Pattern::new(pattern)
         .map_err(|e| eyre::eyre!("invalid rename_exe pattern '{pattern}': {e}"))?;
     if let Some(idx) = available.iter().position(|p| {
         p.file_name()
-            .map(|n| glob.matches(&n.to_string_lossy()))
+            .map(|n| {
+                let name = n.to_string_lossy();
+                !should_skip_file(&name, true) && glob.matches(&name)
+            })
             .unwrap_or(false)
     }) {
         return Ok(Some(available.remove(idx)));
@@ -1013,6 +1021,11 @@ fn take_matching(available: &mut Vec<PathBuf>, pattern: &str) -> eyre::Result<Op
 /// than silently dropping a binary and reporting success.
 fn finish_rename(dir: &Path, path: &Path, file_name: &str, target: &str) -> eyre::Result<()> {
     let target_path = keep_required_extensions(dir, file_name, target, dir.join(target));
+    // Ensure the binary is executable whether or not we move it: ZIP archives drop
+    // the exec bit, and the file may already carry the desired name.
+    if !file::is_executable(path) {
+        file::make_executable(path)?;
+    }
     if path == target_path {
         return Ok(());
     }
@@ -1023,9 +1036,6 @@ fn finish_rename(dir: &Path, path: &Path, file_name: &str, target: &str) -> eyre
             path.display(),
             target_path.display()
         );
-    }
-    if !file::is_executable(path) {
-        file::make_executable(path)?;
     }
     file::rename(path, &target_path)?;
     debug!("Renamed {} to {}", path.display(), target_path.display());
@@ -2173,5 +2183,52 @@ bin = "tool.exe"
             err.to_string().contains("target already exists"),
             "unexpected error: {err}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_rename_exe_table_glob_skips_collateral_files() {
+        // A glob must pick the real binary, not a lexicographically-earlier
+        // collateral file like a license that also matches the pattern.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("ols-license.txt"), b"MIT").unwrap();
+        std::fs::write(tmp.path().join("ols-x86_64-unknown-linux-gnu"), b"bin").unwrap();
+
+        let value = toml::Value::Table({
+            let mut t = toml::value::Table::new();
+            t.insert("ols-*".to_string(), toml::Value::String("ols".to_string()));
+            t
+        });
+
+        apply_rename_exe(tmp.path(), &value, None).unwrap();
+
+        // The binary is renamed; the license is untouched.
+        assert_eq!(std::fs::read(tmp.path().join("ols")).unwrap(), b"bin");
+        assert!(tmp.path().join("ols-license.txt").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_rename_exe_table_sets_exec_bit_when_already_named() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // A ZIP-extracted file already carrying the target name must still be made
+        // executable, matching the behavior of renames that move a file.
+        let tmp = tempfile::tempdir().unwrap();
+        let tool = tmp.path().join("tool");
+        std::fs::write(&tool, b"bin").unwrap();
+        std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(!file::is_executable(&tool));
+
+        let value = toml::Value::Table({
+            let mut t = toml::value::Table::new();
+            t.insert("tool".to_string(), toml::Value::String("tool".to_string()));
+            t
+        });
+
+        apply_rename_exe(tmp.path(), &value, None).unwrap();
+
+        assert!(tool.is_file());
+        assert!(file::is_executable(&tool));
     }
 }

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -567,6 +567,15 @@ pub fn install_artifact(
         .or_else(|| opts.get_string("strip_components"))
         .and_then(|s| s.parse().ok());
 
+    // These options name the installed binary and get joined onto install/bin
+    // dirs throughout this function — a path in either would escape them.
+    // (Table-form rename_exe is not a scalar and is validated in apply_rename_exe.)
+    for option in ["bin", "rename_exe"] {
+        if let Some(name) = lookup_with_fallback(opts, option) {
+            ensure_plain_bin_name(option, &name)?;
+        }
+    }
+
     file::remove_all(&install_path)?;
     file::create_dir_all(&install_path)?;
 
@@ -705,6 +714,11 @@ pub fn install_artifact(
 }
 
 fn make_configured_bin_executable(search_dir: &Path, bin_name: &str) -> Result<()> {
+    // Runs before rename_executable_in_dir validates bin_name; don't chmod
+    // through a traversal path — the rename call right after reports the error.
+    if !file::is_plain_file_name(bin_name) {
+        return Ok(());
+    }
     let bin_path = search_dir.join(bin_name);
     if bin_path.is_file() {
         file::make_executable(bin_path)?;
@@ -807,6 +821,7 @@ pub fn rename_executable_in_dir(
     new_name: &str,
     tool_name: Option<&str>,
 ) -> eyre::Result<()> {
+    ensure_plain_bin_name("rename target", new_name)?;
     let target_path = dir.join(new_name);
 
     // Check if target already exists before iterating
@@ -948,6 +963,13 @@ pub fn apply_rename_exe(
 ) -> eyre::Result<()> {
     match value {
         toml::Value::Table(entries) => {
+            // Validate every target before renaming anything, so a bad entry
+            // fails the install without leaving a half-applied table.
+            for target in entries.values() {
+                if let Some(target) = target.as_str() {
+                    ensure_plain_bin_name("rename_exe", target)?;
+                }
+            }
             // Snapshot the directory once and consume each matched file, so a
             // rename's *output* can never become a later entry's *input*
             // (e.g. `tool-*`→`tool` then `tool`→`x` must not rename twice) and a
@@ -1012,6 +1034,19 @@ fn take_matching(available: &mut Vec<PathBuf>, pattern: &str) -> eyre::Result<Op
     }
 
     Ok(None)
+}
+
+/// Rejects `bin`/`rename_exe` names that are not plain file names (`../tool`,
+/// `/abs/tool`, `bin/tool`), which would otherwise be joined onto the install
+/// or search directory and place the binary outside it.
+pub fn ensure_plain_bin_name(option: &str, name: &str) -> eyre::Result<()> {
+    if !file::is_plain_file_name(name) {
+        bail!(
+            "{option}: '{name}' must be a plain file name \
+             (no path separators or parent directories)"
+        );
+    }
+    Ok(())
 }
 
 /// Renames `path` (named `file_name`) to `target` within `dir`, preserving any
@@ -2183,6 +2218,33 @@ bin = "tool.exe"
             err.to_string().contains("target already exists"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_apply_rename_exe_rejects_path_traversal_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("tool"), b"bin").unwrap();
+
+        // Table form: a target escaping the directory fails before any rename.
+        for target in ["../tool", "/abs/tool", "sub/tool"] {
+            let value = toml::Value::Table({
+                let mut t = toml::value::Table::new();
+                t.insert("tool".to_string(), toml::Value::String(target.to_string()));
+                t
+            });
+            let err = apply_rename_exe(tmp.path(), &value, None).unwrap_err();
+            assert!(
+                err.to_string().contains("plain file name"),
+                "unexpected error for {target:?}: {err}"
+            );
+            assert!(tmp.path().join("tool").is_file(), "nothing may be renamed");
+        }
+
+        // String form takes the same validation path.
+        let value = toml::Value::String("../evil".to_string());
+        let err = apply_rename_exe(tmp.path(), &value, Some("tool")).unwrap_err();
+        assert!(err.to_string().contains("plain file name"), "{err}");
+        assert!(!tmp.path().join("..").join("evil").exists());
     }
 
     #[cfg(unix)]

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -345,6 +345,16 @@ pub fn lookup_with_fallback(opts: &ToolVersionOptions, key: &str) -> Option<Stri
     lookup_platform_key(opts, key).or_else(|| opts.get_string(key))
 }
 
+/// Looks up a raw option value with platform-specific fallback.
+/// Like [`lookup_with_fallback`] but preserves the original `toml::Value` so
+/// callers can distinguish scalar and table forms (e.g. `rename_exe`).
+pub fn lookup_value_with_fallback<'a>(
+    opts: &'a ToolVersionOptions,
+    key: &str,
+) -> Option<&'a toml::Value> {
+    lookup_platform_value(opts, key).or_else(|| opts.opts.get(key))
+}
+
 fn lookup_nested_value<'a>(opts: &'a ToolVersionOptions, key: &str) -> Option<&'a toml::Value> {
     let parts: Vec<&str> = key.split('.').collect();
     if parts.len() < 2 {
@@ -677,7 +687,7 @@ pub fn install_artifact(
         // Handle rename_exe option for archives
         // When bin_path is not explicitly set, auto-detect bin/ subdirectory to match
         // the same logic used by discover_bin_paths() for PATH construction
-        if let Some(rename_to) = lookup_with_fallback(opts, "rename_exe") {
+        if let Some(rename_value) = lookup_value_with_fallback(opts, "rename_exe") {
             let search_dir = if let Some(ref dir) = explicit_bin_path {
                 dir.clone()
             } else {
@@ -688,7 +698,7 @@ pub fn install_artifact(
                     install_path.clone()
                 }
             };
-            rename_executable_in_dir(&search_dir, &rename_to, Some(tool_name))?;
+            apply_rename_exe(&search_dir, rename_value, Some(tool_name))?;
         }
     }
     Ok(())
@@ -917,6 +927,88 @@ pub fn rename_executable_in_dir(
         }
     }
 
+    Ok(())
+}
+
+/// Applies the `rename_exe` option to freshly-extracted archive contents.
+///
+/// Two forms are supported:
+/// - String — `rename_exe = "plz"` — renames the tool's primary executable
+///   (located via the `tool_name` hint) to the given name. This is the original
+///   single-binary behavior.
+/// - Table — `rename_exe = { "ols-*" = "ols", "odinfmt-*" = "odinfmt" }` — renames
+///   every matched executable. Keys are source names that may contain glob
+///   patterns (matched against the file name); values are the new names. This
+///   lets archives that ship several binaries expose all of them under clean
+///   names.
+pub fn apply_rename_exe(
+    search_dir: &Path,
+    value: &toml::Value,
+    tool_name: Option<&str>,
+) -> eyre::Result<()> {
+    match value {
+        toml::Value::Table(entries) => {
+            for (source, target) in entries {
+                let Some(target) = target.as_str() else {
+                    warn!("rename_exe: target for '{source}' is not a string, skipping");
+                    continue;
+                };
+                rename_matching_executable(search_dir, source, target)?;
+            }
+            Ok(())
+        }
+        toml::Value::String(new_name) => rename_executable_in_dir(search_dir, new_name, tool_name),
+        other => {
+            warn!("rename_exe: expected a string or table, got {other}");
+            Ok(())
+        }
+    }
+}
+
+/// Renames a single binary matched by `source_pattern` (an exact file name or a
+/// glob such as `ols-*`) to `target`. Adds the executable bit when the archive
+/// dropped it (common for ZIPs). Used by the table form of `rename_exe`.
+fn rename_matching_executable(dir: &Path, source_pattern: &str, target: &str) -> eyre::Result<()> {
+    // Fast path: exact file name match.
+    let exact = dir.join(source_pattern);
+    if exact.is_file() {
+        return finish_rename(dir, &exact, source_pattern, target);
+    }
+
+    // Otherwise treat the key as a glob against the file names in `dir`.
+    // `file::ls` returns a sorted set, so a pattern matching more than one file
+    // resolves deterministically to the first match.
+    let pattern = glob::Pattern::new(source_pattern)
+        .map_err(|e| eyre::eyre!("invalid rename_exe pattern '{source_pattern}': {e}"))?;
+    for path in file::ls(dir)? {
+        if !path.is_file() {
+            continue;
+        }
+        let file_name = path.file_name().unwrap().to_string_lossy().to_string();
+        if pattern.matches(&file_name) {
+            return finish_rename(dir, &path, &file_name, target);
+        }
+    }
+
+    warn!(
+        "rename_exe: no file matching '{source_pattern}' found in {}",
+        dir.display()
+    );
+    Ok(())
+}
+
+/// Renames `path` (named `file_name`) to `target` within `dir`, preserving any
+/// required extension and ensuring the result is executable.
+fn finish_rename(dir: &Path, path: &Path, file_name: &str, target: &str) -> eyre::Result<()> {
+    let target_path = keep_required_extensions(dir, file_name, target, dir.join(target));
+    if path == target_path {
+        return Ok(());
+    }
+    if !file::is_executable(path) {
+        file::make_executable(path)?;
+    }
+    file::rename(path, &target_path)?;
+    debug!("Renamed {} to {}", path.display(), target_path.display());
     Ok(())
 }
 
@@ -1908,5 +2000,99 @@ bin = "tool.exe"
         assert!(!file::is_executable(&readme));
         assert!(!file::is_executable(&config));
         assert!(!file::is_executable(&unrelated));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_rename_exe_table_renames_multiple_binaries_by_glob() {
+        // An archive that ships several binaries with platform-suffixed names.
+        // The table form should clean up all of them, not just one.
+        let tmp = tempfile::tempdir().unwrap();
+        let ols = tmp.path().join("ols-x86_64-unknown-linux-gnu");
+        let odinfmt = tmp.path().join("odinfmt-x86_64-unknown-linux-gnu");
+        std::fs::write(&ols, b"bin").unwrap();
+        std::fs::write(&odinfmt, b"bin").unwrap();
+
+        let value = toml::Value::Table({
+            let mut t = toml::value::Table::new();
+            t.insert("ols-*".to_string(), toml::Value::String("ols".to_string()));
+            t.insert(
+                "odinfmt-*".to_string(),
+                toml::Value::String("odinfmt".to_string()),
+            );
+            t
+        });
+
+        apply_rename_exe(tmp.path(), &value, Some("ols")).unwrap();
+
+        let ols_renamed = tmp.path().join("ols");
+        let odinfmt_renamed = tmp.path().join("odinfmt");
+        assert!(ols_renamed.is_file(), "ols should be renamed");
+        assert!(odinfmt_renamed.is_file(), "odinfmt should be renamed");
+        assert!(!ols.exists(), "original ols-* should be gone");
+        assert!(!odinfmt.exists(), "original odinfmt-* should be gone");
+        // ZIP archives drop the exec bit; rename should restore it.
+        assert!(file::is_executable(&ols_renamed));
+        assert!(file::is_executable(&odinfmt_renamed));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_rename_exe_table_exact_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let please = tmp.path().join("please");
+        let other = tmp.path().join("please_sandbox");
+        std::fs::write(&please, b"bin").unwrap();
+        std::fs::write(&other, b"bin").unwrap();
+
+        let value = toml::Value::Table({
+            let mut t = toml::value::Table::new();
+            t.insert("please".to_string(), toml::Value::String("plz".to_string()));
+            t
+        });
+
+        apply_rename_exe(tmp.path(), &value, Some("please")).unwrap();
+
+        assert!(tmp.path().join("plz").is_file());
+        assert!(!please.exists());
+        // Untargeted binaries are left untouched.
+        assert!(other.is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_rename_exe_string_delegates_to_single_rename() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("please");
+        std::fs::write(&bin, b"bin").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let value = toml::Value::String("plz".to_string());
+        apply_rename_exe(tmp.path(), &value, Some("please")).unwrap();
+
+        assert!(tmp.path().join("plz").is_file());
+        assert!(!bin.exists());
+    }
+
+    #[test]
+    fn test_apply_rename_exe_table_missing_source_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("keep"), b"bin").unwrap();
+
+        let value = toml::Value::Table({
+            let mut t = toml::value::Table::new();
+            t.insert(
+                "nonexistent-*".to_string(),
+                toml::Value::String("whatever".to_string()),
+            );
+            t
+        });
+
+        // No matching file: warns and leaves the directory untouched.
+        apply_rename_exe(tmp.path(), &value, None).unwrap();
+        assert!(tmp.path().join("keep").is_file());
+        assert!(!tmp.path().join("whatever").exists());
     }
 }

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -948,12 +948,30 @@ pub fn apply_rename_exe(
 ) -> eyre::Result<()> {
     match value {
         toml::Value::Table(entries) => {
+            // Snapshot the directory once and consume each matched file, so a
+            // rename's *output* can never become a later entry's *input*
+            // (e.g. `tool-*`→`tool` then `tool`→`x` must not rename twice) and a
+            // single file satisfies at most one mapping. `file::ls` is sorted, so
+            // a glob matching several files resolves deterministically.
+            let mut available: Vec<PathBuf> = file::ls(search_dir)?
+                .into_iter()
+                .filter(|p| p.is_file())
+                .collect();
             for (source, target) in entries {
                 let Some(target) = target.as_str() else {
                     warn!("rename_exe: target for '{source}' is not a string, skipping");
                     continue;
                 };
-                rename_matching_executable(search_dir, source, target)?;
+                match take_matching(&mut available, source)? {
+                    Some(path) => {
+                        let file_name = path.file_name().unwrap().to_string_lossy().to_string();
+                        finish_rename(search_dir, &path, &file_name, target)?;
+                    }
+                    None => warn!(
+                        "rename_exe: no file matching '{source}' found in {}",
+                        search_dir.display()
+                    ),
+                }
             }
             Ok(())
         }
@@ -965,43 +983,43 @@ pub fn apply_rename_exe(
     }
 }
 
-/// Renames a single binary matched by `source_pattern` (an exact file name or a
-/// glob such as `ols-*`) to `target`. Adds the executable bit when the archive
-/// dropped it (common for ZIPs). Used by the table form of `rename_exe`.
-fn rename_matching_executable(dir: &Path, source_pattern: &str, target: &str) -> eyre::Result<()> {
-    // Fast path: exact file name match.
-    let exact = dir.join(source_pattern);
-    if exact.is_file() {
-        return finish_rename(dir, &exact, source_pattern, target);
+/// Removes and returns the first file in `available` matching `pattern` — an
+/// exact file name (preferred) or a glob such as `ols-*`. Consuming the match
+/// keeps one file from satisfying two mappings and keeps a rename output from
+/// being re-matched by a later pattern.
+fn take_matching(available: &mut Vec<PathBuf>, pattern: &str) -> eyre::Result<Option<PathBuf>> {
+    let exact = std::ffi::OsStr::new(pattern);
+    if let Some(idx) = available.iter().position(|p| p.file_name() == Some(exact)) {
+        return Ok(Some(available.remove(idx)));
     }
 
-    // Otherwise treat the key as a glob against the file names in `dir`.
-    // `file::ls` returns a sorted set, so a pattern matching more than one file
-    // resolves deterministically to the first match.
-    let pattern = glob::Pattern::new(source_pattern)
-        .map_err(|e| eyre::eyre!("invalid rename_exe pattern '{source_pattern}': {e}"))?;
-    for path in file::ls(dir)? {
-        if !path.is_file() {
-            continue;
-        }
-        let file_name = path.file_name().unwrap().to_string_lossy().to_string();
-        if pattern.matches(&file_name) {
-            return finish_rename(dir, &path, &file_name, target);
-        }
+    let glob = glob::Pattern::new(pattern)
+        .map_err(|e| eyre::eyre!("invalid rename_exe pattern '{pattern}': {e}"))?;
+    if let Some(idx) = available.iter().position(|p| {
+        p.file_name()
+            .map(|n| glob.matches(&n.to_string_lossy()))
+            .unwrap_or(false)
+    }) {
+        return Ok(Some(available.remove(idx)));
     }
 
-    warn!(
-        "rename_exe: no file matching '{source_pattern}' found in {}",
-        dir.display()
-    );
-    Ok(())
+    Ok(None)
 }
 
 /// Renames `path` (named `file_name`) to `target` within `dir`, preserving any
-/// required extension and ensuring the result is executable.
+/// required extension and ensuring the result is executable. Refuses to clobber
+/// an existing different file so overlapping mappings can't silently drop a binary.
 fn finish_rename(dir: &Path, path: &Path, file_name: &str, target: &str) -> eyre::Result<()> {
     let target_path = keep_required_extensions(dir, file_name, target, dir.join(target));
     if path == target_path {
+        return Ok(());
+    }
+    if target_path.exists() {
+        warn!(
+            "rename_exe: refusing to overwrite existing '{}' while renaming '{}'",
+            target_path.display(),
+            path.display()
+        );
         return Ok(());
     }
     if !file::is_executable(path) {
@@ -2094,5 +2112,64 @@ bin = "tool.exe"
         apply_rename_exe(tmp.path(), &value, None).unwrap();
         assert!(tmp.path().join("keep").is_file());
         assert!(!tmp.path().join("whatever").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_rename_exe_table_does_not_rename_its_own_output() {
+        // `tool-*` -> `tool` then `tool` -> `renamed` must not chain: the file
+        // produced by the first mapping must not be consumed by the second.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("tool-linux-x64"), b"bin").unwrap();
+
+        let value = toml::Value::Table({
+            let mut t = toml::value::Table::new();
+            t.insert(
+                "tool-*".to_string(),
+                toml::Value::String("tool".to_string()),
+            );
+            t.insert(
+                "tool".to_string(),
+                toml::Value::String("renamed".to_string()),
+            );
+            t
+        });
+
+        apply_rename_exe(tmp.path(), &value, None).unwrap();
+
+        // The `tool-*` mapping wins; the `tool` mapping finds nothing (its only
+        // candidate was the freshly-created output, which is not re-matched).
+        assert!(tmp.path().join("tool").is_file());
+        assert!(!tmp.path().join("renamed").exists());
+        assert!(!tmp.path().join("tool-linux-x64").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_rename_exe_table_refuses_to_clobber_shared_target() {
+        // Two sources mapped to the same target: the first rename wins, the
+        // second is refused rather than silently replacing the first binary.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a-bin"), b"aaa").unwrap();
+        std::fs::write(tmp.path().join("b-bin"), b"bbb").unwrap();
+
+        let value = toml::Value::Table({
+            let mut t = toml::value::Table::new();
+            t.insert(
+                "a-bin".to_string(),
+                toml::Value::String("common".to_string()),
+            );
+            t.insert(
+                "b-bin".to_string(),
+                toml::Value::String("common".to_string()),
+            );
+            t
+        });
+
+        apply_rename_exe(tmp.path(), &value, None).unwrap();
+
+        // `a-bin` renamed to `common`; `b-bin` left in place (not dropped).
+        assert_eq!(std::fs::read(tmp.path().join("common")).unwrap(), b"aaa");
+        assert!(tmp.path().join("b-bin").is_file());
     }
 }

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -567,13 +567,14 @@ pub fn install_artifact(
         .or_else(|| opts.get_string("strip_components"))
         .and_then(|s| s.parse().ok());
 
-    // These options name the installed binary and get joined onto install/bin
-    // dirs throughout this function — a path in either would escape them.
-    // (Table-form rename_exe is not a scalar and is validated in apply_rename_exe.)
-    for option in ["bin", "rename_exe"] {
-        if let Some(name) = lookup_with_fallback(opts, option) {
-            ensure_plain_bin_name(option, &name)?;
-        }
+    // `bin` historically accepts a path within the install directory (for
+    // example `bin/tiny`), while rename_exe names a file in one search dir.
+    if let Some(name) = lookup_with_fallback(opts, "bin") {
+        ensure_safe_relative_bin_path("bin", &name)?;
+    }
+    // Table-form rename_exe is not a scalar and is validated in apply_rename_exe.
+    if let Some(name) = lookup_with_fallback(opts, "rename_exe") {
+        ensure_plain_bin_name("rename_exe", &name)?;
     }
 
     file::remove_all(&install_path)?;
@@ -714,11 +715,7 @@ pub fn install_artifact(
 }
 
 fn make_configured_bin_executable(search_dir: &Path, bin_name: &str) -> Result<()> {
-    // Runs before rename_executable_in_dir validates bin_name; don't chmod
-    // through a traversal path — the rename call right after reports the error.
-    if !file::is_plain_file_name(bin_name) {
-        return Ok(());
-    }
+    ensure_safe_relative_bin_path("bin", bin_name)?;
     let bin_path = search_dir.join(bin_name);
     if bin_path.is_file() {
         file::make_executable(bin_path)?;
@@ -821,7 +818,10 @@ pub fn rename_executable_in_dir(
     new_name: &str,
     tool_name: Option<&str>,
 ) -> eyre::Result<()> {
-    ensure_plain_bin_name("rename target", new_name)?;
+    // This helper is shared by `bin`, which may be a nested path within the
+    // install directory, and scalar `rename_exe`, which is validated as a plain
+    // file name by apply_rename_exe before reaching here.
+    ensure_safe_relative_bin_path("rename target", new_name)?;
     let target_path = dir.join(new_name);
 
     // Check if target already exists before iterating
@@ -977,7 +977,15 @@ pub fn apply_rename_exe(
             // a glob matching several files resolves deterministically.
             let mut available: Vec<PathBuf> = file::ls(search_dir)?
                 .into_iter()
-                .filter(|p| p.is_file())
+                // Do not follow archive-provided symlinks: chmod on a symlink
+                // follows its target and could change permissions outside the
+                // extraction directory.
+                .filter(|p| {
+                    matches!(
+                        p.symlink_metadata(),
+                        Ok(metadata) if metadata.file_type().is_file()
+                    )
+                })
                 .collect();
             for (source, target) in entries {
                 let Some(target) = target.as_str() else {
@@ -997,7 +1005,10 @@ pub fn apply_rename_exe(
             }
             Ok(())
         }
-        toml::Value::String(new_name) => rename_executable_in_dir(search_dir, new_name, tool_name),
+        toml::Value::String(new_name) => {
+            ensure_plain_bin_name("rename_exe", new_name)?;
+            rename_executable_in_dir(search_dir, new_name, tool_name)
+        }
         other => {
             warn!("rename_exe: expected a string or table, got {other}");
             Ok(())
@@ -1044,6 +1055,18 @@ pub fn ensure_plain_bin_name(option: &str, name: &str) -> eyre::Result<()> {
         bail!(
             "{option}: '{name}' must be a plain file name \
              (no path separators or parent directories)"
+        );
+    }
+    Ok(())
+}
+
+/// Rejects a configured binary path that is absolute or contains parent
+/// components, while preserving the established `bin = "bin/tool"` form.
+pub fn ensure_safe_relative_bin_path(option: &str, path: &str) -> eyre::Result<()> {
+    if !file::is_safe_relative_path(path) {
+        bail!(
+            "{option}: '{path}' must be a safe relative path \
+             (no absolute paths or parent directories)"
         );
     }
     Ok(())
@@ -2292,5 +2315,39 @@ bin = "tool.exe"
 
         assert!(tool.is_file());
         assert!(file::is_executable(&tool));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_apply_rename_exe_table_ignores_symlinks() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        std::fs::set_permissions(outside.path(), std::fs::Permissions::from_mode(0o600)).unwrap();
+        let link = tmp.path().join("tool-linux-x64");
+        symlink(outside.path(), &link).unwrap();
+
+        let value = toml::Value::Table({
+            let mut t = toml::value::Table::new();
+            t.insert(
+                "tool-*".to_string(),
+                toml::Value::String("tool".to_string()),
+            );
+            t
+        });
+
+        apply_rename_exe(tmp.path(), &value, None).unwrap();
+
+        assert!(
+            link.is_symlink(),
+            "the archive symlink must remain untouched"
+        );
+        assert!(!tmp.path().join("tool").exists());
+        assert_eq!(
+            outside.path().metadata().unwrap().permissions().mode() & 0o777,
+            0o600,
+            "the external target's permissions must not change"
+        );
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1465,6 +1465,25 @@ pub fn is_plain_file_name(name: &str) -> bool {
     )
 }
 
+/// Whether `path` is a non-empty relative path containing only normal
+/// components. Both slash styles are treated as separators so config values are
+/// validated consistently across platforms.
+pub fn is_safe_relative_path(path: &str) -> bool {
+    if path.is_empty() {
+        return false;
+    }
+    let normalized = path.replace('\\', "/");
+    let bytes = normalized.as_bytes();
+    if normalized.starts_with('/')
+        || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+    {
+        return false;
+    }
+    let mut components = Path::new(&normalized).components();
+    matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.all(|component| matches!(component, std::path::Component::Normal(_)))
+}
+
 fn sanitize_7z_entry_path(path: &str) -> Result<PathBuf> {
     let normalized = PathBuf::from(path.replace('\\', "/"));
     let mut safe_path = PathBuf::new();
@@ -1849,6 +1868,26 @@ mod tests {
             "C:\\tool",
         ] {
             assert!(!is_plain_file_name(bad), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn test_is_safe_relative_path() {
+        for ok in ["tool", "bin/tool", "nested/path/tool.exe", "a b/tool"] {
+            assert!(is_safe_relative_path(ok), "should accept {ok:?}");
+        }
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../tool",
+            "bin/../../tool",
+            "/abs/tool",
+            "..\\tool",
+            "C:\\tool",
+            "\\\\server\\share\\tool",
+        ] {
+            assert!(!is_safe_relative_path(bad), "should reject {bad:?}");
         }
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1447,6 +1447,24 @@ pub fn un7z(archive: &Path, dest: &Path, opts: &ExtractOptions<'_>) -> Result<()
     })
 }
 
+/// Whether `name` is a plain file name: exactly one normal path component, with
+/// no separators, parent/root components, or drive prefixes on any platform.
+/// Use to validate user-supplied names (e.g. `bin`, `rename_exe`, `filter_bins`
+/// tool options) before joining them onto a directory, so a value like
+/// `../evil` or `/abs/path` cannot escape it.
+pub fn is_plain_file_name(name: &str) -> bool {
+    // Reject both separators explicitly: `\` is a legal file-name character on
+    // Unix, but these names come from cross-platform config.
+    if name.contains('/') || name.contains('\\') {
+        return false;
+    }
+    let mut components = Path::new(name).components();
+    matches!(
+        (components.next(), components.next()),
+        (Some(std::path::Component::Normal(_)), None)
+    )
+}
+
 fn sanitize_7z_entry_path(path: &str) -> Result<PathBuf> {
     let normalized = PathBuf::from(path.replace('\\', "/"));
     let mut safe_path = PathBuf::new();
@@ -1812,6 +1830,26 @@ mod tests {
     fn test_run_blocking_outside_runtime() {
         // no tokio runtime at all — must run the closure inline, not panic
         assert_eq!(run_blocking(|| 42), 42);
+    }
+
+    #[test]
+    fn test_is_plain_file_name() {
+        for ok in ["tool", "my-tool.exe", "tool.tar.gz", "..hidden", "a b"] {
+            assert!(is_plain_file_name(ok), "should accept {ok:?}");
+        }
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../tool",
+            "a/b",
+            "/abs/tool",
+            "..\\tool",
+            "a\\b",
+            "C:\\tool",
+        ] {
+            assert!(!is_plain_file_name(bad), "should reject {bad:?}");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Reported in [discussion #8632](https://github.com/jdx/mise/discussions/8632). When a `github` (or `gitlab`/`forgejo`/`http`) release archive ships **multiple** executables, `rename_exe` could only clean up **one** of them because it took a single string value.

Two concrete cases from the thread:

- `github:DanielGavin/ols` — the zip contains `ols-x86_64-unknown-linux-gnu` and `odinfmt-x86_64-unknown-linux-gnu`. You could rename `ols` but not `odinfmt`.
- `github:thought-machine/please` — ships `please`, `please_sandbox`, `build_langserver`.

The only workaround was a `postinstall` `mv` script, or the deprecated `ubi` backend (which warns on every install and also only renames one exe).

> Note: the *original* report (wrong binary picked non-deterministically) was already fixed in #8700. This PR addresses the **remaining** gap surfaced later in the thread: renaming *more than one* binary.

## Change

`rename_exe` now additionally accepts a **table** mapping source patterns to target names:

```toml
[tools."github:DanielGavin/ols"]
version = "latest"
rename_exe = { "ols-*" = "ols", "odinfmt-*" = "odinfmt" }
```

- Keys are exact file names or globs, matched against the extracted files.
- Each match is renamed, and the executable bit is restored (ZIPs commonly drop it).
- Missing sources are skipped with a warning rather than failing the install.
- The existing **string** form (`rename_exe = "plz"`) is completely unchanged.

Wired through both the shared `install_artifact` path (github/gitlab/forgejo) and the `http` backend, including the http extraction cache key so the table form invalidates cache correctly.

## Tests

- Unit tests in `static_helpers.rs` covering the table form (glob + exact match), the string-form delegation, and the missing-source no-op.
- New e2e test `e2e/backend/test_github_rename_exe_multi_bin_table` that installs the real `github:DanielGavin/ols@dev-2026-05` archive from the discussion and asserts both `ols` and `odinfmt` are renamed, the platform-suffixed originals are gone, and both are on PATH.
- Existing `test_github_rename_exe`, `test_github_rename_exe_multi_bin`, and `test_http_rename_exe` still pass.

## Docs

Updated the `rename_exe` sections of `docs/dev-tools/backends/github.md` and `http.md` to document the table form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time binary layout and PATH exposure for archive backends, with added validation that may reject previously accepted unsafe `bin`/`rename_exe` values; scope is bounded by extensive unit and e2e tests.
> 
> **Overview**
> **`rename_exe` can now be a TOML table** mapping source names or globs to target names (e.g. `{ "ols-*" = "ols", "odinfmt-*" = "odinfmt" }`), so one archive can expose several clean binaries on PATH. The existing string form is unchanged and still renames the primary executable.
> 
> Shared extraction (`install_artifact` for GitHub/GitLab/Forgejo and HTTP archives) routes through new **`apply_rename_exe`**: validate all targets up front, match files once (exact name or glob, skipping README/license collateral), avoid chained remaps and duplicate targets, restore the executable bit, and warn on missing sources instead of failing the install.
> 
> **Hardening** rejects path traversal in `bin`, scalar `rename_exe`, and `filter_bins` via `is_plain_file_name` / `is_safe_relative_path`. The HTTP backend hashes `rename_exe` in cache keys (scalar and table) so configs cannot alias or leak unsafe characters into cache directory names.
> 
> Docs cover the table form; a Linux e2e installs `github:DanielGavin/ols` with both binaries renamed and on PATH.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e97634636474b3950f07c5312d28140d67c84f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added table-form `rename_exe` to rename multiple binaries from a single archive using exact filenames or glob patterns.
* **Bug Fixes**
  * Made `rename_exe` consistently applied for cached and downloaded installs, with safer cache-key generation and validation to avoid unsafe characters.
  * Renaming now restores executable permissions when needed, warns on unmatched patterns, and prevents collisions or chained remaps.
* **Documentation**
  * Expanded GitHub and HTTP backend docs with TOML examples and clarified matching, skipping, and executable-bit restoration.
* **Tests**
  * Added unit and e2e coverage for multi-binary table renaming and cache-key safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->