### PR TITLE
registry: add oh-my-pi

### DIFF
--- a/registry/oh-my-pi.toml
+++ b/registry/oh-my-pi.toml
@@ -1,0 +1,8 @@
+description = "AI coding agent for the terminal — hash-anchored edits, optimized tool harness, LSP, Python, browser, subagents, and more"
+test = { cmd = "omp --version", expected = "omp/{{version}}" }
+
+[[backends]]
+full = "github:can1357/oh-my-pi"
+
+[backends.options]
+rename_exe = "omp"


### PR DESCRIPTION
## Summary

Adds [oh-my-pi](https://github.com/can1357/oh-my-pi) (`omp`) — an AI coding agent for the terminal.

Uses the `github:` backend (the tool is not in the aqua registry) with `rename_exe = "omp"` because releases ship bare per-platform binaries (`omp-darwin-arm64`, `omp-linux-x64`, `omp-linux-musl-arm64`, `omp-windows-x64.exe`, ...). Releases carry GitHub attestations, which mise verifies on install.

## Popularity

- GitHub: 19.8k stars, 1.9k forks (repo created 2025-12-31)
- Actively maintained: latest release v17.1.3 published 2026-07-24, near-daily releases
- MIT licensed

## Verification

- `mise ls-remote github:can1357/oh-my-pi` lists all release versions
- `mise install "github:can1357/oh-my-pi[rename_exe=omp]@17.1.3"` installs successfully with verified SLSA/GitHub-attestation provenance
- `omp --version` prints `omp/17.1.3`, matching the `test` stanza

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Oh My Pi terminal coding agent to the package registry.
  * Added configuration for installation, executable naming, source retrieval, and version verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->