### PR TITLE
feat(task): add local output artifact caching

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -1,0 +1,79 @@
+# Task Cache Parity Tracker
+
+> [!IMPORTANT]
+> This is a temporary implementation tracker. Delete this file in the same pull request that checks
+> off the final remaining item.
+
+This tracks the work required to bring mise's experimental task output cache close to Turborepo's
+caching functionality. Nx-specific project inference, affected-project analysis, and distributed
+task execution are outside this tracker because they are broader task-runner features rather than
+cache functionality.
+
+## Experimental local cache
+
+- [x] Opt-in experimental task cache configuration
+- [x] Content-derived keys for sources, task definitions, arguments, declared environment, selected
+      ambient environment variables, resolved tools, operating system, and architecture
+- [x] Store and restore explicitly declared file and directory outputs
+- [x] Preserve directories, regular files, symlinks, permissions, and modification times
+- [x] Reject automatic, absolute, escaping, and source-containing output paths
+- [x] Treat corrupt entries as misses and cache write failures as warnings
+- [x] Integrate artifacts with the existing cache clear and prune commands
+- [x] Document the experimental behavior and configuration schema
+- [x] Cover hits, misses, environment changes, source changes, and invalid configurations in tests
+
+## Local cache parity
+
+- [ ] Include dependency artifact keys in downstream task keys
+- [ ] Allow dependents to restore after dependencies execute or restore
+- [ ] Capture and replay stdout and stderr while respecting mise output modes
+- [ ] Cache useful results for tasks with no filesystem outputs
+- [ ] Support reusable and global input groups
+- [ ] Support global environment inputs and pass-through environment variables
+- [ ] Support negative input and output patterns
+- [ ] Support runtime-command inputs
+- [ ] Include external dependency and lockfile state through explicit input configuration
+- [ ] Add per-run cache read/write controls, including local-only and cache-disabled modes
+- [ ] Add a configurable local task-cache directory
+
+## Inspection and diagnostics
+
+- [ ] Explain the inputs that produced a task's cache key
+- [ ] Report the reason for each cache miss
+- [ ] Show resolved cache inputs and outputs
+- [ ] Add machine-readable cache details to dry-run or task-info output
+- [ ] Report hit rate, bytes restored, and time saved
+- [ ] Add per-task cache inspection and deletion
+
+## Integrity and portability
+
+- [ ] Add an artifact checksum independent of the cache key
+- [ ] Test and harden concurrent readers and writers for the same key
+- [ ] Clean up interrupted and abandoned partial writes
+- [ ] Add configurable cache size and age limits
+- [ ] Test restore behavior on Windows
+- [ ] Test executable bits, symlinks, empty directories, and case-sensitive path edge cases
+- [ ] Benchmark hashing, archive creation, and restoration for large task graphs and artifacts
+- [ ] Avoid rehashing unchanged source files when reliable metadata is available
+- [ ] Add an optional audit mode for undeclared task reads and writes
+
+## Remote cache
+
+- [ ] Extract a versioned cache-store interface from the local filesystem implementation
+- [ ] Define and document a versioned remote cache protocol
+- [ ] Add a composite local and remote cache store
+- [ ] Stream artifact uploads and downloads
+- [ ] Add remote read-only, write-only, and read/write modes
+- [ ] Add authentication and repository or organization namespaces
+- [ ] Add timeouts, retries, request deduplication, and offline fallback
+- [ ] Verify remote artifact integrity and authenticity
+- [ ] Document secret handling for cached logs and artifacts
+- [ ] Provide a self-hosting reference or compatibility test suite
+
+## Stabilization
+
+- [ ] Decide which experimental configuration names become stable
+- [ ] Document cache correctness requirements and deterministic-task expectations
+- [ ] Publish migration notes if the experimental configuration or artifact format changes
+- [ ] Remove the experimental gate
+- [ ] Delete this tracker

--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -1,13 +1,20 @@
-# Task Cache Parity Tracker
+# Task Runner Parity Tracker
 
 > [!IMPORTANT]
 > This is a temporary implementation tracker. Delete this file in the same pull request that checks
 > off the final remaining item.
 
-This tracks the work required to bring mise's experimental task output cache close to Turborepo's
-caching functionality. Nx-specific project inference, affected-project analysis, and distributed
-task execution are outside this tracker because they are broader task-runner features rather than
-cache functionality.
+This tracks the work required to bring mise's experimental task output cache and monorepo task
+graph close to Turborepo's functionality, with selected Nx-style inference where it fits mise's
+language-agnostic model.
+
+Cache lookup, project selection, and task inference are separate layers: the cache decides whether a
+selected task executes or restores an artifact, affected analysis decides which project tasks are
+selected, and workspace providers turn ecosystem metadata into projects, dependencies, and inferred
+tasks. Keeping those layers separate should allow explicit mise tasks to coexist with inference.
+
+Distributed task execution, code generation, and a comprehensive Nx-style plugin ecosystem remain
+outside this tracker.
 
 ## Experimental local cache
 
@@ -22,6 +29,51 @@ cache functionality.
 - [x] Integrate artifacts with the existing cache clear and prune commands
 - [x] Document the experimental behavior and configuration schema
 - [x] Cover hits, misses, environment changes, source changes, and invalid configurations in tests
+
+## Workspace and project graph
+
+- [ ] Define a provider-neutral project model with stable project IDs, roots, metadata, and
+      dependency edges
+- [ ] Define a workspace provider interface that can discover projects and dependencies
+      deterministically
+- [ ] Merge graphs from multiple providers for polyglot repositories
+- [ ] Allow explicit configuration to add, remove, or override inferred projects and dependency
+      edges
+- [ ] Detect project graph cycles and report actionable diagnostics
+- [ ] Preserve dependency traversal through projects that do not implement the requested task
+- [ ] Add human-readable and machine-readable project graph inspection
+
+## Workspace providers and task inference
+
+- [ ] Add a Node workspace provider for npm, pnpm, Yarn, and Bun workspace definitions
+- [ ] Infer Node project dependency edges from declared internal package dependencies
+- [ ] Import package scripts as scoped mise tasks without requiring a `mise.toml` in every package
+- [ ] Add root task defaults that apply by task name across inferred and explicit projects
+- [ ] Add dependency-scoped task relationships equivalent to building the same task in upstream
+      projects first
+- [ ] Define deterministic precedence between provider inference, root task defaults, task
+      templates, and project-local configuration
+- [ ] Allow providers to suggest inputs, outputs, cacheability, and task dependencies when they can
+      derive them confidently
+- [ ] Explain which provider inferred each project, task, input, output, and dependency
+- [ ] Add Cargo workspace and path-dependency inference
+- [ ] Add uv workspace and local/path-dependency inference
+- [ ] Add Go workspace discovery, with explicit dependency overrides where module metadata is
+      insufficient
+
+## Affected project execution
+
+- [ ] Map changed files to their owning projects
+- [ ] Compute affected projects from changed projects and reverse project dependency edges
+- [ ] Add configurable Git base and head revisions with sensible local and CI defaults
+- [ ] Treat workspace-global files and explicitly declared global inputs as affecting the
+      appropriate project set
+- [ ] Account for lockfile changes at project granularity when a provider can determine the affected
+      external dependencies
+- [ ] Allow affected selection to feed existing task patterns, dependency expansion, scheduling, and
+      caching
+- [ ] Show why each project and task was considered affected
+- [ ] Add machine-readable affected-project and affected-task output
 
 ## Local cache parity
 

--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -12,6 +12,7 @@ cache functionality.
 ## Experimental local cache
 
 - [x] Opt-in experimental task cache configuration
+- [x] Scoped cache defaults for eligible tasks with task-level opt-out
 - [x] Content-derived keys for sources, task definitions, arguments, declared environment, selected
       ambient environment variables, resolved tools, operating system, and architecture
 - [x] Store and restore explicitly declared file and directory outputs

--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -54,7 +54,7 @@ cache functionality.
 - [ ] Test restore behavior on Windows
 - [ ] Test executable bits, symlinks, empty directories, and case-sensitive path edge cases
 - [ ] Benchmark hashing, archive creation, and restoration for large task graphs and artifacts
-- [ ] Avoid rehashing unchanged source files when reliable metadata is available
+- [x] Avoid rehashing unchanged source files when reliable metadata is available
 - [ ] Add an optional audit mode for undeclared task reads and writes
 
 ## Remote cache

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -468,6 +468,28 @@ outputs = ["dist"]
 cache = { enabled = true, env = ["NODE_ENV"] }
 ```
 
+To enable caching by default for every eligible task in a config scope, set
+`task_config.cache`. Only tasks with at least one source and explicit output paths inherit this
+default; other tasks remain uncached. A task-local `cache` value overrides the scoped default.
+
+```mise-toml
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+env = ["NODE_ENV"]
+
+[tasks.build]
+run = "npm run build"
+sources = ["package.json", "src/**"]
+outputs = ["dist"]
+
+[tasks.deploy]
+run = "./deploy.sh"
+cache = { enabled = false }
+```
+
 The cache key includes source contents, the task definition and arguments, resolved task environment,
 the values (or absence) of variables named in `cache.env`, resolved tool versions, and the operating
 system and architecture. Variables inherited from the ambient process are ignored unless listed in
@@ -722,6 +744,18 @@ Change the default directory tasks are run from.
 ```toml
 [task_config]
 dir = "{{cwd}}"
+```
+
+### `task_config.cache` <Badge type="warning" text="experimental" />
+
+Sets the default artifact-cache configuration for tasks in this config scope. The default is only
+inherited by cache-eligible tasks with sources and explicit output paths. Task-local and task-template
+cache configuration takes precedence, including `cache = { enabled = false }`.
+
+```toml
+[task_config.cache]
+enabled = true
+env = ["NODE_ENV", "CI"]
 ```
 
 ### `task_config.includes` {#task-config-includes}

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -444,6 +444,44 @@ sources = ["Cargo.toml", "src/**/*.rs"]
 outputs = { auto = true } # this is the default when sources is defined
 ```
 
