### PR TITLE
chore(ci): reject Windows unused-code warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,8 +286,10 @@ jobs:
         with:
           shared-key: build
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
-      - name: cargo clippy
-        run: cargo clippy -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets -- -D warnings
+      - name: check unused code
+        run: cargo check -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets
+        env:
+          RUSTFLAGS: -D unused
       - name: cargo test
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,7 +287,7 @@ jobs:
           shared-key: build
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - name: cargo clippy
-        run: cargo clippy --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets -- -D warnings
+        run: cargo clippy -p mise --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets -- -D warnings
       - name: cargo test
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,6 +286,8 @@ jobs:
         with:
           shared-key: build
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
+      - name: cargo clippy
+        run: cargo clippy --all-features --all-targets -- -D warnings
       - name: cargo test
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,7 +287,7 @@ jobs:
           shared-key: build
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' }}
       - name: cargo clippy
-        run: cargo clippy --all-features --all-targets -- -D warnings
+        run: cargo clippy --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update --all-targets -- -D warnings
       - name: cargo test
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -29,7 +29,9 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::{fmt::Debug, sync::Arc};
 use versions::Versioning;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -15,7 +15,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use eyre::{Result, bail};
+#[cfg(unix)]
+use eyre::Result;
+use eyre::bail;
 use indexmap::IndexMap;
 use serde::Deserialize;
 

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -293,6 +293,7 @@ pub fn pending_plugin_packages_from_config(
 /// Aggregate `[bootstrap.packages]` from the current merged config plus every
 /// tracked config file, mirroring the way `mise prune` protects tool versions
 /// still referenced by other projects.
+#[cfg(unix)]
 pub async fn packages_from_config_and_tracked_config_files(
     config: &Arc<Config>,
 ) -> Result<Vec<ManagerPackages>> {
@@ -300,6 +301,7 @@ pub async fn packages_from_config_and_tracked_config_files(
     packages_from_config_files_and_tracked_config_files(&config.config_files, &tracked_config_files)
 }
 
+#[cfg(unix)]
 fn packages_from_config_files_and_tracked_config_files(
     current_config_files: &ConfigMap,
     tracked_config_files: &ConfigMap,
@@ -323,6 +325,7 @@ fn packages_from_config_files_and_tracked_config_files(
     resolve_managers(by_mgr, false)
 }
 
+#[cfg(unix)]
 fn merge_manager_packages(
     by_mgr: &mut IndexMap<String, Vec<PackageRequest>>,
     manager_packages: Vec<ManagerPackages>,

--- a/src/system/sudo.rs
+++ b/src/system/sudo.rs
@@ -57,6 +57,7 @@ pub(crate) fn argv_with_env(
 /// - `"noninteractive"`: no TTY; the subprocess must use `sudo -n` so it
 ///   fails instead of hanging on a password prompt
 /// - `"deny"`: elevation is disabled or sudo is unavailable
+#[cfg(unix)]
 pub(crate) fn subprocess_mode() -> &'static str {
     if is_root() {
         "interactive"

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,5 @@
 use std::env::join_paths;
+#[cfg(unix)]
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
@@ -110,10 +111,12 @@ fn init() {
 /// Unit tests run single-threaded (`RUST_TEST_THREADS=1` in `.cargo/config.toml`
 /// and in the `test:unit` task), so a guarded set/read/restore sequence is not
 /// observed by other tests.
+#[cfg(unix)]
 pub struct EnvVarGuard {
     prev: Vec<(OsString, Option<OsString>)>,
 }
 
+#[cfg(unix)]
 impl EnvVarGuard {
     pub fn new() -> Self {
         Self { prev: vec![] }
@@ -127,6 +130,7 @@ impl EnvVarGuard {
     }
 }
 
+#[cfg(unix)]
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         // restore in reverse so repeated sets of the same key unwind correctly


### PR DESCRIPTION
## Summary

- check the Rust `unused` lint group across all mise targets on Windows
- use the same Windows-supported feature set as the existing build job
- gate Unix-only imports, helpers, and test utilities to their actual target

## Why

Windows builds emitted warnings for Unix-only code, as reported in [discussion #11251](https://github.com/jdx/mise/discussions/11251). Similar warnings were fixed in #10149 and #10425, but the Windows CI jobs continued to allow warnings, so regressions were not detected.

The new standalone `check unused code` step makes platform-specific `unused_imports` and `dead_code` failures visible before Windows unit tests.

## Validation

- `mise run lint-fix`
- Windows `check unused code` CI step
