### PR TITLE
docs(backend): correct bin_path/asset_pattern template variables

### DIFF
--- a/docs/dev-tools/backends/forgejo.md
+++ b/docs/dev-tools/backends/forgejo.md
@@ -351,7 +351,7 @@ When `no_app = true`:
 ### `bin_path`
 
 ::: v-pre
-Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with variables like `{{ version }}`, `{{ os }}`, `{{ arch }}`, and arch aliases (`{{ darwin_os }}`, `{{ amd64_arch }}`, `{{ x86_64_arch }}`, `{{ gnu_arch }}`):
+Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with `{{ version }}` and the `{{ os() }}` / `{{ arch() }}` functions:
 :::
 
 ```toml
@@ -359,6 +359,26 @@ Specify the directory containing binaries within the extracted archive, or where
 version = "latest"
 bin_path = "tool-{{ version }}/bin" # expands to tool-1.0.0/bin
 ```
+
+Both take keyword arguments that remap the value mise would emit (`linux`, `macos`,
+`windows` for `os()`; `x64`, `arm64` for `arch()`), for when upstream names the directory
+differently:
+
+```toml
+[tools."forgejo:user/repo"]
+version = "latest"
+# expands to tool-1.0.0-linux-x86_64/bin
+bin_path = 'tool-{{ version }}-{{ os() }}-{{ arch(x64="x86_64", arm64="aarch64") }}/bin'
+```
+
+::: tip
+Use a single-quoted TOML string when the template contains double quotes, as above.
+:::
+
+::: v-pre
+There are no bare `{{ os }}` / `{{ arch }}` variables, and no `{{ x86_64_arch }}`-style
+aliases — `{{ arch(x64="x86_64", arm64="aarch64") }}` is how you get those names.
+:::
 
 **Binary path lookup order:**
 

--- a/docs/dev-tools/backends/github.md
+++ b/docs/dev-tools/backends/github.md
@@ -56,6 +56,11 @@ Specifies the pattern to match against release asset names. This is useful when 
 "github:cli/cli" = { version = "latest", asset_pattern = "gh_*_linux_x64.tar.gz" }
 ```
 
+::: v-pre
+Supports the same templating as [`bin_path`](#bin_path): `{{ version }}` plus the
+`{{ os() }}` / `{{ arch() }}` functions (with optional remap keyword arguments).
+:::
+
 ### `additional_asset_patterns`
 
 Downloads additional archives from the same release and extracts them into the primary
@@ -212,7 +217,7 @@ If the binary isn't named the way you want to invoke it, add
 [`bin`](#bin) (selects/renames the binary, including a single bare non-archive binary).
 
 Use [`asset_pattern`](#asset_pattern) instead only when you need full manual control and
-can name the asset portably (it replaces autodetection, so any `{{os}}`/`{{arch}}`
+can name the asset portably (it replaces autodetection, so any <code v-pre>{{ os() }}</code>/<code v-pre>{{ arch() }}</code>
 templating must cover every platform you target):
 
 ```toml
@@ -342,7 +347,7 @@ Without this option, mise's autodetection might select .app bundles on macOS, wh
 ### `bin_path`
 
 ::: v-pre
-Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with variables like `{{ version }}`, `{{ os }}`, `{{ arch }}`, and arch aliases (`{{ darwin_os }}`, `{{ amd64_arch }}`, `{{ x86_64_arch }}`, `{{ gnu_arch }}`):
+Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with `{{ version }}` and the `{{ os() }}` / `{{ arch() }}` functions:
 :::
 
 ```toml
@@ -350,6 +355,26 @@ Specify the directory containing binaries within the extracted archive, or where
 version = "latest"
 bin_path = "cli-{{ version }}/bin" # expands to cli-1.0.0/bin
 ```
+
+Both take keyword arguments that remap the value mise would emit (`linux`, `macos`,
+`windows` for `os()`; `x64`, `arm64` for `arch()`), for when upstream names the directory
+differently:
+
+```toml
+[tools."github:pizlonator/fil-c"]
+version = "latest"
+# expands to filc-0.681-linux-x86_64/build/bin
+bin_path = 'filc-{{ version }}-{{ os() }}-{{ arch(x64="x86_64", arm64="aarch64") }}/build/bin'
+```
+
+::: tip
+Use a single-quoted TOML string when the template contains double quotes, as above.
+:::
+
+::: v-pre
+There are no bare `{{ os }}` / `{{ arch }}` variables, and no `{{ x86_64_arch }}`-style
+aliases — `{{ arch(x64="x86_64", arm64="aarch64") }}` is how you get those names.
+:::
 
 **Binary path lookup order:**
 

