### PR TITLE
feat(github): support additional release assets

### DIFF
--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -81,9 +81,11 @@ are not supported. They are extracted without applying the primary asset's
 `strip_components`, `bin`, or `rename_exe` options. If a supplemental archive contains
 the same path as an earlier archive, the later archive's file wins.
 
-When lockfiles are enabled, mise records the URL, checksum, and verified provenance for
-each supplemental artifact. `--locked` installations use only that recorded artifact
-list and fail if it is incomplete.
+When lockfiles are enabled, mise records the URL and checksum for each supplemental
+artifact, plus any available provenance metadata. Provenance is cryptographically
+verified for the current platform; cross-platform lock entries record detected
+provenance for verification when installed. `--locked` installations use only the
+recorded artifact list and fail if it is incomplete.
 
 ### `matching`
 

--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -56,6 +56,35 @@ Specifies the pattern to match against release asset names. This is useful when 
 "github:cli/cli" = { version = "latest", asset_pattern = "gh_*_linux_x64.tar.gz" }
 ```
 
+### `additional_asset_patterns`
+
+Downloads additional archives from the same release and extracts them into the primary
+asset's install directory, in the order listed. Use this when an upstream distributes one
+installation across a base archive and one or more supplemental archives.
+
+For example, Ollama publishes its Linux AMD64 ROCm support as an archive that must be
+overlaid on the normal Ollama archive:
+
+```toml
+[tools."github:ollama/ollama"]
+version = "latest"
+
+[tools."github:ollama/ollama".platforms]
+linux-x64 = {
+  additional_asset_patterns = ["ollama-linux-amd64-rocm.tar.zst"],
+}
+```
+
+Each pattern must select exactly one archive. Patterns support the same templating as
+[`asset_pattern`](#asset_pattern). Supplemental assets must be archives; bare binaries
+are not supported. They are extracted without applying the primary asset's
+`strip_components`, `bin`, or `rename_exe` options. If a supplemental archive contains
+the same path as an earlier archive, the later archive's file wins.
+
+When lockfiles are enabled, mise records the URL, checksum, and verified provenance for
+each supplemental artifact. `--locked` installations use only that recorded artifact
+list and fail if it is incomplete.
+
 ### `matching`
 
 Narrows asset selection to names containing the given substring, **while keeping platform autodetection**. Unlike [`asset_pattern`](#asset_pattern) (which replaces autodetection entirely), `matching` only refines the candidate set — autodetection still chooses the correct OS/arch from the narrowed list, so a single config stays portable across platforms.
@@ -134,10 +163,14 @@ macos-arm64 = { asset_pattern = "gh_*_macOS_arm64.tar.gz" }
 
 ### Multiple Assets from the Same Release
 
-The GitHub backend installs one release asset for each tool. If a repository publishes
-multiple binaries as separate assets in the same release, define one tool alias per
-binary and point each alias at the same `github:owner/repo` backend, then narrow each
-alias to its binary.
+There are two distinct cases:
+
+- If the assets are parts of one installation, use
+  [`additional_asset_patterns`](#additional_asset_patterns). The supplemental archives
+  are overlaid into the same install directory.
+- If the assets are independent tools that should have separate install directories,
+  define one tool alias per binary and point each alias at the same
+  `github:owner/repo` backend.
 
 Prefer [`matching`](#matching) (or [`matching_regex`](#matching_regex)): it narrows the
 candidate set while **keeping platform autodetection**, so one config works on every
@@ -167,13 +200,9 @@ rename_exe = "oxfmt"
 ```
 
 ::: warning
-A distinct alias per binary is **required**, not just tidy. `matching`/`matching_regex` are
-**not** part of the install path — it is keyed by the tool name (the alias, or `owner/repo`
-when unaliased) and version. Installing the same `github:owner/repo` backend string twice
-with different `matching` values (for example `mise use "github:owner/repo[matching=tool-a]"`
-followed by `mise use "github:owner/repo[matching=tool-b]"`) resolves to the **same**
-directory, so the second install overwrites the first. Giving each binary its own alias gives
-each its own install directory, so they coexist.
+Aliases are not an overlay mechanism. Each alias creates a separate install directory.
+Use them for independent binaries such as `oxlint` and `oxfmt`; use
+`additional_asset_patterns` when both archives must compose one runnable tool.
 :::
 
 If the binary isn't named the way you want to invoke it, add

--- a/e2e/backend/test_github_additional_assets
+++ b/e2e/backend/test_github_additional_assets
@@ -23,8 +23,24 @@ assert_contains "cat mise.lock" 'additional_asset_patterns = "fd-8.7.0.tar.gz"'
 assert_contains "cat mise.lock" 'url = "https://github.com/jdx/mise-test-fixtures/releases/download/v1.0.0/fd-8.7.0.tar.gz"'
 assert_contains "cat mise.lock" 'checksum = "sha256:230cf587de59730a1d7f9c49004f301292927621a336578723518fc9d03f4824"'
 
-# A locked reinstall must use the complete recorded artifact list.
+# Locked mode must reject an incomplete supplemental artifact list.
+cp mise.lock mise.lock.complete
 mise uninstall github:jdx/mise-test-fixtures
+awk '
+  /^\[\[tools\."github:jdx\/mise-test-fixtures"\."platforms\..*"\.additional_artifacts\]\]$/ {
+    skip_artifact = 1
+    next
+  }
+  skip_artifact && /^$/ {
+    skip_artifact = 0
+    next
+  }
+  !skip_artifact { print }
+' mise.lock.complete >mise.lock
+assert_fail "mise install --locked"
+
+# Restoring the complete lock permits the reinstall.
+cp mise.lock.complete mise.lock
 mise install --locked
 install_path=$(mise where github:jdx/mise-test-fixtures)
 assert_contains "$install_path/fd-8.7.0/bin/fd" "alternative to 'find'"

--- a/e2e/backend/test_github_additional_assets
+++ b/e2e/backend/test_github_additional_assets
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+export MISE_LOCKFILE=1
+
+cat <<EOF >mise.toml
+[tools."github:jdx/mise-test-fixtures"]
+version = "1.0.0"
+asset_pattern = "hello-world-1.0.0.tar.gz"
+additional_asset_patterns = ["fd-8.7.0.tar.gz"]
+EOF
+
+touch mise.lock
+mise install
+
+# Both archives are extracted into one installation.
+install_path=$(mise where github:jdx/mise-test-fixtures)
+assert_contains "$install_path/hello-world-1.0.0/bin/hello-world" "hello world"
+assert_contains "$install_path/fd-8.7.0/bin/fd" "alternative to 'find'"
+
+# The supplemental artifact is independently pinned and checksummed.
+assert_contains "cat mise.lock" 'additional_asset_patterns = "fd-8.7.0.tar.gz"'
+assert_contains "cat mise.lock" 'url = "https://github.com/jdx/mise-test-fixtures/releases/download/v1.0.0/fd-8.7.0.tar.gz"'
+assert_contains "cat mise.lock" 'checksum = "sha256:230cf587de59730a1d7f9c49004f301292927621a336578723518fc9d03f4824"'
+
+# A locked reinstall must use the complete recorded artifact list.
+mise uninstall github:jdx/mise-test-fixtures
+mise install --locked
+install_path=$(mise where github:jdx/mise-test-fixtures)
+assert_contains "$install_path/fd-8.7.0/bin/fd" "alternative to 'find'"

--- a/e2e/backend/test_github_additional_assets
+++ b/e2e/backend/test_github_additional_assets
@@ -7,10 +7,19 @@ cat <<EOF >mise.toml
 [tools."github:jdx/mise-test-fixtures"]
 version = "1.0.0"
 asset_pattern = "hello-world-1.0.0.tar.gz"
-additional_asset_patterns = ["fd-8.7.0.tar.gz"]
 EOF
 
 touch mise.lock
+mise install
+
+# Adding a supplemental pattern to an existing version must not be skipped.
+cat <<EOF >mise.toml
+[tools."github:jdx/mise-test-fixtures"]
+version = "1.0.0"
+asset_pattern = "hello-world-1.0.0.tar.gz"
+additional_asset_patterns = ["fd-8.7.0.tar.gz"]
+EOF
+
 mise install
 
 # Both archives are extracted into one installation.

--- a/e2e/backend/test_github_additional_assets
+++ b/e2e/backend/test_github_additional_assets
@@ -39,8 +39,14 @@ awk '
 ' mise.lock.complete >mise.lock
 assert_fail "mise install --locked"
 
-# Restoring the complete lock permits the reinstall.
+# Locked mode must also reject removing the supplemental pattern from config.
 cp mise.lock.complete mise.lock
+cp mise.toml mise.toml.complete
+sed '/additional_asset_patterns/d' mise.toml.complete >mise.toml
+assert_fail "mise install --locked"
+
+# Restoring the complete config and lock permits the reinstall.
+cp mise.toml.complete mise.toml
 mise install --locked
 install_path=$(mise where github:jdx/mise-test-fixtures)
 assert_contains "$install_path/fd-8.7.0/bin/fd" "alternative to 'find'"

--- a/e2e/backend/test_github_additional_assets
+++ b/e2e/backend/test_github_additional_assets
@@ -59,3 +59,10 @@ cp mise.toml.complete mise.toml
 mise install --locked
 install_path=$(mise where github:jdx/mise-test-fixtures)
 assert_contains "$install_path/fd-8.7.0/bin/fd" "alternative to 'find'"
