### PR TITLE
test(task): isolate nested cache input coverage

### DIFF
--- a/e2e/tasks/test_task_artifact_cache_input_groups
+++ b/e2e/tasks/test_task_artifact_cache_input_groups
@@ -11,7 +11,7 @@ global_inputs = [
   "workspace.txt",
   "{{ config_root }}/templated.txt",
   "\\!important.txt",
-  "@group:toolchain",
+  "@group:global-toolchain",
 ]
 
 [task_config.cache]
@@ -42,6 +42,7 @@ EOF
 
 cat <<'EOF' >mise.local.toml
 [task_config.input_groups]
+global-toolchain = ["global-toolchain.txt"]
 toolchain = ["toolchain.txt"]
 app = [
   "packages/app/src/**/*",
@@ -59,6 +60,7 @@ printf 'reincluded-one\n' >packages/app/src/ignored/reincluded.rs
 printf 'workspace-one\n' >workspace.txt
 printf 'templated-one\n' >templated.txt
 printf 'escaped-one\n' >'!important.txt'
+printf 'global-toolchain-one\n' >global-toolchain.txt
 printf 'toolchain-one\n' >toolchain.txt
 
 # Named groups and global inputs resolve independently across layered configs,
@@ -94,40 +96,49 @@ assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "3"
 assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "3"
 assert "wc -l < global-only-runs.txt | tr -d ' '" "2"
 
+# A group referenced only from global inputs independently invalidates every task.
+printf 'global-toolchain-two-changed\n' >global-toolchain.txt
+rm -rf packages/app/dist
+mise run build ::: check ::: global-only
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "4"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "4"
+assert "wc -l < global-only-runs.txt | tr -d ' '" "3"
+
 # Nested groups participate in the cache key as normal source inputs.
 printf 'toolchain-two-changed\n' >toolchain.txt
 rm -rf packages/app/dist
-mise run build ::: check
-assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "4"
-assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "4"
+mise run build ::: check ::: global-only
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "5"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "5"
+assert "wc -l < global-only-runs.txt | tr -d ' '" "3"
 assert "cat packages/app/dist/result.txt" "source-two-changed:workspace-two-changed:toolchain-two-changed"
 
 # Ordered patterns preserve a later repeated include after an exclusion.
 printf 'reincluded-two-changed\n' >packages/app/src/ignored/reincluded.rs
 rm -rf packages/app/dist
 mise run build ::: check
-assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "5"
-assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "5"
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "6"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "6"
 
 # A file left excluded by the ordered patterns does not invalidate either task.
 printf 'excluded-two-changed\n' >packages/app/src/ignored/excluded.txt
 mise run build ::: check
-assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "5"
-assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "5"
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "6"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "6"
 
 # Templated global inputs are rendered before config-root anchoring.
 printf 'templated-two-changed\n' >templated.txt
 rm -rf packages/app/dist
 mise run build ::: check
-assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "6"
-assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "6"
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "7"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "7"
 
 # Escaped-literal global inputs independently participate in invalidation.
 printf 'escaped-two-changed\n' >'!important.txt'
 rm -rf packages/app/dist
 mise run build ::: check
-assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "7"
-assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "7"
+assert "wc -l < packages/app/build-runs.txt | tr -d ' '" "8"
+assert "wc -l < packages/app/check-runs.txt | tr -d ' '" "8"
 
 # Group references are validated even when no input groups or global inputs
 # are configured, rather than being retained as literal source paths.


### PR DESCRIPTION
## Summary

- split the global-input group fixture from the nested task-input group fixture
- verify global-group changes invalidate all scoped tasks
- verify nested task-group changes do not invalidate a task that only receives global inputs

## Why

This follows up on review feedback from #11356. The previous e2e fixture used `toolchain.txt` through both global-input and nested task-group paths, so one working expansion path could mask a regression in the other.

## Validation

- `mise run test:e2e tasks/test_task_artifact_cache_input_groups`
- `mise run lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to an e2e script; no production task-cache logic is modified.
> 
> **Overview**
> **Strengthens the task artifact cache input-groups e2e** so global-only and nested group paths cannot mask each other.
> 
> Global inputs now reference `@group:global-toolchain` backed by `global-toolchain.txt`, while task `app` sources still nest `@group:toolchain` on `toolchain.txt`. The test adds a dedicated step that changing the global-only group re-runs `build`, `check`, and `global-only`, then a separate step where only `toolchain.txt` changes and **`global-only` must stay at 3 runs** while `build`/`check` bump again. Run-count expectations throughout the file are shifted up by one to match the extra global-group invalidation case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f327a92adf7f637b28376437bef6f1a7dda96a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task cache invalidation for changes to globally configured input groups.
  * Ensured nested, excluded, re-included, templated, and escaped input paths are handled correctly when determining whether tasks need to rerun.

* **Tests**
  * Expanded automated coverage for global input groups, cache keys, ordering, exclusions, and configuration-root anchoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->