### PR TITLE
chore(deps): update aube crates to v1.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "937ba27a96fe9311f73a2ee9fe2a5efdc06b3323bf832337c3f9f0d8f28657f1"
+checksum = "5257ecfdaa63cae0fde1d171f482d60c1c5f86a0203c4e5afaa8f82dc8564c8f"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -591,7 +591,7 @@ dependencies = [
  "ci_info",
  "clap",
  "clap_usage",
- "clx 2.1.1",
+ "clx",
  "console",
  "demand",
  "diffy",
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc04a075a2022e1e0099bebd6bf8f0f4061df10d491e4d9af30597e5f6ae919"
+checksum = "9c42cb2c2e2bfc354c95b96095b159d7cb66600fad3e6b517340ea1f653ed7da"
 dependencies = [
  "serde",
  "serde_json",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ef5d3896d505c334f11a6eb0e887c79126275c14f0330538caff063f881f6b"
+checksum = "23a0c79d06a213a26e090061728fc5de2c08788192515ffaf05c1a412614841b"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b833b8b5ed6ae74faa8c5f89e2ad6bf1f9bb8261edbd17524fb45997fd3c9f15"
+checksum = "00832e6deead454ac1e6cb6e0cb7682a63265b568333c76de1ad6782cc55cbcc"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5623df032108290ba325050fe728cd2108503ca0a871539c4efd2e2027f7b011"
+checksum = "8efe1369bc42c0f5bbcf49faa83dea8a796f91d6b1b01b9e826f4830a15ea4c2"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c88cf69ccdb1bb87b6760e5a016a6c9f062e6f4eef87c1c53211170ea438f1c"
+checksum = "64c9fee17d19cf956f5a3bafc7e6ab31dd1e5dad5a152efba1c398eebd41c556"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4f3fd114312f073d4066ac6d56c34cb7d8e90412252e7eb852d1ffb503fda6"
+checksum = "c1180168e831e73632599fe8fa8c39beb4833a121436ec43da65039c1668c591"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2841ffaca859ffbb0615331e321fb3b9f8d0a4286f672fb0eeeca7f8dec36a"
+checksum = "a32ebada99f8ee90bb76dc61e62605c4db4cc63725041afe4a0d931b7cfb628c"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4989123bd09bf08eb384a105ac442963258e57cfe6e1f3721aa13c9edb39d233"
+checksum = "7046aeaebec3356bfb029dae290573493b37ee9e5bafe9c5e4e4053b05c6491a"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9fd6881256ad7d7fedef2439d6b14290df7c35a2bf6e801c1cf206083a9aaa"
+checksum = "fa2f09dd012bb64e1fc0fcb5ed92ba7f38acd3fe3df2c5e94923acf09a1d3f21"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a4fd231797170572d902d724b37f8856156bab128471133662a9da700062fa"
+checksum = "b8938d12c68812bd28a4e4fe4bbbd0116293ce12edbbf63309dface0b617ffe3"
 dependencies = [
  "aube-util",
  "base64 0.22.1",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a164be1cb18767f7ca807dcd6c8263b5e36370a6e484fb2329f4fbf9d13c7e2f"
+checksum = "34914d569dc2ee5e0287a5cc33d18f8528e5b13aaeaf4f596daebc9b2b8cae41"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6e9fc70400dc7ea28378dc7888d9a913c0a0dbbfc5bc31701090521948adc8"
+checksum = "630b803a55740a7b2e1c63543a5520744f534c7819db9d43c157bc71a66c05d3"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -2062,22 +2062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
 dependencies = [
  "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "clx"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2a26324918dd5018f3bb2f0a886dde591ec7248fba8e4d947fe43b6f572e5f"
-dependencies = [
- "console",
- "nix 0.31.3",
- "serde",
- "serde_json",
- "strum 0.28.0",
- "tera 1.20.1",
- "thiserror 2.0.19",
- "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6388,7 +6372,7 @@ dependencies = [
  "ci_info",
  "clap",
  "clap-sort",
- "clx 3.0.0",
+ "clx",
  "color-eyre",
  "color-print",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,10 @@ opt-level = 3
 [dependencies]
 age = { version = "0.12", features = ["ssh"] }
 aho-corasick = "1"
-aube-registry = { version = "1.32", default-features = false, features = [
+aube-registry = { version = "1.33", default-features = false, features = [
   "rustls",
 ] }
-aube = { version = "1.32", default-features = false, features = ["rustls"] }
+aube = { version = "1.33", default-features = false, features = ["rustls"] }
 async-backtrace = "0.2"
 async-trait = "0.1"
 aws-config = { version = "1.5", default-features = false, features = [

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -18,6 +18,7 @@ use crate::semver::{semver_is_at_least, semver_is_older_than};
 use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use async_trait::async_trait;
+use aube::embed::EmbedderRuntime;
 use jiff::Timestamp;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -895,7 +896,7 @@ impl NPMBackend {
             // dependency, so `allow_builds` installs work even when node isn't
             // on the ambient PATH (the in-process installer doesn't inherit the
             // per-command PATH the old `aube add --global` subprocess got).
-            node_bin_dir: self.aube_embed_node_bin_dir(ctx).await,
+            runtime: self.aube_embed_runtime(ctx).await,
             ..Default::default()
         };
         opts.ignore_scripts = matches!(allow_builds, AllowBuilds::None);
@@ -923,13 +924,18 @@ impl NPMBackend {
         eyre::eyre!(build_aube_install_error_message(&err, &self.ba().full()))
     }
 
-    /// Directory containing the `node` mise resolved as a dependency, handed to
-    /// the embedded aube installer so lifecycle scripts spawn on it. `None` (no
-    /// node dependency resolved) lets aube fall back to an ambient `node`.
-    async fn aube_embed_node_bin_dir(&self, ctx: &InstallContext) -> Option<PathBuf> {
+    /// The `node` mise resolved as a dependency, handed to the embedded aube
+    /// installer so lifecycle scripts spawn on it. `None` (no node dependency
+    /// resolved) lets aube fall back to an ambient `node`.
+    ///
+    /// `selector` is the version-manager shape: mise hands over a real bin dir
+    /// holding `node`/`npm`/`npx`, aube prepends it to PATH and uses that node
+    /// for both `NODE` and `npm_node_execpath`. (`wrapper` is for hosts that
+    /// interpose a shim on `node`; mise resolves the real binary here.)
+    async fn aube_embed_runtime(&self, ctx: &InstallContext) -> Option<EmbedderRuntime> {
         let ts = self.dependency_toolset(&ctx.config).await.ok()?;
         let node = ts.which_bin(&ctx.config, "node").await?;
-        node.parent().map(Path::to_path_buf)
+        node.parent().map(EmbedderRuntime::selector)
     }
 
     /// Write the throwaway project's `package.json` + `.npmrc` for an embedded


### PR DESCRIPTION
Bumps `aube` and `aube-registry` 1.32 → 1.33 (all 13 crates move in lockstep).

## Breaking change accounted for

[jdx/aube#1086](https://github.com/jdx/aube/pull/1086) replaced `AddToProjectOptions::node_bin_dir: Option<PathBuf>` with `runtime: Option<EmbedderRuntime>` so hosts can *wrap* node, not just select one. mise only selects, so this uses `EmbedderRuntime::selector(bin_dir)` — aube documents it as "the degenerate case that reproduces the pre-wrapper `node_bin_dir` behavior", and names mise as the motivating example. Behavior is unchanged: lifecycle scripts still run on the node mise resolved as a dependency.

## Behavior change worth knowing about (no mise change needed)

[jdx/aube#1106](https://github.com/jdx/aube/pull/1106) dropped `vite` and `vitepress` from `disableGlobalVirtualStoreForPackages`. aube now writes `node_modules/.modules.yaml` with the store location, which **Vite 8.1+** reads for its filesystem allow-list — so those installs keep the global virtual store instead of falling back to per-project materialization. `next`, `nuxt`, and `parcel` still auto-disable. This is the same class of problem as #9261; if a `npm:vite` / `npm:vitepress` install below 8.1 regresses, that's the cause.

Checked the rest of the 1.33 changelog for mise-visible surface: the settings reorg ([#1104](https://github.com/jdx/aube/pull/1104)) added `update`/`audit` sections but renamed nothing — diffing the setting keys between 1.32 and 1.33 shows no additions or removals, so the synthetic `.npmrc` mise writes (`minimumReleaseAge`, `trustPolicyExclude`) and the `aube.allowBuilds` manifest key are all unchanged. The remaining entries are CLI-only (`aube run` completions/picker), npm-alias patching, FreeBSD host detection, and an `aube login` hardening fix — none reachable from the embedded install path.

## Verification

- `cargo build` — clean
- `cargo test --bin mise npm` — 56 passed
- `mise run test:e2e test_npm_aube` — passes (install, `node_modules/.bin` shim, `aube-lock.yaml`)
- `mise run test:e2e test_npm_package_manager` — passes, covers the `allow_builds` path that feeds `runtime`
- `mise run lint-fix` — clean

`test_npm` aborts in my sandbox on a missing `npm` in PATH, before executing anything — environmental, not a regression.

## Context

`aube` 1.33.0 was initially unpublishable — release-plz shipped the 12 library crates and then failed verifying the `aube` tarball ([jdx/aube#1111](https://github.com/jdx/aube/pull/1111) fixed the `include` list). Until that landed this bump was blocked: the sub-crates' `^1.32.0` reqs resolved to 1.33.0, but `aube-scripts` 1.33 renamed `ScriptSettings::node_exe`, so `aube` 1.32 no longer compiled against them.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump with a small, API-aligned adapter in the npm embed path; intended behavior for Node selection is unchanged.
> 
> **Overview**
> Bumps **`aube`** and **`aube-registry`** from **1.32** to **1.33** (lockfile updates the full aube crate set and **`clx`** to **3.0.0**).
> 
> The npm backend’s embedded install path is updated for aube’s API change: **`AddToProjectOptions::node_bin_dir`** is replaced with **`runtime: Option<EmbedderRuntime>`**. Mise still passes the resolved Node bin directory via **`EmbedderRuntime::selector`**, so lifecycle scripts keep using mise-managed Node when it isn’t on ambient PATH.
> 
> With aube **1.33**, **`vite`** / **`vitepress`** installs may keep the global virtual store (Vite 8.1+ reads store metadata from **`node_modules/.modules.yaml`**); that’s upstream aube behavior, not additional mise logic in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9146468769bc6e8dfc652b3f68259b385e2ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->