### PR TITLE
fix(python): make pip usable on Windows

### DIFF
--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -223,6 +223,25 @@ a different version. See <https://gregoryszorc.com/docs/python-build-standalone/
 more information
 on this option. Set it to "x86_64" for the most compatible binaries.
 
+## Windows
+
+mise uses the same precompiled python-build-standalone binaries on Windows
+(compiling with python-build is not supported there). Two of the upstream
+[quirks](https://github.com/astral-sh/python-build-standalone/blob/main/docs/quirks.rst)
+are smoothed over by mise:
+
+- The archives only ship `python.exe`, so mise creates a `python3.exe` alias
+  next to it.
+- The archives ship no `pip.exe` (pip is only available as `python -m pip`),
+  so mise creates `pip.cmd`/`pip3.cmd` wrappers in the install root that
+  delegate to `python -m pip`. Because they delegate, they keep working even
+  after pip upgrades itself.
+
+The install's `Scripts` directory is included in `PATH`, so console scripts
+from `pip install` (e.g. `black`) are runnable. If you rely on shims instead
+of `mise activate`, run `mise reshim` after `pip install` to generate shims
+for newly installed executables.
+
 ## python-build
 
 Optionally, mise

--- a/e2e-win/python.Tests.ps1
+++ b/e2e-win/python.Tests.ps1
@@ -16,4 +16,68 @@ Describe 'python' {
         $python3Path | Should -Be (Join-Path $installPath 'python3.exe')
         mise x python@3.12.0 -- python3 --version | Should -Be "Python 3.12.0"
     }
+
+    # https://github.com/jdx/mise/discussions/3821 - python-build-standalone
+    # ships no pip.exe on Windows, so mise synthesizes pip.cmd/pip3.cmd
+    It 'synthesizes pip wrappers so pip works out of the box' {
+        # no-op when the previous test already installed it; keeps this test
+        # runnable on its own
+        mise install python@3.12.0 | Out-Null
+        $installPath = (mise where python@3.12.0).Trim()
+        (Join-Path $installPath 'pip.cmd') | Should -Exist
+        (Join-Path $installPath 'pip3.cmd') | Should -Exist
+
+        mise x python@3.12.0 -- pip --version
+        $LASTEXITCODE | Should -Be 0
+        mise x python@3.12.0 -- pip3 --version
+        $LASTEXITCODE | Should -Be 0
+
+        # Check the actual output through an explicit file handle. Piping a
+        # batch-file child into the PowerShell pipeline captures nothing on the
+        # CI runners (a real .exe like python.exe captures fine), so redirect
+        # to a file instead of asserting on pipeline output.
+        $out = Join-Path $TestDrive 'pip-version.txt'
+        $p = Start-Process -FilePath 'mise' -NoNewWindow -Wait -PassThru `
+            -ArgumentList 'x', 'python@3.12.0', '--', 'pip', '--version' `
+            -RedirectStandardOutput $out
+        $p.ExitCode | Should -Be 0
+        (Get-Content $out -Raw) | Should -Match '^pip \d'
+
+        # normalize separators: `mise which` echoes the configured data dir
+        # verbatim (it can contain forward slashes), while `mise where` returns
+        # an absolutized path
+        $whichPip = (mise which pip --tool python@3.12.0).Trim().Replace('/', '\')
+        $whichPip | Should -Be (Join-Path $installPath 'pip.cmd').Replace('/', '\')
+    }
+
+    It 'puts Scripts on PATH so pip-installed console scripts run' {
+        mise install python@3.12.0 | Out-Null
+        mise x python@3.12.0 -- pip install pycowsay | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        $installPath = (mise where python@3.12.0).Trim()
+        (Join-Path $installPath 'Scripts\pycowsay.exe') | Should -Exist
+        mise x python@3.12.0 -- pycowsay moo
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    # https://github.com/jdx/mise/discussions/8872 - default packages used to
+    # spawn <install>\bin\python (a unix-only path) and silently warn
+    It 'installs default packages on Windows' {
+        $pkgFile = Join-Path $TestDrive 'default-python-packages'
+        Set-Content -Path $pkgFile -Value 'pycowsay'
+        $env:MISE_PYTHON_DEFAULT_PACKAGES_FILE = $pkgFile
+        try {
+            # --force wipes the install dir, so pycowsay from the previous
+            # test only comes back if default packages actually installed it
+            mise install python@3.12.0 --force | Out-Null
+            $installPath = (mise where python@3.12.0).Trim()
+            (Join-Path $installPath 'Scripts\pycowsay.exe') | Should -Exist
+            mise x python@3.12.0 -- pycowsay moo
+            $LASTEXITCODE | Should -Be 0
+        }
+        finally {
+            Remove-Item Env:\MISE_PYTHON_DEFAULT_PACKAGES_FILE -ErrorAction SilentlyContinue
+        }
+    }
 }

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -101,6 +101,31 @@ fn install_python3_windows(tv: &ToolVersion) -> Result<()> {
     }
 }
 
+/// Create `pip.cmd`/`pip3.cmd` wrappers next to `python.exe` on Windows.
+///
+/// python-build-standalone Windows archives ship pip only as a site-packages
+/// module — there is no `Scripts\pip.exe` launcher (upstream quirk), and
+/// `python -m pip install --upgrade pip` is a no-op while pip is current, so
+/// the launcher never appears on its own. Like the synthesized `python3.exe`
+/// above, keeping the wrappers inside the install root lets normal PATH and
+/// shim discovery handle them. Delegating to `python -m pip` means the
+/// wrappers always dispatch to the pip currently in site-packages, so they
+/// never go stale even if the user later reinstalls pip itself.
+#[cfg(windows)]
+fn install_pip_wrappers_windows(tv: &ToolVersion) -> Result<()> {
+    // if a real pip launcher ever ships, prefer it over synthesizing wrappers
+    if tv.install_path().join("Scripts").join("pip.exe").exists() {
+        return Ok(());
+    }
+    // CRLF endings per batch-file convention; no trailing `exit /b` needed —
+    // cmd returns the errorlevel of the script's last command.
+    const WRAPPER: &str = "@echo off\r\n\"%~dp0python.exe\" -m pip %*\r\n";
+    for name in ["pip.cmd", "pip3.cmd"] {
+        file::write(tv.install_path().join(name), WRAPPER)?;
+    }
+    Ok(())
+}
+
 /// Sort key for Python versions that handles miniconda's two versioning schemes correctly.
 ///
 /// Miniconda has two formats:
@@ -444,7 +469,10 @@ impl PythonPlugin {
         }
 
         #[cfg(windows)]
-        install_python3_windows(tv)?;
+        {
+            install_python3_windows(tv)?;
+            install_pip_wrappers_windows(tv)?;
+        }
 
         Ok(())
     }
@@ -507,7 +535,7 @@ impl PythonPlugin {
             );
         }
         pr.set_message("install default packages".into());
