### PR TITLE
test(install): cover partial-success case for inactive-tool hint

### DIFF
--- a/e2e/cli/test_install_inactive_hint
+++ b/e2e/cli/test_install_inactive_hint
@@ -44,3 +44,11 @@ INSTALL_FAIL_LOG="$TMPDIR/mise-install-fail.log"
 mise install dummy@other-dummy >"$INSTALL_FAIL_LOG" 2>&1 || true
 assert_contains "cat '$INSTALL_FAIL_LOG'" "on purpose"
 assert_not_contains_text "$(cat "$INSTALL_FAIL_LOG")" "not activated"
+
+# Test: on partial success the hint names only the tools that actually
+# installed — the filter must not degrade to "warn about nothing whenever
+# anything failed" (discussion #11279).
+mise uninstall tiny --all 2>/dev/null || true
+mise install tiny@3.1.0 dummy@other-dummy >"$INSTALL_FAIL_LOG" 2>&1 || true
+assert_contains "cat '$INSTALL_FAIL_LOG'" "tiny installed but not activated"
+assert_not_contains "cat '$INSTALL_FAIL_LOG'" "dummy installed but not activated"


### PR DESCRIPTION
## What changed

This PR started as a fix for https://github.com/jdx/mise/discussions/11279 (a failed `mise install` printed "`<tool>` installed but not activated" immediately before "Failed to install `<tool>`"). While it was in flight, ae74c4587 (#11227) landed the same fix for discussion #11224, so **the code change here is gone** — after rebasing onto `main`, only the extra test coverage remains.

## Why keep it

`main` covers the all-failed case. This adds the mixed case:

```bash
mise install tiny@3.1.0 dummy@other-dummy   # tiny succeeds, dummy fails
```

The hint must still name `tiny`. That guards against the filter regressing into "suppress the hint whenever anything failed" — which would pass the existing test while silently dropping the hint for partial runs.

## Testing

`mise run test:e2e test_install_inactive_hint` passes against `main`'s implementation.

Refs #11279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation feedback so “installed but not activated” guidance appears only for successful installations.
  * Failed installation requests no longer receive misleading activation hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->