### PR TITLE
fix(backend): don't let a disabled backend's plugin shadow the registry

### DIFF
--- a/e2e/backend/test_disable_backends
+++ b/e2e/backend/test_disable_backends
@@ -22,3 +22,14 @@ assert_contains "MISE_DISABLE_BACKENDS=asdf mise doctor -J 2>&1 || true" '"age"'
 assert_contains "MISE_DISABLE_BACKENDS=asdf,vfox mise doctor 2>&1 || true" "asdf (disabled)"
 assert_contains "MISE_DISABLE_BACKENDS=asdf,vfox mise doctor 2>&1 || true" "vfox (disabled)"
 assert_not_contains "mise doctor 2>&1 || true" "(disabled)"
+
+# a leftover plugin must not route a registry shorthand to a disabled backend: with nothing
+# installed through it, resolution falls back to the registry instead of failing the install
+# https://github.com/jdx/mise/discussions/6021
+mise uninstall --all age
+ls "$MISE_DATA_DIR/plugins/age"
+assert "MISE_DISABLE_BACKENDS=asdf mise tool age --backend" "aqua:FiloSottile/age"
+
+# and the install that follows uses the registry backend rather than failing
+MISE_DISABLE_BACKENDS=asdf mise install age
+assert_contains "mise ls age" "1.3.1"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -147,6 +147,33 @@ pub(crate) fn strip_opts(s: &str) -> String {
         .unwrap_or_else(|| s.to_string())
 }
 
+/// Whether a plugin installed under `short` takes precedence over the registry entry.
+///
+/// A plugin whose backend is disabled by `disable_backends` does not, unless a version is
+/// already installed through that same backend. `disable_backends` is an install-time guard
+/// that intentionally keeps reporting the recorded backend of an installed tool, but a
+/// leftover plugin must not route a registry shorthand to a disabled backend and turn the
+/// install into an error when the registry offers an enabled backend (discussions/6021).
+fn plugin_overrides_registry(short: &str) -> bool {
+    let Some(plugin_type) = install_state::get_plugin_type(short) else {
+        return false;
+    };
+    let backend_type = match plugin_type {
+        PluginType::Asdf => BackendType::Asdf,
+        PluginType::Vfox => BackendType::Vfox,
+        PluginType::VfoxBackend => BackendType::VfoxBackend(short.to_string()),
+        PluginType::Package => return true,
+    };
+    if !backend::is_disabled_backend_type(&backend_type) {
+        return true;
+    }
+    // Versions are recorded per shorthand, so check the backend they were installed with:
+    // a version that came from an enabled registry backend must not keep the disabled
+    // plugin authoritative.
+    !install_state::list_versions(short).is_empty()
+        && install_state::backend_type(short).ok().flatten() == Some(backend_type)
+}
+
 fn parse_backend_components(
     short: &str,
     full: Option<&String>,
@@ -395,7 +422,7 @@ impl BackendArg {
         // backend if available. This allows tools to automatically switch backends when
         // the registry changes (e.g., when a tool moves from one maintainer to another).
         if !self.resolution.explicit
-            && install_state::get_plugin_type(short).is_none()
+            && !plugin_overrides_registry(short)
             && let Some(registry_full) = REGISTRY
                 .get(short)
                 .and_then(|rt| rt.backends().first().cloned())


### PR DESCRIPTION
## Summary
- a plugin whose backend is listed in `disable_backends` no longer shadows the registry entry, so a registry shorthand falls back to an enabled backend instead of failing the install
- a tool that already has versions installed through that backend is unaffected — it keeps reporting the recorded backend, which is the documented behavior of this install-time guard (#9905)
- e2e coverage added to the existing `disable_backends` test

## Context
Follow-up to https://github.com/jdx/mise/discussions/6021. #9905 fixed the half of that report about explicit syntax (`mise use ubi:owner/repo`). The other half — @reitzig seeing `usage`/`uv` install through asdf despite `disable_backends = ["asdf"]` — was diagnosed in that thread by @risu729: an installed asdf *plugin* takes precedence over the registry entry. That precedence rule never consulted `disable_backends`.

`BackendArg::full()`:

```rust
if !self.resolution.explicit
    && install_state::get_plugin_type(short).is_none()   // any plugin of that name skips the branch
    && let Some(registry_full) = REGISTRY.get(short).and_then(|rt| rt.backends().first().cloned())
{ return registry_full.to_string(); }
```

Reproduced on 2026.7.14 with `disable_backends = ["asdf"]` and the `usage` asdf plugin installed but no version installed through it:

```console
$ mise registry usage
aqua:jdx/usage cargo:usage-cli          # asdf correctly filtered out here

$ mise use usage
mise ERROR Failed to install asdf:usage@latest: backend asdf is disabled by disable_backends
```

So `mise registry` says the tool comes from aqua while `mise use` insists on the disabled backend and errors out. `mise plugins uninstall usage` makes it resolve to `aqua:jdx/usage` and succeed — that was the workaround in the discussion.

Since `REGISTRY`'s `backends()` already filters disabled backends (`src/registry.rs`), simply letting the branch run is enough to pick an enabled backend.

## Scope
Deliberately unchanged, to stay inside the semantics #9905 documented:

- explicit syntax (`asdf:foo`) still fails at install time with the same error
- names with no registry entry (custom plugins) still resolve to the plugin
- a registry entry whose backends are *all* disabled still behaves as before
- an already-installed tool keeps reporting the backend it was installed with — that's why the new check also requires `install_state::list_versions(short)` to be empty, and why the existing `mise tool age --backend` → `asdf:age` assertion still holds

## Out of scope
For a tool that already has versions installed under the shorthand, a leftover plugin makes `full()` report `asdf:<short>` regardless of the backend recorded in `installs/<tool>/.mise.backend.toml`. That is decided by the `install_state`/plugin fallback at the end of `full()`, not by the registry branch changed here, and it happens with or without `disable_backends` — verified on the released 2026.7.14, which reports `asdf:age` for an aqua-installed `age` whether asdf is disabled or not, and `aqua:FiloSottile/age` once the plugin is removed. This PR leaves that behavior exactly as it is.

## Tests
`e2e/backend/test_disable_backends` already installs `age` through asdf with aqua disabled, which leaves the plugin behind. The new case uninstalls the versions, keeps the plugin, and asserts resolution falls back:

```bash
mise uninstall --all age
ls "$MISE_DATA_DIR/plugins/age"
assert "MISE_DISABLE_BACKENDS=asdf mise tool age --backend" "aqua:FiloSottile/age"
```

That assertion reports `asdf:age` without this change. `mise tool --backend` prints `ba.full()` directly, so it exercises the modified path.

## Notes
I could not compile locally (no C toolchain on that machine), so the before-behavior above was captured with the released 2026.7.14 binary and the change itself is validated by CI.

Relates to https://github.com/jdx/mise/discussions/6021

*This PR was prepared by an AI coding assistant.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution behavior for `mise tool --backend` when backend disabling is enabled, especially ensuring registry-backed shorthand selection isn’t incorrectly routed to disabled plugins.
  * Kept resolution stable across plugin removal/reinstall scenarios under disabled-backends constraints.
* **Tests**
  * Added end-to-end regression coverage for disabled-backend behavior, including verifying correct backend resolution after fully removing and then reinstalling the affected plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
