### PR TITLE
registry: add tak

### DIFF
--- a/registry/tak.toml
+++ b/registry/tak.toml
@@ -1,0 +1,3 @@
+backends = ["github:jdx/tak", "cargo:tak-cli"]
+description = "CLI performance, tracked"
+test = { cmd = "tak --version", expected = "tak {{version}}" }


### PR DESCRIPTION
Adds a registry shorthand for [tak](https://github.com/jdx/tak), a CLI benchmarking tool that gates on cachegrind instruction counts rather than wall clock and stores its history in git notes.

```toml
backends = ["github:jdx/tak", "cargo:tak-cli"]
description = "CLI performance, tracked"
test = { cmd = "tak --version", expected = "tak {{version}}" }
```

`github:` is the primary backend — tak is not in the aqua registry. `cargo:tak-cli` is a source-build fallback for platforms outside the seven published targets, mirroring what `hyperfine.toml` does. The crate is `tak-cli` because bare `tak` on crates.io is a dormant 2016 board-game implementation; the installed binary is `tak`.

## Verification

Installed through the backend on linux-x64:

```
mise github:jdx/tak@0.0.2  [2/3] ✓ GitHub artifact attestations verified
mise github:jdx/tak@0.0.2  [3/3] extract tak-x86_64-unknown-linux-gnu.tar.gz
mise github:jdx/tak@0.0.2  ✓ installed
tak 0.0.2
```

Asset selection picks the right archive unaided and attestations verify. `tak --version` prints `tak 0.0.2`, matching the `test` expectation.

## Popularity

**None — and this PR is knowingly outside the usual bar.** tak was published to crates.io today, has no users, and its README actively tells people to look elsewhere. `CONTRIBUTING`/`CLAUDE.md` say the registry is only for tools that are *already* widely used, and by that rule this entry does not qualify.

It is here because @jdx wrote tak and asked for the entry directly. Recording that explicitly rather than dressing it up with numbers that do not exist.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only metadata addition with no changes to install logic or runtime behavior.
> 
> **Overview**
> Adds **`registry/tak.toml`** so `mise install tak` can resolve **tak**, a git-notes–backed CLI benchmarking tool.
> 
> **Backends:** `github:jdx/tak` as the primary install path (not in aqua), with **`cargo:tak-cli`** as a source-build fallback for platforms without published GitHub artifacts. Includes a **`test`** hook that expects `tak --version` to print `tak {{version}}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b9f208c4a19afa518948523045b79d4151e073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry configuration for the `tak` tool, including backend availability and version verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->