### PR TITLE
feat(task): replay cached task output

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -80,7 +80,7 @@ outside this tracker.
 - [x] Include dependency artifact keys in downstream task keys
 - [x] Allow dependents to restore when dependencies publish stable artifact keys;
       unkeyed dependency work still forces execution
-- [ ] Capture and replay stdout and stderr while respecting mise output modes
+- [x] Capture and replay stdout and stderr while respecting mise output modes
 - [ ] Cache useful results for tasks with no filesystem outputs
 - [ ] Support reusable and global input groups
 - [ ] Support global environment inputs and pass-through environment variables

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -495,15 +495,19 @@ the values (or absence) of variables named in `cache.env`, resolved tool version
 artifact keys, and the operating system and architecture. Variables inherited from the ambient
 process are ignored unless listed in `cache.env`.
 
-Artifacts are stored under `MISE_CACHE_DIR/task-artifacts/v1` as zstd-compressed tar archives. They
+Artifacts are stored under `MISE_CACHE_DIR/task-artifacts/v2` as zstd-compressed tar archives. They
 are included in the existing `mise cache clear` and `mise cache prune` behavior. Only successful task
 runs are cached. Cache read/write failures are treated as misses and never turn a successful task run
 into a failure.
 
-This initial implementation is local-only and does not cache or replay task logs. Cacheable
-dependencies contribute their artifact keys to dependent task keys, so a dependent can restore the
-matching artifact after its dependencies execute, skip, or restore. If a dependency executes without
-a stable artifact key, its dependents conservatively execute.
+Stdout and stderr are stored as ordered, redacted streams and replayed using the output mode selected
+for the cache hit. Prefix, interleave, keep-order, timed, replacing, quiet, silent, and per-stream
+silence therefore apply to replayed output just as they do to live output. Raw and interactive tasks
+retain inherited terminal I/O and conservatively bypass artifact caching.
+
+Cacheable dependencies contribute their artifact keys to dependent task keys, so a dependent can
+restore the matching artifact after its dependencies execute, skip, or restore. If a dependency
+executes without a stable artifact key, its dependents conservatively execute.
 
 ### `shell`
 

