### PR TITLE
fix(generate): error instead of clobbering when task-docs markers are missing

### DIFF
--- a/docs/cli/generate/task-docs.md
+++ b/docs/cli/generate/task-docs.md
@@ -16,6 +16,7 @@ inserts the documentation into an existing file
 This will look for a special comment, `<!-- mise-tasks -->`, and replace it with the generated documentation.
 It will replace everything between the comment and the next comment, `<!-- /mise-tasks -->` so it can be
 run multiple times on the same file to update the documentation.
+The file must already contain both comments; mise errors instead of modifying the file if they are missing.
 
 ### `-I --index`
 

--- a/e2e/generate/test_generate_task_docs_inject_errors
+++ b/e2e/generate/test_generate_task_docs_inject_errors
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+# `mise generate task-docs --inject` must not touch the output file when the
+# mise-tasks markers are missing. It used to assume the block started at byte 0,
+# which truncated marker-less files and panicked on short ones.
+# Discussion: https://github.com/jdx/mise/discussions/4676
+
+cat <<EOF >mise.toml
+[tasks.test]
+run = "echo 'running test task'"
+description = "This is a test task"
+EOF
+
+# --inject must fail, name the marker it could not find, and leave the file
+# byte-identical. cmp rather than command substitution, so a stripped trailing
+# newline cannot hide a rewrite.
+assert_inject_leaves_file_alone() {
+  local file="$1" expected="$2" out
+  cp "$file" "$file.orig"
+  out="$(quiet_assert_fail "mise generate task-docs --inject --output $file")"
+  assert_contains_text "$out" "$expected"
+  assert_not_contains_text "$out" "panicked"
+  if cmp -s "$file" "$file.orig"; then
+    ok "[$file] left unchanged"
+  else
+    fail "[$file] was modified by a failed --inject"
+  fi
+}
+
+# no markers at all: the file used to be truncated to its first 19 bytes
+cat <<EOF >no_markers.md
+# My Project
+
+Important paragraph that must survive.
+
+Another line.
+EOF
+assert_inject_leaves_file_alone no_markers.md "<!-- mise-tasks -->"
+
+# shorter than the marker: this used to panic with
+# "range start index 19 out of range for slice of length 3"
+echo "hi" >short.md
+assert_inject_leaves_file_alone short.md "<!-- mise-tasks -->"
+
+# multibyte content, where byte 19 is not a char boundary
+echo "日本語のドキュメント" >multibyte.md
+assert_inject_leaves_file_alone multibyte.md "<!-- mise-tasks -->"
+
+# start marker but no end marker: everything after it used to be replaced
+cat <<EOF >start_only.md
+# Title
+
+<!-- mise-tasks -->
+
+trailer
+EOF
+assert_inject_leaves_file_alone start_only.md "<!-- /mise-tasks -->"
+
+# markers in the wrong order
+cat <<EOF >reversed.md
+<!-- /mise-tasks -->
+
+body
+
+<!-- mise-tasks -->
+EOF
+assert_inject_leaves_file_alone reversed.md "<!-- /mise-tasks -->"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1916,6 +1916,7 @@ inserts the documentation into an existing file
 This will look for a special comment, `<!\-\- mise\-tasks \-\->`, and replace it with the generated documentation.
 It will replace everything between the comment and the next comment, `<!\-\- /mise\-tasks \-\->` so it can be
 run multiple times on the same file to update the documentation.
+The file must already contain both comments; mise errors instead of modifying the file if they are missing.
 .TP
 \fB\-I, \-\-index\fR
 write only an index of tasks, intended for use with `\-\-multi`

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1364,6 +1364,7 @@ inserts the documentation into an existing file
 This will look for a special comment, `<!-- mise-tasks -->`, and replace it with the generated documentation.
 It will replace everything between the comment and the next comment, `<!-- /mise-tasks -->` so it can be
 run multiple times on the same file to update the documentation.
