### PR TITLE
feat(spm): add install_command option for source installs

### DIFF
--- a/docs/dev-tools/backends/spm.md
+++ b/docs/dev-tools/backends/spm.md
@@ -143,6 +143,30 @@ product in the package, installation fails with a clear error.
 "spm:swiftlang/swiftly" = { version = "latest", filter_bins = "swiftly" }
 ```
 
+### `install_command`
+
+Run an explicit command from the checked-out package directory instead of discovering executable
+products and running `swift build --product`. The command uses mise's default inline shell and
+inherits [`install_env`](#install_env) plus the `PATH` for the Swift dependency. `PREFIX` and
+`MISE_TOOL_INSTALL_PATH` are both set to the tool's installation directory.
+
+This option only applies to source installs and cannot be combined with `filter_bins`. Mise never
+automatically runs a package's Makefile or other installation scripts; the command must be
+configured explicitly.
+
+Useful for packages whose executable is not the only artifact that has to be installed — for
+example a package that also ships a dynamic library or Swift modules that its own `make install`
+target places next to the binary:
+
+```toml
+[tools]
+"spm:owner/repo" = { version = "1.2.3", artifactbundle = false, install_command = "make install PREFIX=\"$MISE_TOOL_INSTALL_PATH\"" }
+```
+
+Some install scripts exit successfully even when the underlying `swift build` failed, so mise
+verifies that the command installed at least one executable into `bin/` and fails the install
+otherwise.
+
 ## Settings
 
 ### `spm.artifactbundle_only`

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -133,6 +133,28 @@ impl<'a> SpmOptions<'a> {
         };
         if bins.is_empty() { None } else { Some(bins) }
     }
+
+    fn install_command(&self) -> eyre::Result<Option<String>> {
+        let Some(value) = self.values.raw().opts.get("install_command") else {
+            return Ok(None);
+        };
+        let Some(command) = value.as_str() else {
+            bail!("install_command must be a non-empty string");
+        };
+        let command = command.trim();
+        if command.is_empty() {
+            bail!("install_command must be a non-empty string");
+        }
+        Ok(Some(command.to_string()))
+    }
+
+    fn source_install_command(&self) -> eyre::Result<Option<String>> {
+        let command = self.install_command()?;
+        if command.is_some() && self.filter_bins().is_some() {
+            bail!("install_command cannot be used with filter_bins");
+        }
+        Ok(command)
+    }
 }
 
 #[async_trait]
@@ -217,6 +239,7 @@ impl Backend for SPMBackend {
         let mut tv = tv;
         let raw_opts = tv.request.options();
         let opts = SpmOptions::new(&raw_opts);
+        let install_command = opts.source_install_command()?;
         let provider = GitProvider::from_ba_with_opts(&self.ba, &opts);
         let repo = SwiftPackageRepo::new(&self.tool_name(), &provider)?;
         let revision = if tv.version == "latest" {
@@ -263,7 +286,8 @@ impl Backend for SPMBackend {
             }
         }
 
-        self.install_from_source(ctx, &tv, &repo, &revision).await?;
+        self.install_from_source(ctx, &tv, &repo, &revision, install_command.as_deref())
+            .await?;
 
         Ok(tv)
     }
@@ -276,6 +300,7 @@ pub fn install_time_option_keys() -> Vec<String> {
         "artifactbundle".into(),
         "artifactbundle_asset".into(),
         "filter_bins".into(),
+        "install_command".into(),
     ]
 }
 
@@ -290,21 +315,27 @@ impl SPMBackend {
         tv: &ToolVersion,
         repo: &SwiftPackageRepo,
         revision: &str,
+        install_command: Option<&str>,
     ) -> eyre::Result<()> {
         let repo_dir = self.clone_package_repo(ctx, tv, repo, revision)?;
 
-        let executables = self.get_executable_names(ctx, &repo_dir, tv).await?;
-        if executables.is_empty() {
-            return Err(eyre::eyre!("No executables found in the package"));
-        }
-        let executables = self.apply_filter_bins(tv, executables)?;
-        let bin_path = tv.install_path().join("bin");
-        file::create_dir_all(&bin_path)?;
-        for executable in executables {
-            let exe_path = self
-                .build_executable(&executable, &repo_dir, ctx, tv)
+        if let Some(install_command) = install_command {
+            self.run_install_command(ctx, tv, &repo_dir, install_command)
                 .await?;
-            file::make_symlink(&exe_path, &bin_path.join(executable))?;
+        } else {
+            let executables = self.get_executable_names(ctx, &repo_dir, tv).await?;
+            if executables.is_empty() {
+                return Err(eyre::eyre!("No executables found in the package"));
+            }
+            let executables = self.apply_filter_bins(tv, executables)?;
+            let bin_path = tv.install_path().join("bin");
+            file::create_dir_all(&bin_path)?;
+            for executable in executables {
+                let exe_path = self
+                    .build_executable(&executable, &repo_dir, ctx, tv)
+                    .await?;
+                file::make_symlink(&exe_path, &bin_path.join(executable))?;
+            }
         }
 
         // delete (huge) intermediate artifacts
@@ -312,6 +343,38 @@ impl SPMBackend {
         file::remove_all(tv.cache_path())?;
 
         Ok(())
+    }
+
+    async fn run_install_command(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+        repo_dir: &Path,
+        install_command: &str,
+    ) -> eyre::Result<()> {
+        let shell = Settings::get().default_inline_shell()?;
+        let (program, shell_args) = shell.split_first().ok_or_else(|| {
+            eyre::eyre!(
+                "default inline shell is empty; check unix_default_inline_shell_args / windows_default_inline_shell_args"
+            )
+        })?;
+
+        CmdLineRunner::new(program)
+            .current_dir(repo_dir)
+            .with_pr(ctx.pr.as_ref())
+            .cmd_body_args(shell_args, install_command)
+            .env_values(tv.install_env())
+            .env("PREFIX", tv.install_path())
+            .env("MISE_TOOL_INSTALL_PATH", tv.install_path())
+            .prepend_path(
+                self.dependency_toolset(&ctx.config)
+                    .await?
+                    .list_paths(&ctx.config)
+                    .await,
+            )?
+            .execute()?;
+
+        verify_install_command_output(install_command, &tv.install_path().join("bin"))
     }
 
     fn clone_package_repo(
@@ -545,6 +608,25 @@ fn filter_executables(
         .into_iter()
         .filter(|e| filter.contains(e))
         .collect())
+}
+
+/// Verifies that `install_command` actually installed an executable into `bin/`.
+///
+/// A package's install script may exit 0 even when the underlying `swift build`
+/// failed (for example when the script does not use `set -e`), which would
+/// otherwise leave mise reporting a successful install for a directory that has
+/// no runnable tool in it.
+fn verify_install_command_output(install_command: &str, bin_path: &Path) -> eyre::Result<()> {
+    if !file::ls(bin_path)?
+        .iter()
+        .any(|entry| entry.is_file() && file::is_executable(entry))
+    {
+        bail!(
+            "install_command `{install_command}` exited successfully but installed no executable into {}; check that it installs into $MISE_TOOL_INSTALL_PATH and that it fails when the build fails",
+            bin_path.display()
+        );
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1233,8 +1315,97 @@ mod tests {
                 "artifactbundle".to_string(),
                 "artifactbundle_asset".to_string(),
                 "filter_bins".to_string(),
+                "install_command".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn test_install_command() {
+        let opts = ToolVersionOptions::default();
+        assert_eq!(SpmOptions::new(&opts).install_command().unwrap(), None);
+
+        let opts = opts_with(
+            "install_command",
+            toml::Value::String("  make install  ".to_string()),
+        );
+        assert_eq!(
+            SpmOptions::new(&opts).install_command().unwrap(),
+            Some("make install".to_string())
+        );
+    }
+
+    #[test]
+    fn test_install_command_rejects_empty_or_invalid_values() {
+        for value in [
+            toml::Value::String(" \t ".to_string()),
+            toml::Value::Boolean(true),
+            toml::Value::Array(vec![toml::Value::String("make install".to_string())]),
+        ] {
+            let opts = opts_with("install_command", value);
+            assert_str_eq!(
+                SpmOptions::new(&opts)
+                    .install_command()
+                    .unwrap_err()
+                    .to_string(),
+                "install_command must be a non-empty string"
+            );
+        }
+    }
+
+    #[test]
+    fn test_install_command_conflicts_with_filter_bins() {
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            "install_command".to_string(),
+            toml::Value::String("make install".to_string()),
+        );
+        opts.opts.insert(
+            "filter_bins".to_string(),
+            toml::Value::String("danger-swift".to_string()),
+        );
+
+        assert_str_eq!(
+            SpmOptions::new(&opts)
+                .source_install_command()
+                .unwrap_err()
+                .to_string(),
+            "install_command cannot be used with filter_bins"
+        );
+    }
+
+    #[test]
+    fn test_verify_install_command_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let bin_path = temp.path().join("bin");
+
+        // missing bin/ or an empty bin/ means the command installed nothing
+        let err = verify_install_command_output("make install", &bin_path)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("installed no executable into"), "{err}");
+        std::fs::create_dir_all(&bin_path).unwrap();
+        assert!(verify_install_command_output("make install", &bin_path).is_err());
+
+        // a directory alone is not an installed executable
+        std::fs::create_dir(bin_path.join("placeholder")).unwrap();
+        assert!(verify_install_command_output("make install", &bin_path).is_err());
+
+        let executable = bin_path.join(if cfg!(windows) {
+            "danger-swift.exe"
+        } else {
+            "danger-swift"
+        });
+        std::fs::write(&executable, "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            // a regular file that cannot be run is not an installed executable
+            assert!(verify_install_command_output("make install", &bin_path).is_err());
+            std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        assert!(verify_install_command_output("make install", &bin_path).is_ok());
     }
 
     fn release_asset(name: &str) -> ArtifactBundleReleaseAsset {


### PR DESCRIPTION
## Summary

This re-lands only the generic part of #11286 (reverted in 4c32d0fa), plus a fix for the second
problem called out in the revert.

- add a general `install_command` option to the `spm` backend for source installs
- fail the install when `install_command` exits successfully but installs nothing into `bin/`
- document the option and cover it with unit tests

**`registry/danger-swift.toml` and `e2e/core/test_swift_slow` are intentionally not touched here**,
so this PR cannot affect the release CI job that the previous change broke.

## Why the previous change broke release CI

`e2e-linux` in `release.yml` runs with `TEST_ALL=1` on `ubuntu-latest` (Ubuntu 26.04). swift.org does
not publish an Ubuntu 26.04 toolchain — the platform list for the current Swift 6.3.3 release stops
at Ubuntu 24.04, and `swift-6.3.3-RELEASE-ubuntu26.04.tar.gz` returns 404 while the 24.04 tarball
returns 200. mise therefore falls back to the 24.04 build (`DEFAULT_UBUNTU_VERSION` in
`src/plugins/core/swift.rs`), whose `swift-build` / `swift-package` cannot start on 26.04
(`libxml2.so.2` vs `libxml2.so.16`).

That makes *any* SwiftPM source build fail on 26.04, not just Danger Swift. The repository already
tracks the same limitation — `e2e/core/test_swift_slow` has
`# TODO: re-enable once Swift provides Ubuntu 26.04 binaries` over two commented-out SwiftFormat
source-build assertions. Nothing in mise can fix that until upstream ships a 26.04 toolchain, so the
`danger-swift` registry entry and its e2e coverage are deferred to a follow-up PR.

