### PR TITLE
feat(mcp): serve mise's command effects to agents

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -23,6 +23,7 @@ Resources available:
 - mise://config - Show configuration files and project root
 
 Tools available:
+- list_commands - Every mise command, with its declared effect on the world
 - install_tool - Install a tool with an optional version (not yet implemented)
 - run_task - Execute a mise task with optional arguments
 
@@ -57,6 +58,8 @@ $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion
 - mise://config - Show configuration info
 
 # Tools available:
+- list_commands - Every mise command and what running it does
+  Example: {"include_hidden": false}
 - install_tool - Install a tool (not yet implemented)
 - run_task - Execute a mise task with optional arguments
   Example: {"task": "build", "args": ["--verbose"]}

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2115,6 +2115,7 @@ Resources available:
 - mise://config - Show configuration files and project root
 
 Tools available:
+- list_commands - Every mise command, with its declared effect on the world
 - install_tool - Install a tool with an optional version (not yet implemented)
 - run_task - Execute a mise task with optional arguments
 
@@ -2149,6 +2150,8 @@ Examples:
     - mise://config - Show configuration info
 
     # Tools available:
+    - list_commands - Every mise command and what running it does
+      Example: {"include_hidden": false}
     - install_tool - Install a tool (not yet implemented)
     - run_task - Execute a mise task with optional arguments
       Example: {"task": "build", "args": ["--verbose"]}

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Run Model Context Protocol (MCP) server
 ///
@@ -38,6 +39,7 @@ use std::collections::HashMap;
 /// - mise://config - Show configuration files and project root
 ///
 /// Tools available:
+/// - list_commands - Every mise command, with its declared effect on the world
 /// - install_tool - Install a tool with an optional version (not yet implemented)
 /// - run_task - Execute a mise task with optional arguments
 ///
@@ -50,6 +52,9 @@ pub struct Mcp {}
 #[derive(Clone)]
 struct MiseServer {
     tool_router: ToolRouter<Self>,
+    /// mise's own usage spec, built once. Deriving it walks the whole clap
+    /// command tree, which is not work to repeat per request.
+    spec: Arc<usage::Spec>,
 }
 
 /// Parameters for installing a tool
@@ -63,6 +68,15 @@ struct InstallToolParams {
     version: Option<String>,
 }
 
+/// Parameters for listing mise's commands
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[schemars(crate = "rmcp::schemars")]
+struct ListCommandsParams {
+    /// Include commands hidden from help. They are still runnable.
+    #[serde(default)]
+    include_hidden: bool,
+}
+
 /// Parameters for running a mise task
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[schemars(crate = "rmcp::schemars")]
@@ -74,12 +88,62 @@ struct RunTaskParams {
     args: Vec<String>,
 }
 
+/// Structured data as pretty JSON text, which is what the other tools here
+/// return and what clients that only read `content` can use.
+fn json_result(value: Value) -> std::result::Result<CallToolResult, ErrorData> {
+    let text = serde_json::to_string_pretty(&value).map_err(|e| ErrorData {
+        code: ErrorCode::INTERNAL_ERROR,
+        message: Cow::Owned(format!("Failed to serialize response: {e}")),
+        data: None,
+    })?;
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+}
+
 #[tool_router]
 impl MiseServer {
     fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
+            spec: Arc::new(crate::cli::usage::spec()),
         }
+    }
+
+    /// Every mise command, with what running it does to the world
+    #[tool(
+        description = "Every mise command, with what running it does: `read` only inspects state, `write` changes it, `destructive` removes something that is work to get back. A command with no effect listed is unclassified — treat it as needing confirmation, not as safe. Call this before running an unfamiliar mise command."
+    )]
+    async fn list_commands(
+        &self,
+        Parameters(ListCommandsParams { include_hidden }): Parameters<ListCommandsParams>,
+    ) -> std::result::Result<CallToolResult, ErrorData> {
+        fn walk(
+            cmd: &usage::SpecCommand,
+            path: &mut Vec<String>,
+            include_hidden: bool,
+            out: &mut Vec<Value>,
+        ) {
+            for (name, sub) in &cmd.subcommands {
+                // A hidden command takes its subtree with it: clap does not
+                // propagate `hide` to children, so a visible child of a hidden
+                // parent is still not a documented path.
+                if sub.hide && !include_hidden {
+                    continue;
+                }
+                path.push(name.clone());
+                out.push(json!({
+                    "command": path.join(" "),
+                    "help": sub.help,
+                    "effect": sub.effect.map(|e| e.as_str()),
+                    "hidden": sub.hide,
+                }));
+                walk(sub, path, include_hidden, out);
+                path.pop();
+            }
+        }
+
+        let mut commands = vec![];
+        walk(&self.spec.cmd, &mut vec![], include_hidden, &mut commands);
+        json_result(json!({ "bin": "mise", "commands": commands }))
     }
 
     /// Install a tool with an optional version