+The file must already contain both comments; mise errors instead of modifying the file if they are missing.
 """#
         }
         flag "-I --index" help="write only an index of tasks, intended for use with `--multi`"

--- a/src/cli/generate/task_docs.rs
+++ b/src/cli/generate/task_docs.rs
@@ -1,6 +1,10 @@
 use crate::config::{self, Config};
 use crate::{dirs, file};
-use std::path::PathBuf;
+use color_eyre::eyre::bail;
+use std::path::{Path, PathBuf};
+
+const TASK_PLACEHOLDER_START: &str = "<!-- mise-tasks -->";
+const TASK_PLACEHOLDER_END: &str = "<!-- /mise-tasks -->";
 
 /// Generate documentation for tasks in a project
 #[derive(Debug, clap::Args)]
@@ -11,6 +15,7 @@ pub struct TaskDocs {
     /// This will look for a special comment, `<!-- mise-tasks -->`, and replace it with the generated documentation.
     /// It will replace everything between the comment and the next comment, `<!-- /mise-tasks -->` so it can be
     /// run multiple times on the same file to update the documentation.
+    /// The file must already contain both comments; mise errors instead of modifying the file if they are missing.
     #[clap(long, short, verbatim_doc_comment)]
     inject: bool,
     /// write only an index of tasks, intended for use with `--multi`
@@ -100,15 +105,8 @@ impl TaskDocs {
                 }
                 if self.inject {
                     doc = format!("\n{}\n", doc.trim());
-                    let mut contents = file::read_to_string(output)?;
-                    let task_placeholder_start = "<!-- mise-tasks -->";
-                    let task_placeholder_end = "<!-- /mise-tasks -->";
-                    let start = contents.find(task_placeholder_start).unwrap_or(0);
-                    let end = contents[start..]
-                        .find(task_placeholder_end)
-                        .map(|e| e + start)
-                        .unwrap_or(contents.len());
-                    contents.replace_range((start + task_placeholder_start.len())..end, &doc);
+                    let contents = file::read_to_string(output)?;
+                    let contents = inject_task_docs(&contents, &doc, output)?;
                     file::write(output, &contents)?;
                 } else {
                     doc = format!("{}\n", doc.trim());
@@ -126,9 +124,92 @@ impl TaskDocs {
     }
 }
 
+/// Replace everything between the mise-tasks markers in `contents` with `doc`.
+///
+/// Both markers must be present, with the end marker after the start marker. When
+/// a marker is missing this errors instead of writing anything: falling back to
+/// "the block starts at byte 0" truncated files that had no markers at all, and
+/// panicked outright on files shorter than the marker (discussions/4676).
+fn inject_task_docs(contents: &str, doc: &str, output: &Path) -> eyre::Result<String> {
+    let Some(start) = contents.find(TASK_PLACEHOLDER_START) else {
+        bail!(
+            "{} does not contain the `{TASK_PLACEHOLDER_START}` marker required by --inject, add:\n\n{TASK_PLACEHOLDER_START}\n{TASK_PLACEHOLDER_END}",
+            file::display_path(output)
+        );
+    };
+    let body_start = start + TASK_PLACEHOLDER_START.len();
+    let Some(end) = contents[body_start..]
+        .find(TASK_PLACEHOLDER_END)
+        .map(|e| e + body_start)
+    else {
+        bail!(
+            "{} contains `{TASK_PLACEHOLDER_START}` but no `{TASK_PLACEHOLDER_END}` after it, --inject requires both markers",
+            file::display_path(output)
+        );
+    };
+    let mut contents = contents.to_string();
+    contents.replace_range(body_start..end, doc);
+    Ok(contents)
+}
+
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
     $ <bold>mise generate task-docs</bold>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::{TASK_PLACEHOLDER_END, TASK_PLACEHOLDER_START, inject_task_docs};
+    use std::path::Path;
+
+    fn inject(contents: &str) -> eyre::Result<String> {
+        inject_task_docs(contents, "\n## `task`\n", Path::new("README.md"))
+    }
+
+    #[test]
+    fn injects_between_markers() {
+        let contents = format!(
+            "# Title\n\n{TASK_PLACEHOLDER_START}\nold\n{TASK_PLACEHOLDER_END}\n\ntrailer\n"
+        );
+        assert_eq!(
+            inject(&contents).unwrap(),
+            format!(
+                "# Title\n\n{TASK_PLACEHOLDER_START}\n## `task`\n{TASK_PLACEHOLDER_END}\n\ntrailer\n"
+            )
+        );
+    }
+
+    #[test]
+    fn errors_without_start_marker() {
+        // used to keep the first 19 bytes and replace the rest of the file
+        let err = inject("# My Project\n\nImportant paragraph that must survive.\n").unwrap_err();
+        assert!(err.to_string().contains(TASK_PLACEHOLDER_START));
+    }
+
+    #[test]
+    fn errors_on_file_shorter_than_marker() {
+        // used to panic: range start index 19 out of range for slice of length 3
+        assert!(inject("hi\n").is_err());
+    }
+
+    #[test]
+    fn errors_when_byte_offset_is_not_a_char_boundary() {
+        // multibyte content: the old code sliced at byte 19 regardless
+        assert!(inject("日本語のドキュメント\n").is_err());
+    }
+
+    #[test]
+    fn errors_without_end_marker() {
+        let contents = format!("# Title\n\n{TASK_PLACEHOLDER_START}\nold\n");
+        let err = inject(&contents).unwrap_err();
+        assert!(err.to_string().contains(TASK_PLACEHOLDER_END));
+    }
+
+    #[test]
+    fn errors_when_end_marker_precedes_start_marker() {
+        let contents = format!("{TASK_PLACEHOLDER_END}\nold\n{TASK_PLACEHOLDER_START}\n");
+        assert!(inject(&contents).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- `mise generate task-docs --inject` now requires both `<!-- mise-tasks -->` and `<!-- /mise-tasks -->` and leaves the file untouched when they are missing, instead of destroying it
- the end marker is searched *after* the start marker, so a reversed pair is an error rather than a silent replace-to-EOF
- extracted the injection into a pure `inject_task_docs()` helper with unit tests, plus an e2e regression test

## Context
The panic reported in https://github.com/jdx/mise/discussions/4676 (both markers present) was fixed in #5651. While confirming that for the reporter, the same code path turned out to still mangle files that *don't* have the markers.

```rust
let start = contents.find(task_placeholder_start).unwrap_or(0);          // no marker -> 0
let end = contents[start..].find(task_placeholder_end)
    .map(|e| e + start).unwrap_or(contents.len());                       // no marker -> EOF
contents.replace_range((start + task_placeholder_start.len())..end, &doc); // always cuts at byte 19
```

With no start marker, `start` is `0` and the replacement begins at byte 19 of a file that has no marker at all.

Reproduced with the released 2026.7.14 binary:

| input | result before this PR |
|---|---|
| README with no markers | truncated to its first 19 bytes, then the docs appended — `# My Project\n\nImpor## \`hello\` …` |
| file shorter than the marker (`hi\n`) | panic: `range start index 19 out of range for slice of length 3` |
| start marker but no end marker | everything from the marker to EOF replaced, no warning |
| end marker before the start marker | same silent replace-to-EOF |
| multibyte file where byte 19 is mid-character | char-boundary panic |

Errors now name the file and the marker that's missing, e.g.:

```
mise ERROR README.md does not contain the `<!-- mise-tasks -->` marker required by --inject, add:

<!-- mise-tasks -->
<!-- /mise-tasks -->
```

The happy path is byte-for-byte the same computation as before, so `e2e/generate/test_generate_task_docs_inject` is unchanged and still passes as the regression check.

## Tests
- unit tests on `inject_task_docs()`: happy path, missing start marker, missing end marker, reversed markers, file shorter than the marker, multibyte content
- `e2e/generate/test_generate_task_docs_inject_errors`: each failure mode asserts a non-zero exit, an error mentioning the missing marker, no `panicked` in the output, and that the file's contents are byte-identical afterwards

## Notes
- the `--inject` long help gained one line ("The file must already contain both comments; mise errors instead of modifying the file if they are missing."); `mise.usage.kdl`, `docs/cli/generate/task-docs.md` and `man/man1/mise.1` were updated to match, so the `mise run render` diff check should stay clean
- I could not compile locally (no C toolchain on that box), so the before/after table above was captured with the released 2026.7.14 binary and the code change itself is validated by the tests in CI

Relates to https://github.com/jdx/mise/discussions/4676

*This PR was prepared by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `mise generate task-docs --inject` now fails with a clear error when the `<!-- mise-tasks -->` / `<!-- /mise-tasks -->` markers are missing, reversed, or otherwise malformed, instead of risking incorrect replacement.
  * Prevents unintended modifications in edge cases involving short files or multibyte content.

* **Documentation**
  * Updated CLI help and manuals to clarify that both marker comments must already exist for injection to work.

* **Tests**
  * Added e2e coverage to verify failure behavior and that target files remain byte-identical on errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->