### PR TITLE
fix(github): clearer error when a GitHub token is rejected with 401

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -75,6 +75,19 @@ mise could not resolve the version requested by the named config file — for ex
 - **Network/API errors**: the backend couldn't list versions (rate limits, offline).
   The underlying error after the colon will say so.
 
+## `HTTP status client error (401 Unauthorized)`
+
+GitHub rejected the credential mise sent, usually because the token is invalid,
+expired, for a different GitHub host, or missing a required scope. The error
+includes a `github auth:` line that names the token source when mise resolved it,
+for example `GITHUB_TOKEN`, `gh CLI (hosts.yml)`, or `github_tokens.toml`.
+
+Check or replace the token in the named source. If the source is not known, mise
+prints `github auth: yes` and refers to a configured GitHub token. If no
+Authorization header was sent, it prints `github auth: no`. See
+[GitHub Tokens](/dev-tools/github-tokens.html) for supported token sources and
+configuration.
+
 ## `HTTP status client error (403 Forbidden)` / `GitHub rate limit exceeded`
 
 You've hit GitHub's API rate limit, which is very low for unauthenticated requests.

--- a/src/github.rs
+++ b/src/github.rs
@@ -609,6 +609,34 @@ pub async fn pick_reachable_asset_url(browser_url: &str, api_url: &str) -> Strin
     }
 }
 
+/// Standard GitHub token env vars, in precedence order (applies to every host).
+const GITHUB_TOKEN_ENV_VARS: &[&str] = &["MISE_GITHUB_TOKEN", "GITHUB_API_TOKEN", "GITHUB_TOKEN"];
+
+/// Returns the env var whose GitHub token for `host` equals `token`, if any.
+///
+/// Side-effect free (env vars only; no `credential_command`, OAuth, or network)
+/// so it is safe to call on an error path — unlike [`resolve_token`], which can
+/// re-spawn the credential helper. Mirrors the value handling in [`resolve_token`]
+/// (the enterprise token is used verbatim; standard tokens are trimmed) so a
+/// rejected credential can be attributed to the exact variable that supplied it,
+/// and not to an unrelated env token when the request carried a netrc or
+/// caller-provided `Authorization` header instead.
+pub fn env_var_for_token(host: &str, token: &str) -> Option<&'static str> {
+    // An empty/whitespace Bearer credential is never a real token — resolve_token
+    // filters those out, so it must not be attributed to any env var.
+    if token.trim().is_empty() {
+        return None;
+    }
+    let is_ghcom = host == "github.com" || host == "api.github.com";
+    if !is_ghcom && env::MISE_GITHUB_ENTERPRISE_TOKEN.as_deref() == Some(token) {
+        return Some("MISE_GITHUB_ENTERPRISE_TOKEN");
+    }
+    GITHUB_TOKEN_ENV_VARS
+        .iter()
+        .copied()
+        .find(|var_name| std::env::var(var_name).is_ok_and(|t| t.trim() == token))
+}
+
 /// Resolve the GitHub token for the given hostname, returning the token and its source.
 ///
 /// Priority:
@@ -638,7 +666,7 @@ pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     }
 
     // 2. Standard env vars (checked individually for correct precedence and source reporting)
