### PR TITLE
fix(bootstrap): detect mise-managed mas

### DIFF
--- a/e2e/cli/test_system_status
+++ b/e2e/cli/test_system_status
@@ -27,24 +27,23 @@ else
   assert_fail "mise bootstrap packages apply --manager mas --dry-run --yes"
 fi
 
-# mise-managed tools are removed from the pristine PATH, but package managers
-# must see the actual PATH inherited by their subprocesses.
+# A configured mise tool does not need to be activated in the parent shell.
 if [[ "$(uname)" == "Darwin" ]]; then
-  mkdir -p bin
-  cat <<'EOF' >bin/mas
+  mkdir -p mas-tool/bin
+  cat <<'EOF' >mas-tool/bin/mas
 #!/bin/sh
 printf '[]\n'
 EOF
-  chmod +x bin/mas
+  chmod +x mas-tool/bin/mas
   cat <<EOF >mise.toml
-[env]
-_.path = "./bin"
+[tools]
+mas = "path:./mas-tool"
 
 [bootstrap.packages]
 "mas:497799835" = "latest"
 EOF
   assert_contains \
-    "mise exec -- mise bootstrap packages apply --manager mas --dry-run --yes" \
+    "mise bootstrap packages apply --manager mas --dry-run --yes" \
     "mas install 497799835"
 fi
 

--- a/e2e/cli/test_system_status
+++ b/e2e/cli/test_system_status
@@ -27,6 +27,27 @@ else
   assert_fail "mise bootstrap packages apply --manager mas --dry-run --yes"
 fi
 
+# mise-managed tools are removed from the pristine PATH, but package managers
+# must see the actual PATH inherited by their subprocesses.
+if [[ "$(uname)" == "Darwin" ]]; then
+  mkdir -p bin
+  cat <<'EOF' >bin/mas
+#!/bin/sh
+printf '[]\n'
+EOF
+  chmod +x bin/mas
+  cat <<EOF >mise.toml
+[env]
+_.path = "./bin"
+
+[bootstrap.packages]
+"mas:497799835" = "latest"
+EOF
+  assert_contains \
+    "mise exec -- mise bootstrap packages apply --manager mas --dry-run --yes" \
+    "mas install 497799835"
+fi
+
 # unknown managers warn but don't fail
 cat <<EOF >mise.toml
 [bootstrap.packages]

--- a/src/system/packages/mas.rs
+++ b/src/system/packages/mas.rs
@@ -1,19 +1,41 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use async_trait::async_trait;
 use eyre::{Result as EyreResult, bail, eyre};
 use serde_json::Value;
+use tokio::sync::OnceCell;
 
 use super::{InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager};
+use crate::backend::configured_toolset_or_path_which;
+use crate::config::Config;
 use crate::result::Result;
 
 /// Mac App Store apps via the `mas` CLI.
-pub struct MasManager {}
+pub struct MasManager {
+    bin: OnceCell<PathBuf>,
+}
 
 impl MasManager {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            bin: OnceCell::new(),
+        }
+    }
+
+    async fn bin(&self) -> Result<&PathBuf> {
+        if !cfg!(target_os = "macos") {
+            bail!("only available on macos");
+        }
+        self.bin
+            .get_or_try_init(|| async {
+                let config = Config::get().await?;
+                configured_toolset_or_path_which(&config, ["mas".to_string()], "mas")
+                    .await?
+                    .ok_or_else(|| eyre!("mas not found"))
+            })
+            .await
     }
 }
 
@@ -153,9 +175,9 @@ fn statuses_from_apps(apps: &[InstalledApp], requests: &[PackageRequest]) -> Vec
         .collect()
 }
 
-async fn mas_list() -> Result<Vec<InstalledApp>> {
+async fn mas_list(mas: &Path) -> Result<Vec<InstalledApp>> {
     debug!("$ mas list --json");
-    let json_output = tokio::process::Command::new("mas")
+    let json_output = tokio::process::Command::new(mas)
         .args(["list", "--json"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -176,7 +198,7 @@ async fn mas_list() -> Result<Vec<InstalledApp>> {
     };
 
     debug!("$ mas list");
-    let text_output = tokio::process::Command::new("mas")
+    let text_output = tokio::process::Command::new(mas)
         .arg("list")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -217,12 +239,16 @@ impl SystemPackageManager for MasManager {
         }
     }
 
+    async fn unavailable_reason_async(&self) -> Option<String> {
+        self.bin().await.err().map(|err| format!("{err:#}"))
+    }
+
     fn supports_version_pins(&self) -> bool {
         false
     }
 
     async fn installed(&self, pkgs: &[PackageRequest]) -> Result<Vec<PackageStatus>> {
-        let apps = mas_list().await?;
+        let apps = mas_list(self.bin().await?).await?;
         Ok(statuses_from_apps(&apps, pkgs))
     }
 
@@ -240,7 +266,7 @@ impl SystemPackageManager for MasManager {
             return Ok(());
         }
         debug!("$ mas {}", args.join(" "));
-        let output = tokio::process::Command::new("mas")
+        let output = tokio::process::Command::new(self.bin().await?)
             .args(&args)
             .stdin(Stdio::null())
             .output()
@@ -263,7 +289,7 @@ impl SystemPackageManager for MasManager {
             return Ok(());
         }
         debug!("$ mas {}", args.join(" "));
-        let output = tokio::process::Command::new("mas")
+        let output = tokio::process::Command::new(self.bin().await?)
             .args(&args)
             .stdin(Stdio::null())
             .output()

--- a/src/system/packages/mas.rs
+++ b/src/system/packages/mas.rs
@@ -206,7 +206,7 @@ impl SystemPackageManager for MasManager {
     }
 
     fn is_available(&self) -> bool {
-        cfg!(target_os = "macos") && crate::file::which("mas").is_some()
+        cfg!(target_os = "macos") && crate::file::which_non_pristine("mas").is_some()
     }
 
     fn unavailable_reason(&self) -> String {


### PR DESCRIPTION
## Summary
- resolve `mas` from the configured toolset before falling back to the live process PATH
- cache and execute the resolved absolute binary for status, install, and upgrade operations
- add a macOS regression proving a configured `mas` works without parent-shell activation or `mise exec`

## Root cause

`MasManager` used the pristine PATH for its availability check. That PATH intentionally removes mise-managed tool directories, so an installed and configured `mas` could be reported as missing unless shell activation happened to expose it another way.

The manager now uses the existing configured-tool-or-PATH resolver. This makes `[tools] mas = "latest"` authoritative when installed, retains support for an external `mas` on PATH, and ensures the availability check and subprocess execution use the same resolved executable.

Addresses [Discussion #11426](https://github.com/jdx/mise/discussions/11426).

## Validation
- `mise run test:e2e e2e/cli/test_system_status`
- `mise run format`
- `cargo test system::packages::mas`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the macOS `mas` package manager before running or previewing package operations.
  * Ensured `mas` install/upgrade previews accurately reflect the commands that would be executed when available.
* **Tests**
  * Updated end-to-end coverage to make `mas` behavior on macOS deterministic, including dry-run output verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->