### PR TITLE
fix(pipx): don't suggest uv when uvx is disabled for the package

### DIFF
--- a/e2e/backend/test_pipx_missing_dependency
+++ b/e2e/backend/test_pipx_missing_dependency
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+# When a pipx package cannot use uvx, the missing-dependency message must not point at uv,
+# and mise must fail with those instructions rather than a bare ENOENT from `pipx install`.
+# Discussion: https://github.com/jdx/mise/discussions/6803
+
+MISE_BIN=$(command -v mise)
+EMPTY_BIN="$PWD/empty-bin"
+mkdir -p "$EMPTY_BIN"
+
+# PATH with neither pipx nor uv on it, so the dependency really is missing
+install_cmd() {
+  echo "env PATH=$EMPTY_BIN $* $MISE_BIN install"
+}
+
+# uvx disabled by the pipx.uvx setting: uv is not an alternative here
+out="$(quiet_assert_fail "$(install_cmd MISE_PIPX_UVX=0) pipx:cowsay@6.1")"
+assert_contains_text "$out" "mise use pipx@latest"
+assert_contains_text "$out" "pipx.uvx"
+assert_not_contains_text "$out" "mise use uv@latest"
+assert_not_contains_text "$out" "os error 2"
+
+# uvx disabled by the package itself
+out="$(quiet_assert_fail "$(install_cmd) 'pipx:cowsay[uvx=false]@6.1'")"
+assert_contains_text "$out" "uvx = false"
+assert_contains_text "$out" "mise use pipx@latest"
+assert_not_contains_text "$out" "mise use uv@latest"
+assert_not_contains_text "$out" "os error 2"
+
+# uvx allowed: uv is still offered, since installing it does solve the problem there
+out="$(quiet_assert_fail "$(install_cmd) pipx:cowsay@6.1")"
+assert_contains_text "$out" "mise use uv@latest"
+assert_contains_text "$out" "mise use pipx@latest"
+assert_not_contains_text "$out" "os error 2"

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -20,7 +20,7 @@ use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset, Tool
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use async_trait::async_trait;
-use eyre::{Result, eyre};
+use eyre::{Result, bail, eyre};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use jiff::Timestamp;
@@ -286,7 +286,8 @@ impl Backend for PIPXBackend {
         let options = PipxOptions::new(&request_options);
 
         // Check if pipx is available (unless uvx is being used)
-        let uv_program = if Settings::get().pipx.uvx != Some(false) && !options.uvx_disabled() {
+        let uvx_allowed = Settings::get().pipx.uvx != Some(false) && !options.uvx_disabled();
+        let uv_program = if uvx_allowed {
             self.dependency_path_for_install(&ctx.config, Some(&ctx.ts), "uv")
                 .await
         } else {
@@ -294,16 +295,47 @@ impl Backend for PIPXBackend {
         };
 
         if uv_program.is_none() {
-            self.warn_if_dependency_missing(
-                &ctx.config,
-                "pipx",
-                &["pipx"],
-                "To use pipx packages with mise, you need to install pipx first:\n\
-                  mise use pipx@latest\n\n\
-                Alternatively, you can use uv/uvx by installing uv:\n\
-                  mise use uv@latest",
-            )
-            .await;
+            // Only offer uv as an alternative when this package can actually use it.
+            // Packages that set `uvx = false` (or a `pipx.uvx = false` setting) always go
+            // through pipx, so pointing at uv there just sends people down a dead end.
+            let instructions = if uvx_allowed {
+                "To use pipx packages with mise, you need to install pipx first:\n  \
+                   mise use pipx@latest\n\n\
+                 Alternatively, you can use uv/uvx by installing uv:\n  \
+                   mise use uv@latest"
+                    .to_string()
+            } else {
+                let reason = if options.uvx_disabled() {
+                    "this package sets `uvx = false`"
+                } else {
+                    "uvx is disabled by the `pipx.uvx` setting"
+                };
+                format!(
+                    "This package is installed with pipx because {reason}, so uv/uvx cannot be \
+                     used for it.\n\nInstall pipx first:\n  mise use pipx@latest"
+                )
+            };
+            self.warn_if_dependency_missing(&ctx.config, "pipx", &["pipx"], &instructions)
+                .await;
+
+            // Fail with the instructions above rather than letting `pipx install` die with a
+            // bare "No such file or directory (os error 2)". Skipped when a configured tool
+            // provides pipx, since mise installs that first — same rule as the warning.
+            let pipx_configured = match self.dependency_toolset(&ctx.config).await {
+                Ok(ts) => ts.versions.keys().any(|ba| ba.short == "pipx"),
+                Err(_) => false,
+            };
+            if !pipx_configured
+                && self
+                    .dependency_path_for_install(&ctx.config, Some(&ctx.ts), "pipx")
+                    .await
+                    .is_none()
+            {
+                bail!(
+                    "pipx is required to install {} but was not found.\n\n{instructions}",
+                    self.ba()
+                );
+            }
         }
 
         let pipx_request = self


### PR DESCRIPTION
## Summary
- only offer uv as an alternative when the package can actually use uvx
- when uvx is disabled, say why (the package's `uvx = false`, or the `pipx.uvx` setting) and give pipx instructions only
- fail with those instructions when pipx is missing, instead of letting `pipx install` die with a bare `No such file or directory (os error 2)`

## Context
From https://github.com/jdx/mise/discussions/6803. `uv_program.is_none()` covered two different situations — "uv is not installed" and "uvx is disabled for this package" — so the second one got advice that cannot work:

```console
$ mise use ansible@11
mise WARN  pipx may be required but was not found.

To use pipx packages with mise, you need to install pipx first:
mise use pipx@latest

Alternatively, you can use uv/uvx by installing uv:      # uv can never install this package
mise use uv@latest

mise ERROR Failed to install pipx:ansible@11: failed to execute command:
  pipx install ansible==11.13.0 … --include-deps: No such file or directory (os error 2)
```

Still reproduces on 2026.7.14. The same output appears for any pipx package once pipx is off `PATH`; `pipx:cowsay@6.1` is a smaller repro.

`registry/ansible.toml` is the only registry entry with `uvx = false`, and it needs it: the `ansible` wheel declares a single console script (`ansible-community`), while `ansible`, `ansible-playbook` and the rest come from its `ansible-core` dependency. pipx exposes those with `--include-deps`; `uv tool install` has no equivalent, so uv is genuinely not an option there.

## Changes
- `src/backend/pipx.rs`: hoist the uvx decision into `uvx_allowed`, build the instructions from it, and name the reason when uvx is off
- same file: before running pipx, bail with those instructions if pipx cannot be resolved and no configured tool provides it — the toolset check mirrors the one `warn_if_dependency_missing` already uses, so "pipx is in the toolset but not installed yet" keeps working as before

Behavior with uvx allowed (the default for every other package) is unchanged.

## Tests
`e2e/backend/test_pipx_missing_dependency` runs `mise install` with a `PATH` that contains neither pipx nor uv, and asserts:

| case | expectation |
|---|---|
| `MISE_PIPX_UVX=0` | mentions `pipx.uvx`, no `mise use uv@latest`, no `os error 2` |
| `pipx:cowsay[uvx=false]@6.1` | mentions `uvx = false`, no `mise use uv@latest`, no `os error 2` |
| default (uvx allowed) | still offers `mise use uv@latest` |

The third case guards against over-correcting: with uvx allowed, installing uv really does fix the problem, so that advice stays.

## Notes
I could not compile locally (no C toolchain on that machine), so the pre-fix output above was captured with the released 2026.7.14 binary and the change itself is validated by CI.

Relates to https://github.com/jdx/mise/discussions/6803

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation errors when using pipx without the required pipx/uv tools.
  * Error output now provides specific, actionable guidance (including which dependency to enable) instead of generic OS/ENOENT-style failures.
  * Updated behavior to fail early with clearer instructions when the expected pipx tooling is unavailable.
* **Tests**
  * Added an end-to-end coverage case for pipx installs when the uvx dependency is missing from `PATH`, validating the correct guidance across supported configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->