### PR TITLE
fix(env): expand ~/ with platform path separators

### DIFF
--- a/e2e-win/bun.Tests.ps1
+++ b/e2e-win/bun.Tests.ps1
@@ -8,6 +8,13 @@ Describe 'bun' {
         mise install bun@1.3.13 --force | Out-Null
 
         $installPath = (mise where bun@1.3.13).Trim()
+
+        # The windows CI jobs run with `MISE_DATA_DIR=~/.local/share/mise`
+        # (.github/workflows/test.yml). Expanding that must use the platform
+        # separator throughout - mise used to emit
+        # `C:\Users\runneradmin\.local/share/mise/installs/...`.
+        $installPath | Should -Not -Match '/'
+
         $binDir = Join-Path $installPath 'bin'
 
         # bun.exe should always be present.

--- a/e2e-win/python.Tests.ps1
+++ b/e2e-win/python.Tests.ps1
@@ -43,11 +43,17 @@ Describe 'python' {
         $p.ExitCode | Should -Be 0
         (Get-Content $out -Raw) | Should -Match '^pip \d'
 
-        # normalize separators: `mise which` echoes the configured data dir
-        # verbatim (it can contain forward slashes), while `mise where` returns
-        # an absolutized path
-        $whichPip = (mise which pip --tool python@3.12.0).Trim().Replace('/', '\')
-        $whichPip | Should -Be (Join-Path $installPath 'pip.cmd').Replace('/', '\')
+        # No separator normalization here on purpose: this doubles as a
+        # regression test for `file::replace_path`. The windows-e2e job runs with
+        # `MISE_DATA_DIR=~/.local/share/mise`, which mise used to expand to
+        # `C:\Users\runneradmin\.local/share/mise` - mixed separators that then
+        # showed up verbatim in `mise which`/`mise where` output. (`$installPath`
+        # comes from `mise where`; PowerShell's `Join-Path` folds `/` to `\` in
+        # its parent argument, so the right-hand side is backslash-only either
+        # way - which is why only the `mise which` side ever looked wrong.)
+        $whichPip = (mise which pip --tool python@3.12.0).Trim()
+        $whichPip | Should -Not -Match '/'
+        $whichPip | Should -Be (Join-Path $installPath 'pip.cmd')
     }
 
     It 'puts Scripts on PATH so pip-installed console scripts run' {

--- a/src/env.rs
+++ b/src/env.rs
@@ -77,7 +77,7 @@ pub static XDG_DATA_HOME: Lazy<PathBuf> =
 pub static XDG_DATA_HOME: Lazy<PathBuf> = Lazy::new(|| {
     var_path("XDG_DATA_HOME")
         .or(var_path("LOCALAPPDATA"))
-        .unwrap_or_else(|| HOME.join("AppData/Local"))
+        .unwrap_or_else(|| HOME.join("AppData").join("Local"))
 });
 pub static XDG_STATE_HOME: Lazy<PathBuf> =
     Lazy::new(|| var_path("XDG_STATE_HOME").unwrap_or_else(|| HOME.join(".local").join("state")));

--- a/src/file.rs
+++ b/src/file.rs
@@ -378,11 +378,35 @@ pub fn replace_paths_in_string<S: Display>(input: S) -> String {
 }
 
 /// replaces "~" with $HOME
+///
+/// The remainder is re-joined one component at a time rather than pushed as a
+/// single slice. `Path::strip_prefix` returns a raw subslice of the input — it
+/// trims the remainder's leading/trailing separators but leaves interior ones
+/// untouched — so `HOME.join(rest)` only prepends a separator. On Windows that
+/// made `~/.local/share/mise` expand to `C:\Users\me\.local/share/mise`, and
+/// since `MISE_DATA_DIR` flows into `dirs::DATA`/`INSTALLS`, that mixed-separator
+/// path surfaced verbatim in `mise where`, `mise which`, `mise ls --json`,
+/// `mise bin-paths`, shims, and error messages.
+///
+/// Rebuilding from `components()` also folds redundant separators and `.`
+/// segments; `..` is preserved. On unix the result is byte-identical to the old
+/// behavior for any ordinary input.
+///
+/// Paths without a `~/` prefix are returned unchanged: a user-supplied
+/// `C:/mise/data` stays exactly as typed. This is a tilde expander, not a path
+/// normalizer — one caller passes glob patterns through it
+/// (`config::expand_task_include`).
 pub fn replace_path<P: AsRef<Path>>(path: P) -> PathBuf {
     let path = path.as_ref();
-    match path.starts_with("~/") {
-        true => dirs::HOME.join(path.strip_prefix("~/").unwrap()),
-        false => path.to_path_buf(),
+    match path.strip_prefix("~/") {
+        Ok(rest) => {
+            let mut expanded = dirs::HOME.to_path_buf();
+            for component in rest.components() {
+                expanded.push(component.as_os_str());
+            }
+            expanded
+        }
+        Err(_) => path.to_path_buf(),
     }
 }
 
@@ -2173,6 +2197,62 @@ mod tests {
         let _config = Config::get().await.unwrap();
         assert_eq!(replace_path(Path::new("~/cwd")), dirs::HOME.join("cwd"));
         assert_eq!(replace_path(Path::new("/cwd")), Path::new("/cwd"));
+    }
+
+    #[test]
+    fn test_replace_path_uses_platform_separators() {
+        // `strip_prefix("~/")` returns a raw subslice of the input, so the naive
+        // `HOME.join(rest)` only prepended a separator and left the interior ones
+        // alone: on Windows `MISE_DATA_DIR=~/.local/share/mise` used to expand to
+        // `C:\Users\me\.local/share/mise`, which then leaked out through
+        // `mise where`, `mise which`, `mise ls --json`, shims, and error messages.
+        //
+        // NOTE: comparing PathBufs is not enough here — `Path`'s `PartialEq` is
+        // component-based and treats `/` and `\` as equivalent on Windows, so the
+        // buggy value compares equal to the correct one. The string form is the
+        // assertion that matters.
+        let expanded = replace_path(Path::new("~/a/b"));
+        let expected = dirs::HOME.join("a").join("b");
+        assert_eq!(expanded, expected);
+        assert_eq!(expanded.to_string_lossy(), expected.to_string_lossy());
+
+        // independent of whatever HOME itself looks like
+        #[cfg(windows)]
+        {
+            let rest = expanded.strip_prefix(*dirs::HOME).unwrap();
+            assert!(
+                !rest.to_string_lossy().contains('/'),
+                "expanded remainder must use `\\`: {}",
+                expanded.display()
+            );
+        }
+
+        // a bare `~` expands to $HOME: `strip_prefix("~/")` is component-based,
+        // so `~` matches the prefix and the remainder is empty
+        assert_eq!(replace_path(Path::new("~")), *dirs::HOME);
+
+        // non-`~/` input is passed through untouched, separators and all
+        assert_eq!(
+            replace_path(Path::new("/cwd/x")).to_string_lossy(),
+            "/cwd/x"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_pathbuf_hashset_is_separator_insensitive() {
+        // `EnvDiff::path` is Vec<PathBuf> and `get_pristine_env` strips
+        // mise-added PATH entries via a HashSet<&PathBuf>. `Path`'s Hash/Eq are
+        // component-based and both `/` and `\` are separators on Windows, so a
+        // `__MISE_DIFF` written by an older mise (mixed separators) still matches
+        // after the expansion fix above — no migration is needed.
+        let mut set = std::collections::HashSet::new();
+        set.insert(PathBuf::from(
+            r"C:\Users\me\.local/share/mise/installs/go/1/bin",
+        ));
+        assert!(set.contains(&PathBuf::from(
+            r"C:\Users\me\.local\share\mise\installs\go\1\bin"
+        )));
     }
 
     #[test]

--- a/src/system/launchd.rs
+++ b/src/system/launchd.rs
@@ -608,11 +608,17 @@ mod tests {
                 crate::dirs::HOME.to_string_lossy().to_string()
             ))
         );
+        // joined component-by-component to match how `file::replace_path`
+        // expands the `~/...` request values: the rendered string uses the
+        // platform separator throughout, so `join("Library/Logs/sync.log")`
+        // would keep forward slashes and mismatch on Windows
         assert_eq!(
             dict.get("StandardOutPath"),
             Some(&Value::String(
                 crate::dirs::HOME
-                    .join("Library/Logs/sync.log")
+                    .join("Library")
+                    .join("Logs")
+                    .join("sync.log")
                     .to_string_lossy()
                     .to_string()
             ))
@@ -621,7 +627,9 @@ mod tests {
             dict.get("StandardErrorPath"),
             Some(&Value::String(
                 crate::dirs::HOME
-                    .join("Library/Logs/sync.err.log")
+                    .join("Library")
+                    .join("Logs")
+                    .join("sync.err.log")
                     .to_string_lossy()
                     .to_string()
             ))


### PR DESCRIPTION
## Summary
- expand `~/` component-by-component in `file::replace_path` so the platform separator is used throughout
- chain the join in the Windows `XDG_DATA_HOME` fallback, which had the same problem
- add a unit test that asserts on the *string* form (a `PathBuf` comparison cannot catch this), and turn two `e2e-win` assertions into regression tests

## Problem
`file::replace_path` expanded `~/foo/bar` by pushing the stripped remainder as a single slice. `Path::strip_prefix` returns a raw subslice of the input — it trims the remainder's leading/trailing separators but leaves the interior ones untouched — so `HOME.join(rest)` only prepends a separator:

```
> $env:MISE_DATA_DIR = '~/.local/share/mise'
> mise where node@22
C:\Users\me\.local/share/mise/installs/node/22.14.0
```

That mixed-separator path then propagates through `var_path` → `MISE_DATA_DIR` → `MISE_INSTALLS_DIR` → `BackendArg::installs_path` → `ToolVersion::install_path`, so it surfaces verbatim from `mise where`, `mise which`, `mise ls --json`, `mise bin-paths`, `mise env --json`, generated shims, and tool-stub error messages.

This isn't hypothetical — mise's own CI hits it: the `windows-unit` and `windows-e2e` jobs both set `MISE_DATA_DIR: ~/.local/share/mise`. `e2e-win/python.Tests.ps1` carried a `.Replace('/', '\')` workaround because of it (removed here, so that assertion now guards the fix).

## Why no `cfg(windows)`
Rebuilding from `components()` uses `MAIN_SEPARATOR`, which is `/` on unix — the result is byte-identical to the old behavior for any ordinary input, so this is a no-op there.

## Behavior changes
Every difference is `Path`-equal to what it replaced, because `Path`'s `Eq`/`Ord`/`Hash` are component-based and treat `/` and `\` as equivalent on Windows (the same property `file::paths_eq` documents). Only the rendered string changes:

| input | before | after |
|---|---|---|
| `~/.local/share/mise` | `C:\Users\me\.local/share/mise` | `C:\Users\me\.local\share\mise` |
| `~/a/./b` | `C:\Users\me\a/./b` | `C:\Users\me\a\b` |
| `~` | `$HOME` with a trailing separator | `$HOME` |
| `~/cwd`, `~//x`, `~/a/` | unchanged | unchanged |

`..` is preserved in both.

## Scope: only `~/`-prefixed inputs
A user-supplied `C:/mise/data` is passed through exactly as typed. It's self-consistent (not mixed), it's what the user wrote, and `replace_path` is also applied to **glob patterns** in `config::expand_task_include` — normalizing every input would rewrite patterns nobody asked to change. This is a tilde expander, not a path normalizer; the doc comment now says so.

## Compatibility — no migration needed
I checked the state that could plausibly be keyed on the old string form, and none of it is:

- **`__MISE_DIFF`**: `EnvDiff::path` is `Vec<PathBuf>` and `get_pristine_env` removes mise-added PATH entries through a `HashSet<&PathBuf>`. Since `Path`'s `Hash`/`Eq` are component-based, a shell activated *before* upgrading still un-does its old-format entries correctly on the next `hook-env`. A unit test now pins this assumption.
- **trust files**: `canonicalize()` first, then hash a `PathBuf`.
- **task source fingerprints**: `Vec<(&PathBuf, u64)>`.
- **hook-env fingerprint**: hashes the raw `MISE_*` env strings, not the expanded form.
- **`glob` (pinned 0.3.3)**: splits patterns via `Path::components()` / `path::is_separator` with an explicit `cfg!(windows)` both-separators branch, and has no backslash-escape syntax — so a `~/`-prefixed task-include glob behaves identically with `\`.

## Tests
- `src/file.rs`: new unit test asserting on `to_string_lossy()`. Worth calling out that the existing `test_replace_path` could never have caught this — `assert_eq!` on `PathBuf` is component-based, so the buggy value compares *equal* to the correct one.
- `src/file.rs`: 4-line Windows test pinning the `HashSet<PathBuf>` separator-insensitivity that the compatibility argument above rests on.
- `e2e-win/bun.Tests.ps1`: one assertion on the existing `mise where` output (no new install, no added CI time).
- `e2e-win/python.Tests.ps1`: dropped the `.Replace('/', '\')` workaround and corrected a comment of mine that was wrong — it claimed `mise where` returns an absolutized path while `mise which` echoes the configured dir verbatim. Both actually print the same unmodified `install_path()`; what made `where` look normalized is that PowerShell's `Join-Path` folds `/` to `\` in its parent argument.

Both Windows CI jobs already run with a `~/` data dir, i.e. exactly the configuration that reproduces this.

Verified locally: `rustfmt --check` and a PowerShell parser check on the two Pester files. Compilation and the test suites are left to CI.

*This PR was prepared by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling to keep installation and tool wrapper locations free of mixed separators.
  * Fixed home-directory (`~/`) path expansion to use platform-appropriate path formatting.
  * Corrected the default Windows data-directory path layout for `XDG_DATA_HOME`.
* **Tests**
  * Expanded Windows e2e coverage for installation paths, `pip` wrapper selection, and `~/` expansion (including mixed-separator regression checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->