### PR TITLE
feat(task): add global and pass-through cache env

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -83,7 +83,7 @@ outside this tracker.
 - [x] Capture and replay stdout and stderr while respecting mise output modes
 - [x] Cache useful results for tasks with no filesystem outputs
 - [x] Support reusable and global input groups
-- [ ] Support global environment inputs and pass-through environment variables
+- [x] Support global environment inputs and pass-through environment variables
 - [ ] Support negative input and output patterns
 - [ ] Support runtime-command inputs
 - [ ] Include external dependency and lockfile state through explicit input configuration

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -557,9 +557,10 @@ scope, including tasks with a task-local `cache` value. Unlike the default value
 global_env = ["CI", "NODE_ENV"]
 ```
 
-Variables named in `cache.env` or `task_config.global_env` remain available when environment
-inheritance is denied. Use `pass_through_env` for variables that a task needs at runtime but which
-must not affect its cache key, such as short-lived credentials. The scoped
+For cache-enabled tasks, variables named in `cache.env` or `task_config.global_env` remain available
+when environment inheritance is denied. Disabled and non-cache tasks do not inherit variables
+through cache configuration. Use `pass_through_env` for variables that a task needs at runtime but
+which must not affect its cache key, such as short-lived credentials. The scoped
 `task_config.global_pass_through_env` equivalent applies to every task. In mise's default,
 non-sandboxed environment mode, ambient variables already pass through; these options matter when
 `deny_env`, `deny_all`, or the corresponding CLI option is active.

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -548,6 +548,35 @@ the values (or absence) of variables named in `cache.env`, resolved tool version
 artifact keys, and the operating system and architecture. Variables inherited from the ambient
 process are ignored unless listed in `cache.env`.
 
+`task_config.global_env` adds ambient variable names to every enabled task cache in the config
+scope, including tasks with a task-local `cache` value. Unlike the default values under
+`task_config.cache`, these names always compose with task-local `cache.env`.
+
+```mise-toml
+[task_config]
+global_env = ["CI", "NODE_ENV"]
+```
+
+Variables named in `cache.env` or `task_config.global_env` remain available when environment
+inheritance is denied. Use `pass_through_env` for variables that a task needs at runtime but which
+must not affect its cache key, such as short-lived credentials. The scoped
+`task_config.global_pass_through_env` equivalent applies to every task. In mise's default,
+non-sandboxed environment mode, ambient variables already pass through; these options matter when
+`deny_env`, `deny_all`, or the corresponding CLI option is active.
+
+```mise-toml
+[task_config]
+global_pass_through_env = ["CI_JOB_TOKEN"]
+
+[tasks.build]
+pass_through_env = ["NPM_TOKEN"]
+```
+
+Pass-through variables can change task behavior without invalidating cached results. Tasks should
+not use them for values that affect generated outputs. Their values are not added to the key or
+persisted as cache metadata, but a task can still expose them by writing them to cached output files
+or logs.
+
 Cache entries are stored under `MISE_CACHE_DIR/task-artifacts/v2`. Filesystem outputs use
 zstd-compressed tar archives; result-only tasks store just their manifest and captured logs. Entries
 are included in the existing `mise cache clear` and `mise cache prune` behavior. Only successful task
@@ -848,6 +877,26 @@ Task-local and task-template cache configuration takes precedence, including
 [task_config.cache]
 enabled = true
 env = ["NODE_ENV", "CI"]
+```
+
+### `task_config.global_env` <Badge type="warning" text="experimental" />
+
+Adds ambient environment variable names to the cache key of every cache-enabled task in the config
+scope. These values compose with task-local `cache.env` rather than acting as defaults.
+
+```toml
+[task_config]
+global_env = ["CI", "NODE_ENV"]
+```
+
+### `task_config.global_pass_through_env` <Badge type="warning" text="experimental" />
+
+Preserves ambient environment variables when environment inheritance is denied, without adding
+their values to task cache keys.
+
+```toml
+[task_config]
+global_pass_through_env = ["CI_JOB_TOKEN"]
 ```
 
 ### `task_config.global_inputs` <Badge type="warning" text="experimental" />

