### PR TITLE
fix(npm): trust packages pinned in mise lockfiles

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -334,6 +334,10 @@ The exemption is scoped to the package you asked for, written to the aube instal
 `allowedUnpopularPackages=<package>`. Transitive dependencies stay gated, and the threshold itself
 is left alone — so this cannot silently admit an unpopular dependency you did not choose.
 
+An npm tool resolved from `mise.lock` is trusted automatically for this download-count check, so
+reproducing an existing lockfile does not require `allow_low_downloads`. The explicit option is
+still required to approve the first unlocked install.
+
 Download count is a popularity signal, not a safety one: a low count means few others have vetted
 the package, so prefer confirming you trust the publisher over reaching for this. It does not affect
 `npm`, `pnpm`, or `bun` installs.

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -925,7 +925,13 @@ impl NPMBackend {
         crate::file::create_dir_all(&install_path)?;
 
         let allow_builds = options.allow_builds()?;
-        self.write_aube_embed_project(&install_path, ctx.before_date, options, &allow_builds)?;
+        self.write_aube_embed_project(
+            &install_path,
+            ctx.before_date,
+            options,
+            &allow_builds,
+            tv.resolved_from_lockfile(),
+        )?;
 
         if let Some(args) = options.aube_args() {
             warn!(
@@ -992,7 +998,12 @@ impl NPMBackend {
             .dependency_path_for_install(&ctx.config, Some(&ctx.ts), AUBE_PROGRAM)
             .await
             .unwrap_or_else(|| AUBE_PROGRAM.into());
-        self.write_aube_cli_project(&tv.install_path(), ctx.before_date, options)?;
+        self.write_aube_cli_project(
+            &tv.install_path(),
+            ctx.before_date,
+            options,
+            tv.resolved_from_lockfile(),
+        )?;
         let mut cmd = CmdLineRunner::new(aube_program)
             .arg("add")
             .arg("--global")
@@ -1057,6 +1068,7 @@ impl NPMBackend {
         before_date: Option<Timestamp>,
         options: &NpmOptions,
         allow_builds: &AllowBuilds,
+        resolved_from_lockfile: bool,
     ) -> Result<()> {
         // Validate the fallible options before writing anything, so a malformed
         // value fails without leaving a half-written project dir behind.
@@ -1091,11 +1103,12 @@ impl NPMBackend {
         if let Some(excludes) = trust_policy_excludes {
             npmrc.push_str(&format!("trustPolicyExclude={excludes}\n"));
         }
-        if allow_low_downloads {
+        if allow_low_downloads || resolved_from_lockfile {
             // Exempt only this tool's own package, not the whole install, so a
             // transitive dependency below the threshold still fails the gate.
             // aube gates the directly-requested packages, which for mise is
-            // always exactly this one.
+            // always exactly this one. A matching mise.lock pin is itself
+            // approval for the download-count check.
             npmrc.push_str(&format!("allowedUnpopularPackages={}\n", self.tool_name()));
         }
         crate::file::write(install_path.join(".npmrc"), npmrc)?;
@@ -1109,6 +1122,7 @@ impl NPMBackend {
         install_path: &Path,
         before_date: Option<Timestamp>,
         options: &NpmOptions<'_>,
+        resolved_from_lockfile: bool,
     ) -> Result<()> {
         let trust_policy_excludes = options.aube_trust_policy_excludes_npmrc_value()?;
         let allow_low_downloads = options.allow_low_downloads()?;
@@ -1130,7 +1144,7 @@ impl NPMBackend {
         if let Some(excludes) = trust_policy_excludes {
             npmrc.push_str(&format!("trustPolicyExclude={excludes}\n"));
         }
-        if allow_low_downloads {
+        if allow_low_downloads || resolved_from_lockfile {
             npmrc.push_str(&format!("allowedUnpopularPackages={}\n", self.tool_name()));
         }
         crate::file::write(install_path.join(".npmrc"), npmrc)?;
@@ -2161,7 +2175,7 @@ mod tests {
         let allow_builds = options.allow_builds().unwrap();
 
         backend
-            .write_aube_embed_project(&install_path, None, &options, &allow_builds)
+            .write_aube_embed_project(&install_path, None, &options, &allow_builds, false)
             .unwrap();
 
         // Trust-policy excludes go in .npmrc for the resolver to read.
@@ -2187,14 +2201,10 @@ mod tests {
             "trust_policy_excludes".to_string(),
             toml::Value::String("undici".into()),
         );
-        raw_options.opts.insert(
-            "allow_low_downloads".to_string(),
-            toml::Value::Boolean(true),
-        );
         let options = NpmOptions::new(&raw_options);
 
         backend
-            .write_aube_cli_project(&install_path, None, &options)
+            .write_aube_cli_project(&install_path, None, &options, true)
             .unwrap();
 
         let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
@@ -2227,7 +2237,7 @@ mod tests {
         let allow_builds = options.allow_builds().unwrap();
 
         backend
-            .write_aube_embed_project(&install_path, None, &options, &allow_builds)
+            .write_aube_embed_project(&install_path, None, &options, &allow_builds, false)
             .unwrap();
 
         // Only the requested package is exempt — not a wildcard, so a
@@ -2254,7 +2264,7 @@ mod tests {
 
         assert!(
             backend
-                .write_aube_embed_project(&install_path, None, &options, &allow_builds)
+                .write_aube_embed_project(&install_path, None, &options, &allow_builds, false)
                 .is_err()
         );
         // Options are validated up front, so the aborted call leaves no
@@ -2294,11 +2304,29 @@ mod tests {
         let allow_builds = options.allow_builds().unwrap();
 
         backend
-            .write_aube_embed_project(&install_path, None, &options, &allow_builds)
+            .write_aube_embed_project(&install_path, None, &options, &allow_builds, false)
             .unwrap();
 
         let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
         assert!(!npmrc.contains("allowedUnpopularPackages"));
+    }
+
+    #[test]
+    fn test_write_aube_embed_project_trusts_mise_lockfile_pin() {
+        let backend = create_npm_backend("bibtex-tidy");
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("npm-bibtex-tidy").join("1.14.0");
+        crate::file::create_dir_all(&install_path).unwrap();
+        let raw_options = ToolVersionOptions::default();
+        let options = NpmOptions::new(&raw_options);
+        let allow_builds = options.allow_builds().unwrap();
+
+        backend
+            .write_aube_embed_project(&install_path, None, &options, &allow_builds, true)
+            .unwrap();
+
+        let npmrc = std::fs::read_to_string(install_path.join(".npmrc")).unwrap();
+        assert!(npmrc.contains("allowedUnpopularPackages=bibtex-tidy\n"));
     }
 
     #[test]

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -41,6 +41,7 @@ pub struct ToolVersion {
     /// Effective install-before cutoff used to resolve this version.
     pub before_date: Option<Timestamp>,
     locked: bool,
+    resolved_from_lockfile: bool,
     pub lock_platforms: BTreeMap<String, PlatformInfo>,
     pub install_path: Option<PathBuf>,
     /// Conda packages resolved during installation: (platform, basename) -> CondaPackageInfo
@@ -70,6 +71,7 @@ impl ToolVersion {
             version,
             before_date: None,
             locked: false,
+            resolved_from_lockfile: false,
             lock_platforms: Default::default(),
             install_path: None,
             conda_packages: Default::default(),
@@ -154,8 +156,13 @@ impl ToolVersion {
         // the original request options so config/core install behavior survives.
         let mut tv = Self::new(request, lt.version);
         tv.locked = true;
+        tv.resolved_from_lockfile = true;
         tv.lock_platforms = lt.platforms;
         tv
+    }
+
+    pub(crate) fn resolved_from_lockfile(&self) -> bool {
+        self.resolved_from_lockfile
     }
 
     pub fn ba(&self) -> &BackendArg {
@@ -960,6 +967,7 @@ mod tests {
 
         assert_eq!(tv.version, "11.17.0");
         assert!(tv.locked);
+        assert!(tv.resolved_from_lockfile());
         assert_eq!(tv.ba().full_without_opts(), "npm:npm");
         assert_eq!(options.depends, Some(vec!["node".to_string()]));
         assert_eq!(
@@ -1147,6 +1155,7 @@ mod tests {
             source: ToolSource::Argument,
         };
         let tv = ToolVersion::new(request, "3.14.6".into());
+        assert!(!tv.resolved_from_lockfile());
 
         // Without locking, runtime_path() follows the stale fuzzy runtime symlink, so
         // it does NOT resolve to the version just installed -- the bug behavior. (This
@@ -1157,6 +1166,7 @@ mod tests {
         // fuzzy runtime symlink, so the postinstall hook sees 3.14.6 (#10347).
         assert_eq!(tv.clone().with_locked().runtime_path(), install_path);
         assert_eq!(tv.clone().with_locked().runtime_path(), tv.install_path());
+        assert!(!tv.with_locked().resolved_from_lockfile());
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- track whether a tool version was actually resolved from `mise.lock`
- treat a matching npm lockfile pin as approval for aube's low-download popularity gate
- apply the exemption to both embedded aube and `aube_cli`, scoped to the requested package only
- keep first-time unlocked installs and OSV malicious-package checks unchanged

## Context

This fixes the hidden embedded prompt reported in https://github.com/jdx/mise/discussions/11375 without requiring every locked npm tool to repeat `allow_low_downloads = true` in configuration.

The corresponding aube behavior for native npm project lockfiles is in https://github.com/jdx/aube/pull/1143.

## Validation

- `mise run lint`
- `mise run test:unit -- backend::npm::tests::test_write_aube_`
- `mise run test:unit -- toolset::tool_version::tests::`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2406f88d84a3ed1fc0fd5ea0bc218f9069c4e5cf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lockfile-pinned npm tools are now automatically trusted during low-download-count checks.
  * Reproducing an existing lockfile no longer requires `allow_low_downloads`.

* **Bug Fixes**
  * First-time unlocked installs continue to require explicit approval through `allow_low_downloads`.

* **Documentation**
  * Clarified when `allow_low_downloads` is required and when lockfile resolution provides automatic approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->