### PR TITLE
fix(npm): explain aube trust downgrade failures

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -299,25 +299,26 @@ not affect `npm`, `pnpm`, or `bun` installs.
 ### Investigating trust downgrades
 
 A `trustPolicy=no-downgrade` failure is a supply-chain signal, not an ordinary inability to find a
-matching version. It means an earlier release had npm trusted-publisher, staged-publish, or
-provenance evidence that the selected release no longer carries.
+matching version. It means an earlier release had stronger npm trusted-publisher, staged-publish,
+or provenance evidence than the selected release.
 
 Before adding an exception:
 
-1. Inspect the npm release, source tag/commit, publisher identity, and tarball, and confirm nothing
-   appears tampered with.
+1. Inspect the npm release, source tag/commit, publisher identity, and tarball, compare the metadata
+   with npmjs.org, and confirm nothing appears tampered with.
 2. Check whether the maintainer intentionally published manually, backported outside the trusted
    workflow, skipped provenance, or used a registry that stripped metadata.
-3. Report the failure upstream. Even when benign, inconsistent trust evidence is a packaging
-   failure the maintainer should correct.
+3. Report inconsistent evidence to the relevant upstream owner. Package-release drift belongs with
+   the maintainer; metadata present on npmjs.org but missing from a proxy or mirror belongs with
+   that registry operator.
 4. Prefer a version-scoped `"<package>@<version>"` exception after review. A bare package name
    exempts every future version.
 
 Using `mise settings npm.shell_out=true` switches to the npm CLI and bypasses this aube check
 entirely, so it should be a last resort rather than the first workaround.
 
