### PR TITLE
fix(bootstrap): honor MISE_VERSION and MISE_INSTALL_PATH in generated script

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -38,6 +38,12 @@ script: |
   ./bin/mise x -- npm test
 ```
 
+By default the generated script installs the version it was generated with, but it honors the same
+`MISE_VERSION` and `MISE_INSTALL_PATH` variables as [the install script](/installing-mise.html).
+An explicit `MISE_INSTALL_PATH` is always used as-is; otherwise `MISE_VERSION` also selects the
+default cache path, so bumping it in CI installs the requested version instead of reusing the one
+that was cached first.
+
 ## Running against untrusted config (safe mode)
 
 When a job resolves tool versions from configuration it does not control — most commonly a bot

--- a/e2e/generate/test_generate_bootstrap
+++ b/e2e/generate/test_generate_bootstrap
@@ -35,3 +35,29 @@ run = ["{{mise_bin}} run other_task"]
 assert_contains "./bin/mise run my_task" "running other_task"
 
 PATH="$OLD_PATH"
+
+# ./bin/mise is the localized script at this point, so generate a plain one too
+assert "mise generate bootstrap -w ./bin/mise-plain"
+
+# a stub at the resolved install path proves which path the script picked: it finds
+# a binary there, skips the install, and execs it. Nothing is downloaded.
+stub() {
+  mkdir -p "$(dirname "$1")"
+  echo '#!/usr/bin/env bash' >"$1"
+  echo "echo \"$2 \$*\"" >>"$1"
+  chmod +x "$1"
+}
+
+# a caller-provided MISE_INSTALL_PATH wins over the path baked into the script
+stub "$PWD/custom/mise" custom-stub
+assert "MISE_INSTALL_PATH=$PWD/custom/mise ./bin/mise-plain hello" "custom-stub hello"
+assert "MISE_INSTALL_PATH=$PWD/custom/mise ./bin/mise hello" "custom-stub hello"
+
+# MISE_VERSION keys the install path, otherwise changing it silently reuses the
+# binary cached for the version the script was generated with. 9999.1.2 never exists.
+stub "$HOME/.cache/mise/mise-9999.1.2" version-stub
+assert "MISE_VERSION=v9999.1.2 ./bin/mise-plain hello" "version-stub hello"
+assert "MISE_VERSION=9999.1.2 ./bin/mise-plain hello" "version-stub hello"
+
+stub "$PWD/.mise/mise-9999.1.2" localized-version-stub
+assert "MISE_VERSION=v9999.1.2 ./bin/mise hello" "localized-version-stub hello"

--- a/src/cli/generate/bootstrap.rs
+++ b/src/cli/generate/bootstrap.rs
@@ -61,6 +61,10 @@ impl Bootstrap {
             .unwrap()
             .as_str();
 
+        // install.sh honors MISE_VERSION and MISE_INSTALL_PATH, so the wrapper must not clobber
+        // them. The install path is keyed by the requested version rather than the version this
+        // script was generated with: `test -f "$MISE_INSTALL_PATH"` skips install.sh entirely, so
+        // a fixed path would make a changed MISE_VERSION silently reuse the cached binary.
         let vars = if self.localize {
             // TODO: this will only work right if it is in the base directory, not an absolute path or has a subdirectory
             let localized_dir = self.localized_dir.to_string_lossy();
@@ -72,7 +76,9 @@ export MISE_DATA_DIR="$localized_dir"
 export MISE_CONFIG_DIR="$localized_dir"
 export MISE_CACHE_DIR="$localized_dir/cache"
 export MISE_STATE_DIR="$localized_dir/state"
-export MISE_INSTALL_PATH="$localized_dir/mise-{version}"
+local mise_version="${{MISE_VERSION:-{version}}}"
+mise_version="${{mise_version#v}}"
+export MISE_INSTALL_PATH="${{MISE_INSTALL_PATH:-$localized_dir/mise-$mise_version}}"
 export MISE_TRUSTED_CONFIG_PATHS="$project_dir${{MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}}"
 export MISE_IGNORED_CONFIG_PATHS="$HOME/.config/mise${{MISE_IGNORED_CONFIG_PATHS:+:$MISE_IGNORED_CONFIG_PATHS}}"
 "#
@@ -81,7 +87,9 @@ export MISE_IGNORED_CONFIG_PATHS="$HOME/.config/mise${{MISE_IGNORED_CONFIG_PATHS
             format!(
                 r#"
 local cache_home="${{XDG_CACHE_HOME:-$HOME/.cache}}/mise"
-export MISE_INSTALL_PATH="$cache_home/mise-{version}"
+local mise_version="${{MISE_VERSION:-{version}}}"
+mise_version="${{mise_version#v}}"
+export MISE_INSTALL_PATH="${{MISE_INSTALL_PATH:-$cache_home/mise-$mise_version}}"
 "#
             )
         };


### PR DESCRIPTION
## Summary
- let a caller-provided `MISE_INSTALL_PATH` win instead of being clobbered by the generated script
- key the install path by the requested `MISE_VERSION`, so changing it installs that version instead of silently reusing whatever was cached first
- with neither variable set the path is byte-identical to today's, so existing installs are still reused

## Context

From https://github.com/jdx/mise/discussions/4963. The script exported the path unconditionally, with the generation-time version baked in:

```bash
local cache_home="${XDG_CACHE_HOME:-$HOME/.cache}/mise"
export MISE_INSTALL_PATH="$cache_home/mise-2026.7.15"
```

Two things follow from that, both still reproducible on 2026.7.15:

**`MISE_INSTALL_PATH` is ignored.** It is a documented option of the install script (`docs/installing-mise.md`), and `install.sh` honors an existing value (`install_path="${MISE_INSTALL_PATH:-$HOME/.local/bin/mise}"`) — only the bootstrap wrapper overrides it.

```console
$ MISE_INSTALL_PATH=/tmp/custom/mise ./bin/mise --version
mise: installed successfully to /home/user/.cache/mise/mise-2026.7.15   # not /tmp/custom/mise
```

**`MISE_VERSION` stops taking effect after the first install.** `test -f "$MISE_INSTALL_PATH"` short-circuits before `install.sh` runs, so a fixed path means the cached binary is reused no matter which version was asked for — including `install.sh`'s own `MISE_INSTALL_SKIP_IF_EXISTS` version check, which never gets a chance to run.

```console
$ MISE_VERSION=v2026.7.13 ./bin/mise --version   # empty cache
2026.7.13 linux-x64 (2026-07-24)                 # …installed as mise-2026.7.15

