### PR TITLE
fix(task): detect cycles in resolved task graph

### DIFF
--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -80,6 +80,30 @@ depends = ["b"]
 run = "echo b"
 depends = ["a"]
 
+[tasks.c]
+run = "echo c"
+depends = ["d"]
+
+[tasks.d]
+run = "echo d"
+depends = ["c"]
+
+[tasks.wait-a]
+run = "echo wait-a"
+wait_for = ["wait-b"]
+
+[tasks.wait-b]
+run = "echo wait-b"
+wait_for = ["wait-a"]
+
+[tasks.wait-c]
+run = "echo wait-c"
+wait_for = ["wait-d"]
+
+[tasks.wait-d]
+run = "echo wait-d"
+wait_for = ["wait-c"]
+
 [tasks.invalid]
 run = "echo invalid"
 depends = ["nonexistent"]
@@ -94,6 +118,8 @@ assert_contains "mise tasks validate 2>&1 || true" "circular-dependency"
 assert_contains "mise tasks validate 2>&1 || true" "a -> b -> a"
 graph_error_count=$(mise tasks validate --json 2>&1 | grep -c '"category": "dependency-graph-error"' || true)
 assert "echo $graph_error_count" "2"
+cycle_error_count=$(mise tasks validate --json 2>&1 | grep -c '"category": "circular-dependency"' || true)
+assert "echo $cycle_error_count" "4"
 
 # A depends_post reference reverses the scheduling edge, so this is acyclic:
 # a runs before b both because a schedules b afterward and b depends on a.

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -26,6 +26,51 @@ assert_contains "mise tasks validate 2>&1 || true" "Circular dependency detected
 assert_contains "mise tasks validate 2>&1 || true" "circular-dependency"
 assert_contains "mise tasks validate 2>&1 || true" "a -> b -> a"
 
+# Test cycles involving wait_for are detected by validation and before execution
+cat <<EOF >mise.toml
+[tasks.a]
+run = "echo a"
+depends = ["b"]
+
+[tasks.b]
+run = "echo b"
+wait_for = ["a"]
+EOF
+
+assert_contains "mise tasks validate 2>&1 || true" "a -> b -> a"
+assert_contains "mise run a 2>&1 || true" "circular dependency detected: a -> b -> a"
+
+# Test cycles introduced by rendering a nested task's usage defaults
+cat <<'EOF' >mise.toml
+[tasks.a]
+run = "echo a"
+depends = ["b"]
+
+[tasks.b]
+usage = 'flag "--enabled" default=#true'
+run = "echo b"
+depends = ["{% if usage.enabled %}a{% endif %}"]
+EOF
+
+assert_contains "mise tasks validate 2>&1 || true" "a -> b -> a"
+assert_contains "mise run a 2>&1 || true" "circular dependency detected: a -> b -> a"
+
+# A depends_post reference reverses the scheduling edge, so this is acyclic:
+# a runs before b both because a schedules b afterward and b depends on a.
+cat <<EOF >mise.toml
+[tasks.a]
+run = "echo a"
+depends_post = ["b"]
+
+[tasks.b]
+run = "echo b"
+depends = ["a"]
+EOF
+
+assert_contains "mise tasks validate" "✓ All 2 task(s) validated successfully"
+assert "mise run a" "a
+b"
+
 # Test missing dependency
 cat <<EOF >mise.toml
 [tasks.valid]

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -55,6 +55,21 @@ EOF
 assert_contains "mise tasks validate 2>&1 || true" "a -> b -> a"
 assert_contains "mise run a 2>&1 || true" "circular dependency detected: a -> b -> a"
 
+# Test non-cycle dependency graph failures are reported as validation errors
+cat <<'EOF' >mise.toml
+[tasks.root]
+run = "echo root"
+depends = ["child"]
+
+[tasks.child]
+usage = "not valid usage syntax"
+run = "echo child"
+depends = ["{{usage.target}}"]
+EOF
+
+assert_contains "mise tasks validate 2>&1 || true" "Failed to build task dependency graph"
+assert_contains "mise tasks validate 2>&1 || true" "dependency-graph-error"
+
 # A depends_post reference reverses the scheduling edge, so this is acyclic:
 # a runs before b both because a schedules b afterward and b depends on a.
 cat <<EOF >mise.toml
@@ -178,7 +193,7 @@ depends = ["missing"]
 EOF
 
 assert_contains "mise tasks validate --json 2>&1 || true" '"tasks_validated": 2'
-assert_contains "mise tasks validate --json 2>&1 || true" '"errors": 1'
+assert_contains "mise tasks validate --json 2>&1 || true" '"errors": 2'
 assert_contains "mise tasks validate --json 2>&1 || true" '"category": "missing-dependency"'
 
 # Test errors-only flag

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -70,6 +70,25 @@ EOF
 assert_contains "mise tasks validate 2>&1 || true" "Failed to build task dependency graph"
 assert_contains "mise tasks validate 2>&1 || true" "dependency-graph-error"
 
+# Test an unrelated graph failure does not hide a cycle in another task graph
+cat <<'EOF' >mise.toml
+[tasks.a]
+run = "echo a"
+depends = ["b"]
+
+[tasks.b]
+run = "echo b"
+depends = ["a"]
+
+[tasks.invalid]
+run = "echo invalid"
+depends = ["nonexistent"]
+EOF
+
+assert_contains "mise tasks validate 2>&1 || true" "dependency-graph-error"
+assert_contains "mise tasks validate 2>&1 || true" "circular-dependency"
+assert_contains "mise tasks validate 2>&1 || true" "a -> b -> a"
+
 # A depends_post reference reverses the scheduling edge, so this is acyclic:
 # a runs before b both because a schedules b afterward and b depends on a.
 cat <<EOF >mise.toml

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -88,6 +88,18 @@ depends = ["d"]
 run = "echo d"
 depends = ["c"]
 
+[tasks.overlap]
+run = "echo overlap"
+depends = ["overlap-left", "overlap-right"]
+
+[tasks.overlap-left]
+run = "echo overlap-left"
+depends = ["overlap"]
+
+[tasks.overlap-right]
+run = "echo overlap-right"
+depends = ["overlap"]
+
 [tasks.wait-a]
 run = "echo wait-a"
 wait_for = ["wait-b"]
@@ -119,7 +131,7 @@ assert_contains "mise tasks validate 2>&1 || true" "a -> b -> a"
 graph_error_count=$(mise tasks validate --json 2>&1 | grep -c '"category": "dependency-graph-error"' || true)
 assert "echo $graph_error_count" "2"
 cycle_error_count=$(mise tasks validate --json 2>&1 | grep -c '"category": "circular-dependency"' || true)
-assert "echo $cycle_error_count" "4"
+assert "echo $cycle_error_count" "6"
 
 # A depends_post reference reverses the scheduling edge, so this is acyclic:
 # a runs before b both because a schedules b afterward and b depends on a.

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -83,11 +83,17 @@ depends = ["a"]
 [tasks.invalid]
 run = "echo invalid"
 depends = ["nonexistent"]
+
+[tasks.also-invalid]
+run = "echo also-invalid"
+depends = ["also-nonexistent"]
 EOF
 
 assert_contains "mise tasks validate 2>&1 || true" "dependency-graph-error"
 assert_contains "mise tasks validate 2>&1 || true" "circular-dependency"
 assert_contains "mise tasks validate 2>&1 || true" "a -> b -> a"
+graph_error_count=$(mise tasks validate --json 2>&1 | grep -c '"category": "dependency-graph-error"' || true)
+assert "echo $graph_error_count" "2"
 
 # A depends_post reference reverses the scheduling edge, so this is acyclic:
 # a runs before b both because a schedules b afterward and b depends on a.

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -86,7 +86,7 @@ depends = ["nonexistent"]
 
 [tasks.also-invalid]
 run = "echo also-invalid"
