### PR TITLE
fix(shell): make pwsh activation work under Set-StrictMode

### DIFF
--- a/e2e-win/activate_strictmode.Tests.ps1
+++ b/e2e-win/activate_strictmode.Tests.ps1
@@ -1,0 +1,46 @@
+Describe 'activate under Set-StrictMode' {
+    # https://github.com/jdx/mise/discussions/5312 - the activation script read
+    # globals that were never assigned, which Set-StrictMode turns into
+    # terminating errors, so `mise activate pwsh | Invoke-Expression` aborted.
+    #
+    # This must run in a child process: mise_hook.Tests.ps1 activates in the
+    # shared Pester runspace, and `mise deactivate` does not remove the
+    # $Global:__mise_pwsh_* sentinels - so an in-process activation here would
+    # skip the very branches under test and pass regardless. -NoProfile keeps a
+    # developer profile from pre-activating for the same reason.
+    It 'activates and runs a bare `mise` without StrictMode errors' {
+        $probe = @'
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+mise activate pwsh | Out-String | Invoke-Expression
+# without this the calls below would fall through to the native executable and
+# pass even if Invoke-Expression never defined the wrapper
+if (-not (Get-Command mise -CommandType Function -ErrorAction SilentlyContinue)) {
+    Write-Output 'ACTIVATION-ERROR: activation did not define the mise function'
+    exit 1
+}
+mise --version | Out-Null
+mise | Out-Null
+Set-Location $env:TEMP
+# the command-not-found hook inspects PSReadLine history, which is unavailable
+# here - it must stay quiet instead of erroring on every unknown command
+try { some-command-that-does-not-exist-xyz } catch { }
+# only StrictMode/handler violations count - mise's own warnings and the shell's
+# own "not recognized" error must not fail this
+$pattern = 'has not been set|cannot be found on this object|Cannot index into a null array|Unable to find type|Index was outside the bounds'
+$strict = $Error | Where-Object { $_.Exception.Message -match $pattern }
+if ($strict) {
+    foreach ($e in $strict) { Write-Output "STRICTMODE-ERROR: $($e.Exception.Message)" }
+    exit 1
+}
+Write-Output 'STRICTMODE-OK'
+'@
+        $out = pwsh -NoProfile -NonInteractive -Command $probe 2>&1 | Out-String
+
+        $out | Should -Not -Match 'has not been set'
+        $out | Should -Not -Match 'cannot be found on this object'
+        $out | Should -Not -Match 'Unable to find type'
+        $out | Should -Match 'STRICTMODE-OK'
+        $LASTEXITCODE | Should -Be 0
+    }
+}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -34,7 +34,7 @@ impl Shell for Pwsh {
                 [CmdletBinding()]
                 param(
                     [Parameter(ValueFromRemainingArguments=$true)]  # Allow any number of arguments, including none
-                    [string[]] $arguments
+                    [string[]] $arguments = @()  # defaults to an empty array: a bare `mise` binds $null, which Set-StrictMode rejects on .count
                 )
 
                 $previous_out_encoding = $OutputEncoding
@@ -101,7 +101,7 @@ impl Shell for Pwsh {
                     }}
                     return
                 }}
