### PR TITLE
chore: release 2026.7.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,87 @@
 # Changelog
 
+## [2026.7.14](https://github.com/jdx/mise/compare/v2026.7.13..v2026.7.14) - 2026-07-26
+
+### 🚀 Features
+
+- **(github)** support additional release assets by @jdx in [#11272](https://github.com/jdx/mise/pull/11272)
+- **(usage)** declare what each command does to the world by @jdx in [#11306](https://github.com/jdx/mise/pull/11306)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** preserve v prefix in HTTP lock URLs by @jdx in [#11267](https://github.com/jdx/mise/pull/11267)
+- **(backend)** strip platform suffix from single binary inside archives by @Marukome0743 in [#11232](https://github.com/jdx/mise/pull/11232)
+- **(brew)** support cask completion stanzas, system_command, and elevated artifact links by @jdx in [#11273](https://github.com/jdx/mise/pull/11273)
+- **(completions)** stop offering mise's own flags after a task name by @jdx in [#11284](https://github.com/jdx/mise/pull/11284)
+- **(env)** make env file expansion opt-in by @jdx in [#11269](https://github.com/jdx/mise/pull/11269)
+- **(env)** convert remaining std::env::vars() call sites to vars_safe() by @JamBalaya56562 in [#11309](https://github.com/jdx/mise/pull/11309)
+- **(github)** prefer .exe assets on Windows by @gologames in [#11257](https://github.com/jdx/mise/pull/11257)
+- **(github)** clearer error when a GitHub token is rejected with 401 by @Marukome0743 in [#11236](https://github.com/jdx/mise/pull/11236)
+- **(lockfile)** respect locked versions for prefix: tool requests by @JamBalaya56562 in [#11255](https://github.com/jdx/mise/pull/11255)
+- **(npm)** serialize aube allow_builds as map by @jdx in [#11262](https://github.com/jdx/mise/pull/11262)
+- **(npm)** sort large version components correctly by @jdx in [#11280](https://github.com/jdx/mise/pull/11280)
+- **(npm)** explain aube trust downgrade failures by @jdx in [#11292](https://github.com/jdx/mise/pull/11292)
+- **(npm)** add allow_low_downloads backend option by @jdx in [#11305](https://github.com/jdx/mise/pull/11305)
+- **(npm)** bump aube to 1.33.1, stop it rendering its own progress display by @jdx in [#11308](https://github.com/jdx/mise/pull/11308)
+- **(python)** make pip usable on Windows by @JamBalaya56562 in [#11278](https://github.com/jdx/mise/pull/11278)
+- **(swift)** record the target distro in lockfile entries by @jdx in [#11299](https://github.com/jdx/mise/pull/11299)
+- **(task)** don't load tasks from an enclosing monorepo root by @jdx in [#11283](https://github.com/jdx/mise/pull/11283)
+- **(task)** include run, sources, and outputs in task_state_key by @rabadin in [#11288](https://github.com/jdx/mise/pull/11288)
+- **(task)** only persist source hash after successful task run by @rabadin in [#11296](https://github.com/jdx/mise/pull/11296)
+- **(version)** make the update-check cache actually suppress retries by @jdx in [#11285](https://github.com/jdx/mise/pull/11285)
+
+### 📚 Documentation
+
+- **(backend)** correct bin_path/asset_pattern template variables by @jdx in [#11298](https://github.com/jdx/mise/pull/11298)
+- **(npm)** document Socket integrations by @jdx in [#11268](https://github.com/jdx/mise/pull/11268)
+- retarget dead clap.rs link to docs.rs/clap by @Bartok9 in [#11194](https://github.com/jdx/mise/pull/11194)
+- generate llms.txt index for AI agents by @jdx in [#11300](https://github.com/jdx/mise/pull/11300)
+
+### ⚡ Performance
+
+- **(cli)** stop rebuilding the clap tree twice on every invocation by @jdx in [#11297](https://github.com/jdx/mise/pull/11297)
+
+### 📦️ Dependency Updates
+
+- update docker/login-action digest to abd2ef4 by @renovate[bot] in [#11261](https://github.com/jdx/mise/pull/11261)
+- update actions/setup-node action to v7 by @renovate[bot] in [#11247](https://github.com/jdx/mise/pull/11247)
+- update ghcr.io/jdx/mise:alpine docker digest to 7a44a65 by @renovate[bot] in [#11264](https://github.com/jdx/mise/pull/11264)
+- update dependency toml to v5 by @renovate[bot] in [#11248](https://github.com/jdx/mise/pull/11248)
+- update rust crate age to 0.12 by @renovate[bot] in [#11246](https://github.com/jdx/mise/pull/11246)
+- update rust crate clx to v3 by @renovate[bot] in [#11270](https://github.com/jdx/mise/pull/11270)
+- update ghcr.io/jdx/mise:rpm docker digest to f26a306 by @renovate[bot] in [#11266](https://github.com/jdx/mise/pull/11266)
+- update ghcr.io/jdx/mise:deb docker digest to b1b88a5 by @renovate[bot] in [#11265](https://github.com/jdx/mise/pull/11265)
+- update rust crate path-absolutize to v4 by @renovate[bot] in [#11249](https://github.com/jdx/mise/pull/11249)
+- update aube crates to v1.33 by @jdx in [#11302](https://github.com/jdx/mise/pull/11302)
+- update actions/checkout digest to 3d3c42e by @renovate[bot] in [#11237](https://github.com/jdx/mise/pull/11237)
+
+### 📦 Registry
+
+- add checkstyle by @zeitlinger in [#11287](https://github.com/jdx/mise/pull/11287)
+- add grok by @jdx in [#11291](https://github.com/jdx/mise/pull/11291)
+- fix croc version test expectation by @jdx in [#11301](https://github.com/jdx/mise/pull/11301)
+- add tak by @jdx in [#11307](https://github.com/jdx/mise/pull/11307)
+
+### Chore
+
+- **(ci)** add cmake to ppa build dependencies by @jdx in [#11274](https://github.com/jdx/mise/pull/11274)
+
+### Security
+
+- **(config)** restrict default shell args to global config by @jdx in [#11293](https://github.com/jdx/mise/pull/11293)
+
+### New Contributors
+
+- @gologames made their first contribution in [#11257](https://github.com/jdx/mise/pull/11257)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`checkstyle/checkstyle`](https://github.com/checkstyle/checkstyle)
+- [`fbtransfer/ktfmt`](https://github.com/fbtransfer/ktfmt)
+- [`isksss/isksh`](https://github.com/isksss/isksh)
+
 ## [2026.7.13](https://github.com/jdx/mise/compare/v2026.7.12..v2026.7.13) - 2026-07-24
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6348,7 +6348,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.13"
+version = "2026.7.14"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.13"
+version = "2026.7.14"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.13 macos-arm64 (2026-07-24)
+2026.7.14 macos-arm64 (2026-07-26)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_13.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_14.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_13.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_14.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -p usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_13.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_14.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_13.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_14.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.13";
+  version = "2026.7.14";
 
   src = lib.cleanSource ./.;
 

--- a/mise.lock
+++ b/mise.lock
@@ -341,6 +341,7 @@ checksum = "sha256:180f970282986f27f7fa9ee216e4971e8dec3624869d4222f22f3e2535fcc
 url = "https://github.com/jdx/communique/releases/download/v1.2.3/communique-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/477186105"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.communique."platforms.linux-x64-baseline"]
 checksum = "sha256:180f970282986f27f7fa9ee216e4971e8dec3624869d4222f22f3e2535fccc58"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.13
+Version: 2026.7.14
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.13"
+version: "2026.7.14"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "1639bafbf14e15d6585eed45623162a65171b432"
+  "tag": "f2cab17924c99504bf3c9014c3b4969763d98f08"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -25105,6 +25105,12 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: checkstyle
+    repo_name: checkstyle
+    description: A development tool for checking Java source code against a coding standard
+    version_prefix: checkstyle-
+    asset: checkstyle-{{.SemVer}}-all.jar
+  - type: github_release
     repo_owner: chenjiandongx
     repo_name: kubectl-images
     description: Show container images used in the cluster
@@ -37860,13 +37866,6 @@ packages:
           - goos: windows
             asset: buck2-{{.Arch}}-{{.OS}}.exe.{{.Format}}
   - type: github_release
-    repo_owner: facebook
-    repo_name: ktfmt
-    description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
-    asset: ktfmt-{{trimV .Version}}-with-dependencies.jar
-    format: raw
-    complete_windows_ext: false
-  - type: github_release
     repo_owner: fallow-rs
     repo_name: fallow
     description: "Codebase intelligence for TypeScript and JavaScript. Free static layer: unused code, duplication, circular deps, complexity hotspots, architecture boundaries. Optional paid runtime layer: hot-path review and cold-path deletion evidence from real production traffic. Rust-native, sub-second, zero-config framework support"
@@ -38392,6 +38391,15 @@ packages:
       type: github_release
       asset: frp_sha256_checksums.txt
       algorithm: sha256
+  - type: github_release
+    repo_owner: fbtransfer
+    repo_name: ktfmt
+    aliases:
+      - name: facebook/ktfmt
+    description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
+    asset: ktfmt-{{trimV .Version}}-with-dependencies.jar
+    format: raw
+    complete_windows_ext: false
   - type: github_release
     repo_owner: fe3dback
     repo_name: go-arch-lint
@@ -50876,6 +50884,29 @@ packages:
       type: github_release
       asset: go-car_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+  - type: github_release
+    repo_owner: isksss
+    repo_name: isksh
+    description: A cross-platform POSIX-oriented shell written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: isksh-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - windows/amd64
   - type: github_release
     repo_owner: ismaelgv
     repo_name: rnr


### PR DESCRIPTION
### 🚀 Features

- **(github)** support additional release assets by @jdx in [#11272](https://github.com/jdx/mise/pull/11272)
- **(usage)** declare what each command does to the world by @jdx in [#11306](https://github.com/jdx/mise/pull/11306)

### 🐛 Bug Fixes

- **(aqua)** preserve v prefix in HTTP lock URLs by @jdx in [#11267](https://github.com/jdx/mise/pull/11267)
- **(backend)** strip platform suffix from single binary inside archives by @Marukome0743 in [#11232](https://github.com/jdx/mise/pull/11232)
- **(brew)** support cask completion stanzas, system_command, and elevated artifact links by @jdx in [#11273](https://github.com/jdx/mise/pull/11273)
- **(completions)** stop offering mise's own flags after a task name by @jdx in [#11284](https://github.com/jdx/mise/pull/11284)
- **(env)** make env file expansion opt-in by @jdx in [#11269](https://github.com/jdx/mise/pull/11269)
- **(env)** convert remaining std::env::vars() call sites to vars_safe() by @JamBalaya56562 in [#11309](https://github.com/jdx/mise/pull/11309)
- **(github)** prefer .exe assets on Windows by @gologames in [#11257](https://github.com/jdx/mise/pull/11257)
- **(github)** clearer error when a GitHub token is rejected with 401 by @Marukome0743 in [#11236](https://github.com/jdx/mise/pull/11236)
- **(lockfile)** respect locked versions for prefix: tool requests by @JamBalaya56562 in [#11255](https://github.com/jdx/mise/pull/11255)
- **(npm)** serialize aube allow_builds as map by @jdx in [#11262](https://github.com/jdx/mise/pull/11262)
- **(npm)** sort large version components correctly by @jdx in [#11280](https://github.com/jdx/mise/pull/11280)
- **(npm)** explain aube trust downgrade failures by @jdx in [#11292](https://github.com/jdx/mise/pull/11292)
- **(npm)** add allow_low_downloads backend option by @jdx in [#11305](https://github.com/jdx/mise/pull/11305)
- **(npm)** bump aube to 1.33.1, stop it rendering its own progress display by @jdx in [#11308](https://github.com/jdx/mise/pull/11308)
- **(python)** make pip usable on Windows by @JamBalaya56562 in [#11278](https://github.com/jdx/mise/pull/11278)
- **(swift)** record the target distro in lockfile entries by @jdx in [#11299](https://github.com/jdx/mise/pull/11299)
- **(task)** don't load tasks from an enclosing monorepo root by @jdx in [#11283](https://github.com/jdx/mise/pull/11283)
- **(task)** include run, sources, and outputs in task_state_key by @rabadin in [#11288](https://github.com/jdx/mise/pull/11288)
- **(task)** only persist source hash after successful task run by @rabadin in [#11296](https://github.com/jdx/mise/pull/11296)
- **(version)** make the update-check cache actually suppress retries by @jdx in [#11285](https://github.com/jdx/mise/pull/11285)

### 📚 Documentation

- **(backend)** correct bin_path/asset_pattern template variables by @jdx in [#11298](https://github.com/jdx/mise/pull/11298)
- **(npm)** document Socket integrations by @jdx in [#11268](https://github.com/jdx/mise/pull/11268)
- retarget dead clap.rs link to docs.rs/clap by @Bartok9 in [#11194](https://github.com/jdx/mise/pull/11194)
- generate llms.txt index for AI agents by @jdx in [#11300](https://github.com/jdx/mise/pull/11300)

### ⚡ Performance

- **(cli)** stop rebuilding the clap tree twice on every invocation by @jdx in [#11297](https://github.com/jdx/mise/pull/11297)

### 📦️ Dependency Updates

- update docker/login-action digest to abd2ef4 by @renovate[bot] in [#11261](https://github.com/jdx/mise/pull/11261)
- update actions/setup-node action to v7 by @renovate[bot] in [#11247](https://github.com/jdx/mise/pull/11247)
- update ghcr.io/jdx/mise:alpine docker digest to 7a44a65 by @renovate[bot] in [#11264](https://github.com/jdx/mise/pull/11264)
- update dependency toml to v5 by @renovate[bot] in [#11248](https://github.com/jdx/mise/pull/11248)
- update rust crate age to 0.12 by @renovate[bot] in [#11246](https://github.com/jdx/mise/pull/11246)
- update rust crate clx to v3 by @renovate[bot] in [#11270](https://github.com/jdx/mise/pull/11270)
- update ghcr.io/jdx/mise:rpm docker digest to f26a306 by @renovate[bot] in [#11266](https://github.com/jdx/mise/pull/11266)
- update ghcr.io/jdx/mise:deb docker digest to b1b88a5 by @renovate[bot] in [#11265](https://github.com/jdx/mise/pull/11265)
- update rust crate path-absolutize to v4 by @renovate[bot] in [#11249](https://github.com/jdx/mise/pull/11249)
- update aube crates to v1.33 by @jdx in [#11302](https://github.com/jdx/mise/pull/11302)
- update actions/checkout digest to 3d3c42e by @renovate[bot] in [#11237](https://github.com/jdx/mise/pull/11237)

### 📦 Registry

- add checkstyle by @zeitlinger in [#11287](https://github.com/jdx/mise/pull/11287)
- add grok by @jdx in [#11291](https://github.com/jdx/mise/pull/11291)
- fix croc version test expectation by @jdx in [#11301](https://github.com/jdx/mise/pull/11301)
- add tak by @jdx in [#11307](https://github.com/jdx/mise/pull/11307)

### Chore

- **(ci)** add cmake to ppa build dependencies by @jdx in [#11274](https://github.com/jdx/mise/pull/11274)

### Security

- **(config)** restrict default shell args to global config by @jdx in [#11293](https://github.com/jdx/mise/pull/11293)

### New Contributors

- @gologames made their first contribution in [#11257](https://github.com/jdx/mise/pull/11257)

## 📦 Aqua Registry Updates

### New Packages (3)

- [`checkstyle/checkstyle`](https://github.com/checkstyle/checkstyle)
- [`fbtransfer/ktfmt`](https://github.com/fbtransfer/ktfmt)
- [`isksss/isksh`](https://github.com/isksss/isksh)