--- a/docs/dev-tools/backends/gitlab.md
+++ b/docs/dev-tools/backends/gitlab.md
@@ -344,7 +344,7 @@ When `no_app = true`:
 ### `bin_path`
 
 ::: v-pre
-Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with variables like `{{ version }}`, `{{ os }}`, `{{ arch }}`, and arch aliases (`{{ darwin_os }}`, `{{ amd64_arch }}`, `{{ x86_64_arch }}`, `{{ gnu_arch }}`):
+Specify the directory containing binaries within the extracted archive, or where to place the downloaded file. This supports Tera templating with `{{ version }}` and the `{{ os() }}` / `{{ arch() }}` functions:
 :::
 
 ```toml
@@ -352,6 +352,26 @@ Specify the directory containing binaries within the extracted archive, or where
 version = "latest"
 bin_path = "gitlab-runner-{{ version }}/bin" # expands to gitlab-runner-1.0.0/bin
 ```
+
+Both take keyword arguments that remap the value mise would emit (`linux`, `macos`,
+`windows` for `os()`; `x64`, `arm64` for `arch()`), for when upstream names the directory
+differently:
+
+```toml
+[tools."gitlab:owner/repo"]
+version = "latest"
+# expands to tool-1.0.0-linux-x86_64/bin
+bin_path = 'tool-{{ version }}-{{ os() }}-{{ arch(x64="x86_64", arm64="aarch64") }}/bin'
+```
+
+::: tip
+Use a single-quoted TOML string when the template contains double quotes, as above.
+:::
+
+::: v-pre
+There are no bare `{{ os }}` / `{{ arch }}` variables, and no `{{ x86_64_arch }}`-style
+aliases — `{{ arch(x64="x86_64", arm64="aarch64") }}` is how you get those names.
+:::
 
 **Binary path lookup order:**
 

--- a/e2e/backend/test_disable_backends
+++ b/e2e/backend/test_disable_backends
@@ -17,3 +17,8 @@ assert "MISE_DISABLE_BACKENDS=asdf mise tool age --backend" "asdf:age"
 eval "$(mise activate bash)" && _mise_hook
 assert_contains "MISE_DISABLE_BACKENDS=asdf mise doctor 2>&1 || true" "age"
 assert_contains "MISE_DISABLE_BACKENDS=asdf mise doctor -J 2>&1 || true" '"age"'
+
+# the backends section marks disabled backends instead of listing them as if enabled
+assert_contains "MISE_DISABLE_BACKENDS=asdf,vfox mise doctor 2>&1 || true" "asdf (disabled)"
+assert_contains "MISE_DISABLE_BACKENDS=asdf,vfox mise doctor 2>&1 || true" "vfox (disabled)"
+assert_not_contains "mise doctor 2>&1 || true" "(disabled)"

