### PR TITLE
fix(task): skip output mtime guard when source_freshness_hash_contents=true

### DIFF
--- a/e2e/tasks/test_task_source_freshness_hash_contents
+++ b/e2e/tasks/test_task_source_freshness_hash_contents
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# When source_freshness_hash_contents=true, mtime must NOT be the final
+# freshness gate — the content hash alone determines freshness. This fixes
+# CI cache-restore scenarios (e.g. GitHub Actions) where all files get their
+# mtime reset to the restore time, making source mtimes appear newer than
+# output mtimes even though nothing has changed.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'touch out.txt && echo built'
+sources = ['src.txt']
+outputs = ['out.txt']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no output → stale → runs
+assert "mise run -q build" "built"
+
+# Simulate CI cache restore: same content, but mtime of src set to a future
+# date (newer than out.txt). With the fix, hash match wins; mtime is ignored.
+touch -t 203001010000 src.txt
+assert_empty "mise run -q build"
+
+# Changing content must still trigger a rebuild
+echo "changed" >src.txt
+assert "mise run -q build" "built"
+
+# Deleting outputs must trigger a rebuild even when content hash matches
+rm out.txt
+assert "mise run -q build" "built"

--- a/e2e/tasks/test_task_source_freshness_hash_contents_multi_output
+++ b/e2e/tasks/test_task_source_freshness_hash_contents_multi_output
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# When source_freshness_hash_contents=true and a task has multiple outputs,
+# deleting any one of them must trigger a rebuild even when the source hash
+# still matches. Previously, get_last_modified(...).is_some() returned true
+# as long as at least one output existed, so a partial output set was
+# incorrectly treated as fresh.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'touch out_a.txt out_b.txt && echo built'
+sources = ['src.txt']
+outputs = ['out_a.txt', 'out_b.txt']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no outputs → stale → runs
+assert "mise run -q build" "built"
+
+# Both outputs present, source unchanged → fresh
+assert_empty "mise run -q build"
+
+# Delete one output — source hash still matches, but output set is incomplete
+rm out_b.txt
+assert "mise run -q build" "built"
+
+# Both outputs restored → fresh again
+assert_empty "mise run -q build"

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -320,16 +320,19 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
         }
 
         // Check for epoch timestamps (files extracted from tarballs without preserved timestamps)
