### PR TITLE
fix(npm): serialize aube allow_builds as map

### DIFF
--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -948,7 +948,11 @@ impl NPMBackend {
             "private": true,
         });
         if let AllowBuilds::Packages(packages) = allow_builds {
-            manifest["aube"] = serde_json::json!({ "allowBuilds": packages });
+            let allow_builds = packages
+                .iter()
+                .map(|package| (package.clone(), serde_json::Value::Bool(true)))
+                .collect::<serde_json::Map<_, _>>();
+            manifest["aube"] = serde_json::json!({ "allowBuilds": allow_builds });
         }
         crate::file::write(
             install_path.join("package.json"),
@@ -1885,9 +1889,13 @@ mod tests {
         let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
         assert!(npmrc.contains("trustPolicyExclude=undici,undici@^5\n"));
         // The build-script allowlist goes in package.json's aube namespace.
-        let manifest = std::fs::read_to_string(install_path.join("package.json")).unwrap();
-        assert!(manifest.contains("\"allowBuilds\""));
-        assert!(manifest.contains("esbuild"));
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(install_path.join("package.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            manifest["aube"]["allowBuilds"],
+            serde_json::json!({ "esbuild": true })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- serialize package-specific `allow_builds` entries as an aube `allowBuilds` boolean map
- strengthen the regression test to assert the exact generated manifest shape

## Root cause

The embedded aube path wrote `aube.allowBuilds` as a JSON array. aube 1.32 reads this setting as a package-to-boolean object, so the configured packages were ignored and installs with reviewed dependency build scripts failed.

## Impact

Package-specific `allow_builds` works again for npm tools installed through embedded aube.

## Validation

- `cargo test backend::npm::tests::` (46 passed)
- `mise run lint-fix`
- pre-commit lint suite

Addresses https://github.com/jdx/mise/discussions/11260

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to synthetic manifest JSON for embedded aube installs; no auth or broader install-path behavior changes beyond restoring intended allowlist semantics.
> 
> **Overview**
> Fixes **package-specific `allow_builds`** for npm tools installed via embedded aube: seed `package.json` now sets `aube.allowBuilds` as a **package-name → `true` map** instead of a JSON array, matching what **aube 1.32+** expects so configured packages (e.g. `esbuild`) are actually allowed to run build scripts.
> 
> The regression test **`test_write_aube_embed_project_emits_npmrc_and_manifest`** now parses the manifest and asserts the exact `{ "esbuild": true }` shape rather than only checking for substring presence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043361ec7ec3cbe8a52e16120eaf3db567eb73e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how package build permissions are recorded in embedded project manifests.
  * Build permissions now use a consistent package-to-approval mapping, improving compatibility with package installation and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->