### PR TITLE
feat(task): add reusable and global cache inputs

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -82,7 +82,7 @@ outside this tracker.
       unkeyed dependency work still forces execution
 - [x] Capture and replay stdout and stderr while respecting mise output modes
 - [x] Cache useful results for tasks with no filesystem outputs
-- [ ] Support reusable and global input groups
+- [x] Support reusable and global input groups
 - [ ] Support global environment inputs and pass-through environment variables
 - [ ] Support negative input and output patterns
 - [ ] Support runtime-command inputs

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -398,6 +398,46 @@ non-negated entry can re-include a file an earlier `!` excluded — for example,
 To include a literal path that begins with `!`, escape the prefix as `\!`
 (e.g. `"\\!important.txt"` in TOML).
 
+#### Reusable and global inputs <Badge type="warning" text="experimental" />
+
+Use `[task_config.input_groups]` to define source patterns once and reuse them across tasks. Reference
+a group from `sources` with `@group:<name>`. Groups can reference other groups; undefined references
+and cycles are configuration errors.
+
+Group entries are resolved relative to the config file that defines them, even when a task uses a
+different `dir`. Ordinary entries written directly in `sources` remain relative to the task directory.
+
+```mise-toml
+[settings]
+experimental = true
+
+[task_config.input_groups]
+toolchain = ["rust-toolchain.toml", "Cargo.lock"]
+rust = ["Cargo.toml", "src/**/*.rs", "@group:toolchain"]
+
+[tasks.build]
+run = "cargo build"
+sources = ["@group:rust"]
+outputs = ["target/debug/mycli"]
+
+[tasks.test]
+run = "cargo test"
+sources = ["@group:rust"]
+outputs = []
+```
+
+`task_config.global_inputs` adds source patterns to every task in the config scope. This is useful
+for repository-wide configuration and lockfiles that should invalidate all cacheable tasks without
+being repeated in each task's `sources`. Global inputs may also reference named groups.
+
+```mise-toml
+[task_config]
+global_inputs = ["mise.toml", ".github/tool-versions", "@group:lockfiles"]
+
+[task_config.input_groups]
+lockfiles = ["Cargo.lock", "pnpm-lock.yaml"]
+```
+
 #### Dependency invalidation
 
 When a task depends on another task that also has `sources` defined, and the dependency runs because
@@ -776,6 +816,27 @@ Task-local and task-template cache configuration takes precedence, including
 [task_config.cache]
 enabled = true
 env = ["NODE_ENV", "CI"]
