### PR TITLE
docs: update stephane-robert guide URL and external post dates

### DIFF
--- a/docs/external-resources.md
+++ b/docs/external-resources.md
@@ -7,13 +7,13 @@ Links to articles, videos, and other resources that are relevant to mise.
 - 2025-02-17 - pitchfork: process manager for developers that pairs well with mise - <https://pitchfork.jdx.dev>
 - 2025-02-04 - A Mise guide for Swift developers - <https://tuist.dev/blog/2025/02/04/mise>
 - 2025-01-26 - devtools.fm: Jeff Dickey - Mise, Usage, and Pitchfork and the Future of Polyglot Tools - <https://www.devtools.fm/episode/129>
-- 2025-01-12 - [fr] Mise-En-Place: Simplifiez la Gestion de vos Environnements et Tâches – <https://blog.stephane-robert.info/docs/developper/autres-outils/mise-en-place/>
+- 2025-01-12 - [fr] Mise-En-Place: Simplifiez la Gestion de vos Environnements et Tâches – <https://blog.stephane-robert.info/docs/outils/systeme/mise/>
 - 2024-11-20 - Migrating from nvm to mise - <https://dev.to/hverlin/migrating-from-nvm-to-mise-4mfp>
 - 2024-06-27 - Managing Development Tool Versions with mise - <https://haril.dev/en/blog/2024/06/27/Easy-devtools-version-management-mise>
-- 2024-06-09 - Replacing pyenv, nvm, direnv with Mise - <https://arunmozhi.in/2024/09/06/replacing-pyenv-nvm-direnv-with-mise>
+- 2024-09-06 - Replacing pyenv, nvm, direnv with Mise - <https://arunmozhi.in/2024/09/06/replacing-pyenv-nvm-direnv-with-mise>
 - 2024-04-14 - Shims: How they work in mise-en-place: <https://jdx.dev/posts/2024-04-13-shims-how-they-work-in-mise-en-place/>
 - 2024-04-07 - Lalaluka stream: Grroxy, Cook, and jdx/mise - <https://www.youtube.com/watch?v=zA1hjrLQiPw>
-- 2024-20-02 - Can Mise replace Volta? - <https://ricostacruz.com/posts/mise-vs-volta>
+- 2024-02-20 - Can Mise replace Volta? - <https://ricostacruz.com/posts/mise-vs-volta>
 - 2024-01-14 - Manage all your runtime versions with one tool (asdf, mise) - <https://blog.andreyfadeev.com/p/manage-all-your-runtime-versions>
 - 2023-12-30 - You should be using mise - <https://andrei-calazans.com/posts/you-should-be-using-rtx/>
 - 2023-03-04 - Beginner's Guide to rtx (mise) - <https://dev.to/jdxcode/beginners-guide-to-rtx-ac4>


### PR DESCRIPTION
Point the French Stephane Robert mise guide at the current docs path (old path only 302s), fix the impossible Volta post date `2024-20-02` → `2024-02-20`, and align the arunmozhi entry date with the post published `2024-09-06`.

Verified: new Stephane path and ricostacruz/arunmozhi publish dates; old path still redirects today.

Opened as draft (Bartok9 markReady often FORBIDDEN on jdx/mise).

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated external resource links for improved accuracy.
  * Corrected publication dates for listed articles, including fixing an incorrect French “Mise-En-Place” link and correcting a date typo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->