### PR TITLE
chore(deps): use rust-aware cargo resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "3"
 members = [
   "crates/vfox",
   "crates/aqua-registry",


### PR DESCRIPTION
## Summary
- explicitly select Cargo resolver version 3 at the workspace root
- make Rust-version-aware dependency selection intentional and visible

## Why
Resolver 3 prefers dependency releases compatible with the package's declared `rust-version`, reducing accidental MSRV breakage during lockfile maintenance. Edition 2024 already implies resolver 3 for this workspace; declaring it explicitly prevents that policy from depending on edition inference.

## Validation
- `cargo metadata --locked --no-deps --format-version 1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single manifest policy line with no code or lockfile changes; behavior should match what edition 2024 already implied.
> 
> **Overview**
> Sets **`resolver = "3"`** on the workspace root in `Cargo.toml`, making Cargo’s Rust-version-aware dependency resolution explicit instead of relying on edition 2024 inference.
> 
> Resolver 3 favors crate versions compatible with each package’s declared **`rust-version`** (e.g. `1.91` on the root crate), which should reduce accidental MSRV breakage when updating the lockfile. No dependency or lockfile changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0889be598cb323b41eaf30fc9f20c4e7b98434d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependency resolution configuration for improved consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->