### PR TITLE
fix(swift): record the target distro in lockfile entries

### DIFF
--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -82,6 +82,26 @@ Each tool entry (`[[tools.name]]`) can contain:
 - **`options`** (optional): Backend-specific options that identify the artifact (e.g., `{exe = "rg", matching = "musl"}`)
 - **`platforms`** (optional): Platform-specific metadata (checksums, URLs, sizes)
 
+A tool can have several entries for the same version when its artifact identity
+depends on more than the platform key. Swift, for example, publishes a different
+Linux tarball per distro, so its entries record which one they describe:
+
+```toml
+[[tools.swift]]
+version = "6.3.1"
+backend = "core:swift"
+options = { swift_platform = "ubuntu24.04" }
+
+[[tools.swift]]
+version = "6.3.1"
+backend = "core:swift"
+options = { swift_platform = "fedora39" }
+```
+
+Entries are matched on options exactly, so a machine only verifies against the
+entry written for its own distro. Pin `swift.platform` to make every machine
+resolve the same artifact, and commit the entry it produces.
+
 ### Platform Keys
 
 The platform key format is generally `os-arch` but can be customized by backends:

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -99,8 +99,10 @@ options = { swift_platform = "fedora39" }
 ```
 
 Entries are matched on options exactly, so a machine only verifies against the
-entry written for its own distro. Pin `swift.platform` to make every machine
-resolve the same artifact, and commit the entry it produces.
+entry written for its own distro. Pin `swift.platform` to make every Linux
+machine resolve the same artifact, and commit the entry it produces. A platform
+whose artifact the tool doesn't publish — `ubi9` has no arm64 build, for
+instance — is reported as skipped rather than locked.
 
 ### Platform Keys
 

--- a/e2e/lockfile/test_lockfile_swift_distro
+++ b/e2e/lockfile/test_lockfile_swift_distro
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Regression test for https://github.com/jdx/mise/discussions/11295
+# Swift's Linux tarballs differ per distro (ubuntu24.04, fedora39, ubi9, …) but
+# the lock platform key is just linux-x64, so an entry written on one distro used
+# to be matched on another and its checksum verified against a different
+# tarball. Entries now record the distro in their options.
+#
+# Locking swift resolves URLs only — it never downloads the ~1GB toolchain.
+
+if [[ "$(uname -s)" != Linux ]]; then
+  echo "skipping: swift artifacts are only distro-specific on linux"
+  exit 0
+fi
+
+export MISE_LOCKFILE=1
+
+write_config() {
+  cat <<EOF >mise.toml
+[settings]
+swift.platform = "$1"
+[tools]
+"core:swift" = "6.3.1"
+EOF
+}
+
+write_config "ubi9"
+mise lock swift --platform linux-x64
+assert_contains "cat mise.lock" 'swift_platform = "ubi9"'
+assert_contains "cat mise.lock" 'swift-6.3.1-RELEASE-ubi9.tar.gz'
+
+# Changing the pinned distro must produce its own entry rather than silently
+# keeping the previous distro's artifact data.
+write_config "ubuntu24.04"
+mise lock swift --platform linux-x64
+assert_contains "cat mise.lock" 'swift_platform = "ubuntu24.04"'
+assert_contains "cat mise.lock" 'swift-6.3.1-RELEASE-ubuntu24.04.tar.gz'
+
+# An entry written before the distro was recorded still pins the version, but
+# its checksum — which describes an unknown distro's tarball — is not reused.
+cat <<EOF >mise.lock
+[[tools.swift]]
+version = "6.3.1"
+backend = "core:swift"
+[tools.swift."platforms.linux-x64"]
+checksum = "blake3:8a95707e406fa824266e95319f9f906415871df8f8dce47304a90302ec9977e8"
+EOF
+cat <<EOF >mise.toml
+[settings]
+swift.platform = "ubi9"
+[tools]
+"core:swift" = "6"
+EOF
+assert_contains "mise install --dry-run 2>&1" "swift@6.3.1"
+
+mise lock swift --platform linux-x64
+assert "grep -c '^\[\[tools.swift\]\]' mise.lock" "2"
+assert_contains "cat mise.lock" 'swift-6.3.1-RELEASE-ubi9.tar.gz'

--- a/e2e/lockfile/test_lockfile_swift_distro
+++ b/e2e/lockfile/test_lockfile_swift_distro
@@ -25,9 +25,12 @@ EOF
 }
 
 write_config "ubi9"
-mise lock swift --platform linux-x64
+mise lock swift --platform linux-x64,linux-arm64
 assert_contains "cat mise.lock" 'swift_platform = "ubi9"'
 assert_contains "cat mise.lock" 'swift-6.3.1-RELEASE-ubi9.tar.gz'
+# swift.org publishes no aarch64 ubi9 build, so that platform is skipped instead
+# of recording a URL that 404s.
+assert_not_contains "cat mise.lock" "ubi9-aarch64"
 
 # Changing the pinned distro must produce its own entry rather than silently
 # keeping the previous distro's artifact data.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -45,7 +45,7 @@ use crate::{
 use crate::{dirs, env, file, hash, versions_host};
 use async_trait::async_trait;
 use backend_type::BackendType;
-use eyre::{Result, bail, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use platform_target::PlatformTarget;
@@ -1195,6 +1195,19 @@ pub trait Backend: Debug + Send + Sync {
     /// this to return false, since they don't have downloadable artifacts with lockable URLs.
     fn supports_lockfile_url(&self) -> bool {
         true
+    }
+
+    /// Whether this backend's artifact-identity options describe the machine
+    /// that wrote a lock entry rather than the tool request.
+    ///
+    /// Swift's Linux artifacts differ per distro, so its options record which
+    /// distro an entry describes. An entry written before those options existed
+    /// can't be attributed to a distro, and guessing the local one would apply
+    /// a foreign artifact's checksum to a different tarball. Backends that
+    /// return true keep such an entry's version pin but ignore its
+    /// checksum/URL, and are excluded from legacy option rekeying.
+    fn lockfile_options_are_host_specific(&self) -> bool {
+        false
     }
 
     async fn description(&self) -> Option<String> {
@@ -2826,23 +2839,42 @@ pub trait Backend: Debug + Send + Sync {
         let platform_key = self.get_platform_key();
 
         // Get or create asset info for this platform
-        let platform_info = tv.lock_platforms.entry(platform_key.clone()).or_default();
+        let locked = tv
+            .lock_platforms
+            .entry(platform_key.clone())
+            .or_default()
+            .clone();
 
-        if let Some(checksum) = &platform_info.checksum {
+        if let Some(checksum) = &locked.checksum {
             ctx.pr.set_message(format!("checksum {filename}"));
             if let Some((algo, check)) = checksum.split_once(':') {
-                hash::ensure_checksum(file, check, Some(ctx.pr.as_ref()), algo)?;
+                hash::ensure_checksum(file, check, Some(ctx.pr.as_ref()), algo).wrap_err_with(
+                    || {
+                        // Name the lock entry the expectation came from: a mismatch
+                        // usually means the entry describes a different artifact
+                        // than the one this machine downloads (e.g. a Swift build
+                        // for another Linux distro).
+                        let entry = self.describe_lock_entry(tv, &platform_key);
+                        match &locked.url {
+                            Some(url) => format!("{entry} locks {url}"),
+                            None => entry,
+                        }
+                    },
+                )?;
             } else {
                 bail!("Invalid checksum: {checksum}");
             }
         } else if lockfile_enabled {
             ctx.pr.set_message(format!("generate checksum {filename}"));
             let hash = hash::file_hash_blake3(file, Some(ctx.pr.as_ref()))?;
-            platform_info.checksum = Some(format!("blake3:{hash}"));
+            tv.lock_platforms
+                .entry(platform_key.clone())
+                .or_default()
+                .checksum = Some(format!("blake3:{hash}"));
         }
 
         // Handle size verification and generation
-        if let Some(expected_size) = platform_info.size {
+        if let Some(expected_size) = locked.size {
             ctx.pr.set_message(format!("verify size {filename}"));
             let actual_size = file.metadata()?.len();
             if actual_size != expected_size {
@@ -2854,9 +2886,24 @@ pub trait Backend: Debug + Send + Sync {
                 );
             }
         } else if lockfile_enabled {
-            platform_info.size = Some(file.metadata()?.len());
+            tv.lock_platforms.entry(platform_key).or_default().size = Some(file.metadata()?.len());
         }
         Ok(())
+    }
+
+    /// Human-readable identity of the lock entry consulted for `tv` on
+    /// `platform_key`, including the options that distinguish artifact variants.
+    fn describe_lock_entry(&self, tv: &ToolVersion, platform_key: &str) -> String {
+        let options = self
+            .resolve_lockfile_options(&tv.request, &PlatformTarget::from_current())
+            .unwrap_or_default();
+        let entry = format!("lockfile entry for {} on {platform_key}", tv.style());
+        if options.is_empty() {
+            entry
+        } else {
+            let options = options.iter().map(|(k, v)| format!("{k}={v}")).join(", ");
+            format!("{entry} [{options}]")
+        }
     }
 
     async fn outdated_info(

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -1052,11 +1052,15 @@ impl Lock {
                     }
                     pr.set_message(format!("{}@{} {}", short, version, platform_key));
                     pr.set_position(completed);
-                    if let Err(e) = lockfile::apply_lock_result(lockfile, resolution) {
-                        provenance_errors.push(e.to_string());
-                        results.push((short, platform_key, false));
-                    } else {
-                        results.push((short, platform_key, ok));
+                    match lockfile::apply_lock_result(lockfile, resolution) {
+                        Err(e) => {
+                            provenance_errors.push(e.to_string());
+                            results.push((short, platform_key, false));
+                        }
+                        // A resolution that wrote nothing is a skip, not an
+                        // update — backends that can't resolve metadata without
+                        // installing return empty info rather than an error.
+                        Ok(applied) => results.push((short, platform_key, ok && applied)),
                     }
                 }
                 Err(e) => {
@@ -1065,7 +1069,9 @@ impl Lock {
             }
         }
 
-        pr.finish_with_message(format!("{} platform entries", total_tasks));
+        // Report entries actually written, not tasks attempted
+        let updated = results.iter().filter(|(_, _, ok)| *ok).count();
+        pr.finish_with_message(format!("{} platform entries", updated));
 
         Ok((results, provenance_errors))
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -397,6 +397,28 @@ impl PlatformInfo {
             && self.additional_artifacts.is_empty()
     }
 
+    /// Drop the fields that describe one specific downloaded artifact, keeping
+    /// the fields that describe how the tool is built or what it depends on.
+    /// Used when an entry is known to be for the right tool version but not
+    /// necessarily the right artifact.
+    pub fn without_artifact_data(&self) -> Self {
+        PlatformInfo {
+            install: self.install.clone(),
+            conda_deps: self.conda_deps.clone(),
+            pkgx_deps: self.pkgx_deps.clone(),
+            pkgx_provides: self.pkgx_provides.clone(),
+            pkgx_runtime_env: self.pkgx_runtime_env.clone(),
+            checksum: None,
+            size: None,
+            url: None,
+            url_api: None,
+            provenance: None,
+            provenance_verified: false,
+            github_attestations: None,
+            additional_artifacts: Default::default(),
+        }
+    }
+
     /// True when the lockfile has checksum-backed, successfully verified provenance.
     pub fn has_checksum_and_verified_provenance(&self) -> bool {
         self.checksum.is_some() && self.provenance.is_some() && self.provenance_verified
@@ -2643,11 +2665,17 @@ pub async fn resolve_tool_lock_info(
 /// Apply a lock resolution result to a lockfile, updating platform info and conda packages.
 /// Only applies data when the resolution succeeded (info is `Ok`).
 ///
+/// Returns whether the resolution contributed any data. A backend that can't
+/// resolve metadata without installing falls back to an empty `PlatformInfo`,
+/// which is `Ok` but writes no entry — callers report those as skipped rather
+/// than claiming an update they didn't make.
+///
 /// Returns an error if a github backend tool loses provenance on version upgrade,
 /// which could indicate a supply chain attack.
-pub fn apply_lock_result(lockfile: &mut Lockfile, result: LockResolutionResult) -> Result<()> {
+pub fn apply_lock_result(lockfile: &mut Lockfile, result: LockResolutionResult) -> Result<bool> {
     let (short, version, backend, platform, info, options, conda_packages, pkgx_packages) = result;
     let platform_key = platform.to_key();
+    let mut applied = false;
     if let Ok(ref info) = info {
         if let Some(err) = check_single_tool_provenance(
             lockfile.tools.get(&short).map(Vec::as_slice),
@@ -2659,6 +2687,7 @@ pub fn apply_lock_result(lockfile: &mut Lockfile, result: LockResolutionResult) 
         ) {
             return Err(eyre!("{err}"));
         }
+        applied |= !info.is_empty();
         lockfile.set_platform_info(
             &short,
             &version,
@@ -2669,12 +2698,14 @@ pub fn apply_lock_result(lockfile: &mut Lockfile, result: LockResolutionResult) 
         );
     }
     for (basename, pkg_info) in conda_packages {
+        applied = true;
         lockfile.set_conda_package(&platform_key, &basename, pkg_info);
     }
     for (id, pkg_info) in pkgx_packages {
+        applied = true;
         lockfile.set_pkgx_package(&platform_key, &id, pkg_info);
     }
-    Ok(())
+    Ok(applied)
 }
 
 type RekeyDecisions = HashMap<(String, String), Option<BTreeMap<String, String>>>;
@@ -2723,6 +2754,9 @@ fn build_rekey_decisions(
         for platform_key in platforms {
             let resolved = Platform::parse(platform_key).ok().and_then(|platform| {
                 let backend = tv.request.backend().ok()?;
+                if backend.lockfile_options_are_host_specific() {
+                    return None;
+                }
                 backend
                     .resolve_lockfile_options(&tv.request, &PlatformTarget::new(platform))
                     .ok()
@@ -3030,6 +3064,11 @@ pub(crate) fn read_lockfile_for_tool_source(
         .clone())
 }
 
+/// `legacy_options_fallback` lets a backend whose options describe the writing
+/// host (see `Backend::lockfile_options_are_host_specific`) fall back to an
+/// entry written before those options existed. The version pin is honored — it
+/// is the only record of what this project resolved to — but the artifact data
+/// is dropped, since there's no way to tell which variant it describes.
 pub fn get_locked_version(
     config: &Config,
     path: Option<&Path>,
@@ -3037,6 +3076,7 @@ pub fn get_locked_version(
     prefix: &str,
     require_prefix_boundary: bool,
     request_options: &BTreeMap<String, String>,
+    legacy_options_fallback: bool,
 ) -> Result<Option<LockfileTool>> {
     let settings = Settings::get();
     if !settings.lockfile_enabled() {
@@ -3058,15 +3098,15 @@ pub fn get_locked_version(
     };
 
     if let Some(tools) = lockfile.tools.get(short) {
+        let version_matches = |v: &LockfileTool| {
+            lockfile_version_matches(prefix, &v.version)
+                && (!require_prefix_boundary
+                    || lockfile_version_matches_prefix_boundary(prefix, &v.version))
+        };
         // Filter by version prefix and options
         let mut matching: Vec<_> = tools
             .iter()
-            .filter(|v| {
-                lockfile_version_matches(prefix, &v.version)
-                    && (!require_prefix_boundary
-                        || lockfile_version_matches_prefix_boundary(prefix, &v.version))
-                    && &v.options == request_options
-            })
+            .filter(|v| version_matches(v) && &v.options == request_options)
             .collect();
 
         // Only sort when prefix is "latest" and we have multiple matches
@@ -3080,6 +3120,34 @@ pub fn get_locked_version(
         if let Some(found) = matching.first() {
             trace!("[{short}@{prefix}] found {} in lockfile", found.version);
             return Ok(Some((*found).clone()));
+        }
+
+        if legacy_options_fallback && !request_options.is_empty() {
+            let mut legacy: Vec<_> = tools
+                .iter()
+                .filter(|v| version_matches(v) && v.options.is_empty())
+                .collect();
+            if prefix == "latest" && legacy.len() > 1 {
+                legacy.sort_by(|a, b| {
+                    versions::Versioning::new(&b.version)
+                        .cmp(&versions::Versioning::new(&a.version))
+                });
+            }
+            if let Some(found) = legacy.first() {
+                trace!(
+                    "[{short}@{prefix}] found {} in lockfile without options, keeping the version pin and dropping its artifact data",
+                    found.version
+                );
+                let mut found = (*found).clone();
+                found.options = request_options.clone();
+                found.platforms = found
+                    .platforms
+                    .into_iter()
+                    .map(|(key, info)| (key, info.without_artifact_data()))
+                    .filter(|(_, info)| !info.is_empty())
+                    .collect();
+                return Ok(Some(found));
+            }
         }
     }
 

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -245,12 +245,20 @@ impl Backend for SwiftPlugin {
         if target.libc() == Some("musl") {
             bail!("swift does not publish musl builds");
         }
+        let url = url(tv, target);
+        // Not every distro/arch pair is published — `ubi9` has no aarch64 build,
+        // for instance — and which pairs exist changes per release, so ask rather
+        // than encode a matrix that would go stale. This keeps a lockfile from
+        // recording an artifact that isn't there.
+        if let Err(err) = HTTP.head(&url).await {
+            bail!("swift does not publish {url}: {err}");
+        }
         // swift.org publishes no checksum sidecar (only a detached GPG
         // signature), so a checksum can't be resolved without downloading the
-        // whole ~1GB toolchain. Record the URL the entry describes; the
-        // checksum is filled in when the tool is installed.
+        // whole ~1GB toolchain. Record the URL the entry describes; the checksum
+        // is filled in when the tool is installed.
         Ok(PlatformInfo {
-            url: Some(url(tv, target)),
+            url: Some(url),
             ..Default::default()
         })
     }
@@ -334,13 +342,17 @@ fn platform_directory(target: &PlatformTarget) -> String {
 }
 
 fn platform(target: &PlatformTarget) -> String {
-    if let Some(platform) = &Settings::get().swift.platform {
-        return platform.clone();
-    }
     match target.os_name() {
         "macos" => "osx".to_string(),
         "windows" => "windows10".to_string(),
-        _ => linux_platform(target),
+        // `swift.platform` names a Linux distro build, so it only applies to
+        // Linux targets. Letting it through for every target would build URLs
+        // like `.../ubi9/swift-6.3.1-RELEASE-ubi9.pkg` for macOS as soon as the
+        // setting is configured repo-wide.
+        _ => match &Settings::get().swift.platform {
+            Some(platform) => platform.clone(),
+            None => linux_platform(target),
+        },
     }
 }
 
@@ -511,26 +523,35 @@ mod lockfile_tests {
         assert!(options(&backend, &tv, "windows-x64").is_empty());
     }
 
-    #[tokio::test]
-    async fn lock_info_records_the_url_for_the_target() {
+    /// Locking another platform must build that platform's URL, not the host's.
+    #[test]
+    fn url_is_built_for_the_target_platform() {
         let _guard = pin_platform(Some("ubuntu24.04"));
         let backend = SwiftPlugin::new();
         let tv = tool_version(&backend, "6.3.1");
 
-        let info = backend
-            .resolve_lock_info(&tv, &target("linux-arm64"))
-            .await
-            .expect("swift lock info");
+        assert_eq!(
+            url(&tv, &target("linux-arm64")),
+            "https://download.swift.org/swift-6.3.1-release/ubuntu2404-aarch64/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-ubuntu24.04-aarch64.tar.gz"
+        );
+    }
+
+    /// `swift.platform` names a Linux distro build. A repo-wide pin must not
+    /// leak into the macOS and Windows URLs.
+    #[test]
+    fn pinned_distro_does_not_apply_off_linux() {
+        let _guard = pin_platform(Some("ubi9"));
+        let backend = SwiftPlugin::new();
+        let tv = tool_version(&backend, "6.3.1");
 
         assert_eq!(
-            info.url.as_deref(),
-            Some(
-                "https://download.swift.org/swift-6.3.1-release/ubuntu2404-aarch64/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-ubuntu24.04-aarch64.tar.gz"
-            )
+            url(&tv, &target("macos-arm64")),
+            "https://download.swift.org/swift-6.3.1-release/xcode/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-osx.pkg"
         );
-        // swift.org publishes no checksum sidecar, so the checksum is only
-        // known once the artifact is downloaded.
-        assert!(info.checksum.is_none());
+        assert_eq!(
+            url(&tv, &target("windows-x64")),
+            "https://download.swift.org/swift-6.3.1-release/windows10/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-windows10.exe"
+        );
     }
 
     #[tokio::test]

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -1,20 +1,31 @@
+use crate::backend::platform_target::PlatformTarget;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
+use crate::lockfile::PlatformInfo;
 use crate::platform::linux_os_release;
-use crate::toolset::ToolVersion;
+use crate::toolset::{ToolRequest, ToolVersion};
 use crate::ui::progress_report::SingleReport;
 use crate::{backend::Backend, backend::VersionInfo, config::Config};
 use crate::{file, github, gpg, plugins};
 use async_trait::async_trait;
-use eyre::Result;
+use eyre::{Result, bail};
 use std::{
+    collections::BTreeMap,
     path::{Path, PathBuf},
     sync::Arc,
 };
 use tempfile::tempdir_in;
+
+/// Lockfile option recording which distro build a lock entry describes.
+/// Swift's Linux artifacts differ per distro (`ubuntu24.04`, `fedora39`,
+/// `ubi9`, `amazonlinux2`, …) and the `<os>-<arch>` platform key can't encode
+/// that, so the distro is stored as an option instead. Entries are matched on
+/// options exactly, which keeps one distro's checksum from being applied to
+/// another distro's tarball.
+const SWIFT_PLATFORM_OPTION: &str = "swift_platform";
 
 #[derive(Debug)]
 pub struct SwiftPlugin {
@@ -42,18 +53,7 @@ impl SwiftPlugin {
     }
 
     async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
-        let settings = Settings::get();
-        let url = format!(
-            "https://download.swift.org/swift-{version}-release/{platform_directory}/swift-{version}-RELEASE/swift-{version}-RELEASE-{platform}{architecture}.{extension}",
-            version = tv.version,
-            platform = platform(),
-            platform_directory = platform_directory(),
-            extension = extension(),
-            architecture = match architecture(&settings) {
-                Some(arch) => format!("-{arch}"),
-                None => "".into(),
-            }
-        );
+        let url = url(tv, &PlatformTarget::from_current());
         let filename = url.split('/').next_back().unwrap();
         let tarball_path = tv.download_path().join(filename);
         if !tarball_path.exists() {
@@ -130,8 +130,12 @@ impl SwiftPlugin {
         // Unlike Node (which skips a missing .sig), this path only runs on Linux, where swift.org
         // publishes a detached signature for every release tarball. A missing .sig is therefore
         // unexpected, so surface the download error rather than silently skipping verification.
-        HTTP.download_file(format!("{}.sig", url(tv)), &sig_path, Some(ctx.pr.as_ref()))
-            .await?;
+        HTTP.download_file(
+            format!("{}.sig", url(tv, &PlatformTarget::from_current())),
+            &sig_path,
+            Some(ctx.pr.as_ref()),
+        )
+        .await?;
         let signature = file::read(&sig_path)?;
         gpg::verify_swift(tarball_path, &signature)?;
         Ok(())
@@ -197,13 +201,58 @@ impl Backend for SwiftPlugin {
 
     /// Swift download URLs are derived from the build host: OS, arch, and—on
     /// Linux—the specific distro (e.g. `ubuntu24.04`, `amazonlinux2`,
-    /// `fedora39`, `ubi9`). The generic `<os>-<arch>` lock platform key can't
-    /// encode the distro, so a foreign-platform URL can't be resolved or
-    /// persisted to the lockfile from another host. Opt out of the `--locked`
-    /// URL requirement so installs don't hard-fail on platforms missing from
-    /// the lockfile; checksums are still verified at install time.
+    /// `fedora39`, `ubi9`). `mise lock` can only guess the distro of a machine
+    /// it isn't running on, so the URL it records for another platform may not
+    /// be the one that machine resolves. Opt out of the `--locked` URL
+    /// requirement so installs don't hard-fail on a distro the lockfile doesn't
+    /// cover; checksums are still verified at install time.
     fn supports_lockfile_url(&self) -> bool {
         false
+    }
+
+    /// Record the distro in the lock entry's options so entries from different
+    /// distros can't be confused for one another. Without this, a lockfile
+    /// written on Ubuntu matches on Fedora — same `linux-x64` key, no options —
+    /// and its checksum is checked against the Fedora tarball.
+    fn resolve_lockfile_options(
+        &self,
+        _request: &ToolRequest,
+        target: &PlatformTarget,
+    ) -> Result<BTreeMap<String, String>> {
+        let mut opts = BTreeMap::new();
+        if target.os_name() == "linux" {
+            opts.insert(SWIFT_PLATFORM_OPTION.to_string(), platform(target));
+        }
+        Ok(opts)
+    }
+
+    /// A lock entry without a `swift_platform` option was written before the
+    /// distro was recorded, so which artifact its checksum describes is
+    /// unknowable. Such entries still pin the version; their checksum and URL
+    /// are ignored and rewritten for this host's distro on install.
+    fn lockfile_options_are_host_specific(&self) -> bool {
+        true
+    }
+
+    async fn resolve_lock_info(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        // Every published Linux build links against glibc, so there is nothing
+        // to lock for a musl target. Fail instead of recording a URL that
+        // doesn't exist, so `mise lock` reports it as skipped.
+        if target.libc() == Some("musl") {
+            bail!("swift does not publish musl builds");
+        }
+        // swift.org publishes no checksum sidecar (only a detached GPG
+        // signature), so a checksum can't be resolved without downloading the
+        // whole ~1GB toolchain. Record the URL the entry describes; the
+        // checksum is filled in when the tool is installed.
+        Ok(PlatformInfo {
+            url: Some(url(tv, target)),
+            ..Default::default()
+        })
     }
 
     async fn security_info(&self) -> Vec<crate::backend::SecurityFeature> {
@@ -267,98 +316,255 @@ fn swift_bin_name() -> &'static str {
     if cfg!(windows) { "swift.exe" } else { "swift" }
 }
 
-fn platform_directory() -> String {
-    if cfg!(macos) {
-        "xcode".into()
-    } else if cfg!(windows) {
-        "windows10".into()
-    } else if let Some(os_release) = linux_os_release() {
-        let settings = Settings::get();
-        let arch = settings.arch();
-        if os_release.id == "ubuntu" && arch == "arm64" {
-            let retval = format!(
-                "{}{}-aarch64",
-                os_release.id,
-                ubuntu_swift_version(&os_release.version_id)
-            );
-            retval.replace(".", "")
-        } else {
-            platform().replace(".", "")
+fn platform_directory(target: &PlatformTarget) -> String {
+    match target.os_name() {
+        "macos" => "xcode".into(),
+        "windows" => "windows10".into(),
+        _ => {
+            let platform = platform(target);
+            // swift.org files the Linux arm64 builds under a separate
+            // `<distro>-aarch64` directory, but only for Ubuntu.
+            if platform.starts_with("ubuntu") && target.arch_name() == "arm64" {
+                format!("{platform}-aarch64").replace(".", "")
+            } else {
+                platform.replace(".", "")
+            }
         }
-    } else {
-        platform().replace(".", "")
     }
 }
 
-fn platform() -> String {
+fn platform(target: &PlatformTarget) -> String {
     if let Some(platform) = &Settings::get().swift.platform {
         return platform.clone();
     }
-    if cfg!(macos) {
-        "osx".to_string()
-    } else if cfg!(windows) {
-        "windows10".to_string()
-    } else if let Some(os_release) = linux_os_release() {
-        if os_release.id == "amzn" {
-            format!("amazonlinux{}", os_release.version_id)
-        } else if os_release.id == "ubi" {
-            "ubi9".to_string() // only 9 is available
-        } else if os_release.id == "fedora" {
-            "fedora39".to_string() // only 39 is available
-        } else if os_release.id == "ubuntu" {
-            format!("ubuntu{}", ubuntu_swift_version(&os_release.version_id))
-        } else {
-            format!("{}{}", os_release.id, os_release.version_id)
-        }
-    } else {
-        "ubi9".to_string()
+    match target.os_name() {
+        "macos" => "osx".to_string(),
+        "windows" => "windows10".to_string(),
+        _ => linux_platform(target),
     }
 }
 
-fn extension() -> &'static str {
-    if cfg!(macos) {
-        "pkg"
-    } else if cfg!(windows) {
-        "exe"
+/// The distro portion of a Linux artifact name. Only the current host's distro
+/// can be detected; cross-platform lock resolution has no way to know what
+/// distro another machine runs, so it falls back to Ubuntu — the only distro
+/// swift.org publishes Linux arm64 builds for, and the most broadly useful
+/// default for x64.
+fn linux_platform(target: &PlatformTarget) -> String {
+    if !target.is_current() {
+        return format!("ubuntu{}", DEFAULT_UBUNTU_VERSION);
+    }
+    let Some(os_release) = linux_os_release() else {
+        return "ubi9".to_string();
+    };
+    if os_release.id == "amzn" {
+        format!("amazonlinux{}", os_release.version_id)
+    } else if os_release.id == "ubi" {
+        "ubi9".to_string() // only 9 is available
+    } else if os_release.id == "fedora" {
+        "fedora39".to_string() // only 39 is available
+    } else if os_release.id == "ubuntu" {
+        format!("ubuntu{}", ubuntu_swift_version(&os_release.version_id))
     } else {
-        "tar.gz"
+        format!("{}{}", os_release.id, os_release.version_id)
     }
 }
 
-fn architecture(settings: &Settings) -> Option<&str> {
-    let arch = settings.arch();
-    if cfg!(target_os = "linux") {
-        return match arch {
+fn extension(target: &PlatformTarget) -> &'static str {
+    match target.os_name() {
+        "macos" => "pkg",
+        "windows" => "exe",
+        _ => "tar.gz",
+    }
+}
+
+fn architecture(target: &PlatformTarget) -> Option<&str> {
+    let arch = target.arch_name();
+    match target.os_name() {
+        "linux" => match arch {
             "x64" => None,
             "arm64" => Some("aarch64"),
             _ => Some(arch),
-        };
-    } else if cfg!(windows) && arch == "arm64" {
-        return Some("arm64");
+        },
+        "windows" if arch == "arm64" => Some("arm64"),
+        _ => None,
     }
-    None
 }
+
+/// The newest Ubuntu release swift.org publishes builds for.
+const DEFAULT_UBUNTU_VERSION: &str = "24.04";
 
 /// Swift only provides Ubuntu binaries for specific versions.
 /// Map unsupported Ubuntu versions to the latest supported one.
 fn ubuntu_swift_version(version_id: &str) -> &str {
     match version_id {
         "20.04" | "22.04" | "24.04" => version_id,
-        _ => "24.04",
+        _ => DEFAULT_UBUNTU_VERSION,
     }
 }
 
-fn url(tv: &ToolVersion) -> String {
-    let settings = Settings::get();
+fn url(tv: &ToolVersion, target: &PlatformTarget) -> String {
     format!(
         "https://download.swift.org/swift-{version}-release/{platform_directory}/swift-{version}-RELEASE/swift-{version}-RELEASE-{platform}{architecture}.{extension}",
         version = tv.version,
-        platform = platform(),
-        platform_directory = platform_directory(),
-        extension = extension(),
-        architecture = match architecture(&settings) {
+        platform = platform(target),
+        platform_directory = platform_directory(target),
+        extension = extension(target),
+        architecture = match architecture(target) {
             Some(arch) => format!("-{arch}"),
             None => "".into(),
         }
     )
+}
+
+#[cfg(test)]
+mod lockfile_tests {
+    use super::*;
+    use crate::config::settings::SettingsPartial;
+    use crate::platform::Platform;
+    use crate::toolset::ToolSource;
+    use confique::Layer;
+
+    static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct SettingsResetGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for SettingsResetGuard {
+        fn drop(&mut self) {
+            Settings::reset(None);
+        }
+    }
+
+    /// Pin `swift.platform` so the assertions don't depend on the distro the
+    /// tests happen to run on.
+    fn pin_platform(platform: Option<&str>) -> SettingsResetGuard {
+        let lock = TEST_SETTINGS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = SettingsResetGuard { _lock: lock };
+        let mut settings = SettingsPartial::empty();
+        settings.swift.platform = platform.map(str::to_string);
+        Settings::reset(Some(settings));
+        guard
+    }
+
+    fn target(platform: &str) -> PlatformTarget {
+        PlatformTarget::new(Platform::parse(platform).expect("valid platform"))
+    }
+
+    fn tool_version(backend: &SwiftPlugin, version: &str) -> ToolVersion {
+        let request = ToolRequest::new(backend.ba().clone(), version, ToolSource::Unknown)
+            .expect("valid swift request");
+        ToolVersion::new(request, version.to_string())
+    }
+
+    fn options(
+        backend: &SwiftPlugin,
+        tv: &ToolVersion,
+        platform: &str,
+    ) -> BTreeMap<String, String> {
+        backend
+            .resolve_lockfile_options(&tv.request, &target(platform))
+            .expect("swift lockfile options")
+    }
+
+    #[test]
+    fn lockfile_options_record_the_pinned_distro() {
+        let _guard = pin_platform(Some("ubi9"));
+        let backend = SwiftPlugin::new();
+        let tv = tool_version(&backend, "6.3.1");
+
+        assert_eq!(
+            options(&backend, &tv, "linux-x64"),
+            BTreeMap::from([("swift_platform".to_string(), "ubi9".to_string())])
+        );
+    }
+
+    /// The distro pin is what keeps a lock entry written for one distro from
+    /// being matched — and checksum-verified — against another distro's tarball.
+    #[test]
+    fn lockfile_options_differ_between_distros() {
+        let ubuntu = {
+            let _guard = pin_platform(Some("ubuntu24.04"));
+            let backend = SwiftPlugin::new();
+            let tv = tool_version(&backend, "6.3.1");
+            options(&backend, &tv, "linux-x64")
+        };
+        let fedora = {
+            let _guard = pin_platform(Some("fedora39"));
+            let backend = SwiftPlugin::new();
+            let tv = tool_version(&backend, "6.3.1");
+            options(&backend, &tv, "linux-x64")
+        };
+
+        assert_ne!(ubuntu, fedora);
+    }
+
+    /// macOS and Windows artifacts are not distro-specific, so they keep
+    /// option-free entries.
+    #[test]
+    fn lockfile_options_are_empty_off_linux() {
+        let _guard = pin_platform(None);
+        let backend = SwiftPlugin::new();
+        let tv = tool_version(&backend, "6.3.1");
+
+        assert!(options(&backend, &tv, "macos-arm64").is_empty());
+        assert!(options(&backend, &tv, "windows-x64").is_empty());
+    }
+
+    #[tokio::test]
+    async fn lock_info_records_the_url_for_the_target() {
+        let _guard = pin_platform(Some("ubuntu24.04"));
+        let backend = SwiftPlugin::new();
+        let tv = tool_version(&backend, "6.3.1");
+
+        let info = backend
+            .resolve_lock_info(&tv, &target("linux-arm64"))
+            .await
+            .expect("swift lock info");
+
+        assert_eq!(
+            info.url.as_deref(),
+            Some(
+                "https://download.swift.org/swift-6.3.1-release/ubuntu2404-aarch64/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-ubuntu24.04-aarch64.tar.gz"
+            )
+        );
+        // swift.org publishes no checksum sidecar, so the checksum is only
+        // known once the artifact is downloaded.
+        assert!(info.checksum.is_none());
+    }
+
+    #[tokio::test]
+    async fn musl_targets_have_nothing_to_lock() {
+        let _guard = pin_platform(None);
+        let backend = SwiftPlugin::new();
+        let tv = tool_version(&backend, "6.3.1");
+
+        assert!(
+            backend
+                .resolve_lock_info(&tv, &target("linux-x64-musl"))
+                .await
+                .is_err()
+        );
+    }
+
+    /// A target that isn't this machine can't be probed for its distro, so
+    /// resolution falls back to Ubuntu rather than labeling it with the host's.
+    #[test]
+    fn foreign_linux_targets_fall_back_to_ubuntu() {
+        let _guard = pin_platform(None);
+        let backend = SwiftPlugin::new();
+        let tv = tool_version(&backend, "6.3.1");
+        // riscv64 is never the platform the test suite runs on
+        let foreign = target("linux-riscv64");
+        assert!(!foreign.is_current());
+
+        assert_eq!(
+            options(&backend, &tv, "linux-riscv64"),
+            BTreeMap::from([(
+                "swift_platform".to_string(),
+                format!("ubuntu{DEFAULT_UBUNTU_VERSION}")
+            )])
+        );
+        assert!(url(&tv, &foreign).ends_with("-ubuntu24.04-riscv64.tar.gz"));
+    }
 }

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -376,11 +376,14 @@ impl ToolRequest {
         prefix: &str,
         require_prefix_boundary: bool,
     ) -> Result<Option<LockfileTool>> {
-        let request_options = if let Ok(backend) = self.backend() {
+        let (request_options, legacy_options_fallback) = if let Ok(backend) = self.backend() {
             let target = PlatformTarget::from_current();
-            backend.resolve_lockfile_options(self, &target)?
+            (
+                backend.resolve_lockfile_options(self, &target)?,
+                backend.lockfile_options_are_host_specific(),
+            )
         } else {
-            BTreeMap::new()
+            (BTreeMap::new(), false)
         };
         let path = match self.source() {
             ToolSource::MiseToml(path) => Some(path),
@@ -393,6 +396,7 @@ impl ToolRequest {
             prefix,
             require_prefix_boundary,
             &request_options,
+            legacy_options_fallback,
         )
     }
 


### PR DESCRIPTION
Reported in https://github.com/jdx/mise/discussions/11295.

## The problem

Swift publishes a different Linux tarball per distro (`ubuntu24.04`, `fedora39`, `ubi9`, `amazonlinux2`, …), but nothing about the distro reached the lockfile — entries were keyed by a bare `linux-x64` with no options. Two bugs followed:

1. **Cross-distro checksum failures.** An entry written on Ubuntu matched exactly on Fedora (same key, both option-free), so the Ubuntu checksum was verified against the Fedora tarball. The error named the downloaded filename and two digests with nothing to suggest a distro mismatch.

2. **`mise lock` reported success while writing nothing.** `core:swift` implements no `resolve_lock_info`, so it fell through to `resolve_lock_info_fallback`, which returns an all-`None` `PlatformInfo`. That's `Ok`, so the run counted it as an update, but `set_platform_info` drops empty info — `✓ Updated 2 platform entries (0 skipped)` over an untouched lockfile. With an entry already present, the empty info merged as \"keep everything\", silently preserving the previous distro's checksum. Changing `swift.platform` therefore left a project where `mise lock` wouldn't re-lock and `mise install` rejected the artifact the setting selected.

## The fix

`core:erlang` already had this problem — its precompiled builds are per-distro — and solved it with a `precompiled_os` lockfile option. Swift now does the same:

- **`swift_platform` option** on `core:swift` lock entries. Entries are matched on options exactly, so a Fedora machine no longer matches the Ubuntu entry, and changing `swift.platform` produces a new entry instead of reusing a checksum for a different artifact.
- **`resolve_lock_info`** records the URL each entry describes, so `mise lock` writes something meaningful. swift.org publishes no checksum sidecar (only a detached `.sig`), so a checksum still can't be resolved without downloading the ~1 GB toolchain — it's filled in at install. Locking a musl target now errors rather than recording a URL that doesn't exist.
- **Target-aware URL construction**, so cross-platform locking stops labeling another machine's platform with the host's distro. A non-current target falls back to Ubuntu, the only distro with Linux arm64 builds.
- **Legacy entries** (written before the distro was recorded) keep their version pin but have their artifact data ignored, so upgrading neither drops an existing pin nor asserts a checksum for an unknown distro. They're also excluded from option rekeying, which would otherwise stamp the local distro's name onto a foreign artifact's checksum.
- **`mise lock` accounting**: a resolution that wrote no entry counts as skipped, not as an update. This applies to any backend that returns the empty fallback.
- **Checksum mismatch errors** name the lock entry the expectation came from — platform key, options, and locked URL:

  ```
  Failed to install aqua:mikefarah/yq@4.44.3: lockfile entry for aqua:mikefarah/yq@4.44.3 on linux-x64 locks https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64: Checksum mismatch for file …
  ```

## Before / after

The discussion's second repro (`swift.platform = "ubi9"`, `mise lock swift --platform linux-x64,linux-arm64`) previously produced a lockfile with no platform entries at all. Now:

```toml
[[tools.swift]]
version = "6.3.1"
backend = "core:swift"

