### PR TITLE
fix: suspend progress while displaying prompts

### DIFF
--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -11,10 +11,51 @@ use crate::ui::progress_report::{ProgressReport, QuietReport, SingleReport, Verb
 pub struct MultiProgressReport {
     quiet: bool,
     use_progress_ui: bool,
+    pause_state: Mutex<ProgressPauseState>,
     total_count: Mutex<usize>,
     completed_count: Mutex<usize>,
     /// Header job for updating progress display
     header_job: Mutex<Option<Arc<progress::ProgressJob>>>,
+}
+
+#[derive(Debug, Default)]
+struct ProgressPauseState {
+    count: usize,
+    resume_on_zero: bool,
+}
+
+impl ProgressPauseState {
+    fn acquire(&mut self, renderer_is_paused: bool) -> bool {
+        let should_pause = self.count == 0 && !renderer_is_paused;
+        if self.count == 0 {
+            self.resume_on_zero = should_pause;
+        }
+        self.count += 1;
+        should_pause
+    }
+
+    fn release(&mut self) -> bool {
+        debug_assert!(self.count > 0, "unbalanced progress suspension");
+        self.count = self.count.saturating_sub(1);
+        if self.count == 0 {
+            std::mem::take(&mut self.resume_on_zero)
+        } else {
+            false
+        }
+    }
+}
+
+/// Keeps the global progress renderer suspended until every overlapping
+/// suspension has been released.
+#[derive(Debug)]
+pub struct ProgressPauseGuard {
+    report: Arc<MultiProgressReport>,
+}
+
+impl Drop for ProgressPauseGuard {
+    fn drop(&mut self) {
+        self.report.resume_progress();
+    }
 }
 
 static INSTANCE: Mutex<Option<Arc<MultiProgressReport>>> = Mutex::new(None);
@@ -76,9 +117,33 @@ impl MultiProgressReport {
         MultiProgressReport {
             quiet: settings.quiet,
             use_progress_ui,
+            pause_state: Mutex::new(ProgressPauseState::default()),
             total_count: Mutex::new(0),
             completed_count: Mutex::new(0),
             header_job: Mutex::new(None),
+        }
+    }
+
+    /// Suspend the animated progress display while another component owns the
+    /// terminal, such as an interactive confirmation prompt.
+    ///
+    /// Suspensions are reference-counted because tool installs run in
+    /// parallel. The renderer resumes only after the final guard is dropped.
+    pub fn pause_progress(self: &Arc<Self>) -> ProgressPauseGuard {
+        let mut state = self.pause_state.lock().unwrap();
+        let renderer_is_paused = !self.use_progress_ui || progress::is_paused();
+        if state.acquire(renderer_is_paused) {
+            progress::pause();
+        }
+        ProgressPauseGuard {
+            report: self.clone(),
+        }
+    }
+
+    fn resume_progress(&self) {
+        let mut state = self.pause_state.lock().unwrap();
+        if state.release() {
+            progress::resume();
         }
     }
 
@@ -232,5 +297,21 @@ mod tests {
         pr.finish_with_message("test".into());
         pr.println("".into());
         pr.set_message("test".into());
+    }
+
+    #[test]
+    fn progress_pause_state_is_reference_counted() {
+        let mut state = ProgressPauseState::default();
+        assert!(state.acquire(false));
+        assert!(!state.acquire(true));
+        assert!(!state.release());
+        assert!(state.release());
+    }
+
+    #[test]
+    fn progress_pause_state_preserves_an_existing_pause() {
+        let mut state = ProgressPauseState::default();
+        assert!(!state.acquire(true));
+        assert!(!state.release());
     }
 }

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -4,6 +4,7 @@ use demand::{Confirm, Dialog, DialogButton};
 
 use crate::env;
 use crate::ui::ctrlc;
+use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::theme::get_theme;
 
 static MUTEX: Mutex<()> = Mutex::new(());
@@ -21,6 +22,7 @@ pub fn confirm_with_default<S: Into<String>>(message: S, default_yes: bool) -> e
     if !console::user_attended_stderr() || env::__USAGE.is_some() {
         return Ok(false);
     }
+    let _progress_pause = MultiProgressReport::try_get().map(|report| report.pause_progress());
     let theme = get_theme();
     let result = Confirm::new(message)
         .selected(default_yes)
@@ -42,6 +44,7 @@ pub fn confirm_with_all<S: Into<String>>(message: S) -> eyre::Result<bool> {
         return Ok(true);
     }
 
+    let _progress_pause = MultiProgressReport::try_get().map(|report| report.pause_progress());
     let theme = get_theme();
     let answer = Dialog::new(message)
         .buttons(vec![


### PR DESCRIPTION
## Summary
- add a reference-counted guard for suspending mise's shared progress renderer
- hold that guard whenever mise displays a confirmation prompt
- preserve an already-paused renderer and resume only after every overlapping suspension ends

## Root cause
Animated progress can repaint stderr while a confirmation owns the terminal, hiding or corrupting the prompt. This was identified in #11419 for aube's low-download confirmation.

This PR carries that renderer fix into mise's shared prompt path instead of coupling it to npm installation phases. It protects existing mise confirmations and the host-routed aube prompts introduced by jdx/aube#1154.

Non-interactive paths and remembered `All` responses do not pause the renderer because no prompt is displayed.

## Validation
- `cargo test progress_pause_state --bin mise`
- `mise run format` (includes all-features cargo check and repository formatting/lint tasks)
- `mise run test:unit` (2,072 passed)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI coordination only; scoped to prompt paths that already gate on interactive stderr, with unit tests for pause refcounting.
> 
> **Overview**
> Fixes animated progress repainting stderr while confirmation dialogs own the terminal (e.g. low-download prompts during parallel installs).
> 
> **`MultiProgressReport`** now exposes a reference-counted **`pause_progress()`** / **`ProgressPauseGuard`** that calls **`progress::pause()`** only on the outermost suspension and **`progress::resume()`** only when the last guard drops. Nested suspensions and an already-paused renderer are handled so resume does not run too early.
> 
> **`confirm_with_default`** and **`confirm_with_all`** acquire that guard right before showing an interactive prompt (after non-interactive early returns). Unit tests cover the pause state refcount logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca395c7dfb1fb18980a15f7ab60238fe69a0d43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress reporting now pauses automatically while interactive confirmation prompts are displayed.
  * Progress rendering resumes automatically after prompts close, including when multiple operations overlap.

* **Bug Fixes**
  * Prevented progress output from interfering with interactive prompts.
  * Preserved existing pause conditions when overlapping pauses are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->