### PR TITLE
fix(mcp): report mise as the server name in initialize

### DIFF
--- a/e2e/cli/test_mcp_protocol
+++ b/e2e/cli/test_mcp_protocol
@@ -124,7 +124,7 @@ def test_initialize(proc):
     assert "tools" in caps, "tools capability missing"
     print("✓ Tools capability present")
 
-    assert result["serverInfo"]["name"] == "rmcp", "wrong server name"
+    assert result["serverInfo"]["name"] == "mise", "wrong server name"
     print("✓ Server info correct")
     return 0
 

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -446,20 +446,6 @@ impl Mcp {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn server_info_identifies_mise() {
-        // rmcp defaults server_info to its own crate name/version, which would
-        // make every MCP client see the server as "rmcp".
-        let info = MiseServer::new().get_info();
-        assert_eq!(info.server_info.name, "mise");
-        assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
-    }
-}
-
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
@@ -493,3 +479,17 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
       Example: {"task": "build", "args": ["--verbose"]}
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_info_identifies_mise() {
+        // rmcp defaults server_info to its own crate name/version, which would
+        // make every MCP client see the server as "rmcp".
+        let info = MiseServer::new().get_info();
+        assert_eq!(info.server_info.name, "mise");
+        assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -5,7 +5,7 @@ use rmcp::{
     RoleServer, ServiceExt,
     handler::server::{ServerHandler, tool::ToolRouter, wrapper::Parameters},
     model::{
-        CallToolRequestParams, CallToolResult, ContentBlock, ErrorCode, ErrorData,
+        CallToolRequestParams, CallToolResult, ContentBlock, ErrorCode, ErrorData, Implementation,
         ListResourcesResult, ListToolsResult, PaginatedRequestParams, ProtocolVersion,
         ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents,
         ServerCapabilities, ServerInfo,
@@ -176,6 +176,7 @@ impl ServerHandler for MiseServer {
             .build();
         ServerInfo::new(capabilities)
             .with_protocol_version(ProtocolVersion::V_2025_03_26)
+            .with_server_info(Implementation::new("mise", env!("CARGO_PKG_VERSION")))
             .with_instructions("Mise MCP server provides access to tools, tasks, environment variables, and configuration")
     }
 
@@ -442,6 +443,20 @@ impl Mcp {
             .map_err(|e| eyre::eyre!("Service error: {}", e))?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_info_identifies_mise() {
+        // rmcp defaults server_info to its own crate name/version, which would
+        // make every MCP client see the server as "rmcp".
+        let info = MiseServer::new().get_info();
+        assert_eq!(info.server_info.name, "mise");
+        assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
     }
 }
 


### PR DESCRIPTION
## What changed

`MiseServer::get_info` built `ServerInfo::new(capabilities)` without ever calling `.with_server_info(...)`. Added it:

```rust
ServerInfo::new(capabilities)
    .with_protocol_version(ProtocolVersion::V_2025_03_26)
    .with_server_info(Implementation::new("mise", env!("CARGO_PKG_VERSION")))
    .with_instructions(...)
```

## Why

rmcp's `InitializeResult::new` defaults `server_info` to `Implementation::from_build_env()`, which is implemented inside the rmcp crate as `env!("CARGO_CRATE_NAME")` / `env!("CARGO_PKG_VERSION")`. Those `env!` macros expand at *rmcp's* compile time, not mise's — so the `initialize` response told every MCP client the server was named `rmcp` at rmcp's version (2.2.0) rather than `mise` at mise's version.

## Verification

Manual `initialize` over stdio against the built binary:

```
$ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}' | mise mcp
```

`result.serverInfo` is now `{"name": "mise", "version": "2026.7.14"}`.

Also added a unit test, `cli::mcp::tests::server_info_identifies_mise`, asserting both the name and the version so a future refactor of the builder chain can't silently drop this again.

## Notes for reviewers

- `Implementation` is imported from `rmcp::model` alongside the other model types rather than path-qualified inline, matching the existing import style in the file.
- `env!("CARGO_PKG_VERSION")` is the idiom already used for mise's own version elsewhere (`src/backend/aube_host.rs`, `src/shims.rs`, `src/config/mod.rs`), so this stays consistent rather than reaching for `cli::version::V`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to MCP handshake identity; no auth, task execution, or resource behavior is altered.
> 
> **Overview**
> MCP **`initialize`** responses now advertise **`mise`** and the mise package version instead of inheriting rmcp’s default **`serverInfo`** (name/version from the rmcp crate at compile time).
> 
> `MiseServer::get_info` sets **`.with_server_info(Implementation::new("mise", env!("CARGO_PKG_VERSION")))`**, and coverage is tightened with a unit test plus an e2e protocol check expecting **`serverInfo.name == "mise"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ffd626df69e5b51a26723d52354741aad10694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MCP clients now receive accurate server identity metadata, reporting the server name as “mise” and the current product version during the initialize handshake.
  * Updated the MCP CLI protocol e2e expectations to ensure the reported identity no longer exposes default library identity details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->