### PR TITLE
feat(task): add workspace graph overrides

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -37,7 +37,7 @@ outside this tracker.
 - [x] Define a workspace provider interface that can discover projects and dependencies
       deterministically
 - [x] Merge graphs from multiple providers for polyglot repositories
-- [ ] Allow explicit configuration to add, remove, or override inferred projects and dependency
+- [x] Allow explicit configuration to add, remove, or override inferred projects and dependency
       edges
 - [ ] Detect project graph cycles and report actionable diagnostics
 - [ ] Preserve dependency traversal through projects that do not implement the requested task

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2364,6 +2364,55 @@
         "lockfile": {
           "description": "Use a single lockfile at the monorepo root for descendant config roots. true opts in now, false keeps lockfiles next to subproject configs, and unset keeps the current behavior until the scheduled default flip.",
           "type": "boolean"
+        },
+        "projects": {
+          "description": "Experimental explicit additions, removals, and overrides applied to provider-inferred workspace projects",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "unevaluatedProperties": false,
+            "properties": {
+              "remove": {
+                "description": "Remove this project and every dependency edge connected to it",
+                "type": "boolean"
+              },
+              "root": {
+                "description": "Add the project at this workspace-relative root or replace its inferred root",
+                "type": "string"
+              },
+              "metadata": {
+                "description": "Replace provider-inferred project metadata",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "depends": {
+                "description": "Replace the complete provider-inferred dependency set",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "uniqueItems": true
+              },
+              "depends_add": {
+                "description": "Add dependency edges after an optional depends replacement",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "uniqueItems": true
+              },
+              "depends_remove": {
+                "description": "Remove dependency edges after an optional depends replacement",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "uniqueItems": true
+              }
+            }
+          }
         }
       }
     },

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -34,6 +34,7 @@ use crate::oci::OciConfig;
 use crate::redactions::Redactions;
 use crate::registry::REGISTRY;
 use crate::system::{BootstrapTomlConfig, DotfilesTomlConfig};
+use crate::task::workspace::WorkspaceProjectOverride;
 use crate::task::{Task, TaskTemplate};
 use crate::tera::{BASE_CONTEXT, contains_template_syntax, get_tera, render_str};
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource, ToolVersionOptions};
@@ -256,7 +257,7 @@ pub struct MiseToml {
     /// Legacy name for monorepo_root, retained during its deprecation period
     #[serde(default)]
     experimental_monorepo_root: Option<bool>,
-    /// Configuration for monorepo task discovery
+    /// Configuration for monorepo and workspace discovery
     #[serde(default)]
     monorepo: Option<MonorepoConfig>,
 }
@@ -294,7 +295,7 @@ pub struct TaskTemplates(pub IndexMap<String, TaskTemplate>);
 #[derive(Debug, Default, Clone)]
 pub struct EnvList(pub(crate) Vec<EnvDirective>);
 
