### PR TITLE
fix(task): run newly executable file tasks

### DIFF
--- a/e2e/tasks/test_task_non_executable_error
+++ b/e2e/tasks/test_task_non_executable_error
@@ -54,3 +54,27 @@ chmod +x mise-tasks/build mise-tasks/test
 assert_contains "mise tasks" "build"
 assert_contains "mise tasks" "test"
 assert "mise run build" "building"
+
+# Monorepo-qualified task names should resolve to the scoped task include directory
+mkdir -p monorepo/projects/frontend/mise-tasks
+cat <<EOF >monorepo/mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/*"]
+EOF
+cat <<'EOF' >monorepo/projects/frontend/mise-tasks/build
+#!/usr/bin/env bash
+echo "frontend building"
+EOF
+chmod 0644 monorepo/projects/frontend/mise-tasks/build
+
+cd monorepo
+assert "MISE_EXPERIMENTAL=1 MISE_YES=1 mise run '//projects/frontend:build'" "frontend building"
+[[ -x projects/frontend/mise-tasks/build ]] ||
+  fail "//projects/frontend:build did not make the task executable"
+
+chmod 0644 projects/frontend/mise-tasks/build
+cd projects/frontend
+assert "MISE_EXPERIMENTAL=1 MISE_YES=1 mise run ':build'" "frontend building"
+[[ -x mise-tasks/build ]] || fail ":build did not make the task executable"

--- a/e2e/tasks/test_task_non_executable_error
+++ b/e2e/tasks/test_task_non_executable_error
@@ -22,12 +22,32 @@ cat <<EOF >mise.toml
 EOF
 
 # Running a task should give a helpful error mentioning non-executable files
-assert_fail_contains "mise run build" "non-executable"
-assert_fail_contains "mise run build" "chmod +x"
+assert_fail_contains "MISE_YES=0 mise run build" "non-executable"
+assert_fail_contains "MISE_YES=0 mise run build" "chmod +x"
 
 # mise tasks ls should warn about non-executable files
 assert_contains "mise tasks 2>&1" "non-executable"
 assert_contains "mise tasks 2>&1" "chmod +x"
+
+# Auto-confirm should make the requested file executable and run it immediately
+assert "MISE_YES=1 mise run build" "building"
+[[ -x mise-tasks/build ]] || fail "MISE_YES did not make the task executable"
+
+assert "MISE_YES=0 mise --yes run test" "testing"
+[[ -x mise-tasks/test ]] || fail "--yes did not make the task executable"
+
+# The yes setting should behave the same way
+chmod 0644 mise-tasks/build
+cat <<EOF >mise.toml
+[tasks.existing]
+run = "true"
+EOF
+cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
+[settings]
+yes = true
+EOF
+assert "env -u MISE_YES mise run build" "building"
+[[ -x mise-tasks/build ]] || fail "yes setting did not make the task executable"
 
 # After making files executable, tasks should work
 chmod +x mise-tasks/build mise-tasks/test

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -614,6 +614,15 @@ impl Config {
         Ok(tasks_arc)
     }
 
+    pub async fn reload_tasks_with_context(
+        &self,
+        ctx: Option<&crate::task::TaskLoadContext>,
+    ) -> Result<Arc<BTreeMap<String, Task>>> {
+        let cache_key = ctx.cloned().unwrap_or_default();
+        self.tasks_cache.remove(&cache_key);
+        self.tasks_with_context(ctx).await
+    }
+
     pub async fn tasks_with_aliases(&self) -> Result<BTreeMap<String, Task>> {
         let tasks = self.tasks().await?;
         Ok(tasks

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -187,12 +187,30 @@ async fn make_task_executable(
     let Some(cwd) = &*dirs::CWD else {
         return Ok(None);
     };
-    let includes = config::task_includes_for_dir(cwd, &config.config_files)?;
-    let Some(path) = includes
-        .iter()
-        .map(|root| root.join(name))
-        .find(|path| path.is_file() && !file::is_executable(path))
-    else {
+    let (task_dir, task_name) = if let Some(name) = name.strip_prefix("//") {
+        let Some((scope, task_name)) = name.split_once(':') else {
+            return Ok(None);
+        };
+        let Some(monorepo_root) = config
+            .config_files
+            .values()
+            .find(|cf| cf.monorepo_root() == Some(true))
+            .and_then(|cf| cf.project_root())
+        else {
+            return Ok(None);
+        };
+        (monorepo_root.join(scope), task_name)
+    } else {
+        (cwd.clone(), name.strip_prefix(':').unwrap_or(name))
+    };
+    let includes = config::task_includes_for_dir(&task_dir, &config.config_files)?;
+    let Some(path) = includes.iter().find_map(|root| {
+        find_non_executable_task_files(std::slice::from_ref(root))
+            .into_iter()
+            .find(|path| {
+                Task::new(path, root, &task_dir).is_ok_and(|task| task.is_match(task_name))
+            })
+    }) else {
         return Ok(None);
     };
 
@@ -515,11 +533,11 @@ pub async fn get_task_lists(
             let is_default_task = t == "default" || {
                 t.starts_with("//") && t.ends_with(":default") && t[2..].matches(':').count() == 1
             };
-            if !is_default_task || !prompt || !console::user_attended_stderr() {
-                if let Some(task) = err_no_task(config, &t, effective_context.as_ref()).await? {
-                    tasks.push(task.with_args(args));
-                    continue;
-                }
+            if (!is_default_task || !prompt || !console::user_attended_stderr())
+                && let Some(task) = err_no_task(config, &t, effective_context.as_ref()).await?
+            {
+                tasks.push(task.with_args(args));
+                continue;
             }
             tasks.push(prompt_for_task().await?);
         } else {

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -176,7 +176,60 @@ fn append_available_tasks(
 }
 
 /// Show an error when a task is not found, with helpful suggestions
-async fn err_no_task(config: &Config, name: &str) -> Result<()> {
+async fn make_task_executable(
+    config: &Arc<Config>,
+    name: &str,
+    task_context: Option<&TaskLoadContext>,
+) -> Result<Option<Task>> {
+    if cfg!(windows) {
+        return Ok(None);
+    }
+    let Some(cwd) = &*dirs::CWD else {
+        return Ok(None);
+    };
+    let includes = config::task_includes_for_dir(cwd, &config.config_files)?;
+    let Some(path) = includes
+        .iter()
+        .map(|root| root.join(name))
+        .find(|path| path.is_file() && !file::is_executable(path))
+    else {
+        return Ok(None);
+    };
+
+    warn!(
+        "no task {} found, but a non-executable file exists at {}",
+        style::ered(name),
+        display_path(&path)
+    );
+    let confirmed = config::Settings::get().yes
+        || prompt::confirm("Mark this file as executable to allow it to be run as a task?")?;
+    if !confirmed {
+        return Ok(None);
+    }
+
+    file::make_executable(&path)?;
+    info!("marked as executable");
+    let all_tasks = config.reload_tasks_with_context(task_context).await?;
+    let tasks_with_aliases = crate::task::build_task_ref_map(all_tasks.iter());
+    let task = tasks_with_aliases
+        .get_matching(name)?
+        .into_iter()
+        .next()
+        .map(|task| (*task).clone());
+    ensure!(
+        task.is_some(),
+        "task {} was not found after marking {} as executable",
+        style::ered(name),
+        display_path(&path)
+    );
+    Ok(task)
+}
+
+async fn err_no_task(
+    config: &Arc<Config>,
+    name: &str,
+    task_context: Option<&TaskLoadContext>,
+) -> Result<Option<Task>> {
     // Check early if the name looks like a mistyped CLI subcommand
     let similar_cmds = suggest_similar_commands(name);
     let (tasks_for_error, showing_all_tasks) = tasks_for_missing_task_error(config, name).await?;
@@ -227,6 +280,10 @@ async fn err_no_task(config: &Config, name: &str) -> Result<()> {
             }
         }
 
+        if let Some(task) = make_task_executable(config, name, task_context).await? {
+            return Ok(Some(task));
+        }
+
         // Check if there are non-executable files in task include directories
         if !cfg!(windows)
             && let Some(cwd) = &*dirs::CWD
@@ -261,27 +318,8 @@ async fn err_no_task(config: &Config, name: &str) -> Result<()> {
             display_path(dirs::CWD.clone().unwrap_or_default())
         );
     }
-    if let Some(cwd) = &*dirs::CWD {
-        let includes = config::task_includes_for_dir(cwd, &config.config_files)?;
-        let path = includes
-            .iter()
-            .map(|d| d.join(name))
-            .find(|d| d.is_file() && !file::is_executable(d));
-        if let Some(path) = path
-            && !cfg!(windows)
-        {
-            warn!(
-                "no task {} found, but a non-executable file exists at {}",
-                style::ered(name),
-                display_path(&path)
-            );
-            let yn =
-                prompt::confirm("Mark this file as executable to allow it to be run as a task?")?;
-            if yn {
-                file::make_executable(&path)?;
-                info!("marked as executable, try running this task again");
-            }
-        }
+    if let Some(task) = make_task_executable(config, name, task_context).await? {
+        return Ok(Some(task));
     }
 
     // Suggest similar tasks using fuzzy matching for monorepo tasks
@@ -478,7 +516,10 @@ pub async fn get_task_lists(
                 t.starts_with("//") && t.ends_with(":default") && t[2..].matches(':').count() == 1
             };
             if !is_default_task || !prompt || !console::user_attended_stderr() {
-                err_no_task(config, &t).await?;
+                if let Some(task) = err_no_task(config, &t, effective_context.as_ref()).await? {
+                    tasks.push(task.with_args(args));
+                    continue;
+                }
             }
             tasks.push(prompt_for_task().await?);
         } else {


### PR DESCRIPTION
## Summary
- run a file task immediately after the user confirms making it executable
- honor `--yes`, `MISE_YES`, and the trusted global `yes` setting for this confirmation
- reload the applicable task discovery context so normal trust checks, task metadata, display names, and dependency handling still apply

## Root cause
The missing-task path changed the file mode but then unconditionally returned the original `no task found` error. It also called the interactive prompt directly without consulting the global `yes` setting. A simple rediscovery would still have returned the cached pre-`chmod` task list.

## User impact
Users no longer need to invoke `mise run` twice after accepting the executable-bit prompt. Automated confirmation modes now behave consistently with other mise prompts.

Addresses https://github.com/jdx/mise/discussions/11333

## Validation
- `mise run lint-fix`
- `mise run test:e2e tasks/test_task_non_executable_error`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the missing-task resolution path (permissions, cache reload, monorepo name mapping); behavior is user-facing but narrow and covered by e2e tests.
> 
> **Overview**
> Fixes the **non-executable file task** path so confirming (or auto-confirming) `chmod +x` **runs the task in the same `mise run`**, instead of chmod’ing and still failing with “no task found.”
> 
> **`make_task_executable`** centralizes discovery of a matching non-executable script (including monorepo names like `//projects/frontend:build` and `:build`), respects global **yes** (`MISE_YES`, `--yes`, `settings.yes`), marks the file executable, then **`reload_tasks_with_context`** clears the task cache and re-resolves the task. **`err_no_task`** can return that task; **`get_task_lists`** queues it like a normal match.
> 
> E2E coverage adds auto-confirm modes and monorepo-qualified runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6220093605b0ce85e2887fccecfc0d9ec17504aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved guidance when a task file isn’t executable, including `chmod +x` remediation.
  - With auto-confirmation enabled, non-executable task files can be made executable automatically and run as expected.
- **Bug Fixes**
  - Task discovery now refreshes correctly after fixing executability, and task resolution continues when a previously-missing match is found.
  - Better handling for monorepo-qualified task names (e.g., project-prefixed and shorthand forms).
- **Tests**
  - Expanded end-to-end coverage for non-executable detection, auto-confirm behavior, and task name resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->