### PR TITLE
feat(task): add configurable cache directory

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -88,7 +88,7 @@ outside this tracker.
 - [x] Support command-output inputs
 - [x] Include external dependency and lockfile state through explicit input configuration
 - [x] Add per-run cache read/write controls, including local-only and cache-disabled modes
-- [ ] Add a configurable local task-cache directory
+- [x] Add a configurable local task-cache directory
 
 ## Inspection and diagnostics
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -695,8 +695,8 @@ Cache entries are stored under `MISE_CACHE_DIR/task-artifacts/v2` by default. Se
 [`task.cache_dir`](/configuration/settings.html#task-cache-dir) setting or
 `MISE_TASK_CACHE_DIR` to choose a different parent directory; mise keeps the artifact format in its
 `v2` child directory. Default and custom locations are included in `mise cache clear` and
-`mise cache prune`. Only successful task runs are cached. Cache read/write failures are treated as
-misses and never turn a successful task run into a failure.
+manual and automatic cache pruning. Only successful task runs are cached. Cache read/write failures
+are treated as misses and never turn a successful task run into a failure.
 
 Stdout and stderr are stored as ordered, redacted streams and replayed using the output mode selected
 for the cache hit. Prefix, interleave, keep-order, timed, replacing, quiet, silent, and per-stream

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -691,11 +691,12 @@ not use them for values that affect generated outputs. Their values are not adde
 persisted as cache metadata, but a task can still expose them by writing them to cached output files
 or logs.
 
-Cache entries are stored under `MISE_CACHE_DIR/task-artifacts/v2`. Filesystem outputs use
-zstd-compressed tar archives; result-only tasks store just their manifest and captured logs. Entries
-are included in the existing `mise cache clear` and `mise cache prune` behavior. Only successful task
-runs are cached. Cache read/write failures are treated as misses and never turn a successful task run
-into a failure.
+Cache entries are stored under `MISE_CACHE_DIR/task-artifacts/v2` by default. Set the experimental
+[`task.cache_dir`](/configuration/settings.html#task-cache-dir) setting or
+`MISE_TASK_CACHE_DIR` to choose a different parent directory; mise keeps the artifact format in its
+`v2` child directory. Default and custom locations are included in `mise cache clear` and
+`mise cache prune`. Only successful task runs are cached. Cache read/write failures are treated as
+misses and never turn a successful task run into a failure.
 
 Stdout and stderr are stored as ordered, redacted streams and replayed using the output mode selected
 for the cache hit. Prefix, interleave, keep-order, timed, replacing, quiet, silent, and per-stream

--- a/e2e/tasks/test_task_artifact_cache_directory
+++ b/e2e/tasks/test_task_artifact_cache_directory
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+task.cache_dir = "config-task-cache"
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+run = """
+mkdir -p dist
+printf 'cached\n' > dist/result.txt
+printf 'ran\n' >> runs.txt
+"""
+sources = ["input.txt"]
+outputs = ["dist"]
+EOF
+
+printf 'input\n' >input.txt
+export MISE_TASK_CACHE_DIR="$PWD/custom-task-cache"
+
+mise run build
+assert "wc -l < runs.txt | tr -d ' '" "1"
+assert "find \"$MISE_TASK_CACHE_DIR/v2\" -type f -name '*.json' | wc -l | tr -d ' '" "1"
+assert_directory_not_exists "$MISE_CACHE_DIR/task-artifacts"
+
+rm -rf dist
+assert_contains "mise run build 2>&1" "restored outputs from cache"
+assert "cat dist/result.txt" "cached"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+mise cache clear
+assert_directory_not_exists "$MISE_TASK_CACHE_DIR/v2"
+assert_directory_exists "$MISE_TASK_CACHE_DIR"
+
+# The config setting is used when the environment override is absent.
+unset MISE_TASK_CACHE_DIR
+rm -rf dist
+mise run build
+assert "wc -l < runs.txt | tr -d ' '" "2"
+assert "find \"$PWD/config-task-cache/v2\" -type f -name '*.json' | wc -l | tr -d ' '" "1"
+
+mise cache clear
+assert_directory_not_exists "$PWD/config-task-cache/v2"
+assert_directory_exists "$PWD/config-task-cache"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1776,6 +1776,10 @@
           "type": "object",
           "unevaluatedProperties": false,
           "properties": {
+            "cache_dir": {
+              "description": "[experimental] Directory for task output cache artifacts.",
+              "type": "string"
+            },
             "disable_paths": {
               "default": [],
               "description": "Paths that mise will not look for tasks in.",

--- a/settings.toml
+++ b/settings.toml
@@ -2603,6 +2603,18 @@ it, and skips sudo entirely when already running as root (e.g. containers/CI).
 env = "MISE_SYSTEM_PACKAGES_SUDO"
 type = "Bool"
 
+[task.cache_dir]
+description = "[experimental] Directory for task output cache artifacts."
+docs = """
+Store task output cache artifacts in this directory instead of
+`MISE_CACHE_DIR/task-artifacts`. mise stores the current artifact format in a
+versioned subdirectory and includes custom locations in `mise cache clear` and
+`mise cache prune`.
+"""
+env = "MISE_TASK_CACHE_DIR"
+optional = true
+type = "Path"
+
 [task.disable_paths]
 default = []
 description = "Paths that mise will not look for tasks in."

--- a/settings.toml
+++ b/settings.toml
@@ -2609,7 +2609,7 @@ docs = """
 Store task output cache artifacts in this directory instead of
 `MISE_CACHE_DIR/task-artifacts`. mise stores the current artifact format in a
 versioned subdirectory and includes custom locations in `mise cache clear` and
-`mise cache prune`.
+manual and automatic cache pruning.
 """
 env = "MISE_TASK_CACHE_DIR"
 optional = true

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -315,10 +315,13 @@ pub(crate) struct PruneOptions {
     pub(crate) age: Duration,
 }
 
+/// Returns every cache root maintained by whole-cache clear and prune operations.
 pub(crate) fn cache_dirs() -> Result<Vec<PathBuf>> {
     cache_dirs_with_task_cache(crate::task::task_cache::task_cache_dir())
 }
 
+/// Adds an external task cache to the global cache roots without double-scanning
+/// task caches already stored beneath `MISE_CACHE_DIR`.
 fn cache_dirs_with_task_cache(task_cache_dir: PathBuf) -> Result<Vec<PathBuf>> {
     let cache_root = dirs::CACHE.absolutize()?.to_path_buf();
     let task_cache_dir = task_cache_dir.absolutize()?.to_path_buf();
@@ -329,6 +332,10 @@ fn cache_dirs_with_task_cache(task_cache_dir: PathBuf) -> Result<Vec<PathBuf>> {
     Ok(cache_dirs)
 }
 
+/// Opportunistically removes stale files from each active cache root.
+///
+/// Each external root keeps its own marker so one project's task cache cannot
+/// suppress automatic pruning for another project that shares `MISE_CACHE_DIR`.
 pub(crate) fn auto_prune() -> Result<()> {
     if !rand::random::<u8>().is_multiple_of(100) {
         return Ok(()); // only prune 1% of the time
@@ -340,36 +347,27 @@ pub(crate) fn auto_prune() -> Result<()> {
             return Ok(());
         }
     };
-    let auto_prune_file = dirs::CACHE.join(".auto_prune");
-    if let Ok(Ok(modified)) = auto_prune_file.metadata().map(|m| m.modified())
-        && modified.elapsed().unwrap_or_default() < age
-    {
-        return Ok(());
-    }
     let cache_dirs = cache_dirs()?;
-    let empty = cache_dirs
-        .iter()
-        .all(|dir| file::ls(dir).unwrap_or_default().is_empty());
-    xx::file::touch_dir(&auto_prune_file)?;
-    if empty {
-        return Ok(());
-    }
-    debug!(
-        "pruning old cache files, this behavior can be modified with the MISE_CACHE_PRUNE_AGE setting"
-    );
     let opts = PruneOptions {
         dry_run: false,
         verbose: false,
         age,
     };
-    for cache_dir in cache_dirs {
-        if cache_dir.exists() {
+    let mut prune_env_cache = false;
+    for (index, cache_dir) in cache_dirs.into_iter().enumerate() {
+        if prepare_auto_prune_root(&cache_dir, age)? {
+            debug!(
+                "pruning old cache files, this behavior can be modified with the MISE_CACHE_PRUNE_AGE setting"
+            );
             prune(&cache_dir, &opts)?;
+            if index == 0 {
+                prune_env_cache = true;
+            }
         }
     }
     // Also prune env cache using env_cache_ttl
     let env_cache_dir = CachedEnv::cache_dir();
-    if env_cache_dir.exists() {
+    if prune_env_cache && env_cache_dir.exists() {
         let env_opts = PruneOptions {
             dry_run: false,
             verbose: false,
@@ -378,6 +376,23 @@ pub(crate) fn auto_prune() -> Result<()> {
         prune(&env_cache_dir, &env_opts)?;
     }
     Ok(())
+}
+
+/// Refreshes a cache root's private auto-prune marker and reports whether the
+/// root contains entries eligible for a pruning pass.
+fn prepare_auto_prune_root(cache_dir: &Path, age: Duration) -> Result<bool> {
+    if !cache_dir.exists() {
+        return Ok(false);
+    }
+    let auto_prune_file = cache_dir.join(".auto_prune");
+    if let Ok(Ok(modified)) = auto_prune_file.metadata().map(|m| m.modified())
+        && modified.elapsed().unwrap_or_default() < age
+    {
+        return Ok(false);
+    }
+    let empty = file::ls(cache_dir)?.is_empty();
+    xx::file::touch_dir(&auto_prune_file)?;
+    Ok(!empty)
 }
 
 pub(crate) fn prune(dir: &Path, opts: &PruneOptions) -> Result<PruneResults> {
@@ -423,6 +438,7 @@ pub(crate) fn prune(dir: &Path, opts: &PruneOptions) -> Result<PruneResults> {
 #[cfg(test)]
 mod tests {
     use crate::config::Config;
+    use std::fs;
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -517,5 +533,20 @@ mod tests {
             cache_dirs_with_task_cache(escaping).unwrap(),
             vec![dirs::CACHE.to_path_buf(), external]
         );
+    }
+
+    #[test]
+    fn auto_prune_markers_are_scoped_per_cache_root() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        fs::write(first.path().join("artifact"), "first").unwrap();
+        fs::write(second.path().join("artifact"), "second").unwrap();
+        let age = Duration::from_secs(60);
+
+        assert!(prepare_auto_prune_root(first.path(), age).unwrap());
+        assert!(prepare_auto_prune_root(second.path(), age).unwrap());
+        assert!(!prepare_auto_prune_root(first.path(), age).unwrap());
+        assert!(first.path().join(".auto_prune").exists());
+        assert!(second.path().join(".auto_prune").exists());
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -10,6 +10,7 @@ use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
+use path_absolutize::Absolutize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::sync::LazyLock as Lazy;
@@ -314,16 +315,18 @@ pub(crate) struct PruneOptions {
     pub(crate) age: Duration,
 }
 
-pub(crate) fn cache_dirs() -> Vec<PathBuf> {
+pub(crate) fn cache_dirs() -> Result<Vec<PathBuf>> {
     cache_dirs_with_task_cache(crate::task::task_cache::task_cache_dir())
 }
 
-fn cache_dirs_with_task_cache(task_cache_dir: PathBuf) -> Vec<PathBuf> {
-    let mut cache_dirs = vec![dirs::CACHE.to_path_buf()];
-    if !task_cache_dir.starts_with(*dirs::CACHE) {
+fn cache_dirs_with_task_cache(task_cache_dir: PathBuf) -> Result<Vec<PathBuf>> {
+    let cache_root = dirs::CACHE.absolutize()?.to_path_buf();
+    let task_cache_dir = task_cache_dir.absolutize()?.to_path_buf();
+    let mut cache_dirs = vec![cache_root.clone()];
+    if !task_cache_dir.starts_with(cache_root) {
         cache_dirs.push(task_cache_dir);
     }
-    cache_dirs
+    Ok(cache_dirs)
 }
 
 pub(crate) fn auto_prune() -> Result<()> {
@@ -343,7 +346,7 @@ pub(crate) fn auto_prune() -> Result<()> {
     {
         return Ok(());
     }
-    let cache_dirs = cache_dirs();
+    let cache_dirs = cache_dirs()?;
     let empty = cache_dirs
         .iter()
         .all(|dir| file::ls(dir).unwrap_or_default().is_empty());
@@ -491,14 +494,28 @@ mod tests {
     fn cache_dirs_adds_only_external_task_cache() {
         let external = tempfile::tempdir().unwrap();
         assert_eq!(
-            cache_dirs_with_task_cache(external.path().to_path_buf()),
+            cache_dirs_with_task_cache(external.path().to_path_buf()).unwrap(),
             vec![dirs::CACHE.to_path_buf(), external.path().to_path_buf()]
         );
 
         let nested = dirs::CACHE.join("task-artifacts").join("v2");
         assert_eq!(
-            cache_dirs_with_task_cache(nested),
+            cache_dirs_with_task_cache(nested).unwrap(),
             vec![dirs::CACHE.to_path_buf()]
+        );
+
+        let external = dirs::CACHE
+            .parent()
+            .unwrap()
+            .join("external-task-cache")
+            .join("v2");
+        let escaping = dirs::CACHE
+            .join("..")
+            .join("external-task-cache")
+            .join("v2");
+        assert_eq!(
+            cache_dirs_with_task_cache(escaping).unwrap(),
+            vec![dirs::CACHE.to_path_buf(), external]
         );
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -314,6 +314,18 @@ pub(crate) struct PruneOptions {
     pub(crate) age: Duration,
 }
 
+pub(crate) fn cache_dirs() -> Vec<PathBuf> {
+    cache_dirs_with_task_cache(crate::task::task_cache::task_cache_dir())
+}
+
+fn cache_dirs_with_task_cache(task_cache_dir: PathBuf) -> Vec<PathBuf> {
+    let mut cache_dirs = vec![dirs::CACHE.to_path_buf()];
+    if !task_cache_dir.starts_with(*dirs::CACHE) {
+        cache_dirs.push(task_cache_dir);
+    }
+    cache_dirs
+}
+
 pub(crate) fn auto_prune() -> Result<()> {
     if !rand::random::<u8>().is_multiple_of(100) {
         return Ok(()); // only prune 1% of the time
@@ -331,7 +343,10 @@ pub(crate) fn auto_prune() -> Result<()> {
     {
         return Ok(());
     }
-    let empty = file::ls(*dirs::CACHE).unwrap_or_default().is_empty();
+    let cache_dirs = cache_dirs();
+    let empty = cache_dirs
+        .iter()
+        .all(|dir| file::ls(dir).unwrap_or_default().is_empty());
     xx::file::touch_dir(&auto_prune_file)?;
     if empty {
         return Ok(());
@@ -344,7 +359,11 @@ pub(crate) fn auto_prune() -> Result<()> {
         verbose: false,
         age,
     };
-    prune(*dirs::CACHE, &opts)?;
+    for cache_dir in cache_dirs {
+        if cache_dir.exists() {
+            prune(&cache_dir, &opts)?;
+        }
+    }
     // Also prune env cache using env_cache_ttl
     let env_cache_dir = CachedEnv::cache_dir();
     if env_cache_dir.exists() {
@@ -466,5 +485,20 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(val, 2);
+    }
+
+    #[test]
+    fn cache_dirs_adds_only_external_task_cache() {
+        let external = tempfile::tempdir().unwrap();
+        assert_eq!(
+            cache_dirs_with_task_cache(external.path().to_path_buf()),
+            vec![dirs::CACHE.to_path_buf(), external.path().to_path_buf()]
+        );
+
+        let nested = dirs::CACHE.join("task-artifacts").join("v2");
+        assert_eq!(
+            cache_dirs_with_task_cache(nested),
+            vec![dirs::CACHE.to_path_buf()]
+        );
     }
 }

--- a/src/cli/cache/clear.rs
+++ b/src/cli/cache/clear.rs
@@ -35,7 +35,7 @@ impl CacheClear {
                     }
                 })
                 .collect(),
-            None => cache::cache_dirs(),
+            None => cache::cache_dirs()?,
         };
         if self.outdate {
             for p in cache_dirs {

--- a/src/cli/cache/clear.rs
+++ b/src/cli/cache/clear.rs
@@ -1,6 +1,6 @@
+use crate::cache;
 use crate::dirs::CACHE;
 use crate::file::{display_path, remove_all_with_retry};
-use crate::task::task_cache::task_cache_dir;
 use crate::toolset::env_cache::CachedEnv;
 use eyre::Result;
 use filetime::set_file_times;
@@ -35,14 +35,7 @@ impl CacheClear {
                     }
                 })
                 .collect(),
-            None => {
-                let mut dirs = vec![CACHE.to_path_buf()];
-                let task_cache_dir = task_cache_dir();
-                if !task_cache_dir.starts_with(*CACHE) {
-                    dirs.push(task_cache_dir);
-                }
-                dirs
-            }
+            None => cache::cache_dirs(),
         };
         if self.outdate {
             for p in cache_dirs {

--- a/src/cli/cache/clear.rs
+++ b/src/cli/cache/clear.rs
@@ -1,5 +1,6 @@
 use crate::dirs::CACHE;
 use crate::file::{display_path, remove_all_with_retry};
+use crate::task::task_cache::task_cache_dir;
 use crate::toolset::env_cache::CachedEnv;
 use eyre::Result;
 use filetime::set_file_times;
@@ -34,7 +35,14 @@ impl CacheClear {
                     }
                 })
                 .collect(),
-            None => vec![CACHE.to_path_buf()],
+            None => {
+                let mut dirs = vec![CACHE.to_path_buf()];
+                let task_cache_dir = task_cache_dir();
+                if !task_cache_dir.starts_with(*CACHE) {
+                    dirs.push(task_cache_dir);
+                }
+                dirs
+            }
         };
         if self.outdate {
             for p in cache_dirs {

--- a/src/cli/cache/prune.rs
+++ b/src/cli/cache/prune.rs
@@ -2,7 +2,6 @@ use crate::cache;
 use crate::cache::{PruneOptions, PruneResults};
 use crate::config::Settings;
 use crate::dirs::CACHE;
-use crate::task::task_cache::task_cache_dir;
 use crate::toolset::env_cache::CachedEnv;
 use bytesize::ByteSize;
 use eyre::Result;
@@ -54,14 +53,7 @@ impl CachePrune {
                     }
                 })
                 .collect(),
-            None => {
-                let mut dirs = vec![CACHE.to_path_buf()];
-                let task_cache_dir = task_cache_dir();
-                if !task_cache_dir.starts_with(*CACHE) {
-                    dirs.push(task_cache_dir);
-                }
-                dirs
-            }
+            None => cache::cache_dirs(),
         };
 
         for p in cache_dirs {

--- a/src/cli/cache/prune.rs
+++ b/src/cli/cache/prune.rs
@@ -2,6 +2,7 @@ use crate::cache;
 use crate::cache::{PruneOptions, PruneResults};
 use crate::config::Settings;
 use crate::dirs::CACHE;
+use crate::task::task_cache::task_cache_dir;
 use crate::toolset::env_cache::CachedEnv;
 use bytesize::ByteSize;
 use eyre::Result;
@@ -53,7 +54,14 @@ impl CachePrune {
                     }
                 })
                 .collect(),
-            None => vec![CACHE.to_path_buf()],
+            None => {
+                let mut dirs = vec![CACHE.to_path_buf()];
+                let task_cache_dir = task_cache_dir();
+                if !task_cache_dir.starts_with(*CACHE) {
+                    dirs.push(task_cache_dir);
+                }
+                dirs
+            }
         };
 
         for p in cache_dirs {

--- a/src/cli/cache/prune.rs
+++ b/src/cli/cache/prune.rs
@@ -53,7 +53,7 @@ impl CachePrune {
                     }
                 })
                 .collect(),
-            None => cache::cache_dirs(),
+            None => cache::cache_dirs()?,
         };
 
         for p in cache_dirs {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -122,6 +122,7 @@ pub(crate) enum TaskCacheOutput {
 
 pub struct TaskArtifactCache {
     root: PathBuf,
+    cache_dir: PathBuf,
     key: String,
     state_path: PathBuf,
 }
@@ -231,6 +232,7 @@ impl TaskArtifactCacheBuilder {
             .join(format!("{state_identity}.key"));
         Ok(TaskArtifactCache {
             root,
+            cache_dir: task_cache_dir(),
             key,
             state_path,
         })
@@ -355,12 +357,15 @@ impl TaskArtifactCache {
             ensure_no_symlink_ancestors(&self.root, root)?;
         }
 
-        let cache_dir = dirs::CACHE.join("task-artifacts").join(CACHE_DIR_VERSION);
-        file::create_dir_all(&cache_dir)?;
+        file::create_dir_all(&self.cache_dir)?;
         let (archive_path, manifest_path) = self.paths();
         let nonce = crate::rand::random_string(8);
-        let archive_partial = cache_dir.join(format!("{}.part-{nonce}.tar.zst", self.key));
-        let manifest_partial = cache_dir.join(format!("{}.part-{nonce}.json", self.key));
+        let archive_partial = self
+            .cache_dir
+            .join(format!("{}.part-{nonce}.tar.zst", self.key));
+        let manifest_partial = self
+            .cache_dir
+            .join(format!("{}.part-{nonce}.json", self.key));
 
         let manifest = CacheManifest {
             format: CACHE_FORMAT_VERSION,
@@ -388,10 +393,9 @@ impl TaskArtifactCache {
     }
 
     fn paths(&self) -> (PathBuf, PathBuf) {
-        let base = dirs::CACHE.join("task-artifacts").join(CACHE_DIR_VERSION);
         (
-            base.join(format!("{}.tar.zst", self.key)),
-            base.join(format!("{}.json", self.key)),
+            self.cache_dir.join(format!("{}.tar.zst", self.key)),
+            self.cache_dir.join(format!("{}.json", self.key)),
         )
     }
 
@@ -403,6 +407,15 @@ impl TaskArtifactCache {
         }
         Ok(manifest)
     }
+}
+
+pub(crate) fn task_cache_dir() -> PathBuf {
+    Settings::get()
+        .task
+        .cache_dir
+        .clone()
+        .unwrap_or_else(|| dirs::CACHE.join("task-artifacts"))
+        .join(CACHE_DIR_VERSION)
 }
 
 pub(crate) fn validate_config(task: &Task, root: &Path) -> Result<()> {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -169,6 +169,8 @@ impl TaskArtifactCache {
 }
 
 impl TaskArtifactCacheBuilder {
+    /// Finishes cache-key construction after task tools, environment, and
+    /// dependency artifacts have been resolved.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn finish(
         self,
@@ -350,6 +352,7 @@ impl TaskArtifactCache {
         }
     }
 
+    /// Stores a successful task's declared outputs and captured logs.
     pub(crate) fn store(&self, task: &Task, output: &[TaskCacheOutput]) -> Result<()> {
         let roots = resolve_output_roots(task, &self.root, true)?;
         let roots = remove_nested_roots(roots);
@@ -392,6 +395,7 @@ impl TaskArtifactCache {
         Ok(())
     }
 
+    /// Returns this cache entry's archive and manifest paths.
     fn paths(&self) -> (PathBuf, PathBuf) {
         (
             self.cache_dir.join(format!("{}.tar.zst", self.key)),
@@ -409,6 +413,7 @@ impl TaskArtifactCache {
     }
 }
 
+/// Returns the versioned directory containing task artifact cache entries.
 pub(crate) fn task_cache_dir() -> PathBuf {
     Settings::get()
         .task


### PR DESCRIPTION
## What
- add experimental `task.cache_dir` and `MISE_TASK_CACHE_DIR` configuration
- route task artifact reads and writes through the selected versioned cache directory
- include custom task-cache locations in `mise cache clear` and `mise cache prune`
- document the setting, update the parity tracker, and add end-to-end coverage for config and environment overrides

## Why
CI systems and monorepos need to place task artifacts on dedicated volumes or in project-specific cache locations without relocating mise's entire cache directory.

## Impact
The default remains `MISE_CACHE_DIR/task-artifacts/v2`. A custom setting is treated as a parent directory and mise stores the current format in its `v2` child. Cache clearing removes only that versioned child, preserving the configured parent directory.

This is an independent follow-up to #11396.

## Checks
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_directory`
- `mise run lint-fix`
- `mise x rust@1.94.1 -- cargo clippy -- -D warnings`
- `mise run render`
- `mise run render:schema`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default paths and cache semantics are preserved; changes are additive configuration and cache-directory enumeration with unit and e2e coverage.
> 
> **Overview**
> Adds experimental **`task.cache_dir`** and **`MISE_TASK_CACHE_DIR`** so task output artifacts can live outside the default `MISE_CACHE_DIR/task-artifacts` tree. mise still stores the current format under a **`v2`** subdirectory of the configured parent; unset behavior is unchanged.
> 
> **Task artifact I/O** now resolves the versioned cache path from settings instead of always using `MISE_CACHE_DIR/task-artifacts/v2` for store, restore, and manifest/archive paths.
> 
> **Cache maintenance** (`mise cache clear`, `mise cache prune`, and automatic pruning) enumerates both the main mise cache root and an external task-cache root when the custom directory is not nested under `MISE_CACHE_DIR`, avoiding duplicate scans. Auto-prune uses a **per-root** `.auto_prune` marker so one project’s external task cache does not block pruning for another.
> 
> Documentation, JSON schema, parity tracker, and an e2e test cover env override precedence, config fallback, hits/misses, and that clear removes only the `v2` child while keeping the parent directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d1a8d8c7f578d24b7c59206e553a19e2eb2229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental `task.cache_dir` setting to configure where task output cache artifacts are stored (versioned `v2` layout).
  * Supports overrides via `MISE_TASK_CACHE_DIR`.
* **Improvements**
  * Cache clear, auto-prune, and prune without a tool filter now apply to both the default cache location and the configured custom task-cache directory.
* **Documentation**
  * Updated task cache documentation and the `mise.toml` schema for `task.cache_dir`, including defaults and which cleanup commands apply.
* **Tests**
  * Added end-to-end coverage for custom directory behavior, overrides, fallback after clearing, and cleanup semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->