### PR TITLE
registry: add ovhcloud-cli (github:ovh/ovhcloud-cli)

### DIFF
--- a/registry/ovhcloud-cli.toml
+++ b/registry/ovhcloud-cli.toml
@@ -1,0 +1,4 @@
+aliases = ["ovhcloud"]
+backends = ["github:ovh/ovhcloud-cli"]
+description = "Official command line interface to manage OVHcloud services"
+test = { cmd = "ovhcloud version -o json", expected = '"version": "v{{version}}"' }


### PR DESCRIPTION
Adds [ovhcloud-cli](https://github.com/ovh/ovhcloud-cli) to the mise registry via the github backend.

Official command line interface to manage OVHcloud services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OVHcloud CLI to the available command-line tool registry.
  * Included version verification support for the registered CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Popularity

Github stars: 159

It is a bit low, yet this tool helps communicating with OVH Cloud Provider via CLI.