### PR TITLE
fix(task): include run, sources, and outputs in task_state_key

### DIFF
--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -397,6 +397,9 @@ fn task_state_key(task: &Task, root: &Path) -> String {
     task.hash(&mut hasher);
     task.config_sources().hash(&mut hasher);
     root.hash(&mut hasher);
+    task.run.hash(&mut hasher);
+    task.sources.hash(&mut hasher);
+    task.outputs.patterns().hash(&mut hasher);
     format!("{:x}", hasher.finish())
 }
 
@@ -615,6 +618,35 @@ mod tests {
             .push(PathBuf::from("mise.toml"));
 
         assert_ne!(primary_key, task_state_key(&task, root));
+    }
+
+    #[test]
+    fn task_state_key_changes_when_run_changes() {
+        use crate::task::RunEntry;
+        let root = Path::new("/project");
+        let mut task = Task {
+            name: "build".to_string(),
+            config_source: PathBuf::from("mise.toml"),
+            run: vec![RunEntry::Script("echo v1".to_string())],
+            ..Default::default()
+        };
+        let key_v1 = task_state_key(&task, root);
+        task.run = vec![RunEntry::Script("echo v2".to_string())];
+        assert_ne!(key_v1, task_state_key(&task, root));
+    }
+
+    #[test]
+    fn task_state_key_changes_when_sources_change() {
+        let root = Path::new("/project");
+        let mut task = Task {
+            name: "build".to_string(),
+            config_source: PathBuf::from("mise.toml"),
+            sources: vec!["src.txt".to_string()],
+            ..Default::default()
+        };
+        let key_v1 = task_state_key(&task, root);
+        task.sources = vec!["other.txt".to_string()];
+        assert_ne!(key_v1, task_state_key(&task, root));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`task_state_key` — used to locate the stored source hash on disk — only covered `name`, `args`, `env`, `config_sources`, and `root`. Changing the `run` command, `sources` patterns, or `outputs` of a task left the key unchanged, so the old stored hash was reused and the task could be incorrectly skipped.

This adds `run`, `sources`, and `outputs` to the key so any change to the task definition invalidates its stored state.

## Test plan

- [x] Two new unit tests: `task_state_key_changes_when_run_changes` and `task_state_key_changes_when_sources_change` — both failed before this fix, both pass after.

*This comment was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task state is now refreshed when task execution settings, source inputs, or output patterns change.
  * Improved reliability of task invalidation when task definitions are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->