### PR TITLE
chore(ci): configure cursor cloud environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,7 @@
 {
   "name": "mise development",
   "user": "root",
-  "install": "cargo build",
+  "install": "rustup toolchain install 1.91 --profile minimal && rustup default 1.91 && cargo build --all-features && ln -sfn \"$PWD/target/debug/mise\" /usr/local/bin/mise",
   "terminals": [
     {
       "name": "Build",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,12 +5,12 @@
   "terminals": [
     {
       "name": "Build",
-      "command": "mise run build",
+      "command": "cargo build --all-features",
       "description": "Build the project with cargo"
     },
     {
-      "name": "Test Watch",
-      "command": "mise run test:unit",
+      "name": "Unit tests",
+      "command": "cargo test --all-features --lib",
       "description": "Run unit tests"
     }
   ]

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,12 +5,12 @@
   "terminals": [
     {
       "name": "Build",
-      "command": "cargo build --all-features",
+      "command": "mise run build",
       "description": "Build the project with cargo"
     },
     {
-      "name": "Unit tests",
-      "command": "cargo test --all-features --lib",
+      "name": "Test Watch",
+      "command": "mise run test:unit",
       "description": "Run unit tests"
     }
   ]

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,7 @@
 {
   "name": "mise development",
   "user": "root",
-  "install": "rustup toolchain install 1.91 --profile minimal && rustup default 1.91 && cargo build --all-features && ln -sfn \"$PWD/target/debug/mise\" /usr/local/bin/mise",
+  "install": "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libssl-dev && rustup toolchain install 1.91 --profile minimal && rustup default 1.91 && cargo build --all-features && ln -sfn \"$PWD/target/debug/mise\" /usr/local/bin/mise",
   "terminals": [
     {
       "name": "Build",


### PR DESCRIPTION
## Summary
- install `libssl-dev` and Rust 1.91 during Cursor cloud setup
- build mise with all features and expose the debug binary on `PATH`
- run the standard project build and unit-test tasks in cloud terminals

## Why
The Cursor cloud base image ships Cargo 1.83, which cannot parse the workspace’s Rust 2024 edition and Rust 1.91 requirement. It also lacks the OpenSSL headers required by `native-tls`.

The setup installs those prerequisites and builds mise before the terminals start. Now that #11323 has removed `cargo-edit` from the project toolset, the terminals can use `mise run build` and `mise run test:unit` instead of bypassing project task configuration with direct Cargo commands.

## Validation
- formatting and JSON checks
- `git diff --check`
- verified the PR changes only `.cursor/environment.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment setup to install required system dependencies.
  * Standardized the Rust toolchain and enabled all project features during builds.
  * Improved availability of the `mise` command in the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->