### PR TITLE
fix(generate): respect quiet flags for git pre-commit

### DIFF
--- a/e2e/generate/test_generate_git_pre_commit
+++ b/e2e/generate/test_generate_git_pre_commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+git init -q .
+
+assert_contains "mise generate git-pre-commit --quiet" "exec mise run pre-commit"
+
+assert_contains "mise generate git-pre-commit --write" "Wrote to"
+test -x .git/hooks/pre-commit
+assert_contains "cat .git/hooks/pre-commit" "exec mise run pre-commit"
+
+assert_contains "mise generate git-pre-commit --write" "Moving existing hook"
+test -f .git/hooks/pre-commit.old
+
+mise generate git-pre-commit --write --hook quiet-hook >/dev/null
+assert_empty "mise generate git-pre-commit --quiet --write --hook quiet-hook 2>&1"
+test -x .git/hooks/quiet-hook
+test -f .git/hooks/quiet-hook.old
+
+mise generate git-pre-commit --write --hook silent-hook >/dev/null
+assert_empty "mise generate git-pre-commit --silent --write --hook silent-hook 2>&1"
+test -x .git/hooks/silent-hook
+test -f .git/hooks/silent-hook.old

--- a/src/cli/generate/git_pre_commit.rs
+++ b/src/cli/generate/git_pre_commit.rs
@@ -1,5 +1,6 @@
 use xx::file::display_path;
 
+use crate::config::Settings;
 use crate::file;
 use crate::git::Git;
 
@@ -29,18 +30,23 @@ impl GitPreCommit {
     pub async fn run(self) -> eyre::Result<()> {
         let output = self.generate();
         if self.write {
+            let quiet = Settings::get().quiet;
             let path = Git::get_root()?.join(".git/hooks").join(&self.hook);
             if path.exists() {
                 let old_path = path.with_extension("old");
-                miseprintln!(
-                    "Moving existing hook to {:?}",
-                    old_path.file_name().unwrap()
-                );
+                if !quiet {
+                    miseprintln!(
+                        "Moving existing hook to {:?}",
+                        old_path.file_name().unwrap()
+                    );
+                }
                 file::rename(&path, path.with_extension("old"))?;
             }
             file::write(&path, &output)?;
             file::make_executable(&path)?;
-            miseprintln!("Wrote to {}", display_path(&path));
+            if !quiet {
+                miseprintln!("Wrote to {}", display_path(&path));
+            }
         } else {
             miseprintln!("{output}");
         }


### PR DESCRIPTION
## Problem

`mise generate git-pre-commit --write` printed `Moving existing hook...` and `Wrote to...` even when global `--quiet` or `--silent` was set. These are auxiliary write-status messages rather than generated content.

## Change

- Gate write-status messages on the existing global quiet setting.
- Preserve hook replacement, file writing, and executable permissions under quiet and silent modes.
- Keep the generated script on standard output without `--write`, because it is the command’s primary output.
- Add E2E coverage for normal writes, hook replacement, quiet mode, silent mode, and non-write output.

## Testing

- `mise exec -- cargo fmt --all -- --check`
- `mise run test:e2e e2e/generate/test_generate_git_pre_commit`
- `mise exec -- cargo check --all-features`
- `mise exec -- shellcheck -x e2e/generate/test_generate_git_pre_commit`
- `mise exec -- shfmt -d -s e2e/generate/test_generate_git_pre_commit`

`mise run lint` was also attempted, but its `hk` wrapper requires a Git working copy and this checkout is managed by Sapling. The relevant underlying checks listed above passed.

Addresses https://github.com/jdx/mise/discussions/4614

---
*This pull request was generated by an AI coding assistant.*