-    for var_name in &["MISE_GITHUB_TOKEN", "GITHUB_API_TOKEN", "GITHUB_TOKEN"] {
+    for var_name in GITHUB_TOKEN_ENV_VARS {
         if let Some(token) = std::env::var(var_name)
             .ok()
             .map(|t| t.trim().to_string())
@@ -994,6 +1022,20 @@ mod tests {
         }
 
         result
+    }
+
+    #[test]
+    fn test_env_var_for_token_matches_only_the_supplying_var() {
+        with_github_token(|| {
+            // with_github_token sets GITHUB_TOKEN=ghp_test and clears the others.
+            assert_eq!(
+                env_var_for_token("github.com", "ghp_test"),
+                Some("GITHUB_TOKEN")
+            );
+            // A token from netrc / a caller-provided header (not this env var) must
+            // not be attributed to GITHUB_TOKEN.
+            assert_eq!(env_var_for_token("github.com", "from-netrc"), None);
+        });
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
-use std::sync::LazyLock as Lazy;
+use std::sync::{LazyLock as Lazy, Mutex};
 use tokio::sync::RwLock;
 use tokio::sync::RwLockReadGuard;
 use xx::regex;
@@ -612,29 +612,31 @@ pub async fn pick_reachable_asset_url(browser_url: &str, api_url: &str) -> Strin
 /// Standard GitHub token env vars, in precedence order (applies to every host).
 const GITHUB_TOKEN_ENV_VARS: &[&str] = &["MISE_GITHUB_TOKEN", "GITHUB_API_TOKEN", "GITHUB_TOKEN"];
 
-/// Returns the env var whose GitHub token for `host` equals `token`, if any.
+static TOKEN_SOURCES: Lazy<Mutex<HashMap<String, (String, TokenSource)>>> =
+    Lazy::new(Default::default);
+
+/// Remembers the source of the token used to build a request header.
 ///
-/// Side-effect free (env vars only; no `credential_command`, OAuth, or network)
-/// so it is safe to call on an error path — unlike [`resolve_token`], which can
-/// re-spawn the credential helper. Mirrors the value handling in [`resolve_token`]
-/// (the enterprise token is used verbatim; standard tokens are trimmed) so a
-/// rejected credential can be attributed to the exact variable that supplied it,
-/// and not to an unrelated env token when the request carried a netrc or
-/// caller-provided `Authorization` header instead.
-pub fn env_var_for_token(host: &str, token: &str) -> Option<&'static str> {
-    // An empty/whitespace Bearer credential is never a real token — resolve_token
-    // filters those out, so it must not be attributed to any env var.
-    if token.trim().is_empty() {
-        return None;
-    }
-    let is_ghcom = host == "github.com" || host == "api.github.com";
-    if !is_ghcom && env::MISE_GITHUB_ENTERPRISE_TOKEN.as_deref() == Some(token) {
-        return Some("MISE_GITHUB_ENTERPRISE_TOKEN");
-    }
-    GITHUB_TOKEN_ENV_VARS
-        .iter()
-        .copied()
-        .find(|var_name| std::env::var(var_name).is_ok_and(|t| t.trim() == token))
+/// The 401 error path must not call [`resolve_token`] again: OAuth resolution can
+/// synchronously refresh a token, which would block inside the async HTTP send path.
+pub(crate) fn remember_token_source(host: &str, token: &str, source: TokenSource) {
+    TOKEN_SOURCES
+        .lock()
+        .unwrap()
+        .insert(host.to_string(), (token.to_string(), source));
+}
+
+/// Returns the recorded source only when `token` is the token sent for `host`.
+///
+/// Matching both values prevents a netrc or caller-provided Authorization header
+/// from being attributed to an unrelated GitHub credential.
+pub(crate) fn token_source_for_token(host: &str, token: &str) -> Option<TokenSource> {
+    TOKEN_SOURCES
+        .lock()
+        .unwrap()
+        .get(host)
+        .filter(|(recorded, _)| recorded == token)
+        .map(|(_, source)| source.clone())
 }
 
 /// Resolve the GitHub token for the given hostname, returning the token and its source.
@@ -747,17 +749,21 @@ pub fn get_headers<U: IntoUrl>(url: U) -> Result<HeaderMap> {
         .into_url()
         .wrap_err("invalid request URL for GitHub auth headers")?;
 
-    if is_github_api_url(&url)
-        && let Some((token, _source)) = resolve_token(url.host_str().unwrap_or("github.com"))
-    {
-        headers.insert(
-            reqwest::header::AUTHORIZATION,
-            HeaderValue::from_str(format!("Bearer {token}").as_str()).unwrap(),
-        );
-        headers.insert(
-            "x-github-api-version",
-            HeaderValue::from_static("2022-11-28"),
-        );
+    if is_github_api_url(&url) {
+        let host = url.host_str().unwrap_or("github.com");
+        if let Some((token, source)) = resolve_token(host) {
+            remember_token_source(host, &token, source);
+            headers.insert(
+                reqwest::header::AUTHORIZATION,
+                HeaderValue::from_str(format!("Bearer {token}").as_str()).unwrap(),
+            );
+            headers.insert(
+                "x-github-api-version",
+                HeaderValue::from_static("2022-11-28"),
+            );
+        } else {
+            TOKEN_SOURCES.lock().unwrap().remove(host);
+        }
     }
 
     if is_github_api_url(&url) && url.path().contains("/releases/assets/") {
@@ -1001,10 +1007,12 @@ mod tests {
         let orig_mise = std::env::var("MISE_GITHUB_TOKEN").ok();
         let orig_api = std::env::var("GITHUB_API_TOKEN").ok();
         let orig_gh = std::env::var("GITHUB_TOKEN").ok();
+        let orig_enterprise = std::env::var("MISE_GITHUB_ENTERPRISE_TOKEN").ok();
 
         env::remove_var("MISE_GITHUB_TOKEN");
         env::remove_var("GITHUB_API_TOKEN");
         env::set_var("GITHUB_TOKEN", "ghp_test");
+        env::remove_var("MISE_GITHUB_ENTERPRISE_TOKEN");
 
         let result = test_fn();
 
@@ -1020,22 +1028,100 @@ mod tests {
             Some(v) => env::set_var("GITHUB_TOKEN", v),
             None => env::remove_var("GITHUB_TOKEN"),
         }
+        match orig_enterprise {
+            Some(v) => env::set_var("MISE_GITHUB_ENTERPRISE_TOKEN", v),
+            None => env::remove_var("MISE_GITHUB_ENTERPRISE_TOKEN"),
+        }
 
         result
     }
 
+    struct TokenEnvGuard {
+        vars: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl TokenEnvGuard {
+        fn clear() -> Self {
+            let vars = GITHUB_TOKEN_ENV_VARS
+                .iter()
+                .copied()
+                .chain(std::iter::once("MISE_GITHUB_ENTERPRISE_TOKEN"))
+                .map(|var| (var, std::env::var(var).ok()))
+                .collect();
+            for var in GITHUB_TOKEN_ENV_VARS
+                .iter()
+                .copied()
+                .chain(std::iter::once("MISE_GITHUB_ENTERPRISE_TOKEN"))
+            {
+                env::remove_var(var);
+            }
+            Self { vars }
+        }
+    }
+
+    impl Drop for TokenEnvGuard {
+        fn drop(&mut self) {
+            for (var, value) in &self.vars {
+                match value {
+                    Some(value) => env::set_var(var, value),
+                    None => env::remove_var(var),
+                }
+            }
+        }
+    }
+
+    struct TokensFileOverrideGuard;
+
+    impl TokensFileOverrideGuard {
+        fn set(host: &str, token: &str) -> Self {
+            let mut tokens = HashMap::new();
+            tokens.insert(host.to_string(), token.to_string());
+            *test_support::TOKENS_FILE_OVERRIDE.write().unwrap() = Some(tokens);
+            Self
+        }
+    }
+
+    impl Drop for TokensFileOverrideGuard {
+        fn drop(&mut self) {
+            *test_support::TOKENS_FILE_OVERRIDE.write().unwrap() = None;
+        }
+    }
+
     #[test]
-    fn test_env_var_for_token_matches_only_the_supplying_var() {
+    fn test_get_headers_remembers_source_for_only_the_supplying_token_and_host() {
         with_github_token(|| {
-            // with_github_token sets GITHUB_TOKEN=ghp_test and clears the others.
+            let host = "github-source-test.example.com";
+            get_headers(format!("https://{host}/api/v3/repos/owner/repo/releases")).unwrap();
             assert_eq!(
-                env_var_for_token("github.com", "ghp_test"),
-                Some("GITHUB_TOKEN")
+                token_source_for_token(host, "ghp_test"),
+                Some(TokenSource::EnvVar("GITHUB_TOKEN"))
             );
-            // A token from netrc / a caller-provided header (not this env var) must
-            // not be attributed to GITHUB_TOKEN.
-            assert_eq!(env_var_for_token("github.com", "from-netrc"), None);
+            assert_eq!(token_source_for_token(host, "from-netrc"), None);
+            assert_eq!(
+                token_source_for_token("another-github.example.com", "ghp_test"),
+                None
+            );
         });
+    }
+
+    #[test]
+    fn test_get_headers_remembers_tokens_file_source() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _env = TokenEnvGuard::clear();
+        let host = "github-tokens-file-test.example.com";
+        let _tokens_file = TokensFileOverrideGuard::set(host, "ghp_from_tokens_file");
+
+        let headers =
+            get_headers(format!("https://{host}/api/v3/repos/owner/repo/releases")).unwrap();
+
+        assert_eq!(
+            headers.get(reqwest::header::AUTHORIZATION).unwrap(),
+            "Bearer ghp_from_tokens_file"
+        );
+        assert_eq!(
+            token_source_for_token(host, "ghp_from_tokens_file"),
+            Some(TokenSource::TokensFile)
+        );
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -656,6 +656,11 @@ pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
         return None;
     }
 
+    #[cfg(test)]
+    if let Some(token) = test_support::lookup_tokens_file_override(&token_lookup_hosts(host)) {
+        return Some((token, TokenSource::TokensFile));
+    }
+
     let is_ghcom = host == "github.com" || host == "api.github.com";
     let lookup_hosts = token_lookup_hosts(host);
 
@@ -699,12 +704,6 @@ pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
     }
 
     // 5. github_tokens.toml
-    #[cfg(test)]
-    if let Some((token, source)) = test_support::lookup_tokens_file_override(&lookup_hosts)
-        .map(|t| (t, TokenSource::TokensFile))
-    {
-        return Some((token, source));
-    }
     for lookup_host in &lookup_hosts {
         if let Some(token) = MISE_GITHUB_TOKENS.get(*lookup_host) {
             return Some((token.clone(), TokenSource::TokensFile));
@@ -879,7 +878,7 @@ pub(crate) mod test_support {
     use std::collections::HashMap;
     use std::sync::RwLock;
 
-    /// Overrides the `github_tokens.toml` path (source #4 in [`super::resolve_token`]).
+    /// Overrides the `github_tokens.toml` source in [`super::resolve_token`].
     /// Keyed by the same lookup hosts `resolve_token` walks — e.g. `"github.com"`.
     /// Hold [`super::TEST_ENV_LOCK`] while mutating; always clear before returning.
     pub(crate) static TOKENS_FILE_OVERRIDE: RwLock<Option<HashMap<String, String>>> =
@@ -1036,40 +1035,6 @@ mod tests {
         result
     }
 
-    struct TokenEnvGuard {
-        vars: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl TokenEnvGuard {
-        fn clear() -> Self {
-            let vars = GITHUB_TOKEN_ENV_VARS
-                .iter()
-                .copied()
-                .chain(std::iter::once("MISE_GITHUB_ENTERPRISE_TOKEN"))
-                .map(|var| (var, std::env::var(var).ok()))
-                .collect();
-            for var in GITHUB_TOKEN_ENV_VARS
-                .iter()
-                .copied()
-                .chain(std::iter::once("MISE_GITHUB_ENTERPRISE_TOKEN"))
-            {
-                env::remove_var(var);
-            }
-            Self { vars }
-        }
-    }
-
-    impl Drop for TokenEnvGuard {
-        fn drop(&mut self) {
-            for (var, value) in &self.vars {
-                match value {
-                    Some(value) => env::set_var(var, value),
-                    None => env::remove_var(var),
-                }
-            }
-        }
-    }
-
     struct TokensFileOverrideGuard;
 
     impl TokensFileOverrideGuard {
@@ -1088,26 +1053,24 @@ mod tests {
     }
 
     #[test]
-    fn test_get_headers_remembers_source_for_only_the_supplying_token_and_host() {
-        with_github_token(|| {
-            let host = "github-source-test.example.com";
-            get_headers(format!("https://{host}/api/v3/repos/owner/repo/releases")).unwrap();
-            assert_eq!(
-                token_source_for_token(host, "ghp_test"),
-                Some(TokenSource::EnvVar("GITHUB_TOKEN"))
-            );
-            assert_eq!(token_source_for_token(host, "from-netrc"), None);
-            assert_eq!(
-                token_source_for_token("another-github.example.com", "ghp_test"),
-                None
-            );
-        });
+    fn test_token_source_memo_matches_only_the_supplying_token_and_host() {
+        let host = "github-source-test.example.com";
+        remember_token_source(host, "ghp_test", TokenSource::EnvVar("GITHUB_TOKEN"));
+
+        assert_eq!(
+            token_source_for_token(host, "ghp_test"),
+            Some(TokenSource::EnvVar("GITHUB_TOKEN"))
+        );
+        assert_eq!(token_source_for_token(host, "from-netrc"), None);
+        assert_eq!(
+            token_source_for_token("another-github.example.com", "ghp_test"),
+            None
+        );
     }
 
     #[test]
     fn test_get_headers_remembers_tokens_file_source() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
-        let _env = TokenEnvGuard::clear();
         let host = "github-tokens-file-test.example.com";
         let _tokens_file = TokensFileOverrideGuard::set(host, "ghp_from_tokens_file");
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -750,6 +750,31 @@ impl Client {
                 }
             }
         }
+        if options.error_for_status && is_github_unauthorized(&url, &resp) {
+            // A static invalid/expired token (env var, gh CLI, ...) produces a 401
+            // that the OAuth-refresh path above cannot recover. Surface a clear
+            // error naming the token source instead of a bare status error. See #7218.
+            let status_error = resp
+                .error_for_status_ref()
+                .expect_err("401 response should be an error");
+            let used_github_token = final_headers.contains_key(AUTHORIZATION);
+            // Attribute the rejection to an env var only when the token we actually
+            // sent matches it — a netrc/caller-provided header must not be blamed on
+            // an unrelated env token.
+            let env_var = final_headers
+                .get(AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "))
+                .zip(original_url.host_str())
+                .and_then(|(token, host)| crate::github::env_var_for_token(host, token));
+            let body = read_bounded_error_body(resp, self.timeout).await;
+            return Err(github_unauthorized_report(
+                status_error,
+                used_github_token,
+                env_var,
+                &body,
+            ));
+        }
         if options.error_for_status && is_github_forbidden(&url, &resp) {
             let status = resp.status();
             let status_error = resp
@@ -757,7 +782,7 @@ impl Client {
                 .expect_err("403 response should be an error");
             let used_github_token = final_headers.contains_key(AUTHORIZATION);
             let rate_limit = github_rate_limit_summary(&resp);
-            let body = resp.text().await.unwrap_or_default();
+            let body = read_bounded_error_body(resp, self.timeout).await;
             // Retry without auth when the response mentions IP allow lists: GitHub App
             // installation tokens (`ghs_*`) get 403 on public API resources for orgs with IP
             // allow lists; stripping auth avoids that path.
@@ -846,6 +871,69 @@ impl TextRequest<'_> {
 
 fn is_github_forbidden(url: &Url, resp: &Response) -> bool {
     resp.status() == StatusCode::FORBIDDEN && url.host_str() == Some("api.github.com")
+}
+
+fn is_github_unauthorized(url: &Url, resp: &Response) -> bool {
+    resp.status() == StatusCode::UNAUTHORIZED && crate::github::is_github_api_url(url)
+}
+
+/// Maximum body bytes buffered when building a GitHub error report, so an
+/// oversized or slow-trickling error response can't exhaust memory. The overall
+/// request timeout bounds the time; this bounds the memory.
+const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
+
+/// Reads at most [`MAX_ERROR_BODY_BYTES`] of the response body for use in an
+/// error message, streaming chunk-by-chunk instead of buffering the whole body,
+/// and abandoning the read after `deadline` so a slowly-trickling response can't
+/// block indefinitely (the `Http` client has no overall request timeout, only an
+/// idle `read_timeout`). On timeout the partial body is dropped and "" returned.
+async fn read_bounded_error_body(resp: Response, deadline: Duration) -> String {
+    let read = async move {
+        let mut resp = resp;
+        let mut bytes = Vec::new();
+        while let Ok(Some(chunk)) = resp.chunk().await {
+            let remaining = MAX_ERROR_BODY_BYTES.saturating_sub(bytes.len());
+            if remaining == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+        }
+        String::from_utf8_lossy(&bytes).to_string()
+    };
+    tokio::time::timeout(deadline, read)
+        .await
+        .unwrap_or_default()
+}
+
+fn github_unauthorized_report(
+    status_error: reqwest::Error,
+    used_github_token: bool,
+    env_var: Option<&str>,
+    body: &str,
+) -> Report {
+    // Only report a token when one was actually sent: the process may have a
+    // GitHub token env var set that wasn't applied to this request.
+    let auth = if !used_github_token {
+        "no".to_string()
+    } else {
+        env_var
+            .map(|var| format!("yes (token from {var})"))
+            .unwrap_or_else(|| "yes".to_string())
+    };
+    let body = format_response_body(body);
+    let hint = if used_github_token {
+        let source = env_var
+            .map(|var| format!("token in `{var}`"))
+            .unwrap_or_else(|| "configured GitHub token".to_string());
+        format!(
+            "\nhint: the {source} was rejected by GitHub (401 Unauthorized). Verify it is a \
+             valid, non-expired token for this host with the required scopes — see \
+             https://mise.jdx.dev/dev-tools/github-tokens.html"
+        )
+    } else {
+        String::new()
+    };
+    eyre!("{status_error}\ngithub auth: {auth}\ngithub response: {body}{hint}")
 }
 
 fn github_forbidden_report(
@@ -1682,6 +1770,137 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(msg.contains("github auth: yes"));
         assert!(msg.contains("github rate limit: 42/5000 (core), resets at 1781337353"));
         assert!(msg.contains(r#"{"message":"secondary rate limit","docs":"url"}"#));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_github_unauthorized_report_names_token_source() {
+        // env var known → the message names it and includes the token-guide hint.
+        let (port, _count) = spawn_canned_server(vec![unauthorized_response()]).await;
+        let url = format!("http://127.0.0.1:{port}/repos/owner/repo/releases");
+        let resp = reqwest::Client::new().get(url).send().await.unwrap();
+        let status_error = resp
+            .error_for_status_ref()
+            .expect_err("401 response should be an error");
+        let body = resp.text().await.unwrap();
+        let err = github_unauthorized_report(status_error, true, Some("GITHUB_TOKEN"), &body);
+        let msg = format!("{err:?}");
+
+        assert!(
+            msg.contains("github auth: yes (token from GITHUB_TOKEN)"),
+            "{msg}"
+        );
+        assert!(msg.contains("Bad credentials"), "{msg}");
+        assert!(
+            msg.contains("token in `GITHUB_TOKEN` was rejected by GitHub (401 Unauthorized)"),
+            "{msg}"
+        );
+        assert!(msg.contains("github-tokens.html"), "{msg}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_github_unauthorized_report_without_env_var() {
+        // Token used but source unknown → generic auth "yes" and generic hint;
+        // no token → auth "no" and no hint.
+        let (port, _count) =
+            spawn_canned_server(vec![unauthorized_response(), unauthorized_response()]).await;
+        let url = format!("http://127.0.0.1:{port}/repos/owner/repo/releases");
+
+        let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+        let status_error = resp.error_for_status_ref().unwrap_err();
+        let body = resp.text().await.unwrap();
+        let used_msg = format!(
+            "{:?}",
+            github_unauthorized_report(status_error, true, None, &body)
+        );
+        assert!(used_msg.contains("github auth: yes"), "{used_msg}");
+        assert!(!used_msg.contains("token from"), "{used_msg}");
+        assert!(used_msg.contains("configured GitHub token"), "{used_msg}");
+
+        let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+        let status_error = resp.error_for_status_ref().unwrap_err();
+        let body = resp.text().await.unwrap();
+        let anon_msg = format!(
+            "{:?}",
+            github_unauthorized_report(status_error, false, None, &body)
+        );
+        assert!(anon_msg.contains("github auth: no"), "{anon_msg}");
+        assert!(!anon_msg.contains("hint:"), "{anon_msg}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_github_unauthorized_report_ignores_env_var_when_no_auth_sent() {
+        // A GitHub token env var may be present in the process even when this
+        // request sent no Authorization header; it must not be reported as used.
+        let (port, _count) = spawn_canned_server(vec![unauthorized_response()]).await;
+        let url = format!("http://127.0.0.1:{port}/repos/owner/repo/releases");
+        let resp = reqwest::Client::new().get(url).send().await.unwrap();
+        let status_error = resp.error_for_status_ref().unwrap_err();
+        let body = resp.text().await.unwrap();
+        let msg = format!(
+            "{:?}",
+            github_unauthorized_report(status_error, false, Some("GITHUB_TOKEN"), &body)
+        );
+
+        assert!(msg.contains("github auth: no"), "{msg}");
+        assert!(!msg.contains("token from"), "{msg}");
+        assert!(!msg.contains("hint:"), "{msg}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_read_bounded_error_body_caps_large_body() {
+        // An oversized error body must be truncated during reading, not buffered
+        // whole, so a hostile endpoint can't exhaust memory.
+        let big_body = "x".repeat(MAX_ERROR_BODY_BYTES + 4096);
+        let raw = format!(
+            "HTTP/1.1 401 Unauthorized\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            big_body.len(),
+            big_body
+        );
+        let leaked: &'static str = Box::leak(raw.into_boxed_str());
+        let (port, _count) = spawn_canned_server(vec![leaked]).await;
+        let url = format!("http://127.0.0.1:{port}/repos/owner/repo/releases");
+        let resp = reqwest::Client::new().get(url).send().await.unwrap();
+
+        let body = read_bounded_error_body(resp, Duration::from_secs(30)).await;
+        assert_eq!(body.len(), MAX_ERROR_BODY_BYTES);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_read_bounded_error_body_honors_deadline() {
+        // A response body that trickles forever (staying under the byte cap and
+        // the idle read_timeout) must still be abandoned at the deadline instead
+        // of blocking indefinitely.
+        use tokio::io::AsyncWriteExt;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                // No Content-Length + `close` → body is read until EOF, which the
+                // server never sends; it just trickles one byte at a time.
+                let _ = sock
+                    .write_all(b"HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n")
+                    .await;
+                loop {
+                    if sock.write_all(b"x").await.is_err() {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+            }
+        });
+        let url = format!("http://127.0.0.1:{port}/repos/owner/repo/releases");
+        let resp = reqwest::Client::new().get(url).send().await.unwrap();
+
+        let start = tokio::time::Instant::now();
+        let body = read_bounded_error_body(resp, Duration::from_millis(150)).await;
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "read must stop at the deadline"
+        );
+        assert!(
+            body.is_empty(),
+            "timed-out read yields no body, got {body:?}"
+        );
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -719,6 +719,11 @@ impl Client {
                 Ok(Some(token)) => {
                     let mut headers = headers.clone();
                     if let Ok(value) = HeaderValue::from_str(format!("Bearer {token}").as_str()) {
+                        crate::github::remember_token_source(
+                            host,
+                            &token,
+                            crate::github::TokenSource::GithubOauth,
+                        );
                         headers.insert(AUTHORIZATION, value);
                         if let Some(retry_state) = &options.retry_state {
                             *retry_state.lock().unwrap() = RetryState {
@@ -758,20 +763,19 @@ impl Client {
                 .error_for_status_ref()
                 .expect_err("401 response should be an error");
             let used_github_token = final_headers.contains_key(AUTHORIZATION);
-            // Attribute the rejection to an env var only when the token we actually
-            // sent matches it — a netrc/caller-provided header must not be blamed on
-            // an unrelated env token.
-            let env_var = final_headers
+            // Use the source captured when this exact token was added to the request.
+            // A netrc/caller-provided header must not be blamed on an unrelated token.
+            let token_source = final_headers
                 .get(AUTHORIZATION)
                 .and_then(|v| v.to_str().ok())
                 .and_then(|v| v.strip_prefix("Bearer "))
                 .zip(original_url.host_str())
-                .and_then(|(token, host)| crate::github::env_var_for_token(host, token));
+                .and_then(|(token, host)| crate::github::token_source_for_token(host, token));
             let body = read_bounded_error_body(resp, self.timeout).await;
             return Err(github_unauthorized_report(
                 status_error,
                 used_github_token,
-                env_var,
+                token_source.as_ref(),
                 &body,
             ));
         }
@@ -908,7 +912,7 @@ async fn read_bounded_error_body(resp: Response, deadline: Duration) -> String {
 fn github_unauthorized_report(
     status_error: reqwest::Error,
     used_github_token: bool,
-    env_var: Option<&str>,
+    token_source: Option<&crate::github::TokenSource>,
     body: &str,
 ) -> Report {
     // Only report a token when one was actually sent: the process may have a
@@ -916,15 +920,17 @@ fn github_unauthorized_report(
     let auth = if !used_github_token {
         "no".to_string()
     } else {
-        env_var
-            .map(|var| format!("yes (token from {var})"))
+        token_source
+            .map(|source| format!("yes (token from {source})"))
             .unwrap_or_else(|| "yes".to_string())
     };
     let body = format_response_body(body);
     let hint = if used_github_token {
-        let source = env_var
-            .map(|var| format!("token in `{var}`"))
-            .unwrap_or_else(|| "configured GitHub token".to_string());
+        let source = match token_source {
+            Some(crate::github::TokenSource::EnvVar(var)) => format!("token in `{var}`"),
+            Some(source) => format!("token from {source}"),
+            None => "configured GitHub token".to_string(),
+        };
         format!(
             "\nhint: the {source} was rejected by GitHub (401 Unauthorized). Verify it is a \
              valid, non-expired token for this host with the required scopes — see \
@@ -1688,6 +1694,26 @@ mod tests {
     fn github_oauth_token_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 51\r\nConnection: close\r\n\r\n{\"access_token\":\"ghu-refreshed\",\"expires_in\":28800}"
     }
+    fn seed_github_oauth_cache(cache_path: &Path) {
+        let settings = crate::config::Settings::get();
+        let cache_key = crate::github::oauth::test_support::cache_key(
+            "127.0.0.1",
+            "Iv1.mock",
+            settings.github.oauth_scopes.trim(),
+        );
+        std::fs::write(
+            cache_path,
+            format!(
+                r#"[tokens.{cache_key}]
+access_token = "ghu-stale"
+expires_at = "2099-01-01T00:00:00Z"
+refresh_token = "ghr-refresh"
+refresh_expires_at = "2099-01-01T00:00:00Z"
+"#
+            ),
+        )
+        .unwrap();
+    }
     fn json_empty_array_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n[]"
     }
@@ -1704,24 +1730,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join("github-oauth-tokens.toml");
         let _guard = set_test_github_oauth(&server_url, cache_path.clone());
-        let settings = crate::config::Settings::get();
-        let cache_key = crate::github::oauth::test_support::cache_key(
-            "127.0.0.1",
-            "Iv1.mock",
-            settings.github.oauth_scopes.trim(),
-        );
-        std::fs::write(
-            &cache_path,
-            format!(
-                r#"[tokens.{cache_key}]
-access_token = "ghu-stale"
-expires_at = "2099-01-01T00:00:00Z"
-refresh_token = "ghr-refresh"
-refresh_expires_at = "2099-01-01T00:00:00Z"
-"#
-            ),
-        )
-        .unwrap();
+        seed_github_oauth_cache(&cache_path);
 
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer ghu-stale"));
@@ -1754,6 +1763,42 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(cache.contains("ghu-refreshed"));
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_github_oauth_401_reports_refreshed_token_source() {
+        let (port, count, _requests) = spawn_recording_server(vec![
+            unauthorized_response(),
+            github_oauth_token_response(),
+            unauthorized_response(),
+        ])
+        .await;
+        let server_url = format!("http://127.0.0.1:{port}");
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("github-oauth-tokens.toml");
+        let _guard = set_test_github_oauth(&server_url, cache_path.clone());
+        seed_github_oauth_cache(&cache_path);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer ghu-stale"));
+        let client = Client::new(Duration::from_secs(3), ClientKind::Http).unwrap();
+        let err = client
+            .get_text_request(format!("{server_url}/api/v3/repos/owner/repo/releases"))
+            .headers(&headers)
+            .send()
+            .await
+            .unwrap_err();
+        let msg = format!("{err:?}");
+
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+        assert!(
+            msg.contains("github auth: yes (token from GitHub OAuth)"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("token from GitHub OAuth was rejected by GitHub"),
+            "{msg}"
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn test_github_forbidden_report_includes_body_and_auth_state() {
         let (port, _count) = spawn_canned_server(vec![github_forbidden_response()]).await;
@@ -1782,7 +1827,12 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
             .error_for_status_ref()
             .expect_err("401 response should be an error");
         let body = resp.text().await.unwrap();
-        let err = github_unauthorized_report(status_error, true, Some("GITHUB_TOKEN"), &body);
+        let err = github_unauthorized_report(
+            status_error,
+            true,
+            Some(&crate::github::TokenSource::EnvVar("GITHUB_TOKEN")),
+            &body,
+        );
         let msg = format!("{err:?}");
 
         assert!(
@@ -1798,7 +1848,46 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_github_unauthorized_report_without_env_var() {
+    async fn test_github_unauthorized_report_names_non_env_token_sources() {
+        let sources = [
+            (crate::github::TokenSource::TokensFile, "github_tokens.toml"),
+            (crate::github::TokenSource::GhCli, "gh CLI (hosts.yml)"),
+            (
+                crate::github::TokenSource::CredentialCommand,
+                "credential_command",
+            ),
+            (crate::github::TokenSource::GithubOauth, "GitHub OAuth"),
+            (
+                crate::github::TokenSource::GitCredential,
+                "git credential fill",
+            ),
+        ];
+        let (port, _count) =
+            spawn_canned_server(vec![unauthorized_response(); sources.len()]).await;
+        let url = format!("http://127.0.0.1:{port}/repos/owner/repo/releases");
+
+        for (source, label) in sources {
+            let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+            let status_error = resp.error_for_status_ref().unwrap_err();
+            let body = resp.text().await.unwrap();
+            let msg = format!(
+                "{:?}",
+                github_unauthorized_report(status_error, true, Some(&source), &body)
+            );
+
+            assert!(
+                msg.contains(&format!("github auth: yes (token from {label})")),
+                "{msg}"
+            );
+            assert!(
+                msg.contains(&format!("token from {label} was rejected by GitHub")),
+                "{msg}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_github_unauthorized_report_without_known_source() {
         // Token used but source unknown → generic auth "yes" and generic hint;
         // no token → auth "no" and no hint.
         let (port, _count) =
@@ -1828,7 +1917,7 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_github_unauthorized_report_ignores_env_var_when_no_auth_sent() {
+    async fn test_github_unauthorized_report_ignores_source_when_no_auth_sent() {
         // A GitHub token env var may be present in the process even when this
         // request sent no Authorization header; it must not be reported as used.
         let (port, _count) = spawn_canned_server(vec![unauthorized_response()]).await;
@@ -1838,7 +1927,12 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let body = resp.text().await.unwrap();
         let msg = format!(
             "{:?}",
-            github_unauthorized_report(status_error, false, Some("GITHUB_TOKEN"), &body)
+            github_unauthorized_report(
+                status_error,
+                false,
+                Some(&crate::github::TokenSource::EnvVar("GITHUB_TOKEN")),
+                &body
+            )
         );
 
         assert!(msg.contains("github auth: no"), "{msg}");


### PR DESCRIPTION
## Problem

When GitHub rejects an invalid, expired, wrong-host, or insufficiently scoped
token, mise previously returned only a bare `401 Unauthorized`. The initial
change added an actionable report, but only environment-variable tokens could
be attributed precisely; tokens from the gh CLI, `github_tokens.toml`, OAuth,
credential commands, and Git credentials were reported generically.

Reported in discussion #7218.

## Change

When a GitHub API request returns 401, mise now:

- reports whether an Authorization header was sent and names every known
  `TokenSource`;
- includes a bounded GitHub response body and a source-specific remediation
  hint;
- records the source when building the header, then matches the exact host and
  Bearer token on the error path instead of resolving credentials again;
- preserves the existing OAuth refresh-first behavior and records refreshed
  tokens as `GitHub OAuth`;
- documents the 401 diagnostic next to the existing 403 guidance in
  `docs/errors.md`.

Example:

```text
HTTP status client error (401 Unauthorized) for url (https://api.github.com/…)
github auth: yes (token from gh CLI (hosts.yml))
github response: Bad credentials
hint: the token from gh CLI (hosts.yml) was rejected by GitHub (401 Unauthorized).
```

The host-and-token match prevents netrc or caller-provided Authorization headers
from being attributed to an unrelated mise credential. It also avoids calling
`resolve_token` from the async error path, where OAuth resolution could perform
a blocking refresh.

### Out of scope

Automatically retrying unauthenticated on 401 is intentionally not done; that
behavior was rejected in #9965. The existing bounded error-body handling and
OAuth retry remain unchanged.

## Testing

- `cargo fmt --all -- --check`
- `markdownlint docs/errors.md`
- `cargo check --all-features`
- GitHub header-source tests for environment variables, `github_tokens.toml`,
  host mismatches, and token mismatches
- 401 report tests for all `TokenSource` variants, unknown sources, and
  unauthenticated requests
- OAuth tests for successful refresh/retry and source attribution when the
  refreshed token is also rejected

Fixes discussion #7218.

---

*This pull request was generated by an AI coding assistant.*