@@ -177,7 +241,13 @@ impl ServerHandler for MiseServer {
         ServerInfo::new(capabilities)
             .with_protocol_version(ProtocolVersion::V_2025_03_26)
             .with_server_info(Implementation::new("mise", env!("CARGO_PKG_VERSION")))
-            .with_instructions("Mise MCP server provides access to tools, tasks, environment variables, and configuration")
+            .with_instructions(
+                "Mise MCP server provides access to tools, tasks, environment variables, and \
+                 configuration. Call list_commands before running an unfamiliar mise command: \
+                 every command declares its effect on the world (`read`, `write`, \
+                 `destructive`), and a command with no effect listed is unclassified rather \
+                 than safe.",
+            )
     }
 
     async fn list_resources(
@@ -474,6 +544,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     - <bold>mise://config</bold> - Show configuration info
 
     # Tools available:
+    - <bold>list_commands</bold> - Every mise command and what running it does
+      Example: {"include_hidden": false}
     - <bold>install_tool</bold> - Install a tool (not yet implemented)
     - <bold>run_task</bold> - Execute a mise task with optional arguments
       Example: {"task": "build", "args": ["--verbose"]}
@@ -483,6 +555,89 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The text of every command row `list_commands` returns.
+    async fn commands(include_hidden: bool) -> Vec<Value> {
+        let res = MiseServer::new()
+            .list_commands(Parameters(ListCommandsParams { include_hidden }))
+            .await
+            .unwrap();
+        let ContentBlock::Text(text) = &res.content[0] else {
+            panic!("expected text content");
+        };
+        serde_json::from_str::<Value>(&text.text).unwrap()["commands"]
+            .as_array()
+            .unwrap()
+            .clone()
+    }
+
+    fn find<'a>(commands: &'a [Value], path: &str) -> &'a Value {
+        commands
+            .iter()
+            .find(|c| c["command"] == path)
+            .unwrap_or_else(|| panic!("no command {path:?}"))
+    }
+
+    #[tokio::test]
+    async fn list_commands_carries_the_declared_effects() {
+        // The point of the tool. If these come back null the classification in
+        // command_effects is not reaching the agent that needs it.
+        let commands = commands(false).await;
+        assert_eq!(find(&commands, "ls")["effect"], "read");
+        assert_eq!(find(&commands, "install")["effect"], "write");
+        assert_eq!(find(&commands, "prune")["effect"], "destructive");
+    }
+
+    #[tokio::test]
+    async fn list_commands_reaches_nested_paths() {
+        let commands = commands(false).await;
+        assert_eq!(find(&commands, "tasks ls")["effect"], "read");
+        assert!(find(&commands, "tasks ls")["help"].is_string());
+    }
+
+    #[tokio::test]
+    async fn hidden_subtrees_are_excluded_by_default() {
+        // clap does not propagate `hide`, so `bootstrap launchd` is hidden
+        // while its children are not; the children must not leak either.
+        let shown = commands(false).await;
+        assert!(!shown.iter().any(|c| c["command"] == "bootstrap launchd"));
+        assert!(
+            !shown
+                .iter()
+                .any(|c| c["command"] == "bootstrap launchd apply")
+        );
+
+        let all = commands(true).await;
+        assert!(all.iter().any(|c| c["command"] == "bootstrap launchd"));
+        assert!(
+            all.iter()
+                .any(|c| c["command"] == "bootstrap launchd apply")
+        );
+    }
+
+    #[tokio::test]
+    async fn nothing_is_unclassified_by_accident() {
+        // command_effects tests its own table, but nothing there proves the
+        // classification survives into what an agent is actually served. A
+        // missing effect reads as "unknown, ask" — fine for `mise run`, whose
+        // effect really is whatever the task does, and a silent gap for
+        // anything else.
+        let deliberate: std::collections::HashSet<_> = crate::cli::command_effects::UNCLASSIFIED
+            .iter()
+            .map(|(cmd, _)| *cmd)
+            .collect();
+        let accidental: Vec<_> = commands(false)
+            .await
+            .iter()
+            .filter(|c| c["effect"].is_null())
+            .map(|c| c["command"].as_str().unwrap().to_string())
+            .filter(|cmd| !deliberate.contains(cmd.as_str()))
+            .collect();
+        assert!(
+            accidental.is_empty(),
+            "unclassified with no entry in command_effects::UNCLASSIFIED: {accidental:?}"
+        );
+    }
 
     #[test]
     fn server_info_identifies_mise() {

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -10,8 +10,13 @@ use eyre::Result;
 #[clap(verbatim_doc_comment, hide = true)]
 pub struct Usage {}
 
-impl Usage {
-    pub fn run(self) -> Result<()> {
+/// mise's own usage spec, with everything clap cannot express applied.
+///
+/// Shared with `mise mcp`, which answers "what does this command do" from the
+/// same `effect=` data this prints. Two constructions would drift, and the one
+/// an agent reads is the one that must not.
+pub fn spec() -> usage::Spec {
+    {
         let cli = Cli::command().version(Resettable::Reset);
         let mut spec: usage::Spec = cli.into();
 
@@ -56,13 +61,19 @@ impl Usage {
         // so it is applied to the derived spec; see command_effects.
         crate::cli::command_effects::apply(&mut spec);
 
+        spec
+    }
+}
+
+impl Usage {
+    pub fn run(self) -> Result<()> {
         // 3.6 added `effect=` (jdx/usage#739) and 4.0 added it on flags and args
         // (jdx/usage#742); older `usage` CLIs reject the spec outright with
         // "unsupported cmd prop effect", so this moves in lockstep with the
         // fields the spec actually carries.
         let min_version = r#"min_usage_version "4.0""#;
         let extra = include_str!("../assets/mise-extra.usage.kdl").trim();
-        println!("{min_version}\n{}\n{extra}", spec.to_string().trim());
+        println!("{min_version}\n{}\n{extra}", spec().to_string().trim());
         Ok(())
     }
 }


### PR DESCRIPTION
mise classifies all 167 of its commands as `read`, `write` or `destructive` (#11306) — and nothing an agent talks to can see any of it. `mise mcp` exposes `install_tool` and `run_task`, neither of which says what a command *does*. An agent about to run `mise prune` has the answer sitting in the binary and no way to ask for it.

This adds `list_commands`, returning the command tree with each command's effect, help and hidden flag:

```
156 visible commands — 74 read, 65 write, 7 destructive, 10 deliberately unclassified
prune         → destructive
ls            → read
install       → write
settings set  → write
run           → (unclassified)
```

## How

`cli::usage::spec()` is extracted out of `Usage::run`, so the spec `mise usage` prints and the one `mise mcp` serves are the same construction rather than two that drift. It's built once in `MiseServer::new` — deriving it walks the whole clap tree, which isn't work to repeat per request.

Hidden commands take their subtree with them. clap doesn't propagate `hide`, so `bootstrap launchd` is hidden while `bootstrap launchd apply` isn't; a flat filter on `hide` would surface the child along with the hidden path it sits under.

## On unclassified commands

A missing effect means *unknown*, not safe, and the tool description says so explicitly. Ten commands are deliberately unset because they run code the user supplies — `run`, `exec`, `watch`, `tool-stub`, `en`, `oci run` — where any label would be a lie in one direction or the other, and `read` in particular would be dangerous.

The risk is a *new* command going unlabeled by accident and reading the same way. A test asserts every unclassified command in the served output has an entry in `command_effects::UNCLASSIFIED`, which is where the reason lives.

## Not in this PR

`describe_command` — per-command flags and args with their own effects — needs `usage::available_flags` from jdx/usage#746 to resolve inherited globals correctly. mise's `run` re-declares root globals as non-global flags, which is precisely the case a hand-rolled ancestor walk gets wrong (it reports the local declaration's absent effect instead of the global's). It follows once that releases.

## Verified

Against a real client handshake — `initialize` → `notifications/initialized` → `tools/list` → `tools/call` — plus five unit tests covering the effects surviving into the output, nested paths, hidden-subtree pruning, and the unclassified guard.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive MCP surface and refactored spec construction; no changes to how mise commands execute on disk.
> 
> **Overview**
> Exposes mise’s **read / write / destructive** command classifications to MCP clients via a new **`list_commands`** tool, so agents can see what a CLI subcommand does before invoking it.
> 
> **`list_commands`** walks the shared usage spec and returns JSON rows (`command`, `help`, `effect`, `hidden`). Optional **`include_hidden`** controls whether hidden commands appear; when hidden, **entire subtrees** are omitted (so children of a hidden parent do not leak). Server instructions now tell clients to call **`list_commands`** first and treat a missing **`effect`** as unknown, not safe.
> 
> **`cli::usage::spec()`** is extracted from **`mise usage`** and reused by **`MiseServer`**, with the spec cached in **`Arc`** at startup. Docs (`docs/cli/mcp.md`, usage KDL) list the new tool. Unit tests cover effects in output, nesting, hidden pruning, and a guard that only deliberately unclassified commands lack an **`effect`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dcf0fd0850f2150367b8f8e5969da72c4b4bfaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `list_commands` MCP tool and resource to enumerate available `mise` commands.
  * Results include command descriptions, declared effects, and hidden-command status.
  * Added an `include_hidden` option to include hidden commands when needed.
  * Nested command effects are now represented consistently.

* **Documentation**
  * Updated MCP documentation and CLI help with the new tool, resource, and usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->