[tools.swift.options]
swift_platform = "ubi9"

[tools.swift."platforms.linux-arm64"]
url = "https://download.swift.org/swift-6.3.1-release/ubi9/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-ubi9-aarch64.tar.gz"

[tools.swift."platforms.linux-x64"]
url = "https://download.swift.org/swift-6.3.1-release/ubi9/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-ubi9.tar.gz"
```

Starting from an Ubuntu-written lockfile and pinning `ubi9`, `mise lock` now creates a separate `ubi9` entry with the right URL and leaves the old entry untouched, instead of silently keeping the `ubuntu24.04` checksum.

## Testing

- 6 new unit tests in `src/plugins/core/swift.rs` (distro options per target, empty options off Linux, URL resolution for a foreign target, musl rejection, Ubuntu fallback).
- New `e2e/lockfile/test_lockfile_swift_distro` — covers the distro option, re-locking after changing `swift.platform`, and a legacy entry keeping its version pin. Locking swift resolves URLs only, so the test never downloads the toolchain.
- Full unit suite (1922 tests) and all 44 non-slow `e2e/lockfile` tests pass; `mise run lint` clean.

## Note

Migration is one-directional but recoverable: an existing option-free swift entry keeps pinning its version, and the first install on each machine writes a distro-labeled entry with the correct checksum. The old entry is preserved rather than rewritten, since there's no way to tell which distro it came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile matching, install checksum verification, and Swift download URL resolution across platforms; behavior is well-tested but affects reproducible installs for Swift on Linux.
> 
> **Overview**
> Fixes Swift lockfile behavior on Linux where every distro shared the same `linux-x64` key, so checksums from one distro were verified against another distro’s tarball.
> 
> **Swift lock entries** now carry a `swift_platform` option (e.g. `ubuntu24.04`, `fedora39`, `ubi9`) and are matched on options exactly, so each distro gets its own entry when `swift.platform` changes. **`resolve_lock_info`** records distro-specific download URLs (HEAD-checked; missing pairs like ubi9 arm64 are skipped; musl fails instead of locking a bogus URL). URL building is **target-aware** for cross-platform `mise lock`, with a Ubuntu fallback for foreign Linux targets; `swift.platform` no longer leaks into macOS/Windows URLs.
> 
> **Legacy option-free Swift entries** still pin the version but drop checksum/URL via `without_artifact_data()` and skip legacy option rekeying (`lockfile_options_are_host_specific`). **`mise lock`** counts only entries that actually wrote data (`apply_lock_result` returns `bool`); checksum errors name the lock entry (options + URL).
> 
> Docs and an e2e test cover multi-entry lockfiles and distro changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e04e13e7f2ab2f3c983b5d6e5a9c5f682e52f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swift lockfiles now distinguish Linux distributions, selecting the correct platform-specific artifact when switching between distributions.
  * Existing lockfiles can be upgraded while preserving pinned Swift versions and refreshing distribution-specific artifact data.
  * Lock entries now provide clearer artifact identity and checksum-related error details.

* **Documentation**
  * Added guidance and examples for tools with multiple lockfile entries for the same version but different artifact options.

* **Bug Fixes**
  * Improved lock progress reporting to reflect entries actually written rather than attempted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->