### PR TITLE
fix(task): display forwarded arguments accurately

### DIFF
--- a/e2e/tasks/test_task_show_full_cmd
+++ b/e2e/tasks/test_task_show_full_cmd
@@ -15,6 +15,22 @@ set -e
 echo first-line
 echo second-line
 """
+
+[tasks.inline-one]
+run = "echo inline-one"
+
+[tasks.inline-multi]
+run = """
+echo inline-first
+echo inline-last
+"""
+
+[tasks.shebang-multi]
+run = """
+#!/usr/bin/env bash
+echo shebang-first
+echo shebang-last
+"""
 EOF
 
 # show_full_cmd ON: the echoed header includes the LATER command line. The literal
@@ -26,3 +42,25 @@ assert_contains "MISE_TASK_SHOW_FULL_CMD=1 mise run multi 2>&1" "echo second-lin
 # command, skipping the shebang/`set` boilerplate, and later lines are truncated.
 assert_contains "mise run multi 2>&1" "echo first-line"
 assert_not_contains "mise run multi 2>&1" "echo second-line"
+
+# Inline arguments are appended to the actual command text. The normal header
+# therefore shows them for a one-line command, but not on the representative
+# first command of a multiline script.
+assert_contains "mise run inline-one arg 2>&1" "echo inline-one arg"
+assert_contains "mise run inline-one 'a with space' 2>&1" "echo inline-one 'a with space'"
+assert_contains "mise run inline-multi arg 2>&1" "echo inline-first"
+assert_not_contains "mise run inline-multi arg 2>&1" "echo inline-first arg"
+
+# With the full command shown, inline arguments appear on the final command
+# where they are appended for execution.
+assert_contains \
+  "MISE_TASK_SHOW_FULL_CMD=1 mise run inline-multi arg 2>&1" \
+  "echo inline-last arg"
+
+# Shebang task arguments are script argv, not arguments to a command in the
+# script, so neither display mode attaches them to a displayed command.
+assert_contains "mise run shebang-multi arg 2>&1" "echo shebang-first"
+assert_not_contains "mise run shebang-multi arg 2>&1" "echo shebang-first arg"
+assert_not_contains \
+  "MISE_TASK_SHOW_FULL_CMD=1 mise run shebang-multi arg 2>&1" \
+  "echo shebang-last arg"

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -111,6 +111,22 @@ fn display_first_command(script: &str) -> String {
     cmd
 }
 
+/// Build the script text represented by the task command header.
+///
+/// Inline task arguments are appended to the command text before selecting the
+/// first command for display, matching how the inline shell is invoked. Shebang
+/// tasks receive arguments as script argv instead, so attaching them to a command
+/// in the script would be misleading.
+fn display_script_with_args(script: &str, args: &[String]) -> String {
+    if script.starts_with("#!") || args.is_empty() {
+        script.to_string()
+    } else if script.is_empty() {
+        shell_words::join(args)
+    } else {
+        format!("{script} {}", shell_words::join(args))
+    }
+}
+
 /// Configuration for TaskExecutor
 pub struct TaskExecutorConfig {
     pub force: bool,
@@ -918,22 +934,20 @@ impl TaskExecutor {
     ) -> Result<()> {
         let config = Config::get().await?;
         let script = script.trim_start();
+        let display_script = display_script_with_args(script, args);
         // For display, skip leading shebang/blank/`set ...` boilerplate and join
         // backslash-continued lines so the header shows the first real command as a
         // single logical line (see display_first_command). When show_full_cmd is set,
         // keep the whole script instead — the reduction would otherwise discard every
         // line past the first command, making the setting a no-op (#10469, #9844).
         let display_script = if Settings::get().task.show_full_cmd {
-            script.to_string()
+            display_script
         } else {
-            display_first_command(script)
+            display_first_command(&display_script)
         };
-        let args_str = args.join(" ");
-        let cmd = match (display_script.is_empty(), args_str.is_empty()) {
-            (true, true) => "$".to_string(),
-            (true, false) => format!("$ {args_str}"),
-            (false, true) => format!("$ {display_script}"),
-            (false, false) => format!("$ {display_script} {args_str}"),
+        let cmd = match display_script.is_empty() {
+            true => "$".to_string(),
+            false => format!("$ {display_script}"),
         };
         if !self.quiet(Some(task)) {
             let msg = style::ebold(trunc(prefix, config.redact(&cmd).trim()))
@@ -1716,11 +1730,28 @@ mod tests {
     fn test_display_first_command_header_has_no_dangling_backslash_with_args() {
         // Reproduces #10083: the joined command plus extra args must not contain
         // the `\ ` sequence that confused the original output.
-        let display_script = display_first_command("echo long_command \\\n  --option1 value1");
-        let args_str = ["--extra", "args"].join(" ");
-        let header = format!("$ {display_script} {args_str}");
+        let args = ["--extra".to_string(), "args".to_string()];
+        let display_script =
+            display_script_with_args("echo long_command \\\n  --option1 value1", &args);
+        let header = format!("$ {}", display_first_command(&display_script));
         assert_eq!(header, "$ echo long_command --option1 value1 --extra args");
         assert!(!header.contains("\\ "));
+    }
+
+    #[test]
+    fn test_display_script_with_args_appends_inline_args() {
+        let args = ["a with space".to_string(), "second".to_string()];
+        assert_eq!(
+            display_script_with_args("echo first\necho last", &args),
+            "echo first\necho last 'a with space' second"
+        );
+    }
+
+    #[test]
+    fn test_display_script_with_args_keeps_shebang_args_off_commands() {
+        let script = "#!/usr/bin/env bash\necho first\necho last";
+        let args = ["arg".to_string()];
+        assert_eq!(display_script_with_args(script, &args), script);
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -111,19 +111,46 @@ fn display_first_command(script: &str) -> String {
     cmd
 }
 
-/// Build the script text represented by the task command header.
-///
-/// Inline task arguments are appended to the command text before selecting the
-/// first command for display, matching how the inline shell is invoked. Shebang
-/// tasks receive arguments as script argv instead, so attaching them to a command
-/// in the script would be misleading.
-fn display_script_with_args(script: &str, args: &[String]) -> String {
-    if script.starts_with("#!") || args.is_empty() {
-        script.to_string()
-    } else if script.is_empty() {
-        shell_words::join(args)
-    } else {
-        format!("{script} {}", shell_words::join(args))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(windows), allow(dead_code))]
+enum InlineArgsStyle {
+    PosixCommandText,
+    CmdCommandText,
+    SeparateArgv,
+}
+
+fn inline_args_style(program: &str, shell_args: &[String]) -> InlineArgsStyle {
+    #[cfg(windows)]
+    {
+        let runs_command = shell_args
+            .iter()
+            .any(|f| f.eq_ignore_ascii_case("/c") || f.eq_ignore_ascii_case("/k"));
+        if crate::path::is_cmd_shell_program(Path::new(program)) && runs_command {
+            return InlineArgsStyle::CmdCommandText;
+        }
+        if !crate::path::is_posix_shell_program(Path::new(program)) {
+            return InlineArgsStyle::SeparateArgv;
+        }
+    }
+    #[cfg(not(windows))]
+    let _ = (program, shell_args);
+    InlineArgsStyle::PosixCommandText
+}
+
+fn append_inline_args(script: &str, args: &[String], style: InlineArgsStyle) -> String {
+    let args = match style {
+        InlineArgsStyle::PosixCommandText => shell_words::join(args),
+        InlineArgsStyle::CmdCommandText => args
+            .iter()
+            .map(|arg| crate::path::quote_arg_for_cmd_body(arg))
+            .join(" "),
+        InlineArgsStyle::SeparateArgv => return script.to_string(),
+    };
+    match (script.is_empty(), args.is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => args,
+        (false, true) => script.to_string(),
+        (false, false) => format!("{script} {args}"),
     }
 }
 
@@ -934,7 +961,7 @@ impl TaskExecutor {
     ) -> Result<()> {
         let config = Config::get().await?;
         let script = script.trim_start();
-        let display_script = display_script_with_args(script, args);
+        let display_script = self.display_script_with_args(script, args, task)?;
         // For display, skip leading shebang/blank/`set ...` boilerplate and join
         // backslash-continued lines so the header shows the first real command as a
         // single logical line (see display_first_command). When show_full_cmd is set,
@@ -969,6 +996,30 @@ impl TaskExecutor {
             self.exec_program(&program, &args, task, env, prefix, cmd_verbatim)
                 .await
         }
+    }
+
+    /// Build the script text represented by the task command header.
+    ///
+    /// Inline task arguments follow the same shell-specific strategy used for
+    /// execution before the first command is selected for display. Shebang tasks
+    /// receive arguments as script argv instead, so attaching them to a command in
+    /// the script would be misleading.
+    fn display_script_with_args(
+        &self,
+        script: &str,
+        args: &[String],
+        task: &Task,
+    ) -> Result<String> {
+        if script.starts_with("#!") || args.is_empty() {
+            return Ok(script.to_string());
+        }
+        let shell = task.shell()?.unwrap_or(self.clone_default_inline_shell()?);
+        let (program, shell_args) = task_shell_parts(&shell, "inline shell")?;
+        Ok(append_inline_args(
+            script,
+            args,
+            inline_args_style(program, shell_args),
+        ))
     }
 
     fn get_file_program_and_args(
@@ -1024,21 +1075,20 @@ impl TaskExecutor {
             // in a single outer quote pair, and use `/s` so cmd strips exactly
             // that pair and runs the rest — inner quotes included — verbatim.
             // See discussion #9355.
-            let runs_command = _shell_args
-                .iter()
-                .any(|f| f.eq_ignore_ascii_case("/c") || f.eq_ignore_ascii_case("/k"));
-            if crate::path::is_cmd_shell_program(Path::new(program)) && runs_command {
-                let cmd_args = crate::path::cmd_verbatim_args(_shell_args, script, args);
-                return Ok((program.to_string(), cmd_args, true));
-            }
-            // Non-POSIX, non-cmd shells (e.g. `pwsh -Command`) use a different
-            // quoting convention than `shell_words` (which is POSIX), so keep
-            // passing their forwarded args as separate argv. Only POSIX shells
-            // (`bash -c`, `sh -c`, …) fall through to the shared append below.
-            if !crate::path::is_posix_shell_program(Path::new(program)) {
-                full_args.push(script.to_string());
-                full_args.extend(args.iter().cloned());
-                return Ok((program.to_string(), full_args[1..].to_vec(), false));
+            match inline_args_style(program, _shell_args) {
+                InlineArgsStyle::CmdCommandText => {
+                    let cmd_args = crate::path::cmd_verbatim_args(_shell_args, script, args);
+                    return Ok((program.to_string(), cmd_args, true));
+                }
+                InlineArgsStyle::SeparateArgv => {
+                    // Non-POSIX, non-cmd shells (e.g. `pwsh -Command`) use a
+                    // different quoting convention than `shell_words` (which is
+                    // POSIX), so keep passing forwarded args as separate argv.
+                    full_args.push(script.to_string());
+                    full_args.extend(args.iter().cloned());
+                    return Ok((program.to_string(), full_args[1..].to_vec(), false));
+                }
+                InlineArgsStyle::PosixCommandText => {}
             }
         }
 
@@ -1731,27 +1781,45 @@ mod tests {
         // Reproduces #10083: the joined command plus extra args must not contain
         // the `\ ` sequence that confused the original output.
         let args = ["--extra".to_string(), "args".to_string()];
-        let display_script =
-            display_script_with_args("echo long_command \\\n  --option1 value1", &args);
+        let display_script = append_inline_args(
+            "echo long_command \\\n  --option1 value1",
+            &args,
+            InlineArgsStyle::PosixCommandText,
+        );
         let header = format!("$ {}", display_first_command(&display_script));
         assert_eq!(header, "$ echo long_command --option1 value1 --extra args");
         assert!(!header.contains("\\ "));
     }
 
     #[test]
-    fn test_display_script_with_args_appends_inline_args() {
+    fn test_append_inline_args_uses_posix_quoting() {
         let args = ["a with space".to_string(), "second".to_string()];
         assert_eq!(
-            display_script_with_args("echo first\necho last", &args),
+            append_inline_args(
+                "echo first\necho last",
+                &args,
+                InlineArgsStyle::PosixCommandText
+            ),
             "echo first\necho last 'a with space' second"
         );
     }
 
     #[test]
-    fn test_display_script_with_args_keeps_shebang_args_off_commands() {
-        let script = "#!/usr/bin/env bash\necho first\necho last";
-        let args = ["arg".to_string()];
-        assert_eq!(display_script_with_args(script, &args), script);
+    fn test_append_inline_args_uses_cmd_quoting() {
+        let args = ["a with space".to_string(), "a&b".to_string()];
+        assert_eq!(
+            append_inline_args("echo", &args, InlineArgsStyle::CmdCommandText),
+            r#"echo "a with space" "a&b""#
+        );
+    }
+
+    #[test]
+    fn test_append_inline_args_keeps_separate_argv_off_command_text() {
+        let args = ["a with space".to_string()];
+        assert_eq!(
+            append_inline_args("Write-Output $args", &args, InlineArgsStyle::SeparateArgv),
+            "Write-Output $args"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- build inline task headers from the same command text that receives forwarded arguments
- keep shebang task argv off representative commands in the displayed script
- preserve argument boundaries with shell quoting in inline task headers
- add unit and E2E coverage for one-line, multiline, shebang, full-command, and spaced-argument cases

## Root cause

The task header selected a representative command from the script and then unconditionally appended forwarded arguments. That made multiline inline tasks appear to pass arguments to their first command and shebang tasks appear to pass arguments to a command in the script, even though shebang arguments are script argv.

The display now appends arguments to the full inline command text before selecting its representative first command. Shebang scripts retain their script body unchanged because their arguments are passed separately as argv.

Addresses [discussion #11343](https://github.com/jdx/mise/discussions/11343).

## Validation
- `mise run test:unit -- task::task_executor::tests::test_display`
- `mise run test:e2e tasks/test_task_show_full_cmd`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to task header display and a small refactor that reuses existing inline-arg execution rules; execution semantics are intended to stay the same.
> 
> **Overview**
> Fixes misleading **`$ ...` task headers** when you pass extra arguments to inline or shebang tasks.
> 
> **Inline scripts** now append forwarded args to the **same command text used at execution** (POSIX `shell_words`, Windows `cmd` quoting, or separate argv for shells like `pwsh`) **before** `display_first_command` or `show_full_cmd` runs. One-line tasks show args on that command; multiline tasks show args only on the **last** line when `show_full_cmd` is on, not on the first displayed line.
> 
> **Shebang scripts** leave the displayed body unchanged—args are script **argv**, not part of a command inside the script.
> 
> Windows inline-shell branching in `get_cmd_program_and_args` is refactored to share `inline_args_style` / `append_inline_args` with the header path. E2E and unit tests cover spaced args, multiline, shebang, and continuation lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ebee0519d0d69a5e0e2d034c40eb5054e34215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how task command headers display inline arguments, including correct behavior across different “show full command” modes.
  * Fixed multi-line rendering so inline args appear on the intended line (and not on the representative first line when appropriate).
  * Ensured shebang-based tasks treat arguments as script argv, so they aren’t incorrectly appended to displayed command text.
  * Corrected quoting/formatting for arguments with spaces and removed continuation artifacts.
* **Tests**
  * Expanded end-to-end coverage for full-command display variants and added additional command-header assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->