### PR TITLE
feat(npm): add standalone aube installer mode

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -25,8 +25,11 @@ auth token helper.
 
 You can also pick a specific installer with
 [`npm.package_manager`](/configuration/settings.html#npm-package-manager). The
-default `auto` uses the embedded aube; setting it to `bun`, `pnpm`, or `npm`
-shells out to that tool, which must then be installed.
+default `auto` uses the embedded aube; setting it to `aube_cli`, `bun`, `pnpm`,
+or `npm` shells out to that tool, which must then be installed. The standalone
+`aube_cli` mode uses mise's built-in HTTP client for version metadata when
+`npm.shell_out` remains at its default `false`, and invokes `aube` directly for
+installation; it does not rely on aube's `npm` compatibility shim.
 
 The npm backend forwards [`minimum_release_age`](/configuration/settings.html#minimum_release_age)
 to transitive dependency resolution during install. The embedded aube installer
@@ -146,14 +149,17 @@ allowing them means allowing code from the selected package and its dependencies
 installation.
 
 With the default `npm.package_manager = "auto"` setting, mise installs through its embedded `aube`
-package manager. Setting `npm.package_manager = "aube"`, `"pnpm"`, `"bun"`, or `"npm"` chooses a
-package manager explicitly (`aube` also uses the embedded one; the others shell out).
-[`npm.shell_out`](/configuration/settings.html#npm-shell-out) forces the npm CLI. The `allow_builds`,
-`trust_policy_excludes`, `pnpm_args`, `bun_args`, and `npm_args` options only affect the package
-manager that is actually used; an approval option for one does not change the behavior of another.
+package manager. Setting `npm.package_manager = "aube"`, `"aube_cli"`, `"pnpm"`, `"bun"`, or
+`"npm"` chooses a package manager explicitly (`aube` also uses the embedded one; the others shell
+out).
+With the default `auto` package manager, [`npm.shell_out`](/configuration/settings.html#npm-shell-out)
+forces the npm CLI. An explicitly selected installer still takes precedence for installation.
+The `allow_builds`, `trust_policy_excludes`, `pnpm_args`, `bun_args`, and `npm_args` options only
+affect the package manager that is actually used; an approval option for one does not change the
+behavior of another.
 
 For tools that need reviewed dependency build scripts, use `allow_builds` with `aube` (default),
-`pnpm`, or npm 11.16.0+.
+`aube_cli`, `pnpm`, or npm 11.16.0+.
 
 ### `aube` (default)
 
@@ -170,6 +176,20 @@ Use `allow_builds` for reviewed dependency builds:
 Use `trust_policy_excludes` for reviewed aube trust-policy exceptions.
 Set `allow_builds = true` to allow every dependency build script when you explicitly accept the risk.
 (The `aube_args` option is ignored now that installs run in-process rather than via the `aube` CLI.)
+
+### `aube_cli`
+
+Set `npm.package_manager = "aube_cli"` to install through a standalone `aube`
+executable while retaining mise's built-in HTTP metadata lookup:
+
+```toml
+[settings.npm]
+package_manager = "aube_cli"
+```
+
+This mode invokes `aube add --global` directly. It forwards `aube_args` and
+`allow_builds`, and does not require `aube activate` or depend on the behavior
+of aube's npm compatibility shim.
 
 ### `pnpm`
 
@@ -245,8 +265,8 @@ go in `[tools]` in `mise.toml`.
 ### `allow_builds`
 
 Packages whose dependency lifecycle build scripts should be approved when
-`settings.npm.package_manager = "aube"`, `"pnpm"`, or npm 11.16.0+. Use this instead of spelling out
-package-manager-specific approval flags in `aube_args`, `pnpm_args`, or `npm_args`.
+`settings.npm.package_manager = "aube"`, `"aube_cli"`, `"pnpm"`, or npm 11.16.0+. Use this instead
+of spelling out package-manager-specific approval flags in `aube_args`, `pnpm_args`, or `npm_args`.
 
 For example, to allow one verified dependency build script:
 
@@ -276,8 +296,8 @@ requires npm 11.16.0+.
 ### `trust_policy_excludes`
 
 Packages or package version ranges that should be exempt from aube's `trustPolicy=no-downgrade`
-check when `settings.npm.package_manager = "aube"`. Use this for reviewed dependency provenance
-metadata churn without disabling the trust policy for the whole install.
+check when `settings.npm.package_manager = "aube"` or `"aube_cli"`. Use this for reviewed dependency
+provenance metadata churn without disabling the trust policy for the whole install.
 
 For example, to exempt every version of a dependency:
 
@@ -336,8 +356,10 @@ Before adding an exception:
 4. Prefer a version-scoped `"<package>@<version>"` exception after review. A bare package name
    exempts every future version.
 
-Using `mise settings npm.shell_out=true` switches to the npm CLI and bypasses this aube check
-entirely, so it should be a last resort rather than the first workaround.
+With the default `auto` package manager, using `mise settings npm.shell_out=true` switches to the npm
+CLI and bypasses this aube check entirely, so it should be a last resort rather than the first
+workaround. An explicit `npm.package_manager = "aube_cli"` selection still uses standalone aube for
+installation.
 
 See aube's [trust-policy documentation](https://aube.jdx.dev/security#trust-policy) for more
 detail.
@@ -345,7 +367,7 @@ detail.
 ### `aube_args`
 
 Additional arguments to pass to `aube add --global` when
-`settings.npm.package_manager = "aube"`.
+`settings.npm.package_manager = "aube_cli"`.
 These are raw user-supplied arguments.
 
 For example, to install `npm` with aube's append-only reporter mode:

--- a/e2e/backend/test_backend_missing_deps
+++ b/e2e/backend/test_backend_missing_deps
@@ -75,7 +75,7 @@ test_npm() {
 
   # Standalone aube mode keeps HTTP metadata but requires the aube executable.
   test_backend_warning "aube CLI" \
-    "MISE_NPM_PACKAGE_MANAGER=aube_cli mise install npm:test-package@latest" \
+    "PATH='' MISE_NPM_PACKAGE_MANAGER=aube_cli '$MISE_BIN' install npm:test-package@latest" \
     "aube may be required but was not found"
 
   # The default install path uses the embedded aube package manager, which

--- a/e2e/backend/test_backend_missing_deps
+++ b/e2e/backend/test_backend_missing_deps
@@ -73,6 +73,11 @@ test_npm() {
   test_backend_warning "npm" "mise install npm:test-package@latest" "npm may be required but was not found"
   unset MISE_NPM_SHELL_OUT
 
+  # Standalone aube mode keeps HTTP metadata but requires the aube executable.
+  test_backend_warning "aube CLI" \
+    "MISE_NPM_PACKAGE_MANAGER=aube_cli mise install npm:test-package@latest" \
+    "aube may be required but was not found"
+
   # The default install path uses the embedded aube package manager, which
   # does not require an npm binary (only node, to run installed tools).
 }

--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -25,9 +25,7 @@ if ! command -v pnpm >/dev/null 2>&1; then
 fi
 
 # Test 1: npm.package_manager = "npm". Pin explicitly rather than relying
-# on the `auto` default — `auto` picks aube when aube is on PATH (including
-# system installs like Homebrew), which would emit `--minimum-release-age`
-# instead of npm's `--before` and break the assertion below on dev machines.
+# on the `auto` default, which uses mise's embedded aube.
 echo "Testing npm backend with npm package manager..."
 unset MISE_NPM_BUN
 export MISE_NPM_PACKAGE_MANAGER=npm
@@ -122,6 +120,35 @@ assert_succeed "find '$tiny_install_dir' -type d -name node_modules -print -quit
 # aube_args is not forwarded to any CLI; mise warns that it is ignored.
 assert_contains "cat '$AUBE_DEBUG_LOG'" "aube_args"
 echo "✓ npm backend successfully installs package using aube (package_manager=aube)"
+mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
+
+# Test 5: npm.package_manager = "aube_cli" (standalone aube executable)
+echo "Testing npm.package_manager=aube_cli..."
+export MISE_NPM_PACKAGE_MANAGER=aube_cli
+
+if ! command -v aube >/dev/null 2>&1; then
+  echo "aube not available in test environment, installing..."
+  assert_succeed "env -u MISE_MINIMUM_RELEASE_AGE mise use aube@latest"
+fi
+
+cat >.mise.toml <<EOF
+[tools]
+"npm:tiny" = { version = "latest", aube_args = "--reporter append-only", allow_builds = "tiny" }
+EOF
+AUBE_CLI_DEBUG_LOG="$TMPDIR/aube_cli_debug.log"
+if ! MISE_DEBUG=1 mise install >"$AUBE_CLI_DEBUG_LOG" 2>&1; then
+  echo "Command failed. Output:"
+  cat "$AUBE_CLI_DEBUG_LOG"
+  exit 1
+fi
+assert_contains "cat '$AUBE_CLI_DEBUG_LOG'" "aube"
+assert_contains "cat '$AUBE_CLI_DEBUG_LOG'" "add"
+assert_contains "cat '$AUBE_CLI_DEBUG_LOG'" "--global"
+assert_contains "cat '$AUBE_CLI_DEBUG_LOG'" "--reporter"
+assert_contains "cat '$AUBE_CLI_DEBUG_LOG'" "append-only"
+assert_contains "cat '$AUBE_CLI_DEBUG_LOG'" "--allow-build=tiny"
+assert_not_contains "cat '$AUBE_CLI_DEBUG_LOG'" "npm view"
+echo "✓ npm backend successfully installs package using standalone aube (package_manager=aube_cli)"
 mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 
 unset MISE_NPM_PACKAGE_MANAGER

--- a/e2e/backend/test_npm_package_manager
+++ b/e2e/backend/test_npm_package_manager
@@ -126,10 +126,10 @@ mise uninstall npm:tiny@latest >/dev/null 2>&1 || true
 echo "Testing npm.package_manager=aube_cli..."
 export MISE_NPM_PACKAGE_MANAGER=aube_cli
 
-if ! command -v aube >/dev/null 2>&1; then
-  echo "aube not available in test environment, installing..."
-  assert_succeed "env -u MISE_MINIMUM_RELEASE_AGE mise use aube@latest"
-fi
+# Always provision the version exercised by this test instead of accepting an
+# arbitrary ambient aube executable.
+AUBE_CLI_TEST_VERSION="1.33.1"
+assert_succeed "env -u MISE_MINIMUM_RELEASE_AGE mise use aube@$AUBE_CLI_TEST_VERSION"
 
 cat >.mise.toml <<EOF
 [tools]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1330,7 +1330,7 @@
               "default": "auto",
               "description": "Package manager to use for installing npm packages.",
               "type": "string",
-              "enum": ["auto", "npm", "aube", "bun", "pnpm"]
+              "enum": ["auto", "npm", "aube", "aube_cli", "bun", "pnpm"]
             },
             "shell_out": {
               "default": false,

--- a/settings.toml
+++ b/settings.toml
@@ -1772,11 +1772,11 @@ default = "auto"
 description = "Package manager to use for installing npm packages."
 docs = """
 Package manager to use for installing npm packages. The default, `auto`, uses
-`aube` when it is installed and falls back to `npm`, similar to how the pipx
-backend uses `uv` when available. Set this to `npm`, `aube`, `bun`, or `pnpm`
-to force a specific package manager.
+mise's embedded `aube` package manager. Set this to `aube_cli` to invoke a
+standalone aube executable, or to `npm`, `bun`, or `pnpm` to invoke that
+package manager instead.
 """
-enum = ["auto", "npm", "aube", "bun", "pnpm"]
+enum = ["auto", "npm", "aube", "aube_cli", "bun", "pnpm"]
 env = "MISE_NPM_PACKAGE_MANAGER"
 rust_type = "NpmPackageManager"
 type = "String"
@@ -1799,8 +1799,9 @@ as `cafile`, client certificates, or an auth token helper). When enabled, npm
 must be installed.
 
 This applies to the default/`auto` package manager. Explicitly selecting a
-package manager with [`npm.package_manager`](#npm-package-manager) (`bun`,
-`pnpm`, or `npm`) always shells out to that tool regardless of this setting.
+package manager with [`npm.package_manager`](#npm-package-manager) (`aube_cli`,
+`bun`, `pnpm`, or `npm`) always shells out to that tool regardless of this
+setting.
 """
 env = "MISE_NPM_SHELL_OUT"
 type = "Bool"

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -152,6 +152,15 @@ impl<'a> NpmOptions<'a> {
         })
     }
 
+    fn aube_cli_lifecycle_script_args(&self) -> eyre::Result<Vec<OsString>> {
+        let args = self.allow_build_args()?;
+        Ok(if args.is_empty() {
+            vec![OsString::from("--ignore-scripts")]
+        } else {
+            args
+        })
+    }
+
     fn npm_lifecycle_script_args(
         allow_builds: AllowBuilds,
         supports_allow_scripts: bool,
@@ -1003,7 +1012,8 @@ impl NPMBackend {
         if let Some(args) = options.aube_args() {
             cmd = cmd.args(shell_words::split(args)?);
         }
-        cmd.args(options.allow_build_args()?).execute()?;
+        cmd.args(options.aube_cli_lifecycle_script_args()?)
+            .execute()?;
         Ok(())
     }
 
@@ -2338,6 +2348,29 @@ mod tests {
                 .allow_build_args()
                 .unwrap(),
             vec![OsString::from("--dangerously-allow-all-builds")]
+        );
+    }
+
+    #[test]
+    fn test_aube_cli_lifecycle_script_args_ignore_scripts_by_default() {
+        let default_options = ToolVersionOptions::default();
+        assert_eq!(
+            NpmOptions::new(&default_options)
+                .aube_cli_lifecycle_script_args()
+                .unwrap(),
+            vec![OsString::from("--ignore-scripts")]
+        );
+
+        let mut allow_options = ToolVersionOptions::default();
+        allow_options.opts.insert(
+            "allow_builds".to_string(),
+            toml::Value::String("esbuild".into()),
+        );
+        assert_eq!(
+            NpmOptions::new(&allow_options)
+                .aube_cli_lifecycle_script_args()
+                .unwrap(),
+            vec![OsString::from("--allow-build=esbuild")]
         );
     }
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -37,6 +37,7 @@ use tokio::sync::Mutex as TokioMutex;
 const BEFORE_DATE_TOLERANCE_SECS: u64 = 60;
 const NPM_ALLOW_SCRIPTS_VERSION: &str = "11.16.0";
 const NPM_MIN_RELEASE_AGE_VERSION: &str = "11.10.0";
+const AUBE_PROGRAM: &str = if cfg!(windows) { "aube.exe" } else { "aube" };
 const BUN_MIN_RELEASE_AGE_VERSION: &str = "1.3.0";
 const NPM_IGNORE_SCRIPTS_ARG: &str = "--ignore-scripts=true";
 const PNPM_MIN_RELEASE_AGE_VERSION: &str = "10.16.0";
@@ -304,6 +305,7 @@ impl Backend for NPMBackend {
         match installer {
             // Embedded aube — no external package-manager binary required.
             NpmPackageManager::Auto | NpmPackageManager::Aube => {}
+            NpmPackageManager::AubeCli => deps.push("aube"),
             NpmPackageManager::Npm => {
                 if !deps.contains(&"npm") {
                     deps.push("npm");
@@ -405,6 +407,9 @@ impl Backend for NPMBackend {
             NpmPackageManager::Auto => unreachable!("auto package manager should be resolved"),
             NpmPackageManager::Aube => {
                 self.install_via_aube_embed(ctx, &tv, &options).await?;
+            }
+            NpmPackageManager::AubeCli => {
+                self.install_via_aube_cli(ctx, &tv, &options).await?;
             }
             NpmPackageManager::Bun => {
                 let mut cmd = CmdLineRunner::new("bun")
@@ -618,7 +623,7 @@ impl NPMBackend {
         let seconds = elapsed_seconds_ceil(before_date, process_now());
         match package_manager {
             NpmPackageManager::Auto => unreachable!("auto package manager should be resolved"),
-            NpmPackageManager::Aube => Vec::new(),
+            NpmPackageManager::Aube | NpmPackageManager::AubeCli => Vec::new(),
             NpmPackageManager::Npm => {
                 // Sub-day windows always emit --before because --min-release-age
                 // is day-granular — which is also the fallback for older npm.
@@ -703,7 +708,7 @@ impl NPMBackend {
     ) -> Option<(&'static str, &'static str, &'static str)> {
         match package_manager {
             NpmPackageManager::Auto => None,
-            NpmPackageManager::Aube => None,
+            NpmPackageManager::Aube | NpmPackageManager::AubeCli => None,
             NpmPackageManager::Npm => None,
             NpmPackageManager::Bun => {
                 Some(("bun", BUN_MIN_RELEASE_AGE_VERSION, "--minimum-release-age"))
@@ -813,6 +818,23 @@ impl NPMBackend {
         match package_manager {
             // Embedded aube is compiled into mise — nothing to check for.
             NpmPackageManager::Aube => {}
+            NpmPackageManager::AubeCli => {
+                if let Some(ts) = _ts
+                    && ts.which_bin(config, AUBE_PROGRAM).await.is_some()
+                {
+                    return;
+                }
+                self.warn_if_dependency_missing(
+                    config,
+                    "aube",
+                    &["aube"],
+                    "To install npm packages with the standalone aube CLI, install aube first:\n\
+                      mise use aube@latest\n\n\
+                    Or use mise's embedded aube by setting:\n\
+                      mise settings npm.package_manager=aube",
+                )
+                .await
+            }
             NpmPackageManager::Bun => {
                 self.warn_if_dependency_missing(
                     config,
@@ -946,6 +968,43 @@ impl NPMBackend {
         Ok(())
     }
 
+    /// Install through a standalone aube executable while keeping version
+    /// metadata on mise's built-in registry client. Calling `aube` directly
+    /// avoids depending on the npm compatibility shim installed by
+    /// `aube activate`.
+    async fn install_via_aube_cli(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+        options: &NpmOptions<'_>,
+    ) -> Result<()> {
+        let aube_program = self
+            .dependency_path_for_install(&ctx.config, Some(&ctx.ts), AUBE_PROGRAM)
+            .await
+            .unwrap_or_else(|| AUBE_PROGRAM.into());
+        self.write_aube_cli_project(&tv.install_path(), ctx.before_date, options)?;
+        let mut cmd = CmdLineRunner::new(aube_program)
+            .arg("add")
+            .arg("--global")
+            .arg(format!("{}@{}", self.tool_name(), tv.version))
+            .with_pr(ctx.pr.as_ref())
+            .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+            .env_values(tv.install_env())
+            .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
+            .prepend_path(
+                self.dependency_toolset(&ctx.config)
+                    .await?
+                    .list_paths(&ctx.config)
+                    .await,
+            )?
+            .current_dir(tv.install_path());
+        if let Some(args) = options.aube_args() {
+            cmd = cmd.args(shell_words::split(args)?);
+        }
+        cmd.args(options.allow_build_args()?).execute()?;
+        Ok(())
+    }
+
     /// Render an aube embedded-install failure into an eyre error that keeps
     /// aube's full cause chain and remediation.
     ///
@@ -1029,6 +1088,45 @@ impl NPMBackend {
         }
         crate::file::write(install_path.join(".npmrc"), npmrc)?;
         Ok(())
+    }
+
+    /// Configure a standalone `aube add --global` invocation to install into
+    /// mise's per-tool prefix rather than aube's user-global prefix.
+    fn write_aube_cli_project(
+        &self,
+        install_path: &Path,
+        before_date: Option<Timestamp>,
+        options: &NpmOptions<'_>,
+    ) -> Result<()> {
+        let trust_policy_excludes = options.aube_trust_policy_excludes_npmrc_value()?;
+        let allow_low_downloads = options.allow_low_downloads()?;
+        let bin_dir = install_path.join("bin");
+        crate::file::create_dir_all(install_path)?;
+        crate::file::create_dir_all(&bin_dir)?;
+        let mut npmrc = format!(
+            "globalDir={}\nglobalBinDir={}\n",
+            Self::npmrc_path_value(install_path),
+            Self::npmrc_path_value(&bin_dir)
+        );
+        if let Some(before_date) = before_date {
+            let minutes = Self::build_aube_minimum_release_age(elapsed_seconds_ceil(
+                before_date,
+                process_now(),
+            ));
+            npmrc.push_str(&format!("minimumReleaseAge={minutes}\n"));
+        }
+        if let Some(excludes) = trust_policy_excludes {
+            npmrc.push_str(&format!("trustPolicyExclude={excludes}\n"));
+        }
+        if allow_low_downloads {
+            npmrc.push_str(&format!("allowedUnpopularPackages={}\n", self.tool_name()));
+        }
+        crate::file::write(install_path.join(".npmrc"), npmrc)?;
+        Ok(())
+    }
+
+    fn npmrc_path_value(path: &Path) -> String {
+        path.to_string_lossy().replace('\\', "/")
     }
 
     fn build_aube_minimum_release_age(seconds: u64) -> u64 {
@@ -1885,6 +1983,10 @@ mod tests {
             None
         );
         assert_eq!(
+            NPMBackend::release_age_package_manager_requirement(NpmPackageManager::AubeCli),
+            None
+        );
+        assert_eq!(
             NPMBackend::release_age_package_manager_requirement(NpmPackageManager::Npm),
             None
         );
@@ -2061,6 +2163,41 @@ mod tests {
             manifest["aube"]["allowBuilds"],
             serde_json::json!({ "esbuild": true })
         );
+    }
+
+    #[test]
+    fn test_write_aube_cli_project_targets_mise_install_prefix() {
+        let backend = create_npm_backend("vercel");
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("npm-vercel").join("54.20.1");
+        let mut raw_options = ToolVersionOptions::default();
+        raw_options.opts.insert(
+            "trust_policy_excludes".to_string(),
+            toml::Value::String("undici".into()),
+        );
+        raw_options.opts.insert(
+            "allow_low_downloads".to_string(),
+            toml::Value::Boolean(true),
+        );
+        let options = NpmOptions::new(&raw_options);
+
+        backend
+            .write_aube_cli_project(&install_path, None, &options)
+            .unwrap();
+
+        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
+        assert!(npmrc.contains(&format!(
+            "globalDir={}\n",
+            NPMBackend::npmrc_path_value(&install_path)
+        )));
+        assert!(npmrc.contains(&format!(
+            "globalBinDir={}\n",
+            NPMBackend::npmrc_path_value(&install_path.join("bin"))
+        )));
+        assert!(npmrc.contains("trustPolicyExclude=undici\n"));
+        assert!(npmrc.contains("allowedUnpopularPackages=vercel\n"));
+        assert!(install_path.join("bin").is_dir());
+        assert!(!install_path.join("package.json").exists());
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -978,6 +978,7 @@ impl NPMBackend {
         tv: &ToolVersion,
         options: &NpmOptions<'_>,
     ) -> Result<()> {
+        let bin_dir = tv.install_path().join("bin");
         let aube_program = self
             .dependency_path_for_install(&ctx.config, Some(&ctx.ts), AUBE_PROGRAM)
             .await
@@ -997,6 +998,7 @@ impl NPMBackend {
                     .list_paths(&ctx.config)
                     .await,
             )?
+            .prepend_path(vec![bin_dir])?
             .current_dir(tv.install_path());
         if let Some(args) = options.aube_args() {
             cmd = cmd.args(shell_words::split(args)?);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -99,6 +99,7 @@ pub enum NpmPackageManager {
     Auto,
     Npm,
     Aube,
+    AubeCli,
     Bun,
     Pnpm,
 }


### PR DESCRIPTION
## Summary

- add `npm.package_manager = "aube_cli"` for installing `npm:` tools through a standalone Aube executable
- keep version metadata on mise's built-in HTTP registry client by default
- invoke `aube add --global` directly instead of relying on Aube's npm compatibility shim
- preserve Aube-specific install controls, including `aube_args`, `allow_builds`, `minimum_release_age`, `trust_policy_excludes`, and `allow_low_downloads`
- document the distinction between embedded `aube` and standalone `aube_cli`

## Why

Since Aube was embedded in mise, `npm.package_manager = "aube"` always selects the embedded library. Users who prefer the separately installed Aube CLI have no explicit installer mode. Using `npm.shell_out` instead routes metadata through `npm view`; when `aube activate` shadows npm, this couples mise to Aube's partial npm compatibility surface and currently breaks version resolution, as reported in [jdx/aube#1134](https://github.com/jdx/aube/discussions/1134).

This change separates the integration from npm emulation: mise resolves versions itself and shells out directly to the standalone `aube` command only for installation.

## User impact

Users can select standalone Aube with:

```toml
[settings.npm]
package_manager = "aube_cli"
```

The existing default and `package_manager = "aube"` behavior remain embedded and unchanged.

## Validation

- `cargo check`
- focused npm backend unit tests
- `mise run test:e2e e2e/backend/test_npm_package_manager`
- `mise run test:e2e e2e/backend/test_backend_missing_deps`
- `mise run render:schema`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new npm install code path that shells out and writes install-time `.npmrc`, but it is opt-in and leaves the default embedded installer untouched.
> 
> **Overview**
> Adds **`npm.package_manager = "aube_cli"`** so `npm:` tools can install through a **standalone `aube` executable** while version resolution still uses mise’s built-in registry HTTP client (unless `npm.shell_out` is on for `auto` only).
> 
> The npm backend runs **`aube add --global`** from the tool install directory, writes a per-install **`.npmrc`** (`globalDir` / `globalBinDir`, `minimumReleaseAge`, `trustPolicyExclude`, `allowedUnpopularPackages`), and forwards **`aube_args`** and **`allow_builds`** (default **`--ignore-scripts`** when no allowlist). This path does not use aube’s npm shim or `aube activate`. Embedded **`aube`** / **`auto`** behavior is unchanged; docs and schema now distinguish embedded vs CLI, and **`aube_args`** is documented for **`aube_cli`** only (still ignored for in-process **`aube`**).
> 
> E2E coverage checks CLI invocation flags and missing-`aube` warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a46bcc925ae9810651bdb35a83156980322123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `aube_cli` as an npm package-manager option.
  * Enabled standalone Aube CLI installs with supported install arguments and build-policy controls.
  * Added missing-install warnings when the standalone Aube executable isn’t available.
* **Documentation**
  * Updated npm configuration docs to clarify mode differences, lifecycle/default behavior, and trust-related settings for `aube_cli`.
* **Tests**
  * Added end-to-end coverage for `aube_cli`, including warning output and installer invocation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->