### PR TITLE
fix(brew): use download client for artifacts

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -77,6 +77,7 @@ struct SendOnceOptions {
     use_netrc: bool,
     retry_github_oauth_401: bool,
     error_for_status: bool,
+    enforce_request_timeout: bool,
     retry_state: Option<RetryStateHandle>,
 }
 
@@ -86,6 +87,7 @@ impl SendOnceOptions {
             use_netrc,
             retry_github_oauth_401: true,
             error_for_status: true,
+            enforce_request_timeout: true,
             retry_state,
         }
     }
@@ -95,11 +97,17 @@ impl SendOnceOptions {
         self
     }
 
+    fn without_request_timeout(mut self) -> Self {
+        self.enforce_request_timeout = false;
+        self
+    }
+
     fn recursive_retry(&self) -> Self {
         Self {
             use_netrc: false,
             retry_github_oauth_401: false,
             error_for_status: self.error_for_status,
+            enforce_request_timeout: self.enforce_request_timeout,
             retry_state: self.retry_state.clone(),
         }
     }
@@ -426,7 +434,12 @@ impl Client {
                 attempt.fetch_add(1, Ordering::Relaxed);
                 bytes_received.store(0, Ordering::Relaxed);
                 let mut resp = self
-                    .send_once_with_https_fallback(Method::GET, request_url, headers, "GET")
+                    .send_once_with_https_fallback_for_download(
+                        Method::GET,
+                        request_url,
+                        headers,
+                        "GET",
+                    )
                     .await?;
                 if let Some(pr) = pr {
                     if let Some(length) = resp.content_length() {
@@ -553,14 +566,12 @@ impl Client {
         .await
     }
 
-    /// One attempt with http→https fallback, no retry. Used as the inner step
-    /// for both `send_with_https_fallback` (which adds retry) and
-    /// `download_file_with_headers` (which has its own outer retry covering the
-    /// chunk stream). Splitting this out avoids retry × retry blowup.
-    /// The fallback only fires on connection-level errors (corporate proxy
-    /// blocking plain http), not on HTTP status errors — falling back to https
-    /// after the server already returned a 4xx/5xx makes no sense.
-    async fn send_once_with_https_fallback(
+    /// One streaming download attempt with http→https fallback and no retry.
+    /// Downloads use the client's idle read timeout and the separate
+    /// `http_download_timeout` budget. A fetch client's request-wide timeout is
+    /// intended for metadata lookups and must not cap the complete body stream.
+    /// The caller adds an outer retry covering the full chunk stream.
+    async fn send_once_with_https_fallback_for_download(
         &self,
         method: Method,
         url: Url,
@@ -572,7 +583,7 @@ impl Client {
             url,
             headers,
             verb_label,
-            SendOnceOptions::new(None, true),
+            SendOnceOptions::new(None, true).without_request_timeout(),
         )
         .await
     }
@@ -664,7 +675,7 @@ impl Client {
 
         let request_timeout = self.request_timeout();
         let mut req = self.reqwest.request(method.clone(), url.clone());
-        if matches!(self.kind, ClientKind::Fetch) {
+        if matches!(self.kind, ClientKind::Fetch) && options.enforce_request_timeout {
             req = req.timeout(request_timeout);
         }
         req = req.headers(final_headers.clone());
@@ -1662,6 +1673,34 @@ mod tests {
         port
     }
 
+    async fn spawn_slow_finite_server() -> u16 {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut request = [0u8; 4096];
+            let _ = socket.read(&mut request).await;
+            if socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\n")
+                .await
+                .is_err()
+            {
+                return;
+            }
+            for byte in b"orbstk" {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                if socket.write_all(&[*byte]).await.is_err() {
+                    return;
+                }
+            }
+        });
+        port
+    }
+
     fn ok_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
     }
@@ -2296,6 +2335,35 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(message.contains("http_download_timeout"));
         assert!(message.contains("MISE_HTTP_DOWNLOAD_TIMEOUT"));
         assert!(!path.exists());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_fetch_client_download_outlives_request_timeout() {
+        let _guard = set_test_http_retries(0);
+        let port = spawn_slow_finite_server().await;
+        let url = format!("http://127.0.0.1:{port}/artifact.dmg");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("artifact.dmg");
+        // Each body read arrives before the 200ms idle timeout, but the complete
+        // response takes longer. Fetch metadata requests retain their total
+        // deadline; streaming downloads instead use http_download_timeout.
+        let client = Client::new(Duration::from_millis(200), ClientKind::Fetch).unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(3),
+            client.download_file_with_headers_timeout(
+                &url,
+                &path,
+                &HeaderMap::new(),
+                None,
+                Duration::from_secs(2),
+            ),
+        )
+        .await
+        .expect("slow finite download exceeded its independent deadline")
+        .unwrap();
+
+        assert_eq!(std::fs::read(path).unwrap(), b"orbstk");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -77,7 +77,6 @@ struct SendOnceOptions {
     use_netrc: bool,
     retry_github_oauth_401: bool,
     error_for_status: bool,
-    enforce_request_timeout: bool,
     retry_state: Option<RetryStateHandle>,
 }
 
@@ -87,7 +86,6 @@ impl SendOnceOptions {
             use_netrc,
             retry_github_oauth_401: true,
             error_for_status: true,
-            enforce_request_timeout: true,
             retry_state,
         }
     }
@@ -97,17 +95,11 @@ impl SendOnceOptions {
         self
     }
 
-    fn without_request_timeout(mut self) -> Self {
-        self.enforce_request_timeout = false;
-        self
-    }
-
     fn recursive_retry(&self) -> Self {
         Self {
             use_netrc: false,
             retry_github_oauth_401: false,
             error_for_status: self.error_for_status,
-            enforce_request_timeout: self.enforce_request_timeout,
             retry_state: self.retry_state.clone(),
         }
     }
@@ -424,8 +416,8 @@ impl Client {
         let bytes_received = Arc::new(AtomicU64::new(0));
 
         // Retry the whole download so a mid-stream chunk failure restarts from
-        // byte 0 instead of failing the install. The download-specific send
-        // helper skips both inner retries and the fetch metadata deadline.
+        // byte 0 instead of failing the install. send_once_with_https_fallback
+        // (not send_with_https_fallback) is used inside to avoid retry-on-retry.
         let download = retry_async("GET", &url, || {
             let attempt = attempt.clone();
             let bytes_received = bytes_received.clone();
@@ -434,12 +426,7 @@ impl Client {
                 attempt.fetch_add(1, Ordering::Relaxed);
                 bytes_received.store(0, Ordering::Relaxed);
                 let mut resp = self
-                    .send_once_with_https_fallback_for_download(
-                        Method::GET,
-                        request_url,
-                        headers,
-                        "GET",
-                    )
+                    .send_once_with_https_fallback(Method::GET, request_url, headers, "GET")
                     .await?;
                 if let Some(pr) = pr {
                     if let Some(length) = resp.content_length() {
@@ -566,12 +553,14 @@ impl Client {
         .await
     }
 
-    /// One streaming download attempt with http→https fallback and no retry.
-    /// Downloads use the client's idle read timeout and the separate
-    /// `http_download_timeout` budget. A fetch client's request-wide timeout is
-    /// intended for metadata lookups and must not cap the complete body stream.
-    /// The caller adds an outer retry covering the full chunk stream.
-    async fn send_once_with_https_fallback_for_download(
+    /// One attempt with http→https fallback, no retry. Used as the inner step
+    /// for both `send_with_https_fallback` (which adds retry) and
+    /// `download_file_with_headers` (which has its own outer retry covering the
+    /// chunk stream). Splitting this out avoids retry × retry blowup.
+    /// The fallback only fires on connection-level errors (corporate proxy
+    /// blocking plain http), not on HTTP status errors — falling back to https
+    /// after the server already returned a 4xx/5xx makes no sense.
+    async fn send_once_with_https_fallback(
         &self,
         method: Method,
         url: Url,
@@ -583,7 +572,7 @@ impl Client {
             url,
             headers,
             verb_label,
-            SendOnceOptions::new(None, true).without_request_timeout(),
+            SendOnceOptions::new(None, true),
         )
         .await
     }
@@ -675,9 +664,7 @@ impl Client {
 
         let request_timeout = self.request_timeout();
         let mut req = self.reqwest.request(method.clone(), url.clone());
-        let request_timeout_applied =
-            matches!(self.kind, ClientKind::Fetch) && options.enforce_request_timeout;
-        if request_timeout_applied {
+        if matches!(self.kind, ClientKind::Fetch) {
             req = req.timeout(request_timeout);
         }
         req = req.headers(final_headers.clone());
@@ -694,9 +681,7 @@ impl Client {
                         .unwrap()
                         .insert(host, err.to_string());
                 }
-                if err.is_timeout()
-                    && (matches!(self.kind, ClientKind::Http) || request_timeout_applied)
-                {
+                if err.is_timeout() {
                     let (setting, env_var) = match self.kind {
                         ClientKind::Http => ("http_timeout", "MISE_HTTP_TIMEOUT"),
                         ClientKind::Fetch => (
@@ -1677,50 +1662,6 @@ mod tests {
         port
     }
 
-    async fn spawn_slow_finite_server() -> u16 {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        tokio::spawn(async move {
-            let Ok((mut socket, _)) = listener.accept().await else {
-                return;
-            };
-            let mut request = [0u8; 4096];
-            let _ = socket.read(&mut request).await;
-            if socket
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\n")
-                .await
-                .is_err()
-            {
-                return;
-            }
-            for byte in b"orbstk" {
-                tokio::time::sleep(Duration::from_millis(50)).await;
-                if socket.write_all(&[*byte]).await.is_err() {
-                    return;
-                }
-            }
-        });
-        port
-    }
-
-    async fn spawn_stalled_response_server() -> u16 {
-        use tokio::io::AsyncReadExt;
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        tokio::spawn(async move {
-            let Ok((mut socket, _)) = listener.accept().await else {
-                return;
-            };
-            let mut request = [0u8; 4096];
-            let _ = socket.read(&mut request).await;
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        });
-        port
-    }
-
     fn ok_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
     }
@@ -2355,79 +2296,6 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(message.contains("http_download_timeout"));
         assert!(message.contains("MISE_HTTP_DOWNLOAD_TIMEOUT"));
         assert!(!path.exists());
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_fetch_client_download_outlives_request_timeout() {
-        let _guard = set_test_http_retries(0);
-        let port = spawn_slow_finite_server().await;
-        let url = format!("http://127.0.0.1:{port}/artifact.dmg");
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("artifact.dmg");
-        // Each body read arrives before the 200ms idle timeout, but the complete
-        // response takes longer. Fetch metadata requests retain their total
-        // deadline; streaming downloads instead use http_download_timeout.
-        let client = Client::new(Duration::from_millis(200), ClientKind::Fetch).unwrap();
-
-        tokio::time::timeout(
-            Duration::from_secs(3),
-            client.download_file_with_headers_timeout(
-                &url,
-                &path,
-                &HeaderMap::new(),
-                None,
-                Duration::from_secs(2),
-            ),
-        )
-        .await
-        .expect("slow finite download exceeded its independent deadline")
-        .unwrap();
-
-        assert_eq!(std::fs::read(path).unwrap(), b"orbstk");
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_fetch_timeout_hint_only_when_request_deadline_applied() {
-        let client = Client::new(Duration::from_millis(50), ClientKind::Fetch).unwrap();
-
-        let metadata_port = spawn_stalled_response_server().await;
-        let metadata_url: Url = format!("http://127.0.0.1:{metadata_port}/versions")
-            .parse()
-            .unwrap();
-        let metadata_err = client
-            .send_once_inner(
-                Method::GET,
-                metadata_url,
-                &HeaderMap::new(),
-                "GET",
-                SendOnceOptions::new(None, true),
-            )
-            .await
-            .unwrap_err();
-        assert!(
-            format!("{metadata_err:#}").contains("fetch_remote_versions_timeout"),
-            "metadata deadline should identify its setting: {metadata_err:#}"
-        );
-
-        let download_port = spawn_stalled_response_server().await;
-        let download_url: Url = format!("http://127.0.0.1:{download_port}/artifact.dmg")
-            .parse()
-            .unwrap();
-        let download_err = client
-            .send_once_inner(
-                Method::GET,
-                download_url,
-                &HeaderMap::new(),
-                "GET",
-                SendOnceOptions::new(None, true).without_request_timeout(),
-            )
-            .await
-            .unwrap_err();
-        assert!(is_transient(&download_err));
-        assert!(
-            !format!("{download_err:#}").contains("fetch_remote_versions_timeout"),
-            "idle timeout must not claim the metadata deadline: {download_err:#}"
-        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -424,8 +424,8 @@ impl Client {
         let bytes_received = Arc::new(AtomicU64::new(0));
 
         // Retry the whole download so a mid-stream chunk failure restarts from
-        // byte 0 instead of failing the install. send_once_with_https_fallback
-        // (not send_with_https_fallback) is used inside to avoid retry-on-retry.
+        // byte 0 instead of failing the install. The download-specific send
+        // helper skips both inner retries and the fetch metadata deadline.
         let download = retry_async("GET", &url, || {
             let attempt = attempt.clone();
             let bytes_received = bytes_received.clone();
@@ -675,7 +675,9 @@ impl Client {
 
         let request_timeout = self.request_timeout();
         let mut req = self.reqwest.request(method.clone(), url.clone());
-        if matches!(self.kind, ClientKind::Fetch) && options.enforce_request_timeout {
+        let request_timeout_applied =
+            matches!(self.kind, ClientKind::Fetch) && options.enforce_request_timeout;
+        if request_timeout_applied {
             req = req.timeout(request_timeout);
         }
         req = req.headers(final_headers.clone());
@@ -692,7 +694,9 @@ impl Client {
                         .unwrap()
                         .insert(host, err.to_string());
                 }
-                if err.is_timeout() {
+                if err.is_timeout()
+                    && (matches!(self.kind, ClientKind::Http) || request_timeout_applied)
+                {
                     let (setting, env_var) = match self.kind {
                         ClientKind::Http => ("http_timeout", "MISE_HTTP_TIMEOUT"),
                         ClientKind::Fetch => (
@@ -1701,6 +1705,22 @@ mod tests {
         port
     }
 
+    async fn spawn_stalled_response_server() -> u16 {
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut request = [0u8; 4096];
+            let _ = socket.read(&mut request).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+        port
+    }
+
     fn ok_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
     }
@@ -2364,6 +2384,50 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         .unwrap();
 
         assert_eq!(std::fs::read(path).unwrap(), b"orbstk");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_fetch_timeout_hint_only_when_request_deadline_applied() {
+        let client = Client::new(Duration::from_millis(50), ClientKind::Fetch).unwrap();
+
+        let metadata_port = spawn_stalled_response_server().await;
+        let metadata_url: Url = format!("http://127.0.0.1:{metadata_port}/versions")
+            .parse()
+            .unwrap();
+        let metadata_err = client
+            .send_once_inner(
+                Method::GET,
+                metadata_url,
+                &HeaderMap::new(),
+                "GET",
+                SendOnceOptions::new(None, true),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{metadata_err:#}").contains("fetch_remote_versions_timeout"),
+            "metadata deadline should identify its setting: {metadata_err:#}"
+        );
+
+        let download_port = spawn_stalled_response_server().await;
+        let download_url: Url = format!("http://127.0.0.1:{download_port}/artifact.dmg")
+            .parse()
+            .unwrap();
+        let download_err = client
+            .send_once_inner(
+                Method::GET,
+                download_url,
+                &HeaderMap::new(),
+                "GET",
+                SendOnceOptions::new(None, true).without_request_timeout(),
+            )
+            .await
+            .unwrap_err();
+        assert!(is_transient(&download_err));
+        assert!(
+            !format!("{download_err:#}").contains("fetch_remote_versions_timeout"),
+            "idle timeout must not claim the metadata deadline: {download_err:#}"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -14,7 +14,7 @@ use super::source;
 use crate::cmd::CmdLineRunner;
 use crate::file::{self, ExtractOptions, ExtractionFormat};
 use crate::hash;
-use crate::http::HTTP_FETCH;
+use crate::http::{HTTP, HTTP_FETCH};
 use crate::result::Result;
 use crate::system::packages::{
     InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager,
@@ -487,7 +487,7 @@ async fn fetch_archive(cask: &Cask, pr: Option<&dyn SingleReport>) -> Result<Pat
         cask.token, cask.version
     ));
     if !archive.exists() {
-        HTTP_FETCH.download_file(&cask.url, &archive, pr).await?;
+        HTTP.download_file(&cask.url, &archive, pr).await?;
         // Strip macOS quarantine so it doesn't propagate into extracted/copied artifacts.
         let _ = std::process::Command::new("xattr")
             .args(["-d", "com.apple.quarantine"])

--- a/src/system/packages/brew/fetch.rs
+++ b/src/system/packages/brew/fetch.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 
 use super::api::BottleFile;
-use crate::http::HTTP_FETCH;
+use crate::http::HTTP;
 use crate::result::Result;
 use crate::ui::progress_report::SingleReport;
 
@@ -29,8 +29,7 @@ pub async fn fetch_bottle(
     // ghcr.io allows anonymous pulls with this static bearer token
     let mut headers = HeaderMap::new();
     headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer QQ=="));
-    HTTP_FETCH
-        .download_file_with_headers(&bottle.url, &path, &headers, pr)
+    HTTP.download_file_with_headers(&bottle.url, &path, &headers, pr)
         .await?;
     if let Some(pr) = pr {
         pr.set_message("checksum".to_string());

--- a/src/system/packages/brew/source.rs
+++ b/src/system/packages/brew/source.rs
@@ -22,7 +22,7 @@ use super::tag;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::file::{ExtractOptions, ExtractionFormat};
-use crate::http::HTTP_FETCH;
+use crate::http::{HTTP, HTTP_FETCH};
 use crate::result::Result;
 use crate::toolset::{InstallOptions, ToolsetBuilder};
 use crate::ui::progress_report::SingleReport;
@@ -263,7 +263,7 @@ async fn fetch_source(formula: &Formula, pr: &dyn SingleReport) -> Result<PathBu
         return Ok(dest);
     }
     pr.set_message(format!("download {basename}"));
-    HTTP_FETCH.download_file(&src.url, &dest, Some(pr)).await?;
+    HTTP.download_file(&src.url, &dest, Some(pr)).await?;
     crate::hash::ensure_checksum(&dest, sha256, Some(pr), "sha256")?;
     Ok(dest)
 }


### PR DESCRIPTION
## Summary

- route cask archives, Homebrew bottles, and formula source archives through the normal download client
- keep Homebrew API requests and checksum-pinned Ruby metadata on the fetch client
- leave the shared HTTP timeout behavior unchanged

## Root cause

The affected OrbStack DMG was treated as a version/metadata fetch because Brew's bulk artifact paths used `HTTP_FETCH`. That client applies `fetch_remote_versions_timeout` as a reqwest request-wide deadline. The deadline does not reset as response data arrives, so a large download could be interrupted after the default 20 seconds even while making progress.

Bulk artifacts are downloads, not version fetches. They should use `HTTP`, which retains the idle/connect timeout from `http_timeout` and the overall download budget from `http_download_timeout`. Small metadata requests continue to use `HTTP_FETCH` and its short request-wide deadline.

Reported in https://github.com/jdx/mise/discussions/11425.

## User impact

Large Brew casks, bottles, and formula source archives can continue downloading beyond `fetch_remote_versions_timeout` while still being bounded by the normal download timeout settings.

## Validation

- `mise run test:unit system::packages::brew::` (130 passed)
- `mise run lint`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing change for brew artifact downloads; metadata fetches unchanged and behavior aligns with the intended HTTP client split.
> 
> **Overview**
> Routes **brew** bottle, cask archive, and formula **source archive** downloads through the general **`HTTP`** client instead of **`HTTP_FETCH`**, so they are not cut off by the fetch client’s metadata-oriented request deadline (`fetch_remote_versions_timeout`).
> 
> **`HTTP_FETCH`** remains in use for small, bounded requests such as cask API JSON and pinned Ruby formula/cask definitions.
> 
> This pairs with the HTTP-layer change that keeps streaming downloads on idle-read and download timeouts rather than the fetch request-wide timeout, fixing large cask installs (e.g. DMGs) that previously restarted every ~20s while data was still flowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0cda0be56193a8d752ec8f30fd8dd18e154c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when downloading Homebrew cask archives, bottles, and source archives.
  * Preserved existing caching, progress reporting, quarantine handling, and checksum verification during downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->