### PR TITLE
fix(brew): support cask completion stanzas, system_command, and elevated artifact links

### DIFF
--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -3295,10 +3295,17 @@ end
                               sudo: false
     echoed = system_command "/bin/echo", args: ["-n", "hello"], print_stderr: false
     File.write staged_path/"result", echoed.stdout if echoed.success?
+    # A no-args executable whose path contains spaces and shell
+    # metacharacters must run via argv, not a shell command line.
+    spaced = system_command staged_path/"my tool $HOME"
+    File.write staged_path/"spaced-result", spaced.stdout
   end
 end
 "##,
         )?;
+        let spaced_tool = tmp.path().join("my tool $HOME");
+        crate::file::write(&spaced_tool, "#!/bin/sh\nprintf spaced-ok\n")?;
+        file::make_executable(&spaced_tool)?;
 
         let output = run_cask_shim_hook(&ruby, &shim, &cask, tmp.path(), "1.0.0", "postflight")?;
         assert!(
@@ -3311,6 +3318,10 @@ end
             tmp.path().join("kubectl")
         );
         assert_eq!(file::read_to_string(tmp.path().join("result"))?, "hello");
+        assert_eq!(
+            file::read_to_string(tmp.path().join("spaced-result"))?,
+            "spaced-ok"
+        );
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -578,6 +578,7 @@ async fn execute_lifecycle_hook(
         ("MISE_BREW_CASK_APPDIR", appdir.display().to_string()),
         ("MISE_BREW_PREFIX", prefix::prefix().display().to_string()),
         ("MISE_BREW_CASK_HOOK", hook.to_string()),
+        ("MISE_BREW_CASK_SUDO", sudo::subprocess_mode().to_string()),
     ]);
     let runner = match pr {
         Some(pr) => runner.with_pr(pr),
@@ -794,6 +795,80 @@ fn repair_app_permissions(path: &Path) {
 fn is_permission_denied(err: &eyre::Report) -> bool {
     err.downcast_ref::<std::io::Error>()
         .is_some_and(|err| err.kind() == std::io::ErrorKind::PermissionDenied)
+}
+
+/// Retry a failed artifact-target mutation with sudo on permission errors.
+///
+/// Cask artifact targets can live in root-owned directories — most commonly
+/// `/usr/local/bin` on Apple Silicon, where casks like docker-desktop
+/// hardcode absolute binary targets. Homebrew elevates its cask
+/// `ln`/`mkdir`/`rm`/`mv` calls when the target directory is not writable;
+/// this matches that behavior. sudo::run honors `system_packages.sudo` and
+/// never prompts for a password without a TTY.
+fn with_sudo_fallback(result: Result<()>, program: &str, args: &[String]) -> Result<()> {
+    match result {
+        Err(err) if is_permission_denied(&err) => sudo::run(program, args, &[]),
+        other => other,
+    }
+}
+
+fn create_dir_all_elevating(dir: &Path) -> Result<()> {
+    with_sudo_fallback(
+        file::create_dir_all(dir),
+        "mkdir",
+        &["-p".into(), "--".into(), dir.display().to_string()],
+    )
+}
+
+fn make_symlink_elevating(source: &Path, link: &Path) -> Result<()> {
+    with_sudo_fallback(
+        file::make_symlink(source, link).map(|_| ()),
+        "ln",
+        &[
+            "-s".into(),
+            "-f".into(),
+            "-h".into(),
+            "--".into(),
+            source.display().to_string(),
+            link.display().to_string(),
+        ],
+    )
+}
+
+fn rename_elevating(from: &Path, to: &Path) -> Result<()> {
+    with_sudo_fallback(
+        file::rename(from, to),
+        "mv",
+        &[
+            "-f".into(),
+            "--".into(),
+            from.display().to_string(),
+            to.display().to_string(),
+        ],
+    )
+}
+
+fn remove_artifact_target_elevating(path: &Path) -> Result<()> {
+    let Ok(metadata) = path.symlink_metadata() else {
+        return Ok(());
+    };
+    let (result, args) = if metadata.file_type().is_symlink() {
+        (
+            file::remove_file(path),
+            vec!["-f".into(), "--".into(), path.display().to_string()],
+        )
+    } else {
+        (
+            file::remove_all(path),
+            vec![
+                "-r".into(),
+                "-f".into(),
+                "--".into(),
+                path.display().to_string(),
+            ],
+        )
+    };
+    with_sudo_fallback(result, "rm", &args)
 }
 
 /// Copy a directory using macOS `ditto`, which preserves resource forks, extended attributes,
@@ -1216,10 +1291,10 @@ fn link_completion(cask: &Cask, caskroom: &Path, target: &Path) -> Result<()> {
         );
     }
     if let Some(parent) = target.parent() {
-        file::create_dir_all(parent)?;
+        create_dir_all_elevating(parent)?;
     }
     ensure_completion_target_replaceable(cask, target)?;
-    file::make_symlink(&caskroom_completion, target)?;
+    make_symlink_elevating(&caskroom_completion, target)?;
     Ok(())
 }
 
