### PR TITLE
fix(shim): attribute missing executables to configured tools

### DIFF
--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -210,6 +210,21 @@ fn parse_backend_components_fallible(
 }
 
 impl BackendArg {
+    pub fn matches_bin_name(&self, bin_name: &str) -> bool {
+        let bin_name = bin_name
+            .strip_suffix(std::env::consts::EXE_SUFFIX)
+            .unwrap_or(bin_name);
+        self.short
+            .rsplit([':', '/'])
+            .next()
+            .is_some_and(|name| name == bin_name)
+            || self
+                .tool_name
+                .rsplit('/')
+                .next()
+                .is_some_and(|name| name == bin_name)
+    }
+
     #[requires(!short.is_empty())]
     pub fn new(short: String, full: Option<String>) -> Self {
         let resolution = BackendResolution::new(full.is_some());
@@ -736,6 +751,18 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use pretty_assertions::{assert_eq, assert_str_eq};
+
+    #[test]
+    fn test_matches_bin_name_uses_tool_identity() {
+        let codex: BackendArg = "codex".into();
+        let explicit_codex: BackendArg = "aqua:openai/codex".into();
+        let node: BackendArg = "node".into();
+
+        assert!(codex.matches_bin_name("codex"));
+        assert!(explicit_codex.matches_bin_name("codex"));
+        assert!(!node.matches_bin_name("codex"));
+        assert!(!codex.matches_bin_name("node"));
+    }
 
     #[tokio::test]
     async fn test_backend_arg() {

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -211,18 +211,25 @@ fn parse_backend_components_fallible(
 
 impl BackendArg {
     pub fn matches_bin_name(&self, bin_name: &str) -> bool {
-        let bin_name = bin_name
-            .strip_suffix(std::env::consts::EXE_SUFFIX)
-            .unwrap_or(bin_name);
-        self.short
-            .rsplit([':', '/'])
-            .next()
-            .is_some_and(|name| name == bin_name)
-            || self
-                .tool_name
-                .rsplit('/')
-                .next()
-                .is_some_and(|name| name == bin_name)
+        let exe_suffix = std::env::consts::EXE_SUFFIX;
+        let bin_name = if exe_suffix.is_empty() {
+            bin_name
+        } else {
+            let suffix_start = bin_name.len().saturating_sub(exe_suffix.len());
+            match (bin_name.get(..suffix_start), bin_name.get(suffix_start..)) {
+                (Some(name), Some(suffix)) if suffix.eq_ignore_ascii_case(exe_suffix) => name,
+                _ => bin_name,
+            }
+        };
+        let matches = |name: &str| {
+            if cfg!(windows) {
+                name.eq_ignore_ascii_case(bin_name)
+            } else {
+                name == bin_name
+            }
+        };
+        self.short.rsplit([':', '/']).next().is_some_and(matches)
+            || self.tool_name.rsplit('/').next().is_some_and(matches)
     }
 
     #[requires(!short.is_empty())]
@@ -762,6 +769,12 @@ mod tests {
         assert!(explicit_codex.matches_bin_name("codex"));
         assert!(!node.matches_bin_name("codex"));
         assert!(!codex.matches_bin_name("node"));
+        if cfg!(windows) {
+            assert!(codex.matches_bin_name("CODEX.EXE"));
+            assert!(explicit_codex.matches_bin_name("Codex.Exe"));
+        } else {
+            assert!(!codex.matches_bin_name("CODEX"));
+        }
     }
 
     #[tokio::test]

--- a/src/cli/which.rs
+++ b/src/cli/which.rs
@@ -57,6 +57,11 @@ impl Which {
                 Ok(())
             }
             None => {
+                if let Some(msg) =
+                    crate::shims::unavailable_configured_tool_message(&config, &ts, &bin_name)
+                {
+                    bail!(msg);
+                }
                 if self.has_shim(&bin_name) {
                     bail!(
                         "{bin_name} is a mise bin however it is not currently active. Use `mise use` to activate it in this directory."

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -757,6 +757,9 @@ async fn err_no_version_set(
         .filter(|t| missing_plugins.contains(t.ba()))
         .collect_vec();
     if missing_tools.is_empty() {
+        if let Some(msg) = unavailable_configured_tool_message(config, &ts, bin_name) {
+            return Err(eyre!(msg));
+        }
         let mut msg = format!("No version is set for shim: {bin_name}\n");
         msg.push_str("Set a global default version with one of the following:\n");
         for tv in tvs {
@@ -777,9 +780,68 @@ async fn err_no_version_set(
     }
 }
 
+pub(crate) fn unavailable_configured_tool_message(
+    config: &Arc<Config>,
+    ts: &Toolset,
+    bin_name: &str,
+) -> Option<String> {
+    let versions = ts
+        .list_current_versions()
+        .into_iter()
+        .filter(|(backend, tv)| {
+            tv.ba().matches_bin_name(bin_name) && backend.is_version_installed(config, tv, true)
+        })
+        .map(|(_, tv)| tv)
+        .collect_vec();
+    if versions.is_empty() {
+        return None;
+    }
+
+    let mut msg = format!("No executable found for configured tool: {bin_name}\n");
+    msg.push_str(
+        "The installed version does not provide this executable with its current backend metadata.\n",
+    );
+    msg.push_str("Reinstall it with:\n");
+    for tv in versions {
+        msg.push_str(&format!(
+            "mise install --force {}@{}\n",
+            tv.ba(),
+            tv.version
+        ));
+    }
+    Some(msg.trim().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::args::BackendArg;
+    use crate::toolset::{ToolRequest, ToolSource, ToolVersionList};
+
+    #[tokio::test]
+    async fn unavailable_tool_message_prefers_matching_configured_tool() {
+        let config = Config::get().await.unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let mut ts = Toolset::new(ToolSource::Argument);
+
+        for name in ["codex", "node"] {
+            let ba = Arc::new(BackendArg::from(name));
+            let request = ToolRequest::new(ba.clone(), "1.0.0", ToolSource::Argument).unwrap();
+            let mut tv = ToolVersion::new(request.clone(), "1.0.0".into());
+            let install_path = temp.path().join(name);
+            file::create_dir_all(&install_path).unwrap();
+            tv.install_path = Some(install_path);
+
+            let mut tvl = ToolVersionList::new(ba.clone(), ToolSource::Argument);
+            tvl.requests.push(request);
+            tvl.versions.push(tv);
+            ts.versions.insert(ba, tvl);
+        }
+
+        let msg = unavailable_configured_tool_message(&config, &ts, "codex").unwrap();
+        assert!(msg.contains("mise install --force codex@1.0.0"));
+        assert!(!msg.contains("node@1.0.0"));
+    }
 
     #[cfg(windows)]
     #[test]


### PR DESCRIPTION
## Summary

- associate failed shims with configured tools by tool identity
- prefer a forced reinstall of the matching configured tool over suggestions from unrelated installed runtimes
- use the same diagnostic for direct `mise which` calls

## Root cause

When a shim could not resolve, mise scanned every installed tool version for any executable with the same filename. An inactive Node installation containing an npm-installed `codex` could therefore cause a failed configured Codex shim to recommend activating that Node version.

## User impact

If a configured tool is installed but no longer exposes its namesake executable, mise now explains that its installation is incompatible with current backend metadata and recommends `mise install --force <tool>@<version>`. Unrelated tools that happen to contain the same executable are not presented as the primary remediation.

## Validation

- `cargo test cli::args::backend_arg::tests::test_matches_bin_name_uses_tool_identity`
- `cargo test unavailable_tool_message_prefers_matching_configured_tool`
- `cargo fmt --all -- --check`
- regression test constructs configured Codex and Node versions and verifies only Codex appears in the repair command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI/shim diagnostics only; no auth, install pipeline, or data-model changes beyond clearer error selection.
> 
> **Overview**
> Fixes **shim and `mise which` errors** that blamed unrelated installed tools when another runtime happened to ship the same executable name (e.g. npm `codex` under Node vs configured Codex).
> 
> Adds **`BackendArg::matches_bin_name`** so resolution keys off tool identity (`short` / `tool_name`, with Windows `.exe` and case handling) instead of scanning every install for a matching filename.
> 
> When a configured tool is **installed but does not expose the requested binary** under current backend metadata, **`unavailable_configured_tool_message`** explains the mismatch and suggests **`mise install --force <tool>@<version>`**. That path runs from shim resolution and from **`mise which`** when lookup fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31e4cfca220c30e1145c0e9f721ff55cc10d457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool detection by matching backend tools more accurately across operating systems, including executable name normalization.
  * Improved error handling when a configured tool version doesn’t provide the requested executable, with clearer, more specific guidance.
  * Added an actionable “reinstall with `mise install --force <tool>@<version>`” message when appropriate.
  * Preserved existing guidance for tools that are not installed or not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->