+```
+
+### `task_config.global_inputs` <Badge type="warning" text="experimental" />
+
+Adds config-root-relative source paths and glob patterns to every task in this config scope. Entries
+may reference a named input group with `@group:<name>`.
+
+```toml
+[task_config]
+global_inputs = ["mise.toml", "@group:lockfiles"]
+```
+
+### `task_config.input_groups` <Badge type="warning" text="experimental" />
+
+Defines reusable, config-root-relative source groups. Tasks reference them from `sources` with
+`@group:<name>`. Groups may reference other groups.
+
+```toml
+[task_config.input_groups]
+lockfiles = ["Cargo.lock", "pnpm-lock.yaml"]
+rust = ["Cargo.toml", "src/**/*.rs", "@group:lockfiles"]
 ```
 
 ### `task_config.includes` {#task-config-includes}

--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -7,11 +7,12 @@ cat <<'EOF' >mise.toml
 experimental = true
 
 [task_config]
-global_inputs = ["workspace.txt", "@group:toolchain"]
-
-[task_config.input_groups]
-toolchain = ["toolchain.txt"]
-app = ["packages/app/src/**/*", "@group:toolchain"]
+global_inputs = [
+  "workspace.txt",
+  "{{ config_root }}/templated.txt",
+  "\\!important.txt",
+  "@group:toolchain",
+]
 
 [task_config.cache]
 enabled = true
@@ -36,12 +37,27 @@ sources = ["@group:app"]
 outputs = []
 EOF
 
+cat <<'EOF' >mise.local.toml
+[task_config.input_groups]
+toolchain = ["toolchain.txt"]
+app = [
+  "packages/app/src/**/*",
+  "!packages/app/src/ignored/**/*",
+  "packages/app/src/**/*",
+  "@group:toolchain",
+]
+EOF
+
 printf 'source-one\n' >packages/app/src/input.txt
+mkdir -p packages/app/src/ignored
+printf 'reincluded-one\n' >packages/app/src/ignored/input.txt
 printf 'workspace-one\n' >workspace.txt
+printf 'templated-one\n' >templated.txt
+printf 'escaped-one\n' >'!important.txt'
 printf 'toolchain-one\n' >toolchain.txt
 
-# Named groups are reusable across tasks, and their paths are rooted at the
-# config rather than each task's working directory.
+# Named groups and global inputs resolve independently across layered configs,
+# and their paths are rooted at the config rather than each task's working directory.
 mise run build ::: check
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "1"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "1"
@@ -72,3 +88,19 @@ mise run build ::: check
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "4"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "4"
 assert "cat packages/app/dist/result.txt" "source-two-changed:workspace-two-changed:toolchain-two-changed"
+
+# Ordered patterns preserve a later repeated include after an exclusion.
+printf 'reincluded-two-changed\n' >packages/app/src/ignored/input.txt
+rm -rf packages/app/dist
+mise run build ::: check
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "5"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "5"
+
+# Templated and escaped-literal global inputs are rendered before config-root
+# anchoring and participate in invalidation.
+printf 'templated-two-changed\n' >templated.txt
+printf 'escaped-two-changed\n' >'!important.txt'
+rm -rf packages/app/dist
+mise run build ::: check
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "6"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "6"

--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -35,6 +35,9 @@ dir = "packages/app"
 run = "printf 'ran\n' >> check-runs.txt"
 sources = ["@group:app"]
 outputs = []
+
+[tasks.global-only]
+run = "printf 'ran\n' >> global-only-runs.txt"
 EOF
 
 cat <<'EOF' >mise.local.toml
@@ -42,15 +45,17 @@ cat <<'EOF' >mise.local.toml
 toolchain = ["toolchain.txt"]
 app = [
   "packages/app/src/**/*",
+  "packages/app/src/**/*.rs",
   "!packages/app/src/ignored/**/*",
-  "packages/app/src/**/*",
+  "packages/app/src/**/*.rs",
   "@group:toolchain",
 ]
 EOF
 
 printf 'source-one\n' >packages/app/src/input.txt
 mkdir -p packages/app/src/ignored
-printf 'reincluded-one\n' >packages/app/src/ignored/input.txt
+printf 'excluded-one\n' >packages/app/src/ignored/excluded.txt
+printf 'reincluded-one\n' >packages/app/src/ignored/reincluded.rs
 printf 'workspace-one\n' >workspace.txt
 printf 'templated-one\n' >templated.txt
 printf 'escaped-one\n' >'!important.txt'
@@ -58,14 +63,21 @@ printf 'toolchain-one\n' >toolchain.txt
 
 # Named groups and global inputs resolve independently across layered configs,
 # and their paths are rooted at the config rather than each task's working directory.
-mise run build ::: check
+mise run build ::: check ::: global-only
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "1"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "1"
+assert "wc -l < global-only-runs.txt | tr -d ' '" "1"
 assert "cat packages/app/dist/result.txt" "source-one:workspace-one:toolchain-one"
+
+# A task with no explicit sources or outputs receives the global inputs and
+# automatic output freshness behavior.
+mise run global-only
+assert "wc -l < global-only-runs.txt | tr -d ' '" "1"
 
 rm -rf packages/app/dist "$MISE_STATE_DIR/task-artifacts"
 assert_contains "mise run build 2>&1" "restored outputs from cache"
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "1"
+assert "cat packages/app/dist/result.txt" "source-one:workspace-one:toolchain-one"
 
 # A grouped input invalidates every task that references the group.
 printf 'source-two-changed\n' >packages/app/src/input.txt
@@ -77,9 +89,10 @@ assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "2"
 # Global inputs invalidate eligible tasks without being repeated in sources.
 printf 'workspace-two-changed\n' >workspace.txt
 rm -rf packages/app/dist
-mise run build ::: check
+mise run build ::: check ::: global-only
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "3"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "3"
+assert "wc -l < global-only-runs.txt | tr -d ' '" "2"
 
 # Nested groups participate in the cache key as normal source inputs.
 printf 'toolchain-two-changed\n' >toolchain.txt
@@ -90,17 +103,28 @@ assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "4"
 assert "cat packages/app/dist/result.txt" "source-two-changed:workspace-two-changed:toolchain-two-changed"
 
 # Ordered patterns preserve a later repeated include after an exclusion.
-printf 'reincluded-two-changed\n' >packages/app/src/ignored/input.txt
+printf 'reincluded-two-changed\n' >packages/app/src/ignored/reincluded.rs
 rm -rf packages/app/dist
 mise run build ::: check
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "5"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "5"
 
-# Templated and escaped-literal global inputs are rendered before config-root
-# anchoring and participate in invalidation.
+# A file left excluded by the ordered patterns does not invalidate either task.
+printf 'excluded-two-changed\n' >packages/app/src/ignored/excluded.txt
+mise run build ::: check
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "5"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "5"
+
+# Templated global inputs are rendered before config-root anchoring.
 printf 'templated-two-changed\n' >templated.txt
-printf 'escaped-two-changed\n' >'!important.txt'
 rm -rf packages/app/dist
 mise run build ::: check
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "6"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "6"
+
+# Escaped-literal global inputs independently participate in invalidation.
+printf 'escaped-two-changed\n' >'!important.txt'
+rm -rf packages/app/dist
+mise run build ::: check
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "7"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "7"

--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+mkdir -p packages/app/src
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_config]
+global_inputs = ["workspace.txt", "@group:toolchain"]
+
+[task_config.input_groups]
+toolchain = ["toolchain.txt"]
+app = ["packages/app/src/**/*", "@group:toolchain"]
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+dir = "packages/app"
+run = '''
+mkdir -p dist
+printf '%s:%s:%s\n' \
+  "$(cat src/input.txt)" \
+  "$(cat ../../workspace.txt)" \
+  "$(cat ../../toolchain.txt)" > dist/result.txt
+printf 'ran\n' >> build-runs.txt
+'''
+sources = ["@group:app"]
+outputs = ["dist"]
+
+[tasks.check]
+dir = "packages/app"
+run = "printf 'ran\n' >> check-runs.txt"
+sources = ["@group:app"]
+outputs = []
+EOF
+
+printf 'source-one\n' >packages/app/src/input.txt
+printf 'workspace-one\n' >workspace.txt
+printf 'toolchain-one\n' >toolchain.txt
+
+# Named groups are reusable across tasks, and their paths are rooted at the
+# config rather than each task's working directory.
+mise run build ::: check
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "1"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "1"
+assert "cat packages/app/dist/result.txt" "source-one:workspace-one:toolchain-one"
+
+rm -rf packages/app/dist "$MISE_STATE_DIR/task-artifacts"
+assert_contains "mise run build 2>&1" "restored outputs from cache"
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "1"
+
+# A grouped input invalidates every task that references the group.
+printf 'source-two-changed\n' >packages/app/src/input.txt
+rm -rf packages/app/dist
+mise run build ::: check
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "2"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "2"
+
+# Global inputs invalidate eligible tasks without being repeated in sources.
+printf 'workspace-two-changed\n' >workspace.txt
+rm -rf packages/app/dist
+mise run build ::: check
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "3"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "3"
+
+# Nested groups participate in the cache key as normal source inputs.
+printf 'toolchain-two-changed\n' >toolchain.txt
+rm -rf packages/app/dist
+mise run build ::: check
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "4"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "4"
+assert "cat packages/app/dist/result.txt" "source-two-changed:workspace-two-changed:toolchain-two-changed"

--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -128,3 +128,16 @@ rm -rf packages/app/dist
 mise run build ::: check
 assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "7"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "7"
+
+# Group references are validated even when no input groups or global inputs
+# are configured, rather than being retained as literal source paths.
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.invalid]
+run = "echo invalid"
+sources = ["@group:missing"]
+EOF
+rm mise.local.toml
+assert_fail_contains "mise task info invalid" 'undefined input group "missing"'

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2284,6 +2284,23 @@
             }
           }
         },
+        "global_inputs": {
+          "description": "experimental config-root-relative source patterns added to every task in this config scope; entries may reference input groups with @group:<name>",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "input_groups": {
+          "description": "experimental reusable config-root-relative source groups referenced with @group:<name>",
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
         "includes": {
           "description": "files/directories to include searching for tasks. Can be local paths or git repository URLs using git:: prefix (e.g., git::https://github.com/org/repo.git//path?ref=branch)",
           "items": {

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -744,10 +744,13 @@ impl Hash for dyn ConfigFile {
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
 pub struct TaskConfig {
     pub includes: Option<Vec<String>>,
     pub dir: Option<String>,
     pub cache: Option<crate::task::TaskCacheConfig>,
+    pub global_inputs: Vec<String>,
+    pub input_groups: IndexMap<String, Vec<String>>,
 }
 
 #[cfg(test)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,9 +20,7 @@ use crate::cli::version;
 use crate::config::config_file::idiomatic_version::IdiomaticVersionFile;
 use crate::config::config_file::min_version::MinVersionSpec;
 use crate::config::config_file::mise_toml::{MiseToml, Tasks};
-use crate::config::config_file::{
-    ConfigFile, TaskConfig, config_trust_root, is_path_trusted, trust_check,
-};
+use crate::config::config_file::{ConfigFile, config_trust_root, is_path_trusted, trust_check};
 use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
@@ -2226,6 +2224,31 @@ fn apply_task_config_cache_default(task: &mut Task, cache: &Option<TaskCacheConf
 
 const TASK_INPUT_GROUP_PREFIX: &str = "@group:";
 
+#[derive(Clone, Debug, Default)]
+struct ResolvedTaskInputs {
+    global_inputs: Option<(Vec<String>, PathBuf)>,
+    input_groups: Option<(IndexMap<String, Vec<String>>, PathBuf)>,
+}
+
+impl ResolvedTaskInputs {
+    fn from_configs(configs: &[&Arc<dyn ConfigFile>]) -> Self {
+        Self {
+            global_inputs: configs.iter().find_map(|cf| {
+                let inputs = &cf.task_config().global_inputs;
+                (!inputs.is_empty()).then(|| (inputs.clone(), cf.config_root()))
+            }),
+            input_groups: configs.iter().find_map(|cf| {
+                let groups = &cf.task_config().input_groups;
+                (!groups.is_empty()).then(|| (groups.clone(), cf.config_root()))
+            }),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.global_inputs.is_none() && self.input_groups.is_none()
+    }
+}
+
 fn anchor_task_input(root: &Path, input: &str) -> String {
     let (exclude, input) = input
         .strip_prefix('!')
@@ -2250,7 +2273,7 @@ fn anchor_task_input(root: &Path, input: &str) -> String {
 
 fn expand_task_inputs(
     entries: &[String],
-    groups: &IndexMap<String, Vec<String>>,
+    task_inputs: &ResolvedTaskInputs,
     root: &Path,
     task_name: &str,
     stack: &mut Vec<String>,
@@ -2266,6 +2289,9 @@ fn expand_task_inputs(
             });
             continue;
         };
+        let (groups, groups_root) = task_inputs.input_groups.as_ref().ok_or_else(|| {
+            eyre!("task {task_name} references undefined input group {group:?} with {entry:?}")
+        })?;
         let inputs = groups.get(group).ok_or_else(|| {
             eyre!("task {task_name} references undefined input group {group:?} with {entry:?}")
         })?;
@@ -2279,60 +2305,96 @@ fn expand_task_inputs(
         }
         stack.push(group.to_string());
         expanded.extend(expand_task_inputs(
-            inputs, groups, root, task_name, stack, true,
+            inputs,
+            task_inputs,
+            groups_root,
+            task_name,
+            stack,
+            true,
         )?);
         stack.pop();
     }
     Ok(expanded)
 }
 
+fn render_task_input_entries(
+    entries: &[String],
+    config_root: &Path,
+    tera_ctx: &tera::Context,
+) -> Result<Vec<String>> {
+    let mut tera_ctx = tera_ctx.clone();
+    tera_ctx.insert("config_root", config_root);
+    let mut tera = crate::tera::get_tera(Some(config_root));
+    entries
+        .iter()
+        .map(|entry| {
+            if contains_template_syntax(entry) {
+                Ok(render_str(&mut tera, entry, &tera_ctx)?)
+            } else {
+                Ok(entry.clone())
+            }
+        })
+        .collect()
+}
+
 async fn apply_task_config_inputs(
     task: &mut Task,
     config: &Arc<Config>,
-    task_config: &TaskConfig,
-    config_root: &Path,
+    task_inputs: &ResolvedTaskInputs,
 ) -> Result<()> {
-    if task_config.global_inputs.is_empty() && task_config.input_groups.is_empty() {
+    if task_inputs.is_empty() {
         return Ok(());
     }
     Settings::get().ensure_experimental("task input groups")?;
 
+    let tera_ctx = task.tera_ctx(config).await?;
+    let global_inputs = match &task_inputs.global_inputs {
+        Some((entries, root)) => Some((
+            render_task_input_entries(entries, root, &tera_ctx)?,
+            root.clone(),
+        )),
+        None => None,
+    };
+    let input_groups = match &task_inputs.input_groups {
+        Some((groups, root)) => Some((
+            groups
+                .iter()
+                .map(|(name, entries)| {
+                    Ok((
+                        name.clone(),
+                        render_task_input_entries(entries, root, &tera_ctx)?,
+                    ))
+                })
+                .collect::<Result<_>>()?,
+            root.clone(),
+        )),
+        None => None,
+    };
+    let task_inputs = ResolvedTaskInputs {
+        global_inputs,
+        input_groups,
+    };
     let had_sources = !task.sources.is_empty();
     let mut sources = expand_task_inputs(
         &task.sources,
-        &task_config.input_groups,
-        config_root,
+        &task_inputs,
+        Path::new(""),
         &task.name,
         &mut vec![],
         false,
     )?;
-    sources.extend(expand_task_inputs(
-        &task_config.global_inputs,
-        &task_config.input_groups,
-        config_root,
-        &task.name,
-        &mut vec![],
-        true,
-    )?);
-
-    if sources
-        .iter()
-        .any(|source| contains_template_syntax(source))
-    {
-        let mut tera = crate::tera::get_tera(Some(config_root));
-        let tera_ctx = task.tera_ctx(config).await?;
-        for source in &mut sources {
-            if contains_template_syntax(source) {
-                *source = render_str(&mut tera, source, &tera_ctx)?;
-            }
-        }
+    if let Some((global_inputs, root)) = &task_inputs.global_inputs {
+        sources.extend(expand_task_inputs(
+            global_inputs,
+            &task_inputs,
+            root,
+            &task.name,
+            &mut vec![],
+            true,
+        )?);
     }
 
-    task.sources = sources
-        .into_iter()
-        .collect::<IndexSet<_>>()
-        .into_iter()
-        .collect();
+    task.sources = sources;
     if !had_sources && !task.sources.is_empty() && task.outputs.is_empty() {
         task.outputs = TaskOutputs::Auto;
     }
@@ -3087,6 +3149,7 @@ async fn load_config_tasks(
     config_root: &Path,
     templates: &IndexMap<String, TaskTemplate>,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
+    task_inputs: &ResolvedTaskInputs,
 ) -> Result<Vec<Task>> {
     let is_global = is_global_config(cf.get_path());
     let config_root = Arc::new(config_root.to_path_buf());
@@ -3108,8 +3171,7 @@ async fn load_config_tasks(
         resolve_task_template(&mut t, templates)?;
         match t.render(&config, &config_root).await {
             Ok(()) => {
-                apply_task_config_inputs(&mut t, &config, cf.task_config(), &cf.config_root())
-                    .await?;
+                apply_task_config_inputs(&mut t, &config, task_inputs).await?;
                 apply_task_config_cache_default(&mut t, &cf.task_config().cache);
                 tasks.push(t);
             }
@@ -3443,6 +3505,7 @@ async fn load_task_sources_from_configs(
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
+    let task_config_inputs = ResolvedTaskInputs::from_configs(&configs);
 
     let (includes, resolve_dir) = configs
         .iter()
@@ -3458,17 +3521,21 @@ async fn load_task_sources_from_configs(
     for cf in &configs {
         let dir = dir.to_path_buf();
         let monorepo_cf = monorepo_context.then_some(*cf);
-        config_tasks
-            .extend(load_config_tasks(config, (*cf).clone(), &dir, templates, monorepo_cf).await?);
+        config_tasks.extend(
+            load_config_tasks(
+                config,
+                (*cf).clone(),
+                &dir,
+                templates,
+                monorepo_cf,
+                &task_config_inputs,
+            )
+            .await?,
+        );
     }
     // Find task_config.dir from the highest-precedence config that defines it
     let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
     let task_config_cache = configs.iter().find_map(|cf| cf.task_config().cache.clone());
-    let task_config_inputs = configs.iter().find_map(|cf| {
-        let task_config = cf.task_config();
-        (!task_config.global_inputs.is_empty() || !task_config.input_groups.is_empty())
-            .then(|| (task_config.clone(), cf.config_root()))
-    });
 
     let mut file_tasks = vec![];
     let monorepo_cf = if monorepo_context {
@@ -3494,9 +3561,7 @@ async fn load_task_sources_from_configs(
             )
             .await?;
             for task in &mut loaded {
-                if let Some((task_config, config_root)) = &task_config_inputs {
-                    apply_task_config_inputs(task, config, task_config, config_root).await?;
-                }
+                apply_task_config_inputs(task, config, &task_config_inputs).await?;
                 apply_task_config_cache_default(task, &task_config_cache);
             }
             if is_global || is_global_task_include_path(&p) {
@@ -3619,22 +3684,36 @@ mod tests {
 
     #[test]
     fn test_expand_task_inputs_supports_nested_groups() -> Result<()> {
-        let groups = IndexMap::from([
-            (
-                "shared".to_string(),
-                vec!["Cargo.toml".to_string(), "src/**/*.rs".to_string()],
-            ),
-            (
-                "production".to_string(),
-                vec!["@group:shared".to_string(), "!src/**/*_test.rs".to_string()],
-            ),
-        ]);
+        let task_inputs = ResolvedTaskInputs {
+            input_groups: Some((
+                IndexMap::from([
+                    (
+                        "shared".to_string(),
+                        vec![
+                            "Cargo.toml".to_string(),
+                            "src/**/*.rs".to_string(),
+                            "\\!important.txt".to_string(),
+                        ],
+                    ),
+                    (
+                        "production".to_string(),
+                        vec![
+                            "@group:shared".to_string(),
+                            "!src/**/*_test.rs".to_string(),
+                            "src/**/*.rs".to_string(),
+                        ],
+                    ),
+                ]),
+                PathBuf::from("/workspace"),
+            )),
+            ..Default::default()
+        };
         let root = Path::new("/workspace");
 
         assert_eq!(
             expand_task_inputs(
                 &["local.txt".to_string(), "@group:production".to_string()],
-                &groups,
+                &task_inputs,
                 root,
                 "build",
                 &mut vec![],
@@ -3644,7 +3723,9 @@ mod tests {
                 "local.txt",
                 "/workspace/Cargo.toml",
                 "/workspace/src/**/*.rs",
+                "/workspace/!important.txt",
                 "!/workspace/src/**/*_test.rs",
+                "/workspace/src/**/*.rs",
             ]
         );
         Ok(())
@@ -3652,14 +3733,20 @@ mod tests {
 
     #[test]
     fn test_expand_task_inputs_rejects_unknown_and_cyclic_groups() {
-        let groups = IndexMap::from([
-            ("a".to_string(), vec!["@group:b".to_string()]),
-            ("b".to_string(), vec!["@group:a".to_string()]),
-        ]);
+        let task_inputs = ResolvedTaskInputs {
+            input_groups: Some((
+                IndexMap::from([
+                    ("a".to_string(), vec!["@group:b".to_string()]),
+                    ("b".to_string(), vec!["@group:a".to_string()]),
+                ]),
+                PathBuf::from("/workspace"),
+            )),
+            ..Default::default()
+        };
 
         let unknown = expand_task_inputs(
             &["@group:missing".to_string()],
-            &groups,
+            &task_inputs,
             Path::new("/workspace"),
             "build",
             &mut vec![],
@@ -3674,7 +3761,7 @@ mod tests {
 
         let cycle = expand_task_inputs(
             &["@group:a".to_string()],
-            &groups,
+            &task_inputs,
             Path::new("/workspace"),
             "build",
             &mut vec![],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2342,7 +2342,11 @@ async fn apply_task_config_inputs(
     config: &Arc<Config>,
     task_inputs: &ResolvedTaskInputs,
 ) -> Result<()> {
-    if task_inputs.is_empty() {
+    let has_group_references = task
+        .sources
+        .iter()
+        .any(|source| source.starts_with(TASK_INPUT_GROUP_PREFIX));
+    if task_inputs.is_empty() && !has_group_references {
         return Ok(());
     }
     Settings::get().ensure_experimental("task input groups")?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,13 +20,16 @@ use crate::cli::version;
 use crate::config::config_file::idiomatic_version::IdiomaticVersionFile;
 use crate::config::config_file::min_version::MinVersionSpec;
 use crate::config::config_file::mise_toml::{MiseToml, Tasks};
-use crate::config::config_file::{ConfigFile, config_trust_root, is_path_trusted, trust_check};
+use crate::config::config_file::{
+    ConfigFile, TaskConfig, config_trust_root, is_path_trusted, trust_check,
+};
 use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::tracking::Tracker;
 use crate::env::{MISE_DEFAULT_CONFIG_FILENAME, MISE_DEFAULT_TOOL_VERSIONS_FILENAME};
 use crate::file::display_path;
 use crate::shorthands::{Shorthands, get_shorthands};
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
+use crate::task::task_sources::TaskOutputs;
 use crate::task::{Task, TaskCacheConfig, TaskTemplate, monorepo_scope, strip_extension};
 use crate::tera::{contains_template_syntax, render_str, take_tera_accessed_files};
 use crate::toolset::env_cache::{CachedNonToolEnv, compute_settings_hash, get_file_mtime};
@@ -2221,6 +2224,121 @@ fn apply_task_config_cache_default(task: &mut Task, cache: &Option<TaskCacheConf
     }
 }
 
+const TASK_INPUT_GROUP_PREFIX: &str = "@group:";
+
+fn anchor_task_input(root: &Path, input: &str) -> String {
+    let (exclude, input) = input
+        .strip_prefix('!')
+        .map(|input| (true, input))
+        .unwrap_or((false, input));
+    let input = input
+        .strip_prefix("\\!")
+        .map(|input| format!("!{input}"))
+        .unwrap_or_else(|| input.to_string());
+    let path = Path::new(&input);
+    let anchored = if path.is_absolute() {
+        input
+    } else {
+        root.join(path).to_string_lossy().to_string()
+    };
+    if exclude {
+        format!("!{anchored}")
+    } else {
+        anchored
+    }
+}
+
+fn expand_task_inputs(
+    entries: &[String],
+    groups: &IndexMap<String, Vec<String>>,
+    root: &Path,
+    task_name: &str,
+    stack: &mut Vec<String>,
+    anchor_literals: bool,
+) -> Result<Vec<String>> {
+    let mut expanded = vec![];
+    for entry in entries {
+        let Some(group) = entry.strip_prefix(TASK_INPUT_GROUP_PREFIX) else {
+            expanded.push(if anchor_literals {
+                anchor_task_input(root, entry)
+            } else {
+                entry.clone()
+            });
+            continue;
+        };
+        let inputs = groups.get(group).ok_or_else(|| {
+            eyre!("task {task_name} references undefined input group {group:?} with {entry:?}")
+        })?;
+        if let Some(cycle_start) = stack.iter().position(|name| name == group) {
+            let mut cycle = stack[cycle_start..].to_vec();
+            cycle.push(group.to_string());
+            bail!(
+                "task {task_name} input group cycle: {}",
+                cycle.iter().join(" -> ")
+            );
+        }
+        stack.push(group.to_string());
+        expanded.extend(expand_task_inputs(
+            inputs, groups, root, task_name, stack, true,
+        )?);
+        stack.pop();
+    }
+    Ok(expanded)
+}
+
+async fn apply_task_config_inputs(
+    task: &mut Task,
+    config: &Arc<Config>,
+    task_config: &TaskConfig,
+    config_root: &Path,
+) -> Result<()> {
+    if task_config.global_inputs.is_empty() && task_config.input_groups.is_empty() {
+        return Ok(());
+    }
+    Settings::get().ensure_experimental("task input groups")?;
+
+    let had_sources = !task.sources.is_empty();
+    let mut sources = expand_task_inputs(
+        &task.sources,
+        &task_config.input_groups,
+        config_root,
+        &task.name,
+        &mut vec![],
+        false,
+    )?;
+    sources.extend(expand_task_inputs(
+        &task_config.global_inputs,
+        &task_config.input_groups,
+        config_root,
+        &task.name,
+        &mut vec![],
+        true,
+    )?);
+
+    if sources
+        .iter()
+        .any(|source| contains_template_syntax(source))
+    {
+        let mut tera = crate::tera::get_tera(Some(config_root));
+        let tera_ctx = task.tera_ctx(config).await?;
+        for source in &mut sources {
+            if contains_template_syntax(source) {
+                *source = render_str(&mut tera, source, &tera_ctx)?;
+            }
+        }
+    }
+
+    task.sources = sources
+        .into_iter()
+        .collect::<IndexSet<_>>()
+        .into_iter()
+        .collect();
+    if !had_sources && !task.sources.is_empty() && task.outputs.is_empty() {
+        task.outputs = TaskOutputs::Auto;
+    }
+    Ok(())
+}
+
 fn default_task_includes() -> Vec<String> {
     vec![
         "mise-tasks".to_string(),
@@ -2990,6 +3108,8 @@ async fn load_config_tasks(
         resolve_task_template(&mut t, templates)?;
         match t.render(&config, &config_root).await {
             Ok(()) => {
+                apply_task_config_inputs(&mut t, &config, cf.task_config(), &cf.config_root())
+                    .await?;
                 apply_task_config_cache_default(&mut t, &cf.task_config().cache);
                 tasks.push(t);
             }
@@ -3344,6 +3464,11 @@ async fn load_task_sources_from_configs(
     // Find task_config.dir from the highest-precedence config that defines it
     let task_config_dir = configs.iter().find_map(|cf| cf.task_config().dir.clone());
     let task_config_cache = configs.iter().find_map(|cf| cf.task_config().cache.clone());
+    let task_config_inputs = configs.iter().find_map(|cf| {
+        let task_config = cf.task_config();
+        (!task_config.global_inputs.is_empty() || !task_config.input_groups.is_empty())
+            .then(|| (task_config.clone(), cf.config_root()))
+    });
 
     let mut file_tasks = vec![];
     let monorepo_cf = if monorepo_context {
@@ -3369,6 +3494,9 @@ async fn load_task_sources_from_configs(
             )
             .await?;
             for task in &mut loaded {
+                if let Some((task_config, config_root)) = &task_config_inputs {
+                    apply_task_config_inputs(task, config, task_config, config_root).await?;
+                }
                 apply_task_config_cache_default(task, &task_config_cache);
             }
             if is_global || is_global_task_include_path(&p) {
@@ -3487,6 +3615,73 @@ mod tests {
 
         assert!(!Arc::ptr_eq(&before, &after));
         Settings::reset(None);
+    }
+
+    #[test]
+    fn test_expand_task_inputs_supports_nested_groups() -> Result<()> {
+        let groups = IndexMap::from([
+            (
+                "shared".to_string(),
+                vec!["Cargo.toml".to_string(), "src/**/*.rs".to_string()],
+            ),
+            (
+                "production".to_string(),
+                vec!["@group:shared".to_string(), "!src/**/*_test.rs".to_string()],
+            ),
+        ]);
+        let root = Path::new("/workspace");
+
+        assert_eq!(
+            expand_task_inputs(
+                &["local.txt".to_string(), "@group:production".to_string()],
+                &groups,
+                root,
+                "build",
+                &mut vec![],
+                false,
+            )?,
+            vec![
+                "local.txt",
+                "/workspace/Cargo.toml",
+                "/workspace/src/**/*.rs",
+                "!/workspace/src/**/*_test.rs",
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_expand_task_inputs_rejects_unknown_and_cyclic_groups() {
+        let groups = IndexMap::from([
+            ("a".to_string(), vec!["@group:b".to_string()]),
+            ("b".to_string(), vec!["@group:a".to_string()]),
+        ]);
+
+        let unknown = expand_task_inputs(
+            &["@group:missing".to_string()],
+            &groups,
+            Path::new("/workspace"),
+            "build",
+            &mut vec![],
+            false,
+        )
+        .unwrap_err();
+        assert!(
+            unknown
+                .to_string()
+                .contains("undefined input group \"missing\"")
+        );
+
+        let cycle = expand_task_inputs(
+            &["@group:a".to_string()],
+            &groups,
+            Path::new("/workspace"),
+            "build",
+            &mut vec![],
+            false,
+        )
+        .unwrap_err();
+        assert!(cycle.to_string().contains("a -> b -> a"));
     }
 
     #[test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -97,6 +97,11 @@ fn normalize_pattern(match_root: &Path, task_cwd: &Path, pattern: &str) -> Strin
         if let Ok(rel) = body_path.strip_prefix(match_root)
             && let Some(rel_str) = rel.to_str()
         {
+            let rel_str = if rel_str.starts_with('!') {
+                format!("\\{rel_str}")
+            } else {
+                rel_str.to_string()
+            };
             return format!("{prefix}{rel_str}");
         }
         return pattern.to_string();
@@ -971,6 +976,16 @@ mod tests {
         let pats = &["\\!important.txt", "!ignored.txt"];
         assert!(matches(pats, "!important.txt"));
         assert!(!matches(pats, "ignored.txt"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn matcher_absolute_literal_bang_under_root() {
+        let root = Path::new("/project");
+        let sources = vec!["/project/!important.txt".to_string()];
+        let matcher = build_source_matcher(root, root, &sources);
+        assert!(is_source(&matcher, Path::new("/project/!important.txt")));
+        assert!(!is_source(&matcher, Path::new("/project/other.txt")));
     }
 
     #[test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -172,13 +172,13 @@ pub(crate) fn last_modified_glob_match(
     let files = patterns
         .iter()
         .flat_map(|pattern| {
-            glob(
-                root_ref
-                    .join(pattern)
-                    .to_str()
-                    .expect("Conversion to string path failed"),
-            )
-            .unwrap()
+            let pattern_path = Path::new(pattern.as_str());
+            let pattern = if pattern_path.is_absolute() {
+                pattern_path.to_path_buf()
+            } else {
+                root_ref.join(pattern_path)
+            };
+            glob(pattern.to_str().expect("Conversion to string path failed")).unwrap()
         })
         .filter_map(|e| e.ok())
         .filter(|e| {
@@ -717,7 +717,13 @@ fn get_file_metadatas(
 
     let mut metadatas = BTreeMap::new();
     for pattern in patterns {
-        let files = glob(root.join(pattern).to_str().unwrap())?;
+        let pattern_path = Path::new(pattern);
+        let pattern = if pattern_path.is_absolute() {
+            pattern_path.to_path_buf()
+        } else {
+            root.join(pattern_path)
+        };
+        let files = glob(pattern.to_str().unwrap())?;
         for file in files.flatten() {
             if let Ok(metadata) = file.metadata() {
                 metadatas.insert(file, metadata);
@@ -726,7 +732,12 @@ fn get_file_metadatas(
     }
 
     for path in paths {
-        let file = root.join(path);
+        let path = Path::new(path);
+        let file = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            root.join(path)
+        };
         if let Ok(metadata) = file.metadata() {
             metadatas.insert(file, metadata);
         }
@@ -1032,6 +1043,33 @@ mod tests {
         ));
         assert!(is_source(&matcher, Path::new("/workspace/lib/shared.go")));
         assert!(!is_source(&matcher, Path::new("/workspace/other/file.go")));
+    }
+
+    #[test]
+    fn absolute_source_patterns_are_enumerated_from_a_subproject() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path();
+        let task_cwd = workspace.join("packages/app");
+        let source = task_cwd.join("src/input.txt");
+        let global = workspace.join("workspace.txt");
+        fs::create_dir_all(source.parent().unwrap())?;
+        fs::write(&source, "source")?;
+        fs::write(&global, "global")?;
+
+        let sources = vec![
+            format!("{}/packages/app/src/**/*", workspace.display()),
+            global.to_string_lossy().to_string(),
+        ];
+        let matcher = build_source_matcher(workspace, &task_cwd, &sources);
+        let metadatas = get_file_metadatas(&task_cwd, &source_glob_patterns(&sources), &matcher)?;
+        let paths = metadatas
+            .into_iter()
+            .map(|(path, _)| path)
+            .collect::<Vec<_>>();
+
+        assert!(paths.contains(&source), "{paths:?}");
+        assert!(paths.contains(&global), "{paths:?}");
+        Ok(())
     }
 
     /// Relative pattern in a subproject task must be anchored at the task CWD,

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -148,16 +148,18 @@ pub(crate) fn source_glob_patterns(sources: &[String]) -> Vec<String> {
 
 /// Get the last modified time from a list of paths
 pub(crate) fn last_modified_path(root: &Path, paths: &[&String]) -> Result<Option<SystemTime>> {
-    let files = paths.iter().map(|p| {
-        let base = Path::new(p);
-        if base.is_relative() {
-            Path::new(&root).join(base)
-        } else {
-            base.to_path_buf()
-        }
-    });
+    let files = paths.iter().map(|p| resolve_task_path(root, p));
 
     last_modified_file(files)
+}
+
+fn resolve_task_path(root: &Path, path: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
 }
 
 /// Get the last modified time from files matching glob patterns
@@ -172,12 +174,7 @@ pub(crate) fn last_modified_glob_match(
     let files = patterns
         .iter()
         .flat_map(|pattern| {
-            let pattern_path = Path::new(pattern.as_str());
-            let pattern = if pattern_path.is_absolute() {
-                pattern_path.to_path_buf()
-            } else {
-                root_ref.join(pattern_path)
-            };
+            let pattern = resolve_task_path(root_ref, pattern);
             glob(pattern.to_str().expect("Conversion to string path failed")).unwrap()
         })
         .filter_map(|e| e.ok())
@@ -717,12 +714,7 @@ fn get_file_metadatas(
 
     let mut metadatas = BTreeMap::new();
     for pattern in patterns {
-        let pattern_path = Path::new(pattern);
-        let pattern = if pattern_path.is_absolute() {
-            pattern_path.to_path_buf()
-        } else {
-            root.join(pattern_path)
-        };
+        let pattern = resolve_task_path(root, pattern);
         let files = glob(pattern.to_str().unwrap())?;
         for file in files.flatten() {
             if let Ok(metadata) = file.metadata() {
@@ -732,12 +724,7 @@ fn get_file_metadatas(
     }
 
     for path in paths {
-        let path = Path::new(path);
-        let file = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            root.join(path)
-        };
+        let file = resolve_task_path(root, path);
         if let Ok(metadata) = file.metadata() {
             metadatas.insert(file, metadata);
         }


### PR DESCRIPTION
## Summary

- add experimental `[task_config.input_groups]` definitions referenced from task `sources` with `@group:<name>`
- support nested groups with actionable errors for missing references and cycles
- add experimental `task_config.global_inputs` that apply config-rooted inputs to every task in scope
- correctly enumerate absolute source paths and globs for tasks running from subproject directories
- document the configuration, update the schema, and mark the parity-tracker item complete

## Why

Shared lockfiles, toolchain files, and source sets currently have to be repeated on every cacheable task. Named groups make those inputs reusable, while global inputs let repository-wide changes invalidate all eligible task results automatically. Config-root anchoring keeps the behavior correct when tasks run from nested package directories.

## Stacking

This PR is stacked on #11351. After #11351 merges, this PR should be rebased and retargeted to `main`.

## Validation

- `cargo test --all-features task_source_checker --quiet`
- `mise run test:e2e tasks/test_task_artifact_cache_input_groups tasks/test_task_artifact_cache tasks/test_task_monorepo_relative_paths`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how task `sources` are resolved and hashed for cache/freshness; incorrect path anchoring would cause missed invalidations or spurious runs, though behavior is gated behind `experimental` and covered by new e2e tests.
> 
> **Overview**
> Adds **experimental** reusable task cache inputs: `[task_config.input_groups]` for named pattern sets referenced from `sources` as `@group:<name>`, and `task_config.global_inputs` to append config-root-relative patterns to every task in the config scope without repeating them per task.
> 
> At task load, mise expands nested group references (with errors for missing groups and cycles), renders Tera in group/global entries, anchors group and global paths to the defining config root while task-local `sources` stay relative to the task `dir`, and merges the result into each task’s effective `sources`. Tasks that only gain inputs from globals and had no `sources`/`outputs` get automatic output freshness behavior. `@group:` references are validated even when no groups are configured.
> 
> **Source matching fixes** in `task_source_checker` treat absolute paths and globs correctly when tasks run from subproject directories (including escaped `!` literals), so cache keys and invalidation stay consistent with the expanded inputs.
> 
> Documentation, JSON schema, parity tracker, unit tests, and an e2e scenario cover cache restore, invalidation, layered configs, and ordered include/exclude patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e391f6f9d8789cd04c4e678d385280a229513e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental reusable input groups (including nested composition) for task sources via `@group:<name>`.
  * Added experimental `global_inputs` to apply source patterns across all tasks in a config scope, with group-based references.
  * Supports templated inputs plus include/exclude and validation for unknown or cyclic group references.
* **Bug Fixes**
  * Improved handling of absolute `sources` (including correct matching in subprojects and preserving escaped `!` semantics).
* **Documentation**
  * Updated task configuration docs and added `global_inputs`/`input_groups` to the configuration schema.
  * Marked “local cache parity” item as completed.
* **Tests**
  * Added unit and end-to-end coverage for input-group expansion and artifact cache invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->