### PR TITLE
registry: add missing tool descriptions

### DIFF
--- a/registry/pipx.toml
+++ b/registry/pipx.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:pypa/pipx", "asdf:mise-plugins/mise-pipx"]
+description = "Install and Run Python Applications in Isolated Environments"
 test = { cmd = "pipx --version", expected = "{{version}}", tools = ["python"] }

--- a/registry/prek.toml
+++ b/registry/prek.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:j178/prek"]
+description = "⚡ A fast Git hook manager written in Rust, designed as a drop-in alternative to pre-commit, reimagined."
 test = { cmd = "prek --version", expected = "prek {{version}}" }

--- a/registry/trufflehog.toml
+++ b/registry/trufflehog.toml
@@ -2,4 +2,5 @@ backends = [
   "aqua:trufflesecurity/trufflehog",
   "github:trufflesecurity/trufflehog",
 ]
+description = "Find, verify, and analyze leaked credentials"
 test = { cmd = "trufflehog --version", expected = "trufflehog {{version}}" }


### PR DESCRIPTION
## Summary
- add the GitHub repository description for `pipx`
- add the GitHub repository description for `prek`
- add the GitHub repository description for `trufflehog`

These are metadata-only updates to existing registry entries. The descriptions are copied verbatim from the repositories:

- `pypa/pipx`: “Install and Run Python Applications in Isolated Environments”
- `j178/prek`: “⚡ A fast Git hook manager written in Rust, designed as a drop-in alternative to pre-commit, reimagined.”
- `trufflesecurity/trufflehog`: “Find, verify, and analyze leaked credentials”

## Popularity
- `pypa/pipx`: 12,888 stars, 584 forks; latest release 1.16.2 on 2026-07-21
- `j178/prek`: 8,128 stars, 227 forks; latest release v0.4.11 on 2026-07-24
- `trufflesecurity/trufflehog`: 27,207 stars, 2,503 forks; latest release v3.96.0 on 2026-07-24

All three are already present in the mise registry; this PR does not add or change any backend.

## Validation
- `taplo check registry/pipx.toml registry/prek.toml registry/trufflehog.toml`
- `cargo test registry::tests` (39 passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptions for the pipx, prek, and trufflehog registry entries.
  * Improved clarity around each tool’s purpose and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->