### PR TITLE
fix(brew): recognize existing brew links when linking kegs

### DIFF
--- a/src/system/packages/brew/pour.rs
+++ b/src/system/packages/brew/pour.rs
@@ -280,24 +280,119 @@ fn relative_target(dest: &Path, link: &Path) -> PathBuf {
 }
 
 /// May we overwrite `dest`? Only if it's a symlink pointing into our Cellar
-/// or opt (i.e. something brew/mise created and can re-create).
+/// or opt (i.e. something brew/mise created and can re-create), or anything
+/// underneath a directory symlink brew created — brew links a directory it
+/// owns entirely as a single symlink, so the regular files and the keg's own
+/// symlinks inside are still brew's.
 fn can_overwrite(dest: &Path) -> bool {
     let Ok(meta) = dest.symlink_metadata() else {
         return true; // doesn't exist
     };
+    if brew_owned_ancestor(dest).is_some() {
+        return true;
+    }
     if !meta.is_symlink() {
         return false;
     }
-    let target = match std::fs::read_link(dest) {
-        Ok(t) => t,
-        Err(err) => {
-            // treat as a conflict (never clobber what we can't identify)
-            debug!("failed to read symlink {}: {err}", dest.display());
-            return false;
-        }
+    points_into_cellar(dest)
+}
+
+/// Does this symlink point into our Cellar or opt? Resolved exactly one hop
+/// and lexically, like brew's own ownership checks (keg.rb: "we only want to
+/// resolve one symlink") — whether a link is ours is a property of the link
+/// itself, and `canonicalize` would fail on dangling links and resolve
+/// relative targets against the CWD.
+fn points_into_cellar(link: &Path) -> bool {
+    let Ok(target) = std::fs::read_link(link) else {
+        return false;
     };
-    let resolved = crate::file::desymlink_path(&dest.parent().unwrap().join(target));
+    let resolved = lexical_normalize(&link.parent().unwrap().join(target));
     resolved.starts_with(prefix::cellar()) || resolved.starts_with(prefix::prefix().join("opt"))
+}
+
+/// Normalize `.` and `..` components without touching the filesystem.
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for part in path.components() {
+        match part {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// The outermost ancestor of `dest` (strictly below the prefix) that is a
+/// symlink pointing into the Cellar — i.e. a directory brew linked wholesale.
+fn brew_owned_ancestor(dest: &Path) -> Option<PathBuf> {
+    let prefix_path = prefix::prefix();
+    let mut ancestors: Vec<&Path> = dest
+        .ancestors()
+        .skip(1)
+        .take_while(|p| *p != prefix_path && p.starts_with(&prefix_path))
+        .collect();
+    ancestors.reverse(); // outermost first
+    for anc in ancestors {
+        if anc
+            .symlink_metadata()
+            .map(|m| m.is_symlink())
+            .unwrap_or(false)
+        {
+            return points_into_cellar(anc).then(|| anc.to_path_buf());
+        }
+    }
+    None
+}
+
+/// Replace brew-created directory symlinks on the way to `dest` with real
+/// directories of symlinks to their old contents — the same expansion brew
+/// performs when another keg needs to place files inside a wholesale-linked
+/// directory (resolve_any_conflicts). The replacement is fully staged before
+/// the symlink is swapped out, so a failure leaves the tree unchanged.
+fn materialize_brew_dirs(dest: &Path) -> Result<()> {
+    while let Some(link_dir) = brew_owned_ancestor(dest) {
+        let raw_target = std::fs::read_link(&link_dir)?;
+        let staging = link_dir.parent().unwrap().join(format!(
+            ".mise-materialize-{}",
+            link_dir.file_name().unwrap().to_string_lossy()
+        ));
+        let staged = (|| -> Result<()> {
+            if staging.exists() {
+                crate::file::remove_all(&staging)?;
+            }
+            crate::file::create_dir_all(&staging)?;
+            // a dangling dir symlink (keg already pruned) has nothing to preserve
+            let target = lexical_normalize(&link_dir.parent().unwrap().join(&raw_target));
+            if target.is_dir() {
+                for entry in std::fs::read_dir(&target)? {
+                    let entry = entry?;
+                    // targets are relative to the link's final location
+                    let child_link = link_dir.join(entry.file_name());
+                    crate::file::make_symlink(
+                        &relative_target(&entry.path(), &child_link),
+                        &staging.join(entry.file_name()),
+                    )?;
+                }
+            }
+            Ok(())
+        })();
+        if let Err(err) = staged {
+            let _ = crate::file::remove_all(&staging);
+            return Err(err);
+        }
+        // swap: a directory cannot be renamed over a symlink, so remove the
+        // link first; if the rename then fails, put the symlink back
+        crate::file::remove_file(&link_dir)?;
+        if let Err(err) = crate::file::rename(&staging, &link_dir) {
+            let _ = crate::file::make_symlink(&raw_target, &link_dir);
+            let _ = crate::file::remove_all(&staging);
+            return Err(err);
+        }
+    }
+    Ok(())
 }
 
 /// Create the opt symlink and (unless keg-only) link the keg's public dirs
@@ -359,6 +454,10 @@ pub fn link_keg(name: &str, pkg_version: &str, keg_only: bool) -> Result<()> {
     let mut failure: Option<eyre::Report> = None;
     for (dest, target) in &links {
         let made = (|| -> Result<()> {
+            // a parent that is a brew directory symlink must become a real
+            // directory first — otherwise the link below would be created
+            // inside (and delete files from) the old keg it points to
+            materialize_brew_dirs(dest)?;
             crate::file::create_dir_all(dest.parent().unwrap())?;
             if dest.symlink_metadata().is_ok() {
                 if let Ok(prev) = std::fs::read_link(dest) {
@@ -389,7 +488,216 @@ pub fn link_keg(name: &str, pkg_version: &str, keg_only: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct BrewPrefixGuard {
+        previous: Option<String>,
+    }
+
+    impl BrewPrefixGuard {
+        fn set(prefix: &Path) -> Self {
+            let previous = crate::env::var("MISE_SYSTEM_BREW_PREFIX").ok();
+            crate::env::set_var("MISE_SYSTEM_BREW_PREFIX", prefix);
+            Self { previous }
+        }
+    }
+
+    impl Drop for BrewPrefixGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(previous) => crate::env::set_var("MISE_SYSTEM_BREW_PREFIX", previous),
+                None => crate::env::remove_var("MISE_SYSTEM_BREW_PREFIX"),
+            }
+        }
+    }
+
+    /// keg with a versioned dylib and its unversioned alias (the relative
+    /// symlink chain every brew library bottle ships), plus a header dir
+    fn write_lib_keg(prefix: &Path, name: &str, version: &str) -> Result<PathBuf> {
+        let keg = prefix.join("Cellar").join(name).join(version);
+        crate::file::create_dir_all(keg.join("lib"))?;
+        crate::file::write(keg.join("lib").join(format!("lib{name}.1.dylib")), version)?;
+        crate::file::make_symlink(
+            Path::new(&format!("lib{name}.1.dylib")),
+            &keg.join("lib").join(format!("lib{name}.dylib")),
+        )?;
+        crate::file::create_dir_all(keg.join("include").join(name))?;
+        crate::file::write(keg.join("include").join(name).join("header.h"), version)?;
+        // keg-internal relative symlink inside the dir brew links wholesale
+        crate::file::make_symlink(
+            Path::new("header.h"),
+            &keg.join("include").join(name).join("alias.h"),
+        )?;
+        Ok(keg)
+    }
+
+    /// link a keg the way real brew does: file symlinks for files whose
+    /// parent dir is shared, one directory symlink for a dir the keg owns
+    fn brew_style_link(prefix: &Path, name: &str, version: &str) -> Result<()> {
+        let cellar_rel = Path::new("../Cellar").join(name).join(version);
+        crate::file::create_dir_all(prefix.join("opt"))?;
+        crate::file::make_symlink(
+            &Path::new("../Cellar").join(name).join(version),
+            &prefix.join("opt").join(name),
+        )?;
+        crate::file::create_dir_all(prefix.join("lib"))?;
+        for lib in [format!("lib{name}.dylib"), format!("lib{name}.1.dylib")] {
+            crate::file::make_symlink(
+                &cellar_rel.join("lib").join(&lib),
+                &prefix.join("lib").join(&lib),
+            )?;
+        }
+        crate::file::create_dir_all(prefix.join("include"))?;
+        crate::file::make_symlink(
+            &cellar_rel.join("include").join(name),
+            &prefix.join("include").join(name),
+        )?;
+        Ok(())
+    }
+
+    fn canonical_tempdir() -> Result<(tempfile::TempDir, PathBuf)> {
+        let tmp = tempfile::tempdir()?;
+        let path = tmp.path().canonicalize()?;
+        Ok((tmp, path))
+    }
+
+    /// the unversioned dylib alias resolves through a relative symlink chain
+    /// inside the Cellar and must still be recognized as brew's
+    #[test]
+    fn test_upgrade_over_brew_file_links() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_tmp, prefix) = canonical_tempdir()?;
+        let _guard = BrewPrefixGuard::set(&prefix);
+        write_lib_keg(&prefix, "foo", "1.0")?;
+        brew_style_link(&prefix, "foo", "1.0")?;
+        write_lib_keg(&prefix, "foo", "2.0")?;
+
+        link_keg("foo", "2.0", false)?;
+
+        let lib_link = prefix.join("lib").join("libfoo.dylib");
+        assert!(lib_link.symlink_metadata()?.is_symlink());
+        assert_eq!(std::fs::read_to_string(&lib_link)?, "2.0");
+        Ok(())
+    }
+
+    /// everything under a brew directory-level symlink is brew's and must
+    /// relink without conflicts or modifying the old keg
+    #[test]
+    fn test_upgrade_over_brew_dir_symlink() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_tmp, prefix) = canonical_tempdir()?;
+        let _guard = BrewPrefixGuard::set(&prefix);
+        let old_keg = write_lib_keg(&prefix, "foo", "1.0")?;
+        brew_style_link(&prefix, "foo", "1.0")?;
+        write_lib_keg(&prefix, "foo", "2.0")?;
+
+        link_keg("foo", "2.0", false)?;
+
+        let header = prefix.join("include").join("foo").join("header.h");
+        assert_eq!(std::fs::read_to_string(&header)?, "2.0");
+        // a keg-internal relative symlink under the dir symlink is brew's too
+        assert_eq!(
+            std::fs::read_to_string(prefix.join("include").join("foo").join("alias.h"))?,
+            "2.0"
+        );
+        // the old keg's own files survive untouched
+        assert_eq!(
+            std::fs::read_to_string(old_keg.join("include").join("foo").join("header.h"))?,
+            "1.0"
+        );
+        Ok(())
+    }
+
+    /// a link into the Cellar whose target continues outside it (bottles
+    /// ship symlinks to system libraries) is still brew's own link
+    #[test]
+    fn test_upgrade_over_link_whose_cellar_target_leaves_the_cellar() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_tmp, prefix) = canonical_tempdir()?;
+        let _guard = BrewPrefixGuard::set(&prefix);
+        for version in ["1.0", "2.0"] {
+            let keg = prefix.join("Cellar").join("foo").join(version);
+            crate::file::create_dir_all(keg.join("lib"))?;
+            crate::file::make_symlink(
+                Path::new("/usr/lib/libSystem.B.dylib"),
+                &keg.join("lib").join("libsys.dylib"),
+            )?;
+        }
+        crate::file::create_dir_all(prefix.join("opt"))?;
+        crate::file::make_symlink(
+            Path::new("../Cellar/foo/1.0"),
+            &prefix.join("opt").join("foo"),
+        )?;
+        crate::file::create_dir_all(prefix.join("lib"))?;
+        crate::file::make_symlink(
+            Path::new("../Cellar/foo/1.0/lib/libsys.dylib"),
+            &prefix.join("lib").join("libsys.dylib"),
+        )?;
+
+        link_keg("foo", "2.0", false)?;
+
+        assert_eq!(
+            std::fs::read_link(prefix.join("lib").join("libsys.dylib"))?,
+            PathBuf::from("../Cellar/foo/2.0/lib/libsys.dylib")
+        );
+        Ok(())
+    }
+
+    /// a regular file that is NOT under a brew directory symlink is foreign
+    /// and must still be reported as a conflict
+    #[test]
+    fn test_foreign_regular_file_still_conflicts() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_tmp, prefix) = canonical_tempdir()?;
+        let _guard = BrewPrefixGuard::set(&prefix);
+        write_lib_keg(&prefix, "foo", "2.0")?;
+        crate::file::create_dir_all(prefix.join("include").join("foo"))?;
+        crate::file::write(prefix.join("include").join("foo").join("header.h"), "mine")?;
+
+        let err = link_keg("foo", "2.0", false).unwrap_err();
+        assert!(err.to_string().contains("not created by mise or brew"));
+        assert_eq!(
+            std::fs::read_to_string(prefix.join("include").join("foo").join("header.h"))?,
+            "mine"
+        );
+        Ok(())
+    }
+
+    /// a shared dir linked wholesale to another keg is expanded into a real
+    /// directory keeping that keg's entries visible, like brew does
+    #[test]
+    fn test_materialize_shared_dir_owned_by_other_keg() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_tmp, prefix) = canonical_tempdir()?;
+        let _guard = BrewPrefixGuard::set(&prefix);
+        // other keg owns share/xml via a dir symlink
+        let other = prefix.join("Cellar").join("other").join("1.0");
+        crate::file::create_dir_all(other.join("share").join("xml"))?;
+        crate::file::write(other.join("share").join("xml").join("other.dtd"), "other")?;
+        crate::file::create_dir_all(prefix.join("share"))?;
+        crate::file::make_symlink(
+            Path::new("../Cellar/other/1.0/share/xml"),
+            &prefix.join("share").join("xml"),
+        )?;
+        // new keg wants a file inside share/xml
+        let keg = prefix.join("Cellar").join("foo").join("2.0");
+        crate::file::create_dir_all(keg.join("share").join("xml"))?;
+        crate::file::write(keg.join("share").join("xml").join("foo.dtd"), "foo")?;
+
+        link_keg("foo", "2.0", false)?;
+
+        let xml = prefix.join("share").join("xml");
+        assert!(!xml.symlink_metadata()?.is_symlink());
+        assert_eq!(std::fs::read_to_string(xml.join("other.dtd"))?, "other");
+        assert_eq!(std::fs::read_to_string(xml.join("foo.dtd"))?, "foo");
+        // the other keg must not have been polluted
+        assert!(!other.join("share").join("xml").join("foo.dtd").exists());
+        Ok(())
+    }
 
     #[test]
     fn test_relative_target() {

--- a/src/system/packages/brew/pour.rs
+++ b/src/system/packages/brew/pour.rs
@@ -385,7 +385,10 @@ fn materialize_brew_dirs(dest: &Path) -> Result<()> {
         }
         // swap: a directory cannot be renamed over a symlink, so remove the
         // link first; if the rename then fails, put the symlink back
-        crate::file::remove_file(&link_dir)?;
+        if let Err(err) = crate::file::remove_file(&link_dir) {
+            let _ = crate::file::remove_all(&staging);
+            return Err(err);
+        }
         if let Err(err) = crate::file::rename(&staging, &link_dir) {
             let _ = crate::file::make_symlink(&raw_target, &link_dir);
             let _ = crate::file::remove_all(&staging);


### PR DESCRIPTION
## Summary

`mise bootstrap packages upgrade` fails on machines where formulae were installed and linked by real Homebrew:

```
INFO  brew:fontconfig                     link
INFO  brew:fontconfig                   ✗ failed
Error: cannot link fontconfig: these files already exist and were not created by mise or brew:
  /opt/homebrew/include/fontconfig/fontconfig.h
  /opt/homebrew/lib/libfontconfig.dylib
  /opt/homebrew/share/fontconfig/conf.avail/10-no-antialias.conf
  ... (~50 more)
```

To work around it I had to `brew unlink` each conflicting formula, 17 in total on my machine. Note that the list above contains `lib/libfontconfig.dylib`, which is a perfectly normal file-level brew symlink; that one comes from cause 2 below, which breaks pure-mise setups as well.

There are three causes, all in the conflict check in `pour.rs`. This PR fixes all three by doing what brew does in the same situations. Only `pour.rs` changes.

### Cause 1: `can_overwrite` does not recognize brew's directory symlinks

The conflict check happens here:

https://github.com/jdx/mise/blob/194f65924f9acb5f5f446b69f63681b65bb40b5e/src/system/packages/brew/pour.rs#L282-L301

Real brew usually links a whole directory as one symlink (`include/glib-2.0 -> ../Cellar/glib/...`). Creating a real directory and linking file by file (`:mkpath`) is the exception, not the rule ([keg.rb#L503-L510](https://github.com/Homebrew/brew/blob/c70b438415d2fca15b6aa2d6a80be4431404417e/Library/Homebrew/keg.rb#L503-L510)). So most library formulae linked by real brew have these directory symlinks.

`can_overwrite` calls lstat on the destination. For a path under a directory symlink, the kernel follows the intermediate symlink, so lstat sees a regular file. The check concludes the file was not created by mise or brew, and reports a conflict.

Just relaxing the check would make things worse: the link pass would then remove and create files through the directory symlink, that is, inside the old keg. The directory symlink has to be turned into a real directory first. brew does exactly this in `resolve_any_conflicts` ([keg.rb#L713-L742](https://github.com/Homebrew/brew/blob/c70b438415d2fca15b6aa2d6a80be4431404417e/Library/Homebrew/keg.rb#L713-L742)).

### Cause 2: symlink targets are resolved the wrong way

`can_overwrite` resolves the destination with `desymlink_path`, which calls `canonicalize` on the raw `read_link` result:

https://github.com/jdx/mise/blob/194f65924f9acb5f5f446b69f63681b65bb40b5e/src/file.rs#L1532-L1541

Two problems:

1. dylib aliases in the Cellar are relative symlinks (`libglib-2.0.dylib -> libglib-2.0.0.dylib`). `canonicalize` resolves that raw relative target against the current working directory and fails, so the check ends up comparing a relative path against the Cellar path, which never matches.
2. It follows the whole symlink chain. Some bottles ship symlinks to system libraries, so a perfectly normal link into the Cellar resolves all the way to `/usr/lib/...` and fails the check.

Problem 1 hits mise's own links too: the second upgrade of any formula that ships a versioned dylib alias (nearly every library) fails the same way, even with no real brew involved.

brew follows the link exactly one step when deciding whether a link is its own (keg.rb: ["we only want to resolve one symlink"](https://github.com/Homebrew/brew/blob/c70b438415d2fca15b6aa2d6a80be4431404417e/Library/Homebrew/keg.rb#L718-L720); [`Keg#unlink`](https://github.com/Homebrew/brew/blob/c70b438415d2fca15b6aa2d6a80be4431404417e/Library/Homebrew/keg.rb#L370-L373) also compares the direct target only).

### Cause 3 (no error reported): links can end up inside another keg

When the destination does not exist yet, `can_overwrite` returns true unconditionally. If the parent directory is a directory symlink owned by another keg (e.g. `share/xml -> Cellar/fontconfig/.../share/xml`), the new symlink is created inside that keg. Nothing reports an error.

## Fix

Two changes, both doing what brew does:

1. **Follow the link one step only** (fixes cause 2). Join the `read_link` result with the link's parent directory, clean up `.`/`..` textually, and check whether the result points under Cellar or opt. `canonicalize` is not involved anymore, so relative targets and dangling links are handled correctly.
2. **Turn brew's directory symlinks into real directories before linking** (fixes causes 1 and 3). Anything under a directory symlink that points into the Cellar is treated as brew's, whether it is a regular file or one of the keg's own symlinks. Before linking, the directory symlink is replaced with a real directory containing symlinks to the same contents, so nothing visible changes. The new directory is built next to the symlink and swapped in only once it is complete, so a failure leaves everything as it was. This is the same thing brew's `resolve_any_conflicts` does. A regular file that is not under such a directory symlink is still reported as a conflict.

The expansion goes one directory level at a time; deeper levels are expanded when a destination path actually goes through them. The result, a real directory containing directory symlinks, is a layout brew itself creates and handles.

## Testing

- 5 new unit tests in `pour.rs`: upgrading over brew's file links (with the relative alias chain), over a link whose Cellar target points to a system library, over a directory symlink (including a keg-internal symlink under it; the old keg is left untouched), a foreign regular file still conflicts, and a shared directory owned by another keg is expanded without writing into that keg. 4 of the 5 fail on main.
- `cargo test --bin mise system::packages::brew`: 119 passed, no regressions.
- `cargo fmt` / `cargo clippy` clean.

## Notes

prune's `symlink_points_into` ([maintenance.rs#L261-L278](https://github.com/jdx/mise/blob/194f65924f9acb5f5f446b69f63681b65bb40b5e/src/system/packages/brew/maintenance.rs#L261-L278)) resolves targets the same broken way and can leave dangling links behind after pruning a keg. I would fix that in a follow-up PR to keep this one small.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keg linking/overwriting during upgrades when brew-managed file or directory symlink alias chains already exist.
  * Ensured existing brew-owned directory symlinks are safely expanded into real directories before link changes, in an all-or-nothing manner.
  * Prevented accidental modification or deletion of contents from previously linked package versions and preserved files from other packages.
  * Continued to reject conflicts with unrelated regular files and safely roll back any failed linking steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->