### PR TITLE
perf(cli): stop rebuilding the clap tree twice on every invocation

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -419,8 +419,55 @@ fn escape_args_after_separator(args: &[String], separator_idx: usize) -> Vec<Str
     result
 }
 
+/// Long and short forms of the top-level flags that consume a following argument.
+///
+/// Hardcoded rather than derived because `env.rs` needs it from `Lazy` statics
+/// during startup — before anything has parsed arguments — and deriving it means
+/// building the entire clap tree, which costs ~3.1M instructions. Doing that
+/// there is what made every mise command ~6.3M instructions more expensive.
+///
+/// `test_global_flags_with_values_matches_clap` asserts this equals what clap
+/// reports, so adding a value-taking flag to [`Cli`] without updating this list
+/// fails CI rather than silently mis-parsing arguments.
+pub(crate) const GLOBAL_FLAGS_WITH_VALUES: &[&str] = &[
+    "--cd",
+    "-C",
+    "--env",
+    "-E",
+    "--jobs",
+    "-j",
+    "--profile",
+    "-P",
+    "--shell",
+    "-s",
+    "--tool",
+    "-t",
+    "--log-level",
+    "--output",
+];
+
+/// Index of the first argument that is not a global flag or one of its values.
+///
+/// Takes a `&Command` so callers that have already built one (argument parsing)
+/// use its real flag set. Callers without one want
+/// [`first_non_global_arg_idx_cached`].
 pub(crate) fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> Option<usize> {
-    let (flags_with_values, _) = get_global_flags(cmd);
+    let flags = get_global_flags(cmd).0;
+    first_non_global_arg_idx_with(|f| flags.iter().any(|x| x == f), args)
+}
+
+/// As [`first_non_global_arg_idx`], against [`GLOBAL_FLAGS_WITH_VALUES`].
+///
+/// For callers with no `Command` to hand, which would otherwise build the whole
+/// tree just to read its top-level arguments.
+pub(crate) fn first_non_global_arg_idx_cached(args: &[String]) -> Option<usize> {
+    first_non_global_arg_idx_with(|f| GLOBAL_FLAGS_WITH_VALUES.contains(&f), args)
+}
+
+fn first_non_global_arg_idx_with(
+    takes_value: impl Fn(&str) -> bool,
+    args: &[String],
+) -> Option<usize> {
     let mut i = 1;
     while i < args.len() {
         let arg = &args[i];
@@ -438,7 +485,7 @@ pub(crate) fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> 
                 false
             } else {
                 let flag_name = arg.split('=').next().unwrap();
-                flags_with_values.iter().any(|f| f == flag_name)
+                takes_value(flag_name)
             }
         } else if let Some(flag_name) = arg.get(..2) {
             // `arg.get(..2)` (not `&arg[..2]`) avoids panicking when the arg is
@@ -446,7 +493,7 @@ pub(crate) fn first_non_global_arg_idx(cmd: &clap::Command, args: &[String]) -> 
             // malformed byte becomes a multi-byte U+FFFD and byte index 2 may not
             // be a char boundary. A short flag is always ASCII, so a non-ASCII
             // prefix simply matches no value-taking flag.
-            arg.len() == 2 && flags_with_values.iter().any(|f| f == flag_name)
+            arg.len() == 2 && takes_value(flag_name)
         } else {
             false
         };