-/// Configuration for [monorepo] section in mise.toml
+/// Configuration for the [monorepo] section in mise.toml.
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct MonorepoConfig {
     /// Explicit list of config roots for monorepo task discovery.
@@ -304,6 +305,11 @@ pub struct MonorepoConfig {
     /// Use a single lockfile at the monorepo root for descendant config roots.
     /// None follows the rollout default; true opts in, false keeps colocated locks.
     pub lockfile: Option<bool>,
+    /// Explicit additions, removals, and overrides for provider-inferred projects.
+    // Consumed when workspace providers are connected to task loading.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub projects: BTreeMap<String, WorkspaceProjectOverride>,
 }
 
 impl EnvList {
@@ -2453,6 +2459,7 @@ fn is_tools_sorted(tools: &IndexMap<BackendArg, MiseTomlToolList>) -> bool {
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     use indoc::{formatdoc, indoc};
@@ -2466,6 +2473,41 @@ mod tests {
     use crate::{config::Config, dirs::CWD};
 
     use super::*;
+
+    #[test]
+    fn test_parse_monorepo_project_overrides() {
+        let config = toml::from_str::<MiseToml>(indoc! {r#"
+            [monorepo.projects."node:app"]
+            root = "apps/app"
+            metadata = { kind = "frontend" }
+            depends = ["node:lib"]
+            depends_add = ["cargo:core"]
+            depends_remove = ["node:legacy"]
+
+            [monorepo.projects."node:legacy"]
+            remove = true
+        "#})
+        .unwrap();
+        let projects = &config.monorepo.unwrap().projects;
+        let app = projects.get("node:app").unwrap();
+
+        assert_eq!(app.root.as_deref(), Some(Path::new("apps/app")));
+        assert_eq!(
+            app.metadata
+                .as_ref()
+                .unwrap()
+                .get("kind")
+                .map(String::as_str),
+            Some("frontend")
+        );
+        assert_eq!(app.depends, Some(BTreeSet::from(["node:lib".to_string()])));
+        assert_eq!(app.depends_add, BTreeSet::from(["cargo:core".to_string()]));
+        assert_eq!(
+            app.depends_remove,
+            BTreeSet::from(["node:legacy".to_string()])
+        );
+        assert!(projects.get("node:legacy").unwrap().remove);
+    }
 
     #[tokio::test]
     async fn test_fixture() {

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -139,6 +139,27 @@ impl WorkspaceProjectGraph {
         providers: &[&dyn WorkspaceProvider],
         workspace_root: &Path,
     ) -> Result<WorkspaceProjectGraph> {
+        let graph = Self::collect_provider_projects(providers, workspace_root)?;
+        graph.validate_dependencies()?;
+        Ok(graph)
+    }
+
+    /// Discovers projects, applies explicit overrides, and validates the result.
+    ///
+    /// Provider edges are intentionally not validated until after overrides so
+    /// explicit configuration can repair incomplete or incorrect inference.
+    pub fn discover_all_with_overrides(
+        providers: &[&dyn WorkspaceProvider],
+        workspace_root: &Path,
+        overrides: &BTreeMap<String, WorkspaceProjectOverride>,
+    ) -> Result<WorkspaceProjectGraph> {
+        Self::collect_provider_projects(providers, workspace_root)?.with_overrides(overrides)
+    }
+
+    fn collect_provider_projects(
+        providers: &[&dyn WorkspaceProvider],
+        workspace_root: &Path,
+    ) -> Result<WorkspaceProjectGraph> {
         let mut providers = providers
             .iter()
             .map(|provider| (provider.id().to_string(), *provider))
@@ -173,9 +194,7 @@ impl WorkspaceProjectGraph {
             }
         }
 
-        let graph = Self { projects };
-        graph.validate_dependencies()?;
-        Ok(graph)
+        Ok(Self { projects })
     }
 
     /// Applies explicit project and dependency changes after provider discovery.
@@ -671,6 +690,45 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("depends on unknown project")
+        );
+    }
+
+    #[test]
+    fn configured_discovery_can_repair_dangling_inferred_edges() {
+        let missing = ProjectId::new("node", "missing").unwrap();
+        let mut app = project("node", "app", "app");
+        app.dependencies.insert(missing);
+        let provider = TestProvider {
+            id: "node",
+            projects: vec![app],
+        };
+        let overrides = BTreeMap::from([(
+            "node:app".to_string(),
+            WorkspaceProjectOverride {
+                depends_remove: BTreeSet::from(["node:missing".to_string()]),
+                ..Default::default()
+            },
+        )]);
+
+        assert!(
+            WorkspaceProjectGraph::discover(&provider, Path::new("/workspace"))
+                .unwrap_err()
+                .to_string()
+                .contains("depends on unknown project")
+        );
+        let graph = WorkspaceProjectGraph::discover_all_with_overrides(
+            &[&provider],
+            Path::new("/workspace"),
+            &overrides,
+        )
+        .unwrap();
+
+        assert!(
+            graph
+                .get(&ProjectId::new("node", "app").unwrap())
+                .unwrap()
+                .dependencies
+                .is_empty()
         );
     }
 }

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Display};
 use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
 
 use eyre::{Result, bail};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A stable, provider-namespaced identifier for a workspace project.
 ///
@@ -30,6 +31,17 @@ impl ProjectId {
 impl Display for ProjectId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, f)
+    }
+}
+
+impl FromStr for ProjectId {
+    type Err = eyre::Report;
+
+    fn from_str(value: &str) -> Result<Self> {
+        let Some((provider, local_id)) = value.split_once(':') else {
+            bail!("workspace project ID {value:?} must include a provider namespace");
+        };
+        Self::new(provider, local_id)
     }
 }
 
