### PR TITLE
docs: fix dead gh CLI tool-stub example URL

### DIFF
--- a/docs/cli/generate/tool-stub.md
+++ b/docs/cli/generate/tool-stub.md
@@ -97,7 +97,7 @@ Examples:
 
 ```
 Generate a tool stub for a single URL:
-$ mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.336.0/gh_2.336.0_linux_amd64.tar.gz"
+$ mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"
 
 Generate a tool stub with platform-specific URLs:
 $ mise generate tool-stub ./bin/rg \

--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -97,7 +97,7 @@ When using platform-specific URLs, the tool stub generator will append new platf
 Generate a tool stub for a tool distributed via HTTP:
 
 ```bash
-mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.336.0/gh_2.336.0_linux_amd64.tar.gz"
+mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"
 ```
 
 This will:
@@ -176,7 +176,7 @@ Running the generation command produces an executable stub like:
 
 version = "latest"
 bin = "bin/gh"
-url = "https://github.com/cli/cli/releases/download/v2.336.0/gh_2.336.0_linux_amd64.tar.gz"
+url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"
 checksum = "blake3:a1b2c3d4e5f6..."
 size = 12345678
 ```

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1515,7 +1515,7 @@ to incrementally build cross-platform tool stubs.
 Examples:
 
     Generate a tool stub for a single URL:
-    $ mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.336.0/gh_2.336.0_linux_amd64.tar.gz"
+    $ mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"
 
     Generate a tool stub with platform-specific URLs:
     $ mise generate tool-stub ./bin/rg \

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -1698,7 +1698,7 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
 
         // Test Windows URL
         let url =
-            "https://github.com/cli/cli/releases/download/v2.336.0/gh_2.336.0_windows_amd64.zip";
+            "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_windows_amd64.zip";
         let platform = detect_platform_from_url(url).unwrap();
         assert_eq!(platform.os, AssetOs::Windows);
         assert_eq!(platform.arch, AssetArch::X64);

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -858,7 +858,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
     Generate a tool stub for a single URL:
-    $ <bold>mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.336.0/gh_2.336.0_linux_amd64.tar.gz"</bold>
+    $ <bold>mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"</bold>
 
     Generate a tool stub with platform-specific URLs:
     $ <bold>mise generate tool-stub ./bin/rg \


### PR DESCRIPTION
Tool-stub examples used `cli/cli` download URLs for non-existent `v2.336.0` (404). Update help/docs/usage plus the platform-detection test fixture to current `v2.96.0` assets (`gh_2.96.0_linux_amd64.tar.gz` / windows zip).

Proof: `gh api repos/cli/cli/releases/tags/v2.336.0` → 404; `v2.96.0` assets include those names; HEAD of linux tarball → 200.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated `mise generate tool-stub` examples to reference the `gh` release `v2.96.0`, including both download URLs and resulting filenames.
  - Kept CLI help text and developer docs aligned by synchronizing the example release artifacts across the documentation set.

- **Tests**
  - Updated the Windows platform-detection test URL to use the `v2.96.0` release asset while preserving the existing OS/architecture assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->