### PR TITLE
fix(shim): detect appimage argv0 as direct invocation

### DIFF
--- a/e2e/cli/test_appimage_argv0
+++ b/e2e/cli/test_appimage_argv0
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+if [[ $(uname -s) != Linux ]]; then
+  exit 0
+fi
+
+mise_bin="$(command -v mise)"
+appimage_path="/tmp/Cursor.AppImage"
+
+# AppImage launchers export ARGV0. zsh propagates that value as argv[0] when it
+# starts external commands, so direct mise invocations must not be treated as
+# shims for the AppImage executable.
+doctor_output="$(bash -c 'exec -a "$1" "$2" doctor' _ "$appimage_path" "$mise_bin" 2>&1 || true)"
+assert_not_contains_text "$doctor_output" "Cursor.AppImage is not a valid shim"
+assert_contains_text "$doctor_output" "version:"
+
+activate_output="$(bash -c 'exec -a "$1" "$2" activate zsh' _ "$appimage_path" "$mise_bin")"
+assert_not_contains_text "$activate_output" "$appimage_path"
+assert_contains_text "$activate_output" "$mise_bin"
+
+# A symlink in mise's configured shims directory must still dispatch normally.
+mise use dummy@latest
+assert_contains "$MISE_DATA_DIR/shims/dummy --version" "This is Dummy"

--- a/e2e/cli/test_system_shims_no_recursion
+++ b/e2e/cli/test_system_shims_no_recursion
@@ -15,8 +15,11 @@ mkdir -p "$shimdir"
 # Simulate a second (system-level) shims directory on PATH.
 # The binary inside it is a symlink to the mise binary, exactly like a real
 # system shim created by `mise install --system`.
-sys_shimdir="$(mktemp -d)"
-trap 'rm -rf "$sys_shimdir"' EXIT
+sys_data_dir="$(mktemp -d)"
+sys_shimdir="$sys_data_dir/shims"
+mkdir -p "$sys_shimdir"
+export MISE_SYSTEM_DATA_DIR="$sys_data_dir"
+trap 'rm -rf "$sys_data_dir"' EXIT
 mise_bin="$(command -v mise)"
 ln -s "$mise_bin" "$sys_shimdir/dummy"
 

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::config::Settings;
 use crate::env::PATH_KEY;
@@ -73,14 +73,9 @@ impl Activate {
         // touch ROOT to allow hook-env to run
         let _ = touch_dir(&dirs::DATA);
 
-        let mise_bin = if cfg!(target_os = "linux") {
+        let mise_bin = if cfg!(target_os = "linux") && *env::IS_RUNNING_AS_SHIM {
             // linux dereferences symlinks, so use argv0 instead
-            let argv0 = PathBuf::from(&*env::ARGV0);
-            let path = if argv0.is_absolute() {
-                argv0
-            } else {
-                which::which(&*env::ARGV0).unwrap_or_else(|_| env::MISE_BIN.clone())
-            };
+            let path = env::MISE_INVOKED_PATH.clone();
             if path.is_absolute() {
                 path
             } else {

--- a/src/env.rs
+++ b/src/env.rs
@@ -364,6 +364,16 @@ pub static MISE_USE_TOML: Lazy<bool> = Lazy::new(|| !var_is_false("MISE_USE_TOML
 pub static MISE_LIST_ALL_VERSIONS: Lazy<bool> = Lazy::new(|| var_is_true("MISE_LIST_ALL_VERSIONS"));
 pub static ARGV0: Lazy<String> = Lazy::new(|| ARGS.read().unwrap()[0].to_string());
 pub static MISE_BIN_NAME: Lazy<&str> = Lazy::new(|| filename(&ARGV0));
+pub static MISE_INVOKED_PATH: Lazy<PathBuf> = Lazy::new(|| {
+    let argv0 = PathBuf::from(&*ARGV0);
+    if argv0.is_absolute() {
+        return argv0;
+    }
+    if argv0.components().count() > 1 {
+        return current_dir().map(|cwd| cwd.join(&argv0)).unwrap_or(argv0);
+    }
+    which::which(&argv0).unwrap_or_else(|_| MISE_BIN.clone())
+});
 pub static MISE_LOG_FILE: Lazy<Option<PathBuf>> = Lazy::new(|| var_path("MISE_LOG_FILE"));
 pub static MISE_LOG_FILE_LEVEL: Lazy<Option<LevelFilter>> = Lazy::new(log_file_level);
 fn find_in_tree(base: &Path, rels: &[&[&str]]) -> Option<PathBuf> {
@@ -451,8 +461,18 @@ pub static IS_RUNNING_AS_SHIM: Lazy<bool> = Lazy::new(|| {
         return true;
     }
 
-    let bin_name = *MISE_BIN_NAME;
-    !is_mise_binary(bin_name)
+    #[cfg(unix)]
+    {
+        MISE_INVOKED_PATH
+            .parent()
+            .is_some_and(crate::file::is_mise_shims_dir)
+    }
+
+    #[cfg(windows)]
+    {
+        let bin_name = *MISE_BIN_NAME;
+        !is_mise_binary(bin_name)
+    }
 });
 
 /// Returns true if the given binary name refers to mise itself (not a shim).

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -21,11 +21,10 @@ use itertools::Itertools;
 use path_absolutize::Absolutize;
 use tokio::task::JoinSet;
 
-// executes as if it was a shim if the command is not "mise", e.g.: "node"
+// Execute tool commands invoked through a mise-managed shim, e.g. "node".
 pub async fn handle_shim() -> Result<()> {
-    // TODO: instead, check if bin is in shims dir
     let bin_name = *env::MISE_BIN_NAME;
-    if env::is_mise_binary(bin_name) || cfg!(test) {
+    if env::is_mise_binary(bin_name) || !*env::IS_RUNNING_AS_SHIM || cfg!(test) {
         return Ok(());
     }
     #[cfg(windows)]


### PR DESCRIPTION
## Summary
- detect Unix shim invocations from mise-managed shim directories instead of trusting `argv[0]` alone
- keep direct mise invocations working when AppImage/zsh overrides `ARGV0`
- preserve the invoked shim path for Linux activation only for genuine shim calls

## Testing
- `mise exec -- cargo fmt --all --check`
- `mise exec -- cargo check --all-features`
- Docker (`rust:1.91-bookworm`) Linux E2E: `e2e/cli/test_appimage_argv0`
- Docker zsh validation with exported `ARGV0=/tmp/Cursor.AppImage` for `mise doctor` and `mise activate zsh`
- related system-shim and doctor-shadowing E2E coverage

Addresses #3537.

*This PR was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux AppImage-style invocation compatibility so `mise doctor` and `mise activate` behave correctly when launched with AppImage-like `argv[0]`.
  * Fixed executable path resolution during `mise activate` when run via mise-managed shims.
  * Prevented unnecessary shim dispatch outside the intended shim execution scenario.
  * Strengthened system shim handling to avoid recursive execution issues.
* **Tests**
  * Added a Linux e2e regression test for AppImage-style invocation and activation.
  * Updated the system shims e2e test to use isolated temporary system data with safer cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->