+### `cache` <Badge type="warning" text="experimental" />
+
+- **Type**: `{ enabled = bool, env = string[] }`
+- **Default**: `{ enabled = false, env = [] }`
+
+Stores declared task outputs in a content-addressed local cache and restores them when the same task
+inputs are seen again. This differs from the normal `sources`/`outputs` freshness check: cached
+artifacts can restore outputs after they have been deleted.
+
+Artifact caching requires [`experimental`](/configuration/settings.html#experimental), at least one
+matching `source`, and explicit output paths. `outputs = { auto = true }`, absolute outputs, and
+outputs that escape the task directory are not supported.
+
+```mise-toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = "npm run build"
+sources = ["package.json", "src/**"]
+outputs = ["dist"]
+cache = { enabled = true, env = ["NODE_ENV"] }
+```
+
+The cache key includes source contents, the task definition and arguments, resolved task environment,
+the values (or absence) of variables named in `cache.env`, resolved tool versions, and the operating
+system and architecture. Variables inherited from the ambient process are ignored unless listed in
+`cache.env`.
+
+Artifacts are stored under `MISE_CACHE_DIR/task-artifacts/v1` as zstd-compressed tar archives. They
+are included in the existing `mise cache clear` and `mise cache prune` behavior. Only successful task
+runs are cached. Cache read/write failures are treated as misses and never turn a successful task run
+into a failure.
+
+This initial implementation is local-only and does not cache or replay task logs. If a dependency
+executes or restores outputs during the current run, dependent tasks conservatively execute rather
+than restoring an artifact.
+
 ### `shell`
 
 - **Type**: `string`

--- a/docs/tasks/templates.md
+++ b/docs/tasks/templates.md
@@ -53,7 +53,7 @@ When a task extends a template, fields are merged according to these rules:
 | `env`                                             | Deep merge (local env added/override template)              |
 | `depends`, `depends_post`, `wait_for`             | Local overrides completely (not merged)                     |
 | `dir`                                             | Local overrides; defaults to config_root if not in template |
-| `sources`, `outputs`                              | Local overrides completely                                  |
+| `sources`, `outputs`, `cache`                     | Local overrides completely                                  |
 | `output`                                          | Local overrides template (if set)                           |
 | Sandbox deny fields                               | Compose with task-local settings                            |
 | Sandbox allow fields                              | Template and task-local values are combined                 |

--- a/e2e/tasks/test_task_artifact_cache
+++ b/e2e/tasks/test_task_artifact_cache
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = '''
+mkdir -p dist/empty
+printf '%s:%s\n' "$PROFILE" "$(cat input.txt)" > dist/result.txt
+printf 'ran\n' >> runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["dist"]
+cache = { enabled = true, env = ["PROFILE"] }
+EOF
+
+printf 'one\n' >input.txt
+
+PROFILE=debug mise run build
+assert "wc -l < runs.txt | tr -d ' '" "1"
+assert "cat dist/result.txt" "debug:one"
+
+# Existing fresh outputs use the normal fast freshness path.
+assert_contains "PROFILE=debug mise run build 2>&1" "sources up-to-date, skipping"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# Missing outputs are restored from the local artifact cache without executing.
+rm -rf dist
+assert_contains "PROFILE=debug mise run build 2>&1" "restored outputs from cache"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+assert "cat dist/result.txt" "debug:one"
+assert_succeed "test -d dist/empty"
+
+# An allowlisted ambient environment change produces a cache miss.
+PROFILE=release mise run build
+assert "wc -l < runs.txt | tr -d ' '" "2"
+assert "cat dist/result.txt" "release:one"
+
+# Source content changes also produce a miss and a distinct artifact.
+printf 'two\n' >input.txt
+PROFILE=release mise run build
+assert "wc -l < runs.txt | tr -d ' '" "3"
+assert "cat dist/result.txt" "release:two"
+
+# The new result is independently restorable.
+rm -rf dist
+assert_contains "PROFILE=release mise run build 2>&1" "restored outputs from cache"
+assert "wc -l < runs.txt | tr -d ' '" "3"
+assert "cat dist/result.txt" "release:two"

--- a/e2e/tasks/test_task_artifact_cache
+++ b/e2e/tasks/test_task_artifact_cache
@@ -48,3 +48,9 @@ rm -rf dist
 assert_contains "PROFILE=release mise run build 2>&1" "restored outputs from cache"
 assert "wc -l < runs.txt | tr -d ' '" "3"
 assert "cat dist/result.txt" "release:two"
+
+# Dry runs must not restore outputs or mutate artifact cache state.
+rm -rf dist
+PROFILE=release mise run --dry-run build
+assert_fail "test -e dist"
+assert "wc -l < runs.txt | tr -d ' '" "3"

--- a/e2e/tasks/test_task_artifact_cache
+++ b/e2e/tasks/test_task_artifact_cache
@@ -54,3 +54,24 @@ rm -rf dist
 PROFILE=release mise run --dry-run build
 assert_fail "test -e dist"
 assert "wc -l < runs.txt | tr -d ' '" "3"
+
+# Usage-derived environment values participate in the cache key.
+cat <<'EOF' >>mise.toml
+
+[tasks.usage-cache]
+usage = 'arg "<value>"'
+run = '''
+mkdir -p usage-dist
+printf '%s\n' "$usage_value" > usage-dist/result.txt
+printf 'ran\n' >> usage-runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["usage-dist"]
+cache = { enabled = true, env = ["usage_value"] }
+EOF
+
+mise run usage-cache alpha
+rm -rf usage-dist
+mise run usage-cache beta
+assert "cat usage-dist/result.txt" "beta"
+assert "wc -l < usage-runs.txt | tr -d ' '" "2"

--- a/e2e/tasks/test_task_artifact_cache
+++ b/e2e/tasks/test_task_artifact_cache
@@ -35,28 +35,37 @@ assert "wc -l < runs.txt | tr -d ' '" "1"
 assert "cat dist/result.txt" "debug:one"
 assert_succeed "test -d dist/empty"
 
+# Clearing the artifact cache invalidates the fast freshness skip even when
+# outputs remain, so the task executes once to repopulate the cache.
+mise cache clear
+assert_not_contains "PROFILE=debug mise run build 2>&1" "sources up-to-date, skipping"
+assert "wc -l < runs.txt | tr -d ' '" "2"
+rm -rf dist
+assert_contains "PROFILE=debug mise run build 2>&1" "restored outputs from cache"
+assert "wc -l < runs.txt | tr -d ' '" "2"
+
 # An allowlisted ambient environment change produces a cache miss.
 PROFILE=release mise run build
-assert "wc -l < runs.txt | tr -d ' '" "2"
+assert "wc -l < runs.txt | tr -d ' '" "3"
 assert "cat dist/result.txt" "release:one"
 
 # Source content changes also produce a miss and a distinct artifact.
 printf 'two\n' >input.txt
 PROFILE=release mise run build
-assert "wc -l < runs.txt | tr -d ' '" "3"
+assert "wc -l < runs.txt | tr -d ' '" "4"
 assert "cat dist/result.txt" "release:two"
 
 # The new result is independently restorable.
 rm -rf dist
 assert_contains "PROFILE=release mise run build 2>&1" "restored outputs from cache"
-assert "wc -l < runs.txt | tr -d ' '" "3"
+assert "wc -l < runs.txt | tr -d ' '" "4"
 assert "cat dist/result.txt" "release:two"
 
 # Dry runs must not restore outputs or mutate artifact cache state.
 rm -rf dist
 PROFILE=release mise run --dry-run build
 assert_fail "test -e dist"
-assert "wc -l < runs.txt | tr -d ' '" "3"
+assert "wc -l < runs.txt | tr -d ' '" "4"
 
 # Usage-derived environment values participate in the cache key.
 cat <<'EOF' >>mise.toml

--- a/e2e/tasks/test_task_artifact_cache
+++ b/e2e/tasks/test_task_artifact_cache
@@ -4,6 +4,10 @@ cat <<'EOF' >mise.toml
 [settings]
 experimental = true
 
+[task_config.cache]
+enabled = true
+env = ["PROFILE"]
+
 [tasks.build]
 run = '''
 mkdir -p dist/empty
@@ -12,7 +16,6 @@ printf 'ran\n' >> runs.txt
 '''
 sources = ["input.txt"]
 outputs = ["dist"]
-cache = { enabled = true, env = ["PROFILE"] }
 EOF
 
 printf 'one\n' >input.txt
@@ -67,7 +70,8 @@ printf 'ran\n' >> usage-runs.txt
 '''
 sources = ["input.txt"]
 outputs = ["usage-dist"]
-cache = { enabled = true, env = ["usage_value"] }
+env = { usage_value = "default" }
+cache = { enabled = true }
 EOF
 
 mise run usage-cache alpha
@@ -75,3 +79,28 @@ rm -rf usage-dist
 mise run usage-cache beta
 assert "cat usage-dist/result.txt" "beta"
 assert "wc -l < usage-runs.txt | tr -d ' '" "2"
+
+# A task-local cache setting overrides the scoped default.
+cat <<'EOF' >>mise.toml
+
+[tasks.uncached]
+run = '''
+mkdir -p uncached-dist
+printf 'ran\n' >> uncached-runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["uncached-dist"]
+cache = { enabled = false }
+
+[tasks.ineligible]
+run = "printf 'ran\n' >> ineligible-runs.txt"
+EOF
+
+mise run uncached
+rm -rf uncached-dist
+mise run uncached
+assert "wc -l < uncached-runs.txt | tr -d ' '" "2"
+
+# Tasks without sources and explicit outputs do not inherit the cache default.
+mise run ineligible
+assert "wc -l < ineligible-runs.txt | tr -d ' '" "1"

--- a/e2e/tasks/test_task_artifact_cache_validation
+++ b/e2e/tasks/test_task_artifact_cache_validation
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.build]
+run = "touch out"
+sources = ["input"]
+outputs = ["out"]
+cache = { enabled = true }
+EOF
+touch input
+
+assert_fail_contains \
+  "MISE_EXPERIMENTAL=0 mise run build" \
+  "task artifact caching is experimental"
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = "touch out"
+sources = ["input"]
+outputs = { auto = true }
+cache = { enabled = true }
+EOF
+
+assert_fail_contains \
+  "mise run build" \
+  "cache requires explicit output files or directories"
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = "touch ../out"
+sources = ["input"]
+outputs = ["../out"]
+cache = { enabled = true }
+EOF
+
+assert_fail_contains "mise run build" "cache output must stay within"
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = "touch input"
+sources = ["input"]
+outputs = ["."]
+cache = { enabled = true }
+EOF
+
+assert_fail_contains "mise run build" "cache output must stay within"

--- a/e2e/tasks/test_task_artifact_cache_validation
+++ b/e2e/tasks/test_task_artifact_cache_validation
@@ -27,6 +27,9 @@ EOF
 assert_fail_contains \
   "mise run build" \
   "cache requires explicit output files or directories"
+assert_fail_contains \
+  "mise run --dry-run build" \
+  "cache requires explicit output files or directories"
 
 cat <<'EOF' >mise.toml
 [settings]

--- a/e2e/tasks/test_task_artifact_cache_validation
+++ b/e2e/tasks/test_task_artifact_cache_validation
@@ -41,6 +41,34 @@ EOF
 
 assert_fail_contains "mise run build" "cache output must stay within"
 
+mkdir outside
+ln -s outside build
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = "mkdir -p build/dist"
+sources = ["input"]
+outputs = ["build/dist"]
+cache = { enabled = true }
+EOF
+
+assert_fail_contains "mise run build" "traverses symlink ancestor"
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = "touch input"
+sources = ["input"]
+outputs = ["input"]
+cache = { enabled = true }
+EOF
+
+assert_fail_contains "mise run build" "cache outputs must not contain source"
+
 cat <<'EOF' >mise.toml
 [settings]
 experimental = true

--- a/e2e/tasks/test_task_info
+++ b/e2e/tasks/test_task_info
@@ -44,6 +44,10 @@ assert_json "mise tasks info lint --json" "$(
   "interactive": false,
   "sources": [],
   "outputs": [],
+  "cache": {
+    "enabled": false,
+    "env": []
+  },
   "shell": null,
   "quiet": false,
   "silent": false,

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -185,6 +185,25 @@
             }
           ]
         },
+        "cache": {
+          "description": "experimental local artifact cache for declared task outputs",
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "store and restore task outputs from the local mise cache",
+              "type": "boolean"
+            },
+            "env": {
+              "description": "ambient environment variable names whose values affect the cache key",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        },
         "output": {
           "description": "output style for this task (prefix, interleave, keep-order, replacing, timed, quiet, silent). Independent of the quiet/silent verbosity fields.",
           "enum": [

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2893,6 +2893,25 @@
             }
           ]
         },
