### PR TITLE
feat(task): add per-run cache controls

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -87,7 +87,7 @@ outside this tracker.
 - [x] Support negative input and output patterns
 - [x] Support command-output inputs
 - [x] Include external dependency and lockfile state through explicit input configuration
-- [ ] Add per-run cache read/write controls, including local-only and cache-disabled modes
+- [x] Add per-run cache read/write controls, including local-only and cache-disabled modes
 - [ ] Add a configurable local task-cache directory
 
 ## Inspection and diagnostics

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -142,26 +142,6 @@ Bypass the environment cache and recompute the environment
 
 Do not use cache on remote tasks
 
-### `--task-cache <TASK_CACHE>`
-
-Set task output cache access for this run
-
-- `read-write` - Read cached results and write new results
-- `read-only` - Read cached results without writing new results
-- `write-only` - Write new results without reading cached results
-- `off` - Disable task output caching
-- `local-only` - Read and write only the local cache
-
-**Choices:**
-
-- `read-write`
-- `read-only`
-- `write-only`
-- `off`
-- `local-only`
-
-**Default:** `read-write`
-
 ### `--no-deps`
 
 Skip automatic dependency preparation
@@ -182,6 +162,26 @@ Skip installing tools before running tasks
 
 Can also be set persistently with the `task.run_auto_install` setting
 or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
+
+### `--task-cache <TASK_CACHE>`
+
+Set task output cache access for this run
+
+- `read-write` - Read cached results and write new results
+- `read-only` - Read cached results without writing new results
+- `write-only` - Write new results without reading cached results
+- `off` - Disable task output caching
+- `local-only` - Read and write only the local cache
+
+**Choices:**
+
+- `read-write`
+- `read-only`
+- `write-only`
+- `off`
+- `local-only`
+
+**Default:** `read-write`
 
 ### `--timeout <TIMEOUT>`
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -171,7 +171,7 @@ Set task output cache access for this run
 - `read-only` - Read cached results without writing new results
 - `write-only` - Write new results without reading cached results
 - `off` - Disable task output caching
-- `local-only` - Read and write only the local cache
+- `local-only` - Read and write only the local cache; currently equivalent to `read-write`
 
 **Choices:**
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -142,6 +142,26 @@ Bypass the environment cache and recompute the environment
 
 Do not use cache on remote tasks
 
+### `--task-cache <TASK_CACHE>`
+
+Set task output cache access for this run
+
+- `read-write` - Read cached results and write new results
+- `read-only` - Read cached results without writing new results
+- `write-only` - Write new results without reading cached results
+- `off` - Disable task output caching
+- `local-only` - Read and write only the local cache
+
+**Choices:**
+
+- `read-write`
+- `read-only`
+- `write-only`
+- `off`
+- `local-only`
+
+**Default:** `read-write`
+
 ### `--no-deps`
 
 Skip automatic dependency preparation

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -156,26 +156,6 @@ Bypass the environment cache and recompute the environment
 
 Do not use cache on remote tasks
 
-### `--task-cache <TASK_CACHE>`
-
-Set task output cache access for this run
-
-- `read-write` - Read cached results and write new results
-- `read-only` - Read cached results without writing new results
-- `write-only` - Write new results without reading cached results
-- `off` - Disable task output caching
-- `local-only` - Read and write only the local cache
-
-**Choices:**
-
-- `read-write`
-- `read-only`
-- `write-only`
-- `off`
-- `local-only`
-
-**Default:** `read-write`
-
 ### `--no-deps`
 
 Skip automatic dependency preparation
@@ -196,6 +176,26 @@ Skip installing tools before running tasks
 
 Can also be set persistently with the `task.run_auto_install` setting
 or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
+
+### `--task-cache <TASK_CACHE>`
+
+Set task output cache access for this run
+
+- `read-write` - Read cached results and write new results
+- `read-only` - Read cached results without writing new results
+- `write-only` - Write new results without reading cached results
+- `off` - Disable task output caching
+- `local-only` - Read and write only the local cache
+
+**Choices:**
+
+- `read-write`
+- `read-only`
+- `write-only`
+- `off`
+- `local-only`
+
+**Default:** `read-write`
 
 ### `--timeout <TIMEOUT>`
 

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -185,7 +185,7 @@ Set task output cache access for this run
 - `read-only` - Read cached results without writing new results
 - `write-only` - Write new results without reading cached results
 - `off` - Disable task output caching
-- `local-only` - Read and write only the local cache
+- `local-only` - Read and write only the local cache; currently equivalent to `read-write`
 
 **Choices:**
 

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -156,6 +156,26 @@ Bypass the environment cache and recompute the environment
 
 Do not use cache on remote tasks
 
