### PR TITLE
registry: add micro (aqua:micro-editor/micro)

### DIFF
--- a/registry/micro.toml
+++ b/registry/micro.toml
@@ -4,11 +4,26 @@ test = { cmd = "micro -version", expected = "Version: {{version}}" }
 
 [[backends]]
 full = "aqua:micro-editor/micro"
-platforms = ["linux-x64", "linux-arm64", "macos-x64", "macos-arm64", "windows-x64"]
+platforms = [
+  "linux-x64",
+  "linux-arm64",
+  "macos-x64",
+  "macos-arm64",
+  "windows-x64",
+]
 
 [[backends]]
 full = "github:micro-editor/micro"
-platforms = ["linux-x64", "linux-x86", "linux-arm64", "macos-x64", "macos-arm64", "windows-x64", "windows-x86", "windows-arm64"]
+platforms = [
+  "linux-x64",
+  "linux-x86",
+  "linux-arm64",
+  "macos-x64",
+  "macos-arm64",
+  "windows-x64",
+  "windows-x86",
+  "windows-arm64",
+]
 
 [backends.options]
 asset_pattern = "micro-{{ version }}-{% if os() == 'linux' %}{% if arch() == 'x64' %}linux64{% elif arch() == 'x86' %}linux32{% elif arch() == 'arm64' %}linux-arm64{% endif %}{% elif os() == 'macos' %}{% if arch() == 'x64' %}osx{% elif arch() == 'arm64' %}macos-arm64{% endif %}{% elif os() == 'windows' %}{% if arch() == 'x64' %}win64{% elif arch() == 'x86' %}win32{% elif arch() == 'arm64' %}win-arm64{% endif %}{% endif %}{% if os() == 'windows' %}.zip{% else %}.tar.gz{% endif %}"

--- a/registry/micro.toml
+++ b/registry/micro.toml
@@ -1,0 +1,15 @@
+description = "A modern and intuitive terminal-based text editor"
+os = ["linux", "macos", "windows"]
+test = { cmd = "micro -version", expected = "Version: {{version}}" }
+
+[[backends]]
+full = "aqua:micro-editor/micro"
+platforms = ["linux-x64", "linux-arm64", "macos-x64", "macos-arm64", "windows-x64"]
+
+[[backends]]
+full = "github:micro-editor/micro"
+platforms = ["linux-x64", "linux-x86", "linux-arm64", "macos-x64", "macos-arm64", "windows-x64", "windows-x86", "windows-arm64"]
+
+[backends.options]
+asset_pattern = "micro-{{ version }}-{% if os() == 'linux' %}{% if arch() == 'x64' %}linux64{% elif arch() == 'x86' %}linux32{% elif arch() == 'arm64' %}linux-arm64{% endif %}{% elif os() == 'macos' %}{% if arch() == 'x64' %}osx{% elif arch() == 'arm64' %}macos-arm64{% endif %}{% elif os() == 'windows' %}{% if arch() == 'x64' %}win64{% elif arch() == 'x86' %}win32{% elif arch() == 'arm64' %}win-arm64{% endif %}{% endif %}{% if os() == 'windows' %}.zip{% else %}.tar.gz{% endif %}"
+bin = "micro"

--- a/registry/micro.toml
+++ b/registry/micro.toml
@@ -4,26 +4,9 @@ test = { cmd = "micro -version", expected = "Version: {{version}}" }
 
 [[backends]]
 full = "aqua:micro-editor/micro"
-platforms = [
-  "linux-x64",
-  "linux-arm64",
-  "macos-x64",
-  "macos-arm64",
-  "windows-x64",
-]
 
 [[backends]]
 full = "github:micro-editor/micro"
-platforms = [
-  "linux-x64",
-  "linux-x86",
-  "linux-arm64",
-  "macos-x64",
-  "macos-arm64",
-  "windows-x64",
-  "windows-x86",
-  "windows-arm64",
-]
 
 [backends.options]
 asset_pattern = "micro-{{ version }}-{% if os() == 'linux' %}{% if arch() == 'x64' %}linux64{% elif arch() == 'x86' %}linux32{% elif arch() == 'arm64' %}linux-arm64{% endif %}{% elif os() == 'macos' %}{% if arch() == 'x64' %}osx{% elif arch() == 'arm64' %}macos-arm64{% endif %}{% elif os() == 'windows' %}{% if arch() == 'x64' %}win64{% elif arch() == 'x86' %}win32{% elif arch() == 'arm64' %}win-arm64{% endif %}{% endif %}{% if os() == 'windows' %}.zip{% else %}.tar.gz{% endif %}"

--- a/registry/micro.toml
+++ b/registry/micro.toml
@@ -1,12 +1,5 @@
 description = "A modern and intuitive terminal-based text editor"
+backends = [
+  "aqua:micro-editor/micro",
+]
 test = { cmd = "micro -version", expected = "Version: {{version}}" }
-
-[[backends]]
-full = "aqua:micro-editor/micro"
-
-[[backends]]
-full = "github:micro-editor/micro"
-
-[backends.options]
-asset_pattern = "micro-{{ version }}-{% if os() == 'linux' %}{% if arch() == 'x64' %}linux64{% elif arch() == 'x86' %}linux32{% elif arch() == 'arm64' %}linux-arm64{% endif %}{% elif os() == 'macos' %}{% if arch() == 'x64' %}osx{% elif arch() == 'arm64' %}macos-arm64{% endif %}{% elif os() == 'windows' %}{% if arch() == 'x64' %}win64{% elif arch() == 'x86' %}win32{% elif arch() == 'arm64' %}win-arm64{% endif %}{% endif %}{% if os() == 'windows' %}.zip{% else %}.tar.gz{% endif %}"
-bin = "micro"

--- a/registry/micro.toml
+++ b/registry/micro.toml
@@ -1,5 +1,4 @@
 description = "A modern and intuitive terminal-based text editor"
-os = ["linux", "macos", "windows"]
 test = { cmd = "micro -version", expected = "Version: {{version}}" }
 
 [[backends]]

--- a/registry/micro.toml
+++ b/registry/micro.toml
@@ -1,5 +1,3 @@
 description = "A modern and intuitive terminal-based text editor"
-backends = [
-  "aqua:micro-editor/micro",
-]
+backends = ["aqua:micro-editor/micro"]
 test = { cmd = "micro -version", expected = "Version: {{version}}" }

--- a/registry/micro.toml
+++ b/registry/micro.toml
@@ -1,3 +1,3 @@
-description = "A modern and intuitive terminal-based text editor"
 backends = ["aqua:micro-editor/micro"]
+description = "A modern and intuitive terminal-based text editor"
 test = { cmd = "micro -version", expected = "Version: {{version}}" }


### PR DESCRIPTION
Added configuration for the micro text editor with supported platforms and backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a registry manifest for the **micro** terminal text editor, including descriptive metadata.
  * Configured a backend entry for the **micro** editor source.
  * Added a version check that runs `micro -version` and verifies the reported `Version` value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->