+
+# Removing the supplemental pattern refreshes stale lock artifacts.
+sed '/additional_asset_patterns/d' mise.toml >mise.toml.primary-only
+mv mise.toml.primary-only mise.toml
+mise install
+assert_fail "$install_path/fd-8.7.0/bin/fd"
+mise install --locked

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -42,6 +42,26 @@ struct ReleaseAsset {
     digest: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct AssetVerification {
+    explicit_pattern: bool,
+    additional_overlay: bool,
+}
+
+impl AssetVerification {
+    const fn primary(explicit_pattern: bool) -> Self {
+        Self {
+            explicit_pattern,
+            additional_overlay: false,
+        }
+    }
+
+    const ADDITIONAL: Self = Self {
+        explicit_pattern: true,
+        additional_overlay: true,
+    };
+}
+
 const DEFAULT_GITHUB_API_BASE_URL: &str = "https://api.github.com";
 const DEFAULT_GITLAB_API_BASE_URL: &str = "https://gitlab.com/api/v4";
 const DEFAULT_FORGEJO_API_BASE_URL: &str = "https://codeberg.org/api/v1";
@@ -588,7 +608,6 @@ impl Backend for UnifiedGitBackend {
         let repo = self.repo();
         let raw_opts = ctx.config.get_tool_opts_with_overrides(&self.ba).await?;
         let opts = self.options(&raw_opts);
-        let api_url = opts.api_url();
 
         // Validate `matching_regex` up front, before the cached-URL branch below.
         // Reusing a cached lockfile URL skips binary selection (the path that
@@ -633,7 +652,7 @@ impl Backend for UnifiedGitBackend {
             }
         } else {
             // Find the asset URL for this specific version
-            self.resolve_asset_url(&tv, &opts, &repo, &api_url).await?
+            self.resolve_asset_url(&tv, &opts, &repo).await?
         };
 
         let additional_assets = match tv.lock_platforms.get(&platform_key) {
@@ -670,7 +689,6 @@ impl Backend for UnifiedGitBackend {
                             &tv,
                             &opts,
                             &repo,
-                            &api_url,
                             &PlatformTarget::from_current(),
                             Some(pattern),
                         )
@@ -730,7 +748,6 @@ impl Backend for UnifiedGitBackend {
         let repo = self.repo();
         let raw_opts = tv.request.options();
         let opts = self.options(&raw_opts);
-        let api_url = opts.api_url();
 
         // Fail closed on an invalid `matching_regex` instead of writing an empty
         // entry. The `Err` arm below intentionally swallows resolution failures so a
@@ -747,7 +764,7 @@ impl Backend for UnifiedGitBackend {
 
         // Resolve asset for the target platform
         let asset = self
-            .resolve_asset_url_for_target(tv, &opts, &repo, &api_url, target)
+            .resolve_asset_url_for_target(tv, &opts, &repo, target)
             .await;
 
         match asset {
@@ -755,16 +772,8 @@ impl Backend for UnifiedGitBackend {
                 let primary_explicit_pattern = opts.asset_pattern_for_target(target).is_some();
                 // Detect provenance availability from release assets and attestation API
                 let mut provenance = if !self.is_gitlab() && !self.is_forgejo() {
-                    self.detect_provenance_type(
-                        tv,
-                        &opts,
-                        &repo,
-                        &api_url,
-                        &asset,
-                        target,
-                        primary_explicit_pattern,
-                    )
-                    .await?
+                    self.detect_provenance_type(tv, &opts, &asset, target, primary_explicit_pattern)
+                        .await?
                 } else {
                     None
                 };
@@ -777,11 +786,8 @@ impl Backend for UnifiedGitBackend {
                         .verify_provenance_at_lock_time(
                             tv,
                             &opts,
-                            &repo,
-                            &api_url,
                             &asset,
-                            primary_explicit_pattern,
-                            false,
+                            AssetVerification::primary(primary_explicit_pattern),
                         )
                         .await
                     {
@@ -806,22 +812,13 @@ impl Backend for UnifiedGitBackend {
                             tv,
                             &opts,
                             &repo,
-                            &api_url,
                             target,
                             Some(&pattern),
                         )
                         .await?;
                     let mut additional_provenance = if !self.is_gitlab() && !self.is_forgejo() {
-                        self.detect_provenance_type(
-                            tv,
-                            &opts,
-                            &repo,
-                            &api_url,
-                            &additional,
-                            target,
-                            true,
-                        )
-                        .await?
+                        self.detect_provenance_type(tv, &opts, &additional, target, true)
+                            .await?
                     } else {
                         None
                     };
@@ -830,11 +827,8 @@ impl Backend for UnifiedGitBackend {
                             .verify_provenance_at_lock_time(
                                 tv,
                                 &opts,
-                                &repo,
-                                &api_url,
                                 &additional,
-                                true,
-                                true,
+                                AssetVerification::ADDITIONAL,
                             )
                             .await
                             .unwrap_or_else(|e| {
@@ -921,19 +915,19 @@ impl UnifiedGitBackend {
         &self,
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
-        repo: &str,
-        api_url: &str,
         asset: &ReleaseAsset,
         target: &PlatformTarget,
         explicit_pattern: bool,
     ) -> Result<Option<ProvenanceType>> {
+        let repo = self.repo();
+        let api_url = opts.api_url();
         let settings = Settings::get();
         let version = &tv.version;
         let version_prefix = opts.version_prefix();
 
         let use_versions_host = self.use_versions_host_for_github_metadata();
         let release =
-            try_with_v_prefix_and_repo(version, version_prefix, Some(repo), |candidate| {
+            try_with_v_prefix_and_repo(version, version_prefix, Some(&repo), |candidate| {
                 let api_url = api_url.to_string();
                 let repo = repo.to_string();
                 async move {
@@ -957,7 +951,7 @@ impl UnifiedGitBackend {
         if settings.github_attestations
             && settings.github.github_attestations
             && opts.github_attestations()
-            && attestations_supported(api_url)
+            && attestations_supported(&api_url)
             && let Some(digest) = asset.digest.as_deref()
         {
             let parts: Vec<&str> = repo.split('/').collect();
@@ -966,7 +960,7 @@ impl UnifiedGitBackend {
                 match crate::github::sigstore::detect_attestations(
                     owner,
                     repo_name,
-                    api_url,
+                    &api_url,
                     digest,
                     self.use_versions_host_for_github_metadata(),
                 )
@@ -1042,12 +1036,11 @@ impl UnifiedGitBackend {
         &self,
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
-        repo: &str,
-        api_url: &str,
         asset: &ReleaseAsset,
-        explicit_pattern: bool,
-        additional_overlay: bool,
+        verification: AssetVerification,
     ) -> Result<Option<ProvenanceType>> {
+        let repo = self.repo();
+        let api_url = opts.api_url();
         let tmp_dir = tempfile::tempdir()?;
         let filename = get_filename_from_url(&asset.url);
         let artifact_path = tmp_dir.path().join(&filename);
@@ -1079,7 +1072,7 @@ impl UnifiedGitBackend {
         if settings.github_attestations
             && settings.github.github_attestations
             && opts.github_attestations()
-            && attestations_supported(api_url)
+            && attestations_supported(&api_url)
         {
             let parts: Vec<&str> = repo.split('/').collect();
             if parts.len() == 2 {
@@ -1089,7 +1082,7 @@ impl UnifiedGitBackend {
                     owner,
                     repo_name,
                     None,
-                    Some(api_url),
+                    Some(&api_url),
                     self.use_versions_host_for_github_metadata(),
                 )
                 .await
@@ -1121,7 +1114,7 @@ impl UnifiedGitBackend {
             let version_prefix = opts.version_prefix();
             let use_versions_host = self.use_versions_host_for_github_metadata();
             let release =
-                try_with_v_prefix_and_repo(version, version_prefix, Some(repo), |candidate| {
+                try_with_v_prefix_and_repo(version, version_prefix, Some(&repo), |candidate| {
                     let api_url = api_url.to_string();
                     let repo = repo.to_string();
                     async move {
@@ -1141,7 +1134,7 @@ impl UnifiedGitBackend {
             // Keep provenance aligned with the matching-selected binary, unless
             // `asset_pattern` is set (it selects the binary, ignoring `matching`).
             let (matching, matching_regex) =
-                opts.matching_for_provenance(&current_platform, explicit_pattern);
+                opts.matching_for_provenance(&current_platform, verification.explicit_pattern);
             let picker = AssetPicker::with_libc(
                 current_platform.os_name().to_string(),
                 current_platform.arch_name().to_string(),
@@ -1194,7 +1187,7 @@ impl UnifiedGitBackend {
                                     tv,
                                     &artifact_path,
                                     &provenance_path,
-                                    additional_overlay,
+                                    verification.additional_overlay,
                                 )
                                 .await
                             {
@@ -1353,9 +1346,10 @@ impl UnifiedGitBackend {
                     &file_path,
                     &asset.name,
                     locked_provenance.as_ref(),
-                    opts.asset_pattern_for_target(&PlatformTarget::from_current())
-                        .is_some(),
-                    false,
+                    AssetVerification::primary(
+                        opts.asset_pattern_for_target(&PlatformTarget::from_current())
+                            .is_some(),
+                    ),
                 )
                 .await?;
 
@@ -1438,8 +1432,7 @@ impl UnifiedGitBackend {
                     &file_path,
                     &asset.name,
                     expected_provenance.as_ref(),
-                    true,
-                    true,
+                    AssetVerification::ADDITIONAL,
                 )
                 .await?;
             if provenance.is_some() {
@@ -1602,10 +1595,9 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
         repo: &str,
-        api_url: &str,
     ) -> Result<ReleaseAsset> {
         let current_platform = PlatformTarget::from_current();
-        self.resolve_asset_url_for_target(tv, opts, repo, api_url, &current_platform)
+        self.resolve_asset_url_for_target(tv, opts, repo, &current_platform)
             .await
     }
 
@@ -1615,10 +1607,9 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
         repo: &str,
-        api_url: &str,
         target: &PlatformTarget,
     ) -> Result<ReleaseAsset> {
-        self.resolve_asset_url_for_target_with_pattern(tv, opts, repo, api_url, target, None)
+        self.resolve_asset_url_for_target_with_pattern(tv, opts, repo, target, None)
             .await
     }
 
@@ -1627,7 +1618,6 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
         repo: &str,
-        api_url: &str,
         target: &PlatformTarget,
         asset_pattern: Option<&str>,
     ) -> Result<ReleaseAsset> {
@@ -1651,7 +1641,6 @@ impl UnifiedGitBackend {
                     tv,
                     opts,
                     repo,
-                    api_url,
                     &candidate,
                     target,
                     asset_pattern,
@@ -1665,7 +1654,6 @@ impl UnifiedGitBackend {
                     tv,
                     opts,
                     repo,
-                    api_url,
                     &candidate,
                     target,
                     asset_pattern,
@@ -1684,7 +1672,6 @@ impl UnifiedGitBackend {
                         tv,
                         opts,
                         repo,
-                        api_url,
                         &candidate,
                         target,
                         asset_pattern,
@@ -1702,13 +1689,13 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
         repo: &str,
-        api_url: &str,
         version: &str,
         target: &PlatformTarget,
         asset_pattern: Option<&str>,
     ) -> Result<ReleaseAsset> {
+        let api_url = opts.api_url();
         let release = self
-            .get_github_release_for_url(api_url, repo, version)
+            .get_github_release_for_url(&api_url, repo, version)
             .await?;
         let available_assets: Vec<String> = release.assets.iter().map(|a| a.name.clone()).collect();
 
@@ -1797,12 +1784,12 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
         repo: &str,
-        api_url: &str,
         version: &str,
         target: &PlatformTarget,
         asset_pattern: Option<&str>,
     ) -> Result<ReleaseAsset> {
-        let release = gitlab::get_release_for_url(api_url, repo, version).await?;
+        let api_url = opts.api_url();
+        let release = gitlab::get_release_for_url(&api_url, repo, version).await?;
         let available_assets: Vec<String> = release
             .assets
             .links
@@ -1890,12 +1877,12 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
         repo: &str,
-        api_url: &str,
         version: &str,
         target: &PlatformTarget,
         asset_pattern: Option<&str>,
     ) -> Result<ReleaseAsset> {
-        let release = forgejo::get_release_for_url(api_url, repo, version).await?;
+        let api_url = opts.api_url();
+        let release = forgejo::get_release_for_url(&api_url, repo, version).await?;
         let available_assets: Vec<String> = release.assets.iter().map(|a| a.name.clone()).collect();
 
         // Build asset list with URLs for checksum fetching
@@ -2224,8 +2211,7 @@ impl UnifiedGitBackend {
         file_path: &std::path::Path,
         asset_name: &str,
         expected_provenance: Option<&ProvenanceType>,
-        explicit_pattern: bool,
-        additional_overlay: bool,
+        verification: AssetVerification,
     ) -> Result<Option<ProvenanceType>> {
         let settings = Settings::get();
 
@@ -2321,15 +2307,7 @@ impl UnifiedGitBackend {
         // Fall back to SLSA provenance (if enabled globally and for github backend)
         if !skip_slsa && settings.slsa && settings.github.slsa {
             match self
-                .try_verify_slsa(
-                    ctx,
-                    tv,
-                    file_path,
-                    asset_name,
-                    &api_url,
-                    explicit_pattern,
-                    additional_overlay,
-                )
+                .try_verify_slsa(ctx, tv, file_path, asset_name, &api_url, verification)
                 .await
             {
                 Ok((true, provenance_url)) => {
@@ -2498,8 +2476,7 @@ impl UnifiedGitBackend {
         file_path: &std::path::Path,
         asset_name: &str,
         api_url: &str,
-        explicit_pattern: bool,
-        additional_overlay: bool,
+        verification: AssetVerification,
     ) -> std::result::Result<(bool, Option<String>), VerificationStatus> {
         if self.is_gitlab() || self.is_forgejo() {
             return Err(VerificationStatus::NoAttestations);
@@ -2547,7 +2524,7 @@ impl UnifiedGitBackend {
         // time, matching the selection used at lock time. Suppressed when
         // `asset_pattern` is set (it selects the binary, ignoring `matching`).
         let (matching, matching_regex) =
-            opts.matching_for_provenance(&current_platform, explicit_pattern);
+            opts.matching_for_provenance(&current_platform, verification.explicit_pattern);
         let picker = AssetPicker::with_libc(
             current_platform.os_name().to_string(),
             current_platform.arch_name().to_string(),
@@ -2615,7 +2592,7 @@ impl UnifiedGitBackend {
                             tv,
                             file_path,
                             &provenance_path,
-                            additional_overlay,
+                            verification.additional_overlay,
                         )
                         .await
                     {

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -16,7 +16,7 @@ use crate::config::{Config, Settings};
 use crate::file;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
-use crate::lockfile::{PlatformInfo, ProvenanceType};
+use crate::lockfile::{ArtifactInfo, PlatformInfo, ProvenanceType};
 use crate::toolset::ToolVersionOptions;
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{backend::Backend, forgejo, github, gitlab};
@@ -25,6 +25,7 @@ use eyre::Result;
 use regex::Regex;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::path::Path;
 use std::sync::Arc;
 use xx::regex;
 
@@ -33,6 +34,7 @@ pub struct UnifiedGitBackend {
     ba: Arc<BackendArg>,
 }
 
+#[derive(Debug, Clone)]
 struct ReleaseAsset {
     name: String,
     url: String,
@@ -88,6 +90,38 @@ impl<'a> GitBackendOptions<'a> {
     fn asset_pattern_for_target(&self, target: &PlatformTarget) -> Option<String> {
         self.values
             .platform_string_for_target("asset_pattern", target)
+    }
+
+    fn additional_asset_patterns_for_target(&self, target: &PlatformTarget) -> Vec<String> {
+        let Some(value) = self
+            .values
+            .platform_value_for_target("additional_asset_patterns", target)
+        else {
+            return Vec::new();
+        };
+        let values: Vec<String> = match value {
+            toml::Value::String(value) => value
+                .split(',')
+                .map(str::trim)
+                .map(str::to_string)
+                .collect(),
+            toml::Value::Array(values) => values
+                .iter()
+                .filter_map(toml::Value::as_str)
+                .map(str::trim)
+                .map(str::to_string)
+                .collect(),
+            _ => {
+                warn!(
+                    "invalid value for `additional_asset_patterns`: expected a string or array of strings"
+                );
+                return Vec::new();
+            }
+        };
+        values
+            .into_iter()
+            .filter(|value| !value.is_empty())
+            .collect()
     }
 
     fn direct_url_for_target(&self, target: &PlatformTarget) -> Option<String> {
@@ -149,8 +183,9 @@ impl<'a> GitBackendOptions<'a> {
     fn matching_for_provenance(
         &self,
         target: &PlatformTarget,
+        explicit_pattern: bool,
     ) -> (Option<&'a str>, Option<&'a str>) {
-        if self.asset_pattern_for_target(target).is_some() {
+        if explicit_pattern || self.asset_pattern_for_target(target).is_some() {
             (None, None)
         } else {
             (self.matching(), self.matching_regex())
@@ -167,6 +202,13 @@ impl<'a> GitBackendOptions<'a> {
         }
         if let Some(value) = self.asset_pattern_for_target(target) {
             result.insert("asset_pattern".to_string(), value);
+        }
+        let additional_asset_patterns = self.additional_asset_patterns_for_target(target);
+        if !additional_asset_patterns.is_empty() {
+            result.insert(
+                "additional_asset_patterns".to_string(),
+                additional_asset_patterns.join(","),
+            );
         }
         if let Some(value) = self.direct_url_for_target(target) {
             result.insert("url".to_string(), value);
@@ -240,6 +282,7 @@ fn is_slsa_format_issue(e: &crate::github::sigstore::AttestationError) -> bool {
 pub fn install_time_option_keys() -> Vec<String> {
     vec![
         "asset_pattern".into(),
+        "additional_asset_patterns".into(),
         "url".into(),
         "version_prefix".into(),
         "no_app".into(),
@@ -265,6 +308,15 @@ impl Backend for UnifiedGitBackend {
 
     fn ba(&self) -> &Arc<BackendArg> {
         &self.ba
+    }
+
+    async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
+        let raw_opts = tv.request.options();
+        let opts = self.options(&raw_opts);
+        3 + opts
+            .additional_asset_patterns_for_target(&PlatformTarget::from_current())
+            .len()
+            * 3
     }
 
     async fn security_info(&self) -> Vec<SecurityFeature> {
@@ -562,6 +614,8 @@ impl Backend for UnifiedGitBackend {
 
         // Check if URL already exists in lockfile platforms first
         let platform_key = self.get_platform_key();
+        let additional_patterns =
+            opts.additional_asset_patterns_for_target(&PlatformTarget::from_current());
 
         let asset = if let Some(existing_platform) = tv.lock_platforms.get(&platform_key)
             && existing_platform.url.is_some()
@@ -582,9 +636,58 @@ impl Backend for UnifiedGitBackend {
             self.resolve_asset_url(&tv, &opts, &repo, &api_url).await?
         };
 
+        let additional_assets = match tv.lock_platforms.get(&platform_key) {
+            Some(platform)
+                if platform.additional_artifacts.len() == additional_patterns.len()
+                    && platform
+                        .additional_artifacts
+                        .iter()
+                        .all(|artifact| !artifact.url.is_empty()) =>
+            {
+                platform
+                    .additional_artifacts
+                    .iter()
+                    .map(|artifact| ReleaseAsset {
+                        name: get_filename_from_url(&artifact.url),
+                        url: artifact.url.clone(),
+                        url_api: artifact.url_api.clone().unwrap_or_default(),
+                        digest: None,
+                    })
+                    .collect()
+            }
+            _ if ctx.locked && !additional_patterns.is_empty() => {
+                eyre::bail!(
+                    "No complete lockfile artifact list found for {} on platform {} (--locked mode)",
+                    tv.style(),
+                    platform_key
+                )
+            }
+            _ => {
+                let mut assets = Vec::new();
+                for pattern in &additional_patterns {
+                    assets.push(
+                        self.resolve_asset_url_for_target_with_pattern(
+                            &tv,
+                            &opts,
+                            &repo,
+                            &api_url,
+                            &PlatformTarget::from_current(),
+                            Some(pattern),
+                        )
+                        .await?,
+                    );
+                }
+                assets
+            }
+        };
+
         // Download and install
         self.download_and_install(ctx, &mut tv, &asset, &opts)
             .await?;
+        for (index, asset) in additional_assets.iter().enumerate() {
+            self.download_verify_and_install_additional_asset(ctx, &mut tv, asset, &opts, index)
+                .await?;
+        }
 
         Ok(tv)
     }
@@ -649,10 +752,19 @@ impl Backend for UnifiedGitBackend {
 
         match asset {
             Ok(asset) => {
+                let primary_explicit_pattern = opts.asset_pattern_for_target(target).is_some();
                 // Detect provenance availability from release assets and attestation API
                 let mut provenance = if !self.is_gitlab() && !self.is_forgejo() {
-                    self.detect_provenance_type(tv, &opts, &repo, &api_url, &asset, target)
-                        .await?
+                    self.detect_provenance_type(
+                        tv,
+                        &opts,
+                        &repo,
+                        &api_url,
+                        &asset,
+                        target,
+                        primary_explicit_pattern,
+                    )
+                    .await?
                 } else {
                     None
                 };
@@ -662,7 +774,15 @@ impl Backend for UnifiedGitBackend {
                 // not just an API query. Cross-platform entries remain detection-only.
                 if provenance.is_some() && target.is_current() {
                     match self
-                        .verify_provenance_at_lock_time(tv, &opts, &repo, &api_url, &asset)
+                        .verify_provenance_at_lock_time(
+                            tv,
+                            &opts,
+                            &repo,
+                            &api_url,
+                            &asset,
+                            primary_explicit_pattern,
+                            false,
+                        )
                         .await
                     {
                         Ok(verified) => {
@@ -679,12 +799,68 @@ impl Backend for UnifiedGitBackend {
                         }
                     }
                 }
+                let mut additional_artifacts = Vec::new();
+                for pattern in opts.additional_asset_patterns_for_target(target) {
+                    let additional = self
+                        .resolve_asset_url_for_target_with_pattern(
+                            tv,
+                            &opts,
+                            &repo,
+                            &api_url,
+                            target,
+                            Some(&pattern),
+                        )
+                        .await?;
+                    let mut additional_provenance = if !self.is_gitlab() && !self.is_forgejo() {
+                        self.detect_provenance_type(
+                            tv,
+                            &opts,
+                            &repo,
+                            &api_url,
+                            &additional,
+                            target,
+                            true,
+                        )
+                        .await?
+                    } else {
+                        None
+                    };
+                    if additional_provenance.is_some() && target.is_current() {
+                        additional_provenance = self
+                            .verify_provenance_at_lock_time(
+                                tv,
+                                &opts,
+                                &repo,
+                                &api_url,
+                                &additional,
+                                true,
+                                true,
+                            )
+                            .await
+                            .unwrap_or_else(|e| {
+                                warn!(
+                                    "lock-time provenance verification failed for additional asset {}: {e}",
+                                    additional.name
+                                );
+                                None
+                            });
+                    }
+                    additional_artifacts.push(ArtifactInfo {
+                        checksum: additional.digest,
+                        url: additional.url,
+                        url_api: (!additional.url_api.is_empty()).then_some(additional.url_api),
+                        provenance: additional_provenance,
+                        ..Default::default()
+                    });
+                }
+
                 Ok(PlatformInfo {
                     url: Some(asset.url),
                     url_api: (!asset.url_api.is_empty()).then_some(asset.url_api),
                     checksum: asset.digest,
                     provenance,
                     github_attestations: None,
+                    additional_artifacts,
                     ..Default::default()
                 })
             }
@@ -749,6 +925,7 @@ impl UnifiedGitBackend {
         api_url: &str,
         asset: &ReleaseAsset,
         target: &PlatformTarget,
+        explicit_pattern: bool,
     ) -> Result<Option<ProvenanceType>> {
         let settings = Settings::get();
         let version = &tv.version;
@@ -836,7 +1013,7 @@ impl UnifiedGitBackend {
             // multi-binary release's per-binary provenance files don't
             // cross-verify the wrong digest. Suppressed when `asset_pattern` is
             // set (it selects the binary, ignoring `matching`).
-            let (matching, matching_regex) = opts.matching_for_provenance(target);
+            let (matching, matching_regex) = opts.matching_for_provenance(target, explicit_pattern);
             let picker = AssetPicker::with_libc(
                 target.os_name().to_string(),
                 target.arch_name().to_string(),
@@ -868,6 +1045,8 @@ impl UnifiedGitBackend {
         repo: &str,
         api_url: &str,
         asset: &ReleaseAsset,
+        explicit_pattern: bool,
+        additional_overlay: bool,
     ) -> Result<Option<ProvenanceType>> {
         let tmp_dir = tempfile::tempdir()?;
         let filename = get_filename_from_url(&asset.url);
@@ -961,7 +1140,8 @@ impl UnifiedGitBackend {
             let current_platform = PlatformTarget::from_current();
             // Keep provenance aligned with the matching-selected binary, unless
             // `asset_pattern` is set (it selects the binary, ignoring `matching`).
-            let (matching, matching_regex) = opts.matching_for_provenance(&current_platform);
+            let (matching, matching_regex) =
+                opts.matching_for_provenance(&current_platform, explicit_pattern);
             let picker = AssetPicker::with_libc(
                 current_platform.os_name().to_string(),
                 current_platform.arch_name().to_string(),
@@ -1014,6 +1194,7 @@ impl UnifiedGitBackend {
                                     tv,
                                     &artifact_path,
                                     &provenance_path,
+                                    additional_overlay,
                                 )
                                 .await
                             {
@@ -1151,6 +1332,10 @@ impl UnifiedGitBackend {
             .lock_platforms
             .get(&platform_key)
             .is_some_and(PlatformInfo::has_checksum_and_verified_provenance);
+        let locked_provenance = tv
+            .lock_platforms
+            .get(&platform_key)
+            .and_then(|platform| platform.provenance.clone());
 
         self.verify_checksum(ctx, tv, &file_path)?;
 
@@ -1162,7 +1347,16 @@ impl UnifiedGitBackend {
             self.ensure_provenance_setting_enabled(tv, &platform_key)?;
         } else {
             let provenance_result = self
-                .verify_attestations_or_slsa(ctx, tv, &file_path, &asset.name)
+                .verify_attestations_or_slsa(
+                    ctx,
+                    tv,
+                    &file_path,
+                    &asset.name,
+                    locked_provenance.as_ref(),
+                    opts.asset_pattern_for_target(&PlatformTarget::from_current())
+                        .is_some(),
+                    false,
+                )
                 .await?;
 
             // Record provenance verification result in lock_platforms
@@ -1181,6 +1375,150 @@ impl UnifiedGitBackend {
         }
 
         Ok(())
+    }
+
+    async fn download_verify_and_install_additional_asset(
+        &self,
+        ctx: &InstallContext,
+        tv: &mut ToolVersion,
+        asset: &ReleaseAsset,
+        opts: &GitBackendOptions<'_>,
+        index: usize,
+    ) -> Result<()> {
+        let filename = asset.name.clone();
+        let file_path = tv.download_path().join(&filename);
+        let platform_key = self.get_platform_key();
+        let mut artifact_info = tv
+            .lock_platforms
+            .get(&platform_key)
+            .and_then(|platform| platform.additional_artifacts.get(index))
+            .cloned()
+            .unwrap_or_default();
+        artifact_info.url = asset.url.clone();
+        artifact_info.url_api = (!asset.url_api.is_empty()).then(|| asset.url_api.clone());
+        if let Some(digest) = &asset.digest {
+            artifact_info.checksum = Some(digest.clone());
+        }
+        let has_lockfile_integrity = artifact_info.has_checksum_and_verified_provenance();
+
+        let url = if asset.url_api.is_empty() {
+            asset.url.clone()
+        } else if asset.url_api.starts_with(DEFAULT_GITHUB_API_BASE_URL)
+            || asset.url_api.starts_with(DEFAULT_GITLAB_API_BASE_URL)
+            || asset.url_api.starts_with(DEFAULT_FORGEJO_API_BASE_URL)
+        {
+            github::pick_reachable_asset_url(&asset.url, &asset.url_api).await
+        } else {
+            asset.url_api.clone()
+        };
+        let headers = if self.is_gitlab() {
+            gitlab::get_headers(&url)
+        } else if self.is_forgejo() {
+            forgejo::get_headers(&url)
+        } else {
+            github::get_headers(&url)?
+        };
+
+        ctx.pr.set_message(format!("download {filename}"));
+        HTTP.download_file_with_headers(url, &file_path, &headers, Some(ctx.pr.as_ref()))
+            .await?;
+        ctx.pr.next_operation();
+
+        self.verify_additional_artifact_checksum(ctx, &file_path, &mut artifact_info)?;
+        let expected_provenance = artifact_info.provenance.clone();
+        if has_lockfile_integrity && !Settings::get().force_provenance_verify() {
+            if let Some(provenance) = expected_provenance.as_ref() {
+                self.ensure_provenance_type_setting_enabled(tv, opts, provenance)?;
+            }
+        } else {
+            let provenance = self
+                .verify_attestations_or_slsa(
+                    ctx,
+                    tv,
+                    &file_path,
+                    &asset.name,
+                    expected_provenance.as_ref(),
+                    true,
+                    true,
+                )
+                .await?;
+            if provenance.is_some() {
+                artifact_info.provenance = provenance;
+            }
+        }
+
+        let platform = tv.lock_platforms.entry(platform_key).or_default();
+        if platform.additional_artifacts.len() <= index {
+            platform
+                .additional_artifacts
+                .resize_with(index + 1, ArtifactInfo::default);
+        }
+        platform.additional_artifacts[index] = artifact_info;
+
+        ctx.pr.next_operation();
+        self.install_additional_archive(&tv.install_path(), &file_path, Some(ctx.pr.as_ref()))?;
+
+        if let Some(bins) = opts.filter_bins() {
+            self.create_symlink_bin_dir(tv, bins)?;
+        }
+        Ok(())
+    }
+
+    fn verify_additional_artifact_checksum(
+        &self,
+        ctx: &InstallContext,
+        file_path: &Path,
+        artifact: &mut ArtifactInfo,
+    ) -> Result<()> {
+        let filename = file_path.file_name().unwrap_or_default().to_string_lossy();
+        if let Some(checksum) = &artifact.checksum {
+            ctx.pr.set_message(format!("checksum {filename}"));
+            let Some((algorithm, expected)) = checksum.split_once(':') else {
+                eyre::bail!("Invalid checksum: {checksum}");
+            };
+            crate::hash::ensure_checksum(file_path, expected, Some(ctx.pr.as_ref()), algorithm)?;
+        } else if Settings::get().lockfile_enabled() {
+            ctx.pr.set_message(format!("generate checksum {filename}"));
+            let hash = crate::hash::file_hash_blake3(file_path, Some(ctx.pr.as_ref()))?;
+            artifact.checksum = Some(format!("blake3:{hash}"));
+        }
+
+        if let Some(expected_size) = artifact.size {
+            let actual_size = file_path.metadata()?.len();
+            if actual_size != expected_size {
+                eyre::bail!(
+                    "Size mismatch for {}: expected {}, got {}",
+                    filename,
+                    expected_size,
+                    actual_size
+                );
+            }
+        } else if Settings::get().lockfile_enabled() {
+            artifact.size = Some(file_path.metadata()?.len());
+        }
+        Ok(())
+    }
+
+    fn install_additional_archive(
+        &self,
+        install_path: &Path,
+        file_path: &Path,
+        pr: Option<&dyn crate::ui::progress_report::SingleReport>,
+    ) -> Result<()> {
+        let format = file::ExtractionFormat::from_file_name(
+            &file_path.file_name().unwrap_or_default().to_string_lossy(),
+        );
+        if !format.is_archive() {
+            eyre::bail!(
+                "additional asset '{}' is not an archive",
+                file_path.display()
+            );
+        }
+        let extract_opts = file::ExtractOptions {
+            pr,
+            ..Default::default()
+        };
+        file::extract_archive(file_path, install_path, format, &extract_opts)
     }
 
     /// Discovers bin paths in the installation directory
@@ -1280,8 +1618,23 @@ impl UnifiedGitBackend {
         api_url: &str,
         target: &PlatformTarget,
     ) -> Result<ReleaseAsset> {
+        self.resolve_asset_url_for_target_with_pattern(tv, opts, repo, api_url, target, None)
+            .await
+    }
+
+    async fn resolve_asset_url_for_target_with_pattern(
+        &self,
+        tv: &ToolVersion,
+        opts: &GitBackendOptions<'_>,
+        repo: &str,
+        api_url: &str,
+        target: &PlatformTarget,
+        asset_pattern: Option<&str>,
+    ) -> Result<ReleaseAsset> {
         // Check for direct platform-specific URLs first
-        if let Some(direct_url) = opts.direct_url_for_target(target) {
+        if asset_pattern.is_none()
+            && let Some(direct_url) = opts.direct_url_for_target(target)
+        {
             return Ok(ReleaseAsset {
                 name: get_filename_from_url(&direct_url),
                 url: direct_url.clone(),
@@ -1295,7 +1648,13 @@ impl UnifiedGitBackend {
         if self.is_gitlab() {
             try_with_v_prefix(version, version_prefix, |candidate| async move {
                 self.resolve_gitlab_asset_url_for_target(
-                    tv, opts, repo, api_url, &candidate, target,
+                    tv,
+                    opts,
+                    repo,
+                    api_url,
+                    &candidate,
+                    target,
+                    asset_pattern,
                 )
                 .await
             })
@@ -1303,7 +1662,13 @@ impl UnifiedGitBackend {
         } else if self.is_forgejo() {
             try_with_v_prefix(version, version_prefix, |candidate| async move {
                 self.resolve_forgejo_asset_url_for_target(
-                    tv, opts, repo, api_url, &candidate, target,
+                    tv,
+                    opts,
+                    repo,
+                    api_url,
+                    &candidate,
+                    target,
+                    asset_pattern,
                 )
                 .await
             })
@@ -1316,7 +1681,13 @@ impl UnifiedGitBackend {
                 Some(repo),
                 |candidate| async move {
                     self.resolve_github_asset_url_for_target(
-                        tv, opts, repo, api_url, &candidate, target,
+                        tv,
+                        opts,
+                        repo,
+                        api_url,
+                        &candidate,
+                        target,
+                        asset_pattern,
                     )
                     .await
                 },
@@ -1334,6 +1705,7 @@ impl UnifiedGitBackend {
         api_url: &str,
         version: &str,
         target: &PlatformTarget,
+        asset_pattern: Option<&str>,
     ) -> Result<ReleaseAsset> {
         let release = self
             .get_github_release_for_url(api_url, repo, version)
@@ -1351,7 +1723,10 @@ impl UnifiedGitBackend {
         // entirely, so it intentionally takes precedence over and ignores
         // `matching`/`matching_regex` (there is no autodetected candidate set left
         // to narrow). Do NOT thread the matching filter into this branch.
-        if let Some(pattern) = opts.asset_pattern_for_target(target) {
+        if let Some(pattern) = asset_pattern
+            .map(str::to_string)
+            .or_else(|| opts.asset_pattern_for_target(target))
+        {
             // Template the pattern for the target platform
             let templated_pattern = template_string_for_target(&pattern, tv, target);
 
@@ -1425,6 +1800,7 @@ impl UnifiedGitBackend {
         api_url: &str,
         version: &str,
         target: &PlatformTarget,
+        asset_pattern: Option<&str>,
     ) -> Result<ReleaseAsset> {
         let release = gitlab::get_release_for_url(api_url, repo, version).await?;
         let available_assets: Vec<String> = release
@@ -1446,7 +1822,10 @@ impl UnifiedGitBackend {
         // entirely, so it intentionally takes precedence over and ignores
         // `matching`/`matching_regex` (there is no autodetected candidate set left
         // to narrow). Do NOT thread the matching filter into this branch.
-        if let Some(pattern) = opts.asset_pattern_for_target(target) {
+        if let Some(pattern) = asset_pattern
+            .map(str::to_string)
+            .or_else(|| opts.asset_pattern_for_target(target))
+        {
             // Template the pattern for the target platform
             let templated_pattern = template_string_for_target(&pattern, tv, target);
 
@@ -1514,6 +1893,7 @@ impl UnifiedGitBackend {
         api_url: &str,
         version: &str,
         target: &PlatformTarget,
+        asset_pattern: Option<&str>,
     ) -> Result<ReleaseAsset> {
         let release = forgejo::get_release_for_url(api_url, repo, version).await?;
         let available_assets: Vec<String> = release.assets.iter().map(|a| a.name.clone()).collect();
@@ -1538,7 +1918,10 @@ impl UnifiedGitBackend {
         // entirely, so it intentionally takes precedence over and ignores
         // `matching`/`matching_regex` (there is no autodetected candidate set left
         // to narrow). Do NOT thread the matching filter into this branch.
-        if let Some(pattern) = opts.asset_pattern_for_target(target) {
+        if let Some(pattern) = asset_pattern
+            .map(str::to_string)
+            .or_else(|| opts.asset_pattern_for_target(target))
+        {
             // Template the pattern for the target platform
             let templated_pattern = template_string_for_target(&pattern, tv, target);
 
@@ -1797,6 +2180,38 @@ impl UnifiedGitBackend {
         })
     }
 
+    fn ensure_provenance_type_setting_enabled(
+        &self,
+        tv: &ToolVersion,
+        opts: &GitBackendOptions<'_>,
+        provenance: &ProvenanceType,
+    ) -> Result<()> {
+        let settings = Settings::get();
+        let disabled = match provenance {
+            ProvenanceType::GithubAttestations => {
+                if !opts.github_attestations() {
+                    return Err(github_attestations_disabled_for_tool_error(tv));
+                }
+                !settings.github_attestations || !settings.github.github_attestations
+            }
+            ProvenanceType::Slsa { .. } => !settings.slsa || !settings.github.slsa,
+            _ => {
+                return Err(eyre::eyre!(
+                    "Lockfile has unexpected provenance type {provenance} for github backend tool {tv}. \
+                     Update the lockfile to remove the stale provenance entry."
+                ));
+            }
+        };
+        if disabled {
+            return Err(eyre::eyre!(
+                "Lockfile requires {provenance} provenance for {tv} but the corresponding \
+                 verification setting is disabled. This may indicate a downgrade attack. \
+                 Enable the setting or update the lockfile."
+            ));
+        }
+        Ok(())
+    }
+
     /// Verify artifact using GitHub artifact attestations or SLSA provenance.
     /// Tries attestations first, falls back to SLSA if no attestations found.
     /// If verification is attempted and fails, it's a hard error.
@@ -1808,19 +2223,12 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         file_path: &std::path::Path,
         asset_name: &str,
+        expected_provenance: Option<&ProvenanceType>,
+        explicit_pattern: bool,
+        additional_overlay: bool,
     ) -> Result<Option<ProvenanceType>> {
         let settings = Settings::get();
 
-        // Read the expected provenance from the lockfile. We use .clone() because tv is
-        // &ToolVersion. The result is validated against this expectation at every return
-        // point: successful verification checks type match, and no-verification triggers
-        // a downgrade error.
-        let platform_key = self.get_platform_key();
-        let locked_provenance = tv
-            .lock_platforms
-            .get(&platform_key)
-            .and_then(|pi| pi.provenance.clone());
-        let expected_provenance = locked_provenance.as_ref();
         // Only verify for GitHub repos (not GitLab/Forgejo)
         if self.is_gitlab() || self.is_forgejo() {
             if let Some(expected) = expected_provenance {
@@ -1913,7 +2321,15 @@ impl UnifiedGitBackend {
         // Fall back to SLSA provenance (if enabled globally and for github backend)
         if !skip_slsa && settings.slsa && settings.github.slsa {
             match self
-                .try_verify_slsa(ctx, tv, file_path, asset_name, &api_url)
+                .try_verify_slsa(
+                    ctx,
+                    tv,
+                    file_path,
+                    asset_name,
+                    &api_url,
+                    explicit_pattern,
+                    additional_overlay,
+                )
                 .await
             {
                 Ok((true, provenance_url)) => {
@@ -2021,9 +2437,12 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         file_path: &std::path::Path,
         provenance_path: &std::path::Path,
+        additional_overlay: bool,
     ) -> Result<bool> {
         let raw_opts = tv.request.options();
-        let format = if let Some(format_opt) = lookup_with_fallback(&raw_opts, "format") {
+        let format = if !additional_overlay
+            && let Some(format_opt) = lookup_with_fallback(&raw_opts, "format")
+        {
             file::ExtractionFormat::from_ext(&format_opt).unwrap_or(file::ExtractionFormat::Raw)
         } else {
             file::ExtractionFormat::from_file_name(
@@ -2037,10 +2456,15 @@ impl UnifiedGitBackend {
             ));
         }
 
-        let mut strip_components = lookup_platform_key(&raw_opts, "strip_components")
-            .or_else(|| raw_opts.get_string("strip_components"))
-            .and_then(|s| s.parse().ok());
-        if strip_components.is_none()
+        let mut strip_components = if additional_overlay {
+            None
+        } else {
+            lookup_platform_key(&raw_opts, "strip_components")
+                .or_else(|| raw_opts.get_string("strip_components"))
+                .and_then(|s| s.parse().ok())
+        };
+        if !additional_overlay
+            && strip_components.is_none()
             && lookup_with_fallback(&raw_opts, "bin_path").is_none()
             && file::should_strip_components(file_path, format)?
         {
@@ -2074,6 +2498,8 @@ impl UnifiedGitBackend {
         file_path: &std::path::Path,
         asset_name: &str,
         api_url: &str,
+        explicit_pattern: bool,
+        additional_overlay: bool,
     ) -> std::result::Result<(bool, Option<String>), VerificationStatus> {
         if self.is_gitlab() || self.is_forgejo() {
             return Err(VerificationStatus::NoAttestations);
@@ -2120,7 +2546,8 @@ impl UnifiedGitBackend {
         // Keep provenance aligned with the matching-selected binary at install
         // time, matching the selection used at lock time. Suppressed when
         // `asset_pattern` is set (it selects the binary, ignoring `matching`).
-        let (matching, matching_regex) = opts.matching_for_provenance(&current_platform);
+        let (matching, matching_regex) =
+            opts.matching_for_provenance(&current_platform, explicit_pattern);
         let picker = AssetPicker::with_libc(
             current_platform.os_name().to_string(),
             current_platform.arch_name().to_string(),
@@ -2184,7 +2611,12 @@ impl UnifiedGitBackend {
                         "SLSA provenance did not cover downloaded artifact for {tv}; trying archive content subjects: {e}"
                     );
                     match self
-                        .try_verify_slsa_archive_contents(tv, file_path, &provenance_path)
+                        .try_verify_slsa_archive_contents(
+                            tv,
+                            file_path,
+                            &provenance_path,
+                            additional_overlay,
+                        )
                         .await
                     {
                         Ok(true) => {
@@ -2372,6 +2804,92 @@ mod tests {
     }
 
     #[test]
+    fn test_additional_asset_patterns_accept_string_array_and_platform_override() {
+        let backend = create_test_backend();
+        let linux = PlatformTarget::new(crate::platform::Platform::parse("linux-x64").unwrap());
+        let macos = PlatformTarget::new(crate::platform::Platform::parse("macos-arm64").unwrap());
+
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "additional_asset_patterns".to_string(),
+            toml::Value::String("base-extra.tar.gz, symbols.zip".to_string()),
+        );
+        assert_eq!(
+            backend
+                .options(&opts)
+                .additional_asset_patterns_for_target(&macos),
+            vec!["base-extra.tar.gz", "symbols.zip"]
+        );
+
+        let mut platforms = toml::Table::new();
+        let mut linux_opts = toml::Table::new();
+        linux_opts.insert(
+            "additional_asset_patterns".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String(" rocm.tar.gz ".to_string()),
+                toml::Value::String("".to_string()),
+            ]),
+        );
+        platforms.insert("linux-x64".to_string(), toml::Value::Table(linux_opts));
+        opts.opts
+            .insert("platforms".to_string(), toml::Value::Table(platforms));
+
+        assert_eq!(
+            backend
+                .options(&opts)
+                .additional_asset_patterns_for_target(&linux),
+            vec!["rocm.tar.gz"]
+        );
+        assert_eq!(
+            backend
+                .options(&opts)
+                .lockfile_options(&linux)
+                .get("additional_asset_patterns"),
+            Some(&"rocm.tar.gz".to_string())
+        );
+    }
+
+    #[test]
+    fn test_additional_archive_overlays_existing_install() {
+        use std::io::Write;
+
+        let backend = create_test_backend();
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("install");
+        std::fs::create_dir_all(&install_path).unwrap();
+        std::fs::write(install_path.join("ollama"), b"base").unwrap();
+        std::fs::write(install_path.join("README"), b"keep").unwrap();
+
+        let archive_path = tmp.path().join("ollama-rocm.zip");
+        let archive = std::fs::File::create(&archive_path).unwrap();
+        let mut zip = zip::ZipWriter::new(archive);
+        zip.start_file(
+            "lib/ollama/rocm/libhip.so",
+            zip::write::SimpleFileOptions::default(),
+        )
+        .unwrap();
+        zip.write_all(b"rocm").unwrap();
+        zip.start_file("ollama", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        zip.write_all(b"overlaid").unwrap();
+        zip.finish().unwrap();
+
+        backend
+            .install_additional_archive(&install_path, &archive_path, None)
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read(install_path.join("ollama")).unwrap(),
+            b"overlaid"
+        );
+        assert_eq!(std::fs::read(install_path.join("README")).unwrap(), b"keep");
+        assert_eq!(
+            std::fs::read(install_path.join("lib/ollama/rocm/libhip.so")).unwrap(),
+            b"rocm"
+        );
+    }
+
+    #[test]
     fn test_filter_bins_falls_back_to_base_when_platform_value_is_empty() {
         use crate::backend::static_helpers::platform_aliases;
 
@@ -2554,6 +3072,11 @@ mod tests {
     }
 
     #[test]
+    fn test_additional_asset_patterns_is_an_install_time_key() {
+        assert!(install_time_option_keys().contains(&"additional_asset_patterns".to_string()));
+    }
+
+    #[test]
     fn test_layout_options_are_install_time_keys() {
         for backend_type in [
             BackendType::Github,
@@ -2717,12 +3240,16 @@ mod tests {
 
         // asset_pattern set for this target -> matching suppressed for provenance.
         assert_eq!(
-            backend.options(&opts).matching_for_provenance(&linux),
+            backend
+                .options(&opts)
+                .matching_for_provenance(&linux, false),
             (None, None)
         );
         // No asset_pattern for this target -> matching flows through to provenance.
         assert_eq!(
-            backend.options(&opts).matching_for_provenance(&macos),
+            backend
+                .options(&opts)
+                .matching_for_provenance(&macos, false),
             (Some("oxlint"), Some("^oxlint-"))
         );
     }

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -969,16 +969,17 @@ impl UnifiedGitBackend {
         tv: &ToolVersion,
         patterns: &[String],
     ) -> Result<()> {
+        let state_path = tv.install_path().join(ADDITIONAL_ASSETS_STATE_FILENAME);
         if patterns.is_empty() {
+            if state_path.exists() {
+                file::remove_file(state_path)?;
+            }
             return Ok(());
         }
         let state = AdditionalAssetsInstallState {
             patterns: patterns.to_vec(),
         };
-        file::write(
-            tv.install_path().join(ADDITIONAL_ASSETS_STATE_FILENAME),
-            toml::to_string(&state)?,
-        )
+        file::write(state_path, toml::to_string(&state)?)
     }
 
     async fn get_github_release_for_url(
@@ -2943,6 +2944,11 @@ mod tests {
             &["extra-*.tar.gz".to_string(), "base-*.tar.gz".to_string()],
         ));
         assert!(!backend.additional_assets_install_state_matches(&tv, &[]));
+
+        backend
+            .write_additional_assets_install_state(&tv, &[])
+            .unwrap();
+        assert!(backend.additional_assets_install_state_matches(&tv, &[]));
     }
 
     #[test]

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -62,6 +62,13 @@ impl AssetVerification {
     };
 }
 
+const ADDITIONAL_ASSETS_STATE_FILENAME: &str = ".mise-additional-assets.toml";
+
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+struct AdditionalAssetsInstallState {
+    patterns: Vec<String>,
+}
+
 const DEFAULT_GITHUB_API_BASE_URL: &str = "https://api.github.com";
 const DEFAULT_GITLAB_API_BASE_URL: &str = "https://gitlab.com/api/v4";
 const DEFAULT_FORGEJO_API_BASE_URL: &str = "https://codeberg.org/api/v1";
@@ -328,6 +335,22 @@ impl Backend for UnifiedGitBackend {
 
     fn ba(&self) -> &Arc<BackendArg> {
         &self.ba
+    }
+
+    async fn is_install_satisfied(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        check_symlink: bool,
+    ) -> Result<bool> {
+        if !self.is_version_installed(config, tv, check_symlink) {
+            return Ok(false);
+        }
+        let raw_opts = config.get_tool_opts_with_overrides(&self.ba).await?;
+        let patterns = self
+            .options(&raw_opts)
+            .additional_asset_patterns_for_target(&PlatformTarget::from_current());
+        Ok(self.additional_assets_install_state_matches(tv, &patterns))
     }
 
     async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
@@ -608,6 +631,8 @@ impl Backend for UnifiedGitBackend {
         let repo = self.repo();
         let raw_opts = ctx.config.get_tool_opts_with_overrides(&self.ba).await?;
         let opts = self.options(&raw_opts);
+        let current_target = PlatformTarget::from_current();
+        let additional_patterns = opts.additional_asset_patterns_for_target(&current_target);
 
         // Validate `matching_regex` up front, before the cached-URL branch below.
         // Reusing a cached lockfile URL skips binary selection (the path that
@@ -633,9 +658,6 @@ impl Backend for UnifiedGitBackend {
 
         // Check if URL already exists in lockfile platforms first
         let platform_key = self.get_platform_key();
-        let current_target = PlatformTarget::from_current();
-        let additional_patterns = opts.additional_asset_patterns_for_target(&current_target);
-
         let asset = if let Some(existing_platform) = tv.lock_platforms.get(&platform_key)
             && existing_platform.url.is_some()
         {
@@ -713,6 +735,7 @@ impl Backend for UnifiedGitBackend {
             self.download_verify_and_install_additional_asset(ctx, &mut tv, asset, &opts, index)
                 .await?;
         }
+        self.write_additional_assets_install_state(&tv, &additional_patterns)?;
 
         Ok(tv)
     }
@@ -924,6 +947,38 @@ impl UnifiedGitBackend {
                 self.pick_by_pattern([name], &pattern, String::as_str)
                     .is_some()
             })
+    }
+
+    fn additional_assets_install_state_matches(
+        &self,
+        tv: &ToolVersion,
+        patterns: &[String],
+    ) -> bool {
+        let state_path = tv.install_path().join(ADDITIONAL_ASSETS_STATE_FILENAME);
+        if !state_path.exists() {
+            return patterns.is_empty();
+        }
+        file::read_to_string(&state_path)
+            .ok()
+            .and_then(|body| toml::from_str::<AdditionalAssetsInstallState>(&body).ok())
+            .is_some_and(|state| state.patterns == patterns)
+    }
+
+    fn write_additional_assets_install_state(
+        &self,
+        tv: &ToolVersion,
+        patterns: &[String],
+    ) -> Result<()> {
+        if patterns.is_empty() {
+            return Ok(());
+        }
+        let state = AdditionalAssetsInstallState {
+            patterns: patterns.to_vec(),
+        };
+        file::write(
+            tv.install_path().join(ADDITIONAL_ASSETS_STATE_FILENAME),
+            toml::to_string(&state)?,
+        )
     }
 
     async fn get_github_release_for_url(
@@ -2858,6 +2913,36 @@ mod tests {
                 .get("additional_asset_patterns"),
             Some(&"rocm.tar.gz".to_string())
         );
+    }
+
+    #[test]
+    fn test_additional_assets_install_state_tracks_patterns() {
+        let backend = create_test_backend();
+        let backend_arg = Arc::new(BackendArg::new(
+            "github:test/repo".to_string(),
+            Some("github:test/repo".to_string()),
+        ));
+        let request =
+            ToolRequest::new(backend_arg, "1.0.0", crate::toolset::ToolSource::Unknown).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("install");
+        file::create_dir_all(&install_path).unwrap();
+        let mut tv = ToolVersion::new(request, "1.0.0".to_string());
+        tv.install_path = Some(install_path);
+        let patterns = vec!["base-*.tar.gz".to_string(), "extra-*.tar.gz".to_string()];
+
+        assert!(backend.additional_assets_install_state_matches(&tv, &[]));
+        assert!(!backend.additional_assets_install_state_matches(&tv, &patterns));
+
+        backend
+            .write_additional_assets_install_state(&tv, &patterns)
+            .unwrap();
+        assert!(backend.additional_assets_install_state_matches(&tv, &patterns));
+        assert!(!backend.additional_assets_install_state_matches(
+            &tv,
+            &["extra-*.tar.gz".to_string(), "base-*.tar.gz".to_string()],
+        ));
+        assert!(!backend.additional_assets_install_state_matches(&tv, &[]));
     }
 
     #[test]

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -633,8 +633,8 @@ impl Backend for UnifiedGitBackend {
 
         // Check if URL already exists in lockfile platforms first
         let platform_key = self.get_platform_key();
-        let additional_patterns =
-            opts.additional_asset_patterns_for_target(&PlatformTarget::from_current());
+        let current_target = PlatformTarget::from_current();
+        let additional_patterns = opts.additional_asset_patterns_for_target(&current_target);
 
         let asset = if let Some(existing_platform) = tv.lock_platforms.get(&platform_key)
             && existing_platform.url.is_some()
@@ -655,13 +655,18 @@ impl Backend for UnifiedGitBackend {
             self.resolve_asset_url(&tv, &opts, &repo).await?
         };
 
+        let locked_additional_artifacts_present = tv
+            .lock_platforms
+            .get(&platform_key)
+            .is_some_and(|platform| !platform.additional_artifacts.is_empty());
         let additional_assets = match tv.lock_platforms.get(&platform_key) {
             Some(platform)
-                if platform.additional_artifacts.len() == additional_patterns.len()
-                    && platform
-                        .additional_artifacts
-                        .iter()
-                        .all(|artifact| !artifact.url.is_empty()) =>
+                if self.additional_artifacts_match_patterns(
+                    &tv,
+                    &current_target,
+                    &additional_patterns,
+                    &platform.additional_artifacts,
+                ) =>
             {
                 platform
                     .additional_artifacts
@@ -674,9 +679,11 @@ impl Backend for UnifiedGitBackend {
                     })
                     .collect()
             }
-            _ if ctx.locked && !additional_patterns.is_empty() => {
+            _ if ctx.locked
+                && (!additional_patterns.is_empty() || locked_additional_artifacts_present) =>
+            {
                 eyre::bail!(
-                    "No complete lockfile artifact list found for {} on platform {} (--locked mode)",
+                    "No matching complete lockfile artifact list found for {} on platform {} (--locked mode)",
                     tv.style(),
                     platform_key
                 )
@@ -689,7 +696,7 @@ impl Backend for UnifiedGitBackend {
                             &tv,
                             &opts,
                             &repo,
-                            &PlatformTarget::from_current(),
+                            &current_target,
                             Some(pattern),
                         )
                         .await?,
@@ -777,6 +784,7 @@ impl Backend for UnifiedGitBackend {
                 } else {
                     None
                 };
+                let mut provenance_verified = false;
 
                 // For the current platform, verify provenance cryptographically at lock time.
                 // This ensures the lockfile's provenance entry is backed by actual verification,
@@ -793,6 +801,7 @@ impl Backend for UnifiedGitBackend {
                     {
                         Ok(verified) => {
                             provenance = verified;
+                            provenance_verified = provenance.is_some();
                         }
                         Err(e) => {
                             // Clear provenance so install-time verification will run.
@@ -822,6 +831,7 @@ impl Backend for UnifiedGitBackend {
                     } else {
                         None
                     };
+                    let mut additional_provenance_verified = false;
                     if additional_provenance.is_some() && target.is_current() {
                         additional_provenance = self
                             .verify_provenance_at_lock_time(
@@ -838,12 +848,14 @@ impl Backend for UnifiedGitBackend {
                                 );
                                 None
                             });
+                        additional_provenance_verified = additional_provenance.is_some();
                     }
                     additional_artifacts.push(ArtifactInfo {
                         checksum: additional.digest,
                         url: additional.url,
                         url_api: (!additional.url_api.is_empty()).then_some(additional.url_api),
                         provenance: additional_provenance,
+                        provenance_verified: additional_provenance_verified,
                         ..Default::default()
                     });
                 }
@@ -853,6 +865,7 @@ impl Backend for UnifiedGitBackend {
                     url_api: (!asset.url_api.is_empty()).then_some(asset.url_api),
                     checksum: asset.digest,
                     provenance,
+                    provenance_verified,
                     github_attestations: None,
                     additional_artifacts,
                     ..Default::default()
@@ -892,6 +905,25 @@ impl UnifiedGitBackend {
 
     fn use_versions_host_for_github_metadata(&self) -> bool {
         backend_arg_matches_registry_backend(&self.ba)
+    }
+
+    fn additional_artifacts_match_patterns(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+        patterns: &[String],
+        artifacts: &[ArtifactInfo],
+    ) -> bool {
+        artifacts.len() == patterns.len()
+            && artifacts.iter().zip(patterns).all(|(artifact, pattern)| {
+                if artifact.url.is_empty() {
+                    return false;
+                }
+                let name = get_filename_from_url(&artifact.url);
+                let pattern = template_string_for_target(pattern, tv, target);
+                self.pick_by_pattern([name], &pattern, String::as_str)
+                    .is_some()
+            })
     }
 
     async fn get_github_release_for_url(
@@ -1357,6 +1389,7 @@ impl UnifiedGitBackend {
             if provenance_result.is_some() {
                 let platform_info = tv.lock_platforms.entry(platform_key).or_default();
                 platform_info.provenance = provenance_result;
+                platform_info.provenance_verified = true;
                 platform_info.github_attestations = None;
             }
         }
@@ -1437,6 +1470,7 @@ impl UnifiedGitBackend {
                 .await?;
             if provenance.is_some() {
                 artifact_info.provenance = provenance;
+                artifact_info.provenance_verified = true;
             }
         }
 
@@ -2902,6 +2936,39 @@ mod tests {
         };
         assert!(matches("test-v1.0.0.zip", "test-*"));
         assert!(!matches("other-v1.0.0.zip", "test-*"));
+    }
+
+    #[test]
+    fn test_additional_artifacts_must_match_pattern_order() {
+        let backend = create_test_backend();
+        let backend_arg = Arc::new(BackendArg::new(
+            "github:test/repo".to_string(),
+            Some("github:test/repo".to_string()),
+        ));
+        let request =
+            ToolRequest::new(backend_arg, "1.0.0", crate::toolset::ToolSource::Unknown).unwrap();
+        let tv = ToolVersion::new(request, "1.0.0".to_string());
+        let target = PlatformTarget::new(crate::platform::Platform::parse("linux-x64").unwrap());
+        let patterns = vec!["base-*.tar.gz".to_string(), "extra-*.tar.gz".to_string()];
+        let artifacts = vec![
+            ArtifactInfo {
+                url: "https://example.com/base-1.0.0.tar.gz".to_string(),
+                ..Default::default()
+            },
+            ArtifactInfo {
+                url: "https://example.com/extra-1.0.0.tar.gz".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        assert!(backend.additional_artifacts_match_patterns(&tv, &target, &patterns, &artifacts));
+        assert!(!backend.additional_artifacts_match_patterns(
+            &tv,
+            &target,
+            &patterns,
+            &[artifacts[1].clone(), artifacts[0].clone()],
+        ));
+        assert!(!backend.additional_artifacts_match_patterns(&tv, &target, &[], &artifacts));
     }
 
     #[test]

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -735,6 +735,11 @@ impl Backend for UnifiedGitBackend {
             self.download_verify_and_install_additional_asset(ctx, &mut tv, asset, &opts, index)
                 .await?;
         }
+        if let Some(platform) = tv.lock_platforms.get_mut(&platform_key) {
+            platform
+                .additional_artifacts
+                .truncate(additional_assets.len());
+        }
         self.write_additional_assets_install_state(&tv, &additional_patterns)?;
 
         Ok(tv)

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -353,8 +353,18 @@ impl Backend for UnifiedGitBackend {
         Ok(self.additional_assets_install_state_matches(tv, &patterns))
     }
 
-    async fn install_operation_count(&self, tv: &ToolVersion, _ctx: &InstallContext) -> usize {
-        let raw_opts = tv.request.options();
+    async fn install_operation_count(&self, tv: &ToolVersion, ctx: &InstallContext) -> usize {
+        let raw_opts = ctx
+            .config
+            .get_tool_opts_with_overrides(&self.ba)
+            .await
+            .unwrap_or_else(|err| {
+                debug!(
+                    "failed to resolve merged options while counting install operations for {}: {err:#}",
+                    tv.style()
+                );
+                tv.request.options()
+            });
         let opts = self.options(&raw_opts);
         3 + opts
             .additional_asset_patterns_for_target(&PlatformTarget::from_current())

--- a/src/backend/options.rs
+++ b/src/backend/options.rs
@@ -1,7 +1,7 @@
 use crate::backend::platform_target::PlatformTarget;
 use crate::backend::static_helpers::{
     list_available_platforms_with_key, lookup_platform_key_for_target, lookup_platform_value,
-    lookup_with_fallback,
+    lookup_platform_value_for_target, lookup_with_fallback,
 };
 use crate::toolset::ToolVersionOptions;
 
@@ -72,6 +72,14 @@ impl<'a> BackendOptions<'a> {
         target: &PlatformTarget,
     ) -> Option<String> {
         lookup_platform_key_for_target(self.raw, key, target)
+    }
+
+    pub(crate) fn platform_value_for_target(
+        &self,
+        key: &str,
+        target: &PlatformTarget,
+    ) -> Option<&'a toml::Value> {
+        lookup_platform_value_for_target(self.raw, key, target).or_else(|| self.raw.opts.get(key))
     }
 
     pub(crate) fn platform_bool_for_target(&self, key: &str, target: &PlatformTarget) -> bool {

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -435,6 +435,20 @@ pub fn lookup_platform_key_for_target(
     )
 }
 
+/// Looks up a raw option value for a specific target platform.
+pub fn lookup_platform_value_for_target<'a>(
+    opts: &'a ToolVersionOptions,
+    key_type: &str,
+    target: &PlatformTarget,
+) -> Option<&'a toml::Value> {
+    lookup_platform_value_for_aliases(
+        target_platform_aliases(target),
+        key_type,
+        |key| lookup_nested_value(opts, key),
+        |key| opts.opts.get(key),
+    )
+}
+
 /// Looks up a raw platform-specific option value.
 pub fn lookup_platform_value<'a>(
     opts: &'a ToolVersionOptions,

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -233,7 +233,6 @@ pub enum GithubAttestationsStatus {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
 pub struct ArtifactInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checksum: Option<String>,
@@ -4833,7 +4832,20 @@ backend = "conda:jq"
             ..Default::default()
         };
 
-        let toml_val: toml::Value = info.clone().into();
+        let mut toml_val: toml::Value = info.clone().into();
+        toml_val
+            .as_table_mut()
+            .unwrap()
+            .get_mut("additional_artifacts")
+            .unwrap()
+            .as_array_mut()
+            .unwrap()[0]
+            .as_table_mut()
+            .unwrap()
+            .insert(
+                "future_lockfile_field".to_string(),
+                toml::Value::String("ignored by older mise versions".to_string()),
+            );
         let parsed: PlatformInfo = toml_val.try_into().unwrap();
 
         assert_eq!(parsed, info);

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -232,6 +232,72 @@ pub enum GithubAttestationsStatus {
     Unavailable,
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checksum: Option<String>,
+    /// Size in bytes (read-only field, preserved from existing lockfiles but not written)
+    #[serde(skip_serializing, default)]
+    pub size: Option<u64>,
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url_api: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<ProvenanceType>,
+}
+
+impl ArtifactInfo {
+    pub fn has_checksum_and_verified_provenance(&self) -> bool {
+        self.checksum.is_some() && self.provenance.is_some()
+    }
+
+    fn merge_with(&self, other: &ArtifactInfo) -> ArtifactInfo {
+        if self.url != other.url {
+            return self.clone();
+        }
+        let checksum = match (&self.checksum, &other.checksum) {
+            (Some(self_checksum), Some(other_checksum)) => {
+                if other_checksum.starts_with("sha256:") && !self_checksum.starts_with("sha256:") {
+                    Some(other_checksum.clone())
+                } else {
+                    Some(self_checksum.clone())
+                }
+            }
+            (Some(checksum), None) | (None, Some(checksum)) => Some(checksum.clone()),
+            (None, None) => None,
+        };
+        let provenance = match (self.provenance.clone(), other.provenance.clone()) {
+            (Some(a), Some(b)) => Some(a.merge(b)),
+            (a, b) => a.or(b),
+        };
+        ArtifactInfo {
+            checksum,
+            size: self.size.or(other.size),
+            url: self.url.clone(),
+            url_api: self.url_api.clone().or_else(|| other.url_api.clone()),
+            provenance,
+        }
+    }
+}
+
+fn merge_additional_artifacts(
+    current: &[ArtifactInfo],
+    other: &[ArtifactInfo],
+) -> Vec<ArtifactInfo> {
+    if current.is_empty() {
+        return other.to_vec();
+    }
+    if current.len() != other.len() {
+        return current.to_vec();
+    }
+    current
+        .iter()
+        .zip(other)
+        .map(|(current, other)| current.merge_with(other))
+        .collect()
+}
+
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
 pub struct PlatformInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -263,6 +329,9 @@ pub struct PlatformInfo {
     /// GitHub attestation probe status when no provenance was verified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_attestations: Option<GithubAttestationsStatus>,
+    /// Ordered release artifacts extracted into the primary artifact's install directory.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub additional_artifacts: Vec<ArtifactInfo>,
 }
 
 // Re-export CondaPackageInfo from conda backend for lockfile serialization
@@ -291,6 +360,7 @@ impl PlatformInfo {
             && self.pkgx_provides.is_none()
             && self.pkgx_runtime_env.is_none()
             && self.provenance.is_none()
+            && self.additional_artifacts.is_empty()
     }
 
     /// True when the lockfile has checksum-backed, successfully verified provenance.
@@ -381,6 +451,11 @@ impl PlatformInfo {
                 .or_else(|| other.pkgx_runtime_env.clone()),
             provenance,
             github_attestations: None,
+            additional_artifacts: if artifact_changed {
+                self.additional_artifacts.clone()
+            } else {
+                merge_additional_artifacts(&self.additional_artifacts, &other.additional_artifacts)
+            },
         }
     }
 }
@@ -499,6 +574,14 @@ impl TryFrom<toml::Value> for PlatformInfo {
                 } else {
                     github_attestations
                 };
+                let additional_artifacts = match t.remove("additional_artifacts") {
+                    Some(toml::Value::Array(values)) => values
+                        .into_iter()
+                        .map(|value| value.try_into().map_err(Report::from))
+                        .collect::<Result<Vec<ArtifactInfo>>>()?,
+                    Some(_) => bail!("additional_artifacts must be an array in lockfile"),
+                    None => Vec::new(),
+                };
                 Ok(PlatformInfo {
                     install,
                     checksum,
@@ -511,6 +594,7 @@ impl TryFrom<toml::Value> for PlatformInfo {
                     pkgx_runtime_env,
                     provenance,
                     github_attestations,
+                    additional_artifacts,
                 })
             }
             _ => bail!("unsupported asset info format"),
@@ -561,6 +645,20 @@ impl From<PlatformInfo> for toml::Value {
             table.insert(
                 "pkgx_runtime_env".to_string(),
                 toml::Value::Table(toml_table_from_string_map(pkgx_runtime_env)),
+            );
+        }
+        if !platform_info.additional_artifacts.is_empty() {
+            let artifacts = platform_info
+                .additional_artifacts
+                .into_iter()
+                .map(|artifact| {
+                    toml::Value::try_from(artifact)
+                        .expect("ArtifactInfo should always serialize to TOML")
+                })
+                .collect::<Vec<_>>();
+            table.insert(
+                "additional_artifacts".to_string(),
+                toml::Value::Array(artifacts),
             );
         }
         if let Some(ref provenance) = platform_info.provenance {
@@ -1145,6 +1243,14 @@ impl Lockfile {
                     pkgx_runtime_env: platform_info.pkgx_runtime_env,
                     provenance,
                     github_attestations: None,
+                    additional_artifacts: if preserve_artifact_fields {
+                        merge_additional_artifacts(
+                            &platform_info.additional_artifacts,
+                            &existing.additional_artifacts,
+                        )
+                    } else {
+                        platform_info.additional_artifacts
+                    },
                 }
             } else {
                 platform_info
@@ -4704,6 +4810,69 @@ backend = "conda:jq"
             }
             _ => panic!("expected Slsa provenance"),
         }
+    }
+
+    #[test]
+    fn test_additional_artifacts_roundtrip() {
+        let info = PlatformInfo {
+            checksum: Some("sha256:primary".to_string()),
+            url: Some("https://example.com/tool.tar.gz".to_string()),
+            additional_artifacts: vec![
+                ArtifactInfo {
+                    checksum: Some("sha256:rocm".to_string()),
+                    url: "https://example.com/tool-rocm.tar.gz".to_string(),
+                    provenance: Some(ProvenanceType::GithubAttestations),
+                    ..Default::default()
+                },
+                ArtifactInfo {
+                    checksum: Some("blake3:debug".to_string()),
+                    url: "https://example.com/tool-debug.zip".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let toml_val: toml::Value = info.clone().into();
+        let parsed: PlatformInfo = toml_val.try_into().unwrap();
+
+        assert_eq!(parsed, info);
+        assert!(!parsed.is_empty());
+    }
+
+    #[test]
+    fn test_additional_artifacts_merge_integrity_for_same_urls() {
+        let resolved = PlatformInfo {
+            url: Some("https://example.com/tool.tar.gz".to_string()),
+            additional_artifacts: vec![ArtifactInfo {
+                url: "https://example.com/tool-rocm.tar.gz".to_string(),
+                url_api: Some("https://api.example.com/rocm".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let installed = PlatformInfo {
+            url: resolved.url.clone(),
+            additional_artifacts: vec![ArtifactInfo {
+                checksum: Some("blake3:rocm".to_string()),
+                url: "https://example.com/tool-rocm.tar.gz".to_string(),
+                provenance: Some(ProvenanceType::Slsa { url: None }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let merged = resolved.merge_with(&installed);
+        assert_eq!(
+            merged.additional_artifacts,
+            vec![ArtifactInfo {
+                checksum: Some("blake3:rocm".to_string()),
+                url: "https://example.com/tool-rocm.tar.gz".to_string(),
+                url_api: Some("https://api.example.com/rocm".to_string()),
+                provenance: Some(ProvenanceType::Slsa { url: None }),
+                ..Default::default()
+            }]
+        );
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -284,17 +284,18 @@ fn merge_additional_artifacts(
     current: &[ArtifactInfo],
     other: &[ArtifactInfo],
 ) -> Vec<ArtifactInfo> {
-    if current.is_empty() {
-        return other.to_vec();
-    }
-    if current.len() != other.len() {
-        return current.to_vec();
-    }
-    current
+    let shared_len = current.len().min(other.len());
+    let mut merged = current
         .iter()
         .zip(other)
         .map(|(current, other)| current.merge_with(other))
-        .collect()
+        .collect::<Vec<_>>();
+    if current.len() > shared_len {
+        merged.extend_from_slice(&current[shared_len..]);
+    } else if other.len() > shared_len {
+        merged.extend_from_slice(&other[shared_len..]);
+    }
+    merged
 }
 
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
@@ -4885,6 +4886,39 @@ backend = "conda:jq"
                 ..Default::default()
             }]
         );
+    }
+
+    #[test]
+    fn test_additional_artifacts_merge_preserves_longer_list() {
+        let short = vec![ArtifactInfo {
+            checksum: Some("sha256:base".to_string()),
+            url: "https://example.com/base.tar.gz".to_string(),
+            ..Default::default()
+        }];
+        let long = vec![
+            ArtifactInfo {
+                url: short[0].url.clone(),
+                url_api: Some("https://api.example.com/base".to_string()),
+                ..Default::default()
+            },
+            ArtifactInfo {
+                checksum: Some("sha256:extra".to_string()),
+                url: "https://example.com/extra.tar.gz".to_string(),
+                ..Default::default()
+            },
+        ];
+        let expected = vec![
+            ArtifactInfo {
+                checksum: short[0].checksum.clone(),
+                url: short[0].url.clone(),
+                url_api: long[0].url_api.clone(),
+                ..Default::default()
+            },
+            long[1].clone(),
+        ];
+
+        assert_eq!(merge_additional_artifacts(&short, &long), expected);
+        assert_eq!(merge_additional_artifacts(&long, &short), expected);
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -5089,6 +5089,21 @@ backend = "conda:jq"
     }
 
     #[test]
+    fn test_merge_provenance_state_prefers_verified() {
+        let verified = Some(ProvenanceType::GithubAttestations);
+        let detected = Some(ProvenanceType::Slsa { url: None });
+
+        assert_eq!(
+            merge_provenance_state(verified.clone(), true, detected.clone(), false),
+            (verified.clone(), true)
+        );
+        assert_eq!(
+            merge_provenance_state(detected, false, verified.clone(), true),
+            (verified, true)
+        );
+    }
+
+    #[test]
     fn test_provenance_merge_preserves_existing() {
         let with_provenance = PlatformInfo {
             provenance: Some(ProvenanceType::GithubAttestations),

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -74,9 +74,10 @@ pub struct LockfileTool {
 type LockfileToolKey = (String, BTreeMap<String, String>);
 type MergeToolEntriesResult = (Vec<LockfileTool>, HashSet<LockfileToolKey>);
 
-/// Type of provenance, ordered by priority (lowest to highest).
-/// The ordering is significant: during verification, higher-priority verified
-/// mechanisms are tried first, and the lockfile records whichever succeeds.
+/// Type of detected or verified provenance, ordered by priority (lowest to highest).
+/// The ordering is significant: during verification, higher-priority mechanisms
+/// are tried first. Lockfile artifact entries separately record whether the
+/// provenance was verified or only detected.
 /// SLSA carries an optional URL for the provenance file (.intoto.jsonl).
 ///
 /// If adding or reordering verified attestation variants, also update
@@ -232,6 +233,29 @@ pub enum GithubAttestationsStatus {
     Unavailable,
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn merge_provenance_state(
+    current: Option<ProvenanceType>,
+    current_verified: bool,
+    other: Option<ProvenanceType>,
+    other_verified: bool,
+) -> (Option<ProvenanceType>, bool) {
+    match (current, other) {
+        (Some(current), Some(_)) if current_verified && !other_verified => (Some(current), true),
+        (Some(_), Some(other)) if !current_verified && other_verified => (Some(other), true),
+        (Some(current), Some(other)) => (
+            Some(current.merge(other)),
+            current_verified && other_verified,
+        ),
+        (Some(current), None) => (Some(current), current_verified),
+        (None, Some(other)) => (Some(other), other_verified),
+        (None, None) => (None, false),
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArtifactInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -244,11 +268,14 @@ pub struct ArtifactInfo {
     pub url_api: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provenance: Option<ProvenanceType>,
+    /// Whether `provenance` was cryptographically verified for this artifact.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub provenance_verified: bool,
 }
 
 impl ArtifactInfo {
     pub fn has_checksum_and_verified_provenance(&self) -> bool {
-        self.checksum.is_some() && self.provenance.is_some()
+        self.checksum.is_some() && self.provenance.is_some() && self.provenance_verified
     }
 
     fn merge_with(&self, other: &ArtifactInfo) -> ArtifactInfo {
@@ -266,16 +293,19 @@ impl ArtifactInfo {
             (Some(checksum), None) | (None, Some(checksum)) => Some(checksum.clone()),
             (None, None) => None,
         };
-        let provenance = match (self.provenance.clone(), other.provenance.clone()) {
-            (Some(a), Some(b)) => Some(a.merge(b)),
-            (a, b) => a.or(b),
-        };
+        let (provenance, provenance_verified) = merge_provenance_state(
+            self.provenance.clone(),
+            self.provenance_verified,
+            other.provenance.clone(),
+            other.provenance_verified,
+        );
         ArtifactInfo {
             checksum,
             size: self.size.or(other.size),
             url: self.url.clone(),
             url_api: self.url_api.clone().or_else(|| other.url_api.clone()),
             provenance,
+            provenance_verified,
         }
     }
 }
@@ -323,9 +353,12 @@ pub struct PlatformInfo {
     /// Pkgx runtime environment for the main package, captured for locked installs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pkgx_runtime_env: Option<BTreeMap<String, String>>,
-    /// Type of provenance verification that succeeded (SLSA carries its URL)
+    /// Type of provenance detected or verified (SLSA carries its URL).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provenance: Option<ProvenanceType>,
+    /// Whether `provenance` was cryptographically verified for this platform.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub provenance_verified: bool,
     /// GitHub attestation probe status when no provenance was verified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_attestations: Option<GithubAttestationsStatus>,
@@ -360,12 +393,13 @@ impl PlatformInfo {
             && self.pkgx_provides.is_none()
             && self.pkgx_runtime_env.is_none()
             && self.provenance.is_none()
+            && !self.provenance_verified
             && self.additional_artifacts.is_empty()
     }
 
     /// True when the lockfile has checksum-backed, successfully verified provenance.
     pub fn has_checksum_and_verified_provenance(&self) -> bool {
-        self.checksum.is_some() && self.provenance.is_some()
+        self.checksum.is_some() && self.provenance.is_some() && self.provenance_verified
     }
 
     /// Merge this PlatformInfo with another, preserving important data.
@@ -415,13 +449,15 @@ impl PlatformInfo {
             self.url_api.clone().or_else(|| other.url_api.clone())
         };
 
-        let provenance = if artifact_changed {
-            self.provenance.clone()
+        let (provenance, provenance_verified) = if artifact_changed {
+            (self.provenance.clone(), self.provenance_verified)
         } else {
-            match (self.provenance.clone(), other.provenance.clone()) {
-                (Some(a), Some(b)) => Some(a.merge(b)),
-                (a, b) => a.or(b),
-            }
+            merge_provenance_state(
+                self.provenance.clone(),
+                self.provenance_verified,
+                other.provenance.clone(),
+                other.provenance_verified,
+            )
         };
         PlatformInfo {
             install: self.install.clone().or_else(|| {
@@ -450,6 +486,7 @@ impl PlatformInfo {
                 .clone()
                 .or_else(|| other.pkgx_runtime_env.clone()),
             provenance,
+            provenance_verified,
             github_attestations: None,
             additional_artifacts: if artifact_changed {
                 self.additional_artifacts.clone()
@@ -569,6 +606,11 @@ impl TryFrom<toml::Value> for PlatformInfo {
                     }
                     _ => None,
                 };
+                let provenance_verified = provenance.is_some()
+                    && matches!(
+                        t.remove("provenance_verified"),
+                        Some(toml::Value::Boolean(true))
+                    );
                 let github_attestations = if provenance.is_some() {
                     None
                 } else {
@@ -593,6 +635,7 @@ impl TryFrom<toml::Value> for PlatformInfo {
                     pkgx_provides,
                     pkgx_runtime_env,
                     provenance,
+                    provenance_verified,
                     github_attestations,
                     additional_artifacts,
                 })
@@ -675,6 +718,9 @@ impl From<PlatformInfo> for toml::Value {
                     table.insert("provenance".to_string(), provenance.to_string().into());
                 }
             }
+        }
+        if platform_info.provenance_verified {
+            table.insert("provenance_verified".to_string(), true.into());
         }
         toml::Value::Table(table)
     }
@@ -1190,16 +1236,18 @@ impl Lockfile {
                     && platform_info.install.is_none()
                     && existing.install.as_deref() == Some("source");
                 let preserve_artifact_fields = !url_changed && !install_changed && !source_to_url;
-                let provenance = if preserve_artifact_fields {
-                    match (
+                let (provenance, provenance_verified) = if preserve_artifact_fields {
+                    merge_provenance_state(
                         platform_info.provenance.clone(),
+                        platform_info.provenance_verified,
                         existing.provenance.clone(),
-                    ) {
-                        (Some(a), Some(b)) => Some(a.merge(b)),
-                        (a, b) => a.or(b),
-                    }
+                        existing.provenance_verified,
+                    )
                 } else {
-                    platform_info.provenance.clone()
+                    (
+                        platform_info.provenance.clone(),
+                        platform_info.provenance_verified,
+                    )
                 };
                 PlatformInfo {
                     install: platform_info.install.or_else(|| {
@@ -1242,6 +1290,7 @@ impl Lockfile {
                     pkgx_provides: platform_info.pkgx_provides,
                     pkgx_runtime_env: platform_info.pkgx_runtime_env,
                     provenance,
+                    provenance_verified,
                     github_attestations: None,
                     additional_artifacts: if preserve_artifact_fields {
                         merge_additional_artifacts(
@@ -4787,6 +4836,7 @@ backend = "conda:jq"
             provenance: Some(ProvenanceType::Slsa {
                 url: Some("https://example.com/tool.intoto.jsonl".to_string()),
             }),
+            provenance_verified: true,
             ..Default::default()
         };
 
@@ -4799,8 +4849,13 @@ backend = "conda:jq"
             slsa_table.get("url").unwrap().as_str().unwrap(),
             "https://example.com/tool.intoto.jsonl"
         );
+        assert_eq!(
+            table.get("provenance_verified").and_then(|v| v.as_bool()),
+            Some(true)
+        );
         let parsed: PlatformInfo = toml_val.try_into().unwrap();
         assert!(parsed.provenance.as_ref().unwrap().is_slsa());
+        assert!(parsed.provenance_verified);
         match &parsed.provenance {
             Some(ProvenanceType::Slsa { url }) => {
                 assert_eq!(
@@ -4822,6 +4877,7 @@ backend = "conda:jq"
                     checksum: Some("sha256:rocm".to_string()),
                     url: "https://example.com/tool-rocm.tar.gz".to_string(),
                     provenance: Some(ProvenanceType::GithubAttestations),
+                    provenance_verified: true,
                     ..Default::default()
                 },
                 ArtifactInfo {
@@ -4976,21 +5032,60 @@ backend = "conda:jq"
         table.insert("provenance".to_string(), "slsa".into());
         table.insert("github_attestations".to_string(), "unavailable".into());
 
-        let parsed: PlatformInfo = toml::Value::Table(table).try_into().unwrap();
+        let parsed: PlatformInfo = toml::Value::Table(table.clone()).try_into().unwrap();
         assert!(parsed.provenance.as_ref().unwrap().is_slsa());
         assert!(parsed.github_attestations.is_none());
+        assert!(!parsed.has_checksum_and_verified_provenance());
+
+        table.insert("provenance_verified".to_string(), true.into());
+        let parsed: PlatformInfo = toml::Value::Table(table).try_into().unwrap();
         assert!(parsed.has_checksum_and_verified_provenance());
 
         let serialized: toml::Value = PlatformInfo {
             checksum: Some("sha256:abc123".to_string()),
             provenance: Some(ProvenanceType::GithubAttestations),
+            provenance_verified: true,
             github_attestations: Some(GithubAttestationsStatus::Unavailable),
             ..Default::default()
         }
         .into();
         let table = serialized.as_table().unwrap();
         assert!(table.get("provenance").is_some());
+        assert_eq!(
+            table.get("provenance_verified").and_then(|v| v.as_bool()),
+            Some(true)
+        );
         assert!(table.get("github_attestations").is_none());
+    }
+
+    #[test]
+    fn test_detected_cross_platform_provenance_is_not_verified() {
+        let detected = PlatformInfo {
+            checksum: Some("sha256:detected".to_string()),
+            provenance: Some(ProvenanceType::GithubAttestations),
+            ..Default::default()
+        };
+        assert!(!detected.has_checksum_and_verified_provenance());
+
+        let verified = PlatformInfo {
+            provenance_verified: true,
+            ..detected.clone()
+        };
+        assert!(verified.has_checksum_and_verified_provenance());
+
+        let detected_artifact = ArtifactInfo {
+            checksum: detected.checksum,
+            url: "https://example.com/supplemental.tar.gz".to_string(),
+            provenance: detected.provenance,
+            ..Default::default()
+        };
+        assert!(!detected_artifact.has_checksum_and_verified_provenance());
+
+        let verified_artifact = ArtifactInfo {
+            provenance_verified: true,
+            ..detected_artifact
+        };
+        assert!(verified_artifact.has_checksum_and_verified_provenance());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `additional_asset_patterns` to the GitHub/GitLab/Forgejo release backend
- extract supplemental archives into the primary asset's install directory in declaration order
- lock and verify each supplemental artifact independently, including checksums and provenance
- document the Ollama ROCm use case and clarify that tool aliases create separate installations rather than overlays

## Motivation

[Discussion #11259](https://github.com/jdx/mise/discussions/11259) needs both Ollama's normal Linux archive and its optional ROCm archive in one installation. The aqua package model selects one release asset, while changing the existing registry entry would make the large ROCm payload unconditional. An explicit GitHub backend overlay keeps the accelerator choice user-controlled and models the upstream release layout directly.

## Validation

- `cargo test additional_`
- `mise run test:e2e e2e/backend/test_github_additional_assets`
- `mise run lint-fix`
- `mise run lint`

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install satisfaction, lockfile merge semantics, and provenance skip paths for multi-artifact installs; mistakes could cause wrong overlays or overly strict/lenient locked installs.
> 
> **Overview**
> Adds **`additional_asset_patterns`** on the GitHub/GitLab/Forgejo backend so one tool install can pull extra release archives from the same tag and **overlay** them into the primary asset’s install directory (later files win on path conflicts). Supplemental archives skip primary-only layout options (`strip_components`, `bin`, `rename_exe`).
> 
> **Install and lock behavior:** Each supplemental asset is resolved, downloaded, checksummed, and provenance-verified on its own. Lockfiles gain ordered **`additional_artifacts`** (`ArtifactInfo` per file) plus **`provenance_verified`** so “detected” vs cryptographically verified provenance is explicit. **`--locked`** requires the lock’s supplemental list to match config; changing patterns after install is tracked via **`.mise-additional-assets.toml`** so adding ROCm-style extras to an already-installed version is not skipped.
> 
> Docs distinguish **one composed installation** (this option, e.g. Ollama + ROCm) from **separate tools** (aliases / `matching` per binary). E2E covers overlay install, lock pinning, and locked-mode strictness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c05754b13b0af4a48cef94da68a26ca78c28fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub-based tools can now install multiple supplemental archive assets per platform using `additional_asset_patterns`, overlaying them into the primary install directory.
  * Lockfiles now store and provenance/verify these supplemental artifacts, and `--locked` fails if the recorded additional set/provenance doesn’t fully match.
  * When an explicit `asset_pattern` is provided, it takes precedence over overlay pattern resolution.
* **Documentation**
  * Expanded GitHub backend “Tool Options” for `additional_asset_patterns`, including overlay behavior and `--locked` expectations.
* **Tests**
  * Added coverage for overlay installation, lockfile recording, and `--locked` strictness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->