@@ -851,6 +898,25 @@ fn validate_cd_path(cd: &Option<PathBuf>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Guards [`GLOBAL_FLAGS_WITH_VALUES`]. It is hardcoded so that startup does
+    /// not have to build the clap tree; this keeps it honest. If you added a
+    /// value-taking flag to `Cli`, add it to that list too.
+    #[test]
+    fn test_global_flags_with_values_matches_clap() {
+        let derived = get_global_flags(&Cli::command()).0;
+        let mut derived_sorted = derived.clone();
+        derived_sorted.sort();
+        let mut hardcoded: Vec<String> = GLOBAL_FLAGS_WITH_VALUES
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        hardcoded.sort();
+        assert_eq!(
+            hardcoded, derived_sorted,
+            "GLOBAL_FLAGS_WITH_VALUES is stale; clap reports {derived:?}"
+        );
+    }
     use super::*;
 
     #[test]

--- a/src/env.rs
+++ b/src/env.rs
@@ -727,8 +727,7 @@ fn prefer_offline(args: &[String]) -> bool {
         return true;
     }
 
-    let command_idx = first_non_global_arg_idx(args);
-    let settings_args_end = command_idx.unwrap_or(args.len());
+    let settings_args_end = first_non_global_arg_idx(args).unwrap_or(args.len());
     if args[..settings_args_end]
         .iter()
         .any(|arg| arg == "--prefer-offline")
@@ -739,47 +738,49 @@ fn prefer_offline(args: &[String]) -> bool {
     prefer_offline_command(args)
 }
 
+/// Commands that should not fetch remote versions.
+const PREFER_OFFLINE_COMMANDS: &[&str] = &[
+    "activate", "current", "direnv", "env", "exec", "hook-env", "ls", "where", "which", "x",
+];
+
+/// Commands whose whole purpose is to enumerate remote versions. See
+/// [`REMOTE_FETCH_COMMAND`].
+const REMOTE_FETCH_COMMANDS: &[&str] = &[
+    "lock",
+    "ls-remote",
+    "list-all",
+    "list-remote",
+    "outdated",
+    "upgrade",
+    "up",
+];
+
 fn first_non_global_arg_idx(args: &[String]) -> Option<usize> {
-    crate::cli::first_non_global_arg_idx(
-        &<crate::cli::Cli as clap::CommandFactory>::command(),
-        args,
-    )
+    // Uses the cached global-flag list rather than building a fresh clap tree.
+    // This runs from `Lazy` statics during startup, so on essentially every
+    // invocation; building the tree here cost ~6.3M instructions per run.
+    crate::cli::first_non_global_arg_idx_cached(args)
 }
 
-fn command_arg(args: &[String]) -> Option<&str> {
-    first_non_global_arg_idx(args)
+/// Whether the subcommand at `command_idx` is one of `names`.
+fn is_command(args: &[String], command_idx: Option<usize>, names: &[&str]) -> bool {
+    command_idx
         .and_then(|idx| args.get(idx))
-        .map(String::as_str)
+        .map(|a| names.contains(&a.as_str()))
+        .unwrap_or_default()
 }
 
 fn prefer_offline_command(args: &[String]) -> bool {
-    command_arg(args)
-        .map(|a| {
-            [
-                "activate", "current", "direnv", "env", "exec", "hook-env", "ls", "where", "which",
-                "x",
-            ]
-            .contains(&a)
-        })
-        .unwrap_or_default()
+    is_command(
+        args,
+        first_non_global_arg_idx(args),
+        PREFER_OFFLINE_COMMANDS,
+    )
 }
 
 /// See [`REMOTE_FETCH_COMMAND`].
 fn remote_fetch_command(args: &[String]) -> bool {
-    command_arg(args)
-        .map(|a| {
-            [
-                "lock",
-                "ls-remote",
-                "list-all",
-                "list-remote",
-                "outdated",
-                "upgrade",
-                "up",
-            ]
-            .contains(&a)
-        })
-        .unwrap_or_default()
+    is_command(args, first_non_global_arg_idx(args), REMOTE_FETCH_COMMANDS)
 }
 
 /// returns true if missing required env vars should produce warnings instead of errors


### PR DESCRIPTION
## Problem

Every `mise` command builds the clap command tree **three times**. One is needed
for argument parsing; the other two come from `env.rs`.

[#11190](https://github.com/jdx/mise/pull/11190) replaced a string scan in
`env.rs` with a call through `crate::cli::first_non_global_arg_idx`, which takes
a `&clap::Command`:

```rust
fn first_non_global_arg_idx(args: &[String]) -> Option<usize> {
    crate::cli::first_non_global_arg_idx(
        &<crate::cli::Cli as clap::CommandFactory>::command(),  // ← builds the whole tree
        args,
    )
}
```

It is called twice per invocation — once directly in `prefer_offline`, once via
`prefer_offline_command` → `command_arg`. Both run from `Lazy` statics during
startup, so essentially every command pays.

Callgrind on 2026.7.13 shows the extra pair:

```
2x  mise::env::PREFER_OFFLINE::{closure#0}  ->  Cli::augment_args
1x  mise::cli::Cli::run::{closure#0}        ->  CommandFactory::command -> augment_args
```

One tree construction measures ~3.1M instructions, so this cost ~6.3M on every
command. Found by bisecting instruction counts between v2026.7.0 and HEAD; the
direct parent→child A/B across #11190 confirms it in isolation.

## Fix

`first_non_global_arg_idx` only ever consults the top-level flags that take a
following value. That list is now a `const`, and `env.rs` uses it instead of
building anything:

```rust
pub(crate) const GLOBAL_FLAGS_WITH_VALUES: &[&str] = &[
    "--cd", "-C", "--env", "-E", "--jobs", "-j", "--profile", "-P",
    "--shell", "-s", "--tool", "-t", "--log-level", "--output",
];
```

Hardcoding it would normally be a drift hazard, which is what #11190 was fixing,
so `test_global_flags_with_values_matches_clap` asserts the const equals what
clap reports. Adding a value-taking flag to `Cli` without updating the list
fails CI rather than silently mis-parsing arguments.

Callers that already have a `Command` (argument parsing) keep using its real flag
set — the two paths share the scan via a predicate, so behaviour is identical.

## Effect

Instruction counts via cachegrind, release feature set
(`--no-default-features --features "rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored"`),
measured in a Debian container with a warmed cache:

| command | before | after | | pre-#11190 |
|---|---:|---:|---|---:|
| `ls` | 39,451,978 | **33,165,753** | −15.9% | 33,212,050 |
| `env` | 39,121,809 | **32,821,732** | −16.1% | 32,840,298 |
| `hook-env -s bash` | 30,800,771 | **24,587,056** | −20.2% | 24,536,438 |
| `--version` | 10,493,720 | 10,461,486 | −0.3% | 10,463,168 |

The right-hand column is `d34aa29b4`, the commit before #11190 landed. The fixed
numbers land within 0.2% of it, so the regression is fully recovered rather than
merely reduced.

## Testing

- **1917 unit tests pass** (1916 + the new drift guard)
- `cargo fmt --check` and `cargo clippy` clean for both changed files
- `prefer_offline` keeps its original shape, so the existing
  `test_prefer_offline_command_skips_global_option_values` and
  `test_remote_fetch_command_skips_global_option_values` cover the behaviour
  unchanged

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance refactor with behavior preserved via shared scan logic and a clap parity test; main risk is stale `GLOBAL_FLAGS_WITH_VALUES` if someone bypasses CI.
> 
> **Overview**
> **Startup no longer builds the full clap command tree twice** when `env.rs` resolves the subcommand for `PREFER_OFFLINE` and `REMOTE_FETCH_COMMAND`. Those paths now use a hardcoded `GLOBAL_FLAGS_WITH_VALUES` list and `first_non_global_arg_idx_cached`, avoiding ~6.3M instructions per run that came from constructing `Cli::command()` inside `Lazy` statics.
> 
> The scan logic is shared via `first_non_global_arg_idx_with`; callers that already have a `&Command` still derive flags from clap. **`test_global_flags_with_values_matches_clap`** keeps the const in sync with `Cli` so new value-taking global flags fail CI instead of mis-parsing argv.
> 
> `env.rs` also pulls prefer-offline and remote-fetch subcommand names into **`PREFER_OFFLINE_COMMANDS`** / **`REMOTE_FETCH_COMMANDS`** and routes command detection through **`is_command`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf88a00ccbef6de1457baaecdf6240f2bfb1bcae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling of global command-line options, including options that require values.
  * Improved detection of subcommands when global options appear before the command.
  * Ensured offline and remote version-fetch behavior is applied consistently across supported commands.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->