--- a/e2e/tasks/test_task_artifact_cache_output
+++ b/e2e/tasks/test_task_artifact_cache_output
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+redactions = ["SECRET"]
+
+[settings]
+experimental = true
+
+[env]
+SECRET = "cache-secret"
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+run = '''
+mkdir -p dist
+printf 'stdout-line\n'
+printf 'stderr-line\n' >&2
+printf 'secret=%s\n' "$SECRET"
+printf 'artifact\n' > dist/result.txt
+printf 'ran\n' >> runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["dist"]
+
+[tasks.partial]
+run = '''
+mkdir -p partial-dist
+printf 'partial-stdout\n'
+printf 'partial-stderr\n' >&2
+printf 'artifact\n' > partial-dist/result.txt
+printf 'ran\n' >> partial-runs.txt
+'''
+sources = ["partial.txt"]
+outputs = ["partial-dist"]
+silent = "stdout"
+
+[tasks.raw]
+run = '''
+mkdir -p raw-dist
+printf 'raw-output\n'
+printf 'artifact\n' > raw-dist/result.txt
+printf 'ran\n' >> raw-runs.txt
+'''
+sources = ["raw.txt"]
+outputs = ["raw-dist"]
+raw = true
+
+[tasks.hidden-first]
+run = '''
+mkdir -p hidden-dist
+printf 'hidden-stdout\n'
+printf 'hidden-stderr\n' >&2
+printf 'artifact\n' > hidden-dist/result.txt
+printf 'ran\n' >> hidden-runs.txt
+'''
+sources = ["hidden.txt"]
+outputs = ["hidden-dist"]
+EOF
+
+printf 'input\n' >input.txt
+printf 'partial\n' >partial.txt
+printf 'raw\n' >raw.txt
+printf 'hidden\n' >hidden.txt
+
+# Capture streams during a normal execution.
+output="$(mise run --output prefix build 2>&1)"
+assert_contains "echo \"$output\"" "stdout-line"
+assert_contains "echo \"$output\"" "stderr-line"
+assert_contains "echo \"$output\"" "secret=[redacted]"
+assert_not_contains "echo \"$output\"" "cache-secret"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# A fresh-output cache hit also replays the stored streams.
+output="$(mise run --output prefix build 2>&1)"
+assert_contains "echo \"$output\"" "sources up-to-date, skipping"
+assert_contains "echo \"$output\"" "[build] stdout-line"
+assert_contains "echo \"$output\"" "[build] stderr-line"
+assert_contains "echo \"$output\"" "[build] secret=[redacted]"
+assert_not_contains "echo \"$output\"" "cache-secret"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# Replay uses the current prefix style rather than storing formatted lines.
+rm -rf dist
+output="$(mise run --output prefix build 2>&1)"
+assert_contains "echo \"$output\"" "[build] stdout-line"
+assert_contains "echo \"$output\"" "[build] stderr-line"
+assert_contains "echo \"$output\"" "restored outputs from cache"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# The same cached streams can be replayed without prefixes in interleave mode.
+rm -rf dist
+output="$(mise run --output interleave build 2>&1)"
+assert_contains "echo \"$output\"" "stdout-line"
+assert_contains "echo \"$output\"" "stderr-line"
+assert_not_contains "echo \"$output\"" "[build] stdout-line"
+assert_not_contains "echo \"$output\"" "[build] stderr-line"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# Quiet hides mise metadata but still replays task output using the chosen style.
+rm -rf dist
+output="$(mise run --quiet --output prefix build 2>&1)"
+assert_contains "echo \"$output\"" "[build] stdout-line"
+assert_contains "echo \"$output\"" "[build] stderr-line"
+assert_not_contains "echo \"$output\"" "restored outputs from cache"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# Silent mode suppresses both cached streams.
+rm -rf dist
+output="$(mise run --output silent build 2>&1)"
+assert "echo -n \"$output\"" ""
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# Per-stream silence is also applied during replay.
+output="$(mise run partial 2>&1)"
+assert_not_contains "echo \"$output\"" "partial-stdout"
+assert_contains "echo \"$output\"" "partial-stderr"
+rm -rf partial-dist
+output="$(mise run partial 2>&1)"
+assert_not_contains "echo \"$output\"" "partial-stdout"
+assert_contains "echo \"$output\"" "partial-stderr"
+assert "wc -l < partial-runs.txt | tr -d ' '" "1"
+
+# Streams captured during a silent execution remain available to a later
+# cache hit with visible output.
+output="$(mise run --output silent hidden-first 2>&1)"
+assert "echo -n \"$output\"" ""
+rm -rf hidden-dist
+output="$(mise run --output prefix hidden-first 2>&1)"
+assert_contains "echo \"$output\"" "[hidden-first] hidden-stdout"
+assert_contains "echo \"$output\"" "[hidden-first] hidden-stderr"
+assert "wc -l < hidden-runs.txt | tr -d ' '" "1"
+
+# Raw tasks retain inherited stdio and conservatively bypass artifact caching.
+mise run raw
+rm -rf raw-dist
+mise run raw
+assert "wc -l < raw-runs.txt | tr -d ' '" "2"

--- a/e2e/tasks/test_task_artifact_cache_resilience
+++ b/e2e/tasks/test_task_artifact_cache_resilience
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+run = '''
+mkdir -p dist
+printf 'artifact\n' > dist/result.txt
+printf 'ran\n' >> runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["dist"]
+
+[tasks.stdin]
+run = '''
+mkdir -p stdin-dist
+IFS= read -r line
+printf '%s\n' "$line" > stdin-dist/result.txt
+'''
+sources = ["stdin.txt"]
+outputs = ["stdin-dist"]
+output = "interleave"
+EOF
+
+printf 'input\n' >input.txt
+printf 'stdin\n' >stdin.txt
+
+# A corrupt current manifest is a cache miss, so the task executes instead of
+# reporting a successful no-work hit without replaying output.
+mise run build
+manifest="$(find "$MISE_CACHE_DIR/task-artifacts/v2" -type f -name '*.json' -print -quit)"
+printf 'invalid manifest\n' >"$manifest"
+mise run build
+assert "wc -l < runs.txt | tr -d ' '" "2"
+
+# Capturing output for a cacheable interleave task must not disconnect stdin.
+printf 'from-stdin\n' | mise run stdin
+assert "cat stdin-dist/result.txt" "from-stdin"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -758,12 +758,14 @@ impl Run {
                     {
                         let mut outputs = timed_outputs.lock().unwrap();
                         for (prefix, out) in outputs.clone() {
-                            let (time, line) = out;
+                            let (time, lines) = out;
                             if time.elapsed().unwrap().as_secs() >= 1 {
-                                if console::colors_enabled() {
-                                    prefix_println!(prefix, "{line}\x1b[0m");
-                                } else {
-                                    prefix_println!(prefix, "{line}");
+                                for line in lines {
+                                    if console::colors_enabled() {
+                                        prefix_println!(prefix, "{line}\x1b[0m");
+                                    } else {
+                                        prefix_println!(prefix, "{line}");
+                                    }
                                 }
                                 outputs.shift_remove(&prefix);
                             }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -103,6 +103,8 @@ where
     duct::cmd(program, args)
 }
 
+type OutputObserver<'a> = Box<dyn Fn(&str) + Send + 'a>;
+
 pub struct CmdLineRunner<'a> {
     cmd: Command,
     pr: Option<&'a dyn SingleReport>,
@@ -113,8 +115,8 @@ pub struct CmdLineRunner<'a> {
     pass_signals: bool,
     on_stdout: Option<Box<dyn Fn(String) + Send + 'a>>,
     on_stderr: Option<Box<dyn Fn(String) + Send + 'a>>,
-    observe_stdout: Option<Box<dyn Fn(&str) + Send + 'a>>,
-    observe_stderr: Option<Box<dyn Fn(&str) + Send + 'a>>,
+    observe_stdout: Option<OutputObserver<'a>>,
+    observe_stderr: Option<OutputObserver<'a>>,
     timeout: Option<Duration>,
     sandbox: Option<crate::sandbox::SandboxConfig>,
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -113,6 +113,8 @@ pub struct CmdLineRunner<'a> {
     pass_signals: bool,
     on_stdout: Option<Box<dyn Fn(String) + Send + 'a>>,
     on_stderr: Option<Box<dyn Fn(String) + Send + 'a>>,
+    observe_stdout: Option<Box<dyn Fn(&str) + Send + 'a>>,
+    observe_stderr: Option<Box<dyn Fn(&str) + Send + 'a>>,
     timeout: Option<Duration>,
     sandbox: Option<crate::sandbox::SandboxConfig>,
 }
@@ -328,6 +330,8 @@ impl<'a> CmdLineRunner<'a> {
             pass_signals: false,
             on_stdout: None,
             on_stderr: None,
+            observe_stdout: None,
+            observe_stderr: None,
             timeout: None,
             sandbox: None,
         }
@@ -411,6 +415,16 @@ impl<'a> CmdLineRunner<'a> {
 
     pub fn with_on_stderr<F: Fn(String) + Send + 'a>(mut self, on_stderr: F) -> Self {
         self.on_stderr = Some(Box::new(on_stderr));
+        self
+    }
+
+    pub(crate) fn with_stdout_observer<F: Fn(&str) + Send + 'a>(mut self, observer: F) -> Self {
+        self.observe_stdout = Some(Box::new(observer));
+        self
+    }
+
+    pub(crate) fn with_stderr_observer<F: Fn(&str) + Send + 'a>(mut self, observer: F) -> Self {
+        self.observe_stderr = Some(Box::new(observer));
         self
     }
 
