### PR TITLE
fix(npm): sort large version components correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6460,6 +6460,7 @@ dependencies = [
  "same-file",
  "seccompiler",
  "self_update",
+ "semver",
  "serde",
  "serde_ignored",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,7 @@ serde = { version = "1", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1"
 serde_yaml = "0.9"
+semver = "1"
 sevenz-rust2 = "0.20"
 sha1 = "0.11"
 sha2 = "0.11"

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -74,12 +74,7 @@ async fn fetch_packument(name: &str) -> Result<aube_registry::Packument> {
 /// stable position at the end.
 pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
     let packument = fetch_packument(name).await?;
-    let mut versions: Vec<&String> = packument.versions.keys().collect();
-    versions.sort_by_cached_key(|v| {
-        let parsed = versions::SemVer::new(v);
-        (parsed.is_none(), parsed)
-    });
-    Ok(versions
+    Ok(sort_versions(packument.versions.keys())
         .into_iter()
         .map(|version| VersionInfo {
             version: version.clone(),
@@ -90,8 +85,59 @@ pub async fn list_versions(name: &str) -> Result<Vec<VersionInfo>> {
         .collect())
 }
 
+fn sort_versions<'a>(versions: impl Iterator<Item = &'a String>) -> Vec<&'a String> {
+    // npm accepts numeric components up to JavaScript's MAX_SAFE_INTEGER.
+    // `versions::SemVer` stores them as u32, so use `semver::Version`'s u64
+    // components and compare precedence without build metadata.
+    let mut versions = versions
+        .map(|version| (version, semver::Version::parse(version).ok()))
+        .collect::<Vec<_>>();
+    versions.sort_by(|(_, a), (_, b)| match (a, b) {
+        (Some(a), Some(b)) => a.cmp_precedence(b),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+    versions.into_iter().map(|(version, _)| version).collect()
+}
+
 /// Resolve the `latest` dist-tag for a package, if the registry publishes one.
 pub async fn latest_dist_tag(name: &str) -> Result<Option<String>> {
     let packument = fetch_packument(name).await?;
     Ok(packument.dist_tags.get("latest").cloned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sort_versions;
+
+    #[test]
+    fn sort_versions_supports_npm_safe_integer_components() {
+        let versions = [
+            "0.52.0",
+            "0.0.8999999999999999",
+            "0.1.0",
+            "0.0.8888888888",
+            "0.0.899999999",
+            "0.0.9007199254740991",
+        ]
+        .map(String::from);
+
+        let sorted = sort_versions(versions.iter())
+            .into_iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            sorted,
+            [
+                "0.0.899999999",
+                "0.0.8888888888",
+                "0.0.8999999999999999",
+                "0.0.9007199254740991",
+                "0.1.0",
+                "0.52.0",
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- sort npm package versions with 64-bit SemVer components
- compare SemVer precedence without build metadata
- add a regression test covering Gemini CLI's large patch versions and npm's `Number.MAX_SAFE_INTEGER`

## Root cause

The npm registry accepts numeric version components up to JavaScript's `Number.MAX_SAFE_INTEGER`, but mise sorted npm metadata with `versions::SemVer`, whose numeric components are `u32`. Larger valid npm versions failed parsing, were placed at the end of the list, and could be selected as the latest fallback. This caused `0.0.8999999999999999` to appear newer than `0.52.0` in discussion https://github.com/jdx/mise/discussions/11275.

## Impact

Npm-backed tools now retain npm-compatible ordering for large numeric components, so `0.0.*` versions remain below `0.1.0` and current stable releases.

## Validation

- `cargo test backend::npm_registry::tests::sort_versions_supports_npm_safe_integer_components`
- `mise run lint-fix`
- `mise run lint` via the pre-commit hook
- live `mise ls-remote npm:@google/gemini-cli --no-versions-host` check; output ends at `0.52.0`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to npm metadata sorting plus a dependency add; behavior matches npm semver ordering for edge-case version numbers.
> 
> **Overview**
> **Fixes npm remote version ordering** when packument keys use numeric components larger than `versions::SemVer` can represent (`u32`). Those versions were treated as unparseable, pushed to the end of the list, and could be chosen as the latest fallback (e.g. `0.0.8999999999999999` appearing above `0.52.0` for packages like `@google/gemini-cli`).
> 
> `list_versions` now sorts via a new `sort_versions` helper that parses with the **`semver` crate** (u64 components, npm-safe up to `Number.MAX_SAFE_INTEGER`) and orders with **`cmp_precedence`** so build metadata does not affect order. Unparseable strings still sort after valid semver.
> 
> Adds a unit test covering large patch components and wires **`semver`** into the main crate dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65eb92dda6679d8dbbfa28b11cd9284cecb8c2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version sorting for npm-compatible semantic versions.
  * Correctly orders versions containing very large numeric components.
  * Keeps invalid or unparseable version strings at the end of results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->