### PR TITLE
fix(env): convert remaining std::env::vars() call sites to vars_safe()

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,10 @@
+# Configuration for `cargo clippy`.
+# https://doc.rust-lang.org/clippy/configuration.html
+#
+# `src/env.rs` does `pub use std::env::*`, so a bare `env::vars()` anywhere in
+# the crate is std's panicking version rather than a mise helper. These entries
+# match on the resolved DefId, so the re-exported spelling is caught too.
+disallowed-methods = [
+  { path = "std::env::vars", reason = "panics on non-UTF-8 environment variables (jdx/mise#5370); use crate::env::vars_safe(), or std::env::vars_os() when values must not be dropped" },
+  { path = "std::env::args", reason = "panics on non-UTF-8 arguments (jdx/mise#10056); use crate::env::args_safe(), or std::env::args_os()" },
+]

--- a/e2e/config/test_env_non_ascii
+++ b/e2e/config/test_env_non_ascii
@@ -19,3 +19,25 @@ assert "mise env"
 # Test 3: Test with actual command that was reported in bug
 # This should not panic (may fail due to network but shouldn't panic)
 mise ls-remote bun >/dev/null 2>&1 || true
+
+# Test 4: a genuinely invalid UTF-8 value must not panic (#5370).
+# std::env::vars() panics if *any* var in the environment is not valid UTF-8, so
+# mise reads the environment through vars_safe(), which skips malformed pairs.
+# The tests above only export *valid* non-ASCII, so they could never catch a
+# reintroduced panic. 0xC0/0xC1 can never appear in valid UTF-8. Both a panic and
+# a graceful error exit non-zero, so the regression marker is the Rust panic
+# text, not the exit status. (Only the value can be malformed here: bash cannot
+# export a variable whose name is not valid UTF-8.)
+INVALID_UTF8_VAR="$(printf '\xc0\xc1')"
+export INVALID_UTF8_VAR
+
+out="$(RUST_BACKTRACE=0 mise --version 2>&1 || true)"
+assert_not_contains_text "$out" "panicked"
+
+out="$(RUST_BACKTRACE=0 mise env 2>&1 || true)"
+assert_not_contains_text "$out" "panicked"
+
+out="$(RUST_BACKTRACE=0 mise ls 2>&1 || true)"
+assert_not_contains_text "$out" "panicked"
+
+unset INVALID_UTF8_VAR

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -280,9 +280,16 @@ where
     // The lazy state must retain the dispatching shim for candidate filtering.
     drop(env::MISE_SHIM_PATH.read().unwrap());
     if sandbox.effective_deny_env() {
-        // When env is sandboxed, clear all vars and only set the filtered ones
-        for (k, _) in std::env::vars() {
-            if !env.contains_key(&k) {
+        // When env is sandboxed, clear all vars and only set the filtered ones.
+        //
+        // Deliberately iterates vars_os() rather than env::vars_safe(): vars_safe()
+        // drops a pair when *either* the key or the value is not valid UTF-8, so a
+        // variable with a non-UTF-8 value (e.g. SECRET=<binary>) would never be
+        // visited here and would survive --deny-env into the sandboxed child.
+        // A key that is not valid UTF-8 can never be present in `env` (a
+        // BTreeMap<String, String>), so treating it as "not allowed" is correct.
+        for (k, _) in std::env::vars_os() {
+            if !k.to_str().is_some_and(|key| env.contains_key(key)) {
                 env::remove_var(&k);
             }
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -997,6 +997,43 @@ mod tests {
         remove_var("MISE_TEST_PATH");
     }
 
+    /// vars_safe() must skip pairs whose key or value is not valid UTF-8 rather
+    /// than panicking the way std::env::vars() does (#5370).
+    #[cfg(unix)]
+    #[test]
+    fn test_vars_safe_skips_invalid_utf8() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        // 0xff can never appear in valid UTF-8.
+        let bad_value_key = "MISE_TEST_VARS_SAFE_BAD_VALUE";
+        let bad_key = OsString::from_vec(b"MISE_TEST_VARS_SAFE_BAD_KEY_\xff".to_vec());
+        let good_key = "MISE_TEST_VARS_SAFE_GOOD";
+
+        // the guard restores the previous environment on drop, so even a failing
+        // assertion below cannot leak a non-UTF-8 var into the test process
+        let mut guard = crate::test::EnvVarGuard::new();
+        guard
+            .set(bad_value_key, OsString::from_vec(vec![0xff]))
+            .set(&bad_key, "ok")
+            .set(good_key, "1");
+
+        // Both malformed vars really are in the process environment...
+        assert!(vars_os().any(|(k, _)| k == bad_value_key));
+        assert!(vars_os().any(|(k, _)| k == bad_key));
+        // ...and vars_safe() returns without panicking.
+        let safe: Vec<(String, String)> = vars_safe().collect();
+
+        assert!(!safe.iter().any(|(k, _)| k == bad_value_key));
+        assert!(
+            !safe
+                .iter()
+                .any(|(k, _)| k.starts_with("MISE_TEST_VARS_SAFE_BAD_KEY_"))
+        );
+        // Valid neighbours are still returned.
+        assert!(safe.iter().any(|(k, v)| k == good_key && v == "1"));
+    }
+
     #[test]
     fn test_auto_env_default_for_version() {
         let v = |s: &str| versions::Versioning::new(s).unwrap();

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -1179,7 +1179,7 @@ mod tests {
 
     impl NodeEnvResetGuard {
         fn clear() -> Self {
-            let vars = std::env::vars()
+            let vars = env::vars_safe()
                 .filter(|(key, _)| key.starts_with("NODE_"))
                 .collect::<BTreeMap<_, _>>();
             for key in vars.keys() {
@@ -1191,7 +1191,7 @@ mod tests {
 
     impl Drop for NodeEnvResetGuard {
         fn drop(&mut self) {
-            for key in std::env::vars()
+            for key in env::vars_safe()
                 .map(|(key, _)| key)
                 .filter(|key| key.starts_with("NODE_"))
                 .collect::<Vec<_>>()

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -138,7 +138,7 @@ impl SandboxConfig {
         // For wildcard patterns, check all parent env vars; for exact names, check directly.
         for pattern in &self.allow_env {
             if pattern.contains('*') {
-                for (key, val) in std::env::vars() {
+                for (key, val) in crate::env::vars_safe() {
                     if !filtered.contains_key(&key) && env_pattern_matches(pattern, &key) {
                         filtered.insert(key, val);
                     }
@@ -322,6 +322,28 @@ mod tests {
         assert!(filtered.contains_key("MYAPP_BAR"));
         assert!(!filtered.contains_key("OTHER_VAR"));
         assert!(filtered.contains_key("PATH")); // default key
+    }
+
+    /// filter_env() walks the parent environment for wildcard allow_env
+    /// patterns; a non-UTF-8 parent var must be skipped, not panic (#5370).
+    #[cfg(unix)]
+    #[test]
+    fn test_filter_env_wildcard_skips_invalid_utf8_parent_var() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let key = "MISE_TEST_SANDBOX_INVALID";
+        let config = SandboxConfig {
+            allow_env: vec!["MISE_TEST_SANDBOX_*".to_string()],
+            ..Default::default()
+        };
+        // restores the environment on drop, even if the assertion below fails
+        let mut guard = crate::test::EnvVarGuard::new();
+        guard.set(key, OsString::from_vec(vec![0xff]));
+
+        let filtered = config.filter_env(&BTreeMap::new());
+
+        assert!(!filtered.contains_key(key));
     }
 
     #[test]

--- a/src/system/packages/plugin.rs
+++ b/src/system/packages/plugin.rs
@@ -77,7 +77,7 @@ impl PackagePluginManager {
                 paths.extend(toolset.list_paths(&config).await);
                 let path =
                     join_paths(&paths).wrap_err("failed to construct package plugin PATH")?;
-                let mut env: IndexMap<String, String> = std::env::vars().collect();
+                let mut env: IndexMap<String, String> = crate::env::vars_safe().collect();
                 env.insert("PATH".into(), path.to_string_lossy().into_owned());
                 Ok(env)
             })

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,5 @@
 use std::env::join_paths;
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
 use indoc::indoc;
@@ -100,6 +101,42 @@ fn init() {
     )
     .unwrap();
     file::make_executable(".mise/tasks/filetask").unwrap();
+}
+
+/// Sets process environment variables for the duration of a test and restores
+/// the previous state when dropped — including on an early panic, so a failing
+/// assertion can never leak a variable into the rest of the test process.
+///
+/// Unit tests run single-threaded (`RUST_TEST_THREADS=1` in `.cargo/config.toml`
+/// and in the `test:unit` task), so a guarded set/read/restore sequence is not
+/// observed by other tests.
+pub struct EnvVarGuard {
+    prev: Vec<(OsString, Option<OsString>)>,
+}
+
+impl EnvVarGuard {
+    pub fn new() -> Self {
+        Self { prev: vec![] }
+    }
+
+    pub fn set<K: AsRef<OsStr>, V: AsRef<OsStr>>(&mut self, key: K, value: V) -> &mut Self {
+        let key = key.as_ref().to_os_string();
+        self.prev.push((key.clone(), env::var_os(&key)));
+        env::set_var(&key, value);
+        self
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // restore in reverse so repeated sets of the same key unwind correctly
+        for (key, prev) in self.prev.drain(..).rev() {
+            match prev {
+                Some(value) => env::set_var(&key, value),
+                None => env::remove_var(&key),
+            }
+        }
+    }
 }
 
 pub fn replace_path(input: &str) -> String {


### PR DESCRIPTION
## Summary
- convert the remaining raw `std::env::vars()` call sites to `crate::env::vars_safe()` (one site needs `vars_os()` instead — see below)
- add a `clippy.toml` disallowing the raw APIs so they can't come back a third time
- add unit tests for `vars_safe()` and the sandbox path, and strengthen the `#5370` e2e test, which could not have caught this

## Context
`std::env::vars()` panics if *any* variable in the process environment is not valid UTF-8. That was #5370 (mise crashed on every invocation for a user who had one such variable). #6708 fixed it by adding `crate::env::vars_safe()` / `args_safe()` and converting the call sites that existed then.

The reason it came back: **`src/env.rs` does `pub use std::env::*`**, so in any file with `use crate::env;` a bare `env::vars()` looks like a mise helper but is std's panicking version. Raw calls have since reappeared in newer code.

This is a narrow but real crash fix, not purely theoretical — three of the four sites are production paths:

| site | reachable via |
|---|---|
| `sandbox::SandboxConfig::filter_env` | `mise exec` **and** `mise run`, whenever an `allow_env` pattern contains a wildcard |
| `system::packages::plugin::hook_env` | any operation on a package plugin |
| `cli::exec::exec_program` | `mise exec --deny-env` / `sandbox.deny_all` (unix) |
| `plugins::core::node` test env guard | test-only |

It is of course much narrower than the original #5370 crash-on-every-invocation, which #6708 already fixed.

### The one non-mechanical change
`cli::exec::exec_program` deliberately iterates `std::env::vars_os()` rather than `vars_safe()`. `vars_safe()` drops a pair when *either* the key or the value is invalid UTF-8, so a variable with a non-UTF-8 **value** (e.g. `SECRET=<binary>`) would never be visited by that loop and would survive `--deny-env` into the sandboxed child. Iterating `vars_os()` and treating a non-UTF-8 key as "not in the allow map" keeps the sandbox failing closed. `env::remove_var` already takes `AsRef<OsStr>`, so the `OsString` key is passed straight through; this mirrors the existing `vars_os()` usage in `task_executor.rs`.

The Windows twin of `exec_program` has no such loop (it warns that the sandbox is unsupported), so there is nothing to change there.

### About the clippy.toml
This would be the repo's first `clippy.toml`. It adds no code behaviour — it's a guard, and CI's existing `cargo clippy -- -D warnings` / `--all-features --all-targets` enforce it with no workflow change. `disallowed_methods` matches on the resolved `DefId`, so it catches `env::vars()` written through the `crate::env` re-export, which is exactly the spelling that let this regress. No `#[allow]` is needed anywhere: `vars_safe`/`args_safe` call `vars_os`/`args_os`, which are different items. `std::env::var` is deliberately not disallowed (it returns `Result` and never panics).

Happy to drop that file if you'd rather not have one — it's independent of the fix itself.

## Tests
- `src/env.rs`: unit test asserting `vars_safe()` skips a var with a non-UTF-8 value *and* one with a non-UTF-8 name, without panicking, while still returning valid neighbours (unix-gated; cleanup runs before the assertions so a failure can't leak a malformed var into the rest of the test process)
- `src/sandbox/mod.rs`: unit test for the wildcard `allow_env` branch with a malformed parent var
- `e2e/config/test_env_non_ascii`: the existing #5370 regression test only exported *valid* non-ASCII (`Ü Ä Ö ß`, `✅`), so it could never have caught a reintroduced panic. It now also exports genuinely invalid UTF-8 (`\xc0\xc1`) and asserts `mise --version` / `env` / `ls` don't print panic text, matching the style of `e2e/cli/test_invalid_utf8_arg`. (Only the value can be malformed there — bash can't export a non-UTF-8 variable *name*; that case is covered by the unit test.)
- `exec_program`'s loop is `#[cfg(all(not(test), unix))]` and the package-plugin path needs an installed plugin, so neither is unit-testable in-process; those rest on review plus the clippy guard.

Verified locally: `rustfmt --check`, `taplo fmt --check` + `taplo check` on the new `clippy.toml`, and `shellcheck -x` + `shfmt` on the e2e script. Compilation, clippy and the test suites are left to CI.

*This PR was prepared by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failures when the environment contains non-UTF-8 keys/values.
  * Improved sandbox “deny environment” clearing so invalid UTF-8 entries are handled correctly.
  * Updated environment filtering and plugin/test environment handling to safely skip malformed entries.

* **Tests**
  * Added e2e regression coverage to ensure commands don’t panic with invalid UTF-8 environment values.
  * Added unit tests for safe environment enumeration and wildcard filtering with non-UTF-8 parent variables.

* **Chores**
  * Tightened linting rules to discourage unsafe environment access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->