### PR TITLE
chore(registry): remove stale registry symlink

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,6 +1,6 @@
 # Taplo configuration for mise
 
-exclude = ["docs/registry/*.toml", "docs/settings.toml"]
+exclude = ["docs/settings.toml"]
 
 
 [formatting]

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -1,1 +1,0 @@
-../registry.toml

--- a/hk.pkl
+++ b/hk.pkl
@@ -61,7 +61,6 @@ fi
     // uses taplo for TOML formatting and validation
     ["taplo"] {
         glob = List("**/*.toml")
-        exclude = List("docs/registry/") // exclude docs/registry/ symlink
         check = "taplo fmt --check {{files}} && taplo check {{files}}"
         fix = "taplo fmt {{files}} && taplo check {{files}}"
     }


### PR DESCRIPTION
## Summary
- remove the broken `docs/registry.toml` symlink
- remove its obsolete Taplo and hk exclusions

## Why
#7820 replaced the monolithic root `registry.toml` with individual `registry/*.toml` files, but left `docs/registry.toml` pointing at the deleted file. The corresponding lint exclusions also remained even though there is no longer a documentation registry symlink to exclude.

The documentation registry loader already reads `registry/*.toml` directly, so these remnants have no consumer.

## Impact
Removes a broken tracked symlink and allows the current registry TOML files to follow the normal lint configuration.

## Validation
- `mise run lint-fix`
- `git diff --check`
- verified no remaining references to the old documentation registry symlink

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an obsolete registry documentation reference.
  * Updated documentation formatting coverage to reflect the current documentation structure.

* **Chores**
  * Refined documentation configuration while preserving existing formatting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->