+        "cache": {
+          "description": "experimental local artifact cache for declared task outputs",
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "store and restore task outputs from the local mise cache",
+              "type": "boolean"
+            },
+            "env": {
+              "description": "ambient environment variable names whose values affect the cache key",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        },
         "output": {
           "description": "output style for this task (prefix, interleave, keep-order, replacing, timed, quiet, silent). Independent of the quiet/silent verbosity fields.",
           "enum": [

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2265,6 +2265,25 @@
           "description": "default directory to run tasks in defined in this file",
           "type": "string"
         },
+        "cache": {
+          "description": "default experimental local artifact cache configuration for eligible tasks with sources and explicit outputs",
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "store and restore eligible task outputs from the local mise cache",
+              "type": "boolean"
+            },
+            "env": {
+              "description": "ambient environment variable names whose values affect eligible task cache keys",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        },
         "includes": {
           "description": "files/directories to include searching for tasks. Can be local paths or git repository URLs using git:: prefix (e.g., git::https://github.com/org/repo.git//path?ref=branch)",
           "items": {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -891,6 +891,9 @@ impl Run {
     fn validate_task(&self, task: &Task) -> Result<()> {
         use crate::file;
         use crate::ui;
+        if task.cache.enabled {
+            Settings::get().ensure_experimental("task artifact caching")?;
+        }
         if let Some(path) = &task.file
             && path.exists()
             && !file::is_executable(path)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -891,7 +891,7 @@ impl Run {
     fn validate_task(&self, task: &Task) -> Result<()> {
         use crate::file;
         use crate::ui;
-        if task.cache.enabled {
+        if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
             Settings::get().ensure_experimental("task artifact caching")?;
         }
         if let Some(path) = &task.file

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -107,7 +107,7 @@ impl TasksInfo {
         if !outputs.is_empty() {
             info::inline_section("Outputs", outputs.join(", "))?;
         }
-        if task.cache.enabled {
+        if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
             info::inline_section("Cache", "enabled")?;
         }
         if let Some(file) = &task.file {
@@ -163,7 +163,7 @@ impl TasksInfo {
             "interactive": task.interactive,
             "sources": task.sources,
             "outputs": task.outputs,
-            "cache": task.cache,
+            "cache": task.cache.clone().unwrap_or_default(),
             "shell": task.shell,
             "quiet": task.quiet,
             "silent": task.silent,

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -107,6 +107,9 @@ impl TasksInfo {
         if !outputs.is_empty() {
             info::inline_section("Outputs", outputs.join(", "))?;
         }
+        if task.cache.enabled {
+            info::inline_section("Cache", "enabled")?;
+        }
         if let Some(file) = &task.file {
             info::inline_section("File", display_path(file))?;
         }
@@ -160,6 +163,7 @@ impl TasksInfo {
             "interactive": task.interactive,
             "sources": task.sources,
             "outputs": task.outputs,
+            "cache": task.cache,
             "shell": task.shell,
             "quiet": task.quiet,
             "silent": task.silent,

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -714,6 +714,7 @@ impl Hash for dyn ConfigFile {
 pub struct TaskConfig {
     pub includes: Option<Vec<String>>,
     pub dir: Option<String>,
+    pub cache: Option<crate::task::TaskCacheConfig>,
 }
 
 #[cfg(test)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,7 +27,7 @@ use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENA
 use crate::file::display_path;
 use crate::shorthands::{Shorthands, get_shorthands};
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
-use crate::task::{Task, TaskTemplate, monorepo_scope, strip_extension};
+use crate::task::{Task, TaskCacheConfig, TaskTemplate, monorepo_scope, strip_extension};
 use crate::tera::{contains_template_syntax, render_str, take_tera_accessed_files};
 use crate::toolset::env_cache::{CachedNonToolEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::{
@@ -2190,6 +2190,16 @@ fn resolve_task_template(
     Ok(())
 }
 
+fn apply_task_config_cache_default(task: &mut Task, cache: &Option<TaskCacheConfig>) {
+    if task.cache.is_none()
+        && !task.sources.is_empty()
+        && !task.outputs.patterns().is_empty()
+        && let Some(cache) = cache
+    {
+        task.cache = Some(cache.clone());
+    }
+}
+
 fn default_task_includes() -> Vec<String> {
     vec![
         "mise-tasks".to_string(),
@@ -2959,6 +2969,7 @@ async fn load_config_tasks(
         resolve_task_template(&mut t, templates)?;
         match t.render(&config, &config_root).await {
             Ok(()) => {
+                apply_task_config_cache_default(&mut t, &cf.task_config().cache);
                 tasks.push(t);
             }
             Err(e) => {
@@ -3311,6 +3322,7 @@ async fn load_task_sources_from_configs(
     }
     // Find task_config.dir from the highest-precedence config that defines it
     let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
+    let task_config_cache = configs.iter().find_map(|cf| cf.task_config().cache.clone());
 
     let mut file_tasks = vec![];
     let monorepo_cf = if monorepo_context {
@@ -3335,6 +3347,9 @@ async fn load_task_sources_from_configs(
                 require_task_include_trust,
             )
             .await?;
+            for task in &mut loaded {
+                apply_task_config_cache_default(task, &task_config_cache);
+            }
             if is_global || is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);
             }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -568,7 +568,7 @@ pub struct Task {
     pub outputs: TaskOutputs,
     /// Experimental local artifact cache configuration.
     #[serde(default)]
-    pub cache: TaskCacheConfig,
+    pub cache: Option<TaskCacheConfig>,
     #[serde(skip)]
     pub raw_outputs: RawOutputTemplates,
     #[serde(default)]
@@ -972,8 +972,7 @@ impl Task {
                 TaskCacheConfig::deserialize(v.clone())
                     .map_err(|e| eyre!("failed to parse cache field in task header: {e}"))
             })
-            .transpose()?
-            .unwrap_or_default();
+            .transpose()?;
         task.file = Some(path.to_path_buf());
         task.shell = p.parse_str("shell");
         task.quiet = p.parse_bool("quiet").unwrap_or_default();
@@ -1870,7 +1869,7 @@ impl Task {
         if !other.outputs.is_empty() {
             self.outputs = other.outputs;
         }
-        if other.cache != TaskCacheConfig::default() {
+        if other.cache.is_some() {
             self.cache = other.cache;
         }
         if other.raw_outputs.templates.is_some() {
@@ -2856,7 +2855,7 @@ mod tests {
     #[cfg(unix)]
     use super::TaskConfirm;
     #[cfg(unix)]
-    use super::TaskOutput;
+    use super::{TaskCacheConfig, TaskOutput};
     use super::{
         clear_usage_env, env_contains_key, name_from_path, tera_tag_has_usage_ref,
         tera_template_has_usage_ref,
@@ -3949,6 +3948,7 @@ echo "hello world"
 #MISE interactive=true
 #MISE sources=["src1.txt", "src2.txt"]
 #MISE outputs=["out1.txt"]
+#MISE cache={enabled=true,env=["PROFILE"]}
 #MISE shell="bash -c"
 #MISE quiet=true
 #MISE silent=true
@@ -3976,6 +3976,13 @@ echo "test"
         assert_eq!(task.raw_args, true);
         assert_eq!(task.interactive, true);
         assert_eq!(task.sources, vec!["src1.txt", "src2.txt"]);
+        assert_eq!(
+            task.cache,
+            Some(TaskCacheConfig {
+                enabled: true,
+                env: vec!["PROFILE".to_string()],
+            })
+        );
         assert_eq!(task.shell, Some("bash -c".to_string()));
         assert_eq!(task.quiet, true);
         assert_eq!(task.output, Some(TaskOutput::Prefix));

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -43,6 +43,7 @@ pub(crate) fn reset() {
 pub type FailedTasks = Arc<std::sync::Mutex<Vec<(Task, Option<i32>)>>>;
 
 mod deps;
+pub mod task_cache;
 pub mod task_confirm;
 pub mod task_context_builder;
 mod task_dep;
@@ -62,6 +63,8 @@ pub mod task_sources;
 pub mod task_template;
 pub mod task_tool_installer;
 
+pub use task_cache::TaskArtifactCache;
+pub use task_cache::TaskCacheConfig;
 pub use task_confirm::TaskConfirm;
 pub(crate) use task_load_context::monorepo_scope;
 pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax};
@@ -563,6 +566,9 @@ pub struct Task {
     pub sources: Vec<String>,
     #[serde(default)]
     pub outputs: TaskOutputs,
+    /// Experimental local artifact cache configuration.
+    #[serde(default)]
+    pub cache: TaskCacheConfig,
     #[serde(skip)]
     pub raw_outputs: RawOutputTemplates,
     #[serde(default)]
@@ -960,6 +966,14 @@ impl Task {
         task.interactive = p.parse_bool("interactive").unwrap_or_default();
         task.sources = p.parse_array("sources").unwrap_or_default();
         task.outputs = p.get_raw("outputs").map(|to| to.into()).unwrap_or_default();
+        task.cache = p
+            .get_raw("cache")
+            .map(|v| {
+                TaskCacheConfig::deserialize(v.clone())
+                    .map_err(|e| eyre!("failed to parse cache field in task header: {e}"))
+            })
+            .transpose()?
+            .unwrap_or_default();
         task.file = Some(path.to_path_buf());
         task.shell = p.parse_str("shell");
         task.quiet = p.parse_bool("quiet").unwrap_or_default();
@@ -1856,6 +1870,9 @@ impl Task {
         if !other.outputs.is_empty() {
             self.outputs = other.outputs;
         }
+        if other.cache != TaskCacheConfig::default() {
+            self.cache = other.cache;
+        }
         if other.raw_outputs.templates.is_some() {
             self.raw_outputs = other.raw_outputs;
         }
@@ -2384,6 +2401,7 @@ impl Default for Task {
             interactive: false,
             sources: vec![],
             outputs: Default::default(),
+            cache: Default::default(),
             raw_outputs: Default::default(),
             shell: None,
             silent: Silent::Off,

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -153,7 +153,10 @@ impl TaskArtifactCache {
     }
 
     pub fn is_current(&self) -> bool {
-        file::read_to_string(&self.state_path).is_ok_and(|key| key.trim() == self.key)
+        let (archive_path, manifest_path) = self.paths();
+        archive_path.is_file()
+            && manifest_path.is_file()
+            && file::read_to_string(&self.state_path).is_ok_and(|key| key.trim() == self.key)
     }
 
     pub fn mark_current(&self) -> Result<()> {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -1,0 +1,426 @@
+use crate::config::{Config, Settings};
+use crate::dirs;
+use crate::file::{self, ExtractOptions, ExtractionFormat};
+use crate::hash;
+use crate::task::task_source_checker::{task_cwd, task_source_content_hash, task_source_paths};
+use crate::task::{RunEntry, Task};
+use crate::toolset::Toolset;
+use eyre::{Context, Result, bail};
+use glob::glob;
+use jdx_tar::{Builder, EntryType, Header};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use std::time::UNIX_EPOCH;
+use walkdir::WalkDir;
+
+const CACHE_FORMAT_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TaskCacheConfig {
+    pub enabled: bool,
+    /// Ambient environment variables whose resolved values affect the cache key.
+    pub env: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CacheKeyMaterial<'a> {
+    format: u8,
+    task: &'a str,
+    run: &'a [RunEntry],
+    args: &'a [String],
+    shell: &'a Option<String>,
+    source_hash: String,
+    environment: BTreeMap<String, Option<String>>,
+    tools: Vec<String>,
+    os: &'static str,
+    arch: &'static str,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CacheManifest {
+    format: u8,
+    key: String,
+    roots: Vec<PathBuf>,
+}
+
+pub struct TaskArtifactCache {
+    root: PathBuf,
+    key: String,
+    state_path: PathBuf,
+}
+
+impl TaskArtifactCache {
+    pub async fn new(
+        task: &Task,
+        config: &Arc<Config>,
+        toolset: &Toolset,
+        resolved_env: &BTreeMap<String, String>,
+        declared_env: &[(String, String)],
+    ) -> Result<Self> {
+        Settings::get().ensure_experimental("task artifact caching")?;
+        let root = task_cwd(task, config).await?;
+        validate_config(task, &root)?;
+        let output_roots = resolve_output_roots(task, &root, false)?;
+        for source in task_source_paths(task, config).await? {
+            if output_roots
+                .iter()
+                .any(|output| source == *output || source.starts_with(output))
+            {
+                bail!(
+                    "task {} cache outputs must not contain source {}",
+                    task.name,
+                    source.display()
+                );
+            }
+        }
+
+        let source_hash = task_source_content_hash(task, config)
+            .await?
+            .ok_or_else(|| eyre::eyre!("task {} has no matching source files", task.name))?;
+        let mut environment = declared_env
+            .iter()
+            .map(|(key, value)| (key.clone(), Some(value.clone())))
+            .collect::<BTreeMap<_, _>>();
+        for key in &task.cache.env {
+            environment.insert(key.clone(), resolved_env.get(key).cloned());
+        }
+        let mut tools = toolset
+            .list_current_versions()
+            .into_iter()
+            .map(|(_, tv)| tv.to_string())
+            .collect::<Vec<_>>();
+        tools.sort();
+
+        let material = CacheKeyMaterial {
+            format: CACHE_FORMAT_VERSION,
+            task: &task.name,
+            run: &task.run,
+            args: &task.args,
+            shell: &task.shell,
+            source_hash,
+            environment,
+            tools,
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+        };
+        let encoded = serde_json::to_vec(&material)?;
+        let key = hash::hash_blake3_to_str(std::str::from_utf8(&encoded)?);
+        let state_identity = hash::hash_blake3_to_str(&format!(
+            "{}\0{}\0{}",
+            root.display(),
+            task.name,
+            task.config_source.display()
+        ));
+        let state_path = dirs::STATE
+            .join("task-artifacts")
+            .join(format!("{state_identity}.key"));
+        Ok(Self {
+            root,
+            key,
+            state_path,
+        })
+    }
+
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn is_current(&self) -> bool {
+        file::read_to_string(&self.state_path).is_ok_and(|key| key.trim() == self.key)
+    }
+
+    pub fn mark_current(&self) -> Result<()> {
+        if let Some(parent) = self.state_path.parent() {
+            file::create_dir_all(parent)?;
+        }
+        file::write(&self.state_path, &self.key)
+    }
+
+    pub fn restore(&self, task: &Task) -> Result<bool> {
+        let (archive_path, manifest_path) = self.paths();
+        if !archive_path.is_file() || !manifest_path.is_file() {
+            return Ok(false);
+        }
+
+        let restore = || -> Result<()> {
+            let manifest: CacheManifest = serde_json::from_slice(&fs::read(&manifest_path)?)?;
+            if manifest.format != CACHE_FORMAT_VERSION || manifest.key != self.key {
+                bail!("task cache manifest does not match cache key");
+            }
+            for root in &manifest.roots {
+                ensure_safe_relative(root)?;
+            }
+
+            let staging = tempfile::Builder::new()
+                .prefix(".mise-task-cache-")
+                .tempdir_in(&self.root)?;
+            file::untar(
+                &archive_path,
+                staging.path(),
+                ExtractionFormat::TarZst,
+                &ExtractOptions {
+                    preserve_mtime: false,
+                    ..Default::default()
+                },
+            )?;
+            for rel in &manifest.roots {
+                let restored = staging.path().join(rel);
+                if !restored.exists() && fs::symlink_metadata(&restored).is_err() {
+                    bail!("task cache archive is missing {}", rel.display());
+                }
+            }
+
+            let mut remove = resolve_output_roots(task, &self.root, false)?;
+            remove.extend(manifest.roots.iter().cloned());
+            remove.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+            remove.dedup();
+            for rel in remove {
+                file::remove_all(self.root.join(rel))?;
+            }
+
+            for rel in &manifest.roots {
+                let from = staging.path().join(rel);
+                let to = self.root.join(rel);
+                if let Some(parent) = to.parent() {
+                    file::create_dir_all(parent)?;
+                }
+                file::move_file(from, to)?;
+            }
+            file::touch_file(&archive_path)?;
+            file::touch_file(&manifest_path)?;
+            Ok(())
+        };
+
+        match restore() {
+            Ok(()) => Ok(true),
+            Err(err) => {
+                warn!("ignoring corrupt task cache entry {}: {err}", self.key);
+                let _ = file::remove_file(&archive_path);
+                let _ = file::remove_file(&manifest_path);
+                Ok(false)
+            }
+        }
+    }
+
+    pub fn store(&self, task: &Task) -> Result<()> {
+        let roots = resolve_output_roots(task, &self.root, true)?;
+        let roots = remove_nested_roots(roots);
+        if roots.is_empty() {
+            bail!("task {} produced no cacheable outputs", task.name);
+        }
+
+        let cache_dir = dirs::CACHE.join("task-artifacts").join("v1");
+        file::create_dir_all(&cache_dir)?;
+        let (archive_path, manifest_path) = self.paths();
+        let nonce = crate::rand::random_string(8);
+        let archive_partial = cache_dir.join(format!("{}.part-{nonce}.tar.zst", self.key));
+        let manifest_partial = cache_dir.join(format!("{}.part-{nonce}.json", self.key));
+
+        write_archive(&archive_partial, &self.root, &roots)?;
+        let manifest = CacheManifest {
+            format: CACHE_FORMAT_VERSION,
+            key: self.key.clone(),
+            roots,
+        };
+        fs::write(&manifest_partial, serde_json::to_vec(&manifest)?)?;
+        file::rename(&archive_partial, &archive_path)?;
+        file::rename(&manifest_partial, &manifest_path)?;
+        Ok(())
+    }
+
+    fn paths(&self) -> (PathBuf, PathBuf) {
+        let base = dirs::CACHE.join("task-artifacts").join("v1");
+        (
+            base.join(format!("{}.tar.zst", self.key)),
+            base.join(format!("{}.json", self.key)),
+        )
+    }
+}
+
+fn validate_config(task: &Task, root: &Path) -> Result<()> {
+    if task.sources.is_empty() {
+        bail!("task {} cache requires at least one source", task.name);
+    }
+    if task.outputs.is_auto() || task.outputs.patterns().is_empty() {
+        bail!(
+            "task {} cache requires explicit output files or directories",
+            task.name
+        );
+    }
+    for output in task.outputs.patterns() {
+        let path = Path::new(&output);
+        ensure_safe_relative(path).wrap_err_with(|| {
+            format!(
+                "task {} cache output must stay within {}: {output}",
+                task.name,
+                root.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn ensure_safe_relative(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        bail!("path must be a non-empty relative path");
+    }
+    if path.components().any(|c| {
+        matches!(
+            c,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        bail!("path must not escape the task directory");
+    }
+    if !path.components().any(|c| matches!(c, Component::Normal(_))) {
+        bail!("path must identify an output beneath the task directory");
+    }
+    Ok(())
+}
+
+fn resolve_output_roots(task: &Task, root: &Path, require_matches: bool) -> Result<Vec<PathBuf>> {
+    let mut resolved = BTreeSet::new();
+    for output in task.outputs.patterns() {
+        ensure_safe_relative(Path::new(&output))?;
+        if crate::task::task_source_checker::is_glob_pattern(&output) {
+            let mut matched = false;
+            for entry in glob(root.join(&output).to_str().unwrap_or_default())? {
+                let path = entry?;
+                let rel = path.strip_prefix(root)?.to_path_buf();
+                ensure_safe_relative(&rel)?;
+                resolved.insert(rel);
+                matched = true;
+            }
+            if require_matches && !matched {
+                bail!("output pattern {output:?} matched no files");
+            }
+        } else {
+            let rel = PathBuf::from(&output);
+            if require_matches
+                && !root.join(&rel).exists()
+                && fs::symlink_metadata(root.join(&rel)).is_err()
+            {
+                bail!("output {} does not exist", rel.display());
+            }
+            resolved.insert(rel);
+        }
+    }
+    Ok(resolved.into_iter().collect())
+}
+
+fn remove_nested_roots(mut roots: Vec<PathBuf>) -> Vec<PathBuf> {
+    roots.sort_by_key(|path| path.components().count());
+    let mut result = Vec::<PathBuf>::new();
+    for root in roots {
+        if !result.iter().any(|parent| root.starts_with(parent)) {
+            result.push(root);
+        }
+    }
+    result.sort();
+    result
+}
+
+fn write_archive(path: &Path, root: &Path, roots: &[PathBuf]) -> Result<()> {
+    let file = File::create(path)?;
+    let encoder = zstd::Encoder::new(file, 0)?;
+    let mut archive = Builder::new(encoder);
+    let mut entries = BTreeMap::<PathBuf, PathBuf>::new();
+    for rel_root in roots {
+        let abs_root = root.join(rel_root);
+        for entry in WalkDir::new(&abs_root).follow_links(false) {
+            let entry = entry?;
+            let abs = entry.path().to_path_buf();
+            let rel = abs.strip_prefix(root)?.to_path_buf();
+            ensure_safe_relative(&rel)?;
+            entries.insert(rel, abs);
+        }
+    }
+
+    for (rel, abs) in entries {
+        let metadata = fs::symlink_metadata(&abs)?;
+        let mut header = Header::new_gnu(if metadata.file_type().is_symlink() {
+            EntryType::Symlink
+        } else if metadata.is_dir() {
+            EntryType::Directory
+        } else {
+            EntryType::File
+        });
+        header.set_mode(metadata_mode(&metadata));
+        header.set_mtime(
+            metadata
+                .modified()
+                .ok()
+                .and_then(|m| m.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0),
+        );
+        if metadata.file_type().is_symlink() {
+            header.set_size(0);
+            archive.append_link(&mut header, &rel, fs::read_link(&abs)?)?;
+        } else if metadata.is_dir() {
+            header.set_size(0);
+            archive.append_data(&mut header, &rel, std::io::empty())?;
+        } else if metadata.is_file() {
+            header.set_size(metadata.len());
+            archive.append_data(&mut header, &rel, File::open(&abs)?)?;
+        } else {
+            bail!("unsupported output file type: {}", rel.display());
+        }
+    }
+    let encoder = archive.into_inner()?;
+    encoder.finish()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn metadata_mode(metadata: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode()
+}
+
+#[cfg(not(unix))]
+fn metadata_mode(metadata: &fs::Metadata) -> u32 {
+    if metadata.permissions().readonly() {
+        0o444
+    } else {
+        0o644
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_deserializes_and_rejects_unknown_fields() {
+        let config: TaskCacheConfig = toml::from_str("enabled = true\nenv = ['PROFILE']").unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.env, ["PROFILE"]);
+        assert!(toml::from_str::<TaskCacheConfig>("remote = true").is_err());
+    }
+
+    #[test]
+    fn safe_relative_paths_reject_escapes() {
+        assert!(ensure_safe_relative(Path::new("dist/app")).is_ok());
+        assert!(ensure_safe_relative(Path::new("../dist")).is_err());
+        assert!(ensure_safe_relative(Path::new("/tmp/dist")).is_err());
+        assert!(ensure_safe_relative(Path::new("")).is_err());
+        assert!(ensure_safe_relative(Path::new(".")).is_err());
+    }
+
+    #[test]
+    fn nested_output_roots_are_collapsed() {
+        assert_eq!(
+            remove_nested_roots(vec![
+                PathBuf::from("dist/a.js"),
+                PathBuf::from("dist"),
+                PathBuf::from("coverage"),
+            ]),
+            vec![PathBuf::from("coverage"), PathBuf::from("dist")]
+        );
+    }
+}

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -2,7 +2,7 @@ use crate::config::{Config, Settings};
 use crate::dirs;
 use crate::file::{self, ExtractOptions, ExtractionFormat};
 use crate::hash;
-use crate::task::task_source_checker::{task_cwd, task_source_content_hash, task_source_paths};
+use crate::task::task_source_checker::{task_cache_inputs, task_cwd};
 use crate::task::{RunEntry, Task};
 use crate::toolset::Toolset;
 use eyre::{Context, Result, bail};
@@ -33,8 +33,11 @@ struct CacheKeyMaterial<'a> {
     run: &'a [RunEntry],
     args: &'a [String],
     shell: &'a Option<String>,
+    outputs: Vec<String>,
+    root: PathBuf,
     source_hash: String,
     environment: BTreeMap<String, Option<String>>,
+    vars: BTreeMap<String, String>,
     tools: Vec<String>,
     os: &'static str,
     arch: &'static str,
@@ -60,15 +63,25 @@ impl TaskArtifactCache {
         toolset: &Toolset,
         resolved_env: &BTreeMap<String, String>,
         declared_env: &[(String, String)],
-    ) -> Result<Self> {
+    ) -> Result<Option<Self>> {
         Settings::get().ensure_experimental("task artifact caching")?;
         let root = task_cwd(task, config).await?;
         validate_config(task, &root)?;
         let output_roots = resolve_output_roots(task, &root, false)?;
-        for source in task_source_paths(task, config).await? {
+        for output in &output_roots {
+            ensure_no_symlink_ancestors(&root, output)?;
+        }
+        let Some(inputs) = task_cache_inputs(task, config).await? else {
+            warn!(
+                "task {} has sources defined but no matching files found; artifact caching disabled",
+                task.name
+            );
+            return Ok(None);
+        };
+        for source in &inputs.source_paths {
             if output_roots
                 .iter()
-                .any(|output| source == *output || source.starts_with(output))
+                .any(|output| source == output || source.starts_with(output))
             {
                 bail!(
                     "task {} cache outputs must not contain source {}",
@@ -78,16 +91,21 @@ impl TaskArtifactCache {
             }
         }
 
-        let source_hash = task_source_content_hash(task, config)
-            .await?
-            .ok_or_else(|| eyre::eyre!("task {} has no matching source files", task.name))?;
         let mut environment = declared_env
             .iter()
             .map(|(key, value)| (key.clone(), Some(value.clone())))
             .collect::<BTreeMap<_, _>>();
-        for key in &task.cache.env {
+        let cache_config = task.cache.as_ref().expect("cache must be configured");
+        for key in &cache_config.env {
             environment.insert(key.clone(), resolved_env.get(key).cloned());
         }
+        let vars = task
+            .tera_ctx(config)
+            .await?
+            .get("vars")
+            .map(|value| serde::Deserialize::deserialize(value.clone()))
+            .transpose()?
+            .unwrap_or_default();
         let mut tools = toolset
             .list_current_versions()
             .into_iter()
@@ -98,11 +116,14 @@ impl TaskArtifactCache {
         let material = CacheKeyMaterial {
             format: CACHE_FORMAT_VERSION,
             task: &task.name,
-            run: &task.run,
+            run: task.run(),
             args: &task.args,
             shell: &task.shell,
-            source_hash,
+            outputs: task.outputs.patterns(),
+            root: inputs.root_identity,
+            source_hash: inputs.source_hash,
             environment,
+            vars,
             tools,
             os: std::env::consts::OS,
             arch: std::env::consts::ARCH,
@@ -118,11 +139,11 @@ impl TaskArtifactCache {
         let state_path = dirs::STATE
             .join("task-artifacts")
             .join(format!("{state_identity}.key"));
-        Ok(Self {
+        Ok(Some(Self {
             root,
             key,
             state_path,
-        })
+        }))
     }
 
     pub fn key(&self) -> &str {
@@ -154,6 +175,9 @@ impl TaskArtifactCache {
             for root in &manifest.roots {
                 ensure_safe_relative(root)?;
             }
+            if remove_nested_roots(manifest.roots.clone()) != manifest.roots {
+                bail!("task cache manifest contains duplicate or nested roots");
+            }
 
             let staging = tempfile::Builder::new()
                 .prefix(".mise-task-cache-")
@@ -172,26 +196,23 @@ impl TaskArtifactCache {
                 if !restored.exists() && fs::symlink_metadata(&restored).is_err() {
                     bail!("task cache archive is missing {}", rel.display());
                 }
+                ensure_no_symlink_ancestors(staging.path(), rel)?;
+                ensure_no_symlink_ancestors(&self.root, rel)?;
             }
 
             let mut remove = resolve_output_roots(task, &self.root, false)?;
             remove.extend(manifest.roots.iter().cloned());
-            remove.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
-            remove.dedup();
-            for rel in remove {
-                file::remove_all(self.root.join(rel))?;
+            let remove = remove_nested_roots(remove);
+            for rel in &remove {
+                ensure_no_symlink_ancestors(&self.root, rel)?;
             }
-
-            for rel in &manifest.roots {
-                let from = staging.path().join(rel);
-                let to = self.root.join(rel);
-                if let Some(parent) = to.parent() {
-                    file::create_dir_all(parent)?;
-                }
-                file::move_file(from, to)?;
+            install_transactionally(&self.root, staging.path(), &manifest.roots, &remove)?;
+            if let Err(err) = file::touch_file(&archive_path) {
+                warn!("failed to update task cache archive access time: {err}");
             }
-            file::touch_file(&archive_path)?;
-            file::touch_file(&manifest_path)?;
+            if let Err(err) = file::touch_file(&manifest_path) {
+                warn!("failed to update task cache manifest access time: {err}");
+            }
             Ok(())
         };
 
@@ -211,6 +232,9 @@ impl TaskArtifactCache {
         let roots = remove_nested_roots(roots);
         if roots.is_empty() {
             bail!("task {} produced no cacheable outputs", task.name);
+        }
+        for root in &roots {
+            ensure_no_symlink_ancestors(&self.root, root)?;
         }
 
         let cache_dir = dirs::CACHE.join("task-artifacts").join("v1");
@@ -324,6 +348,111 @@ fn remove_nested_roots(mut roots: Vec<PathBuf>) -> Vec<PathBuf> {
     result
 }
 
+fn ensure_no_symlink_ancestors(root: &Path, rel: &Path) -> Result<()> {
+    let mut current = root.to_path_buf();
+    let component_count = rel.components().count();
+    for component in rel.components().take(component_count.saturating_sub(1)) {
+        current.push(component);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                bail!(
+                    "output path {} traverses symlink ancestor {}",
+                    rel.display(),
+                    current.display()
+                );
+            }
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+    }
+    Ok(())
+}
+
+fn install_transactionally(
+    root: &Path,
+    staging: &Path,
+    install_roots: &[PathBuf],
+    remove_roots: &[PathBuf],
+) -> Result<()> {
+    let backup = tempfile::Builder::new()
+        .prefix(".mise-task-cache-backup-")
+        .tempdir_in(root)?;
+    let mut backed_up = Vec::new();
+    for rel in remove_roots {
+        let from = root.join(rel);
+        match fs::symlink_metadata(&from) {
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                rollback_install(root, backup.path(), &[], &backed_up);
+                return Err(err).wrap_err_with(|| {
+                    format!("failed to inspect existing output {}", from.display())
+                });
+            }
+        }
+        let to = backup.path().join(rel);
+        let backup_output = (|| -> Result<()> {
+            if let Some(parent) = to.parent() {
+                file::create_dir_all(parent)?;
+            }
+            fs::rename(&from, &to).wrap_err_with(|| format!("failed to back up {}", rel.display()))
+        })();
+        if let Err(err) = backup_output {
+            rollback_install(root, backup.path(), &[], &backed_up);
+            return Err(err);
+        }
+        backed_up.push(rel.clone());
+    }
+
+    let mut installed = Vec::new();
+    for rel in install_roots {
+        let from = staging.join(rel);
+        let to = root.join(rel);
+        let install = (|| -> Result<()> {
+            ensure_no_symlink_ancestors(root, rel)?;
+            if let Some(parent) = to.parent() {
+                file::create_dir_all(parent)?;
+            }
+            fs::rename(&from, &to)
+                .wrap_err_with(|| format!("failed to install cached output {}", rel.display()))
+        })();
+        if let Err(err) = install {
+            rollback_install(root, backup.path(), &installed, &backed_up);
+            return Err(err);
+        }
+        installed.push(rel.clone());
+    }
+    Ok(())
+}
+
+fn rollback_install(root: &Path, backup: &Path, installed: &[PathBuf], backed_up: &[PathBuf]) {
+    for rel in installed.iter().rev() {
+        if let Err(err) = file::remove_all(root.join(rel)) {
+            warn!(
+                "failed to remove partial cache restore {}: {err}",
+                rel.display()
+            );
+        }
+    }
+    for rel in backed_up.iter().rev() {
+        let from = backup.join(rel);
+        let to = root.join(rel);
+        if let Some(parent) = to.parent()
+            && let Err(err) = file::create_dir_all(parent)
+        {
+            warn!(
+                "failed to prepare cache restore rollback {}: {err}",
+                rel.display()
+            );
+            continue;
+        }
+        if let Err(err) = fs::rename(&from, &to) {
+            warn!("failed to roll back cached output {}: {err}", rel.display());
+        }
+    }
+}
+
 fn write_archive(path: &Path, root: &Path, roots: &[PathBuf]) -> Result<()> {
     let file = File::create(path)?;
     let encoder = zstd::Encoder::new(file, 0)?;
@@ -422,5 +551,42 @@ mod tests {
             ]),
             vec![PathBuf::from("coverage"), PathBuf::from("dist")]
         );
+    }
+
+    #[test]
+    fn failed_install_restores_previous_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let staging = tempfile::tempdir_in(root.path()).unwrap();
+        fs::create_dir(root.path().join("dist")).unwrap();
+        fs::write(root.path().join("dist/result.txt"), "old").unwrap();
+        fs::create_dir(staging.path().join("dist")).unwrap();
+        fs::write(staging.path().join("dist/result.txt"), "new").unwrap();
+
+        assert!(
+            install_transactionally(
+                root.path(),
+                staging.path(),
+                &[PathBuf::from("dist"), PathBuf::from("missing")],
+                &[PathBuf::from("dist")],
+            )
+            .is_err()
+        );
+        assert_eq!(
+            fs::read_to_string(root.path().join("dist/result.txt")).unwrap(),
+            "old"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_ancestors_are_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), root.path().join("build")).unwrap();
+
+        assert!(ensure_no_symlink_ancestors(root.path(), Path::new("build/dist")).is_err());
+        assert!(ensure_no_symlink_ancestors(root.path(), Path::new("build")).is_ok());
     }
 }

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -63,6 +63,7 @@ impl TaskArtifactCache {
         toolset: &Toolset,
         resolved_env: &BTreeMap<String, String>,
         declared_env: &[(String, String)],
+        persist_content_hash_cache: bool,
     ) -> Result<Option<Self>> {
         Settings::get().ensure_experimental("task artifact caching")?;
         let root = task_cwd(task, config).await?;
@@ -71,7 +72,8 @@ impl TaskArtifactCache {
         for output in &output_roots {
             ensure_no_symlink_ancestors(&root, output)?;
         }
-        let Some(inputs) = task_cache_inputs(task, config).await? else {
+        let Some(inputs) = task_cache_inputs(task, config, persist_content_hash_cache).await?
+        else {
             warn!(
                 "task {} has sources defined but no matching files found; artifact caching disabled",
                 task.name
@@ -93,7 +95,7 @@ impl TaskArtifactCache {
 
         let mut environment = declared_env
             .iter()
-            .map(|(key, value)| (key.clone(), Some(value.clone())))
+            .map(|(key, _)| (key.clone(), resolved_env.get(key).cloned()))
             .collect::<BTreeMap<_, _>>();
         let cache_config = task.cache.as_ref().expect("cache must be configured");
         for key in &cache_config.env {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -5,7 +5,7 @@ use crate::hash;
 use crate::task::task_source_checker::{task_cache_inputs, task_cwd};
 use crate::task::{RunEntry, Task};
 use crate::toolset::Toolset;
-use eyre::{Context, Result, bail};
+use eyre::{Context, Report, Result, bail, eyre};
 use glob::glob;
 use jdx_tar::{Builder, EntryType, Header};
 use serde::{Deserialize, Serialize};
@@ -393,10 +393,11 @@ fn install_transactionally(
             Ok(_) => {}
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
             Err(err) => {
-                rollback_install(root, backup.path(), &[], &backed_up);
-                return Err(err).wrap_err_with(|| {
-                    format!("failed to inspect existing output {}", from.display())
-                });
+                let err = eyre!(
+                    "failed to inspect existing output {}: {err}",
+                    from.display()
+                );
+                return rollback_after_error(backup, root, &[], &backed_up, err);
             }
         }
         let to = backup.path().join(rel);
@@ -407,8 +408,7 @@ fn install_transactionally(
             fs::rename(&from, &to).wrap_err_with(|| format!("failed to back up {}", rel.display()))
         })();
         if let Err(err) = backup_output {
-            rollback_install(root, backup.path(), &[], &backed_up);
-            return Err(err);
+            return rollback_after_error(backup, root, &[], &backed_up, err);
         }
         backed_up.push(rel.clone());
     }
@@ -426,17 +426,43 @@ fn install_transactionally(
                 .wrap_err_with(|| format!("failed to install cached output {}", rel.display()))
         })();
         if let Err(err) = install {
-            rollback_install(root, backup.path(), &installed, &backed_up);
-            return Err(err);
+            return rollback_after_error(backup, root, &installed, &backed_up, err);
         }
         installed.push(rel.clone());
     }
     Ok(())
 }
 
-fn rollback_install(root: &Path, backup: &Path, installed: &[PathBuf], backed_up: &[PathBuf]) {
+fn rollback_after_error(
+    backup: tempfile::TempDir,
+    root: &Path,
+    installed: &[PathBuf],
+    backed_up: &[PathBuf],
+    err: Report,
+) -> Result<()> {
+    if rollback_install(root, backup.path(), installed, backed_up) {
+        Err(err)
+    } else {
+        let backup = backup.keep();
+        Err(err).wrap_err_with(|| {
+            format!(
+                "cache restore rollback was incomplete; original outputs were preserved at {}",
+                backup.display()
+            )
+        })
+    }
+}
+
+fn rollback_install(
+    root: &Path,
+    backup: &Path,
+    installed: &[PathBuf],
+    backed_up: &[PathBuf],
+) -> bool {
+    let mut complete = true;
     for rel in installed.iter().rev() {
         if let Err(err) = file::remove_all(root.join(rel)) {
+            complete = false;
             warn!(
                 "failed to remove partial cache restore {}: {err}",
                 rel.display()
@@ -449,6 +475,7 @@ fn rollback_install(root: &Path, backup: &Path, installed: &[PathBuf], backed_up
         if let Some(parent) = to.parent()
             && let Err(err) = file::create_dir_all(parent)
         {
+            complete = false;
             warn!(
                 "failed to prepare cache restore rollback {}: {err}",
                 rel.display()
@@ -456,9 +483,11 @@ fn rollback_install(root: &Path, backup: &Path, installed: &[PathBuf], backed_up
             continue;
         }
         if let Err(err) = fs::rename(&from, &to) {
+            complete = false;
             warn!("failed to roll back cached output {}: {err}", rel.display());
         }
     }
+    complete
 }
 
 fn write_archive(path: &Path, root: &Path, roots: &[PathBuf]) -> Result<()> {
@@ -581,6 +610,31 @@ mod tests {
         );
         assert_eq!(
             fs::read_to_string(root.path().join("dist/result.txt")).unwrap(),
+            "old"
+        );
+    }
+
+    #[test]
+    fn incomplete_rollback_preserves_backup_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let backup = tempfile::tempdir_in(root.path()).unwrap();
+        let backup_path = backup.path().to_path_buf();
+        fs::create_dir(backup.path().join("blocked")).unwrap();
+        fs::write(backup.path().join("blocked/output"), "old").unwrap();
+        fs::write(root.path().join("blocked"), "not a directory").unwrap();
+
+        let err = rollback_after_error(
+            backup,
+            root.path(),
+            &[],
+            &[PathBuf::from("blocked/output")],
+            eyre!("install failed"),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("original outputs were preserved"));
+        assert_eq!(
+            fs::read_to_string(backup_path.join("blocked/output")).unwrap(),
             "old"
         );
     }

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -166,6 +166,12 @@ impl TaskArtifactCache {
         if !archive_path.is_file() || !manifest_path.is_file() {
             return Ok(false);
         }
+        // Serialize restores targeting the same working directory across mise
+        // processes so ancestor validation and the following renames are one
+        // cooperative critical section.
+        let _output_lock =
+            crate::lock_file::LockFile::new(&self.root.join(".mise-task-artifact-cache-output"))
+                .lock()?;
 
         let restore = || -> Result<()> {
             let manifest: CacheManifest = serde_json::from_slice(&fs::read(&manifest_path)?)?;

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -7,6 +7,7 @@ use crate::env_diff::EnvDiff;
 use crate::file::is_executable;
 use crate::file::{display_path, replace_path};
 use crate::sandbox::SandboxConfig;
+use crate::task::TaskArtifactCache;
 use crate::task::TaskKey;
 use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_list::split_task_spec;
@@ -274,7 +275,8 @@ impl TaskExecutor {
         }
         // If any dependency actually ran, skip the source freshness check
         // so that downstream tasks are invalidated by upstream changes
-        if !self.force && !dep_ran && sources_are_fresh(task, config).await? {
+        if !task.cache.enabled && !self.force && !dep_ran && sources_are_fresh(task, config).await?
+        {
             if !self.quiet(Some(task)) {
                 self.eprint(task, &prefix, "sources up-to-date, skipping");
             }
@@ -443,6 +445,40 @@ impl TaskExecutor {
             env.insert("__MISE_DIFF".into(), serialized);
         }
 
+        let artifact_cache = if task.cache.enabled {
+            let cache = TaskArtifactCache::new(task, config, &ts, &env, &task_env).await?;
+            if !self.force
+                && !dep_ran
+                && cache.is_current()
+                && sources_are_fresh(task, config).await?
+            {
+                if !self.quiet(Some(task)) {
+                    self.eprint(task, &prefix, "sources up-to-date, skipping");
+                }
+                return Ok(false);
+            }
+            if !self.force && !dep_ran && cache.restore(task)? {
+                if !self.quiet(Some(task)) {
+                    self.eprint(
+                        task,
+                        &prefix,
+                        &format!("restored outputs from cache {}", cache.key()),
+                    );
+                }
+                save_checksum(task, config).await?;
+                if let Err(err) = cache.mark_current() {
+                    warn!(
+                        "task {} artifact cache state update failed: {err}",
+                        task.name
+                    );
+                }
+                return Ok(true);
+            }
+            Some(cache)
+        } else {
+            None
+        };
+
         let timer = std::time::Instant::now();
 
         if let Some(file) = task.file_path(config).await? {
@@ -522,6 +558,12 @@ impl TaskExecutor {
         }
 
         save_checksum(task, config).await?;
+        if let Some(cache) = artifact_cache {
+            match cache.store(task).and_then(|_| cache.mark_current()) {
+                Ok(()) => {}
+                Err(err) => warn!("task {} artifact cache write failed: {err}", task.name),
+            }
+        }
 
         Ok(true)
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -448,43 +448,49 @@ impl TaskExecutor {
             env.insert("__MISE_DIFF".into(), serialized);
         }
 
-        let artifact_cache = if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
-            match TaskArtifactCache::new(task, config, &ts, &env, &task_env).await? {
-                Some(cache) => {
-                    if !self.force
-                        && !dep_ran
-                        && cache.is_current()
-                        && sources_are_fresh(task, config).await?
-                    {
-                        if !self.quiet(Some(task)) {
-                            self.eprint(task, &prefix, "sources up-to-date, skipping");
+        let artifact_cache =
+            if !self.dry_run && task.cache.as_ref().is_some_and(|cache| cache.enabled) {
+                match TaskArtifactCache::new(task, config, &ts, &env, &task_env).await? {
+                    Some(cache) => {
+                        if !self.force
+                            && !dep_ran
+                            && cache.is_current()
+                            && sources_are_fresh(task, config).await?
+                        {
+                            if !self.quiet(Some(task)) {
+                                self.eprint(task, &prefix, "sources up-to-date, skipping");
+                            }
+                            return Ok(false);
                         }
-                        return Ok(false);
+                        if !self.force && !dep_ran && cache.restore(task)? {
+                            if !self.quiet(Some(task)) {
+                                self.eprint(
+                                    task,
+                                    &prefix,
+                                    &format!("restored outputs from cache {}", cache.key()),
+                                );
+                            }
+                            if let Err(err) = save_checksum(task, config).await {
+                                warn!(
+                                    "task {} artifact cache checksum update failed: {err}",
+                                    task.name
+                                );
+                            }
+                            if let Err(err) = cache.mark_current() {
+                                warn!(
+                                    "task {} artifact cache state update failed: {err}",
+                                    task.name
+                                );
+                            }
+                            return Ok(true);
+                        }
+                        Some(cache)
                     }
-                    if !self.force && !dep_ran && cache.restore(task)? {
-                        if !self.quiet(Some(task)) {
-                            self.eprint(
-                                task,
-                                &prefix,
-                                &format!("restored outputs from cache {}", cache.key()),
-                            );
-                        }
-                        save_checksum(task, config).await?;
-                        if let Err(err) = cache.mark_current() {
-                            warn!(
-                                "task {} artifact cache state update failed: {err}",
-                                task.name
-                            );
-                        }
-                        return Ok(true);
-                    }
-                    Some(cache)
+                    None => None,
                 }
-                None => None,
-            }
-        } else {
-            None
-        };
+            } else {
+                None
+            };
 
         let timer = std::time::Instant::now();
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -472,49 +472,49 @@ impl TaskExecutor {
         };
         self.check_confirmation(config, task, &env).await?;
 
-        let artifact_cache =
-            if !self.dry_run && task.cache.as_ref().is_some_and(|cache| cache.enabled) {
-                match TaskArtifactCache::new(task, config, &ts, &env, &task_env).await? {
-                    Some(cache) => {
-                        if !self.force
-                            && !dep_ran
-                            && cache.is_current()
-                            && sources_are_fresh(task, config).await?
-                        {
-                            if !self.quiet(Some(task)) {
-                                self.eprint(task, &prefix, "sources up-to-date, skipping");
-                            }
-                            return Ok(false);
+        let artifact_cache = if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
+            match TaskArtifactCache::new(task, config, &ts, &env, &task_env, !self.dry_run).await? {
+                Some(_) if self.dry_run => None,
+                Some(cache) => {
+                    if !self.force
+                        && !dep_ran
+                        && cache.is_current()
+                        && sources_are_fresh(task, config).await?
+                    {
+                        if !self.quiet(Some(task)) {
+                            self.eprint(task, &prefix, "sources up-to-date, skipping");
                         }
-                        if !self.force && !dep_ran && cache.restore(task)? {
-                            if !self.quiet(Some(task)) {
-                                self.eprint(
-                                    task,
-                                    &prefix,
-                                    &format!("restored outputs from cache {}", cache.key()),
-                                );
-                            }
-                            if let Err(err) = save_checksum(task, config).await {
-                                warn!(
-                                    "task {} artifact cache checksum update failed: {err}",
-                                    task.name
-                                );
-                            }
-                            if let Err(err) = cache.mark_current() {
-                                warn!(
-                                    "task {} artifact cache state update failed: {err}",
-                                    task.name
-                                );
-                            }
-                            return Ok(true);
-                        }
-                        Some(cache)
+                        return Ok(false);
                     }
-                    None => None,
+                    if !self.force && !dep_ran && cache.restore(task)? {
+                        if !self.quiet(Some(task)) {
+                            self.eprint(
+                                task,
+                                &prefix,
+                                &format!("restored outputs from cache {}", cache.key()),
+                            );
+                        }
+                        if let Err(err) = save_checksum(task, config).await {
+                            warn!(
+                                "task {} artifact cache checksum update failed: {err}",
+                                task.name
+                            );
+                        }
+                        if let Err(err) = cache.mark_current() {
+                            warn!(
+                                "task {} artifact cache state update failed: {err}",
+                                task.name
+                            );
+                        }
+                        return Ok(true);
+                    }
+                    Some(cache)
                 }
-            } else {
-                None
-            };
+                None => None,
+            }
+        } else {
+            None
+        };
 
         let timer = std::time::Instant::now();
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -448,6 +448,30 @@ impl TaskExecutor {
             env.insert("__MISE_DIFF".into(), serialized);
         }
 
+        let task_file = task.file_path(config).await?;
+        let usage_args = || {
+            if let Some(file) = &task_file {
+                once(file.to_string_lossy().to_string())
+                    .chain(task.args.iter().cloned())
+                    .collect()
+            } else {
+                once(String::new())
+                    .chain(task.args.iter().cloned())
+                    .collect()
+            }
+        };
+        self.parse_usage_spec_and_init_env(config, task, &mut env, usage_args, extra_vars.clone())
+            .await?;
+
+        // Confirmation must happen before a cache restore because restoring
+        // outputs mutates the working tree just like executing the task.
+        let confirm_guard = if task.interactive {
+            Some(acquire_runtime_lock(task.interactive).await)
+        } else {
+            None
+        };
+        self.check_confirmation(config, task, &env).await?;
+
         let artifact_cache =
             if !self.dry_run && task.cache.as_ref().is_some_and(|cache| cache.enabled) {
                 match TaskArtifactCache::new(task, config, &ts, &env, &task_env).await? {
@@ -494,10 +518,10 @@ impl TaskExecutor {
 
         let timer = std::time::Instant::now();
 
-        if let Some(file) = task.file_path(config).await? {
+        if let Some(file) = task_file {
             let exec_start = std::time::Instant::now();
             remove_auto_output(task, config).await?;
-            self.exec_file(config, &file, task, &env, &prefix, extra_vars)
+            self.exec_file(config, &file, task, &env, &prefix, confirm_guard)
                 .await?;
             trace!(
                 "task {} exec_file took {}ms (total {}ms)",
@@ -515,27 +539,6 @@ impl TaskExecutor {
                     extra_vars.clone(),
                 )
                 .await?;
-
-            let get_args = || {
-                [String::new()]
-                    .iter()
-                    .chain(task.args.iter())
-                    .cloned()
-                    .collect()
-            };
-            self.parse_usage_spec_and_init_env(config, task, &mut env, get_args, extra_vars)
-                .await?;
-
-            // For interactive tasks, acquire the lock before confirmation so the
-            // prompt gets exclusive terminal access (consistent with exec_file path).
-            let confirm_guard = if task.interactive {
-                Some(acquire_runtime_lock(task.interactive).await)
-            } else {
-                None
-            };
-
-            // Check confirmation after usage args are parsed
-            self.check_confirmation(config, task, &env).await?;
 
             let exec_start = std::time::Instant::now();
             remove_auto_output(task, config).await?;
@@ -1056,26 +1059,9 @@ impl TaskExecutor {
         task: &Task,
         env: &BTreeMap<String, String>,
         prefix: &str,
-        extra_vars: Option<IndexMap<String, String>>,
+        guard: Option<RuntimeLockGuard<'static>>,
     ) -> Result<()> {
-        let mut env = env.clone();
-        let command = file.to_string_lossy().to_string();
         let args = task.args.iter().cloned().collect_vec();
-        let get_args = || once(command.clone()).chain(args.clone()).collect_vec();
-        self.parse_usage_spec_and_init_env(config, task, &mut env, get_args, extra_vars)
-            .await?;
-
-        // For interactive tasks, acquire the lock before confirmation so the
-        // prompt gets exclusive terminal access. For non-interactive tasks,
-        // acquire after confirmation to avoid blocking the task graph.
-        let guard = if task.interactive {
-            Some(acquire_runtime_lock(task.interactive).await)
-        } else {
-            None
-        };
-
-        // Check confirmation after usage args are parsed
-        self.check_confirmation(config, task, &env).await?;
 
         if !self.quiet(Some(task)) {
             let cmd = format!("{} {}", display_path(file), args.join(" "))
@@ -1091,7 +1077,7 @@ impl TaskExecutor {
         } else {
             Some(acquire_runtime_lock(task.interactive).await)
         };
-        self.exec(file, &args, task, &env, prefix).await
+        self.exec(file, &args, task, env, prefix).await
     }
 
     async fn exec(

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -275,7 +275,10 @@ impl TaskExecutor {
         }
         // If any dependency actually ran, skip the source freshness check
         // so that downstream tasks are invalidated by upstream changes
-        if !task.cache.enabled && !self.force && !dep_ran && sources_are_fresh(task, config).await?
+        if !task.cache.as_ref().is_some_and(|cache| cache.enabled)
+            && !self.force
+            && !dep_ran
+            && sources_are_fresh(task, config).await?
         {
             if !self.quiet(Some(task)) {
                 self.eprint(task, &prefix, "sources up-to-date, skipping");
@@ -445,36 +448,40 @@ impl TaskExecutor {
             env.insert("__MISE_DIFF".into(), serialized);
         }
 
-        let artifact_cache = if task.cache.enabled {
-            let cache = TaskArtifactCache::new(task, config, &ts, &env, &task_env).await?;
-            if !self.force
-                && !dep_ran
-                && cache.is_current()
-                && sources_are_fresh(task, config).await?
-            {
-                if !self.quiet(Some(task)) {
-                    self.eprint(task, &prefix, "sources up-to-date, skipping");
+        let artifact_cache = if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
+            match TaskArtifactCache::new(task, config, &ts, &env, &task_env).await? {
+                Some(cache) => {
+                    if !self.force
+                        && !dep_ran
+                        && cache.is_current()
+                        && sources_are_fresh(task, config).await?
+                    {
+                        if !self.quiet(Some(task)) {
+                            self.eprint(task, &prefix, "sources up-to-date, skipping");
+                        }
+                        return Ok(false);
+                    }
+                    if !self.force && !dep_ran && cache.restore(task)? {
+                        if !self.quiet(Some(task)) {
+                            self.eprint(
+                                task,
+                                &prefix,
+                                &format!("restored outputs from cache {}", cache.key()),
+                            );
+                        }
+                        save_checksum(task, config).await?;
+                        if let Err(err) = cache.mark_current() {
+                            warn!(
+                                "task {} artifact cache state update failed: {err}",
+                                task.name
+                            );
+                        }
+                        return Ok(true);
+                    }
+                    Some(cache)
                 }
-                return Ok(false);
+                None => None,
             }
-            if !self.force && !dep_ran && cache.restore(task)? {
-                if !self.quiet(Some(task)) {
-                    self.eprint(
-                        task,
-                        &prefix,
-                        &format!("restored outputs from cache {}", cache.key()),
-                    );
-                }
-                save_checksum(task, config).await?;
-                if let Err(err) = cache.mark_current() {
-                    warn!(
-                        "task {} artifact cache state update failed: {err}",
-                        task.name
-                    );
-                }
-                return Ok(true);
-            }
-            Some(cache)
         } else {
             None
         };

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -309,6 +309,7 @@ pub struct TaskCacheInputs {
 pub async fn task_cache_inputs(
     task: &Task,
     config: &Arc<Config>,
+    persist_content_hash_cache: bool,
 ) -> Result<Option<TaskCacheInputs>> {
     if task.sources.is_empty() {
         return Ok(None);
@@ -341,7 +342,7 @@ pub async fn task_cache_inputs(
         source_paths.push(path.strip_prefix(&root).unwrap_or(&path).to_path_buf());
     }
     cache = next;
-    if let Err(e) = save_content_hash_cache(&cache_path, &cache) {
+    if persist_content_hash_cache && let Err(e) = save_content_hash_cache(&cache_path, &cache) {
         trace!("failed to save content hash cache: {e}");
     }
     let root_identity = root

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -299,6 +299,40 @@ async fn compute_source_hash(
     Ok(Some((source_hash, source_hash_path)))
 }
 
+/// Compute a stable content hash for artifact-cache inputs.
+///
+/// Unlike freshness state, this deliberately excludes absolute workspace paths
+/// so identical checkouts can share entries in the global mise cache.
+pub async fn task_source_content_hash(task: &Task, config: &Arc<Config>) -> Result<Option<String>> {
+    if task.sources.is_empty() {
+        return Ok(None);
+    }
+    let (root, mut source_metadatas) = collect_source_metadatas(task, config).await?;
+    if source_metadatas.is_empty() {
+        return Ok(None);
+    }
+    source_metadatas.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let mut hasher = blake3::Hasher::new();
+    for (path, _) in source_metadatas {
+        let relative = path.strip_prefix(&root).unwrap_or(&path);
+        let relative = relative.to_string_lossy();
+        hasher.update(&(relative.len() as u64).to_le_bytes());
+        hasher.update(relative.as_bytes());
+        let contents = hash::file_hash_blake3(&path, None)?;
+        hasher.update(contents.as_bytes());
+    }
+    Ok(Some(hasher.finalize().to_hex().to_string()))
+}
+
+/// Return cache input paths relative to the task directory when possible.
+pub async fn task_source_paths(task: &Task, config: &Arc<Config>) -> Result<Vec<PathBuf>> {
+    let (root, source_metadatas) = collect_source_metadatas(task, config).await?;
+    Ok(source_metadatas
+        .into_iter()
+        .map(|(path, _)| path.strip_prefix(&root).unwrap_or(&path).to_path_buf())
+        .collect())
+}
+
 /// Check if task sources are up to date (fresher than outputs)
 pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool> {
     if task.sources.is_empty() {

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -228,7 +228,7 @@ pub async fn task_cwd(task: &Task, config: &Arc<Config>) -> Result<PathBuf> {
 async fn collect_source_metadatas(
     task: &Task,
     config: &Arc<Config>,
-) -> Result<(PathBuf, Vec<(PathBuf, fs::Metadata)>)> {
+) -> Result<(PathBuf, PathBuf, Vec<(PathBuf, fs::Metadata)>)> {
     let root = task_cwd(task, config).await?;
     // Anchor the Override matcher at the outermost config root that is an
     // ancestor of the task CWD (i.e. the workspace root). This allows
@@ -267,7 +267,7 @@ async fn collect_source_metadatas(
             source_metadatas.push((config_path, meta));
         }
     }
-    Ok((root, source_metadatas))
+    Ok((root, match_root_owned, source_metadatas))
 }
 
 /// Compute the current source hash for a task. Returns `(hash, hash_file_path)`
@@ -280,7 +280,7 @@ async fn compute_source_hash(
         return Ok(None);
     }
     let use_content_hash = Settings::get().task.source_freshness_hash_contents;
-    let (root, source_metadatas) = collect_source_metadatas(task, config).await?;
+    let (root, _, source_metadatas) = collect_source_metadatas(task, config).await?;
     if source_metadatas.is_empty() {
         return Ok(None);
     }
@@ -299,38 +299,60 @@ async fn compute_source_hash(
     Ok(Some((source_hash, source_hash_path)))
 }
 
-/// Compute a stable content hash for artifact-cache inputs.
-///
-/// Unlike freshness state, this deliberately excludes absolute workspace paths
-/// so identical checkouts can share entries in the global mise cache.
-pub async fn task_source_content_hash(task: &Task, config: &Arc<Config>) -> Result<Option<String>> {
+pub struct TaskCacheInputs {
+    pub source_hash: String,
+    pub source_paths: Vec<PathBuf>,
+    pub root_identity: PathBuf,
+}
+
+/// Compute stable paths and content hashes for artifact-cache inputs in one source scan.
+pub async fn task_cache_inputs(
+    task: &Task,
+    config: &Arc<Config>,
+) -> Result<Option<TaskCacheInputs>> {
     if task.sources.is_empty() {
         return Ok(None);
     }
-    let (root, mut source_metadatas) = collect_source_metadatas(task, config).await?;
+    let (root, match_root, mut source_metadatas) = collect_source_metadatas(task, config).await?;
     if source_metadatas.is_empty() {
         return Ok(None);
     }
     source_metadatas.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let cache_path = content_hash_cache_path(task, &root);
+    let mut cache = load_content_hash_cache(&cache_path);
+    let mut next = ContentHashCache::new();
     let mut hasher = blake3::Hasher::new();
-    for (path, _) in source_metadatas {
-        let relative = path.strip_prefix(&root).unwrap_or(&path);
-        let relative = relative.to_string_lossy();
-        hasher.update(&(relative.len() as u64).to_le_bytes());
-        hasher.update(relative.as_bytes());
-        let contents = hash::file_hash_blake3(&path, None)?;
+    let mut source_paths = Vec::with_capacity(source_metadatas.len());
+    for (path, metadata) in source_metadatas {
+        let identity = match path.strip_prefix(&match_root) {
+            Ok(relative) => format!("workspace\0{}", relative.to_string_lossy()),
+            // Retaining the absolute path deliberately disables cross-checkout reuse for
+            // sources outside the workspace instead of allowing ambiguous identities.
+            Err(_) => format!("external\0{}", path.to_string_lossy()),
+        };
+        hasher.update(&(identity.len() as u64).to_le_bytes());
+        hasher.update(identity.as_bytes());
+        let contents = match cache.get(&path) {
+            Some(entry) if cached_entry_matches(entry, &metadata) => entry.hash.clone(),
+            _ => hash::file_hash_blake3(&path, None)?,
+        };
         hasher.update(contents.as_bytes());
+        next.insert(path.clone(), make_cache_entry(&metadata, contents));
+        source_paths.push(path.strip_prefix(&root).unwrap_or(&path).to_path_buf());
     }
-    Ok(Some(hasher.finalize().to_hex().to_string()))
-}
-
-/// Return cache input paths relative to the task directory when possible.
-pub async fn task_source_paths(task: &Task, config: &Arc<Config>) -> Result<Vec<PathBuf>> {
-    let (root, source_metadatas) = collect_source_metadatas(task, config).await?;
-    Ok(source_metadatas
-        .into_iter()
-        .map(|(path, _)| path.strip_prefix(&root).unwrap_or(&path).to_path_buf())
-        .collect())
+    cache = next;
+    if let Err(e) = save_content_hash_cache(&cache_path, &cache) {
+        trace!("failed to save content hash cache: {e}");
+    }
+    let root_identity = root
+        .strip_prefix(&match_root)
+        .unwrap_or(&root)
+        .to_path_buf();
+    Ok(Some(TaskCacheInputs {
+        source_hash: hasher.finalize().to_hex().to_string(),
+        source_paths,
+        root_identity,
+    }))
 }
 
 /// Check if task sources are up to date (fresher than outputs)
@@ -343,7 +365,7 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
     let equal_mtime_is_fresh = settings.task.source_freshness_equal_mtime_is_fresh;
 
     let run = async || -> Result<bool> {
-        let (root, source_metadatas) = collect_source_metadatas(task, config).await?;
+        let (root, _, source_metadatas) = collect_source_metadatas(task, config).await?;
 
         // Check if sources resolved to no files (likely a config mistake)
         if source_metadatas.is_empty() {

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -34,7 +34,7 @@ pub struct TaskTemplate {
     #[serde(default)]
     pub outputs: TaskOutputs,
     #[serde(default)]
-    pub cache: TaskCacheConfig,
+    pub cache: Option<TaskCacheConfig>,
     #[serde(default)]
     pub output: Option<TaskOutput>,
     #[serde(default)]
@@ -168,8 +168,7 @@ impl Task {
             self.outputs = template.outputs.clone();
         }
 
-        if self.cache == TaskCacheConfig::default() && template.cache != TaskCacheConfig::default()
-        {
+        if self.cache.is_none() {
             self.cache = template.cache.clone();
         }
 
@@ -335,6 +334,28 @@ mod tests {
         };
         overridden.merge_template(&template);
         assert_eq!(overridden.output, Some(TaskOutput::Interleave));
+    }
+
+    #[test]
+    fn test_merge_template_cache_can_be_disabled_locally() {
+        let template = TaskTemplate {
+            cache: Some(TaskCacheConfig {
+                enabled: true,
+                env: vec!["PROFILE".to_string()],
+            }),
+            ..Default::default()
+        };
+
+        let mut inherited = Task::default();
+        inherited.merge_template(&template);
+        assert!(inherited.cache.as_ref().is_some_and(|cache| cache.enabled));
+
+        let mut disabled = Task {
+            cache: Some(TaskCacheConfig::default()),
+            ..Default::default()
+        };
+        disabled.merge_template(&template);
+        assert_eq!(disabled.cache, Some(TaskCacheConfig::default()));
     }
 
     #[test]

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -1,7 +1,9 @@
 use crate::config::config_file::mise_toml::{EnvList, deserialize_vars};
 use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
-use crate::task::{RunEntry, Silent, Task, TaskConfirm, TaskDep, TaskOutput, TaskToolValue};
+use crate::task::{
+    RunEntry, Silent, Task, TaskCacheConfig, TaskConfirm, TaskDep, TaskOutput, TaskToolValue,
+};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
@@ -31,6 +33,8 @@ pub struct TaskTemplate {
     pub sources: Vec<String>,
     #[serde(default)]
     pub outputs: TaskOutputs,
+    #[serde(default)]
+    pub cache: TaskCacheConfig,
     #[serde(default)]
     pub output: Option<TaskOutput>,
     #[serde(default)]
@@ -162,6 +166,11 @@ impl Task {
         // outputs: local overrides completely if default
         if self.outputs == TaskOutputs::default() && template.outputs != TaskOutputs::default() {
             self.outputs = template.outputs.clone();
+        }
+
+        if self.cache == TaskCacheConfig::default() && template.cache != TaskCacheConfig::default()
+        {
+            self.cache = template.cache.clone();
         }
 
         // output: use template only if local not set


### PR DESCRIPTION
## Summary

- add an experimental, opt-in local artifact cache for task outputs
- derive cache keys from source contents, task configuration and arguments, declared environment, explicitly allowlisted ambient variables, resolved tools, OS, and architecture
- store successful outputs as zstd-compressed tar archives and safely restore missing outputs without rerunning the task
- document the feature and expose `cache = { enabled = true, env = [...] }` in task schemas and task info

## Motivation

mise's existing `sources`/`outputs` support can skip a task while its outputs remain fresh, but it cannot restore outputs after they are deleted or in another checkout. This adds the local output-artifact half of task caching while keeping the first version deliberately experimental.

## Current scope

- local cache only; no remote cache protocol
- explicit output paths are required; automatic, absolute, escaping, and source-containing outputs are rejected
- ambient environment variables affect the key only when named in `cache.env`
- task logs are not cached or replayed
- when a dependency executes or restores during the current run, dependents conservatively execute
- cache failures degrade to misses or warnings rather than failing a successful task

## Testing

- `mise run lint-fix`
- `cargo test --all-features task_cache --quiet`
- `mise run test:e2e test_task_artifact_cache test_task_artifact_cache_validation`
- `mise run test:e2e test_task_source_freshness test_task_source_freshness_hash_contents test_task_dep_invalidates_sources`

*This pull request was generated with assistance from an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task execution and filesystem restore paths with content-addressed keys; incorrect keys or restore logic could serve stale outputs, though failures degrade to misses/warnings and strict output validation limits blast radius.
> 
> **Overview**
> Adds an **experimental**, opt-in **local artifact cache** so eligible tasks can **restore declared outputs** without rerunning when inputs match a prior successful run—beyond what `sources`/`outputs` freshness alone can do after outputs are removed.
> 
> Tasks gain **`cache = { enabled, env }`** and scopes can set **`task_config.cache`** defaults for tasks with **sources** and **explicit** `outputs` (not `auto`). Keys hash source contents, task definition/args, declared env, optional allowlisted ambient vars, tools, and OS/arch. Artifacts live under **`MISE_CACHE_DIR/task-artifacts/v1`** as zstd tar archives with transactional restore, path/symlink validation, and corrupt-entry misses; write failures warn only.
> 
> **`task_executor`** integrates restore-before-run and store-after-success, adjusts the freshness fast-path for cache-enabled tasks, runs confirmation before restore, and skips cache mutation on dry-run. **`dep_ran`** still forces dependents to execute rather than restore. Docs/schemas, **`mise tasks info`**, template merge rules, and e2e tests cover hits, misses, validation, and scoped defaults. **`TASK_CACHE_PARITY.md`** tracks remaining Turborepo-style work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3436c8dcff2d3072d467df6a097565f1dd4c0136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental, opt-in per-task artifact caching for tasks with explicit outputs.
  * Cache keys can include selected environment variables; `tasks info` now reports cache settings (human + JSON).
* **Bug Fixes**
  * Cache-enabled tasks now bypass the normal “sources fresh” fast-skip when appropriate.
* **Documentation**
  * Documented cache eligibility, key composition, storage/format, miss/failure behavior, and template/task override rules.
  * Added cache parity tracking notes.
* **Tests**
  * Added e2e coverage for cache hits/restores, misses, dry-run behavior, and config validation (including symlink/path safety).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->