### PR TITLE
fix(task): don't load tasks from an enclosing monorepo root

### DIFF
--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -311,7 +311,9 @@ myproject/.worktrees/feature-x/packages/api/mise.toml
 
 From inside `myproject/.worktrees/feature-x`, that directory is the monorepo root: `//packages/api:build` resolves to the worktree's copy, `{{config_root}}` points inside the worktree, and the worktree's own `[monorepo].config_roots` are the ones expanded.
 
-The enclosing `myproject/mise.toml` is still an ancestor config, though, so its tools, environment variables, and tasks continue to be inherited the same way any parent config would be. Its tasks appear **unnamespaced** (outside the `//` namespace of the selected root), so `mise tasks` inside the worktree can list a task twice — once as `//:build` from the worktree and once as `build` from the enclosing checkout. To avoid that entirely, keep worktrees outside the main checkout (e.g. `myproject-worktrees/feature-x`).
+Tasks from the **enclosing** monorepo are not loaded. They belong to a different monorepo's task set rather than to a parent namespace of the selected root, so loading them would place them outside the `//` namespace — you'd see `build` from the main checkout sitting next to `//:build` from the worktree. Everything above the enclosing root (your global config, a `$HOME/mise.toml`) is unaffected and still contributes tasks as usual.
+
+The enclosing config is still an ancestor config for **tools, environment variables, and vars**, which inherit the same way any parent config's would. If you don't want that either, keep worktrees outside the main checkout (e.g. `myproject-worktrees/feature-x`).
 
 ## Listing Tasks
 

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -298,6 +298,21 @@ Single-level globs (`*`) are supported, but recursive globs (`**`) are not. This
 Automatic filesystem walking to discover monorepo subdirectories is deprecated. If you don't define `[monorepo].config_roots`, mise will still walk the filesystem but will emit a deprecation warning. Please migrate to explicit config roots.
 :::
 
+### Nested Monorepo Roots
+
+When more than one config in the hierarchy sets `monorepo_root = true`, the **nearest** one wins. This comes up with git worktrees checked out inside the main checkout:
+
+```
+myproject/mise.toml                       # monorepo_root = true
+myproject/packages/api/mise.toml
+myproject/.worktrees/feature-x/mise.toml  # monorepo_root = true (same repo, other branch)
+myproject/.worktrees/feature-x/packages/api/mise.toml
+```
+
+From inside `myproject/.worktrees/feature-x`, that directory is the monorepo root: `//packages/api:build` resolves to the worktree's copy, `{{config_root}}` points inside the worktree, and the worktree's own `[monorepo].config_roots` are the ones expanded.
+
+The enclosing `myproject/mise.toml` is still an ancestor config, though, so its tools, environment variables, and tasks continue to be inherited the same way any parent config would be. Its tasks appear **unnamespaced** (outside the `//` namespace of the selected root), so `mise tasks` inside the worktree can list a task twice — once as `//:build` from the worktree and once as `build` from the enclosing checkout. To avoid that entirely, keep worktrees outside the main checkout (e.g. `myproject-worktrees/feature-x`).
+
 ## Listing Tasks
 
 The difference between `mise tasks` and `mise tasks --all`:

