### PR TITLE
fix(generate): resolve hooks in git worktrees

### DIFF
--- a/e2e/generate/test_generate_git_pre_commit_worktree
+++ b/e2e/generate/test_generate_git_pre_commit_worktree
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+mkdir repo
+cd repo || exit 1
+git init -q .
+git -c user.email=e2e@example.com -c user.name=e2e commit --allow-empty -qm init
+
+mise generate git-pre-commit --write --hook main-hook --task main-task
+test -x .git/hooks/main-hook
+assert_contains "cat .git/hooks/main-hook" "exec mise run main-task"
+
+git worktree add -q ../worktree
+cd ../worktree || exit 1
+test -f .git
+assert_contains "mise generate git-pre-commit --write --hook worktree-hook --task worktree-task" "Wrote to"
+test -x ../repo/.git/hooks/worktree-hook
+assert_contains "cat ../repo/.git/hooks/worktree-hook" "exec mise run worktree-task"

--- a/src/cli/generate/git_pre_commit.rs
+++ b/src/cli/generate/git_pre_commit.rs
@@ -31,7 +31,7 @@ impl GitPreCommit {
         let output = self.generate();
         if self.write {
             let quiet = Settings::get().quiet;
-            let path = Git::get_root()?.join(".git/hooks").join(&self.hook);
+            let path = Git::get_path("hooks")?.join(&self.hook);
             if path.exists() {
                 let old_path = path.with_extension("old");
                 if !quiet {

--- a/src/git.rs
+++ b/src/git.rs
@@ -393,6 +393,17 @@ impl Git {
             .trim()
             .into())
     }
+
+    pub fn get_path<P: AsRef<Path>>(path: P) -> eyre::Result<PathBuf> {
+        let root = Self::get_root()?;
+        let path = cmd!("git", "-C", &root, "rev-parse", "--git-path", path.as_ref()).read()?;
+        let path = PathBuf::from(path.trim());
+        Ok(if path.is_absolute() {
+            path
+        } else {
+            root.join(path)
+        })
+    }
 }
 
 fn get_git_version() -> Result<String> {


### PR DESCRIPTION
## Problem

`mise generate git-pre-commit --write` constructed the hook destination as `<worktree-root>/.git/hooks/<hook>`. In a linked Git worktree, `.git` is a file that points to the worktree metadata directory, so writing the generated hook failed.

## Change

- Resolve Git-managed paths through `git rev-parse --git-path`.
- Write generated hooks to the shared Git hooks directory returned for both normal repositories and linked worktrees.
- Preserve hook backup, content generation, and executable permissions.
- Add an E2E test that creates a real linked worktree and verifies both normal and worktree hook installation.

## Testing

- `mise run test:e2e e2e/generate/test_generate_git_pre_commit_worktree`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck -x e2e/generate/test_generate_git_pre_commit_worktree`
- `mise exec -- shfmt -d -s e2e/generate/test_generate_git_pre_commit_worktree`

`mise run format` and `mise run lint` were also attempted, but their `hk` wrapper requires a Git working copy and this checkout is managed by Sapling. The relevant underlying checks listed above passed.

Addresses https://github.com/jdx/mise/discussions/4853

---
*This pull request was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git pre-commit hooks now write to the correct hooks directory when working with Git worktrees.
  - Existing hook behavior is preserved, including executable permissions and backup creation.

- **Tests**
  - Added end-to-end coverage verifying hook generation, placement, permissions, and task invocation in both standard repositories and worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->