### PR TITLE
security(config): restrict default shell args to global config

### DIFF
--- a/e2e/config/test_watch_files_shell
+++ b/e2e/config/test_watch_files_shell
@@ -20,7 +20,7 @@ exec bash -c "$2"
 SCRIPT
 chmod +x "$HOME/watch-explicit-shell"
 
-export MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS="$HOME/watch-fallback-shell -c"
+export MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS="\"$HOME/watch-fallback-shell\" -c"
 
 cat <<EOF >mise.toml
 [[watch_files]]
@@ -30,7 +30,7 @@ run = "echo WATCH_FALLBACK_RUN"
 [[watch_files]]
 patterns = ["explicit.txt"]
 run = "echo WATCH_EXPLICIT_RUN"
-shell = "$HOME/watch-explicit-shell -c"
+shell = '"$HOME/watch-explicit-shell" -c'
 EOF
 
 touch fallback.txt explicit.txt

--- a/e2e/config/test_watch_files_shell
+++ b/e2e/config/test_watch_files_shell
@@ -20,10 +20,9 @@ exec bash -c "$2"
 SCRIPT
 chmod +x "$HOME/watch-explicit-shell"
 
-cat <<EOF >mise.toml
-[settings]
-unix_default_inline_shell_args = "$HOME/watch-fallback-shell -c"
+export MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS="$HOME/watch-fallback-shell -c"
 
+cat <<EOF >mise.toml
 [[watch_files]]
 patterns = ["fallback.txt"]
 run = "echo WATCH_FALLBACK_RUN"

--- a/settings.toml
+++ b/settings.toml
@@ -2921,12 +2921,14 @@ type = "ListPath"
 default = "sh"
 description = "Default shell arguments for Unix to be used for file commands. For example, `sh` for sh."
 env = "MISE_UNIX_DEFAULT_FILE_SHELL_ARGS"
+global_only = true
 type = "String"
 
 [unix_default_inline_shell_args]
 default = "sh -c -o errexit"
 description = "Default shell arguments for Unix to be used for inline commands. For example, `sh -c` for sh."
 env = "MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS"
+global_only = true
 type = "String"
 
 [url_replacements]
@@ -3005,12 +3007,14 @@ type = "Bool"
 default = "cmd /c"
 description = "Default shell arguments for Windows to be used for file commands. For example, `cmd /c` for cmd.exe."
 env = "MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS"
+global_only = true
 type = "String"
 
 [windows_default_inline_shell_args]
 default = "cmd /c"
 description = "Default shell arguments for Windows to be used for inline commands. For example, `cmd /c` for cmd.exe."
 env = "MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS"
+global_only = true
 type = "String"
 
 [windows_executable_extensions]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1377,6 +1377,21 @@ mod tests {
         .clone()
     }
 
+    fn default_shell_args_settings_table() -> toml::Table {
+        toml::from_str::<toml::Value>(
+            r#"
+            unix_default_file_shell_args = "malicious-unix-file-shell"
+            unix_default_inline_shell_args = "malicious-unix-inline-shell"
+            windows_default_file_shell_args = "malicious-windows-file-shell"
+            windows_default_inline_shell_args = "malicious-windows-inline-shell"
+            "#,
+        )
+        .unwrap()
+        .as_table()
+        .unwrap()
+        .clone()
+    }
+
     fn settings_partial_from_table(settings: toml::Table) -> SettingsPartial {
         let mut root = toml::Table::new();
         root.insert("settings".to_string(), toml::Value::Table(settings));
@@ -1453,6 +1468,44 @@ mod tests {
         assert_eq!(
             partial.forgejo.credential_command.as_deref(),
             Some("echo forgejo-token")
+        );
+    }
+
+    #[test]
+    fn test_local_config_strips_default_shell_args() {
+        let path = Path::new("/tmp/.mise.toml");
+        let mut settings = default_shell_args_settings_table();
+        strip_local_only_settings(&mut settings, path, false);
+        let partial = settings_partial_from_table(settings);
+
+        assert_eq!(partial.unix_default_file_shell_args, None);
+        assert_eq!(partial.unix_default_inline_shell_args, None);
+        assert_eq!(partial.windows_default_file_shell_args, None);
+        assert_eq!(partial.windows_default_inline_shell_args, None);
+    }
+
+    #[test]
+    fn test_global_config_preserves_default_shell_args() {
+        let path = Path::new("/tmp/global-config.toml");
+        let mut settings = default_shell_args_settings_table();
+        strip_local_only_settings(&mut settings, path, true);
+        let partial = settings_partial_from_table(settings);
+
+        assert_eq!(
+            partial.unix_default_file_shell_args.as_deref(),
+            Some("malicious-unix-file-shell")
+        );
+        assert_eq!(
+            partial.unix_default_inline_shell_args.as_deref(),
+            Some("malicious-unix-inline-shell")
+        );
+        assert_eq!(
+            partial.windows_default_file_shell_args.as_deref(),
+            Some("malicious-windows-file-shell")
+        );
+        assert_eq!(
+            partial.windows_default_inline_shell_args.as_deref(),
+            Some("malicious-windows-inline-shell")
         );
     }
 


### PR DESCRIPTION
## Summary
- mark the Unix and Windows default file/inline shell argument settings as global-only
- add regression coverage proving local config values are stripped while global config values remain supported

## Rationale
Settings from local project configuration are preloaded before trust evaluation. Allowing those files to override the default shell interpreter arguments lets an untrusted repository influence how commands from trusted sources are executed. Applying the existing `global_only` policy to all four settings closes that gap while preserving global configuration and environment-variable customization.

Reported by @arpitjain099.

## Validation
- `cargo test config::settings::tests` (45 passed)
- `mise run lint-fix` (includes formatting, schema validation, shell checks, and `cargo check --all-features`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix for command execution: local repos could previously steer default shell invocation; behavior change for anyone relying on project-level overrides of these four settings.
> 
> **Overview**
> Closes a security gap where **untrusted project `mise.toml` files could override Unix/Windows default file and inline shell arguments** before config trust is evaluated, influencing how mise runs inline and file-based commands.
> 
> The four settings (`unix_default_*` and `windows_default_*` shell args) are now **`global_only`**, so `strip_local_only_settings` drops them from non-global config while **global config and `MISE_*` env vars still apply**. Unit tests assert local stripping vs global preservation.
> 
> The **watch-files shell e2e** no longer sets `unix_default_inline_shell_args` in generated `mise.toml`; it uses **`MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS`** for the fallback-shell case and keeps per-`watch_files` `shell` only in project config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67bcea5ff4c637c83a634af70df40e0ee9b00a5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted default Unix and Windows shell-argument settings to global configuration only.
  - Prevented local configuration from overriding these default shell arguments.
  - Kept the settings intact when loaded from global configuration.
- **Tests**
  - Expanded coverage to verify local vs. global stripping behavior for default shell-argument settings.
- **E2E Tests**
  - Updated watch-file shell argument checks to use an environment-provided default instead of embedding it in generated config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->