### PR TITLE
fix(task): preserve raw output with cli overrides

### DIFF
--- a/e2e/tasks/test_task_raw_output
+++ b/e2e/tasks/test_task_raw_output
@@ -13,6 +13,10 @@ run = 'echo normal task'
 [tasks.raw_task]
 raw = true
 run = 'echo raw task output'
+
+[tasks.interactive_task]
+interactive = true
+run = 'echo interactive task output'
 EOF
 
 # Normal task should use prefix output (from settings)
@@ -29,3 +33,15 @@ if [[ $stdout_output == *"[raw_task]"* ]]; then
   exit 1
 fi
 echo "SUCCESS: raw task stdout has no prefix"
+
+# CLI and environment output overrides must not disable the inherited stdio
+# required by raw and interactive tasks. They should resolve the same way as
+# the equivalent task.output setting, including during a dry run.
+for task in raw_task interactive_task; do
+  assert_contains "mise run --output keep-order $task 2>&1" '$ echo'
+  assert_not_contains "mise run --output keep-order $task 2>&1" "Finished in"
+  assert_contains "MISE_TASK_OUTPUT=keep-order mise run $task 2>&1" '$ echo'
+  assert_not_contains "MISE_TASK_OUTPUT=keep-order mise run $task 2>&1" "Finished in"
+  assert_contains "mise run --output keep-order --dry-run $task 2>&1" '$ echo'
+  assert_not_contains "mise run --output keep-order --dry-run $task 2>&1" "Finished in"
+done

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -285,9 +285,9 @@ impl OutputHandler {
         // Resolve a STYLE only, in precedence order. `Quiet` values map to
         // `Interleave` (their historical stream behavior); the quiet-ness is kept
         // by the `quiet()` predicate independently.
-        // 1. CLI `--output` / `MISE_TASK_OUTPUT` (no raw downgrade, matching prior behavior)
+        // 1. CLI `--output` / `MISE_TASK_OUTPUT`
         if let Some(o) = self.output {
-            return o.style_only();
+            return o.style_with_raw(self.raw(task));
         }
         // 2. per-task `output` style field
         if let Some(o) = task.and_then(|t| t.output) {


### PR DESCRIPTION
## Summary
- apply raw/interactive stdio requirements to CLI `--output` and `MISE_TASK_OUTPUT` overrides
- keep CLI, environment, per-task, and `task.output` behavior consistent
- add regression coverage for raw and interactive tasks, including dry runs

## Root cause
CLI and environment output overrides were resolved with `style_only()`, while per-task and global config output values used `style_with_raw()`. As a result, raw and interactive commands still inherited stdio but mise rendered their metadata using the requested buffered style, producing mixed command and timing output.

## User impact
Raw and interactive tasks now consistently resolve non-suppression output styles to `interleave`, regardless of whether the output value comes from configuration, `--output`, or `MISE_TASK_OUTPUT`.

Fixes the behavior reported in https://github.com/jdx/mise/discussions/11353.

## Validation
- `mise run test:e2e test_task_raw_output`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change in output-style resolution with new e2e regression tests; no auth, data, or security impact.
> 
> **Overview**
> **CLI `--output` and `MISE_TASK_OUTPUT` now honor raw/interactive tasks the same way as `task.output` in config.** Those overrides previously used `style_only()`, so styles like `keep-order` still applied mise metadata (e.g. timing) even when the task needed inherited stdio. Overrides now go through `style_with_raw()`, which downgrades non-silent styles to **interleave** for `raw` and `interactive` tasks.
> 
> E2E coverage adds an `interactive_task` and asserts that `--output keep-order`, `MISE_TASK_OUTPUT=keep-order`, and dry runs show the expected command echo without buffered “Finished in” output for both raw and interactive tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb84df8fb122ffdcdfd460a5ddc788e65117159c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed output overrides so raw tasks consistently preserve their expected output behavior, including when global prefix settings are enabled.
  - Ensured `keep-order` output remains effective when selected through command-line options or environment settings.
  - Preserved correct output behavior for interactive tasks and dry-run previews.
  - Improved consistency of CLI output ordering and task display across supported output configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->