### PR TITLE
fix(deps): pin tree-sitter-iter to 1.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6472,6 +6472,7 @@ dependencies = [
  "tokio-util",
  "toml 1.1.3+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
+ "tree-sitter-iter",
  "ubi",
  "url",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,8 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 toml = { version = "1.0", features = ["parse", "preserve_order"] }
 toml_edit = { version = "0.25", features = ["parse"] }
+# 1.28.0 requires Rust 1.97, newer than mise's MSRV.
+tree-sitter-iter = "=1.27.0"
 ubi = { version = "0.9", default-features = false }
 url = "2"
 urlencoding = "2"
@@ -323,7 +325,14 @@ pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-x64{ ar
 pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-armv7{ archive-suffix }"
 
 [package.metadata.cargo-machete]
-ignored = ["aws-lc-rs", "built", "cfg_aliases", "openssl", "phf_codegen"]
+ignored = [
+  "aws-lc-rs",
+  "built",
+  "cfg_aliases",
+  "openssl",
+  "phf_codegen",
+  "tree-sitter-iter",
+]
 
 [package.metadata.release]
 pre-release-replacements = [


### PR DESCRIPTION
## Summary
- pin `tree-sitter-iter` to exactly 1.27.0
- document why the pin is required
- exempt the deliberate transitive pin from cargo-machete's unused-dependency check

## Root cause

Lock-file maintenance updated `tree-sitter-iter` to 1.28.0 through `yamlpath`. That release requires Rust 1.97, exceeding mise's declared Rust 1.91 MSRV and causing the Linux, macOS, and benchmark builds in #11372 to fail before compilation.

## Impact

Future lock-file refreshes will retain 1.27.0 until the pin is deliberately removed, preserving mise's MSRV.

## Validation
- `cargo update -p tree-sitter-iter --dry-run -v`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo machete --with-metadata`
- `cargo check -p mise --locked`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version constraint only; no application logic changes, with low blast radius beyond reproducible lock resolution.
> 
> **Overview**
> Pins **`tree-sitter-iter`** to **`=1.27.0`** in the root manifest and lockfile so lock maintenance cannot pull **1.28.0** (Rust **1.97**), which breaks builds against mise’s **Rust 1.91** MSRV after transitive updates via **`yamlpath`**.
> 
> Adds a short comment documenting the pin and lists **`tree-sitter-iter`** under **`cargo-machete`** ignores so the deliberate version override is not flagged as an unused direct dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3619e207fe92683f58151161434873b466b11046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->