--- a/e2e/tasks/test_task_monorepo_nested_root
+++ b/e2e/tasks/test_task_monorepo_nested_root
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Test that a nested `monorepo_root = true` config wins over an enclosing one.
+#
+# This is the git-worktree layout from https://github.com/jdx/mise/discussions/11276:
+# a second checkout lives inside the main one (`<repo>/.worktrees/<name>`), so both
+# `<repo>/mise.toml` and `<repo>/.worktrees/<name>/mise.toml` set `monorepo_root = true`.
+# From inside the nested checkout, the *nearest* root must be selected — its namespace,
+# its `[monorepo].config_roots`, and its `{{config_root}}` — not the enclosing one's.
+#
+# Config discovery walks from the cwd upward, so `ConfigMap` is nearest-first and
+# `find_monorepo_config` picks the deepest applicable root. That ordering is what
+# makes this work; this test guards it against a future reordering.
+export MISE_EXPERIMENTAL=1
+
+# Enclosing monorepo root (the "main checkout")
+cat <<'TOML' >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["outer-projects/*"]
+TOML
+
+mkdir -p outer-projects/alpha
+cat <<'TOML' >outer-projects/alpha/mise.toml
+[tasks.build]
+run = 'echo "OUTER alpha build"'
+TOML
+
+# Nested monorepo root (the "worktree"), with its own config_roots layout
+mkdir -p .worktrees/wt/inner-projects/alpha
+cat <<'TOML' >.worktrees/wt/mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["inner-projects/*"]
+
+[tasks.root-task]
+run = 'echo "INNER root-task config_root={{config_root}}"'
+TOML
+
+cat <<'TOML' >.worktrees/wt/inner-projects/alpha/mise.toml
+[tasks.build]
+run = 'echo "INNER alpha build config_root={{config_root}}"'
+TOML
+
+cd .worktrees/wt
+
+# Test 1: the nested root defines the namespace, and its config_roots are the ones
+# expanded — the enclosing root's `outer-projects/*` must not contribute.
+echo "=== Test 1: nested root owns the namespace ==="
+assert_contains "mise tasks --all" "//:root-task"
+assert_contains "mise tasks --all" "//inner-projects/alpha:build"
+assert_not_contains "mise tasks --all" "//outer-projects/alpha:build"
+
+# Test 2: tasks resolve to the nested checkout's files, with its config_root
+echo "=== Test 2: tasks resolve inside the nested root ==="
+assert_contains "mise run //:root-task" "INNER root-task config_root=$PWD"
+assert_contains "mise run //inner-projects/alpha:build" "INNER alpha build config_root=$PWD/inner-projects/alpha"
+
+# Test 3: same from a subproject, where `:build` resolves relative to the nested root
+echo "=== Test 3: relative resolution from a subproject ==="
+cd inner-projects/alpha
+assert_contains "mise run :build" "INNER alpha build config_root=$PWD"
+assert_contains "mise tasks info build" "//inner-projects/alpha:build"
+
+echo "=== All nested monorepo root tests passed! ==="

--- a/e2e/tasks/test_task_monorepo_nested_root
+++ b/e2e/tasks/test_task_monorepo_nested_root
@@ -18,6 +18,15 @@ monorepo_root = true
 
 [monorepo]
 config_roots = ["outer-projects/*"]
+
+[env]
+OUTER_ENV = "outer"
+
+[tasks.root-task]
+run = 'echo "OUTER root-task"'
+
+[tasks.only-in-outer]
+run = 'echo "OUTER only-in-outer"'
 TOML
 
 mkdir -p outer-projects/alpha
@@ -57,10 +66,22 @@ echo "=== Test 2: tasks resolve inside the nested root ==="
 assert_contains "mise run //:root-task" "INNER root-task config_root=$PWD"
 assert_contains "mise run //inner-projects/alpha:build" "INNER alpha build config_root=$PWD/inner-projects/alpha"
 
-# Test 3: same from a subproject, where `:build` resolves relative to the nested root
-echo "=== Test 3: relative resolution from a subproject ==="
+# Test 3: the enclosing monorepo's tasks are not loaded at all. They are a different
+# monorepo's task set, so they must not show up outside the nested root's namespace.
+echo "=== Test 3: enclosing monorepo tasks are dropped ==="
+assert_not_contains "mise tasks --all" "only-in-outer"
+assert_contains "mise run //:root-task" "INNER root-task"
+assert_fail "mise run only-in-outer"
+
+# The enclosing config is still an ancestor config for env and tools
+echo "=== Test 4: env from the enclosing config still inherits ==="
+assert_contains "mise env -s bash" "OUTER_ENV=outer"
+
+# Test 5: same from a subproject, where `:build` resolves relative to the nested root
+echo "=== Test 5: relative resolution from a subproject ==="
 cd inner-projects/alpha
 assert_contains "mise run :build" "INNER alpha build config_root=$PWD"
 assert_contains "mise tasks info build" "//inner-projects/alpha:build"
