### PR TITLE
fix(npm): add allow_low_downloads backend option

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -296,6 +296,28 @@ To exempt only selected versions, use aube's package-version pattern syntax:
 `trust_policy_excludes` is written to the aube install `.npmrc` as `trustPolicyExclude`. It does
 not affect `npm`, `pnpm`, or `bun` installs.
 
+### `allow_low_downloads`
+
+Allows the requested package to install even though its weekly download count falls below aube's
+`lowDownloadThreshold` (1000 by default). Without it, aube refuses:
+
+```
+refusing to add some-tool: only 930 weekly downloads (threshold: 1000).
+```
+
+```toml
+[tools]
+"npm:some-tool" = { version = "latest", allow_low_downloads = true }
+```
+
+The exemption is scoped to the package you asked for, written to the aube install `.npmrc` as
+`allowedUnpopularPackages=<package>`. Transitive dependencies stay gated, and the threshold itself
+is left alone — so this cannot silently admit an unpopular dependency you did not choose.
+
+Download count is a popularity signal, not a safety one: a low count means few others have vetted
+the package, so prefer confirming you trust the publisher over reaching for this. It does not affect
+`npm`, `pnpm`, or `bun` installs.
+
 ### Investigating trust downgrades
 
 A `trustPolicy=no-downgrade` failure is a supply-chain signal, not an ordinary inability to find a

--- a/registry/bibtex-tidy.toml
+++ b/registry/bibtex-tidy.toml
@@ -1,3 +1,10 @@
-backends = ["npm:bibtex-tidy"]
 description = "Cleaner and Formatter for BibTeX files"
 test = { cmd = "bibtex-tidy --version", expected = "v{{version}}" }
+
+[[backends]]
+full = "npm:bibtex-tidy"
+
+[backends.options]
+# ~930 weekly downloads, below aube's 1000 threshold. Curated here, so the
+# registry entry is the popularity decision rather than the download count.
+allow_low_downloads = true

--- a/registry/purty.toml
+++ b/registry/purty.toml
@@ -1,3 +1,10 @@
-backends = ["npm:purty"]
 description = "PureScript pretty-printer"
 test = { cmd = "purty version", expected = "Purty version: {{version}}" }
+
+[[backends]]
+full = "npm:purty"
+
+[backends.options]
+# ~845 weekly downloads, below aube's 1000 threshold. Curated here, so the
+# registry entry is the popularity decision rather than the download count.
+allow_low_downloads = true

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -87,6 +87,23 @@ impl<'a> NpmOptions<'a> {
         )
     }
 
