### PR TITLE
fix(task): make source_freshness_hash_contents skip mtime entirely

### DIFF
--- a/e2e/tasks/test_task_source_freshness_hash_contents
+++ b/e2e/tasks/test_task_source_freshness_hash_contents
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# When source_freshness_hash_contents=true, mtime must NOT be the final
+# freshness gate — the content hash alone determines freshness. This fixes
+# CI cache-restore scenarios (e.g. GitHub Actions) where all files get their
+# mtime reset to the restore time, making source mtimes appear newer than
+# output mtimes even though nothing has changed.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'touch out.txt && echo built'
+sources = ['src.txt']
+outputs = ['out.txt']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no output → stale → runs
+assert "mise run -q build" "built"
+
+# Epoch timestamp (common for tarball-extracted files): without the fix the
+# epoch guard would force a rebuild; with it, hash match wins.
+TZ=UTC touch -t 197001010000 src.txt
+assert_empty "mise run -q build"
+
+# Simulate CI cache restore: same content, but mtime of src set to a future
+# date (newer than out.txt). With the fix, hash match wins; mtime is ignored.
+touch -t 203001010000 src.txt
+assert_empty "mise run -q build"
+
+# Changing content must still trigger a rebuild
+echo "changed" >src.txt
+assert "mise run -q build" "built"
+
+# Deleting outputs must trigger a rebuild even when content hash matches
+rm out.txt
+assert "mise run -q build" "built"

--- a/e2e/tasks/test_task_source_freshness_hash_contents_dir_output
+++ b/e2e/tasks/test_task_source_freshness_hash_contents_dir_output
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# When a task declares a directory as a static output and hash_contents=true,
+# deleting files inside that directory must trigger a rebuild. Previously,
+# directory outputs were recorded as (path, 0) — detecting only whether the
+# directory itself existed, not its contents.
+#
+# Empty nested subdirectories are also tracked: their deletion is detected
+# because directory entries (not just file entries) are recorded in the hash.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'mkdir -p dist/subdir && echo hello > dist/a.txt && echo built'
+sources = ['src.txt']
+outputs = ['dist']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no output directory → stale → runs
+assert "mise run -q build" "built"
+
+# Directory and contents unchanged → fresh
+assert_empty "mise run -q build"
+
+# Delete a file inside the output directory — directory still exists but is
+# incomplete; must trigger a rebuild
+rm dist/a.txt
+assert "mise run -q build" "built"
+
+# Directory restored → fresh again
+assert_empty "mise run -q build"
+
+# Delete an empty nested subdirectory — must also trigger a rebuild because
+# directory entries are included in the output hash
+rm -rf dist/subdir
+assert "mise run -q build" "built"
+
+# Everything restored → fresh again
+assert_empty "mise run -q build"

--- a/e2e/tasks/test_task_source_freshness_hash_contents_multi_output
+++ b/e2e/tasks/test_task_source_freshness_hash_contents_multi_output
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# When source_freshness_hash_contents=true and a task has multiple outputs,
+# deleting any one of them must trigger a rebuild even when the source hash
+# still matches. Previously, get_last_modified(...).is_some() returned true
+# as long as at least one output existed, so a partial output set was
+# incorrectly treated as fresh.
+
+cat <<EOF >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+run = 'touch out_a.txt out_b.txt && echo built'
+sources = ['src.txt']
+outputs = ['out_a.txt', 'out_b.txt']
+EOF
+
+echo "hello" >src.txt
+
+# First run: no stored hash, no outputs → stale → runs
+assert "mise run -q build" "built"
+
+# Both outputs present, source unchanged → fresh
+assert_empty "mise run -q build"
+
+# Delete one output — source hash still matches, but output set is incomplete
+rm out_b.txt
+assert "mise run -q build" "built"
+
+# Both outputs restored → fresh again
+assert_empty "mise run -q build"

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -19,6 +19,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use walkdir::WalkDir;
 
 /// Remove mise's automatic output before rerunning a task so an earlier
 /// success cannot make a failed attempt look fresh.