$ MISE_VERSION=v2026.7.14 ./bin/mise --version
2026.7.13 linux-x64 (2026-07-24)                 # silently still 2026.7.13
```

After the change both behave the same through `./bin/mise` as through `curl https://mise.run | sh`:

```console
$ MISE_VERSION=v2026.7.13 ./bin/mise --version
2026.7.13 linux-x64 (2026-07-24)
$ MISE_VERSION=v2026.7.14 ./bin/mise --version
2026.7.14 linux-x64 (2026-07-26)
$ MISE_INSTALL_PATH=/tmp/custom/mise ./bin/mise --version
mise: installed successfully to /tmp/custom/mise
```

## Changes

- `src/cli/generate/bootstrap.rs`: both the default and `--localize` branches now emit

  ```bash
  local mise_version="${MISE_VERSION:-2026.7.15}"
  mise_version="${mise_version#v}"
  export MISE_INSTALL_PATH="${MISE_INSTALL_PATH:-$cache_home/mise-$mise_version}"
  ```

  The `#v` strip matches `install.sh`'s own `version="${version#v}"`, so `v2026.7.13` and `2026.7.13` resolve to the same path.
- `docs/continuous-integration.md`: note that the generated script honors both variables, and that `MISE_VERSION` changes where the binary is cached.

## Tests

`e2e/generate/test_generate_bootstrap` gains five assertions. Each places a stub at the path the script should resolve to, so the install is skipped and the stub is exec'd — nothing is downloaded:

| case | expectation |
|---|---|
| `MISE_INSTALL_PATH=…` (default and `-l` scripts) | the stub at that path runs |
| `MISE_VERSION=v9999.1.2` / `9999.1.2` | the stub at `~/.cache/mise/mise-9999.1.2` runs |
| `MISE_VERSION=v9999.1.2` (`-l` script) | the stub at `.mise/mise-9999.1.2` runs |

All five fail on the current code (the script execs the binary at its baked-in path instead).

## Notes

The discussion also reports that the script `cd`s to the grandparent directory after a first-run install. That one is already fixed by #6971 and is not touched here — I could not reproduce it on 2026.7.15.

I could not compile locally (memory-constrained machine), so the change is validated by CI. The shell semantics above were verified by applying the same edit to an already-generated bootstrap script and running the scenarios against real releases.

Relates to https://github.com/jdx/mise/discussions/4963

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Bootstrap-generated scripts now honor `MISE_VERSION` for selecting the installed/cached version (supporting both `v`-prefixed and non-prefixed values).
  * Bootstrap wrappers now preserve `MISE_INSTALL_PATH` overrides by default, using it when set and otherwise using the correct computed default path.
  * Localized bootstrap scripts use the expected localized cache/install directory.
* **Tests**
  * Extended end-to-end coverage to verify bootstrap behavior for localized vs plain binaries and environment overrides.
* **Documentation**
  * Updated CI bootstrapping guidance to clarify how `MISE_VERSION` and `MISE_INSTALL_PATH` affect installation and cache selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->