### PR TITLE
fix(npm): bump aube to 1.33.1, stop it rendering its own progress display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5257ecfdaa63cae0fde1d171f482d60c1c5f86a0203c4e5afaa8f82dc8564c8f"
+checksum = "551ab991fd7d877da9f94099163cc278336b52a5a27f6d0d53bf2a99119e1e75"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c42cb2c2e2bfc354c95b96095b159d7cb66600fad3e6b517340ea1f653ed7da"
+checksum = "142d0a70354e58d16a4550c49ea9c7b8b6e4c608d00c66fbfbe63a26f4e19456"
 dependencies = [
  "serde",
  "serde_json",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a0c79d06a213a26e090061728fc5de2c08788192515ffaf05c1a412614841b"
+checksum = "a64288c1754206e9c02f6de7c1c2a07925b5ddccda04652885c2873c7818cca6"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00832e6deead454ac1e6cb6e0cb7682a63265b568333c76de1ad6782cc55cbcc"
+checksum = "5b8766aa34b4f27b87399ca95ececb29b28754f11245cda65e41af49e9ff7515"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efe1369bc42c0f5bbcf49faa83dea8a796f91d6b1b01b9e826f4830a15ea4c2"
+checksum = "5d874c3b77ef64260d3ffc0004238d921a4ea2bde7e942f4d3ad9d880f389a45"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c9fee17d19cf956f5a3bafc7e6ab31dd1e5dad5a152efba1c398eebd41c556"
+checksum = "c5c823bd9dc7f4fafc73143fc245f736daa4221385d566cf0a77277216b219c4"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1180168e831e73632599fe8fa8c39beb4833a121436ec43da65039c1668c591"
+checksum = "26e64a34e8de78be4e274bebcd83e7b5bbcfaefe20b9a083429a1afad7bff4af"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a32ebada99f8ee90bb76dc61e62605c4db4cc63725041afe4a0d931b7cfb628c"
+checksum = "e81cd711e9a73565f51b61ab0f37866a3bc57dd7aa3825a4553af63a7f0b1018"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7046aeaebec3356bfb029dae290573493b37ee9e5bafe9c5e4e4053b05c6491a"
+checksum = "fa129c5b70bf7d6e3a609de1e2bc14ed6f425974b99023123371a19b5edfd6f4"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2f09dd012bb64e1fc0fcb5ed92ba7f38acd3fe3df2c5e94923acf09a1d3f21"
+checksum = "377fcdc8fe07f4b30f11588efcefb41328f6a9d9f1e3dc0e2ce8da2a92fd892d"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8938d12c68812bd28a4e4fe4bbbd0116293ce12edbbf63309dface0b617ffe3"
+checksum = "712a6f0483e4207eecc50caf814465d43e634d04467ddac3a491c4462c23714a"
 dependencies = [
  "aube-util",
  "base64 0.22.1",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34914d569dc2ee5e0287a5cc33d18f8528e5b13aaeaf4f596daebc9b2b8cae41"
+checksum = "08b729c64f4ad8143c1da960561d14014fa0b9069609a23c4f58c5b74b5443eb"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630b803a55740a7b2e1c63543a5520744f534c7819db9d43c157bc71a66c05d3"
+checksum = "d543ba7b5ee964f9f0a021398f68ab8f6fea938ea17bb3ffed1530660d5f48c5"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -1472,7 +1472,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4299,7 +4299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -7267,7 +7267,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -9572,7 +9572,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 

--- a/mise.lock
+++ b/mise.lock
@@ -117,61 +117,62 @@ url_api = "https://api.github.com/repos/FiloSottile/age/releases/assets/33375267
 provenance = "github-attestations"
 
 [[tools.aube]]
-version = "1.26.0"
+version = "1.32.0"
 backend = "github:endevco/aube"
 
 [tools.aube."platforms.linux-arm64"]
-checksum = "sha256:e1f730c01b5130835d3b4d6c293821de78ade6f857869963bd2df82cb9ce67e8"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468523290"
+checksum = "sha256:df67dc7a5de64e64d929431401f922ed73b7460f6e34af401d3f0c9b63abfb63"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485347368"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-arm64-musl"]
-checksum = "sha256:4611bc48714d03a86523a21575cea7d58a9f43ff44b2b372470bb3d0f13ff9b7"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468497318"
+checksum = "sha256:6ffb9e4d33054859a708856fe2ddd585888bc03dabbcd9d6ac3311963f6b2e96"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485320976"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64"]
-checksum = "sha256:17ea729b11825366600a2072d81160bd09c027b3a37c13e2e97aa7295625aa07"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468503747"
+checksum = "sha256:5419e7dbba887a4c1f7ae5675d86dd5d71fa3daa66053d16788e986c66078126"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485325644"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.aube."platforms.linux-x64-baseline"]
-checksum = "sha256:17ea729b11825366600a2072d81160bd09c027b3a37c13e2e97aa7295625aa07"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468503747"
+checksum = "sha256:5419e7dbba887a4c1f7ae5675d86dd5d71fa3daa66053d16788e986c66078126"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485325644"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl"]
-checksum = "sha256:3a6c90676f0003079eaade3a4027c3349612e7587f7ecf699c864395ff26807c"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468505615"
+checksum = "sha256:bc74918c2adf8899b87599b1a43e3be001f42bed3fb44589f6955bca70657559"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485325405"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:3a6c90676f0003079eaade3a4027c3349612e7587f7ecf699c864395ff26807c"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468505615"
+checksum = "sha256:bc74918c2adf8899b87599b1a43e3be001f42bed3fb44589f6955bca70657559"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485325405"
 provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
