### PR TITLE
docs(task): document external cache inputs

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -86,7 +86,7 @@ outside this tracker.
 - [x] Support global environment inputs and pass-through environment variables
 - [x] Support negative input and output patterns
 - [x] Support command-output inputs
-- [ ] Include external dependency and lockfile state through explicit input configuration
+- [x] Include external dependency and lockfile state through explicit input configuration
 - [ ] Add per-run cache read/write controls, including local-only and cache-disabled modes
 - [ ] Add a configurable local task-cache directory
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -558,6 +558,46 @@ none, and may emit at most 16 MiB across stdout and stderr. They should be fast,
 free of side effects because they run whenever mise computes the task's cache key. Command inputs
 are not run during dry runs or when caching is disabled for raw or interactive execution.
 
+#### External dependencies and lockfiles
+
+Declare dependency manifests and lockfiles as filesystem inputs so dependency updates invalidate the
+cache. They can be listed directly in a task's `sources`, shared through an input group, or applied to
+every task in a config scope with `task_config.global_inputs`.
+
+```mise-toml
+[settings]
+experimental = true
+
+[task_config]
+global_inputs = ["@group:node-dependencies"]
+
+[task_config.input_groups]
+node-dependencies = ["package.json", "pnpm-lock.yaml"]
+
+[tasks.build]
+run = "pnpm build"
+sources = ["src/**"]
+outputs = ["dist"]
+cache = { enabled = true }
+```
+
+The lockfile content represents the resolved external dependency graph, so installed dependency
+directories such as `node_modules` generally should not be included. Resolved mise tools already
+participate in the cache key. Use `cache.command_inputs` for relevant external state that is not
+captured in committed files, such as a package registry selection or a compiler wrapper version:
+
+```mise-toml
+[tasks.build]
+run = "pnpm build"
+sources = ["package.json", "pnpm-lock.yaml", "src/**"]
+outputs = ["dist"]
+cache = { enabled = true, command_inputs = ["pnpm config get registry"] }
+```
+
+Only declare deterministic external state that can affect task outputs. Secrets and credentials
+should use pass-through environment variables instead so their values are not included in cache
+keys.
+
 ```mise-toml
 [tasks.lint]
 run = "eslint ."


### PR DESCRIPTION
## What
- document dependency manifests and lockfiles as explicit filesystem cache inputs
- show how command inputs capture deterministic external state not stored in the repository
- mark the external dependency and lockfile parity item complete

## Why
The existing source, input-group, global-input, and command-input features already cover this cache-key state. This documents the intended composition without introducing an overlapping configuration option.

## Checks
- `git diff --check`
- `mise run docs:build`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior changes.
> 
> **Overview**
> Documents how **external dependency and lockfile state** should feed the experimental task cache using existing input mechanisms—no new config surface.
> 
> Adds an **External dependencies and lockfiles** section under `cache` in task configuration docs: list manifests/lockfiles in `sources`, reuse them via `@group:` input groups, or apply repo-wide with `task_config.global_inputs`. Guidance clarifies preferring lockfiles over `node_modules`, using `cache.command_inputs` for deterministic external state not in git (e.g. registry URL), and avoiding secrets in cache keys (use pass-through env instead).
> 
> Marks the corresponding **Local cache parity** tracker item in `TASK_CACHE_PARITY.md` as complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3caed522c089e47e182778c6312ff4a5ca0025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->