### PR TITLE
docs(npm): document Socket integrations

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -105,11 +105,11 @@ sfw mise use -g npm:prettier
 ```
 
 This works at the network layer. Mise's npm metadata client and embedded aube
-installer honor the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and
-`NODE_EXTRA_CA_CERTS` configuration injected by the firewall. Socket currently
-documents npm, yarn, and pnpm rather than mise or aube as supported JavaScript
-package managers, so this interoperability is not an upstream compatibility
-guarantee.
+installer both use aube-registry, which honors the `HTTP_PROXY`, `HTTPS_PROXY`,
+and `NO_PROXY` settings and explicitly loads the `NODE_EXTRA_CA_CERTS` bundle
+into its Rust TLS clients. Socket currently documents npm, yarn, and pnpm rather
+than mise or aube as supported JavaScript package managers, so this
+interoperability is not an upstream compatibility guarantee.
 
 ## Usage
 

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -64,9 +64,13 @@ compatible with Socket's
 Set `AUBE_SECURITY_SCANNER` to enable it:
 
 ```sh
+MISE_NPM_PACKAGE_MANAGER=aube \
 AUBE_SECURITY_SCANNER=/absolute/path/to/scanner.mjs \
   mise install npm:prettier@latest
 ```
+
+Selecting `aube` explicitly ensures the scanner is used even if the user's
+mise settings otherwise select npm, Bun, or pnpm.
 
 The scanner runs after dependency resolution and before package tarballs are
 downloaded. It receives the resolved direct and transitive registry packages;

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -50,6 +50,63 @@ mise use -g pnpm
 mise use -g bun
 ```
 
+## Socket security
+
+There are two ways to use [Socket](https://socket.dev) with `npm:` tools installed
+by mise.
+
+### Bun-compatible security scanner
+
+The embedded aube installer implements
+[Bun's Security Scanner API](https://bun.sh/docs/pm/security-scanner-api) and is
+compatible with Socket's
+[`@socketsecurity/bun-security-scanner`](https://socket.dev/blog/socket-integrates-with-bun-1-3-security-scanner-api).
+Set `AUBE_SECURITY_SCANNER` to enable it:
+
+```sh
+AUBE_SECURITY_SCANNER=/absolute/path/to/scanner.mjs \
+  mise install npm:prettier@latest
+```
+
+The scanner runs after dependency resolution and before package tarballs are
+downloaded. It receives the resolved direct and transitive registry packages;
+a fatal finding blocks the install. A configured scanner also fails closed if
+it cannot start or complete. See
+[aube's security scanner documentation](https://aube.jdx.dev/package-manager/security-scanner.html)
+for the complete behavior and configuration.
+
+Mise installs each `npm:` tool in a synthetic project, so a bare scanner package
+name is not normally resolvable from that project's `node_modules`. Point the
+setting at an absolute module instead. For example, install the Socket scanner
+in a separate, stable directory and place this wrapper beside that directory's
+`node_modules`:
+
+```js
+// scanner.mjs
+export { scanner } from "@socketsecurity/bun-security-scanner";
+```
+
+The scanner bridge requires Node.js 22.6 or newer. It inherits Socket-specific
+environment variables such as `SOCKET_SECURITY_API_KEY`, while aube removes
+common npm and GitHub credentials from the scanner subprocess.
+
+### Socket Firewall
+
+[Socket Firewall](https://docs.socket.dev/docs/socket-firewall-free) can instead
+wrap mise itself:
+
+```sh
+sfw mise install npm:prettier@latest
+sfw mise use -g npm:prettier
+```
+
+This works at the network layer. Mise's npm metadata client and embedded aube
+installer honor the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and
+`NODE_EXTRA_CA_CERTS` configuration injected by the firewall. Socket currently
+documents npm, yarn, and pnpm rather than mise or aube as supported JavaScript
+package managers, so this interoperability is not an upstream compatibility
+guarantee.
+
 ## Usage
 
 The following installs the latest version of [prettier](https://www.npmjs.com/package/prettier)


### PR DESCRIPTION
## Summary

- document using Socket's Bun-compatible security scanner with mise's embedded aube installer
- explain the synthetic-project module-resolution caveat and absolute wrapper setup
- document wrapping npm tool installs with Socket Firewall and clarify Socket's upstream support boundary

## Validation

- `mise run docs:build`
- `mise run lint-fix`
- pre-commit `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the npm backend guide; no runtime or install behavior changes.
> 
> **Overview**
> Adds a **Socket security** section to the npm backend docs, covering two integration paths for `npm:` tools installed via mise.
> 
> The **Bun-compatible security scanner** path documents enabling Socket through embedded aube via `AUBE_SECURITY_SCANNER` (with `MISE_NPM_PACKAGE_MANAGER=aube`), when the scan runs, fail-closed behavior, the synthetic-project module-resolution caveat and absolute `scanner.mjs` wrapper pattern, Node.js 22.6+, and relevant env vars.
> 
> The **Socket Firewall** path documents wrapping `mise` with `sfw`, notes proxy/CA behavior through aube-registry, and states that Socket’s upstream docs target npm/yarn/pnpm—not mise/aube—so interoperability is not guaranteed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728765aeb0735cc970714e04e8e886ebaf4622d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new “Socket security” guidance for using Socket with `npm:` tools installed via mise, including a Bun-compatible security scanner workflow that blocks installs on fatal findings.
  * Documented scanner setup requirements, including environment/config expectations and Node.js version guidance.
  * Added “Socket Firewall” documentation, explaining how it forwards proxy and certificate authority settings (e.g., `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `NODE_EXTRA_CA_CERTS`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->