### PR TITLE
fix(task): skip output mtime guard when source_freshness_hash_contents=true

### DIFF
--- a/e2e/tasks/test_task_source_freshness_hash_contents
+++ b/e2e/tasks/test_task_source_freshness_hash_contents
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# When source_freshness_hash_contents=true, mtime must NOT be the final
+# freshness gate — the content hash alone determines freshness. This fixes
+# CI cache-restore scenarios (e.g. GitHub Actions) where all files get their
+# mtime reset to the restore time, making source mtimes appear newer than
+# output mtimes even though nothing has changed.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'touch out.txt && echo built'
+sources = ['src.txt']
+outputs = ['out.txt']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no output → stale → runs
+assert "mise run -q build" "built"
+
+# Epoch timestamp (common for tarball-extracted files): without the fix the
+# epoch guard would force a rebuild; with it, hash match wins.
+TZ=UTC touch -t 197001010000 src.txt
+assert_empty "mise run -q build"
+
+# Simulate CI cache restore: same content, but mtime of src set to a future
+# date (newer than out.txt). With the fix, hash match wins; mtime is ignored.
+touch -t 203001010000 src.txt
+assert_empty "mise run -q build"
+
+# Changing content must still trigger a rebuild
+echo "changed" >src.txt
+assert "mise run -q build" "built"
+
+# Deleting outputs must trigger a rebuild even when content hash matches
+rm out.txt
+assert "mise run -q build" "built"

--- a/e2e/tasks/test_task_source_freshness_hash_contents_dir_output
+++ b/e2e/tasks/test_task_source_freshness_hash_contents_dir_output
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# When a task declares a directory as a static output and hash_contents=true,
+# deleting files inside that directory must trigger a rebuild. Previously,
+# directory outputs were recorded as (path, 0) — detecting only whether the
+# directory itself existed, not its contents.
+#
+# Empty nested subdirectories are also tracked: their deletion is detected
+# because directory entries (not just file entries) are recorded in the hash.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'mkdir -p dist/subdir && echo hello > dist/a.txt && echo built'
+sources = ['src.txt']
+outputs = ['dist']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no output directory → stale → runs
+assert "mise run -q build" "built"
+
+# Directory and contents unchanged → fresh
+assert_empty "mise run -q build"
+
+# Delete a file inside the output directory — directory still exists but is
+# incomplete; must trigger a rebuild
+rm dist/a.txt
+assert "mise run -q build" "built"
+
+# Directory restored → fresh again
+assert_empty "mise run -q build"
+
+# Delete an empty nested subdirectory — must also trigger a rebuild because
+# directory entries are included in the output hash
+rm -rf dist/subdir
+assert "mise run -q build" "built"
+
+# Everything restored → fresh again
+assert_empty "mise run -q build"

--- a/e2e/tasks/test_task_source_freshness_hash_contents_multi_output
+++ b/e2e/tasks/test_task_source_freshness_hash_contents_multi_output
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# When source_freshness_hash_contents=true and a task has multiple outputs,
+# deleting any one of them must trigger a rebuild even when the source hash
+# still matches. Previously, get_last_modified(...).is_some() returned true
+# as long as at least one output existed, so a partial output set was
+# incorrectly treated as fresh.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'touch out_a.txt out_b.txt && echo built'
+sources = ['src.txt']
+outputs = ['out_a.txt', 'out_b.txt']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no outputs → stale → runs
+assert "mise run -q build" "built"
+
+# Both outputs present, source unchanged → fresh
+assert_empty "mise run -q build"
+
+# Delete one output — source hash still matches, but output set is incomplete
+rm out_b.txt
+assert "mise run -q build" "built"
+
+# Both outputs restored → fresh again
+assert_empty "mise run -q build"

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -320,16 +320,19 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
         }
 
         // Check for epoch timestamps (files extracted from tarballs without preserved timestamps)
