### PR TITLE
registry: fix croc version test expectation

### DIFF
--- a/registry/croc.toml
+++ b/registry/croc.toml
@@ -1,3 +1,3 @@
 backends = ["aqua:schollz/croc"]
 description = "Easily and securely send things from one computer to another 🐊 📦"
-test = { cmd = "croc --version", expected = "croc version v{{version}}" }
+test = { cmd = "croc --version", expected = "croc version {{version}}" }


### PR DESCRIPTION
Upstream dropped the leading `v` from `croc --version`, so the registry expectation no longer matches:

```
expected output not found: croc version v10.6.0, got: croc version 10.6.0
```

One of the tools failing a full `mise test-tool --all` sweep — see #11237, where a renovate `actions/checkout` digest bump touched `.github/workflows/registry.yml` and so ran the whole registry.

## heroku was dropped from this PR

This PR originally also carried a `trust_policy_excludes = ["@hono/node-server@1.19.15"]` entry on `registry/heroku.toml`, for a `trustPolicy=no-downgrade` rejection of that transitive dependency.

That's now fixed upstream instead: jdx/aube#1113 adds `@hono/node-server` to aube's built-in `DEFAULT_TRUST_POLICY_EXCLUDES`, so every consumer gets it rather than just this one registry entry. Dropped here optimistically rather than merged-then-reverted.

The review that justified it, for the record — `@hono/node-server` 2.x is CI-published with SLSA provenance while 1.x backports are hand-published by the sole maintainer without attestation, so 1.19.15 (2026-07-24) landing after the attested 2.0.10 (2026-07-15) is a real provenance regression but a benign one:

| | 2.0.10 | 1.19.15 |
|---|---|---|
| publisher | `GitHub Actions` | `yusukebe` (manual) |
| SLSA provenance | yes | **none** |
| registry signature | yes | yes |

**heroku therefore stays red until aube cuts a release containing that commit and mise bumps to it.** `bcbe59c` merged after the `v1.33.0` tag, and 1.33.0 is still the newest crates.io release, so the bump already landed in #11302 does not include it. Nothing in this PR depends on that — croc is independent.

## Verification

```
$ mise test-tool croc
mise $ .../installs/croc/latest/croc --version
croc version 10.6.0
mise croc: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry test string change with no runtime or install behavior impact.
> 
> **Overview**
> Updates the **croc** registry smoke test so `mise test-tool croc` matches current CLI output.
> 
> Upstream **croc** now prints `croc version 10.6.0` instead of `croc version v10.6.0`, so the expected string in `registry/croc.toml` drops the literal `v` before `{{version}}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c453b44c84ffd3bfcb9cdf7347f8af4a2fa260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected version output formatting in test expectations by removing the unintended `v` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->