@@ -1787,9 +1862,9 @@ fn link_binary(caskroom: &Path, binary: &BinaryArtifact) -> Result<()> {
     }
     let target = binary.target_path()?;
     if let Some(parent) = target.parent() {
-        file::create_dir_all(parent)?;
+        create_dir_all_elevating(parent)?;
     }
-    file::make_symlink(&caskroom_binary, &target)?;
+    make_symlink_elevating(&caskroom_binary, &target)?;
     Ok(())
 }
 
@@ -2529,7 +2604,7 @@ fn remove_obsolete_binary_links(
                 .unwrap_or(link_target)
         };
         if file::desymlink_path(&resolved).starts_with(&token_dir) {
-            file::remove_file(target)?;
+            remove_artifact_target_elevating(target)?;
         }
     }
     Ok(())
@@ -2697,8 +2772,8 @@ impl ArtifactLinkTransaction {
                         ".mise-link-backup-{}",
                         hash::hash_to_str(&target.display().to_string())
                     ));
-                    remove_artifact_target(&backup)?;
-                    file::rename(&target, &backup)?;
+                    remove_artifact_target_elevating(&backup)?;
+                    rename_elevating(&target, &backup)?;
                     Some(backup)
                 } else {
                     None
@@ -2723,10 +2798,10 @@ impl ArtifactLinkTransaction {
     fn rollback(&mut self) -> Result<()> {
         let mut first_error = None;
         for entry in self.backups.iter().rev() {
-            match remove_artifact_target(&entry.target) {
+            match remove_artifact_target_elevating(&entry.target) {
                 Ok(()) => {
                     if let Some(backup) = &entry.backup
-                        && let Err(err) = file::rename(backup, &entry.target)
+                        && let Err(err) = rename_elevating(backup, &entry.target)
                     {
                         first_error.get_or_insert(err);
                     }
@@ -2747,22 +2822,11 @@ impl ArtifactLinkTransaction {
     fn commit(&mut self) -> Result<()> {
         for entry in &self.backups {
             if let Some(backup) = &entry.backup {
-                remove_artifact_target(backup)?;
+                remove_artifact_target_elevating(backup)?;
             }
         }
         self.backups.clear();
         Ok(())
-    }
-}
-
-fn remove_artifact_target(path: &Path) -> Result<()> {
-    let Ok(metadata) = path.symlink_metadata() else {
-        return Ok(());
-    };
-    if metadata.file_type().is_symlink() {
-        file::remove_file(path)
-    } else {
-        file::remove_all(path)
     }
 }
 
@@ -2895,6 +2959,17 @@ mod tests {
         staged_path: &Path,
         version: &str,
     ) -> std::io::Result<std::process::Output> {
+        run_cask_shim_hook(ruby, shim, cask, staged_path, version, "preflight")
+    }
+
+    fn run_cask_shim_hook(
+        ruby: &Path,
+        shim: &Path,
+        cask: &Path,
+        staged_path: &Path,
+        version: &str,
+        hook: &str,
+    ) -> std::io::Result<std::process::Output> {
         std::process::Command::new(ruby)
             .arg(shim)
             .env("LANG", "zz_ZZ.UTF-8")
@@ -2904,7 +2979,7 @@ mod tests {
             .env("MISE_BREW_CASK_STAGED_PATH", staged_path)
             .env("MISE_BREW_CASK_APPDIR", staged_path)
             .env("MISE_BREW_PREFIX", staged_path)
-            .env("MISE_BREW_CASK_HOOK", "preflight")
+            .env("MISE_BREW_CASK_HOOK", hook)
             .output()
     }
 
@@ -3187,6 +3262,121 @@ end
             String::from_utf8_lossy(&output.stderr)
         );
         assert_eq!(file::read_to_string(result)?, "20628");
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cask_shim_supports_completion_stanzas_and_system_command() -> Result<()> {
+        let Some(ruby) = file::which("ruby") else {
+            return Ok(());
+        };
+        let tmp = tempfile::tempdir()?;
+        let shim = tmp.path().join("cask_shim.rb");
+        let cask = tmp.path().join("example.rb");
+        file::write(&shim, CASK_SHIM_RB)?;
+        crate::file::write(tmp.path().join("kubectl"), "kubectl")?;
+        // Modeled on the docker-desktop cask: completion stanzas plus a
+        // postflight that symlinks kubectl via system_command.
+        file::write(
+            &cask,
+            r##"cask "example" do
+  version "1.0.0"
+  app "Example.app"
+  binary "#{appdir}/Example.app/Contents/Resources/bin/example"
+  bash_completion "#{appdir}/Example.app/Contents/Resources/etc/example.bash-completion"
+  zsh_completion "#{appdir}/Example.app/Contents/Resources/etc/example.zsh-completion"
+  fish_completion "#{appdir}/Example.app/Contents/Resources/etc/example.fish-completion"
+  manpage "#{appdir}/Example.app/Contents/Resources/man/example.1"
+  postflight do
+    kubectl_target = staged_path/"kubectl-link"
+    next if kubectl_target.exist?
+    system_command "/bin/ln", args: ["-sfn", staged_path/"kubectl", kubectl_target],
+                              sudo: false
+    echoed = system_command "/bin/echo", args: ["-n", "hello"], print_stderr: false
+    File.write staged_path/"result", echoed.stdout if echoed.success?
+  end
+end
+"##,
+        )?;
+
+        let output = run_cask_shim_hook(&ruby, &shim, &cask, tmp.path(), "1.0.0", "postflight")?;
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            std::fs::read_link(tmp.path().join("kubectl-link"))?,
+            tmp.path().join("kubectl")
+        );
+        assert_eq!(file::read_to_string(tmp.path().join("result"))?, "hello");
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cask_shim_system_command_reports_denied_sudo() -> Result<()> {
+        let Some(ruby) = file::which("ruby") else {
+            return Ok(());
+        };
+        let tmp = tempfile::tempdir()?;
+        let shim = tmp.path().join("cask_shim.rb");
+        let cask = tmp.path().join("example.rb");
+        file::write(&shim, CASK_SHIM_RB)?;
+        file::write(
+            &cask,
+            r#"cask "example" do
+  version "1.0.0"
+  preflight do
+    system_command "/usr/bin/true", args: ["--flag"], sudo: true
+  end
+end
+"#,
+        )?;
+
+        // MISE_BREW_CASK_SUDO is unset, which must behave as "deny".
+        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path(), "1.0.0")?;
+        if nix::unistd::geteuid().is_root() {
+            // root never needs to elevate, so the hook succeeds
+            assert!(output.status.success());
+            return Ok(());
+        }
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("needs sudo"), "{stderr}");
+        assert!(stderr.contains("sudo /usr/bin/true --flag"), "{stderr}");
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cask_shim_system_command_reports_failed_commands() -> Result<()> {
+        let Some(ruby) = file::which("ruby") else {
+            return Ok(());
+        };
+        let tmp = tempfile::tempdir()?;
+        let shim = tmp.path().join("cask_shim.rb");
+        let cask = tmp.path().join("example.rb");
+        file::write(&shim, CASK_SHIM_RB)?;
+        file::write(
+            &cask,
+            r#"cask "example" do
+  version "1.0.0"
+  preflight do
+    system_command "/usr/bin/false"
+  end
+end
+"#,
+        )?;
+
+        let output = run_cask_shim(&ruby, &shim, &cask, tmp.path(), "1.0.0")?;
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("command failed (exit 1): /usr/bin/false"),
+            "{stderr}"
+        );
         Ok(())
     }
 

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -330,7 +330,10 @@ class CaskContext
     opts = {}
     opts[:chdir] = chdir.to_s if chdir
     opts[:stdin_data] = input.to_s if input
-    stdout, stderr, status = Open3.capture3(env, *argv, **opts)
+    # [argv[0], argv[0]] forces argv execution: a lone string would be treated
+    # as a shell command line, breaking paths with spaces and inviting shell
+    # interpretation.
+    stdout, stderr, status = Open3.capture3(env, [argv[0], argv[0]], *argv[1..], **opts)
     $stdout.print(stdout) if print_stdout || verbose
     $stderr.print(stderr) if print_stderr || verbose
 

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -9,8 +9,10 @@
 
 require "etc"
 require "fileutils"
+require "open3"
 require "pathname"
 require "rbconfig"
+require "shellwords"
 
 class Array
   def second
@@ -197,6 +199,24 @@ class Version
   end
 end
 
+class SystemCommandResult
+  attr_reader :stdout, :stderr, :exit_status
+
+  def initialize(stdout, stderr, exit_status)
+    @stdout = stdout
+    @stderr = stderr
+    @exit_status = exit_status
+  end
+
+  def success?
+    @exit_status.zero?
+  end
+
+  def merged_output
+    @stdout + @stderr
+  end
+end
+
 class CaskContext
   attr_reader :token
 
@@ -265,6 +285,12 @@ class CaskContext
   def binary(*) nil end
   def pkg(*) nil end
   def font(*) nil end
+  def manpage(*) nil end
+  # Completion artifacts are linked natively by Rust; the stanzas only need to
+  # parse so lifecycle hooks in the same cask can run.
+  def bash_completion(*) nil end
+  def zsh_completion(*) nil end
+  def fish_completion(*) nil end
   def uninstall(*) nil end
   def zap(*) nil end
 
@@ -284,6 +310,36 @@ class CaskContext
   def on_arm(&block) instance_eval(&block) if Hardware::CPU.arm? end
   def on_macos(&block) instance_eval(&block) if OS.mac? end
   def on_linux(&block) instance_eval(&block) if OS.linux? end
+
+  # Mirrors Homebrew's Cask DSL `system_command` (SystemCommand.run!): raises
+  # on failure unless must_succeed: false. Elevation follows mise's sudo
+  # policy, passed down from Rust via MISE_BREW_CASK_SUDO:
+  # - "interactive": run `sudo`, which may prompt on the controlling TTY
+  # - "noninteractive": run `sudo -n`, so it fails instead of hanging on a
+  #   password prompt that nothing can answer
+  # - "deny": error with the exact command to run manually
+  def system_command(executable, args: [], sudo: false, env: {}, must_succeed: true,
+                     print_stdout: false, print_stderr: true, verbose: false,
+                     input: nil, chdir: nil, **rest)
+    shim_unsupported!("system_command #{rest.keys.join(", ")}") if rest.any?
+
+    env = env.map { |k, v| [k.to_s, v.to_s] }.to_h
+    argv = [executable.to_s, *args.map(&:to_s)]
+    argv = sudo_argv(argv, env) if sudo && Process.euid != 0
+
+    opts = {}
+    opts[:chdir] = chdir.to_s if chdir
+    opts[:stdin_data] = input.to_s if input
+    stdout, stderr, status = Open3.capture3(env, *argv, **opts)
+    $stdout.print(stdout) if print_stdout || verbose
+    $stderr.print(stderr) if print_stderr || verbose
+
+    result = SystemCommandResult.new(stdout, stderr, status.exitstatus || 1)
+    if must_succeed && !result.success?
+      odie "command failed (exit #{result.exit_status}): #{argv.shelljoin}\n#{stderr}"
+    end
+    result
+  end
 
   def staged_path
     MISE_BREW_CASK_STAGED_PATH
@@ -306,6 +362,22 @@ class CaskContext
   end
 
   private
+
+  def sudo_argv(argv, env)
+    # sudo resets the environment; pass env vars through `env` so they reach
+    # the elevated command (same as mise's sudo::run on the Rust side)
+    argv = ["env", *env.map { |k, v| "#{k}=#{v}" }, *argv] unless env.empty?
+    case ENV.fetch("MISE_BREW_CASK_SUDO", "deny")
+    when "interactive"
+      ["sudo", *argv]
+    when "noninteractive"
+      ["sudo", "-n", *argv]
+    else
+      odie "cask lifecycle hook needs sudo, but mise is not allowed to elevate " \
+           "(system_packages.sudo is disabled or sudo is unavailable). Run manually:\n" \
+           "  #{(["sudo"] + argv).shelljoin}"
+    end
+  end
 
   def run_macos_condition(version, method, &block)
     target = MacOSVersion.from_symbol(version)

--- a/src/system/sudo.rs
+++ b/src/system/sudo.rs
@@ -50,6 +50,25 @@ pub(crate) fn argv_with_env(
     argv
 }
 
+/// Elevation mode for helper subprocesses (e.g. the brew cask shim) that may
+/// need sudo themselves. Mirrors [`run`]'s policy without running anything:
+/// - `"interactive"`: sudo may prompt on the controlling TTY (also returned
+///   when already root — the subprocess won't elevate at euid 0 anyway)
+/// - `"noninteractive"`: no TTY; the subprocess must use `sudo -n` so it
+///   fails instead of hanging on a password prompt
+/// - `"deny"`: elevation is disabled or sudo is unavailable
+pub(crate) fn subprocess_mode() -> &'static str {
+    if is_root() {
+        "interactive"
+    } else if !Settings::get().system_packages.sudo || crate::file::which("sudo").is_none() {
+        "deny"
+    } else if console::user_attended_stderr() {
+        "interactive"
+    } else {
+        "noninteractive"
+    }
+}
+
 /// Run `program args...`, elevating with sudo when not running as root.
 ///
 /// - root: runs the command directly (containers/CI)


### PR DESCRIPTION
Fixes the two remaining failures installing the `docker-desktop` cask from https://github.com/jdx/mise/discussions/11168 (after #11174 and #11219).

## 1. Cask shim rejected completion stanzas

The lifecycle shim evaluates the entire cask DSL to reach `preflight`/`postflight` blocks, but had no stubs for `bash_completion`, `zsh_completion`, `fish_completion`, or `manpage`, so any cask using them died in `method_missing`:

```
Error: cask uses `bash_completion`, which mise's cask shim does not support
```

These artifacts are linked natively by the Rust side, so the shim now parses them as no-ops (same as `app`/`binary`/`pkg`).

## 2. Cask shim had no `system_command`

docker-desktop's `postflight` (and `uninstall_postflight`) call `system_command`, e.g.:

```ruby
postflight do
  kubectl_target = Pathname("/usr/local/bin/kubectl")
  next if kubectl_target.exist?
  system_command "/bin/ln", args: ["-sfn", appdir/"Docker.app/Contents/Resources/bin/kubectl", kubectl_target],
                 sudo: !kubectl_target.dirname.writable?
end
```

The shim now implements `system_command` (mirroring Homebrew's `SystemCommand.run!`) with `args:`, `sudo:`, `env:`, `must_succeed:`, `print_stdout:`/`print_stderr:`/`verbose:`, `input:`, and `chdir:`; unknown options still fail loudly. Elevation follows mise's sudo policy, passed down from Rust via `MISE_BREW_CASK_SUDO` (`interactive`/`noninteractive`/`deny`), so it respects `system_packages.sudo` and never hangs on a password prompt without a TTY.

## 3. Artifact links into root-owned dirs failed with EACCES

docker-desktop hardcodes absolute binary targets under `/usr/local` (`/usr/local/bin/docker`, `/usr/local/cli-plugins/docker-compose`, …). On Apple Silicon `/usr/local/bin` is typically owned by `root:wheel`, so backing up the existing target and creating the new symlink failed:

```
mise ERROR failed rename: /usr/local/bin/docker -> /usr/local/bin/.mise-link-backup-…
mise ERROR Permission denied (os error 13)
```

Homebrew elevates its cask `ln`/`mkdir`/`rm`/`mv` calls when the target directory is not writable; mise now does the same: artifact-target mutations (link transaction backups/rollback/commit, binary/completion symlinks, obsolete-link removal) retry through the controlled `sudo::run` path on permission errors.

## Testing

- New shim unit tests: docker-desktop-modeled cask (completions + `postflight` + `system_command` symlink + result object), sudo-denied error path, failed-command error path. Pass under macOS system ruby 2.6 and Homebrew portable-ruby 4.0.6 (the interpreter mise actually selects).
- All 1894 unit tests pass; lint clean.
- End-to-end on an arm64 mac (macOS 26.5.2): `mise bootstrap packages apply -y brew-cask:docker-desktop` with the real cask now downloads, extracts, installs `Docker.app`, and **runs the real postflight through portable-ruby 4.0.6 successfully**. Binary linking into root-owned `/usr/local/bin` correctly escalates; in a non-TTY session it fails cleanly with the copy-pasteable command (`sudo mv -f -- /usr/local/bin/docker …`) instead of a raw EACCES. On an interactive terminal (the reporter's setup, where the #11219 `sudo chown` prompt already worked via Touch ID) the same path prompts and proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run sudo-backed file mutations and lifecycle hooks on system paths; behavior is gated by system_packages.sudo and TTY policy, but mis-elevation or symlink targets could still affect the host install layout.
> 
> **Overview**
> Improves **brew-cask** installs for casks like **docker-desktop** by extending the Ruby lifecycle shim and retrying root-owned artifact paths with mise’s existing sudo policy.
> 
> The **cask shim** now treats `bash_completion`, `zsh_completion`, `fish_completion`, and `manpage` as parse-only no-ops (Rust still links completions), and adds **`system_command`** with argv execution, optional `sudo:`, and elevation driven by **`MISE_BREW_CASK_SUDO`** (`interactive` / `noninteractive` / `deny`) from new **`sudo::subprocess_mode()`**.
> 
> On the Rust side, binary/completion symlinks and link-transaction **mkdir** / **ln** / **mv** / **rm** retry through **`sudo::run`** on permission errors, matching Homebrew when targets live under directories such as **`/usr/local/bin`**. Unit tests cover completion + `system_command` postflight, denied sudo, and failed commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bffa4babf81a64429bf434b7711d5171d4b9a5b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced cask lifecycle handling with completion stanzas and a new system command execution capability that captures stdout/stderr and supports optional elevated runs.
  * Added smarter sudo elevation behavior (interactive vs non-interactive vs denied) for helper subprocesses.

* **Bug Fixes**
  * Fixed permission-denied issues during cask artifact operations (create/move/remove/link) by retrying with elevated execution when appropriate.
  * Improved error reporting when sudo is denied or required commands fail, including actionable guidance.

* **Tests**
  * Expanded coverage for cask completion + system command interactions and sudo-denied scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->