## The "reported as installed" bug is fixed here

Danger Swift's `Scripts/install.sh` has no `set -e` and its last statement is
`mv -f tmpPackage Package.swift`, so `make install` exits 0 even when `swift build` failed. The
reverted implementation only checked the command's exit status, which is why an install with no
executable was still reported as successful.

`run_install_command` now verifies that the command installed at least one file into the tool's
`bin/` directory and fails with an actionable error otherwise. This is generic — it protects against
any install script that swallows build failures.

## Implementation

- validate `install_command` as a non-empty string and reject its use with `filter_bins`
- run the command from the checked-out package with the configured inline shell, `install_env`,
  the Swift dependency `PATH`, and `PREFIX` / `MISE_TOOL_INSTALL_PATH` set to the install directory
- register it as an install-time option so option changes invalidate stale install metadata
- verify `bin/` is non-empty afterwards
- keep artifact bundle installs and the default `swift build --product` path unchanged, and never
  auto-run a package's Makefile

## Testing

- `rustfmt --edition 2024 --check src/backend/spm.rs`
- unit tests added for option parsing, the `filter_bins` conflict, and the new `bin/` verification
- compilation, clippy and the full test suite are left to CI

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `install_command` option for Swift Package Manager source installs to run a specified command from the checked-out package directory.
  * The command inherits mise’s default shell environment plus install-related variables (including install prefix/path) and dependency tool paths.
  * Installation success is now validated by requiring at least one executable to be placed in `bin/` (fails even if the command exits successfully).
* **Documentation**
  * Documented `install_command`, its available environment variables, and constraints (source installs only; incompatible with `filter_bins`).
* **Tests**
  * Added coverage for option parsing, the `install_command` + `filter_bins` conflict, and `bin/`-based validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->