### PR TITLE
fix(task): only persist source hash after successful task run

### DIFF
--- a/e2e/tasks/test_task_source_hash_not_written_on_failure
+++ b/e2e/tasks/test_task_source_hash_not_written_on_failure
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# The source hash must only be persisted after a task succeeds. If it is
+# written before the task runs (on mismatch detection), a failed run advances
+# the hash baseline — the next invocation sees a matching hash and existing
+# outputs and incorrectly skips the task.
+
+cat <<EOF >mise.toml
+[tasks.build]
+run = 'if [ -f poison ]; then exit 1; fi; touch out.txt && echo built'
+sources = ['src.txt']
+outputs = ['out.txt']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no output → stale → succeeds
+assert "mise run -q build" "built"
+
+# Nothing changed → fresh
+assert_empty "mise run -q build"
+
+# Modify src so the hash changes (content + size differ)
+echo "modified content" >src.txt
+
+# Poison the task so the next run fails
+touch poison
+
+# Hash mismatch detected → task runs → fails
+assert_fail "mise run build 2>&1"
+
+# Simulate outputs being newer than sources (e.g. a pre-existing artifact).
+# This is the condition that lets the mtime check say "fresh" on the next run,
+# so only the hash baseline is left to detect staleness.
+sleep 0.1
+touch out.txt
+
+# Remove poison: the task is now able to succeed again
+rm poison
+
+# The hash must NOT have been advanced by the failed run.
+# Without fix: hash was written before the task ran → matches current src →
+#              out.txt newer than src → mtime also says fresh → task skipped (wrong).
+# With fix:    hash was not written → mismatch still detected → task re-runs → "built".
+assert "mise run -q build" "built"

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -223,6 +223,81 @@ pub async fn task_cwd(task: &Task, config: &Arc<Config>) -> Result<PathBuf> {
     }
 }
 
