### PR TITLE
fix(vfox): remove redundant debug argument borrows

### DIFF
--- a/crates/vfox/src/hooks/available.rs
+++ b/crates/vfox/src/hooks/available.rs
@@ -12,7 +12,7 @@ impl Plugin {
     }
 
     pub async fn available_async(&self) -> Result<Vec<AvailableVersion>> {
-        debug!("[vfox:{}] available_async", &self.name);
+        debug!("[vfox:{}] available_async", self.name);
         let ctx = self.context(None)?;
         let available = self
             .eval_async(chunk! {

--- a/crates/vfox/src/hooks/backend_exec_env.rs
+++ b/crates/vfox/src/hooks/backend_exec_env.rs
@@ -23,7 +23,7 @@ impl Plugin {
         &self,
         ctx: BackendExecEnvContext,
     ) -> Result<BackendExecEnvResponse> {
-        debug!("[vfox:{}] backend_exec_env", &self.name);
+        debug!("[vfox:{}] backend_exec_env", self.name);
         self.eval_async(chunk! {
             require "hooks/backend_exec_env"
             return PLUGIN:BackendExecEnv($ctx)

--- a/crates/vfox/src/hooks/backend_install.rs
+++ b/crates/vfox/src/hooks/backend_install.rs
@@ -22,7 +22,7 @@ impl Plugin {
         &self,
         ctx: BackendInstallContext,
     ) -> Result<BackendInstallResponse> {
-        debug!("[vfox:{}] backend_install", &self.name);
+        debug!("[vfox:{}] backend_install", self.name);
         self.eval_async(chunk! {
             require "hooks/backend_install"
             return PLUGIN:BackendInstall($ctx)

--- a/crates/vfox/src/hooks/backend_list_versions.rs
+++ b/crates/vfox/src/hooks/backend_list_versions.rs
@@ -19,7 +19,7 @@ impl Plugin {
         &self,
         ctx: BackendListVersionsContext,
     ) -> Result<BackendListVersionsResponse> {
-        debug!("[vfox:{}] backend_list_versions", &self.name);
+        debug!("[vfox:{}] backend_list_versions", self.name);
         self.eval_async(chunk! {
             require "hooks/backend_list_versions"
             return PLUGIN:BackendListVersions($ctx)

--- a/crates/vfox/src/hooks/env_keys.rs
+++ b/crates/vfox/src/hooks/env_keys.rs
@@ -28,7 +28,7 @@ impl Plugin {
         &self,
         ctx: EnvKeysContext<T>,
     ) -> Result<Vec<EnvKey>> {
-        debug!("[vfox:{}] env_keys", &self.name);
+        debug!("[vfox:{}] env_keys", self.name);
         let env_keys = self
             .eval_async(chunk! {
                 require "hooks/env_keys"

--- a/crates/vfox/src/hooks/mise_env.rs
+++ b/crates/vfox/src/hooks/mise_env.rs
@@ -35,7 +35,7 @@ impl Plugin {
         &self,
         ctx: MiseEnvContext<T>,
     ) -> Result<MiseEnvResult> {
-        debug!("[vfox:{}] mise_env", &self.name);
+        debug!("[vfox:{}] mise_env", self.name);
         let result = self
             .eval_async(chunk! {
                 require "hooks/mise_env"

--- a/crates/vfox/src/hooks/mise_path.rs
+++ b/crates/vfox/src/hooks/mise_path.rs
@@ -15,7 +15,7 @@ impl Plugin {
         &self,
         ctx: MisePathContext<T>,
     ) -> Result<Vec<String>> {
-        debug!("[vfox:{}] mise_path", &self.name);
+        debug!("[vfox:{}] mise_path", self.name);
         let path = self
             .eval_async(chunk! {
                 require "hooks/mise_path"

--- a/crates/vfox/src/hooks/package.rs
+++ b/crates/vfox/src/hooks/package.rs
@@ -40,7 +40,7 @@ impl Plugin {
         &self,
         ctx: PackageInstalledContext,
     ) -> Result<PackageInstalledResponse> {
-        debug!("[vfox:{}] package_installed", &self.name);
+        debug!("[vfox:{}] package_installed", self.name);
         self.eval_async(chunk! {
             require "hooks/package_installed"
             return PLUGIN:PackageInstalled($ctx)
@@ -52,7 +52,7 @@ impl Plugin {
         &self,
         ctx: PackageActionContext,
     ) -> Result<PackageActionResponse> {
-        debug!("[vfox:{}] package_install", &self.name);
+        debug!("[vfox:{}] package_install", self.name);
         self.eval_async(chunk! {
             require "hooks/package_install"
             return PLUGIN:PackageInstall($ctx)
@@ -64,7 +64,7 @@ impl Plugin {
         &self,
         ctx: PackageActionContext,
     ) -> Result<PackageActionResponse> {
-        debug!("[vfox:{}] package_upgrade", &self.name);
+        debug!("[vfox:{}] package_upgrade", self.name);
         self.eval_async(chunk! {
             require "hooks/package_upgrade"
             return PLUGIN:PackageUpgrade($ctx)

--- a/crates/vfox/src/hooks/parse_legacy_file.rs
+++ b/crates/vfox/src/hooks/parse_legacy_file.rs
@@ -18,7 +18,7 @@ pub struct ParseLegacyFileResponse {
 
 impl Plugin {
     pub async fn parse_legacy_file(&self, legacy_file: &Path) -> Result<ParseLegacyFileResponse> {
-        debug!("[vfox:{}] parse_legacy_file", &self.name);
+        debug!("[vfox:{}] parse_legacy_file", self.name);
         let ctx = LegacyFileContext {
             args: vec![],
             filepath: legacy_file.to_path_buf(),

--- a/crates/vfox/src/hooks/post_install.rs
+++ b/crates/vfox/src/hooks/post_install.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 impl Plugin {
     pub async fn post_install(&self, ctx: PostInstallContext) -> Result<()> {
-        debug!("[vfox:{}] post_install", &self.name);
+        debug!("[vfox:{}] post_install", self.name);
         self.exec_async(chunk! {
             require "hooks/post_install"
             PLUGIN:PostInstall($ctx)

--- a/crates/vfox/src/hooks/pre_install.rs
+++ b/crates/vfox/src/hooks/pre_install.rs
@@ -9,7 +9,7 @@ use crate::runtime::Runtime;
 
 impl Plugin {
     pub async fn pre_install(&self, version: &str) -> Result<PreInstall> {
-        debug!("[vfox:{}] pre_install", &self.name);
+        debug!("[vfox:{}] pre_install", self.name);
         let ctx = self.context(Some(version.to_string()))?;
         let pre_install = self
             .eval_async(chunk! {
@@ -29,7 +29,7 @@ impl Plugin {
     ) -> Result<PreInstall> {
         debug!(
             "[vfox:{}] pre_install_for_platform os={} arch={}",
-            &self.name, os, arch
+            self.name, os, arch
         );
         let ctx = self.context(Some(version.to_string()))?;
         let target_os = os.to_string();

--- a/crates/vfox/src/hooks/pre_uninstall.rs
+++ b/crates/vfox/src/hooks/pre_uninstall.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 impl Plugin {
     pub async fn pre_uninstall(&self, ctx: PreUninstallContext) -> Result<()> {
-        debug!("[vfox:{}] pre_uninstall", &self.name);
+        debug!("[vfox:{}] pre_uninstall", self.name);
         self.exec_async(chunk! {
             require "hooks/pre_uninstall"
             PLUGIN:PreUninstall($ctx)

--- a/crates/vfox/src/hooks/pre_use.rs
+++ b/crates/vfox/src/hooks/pre_use.rs
@@ -18,7 +18,7 @@ pub struct PreUseResponse {
 
 impl Plugin {
     pub async fn pre_use(&self, _vfox: &Vfox, _legacy_file: &Path) -> Result<PreUseResponse> {
-        debug!("[vfox:{}] pre_use", &self.name);
+        debug!("[vfox:{}] pre_use", self.name);
         // let ctx = PreUseContext {
         //     installed_sdks: vfox.list_installed_versions(&self.name)?,
         // };


### PR DESCRIPTION
## Summary
- remove redundant references from vfox debug-format arguments
- satisfy Rust 1.97's `clippy::useless_borrows_in_formatting` lint
- preserve runtime behavior

## Validation
- `cargo clippy -p vfox -- -D warnings`
- `cargo test -p vfox --quiet`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only formatting tweaks with no logic or API changes.
> 
> **Overview**
> Updates **`debug!`** calls across vfox plugin hook entry points so plugin names are passed as **`self.name`** instead of **`&self.name`**, matching Rust 1.97’s **`clippy::useless_borrows_in_formatting`** expectations.
> 
> The edits are limited to logging in hook modules (e.g. **`available`**, **`pre_install`**, **`package_*`**, backend hooks); hook behavior and Lua evaluation are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab0501c4e0f99b1527a40111b0be68cf3ecd753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal debug logging consistency across plugin hooks.
  * No user-facing behavior, controls, or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->