### PR TITLE
fix(python): deprecate virtualenv tool option in favor of _.python.venv

### DIFF
--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -88,7 +88,9 @@ mise has two ways to manage Python virtualenvs:
 These are separate mechanisms with different code paths. Options like `uv_create_args` and `python_create_args` in `_.python.venv` are not used by `python.uv_venv_auto`.
 :::
 
-There is also a legacy `virtualenv` tool option (`python = { version = "3.15", virtualenv = ".venv" }` in `[tools]`) that activates an existing venv. A relative path is resolved against the config root of the file that declares it — the same base as `_.python.venv` — so a `virtualenv` set in the global config is not looked up inside unrelated projects. Prefer `_.python.venv` for new configs.
+::: warning
+The legacy `virtualenv` tool option (`python = { version = "3.15", virtualenv = ".venv" }` in `[tools]`) is deprecated and will be removed in a future release. Use `_.python.venv` (below) instead.
+:::
 
 ### `_.python.venv` configuration
 

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -88,6 +88,8 @@ mise has two ways to manage Python virtualenvs:
 These are separate mechanisms with different code paths. Options like `uv_create_args` and `python_create_args` in `_.python.venv` are not used by `python.uv_venv_auto`.
 :::
 
+There is also a legacy `virtualenv` tool option (`python = { version = "3.15", virtualenv = ".venv" }` in `[tools]`) that activates an existing venv. A relative path is resolved against the config root of the file that declares it — the same base as `_.python.venv` — so a `virtualenv` set in the global config is not looked up inside unrelated projects. Prefer `_.python.venv` for new configs.
+
 ### `_.python.venv` configuration
 
 Use `_.python.venv` in the `[env]` section of `mise.toml`:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -123,8 +123,12 @@ of tools. One example of this is virtualenv on python runtimes:
 
 ```toml
 [tools]
-python = { version='3.11', virtualenv='.venv' }
+python = { version='3.11', virtualenv='.venv' } # a relative path resolves against this file's config root
 ```
+
+A relative `virtualenv` path is resolved against the config root of the file that declares it
+(matching `_.python.venv`), not the current project root — so a `virtualenv` set in the global
+config won't be looked up inside unrelated projects.
 
 This will be passed to all plugin scripts as `MISE_TOOL_OPTS__VIRTUALENV=.venv`. The user can specify
 any option, and it will be passed to the plugin in that format.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -123,12 +123,13 @@ of tools. One example of this is virtualenv on python runtimes:
 
 ```toml
 [tools]
-python = { version='3.11', virtualenv='.venv' } # a relative path resolves against this file's config root
+python = { version='3.11', virtualenv='.venv' }
 ```
 
-A relative `virtualenv` path is resolved against the config root of the file that declares it
-(matching `_.python.venv`), not the current project root — so a `virtualenv` set in the global
-config won't be looked up inside unrelated projects.
+::: warning
+The python `virtualenv` tool option is deprecated and will be removed in a future release.
+Use [`_.python.venv`](/lang/python.html#automatic-virtualenv-activation) in the `[env]` section instead.
+:::
 
 This will be passed to all plugin scripts as `MISE_TOOL_OPTS__VIRTUALENV=.venv`. The user can specify
 any option, and it will be passed to the plugin in that format.

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -6,7 +6,6 @@ use crate::build_time::built_info;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
-use crate::config::config_file::config_root;
 use crate::config::{Config, Settings};
 use crate::file::{ExtractOptions, ExtractionFormat, display_path};
 use crate::git::{CloneOptions, Git};
@@ -14,7 +13,7 @@ use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::platform::Platform;
-use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions, Toolset};
+use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{Result, lock_file::LockFile};
 use crate::{dirs, file, plugins, sysconfig};
@@ -530,12 +529,18 @@ impl PythonPlugin {
         let raw_opts = tv.request.options();
         let opts = PythonOptions::new(&raw_opts);
         if let Some(virtualenv) = opts.virtualenv() {
-            let virtualenv: PathBuf = file::replace_path(Path::new(virtualenv));
-            let virtualenv = resolve_virtualenv_path(
-                virtualenv,
-                tv.request.source(),
-                config.project_root.as_deref(),
+            deprecated_at!(
+                "2026.7.0",
+                "2027.7.0",
+                "python.virtualenv",
+                "the python `virtualenv` tool option is deprecated. Use `_.python.venv` in the `[env]` section instead: https://mise.en.dev/lang/python.html#automatic-virtualenv-activation"
             );
+            let mut virtualenv: PathBuf = file::replace_path(Path::new(virtualenv));
+            if !virtualenv.is_absolute() {
+                if let Some(project_root) = &config.project_root {
+                    virtualenv = project_root.join(virtualenv);
+                }
+            }
             if !virtualenv.exists() {
                 warn!(
                     "no venv found at: {p}\n\n\
@@ -791,40 +796,6 @@ impl PythonPlugin {
             )),
         }
     }
-}
-
-/// Resolve a `virtualenv` tool-option path.
-///
-/// `virtualenv` has already been passed through [`file::replace_path`], so a
-/// leading `~` is expanded. Absolute paths are returned as-is. Relative paths are
-/// joined against the config root of the file that *declared* the tool (`source`),
-/// so a `virtualenv` set in the global config resolves against the global config
-/// root rather than the current project. When the source has no backing file
-/// (e.g. a CLI argument), fall back to `project_root`, then the current working
-/// directory.
-fn resolve_virtualenv_path(
-    virtualenv: PathBuf,
-    source: &ToolSource,
-    project_root: Option<&Path>,
-) -> PathBuf {
-    if virtualenv.is_absolute() {
-        return virtualenv;
-    }
-    let virtualenv = virtualenv
-        .strip_prefix("./")
-        .map(Path::to_path_buf)
-        .unwrap_or(virtualenv);
-    let base = source
-        .path()
-        .map(config_root::config_root)
-        .or_else(|| project_root.map(Path::to_path_buf))
-        .unwrap_or_else(|| {
-            dirs::CWD
-                .as_ref()
-                .cloned()
-                .unwrap_or_else(|| PathBuf::from("."))
-        });
-    base.join(virtualenv)
 }
 
 #[async_trait]