+/// Collect source file metadatas for a task, anchored at the correct workspace root.
+async fn collect_source_metadatas(
+    task: &Task,
+    config: &Arc<Config>,
+) -> Result<(PathBuf, Vec<(PathBuf, fs::Metadata)>)> {
+    let root = task_cwd(task, config).await?;
+    // Anchor the Override matcher at the outermost config root that is an
+    // ancestor of the task CWD (i.e. the workspace root). This allows
+    // workspace-rooted patterns like `{{ config_root }}/lib/**/*` to be
+    // correctly relativized so that files inside a subproject directory are
+    // not silently dropped.
+    //
+    // config.project_root cannot be used directly: BTreeMap iterates by
+    // lexicographic path order, so a subproject config may be returned
+    // before the workspace root config (mise.toml) even though
+    // the workspace root has a shorter path.
+    let match_root_owned = config
+        .config_files
+        .values()
+        .filter_map(|cf| cf.project_root())
+        .filter(|pr| root.starts_with(pr) || *pr == root)
+        .min_by_key(|p| p.components().count())
+        .unwrap_or_else(|| root.clone());
+    let match_root = match_root_owned.as_path();
+    let matcher = build_source_matcher(match_root, &root, &task.sources);
+    let glob_patterns = source_glob_patterns(&task.sources);
+    let mut source_metadatas = get_file_metadatas(&root, &glob_patterns, &matcher)?;
+    // Always include every file that contributed to the task definition,
+    // regardless of excludes — a stray `!mise.toml` must not silently
+    // disable invalidation.
+    for config_source in task.config_sources() {
+        let config_path = if config_source.is_absolute() {
+            config_source.to_path_buf()
+        } else {
+            root.join(config_source)
+        };
+        if let Ok(meta) = config_path.metadata()
+            && meta.is_file()
+            && !source_metadatas.iter().any(|(p, _)| p == &config_path)
+        {
+            source_metadatas.push((config_path, meta));
+        }
+    }
+    Ok((root, source_metadatas))
+}
+
+/// Compute the current source hash for a task. Returns `(hash, hash_file_path)`
+/// or `None` if the task has no sources or no matching files were found.
+async fn compute_source_hash(
+    task: &Task,
+    config: &Arc<Config>,
+) -> Result<Option<(String, PathBuf)>> {
+    if task.sources.is_empty() {
+        return Ok(None);
+    }
+    let use_content_hash = Settings::get().task.source_freshness_hash_contents;
+    let (root, source_metadatas) = collect_source_metadatas(task, config).await?;
+    if source_metadatas.is_empty() {
+        return Ok(None);
+    }
+    let source_hash = if use_content_hash {
+        let cache_path = content_hash_cache_path(task, &root);
+        let mut cache = load_content_hash_cache(&cache_path);
+        let h = file_contents_to_hash(&source_metadatas, &mut cache)?;
+        if let Err(e) = save_content_hash_cache(&cache_path, &cache) {
+            trace!("failed to save content hash cache: {e}");
+        }
+        h
+    } else {
+        file_metadatas_to_hash(&source_metadatas)
+    };
+    let source_hash_path = sources_hash_path(task, &root, use_content_hash);
+    Ok(Some((source_hash, source_hash_path)))
+}
+
 /// Check if task sources are up to date (fresher than outputs)
 pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool> {
     if task.sources.is_empty() {
@@ -233,44 +308,7 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
     let equal_mtime_is_fresh = settings.task.source_freshness_equal_mtime_is_fresh;
 
     let run = async || -> Result<bool> {
-        let root = task_cwd(task, config).await?;
-        // Anchor the Override matcher at the outermost config root that is an
-        // ancestor of the task CWD (i.e. the workspace root). This allows
-        // workspace-rooted patterns like `{{ config_root }}/lib/**/*` to be
-        // correctly relativized so that files inside a subproject directory are
-        // not silently dropped.
-        //
-        // config.project_root cannot be used directly: BTreeMap iterates by
-        // lexicographic path order, so a subproject config may be returned
-        // before the workspace root config (mise.toml) even though
-        // the workspace root has a shorter path.
-        let match_root_owned = config
-            .config_files
-            .values()
-            .filter_map(|cf| cf.project_root())
-            .filter(|pr| root.starts_with(pr) || *pr == root)
-            .min_by_key(|p| p.components().count())
-            .unwrap_or_else(|| root.clone());
-        let match_root = match_root_owned.as_path();
-        let matcher = build_source_matcher(match_root, &root, &task.sources);
-        let glob_patterns = source_glob_patterns(&task.sources);
-        let mut source_metadatas = get_file_metadatas(&root, &glob_patterns, &matcher)?;
-        // Always include every file that contributed to the task definition,
-        // regardless of excludes — a stray `!mise.toml` must not silently
-        // disable invalidation.
-        for config_source in task.config_sources() {
-            let config_path = if config_source.is_absolute() {
-                config_source.to_path_buf()
-            } else {
-                root.join(config_source)
-            };
-            if let Ok(meta) = config_path.metadata()
-                && meta.is_file()
-                && !source_metadatas.iter().any(|(p, _)| p == &config_path)
-            {
-                source_metadatas.push((config_path, meta));
-            }
-        }
+        let (root, source_metadatas) = collect_source_metadatas(task, config).await?;
 
         // Check if sources resolved to no files (likely a config mistake)
         if source_metadatas.is_empty() {
@@ -320,23 +358,32 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
                 },
                 source_hash_path.display()
             );
-            file::write(&source_hash_path, &source_hash)?;
+            // Do not write the hash here — the task is about to run. If it
+            // fails, the baseline must stay at the previous value so the next
+            // invocation still detects the mismatch. save_checksum writes the
+            // hash after a successful run.
             return Ok(false);
         }
         let sources = get_last_modified_from_metadatas(&source_metadatas);
         let outputs = get_last_modified(&root, &task.outputs.paths(task, &root))?;
-        file::write(&source_hash_path, &source_hash)?;
         trace!("sources: {sources:?}, outputs: {outputs:?}");
-        match (sources, outputs) {
+        let fresh = match (sources, outputs) {
             (Some(sources), Some(outputs)) => {
                 if equal_mtime_is_fresh {
-                    Ok(sources <= outputs)
+                    sources <= outputs
                 } else {
-                    Ok(sources < outputs)
+                    sources < outputs
                 }
             }
-            _ => Ok(false),
+            _ => false,
+        };
+        if fresh {
+            // Write a snapshot of the current hash so future checks can detect
+            // source changes even when mtime would appear fresh (e.g. after a
+            // touch or a cache restore).
+            file::write(&source_hash_path, &source_hash)?;
         }
+        Ok(fresh)
     };
     Ok(run().await.unwrap_or_else(|err| {
         warn!("sources_are_fresh: {err:?}");
@@ -383,6 +430,15 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
                 );
             }
         }
+    }
+    // Persist the source hash now that the task has succeeded. Doing this here
+    // rather than in sources_are_fresh ensures a failed run never advances the
+    // baseline — the next invocation will detect a mismatch and re-run.
+    if let Some((hash, path)) = compute_source_hash(task, config).await? {
+        if let Some(dir) = path.parent() {
+            file::create_dir_all(dir)?;
+        }
+        file::write(&path, &hash)?;
     }
     Ok(())
 }


### PR DESCRIPTION
The source hash was written to disk on mismatch detection, before the task ran. If the task failed, the baseline was advanced — the next invocation would see a matching hash with existing outputs and incorrectly skip the task.

The hash is now written in two places only:
- sources_are_fresh, when the task is determined to be fresh (snapshot for future detection when mtime would otherwise lie)
- save_checksum, after the task succeeds

A failed run leaves the baseline unchanged, so the next invocation correctly detects the mismatch and re-runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task source tracking so failed runs no longer update the stored source baseline.
  * Ensured source changes are detected correctly on subsequent runs after a failure.
  * Preserved task skipping when sources are unchanged and freshness checks pass.

* **Tests**
  * Added end-to-end coverage for source hash handling across successful, skipped, and failed task runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->