-checksum = "sha256:f1e9cca3b4837cb497b0588641781ecd426b5a4c26cd610743a8fad756e02d8f"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468538559"
+checksum = "sha256:d4c883f6a41f064e587de948645d9128d282b12c3a42eac36920eaf1d63162fe"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485361741"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64"]
-checksum = "sha256:1b594095c26c31e90b5e89ef78cf56ac9b903db83f1ca214db6732d9df09409a"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468508857"
+checksum = "sha256:94fc5c07b56da989f1fafbee24da285ea56451fbb27d9bca27dc558668af4121"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485332026"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64-baseline"]
-checksum = "sha256:1b594095c26c31e90b5e89ef78cf56ac9b903db83f1ca214db6732d9df09409a"
-url = "https://github.com/jdx/aube/releases/download/v1.26.0/aube-v1.26.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/468508857"
+checksum = "sha256:94fc5c07b56da989f1fafbee24da285ea56451fbb27d9bca27dc558668af4121"
+url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485332026"
 provenance = "github-attestations"
 
 [[tools.bun]]

--- a/src/backend/aube_host.rs
+++ b/src/backend/aube_host.rs
@@ -1,0 +1,118 @@
+//! mise's embedder profile for the embedded aube package manager.
+//!
+//! mise links aube in as a library and drives it in-process
+//! ([`aube::embed`]) rather than going through `aube::cli_main`, so nothing
+//! registers a host identity for us. Without one, aube falls back to its
+//! standalone [`aube::embed::AUBE`] profile and behaves like the `aube` CLI:
+//! it prints an `aube <aube-version> by jdx.dev` banner into mise's own
+//! install progress display, sends an `aube/<aube-version>` User-Agent to the
+//! npm registry, resolves and provisions its own node, and validates
+//! `engines.aube` against the aube crate version.
+//!
+//! Only the branding and the four embedder-fixed behavior toggles differ from
+//! [`aube::embed::AUBE`]. Everything that names something on disk — the store
+//! and cache namespaces, the lockfile filename, the `package.json` config
+//! namespace mise writes `allowBuilds` into — is deliberately inherited
+//! verbatim, so an existing `npm:` install and its populated content store
+//! stay valid across this change.
+
+use std::sync::Once;
+
+use aube::embed::{AUBE, Host};
+
+static MISE_HOST: Host = Host {
+    // Branding. `display_name`/`version` are what the install progress banner
+    // renders, and `user_agent` is what the npm registry and lifecycle
+    // scripts' `npm_config_user_agent` see — all of which should say mise,
+    // since the user asked mise for a tool and never chose aube. `vendor:
+    // None` drops the `by jdx.dev` attribution (aube suppresses it for any
+    // registered embedder anyway; being explicit keeps it from depending on
+    // that).
+    name: "mise",
+    display_name: "mise",
+    vendor: None,
+    version: env!("CARGO_PKG_VERSION"),
+    user_agent: concat!("mise/", env!("CARGO_PKG_VERSION")),
+
+    // On-disk and config surface: inherited so this profile is not a
+    // migration. Changing `cache_namespace`/`data_namespace` would orphan the
+    // already-populated content store, and changing `manifest_namespace`
+    // would strand the `aube.allowBuilds` key that
+    // `write_aube_embed_project` writes into every install's `package.json`.
+    self_names: AUBE.self_names,
+    compatible_names: AUBE.compatible_names,
+    lockfile_basename: AUBE.lockfile_basename,
+    workspace_yaml: AUBE.workspace_yaml,
+    manifest_namespace: AUBE.manifest_namespace,
+    env_prefix: AUBE.env_prefix,
+    config_env_prefix: AUBE.config_env_prefix,
+    cache_namespace: AUBE.cache_namespace,
+    data_namespace: AUBE.data_namespace,
+
+    // The install dir is a mise-generated throwaway project holding exactly
+    // one lockfile, so aube's canonical-lockfile precedence is the right (and
+    // only reachable) answer.
+    canonical_lockfile_always_wins: true,
+    // mise owns node provisioning: `install_via_aube_embed` hands aube the
+    // node it resolved as a tool dependency. Leaving aube's own resolver live
+    // would let it probe version files and download a second node behind
+    // mise's back. A per-call `EmbedderRuntime` is honored regardless of this
+    // toggle, and with no node dependency resolved aube still falls back to an
+    // ambient `node` on PATH.
+    runtime_switching: false,
+    // mise's version is not in aube's version namespace, so an `engines.aube`
+    // constraint must not be checked against it. `engines.node` is unaffected.
+    self_engines_check: false,
+    // mise owns its own upgrade path; aube's update notifier and its
+    // aube.jdx.dev endpoints must never run from inside mise.
+    self_update_enabled: false,
+};
+
+static INIT: Once = Once::new();
+
+/// Register mise as aube's host. Idempotent and cheap; call it before any
+/// aube work rather than relying on a single startup hook, so the library
+/// entry points (`npm:` installs and registry metadata queries) are each
+/// self-sufficient.
+///
+/// aube's registration is itself first-write-wins, so the [`Once`] is only to
+/// keep repeat calls off the hot path.
+pub fn init() {
+    INIT.call_once(|| {
+        // No setting defaults: mise passes every install-scoped knob it cares
+        // about (release age, trust-policy excludes, build allowlist) through
+        // the synthetic project's `.npmrc` and `package.json`, which outrank
+        // embedder defaults anyway.
+        aube::embed::initialize(&MISE_HOST, vec![]);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mise_host_keeps_aube_on_disk_layout() {
+        // These are what an already-installed `npm:` tool and the shared
+        // content store are keyed on — a rename here is a silent migration.
+        assert_eq!(MISE_HOST.cache_namespace, AUBE.cache_namespace);
+        assert_eq!(MISE_HOST.data_namespace, AUBE.data_namespace);
+        assert_eq!(MISE_HOST.manifest_namespace, AUBE.manifest_namespace);
+        assert_eq!(MISE_HOST.lockfile_basename, AUBE.lockfile_basename);
+    }
+
+    #[test]
+    fn mise_host_brands_as_mise() {
+        assert_eq!(MISE_HOST.display_name, "mise");
+        assert_eq!(MISE_HOST.vendor, None);
+        assert_eq!(MISE_HOST.version, env!("CARGO_PKG_VERSION"));
+        assert!(MISE_HOST.user_agent.starts_with("mise/"));
+    }
+
+    #[test]
+    fn mise_host_disables_aube_owned_behavior() {
+        assert!(!MISE_HOST.runtime_switching);
+        assert!(!MISE_HOST.self_engines_check);
+        assert!(!MISE_HOST.self_update_enabled);
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -56,6 +56,7 @@ use versions::Versioning;
 pub mod aqua;
 pub mod asdf;
 pub mod asset_matcher;
+pub mod aube_host;
 pub mod backend_type;
 pub mod cargo;
 pub mod conda;

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -17,8 +17,10 @@ use crate::install_context::InstallContext;
 use crate::semver::{semver_is_at_least, semver_is_older_than};
 use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
+use crate::ui::progress_report::SingleReport;
 use async_trait::async_trait;
 use aube::embed::EmbedderRuntime;
+use bytesize::ByteSize;
 use jiff::Timestamp;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -901,6 +903,10 @@ impl NPMBackend {
             );
         }
 
+        // aube renders nothing itself: `Events` mode routes the same phase and
+        // progress numbers to us so mise's own progress job stays the only
+        // thing drawing to the terminal. See [`AubeProgressReporter`].
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let mut opts = aube::embed::AddToProjectOptions {
             // Global-style installs pin the exact resolved version, matching
             // what `aube add --global` wrote to its synthetic manifest.
@@ -909,7 +915,7 @@ impl NPMBackend {
             // `aube.allowBuilds`; only the "allow everything" case needs the
             // invocation flag. `None` leaves scripts skipped (aube's default).
             dangerously_allow_all_builds: matches!(allow_builds, AllowBuilds::All),
-            control: aube::embed::InstallControl::default(),
+            control: aube::embed::InstallControl::events(Arc::new(AubeProgressReporter { tx })),
             // Run dependency lifecycle scripts on the node mise resolved as a
             // dependency, so `allow_builds` installs work even when node isn't
             // on the ambient PATH (the in-process installer doesn't inherit the
@@ -920,9 +926,23 @@ impl NPMBackend {
         opts.ignore_scripts = matches!(allow_builds, AllowBuilds::None);
 
         let package = format!("{}@{}", self.tool_name(), tv.version);
-        aube::embed::add(&install_path, std::slice::from_ref(&package), opts)
-            .await
-            .map_err(|e| self.format_aube_install_error(e))?;
+        let install = aube::embed::add(&install_path, std::slice::from_ref(&package), opts);
+        tokio::pin!(install);
+        // Drain events alongside the install rather than after it: the
+        // reporter only enqueues (it must never wait on us while holding an
+        // install worker), so nothing renders unless someone is pulling.
+        let result = loop {
+            tokio::select! {
+                res = &mut install => break res,
+                Some(event) = rx.recv() => apply_aube_event(event, ctx.pr.as_ref()),
+            }
+        };
+        // Events queued between the last poll and the install returning —
+        // notably the terminal `Complete` snapshot.
+        while let Ok(event) = rx.try_recv() {
+            apply_aube_event(event, ctx.pr.as_ref());
+        }
+        result.map_err(|e| self.format_aube_install_error(e))?;
         Ok(())
     }
 
@@ -1126,6 +1146,95 @@ impl NPMBackend {
             paths.push(install_path.to_path_buf());
         }
         paths
+    }
+}
+
+/// Feeds aube's structured install events into a channel mise drains onto its
+/// own progress job.
+///
+/// aube's default `Human` output mode renders its own clx progress display —
+/// a branded root row with overall counts plus transient child rows per
+/// in-flight tarball fetch — straight to stderr. Because mise and aube both
+/// draw through clx, those rows land as siblings of the job mise already
+/// started for the install, so the user sees two competing progress displays
+/// for one operation, the second one branded by the engine they never chose.
+/// `Events` mode suppresses every one of aube's own writes (the bar, the
+/// `Resolving <pkg>...` lines, and the post-install dependency summary, all of
+/// which are gated on `Human`) and hands the underlying numbers over instead.
+#[derive(Debug)]
+struct AubeProgressReporter {
+    tx: tokio::sync::mpsc::UnboundedSender<aube::embed::InstallEvent>,
+}
+
+impl aube::embed::InstallReporter for AubeProgressReporter {
+    fn report(&self, event: aube::embed::InstallEvent) {
+        // Unbounded, so this never blocks an install worker waiting on us —
+        // what the trait requires. A closed channel means the install already
+        // returned and nobody is left to render the event.
+        let _ = self.tx.send(event);
+    }
+}
+
+/// Render one aube install event onto mise's progress job.
+///
+/// Everything goes in the message; the progress bar is deliberately left
+/// alone. Driving it would mean `set_length(snap.estimated_bytes)`, and that
+/// estimate is a moving, inflated target — aube resolves and downloads
+/// concurrently, so the denominator climbs for most of the install, and it
+/// keeps counting platform-mismatched optional deps that get pruned before
+/// anything fetches them. The result is a bar pinned near 15% with an ETA
+/// swinging between 5s and 30s. The package tally below is the honest number,
+/// and mise's spinner already says the work is live.
+fn apply_aube_event(event: aube::embed::InstallEvent, pr: &dyn SingleReport) {
+    use aube::embed::{InstallEvent, InstallOutputLevel, InstallPhase};
+
+    match event {
+        // The phase repeats on every progress snapshot, which also carries the
+        // counts, so the bare transition needs no separate render.
+        InstallEvent::Phase(_) => {}
+        InstallEvent::Progress(snap) => {
+            let (label, cur, total) = match snap.phase {
+                // Resolving walks a frontier: the denominator is still growing,
+                // and `resolved` can outrun the last total we saw.
+                Some(InstallPhase::Resolving) | None => {
+                    ("resolving", snap.resolved, snap.total.max(snap.resolved))
+                }
+                // Past resolution the package count is final, and progress is
+                // how many are in place — from the store or the network.
+                Some(InstallPhase::Fetching) => {
+                    ("fetching", snap.reused + snap.downloaded, snap.resolved)
+                }
+                Some(InstallPhase::Linking) => {
+                    ("linking", snap.reused + snap.downloaded, snap.resolved)
+                }
+                Some(InstallPhase::Complete) => ("installing", snap.resolved, snap.resolved),
+            };
+
+            // The first snapshot lands before resolution has counted anything;
+            // `0/0 pkgs` is worse than no tally at all.
+            let mut message = if total == 0 {
+                label.to_string()
+            } else {
+                format!("{label} {cur}/{total} pkgs")
+            };
+            // Bytes actually transferred — no denominator, so nothing here can
+            // be wrong the way a percentage would be. Omitted entirely for an
+            // install served from the store, which downloads nothing.
+            if snap.downloaded_bytes > 0 {
+                message.push_str(&format!(
+                    " · {}",
+                    ByteSize::b(snap.downloaded_bytes).display().iec()
+                ));
+            }
+            pr.set_message(message);
+        }
+        // Text aube would have written to stderr itself. Warnings are the
+        // user's business; a fatal error also comes back as the returned
+        // `Err`, so this is never the only place one surfaces.
+        InstallEvent::Output { level, message, .. } => match level {
+            InstallOutputLevel::Info => debug!("aube: {message}"),
+            InstallOutputLevel::Warning | InstallOutputLevel::Error => warn!("{message}"),
+        },
     }
 }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -887,6 +887,7 @@ impl NPMBackend {
         tv: &ToolVersion,
         options: &NpmOptions<'_>,
     ) -> Result<()> {
+        crate::backend::aube_host::init();
         let install_path = tv.install_path();
         crate::file::create_dir_all(&install_path)?;
 

--- a/src/backend/npm_registry.rs
+++ b/src/backend/npm_registry.rs
@@ -34,6 +34,9 @@ use crate::config::Settings;
 /// network on a miss. (Offline state is set from the CLI/env at startup, so
 /// resolving it once at client construction is sufficient.)
 static CLIENT: Lazy<RegistryClient> = Lazy::new(|| {
+    // Before the first registry request, so the memoized User-Agent is
+    // mise's rather than standalone aube's.
+    crate::backend::aube_host::init();
     let config = NpmConfig::load(&meta_dir());
     let settings = Settings::get();
     let mode = if settings.offline() {


### PR DESCRIPTION
## Summary

Bumps the embedded aube package manager, and stops it drawing to the terminal — all rendering for an `npm:` install is now mise's.

### 1. aube crates → 1.33.1 (`Cargo.lock`)

`Cargo.toml`'s `"1.33"` range already covers it, so only the lock moves. Three upstream changes, all reviewed against how mise uses the crate:

- **`node_gyp_bootstrap` no longer shells out to `current_exe`** — a direct embedder fix. Previously an `npm:` package needing node-gyp would have made aube re-exec *the mise binary* as `mise install --ignore-scripts --silent`. It now runs in-process. Only reachable with `allow_builds`, but it was broken.
- **Progress mode selection** — the TTY renderer is no longer gated behind `AUBE_TTY_PROGRESS`; interactive stderr gets it by default. This is what surfaced (2) and (3) below.
- **Trust excludes** — `@hono/node-server` added to aube's defaults; nothing for mise to do.

### 2. Stop aube drawing its own progress display

mise and aube both render through clx, so aube's `Human` output mode put its branded root row and its per-fetch child rows in as **siblings of the job mise had already started** — two competing displays for one install, plus `Resolving <pkg>...` lines and a post-install dependency summary. 1.33.1 made that the default on any interactive terminal:

**Before**
```
npm:cowsay@1.6.0 install                                    ◟
aube 1.33.1 by jdx.dev — resolving  [>      ]  19/34 pkgs · ETA …
   ⠴ require-main-filename@2.0.0
   ⠴ which-module@2.0.1
```

**After**
```
npm:pnpm@9.15.0  fetching 1/1 pkgs · 4.1 MiB                ◟
```

`InstallControl::events` suppresses every one of aube's own writes (the bar, the `Resolving` lines, and the dependency summary are all gated on `Human`) and hands the underlying numbers over instead, which mise renders onto its existing progress job.

Counts and transferred bytes go in the **message, not the progress bar**. Driving the bar would mean `set_length(estimated_bytes)`, and that estimate is a moving, inflated target: aube resolves and downloads concurrently so the denominator climbs for most of the install, and it keeps counting platform-mismatched optional deps that get pruned before anything fetches them. Measured on `npm:aws-cdk@2.147.0`: `estimated_bytes: 66059866` against `downloaded_bytes: 10768754`. Wired to the bar that renders as a bar pinned near 15% with an ETA swinging between 5s and 30s — I tried it, which is why it isn't in the diff. Transferred bytes have no denominator, so nothing about them can be wrong.

Events are drained alongside the install rather than after it: the reporter only enqueues (per the trait contract it must never block an install worker waiting on the consumer), so nothing renders unless someone is pulling.

### 3. Register mise as aube's embedder host (`src/backend/aube_host.rs`)

mise drives aube through `aube::embed` rather than `aube::cli_main`, so nothing registered a host identity and aube fell back to its standalone profile — hence the `aube 1.33.1 by jdx.dev` branding above, an `aube/<aube-version>` User-Agent to the npm registry, and aube's own node provisioning and update notifier being live inside mise.

The profile fixes the branding and turns off three behaviors aube shouldn't own here:

- `runtime_switching: false` — mise hands aube the node it resolved as a tool dependency; leaving aube's own resolver live would let it probe version files and provision a second node behind mise's back. A per-call `EmbedderRuntime` is honored regardless of this toggle.
- `self_engines_check: false` — mise's version is not in aube's version namespace, so `engines.aube` must not be validated against it. `engines.node` is unaffected.
- `self_update_enabled: false` — mise owns its own upgrade path; aube's update notifier and its `aube.jdx.dev` endpoints must never run from inside mise.

Everything that names something on disk — `cache_namespace`, `data_namespace`, `manifest_namespace` (the `aube.allowBuilds` key `write_aube_embed_project` writes), `lockfile_basename` — is inherited verbatim from aube's own profile, so this is **not a migration**: existing `npm:` installs and the already-populated content store stay valid.

### 4. Locked aube CLI 1.26.0 → 1.32.0 (`mise.lock`)

The dev/CI tool pin (used by `npm-publish.yml`) was six releases stale. Refreshed across all 9 platforms via `mise lock aube --bump`.

> [!NOTE]
> This stops at **1.32.0, not 1.33.0**. v1.33.0 was published 2026-07-25T21:41Z and mise's own default `minimum_release_age = 24h` gates it (`mise WARN 1 newer github:endevco/aube release hidden by minimum_release_age`). I did not override the repo's supply-chain default — re-running `mise lock aube --bump` after the release clears 24h will pick it up. 1.33.1 exists only on crates.io, not as a GitHub release, so the CLI cannot reach it at all yet.

## Validation

- `cargo build` and `mise run lint-fix` clean (no lint changes produced)
- `mise run test:unit` → 1940 passed, 0 failed (3 new in `aube_host`)
- e2e: `test_npm`, `test_npm_aube`, `test_npm_package_manager`, `test_npm_devengines`, `test_npm_lock_backend`, `test_npm_install_before`, `test_npm_dep_warning_suppressed`, `test_npm_shim_recursion_system_dir` — all pass
- Progress rendering checked under a pty across all four states: warm store (no byte suffix), cold single-package fetch, cold 231-package tree (`npm:@angular/cli@17.3.8`), and a real 10.7 MB download (`npm:pnpm@9.15.0` → `fetching 1/1 pkgs · 4.1 MiB`)
- `mise install aube` + `mise x aube -- aube --version` → `1.32.0` against the new lock entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Embedded package installations now report progress via event-driven updates for a smoother single-job experience.
  - Embedded aube-based operations are branded as mise, while keeping existing package storage/cache/config layouts compatible (no migration).
- **Bug Fixes**
  - Embedded installs and registry requests no longer inherit aube branding or related behavioral toggles.
  - Ensured the mise host profile is initialized before both installations and the first registry request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->