-        // These are considered stale since we can't trust the mtime
-        for (path, metadata) in &source_metadatas {
-            if let Ok(mtime) = metadata.modified()
-                && mtime == UNIX_EPOCH
-            {
-                debug!(
-                    "source file {} has epoch timestamp, treating as stale",
-                    display_path(path)
-                );
-                return Ok(false);
+        // These are considered stale since we can't trust the mtime.
+        // Skipped in hash mode — content is the authority there, not timestamps.
+        if !use_content_hash {
+            for (path, metadata) in &source_metadatas {
+                if let Ok(mtime) = metadata.modified()
+                    && mtime == UNIX_EPOCH
+                {
+                    debug!(
+                        "source file {} has epoch timestamp, treating as stale",
+                        display_path(path)
+                    );
+                    return Ok(false);
+                }
             }
         }
 
@@ -348,7 +351,8 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
         if let Some(dir) = source_hash_path.parent() {
             file::create_dir_all(dir)?;
         }
-        if source_existing_hash(task, &root, use_content_hash).is_some_and(|h| h != source_hash) {
+        let existing_hash = source_existing_hash(task, &root, use_content_hash);
+        if existing_hash.as_deref().is_some_and(|h| h != source_hash) {
             debug!(
                 "source {} hash mismatch in {}",
                 if use_content_hash {
@@ -363,6 +367,16 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
             // invocation still detects the mismatch. save_checksum writes the
             // hash after a successful run.
             return Ok(false);
+        }
+        if use_content_hash && existing_hash.is_some() {
+            // In hash mode, content alone determines freshness — no mtime check.
+            // Compare against the stored output hash to catch partial/missing outputs.
+            let current_output_hash = compute_output_hash(task, &root)?;
+            let stored_output_hash = output_existing_hash(task, &root);
+            let fresh = current_output_hash.is_some()
+                && current_output_hash.as_deref() == stored_output_hash.as_deref();
+            file::write(&source_hash_path, &source_hash)?;
+            return Ok(fresh);
         }
         let sources = get_last_modified_from_metadatas(&source_metadatas);
         let outputs = get_last_modified(&root, &task.outputs.paths(task, &root))?;
@@ -396,25 +410,21 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
     if task.sources.is_empty() {
         return Ok(());
     }
+    let root = task_cwd(task, config).await?;
     if task.outputs.is_auto() {
-        let root = task_cwd(task, config).await?;
         for p in task.outputs.paths(task, &root) {
             debug!("touching auto output file: {p}");
             file::touch_file(&PathBuf::from(&p))?;
         }
     } else {
-        // Check if explicitly defined outputs were generated
-        // Use task_cwd to respect the task's dir setting, matching sources_are_fresh behavior
-        let root = task_cwd(task, config).await?;
+        // Warn if any explicitly declared output was not generated.
         for output in task.outputs.paths(task, &root) {
             let output_exists = if is_glob_pattern(&output) {
-                // For glob patterns, check if any files match
                 let pattern = root.join(&output);
                 glob(pattern.to_str().unwrap_or_default())
                     .map(|paths| paths.flatten().next().is_some())
                     .unwrap_or(false)
             } else {
-                // For regular paths, check if file exists
                 let path = Path::new(&output);
                 let full_path = if path.is_relative() {
                     root.join(path)
@@ -439,6 +449,17 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
             file::create_dir_all(dir)?;
         }
         file::write(&path, &hash)?;
+    }
+    // Persist the output hash so the next freshness check can detect missing
+    // or incomplete outputs even when the source hash still matches.
+    if Settings::get().task.source_freshness_hash_contents
+        && let Some(h) = compute_output_hash(task, &root)?
+    {
+        let path = outputs_hash_path(task, &root);
+        if let Some(dir) = path.parent() {
+            file::create_dir_all(dir)?;
+        }
+        file::write(&path, &h)?;
     }
     Ok(())
 }
@@ -475,6 +496,127 @@ fn source_existing_hash(task: &Task, root: &Path, content_hash: bool) -> Option<
     } else {
         None
     }
+}
+
+/// Path to the stored output hash for a task.
+fn outputs_hash_path(task: &Task, root: &Path) -> PathBuf {
+    dirs::STATE
+        .join("task-sources")
+        .join(format!("{}-outputs", task_state_key(task, root)))
+}
+
+/// Read the previously stored output hash, if any.
+fn output_existing_hash(task: &Task, root: &Path) -> Option<String> {
+    let path = outputs_hash_path(task, root);
+    if path.exists() {
+        Some(file::read_to_string(&path).unwrap_or_default())
+    } else {
+        None
+    }
+}
+
+/// Compute a content-integrity hash for all current output files.
+///
+/// Returns `None` when any statically-named output is missing (incomplete
+/// outputs), when a glob pattern expands to zero matching filesystem objects,
+/// or when the task declares no outputs. A `Some` value encodes the sorted
+/// `(path, blake3_content_hash)` of every resolved output file — two identical
+/// sets of fully-present, content-identical outputs produce the same hash.
+///
+/// Content hashing (blake3) catches same-size modifications inside directory
+/// outputs that `(path, size)` or `(path, size, mtime)` would miss.
+/// Directory outputs (static or glob-matched) are walked recursively.
+fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
+    let patterns_or_paths = task.outputs.paths(task, root);
+    if patterns_or_paths.is_empty() {
+        return Ok(None);
+    }
+
+    let (glob_pats, static_paths): (Vec<&String>, Vec<&String>) =
+        patterns_or_paths.iter().partition(|p| is_glob_pattern(p));
+
+    // (path, blake3_hex) — full content hash for correctness.
+    let mut entries: Vec<(PathBuf, String)> = Vec::new();
+
+    fn hash_file(path: &Path) -> Result<(PathBuf, String)> {
+        Ok((path.to_path_buf(), hash::file_hash_blake3(path, None)?))
+    }
+
+    /// Walk a directory and push entries for all descendants.
+    /// Files get their blake3 content hash; subdirectories get a "dir" sentinel
+    /// so that additions and deletions of empty nested directories are detected.
+    /// Returns `true` when at least one entry (file or directory) was found.
+    fn push_dir_entries(dir: &Path, entries: &mut Vec<(PathBuf, String)>) -> Result<bool> {
+        let pattern = format!("{}/**/*", dir.to_str().unwrap_or_default());
+        let mut found_any = false;
+        for path in glob(&pattern)?.flatten() {
+            match path.metadata() {
+                Ok(m) if m.is_file() => {
+                    entries.push(hash_file(&path)?);
+                    found_any = true;
+                }
+                Ok(m) if m.is_dir() => {
+                    // Record subdirectory existence so empty nested directories
+                    // are detected when they appear or disappear.
+                    entries.push((path, "dir".to_string()));
+                    found_any = true;
+                }
+                _ => {}
+            }
+        }
+        Ok(found_any)
+    }
+
+    for path_str in static_paths {
+        let path = {
+            let p = Path::new(path_str.as_str());
+            if p.is_relative() {
+                root.join(p)
+            } else {
+                p.to_path_buf()
+            }
+        };
+        match path.metadata() {
+            Ok(m) if m.is_file() => entries.push(hash_file(&path)?),
+            Ok(m) if m.is_dir() => {
+                if !push_dir_entries(&path, &mut entries)? {
+                    // Empty directory — sentinel so its deletion is detected.
+                    entries.push((path, "empty-dir".to_string()));
+                }
+            }
+            Ok(_) => entries.push((path, "other".to_string())),
+            Err(_) => return Ok(None), // missing → outputs incomplete
+        }
+    }
+
+    for pattern_str in glob_pats {
+        let full = root.join(pattern_str.as_str());
+        let mut matched = false;
+        for path in glob(full.to_str().unwrap_or_default())?.flatten() {
+            if let Ok(m) = path.metadata() {
+                if m.is_file() {
+                    entries.push(hash_file(&path)?);
+                    matched = true;
+                } else if m.is_dir() {
+                    if !push_dir_entries(&path, &mut entries)? {
+                        entries.push((path, "empty-dir".to_string()));
+                    }
+                    matched = true;
+                }
+            }
+        }
+        // A glob that matches nothing means expected outputs are missing.
+        if !matched {
+            return Ok(None);
+        }
+    }
+
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(Some(hash::hash_to_str(&entries)))
 }
 
 /// Get file metadata for a list of include-side patterns or paths, retaining


### PR DESCRIPTION
## Summary

\`task.source_freshness_hash_contents\` is documented as "Use content hashing (blake3) instead of metadata for source freshness", but mtime was still used as the final freshness gate even in hash mode. This makes the setting ineffective in CI cache-restore scenarios (e.g. GitHub Actions) where all mtimes are reset to the restore time.

**Root cause:** \`sources_are_fresh\` always fell through to the mtime comparison, even when a matching content-hash baseline existed.

**Fixes:**
- In hash mode, when the source content hash matches the stored baseline, freshness is determined by output hash only — mtime is never consulted.
- The UNIX_EPOCH tarball-mtime guard is also gated on \`!use_content_hash\`.
- **Pre-existing bug:** with multiple outputs, \`get_last_modified(...).is_some()\` returned true as long as any output existed, so a partial output set was treated as fresh. Outputs are now blake3-hashed after each successful run and compared on subsequent checks. Directory outputs are walked recursively — both file contents and subdirectory entries are recorded, so deletions of files or empty nested directories inside a declared output directory are detected.

**Tests:** three new e2e tests (no \`_slow\` suffix, each ≤16s):
- \`test_task_source_freshness_hash_contents\` — mtime changes don't trigger rebuild; content changes do; missing output triggers rebuild
- \`test_task_source_freshness_hash_contents_multi_output\` — partial output set is stale
- \`test_task_source_freshness_hash_contents_dir_output\` — file deleted inside directory is stale; empty nested subdirectory deleted is stale

*This comment was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task freshness evaluation when content-based source hashing is enabled, avoiding timestamp-based staleness and making freshness driven by output stability.
  * Freshness state now better reflects output completeness, ensuring rebuilds occur when outputs are missing, incomplete, or only partially restored (including directory and multi-output cases).
* **Tests**
  * Added end-to-end coverage for content-hash freshness across single-output, multi-output, and directory-output tasks, including cases with modified mtimes and output deletions/restores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->