### PR TITLE
docs(tasks): clarify shebang argument behavior

### DIFF
--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -32,7 +32,14 @@ Extra arguments will be passed to the task, for example, if we want to run in re
 mise run build --release
 ```
 
-If there are multiple commands, the args are only passed to the last command.
+For a precise, validated task interface, define arguments and flags with the
+[`usage` field](/tasks/task-arguments#usage-field). Without a `usage` specification, extra arguments
+are forwarded according to how the task is executed:
+
+- If `run` is an array, the arguments are passed only to its last entry.
+- For a regular inline shell command, the arguments are appended to the command text.
+- A [shebang task](/tasks/toml-tasks#shell-shebang) is executed as a script file, so its interpreter
+  exposes the arguments normally—for example, as `$1` and `$@` in Bash.
 
 Because everything after the task name belongs to the task, mise's own flags have to come
 _before_ it—`mise run --silent build` rather than `mise run build --silent`, which passes

--- a/docs/tasks/toml-tasks.md
+++ b/docs/tasks/toml-tasks.md
@@ -239,6 +239,23 @@ cargo clippy
 '''
 ```
 
+Shebang tasks are executed as script files. Extra arguments that are not defined by a
+[`usage` specification](/tasks/task-arguments#usage-field) are passed as normal script arguments,
+such as `$1` and `$@` in Bash:
+
+```mise-toml
+[tasks.greet]
+run = '''
+#!/usr/bin/env bash
+echo "hello $1"
+'''
+```
+
+```shell
+$ mise run greet world
+hello world
+```
+
 By using a `shebang` (or `shell`), you can run tasks in different languages (e.g., Python, Node.js, Ruby, etc.):
 
 ::: code-group

--- a/e2e/tasks/test_task_shell
+++ b/e2e/tasks/test_task_shell
@@ -34,6 +34,10 @@ tasks.bashshebang3 = """
 echo "{{arg(name='a')}}"
 echo "{{arg(name='b', var=true)}}"
 """
+tasks.bashshebangargs = """
+#!/usr/bin/env bash
+printf '<%s>\\n' "\$@"
+"""
 tasks.escapenode = """
 #!/usr/bin/env -S python3
 print("{{arg(name='a')}}")
@@ -49,6 +53,8 @@ assert "mise run bashshebang2 my_a hello 'world of mise'" "my_a
 hello 'world of mise'"
 assert "mise run bashshebang3 my_a hello 'world of mise'" "my_a
 hello 'world of mise'"
+assert "mise run bashshebangargs 'a with space' second" "<a with space>
+<second>"
 assert "mise run escapenode my_a hello 'world of mise'" "my_a
 hello 'world of mise'"
 assert "mise run escapenode 'a with space' hello 'world of mise'" "a with space


### PR DESCRIPTION
## Summary
- recommend `usage` definitions for precise, validated task interfaces
- clarify argument forwarding for `run` arrays, inline shell commands, and shebang scripts
- document that shebang tasks receive normal interpreter arguments such as `$1` and `$@`
- add E2E coverage that preserves argument boundaries for shebang TOML tasks

## Motivation
[Discussion #11334](https://github.com/jdx/mise/discussions/11334) highlighted that “arguments are passed to the last command” could be read as the last line of a multiline script. In the implementation, it refers to the last entry of a `run` array. Shebang bodies are executed as script files, so forwarded arguments are exposed through the interpreter's normal argv mechanism.

This documents the existing behavior while steering tasks that need a precise argument contract toward the `usage` field.

## Validation
- `mise run test:e2e tasks/test_task_shell`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and e2e test only; no production code paths changed.
> 
> **Overview**
> **Documents how extra task arguments are forwarded** when there is no `usage` spec, replacing the single “last command only” line with three cases: last entry of a `run` array, append for inline shell, and normal script argv (`$1` / `$@`) for shebang tasks.
> 
> **Shebang section in TOML tasks** gains a short explanation plus a `greet` example showing `mise run greet world`.
> 
> **E2E** adds `bashshebangargs` to assert forwarded args reach `$@` with spaces preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ca734e56550e1fde3bd80c6f050627051a5613c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how task arguments are forwarded when no `usage` definition is provided.
  * Added guidance and examples for shebang-based tasks and positional script arguments.
  * Recommended defining precise, validated task interfaces with the `usage` field.

* **Tests**
  * Added coverage confirming that shebang-based tasks correctly receive multiple arguments, including arguments containing spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->