### PR TITLE
feat(task): add workspace project graph model

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -32,9 +32,9 @@ outside this tracker.
 
 ## Workspace and project graph
 
-- [ ] Define a provider-neutral project model with stable project IDs, roots, metadata, and
+- [x] Define a provider-neutral project model with stable project IDs, roots, metadata, and
       dependency edges
-- [ ] Define a workspace provider interface that can discover projects and dependencies
+- [x] Define a workspace provider interface that can discover projects and dependencies
       deterministically
 - [ ] Merge graphs from multiple providers for polyglot repositories
 - [ ] Allow explicit configuration to add, remove, or override inferred projects and dependency

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -62,6 +62,9 @@ pub mod task_source_checker;
 pub mod task_sources;
 pub mod task_template;
 pub mod task_tool_installer;
+// Consumed by workspace providers introduced in follow-up changes.
+#[allow(dead_code)]
+pub mod workspace;
 
 pub(crate) use task_cache::TaskCacheOutput;
 pub use task_cache::{TaskArtifactCache, TaskCacheConfig, TaskCacheMode};

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -157,7 +157,11 @@ fn normalize_project_root(id: &ProjectId, root: &Path) -> Result<PathBuf> {
             Component::CurDir => {}
             Component::Normal(component) => normalized.push(component),
             Component::ParentDir => {
-                bail!("workspace project {id:?} has root {root:?} that escapes the workspace root");
+                if !normalized.pop() {
+                    bail!(
+                        "workspace project {id:?} has root {root:?} that escapes the workspace root"
+                    );
+                }
             }
             Component::RootDir | Component::Prefix(_) => {
                 bail!(
@@ -250,6 +254,20 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("escapes the workspace root")
+        );
+    }
+
+    #[test]
+    fn discovery_normalizes_internal_parent_components() {
+        let provider = TestProvider {
+            projects: vec![project("app", "packages/tmp/../app")],
+        };
+
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap();
+
+        assert_eq!(
+            graph.projects().next().unwrap().root,
+            Path::new("packages/app")
         );
     }
 

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -1,0 +1,281 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{self, Debug, Display};
+use std::path::{Component, Path, PathBuf};
+
+use eyre::{Result, bail};
+use serde::Serialize;
+
+/// A stable, provider-namespaced identifier for a workspace project.
+///
+/// Providers should derive the local part from ecosystem metadata, such as a
+/// package name, rather than from the project's current filesystem location.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct ProjectId(String);
+
+impl ProjectId {
+    /// Creates an ID whose namespace prevents collisions between providers.
+    pub fn new(provider: &str, local_id: &str) -> Result<Self> {
+        validate_id_part("provider", provider)?;
+        validate_id_part("project", local_id)?;
+        Ok(Self(format!("{provider}:{local_id}")))
+    }
+
+    /// Returns the serialized project ID.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for ProjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+fn validate_id_part(kind: &str, value: &str) -> Result<()> {
+    if value.is_empty() {
+        bail!("workspace {kind} ID cannot be empty");
+    }
+    if value.trim() != value || value.chars().any(char::is_control) {
+        bail!(
+            "workspace {kind} ID {value:?} contains surrounding whitespace or control characters"
+        );
+    }
+    if kind == "provider" && value.contains(':') {
+        bail!("workspace provider ID {value:?} cannot contain ':'");
+    }
+    Ok(())
+}
+
+/// A project discovered from ecosystem-specific workspace metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WorkspaceProject {
+    /// Stable identity used by dependency edges and task scoping.
+    pub id: ProjectId,
+    /// Normalized path relative to the workspace root. `.` represents the root.
+    pub root: PathBuf,
+    /// Provider-neutral facts that consumers may use for inspection or inference.
+    pub metadata: BTreeMap<String, String>,
+    /// Projects that this project directly depends on.
+    pub dependencies: BTreeSet<ProjectId>,
+}
+
+impl WorkspaceProject {
+    /// Creates a project with no metadata or dependencies.
+    pub fn new(id: ProjectId, root: impl Into<PathBuf>) -> Self {
+        Self {
+            id,
+            root: root.into(),
+            metadata: BTreeMap::new(),
+            dependencies: BTreeSet::new(),
+        }
+    }
+}
+
+/// Discovers projects and dependency edges from one workspace ecosystem.
+pub trait WorkspaceProvider: Debug + Send + Sync {
+    /// Stable namespace used when constructing project IDs.
+    fn id(&self) -> &str;
+
+    /// Returns every project known to this provider.
+    ///
+    /// The returned order is ignored. Project IDs, metadata, and dependency
+    /// sets determine the canonical graph order instead.
+    fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>>;
+}
+
+/// A validated, deterministically ordered project graph from one provider.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct WorkspaceProjectGraph {
+    projects: BTreeMap<ProjectId, WorkspaceProject>,
+}
+
+impl WorkspaceProjectGraph {
+    /// Discovers and validates a provider's projects.
+    pub fn discover(
+        provider: &dyn WorkspaceProvider,
+        workspace_root: &Path,
+    ) -> Result<WorkspaceProjectGraph> {
+        let provider_id = provider.id();
+        validate_id_part("provider", provider_id)?;
+
+        let mut projects = BTreeMap::new();
+        for mut project in provider.discover(workspace_root)? {
+            let expected_prefix = format!("{provider_id}:");
+            let Some(local_id) = project.id.as_str().strip_prefix(&expected_prefix) else {
+                bail!(
+                    "workspace provider {provider_id:?} returned project ID {:?}; IDs must use the {expected_prefix:?} namespace",
+                    project.id
+                );
+            };
+            validate_id_part("project", local_id)?;
+            project.root = normalize_project_root(&project.id, &project.root)?;
+            let id = project.id.clone();
+            if projects.insert(id.clone(), project).is_some() {
+                bail!("workspace provider {provider_id:?} returned duplicate project ID {id:?}");
+            }
+        }
+
+        let graph = Self { projects };
+        for project in graph.projects() {
+            for dependency in &project.dependencies {
+                if graph.get(dependency).is_none() {
+                    bail!(
+                        "workspace project {:?} depends on unknown project {:?}",
+                        project.id,
+                        dependency
+                    );
+                }
+            }
+        }
+
+        Ok(graph)
+    }
+
+    /// Returns projects in stable project-ID order.
+    pub fn projects(&self) -> impl ExactSizeIterator<Item = &WorkspaceProject> {
+        self.projects.values()
+    }
+
+    /// Finds a project by its stable ID.
+    pub fn get(&self, id: &ProjectId) -> Option<&WorkspaceProject> {
+        self.projects.get(id)
+    }
+}
+
+fn normalize_project_root(id: &ProjectId, root: &Path) -> Result<PathBuf> {
+    if root.is_absolute() {
+        bail!(
+            "workspace project {id:?} has absolute root {root:?}; roots must be workspace-relative"
+        );
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in root.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(component) => normalized.push(component),
+            Component::ParentDir => {
+                bail!("workspace project {id:?} has root {root:?} that escapes the workspace root");
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                bail!(
+                    "workspace project {id:?} has absolute root {root:?}; roots must be workspace-relative"
+                );
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        normalized.push(".");
+    }
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestProvider {
+        projects: Vec<WorkspaceProject>,
+    }
+
+    impl WorkspaceProvider for TestProvider {
+        fn id(&self) -> &str {
+            "test"
+        }
+
+        fn discover(&self, _workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+            Ok(self.projects.clone())
+        }
+    }
+
+    fn project(name: &str, root: &str) -> WorkspaceProject {
+        WorkspaceProject::new(ProjectId::new("test", name).unwrap(), root)
+    }
+
+    #[test]
+    fn project_ids_are_provider_namespaced() {
+        assert_eq!(
+            ProjectId::new("node", "@scope/app").unwrap().as_str(),
+            "node:@scope/app"
+        );
+        assert!(ProjectId::new("", "app").is_err());
+        assert!(ProjectId::new("node", " app").is_err());
+    }
+
+    #[test]
+    fn discovery_is_ordered_and_normalizes_roots() {
+        let provider = TestProvider {
+            projects: vec![project("z", "./packages/z"), project("a", "")],
+        };
+
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap();
+        let projects = graph.projects().collect::<Vec<_>>();
+
+        assert_eq!(projects[0].id.as_str(), "test:a");
+        assert_eq!(projects[0].root, Path::new("."));
+        assert_eq!(projects[1].id.as_str(), "test:z");
+        assert_eq!(projects[1].root, Path::new("packages/z"));
+    }
+
+    #[test]
+    fn discovery_rejects_duplicate_ids() {
+        let provider = TestProvider {
+            projects: vec![project("app", "a"), project("app", "b")],
+        };
+
+        let err = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap_err();
+        assert!(err.to_string().contains("duplicate project ID"));
+    }
+
+    #[test]
+    fn discovery_rejects_invalid_roots() {
+        let absolute = TestProvider {
+            projects: vec![project("app", "/outside")],
+        };
+        let escaping = TestProvider {
+            projects: vec![project("app", "../outside")],
+        };
+
+        assert!(
+            WorkspaceProjectGraph::discover(&absolute, Path::new("/workspace"))
+                .unwrap_err()
+                .to_string()
+                .contains("absolute root")
+        );
+        assert!(
+            WorkspaceProjectGraph::discover(&escaping, Path::new("/workspace"))
+                .unwrap_err()
+                .to_string()
+                .contains("escapes the workspace root")
+        );
+    }
+
+    #[test]
+    fn discovery_rejects_dangling_dependency_edges() {
+        let mut app = project("app", "app");
+        app.dependencies
+            .insert(ProjectId::new("test", "missing").unwrap());
+        let provider = TestProvider {
+            projects: vec![app],
+        };
+
+        let err = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap_err();
+        assert!(err.to_string().contains("depends on unknown project"));
+    }
+
+    #[test]
+    fn discovery_rejects_ids_from_another_provider() {
+        let provider = TestProvider {
+            projects: vec![WorkspaceProject::new(
+                ProjectId::new("other", "app").unwrap(),
+                "app",
+            )],
+        };
+
+        let err = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap_err();
+        assert!(err.to_string().contains("must use the \"test:\" namespace"));
+    }
+}


### PR DESCRIPTION
## What
- add provider-namespaced stable project IDs and a provider-neutral workspace project model
- define a workspace provider discovery interface
- validate and deterministically order discovered projects, metadata, and dependency edges
- reject duplicate IDs, provider namespace mismatches, absolute or escaping roots, and dangling dependency edges
- update the temporary parity tracker for the completed model and provider-interface work

## Why
This establishes the ecosystem-neutral graph boundary needed before Node, Cargo, uv, and Go workspace discovery can share affected-project and task-inference behavior.

## Impact
No user-facing behavior changes yet. The model is intentionally isolated until provider implementations are added in follow-up PRs.

## Checks
- `cargo test --bin mise 'task::workspace::tests::'`
- `mise x rust@1.94.1 -- cargo clippy -- -D warnings`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New internal module only; no changes to task execution, caching, or CLI behavior until providers land in follow-ups.
> 
> **Overview**
> Introduces a **provider-neutral workspace project graph** foundation for future monorepo discovery (Node, Cargo, uv, Go), with **no user-facing behavior** yet.
> 
> Adds `task::workspace` with **`ProjectId`** (`provider:local_id`), **`WorkspaceProject`** (normalized root, metadata, dependency edges), the **`WorkspaceProvider`** discovery trait, and **`WorkspaceProjectGraph::discover`** to validate and order projects deterministically. Discovery **fails** on duplicate IDs, wrong provider namespaces, absolute or escaping roots, and dangling dependencies.
> 
> Wires the module from `task/mod.rs` (currently unused, `dead_code` allowed). **`TASK_CACHE_PARITY.md`** marks the project model and provider interface checklist items complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5adf490a8dcc2deacd0336e3bdd452263ef9435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace project discovery using provider-scoped project identifiers.
  * Projects now include normalized, workspace-relative roots, metadata, and explicit dependency relationships.
  * Building the project graph now enforces deterministic ordering and validates duplicate, invalid, and dangling project references.

* **Documentation**
  * Updated the workspace and project graph checklist to mark the completed project-model and provider-interface items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->