### PR TITLE
registry: add aws-cdk

### DIFF
--- a/registry/aws-cdk.toml
+++ b/registry/aws-cdk.toml
@@ -1,0 +1,7 @@
+aliases = ["cdk"]
+description = "AWS CDK CLI, the command line tool for CDK apps"
+detect = ["cdk.json"]
+test = { cmd = "cdk --version", expected = "{{version}}" }
+
+[[backends]]
+full = "npm:aws-cdk"


### PR DESCRIPTION
Adds the AWS CDK CLI (`cdk`) to the registry.

```toml
aliases = ["cdk"]
description = "AWS CDK CLI, the command line tool for CDK apps"
detect = ["cdk.json"]
test = { cmd = "cdk --version", expected = "{{version}}" }

[[backends]]
full = "npm:aws-cdk"
```

## Popularity

- GitHub (`aws/aws-cdk`): 12.8k stars, 4.6k forks, last push 2026-07-27
- npm (`aws-cdk`): **15,829,786 downloads in the last month** (2026-06-25 → 2026-07-24), 683 published versions, latest `2.1133.0`
- First-party AWS tool; it is *the* deployment CLI for CDK apps and a hard dependency of every CDK project (`cdk synth` / `cdk deploy` / `cdk diff`)
- Widely referenced in AWS documentation, CI templates, and third-party tooling (Projen, SST, cdk-nag, aws-cdk-lib ecosystem)

## Backend choice — why `npm:`

I checked the preferred tiers first and neither can install this tool:

- **aqua:** no package exists — both `pkgs/aws/aws-cdk/registry.yaml` and `pkgs/aws/aws-cdk-cli/registry.yaml` return 404 in `aquaproj/aqua-registry`.
- **github:** the CLI is released from `aws/aws-cdk-cli`, and those releases ship **zero binary assets** — they are npm-publish tags only. Verified against the releases API:

  ```
  cdk@v2.1133.0                        assets=
  aws-cdk@v2.1133.0                    assets=
  @aws-cdk/toolkit-lib@v1.36.1         assets=
  ```

  There is no compiled binary to download; the CLI is distributed exclusively as an npm package.

So `npm:` is the only backend that can both install the tool and list versions. Flagging it explicitly since `npm:` is a tier-3 backend under the contributing rules — happy to close this if you'd rather not carry an npm-only entry.

## Verification

Version listing works (required):

```console
$ mise ls-remote npm:aws-cdk | tail -3
2.1132.1
2.1133.0
3.0.0

$ mise latest npm:aws-cdk
2.1133.0
```

`mise latest` correctly resolves to `2.1133.0` rather than the `3.0.0` entry on npm — that version is [marked deprecated upstream](https://www.npmjs.com/package/aws-cdk) ("This version was published accidentally. Please use 2.x.x instead.") and is not the `latest` dist-tag.

`mise test-tool` passes:

```console
$ mise test-tool aws-cdk
mise aws-cdk@2.1133.0       ✓ installed
mise $ .../installs/aws-cdk/latest/node_modules/.bin/cdk --version
2.1133.0 (build 712d792)
mise aws-cdk: OK
```

No `allow_builds` is needed — the package has no `install`/`postinstall` script, only projen-driven dev scripts.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS CDK CLI detection and version reporting.
  * Registered the `cdk` command alias with its associated npm package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->