### PR TITLE
fix(completions): stop offering mise's own flags after a task name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "demand"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96e17936c1a2340dde9999f89a2f749020a3dd3f8bcf5c321741047b15ca024"
+checksum = "5439b2dab1b826af399f3b21a84538f52102a4b32f0dd59b0c69b40725e20fdd"
 dependencies = [
  "console",
  "fuzzy-matcher",
@@ -6489,7 +6489,7 @@ dependencies = [
  "ubi",
  "url",
  "urlencoding",
- "usage-lib 3.5.6",
+ "usage-lib 3.5.7",
  "versions",
  "vfox",
  "walkdir",
@@ -11167,9 +11167,9 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "3.5.6"
+version = "3.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45174c8a3ffe041c4af8f64eb64b62044a05ed8844e9dc1dab2648c2dea3dd98"
+checksum = "14c48cda5d90702277243e54782ddcae91cf1430a11deee6360f5c46c05a9437"
 dependencies = [
  "clap",
  "heck",

--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -34,6 +34,12 @@ mise run build --release
 
 If there are multiple commands, the args are only passed to the last command.
 
+Because everything after the task name belongs to the task, mise's own flags have to come
+_before_ it—`mise run --silent build` rather than `mise run build --silent`, which passes
+`--silent` to the task and fails with `unexpected word: --silent` unless the task defines it.
+This also means a task is free to define a flag that shares a name with a mise flag, e.g. a
+task with its own `--env`.
+
 :::tip
 You can define arguments/flags for tasks which will provide validation, parsing, autocomplete, and documentation.
 

--- a/e2e/tasks/test_task_completion_global_cd
+++ b/e2e/tasks/test_task_completion_global_cd
@@ -7,6 +7,10 @@
 # (jdx/usage#738). mise used to promote `-r`/`-S` to global in the completion spec
 # because their root globals are long-only, so the parser dropped the shorts that exist
 # only on the non-global `run` redeclarations; that workaround is no longer needed.
+#
+# Needs usage >= 3.5.7. `latest` only reaches it once it clears the default 24h
+# minimum_release_age, so opt out of the delay here.
+export MISE_MINIMUM_RELEASE_AGE=0s
 
 cat <<'EOF' >mise.toml
 [tools]

--- a/e2e/tasks/test_task_completion_global_cd
+++ b/e2e/tasks/test_task_completion_global_cd
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Regression test for https://github.com/jdx/mise/discussions/10069
-# Completion must work when a root global flag (e.g. -C/--cd) precedes `run`, or
-# a `run` flag precedes the task, when the task has a positional arg with
-# choices. -C/--cd, -j/--jobs and -q/--quiet are handled by the upstream usage
-# parser fix (jdx/usage#649). -r/--raw and -S/--silent still need mise's
-# completion-spec promotion: their root globals are long-only, so the parser
-# would drop the -r/-S shorts that only exist on the non-global `run`
-# redeclarations.
+# Completion must work when a root global flag (e.g. -C/--cd) precedes `run`, or a `run`
+# flag precedes the task, when the task has a positional arg with choices. Both are
+# handled by the usage parser: it keeps the inherited global recognized while descending
+# (jdx/usage#649) and scans for the subcommand across any known flag, global or not
+# (jdx/usage#738). mise used to promote `-r`/`-S` to global in the completion spec
+# because their root globals are long-only, so the parser dropped the shorts that exist
+# only on the non-global `run` redeclarations; that workaround is no longer needed.
 
 cat <<'EOF' >mise.toml
 [tools]
@@ -35,9 +35,9 @@ assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise
 beta		beta
 gamma		gamma"
 
-# orphan-short flags: -r/--raw and -S/--silent have no short on the root global,
-# so usage#649 alone would drop the short. The completion-spec promotion keeps
-# them recognized before the mounted task (previously errored: unexpected word).
+# orphan-short flags: -r/--raw and -S/--silent have no short on the root global, so the
+# shorts exist only on the non-global `run` redeclarations. They must stay recognized
+# before the mounted task (previously errored: unexpected word).
 assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -r sample:run -- ''" "alpha		alpha
 beta		beta
 gamma		gamma"
@@ -50,5 +50,19 @@ assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise
 beta		beta
 gamma		gamma"
 assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise tasks run -S sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
+
+# purely-local `run` flags (no root global of the same name at all) must not hide the
+# task either — `mise run --force <task>` used to fail with "unexpected word"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run --force sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -f sample:run -- ''" "alpha		alpha
+beta		beta
+gamma		gamma"
+
+# including one that takes a value, which must be consumed rather than read as the task
+assert "mise exec -- usage complete-word --shell zsh -f ./mise.usage.kdl -- mise run -o interleave sample:run -- ''" "alpha		alpha
 beta		beta
 gamma		gamma"

--- a/e2e/tasks/test_task_completion_global_flags
+++ b/e2e/tasks/test_task_completion_global_flags
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/jdx/mise/discussions/11282
+# Everything after a task name is forwarded to the task, so mise's own flags are not
+# usable there (`mise run my:task --silent` fails with "unexpected word: --silent").
+# Completion must therefore offer only the task's own flags after the task name, and a
+# task flag that shares a name with a mise global (e.g. `--env`) must keep its own
+# choices instead of being shadowed by the global.
+#
+# Requires the usage fix from jdx/usage#738 (parent globals are not inherited into
+# mounted commands).
+
+cat <<'EOF' >mise.toml
+[tools]
+"usage" = { version = "latest", os = ["linux", "macos"] }
+
+[tasks.deploy]
+usage = '''
+flag "--env <name>" {
+  choices "dev" "stage" "prod"
+}
+flag "--bump <type>" {
+  choices "auto" "major" "minor" "patch"
+}
+flag "--output-dir <path>" {}
+'''
+run = 'echo deploy'
+EOF
+
+mise usage >./mise.usage.kdl
+
+# only the task's own flags are offered after the task name — not mise globals like
+# --cd/--env/--jobs/--quiet/--raw/--silent/--verbose/--yes
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise run deploy --" "--bump
+--env
+--output-dir"
+
+# same over the `tasks run` path, which additionally used to leak the `tasks` flags
+# (--all, --extended, --global, --json, --local, --sort, …)
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise tasks run deploy --" "--bump
+--env
+--output-dir"
+
+# and over the naked path (`mise deploy` == `mise run deploy`)
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise deploy --" "--bump
+--env
+--output-dir"
+
+# --env collides with mise's global -E/--env: the task's choices must win (previously
+# fell through to file completion, which is why renaming it to --environment "fixed" it)
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise run deploy --env ''" "dev
+stage
+prod"
+
+# a non-colliding task flag is unaffected
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise run deploy --bump ''" "auto
+major
+minor
+patch"
+
+# mise's flags still complete *before* the task name
+assert_contains "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise run --" "--silent"
+
+# and a global before the task still parses, so the task's own flag values still
+# complete after it (jdx/mise#10069 behavior is preserved)
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise -C . run deploy --bump ''" "auto
+major
+minor
+patch"

--- a/e2e/tasks/test_task_completion_global_flags
+++ b/e2e/tasks/test_task_completion_global_flags
@@ -66,3 +66,9 @@ assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mis
 major
 minor
 patch"
+
+# a global whose name the task also uses keeps parsing as the global before the task,
+# while the task's flag still owns the name after it
+assert "mise exec -- usage complete-word --shell bash -f ./mise.usage.kdl -- mise --env dev run deploy --env ''" "dev
+stage
+prod"

--- a/e2e/tasks/test_task_completion_global_flags
+++ b/e2e/tasks/test_task_completion_global_flags
@@ -7,7 +7,9 @@
 # choices instead of being shadowed by the global.
 #
 # Requires usage >= 3.5.7, which stops the mounting CLI's flags from being inherited
-# into mounted commands (jdx/usage#738).
+# into mounted commands (jdx/usage#738). `latest` only reaches it once it clears the
+# default 24h minimum_release_age, so opt out of the delay here.
+export MISE_MINIMUM_RELEASE_AGE=0s
 
 cat <<'EOF' >mise.toml
 [tools]

--- a/e2e/tasks/test_task_completion_global_flags
+++ b/e2e/tasks/test_task_completion_global_flags
@@ -6,8 +6,8 @@
 # task flag that shares a name with a mise global (e.g. `--env`) must keep its own
 # choices instead of being shadowed by the global.
 #
-# Requires the usage fix from jdx/usage#738 (parent globals are not inherited into
-# mounted commands).
+# Requires usage >= 3.5.7, which stops the mounting CLI's flags from being inherited
+# into mounted commands (jdx/usage#738).
 
 cat <<'EOF' >mise.toml
 [tools]

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1,4 +1,4 @@
-min_usage_version "3.6"
+min_usage_version "3.5.7"
 name mise
 bin mise
 about "Dev tools, env vars, and tasks in one CLI"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2981,7 +2981,7 @@ Change how tasks information is output when running tasks
 Read/write directly to stdin/stdout/stderr instead of by line
 Redactions are not applied with this option
 Configure with `raw` config or `MISE_RAW` env var
-"""# global=#true
+"""#
     flag "-s --shell" help="Shell to use to run toml tasks" {
         long_help #"""
 Shell to use to run toml tasks
@@ -2992,7 +2992,7 @@ Or it can be overridden with the `shell` property on a task.
 """#
         arg <SHELL>
     }
-    flag "-S --silent" help="Don't show any output except for errors" global=#true
+    flag "-S --silent" help="Don't show any output except for errors"
     flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=#true {
         arg <TOOL@VERSION>
     }
@@ -3778,7 +3778,7 @@ Change how tasks information is output when running tasks
 Read/write directly to stdin/stdout/stderr instead of by line
 Redactions are not applied with this option
 Configure with `raw` config or `MISE_RAW` env var
-"""# global=#true
+"""#
         flag "-s --shell" help="Shell to use to run toml tasks" {
             long_help #"""
 Shell to use to run toml tasks
@@ -3789,7 +3789,7 @@ Or it can be overridden with the `shell` property on a task.
 """#
             arg <SHELL>
         }
-        flag "-S --silent" help="Don't show any output except for errors" global=#true
+        flag "-S --silent" help="Don't show any output except for errors"
         flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=#true {
             arg <TOOL@VERSION>
         }

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1,4 +1,4 @@
-min_usage_version "3.5"
+min_usage_version "3.6"
 name mise
 bin mise
 about "Dev tools, env vars, and tasks in one CLI"

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -86,11 +86,13 @@ impl Usage {
             promote_orphan_shorts(tasks_run);
         }
 
-        // Require usage >= 3.5, the release that ships zsh colon completion
-        // fixes for task names and insert strings (see jdx/usage#666 and
-        // jdx/usage#670). This guards old `usage` CLIs from silently
-        // re-triggering the broken colon completion behavior.
-        let min_version = r#"min_usage_version "3.5""#;
+        // Require usage >= 3.6, the release that stops the mounting CLI's global flags
+        // from being inherited into mounted task commands (jdx/usage#738). Older `usage`
+        // CLIs offer mise's globals after a task name — where they are forwarded to the
+        // task and rejected — and let a global shadow a same-named task flag, dropping
+        // its choices (see mise#11282). 3.5 was required for the zsh colon completion
+        // fixes for task names and insert strings (jdx/usage#666, jdx/usage#670).
+        let min_version = r#"min_usage_version "3.6""#;
         let extra = include_str!("../assets/mise-extra.usage.kdl").trim();
         println!("{min_version}\n{}\n{extra}", spec.to_string().trim());
         Ok(())

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -45,13 +45,15 @@ impl Usage {
             tasks_run.restart_token = Some(":::".to_string());
         }
 
-        // Require usage >= 3.6, the release that stops the mounting CLI's global flags
-        // from being inherited into mounted task commands (jdx/usage#738). Older `usage`
-        // CLIs offer mise's globals after a task name — where they are forwarded to the
-        // task and rejected — and let a global shadow a same-named task flag, dropping
-        // its choices (see mise#11282). 3.5 was required for the zsh colon completion
-        // fixes for task names and insert strings (jdx/usage#666, jdx/usage#670).
-        let min_version = r#"min_usage_version "3.6""#;
+        // Require usage >= 3.5.7, the release that stops the mounting CLI's flags from
+        // being inherited into mounted task commands and keeps scanning for the task
+        // across non-global `run` flags (jdx/usage#738). Older `usage` CLIs offer mise's
+        // globals after a task name — where they are forwarded to the task and rejected —
+        // let a global shadow a same-named task flag, dropping its choices (mise#11282),
+        // and fail outright on `mise run --force <task>`. 3.5 was required for the zsh
+        // colon completion fixes for task names and insert strings (jdx/usage#666,
+        // jdx/usage#670).
+        let min_version = r#"min_usage_version "3.5.7""#;
         let extra = include_str!("../assets/mise-extra.usage.kdl").trim();
         println!("{min_version}\n{}\n{extra}", spec.to_string().trim());
         Ok(())

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -2,7 +2,6 @@ use crate::cli::Cli;
 use clap::CommandFactory;
 use clap::builder::Resettable;
 use eyre::Result;
-use std::collections::HashSet;
 
 /// Generate a usage CLI spec
 ///
@@ -19,50 +18,12 @@ impl Usage {
         // Enable "naked" task completions: `mise foo` completes like `mise run foo`
         spec.default_subcommand = Some("run".to_string());
 
-        // The `run`/`tasks run` subcommands redeclare some root globals as their own
-        // non-global flags (see `cli::run::Run`). When the usage parser descends into
-        // a mounted task subcommand it keeps only inherited global flags, so a leading
-        // `mise -C <dir> run <task>` (or `mise run <flag> <task>`) used to mis-parse
-        // the redeclared flag during completion. See mise#10069.
-        //
-        // jdx/usage#649 fixes the common case in the parser: when a subcommand
-        // redeclares an inherited global as non-global, the inherited global (with all
-        // its aliases) is now preserved. That covers `-C`/`--cd`, `-j`/`--jobs`, and
-        // `-q`/`--quiet`, whose short *is* a root global short, so no spec workaround
-        // is needed for them anymore.
-        //
-        // It cannot cover `-r`/`--raw` and `-S`/`--silent`: the root globals are
-        // long-only (`--raw`/`--silent` have no short, see `cli::Cli`), and the `-r`/
-        // `-S` shorts live only on the non-global `run` redeclarations. The parser
-        // preserves the short-less root global and drops the redeclaration, losing the
-        // short. So we still promote just those "orphan short" flags to global in the
-        // completion spec (spec-only; clap runtime parsing is unchanged).
-        let global_shorts: HashSet<char> = spec
-            .cmd
-            .flags
-            .iter()
-            .filter(|f| f.global)
-            .flat_map(|f| f.short.iter().copied())
-            .collect();
-        let global_longs: HashSet<String> = spec
-            .cmd
-            .flags
-            .iter()
-            .filter(|f| f.global)
-            .flat_map(|f| f.long.iter().cloned())
-            .collect();
-        // Promote a redeclared flag only when it carries a short alias that the
-        // matching root global lacks (so jdx/usage#649 would otherwise drop it).
-        let promote_orphan_shorts = |cmd: &mut usage::SpecCommand| {
-            for f in cmd.flags.iter_mut() {
-                let long_is_root_global = f.long.iter().any(|l| global_longs.contains(l));
-                let has_orphan_short = f.short.iter().any(|c| !global_shorts.contains(c));
-                if long_is_root_global && has_orphan_short {
-                    f.global = true;
-                }
-            }
-        };
-
+        // `run`/`tasks run` redeclare some root globals as their own non-global flags and
+        // add shorts the root global lacks (`-r`/`--raw`, `-S`/`--silent`, see
+        // `cli::run::Run`). Those flags used to be promoted back to global here so the
+        // completion parser would still recognize them before a task name (mise#10069);
+        // jdx/usage#738 makes the parser scan across any known flag, global or not, and
+        // bind each word to the flag it was read as, so the promotion is no longer needed.
         if let Some(run) = spec.cmd.subcommands.get_mut("run") {
             run.args = vec![];
             run.mounts.push(usage::SpecMount {
@@ -70,7 +31,6 @@ impl Usage {
             });
             // Enable completions after ::: separator for multi-task invocations
             run.restart_token = Some(":::".to_string());
-            promote_orphan_shorts(run);
         }
 
         if let Some(tasks_run) = spec
@@ -83,7 +43,6 @@ impl Usage {
                 run: "mise tasks --usage".to_string(),
             });
             tasks_run.restart_token = Some(":::".to_string());
-            promote_orphan_shorts(tasks_run);
         }
 
         // Require usage >= 3.6, the release that stops the mounting CLI's global flags


### PR DESCRIPTION
Fixes https://github.com/jdx/mise/discussions/11282.

## The bug

Everything after a task name is forwarded to the task, so mise's own flags aren't usable there:

```console
$ mise run my:task --silent
[my:task] ERROR unexpected word: --silent
```

Completion offered them anyway:

```console
$ mise run my:task --<TAB>
--bump  --cd  --env  --jobs  --locked  --output-dir  --quiet  --raw  --silent  --verbose  --yes
```

and worse, a task flag colliding with a mise global lost its own completion — a task declaring `--env` with `choices "dev" "stage" "prod"` completed as *file names*, while renaming it to `--environment` worked. That workaround is what tipped the reporter off.

[src/cli/usage.rs](src/cli/usage.rs) mounts the task subcommands under `run`/`tasks run` via `mise tasks --usage`, and the usage parser inherited the root globals (plus, on the `tasks run` path, `tasks`' own globals) into those mounted commands, where an inherited global also won the key over a same-named child flag. Not fixable from mise's side — the mount is dynamic, so mise can't strip inherited flags from commands it doesn't emit. Fixed in the parser: **jdx/usage#738**.

## This PR

- requires usage >= 3.5.7 (the [release](https://github.com/jdx/usage/releases/tag/v3.5.7) carrying jdx/usage#738) via `min_usage_version`, so old `usage` CLIs warn instead of silently keeping the broken behavior (same approach as #10313 for 3.5), and regenerates `mise.usage.kdl`
- bumps `usage-lib` 3.5.6 → 3.5.7 in the lockfile, plus an unrelated `demand` 2.0.3 → 2.0.4 patch bump
- sets `MISE_MINIMUM_RELEASE_AGE=0s` in the two completion e2e tests: they need 3.5.7, and `latest` does not reach a release until it clears the default 24h age filter, so without it they install 3.5.6 and fail for a day after every usage release
- **removes `promote_orphan_shorts`**. It existed so the completion parser would still recognize `-r`/`-S` before a task name (#10069), by promoting `run`'s redeclarations of the long-only `--raw`/`--silent` globals back to global. jdx/usage#738 scans for the subcommand across any known flag and binds each word to the flag it was read as, so the promotion is dead weight — and it was itself the reason `--raw`/`--silent` leaked into the flags offered after a task name.
- that removal also fixes a bug no promotion could cover: **purely-local `run` flags used to break task completion entirely.** `mise run --force build <TAB>` (and `-f`, `-o <mode>`, `-n`, `-s`, `-t`, `--timeout`, …) failed with `unexpected word: build` and offered nothing, because Phase 1 stopped scanning at the non-global flag and never reached the mounted task.
- adds `e2e/tasks/test_task_completion_global_flags` covering the `run`, `tasks run` and naked (`mise deploy`) paths, the `--env` collision in both directions (global before the task still parses as the global; the task's flag owns the name after it), and that mise's flags still complete *before* the task name
- extends `e2e/tasks/test_task_completion_global_cd` (the #10069 test) with the `--force` / `-f` / `-o <mode>` cases, and updates its comments now that the promotion is gone
- documents in [docs/tasks/running-tasks.md](docs/tasks/running-tasks.md) that mise's flags go before the task name, and that a task may reuse a mise flag name

## Verified against a `usage` build of jdx/usage#738

| | before | after |
|---|---|---|
| `mise run mytask --<TAB>` | `--bump --cd --env --jobs --locked --output-dir --quiet --raw --silent --verbose --yes` | `--bump --env --output-dir` |
| `mise tasks run mytask --<TAB>` | above + 10 `tasks` flags | `--bump --env --output-dir` |
| `mise mytask --<TAB>` | same leak | `--bump --env --output-dir` |
| `mise run mytask --env <TAB>` | `mise-tasks/ mise.toml …` (files) | `dev stage prod` |
| `mise run --force mytask --bump <TAB>` | `Error: unexpected word: mytask` | `auto major minor patch` |
| `mise run -o interleave mytask --env <TAB>` | `Error: unexpected word: mytask` | `dev stage prod` |
| `mise --env dev run mytask --env <TAB>` | files | `dev stage prod` |
| `mise run -r/-S mytask <TAB>` | works via the promotion | works without it |
| `mise run --<TAB>`, `mise -C . run mytask --bump <TAB>` | | unchanged |

`cargo test --bin mise` (1901 tests) and `mise run lint-fix` are clean.

The lockfile bump is hand-edited to the four affected lines: `cargo update` (even with `--precise`) re-resolves the graph here and downgrades ~20 unrelated transitive deps (`windows-sys 0.61.2 → 0.52.0`, `itertools 0.13 → 0.10`, `base64 0.22 → 0.21`, …). `cargo build --locked` confirms the result is consistent.

Both completion e2e tests — `tasks/test_task_completion_global_flags` (new) and `tasks/test_task_completion_global_cd` (which now exercises the parser instead of the removed promotion) — pass in full against the released `usage` 3.5.7.

## One thing to decide

`min_usage_version "3.5.7"` means users on an older `usage` get a warning per completion, and with the promotion removed they also lose `-r`/`-S` completion before a task name until they upgrade. Drop that hunk if you'd rather not push the upgrade.

*This PR was prepared by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that mise flags must come before the task name (e.g., `mise run --silent build`); anything after the task name is passed to the task.

* **Bug Fixes**
  * Improved shell completion for task-name selection so task-specific flags (and constrained values) complete correctly, without incorrectly offering mise global flags.
  * Ensured `run`/`tasks run` flags like `--raw` and `--silent` are handled properly when they appear before/around a task.

* **Tests**
  * Added/extended end-to-end regression tests covering task completion ordering, collisions, and forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generated completion spec and minimum usage version, so users on older `usage` CLIs may see warnings or worse completion until they upgrade; runtime `mise run` parsing is unchanged.
> 
> **Overview**
> Bumps **`usage`/`usage-lib` to 3.5.7** and sets **`min_usage_version "3.5.7"`** so shell completion relies on **jdx/usage#738** (mounted tasks no longer inherit mise’s CLI flags; the parser can reach the task across non-global `run` flags).
> 
> **Removes `promote_orphan_shorts`** from `src/cli/usage.rs` and drops **`global=#true`** on `run`’s `-r`/`--raw` and `-S`/`--silent` in **`mise.usage.kdl`**, which had been leaking those flags into completions after the task name.
> 
> Documents that **mise flags must appear before the task name** in `docs/tasks/running-tasks.md`. Adds **`e2e/tasks/test_task_completion_global_flags`** and extends **`test_task_completion_global_cd`** for `--force`/`-f`/`-o` and related completion cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6c0643ecaf6819aec79efd6111206bf0964753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