-See aube's [trust-policy investigation guide and dynamically generated exception
-list](https://aube.jdx.dev/trust-policy-exceptions) for more detail.
+See aube's [trust-policy documentation](https://aube.jdx.dev/security#trust-policy) for more
+detail.
 
 ### `aube_args`
 

--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -296,6 +296,29 @@ To exempt only selected versions, use aube's package-version pattern syntax:
 `trust_policy_excludes` is written to the aube install `.npmrc` as `trustPolicyExclude`. It does
 not affect `npm`, `pnpm`, or `bun` installs.
 
+### Investigating trust downgrades
+
+A `trustPolicy=no-downgrade` failure is a supply-chain signal, not an ordinary inability to find a
+matching version. It means an earlier release had npm trusted-publisher, staged-publish, or
+provenance evidence that the selected release no longer carries.
+
+Before adding an exception:
+
+1. Inspect the npm release, source tag/commit, publisher identity, and tarball, and confirm nothing
+   appears tampered with.
+2. Check whether the maintainer intentionally published manually, backported outside the trusted
+   workflow, skipped provenance, or used a registry that stripped metadata.
+3. Report the failure upstream. Even when benign, inconsistent trust evidence is a packaging
+   failure the maintainer should correct.
+4. Prefer a version-scoped `"<package>@<version>"` exception after review. A bare package name
+   exempts every future version.
+
+Using `mise settings npm.shell_out=true` switches to the npm CLI and bypasses this aube check
+entirely, so it should be a last resort rather than the first workaround.
+
+See aube's [trust-policy investigation guide and dynamically generated exception
+list](https://aube.jdx.dev/trust-policy-exceptions) for more detail.
+
 ### `aube_args`
 
 Additional arguments to pass to `aube add --global` when

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1180,21 +1180,23 @@ fn build_aube_install_error_message(err: &miette::Report, tool_full: &str) -> St
     if err.code().map(|c| c.to_string()).as_deref() == Some("ERR_AUBE_TRUST_DOWNGRADE") {
         msg.push_str(&format!(
             "\n\nThis is a supply-chain trust failure, not an ordinary version-resolution error. \
-             An earlier release had trusted publishing evidence that the selected release lost. \
+             An earlier release had stronger trust evidence than the selected release. \
              This can indicate a compromised or tampered release; it can also happen when a \
              maintainer manually publishes, backports outside the trusted workflow, skips \
              provenance for convenience, or uses a registry that strips metadata.\n\n\
              Before bypassing, inspect the package's npm release, source tag/commit, publisher \
-             identity, and tarball. Confirm the release is expected and nothing appears tampered \
-             with, then report the downgrade upstream—the package's release process failed to \
-             preserve its previous trust evidence.\n\n\
+             identity, and tarball; compare the metadata with npmjs.org. Confirm the release is \
+             expected and nothing appears tampered with, then report inconsistent evidence to the \
+             relevant upstream owner. Package-release drift belongs with the maintainer; metadata \
+             present on npmjs.org but missing from a proxy or mirror belongs with that registry \
+             operator.\n\n\
              Only after review, add the narrowest affected `<package>@<version>` to \
              `trust_policy_excludes` for this tool, e.g.:\n  \
              \"{tool_full}\" = {{ version = \"latest\", trust_policy_excludes = [\"<package>@<version>\"] }}\n\
              A bare package name exempts every version. `mise settings npm.shell_out=true` uses \
              the npm CLI and bypasses this check entirely, so it should be a last resort.\n\n\
              Investigation guide and known exceptions: \
-             https://aube.jdx.dev/trust-policy-exceptions"
+             https://aube.jdx.dev/security#trust-policy"
         ));
     } else if let Some(help) = err.help() {
         msg.push_str(&format!("\n  help: {help}"));
@@ -1398,13 +1400,15 @@ mod tests {
         assert!(msg.contains("caused by: trust downgrade for @octokit/endpoint@9.0.6"));
         // mise-native remediation replaces aube's .npmrc-oriented help.
         assert!(msg.contains("not an ordinary version-resolution error"));
+        assert!(msg.contains("stronger trust evidence than the selected release"));
         assert!(msg.contains("nothing appears tampered with"));
-        assert!(msg.contains("report the downgrade upstream"));
+        assert!(msg.contains("report inconsistent evidence to the relevant upstream owner"));
+        assert!(msg.contains("belongs with that registry operator"));
         assert!(msg.contains("narrowest affected `<package>@<version>`"));
         assert!(msg.contains("trust_policy_excludes"));
         assert!(msg.contains("\"npm:danger\""));
         assert!(msg.contains("npm.shell_out=true"));
-        assert!(msg.contains("https://aube.jdx.dev/trust-policy-exceptions"));
+        assert!(msg.contains("https://aube.jdx.dev/security#trust-policy"));
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1179,12 +1179,22 @@ fn build_aube_install_error_message(err: &miette::Report, tool_full: &str) -> St
     }
     if err.code().map(|c| c.to_string()).as_deref() == Some("ERR_AUBE_TRUST_DOWNGRADE") {
         msg.push_str(&format!(
-            "\n\nThis is a supply-chain trust check, not a version-resolution failure. \
-             If you have reviewed the flagged package and want to allow it, add it to \
+            "\n\nThis is a supply-chain trust failure, not an ordinary version-resolution error. \
+             An earlier release had trusted publishing evidence that the selected release lost. \
+             This can indicate a compromised or tampered release; it can also happen when a \
+             maintainer manually publishes, backports outside the trusted workflow, skips \
+             provenance for convenience, or uses a registry that strips metadata.\n\n\
+             Before bypassing, inspect the package's npm release, source tag/commit, publisher \
+             identity, and tarball. Confirm the release is expected and nothing appears tampered \
+             with, then report the downgrade upstream—the package's release process failed to \
+             preserve its previous trust evidence.\n\n\
+             Only after review, add the narrowest affected `<package>@<version>` to \
              `trust_policy_excludes` for this tool, e.g.:\n  \
-             \"{tool_full}\" = {{ version = \"latest\", trust_policy_excludes = [\"<package>\"] }}\n\
-             or run `mise settings npm.shell_out=true` to install with the npm CLI, which \
-             does not run this check."
+             \"{tool_full}\" = {{ version = \"latest\", trust_policy_excludes = [\"<package>@<version>\"] }}\n\
+             A bare package name exempts every version. `mise settings npm.shell_out=true` uses \
+             the npm CLI and bypasses this check entirely, so it should be a last resort.\n\n\
+             Investigation guide and known exceptions: \
+             https://aube.jdx.dev/trust-policy-exceptions"
         ));
     } else if let Some(help) = err.help() {
         msg.push_str(&format!("\n  help: {help}"));
@@ -1387,9 +1397,14 @@ mod tests {
         assert!(msg.contains("aube install failed: failed to resolve dependencies"));
         assert!(msg.contains("caused by: trust downgrade for @octokit/endpoint@9.0.6"));
         // mise-native remediation replaces aube's .npmrc-oriented help.
+        assert!(msg.contains("not an ordinary version-resolution error"));
+        assert!(msg.contains("nothing appears tampered with"));
+        assert!(msg.contains("report the downgrade upstream"));
+        assert!(msg.contains("narrowest affected `<package>@<version>`"));
         assert!(msg.contains("trust_policy_excludes"));
         assert!(msg.contains("\"npm:danger\""));
         assert!(msg.contains("npm.shell_out=true"));
+        assert!(msg.contains("https://aube.jdx.dev/trust-policy-exceptions"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- explain that an embedded aube trust downgrade is a supply-chain signal rather than ordinary version resolution
- tell users to inspect the npm release, source, publisher identity, and tarball for tampering
- direct users to report inconsistent publishing evidence upstream before bypassing the check
- recommend version-scoped `trust_policy_excludes` entries and describe the broader risk of package-wide exclusions or `npm.shell_out=true`
- add the same investigation guidance to the npm backend docs

## Context

mise replaces aube's `.npmrc`-oriented remediation because mise owns the synthetic install project and exposes `trust_policy_excludes` as a tool option. That replacement needs to retain the richer security context being added in [jdx/aube#1110](https://github.com/jdx/aube/pull/1110).

## Validation

- `cargo fmt --check`
- `cargo test test_build_aube_install_error_message_trust_downgrade`
- `mise run docs:build`
- `mise run lint-fix`

The pre-existing untracked `.claude/worktrees/` and `xtasks/fig/` directories were not included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text and documentation only; no install or trust-policy behavior changes.
> 
> **Overview**
> **Expands embedded aube trust-downgrade remediation** so `ERR_AUBE_TRUST_DOWNGRADE` is framed as a supply-chain signal (weaker trust evidence vs an earlier release), not a normal version-resolution error.
> 
> The npm backend’s `build_aube_install_error_message` now walks users through **investigation before bypass**: review release metadata, source, publisher, and tarball; compare with npmjs.org; report drift to maintainers vs registry operators. It recommends **version-scoped** `trust_policy_excludes` (`<package>@<version>`), warns that bare package names exempt all versions, and treats `npm.shell_out=true` as a last resort that skips the check, with a link to aube’s trust-policy docs.
> 
> **Docs** add a matching **Investigating trust downgrades** section under `trust_policy_excludes` in the npm backend guide. Unit tests assert the new message content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a5babdbb2d63eafa0d7eb4379449df36dd6496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trust-downgrade error messages for npm to include clearer supply-chain/provenance investigation steps.
  * Recommend adding narrowly scoped `<package>@<version>` exceptions for affected releases.

* **Documentation**
  * Added troubleshooting guidance for npm trust-policy failures, including validation steps, reporting inconsistencies upstream, and a reference guide.
  * Documented when and how `npm.shell_out=true` bypasses the trust-policy check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->