### PR TITLE
registry: add checkstyle

### DIFF
--- a/registry/checkstyle.toml
+++ b/registry/checkstyle.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:checkstyle/checkstyle"]
+description = "Checks Java source code against a coding standard"
+test = { cmd = 'java -jar "$(command -v checkstyle)" --version', expected = "Checkstyle version: {{version}}", tools = [
+  "java",
+] }


### PR DESCRIPTION
## Summary

- add the `checkstyle` shorthand backed by `aqua:checkstyle/checkstyle`
- verify the downloaded JAR through Java in the registry test

## Why

Checkstyle is a widely used Java static-analysis tool with about 9,000 GitHub stars. Its latest release, `checkstyle-13.8.0`, was published on July 12, 2026.

The Aqua package was accepted in aquaproj/aqua-registry#57625. mise v2026.7.13 predates that merge in its vendored Aqua snapshot, so the registry test currently needs the floating Aqua registry and should become self-contained after the next mise registry refresh.

## Validation

- `MISE_AQUA_BAKED_REGISTRY=false target/debug/mise test-tool checkstyle`
- `taplo format --check registry/checkstyle.toml`
- `git diff --check`

The full `mise run lint-fix` was attempted, but this container cannot write pkl's default cache directory. `cargo check --all-features` additionally requires libclang, which is not installed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Checkstyle validation support for Java code style checks.
  * Added a verification step to confirm the installed Checkstyle version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->