### PR TITLE
docs(settings): render markdown in choice descriptions

### DIFF
--- a/docs/components/setting.vue
+++ b/docs/components/setting.vue
@@ -43,8 +43,8 @@ defineProps(["setting", "level"]);
           >
             <code>{{ choice.value }}</code
             ><template v-if="choice.description">
-              – {{ choice.description }}</template
-            >
+              – <span v-html="choice.description"></span
+            ></template>
           </template>
           <template v-else>
             <code>{{ choice }}</code>

--- a/docs/settings.data.ts
+++ b/docs/settings.data.ts
@@ -50,7 +50,14 @@ export default {
         default: default_,
         docs: md.render(props.docs ?? props.description),
         deprecated: props.deprecated,
-        enum: props.enum,
+        enum: props.enum?.map((choice) =>
+          typeof choice === "object" && choice !== null && choice.description
+            ? {
+                ...choice,
+                description: md.renderInline(choice.description),
+              }
+            : choice,
+        ),
         env: props.env,
         parseEnv: getParseEnv(props.parse_env),
         optional: !props.default_docs && props.optional,


### PR DESCRIPTION
## Summary
- render structured setting choice descriptions as inline Markdown
- display the rendered markup in the settings choices list

## Root cause

The settings data loader rendered top-level descriptions with `markdown-it`, but passed `enum` descriptions through unchanged. Vue then escaped those descriptions as plain text, exposing backticks in the generated settings documentation.

## Impact

Inline markup such as `` `mise install` `` and `` `.venv` `` now renders consistently with the rest of the settings documentation. This addresses [discussion #11331](https://github.com/jdx/mise/discussions/11331).

## Validation
- `mise run docs:build`
- `mise run lint-fix`
- inspected generated HTML for `task.output` and `python.uv_venv_auto`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; HTML comes from the same trusted `settings.toml` source already used for `setting.docs` via `v-html`.
> 
> **Overview**
> **Settings docs** now treat **enum choice descriptions** the same as main setting text: the data loader runs **`markdown-it` inline** on structured choices, and **`setting.vue`** renders those strings with **`v-html`** instead of escaped plain text.
> 
> Inline code and other markup in choices (e.g. for `task.output`, `python.uv_venv_auto`) should display correctly in the generated settings reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7236cba4c28a58f90561d1f6427941f8fa12d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enum option descriptions in the settings documentation now support formatted inline content.
  * Rich descriptions are displayed consistently in the settings interface and generated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->