### PR TITLE
fix(brew): resolve link targets one hop when collecting a keg's links for prune

### DIFF
--- a/src/system/packages/brew/maintenance.rs
+++ b/src/system/packages/brew/maintenance.rs
@@ -268,13 +268,20 @@ fn symlink_points_into(link: &Path, keg: &Path) -> bool {
     let Ok(target) = std::fs::read_link(link) else {
         return false;
     };
-    let target = if target.is_absolute() {
-        target
-    } else {
-        link.parent().unwrap_or_else(|| Path::new("/")).join(target)
+    // resolve one hop only, like link_keg's ownership checks — a Cellar
+    // dylib alias is itself a relative symlink, and chasing the chain
+    // resolved it against the CWD, leaving such links behind as dangling
+    let target =
+        pour::lexical_normalize(&link.parent().unwrap_or_else(|| Path::new("/")).join(target));
+    // canonicalize the parent only, for path spelling (/var -> /private/var);
+    // the final component must stay unresolved
+    let resolved = match (target.parent(), target.file_name()) {
+        (Some(dir), Some(name)) => std::fs::canonicalize(dir)
+            .map(|d| d.join(name))
+            .unwrap_or_else(|_| target.clone()),
+        _ => target.clone(),
     };
-    let keg = file::desymlink_path(keg);
-    file::desymlink_path(&target).starts_with(keg)
+    resolved.starts_with(file::desymlink_path(keg))
 }
 
 fn remove_empty_parents(path: &Path, stop: &Path) -> Result<()> {
@@ -560,6 +567,47 @@ mod tests {
         assert!(tmp.path().join("opt").exists());
         assert!(!keg.exists());
         assert!(!tmp.path().join("Cellar").join("jq").exists());
+        Ok(())
+    }
+
+    /// a prefix link to a Cellar dylib alias resolves through a relative
+    /// symlink chain and must still be removed, not left dangling
+    #[test]
+    fn unlink_and_remove_keg_removes_dylib_alias_links() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let keg = write_keg(
+            tmp.path(),
+            "foo",
+            "1.0",
+            r#"{"installed_on_request":true,"source":{"tap":"homebrew/core"}}"#,
+        )?;
+        file::create_dir_all(keg.join("lib"))?;
+        file::write(keg.join("lib").join("libfoo.1.dylib"), "")?;
+        file::make_symlink(
+            Path::new("libfoo.1.dylib"),
+            &keg.join("lib").join("libfoo.dylib"),
+        )?;
+        let lib = tmp.path().join("lib");
+        file::create_dir_all(&lib)?;
+        for name in ["libfoo.1.dylib", "libfoo.dylib"] {
+            file::make_symlink(
+                &Path::new("../Cellar/foo/1.0/lib").join(name),
+                &lib.join(name),
+            )?;
+        }
+        let candidate = PruneCandidate {
+            name: "foo".to_string(),
+            version: "1.0".to_string(),
+            keg: keg.clone(),
+        };
+
+        unlink_and_remove_keg(&candidate)?;
+
+        assert!(lib.join("libfoo.1.dylib").symlink_metadata().is_err());
+        assert!(lib.join("libfoo.dylib").symlink_metadata().is_err());
+        assert!(!keg.exists());
         Ok(())
     }
 

--- a/src/system/packages/brew/pour.rs
+++ b/src/system/packages/brew/pour.rs
@@ -311,7 +311,7 @@ fn points_into_cellar(link: &Path) -> bool {
 }
 
 /// Normalize `.` and `..` components without touching the filesystem.
-fn lexical_normalize(path: &Path) -> PathBuf {
+pub(super) fn lexical_normalize(path: &Path) -> PathBuf {
     let mut out = PathBuf::new();
     for part in path.components() {
         match part {


### PR DESCRIPTION
## Summary

Follow-up to #11320, as noted in its description: prune's `symlink_points_into` resolves link targets the same broken way that `can_overwrite` used to, so `mise bootstrap packages prune` removes the keg but leaves some of its prefix links behind, dangling.

The links it misses are the unversioned dylib aliases, which exist for nearly every library formula. After pruning e.g. a formula `foo`, the prefix ends up with:

```
/opt/homebrew/lib/libfoo.dylib -> ../Cellar/foo/1.0/lib/libfoo.dylib   (dangling, keg is gone)
```

Anything that scans `lib/` and tries to open the file (linkers, build scripts) then fails on a path that looks present but leads nowhere.

## The bug

Link collection for prune happens here:

https://github.com/jdx/mise/blob/28ea5190cee0f45afb814b339643e6d2595cec3b/src/system/packages/brew/maintenance.rs#L261-L278

`desymlink_path` follows the whole symlink chain, and the chain of a dylib alias link has two hops:

1. `read_link(/opt/homebrew/lib/libfoo.dylib)` returns `../Cellar/foo/1.0/lib/libfoo.dylib`; joining it with the link's parent gives a path whose final component is the Cellar alias, which is itself a symlink.
2. `desymlink_path` therefore calls `read_link` again and gets the alias's raw target `libfoo.1.dylib`, a bare relative path. Canonicalizing that resolves it against the current working directory, fails, and the relative path is returned as-is.
3. `"libfoo.1.dylib".starts_with(keg)` is false, so the link is not collected, and pruning leaves it behind.

This is the same failure #11320 fixed in `can_overwrite`, where it made upgrades of brew-linked (and mise-linked) formulae abort. Here nothing aborts; the damage is just quieter.

## Fix

Resolve the target one hop, the same way #11320 made the ownership checks in `link_keg` work ([`points_into_cellar`](https://github.com/jdx/mise/blob/28ea5190cee0f45afb814b339643e6d2595cec3b/src/system/packages/brew/pour.rs#L305-L312)): join the `read_link` result with the link's parent directory and clean up `.`/`..` textually, reusing `lexical_normalize` from `pour.rs`. Whether a link belongs to the keg is a property of the link itself, not of where its target's own chain continues.

This is also how brew itself decides which links to remove on `brew unlink`, the direct analogue of this operation ([keg.rb#L370-L373](https://github.com/Homebrew/brew/blob/c70b438415d2fca15b6aa2d6a80be4431404417e/Library/Homebrew/keg.rb#L370-L373)):

```ruby
# check whether the file to be unlinked is from the current keg first
next unless dst.symlink?
next if src != dst.resolved_path
```

One difference from `points_into_cellar`: the keg path this function compares against comes out of `desymlink_path`, i.e. fully canonicalized, while the walked prefix paths keep the prefix's own spelling. So the parent directory of the one-hop target is still canonicalized to bridge the spelling (`/var` vs `/private/var` on macOS); only the final component stays unresolved.

## Testing

- New unit test: prune a keg whose prefix links include both the versioned dylib and its alias, and assert both links are gone afterwards. It fails on main with the alias link left dangling (verified by running it against the old implementation).
- `cargo test --bin mise system::packages::brew`: 120 passed, no regressions.
- `cargo fmt` / `cargo clippy` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew maintenance cleanup to correctly identify symlink chains pointing into package directories.
  * Fixed removal of invalid library alias links and their associated package directories.
  * Added coverage for relative symlink chains to help prevent cleanup regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->