### PR TITLE
fix(oci): accept 201 Created on chunked blob PATCH (AWS ECR compat)

### DIFF
--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -1346,7 +1346,10 @@ impl Pusher {
                     .wrap_err("PATCH blob chunk")?;
                 check_upload_err(&err_slot, path)?;
                 let status = resp.status();
-                if status != StatusCode::ACCEPTED {
+                // Per the OCI dist-spec a chunk PATCH returns 202 Accepted, but
+                // AWS ECR answers with 201 Created. Accept both, as the
+                // finalizing PUT below already does.
+                if status != StatusCode::ACCEPTED && status != StatusCode::CREATED {
                     resp.error_for_status_ref()?;
                     let body = resp.text().await.unwrap_or_default();
                     bail!(


### PR DESCRIPTION
Fixes the issue from discussion #11271 (chunked `mise oci push` to AWS ECR fails `blob chunk upload failed: 201`).

### Root cause
In `upload_blob_once` (`src/oci/registry.rs`), the chunk `PATCH` response was accepted only on `202 Accepted`:

```rust
if status != StatusCode::ACCEPTED {
    resp.error_for_status_ref()?;
    bail!("blob chunk upload failed: {}{}\n{}", status.as_u16(), ...);
}
```

The OCI distribution spec has a chunk `PATCH` return `202`, but **AWS ECR returns `201 Created`**, so mise aborted. The finalizing `PUT` a few lines down already tolerates both:

```rust
if status != StatusCode::CREATED && status != StatusCode::ACCEPTED { ... }
```

### Fix
Accept `201` on the chunk `PATCH`, matching the `PUT` (one line):

```rust
if status != StatusCode::ACCEPTED && status != StatusCode::CREATED {
```

### Why it only bites some pushes
Only layers over `UPLOAD_CHUNK_SIZE` (64 MiB) take the chunked path; smaller layers use the monolithic `PUT` (already lenient). And blobs already on the registry are skipped by the `blob_exists()` HEAD, so it only surfaces on the first push of a large layer to a cold repo.

### Testing
You mentioned you don't have easy ECR access — I do, and reproduced it there:
- mise 2026.7.12, `mise oci push --image-dir … --update-index <acct>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>` with a layer > 64 MiB → `blob chunk upload failed: 201`.
- I'll post a direct before/after confirmation from a build of this branch against a real ECR repo as a comment on this PR.

I skipped adding a unit test for the chunk path deliberately — exercising it needs a >64 MiB fixture and the async upload-session plumbing, which felt disproportionate for a one-line status tweak. Happy to add a `mockito`-based test (the repo already dev-deps it) if you'd like one; just say the word and I'll match your preferred style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image uploads to AWS ECR by accepting successful chunk upload responses that use either `202 Accepted` or `201 Created`.
  * Reduced unnecessary upload retries and transient failures during chunked uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->