+    /// Whether this tool's own package may install despite falling below
+    /// aube's weekly-download threshold. Scoped to the requested package
+    /// only — transitive dependencies stay gated.
+    fn allow_low_downloads(&self) -> eyre::Result<bool> {
+        let Some(value) = self.values.raw().opts.get("allow_low_downloads") else {
+            return Ok(false);
+        };
+        match value {
+            toml::Value::Boolean(value) => Ok(*value),
+            toml::Value::String(value) if value.eq_ignore_ascii_case("true") => Ok(true),
+            toml::Value::String(value) if value.eq_ignore_ascii_case("false") => Ok(false),
+            value => Err(eyre::eyre!(
+                "allow_low_downloads must be a boolean, got {value}"
+            )),
+        }
+    }
+
     fn allow_builds(&self) -> eyre::Result<AllowBuilds> {
         let Some(value) = self.values.raw().opts.get("allow_builds") else {
             return Ok(AllowBuilds::None);
@@ -971,6 +988,13 @@ impl NPMBackend {
         if let Some(excludes) = options.aube_trust_policy_excludes_npmrc_value()? {
             npmrc.push_str(&format!("trustPolicyExclude={excludes}\n"));
         }
+        if options.allow_low_downloads()? {
+            // Exempt only this tool's own package, not the whole install, so a
+            // transitive dependency below the threshold still fails the gate.
+            // aube gates the directly-requested packages, which for mise is
+            // always exactly this one.
+            npmrc.push_str(&format!("allowedUnpopularPackages={}\n", self.tool_name()));
+        }
         crate::file::write(install_path.join(".npmrc"), npmrc)?;
         Ok(())
     }
@@ -1213,6 +1237,7 @@ pub fn install_time_option_keys() -> Vec<String> {
         "aube_args".into(),
         "allow_builds".into(),
         "trust_policy_excludes".into(),
+        "allow_low_downloads".into(),
     ]
 }
 
@@ -1915,6 +1940,70 @@ mod tests {
             manifest["aube"]["allowBuilds"],
             serde_json::json!({ "esbuild": true })
         );
+    }
+
+    #[test]
+    fn test_write_aube_embed_project_scopes_allow_low_downloads_to_the_tool() {
+        let backend = create_npm_backend("bibtex-tidy");
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("npm-bibtex-tidy").join("1.14.0");
+        crate::file::create_dir_all(&install_path).unwrap();
+        let mut raw_options = ToolVersionOptions::default();
+        raw_options.opts.insert(
+            "allow_low_downloads".to_string(),
+            toml::Value::Boolean(true),
+        );
+        let options = NpmOptions::new(&raw_options);
+        let allow_builds = options.allow_builds().unwrap();
+
+        backend
+            .write_aube_embed_project(&install_path, None, &options, &allow_builds)
+            .unwrap();
+
+        // Only the requested package is exempt — not a wildcard, so a
+        // transitive dependency below the threshold still fails aube's gate.
+        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
+        assert!(npmrc.contains("allowedUnpopularPackages=bibtex-tidy\n"));
+        assert!(!npmrc.contains('*'));
+        assert!(!npmrc.contains("lowDownloadThreshold"));
+    }
+
+    #[test]
+    fn test_allow_low_downloads_defaults_off_and_rejects_non_bool() {
+        let empty = ToolVersionOptions::default();
+        assert!(!NpmOptions::new(&empty).allow_low_downloads().unwrap());
+
+        let mut string_true = ToolVersionOptions::default();
+        string_true.opts.insert(
+            "allow_low_downloads".to_string(),
+            toml::Value::String("true".into()),
+        );
+        assert!(NpmOptions::new(&string_true).allow_low_downloads().unwrap());
+
+        let mut bad = ToolVersionOptions::default();
+        bad.opts.insert(
+            "allow_low_downloads".to_string(),
+            toml::Value::Integer(1000),
+        );
+        assert!(NpmOptions::new(&bad).allow_low_downloads().is_err());
+    }
+
+    #[test]
+    fn test_write_aube_embed_project_omits_allow_low_downloads_by_default() {
+        let backend = create_npm_backend("bibtex-tidy");
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("npm-bibtex-tidy").join("1.14.0");
+        crate::file::create_dir_all(&install_path).unwrap();
+        let raw_options = ToolVersionOptions::default();
+        let options = NpmOptions::new(&raw_options);
+        let allow_builds = options.allow_builds().unwrap();
+
+        backend
+            .write_aube_embed_project(&install_path, None, &options, &allow_builds)
+            .unwrap();
+
+        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
+        assert!(!npmrc.contains("allowedUnpopularPackages"));
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -960,6 +960,11 @@ impl NPMBackend {
         options: &NpmOptions,
         allow_builds: &AllowBuilds,
     ) -> Result<()> {
+        // Validate the fallible options before writing anything, so a malformed
+        // value fails without leaving a half-written project dir behind.
+        let trust_policy_excludes = options.aube_trust_policy_excludes_npmrc_value()?;
+        let allow_low_downloads = options.allow_low_downloads()?;
+
         let mut manifest = serde_json::json!({
             "name": "mise-npm-install",
             "private": true,
@@ -985,10 +990,10 @@ impl NPMBackend {
             // aube documents minimumReleaseAge in minutes, matching pnpm's setting.
             npmrc.push_str(&format!("minimumReleaseAge={minutes}\n"));
         }
-        if let Some(excludes) = options.aube_trust_policy_excludes_npmrc_value()? {
+        if let Some(excludes) = trust_policy_excludes {
             npmrc.push_str(&format!("trustPolicyExclude={excludes}\n"));
         }
-        if options.allow_low_downloads()? {
+        if allow_low_downloads {
             // Exempt only this tool's own package, not the whole install, so a
             // transitive dependency below the threshold still fails the gate.
             // aube gates the directly-requested packages, which for mise is
@@ -1966,6 +1971,31 @@ mod tests {
         assert!(npmrc.contains("allowedUnpopularPackages=bibtex-tidy\n"));
         assert!(!npmrc.contains('*'));
         assert!(!npmrc.contains("lowDownloadThreshold"));
+    }
+
+    #[test]
+    fn test_write_aube_embed_project_writes_nothing_when_an_option_is_malformed() {
+        let backend = create_npm_backend("bibtex-tidy");
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("npm-bibtex-tidy").join("1.14.0");
+        crate::file::create_dir_all(&install_path).unwrap();
+        let mut raw_options = ToolVersionOptions::default();
+        raw_options.opts.insert(
+            "allow_low_downloads".to_string(),
+            toml::Value::Integer(1000),
+        );
+        let options = NpmOptions::new(&raw_options);
+        let allow_builds = options.allow_builds().unwrap();
+
+        assert!(
+            backend
+                .write_aube_embed_project(&install_path, None, &options, &allow_builds)
+                .is_err()
+        );
+        // Options are validated up front, so the aborted call leaves no
+        // half-written project behind for a later step to trip over.
+        assert!(!install_path.join("package.json").exists());
+        assert!(!install_path.join(".npmrc").exists());
     }
 
     #[test]


### PR DESCRIPTION
aube refuses a package whose weekly download count falls below `lowDownloadThreshold` (1000 by default), and mise currently has **no way to opt out** — `AddToProjectOptions` exposes no `allow_low_downloads` field, so the embedded installer always hits the gate. Two curated registry tools are uninstallable as a result:

```
refusing to add bibtex-tidy: only 930 weekly downloads (threshold: 1000)
refusing to add purty: only 845 weekly downloads (threshold: 1000)
```

Users have no workaround short of `npm.shell_out=true`.

## Approach

New `allow_low_downloads` option, written to the aube install `.npmrc` as `allowedUnpopularPackages=<package>` — naming **only the requested package**:

```toml
[tools]
"npm:some-tool" = { version = "latest", allow_low_downloads = true }
```

I deliberately did not set `lowDownloadThreshold = 0`, which is the other thing aube's error message suggests. That disables the gate for the whole install, so an unpopular *transitive* dependency would sail through too. Scoping to the named package keeps the threshold intact for everything the user didn't explicitly ask for. aube gates the directly-requested set, which for mise is always exactly one package.

Enabled on the two affected registry entries. For a registry tool the entry is itself the popularity decision, which is what the download gate approximates.

## Worth a second opinion

Both are under mise's own registry bar, and `purty`'s last release was **2021-03-02** — over five years ago:

| | weekly downloads | latest release |
|---|---|---|
| bibtex-tidy | 930 | 2024-09-07 |
| purty | 845 | 2021-03-02 |

Deleting the entries is a defensible alternative, `purty` especially. I kept them because removal breaks anyone using the shorthand today, and the option is worth having regardless — but the call is yours, and I'm happy to drop either entry from this PR.

## Verification

- `cargo test --all-features npm` — 59 passed, 0 failed, incl. 3 new tests covering the scoped `.npmrc` value, the default-off path, and non-boolean rejection
- `mise install bibtex-tidy@latest` → installed
- `mise install purty@latest` → installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to aube embed install `.npmrc` generation and opt-in registry entries; supply-chain gates remain for transitive dependencies unless explicitly exempted elsewhere.
> 
> **Overview**
> Adds **`allow_low_downloads`** so embedded **aube** installs can bypass the weekly-download gate for the **requested** npm package only, instead of failing when popularity is below `lowDownloadThreshold` (default 1000).
> 
> When enabled, mise validates the option up front, then writes `allowedUnpopularPackages=<tool>` into the synthetic install `.npmrc` (not a global threshold change), so transitive deps still hit the gate. The option is documented alongside other aube-only tool options and registered as install-time metadata.
> 
> **`bibtex-tidy`** and **`purty`** registry backends are updated to set `allow_low_downloads = true` so curated shorthand installs work again without `npm.shell_out`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d7558938c3ada3f74e1cda415af499caa38d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `allow_low_downloads` option for npm-based installations, allowing specified packages below the weekly download threshold to install.
  * Kept the exemption limited to the requested package; transitive dependencies remain subject to existing checks.
  * Added registry support for enabling the option on selected packages.

* **Documentation**
  * Documented configuration, defaults, scope, and supported package managers for the new option.

* **Bug Fixes**
  * Added validation for accepted option values and ensured the allowance is omitted when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->