@@ -1211,6 +1225,9 @@ impl<'a> CmdLineRunner<'a> {
 
     fn on_stdout(&self, line: String) {
         let _lock = OUTPUT_LOCK.lock().unwrap();
+        if let Some(observer) = &self.observe_stdout {
+            observer(&line);
+        }
         if let Some(on_stdout) = &self.on_stdout {
             on_stdout(line);
             return;
@@ -1234,6 +1251,9 @@ impl<'a> CmdLineRunner<'a> {
 
     fn on_stderr(&self, line: String) {
         let _lock = OUTPUT_LOCK.lock().unwrap();
+        if let Some(observer) = &self.observe_stderr {
+            observer(&line);
+        }
         if let Some(on_stderr) = &self.on_stderr {
             on_stderr(line);
             return;
@@ -1472,17 +1492,29 @@ mod tests {
     async fn test_cmd_line_runner_execute_async() {
         let stdout = Arc::new(Mutex::new(Vec::new()));
         let stderr = Arc::new(Mutex::new(Vec::new()));
+        let observed_stdout = Arc::new(Mutex::new(Vec::new()));
+        let observed_stderr = Arc::new(Mutex::new(Vec::new()));
         let stdout_clone = stdout.clone();
         let stderr_clone = stderr.clone();
+        let observed_stdout_clone = observed_stdout.clone();
+        let observed_stderr_clone = observed_stderr.clone();
         super::CmdLineRunner::new("sh")
             .args(["-c", "printf out; printf err >&2"])
             .with_on_stdout(move |line| stdout_clone.lock().unwrap().push(line))
             .with_on_stderr(move |line| stderr_clone.lock().unwrap().push(line))
+            .with_stdout_observer(move |line| {
+                observed_stdout_clone.lock().unwrap().push(line.to_string());
+            })
+            .with_stderr_observer(move |line| {
+                observed_stderr_clone.lock().unwrap().push(line.to_string());
+            })
             .execute_async()
             .await
             .unwrap();
         assert_eq!(stdout.lock().unwrap().as_slice(), ["out"]);
         assert_eq!(stderr.lock().unwrap().as_slice(), ["err"]);
+        assert_eq!(observed_stdout.lock().unwrap().as_slice(), ["out"]);
+        assert_eq!(observed_stderr.lock().unwrap().as_slice(), ["err"]);
     }
 
     #[tokio::test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -63,8 +63,8 @@ pub mod task_sources;
 pub mod task_template;
 pub mod task_tool_installer;
 
-pub use task_cache::TaskArtifactCache;
-pub use task_cache::TaskCacheConfig;
+pub(crate) use task_cache::TaskCacheOutput;
+pub use task_cache::{TaskArtifactCache, TaskCacheConfig};
 pub use task_confirm::TaskConfirm;
 pub(crate) use task_load_context::monorepo_scope;
 pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax};

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -165,12 +165,15 @@ impl TaskArtifactCache {
         &self.key
     }
 
-    pub fn is_current(&self) -> bool {
+    pub(crate) fn current_output(&self) -> Option<Vec<TaskCacheOutput>> {
         let (archive_path, manifest_path) = self.paths();
-        archive_path.is_file()
-            && manifest_path.is_file()
-            && file::read_to_string(&self.state_path).is_ok_and(|key| key.trim() == self.key)
-            && self.read_manifest().is_ok()
+        if !archive_path.is_file()
+            || !manifest_path.is_file()
+            || !file::read_to_string(&self.state_path).is_ok_and(|key| key.trim() == self.key)
+        {
+            return None;
+        }
+        self.read_manifest().ok().map(|manifest| manifest.output)
     }
 
     pub fn mark_current(&self) -> Result<()> {
@@ -178,10 +181,6 @@ impl TaskArtifactCache {
             file::create_dir_all(parent)?;
         }
         file::write(&self.state_path, &self.key)
-    }
-
-    pub(crate) fn current_output(&self) -> Result<Vec<TaskCacheOutput>> {
-        Ok(self.read_manifest()?.output)
     }
 
     pub(crate) fn restore(&self, task: &Task) -> Result<Option<Vec<TaskCacheOutput>>> {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 use walkdir::WalkDir;
 
-const CACHE_FORMAT_VERSION: u8 = 1;
+const CACHE_FORMAT_VERSION: u8 = 2;
+const CACHE_DIR_VERSION: &str = "v2";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -50,6 +51,14 @@ struct CacheManifest {
     format: u8,
     key: String,
     roots: Vec<PathBuf>,
+    output: Vec<TaskCacheOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "stream", content = "line")]
+pub(crate) enum TaskCacheOutput {
+    Stdout(String),
+    Stderr(String),
 }
 
 pub struct TaskArtifactCache {
@@ -161,6 +170,7 @@ impl TaskArtifactCache {
         archive_path.is_file()
             && manifest_path.is_file()
             && file::read_to_string(&self.state_path).is_ok_and(|key| key.trim() == self.key)
+            && self.read_manifest().is_ok()
     }
 
     pub fn mark_current(&self) -> Result<()> {
@@ -170,10 +180,14 @@ impl TaskArtifactCache {
         file::write(&self.state_path, &self.key)
     }
 
-    pub fn restore(&self, task: &Task) -> Result<bool> {
+    pub(crate) fn current_output(&self) -> Result<Vec<TaskCacheOutput>> {
+        Ok(self.read_manifest()?.output)
+    }
+
+    pub(crate) fn restore(&self, task: &Task) -> Result<Option<Vec<TaskCacheOutput>>> {
         let (archive_path, manifest_path) = self.paths();
         if !archive_path.is_file() || !manifest_path.is_file() {
-            return Ok(false);
+            return Ok(None);
         }
         // Serialize restores targeting the same working directory across mise
         // processes so ancestor validation and the following renames are one
@@ -182,11 +196,8 @@ impl TaskArtifactCache {
             crate::lock_file::LockFile::new(&self.root.join(".mise-task-artifact-cache-output"))
                 .lock()?;
 
-        let restore = || -> Result<()> {
-            let manifest: CacheManifest = serde_json::from_slice(&fs::read(&manifest_path)?)?;
-            if manifest.format != CACHE_FORMAT_VERSION || manifest.key != self.key {
-                bail!("task cache manifest does not match cache key");
-            }
+        let restore = || -> Result<Vec<TaskCacheOutput>> {
+            let manifest = self.read_manifest()?;
             for root in &manifest.roots {
                 ensure_safe_relative(root)?;
             }
@@ -228,21 +239,21 @@ impl TaskArtifactCache {
             if let Err(err) = file::touch_file(&manifest_path) {
                 warn!("failed to update task cache manifest access time: {err}");
             }
-            Ok(())
+            Ok(manifest.output)
         };
 
         match restore() {
-            Ok(()) => Ok(true),
+            Ok(output) => Ok(Some(output)),
             Err(err) => {
                 warn!("ignoring corrupt task cache entry {}: {err}", self.key);
                 let _ = file::remove_file(&archive_path);
                 let _ = file::remove_file(&manifest_path);
-                Ok(false)
+                Ok(None)
             }
         }
     }
 
-    pub fn store(&self, task: &Task) -> Result<()> {
+    pub(crate) fn store(&self, task: &Task, output: &[TaskCacheOutput]) -> Result<()> {
         let roots = resolve_output_roots(task, &self.root, true)?;
         let roots = remove_nested_roots(roots);
         if roots.is_empty() {
@@ -252,7 +263,7 @@ impl TaskArtifactCache {
             ensure_no_symlink_ancestors(&self.root, root)?;
         }
 
-        let cache_dir = dirs::CACHE.join("task-artifacts").join("v1");
+        let cache_dir = dirs::CACHE.join("task-artifacts").join(CACHE_DIR_VERSION);
         file::create_dir_all(&cache_dir)?;
         let (archive_path, manifest_path) = self.paths();
         let nonce = crate::rand::random_string(8);
@@ -264,6 +275,7 @@ impl TaskArtifactCache {
             format: CACHE_FORMAT_VERSION,
             key: self.key.clone(),
             roots,
+            output: output.to_vec(),
         };
         fs::write(&manifest_partial, serde_json::to_vec(&manifest)?)?;
         file::rename(&archive_partial, &archive_path)?;
@@ -272,11 +284,20 @@ impl TaskArtifactCache {
     }
 
     fn paths(&self) -> (PathBuf, PathBuf) {
-        let base = dirs::CACHE.join("task-artifacts").join("v1");
+        let base = dirs::CACHE.join("task-artifacts").join(CACHE_DIR_VERSION);
         (
             base.join(format!("{}.tar.zst", self.key)),
             base.join(format!("{}.json", self.key)),
         )
+    }
+
+    fn read_manifest(&self) -> Result<CacheManifest> {
+        let (_, manifest_path) = self.paths();
+        let manifest: CacheManifest = serde_json::from_slice(&fs::read(manifest_path)?)?;
+        if manifest.format != CACHE_FORMAT_VERSION || manifest.key != self.key {
+            bail!("task cache manifest does not match cache key");
+        }
+        Ok(manifest)
     }
 }
 

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1143,6 +1143,7 @@ impl TaskExecutor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn exec_file(
         &self,
         config: &Arc<Config>,
@@ -1223,6 +1224,7 @@ impl TaskExecutor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn exec_program(
         &self,
         program: &str,

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -16,7 +16,7 @@ use crate::task::task_script_parser::subcommand_name_from_parse;
 use crate::task::task_source_checker::{
     remove_auto_output, save_checksum, sources_are_fresh, task_cwd,
 };
-use crate::task::{Deps, FailedTasks, GetMatchingExt, Task};
+use crate::task::{Deps, FailedTasks, GetMatchingExt, Task, TaskCacheOutput};
 use crate::task::{TaskCompletionState, TaskDependencyState};
 use crate::tera::{contains_template_syntax, render_str};
 use crate::toolset::env_cache::CachedEnv;
@@ -42,6 +42,7 @@ use xx::file;
 /// Global lock for interactive task exclusivity.
 /// Interactive tasks acquire a write lock (exclusive), non-interactive tasks acquire a read lock (shared).
 static TASK_RUNTIME_LOCK: LazyLock<RwLock<()>> = LazyLock::new(|| RwLock::new(()));
+type TaskOutputCapture = Arc<StdMutex<Vec<TaskCacheOutput>>>;
 
 #[allow(dead_code)] // Guards are held for their Drop impl, not read
 enum RuntimeLockGuard<'a> {
@@ -492,6 +493,13 @@ impl TaskExecutor {
             .await?
             {
                 Some(_) if self.dry_run => None,
+                Some(_) if self.raw(Some(task)) => {
+                    warn!(
+                        "task {} artifact caching disabled for raw or interactive execution",
+                        task.name
+                    );
+                    None
+                }
                 Some(cache) => {
                     if !self.force
                         && !dependency_state.any_unkeyed_did_work
@@ -501,6 +509,15 @@ impl TaskExecutor {
                         if !self.quiet(Some(task)) {
                             self.eprint(task, &prefix, "sources up-to-date, skipping");
                         }
+                        match cache.current_output() {
+                            Ok(output) => {
+                                self.output_handler
+                                    .replay_cached_output(task, &prefix, &output);
+                            }
+                            Err(err) => {
+                                warn!("task {} cached output read failed: {err}", task.name);
+                            }
+                        }
                         return Ok(TaskRunOutcome {
                             did_work: false,
                             cache_key: Some(cache.key().to_string()),
@@ -508,7 +525,7 @@ impl TaskExecutor {
                     }
                     if !self.force
                         && !dependency_state.any_unkeyed_did_work
-                        && cache.restore(task)?
+                        && let Some(output) = cache.restore(task)?
                     {
                         if !self.quiet(Some(task)) {
                             self.eprint(
@@ -517,6 +534,8 @@ impl TaskExecutor {
                                 &format!("restored outputs from cache {}", cache.key()),
                             );
                         }
+                        self.output_handler
+                            .replay_cached_output(task, &prefix, &output);
                         if let Err(err) = save_checksum(task, config).await {
                             warn!(
                                 "task {} artifact cache checksum update failed: {err}",
@@ -541,14 +560,25 @@ impl TaskExecutor {
         } else {
             None
         };
+        let output_capture = artifact_cache
+            .as_ref()
+            .map(|_| Arc::new(StdMutex::new(Vec::new())));
 
         let timer = std::time::Instant::now();
 
         if let Some(file) = task_file {
             let exec_start = std::time::Instant::now();
             remove_auto_output(task, config).await?;
-            self.exec_file(config, &file, task, &env, &prefix, confirm_guard)
-                .await?;
+            self.exec_file(
+                config,
+                &file,
+                task,
+                &env,
+                &prefix,
+                confirm_guard,
+                output_capture.as_ref(),
+            )
+            .await?;
             trace!(
                 "task {} exec_file took {}ms (total {}ms)",
                 task.name,
@@ -579,6 +609,7 @@ impl TaskExecutor {
                 &completion_state,
                 semaphore,
                 permit,
+                output_capture.as_ref(),
             )
             .await?;
             trace!(
@@ -601,7 +632,11 @@ impl TaskExecutor {
 
         save_checksum(task, config).await?;
         let cache_key = if let Some(cache) = artifact_cache {
-            match cache.store(task) {
+            let output = output_capture
+                .as_ref()
+                .map(|output| output.lock().unwrap().clone())
+                .unwrap_or_default();
+            match cache.store(task, &output) {
                 Ok(()) => {
                     if let Err(err) = cache.mark_current() {
                         warn!(
@@ -663,6 +698,7 @@ impl TaskExecutor {
         completion_state: &TaskCompletionState,
         semaphore: Arc<Semaphore>,
         permit: &mut Option<OwnedSemaphorePermit>,
+        output_capture: Option<&TaskOutputCapture>,
     ) -> Result<()> {
         let (env, task_env) = full_env;
         use crate::task::RunEntry;
@@ -707,7 +743,8 @@ impl TaskExecutor {
                         if guard.is_none() {
                             guard = Some(acquire_runtime_lock(task.interactive).await);
                         }
-                        self.exec_script(&script, &args, task, env, prefix).await?;
+                        self.exec_script(&script, &args, task, env, prefix, output_capture)
+                            .await?;
                     }
                 }
                 RunEntry::SingleTask {
@@ -963,6 +1000,7 @@ impl TaskExecutor {
         task: &Task,
         env: &BTreeMap<String, String>,
         prefix: &str,
+        output_capture: Option<&TaskOutputCapture>,
     ) -> Result<()> {
         let config = Config::get().await?;
         let script = script.trim_start();
@@ -995,13 +1033,21 @@ impl TaskExecutor {
             let file = dir.path().join("script");
             tokio::fs::write(&file, script.as_bytes()).await?;
             file::make_executable(&file)?;
-            self.exec_with_text_file_busy_retry(&file, args, task, env, prefix)
+            self.exec_with_text_file_busy_retry(&file, args, task, env, prefix, output_capture)
                 .await
         } else {
             let (program, args, cmd_verbatim) =
                 self.get_cmd_program_and_args(script, task, args)?;
-            self.exec_program(&program, &args, task, env, prefix, cmd_verbatim)
-                .await
+            self.exec_program(
+                &program,
+                &args,
+                task,
+                env,
+                prefix,
+                cmd_verbatim,
+                output_capture,
+            )
+            .await
         }
     }
 
@@ -1108,6 +1154,7 @@ impl TaskExecutor {
         env: &BTreeMap<String, String>,
         prefix: &str,
         guard: Option<RuntimeLockGuard<'static>>,
+        output_capture: Option<&TaskOutputCapture>,
     ) -> Result<()> {
         let args = task.args.iter().cloned().collect_vec();
 
@@ -1125,7 +1172,8 @@ impl TaskExecutor {
         } else {
             Some(acquire_runtime_lock(task.interactive).await)
         };
-        self.exec(file, &args, task, env, prefix).await
+        self.exec(file, &args, task, env, prefix, output_capture)
+            .await
     }
 
     async fn exec(
@@ -1135,9 +1183,10 @@ impl TaskExecutor {
         task: &Task,
         env: &BTreeMap<String, String>,
         prefix: &str,
+        output_capture: Option<&TaskOutputCapture>,
     ) -> Result<()> {
         let (program, args) = self.get_file_program_and_args(file, task, args)?;
-        self.exec_program(&program, &args, task, env, prefix, false)
+        self.exec_program(&program, &args, task, env, prefix, false, output_capture)
             .await
     }
 
@@ -1148,13 +1197,17 @@ impl TaskExecutor {
         task: &Task,
         env: &BTreeMap<String, String>,
         prefix: &str,
+        output_capture: Option<&TaskOutputCapture>,
     ) -> Result<()> {
         const ETXTBUSY_RETRIES: usize = 3;
         const ETXTBUSY_SLEEP_MS: u64 = 50;
 
         let mut attempt = 0;
         loop {
-            match self.exec(file, args, task, env, prefix).await {
+            match self
+                .exec(file, args, task, env, prefix, output_capture)
+                .await
+            {
                 Ok(()) => break Ok(()),
                 Err(err) if Self::is_text_file_busy(&err) && attempt < ETXTBUSY_RETRIES => {
                     attempt += 1;
@@ -1181,6 +1234,7 @@ impl TaskExecutor {
         env: &BTreeMap<String, String>,
         prefix: &str,
         cmd_verbatim: bool,
+        output_capture: Option<&TaskOutputCapture>,
     ) -> Result<()> {
         #[cfg(not(windows))]
         let _ = cmd_verbatim;
@@ -1258,6 +1312,8 @@ impl TaskExecutor {
                             prefix_println!(prefix, "{line}");
                         }
                     });
+                } else if output_capture.is_some() {
+                    cmd = cmd.with_on_stdout(|_| {});
                 } else {
                     cmd = cmd.stdout(Stdio::null());
                 }
@@ -1269,6 +1325,8 @@ impl TaskExecutor {
                             self.eprint(task, prefix, &line);
                         }
                     });
+                } else if output_capture.is_some() {
+                    cmd = cmd.with_on_stderr(|_| {});
                 } else {
                     cmd = cmd.stderr(Stdio::null());
                 }
@@ -1284,6 +1342,8 @@ impl TaskExecutor {
                             .unwrap()
                             .on_stdout(&task_clone, prefix_str.clone(), line);
                     });
+                } else if output_capture.is_some() {
+                    cmd = cmd.with_on_stdout(|_| {});
                 } else {
                     cmd = cmd.stdout(Stdio::null());
                 }
@@ -1297,6 +1357,8 @@ impl TaskExecutor {
                             .unwrap()
                             .on_stderr(&task_clone, prefix_str.clone(), line);
                     });
+                } else if output_capture.is_some() {
+                    cmd = cmd.with_on_stderr(|_| {});
                 } else {
                     cmd = cmd.stderr(Stdio::null());
                 }
@@ -1304,10 +1366,18 @@ impl TaskExecutor {
             TaskOutput::Replacing => {
                 // Replacing mode shows a progress indicator unless both streams are suppressed
                 if task.silent.suppresses_stdout() {
-                    cmd = cmd.stdout(Stdio::null());
+                    if output_capture.is_some() {
+                        cmd = cmd.with_on_stdout(|_| {});
+                    } else {
+                        cmd = cmd.stdout(Stdio::null());
+                    }
                 }
                 if task.silent.suppresses_stderr() {
-                    cmd = cmd.stderr(Stdio::null());
+                    if output_capture.is_some() {
+                        cmd = cmd.with_on_stderr(|_| {});
+                    } else {
+                        cmd = cmd.stderr(Stdio::null());
+                    }
                 }
                 // Show progress indicator except when both streams are fully suppressed
                 if !task.silent.suppresses_both() {
@@ -1324,6 +1394,8 @@ impl TaskExecutor {
                             .unwrap()
                             .insert(prefix.to_string(), (SystemTime::now(), line));
                     });
+                } else if output_capture.is_some() {
+                    cmd = cmd.with_on_stdout(|_| {});
                 } else {
                     cmd = cmd.stdout(Stdio::null());
                 }
@@ -1335,18 +1407,31 @@ impl TaskExecutor {
                             self.eprint(task, prefix, &line);
                         }
                     });
+                } else if output_capture.is_some() {
+                    cmd = cmd.with_on_stderr(|_| {});
                 } else {
                     cmd = cmd.stderr(Stdio::null());
                 }
             }
             TaskOutput::Silent => {
-                cmd = cmd.stdout(Stdio::null()).stderr(Stdio::null());
+                if output_capture.is_some() {
+                    cmd = cmd.with_on_stdout(|_| {}).with_on_stderr(|_| {});
+                } else {
+                    cmd = cmd.stdout(Stdio::null()).stderr(Stdio::null());
+                }
             }
             // `Quiet` is no longer returned by `output()` (verbosity is decoupled
             // from style; it maps to `Interleave`), but the variant still exists as
             // a config value so it's kept here for match exhaustiveness.
             TaskOutput::Quiet | TaskOutput::Interleave => {
-                if raw || redactions.is_empty() {
+                if output_capture.is_some() {
+                    if task.silent.suppresses_stdout() {
+                        cmd = cmd.with_on_stdout(|_| {});
+                    }
+                    if task.silent.suppresses_stderr() {
+                        cmd = cmd.with_on_stderr(|_| {});
+                    }
+                } else if raw || redactions.is_empty() {
                     cmd = cmd.stdin(Stdio::inherit());
                     if !task.silent.suppresses_stdout() {
                         cmd = cmd.stdout(Stdio::inherit());
@@ -1360,6 +1445,23 @@ impl TaskExecutor {
                     }
                 }
             }
+        }
+        if let Some(output_capture) = output_capture {
+            let stdout = output_capture.clone();
+            let stderr = output_capture.clone();
+            cmd = cmd
+                .with_stdout_observer(move |line| {
+                    stdout
+                        .lock()
+                        .unwrap()
+                        .push(TaskCacheOutput::Stdout(line.to_string()));
+                })
+                .with_stderr_observer(move |line| {
+                    stderr
+                        .lock()
+                        .unwrap()
+                        .push(TaskCacheOutput::Stderr(line.to_string()));
+                });
         }
         let dir = task_cwd(task, &config).await?;
         if !dir.exists() {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -501,23 +501,20 @@ impl TaskExecutor {
                     None
                 }
                 Some(cache) => {
-                    if !self.force
+                    let current_output = if !self.force
                         && !dependency_state.any_unkeyed_did_work
-                        && cache.is_current()
                         && sources_are_fresh(task, config).await?
                     {
+                        cache.current_output()
+                    } else {
+                        None
+                    };
+                    if let Some(output) = current_output {
                         if !self.quiet(Some(task)) {
                             self.eprint(task, &prefix, "sources up-to-date, skipping");
                         }
-                        match cache.current_output() {
-                            Ok(output) => {
-                                self.output_handler
-                                    .replay_cached_output(task, &prefix, &output);
-                            }
-                            Err(err) => {
-                                warn!("task {} cached output read failed: {err}", task.name);
-                            }
-                        }
+                        self.output_handler
+                            .replay_cached_output(task, &prefix, &output);
                         return Ok(TaskRunOutcome {
                             did_work: false,
                             cache_key: Some(cache.key().to_string()),
@@ -1392,7 +1389,7 @@ impl TaskExecutor {
                         timed_outputs
                             .lock()
                             .unwrap()
-                            .insert(prefix.to_string(), (SystemTime::now(), line));
+                            .insert(prefix.to_string(), (SystemTime::now(), vec![line]));
                     });
                 } else if output_capture.is_some() {
                     cmd = cmd.with_on_stdout(|_| {});
@@ -1424,6 +1421,9 @@ impl TaskExecutor {
             // from style; it maps to `Interleave`), but the variant still exists as
             // a config value so it's kept here for match exhaustiveness.
             TaskOutput::Quiet | TaskOutput::Interleave => {
+                if raw || redactions.is_empty() {
+                    cmd = cmd.stdin(Stdio::inherit());
+                }
                 if output_capture.is_some() {
                     if task.silent.suppresses_stdout() {
                         cmd = cmd.with_on_stdout(|_| {});
@@ -1432,7 +1432,6 @@ impl TaskExecutor {
                         cmd = cmd.with_on_stderr(|_| {});
                     }
                 } else if raw || redactions.is_empty() {
-                    cmd = cmd.stdin(Stdio::inherit());
                     if !task.silent.suppresses_stdout() {
                         cmd = cmd.stdout(Stdio::inherit());
                     } else {

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -183,7 +183,7 @@ pub struct OutputHandlerConfig {
 pub struct OutputHandler {
     pub keep_order_state: Arc<Mutex<KeepOrderState>>,
     pub task_prs: TaskPrMap,
-    pub timed_outputs: Arc<Mutex<IndexMap<String, (SystemTime, String)>>>,
+    pub timed_outputs: Arc<Mutex<IndexMap<String, (SystemTime, Vec<String>)>>>,
 
     // Configuration from CLI args
     output: Option<TaskOutput>,
@@ -334,6 +334,21 @@ impl OutputHandler {
         output: &[TaskCacheOutput],
     ) {
         let mode = self.output(Some(task));
+        if mode == TaskOutput::Timed && !task.silent.suppresses_stdout() {
+            let stdout = output
+                .iter()
+                .filter_map(|line| match line {
+                    TaskCacheOutput::Stdout(line) => Some(line.clone()),
+                    TaskCacheOutput::Stderr(_) => None,
+                })
+                .collect::<Vec<_>>();
+            if !stdout.is_empty() {
+                self.timed_outputs
+                    .lock()
+                    .unwrap()
+                    .insert(prefix.to_string(), (SystemTime::now(), stdout));
+            }
+        }
         for line in output {
             match line {
                 TaskCacheOutput::Stdout(_) if task.silent.suppresses_stdout() => continue,
@@ -373,12 +388,7 @@ impl OutputHandler {
                         self.get_or_init_task_pr(task).println(line.clone());
                     }
                 }
-                (TaskOutput::Timed, TaskCacheOutput::Stdout(line)) => {
-                    self.timed_outputs
-                        .lock()
-                        .unwrap()
-                        .insert(prefix.to_string(), (SystemTime::now(), line.clone()));
-                }
+                (TaskOutput::Timed, TaskCacheOutput::Stdout(_)) => {}
                 (TaskOutput::Interleave | TaskOutput::Quiet, TaskCacheOutput::Stdout(line)) => {
                     if console::colors_enabled() {
                         println!("{line}\x1b[0m");
@@ -433,5 +443,35 @@ impl OutputHandler {
         } else {
             self.jobs.unwrap_or(Settings::get().jobs)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_timed_output_preserves_all_stdout_lines() {
+        let handler = OutputHandler::new(OutputHandlerConfig {
+            output: Some(TaskOutput::Timed),
+            silent: false,
+            quiet: false,
+            raw: false,
+            is_linear: true,
+            jobs: None,
+        });
+        let task = Task::default();
+
+        handler.replay_cached_output(
+            &task,
+            "build",
+            &[
+                TaskCacheOutput::Stdout("first".into()),
+                TaskCacheOutput::Stdout("second".into()),
+            ],
+        );
+
+        let outputs = handler.timed_outputs.lock().unwrap();
+        assert_eq!(outputs.get("build").unwrap().1, ["first", "second"]);
     }
 }

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
 type TaskPrMap = Arc<Mutex<IndexMap<Task, Arc<Box<dyn SingleReport>>>>>;
+type TimedOutputMap = Arc<Mutex<IndexMap<String, (SystemTime, Vec<String>)>>>;
 
 /// A single line of output, tagged by stream.
 pub enum KeepOrderLine {
@@ -183,7 +184,7 @@ pub struct OutputHandlerConfig {
 pub struct OutputHandler {
     pub keep_order_state: Arc<Mutex<KeepOrderState>>,
     pub task_prs: TaskPrMap,
-    pub timed_outputs: Arc<Mutex<IndexMap<String, (SystemTime, Vec<String>)>>>,
+    pub timed_outputs: TimedOutputMap,
 
     // Configuration from CLI args
     output: Option<TaskOutput>,

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -1,7 +1,7 @@
 use crate::config::Settings;
-use crate::task::Task;
 use crate::task::task_helpers::task_needs_permit;
 use crate::task::task_output::TaskOutput;
+use crate::task::{Task, TaskCacheOutput};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use indexmap::IndexMap;
@@ -322,6 +322,77 @@ impl OutputHandler {
             }
             _ => {
                 prefix_eprintln!(prefix, "{line}");
+            }
+        }
+    }
+
+    /// Replay cached task output through the currently selected output style.
+    pub(crate) fn replay_cached_output(
+        &self,
+        task: &Task,
+        prefix: &str,
+        output: &[TaskCacheOutput],
+    ) {
+        let mode = self.output(Some(task));
+        for line in output {
+            match line {
+                TaskCacheOutput::Stdout(_) if task.silent.suppresses_stdout() => continue,
+                TaskCacheOutput::Stderr(_) if task.silent.suppresses_stderr() => continue,
+                _ => {}
+            }
+            match (mode, line) {
+                (TaskOutput::Silent, _) => {}
+                (TaskOutput::Prefix, TaskCacheOutput::Stdout(line)) => {
+                    print_stdout(prefix, line);
+                }
+                (TaskOutput::Prefix, TaskCacheOutput::Stderr(line))
+                | (TaskOutput::Timed, TaskCacheOutput::Stderr(line)) => {
+                    print_stderr(prefix, line);
+                }
+                (TaskOutput::KeepOrder, TaskCacheOutput::Stdout(line)) => {
+                    self.keep_order_state.lock().unwrap().on_stdout(
+                        task,
+                        prefix.to_string(),
+                        line.clone(),
+                    );
+                }
+                (TaskOutput::KeepOrder, TaskCacheOutput::Stderr(line)) => {
+                    self.keep_order_state.lock().unwrap().on_stderr(
+                        task,
+                        prefix.to_string(),
+                        line.clone(),
+                    );
+                }
+                (TaskOutput::Replacing, TaskCacheOutput::Stdout(line)) => {
+                    if !line.trim().is_empty() {
+                        self.get_or_init_task_pr(task).set_message(line.clone());
+                    }
+                }
+                (TaskOutput::Replacing, TaskCacheOutput::Stderr(line)) => {
+                    if !line.trim().is_empty() {
+                        self.get_or_init_task_pr(task).println(line.clone());
+                    }
+                }
+                (TaskOutput::Timed, TaskCacheOutput::Stdout(line)) => {
+                    self.timed_outputs
+                        .lock()
+                        .unwrap()
+                        .insert(prefix.to_string(), (SystemTime::now(), line.clone()));
+                }
+                (TaskOutput::Interleave | TaskOutput::Quiet, TaskCacheOutput::Stdout(line)) => {
+                    if console::colors_enabled() {
+                        println!("{line}\x1b[0m");
+                    } else {
+                        println!("{line}");
+                    }
+                }
+                (TaskOutput::Interleave | TaskOutput::Quiet, TaskCacheOutput::Stderr(line)) => {
+                    if console::colors_enabled_stderr() {
+                        eprintln!("{line}\x1b[0m");
+                    } else {
+                        eprintln!("{line}");
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- capture successful task stdout and stderr as stream-tagged, redacted cache data
- replay cached output through the output mode selected for the cache hit
- preserve prefix, interleave, keep-order, timed, replacing, quiet, silent, and per-stream silence behavior
- conservatively bypass artifact caching for raw and interactive tasks, which require inherited terminal I/O
- bump the experimental local artifact format and directory to `v2`
- document the behavior and update the temporary parity tracker

This follows #11340 and closes the next local-cache parity item without storing terminal-formatted output in the artifact. A task can therefore execute under one display mode and replay under another.

## User impact

Both fresh-output cache hits and restored-output cache hits replay the successful task's logs. Cached logs have already passed through mise's redaction layer, and the current invocation still controls whether streams are prefixed, hidden, buffered, or displayed directly.

Raw and interactive tasks continue to use inherited byte-stream I/O and run uncached rather than changing their terminal semantics to make capture possible.

## Validation

- `mise run lint-fix`
- `cargo fmt --all -- --check`
- `cargo check --all-features`
- `cargo test --all-features test_cmd_line_runner_execute_async --quiet`
- `cargo test --all-features task_cache --quiet`
- `mise run test:e2e test_task_artifact_cache_output test_task_artifact_cache_dependencies test_task_output_style_decoupling test_task_keep_order test_task_quiet_silent_flags test_task_silent_streams`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task execution, caching format (v2), and all output modes; behavior is well-covered by e2e tests but touches widely used run paths and invalidates v1 artifact caches.
> 
> **Overview**
> Experimental task artifact caching now **persists successful runs’ stdout and stderr** as ordered, **redacted** stream chunks in the cache manifest, and **replays them on cache hits** (fresh skip and restore paths) through whatever **output mode** the current `mise run` uses—prefix, interleave, keep-order, timed, replacing, quiet, silent, and per-stream silence.
> 
> Replay applies **current** formatting (e.g. prefixes are not baked into stored lines). **Timed** mode now buffers **multiple** stdout lines per task prefix for both live and replayed output.
> 
> **CmdLineRunner** gains stdout/stderr **observers** so capture can run alongside display handlers without changing live I/O semantics; capture paths avoid nulling stdio when observers are active so **stdin** stays available for cacheable tasks.
> 
> **Raw** (and interactive) tasks **bypass** artifact caching so inherited terminal I/O is unchanged. Cache storage moves to **`task-artifacts/v2`** (format version 2); corrupt manifests are treated as misses. Docs and e2e tests cover replay, redaction, resilience, and raw bypass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa75f280160a386d8d07e0a03a7487d795f3c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Task artifact caching now captures and replays redacted stdout/stderr (cache format v2), including correct behavior across output/ordering/quiet/silent modes.
  - Timed and formatted output replay now supports multiple cached stdout lines.
  - Cache replay is skipped for raw tasks.
- **Documentation**
  - Updated cache documentation to reflect v2 format, ordered redacted streams replay, dependency key behavior, and miss/failure handling.
  - Marked stdout/stderr cache parity as complete.
- **Tests**
  - Added end-to-end coverage for cache/output-mode replay and resilience to corrupted cache manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->