### PR TITLE
registry: fix danger-swift installation

### DIFF
--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -143,6 +143,32 @@ product in the package, installation fails with a clear error.
 "spm:swiftlang/swiftly" = { version = "latest", filter_bins = "swiftly" }
 ```
 
+### `install_command`
+
+Run an explicit command from the checked-out package directory instead of discovering executable
+products and running `swift build --product`. The command uses mise's default inline shell and
+inherits [`install_env`](#install_env) plus the `PATH` for the Swift dependency. `PREFIX` and
+`MISE_TOOL_INSTALL_PATH` are both set to the tool's installation directory.
+
+This option only applies to source installs and cannot be combined with `filter_bins`. Mise never
+automatically runs a package's Makefile or other installation scripts; the command must be
+configured explicitly.
+
+For example, Danger Swift's official `make install` installs both its executable and the dynamic
+library required by `danger-swift local`:
+
+```toml
+[tools]
+"spm:danger/swift" = { version = "3.22.1", artifactbundle = false, install_command = "make install PREFIX=\"$MISE_TOOL_INSTALL_PATH\"" }
+```
+
+The `danger-swift` registry shorthand already supplies these options, so this is sufficient:
+
+```toml
+[tools]
+danger-swift = "3.22.1"
+```
+
 ## Settings
 
 ### `spm.artifactbundle_only`

--- a/e2e/core/test_swift_slow
+++ b/e2e/core/test_swift_slow
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export MISE_EXPERIMENTAL=1
+export MISE_NPM_SHELL_OUT=1
 export MISE_USE_VERSIONS_HOST=0
 
 MISE_DEBUG=1 mise use swift@6
@@ -12,6 +13,47 @@ assert_matches "mise x -- swift --version" 'Swift version 6\.'
 #assert "mise x spm:https://github.com/nicklockwood/SwiftFormat.git@0.53.10 -- swiftformat --version" "0.53.10"
 
 assert "mise x spm:nicklockwood/SwiftFormat@0.61.1 -- swiftformat --version" "0.61.1"
+
+if [[ $(uname -s) == Darwin ]]; then
+  # danger-swift invokes xcrun on macOS, so build its modules with the same
+  # Apple Swift toolchain rather than the separately packaged Swift toolchain.
+  mise unuse --no-prune swift
+fi
+mise install node@24 danger-swift@3.22.1 npm:danger@13.0.10
+danger_install_path="$(mise where danger-swift@3.22.1)"
+test -x "$danger_install_path/bin/danger-swift"
+test -f "$danger_install_path/lib/danger/libDanger.dylib" ||
+  test -f "$danger_install_path/lib/danger/libDanger.so"
+find "$danger_install_path/lib/danger" -name 'Danger.swiftmodule' -print -quit | grep -q .
+
+cat >Dangerfile.swift <<'EOF'
+import Danger
+import Foundation
+
+nonisolated(unsafe) let danger = Danger()
+danger.fail("mise Danger Swift integration test")
+EOF
+
+git init -q -b master
+git config user.email e2e@example.com
+git config user.name "mise e2e"
+git add Dangerfile.swift
+git commit -q -m initial
+git checkout -q -b test
+cp Dangerfile.swift Changed.swift
+git add Changed.swift
+git commit -q -m change
+
+if [[ $(uname -s) == Darwin ]]; then
+  export CFFIXED_USER_HOME="$HOME"
+fi
+
+danger_output="$(
+  mise x node@24 danger-swift@3.22.1 npm:danger@13.0.10 -- danger-swift local 2>&1
+)"
+assert_contains_text "$danger_output" "Danger: ⅹ Failing the build"
+assert_contains_text "$danger_output" "mise Danger Swift integration test"
+assert_not_contains_text "$danger_output" "Could not find a libDanger"
 
 # test package with resources (`templates list` command depends on resources being installed)
 #assert "mise x spm:SwiftGen/SwiftGen@6.6.2 --verbose -- swiftgen templates list --only colors" "colors:

--- a/registry/danger-swift.toml
+++ b/registry/danger-swift.toml
@@ -1,2 +1,4 @@
-backends = ["spm:danger/swift"]
+backends = [
+  { full = "spm:danger/swift", options = { artifactbundle = false, install_command = "make install PREFIX=\"$MISE_TOOL_INSTALL_PATH\"" } },
+]
 description = "Stop saying 'you forgot to …' in code review"

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -133,6 +133,28 @@ impl<'a> SpmOptions<'a> {
         };
         if bins.is_empty() { None } else { Some(bins) }
     }
+
+    fn install_command(&self) -> eyre::Result<Option<String>> {
+        let Some(value) = self.values.raw().opts.get("install_command") else {
+            return Ok(None);
+        };
+        let Some(command) = value.as_str() else {
+            bail!("install_command must be a non-empty string");
+        };
+        let command = command.trim();
+        if command.is_empty() {
+            bail!("install_command must be a non-empty string");
+        }
+        Ok(Some(command.to_string()))
+    }
+
+    fn source_install_command(&self) -> eyre::Result<Option<String>> {
+        let command = self.install_command()?;
+        if command.is_some() && self.filter_bins().is_some() {
+            bail!("install_command cannot be used with filter_bins");
+        }
+        Ok(command)
+    }
 }
 
 #[async_trait]
@@ -217,6 +239,7 @@ impl Backend for SPMBackend {
         let mut tv = tv;
         let raw_opts = tv.request.options();
         let opts = SpmOptions::new(&raw_opts);
+        let install_command = opts.source_install_command()?;
         let provider = GitProvider::from_ba_with_opts(&self.ba, &opts);
         let repo = SwiftPackageRepo::new(&self.tool_name(), &provider)?;
         let revision = if tv.version == "latest" {
@@ -263,7 +286,8 @@ impl Backend for SPMBackend {
             }
         }
 
-        self.install_from_source(ctx, &tv, &repo, &revision).await?;
+        self.install_from_source(ctx, &tv, &repo, &revision, install_command.as_deref())
+            .await?;
 
         Ok(tv)
     }
@@ -276,6 +300,7 @@ pub fn install_time_option_keys() -> Vec<String> {
         "artifactbundle".into(),
         "artifactbundle_asset".into(),
         "filter_bins".into(),
+        "install_command".into(),
     ]
 }
 
@@ -290,21 +315,27 @@ impl SPMBackend {
         tv: &ToolVersion,
         repo: &SwiftPackageRepo,
         revision: &str,
+        install_command: Option<&str>,
     ) -> eyre::Result<()> {
         let repo_dir = self.clone_package_repo(ctx, tv, repo, revision)?;
 
-        let executables = self.get_executable_names(ctx, &repo_dir, tv).await?;
-        if executables.is_empty() {
-            return Err(eyre::eyre!("No executables found in the package"));
-        }
-        let executables = self.apply_filter_bins(tv, executables)?;
-        let bin_path = tv.install_path().join("bin");
-        file::create_dir_all(&bin_path)?;
-        for executable in executables {
-            let exe_path = self
-                .build_executable(&executable, &repo_dir, ctx, tv)
+        if let Some(install_command) = install_command {
+            self.run_install_command(ctx, tv, &repo_dir, install_command)
                 .await?;
-            file::make_symlink(&exe_path, &bin_path.join(executable))?;
+        } else {
+            let executables = self.get_executable_names(ctx, &repo_dir, tv).await?;
+            if executables.is_empty() {
+                return Err(eyre::eyre!("No executables found in the package"));
+            }
+            let executables = self.apply_filter_bins(tv, executables)?;
+            let bin_path = tv.install_path().join("bin");
+            file::create_dir_all(&bin_path)?;
+            for executable in executables {
+                let exe_path = self
+                    .build_executable(&executable, &repo_dir, ctx, tv)
+                    .await?;
+                file::make_symlink(&exe_path, &bin_path.join(executable))?;
+            }
         }
 
         // delete (huge) intermediate artifacts
@@ -312,6 +343,36 @@ impl SPMBackend {
         file::remove_all(tv.cache_path())?;
 
         Ok(())
+    }
+
+    async fn run_install_command(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+        repo_dir: &Path,
+        install_command: &str,
+    ) -> eyre::Result<()> {
+        let shell = Settings::get().default_inline_shell()?;
+        let (program, shell_args) = shell.split_first().ok_or_else(|| {
+            eyre::eyre!(
+                "default inline shell is empty; check unix_default_inline_shell_args / windows_default_inline_shell_args"
+            )
+        })?;
+
+        CmdLineRunner::new(program)
+            .current_dir(repo_dir)
+            .with_pr(ctx.pr.as_ref())
+            .cmd_body_args(shell_args, install_command)
+            .env_values(tv.install_env())
+            .env("PREFIX", tv.install_path())
+            .env("MISE_TOOL_INSTALL_PATH", tv.install_path())
+            .prepend_path(
+                self.dependency_toolset(&ctx.config)
+                    .await?
+                    .list_paths(&ctx.config)
+                    .await,
+            )?
+            .execute()
     }
 
     fn clone_package_repo(
@@ -1233,7 +1294,62 @@ mod tests {
                 "artifactbundle".to_string(),
                 "artifactbundle_asset".to_string(),
                 "filter_bins".to_string(),
+                "install_command".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn test_install_command() {
+        let opts = ToolVersionOptions::default();
+        assert_eq!(SpmOptions::new(&opts).install_command().unwrap(), None);
+
+        let opts = opts_with(
+            "install_command",
+            toml::Value::String("  make install  ".to_string()),
+        );
+        assert_eq!(
+            SpmOptions::new(&opts).install_command().unwrap(),
+            Some("make install".to_string())
+        );
+    }
+
+    #[test]
+    fn test_install_command_rejects_empty_or_invalid_values() {
+        for value in [
+            toml::Value::String(" \t ".to_string()),
+            toml::Value::Boolean(true),
+            toml::Value::Array(vec![toml::Value::String("make install".to_string())]),
+        ] {
+            let opts = opts_with("install_command", value);
+            assert_str_eq!(
+                SpmOptions::new(&opts)
+                    .install_command()
+                    .unwrap_err()
+                    .to_string(),
+                "install_command must be a non-empty string"
+            );
+        }
+    }
+
+    #[test]
+    fn test_install_command_conflicts_with_filter_bins() {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "install_command".to_string(),
+            toml::Value::String("make install".to_string()),
+        );
+        opts.opts.insert(
+            "filter_bins".to_string(),
+            toml::Value::String("danger-swift".to_string()),
+        );
+
+        assert_str_eq!(
+            SpmOptions::new(&opts)
+                .source_install_command()
+                .unwrap_err()
+                .to_string(),
+            "install_command cannot be used with filter_bins"
         );
     }
 


### PR DESCRIPTION
## Summary

- add an explicit `install_command` option for Swift Package Manager source installs
- use Danger Swift official installer so the executable, `libDanger`, and Swift modules are installed together
- document the generic behavior and add regression coverage for Danger Swift local execution

## Root cause

The SPM backend only discovered executable products and ran `swift build --product`. Danger Swift also needs its dynamic `libDanger` library and Swift modules at runtime, and those artifacts are only placed correctly by its official install target.

## Implementation

- validate `install_command` as a non-empty string and reject its use with `filter_bins`
- run the command from the checked-out package with the configured inline shell, `install_env`, Swift dependency `PATH`, and fixed `PREFIX` / `MISE_TOOL_INSTALL_PATH`
- register it as an install-time option so option changes invalidate stale install metadata
- keep artifact bundle installs unchanged and never auto-run package Makefiles
- configure the existing `danger-swift` registry entry to force a source install and run `make install PREFIX="$MISE_TOOL_INSTALL_PATH"`

## Testing

- `cargo fmt --all -- --check`
- `shellcheck -x e2e/core/test_swift_slow`
- `shfmt -d -s e2e/core/test_swift_slow`
- `markdownlint docs/dev-tools/backends/spm.md`
- `taplo fmt --check` / `taplo check` for `registry/danger-swift.toml`
- `cargo test backend::spm::tests` (23 passed)
- `cargo check --all-features`
- `mise run test:e2e e2e/core/test_swift_slow` on macOS, including SwiftFormat and `danger-swift local` with Danger JS 13.0.10
- built the current source as a linux-x64 ELF in `ghcr.io/jdx/mise:e2e`; the full Docker E2E is left to the native CI runner because local arm64 Docker required slow QEMU emulation

## Popularity

- GitHub: approximately 1.1k stars and 151 forks
- Latest release: 3.22.1
- Active development: repository activity observed on 2026-07-23

Addresses https://github.com/jdx/mise/discussions/3540

*This pull request was generated with assistance from an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom installation commands when installing Swift packages from source.
  * Custom commands run with the configured environment, dependency tools, and installation paths.
  * Added documentation and an example for configuring custom SPM install commands.

* **Bug Fixes**
  * Improved Danger Swift installation to ensure its CLI, libraries, and Swift modules are correctly available across platforms.
  * Added validation for invalid or conflicting installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->