### PR TITLE
chore: release 2026.7.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## [2026.7.16](https://github.com/jdx/mise/compare/v2026.7.15..v2026.7.16) - 2026-07-29
+
+### 🚀 Features
+
+- **(bootstrap)** consolidate dotfiles commands by @jdx in [#11436](https://github.com/jdx/mise/pull/11436)
+- **(bootstrap)** add bs command alias by @jdx in [#11439](https://github.com/jdx/mise/pull/11439)
+- **(cargo)** discover native binary release artifacts by @jdx in [#11433](https://github.com/jdx/mise/pull/11433)
+- **(dotfiles)** add unapply command by @jdx in [#11437](https://github.com/jdx/mise/pull/11437)
+- **(mcp)** serve mise's command effects to agents by @jdx in [#11389](https://github.com/jdx/mise/pull/11389)
+- **(spm)** add install_command option for source installs by @Marukome0743 in [#11369](https://github.com/jdx/mise/pull/11369)
+- **(task)** add command inputs to cache by @jdx in [#11381](https://github.com/jdx/mise/pull/11381)
+- **(task)** add per-run cache controls by @jdx in [#11396](https://github.com/jdx/mise/pull/11396)
+- **(task)** add workspace project graph model by @jdx in [#11400](https://github.com/jdx/mise/pull/11400)
+- **(task)** add configurable cache directory by @jdx in [#11399](https://github.com/jdx/mise/pull/11399)
+- **(task)** merge workspace provider graphs by @jdx in [#11418](https://github.com/jdx/mise/pull/11418)
+- **(task)** add workspace graph overrides by @jdx in [#11420](https://github.com/jdx/mise/pull/11420)
+- **(task)** detect workspace project cycles by @jdx in [#11422](https://github.com/jdx/mise/pull/11422)
+- **(task)** preserve workspace dependency traversal by @jdx in [#11424](https://github.com/jdx/mise/pull/11424)
+- **(task)** inspect workspace project graph by @jdx in [#11427](https://github.com/jdx/mise/pull/11427)
+- **(task)** discover node workspace projects by @jdx in [#11430](https://github.com/jdx/mise/pull/11430)
+- **(task)** discover node workspaces with aube by @jdx in [#11445](https://github.com/jdx/mise/pull/11445)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** preserve legacy root binary layouts by @jdx in [#11397](https://github.com/jdx/mise/pull/11397)
+- **(backend)** report version listing fetch failures instead of blaming filters by @jdx in [#11391](https://github.com/jdx/mise/pull/11391)
+- **(bootstrap)** honor MISE_VERSION and MISE_INSTALL_PATH in generated script by @JamBalaya56562 in [#11401](https://github.com/jdx/mise/pull/11401)
+- **(bootstrap)** detect mise-managed mas by @jdx in [#11429](https://github.com/jdx/mise/pull/11429)
+- **(brew)** maintain linked-keg compatibility records by @benjaminwestern in [#11371](https://github.com/jdx/mise/pull/11371)
+- **(brew)** adopt existing cask completion links by @jdx in [#11383](https://github.com/jdx/mise/pull/11383)
+- **(brew)** use download client for artifacts by @jdx in [#11428](https://github.com/jdx/mise/pull/11428)
+- **(config)** preserve trailing comments when rewriting mise.toml by @JamBalaya56562 in [#11415](https://github.com/jdx/mise/pull/11415)
+- **(dotfiles)** prune stale symlink-each links, add exclude patterns by @jdx in [#11388](https://github.com/jdx/mise/pull/11388)
+- **(generate)** respect quiet flags for git pre-commit by @Marukome0743 in [#11310](https://github.com/jdx/mise/pull/11310)
+- **(generate)** use current env directive syntax by @Marukome0743 in [#11311](https://github.com/jdx/mise/pull/11311)
+- **(generate)** resolve hooks in git worktrees by @Marukome0743 in [#11313](https://github.com/jdx/mise/pull/11313)
+- **(link)** reject selector-style link requests by @risu729 in [#11218](https://github.com/jdx/mise/pull/11218)
+- **(npm)** trust packages pinned in mise lockfiles by @jdx in [#11384](https://github.com/jdx/mise/pull/11384)
+- **(npm)** route aube prompts through mise by @jdx in [#11441](https://github.com/jdx/mise/pull/11441)
+- **(oci)** accept 201 Created on chunked blob PATCH (AWS ECR compat) by @fire-ant in [#11376](https://github.com/jdx/mise/pull/11376)
+- **(pipx)** don't suggest uv when uvx is disabled for the package by @JamBalaya56562 in [#11373](https://github.com/jdx/mise/pull/11373)
+- **(shim)** attribute missing executables to configured tools by @jdx in [#11398](https://github.com/jdx/mise/pull/11398)
+- **(task)** support mixed file task dependencies by @jdx in [#11382](https://github.com/jdx/mise/pull/11382)
+- **(task)** deduplicate equivalent task sources by @risu729 in [#11204](https://github.com/jdx/mise/pull/11204)
+- **(task)** support multi-line arrays in file task headers by @Marukome0743 in [#11412](https://github.com/jdx/mise/pull/11412)
+- **(task)** allow false to override script headers by @risu729 in [#11112](https://github.com/jdx/mise/pull/11112)
+- **(task)** treat missing content-hash baseline as stale by @JamBalaya56562 in [#11447](https://github.com/jdx/mise/pull/11447)
+- suspend progress while displaying prompts by @jdx in [#11421](https://github.com/jdx/mise/pull/11421)
+
+### 🚜 Refactor
+
+- **(cli)** defer process termination by @risu729 in [#11440](https://github.com/jdx/mise/pull/11440)
+
+### 📚 Documentation
+
+- **(self-update)** document how packagers disable self-update by @JamBalaya56562 in [#11446](https://github.com/jdx/mise/pull/11446)
+- **(task)** document external cache inputs by @jdx in [#11395](https://github.com/jdx/mise/pull/11395)
+- replace dead taobao node mirror example with npmmirror by @Bartok9 in [#11217](https://github.com/jdx/mise/pull/11217)
+- fix redactions glob example using removed nested syntax by @Marukome0743 in [#11448](https://github.com/jdx/mise/pull/11448)
+
+### ⚡ Performance
+
+- replace the hyperfine job with instruction counting by @jdx in [#11387](https://github.com/jdx/mise/pull/11387)
+
+### 📦️ Dependency Updates
+
+- use rust-aware cargo resolver by @jdx in [#11380](https://github.com/jdx/mise/pull/11380)
+- pin tree-sitter-iter to 1.27.0 by @jdx in [#11385](https://github.com/jdx/mise/pull/11385)
+- lock file maintenance by @renovate[bot] in [#11372](https://github.com/jdx/mise/pull/11372)
+- pin decmpfs to unbreak musl builds by @jdx in [5f6d3d7](https://github.com/jdx/mise/commit/5f6d3d7b65d8d9d3c62d2a35f934bd60bcc42089)
+- update ghcr.io/jdx/mise:deb docker digest to d6ed2ad by @renovate[bot] in [#11403](https://github.com/jdx/mise/pull/11403)
+- update ghcr.io/jdx/mise:alpine docker digest to 9b376ce by @renovate[bot] in [#11402](https://github.com/jdx/mise/pull/11402)
+- update node.js to v24.18.0 by @renovate[bot] in [#11410](https://github.com/jdx/mise/pull/11410)
+- update ghcr.io/jdx/mise:rpm docker digest to 55792a7 by @renovate[bot] in [#11404](https://github.com/jdx/mise/pull/11404)
+- update jdx/mise-action digest to 9e7f763 by @renovate[bot] in [#11405](https://github.com/jdx/mise/pull/11405)
+- update jdx/pr-closer action to v1.2.0 by @renovate[bot] in [#11409](https://github.com/jdx/mise/pull/11409)
+- update actions/checkout action to v7.0.1 by @renovate[bot] in [#11406](https://github.com/jdx/mise/pull/11406)
+- update dependency go to v1.26.5 by @renovate[bot] in [#11407](https://github.com/jdx/mise/pull/11407)
+- update dependency prettier to v3.9.6 by @renovate[bot] in [#11414](https://github.com/jdx/mise/pull/11414)
+- update dependency python to v3.14.6 by @renovate[bot] in [#11408](https://github.com/jdx/mise/pull/11408)
+- update docker/login-action digest to 371161b by @renovate[bot] in [#11416](https://github.com/jdx/mise/pull/11416)
+- update rust crate ubi to 0.10 by @renovate[bot] in [#11411](https://github.com/jdx/mise/pull/11411)
+
+### 📦 Registry
+
+- add micro ([aqua:micro-editor/micro](https://github.com/micro-editor/micro)) by @Jai-JAP in [#11378](https://github.com/jdx/mise/pull/11378)
+- add tealdeer ([aqua:tealdeer-rs/tealdeer github:tealdeer-rs/tealdeer](https://github.com/tealdeer-rs/tealdeer github:tealdeer-rs/tealdeer)) by @Jai-JAP in [#11390](https://github.com/jdx/mise/pull/11390)
+- add aws-cdk by @garysassano in [#11394](https://github.com/jdx/mise/pull/11394)
+
+### Chore
+
+- update aqua registry workspace exclusion by @risu729 in [#11349](https://github.com/jdx/mise/pull/11349)
+
+### New Contributors
+
+- @Jai-JAP made their first contribution in [#11390](https://github.com/jdx/mise/pull/11390)
+- @fire-ant made their first contribution in [#11376](https://github.com/jdx/mise/pull/11376)
+- @benjaminwestern made their first contribution in [#11371](https://github.com/jdx/mise/pull/11371)
+
 ## [2026.7.15](https://github.com/jdx/mise/compare/v2026.7.14..v2026.7.15) - 2026-07-27
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6313,7 +6313,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.15"
+version = "2026.7.16"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.15"
+version = "2026.7.16"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.15 macos-arm64 (2026-07-27)
+2026.7.16 macos-arm64 (2026-07-29)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_15.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_16.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_15.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_16.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -p usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_15.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_16.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_15.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_16.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.15";
+  version = "2026.7.16";
 
   src = lib.cleanSource ./.;
 

--- a/mise.lock
+++ b/mise.lock
@@ -137,6 +137,7 @@ checksum = "sha256:5419e7dbba887a4c1f7ae5675d86dd5d71fa3daa66053d16788e986c66078
 url = "https://github.com/jdx/aube/releases/download/v1.32.0/aube-v1.32.0-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/485325644"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.aube."platforms.linux-x64-baseline"]
 checksum = "sha256:5419e7dbba887a4c1f7ae5675d86dd5d71fa3daa66053d16788e986c66078126"
@@ -332,6 +333,7 @@ checksum = "sha256:180f970282986f27f7fa9ee216e4971e8dec3624869d4222f22f3e2535fcc
 url = "https://github.com/jdx/communique/releases/download/v1.2.3/communique-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/477186105"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.communique."platforms.linux-x64-baseline"]
 checksum = "sha256:180f970282986f27f7fa9ee216e4971e8dec3624869d4222f22f3e2535fccc58"
@@ -497,6 +499,7 @@ checksum = "sha256:1430efa4e44f58921e27db931820187bbac297b33c0dd7c11ae5e382fa11b
 url = "https://github.com/jdx/tak/releases/download/v0.0.5/tak-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/tak/releases/assets/491688672"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.linux-x64-baseline"]
 checksum = "sha256:1430efa4e44f58921e27db931820187bbac297b33c0dd7c11ae5e382fa11b93e"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.15
+Version: 2026.7.16
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.15"
+version: "2026.7.16"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "ec35b786bd16bbd68288b8a05a0ffe517369a202"
+  "tag": "b18b6506f5c88356b2f7a902a154b9a90080358d"
 }


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** consolidate dotfiles commands by @jdx in [#11436](https://github.com/jdx/mise/pull/11436)
- **(bootstrap)** add bs command alias by @jdx in [#11439](https://github.com/jdx/mise/pull/11439)
- **(cargo)** discover native binary release artifacts by @jdx in [#11433](https://github.com/jdx/mise/pull/11433)
- **(dotfiles)** add unapply command by @jdx in [#11437](https://github.com/jdx/mise/pull/11437)
- **(mcp)** serve mise's command effects to agents by @jdx in [#11389](https://github.com/jdx/mise/pull/11389)
- **(spm)** add install_command option for source installs by @Marukome0743 in [#11369](https://github.com/jdx/mise/pull/11369)
- **(task)** add command inputs to cache by @jdx in [#11381](https://github.com/jdx/mise/pull/11381)
- **(task)** add per-run cache controls by @jdx in [#11396](https://github.com/jdx/mise/pull/11396)
- **(task)** add workspace project graph model by @jdx in [#11400](https://github.com/jdx/mise/pull/11400)
- **(task)** add configurable cache directory by @jdx in [#11399](https://github.com/jdx/mise/pull/11399)
- **(task)** merge workspace provider graphs by @jdx in [#11418](https://github.com/jdx/mise/pull/11418)
- **(task)** add workspace graph overrides by @jdx in [#11420](https://github.com/jdx/mise/pull/11420)
- **(task)** detect workspace project cycles by @jdx in [#11422](https://github.com/jdx/mise/pull/11422)
- **(task)** preserve workspace dependency traversal by @jdx in [#11424](https://github.com/jdx/mise/pull/11424)
- **(task)** inspect workspace project graph by @jdx in [#11427](https://github.com/jdx/mise/pull/11427)
- **(task)** discover node workspace projects by @jdx in [#11430](https://github.com/jdx/mise/pull/11430)
- **(task)** discover node workspaces with aube by @jdx in [#11445](https://github.com/jdx/mise/pull/11445)

### 🐛 Bug Fixes

- **(aqua)** preserve legacy root binary layouts by @jdx in [#11397](https://github.com/jdx/mise/pull/11397)
- **(backend)** report version listing fetch failures instead of blaming filters by @jdx in [#11391](https://github.com/jdx/mise/pull/11391)
- **(bootstrap)** honor MISE_VERSION and MISE_INSTALL_PATH in generated script by @JamBalaya56562 in [#11401](https://github.com/jdx/mise/pull/11401)
- **(bootstrap)** detect mise-managed mas by @jdx in [#11429](https://github.com/jdx/mise/pull/11429)
- **(brew)** maintain linked-keg compatibility records by @benjaminwestern in [#11371](https://github.com/jdx/mise/pull/11371)
- **(brew)** adopt existing cask completion links by @jdx in [#11383](https://github.com/jdx/mise/pull/11383)
- **(brew)** use download client for artifacts by @jdx in [#11428](https://github.com/jdx/mise/pull/11428)
- **(config)** preserve trailing comments when rewriting mise.toml by @JamBalaya56562 in [#11415](https://github.com/jdx/mise/pull/11415)
- **(dotfiles)** prune stale symlink-each links, add exclude patterns by @jdx in [#11388](https://github.com/jdx/mise/pull/11388)
- **(generate)** respect quiet flags for git pre-commit by @Marukome0743 in [#11310](https://github.com/jdx/mise/pull/11310)
- **(generate)** use current env directive syntax by @Marukome0743 in [#11311](https://github.com/jdx/mise/pull/11311)
- **(generate)** resolve hooks in git worktrees by @Marukome0743 in [#11313](https://github.com/jdx/mise/pull/11313)
- **(link)** reject selector-style link requests by @risu729 in [#11218](https://github.com/jdx/mise/pull/11218)
- **(npm)** trust packages pinned in mise lockfiles by @jdx in [#11384](https://github.com/jdx/mise/pull/11384)
- **(npm)** route aube prompts through mise by @jdx in [#11441](https://github.com/jdx/mise/pull/11441)
- **(oci)** accept 201 Created on chunked blob PATCH (AWS ECR compat) by @fire-ant in [#11376](https://github.com/jdx/mise/pull/11376)
- **(pipx)** don't suggest uv when uvx is disabled for the package by @JamBalaya56562 in [#11373](https://github.com/jdx/mise/pull/11373)
- **(shim)** attribute missing executables to configured tools by @jdx in [#11398](https://github.com/jdx/mise/pull/11398)
- **(task)** support mixed file task dependencies by @jdx in [#11382](https://github.com/jdx/mise/pull/11382)
- **(task)** deduplicate equivalent task sources by @risu729 in [#11204](https://github.com/jdx/mise/pull/11204)
- **(task)** support multi-line arrays in file task headers by @Marukome0743 in [#11412](https://github.com/jdx/mise/pull/11412)
- **(task)** allow false to override script headers by @risu729 in [#11112](https://github.com/jdx/mise/pull/11112)
- **(task)** treat missing content-hash baseline as stale by @JamBalaya56562 in [#11447](https://github.com/jdx/mise/pull/11447)
- suspend progress while displaying prompts by @jdx in [#11421](https://github.com/jdx/mise/pull/11421)

### 🚜 Refactor

- **(cli)** defer process termination by @risu729 in [#11440](https://github.com/jdx/mise/pull/11440)

### 📚 Documentation

- **(self-update)** document how packagers disable self-update by @JamBalaya56562 in [#11446](https://github.com/jdx/mise/pull/11446)
- **(task)** document external cache inputs by @jdx in [#11395](https://github.com/jdx/mise/pull/11395)
- replace dead taobao node mirror example with npmmirror by @Bartok9 in [#11217](https://github.com/jdx/mise/pull/11217)
- fix redactions glob example using removed nested syntax by @Marukome0743 in [#11448](https://github.com/jdx/mise/pull/11448)

### ⚡ Performance

- replace the hyperfine job with instruction counting by @jdx in [#11387](https://github.com/jdx/mise/pull/11387)

### 📦️ Dependency Updates

- use rust-aware cargo resolver by @jdx in [#11380](https://github.com/jdx/mise/pull/11380)
- pin tree-sitter-iter to 1.27.0 by @jdx in [#11385](https://github.com/jdx/mise/pull/11385)
- lock file maintenance by @renovate[bot] in [#11372](https://github.com/jdx/mise/pull/11372)
- pin decmpfs to unbreak musl builds by @jdx in [5f6d3d7](https://github.com/jdx/mise/commit/5f6d3d7b65d8d9d3c62d2a35f934bd60bcc42089)
- update ghcr.io/jdx/mise:deb docker digest to d6ed2ad by @renovate[bot] in [#11403](https://github.com/jdx/mise/pull/11403)
- update ghcr.io/jdx/mise:alpine docker digest to 9b376ce by @renovate[bot] in [#11402](https://github.com/jdx/mise/pull/11402)
- update node.js to v24.18.0 by @renovate[bot] in [#11410](https://github.com/jdx/mise/pull/11410)
- update ghcr.io/jdx/mise:rpm docker digest to 55792a7 by @renovate[bot] in [#11404](https://github.com/jdx/mise/pull/11404)
- update jdx/mise-action digest to 9e7f763 by @renovate[bot] in [#11405](https://github.com/jdx/mise/pull/11405)
- update jdx/pr-closer action to v1.2.0 by @renovate[bot] in [#11409](https://github.com/jdx/mise/pull/11409)
- update actions/checkout action to v7.0.1 by @renovate[bot] in [#11406](https://github.com/jdx/mise/pull/11406)
- update dependency go to v1.26.5 by @renovate[bot] in [#11407](https://github.com/jdx/mise/pull/11407)
- update dependency prettier to v3.9.6 by @renovate[bot] in [#11414](https://github.com/jdx/mise/pull/11414)
- update dependency python to v3.14.6 by @renovate[bot] in [#11408](https://github.com/jdx/mise/pull/11408)
- update docker/login-action digest to 371161b by @renovate[bot] in [#11416](https://github.com/jdx/mise/pull/11416)
- update rust crate ubi to 0.10 by @renovate[bot] in [#11411](https://github.com/jdx/mise/pull/11411)

### 📦 Registry

- add micro ([aqua:micro-editor/micro](https://github.com/micro-editor/micro)) by @Jai-JAP in [#11378](https://github.com/jdx/mise/pull/11378)
- add tealdeer ([aqua:tealdeer-rs/tealdeer github:tealdeer-rs/tealdeer](https://github.com/tealdeer-rs/tealdeer github:tealdeer-rs/tealdeer)) by @Jai-JAP in [#11390](https://github.com/jdx/mise/pull/11390)
- add aws-cdk by @garysassano in [#11394](https://github.com/jdx/mise/pull/11394)

### Chore

- update aqua registry workspace exclusion by @risu729 in [#11349](https://github.com/jdx/mise/pull/11349)

### New Contributors

- @Jai-JAP made their first contribution in [#11390](https://github.com/jdx/mise/pull/11390)
- @fire-ant made their first contribution in [#11376](https://github.com/jdx/mise/pull/11376)
- @benjaminwestern made their first contribution in [#11371](https://github.com/jdx/mise/pull/11371)