### PR TITLE
chore(deps): bump clx to 2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20daab9df9e49b0478215055d38362d5973043b7a4af836a58968760755e9a9f"
+checksum = "4c2a26324918dd5018f3bb2f0a886dde591ec7248fba8e4d947fe43b6f572e5f"
 dependencies = [
  "console",
  "nix 0.31.3",


### PR DESCRIPTION
## Summary
- bump `clx` from 2.1.0 to 2.1.1 in `Cargo.lock`
- update the locked crates.io checksum

## Impact
Keeps the locked `clx` dependency on the latest compatible 2.x patch release. No source or configuration changes are included.

## Validation
- `cargo check --locked`
- pre-commit `mise run lint` (includes `cargo check --all-features`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch dependency update within the existing `clx` 2.x constraint; no application logic changes.
> 
> **Overview**
> Updates the lockfile so **`clx`** moves from **2.1.0** to **2.1.1** and refreshes the crates.io checksum. **`Cargo.toml`** still pins **`clx = "2"`**; there are **no Rust source or config edits** in this PR.
> 
> This is a routine patch bump for the terminal/progress UI dependency (`clx::progress` in logging and multi-progress reporting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95f1783690e8ef1cedcd2025c564610270613f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->