### PR TITLE
fix(task): implement "instead of metadata" for source_freshness_hash_contents

### DIFF
--- a/e2e/tasks/test_task_source_freshness_hash_contents
+++ b/e2e/tasks/test_task_source_freshness_hash_contents
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# When source_freshness_hash_contents=true, mtime must NOT be the final
+# freshness gate — the content hash alone determines freshness. This fixes
+# CI cache-restore scenarios (e.g. GitHub Actions) where all files get their
+# mtime reset to the restore time, making source mtimes appear newer than
+# output mtimes even though nothing has changed.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'touch out.txt && echo built'
+sources = ['src.txt']
+outputs = ['out.txt']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no output → stale → runs
+assert "mise run -q build" "built"
+
+# Second run: nothing changed → fresh
+assert_empty "mise run -q build"
+
+# Simulate CI cache restore: same content, but mtime of src reset to "now"
+# (newer than out.txt). With the fix, hash match wins; mtime is ignored.
+sleep 0.1
+touch src.txt
+assert_empty "mise run -q build"
+
+# Changing content must still trigger a rebuild
+echo "changed" >src.txt
+assert "mise run -q build" "built"
+
+# Touching src again (same content as after last rebuild) must remain fresh
+sleep 0.1
+touch src.txt
+assert_empty "mise run -q build"
+
+# Deleting outputs must trigger a rebuild even when content hash matches
+rm out.txt
+assert "mise run -q build" "built"

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -282,16 +282,19 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
         }
 
         // Check for epoch timestamps (files extracted from tarballs without preserved timestamps)
-        // These are considered stale since we can't trust the mtime
-        for (path, metadata) in &source_metadatas {
-            if let Ok(mtime) = metadata.modified()
-                && mtime == UNIX_EPOCH
-            {
-                debug!(
-                    "source file {} has epoch timestamp, treating as stale",
-                    display_path(path)
-                );
-                return Ok(false);
+        // These are considered stale since we can't trust the mtime.
+        // Skipped in hash mode — content is the authority there, not timestamps.
+        if !use_content_hash {
+            for (path, metadata) in &source_metadatas {
+                if let Ok(mtime) = metadata.modified()
+                    && mtime == UNIX_EPOCH
+                {
+                    debug!(
+                        "source file {} has epoch timestamp, treating as stale",
+                        display_path(path)
+                    );
+                    return Ok(false);
+                }
             }
         }
 

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -310,7 +310,8 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
         if let Some(dir) = source_hash_path.parent() {
             file::create_dir_all(dir)?;
         }
-        if source_existing_hash(task, &root, use_content_hash).is_some_and(|h| h != source_hash) {
+        let existing_hash = source_existing_hash(task, &root, use_content_hash);
+        if existing_hash.as_deref().is_some_and(|h| h != source_hash) {
             debug!(
                 "source {} hash mismatch in {}",
                 if use_content_hash {
@@ -322,6 +323,13 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
             );
             file::write(&source_hash_path, &source_hash)?;
             return Ok(false);
+        }
+        if use_content_hash && existing_hash.is_some() {
+            // In hash mode, content alone determines freshness — no mtime check.
+            let outputs_exist =
+                get_last_modified(&root, &task.outputs.paths(task, &root))?.is_some();
+            file::write(&source_hash_path, &source_hash)?;
+            return Ok(outputs_exist);
         }
         let sources = get_last_modified_from_metadatas(&source_metadatas);
         let outputs = get_last_modified(&root, &task.outputs.paths(task, &root))?;


### PR DESCRIPTION
`source_freshness_hash_contents` is documented as _"Use content hashing (blake3) instead of metadata for source freshness"_, but mtime was still used as the final freshness gate even in hash mode. This makes the setting ineffective when sources and outputs are restored from a cache (e.g. GitHub Actions), where all mtimes are reset to the restore time — tasks re-run on every CI run despite unchanged content.

With this fix, once a stored hash baseline exists and matches, content alone determines freshness — outputs are only checked for existence, not compared by mtime — which is what the documentation promises.

**First-run behaviour is unchanged:** when no stored hash exists yet, the existing mtime path runs as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task freshness behavior when source content hashing is enabled.
  * Tasks stay fresh when source file timestamps change but contents are unchanged.
  * Tasks rerun when source contents change or when expected outputs are missing.

* **Tests**
  * Added end-to-end coverage for initial execution, unchanged sources, simulated cache restores, source updates, and deleted outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->