### PR TITLE
feat(task): add config-scoped default shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,14 @@
 
 - **(config)** restrict default shell args to global config by @jdx in [#11293](https://github.com/jdx/mise/pull/11293)
 
+> [!WARNING]
+> `unix_default_file_shell_args`, `unix_default_inline_shell_args`,
+> `windows_default_file_shell_args`, and `windows_default_inline_shell_args` in project config files
+> are now ignored. These settings were applied before trust evaluation and could change the
+> interpreter used by commands from trusted sources. To select a shell for project tasks, use
+> [`task_config.shell`](https://mise.en.dev/tasks/task-configuration.html#task-config-shell) on a
+> release that supports it, or set `shell` on each task.
+
 ### New Contributors
 
 - @gologames made their first contribution in [#11257](https://github.com/jdx/mise/pull/11257)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,9 @@
 > are now ignored. These settings were applied before trust evaluation and could change the
 > interpreter used by commands from trusted sources. To select a shell for project tasks, use
 > [`task_config.shell`](https://mise.en.dev/tasks/task-configuration.html#task-config-shell) on a
-> release that supports it, or set `shell` on each task.
+> release that supports it, or set `shell` on each task. Monorepos can set
+> `task_config.cascade = true` at the project root to share the task shell and other task defaults
+> with descendant config roots.
 
 ### New Contributors
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -794,7 +794,22 @@ I don't want to turn all file tasks into tera templates just for this feature.
 
 Options available in the top-level `mise.toml` `[task_config]` section. These apply to all tasks which
 are included by that config file or use the same root directory, e.g.: `~/src/myproject/mise.toml`'s `[task_config]`
-applies to file tasks like `~/src/myproject/mise-tasks/mytask` but not to tasks in `~/src/myproject/subproj/mise.toml`.
+applies to file tasks like `~/src/myproject/mise-tasks/mytask`. Set `cascade = true` to also apply the
+section to tasks owned by descendant config roots.
+
+### `task_config.cascade`
+
+Cascade this config's `[task_config]` values to descendant config roots. Descendant values override
+individual inherited fields. A descendant can set `cascade = false` to stop inheriting the section.
+
+```toml
+[task_config]
+cascade = true
+shell = "bash -c"
+```
+
+This applies to `dir`, `shell`, `cache`, and `includes`. Inherited include paths remain relative to
+the config root where they were defined, allowing a monorepo root to provide one shared task set.
 
 ### `task_config.dir`
 
@@ -808,7 +823,8 @@ dir = "{{cwd}}"
 ### `task_config.shell`
 
 Set the default shell for tasks in this config scope. A task's explicit `shell` setting takes
-precedence, including a `shell` inherited from a task template.
+precedence, including a `shell` inherited from a task template. With `task_config.cascade = true`,
+descendant config roots inherit this default and may override it with their own `task_config.shell`.
 
 ```toml
 [task_config]
@@ -894,8 +910,10 @@ includes = [
 ]
 ```
 
-For local and monorepo task discovery, mise uses the nearest config file that defines `task_config.includes`.
-That means a child config's `includes` replaces both the defaults and any `includes` defined by parent configs for that directory.
+For local and monorepo task discovery, mise uses the nearest config file that defines
+`task_config.includes`. When the parent has `task_config.cascade = true`, its includes are inherited
+until a child defines its own. A child config's `includes` replaces both the defaults and any
+inherited `includes` for that directory.
 Global config files are loaded independently, so each global config file uses its own `task_config.includes` or the default directories if `includes` is unset.
 
 Entries are evaluated in order, and when more than one include defines a task with the same name the **last** entry in the list wins.

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -805,6 +805,22 @@ Change the default directory tasks are run from.
 dir = "{{cwd}}"
 ```
 
+### `task_config.shell`
+
+Set the default shell for tasks in this config scope. A task's explicit `shell` setting takes
+precedence, including a `shell` inherited from a task template.
+
+```toml
+[task_config]
+shell = "bash -c"
+```
+
+Unlike the global-only
+[`unix_default_inline_shell_args`](/configuration/settings.html#unix_default_inline_shell_args) and
+[`windows_default_inline_shell_args`](/configuration/settings.html#windows_default_inline_shell_args)
+settings, this default is scoped to project tasks and cannot change the interpreter used by hooks,
+tool installation, or tasks from another config root.
+
 ### `task_config.cache` <Badge type="warning" text="experimental" />
 
 Sets the default artifact-cache configuration for tasks in this config scope. The default is only

--- a/e2e/tasks/test_task_config_shell
+++ b/e2e/tasks/test_task_config_shell
@@ -42,6 +42,10 @@ EOF
 cat <<'EOF' >tasks.toml
 [included]
 run = "echo INCLUDED"
+
+[included-templated]
+extends = "override"
+run = "echo INCLUDED_TEMPLATED"
 EOF
 
 mkdir child
@@ -58,4 +62,6 @@ assert "mise run explicit" "OVERRIDE_SHELL
 EXPLICIT"
 assert "mise run templated" "OVERRIDE_SHELL
 TEMPLATED"
+assert "mise run included-templated" "OVERRIDE_SHELL
+INCLUDED_TEMPLATED"
 assert "mise -C child run child" "CHILD"

--- a/e2e/tasks/test_task_config_shell
+++ b/e2e/tasks/test_task_config_shell
@@ -24,7 +24,13 @@ cat <<'EOF' >mise.toml
 monorepo_root = true
 
 [monorepo]
-config_roots = ["child", "child-override", "child-no-cascade"]
+config_roots = [
+    "child",
+    "child-override",
+    "child-middle/nested",
+    "child-no-cascade",
+    "child-no-cascade/nested",
+]
 
 [task_config]
 cascade = true
@@ -57,9 +63,12 @@ run = "echo INCLUDED_TEMPLATED"
 EOF
 
 mkdir -p task-cwd "child/shell wrappers" child/task-cwd \
-  "child-override/shell wrappers" child-override/task-cwd child-no-cascade
+  "child-override/shell wrappers" child-override/task-cwd \
+  "child-middle/nested/shell wrappers" child-middle/nested/middle-cwd \
+  child-no-cascade/nested
 cp "shell wrappers/default" "child/shell wrappers/default"
 cp "shell wrappers/override" "child-override/shell wrappers/override"
+cp "shell wrappers/default" "child-middle/nested/shell wrappers/default"
 cat <<'EOF' >child/mise.toml
 [tasks.child]
 run = "echo CHILD"
@@ -82,6 +91,21 @@ cascade = false
 
 [tasks.child]
 run = "echo CHILD_NO_CASCADE"
+EOF
+
+cat <<'EOF' >child-no-cascade/nested/mise.toml
+[tasks.child]
+run = "echo NESTED_NO_CASCADE"
+EOF
+
+cat <<'EOF' >child-middle/mise.toml
+[task_config]
+dir = "{{config_root}}/middle-cwd"
+EOF
+
+cat <<'EOF' >child-middle/nested/mise.toml
+[tasks.child]
+run = 'echo NESTED_MERGED; basename "$PWD"'
 EOF
 
 assert "mise run inline" "TASK_CONFIG_SHELL
@@ -109,3 +133,7 @@ INCLUDED"
 assert "mise run //child-override:child" "OVERRIDE_SHELL
 CHILD_OVERRIDE"
 assert "mise run //child-no-cascade:child" "CHILD_NO_CASCADE"
+assert "mise run //child-no-cascade/nested:child" "NESTED_NO_CASCADE"
+assert "mise run //child-middle/nested:child" "TASK_CONFIG_SHELL
+NESTED_MERGED
+middle-cwd"

--- a/e2e/tasks/test_task_config_shell
+++ b/e2e/tasks/test_task_config_shell
@@ -34,7 +34,7 @@ config_roots = [
 
 [task_config]
 cascade = true
-includes = ["tasks.toml"]
+includes = ["tasks.toml", "shared-tasks"]
 dir = "{{config_root}}/task-cwd"
 shell = '"{{config_root}}/shell wrappers/default" -c'
 
@@ -62,7 +62,7 @@ extends = "override"
 run = "echo INCLUDED_TEMPLATED"
 EOF
 
-mkdir -p task-cwd "child/shell wrappers" child/task-cwd \
+mkdir -p task-cwd shared-tasks "child/shell wrappers" child/task-cwd \
   "child-override/shell wrappers" child-override/task-cwd \
   "child-middle/nested/shell wrappers" child-middle/nested/middle-cwd \
   child-no-cascade/nested
@@ -137,3 +137,9 @@ assert "mise run //child-no-cascade/nested:child" "NESTED_NO_CASCADE"
 assert "mise run //child-middle/nested:child" "TASK_CONFIG_SHELL
 NESTED_MERGED
 middle-cwd"
+
+mise -C child tasks add --file generated -- echo GENERATED
+assert "test -f shared-tasks/generated && echo CREATED" "CREATED"
+
+mise -C child-no-cascade tasks add --file generated -- echo GENERATED
+assert "test -f child-no-cascade/mise-tasks/generated && echo CREATED" "CREATED"

--- a/e2e/tasks/test_task_config_shell
+++ b/e2e/tasks/test_task_config_shell
@@ -53,6 +53,11 @@ extends = "override"
 run = "echo TEMPLATED"
 EOF
 
+cat <<'EOF' >mise.local.toml
+[tasks.overlay]
+run = "echo OVERLAY"
+EOF
+
 cat <<'EOF' >tasks.toml
 [included]
 run = "echo INCLUDED"
@@ -118,6 +123,8 @@ assert "mise run templated" "OVERRIDE_SHELL
 TEMPLATED"
 assert "mise run included-templated" "OVERRIDE_SHELL
 INCLUDED_TEMPLATED"
+assert "mise run overlay" "TASK_CONFIG_SHELL
+OVERLAY"
 assert "mise -C child run child" "TASK_CONFIG_SHELL
 CHILD"
 assert "mise -C child run included" "TASK_CONFIG_SHELL

--- a/e2e/tasks/test_task_config_shell
+++ b/e2e/tasks/test_task_config_shell
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Test that task_config.shell is inherited by inline and included TOML tasks,
+# while task-local and task-template shells take precedence.
+
+mkdir -p "shell wrappers"
+
+cat <<'SCRIPT' >"shell wrappers/default"
+#!/usr/bin/env bash
+echo TASK_CONFIG_SHELL
+exec bash "$@"
+SCRIPT
+chmod +x "shell wrappers/default"
+
+cat <<'SCRIPT' >"shell wrappers/override"
+#!/usr/bin/env bash
+echo OVERRIDE_SHELL
+exec bash "$@"
+SCRIPT
+chmod +x "shell wrappers/override"
+
+cat <<'EOF' >mise.toml
+[task_config]
+includes = ["tasks.toml"]
+shell = '"{{config_root}}/shell wrappers/default" -c'
+
+[task_templates.override]
+shell = '"{{config_root}}/shell wrappers/override" -c'
+
+[tasks.inline]
+run = "echo INLINE"
+
+[tasks.explicit]
+run = "echo EXPLICIT"
+shell = '"{{config_root}}/shell wrappers/override" -c'
+
+[tasks.templated]
+extends = "override"
+run = "echo TEMPLATED"
+EOF
+
+cat <<'EOF' >tasks.toml
+[included]
+run = "echo INCLUDED"
+EOF
+
+mkdir child
+cat <<'EOF' >child/mise.toml
+[tasks.child]
+run = "echo CHILD"
+EOF
+
+assert "mise run inline" "TASK_CONFIG_SHELL
+INLINE"
+assert "mise run included" "TASK_CONFIG_SHELL
+INCLUDED"
+assert "mise run explicit" "OVERRIDE_SHELL
+EXPLICIT"
+assert "mise run templated" "OVERRIDE_SHELL
+TEMPLATED"
+assert "mise -C child run child" "CHILD"

--- a/e2e/tasks/test_task_config_shell
+++ b/e2e/tasks/test_task_config_shell
@@ -2,6 +2,7 @@
 
 # Test that task_config.shell is inherited by inline and included TOML tasks,
 # while task-local and task-template shells take precedence.
+export MISE_EXPERIMENTAL=1
 
 mkdir -p "shell wrappers"
 
@@ -20,8 +21,15 @@ SCRIPT
 chmod +x "shell wrappers/override"
 
 cat <<'EOF' >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["child", "child-override", "child-no-cascade"]
+
 [task_config]
+cascade = true
 includes = ["tasks.toml"]
+dir = "{{config_root}}/task-cwd"
 shell = '"{{config_root}}/shell wrappers/default" -c'
 
 [task_templates.override]
@@ -48,10 +56,32 @@ extends = "override"
 run = "echo INCLUDED_TEMPLATED"
 EOF
 
-mkdir child
+mkdir -p task-cwd "child/shell wrappers" child/task-cwd \
+  "child-override/shell wrappers" child-override/task-cwd child-no-cascade
+cp "shell wrappers/default" "child/shell wrappers/default"
+cp "shell wrappers/override" "child-override/shell wrappers/override"
 cat <<'EOF' >child/mise.toml
 [tasks.child]
 run = "echo CHILD"
+
+[tasks.cwd]
+run = 'basename "$PWD"'
+EOF
+
+cat <<'EOF' >child-override/mise.toml
+[task_config]
+shell = '"{{config_root}}/shell wrappers/override" -c'
+
+[tasks.child]
+run = "echo CHILD_OVERRIDE"
+EOF
+
+cat <<'EOF' >child-no-cascade/mise.toml
+[task_config]
+cascade = false
+
+[tasks.child]
+run = "echo CHILD_NO_CASCADE"
 EOF
 
 assert "mise run inline" "TASK_CONFIG_SHELL
@@ -64,4 +94,18 @@ assert "mise run templated" "OVERRIDE_SHELL
 TEMPLATED"
 assert "mise run included-templated" "OVERRIDE_SHELL
 INCLUDED_TEMPLATED"
-assert "mise -C child run child" "CHILD"
+assert "mise -C child run child" "TASK_CONFIG_SHELL
+CHILD"
+assert "mise -C child run included" "TASK_CONFIG_SHELL
+INCLUDED"
+assert "mise -C child run cwd" "TASK_CONFIG_SHELL
+task-cwd"
+assert "mise -C child-override run child" "OVERRIDE_SHELL
+CHILD_OVERRIDE"
+assert "mise run //child:child" "TASK_CONFIG_SHELL
+CHILD"
+assert "mise run //child:included" "TASK_CONFIG_SHELL
+INCLUDED"
+assert "mise run //child-override:child" "OVERRIDE_SHELL
+CHILD_OVERRIDE"
+assert "mise run //child-no-cascade:child" "CHILD_NO_CASCADE"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2261,6 +2261,11 @@
       "type": "object",
       "unevaluatedProperties": false,
       "properties": {
+        "cascade": {
+          "default": false,
+          "description": "cascade task configuration to descendant config roots",
+          "type": "boolean"
+        },
         "dir": {
           "description": "default directory to run tasks in defined in this file",
           "type": "string"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2265,6 +2265,10 @@
           "description": "default directory to run tasks in defined in this file",
           "type": "string"
         },
+        "shell": {
+          "description": "default shell to run tasks with in this config scope",
+          "type": "string"
+        },
         "cache": {
           "description": "default experimental local artifact cache configuration for eligible tasks with sources and explicit outputs",
           "type": "object",

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -746,6 +746,7 @@ impl Hash for dyn ConfigFile {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct TaskConfig {
+    pub cascade: Option<bool>,
     pub includes: Option<Vec<String>>,
     pub dir: Option<String>,
     pub shell: Option<String>,

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -748,6 +748,7 @@ impl Hash for dyn ConfigFile {
 pub struct TaskConfig {
     pub includes: Option<Vec<String>>,
     pub dir: Option<String>,
+    pub shell: Option<String>,
     pub cache: Option<crate::task::TaskCacheConfig>,
     pub global_inputs: Vec<String>,
     pub input_groups: IndexMap<String, Vec<String>>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3634,12 +3634,6 @@ async fn load_task_file(
         task.name = name.clone();
         task.config_source = path.to_path_buf();
         task.config_root = Some(config_root.to_path_buf());
-        if task.dir.is_none() {
-            task.dir = task_config_dir.clone();
-        }
-        if task.shell.is_none() {
-            task.shell = task_config_shell.clone();
-        }
         if let Some(monorepo_cf) = monorepo_cf {
             task.cf = Some(monorepo_cf.clone());
         }
@@ -3648,6 +3642,12 @@ async fn load_task_file(
     for (_, mut task) in tasks {
         let config_root = config_root.to_path_buf();
         resolve_task_template(&mut task, templates)?;
+        if task.dir.is_none() {
+            task.dir = task_config_dir.clone();
+        }
+        if task.shell.is_none() {
+            task.shell = task_config_shell.clone();
+        }
         match task.render(config, &config_root).await {
             Ok(()) => {
                 out.push(task);
@@ -4739,6 +4739,7 @@ vars = { target = "linux" }
             &config,
             &tasks_toml,
             temp_dir.path(),
+            &None,
             &None,
             &IndexMap::new(),
             None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2232,6 +2232,14 @@ struct ResolvedTaskInputs {
     input_groups: Option<(IndexMap<String, Vec<String>>, PathBuf)>,
 }
 
+#[derive(Clone, Debug, Default)]
+struct ResolvedTaskConfig {
+    inputs: ResolvedTaskInputs,
+    dir: Option<String>,
+    shell: Option<String>,
+    cache: Option<TaskCacheConfig>,
+}
+
 impl ResolvedTaskInputs {
     fn from_configs(configs: &[&Arc<dyn ConfigFile>]) -> Self {
         Self {
@@ -3179,10 +3187,7 @@ async fn load_config_tasks(
     config_root: &Path,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
-    task_inputs: &ResolvedTaskInputs,
-    task_config_dir: &Option<String>,
-    task_config_shell: &Option<String>,
-    task_config_cache: &Option<TaskCacheConfig>,
+    task_config: &ResolvedTaskConfig,
 ) -> Result<Vec<Task>> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
@@ -3203,15 +3208,15 @@ async fn load_config_tasks(
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
         if t.dir.is_none() {
-            t.dir = task_config_dir.clone();
+            t.dir = task_config.dir.clone();
         }
         if t.shell.is_none() {
-            t.shell = task_config_shell.clone();
+            t.shell = task_config.shell.clone();
         }
         match t.render(&config, &config_root).await {
             Ok(()) => {
-                apply_task_config_inputs(&mut t, &config, task_inputs).await?;
-                apply_task_config_cache_default(&mut t, task_config_cache);
+                apply_task_config_inputs(&mut t, &config, &task_config.inputs).await?;
+                apply_task_config_cache_default(&mut t, &task_config.cache);
                 tasks.push(t);
             }
             Err(e) => {
@@ -3234,8 +3239,7 @@ async fn load_tasks_includes(
     config: &Arc<Config>,
     root: &Path,
     config_root: &Path,
-    task_config_dir: &Option<String>,
-    task_config_shell: &Option<String>,
+    task_config: &ResolvedTaskConfig,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     require_trust: bool,
@@ -3246,8 +3250,8 @@ async fn load_tasks_includes(
             config,
             root,
             config_root,
-            task_config_dir,
-            task_config_shell,
+            &task_config.dir,
+            &task_config.shell,
             templates,
             monorepo_cf,
         )
@@ -3286,8 +3290,8 @@ async fn load_tasks_includes(
                     config,
                     &path,
                     config_root,
-                    task_config_dir,
-                    task_config_shell,
+                    &task_config.dir,
+                    &task_config.shell,
                     templates,
                     monorepo_cf,
                 )
@@ -3308,7 +3312,7 @@ async fn load_tasks_includes(
                 monorepo_cf.cloned(),
             )?;
             if task.shell.is_none() {
-                task.shell = task_config_shell.clone();
+                task.shell = task_config.shell.clone();
             }
             if let Err(err) = task.render(&config, &config_root).await {
                 if monorepo_cf.is_some() {
@@ -3323,7 +3327,7 @@ async fn load_tasks_includes(
                 }
             }
             if task.dir.is_none()
-                && let Some(ref dir) = *task_config_dir
+                && let Some(ref dir) = task_config.dir
             {
                 task.dir = Some(if contains_template_syntax(dir) {
                     let mut tera = crate::tera::get_tera(Some(config_root.as_ref()));
@@ -3655,8 +3659,6 @@ async fn load_task_sources_from_configs(
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
-    let task_config_inputs = ResolvedTaskInputs::from_configs(&configs);
-
     let (includes, resolve_dir) = configs
         .iter()
         .find_map(|cf| match cf.task_config_includes() {
@@ -3677,18 +3679,21 @@ async fn load_task_sources_from_configs(
 
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.
-    let task_config_dir = configs
-        .iter()
-        .find_map(|cf| cf.task_config().dir.clone())
-        .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.dir.clone()));
-    let task_config_shell = configs
-        .iter()
-        .find_map(|cf| cf.task_config().shell.clone())
-        .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.shell.clone()));
-    let task_config_cache = configs
-        .iter()
-        .find_map(|cf| cf.task_config().cache.clone())
-        .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.cache.clone()));
+    let task_config = ResolvedTaskConfig {
+        inputs: ResolvedTaskInputs::from_configs(&configs),
+        dir: configs
+            .iter()
+            .find_map(|cf| cf.task_config().dir.clone())
+            .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.dir.clone())),
+        shell: configs
+            .iter()
+            .find_map(|cf| cf.task_config().shell.clone())
+            .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.shell.clone())),
+        cache: configs
+            .iter()
+            .find_map(|cf| cf.task_config().cache.clone())
+            .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.cache.clone())),
+    };
 
     let mut config_tasks = vec![];
     for cf in &configs {
@@ -3701,10 +3706,7 @@ async fn load_task_sources_from_configs(
                 &dir,
                 templates,
                 monorepo_cf,
-                &task_config_inputs,
-                &task_config_dir,
-                &task_config_shell,
-                &task_config_cache,
+                &task_config,
             )
             .await?,
         );
@@ -3727,16 +3729,15 @@ async fn load_task_sources_from_configs(
                 config,
                 &p,
                 dir,
-                &task_config_dir,
-                &task_config_shell,
+                &task_config,
                 templates,
                 monorepo_cf,
                 require_task_include_trust,
             )
             .await?;
             for task in &mut loaded {
-                apply_task_config_inputs(task, config, &task_config_inputs).await?;
-                apply_task_config_cache_default(task, &task_config_cache);
+                apply_task_config_inputs(task, config, &task_config.inputs).await?;
+                apply_task_config_cache_default(task, &task_config.cache);
             }
             if is_global || is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2597,10 +2597,6 @@ async fn load_local_tasks_with_context(
             .and_then(|cf| cf.monorepo())
             .map(|m| &m.config_roots);
         let subdirs = discover_monorepo_subdirs(monorepo_root, config_roots, ctx)?;
-        let cascaded_task_config = monorepo_config
-            .map(cascaded_task_config)
-            .transpose()?
-            .flatten();
 
         // Load tasks from subdirectories in parallel
         let subdir_tasks_futures: Vec<_> = subdirs
@@ -2610,35 +2606,56 @@ async fn load_local_tasks_with_context(
                 let config = config.clone();
                 let monorepo_root = monorepo_root.clone();
                 let templates = templates.clone();
-                let cascaded_task_config = cascaded_task_config.clone();
                 async move {
-                    let config_paths = config_paths_in_dir(&subdir);
-                    let found_config = !config_paths.is_empty();
-                    let mut parsed_configs = ConfigMap::new();
-                    for config_path in config_paths {
-                        match config_file::parse(&config_path).await {
-                            Ok(cf) => {
-                                parsed_configs.insert(config_path, cf);
+                    let exact_config_paths = config_paths_in_dir(&subdir);
+                    let found_config = !exact_config_paths.is_empty();
+                    let mut hierarchy_configs = config
+                        .config_files
+                        .iter()
+                        .filter(|(_, cf)| {
+                            let root = cf.config_root();
+                            path_starts_with_resolved(&root, &monorepo_root)
+                                && path_starts_with_resolved(&subdir, &root)
+                        })
+                        .map(|(path, cf)| (path.clone(), cf.clone()))
+                        .collect::<ConfigMap>();
+                    let mut hierarchy_dirs = subdir
+                        .ancestors()
+                        .take_while(|dir| path_starts_with_resolved(dir, &monorepo_root))
+                        .map(Path::to_path_buf)
+                        .collect::<Vec<_>>();
+                    hierarchy_dirs.reverse();
+                    for hierarchy_dir in hierarchy_dirs {
+                        for config_path in config_paths_in_dir(&hierarchy_dir) {
+                            if hierarchy_configs.contains_key(&config_path) {
+                                continue;
                             }
-                            Err(err) => {
-                                let rel_path = subdir
-                                    .strip_prefix(&monorepo_root)
-                                    .unwrap_or(&subdir);
-                                warn!(
-                                    "Failed to parse config file {} in monorepo subdirectory {}: {}. Tasks from this directory will not be loaded.",
-                                    config_path.display(),
-                                    rel_path.display(),
-                                    err
-                                );
+                            match config_file::parse(&config_path).await {
+                                Ok(cf) => {
+                                    hierarchy_configs.insert(config_path, cf);
+                                }
+                                Err(err) => {
+                                    let rel_path = hierarchy_dir
+                                        .strip_prefix(&monorepo_root)
+                                        .unwrap_or(&hierarchy_dir);
+                                    warn!(
+                                        "Failed to parse config file {} in monorepo directory {}: {}. Cascaded task configuration from this directory will be ignored.",
+                                        config_path.display(),
+                                        rel_path.display(),
+                                        err
+                                    );
+                                }
                             }
                         }
                     }
+                    let configs = configs_at_root(&subdir, &hierarchy_configs);
+                    let cascaded_task_config =
+                        cascaded_task_config_for_dir(&subdir, &hierarchy_configs)?;
 
                     if found_config {
-                        if parsed_configs.is_empty() {
+                        if configs.is_empty() {
                             return Ok(vec![]);
                         }
-                        let configs = parsed_configs.values().collect();
                         let mut tasks = load_tasks_from_configs(
                             &config,
                             &subdir,
@@ -3501,34 +3518,68 @@ struct CascadedTaskConfig {
     includes_root: PathBuf,
 }
 
-fn cascaded_task_config(cf: &Arc<dyn ConfigFile>) -> Result<Option<CascadedTaskConfig>> {
-    if cf.task_config().cascade != Some(true) {
-        return Ok(None);
+fn merge_cascaded_task_config(
+    cascaded: &mut CascadedTaskConfig,
+    configs: &[&Arc<dyn ConfigFile>],
+) -> Result<()> {
+    if let Some(dir) = configs.iter().find_map(|cf| cf.task_config().dir.clone()) {
+        cascaded.task_config.dir = Some(dir);
     }
-    let mut task_config = cf.task_config().clone();
-    task_config.includes = cf.task_config_includes()?;
-    Ok(Some(CascadedTaskConfig {
-        task_config,
-        includes_root: cf.config_root(),
-    }))
+    if let Some(shell) = configs.iter().find_map(|cf| cf.task_config().shell.clone()) {
+        cascaded.task_config.shell = Some(shell);
+    }
+    if let Some(cache) = configs.iter().find_map(|cf| cf.task_config().cache.clone()) {
+        cascaded.task_config.cache = Some(cache);
+    }
+    if let Some((includes, root)) = configs
+        .iter()
+        .find_map(|cf| match cf.task_config_includes() {
+            Ok(Some(includes)) => Some(Ok((includes, cf.config_root()))),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .transpose()?
+    {
+        cascaded.task_config.includes = Some(includes);
+        cascaded.includes_root = root;
+    }
+    Ok(())
 }
 
 fn cascaded_task_config_for_dir(
     dir: &Path,
     config_files: &ConfigMap,
 ) -> Result<Option<CascadedTaskConfig>> {
-    config_files
+    let mut roots = config_files
         .values()
         .filter(|cf| !is_global_config(cf.get_path()))
-        .filter(|cf| {
-            let root = cf.config_root();
-            !paths_equal_resolved(&root, dir) && path_starts_with_resolved(dir, &root)
-        })
-        .filter(|cf| cf.task_config().cascade == Some(true))
-        .max_by_key(|cf| cf.config_root().components().count())
-        .map(cascaded_task_config)
-        .transpose()
-        .map(Option::flatten)
+        .map(|cf| cf.config_root())
+        .filter(|root| !paths_equal_resolved(root, dir) && path_starts_with_resolved(dir, root))
+        .unique()
+        .collect::<Vec<_>>();
+    roots.sort_by_key(|root| root.components().count());
+
+    let mut cascaded = None;
+    for root in roots {
+        let configs = configs_at_root(&root, config_files);
+        match configs.iter().find_map(|cf| cf.task_config().cascade) {
+            Some(false) => {
+                cascaded = None;
+                continue;
+            }
+            Some(true) if cascaded.is_none() => {
+                cascaded = Some(CascadedTaskConfig {
+                    task_config: TaskConfig::default(),
+                    includes_root: root,
+                });
+            }
+            _ => {}
+        }
+        if let Some(cascaded) = &mut cascaded {
+            merge_cascaded_task_config(cascaded, &configs)?;
+        }
+    }
+    Ok(cascaded)
 }
 
 impl TaskSources {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,9 @@ use crate::cli::version;
 use crate::config::config_file::idiomatic_version::IdiomaticVersionFile;
 use crate::config::config_file::min_version::MinVersionSpec;
 use crate::config::config_file::mise_toml::{MiseToml, Tasks};
-use crate::config::config_file::{ConfigFile, config_trust_root, is_path_trusted, trust_check};
+use crate::config::config_file::{
+    ConfigFile, TaskConfig, config_trust_root, is_path_trusted, trust_check,
+};
 use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
@@ -2595,6 +2597,10 @@ async fn load_local_tasks_with_context(
             .and_then(|cf| cf.monorepo())
             .map(|m| &m.config_roots);
         let subdirs = discover_monorepo_subdirs(monorepo_root, config_roots, ctx)?;
+        let cascaded_task_config = monorepo_config
+            .map(cascaded_task_config)
+            .transpose()?
+            .flatten();
 
         // Load tasks from subdirectories in parallel
         let subdir_tasks_futures: Vec<_> = subdirs
@@ -2604,6 +2610,7 @@ async fn load_local_tasks_with_context(
                 let config = config.clone();
                 let monorepo_root = monorepo_root.clone();
                 let templates = templates.clone();
+                let cascaded_task_config = cascaded_task_config.clone();
                 async move {
                     let config_paths = config_paths_in_dir(&subdir);
                     let found_config = !config_paths.is_empty();
@@ -2638,30 +2645,26 @@ async fn load_local_tasks_with_context(
                             configs,
                             &templates,
                             true,
+                            cascaded_task_config.as_ref(),
                         )
                         .await?;
                         prefix_monorepo_task_names(&mut tasks, &subdir, &monorepo_root);
                         return Ok(tasks);
                     }
 
-                    // If no config file exists, still load default task include dirs.
-                    let mut task_map: IndexMap<String, Task> = IndexMap::new();
-                    let includes = task_includes_for_dir(&subdir, &config.config_files)?;
-                    for include in includes {
-                        let mut subdir_tasks = load_tasks_includes(
-                            &config, &include, &subdir, &None, &None, &templates, None, true,
-                        )
-                        .await?;
-                        if is_global_task_include_path(&include) {
-                            mark_tasks_as_global(&mut subdir_tasks);
-                        }
-                        prefix_monorepo_task_names(&mut subdir_tasks, &subdir, &monorepo_root);
-                        for task in subdir_tasks {
-                            task_map.insert(task.name.clone(), task);
-                        }
-                    }
-
-                    Ok::<Vec<Task>, eyre::Report>(task_map.into_values().collect())
+                    // If no config file exists, load file tasks with any task
+                    // configuration cascaded from the monorepo root.
+                    let mut tasks = load_tasks_from_configs(
+                        &config,
+                        &subdir,
+                        vec![],
+                        &templates,
+                        true,
+                        cascaded_task_config.as_ref(),
+                    )
+                    .await?;
+                    prefix_monorepo_task_names(&mut tasks, &subdir, &monorepo_root);
+                    Ok::<Vec<Task>, eyre::Report>(tasks)
                 }
             })
             .collect();
@@ -2996,9 +2999,15 @@ async fn load_global_tasks(
     let mut tasks: IndexMap<String, Task> = IndexMap::new();
     let mut seen_config_task_names = BTreeSet::new();
     for cf in configs {
-        let sources =
-            load_task_sources_from_configs(config, &cf.config_root(), vec![cf], templates, false)
-                .await?;
+        let sources = load_task_sources_from_configs(
+            config,
+            &cf.config_root(),
+            vec![cf],
+            templates,
+            false,
+            None,
+        )
+        .await?;
         let mut inline_tasks = IndexMap::new();
         for task in &sources.config_tasks {
             inline_tasks
@@ -3154,6 +3163,7 @@ async fn load_config_tasks(
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     task_inputs: &ResolvedTaskInputs,
+    cascaded_task_config: Option<&CascadedTaskConfig>,
 ) -> Result<Vec<Task>> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
@@ -3173,13 +3183,24 @@ async fn load_config_tasks(
         }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
+        if t.dir.is_none() && cf.task_config().dir.is_none() {
+            t.dir = cascaded_task_config.and_then(|tc| tc.task_config.dir.clone());
+        }
         if t.shell.is_none() {
-            t.shell = cf.task_config().shell.clone();
+            t.shell = cf
+                .task_config()
+                .shell
+                .clone()
+                .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.shell.clone()));
         }
         match t.render(&config, &config_root).await {
             Ok(()) => {
                 apply_task_config_inputs(&mut t, &config, task_inputs).await?;
-                apply_task_config_cache_default(&mut t, &cf.task_config().cache);
+                let cache =
+                    cf.task_config().cache.clone().or_else(|| {
+                        cascaded_task_config.and_then(|tc| tc.task_config.cache.clone())
+                    });
+                apply_task_config_cache_default(&mut t, &cache);
                 tasks.push(t);
             }
             Err(e) => {
@@ -3457,12 +3478,57 @@ pub async fn load_tasks_in_dir(
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let configs = configs_at_root(dir, config_files);
-    load_tasks_from_configs(config, dir, configs, templates, false).await
+    let cascaded_task_config = cascaded_task_config_for_dir(dir, config_files)?;
+    load_tasks_from_configs(
+        config,
+        dir,
+        configs,
+        templates,
+        false,
+        cascaded_task_config.as_ref(),
+    )
+    .await
 }
 
 struct TaskSources {
     file_tasks: Vec<Task>,
     config_tasks: Vec<Task>,
+}
+
+#[derive(Clone)]
+struct CascadedTaskConfig {
+    task_config: TaskConfig,
+    includes_root: PathBuf,
+}
+
+fn cascaded_task_config(cf: &Arc<dyn ConfigFile>) -> Result<Option<CascadedTaskConfig>> {
+    if cf.task_config().cascade != Some(true) {
+        return Ok(None);
+    }
+    let mut task_config = cf.task_config().clone();
+    task_config.includes = cf.task_config_includes()?;
+    Ok(Some(CascadedTaskConfig {
+        task_config,
+        includes_root: cf.config_root(),
+    }))
+}
+
+fn cascaded_task_config_for_dir(
+    dir: &Path,
+    config_files: &ConfigMap,
+) -> Result<Option<CascadedTaskConfig>> {
+    config_files
+        .values()
+        .filter(|cf| !is_global_config(cf.get_path()))
+        .filter(|cf| {
+            let root = cf.config_root();
+            !paths_equal_resolved(&root, dir) && path_starts_with_resolved(dir, &root)
+        })
+        .filter(|cf| cf.task_config().cascade == Some(true))
+        .max_by_key(|cf| cf.config_root().components().count())
+        .map(cascaded_task_config)
+        .transpose()
+        .map(Option::flatten)
 }
 
 impl TaskSources {
@@ -3494,12 +3560,18 @@ async fn load_tasks_from_configs(
     configs: Vec<&Arc<dyn ConfigFile>>,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_context: bool,
+    cascaded_task_config: Option<&CascadedTaskConfig>,
 ) -> Result<Vec<Task>> {
-    Ok(
-        load_task_sources_from_configs(config, dir, configs, templates, monorepo_context)
-            .await?
-            .into_tasks(),
+    Ok(load_task_sources_from_configs(
+        config,
+        dir,
+        configs,
+        templates,
+        monorepo_context,
+        cascaded_task_config,
     )
+    .await?
+    .into_tasks())
 }
 
 /// Load file and inline task sources without merging them.
@@ -3513,7 +3585,14 @@ async fn load_task_sources_from_configs(
     configs: Vec<&Arc<dyn ConfigFile>>,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_context: bool,
+    cascaded_task_config: Option<&CascadedTaskConfig>,
 ) -> Result<TaskSources> {
+    let cascaded_task_config =
+        if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
+            None
+        } else {
+            cascaded_task_config
+        };
     let is_global = configs.iter().any(|cf| is_global_config(cf.get_path()));
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
@@ -3528,6 +3607,14 @@ async fn load_task_sources_from_configs(
             Err(err) => Some(Err(err)),
         })
         .transpose()?
+        .or_else(|| {
+            cascaded_task_config.and_then(|tc| {
+                tc.task_config
+                    .includes
+                    .clone()
+                    .map(|includes| (includes, tc.includes_root.clone()))
+            })
+        })
         .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf()));
 
     let mut config_tasks = vec![];
@@ -3542,14 +3629,24 @@ async fn load_task_sources_from_configs(
                 templates,
                 monorepo_cf,
                 &task_config_inputs,
+                cascaded_task_config,
             )
             .await?,
         );
     }
     // Find task_config.dir from the highest-precedence config that defines it
-    let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
-    let task_config_shell = configs.iter().find_map(|cf| cf.task_config().shell.clone());
-    let task_config_cache = configs.iter().find_map(|cf| cf.task_config().cache.clone());
+    let task_config_dir = configs
+        .iter()
+        .find_map(|cf| cf.task_config().dir.clone())
+        .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.dir.clone()));
+    let task_config_shell = configs
+        .iter()
+        .find_map(|cf| cf.task_config().shell.clone())
+        .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.shell.clone()));
+    let task_config_cache = configs
+        .iter()
+        .find_map(|cf| cf.task_config().cache.clone())
+        .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.cache.clone()));
 
     let mut file_tasks = vec![];
     let monorepo_cf = if monorepo_context {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3423,6 +3423,12 @@ fn task_include_patterns_for_dir(
     config_files: &ConfigMap,
 ) -> Result<(Vec<String>, PathBuf, bool)> {
     let configs = configs_at_root(dir, config_files);
+    let cascaded_task_config =
+        if configs.iter().find_map(|cf| cf.task_config().cascade) == Some(false) {
+            None
+        } else {
+            cascaded_task_config_for_dir(dir, config_files)?
+        };
 
     // Find the highest-precedence config that has explicit task_config.includes
     // and resolve paths relative to that config file's directory
@@ -3437,6 +3443,13 @@ fn task_include_patterns_for_dir(
             Err(err) => Some(Err(err)),
         })
         .transpose()?
+        .or_else(|| {
+            cascaded_task_config.and_then(|tc| {
+                tc.task_config
+                    .includes
+                    .map(|includes| (includes, tc.includes_root, false))
+            })
+        })
         .unwrap_or_else(|| {
             // Default includes should be resolved relative to the search directory
             (default_task_includes(), dir.to_path_buf(), true)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3180,7 +3180,9 @@ async fn load_config_tasks(
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     task_inputs: &ResolvedTaskInputs,
-    cascaded_task_config: Option<&CascadedTaskConfig>,
+    task_config_dir: &Option<String>,
+    task_config_shell: &Option<String>,
+    task_config_cache: &Option<TaskCacheConfig>,
 ) -> Result<Vec<Task>> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
@@ -3200,24 +3202,16 @@ async fn load_config_tasks(
         }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
-        if t.dir.is_none() && cf.task_config().dir.is_none() {
-            t.dir = cascaded_task_config.and_then(|tc| tc.task_config.dir.clone());
+        if t.dir.is_none() {
+            t.dir = task_config_dir.clone();
         }
         if t.shell.is_none() {
-            t.shell = cf
-                .task_config()
-                .shell
-                .clone()
-                .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.shell.clone()));
+            t.shell = task_config_shell.clone();
         }
         match t.render(&config, &config_root).await {
             Ok(()) => {
                 apply_task_config_inputs(&mut t, &config, task_inputs).await?;
-                let cache =
-                    cf.task_config().cache.clone().or_else(|| {
-                        cascaded_task_config.and_then(|tc| tc.task_config.cache.clone())
-                    });
-                apply_task_config_cache_default(&mut t, &cache);
+                apply_task_config_cache_default(&mut t, task_config_cache);
                 tasks.push(t);
             }
             Err(e) => {
@@ -3681,24 +3675,8 @@ async fn load_task_sources_from_configs(
         })
         .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf()));
 
-    let mut config_tasks = vec![];
-    for cf in &configs {
-        let dir = dir.to_path_buf();
-        let monorepo_cf = monorepo_context.then_some(*cf);
-        config_tasks.extend(
-            load_config_tasks(
-                config,
-                (*cf).clone(),
-                &dir,
-                templates,
-                monorepo_cf,
-                &task_config_inputs,
-                cascaded_task_config,
-            )
-            .await?,
-        );
-    }
-    // Find task_config.dir from the highest-precedence config that defines it
+    // Resolve task defaults once for the config root so inline tasks from
+    // lower-precedence overlay files use the same defaults as file tasks.
     let task_config_dir = configs
         .iter()
         .find_map(|cf| cf.task_config().dir.clone())
@@ -3711,6 +3689,26 @@ async fn load_task_sources_from_configs(
         .iter()
         .find_map(|cf| cf.task_config().cache.clone())
         .or_else(|| cascaded_task_config.and_then(|tc| tc.task_config.cache.clone()));
+
+    let mut config_tasks = vec![];
+    for cf in &configs {
+        let dir = dir.to_path_buf();
+        let monorepo_cf = monorepo_context.then_some(*cf);
+        config_tasks.extend(
+            load_config_tasks(
+                config,
+                (*cf).clone(),
+                &dir,
+                templates,
+                monorepo_cf,
+                &task_config_inputs,
+                &task_config_dir,
+                &task_config_shell,
+                &task_config_cache,
+            )
+            .await?,
+        );
+    }
 
     let mut file_tasks = vec![];
     let monorepo_cf = if monorepo_context {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2649,7 +2649,7 @@ async fn load_local_tasks_with_context(
                     let includes = task_includes_for_dir(&subdir, &config.config_files)?;
                     for include in includes {
                         let mut subdir_tasks = load_tasks_includes(
-                            &config, &include, &subdir, &None, &templates, None, true,
+                            &config, &include, &subdir, &None, &None, &templates, None, true,
                         )
                         .await?;
                         if is_global_task_include_path(&include) {
@@ -3173,6 +3173,9 @@ async fn load_config_tasks(
         }
         // Resolve template if the task extends one
         resolve_task_template(&mut t, templates)?;
+        if t.shell.is_none() {
+            t.shell = cf.task_config().shell.clone();
+        }
         match t.render(&config, &config_root).await {
             Ok(()) => {
                 apply_task_config_inputs(&mut t, &config, task_inputs).await?;
@@ -3200,6 +3203,7 @@ async fn load_tasks_includes(
     root: &Path,
     config_root: &Path,
     task_config_dir: &Option<String>,
+    task_config_shell: &Option<String>,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     require_trust: bool,
@@ -3211,6 +3215,7 @@ async fn load_tasks_includes(
             root,
             config_root,
             task_config_dir,
+            task_config_shell,
             templates,
             monorepo_cf,
         )
@@ -3250,6 +3255,7 @@ async fn load_tasks_includes(
                     &path,
                     config_root,
                     task_config_dir,
+                    task_config_shell,
                     templates,
                     monorepo_cf,
                 )
@@ -3269,6 +3275,9 @@ async fn load_tasks_includes(
                 &config_root,
                 monorepo_cf.cloned(),
             )?;
+            if task.shell.is_none() {
+                task.shell = task_config_shell.clone();
+            }
             if let Err(err) = task.render(&config, &config_root).await {
                 if monorepo_cf.is_some() {
                     warn!(
@@ -3539,6 +3548,7 @@ async fn load_task_sources_from_configs(
     }
     // Find task_config.dir from the highest-precedence config that defines it
     let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
+    let task_config_shell = configs.iter().find_map(|cf| cf.task_config().shell.clone());
     let task_config_cache = configs.iter().find_map(|cf| cf.task_config().cache.clone());
 
     let mut file_tasks = vec![];
@@ -3559,6 +3569,7 @@ async fn load_task_sources_from_configs(
                 &p,
                 dir,
                 &task_config_dir,
+                &task_config_shell,
                 templates,
                 monorepo_cf,
                 require_task_include_trust,
@@ -3611,6 +3622,7 @@ async fn load_task_file(
     path: &Path,
     config_root: &Path,
     task_config_dir: &Option<String>,
+    task_config_shell: &Option<String>,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
 ) -> Result<Vec<Task>> {
@@ -3624,6 +3636,9 @@ async fn load_task_file(
         task.config_root = Some(config_root.to_path_buf());
         if task.dir.is_none() {
             task.dir = task_config_dir.clone();
+        }
+        if task.shell.is_none() {
+            task.shell = task_config_shell.clone();
         }
         if let Some(monorepo_cf) = monorepo_cf {
             task.cf = Some(monorepo_cf.clone());


### PR DESCRIPTION
## Summary
- add `task_config.shell` as a default shell for tasks in the same config scope
- preserve task-local and task-template `shell` precedence
- document the setting and add schema support
- highlight the 2026.7.14 breaking security change and its migration path

## Rationale
PR #11293 made the process-wide default shell settings global-only because project settings are loaded before trust evaluation and could influence commands from trusted sources. Restoring those settings after trust would still let a project-wide value leak into unrelated global tasks, hooks, and tool installation.

`task_config.shell` keeps the customization attached to the tasks owned by that config root. It applies to inline tasks and included TOML tasks, while an explicit task or template shell wins. Child config roots do not inherit the parent task shell default.

This provides a project-level migration path for users who standardized task shells with `unix_default_inline_shell_args` or `windows_default_inline_shell_args` without reopening the ambient interpreter vulnerability.

Follow-up to #11293 and https://github.com/jdx/mise/pull/11293#issuecomment-5085960084.

## Validation
- `mise run test:e2e tasks/test_task_config_shell`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central task-loading and monorepo discovery paths where wrong merge order could affect which shell or includes run, but defaults stay scoped to project tasks rather than global hooks or installs.
> 
> **Overview**
> Adds **`task_config.shell`** as a project-scoped default interpreter for inline, included TOML, and file tasks when a task does not set its own `shell`. Task-local `shell` and shells from **`task_templates`** still win.
> 
> Introduces **`task_config.cascade`** so a root can push **`dir`**, **`shell`**, **`cache`**, and **`includes`** to descendant config roots; children can override individual fields or set **`cascade = false`** to stop inheritance. Monorepo subdirectory loading now walks the config hierarchy and applies merged **`ResolvedTaskConfig`** defaults (including inherited **`includes`** with paths relative to the defining root).
> 
> Docs and schema document the new options; the changelog warns that project-level **`unix_*` / `windows_*` default shell args** are ignored (per #11293) and points users at **`task_config.shell`** or per-task **`shell`**. E2E coverage exercises inheritance, overrides, and cascade on/off across monorepo layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42283365969bc767d99c75d357d815c2f293c597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `task_config.shell` as a scoped default shell for tasks.
  * If a task’s `shell` is unset, it inherits from the most relevant scoped default; task-local and template-derived `shell` still take precedence.
  * Works across inline tasks, included tasks, and child directory task loading, including cascading and `cascade = false`.

* **Documentation**
  * Updated task configuration docs to clarify `cascade`/`includes` behavior and `task_config.shell` scope/precedence.
  * Added a changelog warning that legacy global default shell-argument settings in config files are ignored; use `task_config.shell` or per-task `shell`.

* **Tests**
  * Added end-to-end coverage for shell inheritance/precedence across inline, included, templated tasks, and non-cascading roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->