+assert_not_contains "mise tasks --all" "only-in-outer"
 
 echo "=== All nested monorepo root tests passed! ==="

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1116,8 +1116,9 @@ fn find_monorepo_root(config_files: &ConfigMap) -> Option<PathBuf> {
 /// git worktree checked out inside the main checkout (`<repo>/.worktrees/<name>`),
 /// where both configs set `monorepo_root = true`: the nested one wins, and its
 /// `[monorepo].config_roots` are the ones expanded. Configs above the selected root
-/// still inherit as ordinary parent configs (env, tools, unnamespaced tasks).
-/// See `e2e/tasks/test_task_monorepo_nested_root` and
+/// still inherit as ordinary parent configs for env/tools/vars, but tasks from an
+/// enclosing monorepo are dropped — see [`dir_is_in_enclosing_monorepo`],
+/// `e2e/tasks/test_task_monorepo_nested_root`, and
 /// https://github.com/jdx/mise/discussions/11276.
 fn find_monorepo_config(config_files: &ConfigMap) -> Option<&Arc<dyn ConfigFile>> {
     config_files
@@ -2263,6 +2264,40 @@ fn prefix_monorepo_task_names(tasks: &mut [Task], dir: &Path, monorepo_root: &Pa
     }
 }
 
+/// Monorepo roots that enclose the selected one.
+///
+/// This happens when a git worktree is checked out inside the main checkout
+/// (`<repo>/.worktrees/<name>`) and both configs set `monorepo_root = true`:
+/// [`find_monorepo_config`] selects the nested root, but the enclosing one is still
+/// an ancestor config.
+fn enclosing_monorepo_roots(config_files: &ConfigMap, selected_root: &Path) -> Vec<PathBuf> {
+    config_files
+        .values()
+        .filter(|cf| cf.monorepo_root() == Some(true))
+        .filter_map(|cf| cf.project_root())
+        .filter(|root| root != selected_root && selected_root.starts_with(root))
+        .collect()
+}
+
+/// Whether a directory's tasks belong to an enclosing monorepo rather than the
+/// selected one.
+///
+/// Such tasks are a *different* monorepo's task set, not a parent namespace of the
+/// selected root, so loading them would put them outside the selected root's `//`
+/// namespace — e.g. `build` next to `//:build` from another checkout of the same repo.
+/// Directories above the enclosing root (`$HOME`, global config) are unaffected and
+/// keep inheriting normally.
+fn dir_is_in_enclosing_monorepo(
+    dir: &Path,
+    selected_root: &Path,
+    enclosing_roots: &[PathBuf],
+) -> bool {
+    !dir.starts_with(selected_root)
+        && enclosing_roots
+            .iter()
+            .any(|enclosing| dir.starts_with(enclosing))
+}
+
 async fn load_local_tasks_with_context(
     config: &Arc<Config>,
     ctx: Option<&crate::task::TaskLoadContext>,
@@ -2280,8 +2315,22 @@ async fn load_local_tasks_with_context(
         .filter(|(_, cf)| !is_global_config(cf.get_path()))
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect::<IndexMap<_, _>>();
+    let enclosing_roots = monorepo_root
+        .as_deref()
+        .map(|root| enclosing_monorepo_roots(&config.config_files, root))
+        .unwrap_or_default();
     for d in all_dirs()? {
         if cfg!(test) && !d.starts_with(*dirs::HOME) {
+            continue;
+        }
+        if let Some(ref monorepo_root) = monorepo_root
+            && dir_is_in_enclosing_monorepo(&d, monorepo_root, &enclosing_roots)
+        {
+            trace!(
+                "skipping tasks in {}: belongs to a monorepo enclosing {}",
+                display_path(&d),
+                display_path(monorepo_root)
+            );
             continue;
         }
         let mut dir_tasks = load_tasks_in_dir(config, &d, &local_config_files, templates).await?;
@@ -3389,6 +3438,55 @@ mod tests {
 
         assert!(!Arc::ptr_eq(&before, &after));
         Settings::reset(None);
+    }
+
+    #[test]
+    fn test_dir_is_in_enclosing_monorepo() {
+        // https://github.com/jdx/mise/discussions/11276: a worktree checked out inside
+        // the main checkout, both setting monorepo_root = true.
+        let selected = Path::new("/repo/.worktrees/wt");
+        let enclosing = vec![PathBuf::from("/repo")];
+
+        // the enclosing root itself, and anything between it and the selected root
+        assert!(dir_is_in_enclosing_monorepo(
+            Path::new("/repo"),
+            selected,
+            &enclosing
+        ));
+        assert!(dir_is_in_enclosing_monorepo(
+            Path::new("/repo/.worktrees"),
+            selected,
+            &enclosing
+        ));
+
+        // the selected root and its subprojects
+        assert!(!dir_is_in_enclosing_monorepo(
+            selected, selected, &enclosing
+        ));
+        assert!(!dir_is_in_enclosing_monorepo(
+            Path::new("/repo/.worktrees/wt/packages/api"),
+            selected,
+            &enclosing
+        ));
+
+        // above the enclosing root: still inherits normally
+        assert!(!dir_is_in_enclosing_monorepo(
+            Path::new("/"),
+            selected,
+            &enclosing
+        ));
+        assert!(!dir_is_in_enclosing_monorepo(
+            Path::new("/home/user"),
+            selected,
+            &enclosing
+        ));
+
+        // no enclosing monorepo: nothing is ever skipped
+        assert!(!dir_is_in_enclosing_monorepo(
+            Path::new("/repo"),
+            selected,
+            &[]
+        ));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1109,6 +1109,16 @@ fn find_monorepo_root(config_files: &ConfigMap) -> Option<PathBuf> {
 }
 
 /// Find the config file that has monorepo_root = true
+///
+/// `ConfigMap` is ordered nearest-first — [`load_config_paths`] builds it from
+/// [`file::all_dirs`], which walks from the cwd upward — so the first match is the
+/// *deepest* applicable monorepo root. That matters when monorepo roots nest, e.g. a
+/// git worktree checked out inside the main checkout (`<repo>/.worktrees/<name>`),
+/// where both configs set `monorepo_root = true`: the nested one wins, and its
+/// `[monorepo].config_roots` are the ones expanded. Configs above the selected root
+/// still inherit as ordinary parent configs (env, tools, unnamespaced tasks).
+/// See `e2e/tasks/test_task_monorepo_nested_root` and
+/// https://github.com/jdx/mise/discussions/11276.
 fn find_monorepo_config(config_files: &ConfigMap) -> Option<&Arc<dyn ConfigFile>> {
     config_files
         .values()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2275,7 +2275,10 @@ fn enclosing_monorepo_roots(config_files: &ConfigMap, selected_root: &Path) -> V
         .values()
         .filter(|cf| cf.monorepo_root() == Some(true))
         .filter_map(|cf| cf.project_root())
-        .filter(|root| root != selected_root && selected_root.starts_with(root))
+        .filter(|root| {
+            !paths_equal_resolved(root, selected_root)
+                && path_starts_with_resolved(selected_root, root)
+        })
         .collect()
 }
 
@@ -2287,15 +2290,25 @@ fn enclosing_monorepo_roots(config_files: &ConfigMap, selected_root: &Path) -> V
 /// namespace — e.g. `build` next to `//:build` from another checkout of the same repo.
 /// Directories above the enclosing root (`$HOME`, global config) are unaffected and
 /// keep inheriting normally.
+///
+/// Prefix checks go through [`path_starts_with_resolved`] because `dir` comes from the
+/// cwd walk while the roots come from a config's `project_root`, and those can be
+/// different symlink spellings of the same path (e.g. Fedora Atomic's `/home` ->
+/// `/var/home`) when a task's config hierarchy was loaded from another directory.
+/// The empty-`enclosing_roots` early return keeps the non-nested case — every monorepo
+/// that isn't checked out inside another one — free of the resolved fallback's syscalls.
 fn dir_is_in_enclosing_monorepo(
     dir: &Path,
     selected_root: &Path,
     enclosing_roots: &[PathBuf],
 ) -> bool {
-    !dir.starts_with(selected_root)
-        && enclosing_roots
-            .iter()
-            .any(|enclosing| dir.starts_with(enclosing))
+    if enclosing_roots.is_empty() {
+        return false;
+    }
+    enclosing_roots
+        .iter()
+        .any(|enclosing| path_starts_with_resolved(dir, enclosing))
+        && !path_starts_with_resolved(dir, selected_root)
 }
 
 async fn load_local_tasks_with_context(
@@ -3487,6 +3500,34 @@ mod tests {
             selected,
             &[]
         ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_dir_is_in_enclosing_monorepo_across_symlinked_prefix() {
+        // `dir` comes from the cwd walk and the roots from a config's project_root, so
+        // they can be different symlink spellings of the same path (Fedora Atomic's
+        // /home -> /var/home). The raw prefix check misses; the resolved one must not.
+        let tmp = TempDir::new().unwrap();
+        let real = tmp.path().join("real");
+        let selected = real.join("repo/.worktrees/wt");
+        fs::create_dir_all(&selected).unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let enclosing = vec![real.join("repo")];
+
+        // the enclosing root, reached through the symlinked prefix
+        let dir = link.join("repo");
+        assert!(
+            !dir.starts_with(&enclosing[0]),
+            "raw check should miss here"
+        );
+        assert!(dir_is_in_enclosing_monorepo(&dir, &selected, &enclosing));
+
+        // the selected root through that same prefix is still not skipped
+        let dir = link.join("repo/.worktrees/wt");
+        assert!(!dir_is_in_enclosing_monorepo(&dir, &selected, &enclosing));
     }
 
     #[test]


### PR DESCRIPTION
## Context

[Discussion #11276](https://github.com/jdx/mise/discussions/11276) reports that with a git worktree checked out inside the main checkout (`<repo>/.worktrees/<name>`), mise uses `<repo>/mise.toml` instead of the worktree's own config for tasks and `{{config_root}}`, even though both set `monorepo_root = true`.

**Monorepo root *selection* was never wrong.** `ConfigMap` is ordered nearest-first (`load_config_paths` builds it from `file::all_dirs`, which walks from the cwd upward), so `find_monorepo_config`'s `.find()` already returns the deepest applicable root. From inside the worktree the namespace, the expanded `[monorepo].config_roots`, and `{{config_root}}` all resolve to the worktree, on 2026.7.0 and on main. (A reply on the discussion suggested `.find()` returns the *outermost* root and that selection needed to change — that doesn't match the ordering, so selection is untouched here.)

What *was* wrong is what happens to the enclosing root's tasks.

## The bug

The enclosing `<repo>/mise.toml` is still an ancestor config, and `prefix_monorepo_task_names` only namespaces directories at or below the selected root. So the main checkout's tasks were loaded **outside** the selected root's `//` namespace. From inside the worktree:

```
//:whoami       -> .worktrees/wt/mise.toml   # worktree
whoami          -> repo/mise.toml            # main checkout, same name, unnamespaced
only-in-main    -> repo/mise.toml            # exists only on the main checkout's branch
```

`mise run only-in-main` ran the main checkout's task with `config_root = <repo>` — the reported symptom, reached through inheritance rather than root selection. Since worktrees sit on different branches, the two task sets legitimately diverge, so this is easy to hit.

## The fix

Skip directories that belong to an **enclosing** monorepo root. Those tasks are a different monorepo's task set, not a parent namespace of the selected root.

Scope is deliberately tight:

- Only directories at-or-below an enclosing `monorepo_root = true` config and outside the selected root are skipped. Everything **above** the enclosing root — `$HOME/mise.toml`, global config — still contributes tasks as before.
- Tools, env, and vars still inherit from the enclosing config, the same as from any parent config. Only tasks change.
- No effect unless two monorepo roots nest, which no existing test or documented layout did.

## Also in here

- `e2e/tasks/test_task_monorepo_nested_root` — the nested layout end to end: the nested root owns the `//` namespace, the enclosing root's `config_roots` don't contribute, the enclosing root's tasks are gone, env still inherits, and tasks/`{{config_root}}` resolve inside the nested checkout from both the root and a subproject.
- Unit test for the pure directory predicate.
- Doc comment on `find_monorepo_config` explaining why `.find()` is correct, so the nearest-first ordering dependency is discoverable rather than accidental.
- "Nested Monorepo Roots" section in `docs/tasks/monorepo.md`.

## Testing

```
cargo test --all-features config::tests::test_dir_is_in_enclosing_monorepo   pass
mise run test:e2e <all e2e/tasks/*monorepo*>                                 pass
mise run test:e2e test_install_monorepo test_deps test_lock_project_root_scope
  test_task_monorepo_errors test_task_monorepo_aliases
  test_task_monorepo_run_project_tasks test_task_monorepo_includes_relative_path
  test_task_file_alias_run                                                   pass
mise run lint                                                                pass
```

`test_task_monorepo_edge_cases` fails in my sandbox before and after this change — it needs `node` on `PATH`, which isn't installed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified nested `monorepo_root = true` precedence (deepest applicable selection wins) and explained git worktree task discovery behavior, including that enclosing tasks aren’t loaded into the selected namespace while env/tools/vars inheritance remains.
  * Added guidance to keep worktrees outside the main checkout if you want to avoid outer inheritance.

* **Tests**
  * Added an end-to-end test for nested monorepo roots in git worktree layouts, including `{{config_root}}` resolution from subdirectories.

* **Bug Fixes**
  * Corrected task discovery to properly exclude directories belonging to enclosing monorepo roots, including cases involving symlinked path prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tasks appear when two `monorepo_root = true` configs nest; behavior is narrow but affects real worktree workflows and task discovery.
> 
> **Overview**
> Fixes **git worktree inside main checkout** layouts where both `mise.toml` files set `monorepo_root = true`. The **nearest** root was already used for `//` names and `{{config_root}}`, but the **outer** checkout’s tasks still loaded as **unnamespaced** tasks next to `//:…` (e.g. running main-branch-only tasks from inside the worktree).
> 
> **Task loading** now **skips** ancestor directories that belong to an **enclosing** monorepo root (between the outer root and the selected nested root). **Env, tools, and vars** from the outer config still inherit; configs above the outer root (global, `$HOME`) are unchanged. Prefix checks use **resolved paths** so symlink spellings (e.g. `/home` vs `/var/home`) don’t miss skips.
> 
> Adds **docs** on nested monorepo precedence, an **e2e** test for the worktree layout, and **unit tests** for `dir_is_in_enclosing_monorepo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d4f62f0c0658f9fb00fd9bba0083f7a800fc83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->