+### `--task-cache <TASK_CACHE>`
+
+Set task output cache access for this run
+
+- `read-write` - Read cached results and write new results
+- `read-only` - Read cached results without writing new results
+- `write-only` - Write new results without reading cached results
+- `off` - Disable task output caching
+- `local-only` - Read and write only the local cache
+
+**Choices:**
+
+- `read-write`
+- `read-only`
+- `write-only`
+- `off`
+- `local-only`
+
+**Default:** `read-write`
+
 ### `--no-deps`
 
 Skip automatic dependency preparation

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -598,6 +598,32 @@ Only declare deterministic external state that can affect task outputs. Secrets 
 should use pass-through environment variables instead so their values are not included in cache
 keys.
 
+#### Per-run cache access
+
+Use `mise run --task-cache <mode>` or `MISE_TASK_CACHE` to control task output cache reads and writes
+for one run:
+
+- `read-write` uses cached results and publishes new results. This is the default.
+- `read-only` uses cached results but does not publish misses.
+- `write-only` publishes results but always executes instead of restoring.
+- `off` disables task output caching and uses ordinary source/output freshness checks.
+- `local-only` reads and writes only the local cache. It currently behaves like `read-write` because
+  remote caching is not yet available.
+
+```bash
+# Prevent an untrusted pull request from publishing cache entries
+mise run --task-cache read-only test
+
+# Warm the local cache without consuming existing entries
+mise run --task-cache write-only build
+
+# Diagnose a task without reading or writing task output artifacts
+mise run --task-cache off build
+```
+
+These modes only affect the experimental task output cache configured by a task's `cache` property.
+The existing `--no-cache` option controls fetching remote task definitions instead.
+
 ```mise-toml
 [tasks.lint]
 run = "eslint ."

--- a/e2e/tasks/test_task_artifact_cache_global_env
+++ b/e2e/tasks/test_task_artifact_cache_global_env
@@ -44,8 +44,14 @@ GLOBAL_PROFILE=release LOCAL_PROFILE=two GLOBAL_SECRET=global-secret TASK_SECRET
 assert "cat dist/result.txt" "release:two"
 assert "wc -l < runs.txt | tr -d ' '" "3"
 
+# Disabling artifact caching does not change the task's sandbox environment.
+rm -rf dist
+GLOBAL_PROFILE=off LOCAL_PROFILE=off GLOBAL_SECRET=global-secret TASK_SECRET=task-secret mise run --task-cache off build
+assert "cat dist/result.txt" "off:off"
+assert "wc -l < runs.txt | tr -d ' '" "4"
+
 # Pass-through env values are available to the task but do not affect its key.
 rm -rf dist
 assert_contains "GLOBAL_PROFILE=release LOCAL_PROFILE=two GLOBAL_SECRET=rotated TASK_SECRET=rotated mise run build 2>&1" "restored outputs from cache"
 assert "cat dist/result.txt" "release:two"
-assert "wc -l < runs.txt | tr -d ' '" "3"
+assert "wc -l < runs.txt | tr -d ' '" "4"

--- a/e2e/tasks/test_task_artifact_cache_modes
+++ b/e2e/tasks/test_task_artifact_cache_modes
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+run = '''
+mkdir -p dist
+printf '%s:%s\n' "$PROFILE" "$(cat input.txt)" > dist/result.txt
+printf 'ran\n' >> runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["dist"]
+cache = { enabled = true, env = ["PROFILE"] }
+EOF
+
+printf 'one\n' >input.txt
+
+# Populate an artifact using the default read-write mode.
+PROFILE=seed mise run build
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# Read-only mode restores existing artifacts.
+rm -rf dist
+assert_contains \
+  "PROFILE=seed mise run --task-cache read-only build 2>&1" \
+  "restored outputs from cache"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+# Read-only misses execute without publishing a new artifact.
+PROFILE=read-only mise run --task-cache read-only build
+assert "wc -l < runs.txt | tr -d ' '" "2"
+rm -rf dist
+MISE_TASK_CACHE=read-only PROFILE=read-only mise run build
+assert "wc -l < runs.txt | tr -d ' '" "3"
+
+# Write-only mode publishes artifacts but never restores them.
+PROFILE=write-only mise run --task-cache write-only build
+assert "wc -l < runs.txt | tr -d ' '" "4"
+rm -rf dist
+assert_not_contains \
+  "PROFILE=write-only mise run --task-cache write-only build 2>&1" \
+  "restored outputs from cache"
+assert "wc -l < runs.txt | tr -d ' '" "5"
+
+# Local-only mode can restore the artifact published by write-only mode.
+rm -rf dist
+assert_contains \
+  "PROFILE=write-only mise run --task-cache local-only build 2>&1" \
+  "restored outputs from cache"
+assert "wc -l < runs.txt | tr -d ' '" "5"
+
+# Off mode neither reads nor writes task output artifacts.
+rm -rf dist
+PROFILE=off mise run --task-cache off build
+assert "wc -l < runs.txt | tr -d ' '" "6"
+rm -rf dist
+PROFILE=off mise run --task-cache off build
+assert "wc -l < runs.txt | tr -d ' '" "7"
+
+assert_fail_contains \
+  "mise run --task-cache invalid build 2>&1" \
+  "invalid value 'invalid'"

--- a/e2e/tasks/test_task_artifact_cache_modes
+++ b/e2e/tasks/test_task_artifact_cache_modes
@@ -21,43 +21,52 @@ printf 'one\n' >input.txt
 PROFILE=seed mise run build
 assert "wc -l < runs.txt | tr -d ' '" "1"
 
-# Read-only mode restores existing artifacts.
+# Make another key current before restoring the seed artifact read-only.
+PROFILE=other mise run build
+assert "wc -l < runs.txt | tr -d ' '" "2"
+
+# Read-only mode restores existing artifacts without updating cache state.
 rm -rf dist
 assert_contains \
   "PROFILE=seed mise run --task-cache read-only build 2>&1" \
   "restored outputs from cache"
-assert "wc -l < runs.txt | tr -d ' '" "1"
-
-# Read-only misses execute without publishing a new artifact.
-PROFILE=read-only mise run --task-cache read-only build
 assert "wc -l < runs.txt | tr -d ' '" "2"
-rm -rf dist
-MISE_TASK_CACHE=read-only PROFILE=read-only mise run build
+output=$(PROFILE=seed mise run --task-cache read-only build 2>&1)
+assert_contains "echo \"$output\"" "restored outputs from cache"
+assert_not_contains "echo \"$output\"" "sources up-to-date, skipping"
+assert "wc -l < runs.txt | tr -d ' '" "2"
+
+# Read-only misses execute without publishing a new artifact. Naked task
+# invocation must honor MISE_TASK_CACHE as well as `mise run`.
+PROFILE=read-only mise run --task-cache read-only build
 assert "wc -l < runs.txt | tr -d ' '" "3"
+rm -rf dist
+MISE_TASK_CACHE=read-only PROFILE=read-only mise build
+assert "wc -l < runs.txt | tr -d ' '" "4"
 
 # Write-only mode publishes artifacts but never restores them.
 PROFILE=write-only mise run --task-cache write-only build
-assert "wc -l < runs.txt | tr -d ' '" "4"
+assert "wc -l < runs.txt | tr -d ' '" "5"
 rm -rf dist
 assert_not_contains \
   "PROFILE=write-only mise run --task-cache write-only build 2>&1" \
   "restored outputs from cache"
-assert "wc -l < runs.txt | tr -d ' '" "5"
+assert "wc -l < runs.txt | tr -d ' '" "6"
 
 # Local-only mode can restore the artifact published by write-only mode.
 rm -rf dist
 assert_contains \
   "PROFILE=write-only mise run --task-cache local-only build 2>&1" \
   "restored outputs from cache"
-assert "wc -l < runs.txt | tr -d ' '" "5"
+assert "wc -l < runs.txt | tr -d ' '" "6"
 
 # Off mode neither reads nor writes task output artifacts.
 rm -rf dist
 PROFILE=off mise run --task-cache off build
-assert "wc -l < runs.txt | tr -d ' '" "6"
+assert "wc -l < runs.txt | tr -d ' '" "7"
 rm -rf dist
 PROFILE=off mise run --task-cache off build
-assert "wc -l < runs.txt | tr -d ' '" "7"
+assert "wc -l < runs.txt | tr -d ' '" "8"
 
 assert_fail_contains \
   "mise run --task-cache invalid build 2>&1" \

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3145,6 +3145,18 @@ Skip installing tools before running tasks
 Can also be set persistently with the `task.run_auto_install` setting
 or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
 .TP
+\fB\-\-task\-cache\fR \fI<TASK_CACHE>\fR
+Set task output cache access for this run
+
+\- `read\-write` \- Read cached results and write new results
+\- `read\-only` \- Read cached results without writing new results
+\- `write\-only` \- Write new results without reading cached results
+\- `off` \- Disable task output caching
+\- `local\-only` \- Read and write only the local cache
+.RS
+\fIDefault: \fRread\-write
+.RE
+.TP
 \fB\-\-timeout\fR \fI<TIMEOUT>\fR
 Timeout for the task to complete
 e.g.: 30s, 5m
@@ -3906,6 +3918,18 @@ Skip installing tools before running tasks
 
 Can also be set persistently with the `task.run_auto_install` setting
 or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
+.TP
+\fB\-\-task\-cache\fR \fI<TASK_CACHE>\fR
+Set task output cache access for this run
+
+\- `read\-write` \- Read cached results and write new results
+\- `read\-only` \- Read cached results without writing new results
+\- `write\-only` \- Write new results without reading cached results
+\- `off` \- Disable task output caching
+\- `local\-only` \- Read and write only the local cache
+.RS
+\fIDefault: \fRread\-write
+.RE
 .TP
 \fB\-\-timeout\fR \fI<TIMEOUT>\fR
 Timeout for the task to complete

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3152,7 +3152,7 @@ Set task output cache access for this run
 \- `read\-only` \- Read cached results without writing new results
 \- `write\-only` \- Write new results without reading cached results
 \- `off` \- Disable task output caching
-\- `local\-only` \- Read and write only the local cache
+\- `local\-only` \- Read and write only the local cache; currently equivalent to `read\-write`
 .RS
 \fIDefault: \fRread\-write
 .RE
@@ -3926,7 +3926,7 @@ Set task output cache access for this run
 \- `read\-only` \- Read cached results without writing new results
 \- `write\-only` \- Write new results without reading cached results
 \- `off` \- Disable task output caching
-\- `local\-only` \- Read and write only the local cache
+\- `local\-only` \- Read and write only the local cache; currently equivalent to `read\-write`
 .RS
 \fIDefault: \fRread\-write
 .RE

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3047,7 +3047,7 @@ Set task output cache access for this run
 - `read-only` - Read cached results without writing new results
 - `write-only` - Write new results without reading cached results
 - `off` - Disable task output caching
-- `local-only` - Read and write only the local cache
+- `local-only` - Read and write only the local cache; currently equivalent to `read-write`
 """#
         arg <TASK_CACHE> {
             choices read-write read-only write-only off local-only
@@ -3858,7 +3858,7 @@ Set task output cache access for this run
 - `read-only` - Read cached results without writing new results
 - `write-only` - Write new results without reading cached results
 - `off` - Disable task output caching
-- `local-only` - Read and write only the local cache
+- `local-only` - Read and write only the local cache; currently equivalent to `read-write`
 """#
             arg <TASK_CACHE> {
                 choices read-write read-only write-only off local-only

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3022,20 +3022,6 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
     flag --deny-write help="Block all filesystem writes"
     flag --fresh-env help="Bypass the environment cache and recompute the environment"
     flag --no-cache help="Do not use cache on remote tasks"
-    flag --task-cache help="Set task output cache access for this run" default=read-write {
-        long_help #"""
-Set task output cache access for this run
-
-- `read-write` - Read cached results and write new results
-- `read-only` - Read cached results without writing new results
-- `write-only` - Write new results without reading cached results
-- `off` - Disable task output caching
-- `local-only` - Read and write only the local cache
-"""#
-        arg <TASK_CACHE> {
-            choices read-write read-only write-only off local-only
-        }
-    }
     flag --no-deps help="Skip automatic dependency preparation"
     flag --no-timings help="Hides elapsed time after each task completes" {
         long_help #"""
@@ -3052,6 +3038,20 @@ Skip installing tools before running tasks
 Can also be set persistently with the `task.run_auto_install` setting
 or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
 """#
+    }
+    flag --task-cache help="Set task output cache access for this run" default=read-write {
+        long_help #"""
+Set task output cache access for this run
+
+- `read-write` - Read cached results and write new results
+- `read-only` - Read cached results without writing new results
+- `write-only` - Write new results without reading cached results
+- `off` - Disable task output caching
+- `local-only` - Read and write only the local cache
+"""#
+        arg <TASK_CACHE> {
+            choices read-write read-only write-only off local-only
+        }
     }
     flag --timeout help=#"""
 Timeout for the task to complete
@@ -3833,20 +3833,6 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
         flag --deny-write help="Block all filesystem writes"
         flag --fresh-env help="Bypass the environment cache and recompute the environment"
         flag --no-cache help="Do not use cache on remote tasks"
-        flag --task-cache help="Set task output cache access for this run" default=read-write {
-            long_help #"""
-Set task output cache access for this run
-
-- `read-write` - Read cached results and write new results
-- `read-only` - Read cached results without writing new results
-- `write-only` - Write new results without reading cached results
-- `off` - Disable task output caching
-- `local-only` - Read and write only the local cache
-"""#
-            arg <TASK_CACHE> {
-                choices read-write read-only write-only off local-only
-            }
-        }
         flag --no-deps help="Skip automatic dependency preparation"
         flag --no-timings help="Hides elapsed time after each task completes" {
             long_help #"""
@@ -3863,6 +3849,20 @@ Skip installing tools before running tasks
 Can also be set persistently with the `task.run_auto_install` setting
 or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
 """#
+        }
+        flag --task-cache help="Set task output cache access for this run" default=read-write {
+            long_help #"""
+Set task output cache access for this run
+
+- `read-write` - Read cached results and write new results
+- `read-only` - Read cached results without writing new results
+- `write-only` - Write new results without reading cached results
+- `off` - Disable task output caching
+- `local-only` - Read and write only the local cache
+"""#
+            arg <TASK_CACHE> {
+                choices read-write read-only write-only off local-only
+            }
         }
         flag --timeout help=#"""
 Timeout for the task to complete

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3022,6 +3022,20 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
     flag --deny-write help="Block all filesystem writes"
     flag --fresh-env help="Bypass the environment cache and recompute the environment"
     flag --no-cache help="Do not use cache on remote tasks"
+    flag --task-cache help="Set task output cache access for this run" default=read-write {
+        long_help #"""
+Set task output cache access for this run
+
+- `read-write` - Read cached results and write new results
+- `read-only` - Read cached results without writing new results
+- `write-only` - Write new results without reading cached results
+- `off` - Disable task output caching
+- `local-only` - Read and write only the local cache
+"""#
+        arg <TASK_CACHE> {
+            choices read-write read-only write-only off local-only
+        }
+    }
     flag --no-deps help="Skip automatic dependency preparation"
     flag --no-timings help="Hides elapsed time after each task completes" {
         long_help #"""
@@ -3819,6 +3833,20 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
         flag --deny-write help="Block all filesystem writes"
         flag --fresh-env help="Bypass the environment cache and recompute the environment"
         flag --no-cache help="Do not use cache on remote tasks"
+        flag --task-cache help="Set task output cache access for this run" default=read-write {
+            long_help #"""
+Set task output cache access for this run
+
+- `read-write` - Read cached results and write new results
+- `read-only` - Read cached results without writing new results
+- `write-only` - Write new results without reading cached results
+- `off` - Disable task output caching
+- `local-only` - Read and write only the local cache
+"""#
+            arg <TASK_CACHE> {
+                choices read-write read-only write-only off local-only
+            }
+        }
         flag --no-deps help="Skip automatic dependency preparation"
         flag --no-timings help="Hides elapsed time after each task completes" {
             long_help #"""

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -995,6 +995,7 @@ impl Bootstrap {
             context_builder: Default::default(),
             executor: None,
             no_cache: Default::default(),
+            task_cache: Default::default(),
             timeout: None,
             skip_deps: false,
             // a dry run must not auto-install tools before the (not actually

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -995,7 +995,7 @@ impl Bootstrap {
             context_builder: Default::default(),
             executor: None,
             no_cache: Default::default(),
-            task_cache: Default::default(),
+            task_cache: crate::task::TaskCacheMode::from_env()?,
             timeout: None,
             skip_deps: false,
             // a dry run must not auto-install tools before the (not actually

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -792,6 +792,7 @@ impl Cli {
                         context_builder: Default::default(),
                         executor: None,
                         no_cache: Default::default(),
+                        task_cache: Default::default(),
                         timeout: None,
                         skip_deps: false,
                         skip_tools: false,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -792,7 +792,7 @@ impl Cli {
                         context_builder: Default::default(),
                         executor: None,
                         no_cache: Default::default(),
-                        task_cache: Default::default(),
+                        task_cache: crate::task::TaskCacheMode::from_env()?,
                         timeout: None,
                         skip_deps: false,
                         skip_tools: false,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -182,22 +182,6 @@ pub struct Run {
     #[clap(long, verbatim_doc_comment, env = "MISE_TASK_REMOTE_NO_CACHE")]
     pub no_cache: bool,
 
-    /// Set task output cache access for this run
-    ///
-    /// - `read-write` - Read cached results and write new results
-    /// - `read-only` - Read cached results without writing new results
-    /// - `write-only` - Write new results without reading cached results
-    /// - `off` - Disable task output caching
-    /// - `local-only` - Read and write only the local cache
-    #[clap(
-        long,
-        value_enum,
-        default_value = "read-write",
-        env = "MISE_TASK_CACHE",
-        verbatim_doc_comment
-    )]
-    pub task_cache: TaskCacheMode,
-
     /// Skip automatic dependency preparation
     #[clap(long)]
     pub no_deps: bool,
@@ -218,6 +202,22 @@ pub struct Run {
     /// or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
     #[clap(long, verbatim_doc_comment)]
     pub skip_tools: bool,
+
+    /// Set task output cache access for this run
+    ///
+    /// - `read-write` - Read cached results and write new results
+    /// - `read-only` - Read cached results without writing new results
+    /// - `write-only` - Write new results without reading cached results
+    /// - `off` - Disable task output caching
+    /// - `local-only` - Read and write only the local cache
+    #[clap(
+        long,
+        value_enum,
+        default_value = "read-write",
+        env = "MISE_TASK_CACHE",
+        verbatim_doc_comment
+    )]
+    pub task_cache: TaskCacheMode,
 
     /// Timeout for the task to complete
     /// e.g.: 30s, 5m

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -17,7 +17,7 @@ use crate::task::task_helpers::task_needs_permit;
 use crate::task::task_list::{get_task_lists, resolve_depends};
 use crate::task::task_output::TaskOutput;
 use crate::task::task_output_handler::OutputHandler;
-use crate::task::{Deps, Task};
+use crate::task::{Deps, Task, TaskCacheMode};
 use crate::toolset::{InstallOptions, ResolveOptions, ToolVersion, ToolsetBuilder};
 use crate::ui::{ctrlc, info, style};
 use clap::{CommandFactory, ValueHint};
@@ -181,6 +181,22 @@ pub struct Run {
     /// Do not use cache on remote tasks
     #[clap(long, verbatim_doc_comment, env = "MISE_TASK_REMOTE_NO_CACHE")]
     pub no_cache: bool,
+
+    /// Set task output cache access for this run
+    ///
+    /// - `read-write` - Read cached results and write new results
+    /// - `read-only` - Read cached results without writing new results
+    /// - `write-only` - Write new results without reading cached results
+    /// - `off` - Disable task output caching
+    /// - `local-only` - Read and write only the local cache
+    #[clap(
+        long,
+        value_enum,
+        default_value = "read-write",
+        env = "MISE_TASK_CACHE",
+        verbatim_doc_comment
+    )]
+    pub task_cache: TaskCacheMode,
 
     /// Skip automatic dependency preparation
     #[clap(long)]
@@ -796,6 +812,7 @@ impl Run {
             continue_on_error: self.continue_on_error,
             dry_run: self.dry_run,
             skip_deps: self.skip_deps,
+            task_cache: self.task_cache,
             sandbox: crate::sandbox::SandboxConfig::from_settings_and_cli(
                 &Settings::get().sandbox,
                 self.deny_all,
@@ -899,7 +916,7 @@ impl Run {
     fn validate_task(&self, task: &Task) -> Result<()> {
         use crate::file;
         use crate::ui;
-        if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
+        if self.task_cache.enabled() && task.cache.as_ref().is_some_and(|cache| cache.enabled) {
             Settings::get().ensure_experimental("task artifact caching")?;
         }
         if !task.pass_through_env.is_empty() {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -209,7 +209,7 @@ pub struct Run {
     /// - `read-only` - Read cached results without writing new results
     /// - `write-only` - Write new results without reading cached results
     /// - `off` - Disable task output caching
-    /// - `local-only` - Read and write only the local cache
+    /// - `local-only` - Read and write only the local cache; currently equivalent to `read-write`
     #[clap(
         long,
         value_enum,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -64,7 +64,7 @@ pub mod task_template;
 pub mod task_tool_installer;
 
 pub(crate) use task_cache::TaskCacheOutput;
-pub use task_cache::{TaskArtifactCache, TaskCacheConfig};
+pub use task_cache::{TaskArtifactCache, TaskCacheConfig, TaskCacheMode};
 pub use task_confirm::TaskConfirm;
 pub(crate) use task_load_context::monorepo_scope;
 pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax};

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -49,6 +49,21 @@ pub enum TaskCacheMode {
 }
 
 impl TaskCacheMode {
+    pub(crate) fn from_env() -> Result<Self> {
+        let Some(value) = std::env::var_os("MISE_TASK_CACHE") else {
+            return Ok(Self::default());
+        };
+        let value = value
+            .into_string()
+            .map_err(|_| eyre!("MISE_TASK_CACHE must be valid UTF-8"))?;
+        <Self as clap::ValueEnum>::from_str(&value, false).map_err(|_| {
+            eyre!(
+                "invalid MISE_TASK_CACHE value {value:?}; expected read-write, read-only, \
+                 write-only, off, or local-only"
+            )
+        })
+    }
+
     pub(crate) fn enabled(self) -> bool {
         self != Self::Off
     }

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -33,6 +33,35 @@ pub struct TaskCacheConfig {
     pub command_inputs: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum TaskCacheMode {
+    /// Read cached results and write new results.
+    #[default]
+    ReadWrite,
+    /// Read cached results without writing new results.
+    ReadOnly,
+    /// Write new results without reading cached results.
+    WriteOnly,
+    /// Disable task output caching for this run.
+    Off,
+    /// Read and write only the local cache.
+    LocalOnly,
+}
+
+impl TaskCacheMode {
+    pub(crate) fn enabled(self) -> bool {
+        self != Self::Off
+    }
+
+    pub(crate) fn reads(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::ReadOnly | Self::LocalOnly)
+    }
+
+    pub(crate) fn writes(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::WriteOnly | Self::LocalOnly)
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct CacheKeyMaterial<'a> {
     format: u8,

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -17,7 +17,7 @@ use crate::task::task_script_parser::subcommand_name_from_parse;
 use crate::task::task_source_checker::{
     remove_auto_output, save_checksum, sources_are_fresh, task_cwd,
 };
-use crate::task::{Deps, FailedTasks, GetMatchingExt, Task, TaskCacheOutput};
+use crate::task::{Deps, FailedTasks, GetMatchingExt, Task, TaskCacheMode, TaskCacheOutput};
 use crate::task::{TaskCompletionState, TaskDependencyState};
 use crate::tera::{contains_template_syntax, render_str};
 use crate::toolset::env_cache::CachedEnv;
@@ -168,6 +168,7 @@ pub struct TaskExecutorConfig {
     pub continue_on_error: bool,
     pub dry_run: bool,
     pub skip_deps: bool,
+    pub task_cache: TaskCacheMode,
     /// CLI-level sandbox overrides (merged with task-level sandbox config)
     pub sandbox: crate::sandbox::SandboxConfig,
 }
@@ -187,6 +188,7 @@ pub struct TaskExecutor {
     pub continue_on_error: bool,
     pub dry_run: bool,
     pub skip_deps: bool,
+    pub task_cache: TaskCacheMode,
     pub sandbox: crate::sandbox::SandboxConfig,
 }
 
@@ -214,6 +216,7 @@ impl TaskExecutor {
             continue_on_error: config.continue_on_error,
             dry_run: config.dry_run,
             skip_deps: config.skip_deps,
+            task_cache: config.task_cache,
             sandbox: config.sandbox,
         }
     }
@@ -295,7 +298,7 @@ impl TaskExecutor {
             cache_env: task
                 .cache
                 .iter()
-                .filter(|cache| cache.enabled)
+                .filter(|cache| self.task_cache.enabled() && cache.enabled)
                 .flat_map(|cache| &cache.env)
                 .chain(self.sandbox.cache_env.iter())
                 .cloned()
@@ -343,7 +346,7 @@ impl TaskExecutor {
         }
         // If any dependency executed or restored, skip the source freshness check
         // so that downstream tasks are invalidated by upstream changes.
-        if !task.cache.as_ref().is_some_and(|cache| cache.enabled)
+        if !(self.task_cache.enabled() && task.cache.as_ref().is_some_and(|cache| cache.enabled))
             && !self.force
             && !dependency_state.any_did_work
             && sources_are_fresh(task, config).await?
@@ -540,7 +543,9 @@ impl TaskExecutor {
         };
         self.check_confirmation(config, task, &env).await?;
 
-        let artifact_cache = if task.cache.as_ref().is_some_and(|cache| cache.enabled) {
+        let artifact_cache = if self.task_cache.enabled()
+            && task.cache.as_ref().is_some_and(|cache| cache.enabled)
+        {
             match TaskArtifactCache::prepare(task, config, self.dry_run).await? {
                 Some(_) if self.dry_run => None,
                 Some(_) if self.raw(Some(task)) => {
@@ -565,7 +570,8 @@ impl TaskExecutor {
                             command_inputs,
                         )
                         .await?;
-                    let current_output = if !self.force
+                    let current_output = if self.task_cache.reads()
+                        && !self.force
                         && !dependency_state.any_unkeyed_did_work
                         && (task.outputs.is_no_files() || sources_are_fresh(task, config).await?)
                     {
@@ -584,7 +590,8 @@ impl TaskExecutor {
                             cache_key: Some(cache.key().to_string()),
                         });
                     }
-                    if !self.force
+                    if self.task_cache.reads()
+                        && !self.force
                         && !dependency_state.any_unkeyed_did_work
                         && let Some(output) = cache.restore(task)?
                     {
@@ -628,6 +635,7 @@ impl TaskExecutor {
         };
         let output_capture = artifact_cache
             .as_ref()
+            .filter(|_| self.task_cache.writes())
             .map(|_| Arc::new(StdMutex::new(Vec::new())));
 
         let timer = std::time::Instant::now();
@@ -697,7 +705,9 @@ impl TaskExecutor {
         }
 
         save_checksum(task, config).await?;
-        let cache_key = if let Some(cache) = artifact_cache {
+        let cache_key = if self.task_cache.writes()
+            && let Some(cache) = artifact_cache
+        {
             let output = output_capture
                 .as_ref()
                 .map(|output| output.lock().unwrap().clone())

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -615,7 +615,9 @@ impl TaskExecutor {
                                 task.name
                             );
                         }
-                        if let Err(err) = cache.mark_current() {
+                        if self.task_cache.writes()
+                            && let Err(err) = cache.mark_current()
+                        {
                             warn!(
                                 "task {} artifact cache state update failed: {err}",
                                 task.name

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -298,7 +298,7 @@ impl TaskExecutor {
             cache_env: task
                 .cache
                 .iter()
-                .filter(|cache| self.task_cache.enabled() && cache.enabled)
+                .filter(|cache| cache.enabled)
                 .flat_map(|cache| &cache.env)
                 .chain(self.sandbox.cache_env.iter())
                 .cloned()

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -346,7 +346,9 @@ impl TaskExecutor {
         }
         // If any dependency executed or restored, skip the source freshness check
         // so that downstream tasks are invalidated by upstream changes.
-        if !(self.task_cache.enabled() && task.cache.as_ref().is_some_and(|cache| cache.enabled))
+        let artifact_cache_enabled =
+            self.task_cache.enabled() && task.cache.as_ref().is_some_and(|cache| cache.enabled);
+        if !artifact_cache_enabled
             && !self.force
             && !dependency_state.any_did_work
             && sources_are_fresh(task, config).await?


### PR DESCRIPTION
## What
- add `--task-cache` and `MISE_TASK_CACHE` per-run controls
- support `read-write`, `read-only`, `write-only`, `off`, and `local-only` modes
- preserve stable dependency cache keys only when an artifact is restored or successfully published
- document the modes and mark the parity tracker item complete

## Why
CI and local workflows need to control cache consumption and publication independently. Read-only mode lets untrusted jobs consume existing results without publishing misses, write-only mode warms the cache without consuming entries, and off mode provides a clean diagnostic path.

## Impact
This is experimental and only affects tasks with task output caching enabled. The default remains `read-write`. `local-only` currently matches read-write behavior because remote caching is not yet implemented, while establishing the per-run contract needed for that follow-up.

## Stack
- depends on #11395

## Checks
- `mise run lint`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache e2e/tasks/test_task_artifact_cache_modes`
- `cargo test --bin mise task_cache`
- `mise run docs:build`
- `mise run render:usage`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when cached artifacts are read, written, and how dependents see keys; default read-write preserves prior behavior, but mis-set modes in CI could skip restores or publish unwanted entries.
> 
> **Overview**
> Adds **`--task-cache`** and **`MISE_TASK_CACHE`** so a single run can control the experimental **task output cache** independently of task config. Modes are **`read-write`** (default), **`read-only`**, **`write-only`**, **`off`**, and **`local-only`** (documented as equivalent to read-write until remote cache exists).
> 
> The executor now gates artifact **restore**, **skip-via-current-output**, **`mark_current`**, and **store** on per-mode **`reads()`** / **`writes()`**. **`off`** disables artifact caching and keeps normal **`sources`** freshness behavior. The experimental check for artifact caching only runs when the run mode is not **`off`**. Bootstrap and naked task entry points pick up **`TaskCacheMode::from_env()`** so **`mise build`** honors **`MISE_TASK_CACHE`** like **`mise run`**.
> 
> Docs, usage/man output, parity tracker, and e2e coverage (`test_task_artifact_cache_modes`, **`--task-cache off`** in global-env test) accompany the change. This is separate from **`--no-cache`** (remote task definitions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9729ba11417ae3dc6128cd80837de8489fe5bfa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-run task output caching control via `--task-cache <mode>` (also `MISE_TASK_CACHE`) for both `mise run` and `mise tasks run`.
  * Supported modes: `read-write` (default), `read-only`, `write-only`, `local-only`, and `off` (`local-only` acts like `read-write` without remote caching).
* **Documentation**
  * Updated CLI help, man page, and task configuration docs to describe the new flag, modes, and scope for the experimental task output cache.
* **Tests**
  * Added e2e coverage for all cache modes, restore/publish behavior, and invalid value validation (plus environment-related caching expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->