### PR TITLE
fix(aqua): preserve v prefix in HTTP lock URLs

### DIFF
--- a/e2e/lockfile/test_lockfile_aqua_http_v_prefix
+++ b/e2e/lockfile/test_lockfile_aqua_http_v_prefix
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+export MISE_AQUA_BAKED_REGISTRY=0
+
+HTTP_PORT_FILE="$TMPDIR/mise_http_test_port"
+MISE_HTTP_TEST_PORT_FILE="$HTTP_PORT_FILE" python3 "${TEST_ROOT}/helpers/scripts/http_test_server.py" 0 &
+HTTP_SERVER_PID=$!
+
+cleanup() {
+  kill "$HTTP_SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_file "$HTTP_PORT_FILE" "HTTP test server port file" 30 "$HTTP_SERVER_PID"
+HTTP_PORT=$(cat "$HTTP_PORT_FILE")
+
+REGISTRY_DIR="$PWD/aqua-registry-local"
+mkdir -p "$REGISTRY_DIR"
+
+cat <<EOF >"$REGISTRY_DIR/registry.yaml"
+packages:
+  - type: http
+    name: example/v-prefix
+    url: http://127.0.0.1:$HTTP_PORT/tool-{{.Version}}
+    format: raw
+    supported_envs:
+      - linux
+EOF
+
+export MISE_AQUA_REGISTRY_URL="file://$REGISTRY_DIR"
+
+cat <<'EOF' >mise.toml
+[tools]
+"aqua:example/v-prefix" = "1.2.3"
+EOF
+
+mise lock --platform linux-x64
+
+assert_contains "cat mise.lock" "url = \"http://127.0.0.1:$HTTP_PORT/tool-v1.2.3\""
+assert_not_contains "cat mise.lock" "url = \"http://127.0.0.1:$HTTP_PORT/tool-1.2.3\""

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -3182,7 +3182,13 @@ async fn resolve_aqua_http_url(
     let Ok(prefixed_url) = pkg.url(prefixed_version, target_os, target_arch) else {
         return Ok((url, version.to_string()));
     };
-    if prefixed_url == url || HTTP.head(&prefixed_url).await.is_ok() {
+    // Some artifact hosts reject HEAD even though GET is supported. get_async()
+    // only waits for the response headers; dropping the response avoids downloading
+    // the artifact during URL resolution.
+    if prefixed_url == url
+        || HTTP.head(&prefixed_url).await.is_ok()
+        || HTTP.get_async(&prefixed_url).await.is_ok()
+    {
         Ok((prefixed_url, prefixed_version.to_string()))
     } else {
         Ok((url, version.to_string()))
@@ -4516,8 +4522,14 @@ mod lock_candidate_tests {
     #[tokio::test]
     async fn test_http_url_falls_back_to_unprefixed_version() {
         let mut server = mockito::Server::new_async().await;
-        let prefixed = server
+        let prefixed_head = server
             .mock("HEAD", "/tool-v1.2.3")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+        let prefixed_get = server
+            .mock("GET", "/tool-v1.2.3")
             .with_status(404)
             .expect(1)
             .create_async()
@@ -4529,9 +4541,38 @@ mod lock_candidate_tests {
             .await
             .unwrap();
 
-        prefixed.assert_async().await;
+        prefixed_head.assert_async().await;
+        prefixed_get.assert_async().await;
         assert_eq!(url, format!("{}/tool-1.2.3", server.url()));
         assert_eq!(version, "1.2.3");
+    }
+
+    #[tokio::test]
+    async fn test_http_url_uses_get_when_head_is_rejected() {
+        let mut server = mockito::Server::new_async().await;
+        let prefixed_head = server
+            .mock("HEAD", "/tool-v1.2.3")
+            .with_status(405)
+            .expect(1)
+            .create_async()
+            .await;
+        let prefixed_get = server
+            .mock("GET", "/tool-v1.2.3")
+            .with_status(200)
+            .expect(1)
+            .create_async()
+            .await;
+        let mut pkg = AquaPackage::default();
+        pkg.url = format!("{}/tool-{{{{.Version}}}}", server.url());
+
+        let (url, version) = resolve_aqua_http_url(&pkg, "1.2.3", Some("v1.2.3"), "linux", "amd64")
+            .await
+            .unwrap();
+
+        prefixed_head.assert_async().await;
+        prefixed_get.assert_async().await;
+        assert_eq!(url, format!("{}/tool-v1.2.3", server.url()));
+        assert_eq!(version, "v1.2.3");
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -532,7 +532,11 @@ impl Backend for AquaBackend {
                 platform_key
             );
         } else {
-            let (url, url_api, v, digest) = if let Some(v_prefixed) = v_prefixed {
+            let (url, url_api, v, digest) = if pkg.r#type == AquaPackageType::Http {
+                let (url, resolved_version) =
+                    resolve_aqua_http_url(&pkg, &v, v_prefixed.as_deref(), os(), arch()).await?;
+                (url, None, resolved_version, None)
+            } else if let Some(v_prefixed) = v_prefixed {
                 // Try v-prefixed version first because most aqua packages use v-prefixed versions
                 match self.get_url(&pkg, v_prefixed.as_ref()).await {
                     // If the url is already checked, use it
@@ -831,7 +835,17 @@ impl Backend for AquaBackend {
                     bail!("github_content package requires `path`")
                 }
             }
-            AquaPackageType::Http => (pkg.url(&v, target_os, target_arch).ok(), None, None),
+            AquaPackageType::Http => {
+                match resolve_aqua_http_url(&pkg, &v, v_prefixed.as_deref(), target_os, target_arch)
+                    .await
+                {
+                    Ok((url, resolved_version)) => {
+                        v = resolved_version;
+                        (Some(url), None, None)
+                    }
+                    Err(_) => (None, None, None),
+                }
+            }
             _ => (None, None, None),
         };
 
@@ -3158,6 +3172,27 @@ fn select_github_probe_url<'a>(
     }
 }
 
+async fn resolve_aqua_http_url(
+    pkg: &AquaPackage,
+    version: &str,
+    prefixed_version: Option<&str>,
+    target_os: &str,
+    target_arch: &str,
+) -> Result<(String, String)> {
+    let url = pkg.url(version, target_os, target_arch)?;
+    let Some(prefixed_version) = prefixed_version else {
+        return Ok((url, version.to_string()));
+    };
+    let Ok(prefixed_url) = pkg.url(prefixed_version, target_os, target_arch) else {
+        return Ok((url, version.to_string()));
+    };
+    if prefixed_url == url || HTTP.head(&prefixed_url).await.is_ok() {
+        Ok((prefixed_url, prefixed_version.to_string()))
+    } else {
+        Ok((url, version.to_string()))
+    }
+}
+
 fn version_with_prefix<'a>(version: &'a str, version_prefix: Option<&str>) -> Cow<'a, str> {
     if let Some(prefix) = version_prefix
         && !version.starts_with(prefix)
@@ -4459,6 +4494,48 @@ mod lock_candidate_tests {
         let (v, candidates) = build_lock_candidates("1.7.1", None, Some("jq-"));
         assert_eq!(v, "jq-1.7.1");
         assert_eq!(candidates, vec!["jq-v1.7.1", "jq-1.7.1"]);
+    }
+
+    #[tokio::test]
+    async fn test_http_url_prefers_reachable_v_prefixed_version() {
+        let mut server = mockito::Server::new_async().await;
+        let prefixed = server
+            .mock("HEAD", "/tool-v1.2.3")
+            .with_status(200)
+            .expect(1)
+            .create_async()
+            .await;
+        let mut pkg = AquaPackage::default();
+        pkg.url = format!("{}/tool-{{{{.Version}}}}", server.url());
+
+        let (url, version) = resolve_aqua_http_url(&pkg, "1.2.3", Some("v1.2.3"), "linux", "amd64")
+            .await
+            .unwrap();
+
+        prefixed.assert_async().await;
+        assert_eq!(url, format!("{}/tool-v1.2.3", server.url()));
+        assert_eq!(version, "v1.2.3");
+    }
+
+    #[tokio::test]
+    async fn test_http_url_falls_back_to_unprefixed_version() {
+        let mut server = mockito::Server::new_async().await;
+        let prefixed = server
+            .mock("HEAD", "/tool-v1.2.3")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+        let mut pkg = AquaPackage::default();
+        pkg.url = format!("{}/tool-{{{{.Version}}}}", server.url());
+
+        let (url, version) = resolve_aqua_http_url(&pkg, "1.2.3", Some("v1.2.3"), "linux", "amd64")
+            .await
+            .unwrap();
+
+        prefixed.assert_async().await;
+        assert_eq!(url, format!("{}/tool-1.2.3", server.url()));
+        assert_eq!(version, "1.2.3");
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -836,15 +836,11 @@ impl Backend for AquaBackend {
                 }
             }
             AquaPackageType::Http => {
-                match resolve_aqua_http_url(&pkg, &v, v_prefixed.as_deref(), target_os, target_arch)
-                    .await
-                {
-                    Ok((url, resolved_version)) => {
-                        v = resolved_version;
-                        (Some(url), None, None)
-                    }
-                    Err(_) => (None, None, None),
-                }
+                let (url, resolved_version) =
+                    resolve_aqua_http_url(&pkg, &v, v_prefixed.as_deref(), target_os, target_arch)
+                        .await?;
+                v = resolved_version;
+                (Some(url), None, None)
             }
             _ => (None, None, None),
         };


### PR DESCRIPTION
## Summary

- share HTTP version-candidate resolution between aqua installs and lock generation
- preserve a reachable `v`-prefixed version in cross-platform lockfile URLs and checksum rendering
- add unit coverage for prefixed selection and bare-version fallback
- add an end-to-end cross-platform lock regression test

## Root cause

Aqua HTTP installs probed a synthesized `v`-prefixed URL when GitHub release metadata did not contain the requested version. Cross-platform lock generation built its URL directly from the normalized bare version instead. For tag-only Atlas releases such as `v1.2.3`, this produced a working macOS install URL but an invalid unprefixed Linux URL in `mise.lock`, which later failed with a 404.

Fixes the behavior reported in https://github.com/jdx/mise/discussions/11258.

## Validation

- `cargo test test_http_url_`
- `mise run test:e2e e2e/lockfile/test_lockfile_aqua_http_v_prefix`
- `mise run lint-fix`
- pre-commit `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes download URL resolution for Aqua HTTP installs and lockfile generation with network probes; behavior is scoped to HTTP package type but affects artifact fetch paths users rely on.
> 
> **Overview**
> Fixes **cross-platform lockfiles** for Aqua **HTTP** packages where artifacts only exist under a **`v`-prefixed** path (e.g. `tool-v1.2.3` vs `tool-1.2.3`). Lock generation used to template URLs from the bare version while installs could already pick the prefixed URL, so `mise.lock` could 404 on other platforms.
> 
> Adds shared **`resolve_aqua_http_url`**: when a `v`-prefixed candidate exists, it prefers that URL if it matches the unprefixed URL or **HEAD/GET** succeeds (GET covers hosts that reject HEAD). **Install** and **`resolve_lock_info`** both call this for `AquaPackageType::Http`, so stored URL and resolved version stay aligned.
> 
> Adds **mockito** unit tests for prefer-prefix, fallback, and HEAD→GET behavior, plus an **e2e** lock test with a local HTTP registry asserting `mise lock --platform linux-x64` writes the `v`-prefixed URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6844a323a648452ebe1913d9e4abb4ae4b471b50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Aqua tool download and lockfile URL resolution when registries use version-prefixed URL formats (for example `v1.2.3`).
  * The resolver now prefers the reachable prefixed variant and falls back to the standard URL format when the prefixed URL is not available.
  * Ensured generated lockfiles store the correct resolved URL and version, including for cross-platform lock generation.
* **Tests**
  * Added end-to-end coverage for HTTP version-prefixed URL resolution and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->