### PR TITLE
chore: update aqua registry workspace exclusion

### DIFF
--- a/mise.code-workspace
+++ b/mise.code-workspace
@@ -18,7 +18,7 @@
       "!**/CHANGELOG.md"
     ],
     "files.exclude": {
-      "crates/aqua-registry/aqua-registry/**": true
+      "vendor/aqua-registry/**": true
     },
     "markdown.validate.enabled": true,
   },

--- a/mise.code-workspace
+++ b/mise.code-workspace
@@ -18,7 +18,7 @@
       "!**/CHANGELOG.md"
     ],
     "files.exclude": {
-      "aqua-registry/**": true
+      "crates/aqua-registry/aqua-registry/**": true
     },
     "markdown.validate.enabled": true,
   },


### PR DESCRIPTION
## Summary
- update the VS Code workspace exclusion for the vendored Aqua registry

## Why
#9535 moved the generated Aqua registry payload to `vendor/aqua-registry/`, but `mise.code-workspace` continued excluding the old top-level `aqua-registry/` path.

## Impact
VS Code and Cursor users opening `mise.code-workspace` will hide the current 3.2 MB vendored registry data instead of targeting a directory that no longer exists. The Aqua registry Rust source remains visible.

## Validation
- formatting and JSON checks
- `git diff --check`
- verified `vendor/aqua-registry/` is the current registry payload consumed by `build.rs` and release tooling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace editor visibility settings to exclude generated registry files by narrowing the excluded path to `vendor/aqua-registry/**` for clearer focus in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->