--- a/e2e/tasks/test_task_artifact_cache_global_env
+++ b/e2e/tasks/test_task_artifact_cache_global_env
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_config]
+global_env = ["GLOBAL_PROFILE"]
+global_pass_through_env = ["GLOBAL_SECRET"]
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+run = '''
+test "$GLOBAL_SECRET" = "global-secret"
+test "$TASK_SECRET" = "task-secret"
+mkdir -p dist
+printf '%s:%s\n' "$GLOBAL_PROFILE" "$LOCAL_PROFILE" > dist/result.txt
+printf 'ran\n' >> runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["dist"]
+deny_env = true
+pass_through_env = ["TASK_SECRET"]
+cache = { enabled = true, env = ["LOCAL_PROFILE"] }
+EOF
+
+printf 'input\n' >input.txt
+
+GLOBAL_PROFILE=debug LOCAL_PROFILE=one GLOBAL_SECRET=global-secret TASK_SECRET=task-secret mise run build
+assert "cat dist/result.txt" "debug:one"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# A task-local cache config still composes with the scoped global env input.
+rm -rf dist
+GLOBAL_PROFILE=release LOCAL_PROFILE=one GLOBAL_SECRET=global-secret TASK_SECRET=task-secret mise run build
+assert "cat dist/result.txt" "release:one"
+assert "wc -l < runs.txt | tr -d ' '" "2"
+
+# Task-local hashed env inputs also remain available under deny_env.
+rm -rf dist
+GLOBAL_PROFILE=release LOCAL_PROFILE=two GLOBAL_SECRET=global-secret TASK_SECRET=task-secret mise run build
+assert "cat dist/result.txt" "release:two"
+assert "wc -l < runs.txt | tr -d ' '" "3"
+
+# Pass-through env values are available to the task but do not affect its key.
+rm -rf dist
+assert_contains "GLOBAL_PROFILE=release LOCAL_PROFILE=two GLOBAL_SECRET=rotated TASK_SECRET=rotated mise run build 2>&1" "restored outputs from cache"
+assert "cat dist/result.txt" "release:two"
+assert "wc -l < runs.txt | tr -d ' '" "3"

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -360,6 +360,13 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "pass_through_env": {
+          "description": "experimental ambient env vars preserved under environment denial without affecting the task cache key",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2293,6 +2293,20 @@
             }
           }
         },
+        "global_env": {
+          "description": "experimental ambient environment variable names added to every enabled task cache key in this config scope",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "global_pass_through_env": {
+          "description": "experimental ambient environment variable names preserved under environment denial without affecting task cache keys",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "global_inputs": {
           "description": "experimental config-root-relative source patterns added to every task in this config scope; entries may reference input groups with @group:<name>",
           "items": {
@@ -3109,6 +3123,13 @@
         },
         "allow_env": {
           "description": "allow specific env vars through",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pass_through_env": {
+          "description": "experimental ambient env vars preserved under environment denial without affecting the task cache key",
           "items": {
             "type": "string"
           },

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -247,6 +247,8 @@ impl Exec {
                 allow_write: self.allow_write,
                 allow_net: self.allow_net,
                 allow_env: self.allow_env,
+                pass_through_env: vec![],
+                cache_env: vec![],
             },
         );
         sandbox.resolve_paths();

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -808,6 +808,8 @@ impl Run {
                     allow_write: self.allow_write.clone(),
                     allow_net: self.allow_net.clone(),
                     allow_env: self.allow_env.clone(),
+                    pass_through_env: vec![],
+                    cache_env: vec![],
                 },
             ),
         };

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -902,6 +902,9 @@ impl Run {
         if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
             Settings::get().ensure_experimental("task artifact caching")?;
         }
+        if !task.pass_through_env.is_empty() {
+            Settings::get().ensure_experimental("task environment pass-through")?;
+        }
         if let Some(path) = &task.file
             && path.exists()
             && !file::is_executable(path)

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -751,6 +751,8 @@ pub struct TaskConfig {
     pub dir: Option<String>,
     pub shell: Option<String>,
     pub cache: Option<crate::task::TaskCacheConfig>,
+    pub global_env: Vec<String>,
+    pub global_pass_through_env: Vec<String>,
     pub global_inputs: Vec<String>,
     pub input_groups: IndexMap<String, Vec<String>>,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2224,6 +2224,61 @@ fn apply_task_config_cache_default(task: &mut Task, cache: &Option<TaskCacheConf
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct ResolvedTaskEnvironment {
+    global_env: Vec<String>,
+    global_pass_through_env: Vec<String>,
+}
+
+impl ResolvedTaskEnvironment {
+    fn from_configs(configs: &[&Arc<dyn ConfigFile>], cascaded: Option<&TaskConfig>) -> Self {
+        Self {
+            global_env: configs
+                .iter()
+                .find_map(|cf| {
+                    let env = &cf.task_config().global_env;
+                    (!env.is_empty()).then(|| env.clone())
+                })
+                .or_else(|| {
+                    cascaded
+                        .map(|tc| tc.global_env.clone())
+                        .filter(|env| !env.is_empty())
+                })
+                .unwrap_or_default(),
+            global_pass_through_env: configs
+                .iter()
+                .find_map(|cf| {
+                    let env = &cf.task_config().global_pass_through_env;
+                    (!env.is_empty()).then(|| env.clone())
+                })
+                .or_else(|| {
+                    cascaded
+                        .map(|tc| tc.global_pass_through_env.clone())
+                        .filter(|env| !env.is_empty())
+                })
+                .unwrap_or_default(),
+        }
+    }
+
+    fn apply(&self, task: &mut Task) -> Result<()> {
+        if self.global_env.is_empty() && self.global_pass_through_env.is_empty() {
+            return Ok(());
+        }
+        Settings::get().ensure_experimental("global task environment configuration")?;
+
+        if let Some(cache) = &mut task.cache {
+            cache.env.extend(self.global_env.iter().cloned());
+            cache.env.sort();
+            cache.env.dedup();
+        }
+        task.pass_through_env
+            .extend(self.global_pass_through_env.iter().cloned());
+        task.pass_through_env.sort();
+        task.pass_through_env.dedup();
+        Ok(())
+    }
+}
+
 const TASK_INPUT_GROUP_PREFIX: &str = "@group:";
 
 #[derive(Clone, Debug, Default)]
@@ -2235,6 +2290,7 @@ struct ResolvedTaskInputs {
 #[derive(Clone, Debug, Default)]
 struct ResolvedTaskConfig {
     inputs: ResolvedTaskInputs,
+    environment: ResolvedTaskEnvironment,
     dir: Option<String>,
     shell: Option<String>,
     cache: Option<TaskCacheConfig>,
@@ -3217,6 +3273,7 @@ async fn load_config_tasks(
             Ok(()) => {
                 apply_task_config_inputs(&mut t, &config, &task_config.inputs).await?;
                 apply_task_config_cache_default(&mut t, &task_config.cache);
+                task_config.environment.apply(&mut t)?;
                 tasks.push(t);
             }
             Err(e) => {
@@ -3542,6 +3599,18 @@ fn merge_cascaded_task_config(
     if let Some(cache) = configs.iter().find_map(|cf| cf.task_config().cache.clone()) {
         cascaded.task_config.cache = Some(cache);
     }
+    if let Some(global_env) = configs.iter().find_map(|cf| {
+        let env = &cf.task_config().global_env;
+        (!env.is_empty()).then(|| env.clone())
+    }) {
+        cascaded.task_config.global_env = global_env;
+    }
+    if let Some(global_pass_through_env) = configs.iter().find_map(|cf| {
+        let env = &cf.task_config().global_pass_through_env;
+        (!env.is_empty()).then(|| env.clone())
+    }) {
+        cascaded.task_config.global_pass_through_env = global_pass_through_env;
+    }
     if let Some((includes, root)) = configs
         .iter()
         .find_map(|cf| match cf.task_config_includes() {
@@ -3681,6 +3750,10 @@ async fn load_task_sources_from_configs(
     // lower-precedence overlay files use the same defaults as file tasks.
     let task_config = ResolvedTaskConfig {
         inputs: ResolvedTaskInputs::from_configs(&configs),
+        environment: ResolvedTaskEnvironment::from_configs(
+            &configs,
+            cascaded_task_config.map(|tc| &tc.task_config),
+        ),
         dir: configs
             .iter()
             .find_map(|cf| cf.task_config().dir.clone())
@@ -3738,6 +3811,7 @@ async fn load_task_sources_from_configs(
             for task in &mut loaded {
                 apply_task_config_inputs(task, config, &task_config.inputs).await?;
                 apply_task_config_cache_default(task, &task_config.cache);
+                task_config.environment.apply(task)?;
             }
             if is_global || is_global_task_include_path(&p) {
                 mark_tasks_as_global(&mut loaded);

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -24,6 +24,10 @@ pub struct SandboxConfig {
     pub allow_write: Vec<PathBuf>,
     pub allow_net: Vec<String>,
     pub allow_env: Vec<String>,
+    /// Environment patterns that survive an active env sandbox without enabling it themselves.
+    pub pass_through_env: Vec<String>,
+    /// Exact hashed environment names that survive an active env sandbox.
+    pub cache_env: Vec<String>,
 }
 
 /// Minimal env vars inherited when deny_env is active.
@@ -128,7 +132,13 @@ impl SandboxConfig {
         if !self.effective_deny_env() {
             return env.clone();
         }
-        let env_matches = |k: &str| self.allow_env.iter().any(|pat| env_pattern_matches(pat, k));
+        let env_patterns = self.allow_env.iter().chain(&self.pass_through_env);
+        let env_matches = |k: &str| {
+            self.cache_env.iter().any(|name| name == k)
+                || env_patterns
+                    .clone()
+                    .any(|pattern| env_pattern_matches(pattern, k))
+        };
         let mut filtered: std::collections::BTreeMap<String, String> = env
             .iter()
             .filter(|(k, _)| DEFAULT_ENV_KEYS.contains(&k.as_str()) || env_matches(k))
@@ -136,7 +146,7 @@ impl SandboxConfig {
             .collect();
         // Pull in allowed vars from parent env that might not be in mise's env map.
         // For wildcard patterns, check all parent env vars; for exact names, check directly.
-        for pattern in &self.allow_env {
+        for pattern in self.allow_env.iter().chain(&self.pass_through_env) {
             if pattern.contains('*') {
                 for (key, val) in crate::env::vars_safe() {
                     if !filtered.contains_key(&key) && env_pattern_matches(pattern, &key) {
@@ -147,6 +157,13 @@ impl SandboxConfig {
                 && let Ok(val) = std::env::var(pattern)
             {
                 filtered.insert(pattern.clone(), val);
+            }
+        }
+        for key in &self.cache_env {
+            if !filtered.contains_key(key)
+                && let Ok(val) = std::env::var(key)
+            {
+                filtered.insert(key.clone(), val);
             }
         }
         // Also ensure essential vars from parent env are present
@@ -322,6 +339,48 @@ mod tests {
         assert!(filtered.contains_key("MYAPP_BAR"));
         assert!(!filtered.contains_key("OTHER_VAR"));
         assert!(filtered.contains_key("PATH")); // default key
+    }
+
+    #[test]
+    fn test_pass_through_env_only_filters_when_env_is_denied() {
+        let mut env = BTreeMap::new();
+        env.insert("PASSED_SECRET".to_string(), "secret".to_string());
+        env.insert("OTHER_VAR".to_string(), "other".to_string());
+        let loose = SandboxConfig {
+            pass_through_env: vec!["PASSED_*".to_string()],
+            ..Default::default()
+        };
+
+        assert!(!loose.effective_deny_env());
+        assert_eq!(loose.filter_env(&env), env);
+
+        let strict = SandboxConfig {
+            deny_env: true,
+            ..loose
+        };
+        let filtered = strict.filter_env(&env);
+        assert_eq!(
+            filtered.get("PASSED_SECRET").map(String::as_str),
+            Some("secret")
+        );
+        assert!(!filtered.contains_key("OTHER_VAR"));
+    }
+
+    #[test]
+    fn test_cache_env_uses_exact_names() {
+        let config = SandboxConfig {
+            deny_env: true,
+            cache_env: vec!["HASHED_*".to_string(), "EXACT".to_string()],
+            ..Default::default()
+        };
+        let env = BTreeMap::from([
+            ("HASHED_VALUE".to_string(), "not-selected".to_string()),
+            ("EXACT".to_string(), "selected".to_string()),
+        ]);
+
+        let filtered = config.filter_env(&env);
+        assert!(!filtered.contains_key("HASHED_VALUE"));
+        assert_eq!(filtered.get("EXACT").map(String::as_str), Some("selected"));
     }
 
     /// filter_env() walks the parent environment for wildcard allow_env

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -639,6 +639,9 @@ pub struct Task {
     /// Allow specific env vars through
     #[serde(default)]
     pub allow_env: Vec<String>,
+    /// Preserve ambient env vars when env inheritance is denied without hashing their values
+    #[serde(default)]
+    pub pass_through_env: Vec<String>,
 
     /// Name of the task template to extend
     #[serde(default)]
@@ -983,6 +986,7 @@ impl Task {
         task.output = p
             .get_raw("output")
             .and_then(|v| TaskOutput::deserialize(v.clone()).ok());
+        task.pass_through_env = p.parse_array("pass_through_env").unwrap_or_default();
         task.tools = p
             .parse_table("tools")
             .map(|t| {
@@ -1894,6 +1898,7 @@ impl Task {
         self.allow_write.extend(other.allow_write);
         self.allow_net.extend(other.allow_net);
         self.allow_env.extend(other.allow_env);
+        self.pass_through_env.extend(other.pass_through_env);
     }
 
     fn has_render_templates(&self) -> bool {
@@ -2417,6 +2422,7 @@ impl Default for Task {
             allow_write: vec![],
             allow_net: vec![],
             allow_env: vec![],
+            pass_through_env: vec![],
             extends: None,
             show_args_in_prefix: false,
             depends_raw: None,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -3946,6 +3946,7 @@ echo "hello world"
 #MISE sources=["src1.txt", "src2.txt"]
 #MISE outputs=["out1.txt"]
 #MISE cache={enabled=true,env=["PROFILE"]}
+#MISE pass_through_env=["DEPLOY_TOKEN"]
 #MISE shell="bash -c"
 #MISE quiet=true
 #MISE silent=true
@@ -3980,6 +3981,7 @@ echo "test"
                 env: vec!["PROFILE".to_string()],
             })
         );
+        assert_eq!(task.pass_through_env, ["DEPLOY_TOKEN"]);
         assert_eq!(task.shell, Some("bash -c".to_string()));
         assert_eq!(task.quiet, true);
         assert_eq!(task.output, Some(TaskOutput::Prefix));

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -251,9 +251,6 @@ impl TaskExecutor {
         task: &Task,
         config: &Arc<Config>,
     ) -> Result<SandboxConfig> {
-        if !task.pass_through_env.is_empty() {
-            Settings::get().ensure_experimental("task environment pass-through")?;
-        }
         let task_base = task.dir(config).await?;
         let resolve_task_path =
             |p: &PathBuf| -> PathBuf { resolve_task_sandbox_path(p, task_base.as_deref()) };

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -251,6 +251,9 @@ impl TaskExecutor {
         task: &Task,
         config: &Arc<Config>,
     ) -> Result<SandboxConfig> {
+        if !task.pass_through_env.is_empty() {
+            Settings::get().ensure_experimental("task environment pass-through")?;
+        }
         let task_base = task.dir(config).await?;
         let resolve_task_path =
             |p: &PathBuf| -> PathBuf { resolve_task_sandbox_path(p, task_base.as_deref()) };
@@ -281,6 +284,20 @@ impl TaskExecutor {
                 .allow_env
                 .iter()
                 .chain(self.sandbox.allow_env.iter())
+                .cloned()
+                .collect(),
+            pass_through_env: task
+                .pass_through_env
+                .iter()
+                .chain(self.sandbox.pass_through_env.iter())
+                .cloned()
+                .collect(),
+            cache_env: task
+                .cache
+                .iter()
+                .filter(|cache| cache.enabled)
+                .flat_map(|cache| &cache.env)
+                .chain(self.sandbox.cache_env.iter())
                 .cloned()
                 .collect(),
         };

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -80,6 +80,9 @@ pub struct TaskTemplate {
     /// Allow specific env vars through
     #[serde(default)]
     pub allow_env: Vec<String>,
+    /// Preserve ambient env vars when env inheritance is denied without hashing their values
+    #[serde(default)]
+    pub pass_through_env: Vec<String>,
 }
 
 impl Task {
@@ -225,6 +228,8 @@ impl Task {
         self.allow_write.splice(0..0, template.allow_write.clone());
         self.allow_net.splice(0..0, template.allow_net.clone());
         self.allow_env.splice(0..0, template.allow_env.clone());
+        self.pass_through_env
+            .splice(0..0, template.pass_through_env.clone());
     }
 }
 
@@ -460,6 +465,7 @@ mod tests {
             deny_net: true,
             allow_read: vec!["task-read".into()],
             allow_env: vec!["TASK_*".to_string()],
+            pass_through_env: vec!["TASK_SECRET".to_string()],
             ..Default::default()
         };
         let template = TaskTemplate {
@@ -471,6 +477,7 @@ mod tests {
             allow_write: vec!["template-write".into()],
             allow_net: vec!["example.com".to_string()],
             allow_env: vec!["TEMPLATE_*".to_string()],
+            pass_through_env: vec!["TEMPLATE_SECRET".to_string()],
             ..Default::default()
         };
 
@@ -496,6 +503,10 @@ mod tests {
         assert_eq!(
             task.allow_env,
             vec!["TEMPLATE_*".to_string(), "TASK_*".to_string()]
+        );
+        assert_eq!(
+            task.pass_through_env,
+            vec!["TEMPLATE_SECRET".to_string(), "TASK_SECRET".to_string()]
         );
     }
 }


### PR DESCRIPTION
## Summary
- add experimental `task_config.global_env` inputs that compose with task-local cache env configuration
- add task-local and config-scoped pass-through env variables that survive environment sandboxing without affecting cache keys
- keep hashed cache env inputs available under `deny_env`, and update the schema, docs, parity tracker, and E2E coverage

## Tests
- `mise run test:e2e tasks/test_task_artifact_cache_global_env`
- `cargo test --quiet sandbox::tests`
- `cargo test --quiet task::task_template::tests::test_merge_template_sandbox_config`
- `mise run render:schema`
- `mise run lint-fix`
- `cargo check --all-features --quiet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task cache key composition and env sandbox filtering; incorrect pass-through vs hashed env could cause stale cache hits or broken runs under deny_env.
> 
> **Overview**
> Adds experimental **scoped global cache env inputs** and **pass-through env** so task artifact caching and sandboxed runs can share consistent environment rules.
> 
> **`task_config.global_env`** merges ambient variable names into every **cache-enabled** task’s `cache.env` (alongside task-local `cache.env`), so those values participate in cache keys and stay visible when **`deny_env`** is on. **`task_config.global_pass_through_env`** and per-task **`pass_through_env`** inject names into the sandbox without hashing them, which matters for tokens under env denial while still allowing cache hits when only pass-through values change.
> 
> Config resolution applies the new `TaskConfig` fields when loading tasks; the sandbox **`filter_env`** path now honors **`pass_through_env`** (pattern-style, like `allow_env`) and **`cache_env`** (exact names from enabled cache env lists). Schema, docs, parity tracker, and an e2e exercise global vs local hashed env and pass-through cache reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429429879ba3feec4908b6948afedf6426b42495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental support for scoped global environment variables that participate in task cache keying.
  * Added `pass_through_env` controls to keep selected ambient variables available when environment inheritance is denied, without affecting cache keys.
* **Documentation**
  * Documented `global_env`, `global_pass_through_env`, and per-task `pass_through_env`, including TOML examples and cache-key behavior.
* **Tests**
  * Added end-to-end coverage verifying cache-key reuse and runtime behavior with global/local environment inputs.
* **Chores**
  * Updated the cache-parity checklist to mark global environment input handling as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->