### PR TITLE
fix(npm): preserve aube confirmation prompts

### DIFF
--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -17,6 +17,7 @@ use crate::install_context::InstallContext;
 use crate::semver::{semver_is_at_least, semver_is_older_than};
 use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
+use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use async_trait::async_trait;
 use aube::embed::EmbedderRuntime;
@@ -963,6 +964,12 @@ impl NPMBackend {
         opts.ignore_scripts = matches!(allow_builds, AllowBuilds::None);
 
         let package = format!("{}@{}", self.tool_name(), tv.version);
+        // aube runs its low-download supply-chain gate before emitting install
+        // progress events. That gate may write an interactive confirmation
+        // directly to stderr and wait on stdin, so keep clx from repainting
+        // over it. Resume on the first phase/progress event, after the gate has
+        // completed; the guard also resumes on every early-error path.
+        let mut progress_pause = Some(MultiProgressReport::get().pause_progress());
         let install = aube::embed::add(&install_path, std::slice::from_ref(&package), opts);
         tokio::pin!(install);
         // Drain events alongside the install rather than after it: the
@@ -971,7 +978,17 @@ impl NPMBackend {
         let result = loop {
             tokio::select! {
                 res = &mut install => break res,
-                Some(event) = rx.recv() => apply_aube_event(event, ctx.pr.as_ref()),
+                Some(event) = rx.recv() => {
+                    let starts_install = matches!(
+                        &event,
+                        aube::embed::InstallEvent::Phase(_)
+                            | aube::embed::InstallEvent::Progress(_)
+                    );
+                    apply_aube_event(event, ctx.pr.as_ref());
+                    if starts_install {
+                        drop(progress_pause.take());
+                    }
+                },
             }
         };
         // Events queued between the last poll and the install returning —

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -11,10 +11,51 @@ use crate::ui::progress_report::{ProgressReport, QuietReport, SingleReport, Verb
 pub struct MultiProgressReport {
     quiet: bool,
     use_progress_ui: bool,
+    pause_state: Mutex<ProgressPauseState>,
     total_count: Mutex<usize>,
     completed_count: Mutex<usize>,
     /// Header job for updating progress display
     header_job: Mutex<Option<Arc<progress::ProgressJob>>>,
+}
+
+#[derive(Debug, Default)]
+struct ProgressPauseState {
+    count: usize,
+    resume_on_zero: bool,
+}
+
+impl ProgressPauseState {
+    fn acquire(&mut self, renderer_is_paused: bool) -> bool {
+        let should_pause = self.count == 0 && !renderer_is_paused;
+        if self.count == 0 {
+            self.resume_on_zero = should_pause;
+        }
+        self.count += 1;
+        should_pause
+    }
+
+    fn release(&mut self) -> bool {
+        debug_assert!(self.count > 0, "unbalanced progress suspension");
+        self.count = self.count.saturating_sub(1);
+        if self.count == 0 {
+            std::mem::take(&mut self.resume_on_zero)
+        } else {
+            false
+        }
+    }
+}
+
+/// Keeps the global progress renderer suspended until every overlapping
+/// suspension has been released.
+#[derive(Debug)]
+pub struct ProgressPauseGuard {
+    report: Arc<MultiProgressReport>,
+}
+
+impl Drop for ProgressPauseGuard {
+    fn drop(&mut self) {
+        self.report.resume_progress();
+    }
 }
 
 static INSTANCE: Mutex<Option<Arc<MultiProgressReport>>> = Mutex::new(None);
@@ -76,9 +117,33 @@ impl MultiProgressReport {
         MultiProgressReport {
             quiet: settings.quiet,
             use_progress_ui,
+            pause_state: Mutex::new(ProgressPauseState::default()),
             total_count: Mutex::new(0),
             completed_count: Mutex::new(0),
             header_job: Mutex::new(None),
+        }
+    }
+
+    /// Suspend the animated progress display while another component owns the
+    /// terminal, such as an interactive confirmation prompt.
+    ///
+    /// Suspensions are reference-counted because tool installs run in
+    /// parallel. The renderer resumes only after the final guard is dropped.
+    pub fn pause_progress(self: &Arc<Self>) -> ProgressPauseGuard {
+        let mut state = self.pause_state.lock().unwrap();
+        let renderer_is_paused = !self.use_progress_ui || progress::is_paused();
+        if state.acquire(renderer_is_paused) {
+            progress::pause();
+        }
+        ProgressPauseGuard {
+            report: self.clone(),
+        }
+    }
+
+    fn resume_progress(&self) {
+        let mut state = self.pause_state.lock().unwrap();
+        if state.release() {
+            progress::resume();
         }
     }
 
@@ -232,5 +297,21 @@ mod tests {
         pr.finish_with_message("test".into());
         pr.println("".into());
         pr.set_message("test".into());
+    }
+
+    #[test]
+    fn progress_pause_state_is_reference_counted() {
+        let mut state = ProgressPauseState::default();
+        assert!(state.acquire(false));
+        assert!(!state.acquire(true));
+        assert!(!state.release());
+        assert!(state.release());
+    }
+
+    #[test]
+    fn progress_pause_state_preserves_an_existing_pause() {
+        let mut state = ProgressPauseState::default();
+        assert!(!state.acquire(true));
+        assert!(!state.release());
     }
 }


### PR DESCRIPTION
## Summary
- suspend mise's animated progress renderer while embedded aube runs its pre-install supply-chain gates
- resume progress when aube emits its first install phase or progress event
- reference-count overlapping suspensions so parallel installs cannot resume the renderer over another prompt

## Root cause

Embedded aube checks low-download packages before it emits install progress events. Its confirmation prompt writes directly to stderr and waits on stdin, while mise's existing clx progress job continues repainting the terminal. The next spinner frame therefore erases the warning and `[y/N]` prompt.

This fixes the behavior reported in https://github.com/jdx/mise/discussions/11417.

## User impact

Low-download npm packages now leave aube's warning and confirmation prompt visible. After the user answers, mise resumes normal install progress. Early failures and already-paused renderers also restore their prior state safely.

## Validation
- `mise run format` (includes all-features cargo check and repository lint-fix tasks)
- `cargo test progress_pause_state --bin mise`
- isolated PTY reproduction with `npm:octofriend@0.0.56`, a three-second delayed `y` response, and forced progress rendering; the prompt remained visible and the install completed

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI coordination only; scoped to embedded aube npm installs and progress pause/resume with unit tests for refcount behavior.
> 
> **Overview**
> Embedded **aube** can show an interactive low-download confirmation on stderr before any install progress events; mise’s **clx** spinner was repainting over that prompt.
> 
> **`MultiProgressReport`** now exposes a reference-counted **`pause_progress()`** guard that calls **`progress::pause()`** / **`resume()`** so parallel installs only resume the renderer after every suspension ends, without undoing an already-paused state.
> 
> During **`install_via_aube_embed`**, a pause guard is held from install start until the first **Phase** or **Progress** event (or until the guard drops on early failure), so the warning and **`[y/N]`** stay visible and normal install progress resumes afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 093822eb3b223b236df45759ceb669bcef4a879c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation prompts by preventing progress indicators from overwriting interactive confirmation messages.
  * Progress display now pauses during installation confirmation and resumes automatically when installation begins.
  * Improved handling of concurrent progress pauses so existing paused states are preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->