@@ -71,6 +83,24 @@ impl WorkspaceProject {
             dependencies: BTreeSet::new(),
         }
     }
+}
+
+/// Explicit changes applied after workspace providers discover their projects.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct WorkspaceProjectOverride {
+    /// Removes the project and every dependency edge connected to it.
+    pub remove: bool,
+    /// Adds a project at this root or replaces an inferred project's root.
+    pub root: Option<PathBuf>,
+    /// Replaces provider-inferred metadata when present.
+    pub metadata: Option<BTreeMap<String, String>>,
+    /// Replaces the complete provider-inferred dependency set when present.
+    pub depends: Option<BTreeSet<String>>,
+    /// Adds dependency edges after an optional `depends` replacement.
+    pub depends_add: BTreeSet<String>,
+    /// Removes dependency edges after an optional `depends` replacement.
+    pub depends_remove: BTreeSet<String>,
 }
 
 /// Discovers projects and dependency edges from one workspace ecosystem.
@@ -144,19 +174,67 @@ impl WorkspaceProjectGraph {
         }
 
         let graph = Self { projects };
-        for project in graph.projects() {
-            for dependency in &project.dependencies {
-                if graph.get(dependency).is_none() {
-                    bail!(
-                        "workspace project {:?} depends on unknown project {:?}",
-                        project.id,
-                        dependency
-                    );
-                }
+        graph.validate_dependencies()?;
+        Ok(graph)
+    }
+
+    /// Applies explicit project and dependency changes after provider discovery.
+    pub fn with_overrides(
+        mut self,
+        overrides: &BTreeMap<String, WorkspaceProjectOverride>,
+    ) -> Result<Self> {
+        let mut removed = BTreeSet::new();
+        for (raw_id, config) in overrides {
+            let id = raw_id.parse::<ProjectId>()?;
+            validate_override(&id, config)?;
+
+            if config.remove {
+                self.projects.remove(&id);
+                removed.insert(id);
+                continue;
             }
+
+            if !self.projects.contains_key(&id) {
+                let root = config.root.clone().ok_or_else(|| {
+                    eyre::eyre!(
+                        "workspace project {id:?} is not inferred and requires an explicit root"
+                    )
+                })?;
+                self.projects
+                    .insert(id.clone(), WorkspaceProject::new(id.clone(), root));
+            }
+
+            let project = self.projects.get_mut(&id).expect("project was inserted");
+            if let Some(root) = &config.root {
+                project.root = normalize_project_root(&id, root)?;
+            }
+            if let Some(metadata) = &config.metadata {
+                project.metadata.clone_from(metadata);
+            }
+            if let Some(depends) = &config.depends {
+                project.dependencies = parse_dependency_ids(&id, "depends", depends)?;
+            }
+            let depends_remove =
+                parse_dependency_ids(&id, "depends_remove", &config.depends_remove)?;
+            project
+                .dependencies
+                .retain(|dependency| !depends_remove.contains(dependency));
+            project.dependencies.extend(parse_dependency_ids(
+                &id,
+                "depends_add",
+                &config.depends_add,
+            )?);
         }
 
-        Ok(graph)
+        if !removed.is_empty() {
+            for project in self.projects.values_mut() {
+                project
+                    .dependencies
+                    .retain(|dependency| !removed.contains(dependency));
+            }
+        }
+        self.validate_dependencies()?;
+        Ok(self)
     }
 
     /// Returns projects in stable project-ID order.
@@ -168,6 +246,58 @@ impl WorkspaceProjectGraph {
     pub fn get(&self, id: &ProjectId) -> Option<&WorkspaceProject> {
         self.projects.get(id)
     }
+
+    fn validate_dependencies(&self) -> Result<()> {
+        for project in self.projects() {
+            for dependency in &project.dependencies {
+                if self.get(dependency).is_none() {
+                    bail!(
+                        "workspace project {:?} depends on unknown project {:?}",
+                        project.id,
+                        dependency
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_override(id: &ProjectId, config: &WorkspaceProjectOverride) -> Result<()> {
+    if config.remove
+        && (config.root.is_some()
+            || config.metadata.is_some()
+            || config.depends.is_some()
+            || !config.depends_add.is_empty()
+            || !config.depends_remove.is_empty())
+    {
+        bail!("removed workspace project {id:?} cannot define other overrides");
+    }
+    if let Some(dependency) = config
+        .depends_add
+        .intersection(&config.depends_remove)
+        .next()
+    {
+        bail!("workspace project {id:?} cannot both add and remove dependency {dependency:?}");
+    }
+    Ok(())
+}
+
+fn parse_dependency_ids(
+    project_id: &ProjectId,
+    field: &str,
+    dependencies: &BTreeSet<String>,
+) -> Result<BTreeSet<ProjectId>> {
+    dependencies
+        .iter()
+        .map(|dependency| {
+            dependency.parse::<ProjectId>().map_err(|err| {
+                eyre::eyre!(
+                    "workspace project {project_id:?} has invalid {field} entry {dependency:?}: {err}"
+                )
+            })
+        })
+        .collect()
 }
 
 fn normalize_project_root(id: &ProjectId, root: &Path) -> Result<PathBuf> {
@@ -385,5 +515,162 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("duplicate workspace provider ID"));
+    }
+
+    #[test]
+    fn overrides_add_remove_and_modify_projects() {
+        let lib_id = ProjectId::new("node", "lib").unwrap();
+        let old_id = ProjectId::new("node", "old").unwrap();
+        let mut app = project("node", "app", "apps/app");
+        app.dependencies = BTreeSet::from([lib_id.clone(), old_id.clone()]);
+        let node = TestProvider {
+            id: "node",
+            projects: vec![
+                app,
+                project("node", "lib", "packages/lib"),
+                project("node", "old", "packages/old"),
+            ],
+        };
+        let cargo = TestProvider {
+            id: "cargo",
+            projects: vec![project("cargo", "core", "crates/core")],
+        };
+        let overrides = BTreeMap::from([
+            (
+                "custom:docs".to_string(),
+                WorkspaceProjectOverride {
+                    root: Some("docs".into()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "node:app".to_string(),
+                WorkspaceProjectOverride {
+                    root: Some("apps/web".into()),
+                    metadata: Some(BTreeMap::from([(
+                        "kind".to_string(),
+                        "frontend".to_string(),
+                    )])),
+                    depends_add: BTreeSet::from([
+                        "cargo:core".to_string(),
+                        "custom:docs".to_string(),
+                    ]),
+                    depends_remove: BTreeSet::from(["node:old".to_string()]),
+                    ..Default::default()
+                },
+            ),
+            (
+                "node:lib".to_string(),
+                WorkspaceProjectOverride {
+                    remove: true,
+                    ..Default::default()
+                },
+            ),
+        ]);
+
+        let graph = WorkspaceProjectGraph::discover_all(&[&node, &cargo], Path::new("/workspace"))
+            .unwrap()
+            .with_overrides(&overrides)
+            .unwrap();
+        let app = graph.get(&ProjectId::new("node", "app").unwrap()).unwrap();
+
+        assert!(graph.get(&lib_id).is_none());
+        assert_eq!(app.root, Path::new("apps/web"));
+        assert_eq!(
+            app.metadata,
+            BTreeMap::from([("kind".to_string(), "frontend".to_string())])
+        );
+        assert_eq!(
+            app.dependencies,
+            BTreeSet::from([
+                ProjectId::new("cargo", "core").unwrap(),
+                ProjectId::new("custom", "docs").unwrap(),
+            ])
+        );
+    }
+
+    #[test]
+    fn overrides_can_replace_dependencies() {
+        let mut app = project("node", "app", "app");
+        app.dependencies
+            .insert(ProjectId::new("node", "inferred").unwrap());
+        let provider = TestProvider {
+            id: "node",
+            projects: vec![
+                app,
+                project("node", "inferred", "inferred"),
+                project("node", "explicit", "explicit"),
+            ],
+        };
+        let overrides = BTreeMap::from([(
+            "node:app".to_string(),
+            WorkspaceProjectOverride {
+                depends: Some(BTreeSet::from(["node:explicit".to_string()])),
+                ..Default::default()
+            },
+        )]);
+
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace"))
+            .unwrap()
+            .with_overrides(&overrides)
+            .unwrap();
+
+        assert_eq!(
+            graph
+                .get(&ProjectId::new("node", "app").unwrap())
+                .unwrap()
+                .dependencies,
+            BTreeSet::from([ProjectId::new("node", "explicit").unwrap()])
+        );
+    }
+
+    #[test]
+    fn overrides_reject_invalid_combinations_and_dangling_edges() {
+        let graph = WorkspaceProjectGraph::default();
+        let missing_root = BTreeMap::from([(
+            "custom:new".to_string(),
+            WorkspaceProjectOverride::default(),
+        )]);
+        assert!(
+            graph
+                .clone()
+                .with_overrides(&missing_root)
+                .unwrap_err()
+                .to_string()
+                .contains("requires an explicit root")
+        );
+
+        let remove_with_root = BTreeMap::from([(
+            "custom:old".to_string(),
+            WorkspaceProjectOverride {
+                remove: true,
+                root: Some("old".into()),
+                ..Default::default()
+            },
+        )]);
+        assert!(
+            graph
+                .clone()
+                .with_overrides(&remove_with_root)
+                .unwrap_err()
+                .to_string()
+                .contains("cannot define other overrides")
+        );
+
+        let dangling = BTreeMap::from([(
+            "custom:new".to_string(),
+            WorkspaceProjectOverride {
+                root: Some("new".into()),
+                depends_add: BTreeSet::from(["custom:missing".to_string()]),
+                ..Default::default()
+            },
+        )]);
+        assert!(
+            graph
+                .with_overrides(&dangling)
+                .unwrap_err()
+                .to_string()
+                .contains("depends on unknown project")
+        );
     }
 }


### PR DESCRIPTION
## What
- parse experimental workspace project overrides from `[monorepo.projects."provider:project"]`
- support adding projects and overriding inferred roots or metadata
- support replacing, adding, and removing dependency edges
- remove incident edges when an inferred project is explicitly removed
- validate project IDs, required roots, conflicting operations, escaping paths, and dangling edges
- add JSON schema coverage and focused configuration/graph tests
- update the temporary parity tracker

## Why
Provider inference needs an explicit escape hatch for incomplete or incorrect ecosystem metadata. Applying overrides after all providers merge preserves deterministic inference while letting users correct project membership and cross-ecosystem dependency edges.

## Impact
This is an experimental foundation with no user-facing task behavior until workspace providers are connected to task loading. It is stacked on #11418 so this PR contains only the override layer.

## Checks
- `cargo test --bin mise 'task::workspace::tests::'`
- `cargo test --bin mise 'config::config_file::mise_toml::tests::test_parse_monorepo_project_overrides'`
- `mise run render:schema`
- `mise x rust@1.94.1 -- cargo clippy -- -D warnings`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experimental graph/config plumbing only; parsed `projects` is unused at runtime until workspace providers connect to task loading, with validation covered by focused tests.
> 
> **Overview**
> Introduces an **experimental override layer** for the workspace project graph so users can correct provider inference via `[monorepo.projects."provider:id"]` in `mise.toml`.
> 
> **Configuration and schema:** New fields include `remove`, `root`, `metadata`, `depends`, `depends_add`, and `depends_remove`, documented in `schema/mise.json` and parsed on `MonorepoConfig.projects` (not yet consumed by task loading).
> 
> **Graph behavior:** `WorkspaceProjectGraph` gains `with_overrides` and `discover_all_with_overrides`, applying overrides after multi-provider merge and **deferring dependency validation** until afterward so dangling inferred edges can be fixed in config. Removing a project also strips edges pointing at it. `ProjectId` gains `FromStr` for config keys.
> 
> **Tests:** Unit tests cover override combinations, invalid configs, and repairing dangling edges; the task-cache parity tracker marks explicit project/edge overrides as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7017f29f730dc47e139a869d5d7f50360b080551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental workspace project configuration for explicitly adding, removing, or overriding inferred projects.
  * Added support for customizing project roots, metadata, and dependency relationships.
  * Added validation to prevent invalid configurations and dangling project dependencies.
* **Documentation**
  * Marked workspace and project graph override support as completed in the configuration checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->