### PR TITLE
fix(task): support mixed file task dependencies

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -76,7 +76,7 @@ run = "cargo build"
 
 ### `depends`
 
-- **Type**: `string | string[] | { task: string, args?: string[], env?: { [key]: string } }[]`
+- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string } })[]`
 
 Tasks that must be run before this task. This is a list of task names or aliases. Arguments can be
 passed to the task, e.g.: `depends = ["build --release"]`. If multiple tasks have the same dependency,
@@ -127,6 +127,17 @@ depends = [
 run = "./deploy.sh"
 ```
 
+String and structured dependencies can be mixed in the same array:
+
+```mise-toml
+[tasks.check]
+depends = [
+  "lint",
+  { task = "test", env = { CI = "true" } },
+]
+run = "echo checks complete"
+```
+
 Note: These environment variables are passed only to the specified dependency, not to the current task or other dependencies.
 
 #### Passing parent task arguments to dependencies
@@ -174,7 +185,7 @@ forward its resolved arguments to its own dependencies.
 
 ### `depends_post`
 
-- **Type**: `string | string[] | { task: string, args?: string[], env?: { [key]: string } }[]`
+- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string } })[]`
 
 Like `depends` but these tasks run _after_ this task and its dependencies complete. For example, you
 may want a `postlint` task that you can run individually without also running `lint`:
@@ -191,7 +202,7 @@ Supports the same argument and environment variable syntax as `depends`.
 
 ### `wait_for`
 
-- **Type**: `string | string[] | { task: string, args?: string[], env?: { [key]: string } }[]`
+- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string } })[]`
 
 Similar to `depends`, it will wait for these tasks to complete before running however they won't be
 added to the list of tasks to run. This is essentially optional dependencies.

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -684,6 +684,17 @@ fn parse_mise_header_toml(body: &str) -> Result<Vec<toml::Value>> {
         .collect()
 }
 
+fn parse_task_dependencies(parser: &mut TrackingTomlParser<'_>, key: &str) -> Result<Vec<TaskDep>> {
+    parser
+        .get_raw(key)
+        .map(|value| {
+            deserialize_arr::<_, Vec<TaskDep>, TaskDep>(value.clone())
+                .map_err(|e| eyre!("failed to parse {key} field in task header: {e}"))
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
+}
+
 /// Whether a task include file contains Tera template syntax only after TOML
 /// decoding (e.g. `{{` written as `{{`). Such escapes pass a
 /// raw-text scan but decode to real templates that render — and can `exec()` —
@@ -958,9 +969,9 @@ impl Task {
                     .map_err(|e| eyre!("failed to parse confirm field in task header: {e}"))
             })
             .transpose()?;
-        task.depends = p.parse_array("depends").unwrap_or_default();
-        task.depends_post = p.parse_array("depends_post").unwrap_or_default();
-        task.wait_for = p.parse_array("wait_for").unwrap_or_default();
+        task.depends = parse_task_dependencies(&mut p, "depends")?;
+        task.depends_post = parse_task_dependencies(&mut p, "depends_post")?;
+        task.wait_for = parse_task_dependencies(&mut p, "wait_for")?;
         task.env = p.parse_env("env")?.unwrap_or_default();
         task.dir = p.parse_str("dir");
         task.hide = !file::is_executable(path) || p.parse_bool("hide").unwrap_or_default();
@@ -4018,6 +4029,50 @@ echo "test"
             script_lines,
             parsed_fields
         );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_parses_structured_file_task_dependencies() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let tasks_dir = temp_dir.path().join("tasks");
+        fs::create_dir(&tasks_dir).unwrap();
+        let task_file = tasks_dir.join("structured-dependencies");
+        fs::write(
+            &task_file,
+            r#"#!/usr/bin/env bash
+#MISE depends=["simple", {task="structured", args=["--flag"], env={MODE="test"}}]
+#MISE depends_post=[["cleanup", "--all"], {task="notify"}]
+#MISE wait_for=["setup", {task="service", env={PORT="3000"}}]
+echo "test"
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(&task_file, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let config = Config::get().await.unwrap();
+        let task = Task::from_path(&config, &task_file, &tasks_dir, temp_dir.path())
+            .await
+            .unwrap();
+
+        assert_eq!(task.depends.len(), 2);
+        assert_eq!(task.depends[0].task, "simple");
+        assert_eq!(task.depends[1].task, "structured");
+        assert_eq!(task.depends[1].args, ["--flag"]);
+        assert_eq!(task.depends[1].env.get("MODE").unwrap(), "test");
+
+        assert_eq!(task.depends_post.len(), 2);
+        assert_eq!(task.depends_post[0].task, "cleanup");
+        assert_eq!(task.depends_post[0].args, ["--all"]);
+        assert_eq!(task.depends_post[1].task, "notify");
+
+        assert_eq!(task.wait_for.len(), 2);
+        assert_eq!(task.wait_for[0].task, "setup");
+        assert_eq!(task.wait_for[1].task, "service");
+        assert_eq!(task.wait_for[1].env.get("PORT").unwrap(), "3000");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- clarify that `depends`, `depends_post`, and `wait_for` accept heterogeneous arrays
- add an example mixing string and structured dependency entries
- make file-task `#MISE` headers parse the same string, nested-array, and structured dependency forms as TOML tasks
- add regression coverage for all three file-task dependency fields

## Why

The documented type notation implied that dependency arrays had to contain either only strings or only structured objects. While regular TOML tasks and the JSON schema already supported heterogeneous arrays, file-task headers used a separate string-only parser that silently discarded nested arrays and structured objects.

This resolves the ambiguity raised in discussion #11370 and addresses the review finding that the documented forms were unsafe in file-task headers.

## Validation

- `mise run docs:build`
- `mise run format` / lint-fix pipeline, including `cargo check --all-features`
- `cargo test test_parses_structured_file_task_dependencies`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated task configuration guidance to support mixing simple string and structured dependency entries.
  * Clarified accepted formats for `depends`, `depends_post`, and `wait_for`.
  * Added an example demonstrating combined dependency formats in a single configuration.
* **Bug Fixes**
  * Improved task dependency parsing to provide field-specific error messages when configuration is invalid.
* **Tests**
  * Added coverage for structured dependency entries in task headers, including mixed formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->