### PR TITLE
feat(task): cache tasks without file outputs

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -81,7 +81,7 @@ outside this tracker.
 - [x] Allow dependents to restore when dependencies publish stable artifact keys;
       unkeyed dependency work still forces execution
 - [x] Capture and replay stdout and stderr while respecting mise output modes
-- [ ] Cache useful results for tasks with no filesystem outputs
+- [x] Cache useful results for tasks with no filesystem outputs
 - [ ] Support reusable and global input groups
 - [ ] Support global environment inputs and pass-through environment variables
 - [ ] Support negative input and output patterns

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -449,13 +449,17 @@ outputs = { auto = true } # this is the default when sources is defined
 - **Type**: `{ enabled = bool, env = string[] }`
 - **Default**: `{ enabled = false, env = [] }`
 
-Stores declared task outputs in a content-addressed local cache and restores them when the same task
-inputs are seen again. This differs from the normal `sources`/`outputs` freshness check: cached
-artifacts can restore outputs after they have been deleted.
+Stores successful task results in a content-addressed local cache and reuses them when the same task
+inputs are seen again. Declared filesystem outputs are restored after deletion. Tasks with
+`outputs = []` cache their successful result and logs without storing filesystem artifacts, which is
+useful for checks such as linting, testing, and type checking.
+Declaring `outputs = []` asserts that the task has no filesystem side effects that a cache hit needs
+to reproduce.
 
 Artifact caching requires [`experimental`](/configuration/settings.html#experimental), at least one
-matching `source`, and explicit output paths. `outputs = { auto = true }`, absolute outputs, and
-outputs that escape the task directory are not supported.
+matching `source`, and either explicit output paths or `outputs = []`.
+`outputs = { auto = true }`, absolute outputs, and outputs that escape the task directory are not
+supported.
 
 ```mise-toml
 [settings]
@@ -468,9 +472,18 @@ outputs = ["dist"]
 cache = { enabled = true, env = ["NODE_ENV"] }
 ```
 
+```mise-toml
+[tasks.lint]
+run = "eslint ."
+sources = ["package.json", "src/**"]
+outputs = []
+cache = { enabled = true }
+```
+
 To enable caching by default for every eligible task in a config scope, set
-`task_config.cache`. Only tasks with at least one source and explicit output paths inherit this
-default; other tasks remain uncached. A task-local `cache` value overrides the scoped default.
+`task_config.cache`. Only tasks with at least one source and either explicit output paths or
+`outputs = []` inherit this default; other tasks remain uncached. A task-local `cache` value
+overrides the scoped default.
 
 ```mise-toml
 [settings]
@@ -495,7 +508,8 @@ the values (or absence) of variables named in `cache.env`, resolved tool version
 artifact keys, and the operating system and architecture. Variables inherited from the ambient
 process are ignored unless listed in `cache.env`.
 
-Artifacts are stored under `MISE_CACHE_DIR/task-artifacts/v2` as zstd-compressed tar archives. They
+Cache entries are stored under `MISE_CACHE_DIR/task-artifacts/v2`. Filesystem outputs use
+zstd-compressed tar archives; result-only tasks store just their manifest and captured logs. Entries
 are included in the existing `mise cache clear` and `mise cache prune` behavior. Only successful task
 runs are cached. Cache read/write failures are treated as misses and never turn a successful task run
 into a failure.
@@ -754,8 +768,9 @@ dir = "{{cwd}}"
 ### `task_config.cache` <Badge type="warning" text="experimental" />
 
 Sets the default artifact-cache configuration for tasks in this config scope. The default is only
-inherited by cache-eligible tasks with sources and explicit output paths. Task-local and task-template
-cache configuration takes precedence, including `cache = { enabled = false }`.
+inherited by cache-eligible tasks with sources and either explicit output paths or `outputs = []`.
+Task-local and task-template cache configuration takes precedence, including
+`cache = { enabled = false }`.
 
 ```toml
 [task_config.cache]

--- a/e2e/tasks/test_task_artifact_cache_no_outputs
+++ b/e2e/tasks/test_task_artifact_cache_no_outputs
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+
+[tasks.check]
+run = '''
+printf 'check-stdout\n'
+printf 'check-stderr\n' >&2
+printf 'ran\n' >> runs.txt
+'''
+sources = ["input.txt"]
+outputs = []
+EOF
+
+printf 'one\n' >input.txt
+
+# Explicitly empty outputs inherit the scoped cache default and store logs
+# without creating an artifact archive.
+output="$(mise run --output prefix check 2>&1)"
+assert_contains "echo \"$output\"" "[check] check-stdout"
+assert_contains "echo \"$output\"" "[check] check-stderr"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+assert "find \"$MISE_CACHE_DIR/task-artifacts/v2\" -type f -name '*.json' | wc -l | tr -d ' '" "1"
+assert "find \"$MISE_CACHE_DIR/task-artifacts/v2\" -type f -name '*.tar.zst' | wc -l | tr -d ' '" "0"
+
+# A current result hit skips execution and replays its cached logs.
+output="$(mise run --output prefix check 2>&1)"
+assert_contains "echo \"$output\"" "sources up-to-date, skipping"
+assert_contains "echo \"$output\"" "[check] check-stdout"
+assert_contains "echo \"$output\"" "[check] check-stderr"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# The manifest can restore the successful result after local state is removed.
+rm -rf "$MISE_STATE_DIR/task-artifacts"
+output="$(mise run --output prefix check 2>&1)"
+assert_contains "echo \"$output\"" "restored result from cache"
+assert_contains "echo \"$output\"" "[check] check-stdout"
+assert_contains "echo \"$output\"" "[check] check-stderr"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# Changed inputs miss and replace the result-only cache entry.
+printf 'two\n' >input.txt
+mise run check
+assert "wc -l < runs.txt | tr -d ' '" "2"
+
+# Clearing the cache forces execution even if local freshness state remains.
+mise cache clear
+mise run check
+assert "wc -l < runs.txt | tr -d ' '" "3"

--- a/e2e/tasks/test_task_artifact_cache_validation
+++ b/e2e/tasks/test_task_artifact_cache_validation
@@ -26,10 +26,10 @@ EOF
 
 assert_fail_contains \
   "mise run build" \
-  "cache requires explicit output files or directories"
+  "cache requires explicit outputs or outputs = []"
 assert_fail_contains \
   "mise run --dry-run build" \
-  "cache requires explicit output files or directories"
+  "cache requires explicit outputs or outputs = []"
 
 cat <<'EOF' >mise.toml
 [settings]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2214,7 +2214,7 @@ fn resolve_task_template(
 fn apply_task_config_cache_default(task: &mut Task, cache: &Option<TaskCacheConfig>) {
     if task.cache.is_none()
         && !task.sources.is_empty()
-        && !task.outputs.patterns().is_empty()
+        && !task.outputs.is_auto()
         && let Some(cache) = cache
     {
         task.cache = Some(cache.clone());

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -167,13 +167,16 @@ impl TaskArtifactCache {
 
     pub(crate) fn current_output(&self) -> Option<Vec<TaskCacheOutput>> {
         let (archive_path, manifest_path) = self.paths();
-        if !archive_path.is_file()
-            || !manifest_path.is_file()
+        if !manifest_path.is_file()
             || !file::read_to_string(&self.state_path).is_ok_and(|key| key.trim() == self.key)
         {
             return None;
         }
-        self.read_manifest().ok().map(|manifest| manifest.output)
+        let manifest = self.read_manifest().ok()?;
+        if !manifest.roots.is_empty() && !archive_path.is_file() {
+            return None;
+        }
+        Some(manifest.output)
     }
 
     pub fn mark_current(&self) -> Result<()> {
@@ -185,16 +188,9 @@ impl TaskArtifactCache {
 
     pub(crate) fn restore(&self, task: &Task) -> Result<Option<Vec<TaskCacheOutput>>> {
         let (archive_path, manifest_path) = self.paths();
-        if !archive_path.is_file() || !manifest_path.is_file() {
+        if !manifest_path.is_file() {
             return Ok(None);
         }
-        // Serialize restores targeting the same working directory across mise
-        // processes so ancestor validation and the following renames are one
-        // cooperative critical section.
-        let _output_lock =
-            crate::lock_file::LockFile::new(&self.root.join(".mise-task-artifact-cache-output"))
-                .lock()?;
-
         let restore = || -> Result<Vec<TaskCacheOutput>> {
             let manifest = self.read_manifest()?;
             for root in &manifest.roots {
@@ -202,6 +198,22 @@ impl TaskArtifactCache {
             }
             if remove_nested_roots(manifest.roots.clone()) != manifest.roots {
                 bail!("task cache manifest contains duplicate or nested roots");
+            }
+            if manifest.roots.is_empty() {
+                if let Err(err) = file::touch_file(&manifest_path) {
+                    warn!("failed to update task cache manifest access time: {err}");
+                }
+                return Ok(manifest.output);
+            }
+            // Serialize restores targeting the same working directory across
+            // mise processes so validation and renames form one cooperative
+            // critical section. Result-only entries never mutate the task root.
+            let _output_lock = crate::lock_file::LockFile::new(
+                &self.root.join(".mise-task-artifact-cache-output"),
+            )
+            .lock()?;
+            if !archive_path.is_file() {
+                bail!("task cache archive is missing");
             }
 
             let staging = tempfile::Builder::new()
@@ -255,9 +267,6 @@ impl TaskArtifactCache {
     pub(crate) fn store(&self, task: &Task, output: &[TaskCacheOutput]) -> Result<()> {
         let roots = resolve_output_roots(task, &self.root, true)?;
         let roots = remove_nested_roots(roots);
-        if roots.is_empty() {
-            bail!("task {} produced no cacheable outputs", task.name);
-        }
         for root in &roots {
             ensure_no_symlink_ancestors(&self.root, root)?;
         }
@@ -269,15 +278,21 @@ impl TaskArtifactCache {
         let archive_partial = cache_dir.join(format!("{}.part-{nonce}.tar.zst", self.key));
         let manifest_partial = cache_dir.join(format!("{}.part-{nonce}.json", self.key));
 
-        write_archive(&archive_partial, &self.root, &roots)?;
         let manifest = CacheManifest {
             format: CACHE_FORMAT_VERSION,
             key: self.key.clone(),
             roots,
             output: output.to_vec(),
         };
+        if !manifest.roots.is_empty() {
+            write_archive(&archive_partial, &self.root, &manifest.roots)?;
+        }
         fs::write(&manifest_partial, serde_json::to_vec(&manifest)?)?;
-        file::rename(&archive_partial, &archive_path)?;
+        if !manifest.roots.is_empty() {
+            file::rename(&archive_partial, &archive_path)?;
+        } else {
+            let _ = file::remove_file(&archive_path);
+        }
         file::rename(&manifest_partial, &manifest_path)?;
         Ok(())
     }
@@ -304,9 +319,9 @@ fn validate_config(task: &Task, root: &Path) -> Result<()> {
     if task.sources.is_empty() {
         bail!("task {} cache requires at least one source", task.name);
     }
-    if task.outputs.is_auto() || task.outputs.patterns().is_empty() {
+    if task.outputs.is_auto() {
         bail!(
-            "task {} cache requires explicit output files or directories",
+            "task {} cache requires explicit outputs or outputs = []",
             task.name
         );
     }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -546,7 +546,7 @@ impl TaskExecutor {
                 Some(cache) => {
                     let current_output = if !self.force
                         && !dependency_state.any_unkeyed_did_work
-                        && sources_are_fresh(task, config).await?
+                        && (task.outputs.is_no_files() || sources_are_fresh(task, config).await?)
                     {
                         cache.current_output()
                     } else {
@@ -568,10 +568,15 @@ impl TaskExecutor {
                         && let Some(output) = cache.restore(task)?
                     {
                         if !self.quiet(Some(task)) {
+                            let kind = if task.outputs.is_no_files() {
+                                "result"
+                            } else {
+                                "outputs"
+                            };
                             self.eprint(
                                 task,
                                 &prefix,
-                                &format!("restored outputs from cache {}", cache.key()),
+                                &format!("restored {kind} from cache {}", cache.key()),
                             );
                         }
                         self.output_handler

--- a/src/task/task_sources.rs
+++ b/src/task/task_sources.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 #[derive(Debug, Clone, Eq, PartialEq, strum::EnumIs)]
 pub enum TaskOutputs {
     Files(Vec<String>),
+    NoFiles,
     Auto,
 }
 
@@ -30,20 +31,21 @@ impl TaskOutputs {
     pub fn is_empty(&self) -> bool {
         match self {
             TaskOutputs::Files(files) => files.is_empty(),
-            TaskOutputs::Auto => false,
+            TaskOutputs::NoFiles | TaskOutputs::Auto => false,
         }
     }
 
     pub fn patterns(&self) -> Vec<String> {
         match self {
             TaskOutputs::Files(files) => files.clone(),
-            TaskOutputs::Auto => vec![],
+            TaskOutputs::NoFiles | TaskOutputs::Auto => vec![],
         }
     }
 
     pub fn paths(&self, task: &Task, root: &Path) -> Vec<String> {
         match self {
             TaskOutputs::Files(files) => files.clone(),
+            TaskOutputs::NoFiles => vec![],
             TaskOutputs::Auto => vec![self.auto_path(task, root)],
         }
     }
@@ -51,7 +53,7 @@ impl TaskOutputs {
     pub fn has_tera_template(&self) -> bool {
         match self {
             TaskOutputs::Files(files) => files.iter().any(|file| contains_template_syntax(file)),
-            TaskOutputs::Auto => false,
+            TaskOutputs::NoFiles | TaskOutputs::Auto => false,
         }
     }
 
@@ -61,7 +63,7 @@ impl TaskOutputs {
                 templates: Some(files.clone()),
                 original_env: None,
             },
-            TaskOutputs::Auto => RawOutputTemplates::default(),
+            TaskOutputs::NoFiles | TaskOutputs::Auto => RawOutputTemplates::default(),
         }
     }
 
@@ -99,7 +101,7 @@ impl TaskOutputs {
                     original_env,
                 })
             }
-            TaskOutputs::Auto => Ok(RawOutputTemplates::default()),
+            TaskOutputs::NoFiles | TaskOutputs::Auto => Ok(RawOutputTemplates::default()),
         }
     }
 
@@ -149,6 +151,7 @@ impl From<&toml::Value> for TaskOutputs {
     fn from(value: &toml::Value) -> Self {
         match value {
             toml::Value::String(file) => TaskOutputs::Files(vec![file.to_string()]),
+            toml::Value::Array(files) if files.is_empty() => TaskOutputs::NoFiles,
             toml::Value::Array(files) => TaskOutputs::Files(
                 files
                     .iter()
@@ -194,7 +197,11 @@ impl<'de> Deserialize<'de> for TaskOutputs {
                 while let Some(file) = seq.next_element()? {
                     files.push(file);
                 }
-                Ok(TaskOutputs::Files(files))
+                if files.is_empty() {
+                    Ok(TaskOutputs::NoFiles)
+                } else {
+                    Ok(TaskOutputs::Files(files))
+                }
             }
 
             fn visit_map<A: serde::de::MapAccess<'de>>(
@@ -231,6 +238,7 @@ impl Serialize for TaskOutputs {
                 }
                 seq.end()
             }
+            TaskOutputs::NoFiles => serializer.serialize_seq(Some(0))?.end(),
             TaskOutputs::Auto => {
                 let mut m = serializer.serialize_map(Some(1))?;
                 m.serialize_entry("auto", &true)?;
@@ -256,6 +264,11 @@ mod tests {
         let outputs = TaskOutputs::from(value);
         assert_eq!(outputs, TaskOutputs::Files(vec!["file1".to_string()]));
 
+        let value: toml::Table = toml::from_str("outputs = []").unwrap();
+        let value = value.get("outputs").unwrap();
+        let outputs = TaskOutputs::from(value);
+        assert_eq!(outputs, TaskOutputs::NoFiles);
+
         let value: toml::Table = toml::from_str("outputs = { auto = true }").unwrap();
         let value = value.get("outputs").unwrap();
         let outputs = TaskOutputs::from(value);
@@ -271,6 +284,10 @@ mod tests {
         let outputs = TaskOutputs::Auto;
         let serialized = serde_json::to_string(&outputs).unwrap();
         assert_eq!(serialized, "{\"auto\":true}");
+
+        let outputs = TaskOutputs::NoFiles;
+        let serialized = serde_json::to_string(&outputs).unwrap();
+        assert_eq!(serialized, "[]");
     }
 
     #[test]
@@ -280,6 +297,9 @@ mod tests {
 
         let deserialized: TaskOutputs = serde_json::from_str("[\"file1\"]").unwrap();
         assert_eq!(deserialized, TaskOutputs::Files(vec!["file1".to_string()]));
+
+        let deserialized: TaskOutputs = serde_json::from_str("[]").unwrap();
+        assert_eq!(deserialized, TaskOutputs::NoFiles);
 
         let deserialized: TaskOutputs = serde_json::from_str("{ \"auto\": true }").unwrap();
         assert_eq!(deserialized, TaskOutputs::Auto);


### PR DESCRIPTION
## Summary

- support `outputs = []` as an explicit result-only task cache declaration
- store successful results and replayable logs without creating an artifact archive
- allow scoped cache defaults to apply to result-only tasks
- document the behavior and mark the parity-tracker item complete

## Why

Checks such as linting, testing, and type checking often produce no filesystem artifacts, but their successful result and logs are still useful to cache. This closes that local-cache parity gap while requiring users to explicitly assert that no filesystem side effects need restoration.

## Stacking

This PR is stacked on #11347 and should be retargeted to `main` after that PR merges.

## Validation

- `mise run lint-fix`
- `cargo check --all-features`
- `cargo test --all-features task_outputs --quiet`
- `cargo test --all-features task_cache --quiet`
- `mise run test:e2e tasks/test_task_artifact_cache_no_outputs tasks/test_task_artifact_cache tasks/test_task_artifact_cache_validation tasks/test_task_artifact_cache_output`

The e2e coverage verifies current hits, manifest-only restoration, log replay, source invalidation, scoped defaults, cache clearing, and that result-only entries create no tar archive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes experimental task cache store/restore and skip logic; incorrect `outputs = []` could skip work if users misdeclare side effects, though behavior is opt-in and covered by new e2e tests.
> 
> **Overview**
> Adds **`outputs = []`** as an explicit “result-only” cache mode for tasks that produce no filesystem artifacts (lint, test, typecheck). Successful runs can be skipped or restored from cache with **manifest + replayed stdout/stderr**, without writing a **`.tar.zst`** archive.
> 
> **`TaskOutputs::NoFiles`** is parsed from an empty `outputs` array; cache validation and scoped **`task_config.cache`** defaults now treat **`outputs = []`** like explicit output paths (still rejecting **`outputs = { auto = true }`**). **Store/restore** only unpacks archives when manifest roots are non-empty; result-only entries skip the output-directory lock and tolerate a missing archive when the JSON manifest is present.
> 
> The executor treats result-only tasks as cache-eligible on the “sources up-to-date” fast path without requiring output freshness, and reports **“restored result”** vs **“restored outputs”** on cache hits. Docs, parity tracker, validation messages, and e2e coverage for hits, manifest-only restore, log replay, invalidation, and scoped defaults are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b47d1d22563cbbed998330ba494122873dd5e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks configured with `outputs = []` can now use caching.
  * Cached result-only tasks replay successful results and logs without storing filesystem artifacts.
  * Cached results can be restored after local cache state is removed.

* **Bug Fixes**
  * Improved cache validation and clearer errors for unsupported output configurations.
  * Cache reuse now correctly handles tasks without filesystem outputs.

* **Documentation**
  * Expanded task-cache configuration guidance, eligibility rules, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->