-                if (-not $__mise_pwsh_chpwd){{
+                if (-not (Test-Path variable:global:__mise_pwsh_chpwd)){{
                     $Global:__mise_pwsh_chpwd= $true
                     $_mise_chpwd_hook = [EventHandler[System.Management.Automation.LocationChangedEventArgs]] {{
                         param([object] $source, [System.Management.Automation.LocationChangedEventArgs] $eventArgs)
@@ -111,7 +111,7 @@ impl Shell for Pwsh {
                     }};
                     $__mise_pwsh_previous_chpwd_function=$ExecutionContext.SessionState.InvokeCommand.LocationChangedAction;
 
-                    if ($__mise_original_pwsh_chpwd_function) {{
+                    if ($__mise_pwsh_previous_chpwd_function) {{
                         $ExecutionContext.SessionState.InvokeCommand.LocationChangedAction = [Delegate]::Combine($__mise_pwsh_previous_chpwd_function, $_mise_chpwd_hook)
                     }}
                     else {{
@@ -123,7 +123,7 @@ impl Shell for Pwsh {
             Remove-Item -ErrorAction SilentlyContinue -Path Function:/__enable_mise_chpwd
 
             function __enable_mise_prompt {{
-                if (-not $__mise_pwsh_previous_prompt_function){{
+                if (-not (Test-Path variable:global:__mise_pwsh_previous_prompt_function)){{
                     $Global:__mise_pwsh_previous_prompt_function=$function:prompt
                     function global:prompt {{
                         if (Test-Path -Path Function:\_mise_hook){{
@@ -141,13 +141,31 @@ impl Shell for Pwsh {
         }
         if Settings::get().not_found_auto_install {
             out.push_str(&formatdoc! {r#"
-            if (-not $__mise_pwsh_command_not_found){{
+            if (-not (Test-Path variable:global:__mise_pwsh_command_not_found)){{
                 $Global:__mise_pwsh_command_not_found= $true
                 function __enable_mise_command_not_found {{
                     $_mise_pwsh_cmd_not_found_hook = [EventHandler[System.Management.Automation.CommandLookupEventArgs]] {{
                         param([object] $Name, [System.Management.Automation.CommandLookupEventArgs] $eventArgs)
                         end {{
-                            if ([Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems()[-1].CommandLine -match ([regex]::Escape($Name))) {{
+                            # Only auto-install when the missing command is what the
+                            # user actually typed. PSReadLine is absent in
+                            # non-interactive sessions, and even when its module is
+                            # loaded GetHistoryItems() throws until the line editor
+                            # initializes, so treat "cannot tell" as "not typed".
+                            $lastCommand = $null
+                            try {{
+                                $psReadLine = 'Microsoft.PowerShell.PSConsoleReadLine' -as [type]
+                                if ($psReadLine) {{
+                                    $history = @($psReadLine::GetHistoryItems())
+                                    if ($history.Count -gt 0) {{
+                                        $lastCommand = $history[-1].CommandLine
+                                    }}
+                                }}
+                            }} catch {{ }}
+                            # compare whole tokens: a substring match would fire for
+                            # `mise` when the user typed `premise`, while matching only
+                            # the first token would miss `... | some-missing-tool`
+                            if ($lastCommand -and (($lastCommand -split '\s+') -contains $Name)) {{
                                 if (& "{exe}" hook-not-found -s pwsh -- $Name){{
                                     _mise_hook
                                     if (Get-Command $Name -ErrorAction SilentlyContinue){{

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -11,7 +11,7 @@ function mise {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromRemainingArguments=$true)]  # Allow any number of arguments, including none
-        [string[]] $arguments
+        [string[]] $arguments = @()  # defaults to an empty array: a bare `mise` binds $null, which Set-StrictMode rejects on .count
     )
 
     $previous_out_encoding = $OutputEncoding
@@ -74,7 +74,7 @@ function __enable_mise_chpwd{
         }
         return
     }
-    if (-not $__mise_pwsh_chpwd){
+    if (-not (Test-Path variable:global:__mise_pwsh_chpwd)){
         $Global:__mise_pwsh_chpwd= $true
         $_mise_chpwd_hook = [EventHandler[System.Management.Automation.LocationChangedEventArgs]] {
             param([object] $source, [System.Management.Automation.LocationChangedEventArgs] $eventArgs)
@@ -84,7 +84,7 @@ function __enable_mise_chpwd{
         };
         $__mise_pwsh_previous_chpwd_function=$ExecutionContext.SessionState.InvokeCommand.LocationChangedAction;
 
-        if ($__mise_original_pwsh_chpwd_function) {
+        if ($__mise_pwsh_previous_chpwd_function) {
             $ExecutionContext.SessionState.InvokeCommand.LocationChangedAction = [Delegate]::Combine($__mise_pwsh_previous_chpwd_function, $_mise_chpwd_hook)
         }
         else {
@@ -96,7 +96,7 @@ __enable_mise_chpwd
 Remove-Item -ErrorAction SilentlyContinue -Path Function:/__enable_mise_chpwd
 
 function __enable_mise_prompt {
-    if (-not $__mise_pwsh_previous_prompt_function){
+    if (-not (Test-Path variable:global:__mise_pwsh_previous_prompt_function)){
         $Global:__mise_pwsh_previous_prompt_function=$function:prompt
         function global:prompt {
             if (Test-Path -Path Function:\_mise_hook){
@@ -110,13 +110,31 @@ __enable_mise_prompt
 Remove-Item -ErrorAction SilentlyContinue -Path Function:/__enable_mise_prompt
 
 _mise_hook
-if (-not $__mise_pwsh_command_not_found){
+if (-not (Test-Path variable:global:__mise_pwsh_command_not_found)){
     $Global:__mise_pwsh_command_not_found= $true
     function __enable_mise_command_not_found {
         $_mise_pwsh_cmd_not_found_hook = [EventHandler[System.Management.Automation.CommandLookupEventArgs]] {
             param([object] $Name, [System.Management.Automation.CommandLookupEventArgs] $eventArgs)
             end {
-                if ([Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems()[-1].CommandLine -match ([regex]::Escape($Name))) {
+                # Only auto-install when the missing command is what the
+                # user actually typed. PSReadLine is absent in
+                # non-interactive sessions, and even when its module is
+                # loaded GetHistoryItems() throws until the line editor
+                # initializes, so treat "cannot tell" as "not typed".
+                $lastCommand = $null
+                try {
+                    $psReadLine = 'Microsoft.PowerShell.PSConsoleReadLine' -as [type]
+                    if ($psReadLine) {
+                        $history = @($psReadLine::GetHistoryItems())
+                        if ($history.Count -gt 0) {
+                            $lastCommand = $history[-1].CommandLine
+                        }
+                    }
+                } catch { }
+                # compare whole tokens: a substring match would fire for
+                # `mise` when the user typed `premise`, while matching only
+                # the first token would miss `... | some-missing-tool`
+                if ($lastCommand -and (($lastCommand -split '\s+') -contains $Name)) {
                     if (& "/some/dir/mise" hook-not-found -s pwsh -- $Name){
                         _mise_hook
                         if (Get-Command $Name -ErrorAction SilentlyContinue){


### PR DESCRIPTION
## Summary
- guard the three uninitialized globals the pwsh activation script reads, so `Set-StrictMode` doesn't abort activation
- fix a typo that made the chpwd `[Delegate]::Combine` branch dead code (mise was silently clobbering a pre-existing `LocationChangedAction`)
- default the `mise` function's `$arguments` to `@()`, so a bare `mise` works under StrictMode too
- stop the command-not-found hook from erroring on every unknown command when PSReadLine isn't available
- add an `e2e-win` regression test that exercises all of the above in a child StrictMode pwsh

## Context
Fixes https://github.com/jdx/mise/discussions/5312.

`Set-StrictMode` makes reading a never-assigned variable a terminating error. The activation script reads three globals that are only assigned *inside* the branch that tests them, so `mise activate pwsh | Invoke-Expression` aborts at the first one:

```
The variable '$__mise_pwsh_chpwd' cannot be retrieved because it has not been set.
```

Because that error is terminating, the chpwd, prompt and command-not-found blocks never run at all — the user gets an error and a half-activated shell.

Four distinct problems, all verified on Windows 11 against v2026.7.x before and after the change:

1. **Uninitialized global reads** (`$__mise_pwsh_chpwd`, `$__mise_pwsh_previous_prompt_function`, `$__mise_pwsh_command_not_found`). Now guarded with `Test-Path variable:global:...`, which mirrors the `Test-Path -Path Env:/__MISE_ORIG_PATH` and `Test-Path -Path Function:\_mise_hook` guards this same script already uses — same idiom, different provider. Testing *existence* rather than truthiness also fixes a latent bug in the prompt latch: if `$function:prompt` were `$null`, the old check never latched and the prompt got re-wrapped on every activation.

2. **A typo that disabled hook chaining.** The chpwd block tested `$__mise_pwsh_original_chpwd_function`, which is assigned nowhere in the repo; the variable assigned on the line above is `$__mise_pwsh_previous_chpwd_function`. Besides tripping StrictMode, this made the `[Delegate]::Combine` branch unreachable, so mise **overwrote** any `LocationChangedAction` another module had installed instead of chaining onto it. Fixing the name restores the behavior the code was written for — worth calling out as a behavior change, even though it only affects users who had another `cd` hook.

3. **A bare `mise` under StrictMode.** `ValueFromRemainingArguments` binds `$null` (not an empty array) when the function is called with no arguments, so `$arguments.count` was a property access on `$null`:

   ```
   The property 'count' cannot be found on this object.
   ```

   Defaulting the parameter to `@()` fixes that and also protects the `-contains`, `$arguments[0]` and `.Length` uses further down.

4. **The command-not-found hook erroring on every unknown command.** It inspects PSReadLine's history to decide whether the missing command is what the user actually typed. PSReadLine is absent in non-interactive sessions — and, less obviously, even when its module *is* loaded `GetHistoryItems()` throws `NullReferenceException` until the line editor initializes. So every unknown command produced

   ```
   Unable to find type [Microsoft.PowerShell.PSConsoleReadLine].
   ```

   on top of the shell's own "not recognized" error, and an empty history additionally indexed out of bounds (`Index was outside the bounds of the array` under StrictMode 3.0+). The type is now looked up by name, the call is guarded, and "cannot tell what was typed" is treated as "not typed" — which is what already effectively happened, minus the noise. Interactive behavior is unchanged.

## Verification
I can't run the Windows CI locally, but since the template *is* the emitted text, I verified by applying these exact edits to the script `mise activate pwsh` produces and running it in a child `pwsh -NoProfile -NonInteractive` under `Set-StrictMode -Version Latest`:

| scenario | before | after |
|---|---|---|
| `mise activate pwsh \| Invoke-Expression` | `'$__mise_pwsh_chpwd' ... has not been set` | no errors |
| bare `mise` | `The property 'count' cannot be found` | prints help |
| unknown command | 2 errors (incl. `Unable to find type [...PSConsoleReadLine]`) | 1 error (just the shell's own) |
| activate a second time (latch) | — | no errors, no re-wrap |
| `Set-Location` (chpwd hook) | — | no errors |

I also confirmed the sender argument of `CommandNotFoundAction` really is the command name (a `System.String`), so the existing `$Name` usage is correct and unchanged.

## Tests
`e2e-win/activate_strictmode.Tests.ps1` runs everything in a **child** process. That matters: `mise_hook.Tests.ps1` activates in the shared Pester runspace and `mise deactivate` does not remove the `$Global:__mise_pwsh_*` sentinels, so an in-process activation would skip exactly the branches under test and pass no matter what. `-NoProfile` prevents a developer profile from pre-activating for the same reason. It asserts the wrapper function was actually defined (otherwise the later calls would silently fall through to the native executable), and only matches StrictMode/handler-shaped messages so mise's own warnings can't fail it. Confirmed it fails against an unfixed mise — catching all six distinct errors — and passes with the fix.

The snapshot was hand-edited to match; `src/shell/snapshots/mise__shell__pwsh__tests__activate.snap` is the only affected artifact (no `assert!(contains)` assertions exist in `src/shell/`).

Side note: `scripts/build-tarball.ps1` already opens with `Set-StrictMode -Version Latest`, so mise's own PowerShell tooling assumes it.

*This PR was prepared by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pwsh` activation to work cleanly with `Set-StrictMode -Version Latest`, including safer behavior when no activation arguments are provided.
  * Updated hook enablement to more reliably detect existing prior state before activating prompt/chpwd/command-not-found behavior.
  * Reworked command-not-found matching to be more resilient, safely handling history and only triggering auto-install when the missing command is confidently identified.

* **Tests**
  * Added an end-to-end Pester test for strict-mode activation that validates wrapper creation, expected output, and successful exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->