### PR TITLE
feat(config): parse registry idiomatic version files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -344,11 +344,7 @@ fn codegen_registry() {
                 .map(|o| format!("\"{o}\""))
                 .collect::<Vec<_>>()
                 .join(", "),
-            idiomatic_files = idiomatic_files
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join(", "),
+            idiomatic_files = idiomatic_files.to_vec().join(", "),
             detect = detect
                 .iter()
                 .map(|f| format!("\"{f}\""))

--- a/build.rs
+++ b/build.rs
@@ -239,7 +239,58 @@ fn codegen_registry() {
                     .as_array()
                     .unwrap()
                     .iter()
-                    .map(|f| f.as_str().unwrap().to_string())
+                    .map(|f| match f {
+                        toml::Value::String(path) => format!(
+                            "RegistryIdiomaticFile {{ path: {}, version_regex: None, version_json_path: None, version_expr: None }}",
+                            raw_string_literal(path)
+                        ),
+                        toml::Value::Table(spec) => {
+                            for key in spec.keys() {
+                                assert!(
+                                    matches!(
+                                        key.as_str(),
+                                        "path"
+                                            | "version_regex"
+                                            | "version_json_path"
+                                            | "version_expr"
+                                    ),
+                                    "[{short}] unknown idiomatic file field: {key}"
+                                );
+                            }
+                            let required = |key: &str| {
+                                spec.get(key)
+                                    .and_then(|value| value.as_str())
+                                    .unwrap_or_else(|| {
+                                        panic!(
+                                            "[{short}] idiomatic_files.{key} must be a string"
+                                        )
+                                    })
+                            };
+                            let optional = |key: &str| {
+                                spec.get(key)
+                                    .map(|value| {
+                                        value.as_str().unwrap_or_else(|| {
+                                            panic!(
+                                                "[{short}] idiomatic_files.{key} must be a string"
+                                            )
+                                        })
+                                    })
+                                    .map(raw_string_literal)
+                                    .map(|value| format!("Some({value})"))
+                                    .unwrap_or_else(|| "None".to_string())
+                            };
+                            format!(
+                                "RegistryIdiomaticFile {{ path: {}, version_regex: {}, version_json_path: {}, version_expr: {} }}",
+                                raw_string_literal(required("path")),
+                                optional("version_regex"),
+                                optional("version_json_path"),
+                                optional("version_expr"),
+                            )
+                        }
+                        _ => panic!(
+                            "[{short}] idiomatic_files entries must be strings or tables"
+                        ),
+                    })
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
@@ -295,7 +346,7 @@ fn codegen_registry() {
                 .join(", "),
             idiomatic_files = idiomatic_files
                 .iter()
-                .map(|f| format!("\"{f}\""))
+                .cloned()
                 .collect::<Vec<_>>()
                 .join(", "),
             detect = detect

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,35 +395,51 @@ other developers to use a specific tool like mise or asdf.
 They support aliases, which means you can have an `.nvmrc` file with `lts/hydrogen` and it will work
 in mise and nvm. Here are some of the supported idiomatic version files:
 
-| Plugin     | Idiomatic Files                           |
-| ---------- | ----------------------------------------- |
-| atmos      | `.atmos-version`                          |
-| bun        | `.bun-version`, `package.json`            |
-| crystal    | `.crystal-version`                        |
-| deno       | `.deno-version`, `package.json`           |
-| dotnet     | `global.json`                             |
-| elixir     | `.exenv-version`                          |
-| go         | `.go-version`, `go.mod`                   |
-| java       | `.java-version`, `.sdkmanrc`              |
-| node       | `.nvmrc`, `.node-version`, `package.json` |
-| npm        | `package.json`                            |
-| opentofu   | `.opentofu-version`                       |
-| packer     | `.packer-version`                         |
-| perl       | `.perl-version`                           |
-| pnpm       | `package.json`                            |
-| python     | `.python-version`, `.python-versions`     |
-| ruby       | `.ruby-version`, `Gemfile`                |
-| rust       | `rust-toolchain.toml`                     |
-| terraform  | `.terraform-version`                      |
-| terragrunt | `.terragrunt-version`                     |
-| terramate  | `.terramate-version`                      |
-| yarn       | `.yvmrc`, `package.json`                  |
+| Plugin        | Idiomatic Files                                                                                    |
+| ------------- | -------------------------------------------------------------------------------------------------- |
+| atmos         | `.atmos-version`                                                                                   |
+| bun           | `.bun-version`, `package.json`                                                                     |
+| chezmoi       | `.chezmoiversion`                                                                                  |
+| cmake         | `CMakeLists.txt`                                                                                   |
+| crystal       | `.crystal-version`                                                                                 |
+| dagger        | `dagger.json`                                                                                      |
+| deno          | `.deno-version`, `package.json`                                                                    |
+| dotnet        | `global.json`                                                                                      |
+| earthly       | `Earthfile`                                                                                        |
+| elixir        | `.exenv-version`                                                                                   |
+| go            | `.go-version`, `go.mod`                                                                            |
+| golangci-lint | `.golangci.yml`, `.golangci.yaml`, `.golangci.toml`, `.golangci.json`                              |
+| goreleaser    | `.goreleaser.yml`, `.goreleaser.yaml`, `goreleaser.yml`, `goreleaser.yaml`, `.config/goreleaser.*` |
+| java          | `.java-version`, `.sdkmanrc`                                                                       |
+| lefthook      | `lefthook.*`, `.lefthook.*`, `.config/lefthook.*`                                                  |
+| node          | `.nvmrc`, `.node-version`, `package.json`                                                          |
+| npm           | `package.json`                                                                                     |
+| opentofu      | `.opentofu-version`                                                                                |
+| packer        | `.packer-version`                                                                                  |
+| perl          | `.perl-version`                                                                                    |
+| pixi          | `pixi.toml`, `pyproject.toml`                                                                      |
+| pnpm          | `package.json`                                                                                     |
+| pre-commit    | `.pre-commit-config.yaml`                                                                          |
+| python        | `.python-version`, `.python-versions`                                                              |
+| ruby          | `.ruby-version`, `Gemfile`                                                                         |
+| ruff          | `ruff.toml`, `.ruff.toml`                                                                          |
+| rust          | `rust-toolchain.toml`                                                                              |
+| task          | `Taskfile.yml`, `Taskfile.yaml`, `taskfile.yml`, `taskfile.yaml`                                   |
+| terraform     | `.terraform-version`                                                                               |
+| terragrunt    | `.terragrunt-version`                                                                              |
+| terramate     | `.terramate-version`                                                                               |
+| yarn          | `.yvmrc`, `package.json`                                                                           |
 
 Registry-backed tools can also describe how mise should extract versions from structured
 idiomatic files. Registry entries may use the same `version_regex`, `version_json_path`, and
 `version_expr` parsers as the [HTTP backend](/dev-tools/backends/http.html#version-listing).
 This lets tools installed through backends such as `aqua:` and `github:` support JSON manifests
 and other tool-specific version files without requiring an asdf or vfox plugin.
+
+Some files declare a minimum compatible version or a configuration-format major rather than an
+exact binary release. mise treats that value as a normal version request, so a value such as
+`3.25` selects the latest matching CMake 3.25 release and a GoReleaser config `version: 2` selects
+the latest GoReleaser 2.x release.
 
 For `go.mod`, the `toolchain goX.Y.Z` directive (an exact toolchain pin) is used when present.
 Otherwise the `go X.Y` directive is used; because it declares only the _minimum_ required Go
@@ -433,9 +449,9 @@ In mise, these are disabled by default, see <https://github.com/jdx/mise/discuss
 
 - `mise settings add idiomatic_version_file_enable_tools python` for a specific tool such as Python ([docs](/configuration/settings.html#idiomatic_version_file_enable_tools))
 
-There is a performance cost to having these when they're parsed as it's performed by the plugin in
-`bin/parse-version-file`. However, these are [cached](/cache-behavior) so it's not a huge deal.
-You may not even notice.
+There is a small performance cost to discovering and parsing these files. Registry parsers run
+in-process; plugin-provided files may invoke the plugin's parser. Results are [cached](/cache-behavior),
+so this is generally not noticeable.
 
 ::: info
 asdf called these "legacy version files". I think this was a bad name since it implies

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,40 +395,46 @@ other developers to use a specific tool like mise or asdf.
 They support aliases, which means you can have an `.nvmrc` file with `lts/hydrogen` and it will work
 in mise and nvm. Here are some of the supported idiomatic version files:
 
-| Plugin        | Idiomatic Files                                                                                    |
-| ------------- | -------------------------------------------------------------------------------------------------- |
-| atmos         | `.atmos-version`                                                                                   |
-| bun           | `.bun-version`, `package.json`                                                                     |
-| chezmoi       | `.chezmoiversion`                                                                                  |
-| cmake         | `CMakeLists.txt`                                                                                   |
-| crystal       | `.crystal-version`                                                                                 |
-| dagger        | `dagger.json`                                                                                      |
-| deno          | `.deno-version`, `package.json`                                                                    |
-| dotnet        | `global.json`                                                                                      |
-| earthly       | `Earthfile`                                                                                        |
-| elixir        | `.exenv-version`                                                                                   |
-| go            | `.go-version`, `go.mod`                                                                            |
-| golangci-lint | `.golangci.yml`, `.golangci.yaml`, `.golangci.toml`, `.golangci.json`                              |
-| goreleaser    | `.goreleaser.yml`, `.goreleaser.yaml`, `goreleaser.yml`, `goreleaser.yaml`, `.config/goreleaser.*` |
-| java          | `.java-version`, `.sdkmanrc`                                                                       |
-| lefthook      | `lefthook.*`, `.lefthook.*`, `.config/lefthook.*`                                                  |
-| node          | `.nvmrc`, `.node-version`, `package.json`                                                          |
-| npm           | `package.json`                                                                                     |
-| opentofu      | `.opentofu-version`                                                                                |
-| packer        | `.packer-version`                                                                                  |
-| perl          | `.perl-version`                                                                                    |
-| pixi          | `pixi.toml`, `pyproject.toml`                                                                      |
-| pnpm          | `package.json`                                                                                     |
-| pre-commit    | `.pre-commit-config.yaml`                                                                          |
-| python        | `.python-version`, `.python-versions`                                                              |
-| ruby          | `.ruby-version`, `Gemfile`                                                                         |
-| ruff          | `ruff.toml`, `.ruff.toml`                                                                          |
-| rust          | `rust-toolchain.toml`                                                                              |
-| task          | `Taskfile.yml`, `Taskfile.yaml`, `taskfile.yml`, `taskfile.yaml`                                   |
-| terraform     | `.terraform-version`                                                                               |
-| terragrunt    | `.terragrunt-version`                                                                              |
-| terramate     | `.terramate-version`                                                                               |
-| yarn          | `.yvmrc`, `package.json`                                                                           |
+<!-- mise:idiomatic-version-files:start -->
+
+| Plugin        | Idiomatic Files                                                                                                                                                                                                                                                                                            |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| atmos         | `.atmos-version`                                                                                                                                                                                                                                                                                           |
+| bun           | `.bun-version`, `package.json`                                                                                                                                                                                                                                                                             |
+| chezmoi       | `.chezmoiversion`                                                                                                                                                                                                                                                                                          |
+| cmake         | `CMakeLists.txt`                                                                                                                                                                                                                                                                                           |
+| crystal       | `.crystal-version`                                                                                                                                                                                                                                                                                         |
+| dagger        | `dagger.json`                                                                                                                                                                                                                                                                                              |
+| deno          | `.deno-version`, `package.json`                                                                                                                                                                                                                                                                            |
+| dotnet        | `global.json`                                                                                                                                                                                                                                                                                              |
+| earthly       | `Earthfile`                                                                                                                                                                                                                                                                                                |
+| elixir        | `.exenv-version`                                                                                                                                                                                                                                                                                           |
+| go            | `.go-version`, `go.mod`                                                                                                                                                                                                                                                                                    |
+| golangci-lint | `.golangci.yml`, `.golangci.yaml`, `.golangci.toml`, `.golangci.json`                                                                                                                                                                                                                                      |
+| goreleaser    | `.config/goreleaser.yml`, `.config/goreleaser.yaml`, `.goreleaser.yml`, `.goreleaser.yaml`, `goreleaser.yml`, `goreleaser.yaml`                                                                                                                                                                            |
+| java          | `.java-version`, `.sdkmanrc`                                                                                                                                                                                                                                                                               |
+| lefthook      | `lefthook.yml`, `lefthook.yaml`, `.lefthook.yml`, `.lefthook.yaml`, `lefthook.toml`, `.lefthook.toml`, `lefthook.json`, `.lefthook.json`, `lefthook.jsonc`, `.lefthook.jsonc`, `.config/lefthook.yml`, `.config/lefthook.yaml`, `.config/lefthook.toml`, `.config/lefthook.json`, `.config/lefthook.jsonc` |
+| node          | `.nvmrc`, `.node-version`, `package.json`                                                                                                                                                                                                                                                                  |
+| npm           | `package.json`                                                                                                                                                                                                                                                                                             |
+| opentofu      | `.opentofu-version`                                                                                                                                                                                                                                                                                        |
+| packer        | `.packer-version`                                                                                                                                                                                                                                                                                          |
+| perl          | `.perl-version`                                                                                                                                                                                                                                                                                            |
+| pixi          | `pixi.toml`, `pyproject.toml`                                                                                                                                                                                                                                                                              |
+| pnpm          | `package.json`                                                                                                                                                                                                                                                                                             |
+| pre-commit    | `.pre-commit-config.yaml`                                                                                                                                                                                                                                                                                  |
+| python        | `.python-version`, `.python-versions`                                                                                                                                                                                                                                                                      |
+| ruby          | `.ruby-version`, `Gemfile`                                                                                                                                                                                                                                                                                 |
+| ruff          | `ruff.toml`, `.ruff.toml`                                                                                                                                                                                                                                                                                  |
+| rust          | `rust-toolchain.toml`                                                                                                                                                                                                                                                                                      |
+| swift         | `.swift-version`                                                                                                                                                                                                                                                                                           |
+| task          | `Taskfile.yml`, `Taskfile.yaml`, `taskfile.yml`, `taskfile.yaml`                                                                                                                                                                                                                                           |
+| terraform     | `.terraform-version`                                                                                                                                                                                                                                                                                       |
+| terragrunt    | `.terragrunt-version`                                                                                                                                                                                                                                                                                      |
+| terramate     | `.terramate-version`                                                                                                                                                                                                                                                                                       |
+| yarn          | `.yvmrc`, `package.json`                                                                                                                                                                                                                                                                                   |
+| zig           | `.zig-version`                                                                                                                                                                                                                                                                                             |
+
+<!-- mise:idiomatic-version-files:end -->
 
 Registry-backed tools can also describe how mise should extract versions from structured
 idiomatic files. Registry entries may use the same `version_regex`, `version_json_path`, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -419,6 +419,12 @@ in mise and nvm. Here are some of the supported idiomatic version files:
 | terramate  | `.terramate-version`                      |
 | yarn       | `.yvmrc`, `package.json`                  |
 
+Registry-backed tools can also describe how mise should extract versions from structured
+idiomatic files. Registry entries may use the same `version_regex`, `version_json_path`, and
+`version_expr` parsers as the [HTTP backend](/dev-tools/backends/http.html#version-listing).
+This lets tools installed through backends such as `aqua:` and `github:` support JSON manifests
+and other tool-specific version files without requiring an asdf or vfox plugin.
+
 For `go.mod`, the `toolchain goX.Y.Z` directive (an exact toolchain pin) is used when present.
 Otherwise the `go X.Y` directive is used; because it declares only the _minimum_ required Go
 version, mise resolves it to the latest matching patch (e.g. `go 1.22` → latest `1.22.x`).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -737,6 +737,14 @@ The supported parser fields are:
 These parsers are evaluated in-process and cannot run shell commands. Plain string entries remain
 compatible with existing registry entries and backend-native parsers.
 
+Only extract a value that determines compatibility with the tool binary. Good candidates include
+an exact version, a minimum/required version, or a configuration-format major that is intentionally
+coupled to the CLI major. Do not extract unrelated project versions, dependency versions, lockfile
+schema revisions, or generic `version` fields that do not constrain the tool itself.
+
+Include all filenames that the tool officially searches, including documented nested paths such as
+`.config/tool.yml`. When suffixes overlap, mise uses the most specific matching path.
+
 Idiomatic files are disabled by default. Users enable them for a registry shorthand with:
 
 ```sh

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -706,6 +706,43 @@ aliases = ["alt-name"] # Optional alternative names
 os = ["linux", "macos"] # Optional OS restrictions
 ```
 
+#### Idiomatic version files
+
+Registry tools can opt into [idiomatic version files](/configuration.html#idiomatic-version-files)
+with `idiomatic_files`. A filename string uses mise's default plain-text parser:
+
+```toml
+backends = ["aqua:owner/repo"]
+idiomatic_files = [".your-tool-version"]
+```
+
+For structured or tool-specific files, use a table with the same parsing options supported by the
+[HTTP backend's version listing](/dev-tools/backends/http.html#version-listing):
+
+```toml
+idiomatic_files = [
+  { path = "your-tool.json", version_json_path = ".toolchain.version" },
+  { path = "your-tool.conf", version_regex = 'version\s*=\s*"([^"]+)"' },
+]
+```
+
+The supported parser fields are:
+
+- `version_regex`: extract every regex match, using the first capture group when present.
+- `version_json_path`: extract values using mise's jq-like JSON path syntax.
+- `version_expr`: extract or post-process versions using an
+  [expr-lang](https://expr-lang.org/) expression. The original contents are available as `body`,
+  and versions produced by `version_regex` or `version_json_path` are available as `versions`.
+
+These parsers are evaluated in-process and cannot run shell commands. Plain string entries remain
+compatible with existing registry entries and backend-native parsers.
+
+Idiomatic files are disabled by default. Users enable them for a registry shorthand with:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools your-tool
+```
+
 ### Backend Priority
 
 List backends in order of preference. Users will get the first available

--- a/e2e/backend/test_registry_idiomatic_version_files
+++ b/e2e/backend/test_registry_idiomatic_version_files
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+mise settings set idiomatic_version_file_enable_tools "dagger,task"
+
+cat >dagger.json <<'EOF'
+{
+  "name": "example",
+  "engineVersion": "v0.21.7"
+}
+EOF
+
+assert_contains "mise tool dagger" "0.21.7"
+
+cat >Taskfile.yml <<'EOF'
+version: '3.17'
+
+tasks:
+  default:
+    cmds:
+      - echo hello
+EOF
+
+assert_contains "mise tool task" "3.17"
+
+mv Taskfile.yml taskfile.yaml
+assert_contains "mise tool task" "3.17"

--- a/e2e/backend/test_registry_idiomatic_version_files
+++ b/e2e/backend/test_registry_idiomatic_version_files
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-mise settings set idiomatic_version_file_enable_tools "dagger,task"
+mise settings set idiomatic_version_file_enable_tools "chezmoi,cmake,dagger,earthly,golangci-lint,goreleaser,lefthook,pixi,pre-commit,ruff,task"
 
 cat >dagger.json <<'EOF'
 {
@@ -24,3 +24,60 @@ assert_contains "mise tool task" "3.17"
 
 mv Taskfile.yml taskfile.yaml
 assert_contains "mise tool task" "3.17"
+
+echo "v2.71.1" >.chezmoiversion
+assert_contains "mise tool chezmoi" "2.71.1"
+
+cat >CMakeLists.txt <<'EOF'
+cmake_minimum_required(VERSION 3.25)
+project(example)
+EOF
+assert_contains "mise tool cmake" "3.25"
+
+cat >Earthfile <<'EOF'
+VERSION --pass-args 0.8
+
+build:
+    FROM alpine
+EOF
+assert_contains "mise tool earthly" "0.8"
+
+cat >.golangci.json <<'EOF'
+{
+  "version": "2"
+}
+EOF
+assert_contains "mise tool golangci-lint" "2"
+
+mkdir -p .config
+cat >.config/goreleaser.yaml <<'EOF'
+version: 2
+builds:
+  - id: example
+EOF
+assert_contains "mise tool goreleaser" "2"
+
+cat >.config/lefthook.jsonc <<'EOF'
+{
+  "min_version": "2.1.0"
+}
+EOF
+assert_contains "mise tool lefthook" "2.1.0"
+
+cat >pyproject.toml <<'EOF'
+[tool.pixi.workspace]
+name = "example"
+requires-pixi = "0.58.0"
+EOF
+assert_contains "mise tool pixi" "0.58.0"
+
+cat >.pre-commit-config.yaml <<'EOF'
+minimum_pre_commit_version: "4.0.0"
+repos: []
+EOF
+assert_contains "mise tool pre-commit" "4.0.0"
+
+cat >.ruff.toml <<'EOF'
+required-version = "0.14.0"
+EOF
+assert_contains "mise tool ruff" "0.14.0"

--- a/e2e/backend/test_registry_idiomatic_version_files
+++ b/e2e/backend/test_registry_idiomatic_version_files
@@ -22,14 +22,20 @@ EOF
 
 assert_contains "mise tool task" "3.17"
 
-mv Taskfile.yml taskfile.yaml
+mv Taskfile.yml Taskfile.yaml
+assert_contains "mise tool task" "3.17"
+
+mv Taskfile.yaml taskfile.yml
+assert_contains "mise tool task" "3.17"
+
+mv taskfile.yml taskfile.yaml
 assert_contains "mise tool task" "3.17"
 
 echo "v2.71.1" >.chezmoiversion
 assert_contains "mise tool chezmoi" "2.71.1"
 
 cat >CMakeLists.txt <<'EOF'
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.25...3.28)
 project(example)
 EOF
 assert_contains "mise tool cmake" "3.25"

--- a/e2e/backend/test_registry_idiomatic_version_files
+++ b/e2e/backend/test_registry_idiomatic_version_files
@@ -48,11 +48,7 @@ build:
 EOF
 assert_contains "mise tool earthly" "0.8"
 
-cat >.golangci.json <<'EOF'
-{
-  "version": "2"
-}
-EOF
+echo '{"version":"2"}' >.golangci.json
 assert_contains "mise tool golangci-lint" "2"
 
 mkdir -p .config

--- a/registry/bun.toml
+++ b/registry/bun.toml
@@ -1,4 +1,5 @@
 backends = ["core:bun"]
 description = "Bun is a fast JavaScript all-in-one toolkit"
 detect = ["bun.lock", "bun.lockb", "bunfig.toml"]
+idiomatic_files = [".bun-version", "package.json"]
 test = { cmd = "bun --version", expected = "{{version}}" }

--- a/registry/chezmoi.toml
+++ b/registry/chezmoi.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:twpayne/chezmoi", "asdf:joke/asdf-chezmoi"]
 description = "Manage your dotfiles across multiple diverse machines, securely"
+idiomatic_files = [".chezmoiversion"]
 test = { cmd = "chezmoi --version", expected = "chezmoi version v{{version}}" }

--- a/registry/cmake.toml
+++ b/registry/cmake.toml
@@ -5,7 +5,7 @@ backends = [
 ]
 description = "CMake is a tool to manage building of source code. Originally, CMake was designed as a generator for various dialects of Makefile, today CMake generates modern buildsystems such as Ninja as well as project files for IDEs such as Visual Studio and Xcode"
 idiomatic_files = [
-  { path = "CMakeLists.txt", version_regex = '''(?im)^\s*cmake_minimum_required\s*\(\s*VERSION\s+v?([0-9][0-9A-Za-z.+-]*)''' },
+  { path = "CMakeLists.txt", version_regex = '''(?im)^\s*cmake_minimum_required\s*\(\s*VERSION\s+v?([0-9]+(?:\.[0-9]+){0,3})''' },
 ]
 test = { cmd = "cmake --version", expected = """
 cmake version {{version}}

--- a/registry/cmake.toml
+++ b/registry/cmake.toml
@@ -4,6 +4,9 @@ backends = [
   "vfox:mise-plugins/vfox-cmake",
 ]
 description = "CMake is a tool to manage building of source code. Originally, CMake was designed as a generator for various dialects of Makefile, today CMake generates modern buildsystems such as Ninja as well as project files for IDEs such as Visual Studio and Xcode"
+idiomatic_files = [
+  { path = "CMakeLists.txt", version_regex = '''(?im)^\s*cmake_minimum_required\s*\(\s*VERSION\s+v?([0-9][0-9A-Za-z.+-]*)''' },
+]
 test = { cmd = "cmake --version", expected = """
 cmake version {{version}}
 

--- a/registry/crystal.toml
+++ b/registry/crystal.toml
@@ -4,3 +4,4 @@ backends = [
   "vfox:mise-plugins/vfox-crystal",
 ]
 description = "Crystal: A language for humans and computers"
+idiomatic_files = [".crystal-version"]

--- a/registry/dagger.toml
+++ b/registry/dagger.toml
@@ -1,2 +1,5 @@
 backends = ["aqua:dagger/dagger", "asdf:virtualstaticvoid/asdf-dagger"]
 description = "A portable devkit for CI/CD pipelines"
+idiomatic_files = [
+  { path = "dagger.json", version_regex = '"engineVersion"\s*:\s*"v?([^"]+)"' },
+]

--- a/registry/deno.toml
+++ b/registry/deno.toml
@@ -1,2 +1,3 @@
 backends = ["core:deno"]
 description = "A modern runtime for JavaScript and TypeScript (Builtin plugin)"
+idiomatic_files = [".deno-version", "package.json"]

--- a/registry/dotnet.toml
+++ b/registry/dotnet.toml
@@ -5,3 +5,4 @@ backends = [
   "asdf:mise-plugins/mise-dotnet",
 ]
 description = ".NET SDK"
+idiomatic_files = ["global.json"]

--- a/registry/earthly.toml
+++ b/registry/earthly.toml
@@ -1,2 +1,5 @@
 backends = ["aqua:earthly/earthly", "asdf:YR-ZR0/asdf-earthly"]
 description = "Repeatable builds"
+idiomatic_files = [
+  { path = "Earthfile", version_regex = '(?m)^\s*VERSION(?:\s+--\S+)*\s+v?([0-9]+(?:\.[0-9]+){1,2})' },
+]

--- a/registry/elixir.toml
+++ b/registry/elixir.toml
@@ -1,2 +1,3 @@
 backends = ["core:elixir"]
 description = "Elixir is a dynamic, functional language for building scalable and maintainable applications"
+idiomatic_files = [".exenv-version"]

--- a/registry/go.toml
+++ b/registry/go.toml
@@ -1,3 +1,4 @@
 backends = ["core:go"]
 description = "go lang (Builtin plugin)"
 detect = ["go.mod", "go.sum"]
+idiomatic_files = [".go-version", "go.mod"]

--- a/registry/golangci-lint.toml
+++ b/registry/golangci-lint.toml
@@ -4,5 +4,5 @@ idiomatic_files = [
   { path = ".golangci.yml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
   { path = ".golangci.yaml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
   { path = ".golangci.toml", version_regex = '''(?m)^\s*version\s*=\s*["']?v?([0-9]+)''' },
-  { path = ".golangci.json", version_regex = '''(?m)^\s*"version"\s*:\s*"v?([0-9]+)''' },
+  { path = ".golangci.json", version_json_path = ".version" },
 ]

--- a/registry/golangci-lint.toml
+++ b/registry/golangci-lint.toml
@@ -1,2 +1,8 @@
 backends = ["aqua:golangci/golangci-lint", "asdf:hypnoglow/asdf-golangci-lint"]
 description = "Fast linters Runner for Go"
+idiomatic_files = [
+  { path = ".golangci.yml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
+  { path = ".golangci.yaml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
+  { path = ".golangci.toml", version_regex = '''(?m)^\s*version\s*=\s*["']?v?([0-9]+)''' },
+  { path = ".golangci.json", version_regex = '''(?m)^\s*"version"\s*:\s*"v?([0-9]+)''' },
+]

--- a/registry/goreleaser.toml
+++ b/registry/goreleaser.toml
@@ -1,2 +1,10 @@
 backends = ["aqua:goreleaser/goreleaser", "asdf:kforsthoevel/asdf-goreleaser"]
 description = "Deliver Go binaries as fast and easily as possible"
+idiomatic_files = [
+  { path = ".config/goreleaser.yml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
+  { path = ".config/goreleaser.yaml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
+  { path = ".goreleaser.yml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
+  { path = ".goreleaser.yaml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
+  { path = "goreleaser.yml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
+  { path = "goreleaser.yaml", version_regex = '''(?m)^\s*version\s*:\s*["']?v?([0-9]+)''' },
+]

--- a/registry/java.toml
+++ b/registry/java.toml
@@ -1,2 +1,3 @@
 backends = ["core:java"]
 description = "jdk java"
+idiomatic_files = [".java-version", ".sdkmanrc"]

--- a/registry/lefthook.toml
+++ b/registry/lefthook.toml
@@ -4,4 +4,21 @@ backends = [
   "go:github.com/evilmartians/lefthook",
 ]
 description = "Fast and powerful Git hooks manager for any type of projects"
+idiomatic_files = [
+  { path = "lefthook.yml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = "lefthook.yaml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".lefthook.yml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".lefthook.yaml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = "lefthook.toml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".lefthook.toml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = "lefthook.json", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".lefthook.json", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = "lefthook.jsonc", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".lefthook.jsonc", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".config/lefthook.yml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".config/lefthook.yaml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".config/lefthook.toml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".config/lefthook.json", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".config/lefthook.jsonc", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+]
 test = { cmd = "lefthook version", expected = "{{version}}" }

--- a/registry/node.toml
+++ b/registry/node.toml
@@ -1,3 +1,4 @@
 backends = ["core:node"]
 description = "Node.js® is a free, open-source, cross-platform JavaScript runtime environment that lets developers create servers, web apps, command line tools and scripts (Builtin plugin)"
 detect = ["package.json", ".nvmrc", ".node-version"]
+idiomatic_files = [".nvmrc", ".node-version", "package.json"]

--- a/registry/pixi.toml
+++ b/registry/pixi.toml
@@ -1,3 +1,7 @@
 backends = ["github:prefix-dev/pixi"]
 description = "Package management made easy"
+idiomatic_files = [
+  { path = "pixi.toml", version_regex = '''(?m)^\s*requires-pixi\s*=\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = "pyproject.toml", version_regex = '''(?m)^\s*requires-pixi\s*=\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+]
 test = { cmd = "pixi -V", expected = "pixi {{version}}" }

--- a/registry/pre-commit.toml
+++ b/registry/pre-commit.toml
@@ -4,4 +4,7 @@ backends = [
   "pipx:pre-commit",
 ]
 description = "A framework for managing and maintaining multi-language pre-commit hooks"
+idiomatic_files = [
+  { path = ".pre-commit-config.yaml", version_regex = '''(?m)^\s*minimum_pre_commit_version\s*:\s*["']?v?([0-9][0-9A-Za-z.+-]*)''' },
+]
 test = { cmd = "pre-commit --version", expected = "pre-commit {{version}}" }

--- a/registry/python.toml
+++ b/registry/python.toml
@@ -1,3 +1,4 @@
 backends = ["core:python"]
 description = "python language"
 detect = ["pyproject.toml", ".python-version", "setup.py", "requirements.txt"]
+idiomatic_files = [".python-version", ".python-versions"]

--- a/registry/ruby.toml
+++ b/registry/ruby.toml
@@ -1,3 +1,4 @@
 backends = ["core:ruby"]
 description = "Ruby language"
 detect = ["Gemfile", ".ruby-version", "Rakefile"]
+idiomatic_files = [".ruby-version", "Gemfile"]

--- a/registry/ruff.toml
+++ b/registry/ruff.toml
@@ -1,3 +1,7 @@
 backends = ["aqua:astral-sh/ruff", "asdf:simhem/asdf-ruff"]
 description = "An extremely fast Python linter and code formatter, written in Rust"
+idiomatic_files = [
+  { path = "ruff.toml", version_regex = '''(?m)^\s*required-version\s*=\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+  { path = ".ruff.toml", version_regex = '''(?m)^\s*required-version\s*=\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },
+]
 test = { cmd = "ruff --version", expected = "ruff {{version}}" }

--- a/registry/rust.toml
+++ b/registry/rust.toml
@@ -1,2 +1,3 @@
 backends = ["core:rust", "asdf:code-lever/asdf-rust"]
 description = "Rust language"
+idiomatic_files = ["rust-toolchain.toml"]

--- a/registry/swift.toml
+++ b/registry/swift.toml
@@ -1,3 +1,4 @@
 backends = ["core:swift"]
 description = "Swift Lang (Core)"
+idiomatic_files = [".swift-version"]
 os = ["linux", "macos"]

--- a/registry/task.toml
+++ b/registry/task.toml
@@ -1,3 +1,9 @@
 backends = ["aqua:go-task/task", "asdf:particledecay/asdf-task"]
 description = "A task runner / simpler Make alternative written in Go"
+idiomatic_files = [
+  { path = "Taskfile.yml", version_regex = '(?m)^version:\s*[^0-9]*([0-9]+(?:\.[0-9]+){0,2})' },
+  { path = "Taskfile.yaml", version_regex = '(?m)^version:\s*[^0-9]*([0-9]+(?:\.[0-9]+){0,2})' },
+  { path = "taskfile.yml", version_regex = '(?m)^version:\s*[^0-9]*([0-9]+(?:\.[0-9]+){0,2})' },
+  { path = "taskfile.yaml", version_regex = '(?m)^version:\s*[^0-9]*([0-9]+(?:\.[0-9]+){0,2})' },
+]
 test = { cmd = "task --version", expected = "{{version}}" }

--- a/registry/task.toml
+++ b/registry/task.toml
@@ -1,9 +1,9 @@
 backends = ["aqua:go-task/task", "asdf:particledecay/asdf-task"]
 description = "A task runner / simpler Make alternative written in Go"
 idiomatic_files = [
-  { path = "Taskfile.yml", version_regex = '(?m)^version:\s*[^0-9]*([0-9]+(?:\.[0-9]+){0,2})' },
-  { path = "Taskfile.yaml", version_regex = '(?m)^version:\s*[^0-9]*([0-9]+(?:\.[0-9]+){0,2})' },
-  { path = "taskfile.yml", version_regex = '(?m)^version:\s*[^0-9]*([0-9]+(?:\.[0-9]+){0,2})' },
-  { path = "taskfile.yaml", version_regex = '(?m)^version:\s*[^0-9]*([0-9]+(?:\.[0-9]+){0,2})' },
+  { path = "Taskfile.yml", version_regex = '(?m)^version:[ \t]*[^0-9\r\n]*([0-9]+(?:\.[0-9]+){0,2})' },
+  { path = "Taskfile.yaml", version_regex = '(?m)^version:[ \t]*[^0-9\r\n]*([0-9]+(?:\.[0-9]+){0,2})' },
+  { path = "taskfile.yml", version_regex = '(?m)^version:[ \t]*[^0-9\r\n]*([0-9]+(?:\.[0-9]+){0,2})' },
+  { path = "taskfile.yaml", version_regex = '(?m)^version:[ \t]*[^0-9\r\n]*([0-9]+(?:\.[0-9]+){0,2})' },
 ]
 test = { cmd = "task --version", expected = "{{version}}" }

--- a/registry/yarn.toml
+++ b/registry/yarn.toml
@@ -6,5 +6,5 @@ backends = [
 ]
 description = "Yarn is a package manager that doubles down as project manager. Whether you work on simple projects or industry monorepos, whether you're an open source developer or an enterprise user, Yarn has your back"
 detect = ["yarn.lock", ".yarnrc.yml"]
-idiomatic_files = ["package.json"]
+idiomatic_files = [".yvmrc", "package.json"]
 test = { cmd = "yarn --version", expected = "{{version}}" }

--- a/registry/zig.toml
+++ b/registry/zig.toml
@@ -1,2 +1,3 @@
 backends = ["core:zig"]
 description = "Zig is a general-purpose programming language and toolchain for maintaining robust, optimal and reusable software"
+idiomatic_files = [".zig-version"]

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -147,9 +147,36 @@
     "idiomatic_files": {
       "type": "array",
       "items": {
-        "type": "string"
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Idiomatic version filename"
+              },
+              "version_regex": {
+                "type": "string",
+                "description": "Regular expression used to extract versions"
+              },
+              "version_json_path": {
+                "type": "string",
+                "description": "jq-like path used to extract versions from JSON"
+              },
+              "version_expr": {
+                "type": "string",
+                "description": "expr-lang expression used to extract or post-process versions"
+              }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+          }
+        ]
       },
-      "description": "Files that indicate this tool should be used in a project"
+      "description": "Files that indicate this tool should be used in a project, optionally with version extraction rules"
     },
     "os": {
       "type": "array",

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -28,7 +28,9 @@ use crate::path_env::PathEnv;
 use crate::platform::Platform;
 use crate::plugins::core::CORE_PLUGINS;
 use crate::plugins::{PEP440_PRERELEASE_REGEX, PluginType, VERSION_REGEX};
-use crate::registry::{REGISTRY, full_to_url, normalize_remote, tool_enabled};
+use crate::registry::{
+    REGISTRY, RegistryIdiomaticFile, full_to_url, normalize_remote, tool_enabled,
+};
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::semver::semver_triplet;
 use crate::tera::{contains_template_syntax, get_tera, render_str};
@@ -524,6 +526,23 @@ pub(crate) fn normalize_idiomatic_contents(contents: &str) -> String {
         .join("\n")
 }
 
+fn parse_registry_idiomatic_file(
+    path: &Path,
+    spec: &RegistryIdiomaticFile,
+) -> Result<Option<Vec<String>>> {
+    if !spec.has_parser() {
+        return Ok(None);
+    }
+    let contents = file::read_to_string(path)?;
+    version_list::parse_version_list(
+        &contents,
+        spec.version_regex,
+        spec.version_json_path,
+        spec.version_expr,
+    )
+    .map(Some)
+}
+
 fn executable_names(bin: &str) -> Vec<String> {
     let mut names = vec![bin.to_string()];
     if cfg!(target_os = "windows") && Path::new(bin).extension().is_none() {
@@ -614,6 +633,43 @@ mod tests {
         assert_eq!(
             normalize_idiomatic_contents("# full line comment\n3.14.2 # inline comment\n   \n\n"),
             "3.14.2"
+        );
+    }
+
+    #[test]
+    fn test_parse_registry_idiomatic_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tool.json");
+        fs::write(
+            &path,
+            r#"{"releases":[{"channel":"beta","version":"2.0.0"},{"channel":"stable","version":"1.2.3"}]}"#,
+        )
+        .unwrap();
+        let spec = RegistryIdiomaticFile {
+            path: "tool.json",
+            version_regex: None,
+            version_json_path: Some(".releases[?channel=stable].version"),
+            version_expr: None,
+        };
+
+        assert_eq!(
+            parse_registry_idiomatic_file(&path, &spec).unwrap(),
+            Some(vec!["1.2.3".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_registry_idiomatic_file_without_parser_uses_backend_fallback() {
+        let spec = RegistryIdiomaticFile {
+            path: ".tool-version",
+            version_regex: None,
+            version_json_path: None,
+            version_expr: None,
+        };
+
+        assert_eq!(
+            parse_registry_idiomatic_file(Path::new("does-not-need-to-exist"), &spec).unwrap(),
+            None
         );
     }
 
@@ -2045,7 +2101,7 @@ pub trait Backend: Debug + Send + Sync {
     async fn idiomatic_filenames(&self) -> Result<Vec<String>> {
         let mut filenames = self._idiomatic_filenames().await?;
         if let Some(rt) = REGISTRY.get(self.id()) {
-            filenames.extend(rt.idiomatic_files.iter().map(|s| s.to_string()));
+            filenames.extend(rt.idiomatic_files.iter().map(|f| f.path.to_string()));
         }
         filenames = filenames.into_iter().unique().collect();
         Ok(filenames)
@@ -2068,6 +2124,14 @@ pub trait Backend: Debug + Send + Sync {
                 path,
                 self.id(),
             );
+        }
+        if let Some(spec) = REGISTRY.get(self.id()).and_then(|rt| {
+            let filename = path.file_name()?.to_str()?;
+            rt.idiomatic_files
+                .iter()
+                .find(|spec| spec.path == filename && spec.has_parser())
+        }) {
+            return Ok(parse_registry_idiomatic_file(path, spec)?.unwrap_or_default());
         }
         self._parse_idiomatic_file(path).await
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -543,6 +543,21 @@ fn parse_registry_idiomatic_file(
     .map(Some)
 }
 
+fn parse_matching_registry_idiomatic_file(
+    path: &Path,
+    specs: &[RegistryIdiomaticFile],
+) -> Result<Option<Vec<String>>> {
+    match specs
+        .iter()
+        .filter(|spec| path.ends_with(spec.path))
+        .max_by_key(|spec| Path::new(spec.path).components().count())
+        .filter(|spec| spec.has_parser())
+    {
+        Some(spec) => parse_registry_idiomatic_file(path, spec),
+        None => Ok(None),
+    }
+}
+
 fn executable_names(bin: &str) -> Vec<String> {
     let mut names = vec![bin.to_string()];
     if cfg!(target_os = "windows") && Path::new(bin).extension().is_none() {
@@ -655,6 +670,43 @@ mod tests {
         assert_eq!(
             parse_registry_idiomatic_file(&path, &spec).unwrap(),
             Some(vec!["1.2.3".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_parse_matching_registry_idiomatic_file_uses_relative_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("subdir/tool.json");
+        fs::create_dir(path.parent().unwrap()).unwrap();
+        fs::write(&path, r#"{"version":"1.2.3"}"#).unwrap();
+        let specs = [RegistryIdiomaticFile {
+            path: "subdir/tool.json",
+            version_regex: None,
+            version_json_path: Some(".version"),
+            version_expr: None,
+        }];
+
+        assert_eq!(
+            parse_matching_registry_idiomatic_file(&path, &specs).unwrap(),
+            Some(vec!["1.2.3".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_parse_matching_registry_idiomatic_file_overrides_package_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        fs::write(&path, r#"{"tool":{"version":"4.5.6"}}"#).unwrap();
+        let specs = [RegistryIdiomaticFile {
+            path: "package.json",
+            version_regex: None,
+            version_json_path: Some(".tool.version"),
+            version_expr: None,
+        }];
+
+        assert_eq!(
+            parse_matching_registry_idiomatic_file(&path, &specs).unwrap(),
+            Some(vec!["4.5.6".to_string()])
         );
     }
 
@@ -2119,19 +2171,19 @@ pub trait Backend: Debug + Send + Sync {
     /// every backend needing to implement `package.json` support. For other files, it
     /// delegates to `_parse_idiomatic_file`.
     async fn parse_idiomatic_file(&self, path: &Path) -> eyre::Result<Vec<String>> {
+        if let Some(versions) = REGISTRY
+            .get(self.id())
+            .map(|rt| parse_matching_registry_idiomatic_file(path, rt.idiomatic_files))
+            .transpose()?
+            .flatten()
+        {
+            return Ok(versions);
+        }
         if crate::config::config_file::idiomatic_version::package_json::is_package_json(path) {
             return crate::config::config_file::idiomatic_version::package_json::parse(
                 path,
                 self.id(),
             );
-        }
-        if let Some(spec) = REGISTRY.get(self.id()).and_then(|rt| {
-            let filename = path.file_name()?.to_str()?;
-            rt.idiomatic_files
-                .iter()
-                .find(|spec| spec.path == filename && spec.has_parser())
-        }) {
-            return Ok(parse_registry_idiomatic_file(path, spec)?.unwrap_or_default());
         }
         self._parse_idiomatic_file(path).await
     }
@@ -2142,15 +2194,25 @@ pub trait Backend: Debug + Send + Sync {
         &self,
         path: &Path,
     ) -> eyre::Result<Vec<(String, ToolVersionOptions)>> {
-        let versions =
-            if crate::config::config_file::idiomatic_version::package_json::is_package_json(path) {
-                crate::config::config_file::idiomatic_version::package_json::parse(path, self.id())?
-                    .into_iter()
-                    .map(|version| (version, None))
-                    .collect()
-            } else {
-                self._parse_idiomatic_file_with_options(path).await?
-            };
+        let versions = if let Some(versions) = REGISTRY
+            .get(self.id())
+            .map(|rt| parse_matching_registry_idiomatic_file(path, rt.idiomatic_files))
+            .transpose()?
+            .flatten()
+        {
+            versions
+                .into_iter()
+                .map(|version| (version, None))
+                .collect()
+        } else if crate::config::config_file::idiomatic_version::package_json::is_package_json(path)
+        {
+            crate::config::config_file::idiomatic_version::package_json::parse(path, self.id())?
+                .into_iter()
+                .map(|version| (version, None))
+                .collect()
+        } else {
+            self._parse_idiomatic_file_with_options(path).await?
+        };
         let options = self.ba().opts();
         Ok(versions
             .into_iter()

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -1,9 +1,13 @@
 use crate::cli::Cli;
 use crate::file;
+use crate::registry;
 use clap::{Command, CommandFactory};
-use eyre::Result;
+use eyre::{ContextCompat, Result, ensure};
 use indoc::formatdoc;
 use itertools::Itertools;
+
+const IDIOMATIC_FILES_START: &str = "<!-- mise:idiomatic-version-files:start -->";
+const IDIOMATIC_FILES_END: &str = "<!-- mise:idiomatic-version-files:end -->";
 
 /// internal command to generate markdown from help
 #[derive(Debug, clap::Args)]
@@ -15,6 +19,7 @@ impl RenderHelp {
         xx::file::mkdirp("docs/.vitepress")?;
 
         file::write("docs/.vitepress/cli_commands.ts", render_command_ts())?;
+        render_idiomatic_version_files()?;
         if cfg!(windows) {
             cmd!("prettier.cmd", "--write", "docs/.vitepress/cli_commands.ts").run()?;
         } else {
@@ -22,6 +27,72 @@ impl RenderHelp {
         }
         Ok(())
     }
+}
+
+fn render_idiomatic_version_files() -> Result<()> {
+    let path = "docs/configuration.md";
+    let content = file::read_to_string(path)?;
+    let start = content
+        .find(IDIOMATIC_FILES_START)
+        .wrap_err("missing idiomatic version files start marker")?
+        + IDIOMATIC_FILES_START.len();
+    let end = content
+        .find(IDIOMATIC_FILES_END)
+        .wrap_err("missing idiomatic version files end marker")?;
+    ensure!(start <= end, "idiomatic version files markers are reversed");
+
+    let table = render_idiomatic_version_files_table();
+    let rendered = format!(
+        "{}\n\n{}\n\n{}",
+        &content[..start],
+        table.trim(),
+        &content[end..]
+    );
+    file::write(path, rendered)?;
+    Ok(())
+}
+
+fn render_idiomatic_version_files_table() -> String {
+    let rows = registry::baked_registry()
+        .iter()
+        .filter(|(plugin, tool)| *plugin == tool.short && !tool.idiomatic_files.is_empty())
+        .map(|(plugin, tool)| {
+            let files = tool
+                .idiomatic_files
+                .iter()
+                .map(|file| format!("`{}`", file.path))
+                .join(", ");
+            (plugin, files)
+        })
+        .sorted_by_key(|(plugin, _)| *plugin)
+        .collect_vec();
+    let plugin_width = rows
+        .iter()
+        .map(|(plugin, _)| plugin.len())
+        .max()
+        .unwrap_or_default()
+        .max("Plugin".len());
+    let files_width = rows
+        .iter()
+        .map(|(_, files)| files.len())
+        .max()
+        .unwrap_or_default()
+        .max("Idiomatic Files".len());
+
+    let mut table = format!(
+        "| {plugin:<plugin_width$} | {files:<files_width$} |\n\
+         | {plugin_rule:<plugin_width$} | {files_rule:<files_width$} |\n",
+        plugin = "Plugin",
+        files = "Idiomatic Files",
+        plugin_rule = "-".repeat(plugin_width),
+        files_rule = "-".repeat(files_width),
+    );
+    for (plugin, files) in rows {
+        table.push_str(&format!(
+            "| {plugin:<plugin_width$} | {files:<files_width$} |\n"
+        ));
+    }
+    table
 }
 
 fn render_command_ts() -> String {
@@ -72,4 +143,29 @@ fn render_command(command: &mut Command, indent: usize) -> String {
     }
     output.push_str(&format!("{pad}}},\n"));
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idiomatic_version_files_table_comes_from_baked_registry() {
+        let table = render_idiomatic_version_files_table();
+
+        assert!(
+            table
+                .lines()
+                .any(|line| line.starts_with("| cmake ") && line.contains("`CMakeLists.txt`"))
+        );
+        assert!(table.lines().any(|line| {
+            line.starts_with("| node ")
+                && line.contains("`.nvmrc`, `.node-version`, `package.json`")
+        }));
+        assert!(
+            table
+                .lines()
+                .any(|line| line.starts_with("| zig ") && line.contains("`.zig-version`"))
+        );
+    }
 }

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, Once};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -644,15 +644,48 @@ fn trust_file_hash(path: &Path) -> eyre::Result<bool> {
     Ok(hash == actual)
 }
 
-async fn filename_is_idiomatic(file_name: String) -> Option<Vec<Arc<dyn Backend>>> {
-    let mut backends = vec![];
+pub(crate) fn matching_idiomatic_filenames<'a>(
+    path: &Path,
+    filenames: impl IntoIterator<Item = &'a str>,
+) -> Vec<&'a str> {
+    let matches = filenames
+        .into_iter()
+        .filter(|filename| path.ends_with(filename))
+        .collect::<Vec<_>>();
+    let max_components = matches
+        .iter()
+        .map(|filename| Path::new(filename).components().count())
+        .max()
+        .unwrap_or_default();
+    matches
+        .into_iter()
+        .filter(|filename| Path::new(filename).components().count() == max_components)
+        .collect()
+}
+
+async fn path_is_idiomatic(path: &Path) -> Option<Vec<Arc<dyn Backend>>> {
+    let mut backends_by_filename = BTreeMap::<String, Vec<Arc<dyn Backend>>>::new();
     for b in backend::list() {
         match b.idiomatic_filenames().await {
-            Ok(filenames) if filenames.contains(&file_name) => backends.push(b),
+            Ok(filenames) => {
+                for filename in filenames {
+                    backends_by_filename
+                        .entry(filename)
+                        .or_default()
+                        .push(b.clone());
+                }
+            }
             Err(e) => debug!("idiomatic_filenames failed for {}: {:?}", b, e),
-            _ => {}
         }
     }
+    let mut seen = HashSet::new();
+    let backends =
+        matching_idiomatic_filenames(path, backends_by_filename.keys().map(String::as_str))
+            .into_iter()
+            .flat_map(|filename| backends_by_filename.get(filename).into_iter().flatten())
+            .filter(|backend| seen.insert(backend.id().to_string()))
+            .cloned()
+            .collect::<Vec<_>>();
     if backends.is_empty() {
         None
     } else {
@@ -678,7 +711,7 @@ async fn detect_config_file_type(path: &Path) -> Option<ConfigFileType> {
         f if env::MISE_OVERRIDE_CONFIG_FILENAMES.contains(f) => Some(ConfigFileType::MiseToml),
         f if env::MISE_DEFAULT_CONFIG_FILENAME.as_str() == f => Some(ConfigFileType::MiseToml),
         f => {
-            if let Some(backends) = filename_is_idiomatic(f.to_string()).await {
+            if let Some(backends) = path_is_idiomatic(path).await {
                 Some(ConfigFileType::IdiomaticVersion(backends))
             } else if f.ends_with(".toml") {
                 Some(ConfigFileType::MiseToml)
@@ -726,6 +759,7 @@ mod tests {
     #[tokio::test]
     async fn test_detect_config_file_type() {
         env::set_var("MISE_EXPERIMENTAL", "true");
+        backend::load_tools().await.unwrap();
         assert!(matches!(
             detect_config_file_type(Path::new("/foo/bar/.nvmrc")).await,
             Some(ConfigFileType::IdiomaticVersion(_))
@@ -746,6 +780,34 @@ mod tests {
             detect_config_file_type(Path::new("/foo/bar/rust-toolchain.toml")).await,
             Some(ConfigFileType::IdiomaticVersion(_))
         ));
+        assert!(matches!(
+            detect_config_file_type(Path::new("/foo/bar/.config/goreleaser.yaml")).await,
+            Some(ConfigFileType::IdiomaticVersion(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_parse_nested_registry_idiomatic_file() -> Result<()> {
+        env::set_var("MISE_EXPERIMENTAL", "true");
+        backend::load_tools().await?;
+        let dir = tempfile::tempdir()?;
+        let config_dir = dir.path().join(".config");
+        std::fs::create_dir_all(&config_dir)?;
+        let path = config_dir.join("goreleaser.yaml");
+        file::write(&path, "version: 2\n")?;
+
+        let tools = parse(&path)
+            .await?
+            .to_tool_request_set()?
+            .into_iter()
+            .collect::<Vec<_>>();
+        let (_, versions, _) = tools
+            .iter()
+            .find(|(backend, _, _)| backend.short == "goreleaser")
+            .expect("goreleaser should be parsed from its nested idiomatic path");
+
+        assert_eq!(versions[0].version(), "2");
+        Ok(())
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2014,19 +2014,9 @@ fn matching_idiomatic_tools(
     path: &Path,
     idiomatic_filenames: &BTreeMap<String, Vec<String>>,
 ) -> Vec<String> {
-    let matches = idiomatic_filenames
-        .iter()
-        .filter(|(filename, _)| path.ends_with(filename))
-        .collect_vec();
-    let max_components = matches
-        .iter()
-        .map(|(filename, _)| Path::new(filename).components().count())
-        .max()
-        .unwrap_or_default();
-    matches
+    config_file::matching_idiomatic_filenames(path, idiomatic_filenames.keys().map(String::as_str))
         .into_iter()
-        .filter(|(filename, _)| Path::new(filename).components().count() == max_components)
-        .flat_map(|(_, plugins)| plugins)
+        .flat_map(|filename| idiomatic_filenames.get(filename).into_iter().flatten())
         .unique()
         .cloned()
         .collect()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1995,19 +1995,41 @@ async fn parse_config_file(
     f: &PathBuf,
     idiomatic_filenames: &BTreeMap<String, Vec<String>>,
 ) -> Result<Arc<dyn ConfigFile>> {
-    match idiomatic_filenames.get(&f.file_name().unwrap().to_string_lossy().to_string()) {
-        Some(plugin) => {
-            trace!("idiomatic version file: {}", display_path(f));
-            let tools = backend::list()
-                .into_iter()
-                .filter(|f| plugin.contains(&f.to_string()))
-                .collect::<Vec<_>>();
-            IdiomaticVersionFile::parse(f.into(), tools)
-                .await
-                .map(|f| Arc::new(f) as Arc<dyn ConfigFile>)
-        }
-        None => config_file::parse(f).await,
+    let plugins = matching_idiomatic_tools(f, idiomatic_filenames);
+    if plugins.is_empty() {
+        config_file::parse(f).await
+    } else {
+        trace!("idiomatic version file: {}", display_path(f));
+        let tools = backend::list()
+            .into_iter()
+            .filter(|backend| plugins.contains(&backend.to_string()))
+            .collect::<Vec<_>>();
+        IdiomaticVersionFile::parse(f.into(), tools)
+            .await
+            .map(|f| Arc::new(f) as Arc<dyn ConfigFile>)
     }
+}
+
+fn matching_idiomatic_tools(
+    path: &Path,
+    idiomatic_filenames: &BTreeMap<String, Vec<String>>,
+) -> Vec<String> {
+    let matches = idiomatic_filenames
+        .iter()
+        .filter(|(filename, _)| path.ends_with(filename))
+        .collect_vec();
+    let max_components = matches
+        .iter()
+        .map(|(filename, _)| Path::new(filename).components().count())
+        .max()
+        .unwrap_or_default();
+    matches
+        .into_iter()
+        .filter(|(filename, _)| Path::new(filename).components().count() == max_components)
+        .flat_map(|(_, plugins)| plugins)
+        .unique()
+        .cloned()
+        .collect()
 }
 
 fn load_aliases(config_files: &ConfigMap) -> Result<AliasMap> {
@@ -4342,6 +4364,25 @@ config_roots = ["apps/api", "apps/web"]
         assert!(!result.contains_key(&sub_dir));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_matching_idiomatic_tools_uses_relative_paths() {
+        let idiomatic_filenames = BTreeMap::from([
+            (
+                "subdir/tool.json".to_string(),
+                vec!["nested-tool".to_string()],
+            ),
+            ("tool.json".to_string(), vec!["root-tool".to_string()]),
+        ]);
+
+        assert_eq!(
+            matching_idiomatic_tools(
+                Path::new("/tmp/project/subdir/tool.json"),
+                &idiomatic_filenames
+            ),
+            vec!["nested-tool"]
+        );
     }
 
     #[tokio::test]

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -195,10 +195,6 @@ impl Backend for BunPlugin {
         Ok(versions)
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec![".bun-version".into(), "package.json".into()])
-    }
-
     async fn install_version_(
         &self,
         ctx: &InstallContext,

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -120,10 +120,6 @@ impl Backend for DenoPlugin {
         Ok(versions)
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec![".deno-version".into(), "package.json".into()])
-    }
-
     async fn install_version_(
         &self,
         ctx: &InstallContext,

--- a/src/plugins/core/dotnet.rs
+++ b/src/plugins/core/dotnet.rs
@@ -155,10 +155,6 @@ impl Backend for DotnetPlugin {
             .collect())
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec!["global.json".into()])
-    }
-
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         let content = file::read_to_string(path)?;
         let global_json: GlobalJson = serde_json::from_str(&content)?;

--- a/src/plugins/core/elixir.rs
+++ b/src/plugins/core/elixir.rs
@@ -171,10 +171,6 @@ impl Backend for ElixirPlugin {
         Ok(versions)
     }
 
-    async fn _idiomatic_filenames(&self) -> eyre::Result<Vec<String>> {
-        Ok(vec![".exenv-version".into()])
-    }
-
     fn get_dependencies(&self) -> Result<Vec<&str>> {
         Ok(vec!["erlang"])
     }

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -280,10 +280,6 @@ impl Backend for GoPlugin {
         };
         Ok(versions)
     }
-    async fn _idiomatic_filenames(&self) -> eyre::Result<Vec<String>> {
-        Ok(vec![".go-version".into(), "go.mod".into()])
-    }
-
     async fn _parse_idiomatic_file(&self, path: &Path) -> eyre::Result<Vec<String>> {
         let v = match path.file_name() {
             Some(name) if name == "go.mod" => parse_gomod(&file::read_to_string(path)?),

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -529,10 +529,6 @@ impl Backend for JavaPlugin {
         })
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec![".java-version".into(), ".sdkmanrc".into()])
-    }
-
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         let contents = file::read_to_string(path)?;
         if path.file_name() == Some(".sdkmanrc".as_ref()) {

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -642,14 +642,6 @@ impl Backend for NodePlugin {
         Ok(aliases)
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec![
-            ".node-version".into(),
-            ".nvmrc".into(),
-            "package.json".into(),
-        ])
-    }
-
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         let contents = file::read_to_string(path)?;
         let body = normalize_idiomatic_contents(&contents);

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -878,13 +878,6 @@ impl Backend for PythonPlugin {
         }
     }
 
-    async fn _idiomatic_filenames(&self) -> eyre::Result<Vec<String>> {
-        Ok(vec![
-            ".python-version".to_string(),
-            ".python-versions".to_string(),
-        ])
-    }
-
     /// Python versions follow PEP 440, so `3.15.0a8`-style separator-less
     /// alpha suffixes are pre-releases that the shared filter wouldn't catch
     /// on its own. See `fuzzy_match_versions_pep440`.

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -946,10 +946,6 @@ impl Backend for RubyPlugin {
         .await
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec![".ruby-version".into(), "Gemfile".into()])
-    }
-
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         let v = match path.file_name() {
             Some(name) if name == "Gemfile" => parse_gemfile(&file::read_to_string(path)?),

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -187,10 +187,6 @@ impl Backend for RubyPlugin {
         Ok(versions)
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec![".ruby-version".into(), "Gemfile".into()])
-    }
-
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         let v = match path.file_name() {
             Some(name) if name == "Gemfile" => parse_gemfile(&file::read_to_string(path)?),

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -321,10 +321,6 @@ impl Backend for RustPlugin {
         Ok(versions)
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec!["rust-toolchain.toml".into()])
-    }
-
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         Ok(self
             ._parse_idiomatic_file_with_options(path)

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -298,10 +298,6 @@ impl Backend for SwiftPlugin {
         Ok(versions)
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec![".swift-version".into()])
-    }
-
     async fn install_version_(
         &self,
         ctx: &InstallContext,

--- a/src/plugins/core/zig.rs
+++ b/src/plugins/core/zig.rs
@@ -365,10 +365,6 @@ impl Backend for ZigPlugin {
         }
     }
 
-    async fn _idiomatic_filenames(&self) -> Result<Vec<String>> {
-        Ok(vec![".zig-version".into()])
-    }
-
     async fn install_version_(
         &self,
         ctx: &InstallContext,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -115,8 +115,24 @@ pub struct RegistryTool {
     pub overrides: &'static [&'static str],
     pub test: &'static Option<RegistryToolTest>,
     pub os: &'static [&'static str],
-    pub idiomatic_files: &'static [&'static str],
+    pub idiomatic_files: &'static [RegistryIdiomaticFile],
     pub detect: &'static [&'static str],
+}
+
+#[derive(Debug, Clone)]
+pub struct RegistryIdiomaticFile {
+    pub path: &'static str,
+    pub version_regex: Option<&'static str>,
+    pub version_json_path: Option<&'static str>,
+    pub version_expr: Option<&'static str>,
+}
+
+impl RegistryIdiomaticFile {
+    pub fn has_parser(&self) -> bool {
+        self.version_regex.is_some()
+            || self.version_json_path.is_some()
+            || self.version_expr.is_some()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -329,7 +345,7 @@ fn parse_registry_tool(short: &str, value: &toml::Value) -> Result<RegistryTool>
     let aliases = string_array(table.get("aliases"), "aliases")?;
     let overrides = string_array(table.get("overrides"), "overrides")?;
     let os = string_array(table.get("os"), "os")?;
-    let idiomatic_files = string_array(table.get("idiomatic_files"), "idiomatic_files")?;
+    let idiomatic_files = parse_registry_idiomatic_files(table.get("idiomatic_files"))?;
     let detect = string_array(table.get("detect"), "detect")?;
     let description = table
         .get("description")
@@ -353,6 +369,66 @@ fn parse_registry_tool(short: &str, value: &toml::Value) -> Result<RegistryTool>
         idiomatic_files: leak_vec(idiomatic_files),
         detect: leak_vec(detect),
     })
+}
+
+fn parse_registry_idiomatic_files(
+    value: Option<&toml::Value>,
+) -> Result<Vec<RegistryIdiomaticFile>> {
+    value
+        .map(|value| {
+            value
+                .as_array()
+                .ok_or_else(|| eyre::eyre!("idiomatic_files must be an array"))?
+                .iter()
+                .map(parse_registry_idiomatic_file)
+                .collect()
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
+}
+
+fn parse_registry_idiomatic_file(value: &toml::Value) -> Result<RegistryIdiomaticFile> {
+    match value {
+        toml::Value::String(path) => Ok(RegistryIdiomaticFile {
+            path: leak_string(path.clone()),
+            version_regex: None,
+            version_json_path: None,
+            version_expr: None,
+        }),
+        toml::Value::Table(table) => {
+            for key in table.keys() {
+                ensure!(
+                    matches!(
+                        key.as_str(),
+                        "path" | "version_regex" | "version_json_path" | "version_expr"
+                    ),
+                    "unknown idiomatic file field: {key}"
+                );
+            }
+            let string = |key: &str| -> Result<Option<&'static str>> {
+                table
+                    .get(key)
+                    .map(|value| {
+                        value
+                            .as_str()
+                            .map(|value| leak_string(value.to_string()))
+                            .ok_or_else(|| eyre::eyre!("idiomatic_files.{key} must be a string"))
+                    })
+                    .transpose()
+            };
+            let path = string("path")?
+                .ok_or_else(|| eyre::eyre!("idiomatic_files.path must be a string"))?;
+            Ok(RegistryIdiomaticFile {
+                path,
+                version_regex: string("version_regex")?,
+                version_json_path: string("version_json_path")?,
+                version_expr: string("version_expr")?,
+            })
+        }
+        _ => Err(eyre::eyre!(
+            "idiomatic_files entries must be strings or tables"
+        )),
+    }
 }
 
 fn parse_registry_backend(value: &toml::Value) -> Result<RegistryBackend> {
@@ -687,6 +763,11 @@ backends = [
   "aqua:example/tool",
   { full = "github:example/tool", platforms = ["linux-x64"], options = { bin = "example" } },
 ]
+idiomatic_files = [
+  ".example-version",
+  { path = "example.json", version_json_path = ".tool.version" },
+  { path = "example.txt", version_regex = 'version=(\S+)', version_expr = "versions[0]" },
+]
 test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
 "#
             .to_string(),
@@ -702,7 +783,40 @@ test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
             tool.backend_options("github:example/tool").get("bin"),
             Some("example")
         );
+        assert_eq!(tool.idiomatic_files[0].path, ".example-version");
+        assert!(!tool.idiomatic_files[0].has_parser());
+        assert_eq!(tool.idiomatic_files[1].path, "example.json");
+        assert_eq!(
+            tool.idiomatic_files[1].version_json_path,
+            Some(".tool.version")
+        );
+        assert_eq!(
+            tool.idiomatic_files[2].version_regex,
+            Some(r"version=(\S+)")
+        );
+        assert_eq!(tool.idiomatic_files[2].version_expr, Some("versions[0]"));
         assert_eq!(tool.test.as_ref().unwrap().tools, &["node"]);
+    }
+
+    #[test]
+    fn test_dynamic_registry_rejects_unknown_idiomatic_file_fields() {
+        use super::*;
+
+        let err = registry_from_sources(BTreeMap::from([(
+            "example".to_string(),
+            r#"
+backends = ["aqua:example/tool"]
+idiomatic_files = [{ path = ".example-version", parser = "shell" }]
+"#
+            .to_string(),
+        )]))
+        .err()
+        .unwrap();
+
+        assert!(
+            format!("{err:#}").contains("unknown idiomatic file field: parser"),
+            "{err:#}"
+        );
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -24,6 +24,11 @@ use url::Url;
 
 // the registry is generated from registry/ in the project root
 static BAKED_REGISTRY: Registry = include!(concat!(env!("OUT_DIR"), "/registry.rs"));
+
+pub(crate) fn baked_registry() -> &'static Registry {
+    &BAKED_REGISTRY
+}
+
 pub static REGISTRY: Lazy<&'static Registry> = Lazy::new(|| {
     if !Settings::get().registry_floating {
         return &BAKED_REGISTRY;


### PR DESCRIPTION
## Summary

- allow registry `idiomatic_files` entries to define `version_regex`, `version_json_path`, and `version_expr` parser metadata
- reuse the existing HTTP/S3 version-list parser in-process for Aqua, GitHub, and other registry backends
- preserve filename-only entries and backend-native parsing as compatibility fallbacks
- support structured parsers in baked and floating registries
- give configured parsers precedence over native parsing and support nested idiomatic paths
- document the registry format, selection behavior, and supported tool catalog

## Registry coverage

This PR adds idiomatic parsing for 11 registry tools:

- Dagger: `dagger.json` → `engineVersion`
- Task: all standard `Taskfile.yml` / `Taskfile.yaml` casing variants → `version`
- chezmoi: `.chezmoiversion`
- CMake: `CMakeLists.txt` → `cmake_minimum_required(VERSION ...)`
- Earthly: `Earthfile` → `VERSION`
- golangci-lint: all four documented config formats → config major
- GoReleaser: all six documented config paths → config major
- Lefthook: YAML, TOML, JSON, and JSONC names, including nested `.config/` paths → `min_version`
- Pixi: `pixi.toml` and `pyproject.toml` → `requires-pixi`
- pre-commit: `.pre-commit-config.yaml` → `minimum_pre_commit_version`
- Ruff: `ruff.toml` and `.ruff.toml` → `required-version`

The catalog intentionally uses only exact versions, minimum/required versions, or configuration-format majors that are coupled to the compatible CLI major. It avoids unrelated project and schema version fields.

## User impact

Users continue opting in per tool:

```sh
mise settings add idiomatic_version_file_enable_tools dagger task lefthook
```

Existing filename-only entries behave unchanged. Structured parsing runs in-process and does not execute plugin or shell code.

## Popularity

- [Task](https://mise-versions.jdx.dev/tools/task): 29,815 mise downloads and 117 tracked versions
- [Dagger](https://mise-versions.jdx.dev/tools/dagger): 5,083 mise downloads and 935 tracked versions
- [Lefthook](https://mise-versions.jdx.dev/tools/lefthook): 105,691 mise downloads and 218 tracked versions
- [chezmoi](https://mise-versions.jdx.dev/tools/chezmoi): 13,614 mise downloads and 255 tracked versions
- The remaining additions are existing registry tools with established official configuration formats.

## Validation

- `mise run lint`
- `mise run lint-fix`
- `mise run test:unit` — 1,969 passed
- `cargo test registry_idiomatic_file`
- `cargo test dynamic_registry`
- `mise run test:e2e backend/test_registry_idiomatic_version_files` — all 11 tools passed

*This pull request was generated by an AI coding assistant.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Registry-backed tools can now configure idiomatic file version parsing using structured `idiomatic_files` entries (path + optional rules).
  - Added support for `version_regex`, `version_json_path`, and `version_expr`.
- **Bug Fixes**
  - Improved idiomatic-version-file detection by matching registry-defined parsers via path-suffix specificity/precedence, with registry-first parsing fallback.
  - Registry rejects unknown `idiomatic_files` fields.
- **Documentation**
  - Updated configuration and contributing docs with new idiomatic-version-file behavior and examples.
- **Schema**
  - Updated the registry tool JSON schema for the new `idiomatic_files` shape.
- **Tests**
  - Expanded backend and end-to-end coverage, including filename variants (e.g., Taskfile.yml vs Taskfile.yaml).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect config discovery and version resolution across many tools; incorrect regex/JSON paths could mis-resolve versions, though behavior remains opt-in via `idiomatic_version_file_enable_tools` and plain entries stay compatible.
> 
> **Overview**
> **Registry `idiomatic_files` can now be plain paths or tables** with `version_regex`, `version_json_path`, and `version_expr` (same model as the HTTP backend). Build-time and runtime registry loading both accept the new shape; unknown table keys are rejected.
> 
> **Parsing runs in-process** via `version_list::parse_version_list` when a registry spec defines a parser. Registry parsers take precedence over backend-native idiomatic parsing; entries without parsers still fall back to plain-text or plugin behavior. **Path matching** uses suffix specificity (e.g. nested `.config/goreleaser.yaml` over generic names).
> 
> **Discovery** no longer keys only on `file_name()`: config detection and idiomatic tool resolution match full relative paths and pick the most specific registered filename.
> 
> **Core plugins** drop duplicated `_idiomatic_filenames` in favor of centralized `registry/*.toml` entries (including many language runtimes). **New structured parsers** are added for tools such as dagger, task, cmake, lefthook, goreleaser, pixi, ruff, and others; **yarn** gains `.yvmrc` in idiomatic files.
> 
> **Docs** explain registry parsers and minimum/major version semantics; the idiomatic-files table is **regenerated** from the baked registry via `mise render-help`. **Schema**, contributing guide, unit tests, and an e2e script cover the 11 structured tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e243d60f8b225b09d952833da585659a7d8cfa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->