-        CmdLineRunner::new(tv.install_path().join("bin/python"))
+        CmdLineRunner::new(python_path(tv))
             .with_pr(pr)
             .arg("-m")
             .arg("pip")
@@ -919,7 +947,14 @@ impl Backend for PythonPlugin {
         _config: &Arc<Config>,
         tv: &ToolVersion,
     ) -> eyre::Result<Vec<PathBuf>> {
-        Ok(vec![tv.install_path()])
+        // The install root holds python.exe/python3.exe and the synthesized
+        // pip wrappers; Scripts is where pip installs console-script
+        // launchers (black.exe, ...). Root stays first so interpreter/pip
+        // resolution is stable. Scripts is returned unconditionally per the
+        // trait contract (candidates, not existing dirs — see
+        // Backend::list_bin_paths docs); it may not exist until the first
+        // `pip install`.
+        Ok(vec![tv.install_path(), tv.install_path().join("Scripts")])
     }
 
     async fn exec_env(
@@ -932,7 +967,9 @@ impl Backend for PythonPlugin {
         match self.get_virtualenv(config, tv).await {
             Err(e) => warn!("failed to get virtualenv: {e}"),
             Ok(Some(virtualenv)) => {
-                let bin = virtualenv.join("bin");
+                // Windows venvs place executables in Scripts, not bin (same
+                // handling as the `_.python.venv` env directive)
+                let bin = virtualenv.join(if cfg!(windows) { "Scripts" } else { "bin" });
                 hm.insert("VIRTUAL_ENV".into(), virtualenv.to_string_lossy().into());
                 hm.insert("MISE_ADD_PATH".into(), bin.to_string_lossy().into());
             }


### PR DESCRIPTION
## Summary
- include the install's `Scripts` directory in `list_bin_paths` on Windows, so pip-installed console scripts get PATH entries and shims
- synthesize `pip.cmd`/`pip3.cmd` wrappers (delegating to `python -m pip`) at install time, so `pip` works on a fresh install — same philosophy as the existing `python3.exe` synthesis in the same file
- fix `install_default_packages` to spawn `python_path(tv)` instead of the unix-only `<install>/bin/python` (fixes #8872)
- point the deprecated `virtualenv` tool option's `exec_env` at `Scripts` on Windows, matching the `_.python.venv` directive
- extend `e2e-win/python.Tests.ps1` with wrapper / Scripts-on-PATH / default-packages regression tests; add a Windows section to `docs/lang/python.md`

## Context
Fixes the long-standing report in https://github.com/jdx/mise/discussions/3821 (open since 2024-12, 9 upvotes, "same issue" reports continuing into 2026-03) and https://github.com/jdx/mise/discussions/8872.

Reproduced on v2026.7.11 (isolated env, `mise install python@3.12.0`):

```
> mise x python@3.12.0 -- pip --version
mise ERROR cannot find binary path
```

`<install>\Scripts` exists in the archive (empty apart from a `.empty` placeholder) but was not on PATH; the root ships only `python.exe`/`pythonw.exe`.

Three root causes, all addressed:

1. **`Scripts` invisible.** The Windows `list_bin_paths` override returned only the install root. Everything pip installs — including `pip.exe` itself after a pip reinstall, and console scripts like `black.exe` — lands in `Scripts` and was unreachable via PATH, shims, and `mise which`. Now `[install root, Scripts]` is returned (root first, so interpreter resolution is unchanged; `Scripts` is a candidate per the `list_bin_paths` trait contract and may not exist until the first `pip install`). Precedent: the conda backend already enumerates `Scripts` on Windows.
2. **No `pip.exe` ships at all.** python-build-standalone documents this [quirk](https://github.com/astral-sh/python-build-standalone/blob/main/docs/quirks.rst): pip is preinstalled as a site-packages module but no launcher is generated. And `python -m pip install --upgrade pip` cannot heal it — it's a no-op while pip is current (exactly the trap the original reporter hit). mise now writes two 2-line `pip.cmd`/`pip3.cmd` wrappers next to `python.exe`, mirroring `install_python3_windows` directly above. Synthesis is skipped if a real `Scripts\pip.exe` ever ships upstream.
   - Collision analysis: if a user later force-reinstalls pip and a real `Scripts\pip.exe` appears, shim generation dedupes by name (no error) and PATH/`which` resolve the root wrapper consistently. That shadowing is behaviorally a no-op: `-m pip` always dispatches to the pip currently in site-packages, so the wrapper can never go stale.
3. **Default packages broken on Windows** (#8872): `install_default_packages` hardcoded `<install>/bin/python`; it now uses the existing `python_path()` helper. Console scripts installed by it are reachable thanks to (1).

Known pre-existing limitations, out of scope: in `hardlink`/`symlink` shim modes, invoking a shim with an explicit `.exe` extension can't resolve `.cmd`-backed bins (shared with `npm.cmd`); Ctrl+C in any `.cmd` prints cmd's "Terminate batch job" prompt (shared with npm.cmd and mise's file-mode shims).

## Tests
- extended `e2e-win/python.Tests.ps1` (runs on the windows e2e job):
  - fresh install: `pip.cmd`/`pip3.cmd` exist, `pip --version`/`pip3 --version` work, `mise which pip` resolves to the wrapper
  - `pip install pycowsay` → `Scripts\pycowsay.exe` exists and runs
  - default packages: `MISE_PYTHON_DEFAULT_PACKAGES_FILE` + `mise install --force` → package usable (fails before this fix with the unix-path spawn)
- docs: new "Windows" section in `docs/lang/python.md` (previously zero Windows content)

*This PR was prepared by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows precompiled Python installs with automatic `pip.cmd`/`pip3.cmd` (and `python3.exe`) when the usual executables aren’t present.
  * Improved Windows command discovery so `pip install` console scripts work from the `Scripts` directory.
  * Default Python packages can now be installed from a configured package file during Windows install flows.
  * Updated Windows virtual environment behavior to expose tools via `Scripts`.

* **Documentation**
  * Added a Windows section with compatibility details and guidance (including when to run `mise reshim`).

* **Tests**
  * Added Windows integration tests covering wrapper generation, package installation, and virtual environment execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->