### PR TITLE
feat(task): include dependency artifacts in cache keys

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -78,7 +78,8 @@ outside this tracker.
 ## Local cache parity
 
 - [x] Include dependency artifact keys in downstream task keys
-- [x] Allow dependents to restore after dependencies execute or restore
+- [x] Allow dependents to restore when dependencies publish stable artifact keys;
+      unkeyed dependency work still forces execution
 - [ ] Capture and replay stdout and stderr while respecting mise output modes
 - [ ] Cache useful results for tasks with no filesystem outputs
 - [ ] Support reusable and global input groups

--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -77,8 +77,8 @@ outside this tracker.
 
 ## Local cache parity
 
-- [ ] Include dependency artifact keys in downstream task keys
-- [ ] Allow dependents to restore after dependencies execute or restore
+- [x] Include dependency artifact keys in downstream task keys
+- [x] Allow dependents to restore after dependencies execute or restore
 - [ ] Capture and replay stdout and stderr while respecting mise output modes
 - [ ] Cache useful results for tasks with no filesystem outputs
 - [ ] Support reusable and global input groups

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -491,18 +491,19 @@ cache = { enabled = false }
 ```
 
 The cache key includes source contents, the task definition and arguments, resolved task environment,
-the values (or absence) of variables named in `cache.env`, resolved tool versions, and the operating
-system and architecture. Variables inherited from the ambient process are ignored unless listed in
-`cache.env`.
+the values (or absence) of variables named in `cache.env`, resolved tool versions, dependency
+artifact keys, and the operating system and architecture. Variables inherited from the ambient
+process are ignored unless listed in `cache.env`.
 
 Artifacts are stored under `MISE_CACHE_DIR/task-artifacts/v1` as zstd-compressed tar archives. They
 are included in the existing `mise cache clear` and `mise cache prune` behavior. Only successful task
 runs are cached. Cache read/write failures are treated as misses and never turn a successful task run
 into a failure.
 
-This initial implementation is local-only and does not cache or replay task logs. If a dependency
-executes or restores outputs during the current run, dependent tasks conservatively execute rather
-than restoring an artifact.
+This initial implementation is local-only and does not cache or replay task logs. Cacheable
+dependencies contribute their artifact keys to dependent task keys, so a dependent can restore the
+matching artifact after its dependencies execute, skip, or restore. If a dependency executes without
+a stable artifact key, its dependents conservatively execute.
 
 ### `shell`
 

--- a/e2e/tasks/test_task_artifact_cache_dependencies
+++ b/e2e/tasks/test_task_artifact_cache_dependencies
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+
+[tasks.lib]
+run = '''
+mkdir -p lib-dist
+cat lib.txt > lib-dist/result.txt
+printf 'ran\n' >> lib-runs.txt
+'''
+sources = ["lib.txt"]
+outputs = ["lib-dist"]
+
+[tasks.app]
+depends = ["lib"]
+run = '''
+mkdir -p app-dist
+cat lib-dist/result.txt app.txt > app-dist/result.txt
+printf 'ran\n' >> app-runs.txt
+'''
+sources = ["app.txt"]
+outputs = ["app-dist"]
+
+[tasks.prepare]
+run = '''
+mkdir -p prepare-dist
+cat prepare.txt > prepare-dist/result.txt
+printf 'ran\n' >> prepare-runs.txt
+'''
+sources = ["prepare.txt"]
+outputs = ["prepare-dist"]
+cache = { enabled = false }
+
+[tasks.consume]
+depends = ["prepare"]
+run = '''
+mkdir -p consume-dist
+cat prepare-dist/result.txt consume.txt > consume-dist/result.txt
+printf 'ran\n' >> consume-runs.txt
+'''
+sources = ["consume.txt"]
+outputs = ["consume-dist"]
+EOF
+
+printf 'lib-one\n' >lib.txt
+printf 'app\n' >app.txt
+printf 'prepare-one\n' >prepare.txt
+printf 'consume\n' >consume.txt
+
+mise run app
+assert "wc -l < lib-runs.txt | tr -d ' '" "1"
+assert "wc -l < app-runs.txt | tr -d ' '" "1"
+assert "cat app-dist/result.txt" $'lib-one\napp'
+
+# A fresh dependency still publishes its identity when it skips, allowing a
+# missing downstream output to restore.
+rm -rf app-dist
+assert_contains "mise run app 2>&1" "restored outputs from cache"
+assert "wc -l < lib-runs.txt | tr -d ' '" "1"
+assert "wc -l < app-runs.txt | tr -d ' '" "1"
+
+# A restored dependency contributes the same identity to the downstream key,
+# so both tasks can restore without executing.
+rm -rf lib-dist app-dist
+assert_contains "mise run app 2>&1" "restored outputs from cache"
+assert "wc -l < lib-runs.txt | tr -d ' '" "1"
+assert "wc -l < app-runs.txt | tr -d ' '" "1"
+assert "cat app-dist/result.txt" $'lib-one\napp'
+
+# Changing the dependency changes its artifact identity and invalidates the
+# downstream artifact even though the downstream task's own sources are unchanged.
+printf 'lib-two\n' >lib.txt
+mise run app
+assert "wc -l < lib-runs.txt | tr -d ' '" "2"
+assert "wc -l < app-runs.txt | tr -d ' '" "2"
+assert "cat app-dist/result.txt" $'lib-two\napp'
+
+# Returning to a previously cached dependency identity restores both the
+# dependency and the matching downstream artifact.
+printf 'lib-one\n' >lib.txt
+rm -rf lib-dist app-dist
+assert_contains "mise run app 2>&1" "restored outputs from cache"
+assert "wc -l < lib-runs.txt | tr -d ' '" "2"
+assert "wc -l < app-runs.txt | tr -d ' '" "2"
+assert "cat app-dist/result.txt" $'lib-one\napp'
+
+# A dependency that executes without a stable cache identity still forces
+# conservative downstream execution.
+mise run consume
+assert "wc -l < prepare-runs.txt | tr -d ' '" "1"
+assert "wc -l < consume-runs.txt | tr -d ' '" "1"
+printf 'prepare-two\n' >prepare.txt
+mise run consume
+assert "wc -l < prepare-runs.txt | tr -d ' '" "2"
+assert "wc -l < consume-runs.txt | tr -d ' '" "2"
+assert "cat consume-dist/result.txt" $'prepare-two\nconsume'

--- a/e2e/tasks/test_task_artifact_cache_dependencies
+++ b/e2e/tasks/test_task_artifact_cache_dependencies
@@ -45,12 +45,33 @@ printf 'ran\n' >> consume-runs.txt
 '''
 sources = ["consume.txt"]
 outputs = ["consume-dist"]
+
+[tasks.parent]
+depends_post = ["after"]
+run = '''
+mkdir -p parent-dist
+cat parent.txt > parent-dist/result.txt
+printf 'ran\n' >> parent-runs.txt
+'''
+sources = ["parent.txt"]
+outputs = ["parent-dist"]
+
+[tasks.after]
+run = '''
+mkdir -p after-dist
+cat parent-dist/result.txt after.txt > after-dist/result.txt
+printf 'ran\n' >> after-runs.txt
+'''
+sources = ["after.txt"]
+outputs = ["after-dist"]
 EOF
 
 printf 'lib-one\n' >lib.txt
 printf 'app\n' >app.txt
 printf 'prepare-one\n' >prepare.txt
 printf 'consume\n' >consume.txt
+printf 'parent-one\n' >parent.txt
+printf 'after\n' >after.txt
 
 mise run app
 assert "wc -l < lib-runs.txt | tr -d ' '" "1"
@@ -99,3 +120,18 @@ mise run consume
 assert "wc -l < prepare-runs.txt | tr -d ' '" "2"
 assert "wc -l < consume-runs.txt | tr -d ' '" "2"
 assert "cat consume-dist/result.txt" $'prepare-two\nconsume'
+
+# A post-dependency includes the parent artifact identity just like a regular
+# dependency, so it restores only for the matching parent outputs.
+mise run parent
+assert "wc -l < parent-runs.txt | tr -d ' '" "1"
+assert "wc -l < after-runs.txt | tr -d ' '" "1"
+rm -rf parent-dist after-dist
+assert_contains "mise run parent 2>&1" "restored outputs from cache"
+assert "wc -l < parent-runs.txt | tr -d ' '" "1"
+assert "wc -l < after-runs.txt | tr -d ' '" "1"
+printf 'parent-two\n' >parent.txt
+mise run parent
+assert "wc -l < parent-runs.txt | tr -d ' '" "2"
+assert "wc -l < after-runs.txt | tr -d ' '" "2"
+assert "cat after-dist/result.txt" $'parent-two\nafter'

--- a/e2e/tasks/test_task_delegation_dedup
+++ b/e2e/tasks/test_task_delegation_dedup
@@ -24,6 +24,12 @@ run = [{ task = "check:security" }]
 
 [tasks.all]
 depends = ["fix:security"]
+
+[tasks.sequence]
+run = [
+  { task = "check:security" },
+  { task = "check:security" },
+]
 EOF
 
 # "setup" output must appear exactly once (exclude the "$ echo ..." command line)
@@ -43,3 +49,15 @@ assert_contains "echo \"$output\"" "security check done"
 # Standalone call should still trigger setup as a dependency
 assert_contains "mise run -f check:security" ">>> SETUP RUNNING <<<"
 assert_contains "mise run -f check:security" "security check done"
+
+# Sequential injected graphs share completed state, so the second entry does
+# not repeat either the delegated task or its dependency.
+output="$(mise run -f sequence 2>&1)"
+setup_count="$(echo "$output" | grep -v '^\[setup\] \$' | grep -c '>>> SETUP RUNNING <<<')"
+security_count="$(echo "$output" | grep -v '^\[check:security\] \$' | grep -c 'security check done')"
+if [[ $setup_count -ne 1 || $security_count -ne 1 ]]; then
+  echo "Expected setup and check:security to run exactly once"
+  echo "Full output:"
+  echo "$output"
+  exit 1
+fi

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -636,16 +636,16 @@ impl Run {
         let semaphore = ctx.semaphore.clone();
         ctx.jset.lock().await.spawn(async move {
             let mut permit = permit_opt;
-            let (completed, dep_ran) = {
+            let (completion_state, dependency_state) = {
                 let deps = deps_for_remove.lock().await;
-                (deps.handled_task_keys(), deps.any_dep_ran(&task))
+                (deps.completion_state(), deps.dependency_state(&task))
             };
             let (result, panicked) = match AssertUnwindSafe(this.run_task_sched(
                 &task,
                 &ctx.config,
                 ctx.sched_tx.clone(),
-                completed,
-                dep_ran,
+                completion_state,
+                dependency_state,
                 semaphore,
                 &mut permit,
             ))
@@ -658,13 +658,17 @@ impl Run {
                     true,
                 ),
             };
-            // If the task actually ran (not skipped) and has sources defined,
+            // If the task executed or restored outputs and has sources defined,
             // mark it so dependents' source freshness checks are invalidated.
             // Tasks without sources always run and should not trigger invalidation.
-            if let Ok(true) = &result
-                && !task.sources.is_empty()
-            {
-                deps_for_remove.lock().await.mark_ran(&task);
+            if let Ok(outcome) = &result {
+                let mut deps = deps_for_remove.lock().await;
+                if outcome.did_work && !task.sources.is_empty() {
+                    deps.mark_did_work(&task);
+                }
+                if let Some(cache_key) = &outcome.cache_key {
+                    deps.mark_cache_key(&task, cache_key.clone());
+                }
             }
             if let Err(err) = &result {
                 let status = if panicked {
@@ -862,11 +866,11 @@ impl Run {
         task: &Task,
         config: &Arc<Config>,
         sched_tx: Arc<tokio::sync::mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
-        completed_tasks: std::collections::HashSet<crate::task::TaskKey>,
-        dep_ran: bool,
+        completion_state: crate::task::TaskCompletionState,
+        dependency_state: crate::task::TaskDependencyState,
         semaphore: Arc<tokio::sync::Semaphore>,
         permit: &mut Option<tokio::sync::OwnedSemaphorePermit>,
-    ) -> Result<bool> {
+    ) -> Result<crate::task::task_executor::TaskRunOutcome> {
         self.executor
             .as_ref()
             .expect("executor must be initialized before running tasks")
@@ -874,8 +878,8 @@ impl Run {
                 task,
                 config,
                 sched_tx,
-                completed_tasks,
-                dep_ran,
+                completion_state,
+                dependency_state,
                 semaphore,
                 permit,
             )

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -56,13 +56,28 @@ impl fmt::Display for TaskCycleError {
 
 impl std::error::Error for TaskCycleError {}
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaskDependencyState {
+    pub cache_keys: Vec<String>,
+    pub any_did_work: bool,
+    pub any_unkeyed_did_work: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TaskCompletionState {
+    completed: HashSet<TaskKey>,
+    did_work: HashSet<TaskKey>,
+    cache_keys: HashMap<TaskKey, String>,
+}
+
 #[derive(Debug)]
 pub struct Deps {
     pub graph: DiGraph<Task, ()>,
     sent: HashSet<TaskKey>, // tasks that have already started so should not run again
     removed: HashSet<TaskKey>, // tasks that have already finished to track if we are in an infinite loop
     executed: HashSet<TaskKey>, // tasks that actually began executing (not just scheduled)
-    ran: HashSet<TaskKey>, // tasks that actually ran their commands (not skipped due to fresh sources)
+    did_work: HashSet<TaskKey>, // tasks that executed or restored outputs (not freshness-skipped)
+    cache_keys: HashMap<TaskKey, String>, // stable artifact identities published by completed tasks
     dep_edges: HashMap<TaskKey, HashSet<TaskKey>>, // maps each task to its direct dependency task keys
     post_dep_parents: HashMap<TaskKey, HashSet<TaskKey>>, // maps each post-dep to its parent tasks
     tx: mpsc::UnboundedSender<Option<Task>>,
@@ -202,14 +217,16 @@ impl Deps {
         let sent = HashSet::new();
         let removed = HashSet::new();
         let executed = HashSet::new();
-        let ran = HashSet::new();
+        let did_work = HashSet::new();
+        let cache_keys = HashMap::new();
         Ok(Self {
             graph,
             tx,
             sent,
             removed,
             executed,
-            ran,
+            did_work,
+            cache_keys,
             dep_edges,
             post_dep_parents,
         })
@@ -221,13 +238,15 @@ impl Deps {
     pub async fn new_pruned(
         config: &Arc<Config>,
         tasks: Vec<Task>,
-        completed: &HashSet<TaskKey>,
+        completed: &TaskCompletionState,
     ) -> eyre::Result<Self> {
         let mut deps = Self::new(config, tasks).await?;
+        deps.did_work.extend(completed.did_work.iter().cloned());
+        deps.cache_keys.extend(completed.cache_keys.clone());
         let mut to_remove = vec![];
         for idx in deps.graph.node_indices() {
             let key = task_key(&deps.graph[idx]);
-            if completed.contains(&key) {
+            if completed.completed.contains(&key) {
                 to_remove.push(idx);
             }
         }
@@ -284,12 +303,13 @@ impl Deps {
         self.graph.node_count() == 0
     }
 
-    /// Snapshot of task keys that have completed (removed from the graph).
-    /// Used by `new_pruned` so sub-graphs skip tasks the parent already ran.
-    /// Only includes confirmed-complete tasks, not in-flight ones, to
-    /// preserve dependency ordering in the sub-graph.
-    pub fn handled_task_keys(&self) -> HashSet<TaskKey> {
-        self.removed.clone()
+    /// Snapshot completed task state for nested task sub-graphs.
+    pub fn completion_state(&self) -> TaskCompletionState {
+        TaskCompletionState {
+            completed: self.removed.clone(),
+            did_work: self.did_work.clone(),
+            cache_keys: self.cache_keys.clone(),
+        }
     }
 
     /// Check if a post-dep task should actually run: it must be a post-dependency
@@ -310,18 +330,36 @@ impl Deps {
         self.executed.insert(task_key(task));
     }
 
-    /// Mark a task as having actually run its commands (not skipped due to fresh sources).
+    /// Mark a task as having executed or restored outputs.
     /// Used to invalidate dependent tasks' source freshness checks.
-    pub fn mark_ran(&mut self, task: &Task) {
-        self.ran.insert(task_key(task));
+    pub fn mark_did_work(&mut self, task: &Task) {
+        self.did_work.insert(task_key(task));
     }
 
-    /// Check if any direct dependency of the given task actually ran (not skipped).
-    pub fn any_dep_ran(&self, task: &Task) -> bool {
+    /// Record a stable artifact identity produced or reused by a completed task.
+    pub fn mark_cache_key(&mut self, task: &Task, cache_key: String) {
+        self.cache_keys.insert(task_key(task), cache_key);
+    }
+
+    /// Return the completed direct-dependency state needed for freshness and artifact caching.
+    pub fn dependency_state(&self, task: &Task) -> TaskDependencyState {
         let key = task_key(task);
-        self.dep_edges
-            .get(&key)
-            .is_some_and(|deps| deps.iter().any(|dep_key| self.ran.contains(dep_key)))
+        let Some(deps) = self.dep_edges.get(&key) else {
+            return TaskDependencyState::default();
+        };
+        let mut cache_keys = deps
+            .iter()
+            .filter_map(|dep_key| self.cache_keys.get(dep_key).cloned())
+            .collect::<Vec<_>>();
+        cache_keys.sort();
+        cache_keys.dedup();
+        TaskDependencyState {
+            cache_keys,
+            any_did_work: deps.iter().any(|dep_key| self.did_work.contains(dep_key)),
+            any_unkeyed_did_work: deps.iter().any(|dep_key| {
+                self.did_work.contains(dep_key) && !self.cache_keys.contains_key(dep_key)
+            }),
+        }
     }
 
     /// Remove multiple tasks from the graph in a batch, emitting leaves only once at the end.

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -57,17 +57,31 @@ impl fmt::Display for TaskCycleError {
 impl std::error::Error for TaskCycleError {}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// State contributed by a task's completed direct dependencies.
 pub struct TaskDependencyState {
+    /// Stable artifact identities to include in the task's cache key.
     pub cache_keys: Vec<String>,
+    /// Whether any dependency executed or restored outputs.
     pub any_did_work: bool,
+    /// Whether any dependency did work without publishing a stable artifact identity.
     pub any_unkeyed_did_work: bool,
 }
 
 #[derive(Debug, Clone, Default)]
+/// Completed task state that can be propagated into a nested task graph.
 pub struct TaskCompletionState {
     completed: HashSet<TaskKey>,
     did_work: HashSet<TaskKey>,
     cache_keys: HashMap<TaskKey, String>,
+}
+
+impl TaskCompletionState {
+    /// Merge state returned by a completed nested task graph.
+    pub fn merge(&mut self, other: Self) {
+        self.completed.extend(other.completed);
+        self.did_work.extend(other.did_work);
+        self.cache_keys.extend(other.cache_keys);
+    }
 }
 
 #[derive(Debug)]
@@ -341,12 +355,16 @@ impl Deps {
         self.cache_keys.insert(task_key(task), cache_key);
     }
 
-    /// Return the completed direct-dependency state needed for freshness and artifact caching.
+    /// Return the completed dependency state needed for freshness and artifact caching.
     pub fn dependency_state(&self, task: &Task) -> TaskDependencyState {
         let key = task_key(task);
-        let Some(deps) = self.dep_edges.get(&key) else {
-            return TaskDependencyState::default();
-        };
+        let deps = self
+            .dep_edges
+            .get(&key)
+            .into_iter()
+            .flatten()
+            .chain(self.post_dep_parents.get(&key).into_iter().flatten())
+            .collect::<HashSet<_>>();
         let mut cache_keys = deps
             .iter()
             .filter_map(|dep_key| self.cache_keys.get(dep_key).cloned())
@@ -551,6 +569,101 @@ mod tests {
             name: name.to_string(),
             ..Default::default()
         }
+    }
+
+    fn deps_with_relationships(
+        dep_edges: HashMap<TaskKey, HashSet<TaskKey>>,
+        post_dep_parents: HashMap<TaskKey, HashSet<TaskKey>>,
+    ) -> Deps {
+        let (tx, _) = mpsc::unbounded_channel();
+        Deps {
+            graph: DiGraph::new(),
+            sent: HashSet::new(),
+            removed: HashSet::new(),
+            executed: HashSet::new(),
+            did_work: HashSet::new(),
+            cache_keys: HashMap::new(),
+            dep_edges,
+            post_dep_parents,
+            tx,
+        }
+    }
+
+    #[test]
+    fn dependency_state_tracks_direct_artifact_identity_and_unkeyed_work() {
+        let a = task("a");
+        let b = task("b");
+        let c = task("c");
+        let dep_edges = HashMap::from([
+            (task_key(&b), HashSet::from([task_key(&a)])),
+            (task_key(&c), HashSet::from([task_key(&b)])),
+        ]);
+        let mut deps = deps_with_relationships(dep_edges, HashMap::new());
+
+        deps.mark_did_work(&b);
+        assert_eq!(
+            deps.dependency_state(&c),
+            TaskDependencyState {
+                cache_keys: vec![],
+                any_did_work: true,
+                any_unkeyed_did_work: true,
+            }
+        );
+
+        deps.mark_cache_key(&b, "b-key".to_string());
+        assert_eq!(
+            deps.dependency_state(&c),
+            TaskDependencyState {
+                cache_keys: vec!["b-key".to_string()],
+                any_did_work: true,
+                any_unkeyed_did_work: false,
+            }
+        );
+    }
+
+    #[test]
+    fn dependency_state_includes_post_dependency_parents() {
+        let parent = task("parent");
+        let post = task("post");
+        let post_dep_parents =
+            HashMap::from([(task_key(&post), HashSet::from([task_key(&parent)]))]);
+        let mut deps = deps_with_relationships(HashMap::new(), post_dep_parents);
+
+        deps.mark_did_work(&parent);
+        deps.mark_cache_key(&parent, "parent-key".to_string());
+
+        assert_eq!(
+            deps.dependency_state(&post),
+            TaskDependencyState {
+                cache_keys: vec!["parent-key".to_string()],
+                any_did_work: true,
+                any_unkeyed_did_work: false,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn new_pruned_preserves_completed_artifact_state() {
+        let completed_task = task("completed");
+        let key = task_key(&completed_task);
+        let completion_state = TaskCompletionState {
+            completed: HashSet::from([key.clone()]),
+            did_work: HashSet::from([key.clone()]),
+            cache_keys: HashMap::from([(key.clone(), "completed-key".to_string())]),
+        };
+        let config = Config::get().await.unwrap();
+
+        let deps = Deps::new_pruned(&config, vec![completed_task], &completion_state)
+            .await
+            .unwrap();
+        let propagated = deps.completion_state();
+
+        assert!(deps.is_empty());
+        assert!(propagated.did_work.contains(&key));
+        assert_eq!(
+            propagated.cache_keys.get(&key).map(String::as_str),
+            Some("completed-key")
+        );
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -78,7 +78,7 @@ use crate::file::display_path;
 use crate::fuzzy::{FuzzyMatcher, FuzzyPattern};
 use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions, Toolset};
 use crate::ui::style;
-pub use deps::{Deps, TaskCycleError, TaskKey};
+pub use deps::{Deps, TaskCompletionState, TaskCycleError, TaskDependencyState, TaskKey};
 use task_dep::TaskDep;
 use task_sources::{RawOutputTemplates, TaskOutputs};
 

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -36,6 +36,8 @@ struct CacheKeyMaterial<'a> {
     outputs: Vec<String>,
     root: PathBuf,
     source_hash: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dependency_keys: Vec<String>,
     environment: BTreeMap<String, Option<String>>,
     vars: BTreeMap<String, String>,
     tools: Vec<String>,
@@ -63,6 +65,7 @@ impl TaskArtifactCache {
         toolset: &Toolset,
         resolved_env: &BTreeMap<String, String>,
         declared_env: &[(String, String)],
+        dependency_keys: &[String],
         persist_content_hash_cache: bool,
     ) -> Result<Option<Self>> {
         Settings::get().ensure_experimental("task artifact caching")?;
@@ -124,6 +127,7 @@ impl TaskArtifactCache {
             outputs: task.outputs.patterns(),
             root: inputs.root_identity,
             source_hash: inputs.source_hash,
+            dependency_keys: dependency_keys.to_vec(),
             environment,
             vars,
             tools,

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -667,6 +667,7 @@ impl TaskExecutor {
         let (env, task_env) = full_env;
         use crate::task::RunEntry;
         let mut script_iter = rendered_scripts.into_iter();
+        let mut completion_state = completion_state.clone();
 
         let needs_tera = task.run().iter().any(RunEntry::has_tera_template);
         let mut tera_state = if needs_tera {
@@ -735,16 +736,18 @@ impl TaskExecutor {
                     // but we're holding the only one).
                     let had_permit = permit.is_some();
                     *permit = None;
-                    self.inject_and_wait(
-                        config,
-                        &[resolved_spec],
-                        task_env,
-                        override_args.as_deref(),
-                        override_env_ref,
-                        sched_tx.clone(),
-                        completion_state,
-                    )
-                    .await?;
+                    let completed = self
+                        .inject_and_wait(
+                            config,
+                            &[resolved_spec],
+                            task_env,
+                            override_args.as_deref(),
+                            override_env_ref,
+                            sched_tx.clone(),
+                            &completion_state,
+                        )
+                        .await?;
+                    completion_state.merge(completed);
                     if had_permit {
                         *permit = Some(semaphore.clone().acquire_owned().await?);
                     }
@@ -757,16 +760,18 @@ impl TaskExecutor {
                     guard = None; // drop lock before waiting on sub-tasks
                     let had_permit = permit.is_some();
                     *permit = None;
-                    self.inject_and_wait(
-                        config,
-                        &resolved_tasks,
-                        task_env,
-                        None,
-                        None,
-                        sched_tx.clone(),
-                        completion_state,
-                    )
-                    .await?;
+                    let completed = self
+                        .inject_and_wait(
+                            config,
+                            &resolved_tasks,
+                            task_env,
+                            None,
+                            None,
+                            sched_tx.clone(),
+                            &completion_state,
+                        )
+                        .await?;
+                    completion_state.merge(completed);
                     if had_permit {
                         *permit = Some(semaphore.clone().acquire_owned().await?);
                     }
@@ -786,7 +791,7 @@ impl TaskExecutor {
         override_env: Option<&[(String, String)]>,
         sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
         completion_state: &TaskCompletionState,
-    ) -> Result<()> {
+    ) -> Result<TaskCompletionState> {
         use crate::task::TaskLoadContext;
         trace!("inject start: {}", specs.join(", "));
         // Build tasks list from specs
@@ -947,7 +952,8 @@ impl TaskExecutor {
             return Err(eyre!("task sequence aborted due to failure"));
         }
 
-        Ok(())
+        let completion_state = sub_deps.lock().await.completion_state();
+        Ok(completion_state)
     }
 
     async fn exec_script(

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -8,7 +8,6 @@ use crate::file::is_executable;
 use crate::file::{display_path, replace_path};
 use crate::sandbox::SandboxConfig;
 use crate::task::TaskArtifactCache;
-use crate::task::TaskKey;
 use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_list::split_task_spec;
 use crate::task::task_output::{TaskOutput, trunc};
@@ -18,6 +17,7 @@ use crate::task::task_source_checker::{
     remove_auto_output, save_checksum, sources_are_fresh, task_cwd,
 };
 use crate::task::{Deps, FailedTasks, GetMatchingExt, Task};
+use crate::task::{TaskCompletionState, TaskDependencyState};
 use crate::tera::{contains_template_syntax, render_str};
 use crate::toolset::env_cache::CachedEnv;
 use crate::ui::{style, time};
@@ -143,6 +143,12 @@ pub struct TaskExecutor {
     pub sandbox: crate::sandbox::SandboxConfig,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaskRunOutcome {
+    pub did_work: bool,
+    pub cache_key: Option<String>,
+}
+
 impl TaskExecutor {
     pub fn new(
         context_builder: TaskContextBuilder,
@@ -253,37 +259,38 @@ impl TaskExecutor {
         self.timings || Settings::get().task.timings.unwrap_or(default)
     }
 
-    /// Run a task, returning true if the task actually executed (not skipped).
+    /// Run a task, returning whether it did work and any stable artifact identity
+    /// it produced or reused.
     #[allow(clippy::too_many_arguments)]
     pub async fn run_task_sched(
         &self,
         task: &Task,
         config: &Arc<Config>,
         sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
-        completed_tasks: HashSet<TaskKey>,
-        dep_ran: bool,
+        completion_state: TaskCompletionState,
+        dependency_state: TaskDependencyState,
         semaphore: Arc<Semaphore>,
         permit: &mut Option<OwnedSemaphorePermit>,
-    ) -> Result<bool> {
+    ) -> Result<TaskRunOutcome> {
         let prefix = task.estyled_prefix();
         let total_start = std::time::Instant::now();
         if Settings::get().task.skip.contains(&task.name) {
             if !self.quiet(Some(task)) {
                 self.eprint(task, &prefix, "skipping task");
             }
-            return Ok(false);
+            return Ok(TaskRunOutcome::default());
         }
-        // If any dependency actually ran, skip the source freshness check
-        // so that downstream tasks are invalidated by upstream changes
+        // If any dependency executed or restored, skip the source freshness check
+        // so that downstream tasks are invalidated by upstream changes.
         if !task.cache.as_ref().is_some_and(|cache| cache.enabled)
             && !self.force
-            && !dep_ran
+            && !dependency_state.any_did_work
             && sources_are_fresh(task, config).await?
         {
             if !self.quiet(Some(task)) {
                 self.eprint(task, &prefix, "sources up-to-date, skipping");
             }
-            return Ok(false);
+            return Ok(TaskRunOutcome::default());
         }
 
         let mut tools = self.tool.clone();
@@ -473,20 +480,36 @@ impl TaskExecutor {
         self.check_confirmation(config, task, &env).await?;
 
         let artifact_cache = if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
-            match TaskArtifactCache::new(task, config, &ts, &env, &task_env, !self.dry_run).await? {
+            match TaskArtifactCache::new(
+                task,
+                config,
+                &ts,
+                &env,
+                &task_env,
+                &dependency_state.cache_keys,
+                !self.dry_run,
+            )
+            .await?
+            {
                 Some(_) if self.dry_run => None,
                 Some(cache) => {
                     if !self.force
-                        && !dep_ran
+                        && !dependency_state.any_unkeyed_did_work
                         && cache.is_current()
                         && sources_are_fresh(task, config).await?
                     {
                         if !self.quiet(Some(task)) {
                             self.eprint(task, &prefix, "sources up-to-date, skipping");
                         }
-                        return Ok(false);
+                        return Ok(TaskRunOutcome {
+                            did_work: false,
+                            cache_key: Some(cache.key().to_string()),
+                        });
                     }
-                    if !self.force && !dep_ran && cache.restore(task)? {
+                    if !self.force
+                        && !dependency_state.any_unkeyed_did_work
+                        && cache.restore(task)?
+                    {
                         if !self.quiet(Some(task)) {
                             self.eprint(
                                 task,
@@ -506,7 +529,10 @@ impl TaskExecutor {
                                 task.name
                             );
                         }
-                        return Ok(true);
+                        return Ok(TaskRunOutcome {
+                            did_work: true,
+                            cache_key: Some(cache.key().to_string()),
+                        });
                     }
                     Some(cache)
                 }
@@ -550,7 +576,7 @@ impl TaskExecutor {
                 rendered_run_scripts,
                 sched_tx,
                 confirm_guard,
-                &completed_tasks,
+                &completion_state,
                 semaphore,
                 permit,
             )
@@ -574,14 +600,30 @@ impl TaskExecutor {
         }
 
         save_checksum(task, config).await?;
-        if let Some(cache) = artifact_cache {
-            match cache.store(task).and_then(|_| cache.mark_current()) {
-                Ok(()) => {}
-                Err(err) => warn!("task {} artifact cache write failed: {err}", task.name),
+        let cache_key = if let Some(cache) = artifact_cache {
+            match cache.store(task) {
+                Ok(()) => {
+                    if let Err(err) = cache.mark_current() {
+                        warn!(
+                            "task {} artifact cache state update failed: {err}",
+                            task.name
+                        );
+                    }
+                    Some(cache.key().to_string())
+                }
+                Err(err) => {
+                    warn!("task {} artifact cache write failed: {err}", task.name);
+                    None
+                }
             }
-        }
+        } else {
+            None
+        };
 
-        Ok(true)
+        Ok(TaskRunOutcome {
+            did_work: true,
+            cache_key,
+        })
     }
 
     fn insert_env_excluded_from_nested_mise_diff(
@@ -618,7 +660,7 @@ impl TaskExecutor {
         rendered_scripts: Vec<(String, Vec<String>)>,
         sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
         existing_guard: Option<RuntimeLockGuard<'static>>,
-        completed_tasks: &HashSet<TaskKey>,
+        completion_state: &TaskCompletionState,
         semaphore: Arc<Semaphore>,
         permit: &mut Option<OwnedSemaphorePermit>,
     ) -> Result<()> {
@@ -700,7 +742,7 @@ impl TaskExecutor {
                         override_args.as_deref(),
                         override_env_ref,
                         sched_tx.clone(),
-                        completed_tasks,
+                        completion_state,
                     )
                     .await?;
                     if had_permit {
@@ -722,7 +764,7 @@ impl TaskExecutor {
                         None,
                         None,
                         sched_tx.clone(),
-                        completed_tasks,
+                        completion_state,
                     )
                     .await?;
                     if had_permit {
@@ -743,7 +785,7 @@ impl TaskExecutor {
         override_args: Option<&[String]>,
         override_env: Option<&[(String, String)]>,
         sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
-        completed_tasks: &HashSet<TaskKey>,
+        completion_state: &TaskCompletionState,
     ) -> Result<()> {
         use crate::task::TaskLoadContext;
         trace!("inject start: {}", specs.join(", "));
@@ -805,7 +847,7 @@ impl TaskExecutor {
                 to_run.push(t);
             }
         }
-        let sub_deps = Deps::new_pruned(config, to_run, completed_tasks).await?;
+        let sub_deps = Deps::new_pruned(config, to_run, completion_state).await?;
         let sub_deps = Arc::new(Mutex::new(sub_deps));
 
         // Pump subgraph into scheduler and signal completion via oneshot when done


### PR DESCRIPTION
## Summary

- include direct dependency artifact keys in a task's cache key
- let dependents restore cached outputs after cacheable dependencies execute, skip, or restore
- preserve conservative execution when a dependency did work without producing a stable artifact key
- carry dependency cache state through nested task graphs
- document the behavior and update the temporary parity tracker

This is the next experimental task-cache follow-up to #11328. It makes downstream artifact identities transitively reflect the dependency graph, closing the key prerequisite for changed-workspace execution parity.

## User impact

Cacheable task graphs can now reuse downstream artifacts when their dependencies resolve to the same artifact identities. Changing an upstream task's inputs changes its artifact key and therefore invalidates the matching downstream cache key. Uncached or failed-to-store upstream work remains conservative and forces downstream execution.

## Validation

- `mise run lint-fix`
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `mise run test:e2e test_task_artifact_cache test_task_dep_invalidates_sources test_task_delegation_dedup`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task scheduling, cache key hashing, and nested graph state propagation; incorrect key or dependency logic could cause stale restores or missed invalidation, though conservative unkeyed-dependency handling and new e2e tests mitigate this.
> 
> **Overview**
> Experimental task artifact caching now **folds direct dependency artifact keys into each task’s cache key**, so downstream artifacts stay aligned with upstream inputs across execute, skip, and restore paths.
> 
> The scheduler tracks **`TaskCompletionState`** (completed tasks, whether they did work, and published cache keys) and **`TaskDependencyState`** per task. Dependents can **restore from cache** when dependencies expose stable keys; if a dependency ran without a key (e.g. cache disabled), dependents still **execute conservatively**. **`depends_post`** parents contribute keys the same way as regular dependencies. **Nested** `run = [{ task = ... }]` graphs **merge** completion state so delegated tasks do not rerun shared work.
> 
> Docs and the parity tracker describe the new key material and behavior; new e2e coverage exercises lib→app restores, invalidation on upstream change, uncached deps, and post-deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77dc5f94749c1085f5c7355f855ef3b24720e075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task artifact caching so downstream tasks restore or reuse cached outputs based on stable dependency cache identities.
  - Added safer invalidation: downstream artifacts are refreshed when dependency inputs change, while uncached dependencies trigger conservative re-execution.

- **New Features**
  - Cache keys now incorporate dependency key material to strengthen cache correctness across task graphs.

- **Documentation**
  - Updated cache-key and dependency interaction documentation, including cache failure (“miss”) semantics.

- **Tests**
  - Expanded end-to-end coverage for dependency cache restoration/invalidation (including post-dependency behavior) and added a delegation deduplication scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->