-        // These are considered stale since we can't trust the mtime
-        for (path, metadata) in &source_metadatas {
-            if let Ok(mtime) = metadata.modified()
-                && mtime == UNIX_EPOCH
-            {
-                debug!(
-                    "source file {} has epoch timestamp, treating as stale",
-                    display_path(path)
-                );
-                return Ok(false);
+        // These are considered stale since we can't trust the mtime.
+        // Skipped in hash mode — content is the authority there, not timestamps.
+        if !use_content_hash {
+            for (path, metadata) in &source_metadatas {
+                if let Ok(mtime) = metadata.modified()
+                    && mtime == UNIX_EPOCH
+                {
+                    debug!(
+                        "source file {} has epoch timestamp, treating as stale",
+                        display_path(path)
+                    );
+                    return Ok(false);
+                }
             }
         }
 
@@ -348,7 +351,8 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
         if let Some(dir) = source_hash_path.parent() {
             file::create_dir_all(dir)?;
         }
-        if source_existing_hash(task, &root, use_content_hash).is_some_and(|h| h != source_hash) {
+        let existing_hash = source_existing_hash(task, &root, use_content_hash);
+        if existing_hash.as_deref().is_some_and(|h| h != source_hash) {
             debug!(
                 "source {} hash mismatch in {}",
                 if use_content_hash {
@@ -363,6 +367,16 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
             // invocation still detects the mismatch. save_checksum writes the
             // hash after a successful run.
             return Ok(false);
+        }
+        if use_content_hash && existing_hash.is_some() {
+            // In hash mode, content alone determines freshness — no mtime check.
+            // Compare against the stored output hash to catch partial/missing outputs.
+            let current_output_hash = compute_output_hash(task, &root)?;
+            let stored_output_hash = output_existing_hash(task, &root);
+            let fresh = current_output_hash.is_some()
+                && current_output_hash.as_deref() == stored_output_hash.as_deref();
+            file::write(&source_hash_path, &source_hash)?;
+            return Ok(fresh);
         }
         let sources = get_last_modified_from_metadatas(&source_metadatas);
         let outputs = get_last_modified(&root, &task.outputs.paths(task, &root))?;
@@ -396,25 +410,21 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
     if task.sources.is_empty() {
         return Ok(());
     }
+    let root = task_cwd(task, config).await?;
     if task.outputs.is_auto() {
-        let root = task_cwd(task, config).await?;
         for p in task.outputs.paths(task, &root) {
             debug!("touching auto output file: {p}");
             file::touch_file(&PathBuf::from(&p))?;
         }
     } else {
-        // Check if explicitly defined outputs were generated
-        // Use task_cwd to respect the task's dir setting, matching sources_are_fresh behavior
-        let root = task_cwd(task, config).await?;
+        // Warn if any explicitly declared output was not generated.
         for output in task.outputs.paths(task, &root) {
             let output_exists = if is_glob_pattern(&output) {
-                // For glob patterns, check if any files match
                 let pattern = root.join(&output);
                 glob(pattern.to_str().unwrap_or_default())
                     .map(|paths| paths.flatten().next().is_some())
                     .unwrap_or(false)
             } else {
-                // For regular paths, check if file exists
                 let path = Path::new(&output);
                 let full_path = if path.is_relative() {
                     root.join(path)
@@ -439,6 +449,17 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
             file::create_dir_all(dir)?;
         }
         file::write(&path, &hash)?;
+    }
+    // Persist the output hash so the next freshness check can detect missing
+    // or incomplete outputs even when the source hash still matches.
+    if Settings::get().task.source_freshness_hash_contents {
+        if let Some(h) = compute_output_hash(task, &root)? {
+            let path = outputs_hash_path(task, &root);
+            if let Some(dir) = path.parent() {
+                file::create_dir_all(dir)?;
+            }
+            file::write(&path, &h)?;
+        }
     }
     Ok(())
 }
@@ -475,6 +496,76 @@ fn source_existing_hash(task: &Task, root: &Path, content_hash: bool) -> Option<
     } else {
         None
     }
+}
+
+/// Path to the stored output hash for a task.
+fn outputs_hash_path(task: &Task, root: &Path) -> PathBuf {
+    dirs::STATE
+        .join("task-sources")
+        .join(format!("{}-outputs", task_state_key(task, root)))
+}
+
+/// Read the previously stored output hash, if any.
+fn output_existing_hash(task: &Task, root: &Path) -> Option<String> {
+    let path = outputs_hash_path(task, root);
+    if path.exists() {
+        Some(file::read_to_string(&path).unwrap_or_default())
+    } else {
+        None
+    }
+}
+
+/// Compute a stability hash for all current output files.
+///
+/// Returns `None` when any statically-named output is missing (incomplete
+/// outputs), when all glob patterns expand to zero files, or when the task
+/// declares no outputs. A `Some` value encodes the sorted `(path, size)` of
+/// every resolved output file — two identical sets of fully-present outputs
+/// produce the same hash.
+fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
+    let patterns_or_paths = task.outputs.paths(task, root);
+    if patterns_or_paths.is_empty() {
+        return Ok(None);
+    }
+
+    let (glob_pats, static_paths): (Vec<&String>, Vec<&String>) =
+        patterns_or_paths.iter().partition(|p| is_glob_pattern(p));
+
+    let mut entries: Vec<(PathBuf, u64)> = Vec::new();
+
+    for path_str in static_paths {
+        let path = {
+            let p = Path::new(path_str.as_str());
+            if p.is_relative() {
+                root.join(p)
+            } else {
+                p.to_path_buf()
+            }
+        };
+        match path.metadata() {
+            Ok(m) if m.is_file() => entries.push((path, m.len())),
+            // A missing or non-file static output means outputs are incomplete.
+            _ => return Ok(None),
+        }
+    }
+
+    for pattern_str in glob_pats {
+        let full = root.join(pattern_str.as_str());
+        for path in glob(full.to_str().unwrap_or_default())?.flatten() {
+            if let Ok(m) = path.metadata()
+                && m.is_file()
+            {
+                entries.push((path, m.len()));
+            }
+        }
+    }
+
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(Some(hash::hash_to_str(&entries)))
 }
 
 /// Get file metadata for a list of include-side patterns or paths, retaining


### PR DESCRIPTION
\`task.source_freshness_hash_contents\` is documented as "Use content hashing (blake3) instead of metadata for source freshness"[1], but mtime was still used as the final freshness gate even in hash mode. This makes the setting ineffective when sources and outputs are restored from a cache (e.g. GitHub Actions), where all mtimes are reset to the restore time — tasks re-run on every CI run despite unchanged content.

With this fix:
- When a stored hash baseline exists and matches, content alone determines freshness; outputs are only checked for existence, not compared by mtime.
- The UNIX_EPOCH tarball-mtime guard is also skipped in hash mode, since content is the authority there, not timestamps.

First-run behaviour is unchanged: when no stored baseline exists yet, the existing mtime path runs as before.

[1] https://mise.jdx.dev/configuration/settings.html#task-source_freshness_hash_contents

*This comment was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task freshness detection in content-hash mode by ignoring modification-time staleness checks and relying on stored output/content hashes.
  * Tasks now rerun correctly when sources change, when outputs are missing, or when output completeness differs—even if source contents appear unchanged.
* **Tests**
  * Added end-to-end coverage for content-hash freshness behavior, including cache-restore scenarios and multi-output tasks (initial run, fresh runs, partial outputs, and restored outputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->