### PR TITLE
chore: release 2026.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,92 @@
 # Changelog
 
+## [2026.7.15](https://github.com/jdx/mise/compare/v2026.7.14..v2026.7.15) - 2026-07-27
+
+### 🚀 Features
+
+- **(config)** parse registry idiomatic version files by @jdx in [#11341](https://github.com/jdx/mise/pull/11341)
+- **(deps)** explain inactive providers by @risu729 in [#11182](https://github.com/jdx/mise/pull/11182)
+- **(npm)** add standalone aube installer mode by @jdx in [#11357](https://github.com/jdx/mise/pull/11357)
+- **(task)** add local output artifact caching by @jdx in [#11328](https://github.com/jdx/mise/pull/11328)
+- **(task)** include dependency artifacts in cache keys by @jdx in [#11340](https://github.com/jdx/mise/pull/11340)
+- **(task)** replay cached task output by @jdx in [#11347](https://github.com/jdx/mise/pull/11347)
+- **(task)** cache tasks without file outputs by @jdx in [#11351](https://github.com/jdx/mise/pull/11351)
+- **(task)** add reusable and global cache inputs by @jdx in [#11356](https://github.com/jdx/mise/pull/11356)
+- **(task)** add config-scoped default shell by @jdx in [#11354](https://github.com/jdx/mise/pull/11354)
+- **(task)** add global and pass-through cache env by @jdx in [#11363](https://github.com/jdx/mise/pull/11363)
+- **(task)** support negative output patterns by @jdx in [#11367](https://github.com/jdx/mise/pull/11367)
+
+### 🐛 Bug Fixes
+
+- **(backend)** don't let a disabled backend's plugin shadow the registry by @JamBalaya56562 in [#11362](https://github.com/jdx/mise/pull/11362)
+- **(brew)** recognize existing brew links when linking kegs by @mjun0812 in [#11320](https://github.com/jdx/mise/pull/11320)
+- **(brew)** resolve link targets one hop when collecting a keg's links for prune by @mjun0812 in [#11330](https://github.com/jdx/mise/pull/11330)
+- **(env)** expand ~/ with platform path separators by @JamBalaya56562 in [#11312](https://github.com/jdx/mise/pull/11312)
+- **(generate)** error instead of clobbering when task-docs markers are missing by @JamBalaya56562 in [#11359](https://github.com/jdx/mise/pull/11359)
+- **(mcp)** report mise as the server name in initialize by @jdx in [#11361](https://github.com/jdx/mise/pull/11361)
+- **(shell)** make pwsh activation work under Set-StrictMode by @JamBalaya56562 in [#11314](https://github.com/jdx/mise/pull/11314)
+- **(task)** make source_freshness_hash_contents skip mtime entirely by @rabadin in [#11319](https://github.com/jdx/mise/pull/11319)
+- **(task)** run newly executable file tasks by @jdx in [#11337](https://github.com/jdx/mise/pull/11337)
+- **(task)** detect cycles in resolved task graph by @jdx in [#11329](https://github.com/jdx/mise/pull/11329)
+- **(task)** display forwarded arguments accurately by @jdx in [#11344](https://github.com/jdx/mise/pull/11344)
+- **(task)** preserve raw output with cli overrides by @jdx in [#11355](https://github.com/jdx/mise/pull/11355)
+- **(vfox)** remove redundant debug argument borrows by @jdx in [#11352](https://github.com/jdx/mise/pull/11352)
+
+### 🚜 Refactor
+
+- **(e2e)** remove fd and ripgrep dependencies by @risu729 in [#11303](https://github.com/jdx/mise/pull/11303)
+
+### 📚 Documentation
+
+- **(contributing)** standardize AI disclosures by @jdx in [#11368](https://github.com/jdx/mise/pull/11368)
+- **(settings)** render markdown in choice descriptions by @jdx in [#11335](https://github.com/jdx/mise/pull/11335)
+- **(shims)** describe how activate treats the shims dir with auto-install by @JamBalaya56562 in [#11366](https://github.com/jdx/mise/pull/11366)
+- **(tasks)** clarify shebang argument behavior by @jdx in [#11336](https://github.com/jdx/mise/pull/11336)
+
+### 🧪 Testing
+
+- **(task)** isolate nested cache input coverage by @jdx in [#11360](https://github.com/jdx/mise/pull/11360)
+
+### 📦️ Dependency Updates
+
+- update clx and demand by @jdx in [#11358](https://github.com/jdx/mise/pull/11358)
+- update aube crates to v1.34.0 by @jdx in [#11364](https://github.com/jdx/mise/pull/11364)
+- bump aube to 1.34.0 by @jdx in [#11365](https://github.com/jdx/mise/pull/11365)
+
+### 📦 Registry
+
+- add oh-my-pi by @slbls in [#11324](https://github.com/jdx/mise/pull/11324)
+- add missing tool descriptions by @risu729 in [#11322](https://github.com/jdx/mise/pull/11322)
+- fix danger-swift installation by @Marukome0743 in [#11286](https://github.com/jdx/mise/pull/11286)
+- revert danger-swift installation fix by @jdx in [4c32d0f](https://github.com/jdx/mise/commit/4c32d0fac60f83a07c3284f08d7e750c9f049b81)
+
+### Chore
+
+- **(ci)** reject Windows unused-code warnings by @risu729 in [#11332](https://github.com/jdx/mise/pull/11332)
+- **(ci)** configure cursor cloud environment by @risu729 in [#11294](https://github.com/jdx/mise/pull/11294)
+- **(registry)** remove stale description updater by @risu729 in [#11321](https://github.com/jdx/mise/pull/11321)
+- **(registry)** remove stale registry symlink by @risu729 in [#11345](https://github.com/jdx/mise/pull/11345)
+- **(release)** replace cargo version tooling by @risu729 in [#11323](https://github.com/jdx/mise/pull/11323)
+- **(release)** remove broken cargo-release task by @risu729 in [#11342](https://github.com/jdx/mise/pull/11342)
+- **(task)** remove stale project tasks by @risu729 in [#11338](https://github.com/jdx/mise/pull/11338)
+- remove stale plugin ranking script by @risu729 in [#11346](https://github.com/jdx/mise/pull/11346)
+- remove agent os remnants by @risu729 in [#11348](https://github.com/jdx/mise/pull/11348)
+
+### New Contributors
+
+- @mjun0812 made their first contribution in [#11330](https://github.com/jdx/mise/pull/11330)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (1)
+
+- [`borghei/ink`](https://github.com/borghei/ink)
+
+#### Updated Packages (2)
+
+- [`UpCloudLtd/upcloud-cli`](https://github.com/UpCloudLtd/upcloud-cli)
+- [`dex4er/tf`](https://github.com/dex4er/tf)
+
 ## [2026.7.14](https://github.com/jdx/mise/compare/v2026.7.13..v2026.7.14) - 2026-07-26
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.14"
+version = "2026.7.15"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.14"
+version = "2026.7.15"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.14 macos-arm64 (2026-07-26)
+2026.7.15 macos-arm64 (2026-07-27)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_14.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_15.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_14.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_15.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -p usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_14.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_15.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_14.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_15.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.14";
+  version = "2026.7.15";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "31.1k",
+      stars: "31.2k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.14
+Version: 2026.7.15
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.14"
+version: "2026.7.15"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "f2cab17924c99504bf3c9014c3b4969763d98f08"
+  "tag": "ec35b786bd16bbd68288b8a05a0ffe517369a202"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -8561,6 +8561,20 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 3.34.0")
+        asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: UpCloudLtd/workflows/.github/workflows/build-provenance.yaml
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -8572,6 +8586,15 @@ packages:
           algorithm: sha256
         github_artifact_attestations:
           signer_workflow: UpCloudLtd/workflows/.github/workflows/build-provenance.yaml
+        cosign:
+          bundle:
+            type: github_release
+            asset: upcloud-cli.sigstore.json
+          opts:
+            - --certificate-identity
+            - https://github.com/UpCloudLtd/workflows/.github/workflows/build-provenance.yaml@refs/heads/main
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -21007,6 +21030,28 @@ packages:
         github_artifact_attestations:
           signer_workflow: borgbackup/borg/.github/workflows/ci.yml
   - type: github_release
+    repo_owner: borghei
+    repo_name: ink
+    description: Terminal markdown reader with syntax highlighting, inline images, and themes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.2")
+        asset: ink-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+      - version_constraint: "true"
+        asset: ink-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+  - type: github_release
     repo_owner: boyter
     repo_name: scc
     description: "Sloc, Cloc and Code: scc is a very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go"
@@ -33349,6 +33394,13 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 2.14.0")
+        asset: tf-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: tf-{{.OS}}-{{.Arch}}
         format: raw
@@ -33356,6 +33408,8 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: dex4er/tf/\.github/workflows/release\.yaml
   - type: github_release
     repo_owner: dhall-lang
     repo_name: dhall-haskell


### PR DESCRIPTION
### 🚀 Features

- **(config)** parse registry idiomatic version files by @jdx in [#11341](https://github.com/jdx/mise/pull/11341)
- **(deps)** explain inactive providers by @risu729 in [#11182](https://github.com/jdx/mise/pull/11182)
- **(npm)** add standalone aube installer mode by @jdx in [#11357](https://github.com/jdx/mise/pull/11357)
- **(task)** add local output artifact caching by @jdx in [#11328](https://github.com/jdx/mise/pull/11328)
- **(task)** include dependency artifacts in cache keys by @jdx in [#11340](https://github.com/jdx/mise/pull/11340)
- **(task)** replay cached task output by @jdx in [#11347](https://github.com/jdx/mise/pull/11347)
- **(task)** cache tasks without file outputs by @jdx in [#11351](https://github.com/jdx/mise/pull/11351)
- **(task)** add reusable and global cache inputs by @jdx in [#11356](https://github.com/jdx/mise/pull/11356)
- **(task)** add config-scoped default shell by @jdx in [#11354](https://github.com/jdx/mise/pull/11354)
- **(task)** add global and pass-through cache env by @jdx in [#11363](https://github.com/jdx/mise/pull/11363)
- **(task)** support negative output patterns by @jdx in [#11367](https://github.com/jdx/mise/pull/11367)

### 🐛 Bug Fixes

- **(backend)** don't let a disabled backend's plugin shadow the registry by @JamBalaya56562 in [#11362](https://github.com/jdx/mise/pull/11362)
- **(brew)** recognize existing brew links when linking kegs by @mjun0812 in [#11320](https://github.com/jdx/mise/pull/11320)
- **(brew)** resolve link targets one hop when collecting a keg's links for prune by @mjun0812 in [#11330](https://github.com/jdx/mise/pull/11330)
- **(env)** expand ~/ with platform path separators by @JamBalaya56562 in [#11312](https://github.com/jdx/mise/pull/11312)
- **(generate)** error instead of clobbering when task-docs markers are missing by @JamBalaya56562 in [#11359](https://github.com/jdx/mise/pull/11359)
- **(mcp)** report mise as the server name in initialize by @jdx in [#11361](https://github.com/jdx/mise/pull/11361)
- **(shell)** make pwsh activation work under Set-StrictMode by @JamBalaya56562 in [#11314](https://github.com/jdx/mise/pull/11314)
- **(task)** make source_freshness_hash_contents skip mtime entirely by @rabadin in [#11319](https://github.com/jdx/mise/pull/11319)
- **(task)** run newly executable file tasks by @jdx in [#11337](https://github.com/jdx/mise/pull/11337)
- **(task)** detect cycles in resolved task graph by @jdx in [#11329](https://github.com/jdx/mise/pull/11329)
- **(task)** display forwarded arguments accurately by @jdx in [#11344](https://github.com/jdx/mise/pull/11344)
- **(task)** preserve raw output with cli overrides by @jdx in [#11355](https://github.com/jdx/mise/pull/11355)
- **(vfox)** remove redundant debug argument borrows by @jdx in [#11352](https://github.com/jdx/mise/pull/11352)

### 🚜 Refactor

- **(e2e)** remove fd and ripgrep dependencies by @risu729 in [#11303](https://github.com/jdx/mise/pull/11303)

### 📚 Documentation

- **(contributing)** standardize AI disclosures by @jdx in [#11368](https://github.com/jdx/mise/pull/11368)
- **(settings)** render markdown in choice descriptions by @jdx in [#11335](https://github.com/jdx/mise/pull/11335)
- **(shims)** describe how activate treats the shims dir with auto-install by @JamBalaya56562 in [#11366](https://github.com/jdx/mise/pull/11366)
- **(tasks)** clarify shebang argument behavior by @jdx in [#11336](https://github.com/jdx/mise/pull/11336)

### 🧪 Testing

- **(task)** isolate nested cache input coverage by @jdx in [#11360](https://github.com/jdx/mise/pull/11360)

### 📦️ Dependency Updates

- update clx and demand by @jdx in [#11358](https://github.com/jdx/mise/pull/11358)
- update aube crates to v1.34.0 by @jdx in [#11364](https://github.com/jdx/mise/pull/11364)
- bump aube to 1.34.0 by @jdx in [#11365](https://github.com/jdx/mise/pull/11365)

### 📦 Registry

- add oh-my-pi by @slbls in [#11324](https://github.com/jdx/mise/pull/11324)
- add missing tool descriptions by @risu729 in [#11322](https://github.com/jdx/mise/pull/11322)
- fix danger-swift installation by @Marukome0743 in [#11286](https://github.com/jdx/mise/pull/11286)
- revert danger-swift installation fix by @jdx in [4c32d0f](https://github.com/jdx/mise/commit/4c32d0fac60f83a07c3284f08d7e750c9f049b81)

### Chore

- **(ci)** reject Windows unused-code warnings by @risu729 in [#11332](https://github.com/jdx/mise/pull/11332)
- **(ci)** configure cursor cloud environment by @risu729 in [#11294](https://github.com/jdx/mise/pull/11294)
- **(registry)** remove stale description updater by @risu729 in [#11321](https://github.com/jdx/mise/pull/11321)
- **(registry)** remove stale registry symlink by @risu729 in [#11345](https://github.com/jdx/mise/pull/11345)
- **(release)** replace cargo version tooling by @risu729 in [#11323](https://github.com/jdx/mise/pull/11323)
- **(release)** remove broken cargo-release task by @risu729 in [#11342](https://github.com/jdx/mise/pull/11342)
- **(task)** remove stale project tasks by @risu729 in [#11338](https://github.com/jdx/mise/pull/11338)
- remove stale plugin ranking script by @risu729 in [#11346](https://github.com/jdx/mise/pull/11346)
- remove agent os remnants by @risu729 in [#11348](https://github.com/jdx/mise/pull/11348)

### New Contributors

- @mjun0812 made their first contribution in [#11330](https://github.com/jdx/mise/pull/11330)

## 📦 Aqua Registry Updates

### New Packages (1)

- [`borghei/ink`](https://github.com/borghei/ink)

### Updated Packages (2)

- [`UpCloudLtd/upcloud-cli`](https://github.com/UpCloudLtd/upcloud-cli)
- [`dex4er/tf`](https://github.com/dex4er/tf)