@@ -1269,52 +1240,6 @@ mod tests {
     fn python_options_reads_virtualenv() {
         let opts = opts_with("virtualenv", ".venv");
         assert_eq!(PythonOptions::new(&opts).virtualenv(), Some(".venv"));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn resolve_virtualenv_path_absolute_passthrough() {
-        let out = resolve_virtualenv_path(
-            PathBuf::from("/abs/venv"),
-            &ToolSource::Argument,
-            Some(Path::new("/some/project")),
-        );
-        assert_eq!(out, PathBuf::from("/abs/venv"));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn resolve_virtualenv_path_relative_uses_declaring_config_root() {
-        // A relative venv resolves against the config file that declared the tool,
-        // NOT the passed-in project_root. This is the bug being fixed (#6019): a
-        // `virtualenv` in the global config must not resolve into unrelated projects.
-        let source = ToolSource::MiseToml(PathBuf::from("/tmp/mise-test-proj/mise.toml"));
-        let out = resolve_virtualenv_path(
-            PathBuf::from(".venv"),
-            &source,
-            Some(Path::new("/tmp/some-other-project")),
-        );
-        assert_eq!(out, PathBuf::from("/tmp/mise-test-proj/.venv"));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn resolve_virtualenv_path_relative_argument_falls_back_to_project_root() {
-        // No backing config file (e.g. a CLI argument) -> fall back to project_root.
-        let out = resolve_virtualenv_path(
-            PathBuf::from(".venv"),
-            &ToolSource::Argument,
-            Some(Path::new("/tmp/mise-fallback-proj")),
-        );
-        assert_eq!(out, PathBuf::from("/tmp/mise-fallback-proj/.venv"));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn resolve_virtualenv_path_relative_no_base_uses_cwd() {
-        // No source path and no project_root -> resolve under CWD.
-        let out = resolve_virtualenv_path(PathBuf::from(".venv"), &ToolSource::Argument, None);
-        assert_eq!(out, dirs::CWD.as_ref().unwrap().join(".venv"));
     }
 
     #[test]

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -536,10 +536,10 @@ impl PythonPlugin {
                 "the python `virtualenv` tool option is deprecated. Use `_.python.venv` in the `[env]` section instead: https://mise.en.dev/lang/python.html#automatic-virtualenv-activation"
             );
             let mut virtualenv: PathBuf = file::replace_path(Path::new(virtualenv));
-            if !virtualenv.is_absolute() {
-                if let Some(project_root) = &config.project_root {
-                    virtualenv = project_root.join(virtualenv);
-                }
+            if !virtualenv.is_absolute()
+                && let Some(project_root) = &config.project_root
+            {
+                virtualenv = project_root.join(virtualenv);
             }
             if !virtualenv.exists() {
                 warn!(

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -6,6 +6,7 @@ use crate::build_time::built_info;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
+use crate::config::config_file::config_root;
 use crate::config::{Config, Settings};
 use crate::file::{ExtractOptions, ExtractionFormat, display_path};
 use crate::git::{CloneOptions, Git};
@@ -13,7 +14,7 @@ use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::platform::Platform;
-use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
+use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
 use crate::{Result, lock_file::LockFile};
 use crate::{dirs, file, plugins, sysconfig};
@@ -529,13 +530,12 @@ impl PythonPlugin {
         let raw_opts = tv.request.options();
         let opts = PythonOptions::new(&raw_opts);
         if let Some(virtualenv) = opts.virtualenv() {
-            let mut virtualenv: PathBuf = file::replace_path(Path::new(virtualenv));
-            if !virtualenv.is_absolute() {
-                // TODO: use the path of the config file that specified python, not the top one like this
-                if let Some(project_root) = &config.project_root {
-                    virtualenv = project_root.join(virtualenv);
-                }
-            }
+            let virtualenv: PathBuf = file::replace_path(Path::new(virtualenv));
+            let virtualenv = resolve_virtualenv_path(
+                virtualenv,
+                tv.request.source(),
+                config.project_root.as_deref(),
+            );
             if !virtualenv.exists() {
                 warn!(
                     "no venv found at: {p}\n\n\
@@ -791,6 +791,40 @@ impl PythonPlugin {
             )),
         }
     }
+}
+
+/// Resolve a `virtualenv` tool-option path.
+///
+/// `virtualenv` has already been passed through [`file::replace_path`], so a
+/// leading `~` is expanded. Absolute paths are returned as-is. Relative paths are
+/// joined against the config root of the file that *declared* the tool (`source`),
+/// so a `virtualenv` set in the global config resolves against the global config
+/// root rather than the current project. When the source has no backing file
+/// (e.g. a CLI argument), fall back to `project_root`, then the current working
+/// directory.
+fn resolve_virtualenv_path(
+    virtualenv: PathBuf,
+    source: &ToolSource,
+    project_root: Option<&Path>,
+) -> PathBuf {
+    if virtualenv.is_absolute() {
+        return virtualenv;
+    }
+    let virtualenv = virtualenv
+        .strip_prefix("./")
+        .map(Path::to_path_buf)
+        .unwrap_or(virtualenv);
+    let base = source
+        .path()
+        .map(config_root::config_root)
+        .or_else(|| project_root.map(Path::to_path_buf))
+        .unwrap_or_else(|| {
+            dirs::CWD
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| PathBuf::from("."))
+        });
+    base.join(virtualenv)
 }
 
 #[async_trait]
@@ -1235,6 +1269,52 @@ mod tests {
     fn python_options_reads_virtualenv() {
         let opts = opts_with("virtualenv", ".venv");
         assert_eq!(PythonOptions::new(&opts).virtualenv(), Some(".venv"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_virtualenv_path_absolute_passthrough() {
+        let out = resolve_virtualenv_path(
+            PathBuf::from("/abs/venv"),
+            &ToolSource::Argument,
+            Some(Path::new("/some/project")),
+        );
+        assert_eq!(out, PathBuf::from("/abs/venv"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_virtualenv_path_relative_uses_declaring_config_root() {
+        // A relative venv resolves against the config file that declared the tool,
+        // NOT the passed-in project_root. This is the bug being fixed (#6019): a
+        // `virtualenv` in the global config must not resolve into unrelated projects.
+        let source = ToolSource::MiseToml(PathBuf::from("/tmp/mise-test-proj/mise.toml"));
+        let out = resolve_virtualenv_path(
+            PathBuf::from(".venv"),
+            &source,
+            Some(Path::new("/tmp/some-other-project")),
+        );
+        assert_eq!(out, PathBuf::from("/tmp/mise-test-proj/.venv"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_virtualenv_path_relative_argument_falls_back_to_project_root() {
+        // No backing config file (e.g. a CLI argument) -> fall back to project_root.
+        let out = resolve_virtualenv_path(
+            PathBuf::from(".venv"),
+            &ToolSource::Argument,
+            Some(Path::new("/tmp/mise-fallback-proj")),
+        );
+        assert_eq!(out, PathBuf::from("/tmp/mise-fallback-proj/.venv"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_virtualenv_path_relative_no_base_uses_cwd() {
+        // No source path and no project_root -> resolve under CWD.
+        let out = resolve_virtualenv_path(PathBuf::from(".venv"), &ToolSource::Argument, None);
+        assert_eq!(out, dirs::CWD.as_ref().unwrap().join(".venv"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Per @jdx's review, this PR now **deprecates** the legacy python `virtualenv` tool option instead of improving it.

- Emits a `deprecated_at!` warning when the `virtualenv` tool option is used, steering users to the `_.python.venv` env directive (same activate-an-existing-venv behavior).
- **warn immediately** (`2026.7.0`), **remove in ~12 months** (`2027.7.0`).
- Docs (`docs/plugins.md`, `docs/lang/python.md`) now carry a deprecation banner.
- The earlier path-resolution change (and its helper/tests) has been reverted; `get_virtualenv` keeps its original behavior aside from the deprecation warning.

This resolves [discussion #6019](https://github.com/jdx/mise/discussions/6019) by migration (users move to `_.python.venv`, which resolves relative paths against the declaring config file) rather than by touching the legacy resolution path.

### Commits
1. `5a73042` — original path-resolution fix (superseded)
2. `d378f87` — pivot to deprecation per review

(Kept as additive commits so the maintainer's review history stays intact; happy to squash on merge.)

---

Refs #6019

*This pull request was created by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Python “Tool Options” documentation to mark the legacy `python.virtualenv` option as deprecated, advising users to use `_.python.venv` in the `[env]` section instead.
* **User Experience**
  * Added a deprecation warning when the legacy `python.virtualenv` option is used, pointing users to `_.python.venv` for future-compatible configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->