### PR TITLE
chore(ci): add cmake to ppa build dependencies

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -204,7 +204,7 @@ jobs:
           Section: utils
           Priority: optional
           Maintainer: ${MAINTAINER_NAME} <${MAINTAINER_EMAIL}>
-          Build-Depends: debhelper-compat (= 13), rustc (>= 1.91), cargo, libssl-dev, pkgconf
+          Build-Depends: debhelper-compat (= 13), rustc (>= 1.91), cargo, cmake, libssl-dev, pkgconf
           Standards-Version: 4.6.2
           Homepage: https://mise.jdx.dev
           Vcs-Git: https://github.com/jdx/mise.git


### PR DESCRIPTION
## Summary
- add `cmake` to the Debian source package build dependencies generated by the PPA publishing workflow

## Root cause
`libz-ng-sys` builds its bundled zlib-ng source with CMake. Launchpad's Ubuntu Resolute build environment did not install CMake, so the build stopped with `failed to execute command: No such file or directory` before compiling `libz-ng-sys`.

## Impact
Future PPA builds install the native build tool required by `libz-ng-sys` instead of failing during `cargo build`.

## Validation
- `git diff --check`
- `actionlint .github/workflows/ppa-publish.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single packaging dependency line in CI with no runtime or application logic changes.
> 
> **Overview**
> Adds **`cmake`** to the **`Build-Depends`** line in the **`debian/control`** file that the PPA publish workflow generates, so Launchpad installs it before **`cargo build`**.
> 
> This unblocks PPA builds where **`libz-ng-sys`** (pulled in via **`flate2`**) needs CMake to compile bundled zlib-ng; without it the build failed with a missing-command error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb179974d6d1f1208fa52a6bb85210fff2dc880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Debian package build reliability.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->