### PR TITLE
fix(generate): use current env directive syntax

### DIFF
--- a/e2e/generate/test_generate_config
+++ b/e2e/generate/test_generate_config
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+assert_contains "mise generate config -n" '_.file = ".env"'
+assert_contains "mise generate config -n" '_.path = "./node_modules/.bin"'
+assert_not_contains "mise generate config -n" 'mise.file = ".env"'
+assert_not_contains "mise generate config -n" 'mise.path = "./node_modules/.bin"'
+
 cat <<EOF >.tool-versions
 node 22
 python 3.9 3.10 3.11

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -297,8 +297,8 @@ impl Edit {
 
             # [env]
             # NODE_ENV = "development"
-            # mise.file = ".env"                # load vars from a dotenv file
-            # mise.path = "./node_modules/.bin" # add a directory to PATH
+            # _.file = ".env"                # load vars from a dotenv file
+            # _.path = "./node_modules/.bin" # add a directory to PATH
 
             # [tools]
             # node = "22"


### PR DESCRIPTION
## Problem

`mise generate config` still advertised the legacy `mise.file` and `mise.path` environment directive syntax in its default template, while current documentation and examples use `_.file` and `_.path`. This could make newly generated configuration confusing.

## Change

- Update the default generated config examples to use `_.file` and `_.path`.
- Keep support for the legacy directive syntax unchanged.
- Add E2E coverage that requires the current syntax and rejects the legacy syntax in dry-run output.

## Testing

- `mise run test:e2e e2e/generate/test_generate_config`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck -x e2e/generate/test_generate_config`
- `mise exec -- shfmt -d -s e2e/generate/test_generate_config`

`mise run format` and `mise run lint` were also attempted, but their `hk` wrapper requires a Git working copy and this checkout is managed by Sapling. The relevant underlying checks listed above passed.

Addresses https://github.com/jdx/mise/discussions/4840

---
*This pull request was generated by an AI coding assistant.*