-depends = ["also-nonexistent"]
+depends = ["nonexistent"]
 EOF
 
 assert_contains "mise tasks validate 2>&1 || true" "dependency-graph-error"

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -159,14 +159,12 @@ impl TasksValidate {
 
         // A wait_for relationship only applies when both tasks are selected, so
         // retry the tasks whose individual graphs built successfully together.
-        if valid_tasks.len() > 1 {
-            if let Err(err) = Deps::new(config, valid_tasks).await {
-                if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                    return Some(cycle_issue(cycle, err.to_string()));
-                }
-            }
+        if valid_tasks.len() <= 1 {
+            return None;
         }
-        None
+        let err = Deps::new(config, valid_tasks).await.err()?;
+        let cycle = err.downcast_ref::<TaskCycleError>()?;
+        Some(cycle_issue(cycle, err.to_string()))
     }
 
     fn get_all_tasks(&self, all_tasks: &BTreeMap<String, Task>) -> Vec<Task> {

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -6,7 +6,7 @@ use crate::config::Config;
 use crate::duration;
 use crate::file;
 use crate::task::task_fetcher::TaskFetcher;
-use crate::task::{GetMatchingExt, Task, build_task_ref_map, resolve_task_pattern};
+use crate::task::{Deps, GetMatchingExt, Task, build_task_ref_map, resolve_task_pattern};
 use crate::tera::contains_template_syntax;
 use crate::ui::style;
 use console::style as console_style;
@@ -84,6 +84,23 @@ impl TasksValidate {
 
         // Run validation
         let mut issues = Vec::new();
+        if let Err(err) = Deps::new(&config, tasks.clone()).await {
+            let details = err.to_string();
+            if details.contains("circular dependency detected") {
+                let task = details
+                    .split_once(": ")
+                    .and_then(|(_, path)| path.split(" -> ").next())
+                    .unwrap_or("task graph")
+                    .to_string();
+                issues.push(ValidationIssue {
+                    task,
+                    severity: Severity::Error,
+                    category: "circular-dependency".to_string(),
+                    message: "Circular dependency detected".to_string(),
+                    details: Some(details),
+                });
+            }
+        }
         for task in &tasks {
             issues.extend(self.validate_task(task, &all_tasks, &config).await);
         }
@@ -164,64 +181,35 @@ impl TasksValidate {
     ) -> Vec<ValidationIssue> {
         let mut issues = Vec::new();
 
-        // 1. Validate circular dependencies
-        issues.extend(self.validate_circular_dependencies(task, all_tasks));
-
-        // 2. Validate missing task references
+        // 1. Validate missing task references
         issues.extend(self.validate_missing_references(task, all_tasks));
 
-        // 3. Validate usage spec parsing
+        // 2. Validate usage spec parsing
         issues.extend(self.validate_usage_spec(task, config).await);
 
-        // 4. Validate timeout format
+        // 3. Validate timeout format
         issues.extend(self.validate_timeout(task));
 
-        // 5. Validate alias conflicts
+        // 4. Validate alias conflicts
         issues.extend(self.validate_aliases(task, all_tasks));
 
-        // 6. Validate file existence
+        // 5. Validate file existence
         issues.extend(self.validate_file_existence(task));
 
-        // 7. Validate directory template
+        // 6. Validate directory template
         issues.extend(self.validate_directory(task, config).await);
 
-        // 8. Validate shell command
+        // 7. Validate shell command
         issues.extend(self.validate_shell(task));
 
-        // 9. Validate source globs
+        // 8. Validate source globs
         issues.extend(self.validate_source_patterns(task));
 
-        // 10. Validate output patterns
+        // 9. Validate output patterns
         issues.extend(self.validate_output_patterns(task));
 
-        // 11. Validate run entries
+        // 10. Validate run entries
         issues.extend(self.validate_run_entries(task, all_tasks));
-
-        issues
-    }
-
-    fn validate_circular_dependencies(
-        &self,
-        task: &Task,
-        all_tasks: &BTreeMap<String, Task>,
-    ) -> Vec<ValidationIssue> {
-        let mut issues = Vec::new();
-
-        match task.all_depends(all_tasks) {
-            Ok(_) => {}
-            Err(e) => {
-                let err_msg = e.to_string();
-                if err_msg.contains("circular dependency") {
-                    issues.push(ValidationIssue {
-                        task: task.name.clone(),
-                        severity: Severity::Error,
-                        category: "circular-dependency".to_string(),
-                        message: "Circular dependency detected".to_string(),
-                        details: Some(err_msg),
-                    });
-                }
-            }
-        }
 
         issues
     }

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -88,10 +88,15 @@ impl TasksValidate {
         let mut issues = Vec::new();
         if let Err(err) = Deps::new(&config, tasks.clone()).await {
             let details = err.to_string();
+            let additional_issues = self.find_additional_graph_issues(&config, &tasks).await;
             if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                issues.push(cycle_issue(cycle, details));
+                if !additional_issues
+                    .iter()
+                    .any(|issue| issue.category == "circular-dependency")
+                {
+                    issues.push(cycle_issue(cycle, details));
+                }
             } else {
-                let additional_issues = self.find_additional_graph_issues(&config, &tasks).await;
                 let graph_error_is_represented = additional_issues.iter().any(|issue| {
                     issue.category == "dependency-graph-error"
                         && issue.details.as_deref() == Some(details.as_str())
@@ -99,8 +104,8 @@ impl TasksValidate {
                 if !graph_error_is_represented {
                     issues.push(graph_error_issue("task graph", details));
                 }
-                issues.extend(additional_issues);
             }
+            issues.extend(additional_issues);
         }
         for task in &tasks {
             issues.extend(self.validate_task(task, &all_tasks, &config).await);

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -6,7 +6,9 @@ use crate::config::Config;
 use crate::duration;
 use crate::file;
 use crate::task::task_fetcher::TaskFetcher;
-use crate::task::{Deps, GetMatchingExt, Task, build_task_ref_map, resolve_task_pattern};
+use crate::task::{
+    Deps, GetMatchingExt, Task, TaskCycleError, build_task_ref_map, resolve_task_pattern,
+};
 use crate::tera::contains_template_syntax;
 use crate::ui::style;
 use console::style as console_style;
@@ -86,20 +88,29 @@ impl TasksValidate {
         let mut issues = Vec::new();
         if let Err(err) = Deps::new(&config, tasks.clone()).await {
             let details = err.to_string();
-            if details.contains("circular dependency detected") {
-                let task = details
-                    .split_once(": ")
-                    .and_then(|(_, path)| path.split(" -> ").next())
-                    .unwrap_or("task graph")
-                    .to_string();
-                issues.push(ValidationIssue {
-                    task,
-                    severity: Severity::Error,
-                    category: "circular-dependency".to_string(),
-                    message: "Circular dependency detected".to_string(),
-                    details: Some(details),
-                });
-            }
+            let (task, category, message) =
+                if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
+                    let task = cycle
+                        .path()
+                        .first()
+                        .map(String::as_str)
+                        .unwrap_or("task graph")
+                        .to_string();
+                    (task, "circular-dependency", "Circular dependency detected")
+                } else {
+                    (
+                        "task graph".to_string(),
+                        "dependency-graph-error",
+                        "Failed to build task dependency graph",
+                    )
+                };
+            issues.push(ValidationIssue {
+                task,
+                severity: Severity::Error,
+                category: category.to_string(),
+                message: message.to_string(),
+                details: Some(details),
+            });
         }
         for task in &tasks {
             issues.extend(self.validate_task(task, &all_tasks, &config).await);

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -7,7 +7,7 @@ use crate::duration;
 use crate::file;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{
-    Deps, GetMatchingExt, Task, TaskCycleError, build_task_ref_map, resolve_task_pattern,
+    Deps, GetMatchingExt, Task, TaskCycleError, TaskKey, build_task_ref_map, resolve_task_pattern,
 };
 use crate::tera::contains_template_syntax;
 use crate::ui::style;
@@ -152,7 +152,7 @@ impl TasksValidate {
     ) -> Vec<ValidationIssue> {
         let mut issues = Vec::new();
         let mut valid_tasks = Vec::new();
-        let mut reported_cycles = HashSet::new();
+        let mut reported_cycles: HashSet<Vec<TaskKey>> = HashSet::new();
         let mut reported_error_details = HashSet::new();
         if let Some(cycle) = initial_cycle {
             push_cycle_issue(&mut issues, &mut reported_cycles, cycle);
@@ -763,17 +763,17 @@ fn cycle_issue(path: &[String]) -> ValidationIssue {
 
 fn push_cycle_issue(
     issues: &mut Vec<ValidationIssue>,
-    reported_cycles: &mut HashSet<Vec<String>>,
+    reported_cycles: &mut HashSet<Vec<TaskKey>>,
     cycle: &TaskCycleError,
 ) {
-    for path in cycle.paths() {
-        if reported_cycles.insert(canonical_cycle(path)) {
+    for (path, keys) in cycle.paths().iter().zip(cycle.keys()) {
+        if reported_cycles.insert(canonical_cycle(keys)) {
             issues.push(cycle_issue(path));
         }
     }
 }
 
-fn canonical_cycle(path: &[String]) -> Vec<String> {
+fn canonical_cycle<T: Clone + Ord>(path: &[T]) -> Vec<T> {
     let path = if path.len() > 1 && path.first() == path.last() {
         &path[..path.len() - 1]
     } else {
@@ -833,3 +833,32 @@ The validate command performs the following checks:
   • <bold>Run Entries</bold>: Ensures tasks reference valid dependencies
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task_key(name: &str, value: &str) -> TaskKey {
+        (
+            name.to_string(),
+            Vec::new(),
+            vec![("TARGET".to_string(), value.to_string())],
+        )
+    }
+
+    #[test]
+    fn cycle_identity_includes_environment_values() {
+        let red = vec![
+            task_key("build", "red"),
+            task_key("test", "red"),
+            task_key("build", "red"),
+        ];
+        let blue = vec![
+            task_key("build", "blue"),
+            task_key("test", "blue"),
+            task_key("build", "blue"),
+        ];
+
+        assert_ne!(canonical_cycle(&red), canonical_cycle(&blue));
+    }
+}

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -91,11 +91,15 @@ impl TasksValidate {
             if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
                 issues.push(cycle_issue(cycle, details));
             } else {
-                issues.push(graph_error_issue("task graph", details.clone()));
-                issues.extend(
-                    self.find_additional_graph_issues(&config, &tasks, details)
-                        .await,
-                );
+                let additional_issues = self.find_additional_graph_issues(&config, &tasks).await;
+                let graph_error_is_represented = additional_issues.iter().any(|issue| {
+                    issue.category == "dependency-graph-error"
+                        && issue.details.as_deref() == Some(details.as_str())
+                });
+                if !graph_error_is_represented {
+                    issues.push(graph_error_issue("task graph", details));
+                }
+                issues.extend(additional_issues);
             }
         }
         for task in &tasks {
@@ -139,12 +143,11 @@ impl TasksValidate {
         &self,
         config: &Arc<Config>,
         tasks: &[Task],
-        reported_details: String,
     ) -> Vec<ValidationIssue> {
         let mut issues = Vec::new();
         let mut valid_tasks = Vec::new();
         let mut found_cycle = None;
-        let mut reported_errors = HashSet::from([reported_details]);
+        let mut reported_error_details = HashSet::new();
         for task in tasks {
             match Deps::new(config, vec![task.clone()]).await {
                 Ok(_) => valid_tasks.push(task.clone()),
@@ -153,9 +156,8 @@ impl TasksValidate {
                         found_cycle.get_or_insert_with(|| cycle_issue(cycle, err.to_string()));
                     } else {
                         let details = err.to_string();
-                        if reported_errors.insert(details.clone()) {
-                            issues.push(graph_error_issue(&task.name, details));
-                        }
+                        reported_error_details.insert(details.clone());
+                        issues.push(graph_error_issue(&task.name, details));
                     }
                 }
             }
@@ -173,7 +175,7 @@ impl TasksValidate {
                 found_cycle.get_or_insert_with(|| cycle_issue(cycle, err.to_string()));
             } else {
                 let details = err.to_string();
-                if reported_errors.insert(details.clone()) {
+                if reported_error_details.insert(details.clone()) {
                     issues.push(graph_error_issue("task graph", details));
                 }
             }

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -91,16 +91,11 @@ impl TasksValidate {
             if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
                 issues.push(cycle_issue(cycle, details));
             } else {
-                issues.push(ValidationIssue {
-                    task: "task graph".to_string(),
-                    severity: Severity::Error,
-                    category: "dependency-graph-error".to_string(),
-                    message: "Failed to build task dependency graph".to_string(),
-                    details: Some(details),
-                });
-                if let Some(issue) = self.find_cycle_in_valid_subgraph(&config, &tasks).await {
-                    issues.push(issue);
-                }
+                issues.push(graph_error_issue("task graph", details.clone()));
+                issues.extend(
+                    self.find_additional_graph_issues(&config, &tasks, details)
+                        .await,
+                );
             }
         }
         for task in &tasks {
@@ -140,18 +135,27 @@ impl TasksValidate {
         Ok(())
     }
 
-    async fn find_cycle_in_valid_subgraph(
+    async fn find_additional_graph_issues(
         &self,
         config: &Arc<Config>,
         tasks: &[Task],
-    ) -> Option<ValidationIssue> {
+        reported_details: String,
+    ) -> Vec<ValidationIssue> {
+        let mut issues = Vec::new();
         let mut valid_tasks = Vec::new();
+        let mut found_cycle = None;
+        let mut reported_errors = HashSet::from([reported_details]);
         for task in tasks {
             match Deps::new(config, vec![task.clone()]).await {
                 Ok(_) => valid_tasks.push(task.clone()),
                 Err(err) => {
                     if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                        return Some(cycle_issue(cycle, err.to_string()));
+                        found_cycle.get_or_insert_with(|| cycle_issue(cycle, err.to_string()));
+                    } else {
+                        let details = err.to_string();
+                        if reported_errors.insert(details.clone()) {
+                            issues.push(graph_error_issue(&task.name, details));
+                        }
                     }
                 }
             }
@@ -159,12 +163,23 @@ impl TasksValidate {
 
         // A wait_for relationship only applies when both tasks are selected, so
         // retry the tasks whose individual graphs built successfully together.
-        if valid_tasks.len() <= 1 {
-            return None;
+        let combined_error = if valid_tasks.len() > 1 {
+            Deps::new(config, valid_tasks).await.err()
+        } else {
+            None
+        };
+        if let Some(err) = combined_error {
+            if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
+                found_cycle.get_or_insert_with(|| cycle_issue(cycle, err.to_string()));
+            } else {
+                let details = err.to_string();
+                if reported_errors.insert(details.clone()) {
+                    issues.push(graph_error_issue("task graph", details));
+                }
+            }
         }
-        let err = Deps::new(config, valid_tasks).await.err()?;
-        let cycle = err.downcast_ref::<TaskCycleError>()?;
-        Some(cycle_issue(cycle, err.to_string()))
+        issues.extend(found_cycle);
+        issues
     }
 
     fn get_all_tasks(&self, all_tasks: &BTreeMap<String, Task>) -> Vec<Task> {
@@ -733,6 +748,16 @@ fn cycle_issue(cycle: &TaskCycleError, details: String) -> ValidationIssue {
         severity: Severity::Error,
         category: "circular-dependency".to_string(),
         message: "Circular dependency detected".to_string(),
+        details: Some(details),
+    }
+}
+
+fn graph_error_issue(task: &str, details: String) -> ValidationIssue {
+    ValidationIssue {
+        task: task.to_string(),
+        severity: Severity::Error,
+        category: "dependency-graph-error".to_string(),
+        message: "Failed to build task dependency graph".to_string(),
         details: Some(details),
     }
 }

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -8,7 +8,6 @@ use crate::file;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{
     Deps, GetMatchingExt, Task, TaskCycleError, build_task_ref_map, resolve_task_pattern,
-    task_cycle_label,
 };
 use crate::tera::contains_template_syntax;
 use crate::ui::style;
@@ -87,14 +86,14 @@ impl TasksValidate {
 
         // Run validation
         let mut issues = Vec::new();
-        if let Err(err) = Deps::new(&config, tasks.clone()).await {
-            let details = err.to_string();
+        if let Err(err) = Deps::new_for_validation(&config, tasks.clone()).await {
             if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
                 issues.extend(
-                    self.find_additional_graph_issues(&config, &tasks, Some((cycle, details)))
+                    self.find_additional_graph_issues(&config, &tasks, Some(cycle))
                         .await,
                 );
             } else {
+                let details = err.to_string();
                 let additional_issues = self
                     .find_additional_graph_issues(&config, &tasks, None)
                     .await;
@@ -149,21 +148,21 @@ impl TasksValidate {
         &self,
         config: &Arc<Config>,
         tasks: &[Task],
-        initial_cycle: Option<(&TaskCycleError, String)>,
+        initial_cycle: Option<&TaskCycleError>,
     ) -> Vec<ValidationIssue> {
         let mut issues = Vec::new();
         let mut valid_tasks = Vec::new();
         let mut reported_cycles = HashSet::new();
         let mut reported_error_details = HashSet::new();
-        if let Some((cycle, details)) = initial_cycle {
-            push_cycle_issue(&mut issues, &mut reported_cycles, cycle, details);
+        if let Some(cycle) = initial_cycle {
+            push_cycle_issue(&mut issues, &mut reported_cycles, cycle);
         }
         for task in tasks {
-            match Deps::new(config, vec![task.clone()]).await {
+            match Deps::new_for_validation(config, vec![task.clone()]).await {
                 Ok(_) => valid_tasks.push(task.clone()),
                 Err(err) => {
                     if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                        push_cycle_issue(&mut issues, &mut reported_cycles, cycle, err.to_string());
+                        push_cycle_issue(&mut issues, &mut reported_cycles, cycle);
                     } else {
                         let details = err.to_string();
                         reported_error_details.insert(details.clone());
@@ -175,24 +174,16 @@ impl TasksValidate {
 
         // A wait_for relationship only applies when both tasks are selected, so
         // retry the tasks whose individual graphs built successfully together.
-        while valid_tasks.len() > 1 {
-            let Some(err) = Deps::new(config, valid_tasks.clone()).await.err() else {
-                break;
-            };
+        if valid_tasks.len() > 1
+            && let Some(err) = Deps::new_for_validation(config, valid_tasks).await.err()
+        {
             if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                push_cycle_issue(&mut issues, &mut reported_cycles, cycle, err.to_string());
-                let cycle_labels: HashSet<_> = cycle.path().iter().map(String::as_str).collect();
-                let previous_len = valid_tasks.len();
-                valid_tasks.retain(|task| !cycle_labels.contains(task_cycle_label(task).as_str()));
-                if valid_tasks.len() == previous_len {
-                    break;
-                }
+                push_cycle_issue(&mut issues, &mut reported_cycles, cycle);
             } else {
                 let details = err.to_string();
                 if reported_error_details.insert(details.clone()) {
                     issues.push(graph_error_issue("task graph", details));
                 }
-                break;
             }
         }
         issues
@@ -752,9 +743,8 @@ impl TasksValidate {
     }
 }
 
-fn cycle_issue(cycle: &TaskCycleError, details: String) -> ValidationIssue {
-    let task = cycle
-        .path()
+fn cycle_issue(path: &[String]) -> ValidationIssue {
+    let task = path
         .first()
         .map(String::as_str)
         .unwrap_or("task graph")
@@ -764,7 +754,10 @@ fn cycle_issue(cycle: &TaskCycleError, details: String) -> ValidationIssue {
         severity: Severity::Error,
         category: "circular-dependency".to_string(),
         message: "Circular dependency detected".to_string(),
-        details: Some(details),
+        details: Some(format!(
+            "circular dependency detected: {}",
+            path.iter().join(" -> ")
+        )),
     }
 }
 
@@ -772,10 +765,11 @@ fn push_cycle_issue(
     issues: &mut Vec<ValidationIssue>,
     reported_cycles: &mut HashSet<Vec<String>>,
     cycle: &TaskCycleError,
-    details: String,
 ) {
-    if reported_cycles.insert(canonical_cycle(cycle.path())) {
-        issues.push(cycle_issue(cycle, details));
+    for path in cycle.paths() {
+        if reported_cycles.insert(canonical_cycle(path)) {
+            issues.push(cycle_issue(path));
+        }
     }
 }
 

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -88,29 +88,20 @@ impl TasksValidate {
         let mut issues = Vec::new();
         if let Err(err) = Deps::new(&config, tasks.clone()).await {
             let details = err.to_string();
-            let (task, category, message) =
-                if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                    let task = cycle
-                        .path()
-                        .first()
-                        .map(String::as_str)
-                        .unwrap_or("task graph")
-                        .to_string();
-                    (task, "circular-dependency", "Circular dependency detected")
-                } else {
-                    (
-                        "task graph".to_string(),
-                        "dependency-graph-error",
-                        "Failed to build task dependency graph",
-                    )
-                };
-            issues.push(ValidationIssue {
-                task,
-                severity: Severity::Error,
-                category: category.to_string(),
-                message: message.to_string(),
-                details: Some(details),
-            });
+            if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
+                issues.push(cycle_issue(cycle, details));
+            } else {
+                issues.push(ValidationIssue {
+                    task: "task graph".to_string(),
+                    severity: Severity::Error,
+                    category: "dependency-graph-error".to_string(),
+                    message: "Failed to build task dependency graph".to_string(),
+                    details: Some(details),
+                });
+                if let Some(issue) = self.find_cycle_in_valid_subgraph(&config, &tasks).await {
+                    issues.push(issue);
+                }
+            }
         }
         for task in &tasks {
             issues.extend(self.validate_task(task, &all_tasks, &config).await);
@@ -147,6 +138,35 @@ impl TasksValidate {
         }
 
         Ok(())
+    }
+
+    async fn find_cycle_in_valid_subgraph(
+        &self,
+        config: &Arc<Config>,
+        tasks: &[Task],
+    ) -> Option<ValidationIssue> {
+        let mut valid_tasks = Vec::new();
+        for task in tasks {
+            match Deps::new(config, vec![task.clone()]).await {
+                Ok(_) => valid_tasks.push(task.clone()),
+                Err(err) => {
+                    if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
+                        return Some(cycle_issue(cycle, err.to_string()));
+                    }
+                }
+            }
+        }
+
+        // A wait_for relationship only applies when both tasks are selected, so
+        // retry the tasks whose individual graphs built successfully together.
+        if valid_tasks.len() > 1 {
+            if let Err(err) = Deps::new(config, valid_tasks).await {
+                if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
+                    return Some(cycle_issue(cycle, err.to_string()));
+                }
+            }
+        }
+        None
     }
 
     fn get_all_tasks(&self, all_tasks: &BTreeMap<String, Task>) -> Vec<Task> {
@@ -700,6 +720,22 @@ impl TasksValidate {
         }
 
         Ok(())
+    }
+}
+
+fn cycle_issue(cycle: &TaskCycleError, details: String) -> ValidationIssue {
+    let task = cycle
+        .path()
+        .first()
+        .map(String::as_str)
+        .unwrap_or("task graph")
+        .to_string();
+    ValidationIssue {
+        task,
+        severity: Severity::Error,
+        category: "circular-dependency".to_string(),
+        message: "Circular dependency detected".to_string(),
+        details: Some(details),
     }
 }
 

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -8,6 +8,7 @@ use crate::file;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{
     Deps, GetMatchingExt, Task, TaskCycleError, build_task_ref_map, resolve_task_pattern,
+    task_cycle_label,
 };
 use crate::tera::contains_template_syntax;
 use crate::ui::style;
@@ -88,15 +89,15 @@ impl TasksValidate {
         let mut issues = Vec::new();
         if let Err(err) = Deps::new(&config, tasks.clone()).await {
             let details = err.to_string();
-            let additional_issues = self.find_additional_graph_issues(&config, &tasks).await;
             if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                if !additional_issues
-                    .iter()
-                    .any(|issue| issue.category == "circular-dependency")
-                {
-                    issues.push(cycle_issue(cycle, details));
-                }
+                issues.extend(
+                    self.find_additional_graph_issues(&config, &tasks, Some((cycle, details)))
+                        .await,
+                );
             } else {
+                let additional_issues = self
+                    .find_additional_graph_issues(&config, &tasks, None)
+                    .await;
                 let graph_error_is_represented = additional_issues.iter().any(|issue| {
                     issue.category == "dependency-graph-error"
                         && issue.details.as_deref() == Some(details.as_str())
@@ -104,8 +105,8 @@ impl TasksValidate {
                 if !graph_error_is_represented {
                     issues.push(graph_error_issue("task graph", details));
                 }
+                issues.extend(additional_issues);
             }
-            issues.extend(additional_issues);
         }
         for task in &tasks {
             issues.extend(self.validate_task(task, &all_tasks, &config).await);
@@ -148,17 +149,21 @@ impl TasksValidate {
         &self,
         config: &Arc<Config>,
         tasks: &[Task],
+        initial_cycle: Option<(&TaskCycleError, String)>,
     ) -> Vec<ValidationIssue> {
         let mut issues = Vec::new();
         let mut valid_tasks = Vec::new();
-        let mut found_cycle = None;
+        let mut reported_cycles = HashSet::new();
         let mut reported_error_details = HashSet::new();
+        if let Some((cycle, details)) = initial_cycle {
+            push_cycle_issue(&mut issues, &mut reported_cycles, cycle, details);
+        }
         for task in tasks {
             match Deps::new(config, vec![task.clone()]).await {
                 Ok(_) => valid_tasks.push(task.clone()),
                 Err(err) => {
                     if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                        found_cycle.get_or_insert_with(|| cycle_issue(cycle, err.to_string()));
+                        push_cycle_issue(&mut issues, &mut reported_cycles, cycle, err.to_string());
                     } else {
                         let details = err.to_string();
                         reported_error_details.insert(details.clone());
@@ -170,22 +175,26 @@ impl TasksValidate {
 
         // A wait_for relationship only applies when both tasks are selected, so
         // retry the tasks whose individual graphs built successfully together.
-        let combined_error = if valid_tasks.len() > 1 {
-            Deps::new(config, valid_tasks).await.err()
-        } else {
-            None
-        };
-        if let Some(err) = combined_error {
+        while valid_tasks.len() > 1 {
+            let Some(err) = Deps::new(config, valid_tasks.clone()).await.err() else {
+                break;
+            };
             if let Some(cycle) = err.downcast_ref::<TaskCycleError>() {
-                found_cycle.get_or_insert_with(|| cycle_issue(cycle, err.to_string()));
+                push_cycle_issue(&mut issues, &mut reported_cycles, cycle, err.to_string());
+                let cycle_labels: HashSet<_> = cycle.path().iter().map(String::as_str).collect();
+                let previous_len = valid_tasks.len();
+                valid_tasks.retain(|task| !cycle_labels.contains(task_cycle_label(task).as_str()));
+                if valid_tasks.len() == previous_len {
+                    break;
+                }
             } else {
                 let details = err.to_string();
                 if reported_error_details.insert(details.clone()) {
                     issues.push(graph_error_issue("task graph", details));
                 }
+                break;
             }
         }
-        issues.extend(found_cycle);
         issues
     }
 
@@ -757,6 +766,36 @@ fn cycle_issue(cycle: &TaskCycleError, details: String) -> ValidationIssue {
         message: "Circular dependency detected".to_string(),
         details: Some(details),
     }
+}
+
+fn push_cycle_issue(
+    issues: &mut Vec<ValidationIssue>,
+    reported_cycles: &mut HashSet<Vec<String>>,
+    cycle: &TaskCycleError,
+    details: String,
+) {
+    if reported_cycles.insert(canonical_cycle(cycle.path())) {
+        issues.push(cycle_issue(cycle, details));
+    }
+}
+
+fn canonical_cycle(path: &[String]) -> Vec<String> {
+    let path = if path.len() > 1 && path.first() == path.last() {
+        &path[..path.len() - 1]
+    } else {
+        path
+    };
+    (0..path.len())
+        .map(|offset| {
+            path.iter()
+                .cycle()
+                .skip(offset)
+                .take(path.len())
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .min()
+        .unwrap_or_default()
 }
 
 fn graph_error_issue(task: &str, details: String) -> ValidationIssue {

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -17,9 +17,9 @@ use tokio::sync::mpsc;
 /// Unique key for a task instance, including name, args, and env vars
 pub type TaskKey = (String, Vec<String>, Vec<(String, String)>);
 
-#[derive(Debug)]
 pub struct TaskCycleError {
     paths: Vec<Vec<String>>,
+    keys: Vec<Vec<TaskKey>>,
 }
 
 impl TaskCycleError {
@@ -29,6 +29,18 @@ impl TaskCycleError {
 
     pub fn paths(&self) -> &[Vec<String>] {
         &self.paths
+    }
+
+    pub(crate) fn keys(&self) -> &[Vec<TaskKey>] {
+        &self.keys
+    }
+}
+
+impl fmt::Debug for TaskCycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TaskCycleError")
+            .field("paths", &self.paths)
+            .finish_non_exhaustive()
     }
 }
 
@@ -180,7 +192,11 @@ impl Deps {
                         .collect()
                 })
                 .collect();
-            return Err(eyre::Report::new(TaskCycleError { paths }));
+            let keys = cycles
+                .iter()
+                .map(|cycle| cycle.iter().map(|&idx| task_key(&graph[idx])).collect())
+                .collect();
+            return Err(eyre::Report::new(TaskCycleError { paths, keys }));
         }
         let (tx, _) = mpsc::unbounded_channel();
         let sent = HashSet::new();

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -3,9 +3,10 @@ use crate::config::env_directive::EnvDirective;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Task, dep_has_usage_ref, parse_usage_values_from_task};
 use crate::{config::Config, task::task_list::resolve_depends};
+use eyre::eyre;
 use itertools::Itertools;
 use petgraph::Direction;
-use petgraph::graph::DiGraph;
+use petgraph::graph::{DiGraph, NodeIndex};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -124,6 +125,13 @@ impl Deps {
                 stack.push(b.clone());
             }
             seen.insert(a);
+        }
+        if let Some(cycle) = find_cycle(&graph) {
+            let cycle = cycle
+                .iter()
+                .map(|&idx| task_cycle_label(&graph[idx]))
+                .join(" -> ");
+            return Err(eyre!("circular dependency detected: {cycle}"));
         }
         let (tx, _) = mpsc::unbounded_channel();
         let sent = HashSet::new();
@@ -331,4 +339,96 @@ fn leaves(graph: &DiGraph<Task, ()>) -> Vec<Task> {
         .externals(Direction::Outgoing)
         .map(|idx| graph[idx].clone())
         .collect()
+}
+
+fn task_cycle_label(task: &Task) -> String {
+    if task.args.is_empty() {
+        task.name.clone()
+    } else {
+        format!("{} {}", task.name, task.args.join(" "))
+    }
+}
+
+fn find_cycle(graph: &DiGraph<Task, ()>) -> Option<Vec<NodeIndex>> {
+    fn visit(
+        graph: &DiGraph<Task, ()>,
+        node: NodeIndex,
+        states: &mut HashMap<NodeIndex, u8>,
+        stack: &mut Vec<NodeIndex>,
+    ) -> Option<Vec<NodeIndex>> {
+        states.insert(node, 1);
+        stack.push(node);
+
+        for dependency in graph.neighbors_directed(node, Direction::Outgoing) {
+            match states.get(&dependency).copied().unwrap_or_default() {
+                0 => {
+                    if let Some(cycle) = visit(graph, dependency, states, stack) {
+                        return Some(cycle);
+                    }
+                }
+                1 => {
+                    let start = stack.iter().position(|&idx| idx == dependency)?;
+                    let mut cycle = stack[start..].to_vec();
+                    cycle.push(dependency);
+                    return Some(cycle);
+                }
+                _ => {}
+            }
+        }
+
+        stack.pop();
+        states.insert(node, 2);
+        None
+    }
+
+    let mut states = HashMap::new();
+    let mut stack = Vec::new();
+    for node in graph.node_indices() {
+        if !states.contains_key(&node)
+            && let Some(cycle) = visit(graph, node, &mut states, &mut stack)
+        {
+            return Some(cycle);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(name: &str) -> Task {
+        Task {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn finds_cycle_path() {
+        let mut graph = DiGraph::new();
+        let a = graph.add_node(task("a"));
+        let b = graph.add_node(task("b"));
+        let c = graph.add_node(task("c"));
+        graph.update_edge(a, b, ());
+        graph.update_edge(b, c, ());
+        graph.update_edge(c, a, ());
+
+        let cycle = find_cycle(&graph).unwrap();
+        let labels = cycle
+            .iter()
+            .map(|&idx| task_cycle_label(&graph[idx]))
+            .collect_vec();
+        assert_eq!(labels, ["a", "b", "c", "a"]);
+    }
+
+    #[test]
+    fn accepts_acyclic_graph() {
+        let mut graph = DiGraph::new();
+        let a = graph.add_node(task("a"));
+        let b = graph.add_node(task("b"));
+        graph.update_edge(b, a, ());
+
+        assert!(find_cycle(&graph).is_none());
+    }
 }

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -364,7 +364,7 @@ fn leaves(graph: &DiGraph<Task, ()>) -> Vec<Task> {
         .collect()
 }
 
-fn task_cycle_label(task: &Task) -> String {
+pub(crate) fn task_cycle_label(task: &Task) -> String {
     let label = if task.args.is_empty() {
         task.name.clone()
     } else {

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -5,6 +5,7 @@ use crate::task::{Task, dep_has_usage_ref, parse_usage_values_from_task};
 use crate::{config::Config, task::task_list::resolve_depends};
 use itertools::Itertools;
 use petgraph::Direction;
+use petgraph::algo::kosaraju_scc;
 use petgraph::graph::{DiGraph, NodeIndex};
 use std::{
     collections::{HashMap, HashSet},
@@ -18,12 +19,16 @@ pub type TaskKey = (String, Vec<String>, Vec<(String, String)>);
 
 #[derive(Debug)]
 pub struct TaskCycleError {
-    path: Vec<String>,
+    paths: Vec<Vec<String>>,
 }
 
 impl TaskCycleError {
     pub fn path(&self) -> &[String] {
-        &self.path
+        self.paths.first().map(Vec::as_slice).unwrap_or_default()
+    }
+
+    pub fn paths(&self) -> &[Vec<String>] {
+        &self.paths
     }
 }
 
@@ -32,7 +37,7 @@ impl fmt::Display for TaskCycleError {
         write!(
             f,
             "circular dependency detected: {}",
-            self.path.iter().join(" -> ")
+            self.path().iter().join(" -> ")
         )
     }
 }
@@ -72,6 +77,21 @@ pub fn task_key(task: &Task) -> TaskKey {
 /// manages a dependency graph of tasks so `mise run` knows what to run next
 impl Deps {
     pub async fn new(config: &Arc<Config>, tasks: Vec<Task>) -> eyre::Result<Self> {
+        Self::new_with_cycle_limit(config, tasks, Some(1)).await
+    }
+
+    pub(crate) async fn new_for_validation(
+        config: &Arc<Config>,
+        tasks: Vec<Task>,
+    ) -> eyre::Result<Self> {
+        Self::new_with_cycle_limit(config, tasks, None).await
+    }
+
+    async fn new_with_cycle_limit(
+        config: &Arc<Config>,
+        tasks: Vec<Task>,
+        cycle_limit: Option<usize>,
+    ) -> eyre::Result<Self> {
         let mut graph = DiGraph::new();
         let mut indexes = HashMap::new();
         let mut stack = vec![];
@@ -149,12 +169,18 @@ impl Deps {
             }
             seen.insert(a);
         }
-        if let Some(cycle) = find_cycle(&graph) {
-            let path = cycle
+        let cycles = find_cycles(&graph, cycle_limit);
+        if !cycles.is_empty() {
+            let paths = cycles
                 .iter()
-                .map(|&idx| task_cycle_label(&graph[idx]))
+                .map(|cycle| {
+                    cycle
+                        .iter()
+                        .map(|&idx| task_cycle_label(&graph[idx]))
+                        .collect()
+                })
                 .collect();
-            return Err(eyre::Report::new(TaskCycleError { path }));
+            return Err(eyre::Report::new(TaskCycleError { paths }));
         }
         let (tx, _) = mpsc::unbounded_channel();
         let sent = HashSet::new();
@@ -388,73 +414,78 @@ pub(crate) fn task_cycle_label(task: &Task) -> String {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
-enum VisitState {
-    #[default]
-    Unvisited,
-    InProgress,
-    Complete,
-}
-
-fn find_cycle(graph: &DiGraph<Task, ()>) -> Option<Vec<NodeIndex>> {
-    let mut states = HashMap::new();
-    for root in graph.node_indices() {
-        if states.get(&root).copied().unwrap_or_default() != VisitState::Unvisited {
+fn find_cycles(graph: &DiGraph<Task, ()>, limit: Option<usize>) -> Vec<Vec<NodeIndex>> {
+    let mut cycles = Vec::new();
+    for mut component in kosaraju_scc(graph) {
+        component.sort_by_key(|node| node.index());
+        let component: HashSet<_> = component.into_iter().collect();
+        if component.len() == 1 {
+            let node = *component.iter().next().unwrap();
+            if graph.find_edge(node, node).is_some() {
+                cycles.push(vec![node, node]);
+            }
+            if limit.is_some_and(|limit| cycles.len() >= limit) {
+                return cycles;
+            }
             continue;
         }
 
-        states.insert(root, VisitState::InProgress);
-        let mut path = vec![root];
-        let mut stack = vec![(
-            root,
-            graph
-                .neighbors_directed(root, Direction::Outgoing)
-                .collect_vec(),
-            0,
-        )];
+        let mut starts = component.iter().copied().collect_vec();
+        starts.sort_by_key(|node| node.index());
+        for start in starts {
+            let mut path = vec![start];
+            let mut in_path = HashSet::from([start]);
+            let mut stack = vec![(
+                start,
+                graph
+                    .neighbors_directed(start, Direction::Outgoing)
+                    .filter(|node| component.contains(node))
+                    .sorted_by_key(|node| node.index())
+                    .collect_vec(),
+                0,
+            )];
 
-        while !stack.is_empty() {
-            let dependency = {
-                let (_, dependencies, next) = stack.last_mut().unwrap();
-                if *next < dependencies.len() {
-                    let dependency = dependencies[*next];
-                    *next += 1;
-                    Some(dependency)
-                } else {
-                    None
-                }
-            };
+            while !stack.is_empty() {
+                let dependency = {
+                    let (_, dependencies, next) = stack.last_mut().unwrap();
+                    if *next < dependencies.len() {
+                        let dependency = dependencies[*next];
+                        *next += 1;
+                        Some(dependency)
+                    } else {
+                        None
+                    }
+                };
 
-            let Some(dependency) = dependency else {
-                let (node, _, _) = stack.pop().unwrap();
-                path.pop();
-                states.insert(node, VisitState::Complete);
-                continue;
-            };
-
-            match states.get(&dependency).copied().unwrap_or_default() {
-                VisitState::Unvisited => {
-                    states.insert(dependency, VisitState::InProgress);
+                let Some(dependency) = dependency else {
+                    let (node, _, _) = stack.pop().unwrap();
+                    path.pop();
+                    in_path.remove(&node);
+                    continue;
+                };
+                if dependency == start {
+                    let mut cycle = path.clone();
+                    cycle.push(start);
+                    cycles.push(cycle);
+                    if limit.is_some_and(|limit| cycles.len() >= limit) {
+                        return cycles;
+                    }
+                } else if dependency.index() >= start.index() && in_path.insert(dependency) {
                     path.push(dependency);
                     stack.push((
                         dependency,
                         graph
                             .neighbors_directed(dependency, Direction::Outgoing)
+                            .filter(|node| component.contains(node))
+                            .sorted_by_key(|node| node.index())
                             .collect_vec(),
                         0,
                     ));
                 }
-                VisitState::InProgress => {
-                    let start = path.iter().position(|&idx| idx == dependency)?;
-                    let mut cycle = path[start..].to_vec();
-                    cycle.push(dependency);
-                    return Some(cycle);
-                }
-                VisitState::Complete => {}
             }
         }
     }
-    None
+    cycles
 }
 
 #[cfg(test)]
@@ -478,7 +509,7 @@ mod tests {
         graph.update_edge(b, c, ());
         graph.update_edge(c, a, ());
 
-        let cycle = find_cycle(&graph).unwrap();
+        let cycle = find_cycles(&graph, Some(1)).pop().unwrap();
         let labels = cycle
             .iter()
             .map(|&idx| task_cycle_label(&graph[idx]))
@@ -493,7 +524,7 @@ mod tests {
         let b = graph.add_node(task("b"));
         graph.update_edge(b, a, ());
 
-        assert!(find_cycle(&graph).is_none());
+        assert!(find_cycles(&graph, None).is_empty());
     }
 
     #[test]
@@ -506,7 +537,34 @@ mod tests {
             graph.update_edge(pair[0], pair[1], ());
         }
 
-        assert!(find_cycle(&graph).is_none());
+        assert!(find_cycles(&graph, None).is_empty());
+    }
+
+    #[test]
+    fn finds_overlapping_cycles() {
+        let mut graph = DiGraph::new();
+        let root = graph.add_node(task("root"));
+        let left = graph.add_node(task("left"));
+        let right = graph.add_node(task("right"));
+        graph.update_edge(root, left, ());
+        graph.update_edge(left, root, ());
+        graph.update_edge(root, right, ());
+        graph.update_edge(right, root, ());
+
+        let cycles = find_cycles(&graph, None)
+            .into_iter()
+            .map(|cycle| {
+                cycle
+                    .iter()
+                    .map(|&idx| task_cycle_label(&graph[idx]))
+                    .collect_vec()
+            })
+            .collect_vec();
+
+        assert_eq!(
+            cycles,
+            [["root", "left", "root"], ["root", "right", "root"]]
+        );
     }
 
     #[test]

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -365,21 +365,45 @@ fn leaves(graph: &DiGraph<Task, ()>) -> Vec<Task> {
 }
 
 fn task_cycle_label(task: &Task) -> String {
-    if task.args.is_empty() {
+    let label = if task.args.is_empty() {
         task.name.clone()
     } else {
         format!("{} {}", task.name, task.args.join(" "))
+    };
+    let env_keys = task
+        .env
+        .0
+        .iter()
+        .filter_map(|directive| match directive {
+            EnvDirective::Val(key, _, _) => Some(key),
+            _ => None,
+        })
+        .sorted()
+        .unique()
+        .join(", ");
+    if env_keys.is_empty() {
+        label
+    } else {
+        format!("{label} [env: {env_keys}]")
     }
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum VisitState {
+    #[default]
+    Unvisited,
+    InProgress,
+    Complete,
 }
 
 fn find_cycle(graph: &DiGraph<Task, ()>) -> Option<Vec<NodeIndex>> {
     let mut states = HashMap::new();
     for root in graph.node_indices() {
-        if states.contains_key(&root) {
+        if states.get(&root).copied().unwrap_or_default() != VisitState::Unvisited {
             continue;
         }
 
-        states.insert(root, 1);
+        states.insert(root, VisitState::InProgress);
         let mut path = vec![root];
         let mut stack = vec![(
             root,
@@ -404,13 +428,13 @@ fn find_cycle(graph: &DiGraph<Task, ()>) -> Option<Vec<NodeIndex>> {
             let Some(dependency) = dependency else {
                 let (node, _, _) = stack.pop().unwrap();
                 path.pop();
-                states.insert(node, 2);
+                states.insert(node, VisitState::Complete);
                 continue;
             };
 
             match states.get(&dependency).copied().unwrap_or_default() {
-                0 => {
-                    states.insert(dependency, 1);
+                VisitState::Unvisited => {
+                    states.insert(dependency, VisitState::InProgress);
                     path.push(dependency);
                     stack.push((
                         dependency,
@@ -420,13 +444,13 @@ fn find_cycle(graph: &DiGraph<Task, ()>) -> Option<Vec<NodeIndex>> {
                         0,
                     ));
                 }
-                1 => {
+                VisitState::InProgress => {
                     let start = path.iter().position(|&idx| idx == dependency)?;
                     let mut cycle = path[start..].to_vec();
                     cycle.push(dependency);
                     return Some(cycle);
                 }
-                _ => {}
+                VisitState::Complete => {}
             }
         }
     }
@@ -483,5 +507,25 @@ mod tests {
         }
 
         assert!(find_cycle(&graph).is_none());
+    }
+
+    #[test]
+    fn cycle_label_disambiguates_environment_variants_without_values() {
+        let mut task = task("build");
+        task.args = vec!["linux".to_string()];
+        task.env.0 = vec![
+            EnvDirective::Val(
+                "TOKEN".to_string(),
+                "secret".to_string(),
+                Default::default(),
+            ),
+            EnvDirective::Val(
+                "TARGET".to_string(),
+                "linux".to_string(),
+                Default::default(),
+            ),
+        ];
+
+        assert_eq!(task_cycle_label(&task), "build linux [env: TARGET, TOKEN]");
     }
 }

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -3,18 +3,41 @@ use crate::config::env_directive::EnvDirective;
 use crate::task::task_fetcher::TaskFetcher;
 use crate::task::{Task, dep_has_usage_ref, parse_usage_values_from_task};
 use crate::{config::Config, task::task_list::resolve_depends};
-use eyre::eyre;
 use itertools::Itertools;
 use petgraph::Direction;
 use petgraph::graph::{DiGraph, NodeIndex};
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     sync::Arc,
 };
 use tokio::sync::mpsc;
 
 /// Unique key for a task instance, including name, args, and env vars
 pub type TaskKey = (String, Vec<String>, Vec<(String, String)>);
+
+#[derive(Debug)]
+pub struct TaskCycleError {
+    path: Vec<String>,
+}
+
+impl TaskCycleError {
+    pub fn path(&self) -> &[String] {
+        &self.path
+    }
+}
+
+impl fmt::Display for TaskCycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "circular dependency detected: {}",
+            self.path.iter().join(" -> ")
+        )
+    }
+}
+
+impl std::error::Error for TaskCycleError {}
 
 #[derive(Debug)]
 pub struct Deps {
@@ -127,11 +150,11 @@ impl Deps {
             seen.insert(a);
         }
         if let Some(cycle) = find_cycle(&graph) {
-            let cycle = cycle
+            let path = cycle
                 .iter()
                 .map(|&idx| task_cycle_label(&graph[idx]))
-                .join(" -> ");
-            return Err(eyre!("circular dependency detected: {cycle}"));
+                .collect();
+            return Err(eyre::Report::new(TaskCycleError { path }));
         }
         let (tx, _) = mpsc::unbounded_channel();
         let sent = HashSet::new();
@@ -350,44 +373,61 @@ fn task_cycle_label(task: &Task) -> String {
 }
 
 fn find_cycle(graph: &DiGraph<Task, ()>) -> Option<Vec<NodeIndex>> {
-    fn visit(
-        graph: &DiGraph<Task, ()>,
-        node: NodeIndex,
-        states: &mut HashMap<NodeIndex, u8>,
-        stack: &mut Vec<NodeIndex>,
-    ) -> Option<Vec<NodeIndex>> {
-        states.insert(node, 1);
-        stack.push(node);
+    let mut states = HashMap::new();
+    for root in graph.node_indices() {
+        if states.contains_key(&root) {
+            continue;
+        }
 
-        for dependency in graph.neighbors_directed(node, Direction::Outgoing) {
+        states.insert(root, 1);
+        let mut path = vec![root];
+        let mut stack = vec![(
+            root,
+            graph
+                .neighbors_directed(root, Direction::Outgoing)
+                .collect_vec(),
+            0,
+        )];
+
+        while !stack.is_empty() {
+            let dependency = {
+                let (_, dependencies, next) = stack.last_mut().unwrap();
+                if *next < dependencies.len() {
+                    let dependency = dependencies[*next];
+                    *next += 1;
+                    Some(dependency)
+                } else {
+                    None
+                }
+            };
+
+            let Some(dependency) = dependency else {
+                let (node, _, _) = stack.pop().unwrap();
+                path.pop();
+                states.insert(node, 2);
+                continue;
+            };
+
             match states.get(&dependency).copied().unwrap_or_default() {
                 0 => {
-                    if let Some(cycle) = visit(graph, dependency, states, stack) {
-                        return Some(cycle);
-                    }
+                    states.insert(dependency, 1);
+                    path.push(dependency);
+                    stack.push((
+                        dependency,
+                        graph
+                            .neighbors_directed(dependency, Direction::Outgoing)
+                            .collect_vec(),
+                        0,
+                    ));
                 }
                 1 => {
-                    let start = stack.iter().position(|&idx| idx == dependency)?;
-                    let mut cycle = stack[start..].to_vec();
+                    let start = path.iter().position(|&idx| idx == dependency)?;
+                    let mut cycle = path[start..].to_vec();
                     cycle.push(dependency);
                     return Some(cycle);
                 }
                 _ => {}
             }
-        }
-
-        stack.pop();
-        states.insert(node, 2);
-        None
-    }
-
-    let mut states = HashMap::new();
-    let mut stack = Vec::new();
-    for node in graph.node_indices() {
-        if !states.contains_key(&node)
-            && let Some(cycle) = visit(graph, node, &mut states, &mut stack)
-        {
-            return Some(cycle);
         }
     }
     None
@@ -428,6 +468,19 @@ mod tests {
         let a = graph.add_node(task("a"));
         let b = graph.add_node(task("b"));
         graph.update_edge(b, a, ());
+
+        assert!(find_cycle(&graph).is_none());
+    }
+
+    #[test]
+    fn accepts_deep_acyclic_graph() {
+        let mut graph = DiGraph::new();
+        let nodes = (0..10_000)
+            .map(|i| graph.add_node(task(&format!("task-{i}"))))
+            .collect_vec();
+        for pair in nodes.windows(2) {
+            graph.update_edge(pair[0], pair[1], ());
+        }
 
         assert!(find_cycle(&graph).is_none());
     }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -75,7 +75,6 @@ use crate::file::display_path;
 use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
 use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, Toolset};
 use crate::ui::style;
-pub(crate) use deps::task_cycle_label;
 pub use deps::{Deps, TaskCycleError, TaskKey};
 use task_dep::TaskDep;
 use task_sources::{RawOutputTemplates, TaskOutputs};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -75,6 +75,7 @@ use crate::file::display_path;
 use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
 use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, Toolset};
 use crate::ui::style;
+pub(crate) use deps::task_cycle_label;
 pub use deps::{Deps, TaskCycleError, TaskKey};
 use task_dep::TaskDep;
 use task_sources::{RawOutputTemplates, TaskOutputs};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1124,14 +1124,14 @@ impl Task {
 
     pub fn all_depends(&self, tasks: &BTreeMap<String, Task>) -> Result<Vec<Task>> {
         let tasks_ref = build_task_ref_map(tasks.iter());
-        let mut path = vec![self.name.clone()];
-        self.all_depends_recursive(&tasks_ref, &mut path)
+        let mut visited = HashSet::from([self.name.clone()]);
+        self.all_depends_recursive(&tasks_ref, &mut visited)
     }
 
     fn all_depends_recursive(
         &self,
         tasks: &BTreeMap<String, &Task>,
-        path: &mut Vec<String>,
+        visited: &mut HashSet<String>,
     ) -> Result<Vec<Task>> {
         let mut depends: Vec<Task> = self
             .depends
@@ -1143,20 +1143,14 @@ impl Task {
             .filter_ok(|t| t.name != self.name)
             .collect::<Result<Vec<_>>>()?;
 
-        // Collect transitive dependencies with cycle detection
+        // Collect transitive dependencies without following the same task twice.
+        // Cycle detection happens after the runtime graph has resolved wait_for,
+        // depends_post direction, usage templates, args, and environment variants.
         for dep in depends.clone() {
-            if path.contains(&dep.name) {
-                // Circular dependency detected - build path string for error message
-                let cycle_path = path
-                    .iter()
-                    .skip_while(|&name| name != &dep.name)
-                    .chain(std::iter::once(&dep.name))
-                    .join(" -> ");
-                return Err(eyre!("circular dependency detected: {}", cycle_path));
+            if !visited.insert(dep.name.clone()) {
+                continue;
             }
-            path.push(dep.name.clone());
-            let mut extra = dep.all_depends_recursive(tasks, path)?;
-            path.pop(); // Remove from path after processing this branch
+            let mut extra = dep.all_depends_recursive(tasks, visited)?;
             extra.retain(|t| t.name != self.name); // prevent depending on ourself
             depends.extend(extra);
         }
@@ -3633,7 +3627,7 @@ echo "hello world"
     }
 
     #[test]
-    fn test_circular_dependency_detection() {
+    fn test_circular_dependency_resolution_terminates() {
         use super::Task;
         use std::collections::BTreeMap;
 
@@ -3663,15 +3657,12 @@ echo "hello world"
         tasks.insert("task_a".to_string(), task_a.clone());
         tasks.insert("task_b".to_string(), task_b);
 
-        // Should detect circular dependency
-        let result = task_a.all_depends(&tasks);
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(err_msg.contains("circular dependency detected"));
+        let deps = task_a.all_depends(&tasks).unwrap();
+        assert_eq!(deps.iter().map(|t| &t.name).collect::<Vec<_>>(), ["task_b"]);
     }
 
     #[test]
-    fn test_transitive_circular_dependency_detection() {
+    fn test_transitive_circular_dependency_resolution_terminates() {
         use super::Task;
         use std::collections::BTreeMap;
 
@@ -3712,11 +3703,11 @@ echo "hello world"
         tasks.insert("task_b".to_string(), task_b);
         tasks.insert("task_c".to_string(), task_c);
 
-        // Should detect circular dependency
-        let result = task_a.all_depends(&tasks);
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(err_msg.contains("circular dependency detected"));
+        let deps = task_a.all_depends(&tasks).unwrap();
+        assert_eq!(
+            deps.iter().map(|t| &t.name).collect::<Vec<_>>(),
+            ["task_b", "task_c"]
+        );
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -75,7 +75,7 @@ use crate::file::display_path;
 use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
 use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, Toolset};
 use crate::ui::style;
-pub use deps::{Deps, TaskKey};
+pub use deps::{Deps, TaskCycleError, TaskKey};
 use task_dep::TaskDep;
 use task_sources::{RawOutputTemplates, TaskOutputs};
 


### PR DESCRIPTION
## Summary

- detect circular task dependencies after building the fully resolved scheduler graph
- include `wait_for`, rendered `{{usage.*}}` dependencies, task arguments, and the actual `depends_post` edge direction
- reuse runtime graph validation in `mise tasks validate`
- report the concrete cycle path before any task begins executing

## Root cause

Cycle detection previously ran while recursively collecting `depends` and `depends_post` definitions. That traversal excluded `wait_for` and deferred usage-templated dependencies, and it treated `depends_post` as having the same direction as `depends`. As a result, some real cycles reached the scheduler's no-leaves panic path, while some valid post-dependency graphs were rejected.

The dependency collector now only prevents recursive rediscovery. The completed runtime graph is the authoritative source for cycle detection.

Addresses [discussion #11318](https://github.com/jdx/mise/discussions/11318).

## Validation

- `cargo test task::deps::tests`
- `cargo test circular_dependency_resolution_terminates`
- `cargo test no_false_positive_for_diamond_dependency`
- `mise run test:e2e e2e/tasks/test_task_validate`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task scheduling and validation paths; behavior shifts for cycles, wait_for, templated deps, and depends_post, though covered by new unit and e2e tests.
> 
> **Overview**
> **Circular dependency detection** now runs on the fully resolved scheduler graph (`Deps`) instead of a shallow recursive walk over `depends` / `depends_post`. That graph includes **`wait_for`**, rendered **`{{usage.*}}`** dependencies, args/env task instances, and the real **`depends_post`** edge direction—so cycles surface with a concrete path in both **`mise tasks validate`** and **`mise run`** (via `TaskCycleError`).
> 
> **`mise tasks validate`** builds the graph up front, reports **`circular-dependency`** vs **`dependency-graph-error`** separately, deduplicates cycles (including env-variant keys), and can still surface cycles when other tasks fail graph construction. Per-task recursive cycle checks were removed; **`all_depends`** only avoids revisiting names and no longer errors on cycles.
> 
> E2E coverage adds **`wait_for`**, usage-default cycles, mixed failure scenarios, and confirms **`depends_post` + `depends`** can validate and run as acyclic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2def8f06087eb26ed3a0391ef990e2504696b40d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circular-dependency handling: validation now reports a consistent `circular dependency detected: ...` message with the complete cycle path (including `wait_for` and nested task defaults).
  * Validation now clearly separates circular-dependency errors from dependency-graph build failures, including consistent `--json` error counting.
  * Direct and transitive circular reference resolution now succeeds and returns the deduplicated dependency set.
  * Fixed execution ordering for acyclic effective scheduling graphs involving post-dependencies.
* **Tests**
  * Expanded end-to-end assertions for cycle detection, non-cycle graph build failures, and `depends_post` execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->