--- a/e2e/backend/test_github_bin_path_template
+++ b/e2e/backend/test_github_bin_path_template
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# bin_path and asset_pattern support {{ version }} plus the os()/arch() functions,
+# including their remapping keyword arguments. os/arch are functions, not variables --
+# `{{ os }}` fails to parse, so keep this pinned to the documented syntax.
+
+cat <<EOF >mise.toml
+[tools."github:jdx/mise-test-fixtures"]
+version = "1.0.0"
+asset_pattern = 'hello-world-{{ version }}.tar.{{ os(linux="gz", macos="gz") }}'
+bin_path = 'hello-world-{{ version }}/{{ os(linux="bin", macos="bin") }}'
+postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world"
+EOF
+
+mise install
+assert_contains "mise x -- hello-world" "hello world"
+assert_contains "mise bin-paths github:jdx/mise-test-fixtures@1.0.0" "hello-world-1.0.0/bin"
+
+# arch() remapping renders into bin_path too
+cat <<EOF >mise.toml
+[tools."github:jdx/mise-test-fixtures"]
+version = "1.0.0"
+asset_pattern = "hello-world-1.0.0.tar.gz"
+bin_path = 'hello-world-{{ version }}/bin-{{ arch(x64="x86_64", arm64="aarch64") }}'
+EOF
+
+mise install
+assert_contains "mise bin-paths github:jdx/mise-test-fixtures@1.0.0" "hello-world-1.0.0/bin-"
+
+# `{{ os }}` is not a variable -- make sure the failure stays a clear parse error
+cat <<EOF >mise.toml
+[tools."github:jdx/mise-test-fixtures"]
+version = "1.0.0"
+bin_path = "hello-world-{{ version }}-{{ os }}/bin"
+EOF
+
+assert_fail "mise install" "failed to parse template"

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -1101,7 +1101,13 @@ async fn render_env_files(config: &Arc<Config>) -> eyre::Result<String> {
 fn render_backends() -> String {
     BackendType::iter()
         .filter(|b| b != &BackendType::Unknown)
-        .map(|b| b.to_string())
+        .map(|b| {
+            if backend::is_disabled_backend_type(&b) {
+                format!("{b} {}", style::ndim("(disabled)"))
+            } else {
+                b.to_string()
+            }
+        })
         .join("\n")
 }
 


### PR DESCRIPTION
Reported in https://github.com/jdx/mise/discussions/11290.

## The bug

The `bin_path` docs for the github/gitlab/forgejo backends advertise Tera variables that have never existed in a `mise.toml`:

```toml
[tools]
"github:pizlonator/fil-c" = { version = "latest", bin_path = "filc-{{ version }}-{{ os }}-{{ x86_64_arch }}/build/bin" }
```

```
Error: failed to parse template filc-{{ version }}-{{ os }}-{{ x86_64_arch }}/build/bin
  error: Variable `os` is not defined. Available variables: config_root, cwd, env,
  mise_bin, mise_pid, vars, version, xdg_cache_home, ...
```

The failure is at config load, not install:

- `mise_toml.rs` renders every tool-option string with `BASE_CONTEXT` + `version` only, and errors propagate — so one bad option fails the whole config.
- `os`/`arch` are registered as Tera **functions**, not variables, so they need parentheses: `{{ os() }}`, `{{ arch() }}`.
- The arch alias names (`darwin_os`, `amd64_arch`, `x86_64_arch`, `gnu_arch`) exist in only two places, neither reachable from a `mise.toml` value: the deprecated single-brace substitution in `github.rs` (used by registry entries like `clusterawsadm`), and github's install-time `template_string_for_target` context — which a `mise.toml` value never reaches because config load rejects it first.

The drift came from #7723, which rewrote the old `{name}-{version}` text into a Tera variable list without adding those variables. There was no test covering templated `bin_path`, so it went unnoticed.

## The fix

Document the syntax that actually works. The `os()`/`arch()` remap keyword arguments already cover everything the alias names were for, so no new variables are needed:

```toml
[tools."github:pizlonator/fil-c"]
version = "latest"
# expands to filc-0.681-linux-x86_64/build/bin
bin_path = 'filc-{{ version }}-{{ os() }}-{{ arch(x64="x86_64", arm64="aarch64") }}/build/bin'
```

Also in this PR:

- `asset_pattern` gets an explicit note about its templating (verified: same `{{ version }}` + `os()`/`arch()` support), and the stale `{{os}}`/`{{arch}}` mention above it is corrected.
- New e2e test `e2e/backend/test_github_bin_path_template` pins the working syntax for both `bin_path` and `asset_pattern`, and asserts `{{ os }}` still fails with a clear parse error.
- `mise doctor` now marks disabled backends as `asdf (disabled)` instead of listing every compiled-in backend as if enabled — the second half of the discussion report. Covered in `e2e/backend/test_disable_backends`.

```
backends:
  aqua
  asdf (disabled)
  cargo
  ...
  vfox (disabled)
```

## Testing

- `mise run test:e2e test_github_bin_path_template` — pass
- `mise run test:e2e test_disable_backends` — pass
- `mise run lint-fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doctor display changes plus e2e tests; no install-path or templating engine behavior changes in the diff.
> 
> **Overview**
> Fixes **misleading GitHub, GitLab, and Forgejo docs** that described nonexistent Tera variables (`{{ os }}`, `{{ arch }}`, `x86_64_arch`-style aliases) for `bin_path` and `asset_pattern`. The pages now document **`{{ version }}` with `{{ os() }}` / `{{ arch() }}`**, including remap keyword arguments, examples, and an explicit note that bare `{{ os }}` is invalid. GitHub docs also call out the same templating for **`asset_pattern`** and fix the portable-`asset_pattern` wording to use `{{ os() }}` / `{{ arch() }}`.
> 
> **`mise doctor`** labels backends disabled via `MISE_DISABLE_BACKENDS` as `asdf (disabled)` instead of listing them like enabled backends.
> 
> New e2e coverage pins working `bin_path`/`asset_pattern` templates and the `{{ os }}` parse error, and asserts doctor output for disabled backends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216ff634678b70007d77c685e734d199e05be875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized backend configuration template guidance across GitHub, GitLab, and Forgejo to use `os()`/`arch()` function-call syntax (including architecture/OS remapping examples).
  * Clarified template handling rules and improved TOML quoting tips for embedded quotes.
* **Tests**
  * Added end-to-end coverage for `mise.toml` template rendering, architecture-specific bin paths, and clearer failures on invalid template syntax.
* **Bug Fixes**
  * Improved `mise doctor` output to consistently label disabled backends with a “(disabled)” indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->