@@ -320,16 +321,19 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
         }
 
         // Check for epoch timestamps (files extracted from tarballs without preserved timestamps)
-        // These are considered stale since we can't trust the mtime
-        for (path, metadata) in &source_metadatas {
-            if let Ok(mtime) = metadata.modified()
-                && mtime == UNIX_EPOCH
-            {
-                debug!(
-                    "source file {} has epoch timestamp, treating as stale",
-                    display_path(path)
-                );
-                return Ok(false);
+        // These are considered stale since we can't trust the mtime.
+        // Skipped in hash mode — content is the authority there, not timestamps.
+        if !use_content_hash {
+            for (path, metadata) in &source_metadatas {
+                if let Ok(mtime) = metadata.modified()
+                    && mtime == UNIX_EPOCH
+                {
+                    debug!(
+                        "source file {} has epoch timestamp, treating as stale",
+                        display_path(path)
+                    );
+                    return Ok(false);
+                }
             }
         }
 
@@ -348,7 +352,8 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
         if let Some(dir) = source_hash_path.parent() {
             file::create_dir_all(dir)?;
         }
-        if source_existing_hash(task, &root, use_content_hash).is_some_and(|h| h != source_hash) {
+        let existing_hash = source_existing_hash(task, &root, use_content_hash);
+        if existing_hash.as_deref().is_some_and(|h| h != source_hash) {
             debug!(
                 "source {} hash mismatch in {}",
                 if use_content_hash {
@@ -363,6 +368,16 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
             // invocation still detects the mismatch. save_checksum writes the
             // hash after a successful run.
             return Ok(false);
+        }
+        if use_content_hash && existing_hash.is_some() {
+            // In hash mode, content alone determines freshness — no mtime check.
+            // Compare against the stored output hash to catch partial/missing outputs.
+            let current_output_hash = compute_output_hash(task, &root)?;
+            let stored_output_hash = output_existing_hash(task, &root);
+            let fresh = current_output_hash.is_some()
+                && current_output_hash.as_deref() == stored_output_hash.as_deref();
+            file::write(&source_hash_path, &source_hash)?;
+            return Ok(fresh);
         }
         let sources = get_last_modified_from_metadatas(&source_metadatas);
         let outputs = get_last_modified(&root, &task.outputs.paths(task, &root))?;
@@ -396,25 +411,21 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
     if task.sources.is_empty() {
         return Ok(());
     }
+    let root = task_cwd(task, config).await?;
     if task.outputs.is_auto() {
-        let root = task_cwd(task, config).await?;
         for p in task.outputs.paths(task, &root) {
             debug!("touching auto output file: {p}");
             file::touch_file(&PathBuf::from(&p))?;
         }
     } else {
-        // Check if explicitly defined outputs were generated
-        // Use task_cwd to respect the task's dir setting, matching sources_are_fresh behavior
-        let root = task_cwd(task, config).await?;
+        // Warn if any explicitly declared output was not generated.
         for output in task.outputs.paths(task, &root) {
             let output_exists = if is_glob_pattern(&output) {
-                // For glob patterns, check if any files match
                 let pattern = root.join(&output);
                 glob(pattern.to_str().unwrap_or_default())
                     .map(|paths| paths.flatten().next().is_some())
                     .unwrap_or(false)
             } else {
-                // For regular paths, check if file exists
                 let path = Path::new(&output);
                 let full_path = if path.is_relative() {
                     root.join(path)
@@ -439,6 +450,33 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
             file::create_dir_all(dir)?;
         }
         file::write(&path, &hash)?;
+    }
+    // Persist the output hash so the next freshness check can detect missing
+    // or incomplete outputs even when the source hash still matches.
+    // Traversal errors (broken symlinks, unreadable files) are warned but not
+    // propagated — the task itself succeeded; failing here would be misleading.
+    // Without a stored output hash the next freshness check will conservatively
+    // treat the task as stale.
+    if Settings::get().task.source_freshness_hash_contents {
+        let out_path = outputs_hash_path(task, &root);
+        match compute_output_hash(task, &root) {
+            Ok(Some(h)) => {
+                if let Some(dir) = out_path.parent() {
+                    file::create_dir_all(dir)?;
+                }
+                file::write(&out_path, &h)?;
+            }
+            Ok(None) => {} // no outputs defined — nothing to save
+            Err(e) => {
+                // Remove the stale baseline so the next run is not skipped
+                // against an obsolete output snapshot.
+                let _ = std::fs::remove_file(&out_path);
+                warn!(
+                    "task {} output hashing failed; next run will not be skipped: {e}",
+                    task.name
+                );
+            }
+        }
     }
     Ok(())
 }
@@ -475,6 +513,136 @@ fn source_existing_hash(task: &Task, root: &Path, content_hash: bool) -> Option<
     } else {
         None
     }
+}
+
+/// Path to the stored output hash for a task.
+fn outputs_hash_path(task: &Task, root: &Path) -> PathBuf {
+    dirs::STATE
+        .join("task-sources")
+        .join(format!("{}-outputs", task_state_key(task, root)))
+}
+
+/// Read the previously stored output hash, if any.
+fn output_existing_hash(task: &Task, root: &Path) -> Option<String> {
+    let path = outputs_hash_path(task, root);
+    if path.exists() {
+        Some(file::read_to_string(&path).unwrap_or_default())
+    } else {
+        None
+    }
+}
+
+/// Compute a content-integrity hash for all current output files.
+///
+/// Returns `None` when any statically-named output is missing (incomplete
+/// outputs), when a glob pattern expands to zero matching filesystem objects,
+/// or when the task declares no outputs. A `Some` value encodes the sorted
+/// `(path, blake3_content_hash)` of every resolved output file — two identical
+/// sets of fully-present, content-identical outputs produce the same hash.
+///
+/// Content hashing (blake3) catches same-size modifications inside directory
+/// outputs that `(path, size)` or `(path, size, mtime)` would miss.
+/// Directory outputs (static or glob-matched) are walked recursively.
+fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
+    let patterns_or_paths = task.outputs.paths(task, root);
+    if patterns_or_paths.is_empty() {
+        return Ok(None);
+    }
+
+    let (glob_pats, static_paths): (Vec<&String>, Vec<&String>) =
+        patterns_or_paths.iter().partition(|p| is_glob_pattern(p));
+
+    // (path, blake3_hex) — full content hash for correctness.
+    let mut entries: Vec<(PathBuf, String)> = Vec::new();
+
+    fn hash_file(path: &Path) -> Result<(PathBuf, String)> {
+        Ok((path.to_path_buf(), hash::file_hash_blake3(path, None)?))
+    }
+
+    /// Walk a directory and push entries for all descendants.
+    /// Files get their blake3 content hash; subdirectories get a "dir" sentinel
+    /// so that additions/deletions of empty nested directories are detected.
+    /// Symlinked directories are followed so content changes inside them are
+    /// caught. Returns `true` when at least one entry was found.
+    fn push_dir_entries(dir: &Path, entries: &mut Vec<(PathBuf, String)>) -> Result<bool> {
+        let mut found_any = false;
+        for entry in WalkDir::new(dir).follow_links(true).into_iter() {
+            let entry = entry?;
+            let path = entry.path();
+            if path == dir {
+                continue; // skip the root directory itself
+            }
+            if entry.file_type().is_file() {
+                entries.push(hash_file(path)?);
+                found_any = true;
+            } else if entry.file_type().is_dir() {
+                entries.push((path.to_path_buf(), "dir".to_string()));
+                found_any = true;
+            }
+        }
+        Ok(found_any)
+    }
+
+    for path_str in static_paths {
+        let path = {
+            let p = Path::new(path_str.as_str());
+            if p.is_relative() {
+                root.join(p)
+            } else {
+                p.to_path_buf()
+            }
+        };
+        match path.metadata() {
+            Ok(m) if m.is_file() => entries.push(hash_file(&path)?),
+            Ok(m) if m.is_dir() => {
+                if !push_dir_entries(&path, &mut entries)? {
+                    // Empty directory — sentinel so its deletion is detected.
+                    entries.push((path, "empty-dir".to_string()));
+                }
+            }
+            Ok(_) => entries.push((path, "other".to_string())),
+            Err(_) => return Ok(None), // missing → outputs incomplete
+        }
+    }
+
+    for pattern_str in glob_pats {
+        let full = root.join(pattern_str.as_str());
+        let mut matched = false;
+        for entry in glob(full.to_str().unwrap_or_default())? {
+            // Propagate glob resolution errors (OS errors during directory
+            // reads) rather than silently skipping them — a partial result
+            // could produce the same hash as a complete one.
+            let path = entry?;
+            match path.metadata() {
+                Ok(m) if m.is_file() => {
+                    entries.push(hash_file(&path)?);
+                    matched = true;
+                }
+                Ok(m) if m.is_dir() => {
+                    if !push_dir_entries(&path, &mut entries)? {
+                        entries.push((path, "empty-dir".to_string()));
+                    }
+                    matched = true;
+                }
+                Ok(_) => {
+                    entries.push((path, "other".to_string()));
+                    matched = true;
+                }
+                Err(_) => return Ok(None), // unreadable entry → treat as incomplete
+            }
+        }
+        // A glob that matches nothing means expected outputs are missing.
+        if !matched {
+            return Ok(None);
+        }
+    }
+
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(Some(hash::hash_to_str(&entries)))
 }
 
 /// Get file metadata for a list of include-side patterns or paths, retaining


### PR DESCRIPTION
## What this fixes

When \`task.source_freshness_hash_contents = true\`, content hash should be the sole freshness authority — that's what the setting documents. But mtime was still the final gate, making the setting ineffective in CI cache-restore scenarios (e.g. GitHub Actions) where all timestamps reset on cache restore. Tasks re-ran on every CI job despite unchanged content.

## Changes

- **Core fix**: skip mtime comparison when source content hash matches the stored baseline
- Skip the UNIX_EPOCH tarball-mtime guard in hash mode (epoch timestamps are a proxy for "mtime unknown" — irrelevant when content hash decides)
- Track output integrity with blake3 after each successful run: detects missing, partially deleted, and content-modified outputs
- Walk directory outputs with `WalkDir(follow_links=true)`; record file content hashes and subdirectory entries — catches content changes inside symlinked directories and deletions of empty nested subdirectories

## Tests

Three new e2e tests (no `_slow` suffix, each ≤16s):
- `test_task_source_freshness_hash_contents` — mtime changes don't trigger rebuild; content changes do; missing output triggers rebuild
- `test_task_source_freshness_hash_contents_multi_output` — partial output set is stale
- `test_task_source_freshness_hash_contents_dir_output` — deleted file inside directory output is stale; deleted empty nested subdirectory is also stale

## Related PRs

This PR builds on three prerequisite PRs that have already merged:
- #11202 — introduced `source_freshness_hash_contents` setting
- #11288 — fixed task state key to include all definition fields
- #11296 — fixed hash not being saved on successful run

*This PR was created with assistance from an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced freshness detection for `source_freshness_hash_contents` by switching hash-mode skipping to a deterministic outputs-integrity hash (including directory structure and empty directories), while avoiding mtime-based staleness.
  * More reliable rebuild behavior when outputs are missing, partially restored/deleted, glob results change, or output sets are incomplete (including multi-output tasks).
* **Tests**
  * Added end-to-end coverage for hash-based freshness across single-file output, directory output (including empty subdirectories), and multi-output scenarios with deletion/restore cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->