### PR TITLE
feat(task): discover node workspace projects

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -45,7 +45,7 @@ outside this tracker.
 
 ## Workspace providers and task inference
 
-- [ ] Add a Node workspace provider for npm, pnpm, Yarn, and Bun workspace definitions
+- [x] Add a Node workspace provider for npm, pnpm, Yarn, and Bun workspace definitions
 - [ ] Infer Node project dependency edges from declared internal package dependencies
 - [ ] Import package scripts as scoped mise tasks without requiring a `mise.toml` in every package
 - [ ] Add root task defaults that apply by task name across inferred and explicit projects

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -315,6 +315,62 @@ Tasks from the **enclosing** monorepo are not loaded. They belong to a different
 
 The enclosing config is still an ancestor config for **tools, environment variables, and vars**, which inherit the same way any parent config's would. If you don't want that either, keep worktrees outside the main checkout (e.g. `myproject-worktrees/feature-x`).
 
+## Workspace Project Graph (Experimental)
+
+mise can infer a provider-neutral project graph from ecosystem workspace metadata. This graph is separate from config-root task discovery: a project does not need its own `mise.toml` to appear in the graph.
+
+Enable experimental features and mark the repository root:
+
+```toml
+# /myproject/mise.toml
+experimental = true
+monorepo_root = true
+```
+
+Inspect the inferred projects with:
+
+```bash
+mise tasks graph
+mise tasks graph --json
+```
+
+### Node Workspace Discovery
+
+The Node provider discovers npm, pnpm, Yarn, and Bun workspace packages from:
+
+- `pnpm-workspace.yaml`
+- the `workspaces` array in the root `package.json`
+- the Yarn Classic object form, `workspaces.packages`
+
+When both files exist, `pnpm-workspace.yaml` defines membership. Its named root package is always included, matching pnpm workspace behavior. Positive and negative workspace glob patterns are supported. The scanner skips `.git` and `node_modules`, but does not apply Git ignore files or `.ignore` files.
+
+Each discovered package must have a `name` in its `package.json`. mise uses that stable ecosystem identity to create an ID such as `node:@acme/web`; moving the package to another directory does not change its ID. `mise tasks graph` also reports the package root, workspace-definition source, and detected package manager.
+
+### Project Overrides
+
+Use `[monorepo.projects]` in the root `mise.toml` to correct or extend provider inference. Project IDs containing `:` or scoped package names must be quoted:
+
+```toml
+[monorepo.projects."node:@acme/web"]
+root = "apps/web"
+depends_add = ["custom:docs"]
+depends_remove = ["node:@acme/legacy"]
+
+[monorepo.projects."custom:docs"]
+root = "docs"
+metadata = { kind = "documentation" }
+```
+
+An override can:
+
+- set `remove = true` to remove an inferred project and its connected edges
+- set `root` or `metadata` to replace inferred values
+- set `depends` to replace the complete inferred dependency set
+- use `depends_add` and `depends_remove` to adjust individual edges
+- add a provider-independent project by giving a new namespaced ID an explicit `root`
+
+The final graph must reference existing project IDs and must not contain dependency cycles. Diagnostics identify the affected projects and the override fields that can repair the graph.
+
 ## Listing Tasks
 
 The difference between `mise tasks` and `mise tasks --all`:

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -342,7 +342,7 @@ The Node provider discovers npm, pnpm, Yarn, and Bun workspace packages from:
 - the `workspaces` array in the root `package.json`
 - the Yarn Classic object form, `workspaces.packages`
 
-When both files exist, `pnpm-workspace.yaml` defines membership. Its named root package is always included, matching pnpm workspace behavior. Positive and negative workspace glob patterns are supported. The scanner skips `.git` and `node_modules`, but does not apply Git ignore files or `.ignore` files.
+When both files exist, `pnpm-workspace.yaml` defines membership. If the root `package.json` is valid and has a `name`, it is implicitly included, matching pnpm workspace behavior. Positive and negative patterns, recursive `**` globs, and brace patterns such as `packages/{web,api}` are supported for Node workspace discovery. The scanner skips `.git` and `node_modules`, but does not apply Git ignore files or `.ignore` files.
 
 Each discovered package must have a `name` in its `package.json`. mise uses that stable ecosystem identity to create an ID such as `node:@acme/web`; moving the package to another directory does not change its ID. `mise tasks graph` also reports the package root, workspace-definition source, and detected package manager.
 

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -342,7 +342,7 @@ The Node provider discovers npm, pnpm, Yarn, and Bun workspace packages from:
 - the `workspaces` array in the root `package.json`
 - the Yarn Classic object form, `workspaces.packages`
 
-When both files exist, `pnpm-workspace.yaml` defines membership. If the root `package.json` is valid and has a `name`, it is implicitly included, matching pnpm workspace behavior. Positive and negative patterns, recursive `**` globs, and brace patterns such as `packages/{web,api}` are supported for Node workspace discovery. The scanner skips `.git` and `node_modules`, but does not apply Git ignore files or `.ignore` files.
+When both files exist, `pnpm-workspace.yaml` defines membership. For pnpm and detected Yarn workspaces, a valid root `package.json` with a `name` is implicitly included. Positive and negative patterns, recursive `**` globs, and brace patterns such as `packages/{web,api}` are supported for Node workspace discovery. The scanner skips `.git` and `node_modules`, but does not apply Git ignore files or `.ignore` files.
 
 Each discovered package must have a `name` in its `package.json`. mise uses that stable ecosystem identity to create an ID such as `node:@acme/web`; moving the package to another directory does not change its ID. `mise tasks graph` also reports the package root, workspace-definition source, and detected package manager.
 

--- a/e2e/tasks/test_task_node_workspace_graph
+++ b/e2e/tasks/test_task_node_workspace_graph
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+cat <<'EOF' >mise.toml
+monorepo_root = true
+EOF
+
+cat <<'EOF' >package.json
+{
+  "packageManager": "bun@1.3.0",
+  "workspaces": ["packages/*"]
+}
+EOF
+
+mkdir -p packages/app packages/lib
+cat <<'EOF' >packages/app/package.json
+{
+  "name": "@scope/app"
+}
+EOF
+cat <<'EOF' >packages/lib/package.json
+{
+  "name": "lib"
+}
+EOF
+
+assert_contains "mise tasks graph" "node:@scope/app"
+assert_contains "mise tasks graph" "packages/app"
+assert_contains "mise tasks graph" '"package_manager":"bun"'
+assert_contains "mise tasks graph" '"workspace_source":"package.json"'
+
+assert_json "mise tasks graph --json | jq '.projects | map({id, root})'" '[
+  {
+    "id": "node:@scope/app",
+    "root": "packages/app"
+  },
+  {
+    "id": "node:lib",
+    "root": "packages/lib"
+  }
+]'

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -464,9 +464,10 @@ impl Config {
             .map(|config| &config.projects)
             .cloned()
             .unwrap_or_default();
+        let node = crate::task::workspace::node::NodeWorkspaceProvider;
 
         crate::task::workspace::WorkspaceProjectGraph::discover_all_with_overrides(
-            &[],
+            &[&node],
             &monorepo_root,
             &overrides,
         )

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
 
+pub mod node;
+
 /// A stable, provider-namespaced identifier for a workspace project.
 ///
 /// Providers should derive the local part from ecosystem metadata, such as a

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -1,0 +1,466 @@
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+use eyre::{Context, Result, bail};
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+use ignore::WalkBuilder;
+use serde::Deserialize;
+
+use crate::file;
+
+use super::{ProjectId, WorkspaceProject, WorkspaceProvider};
+
+const PACKAGE_JSON: &str = "package.json";
+const PNPM_WORKSPACE: &str = "pnpm-workspace.yaml";
+
+/// Discovers Node projects from npm, pnpm, Yarn, and Bun workspace definitions.
+#[derive(Debug, Default)]
+pub struct NodeWorkspaceProvider;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PackageJson {
+    name: Option<String>,
+    package_manager: Option<String>,
+    workspaces: Option<PackageJsonWorkspaces>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PackageJsonWorkspaces {
+    Patterns(Vec<String>),
+    Config {
+        #[serde(default)]
+        packages: Vec<String>,
+    },
+}
+
+impl PackageJsonWorkspaces {
+    fn patterns(self) -> Vec<String> {
+        match self {
+            Self::Patterns(patterns) => patterns,
+            Self::Config { packages } => packages,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PnpmWorkspace {
+    #[serde(default)]
+    packages: Vec<String>,
+}
+
+struct WorkspaceDefinition {
+    patterns: Vec<String>,
+    source: &'static str,
+    package_manager: Option<String>,
+    include_named_root: bool,
+}
+
+impl WorkspaceProvider for NodeWorkspaceProvider {
+    fn id(&self) -> &str {
+        "node"
+    }
+
+    fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+        let Some(definition) = workspace_definition(workspace_root)? else {
+            return Ok(Vec::new());
+        };
+        let mut roots = expand_workspace_patterns(workspace_root, &definition.patterns)?;
+        if definition.include_named_root {
+            let root_manifest_path = workspace_root.join(PACKAGE_JSON);
+            if root_manifest_path.is_file()
+                && read_package_json(&root_manifest_path)?.name.is_some()
+            {
+                roots.insert(PathBuf::from("."));
+            }
+        }
+
+        roots
+            .into_iter()
+            .map(|root| {
+                let manifest_path = workspace_root.join(&root).join(PACKAGE_JSON);
+                let manifest = read_package_json(&manifest_path)?;
+                let name = manifest.name.ok_or_else(|| {
+                    eyre::eyre!(
+                        "Node workspace package at {} is missing the package.json \"name\" field",
+                        root.display()
+                    )
+                })?;
+                let mut project = WorkspaceProject::new(ProjectId::new(self.id(), &name)?, root);
+                project.metadata.insert(
+                    "workspace_source".to_string(),
+                    definition.source.to_string(),
+                );
+                if let Some(package_manager) = &definition.package_manager {
+                    project
+                        .metadata
+                        .insert("package_manager".to_string(), package_manager.clone());
+                }
+                Ok(project)
+            })
+            .collect()
+    }
+}
+
+fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinition>> {
+    let root_manifest_path = workspace_root.join(PACKAGE_JSON);
+    let root_manifest = root_manifest_path
+        .is_file()
+        .then(|| read_package_json(&root_manifest_path))
+        .transpose()?;
+    let pnpm_workspace_path = workspace_root.join(PNPM_WORKSPACE);
+
+    if pnpm_workspace_path.is_file() {
+        let contents = file::read_to_string(&pnpm_workspace_path)?;
+        let workspace: PnpmWorkspace = serde_yaml::from_str(&contents).wrap_err_with(|| {
+            format!(
+                "failed to parse Node workspace definition {}",
+                pnpm_workspace_path.display()
+            )
+        })?;
+        return Ok(Some(WorkspaceDefinition {
+            patterns: workspace.packages,
+            source: PNPM_WORKSPACE,
+            package_manager: Some("pnpm".to_string()),
+            include_named_root: true,
+        }));
+    }
+
+    let Some(root_manifest) = root_manifest else {
+        return Ok(None);
+    };
+    let Some(workspaces) = root_manifest.workspaces else {
+        return Ok(None);
+    };
+    Ok(Some(WorkspaceDefinition {
+        patterns: workspaces.patterns(),
+        source: PACKAGE_JSON,
+        package_manager: detect_package_manager(workspace_root, root_manifest.package_manager),
+        include_named_root: false,
+    }))
+}
+
+fn read_package_json(path: &Path) -> Result<PackageJson> {
+    let contents = file::read_to_string(path)?;
+    serde_json::from_str(&contents)
+        .wrap_err_with(|| format!("failed to parse Node package manifest {}", path.display()))
+}
+
+fn detect_package_manager(workspace_root: &Path, configured: Option<String>) -> Option<String> {
+    configured
+        .as_deref()
+        .map(|value| value.split_once('@').map_or(value, |(name, _)| name))
+        .filter(|manager| matches!(*manager, "npm" | "pnpm" | "yarn" | "bun"))
+        .map(str::to_string)
+        .or_else(|| {
+            [
+                ("bun", ["bun.lock", "bun.lockb"].as_slice()),
+                ("yarn", ["yarn.lock"].as_slice()),
+                (
+                    "npm",
+                    ["package-lock.json", "npm-shrinkwrap.json"].as_slice(),
+                ),
+            ]
+            .into_iter()
+            .find_map(|(manager, lockfiles)| {
+                lockfiles
+                    .iter()
+                    .any(|lockfile| workspace_root.join(lockfile).is_file())
+                    .then(|| manager.to_string())
+            })
+        })
+}
+
+fn expand_workspace_patterns(
+    workspace_root: &Path,
+    patterns: &[String],
+) -> Result<BTreeSet<PathBuf>> {
+    let mut included = GlobSetBuilder::new();
+    let mut excluded = GlobSetBuilder::new();
+    let mut has_includes = false;
+    for raw_pattern in patterns {
+        let (target, pattern) = raw_pattern
+            .strip_prefix('!')
+            .map_or((&mut included, raw_pattern.as_str()), |pattern| {
+                (&mut excluded, pattern)
+            });
+        validate_workspace_pattern(pattern)?;
+        let pattern = normalize_workspace_pattern(pattern);
+        target.add(
+            GlobBuilder::new(pattern)
+                .literal_separator(true)
+                .backslash_escape(false)
+                .build()
+                .wrap_err_with(|| format!("invalid Node workspace pattern {pattern:?}"))?,
+        );
+        if !raw_pattern.starts_with('!') {
+            has_includes = true;
+        }
+    }
+    if !has_includes {
+        return Ok(BTreeSet::new());
+    }
+    collect_matching_package_roots(workspace_root, &included.build()?, &excluded.build()?)
+}
+
+fn validate_workspace_pattern(pattern: &str) -> Result<()> {
+    if pattern.is_empty() {
+        bail!("Node workspace pattern cannot be empty");
+    }
+    let path = Path::new(pattern);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        bail!(
+            "Node workspace pattern {pattern:?} must be relative and cannot escape the workspace root"
+        );
+    }
+    Ok(())
+}
+
+fn normalize_workspace_pattern(pattern: &str) -> &str {
+    let pattern = pattern
+        .strip_prefix("./")
+        .unwrap_or(pattern)
+        .trim_end_matches('/');
+    if pattern.is_empty() { "." } else { pattern }
+}
+
+fn collect_matching_package_roots(
+    workspace_root: &Path,
+    included: &GlobSet,
+    excluded: &GlobSet,
+) -> Result<BTreeSet<PathBuf>> {
+    let mut roots = BTreeSet::new();
+    let mut builder = WalkBuilder::new(workspace_root);
+    builder
+        .hidden(false)
+        .git_exclude(false)
+        .git_global(false)
+        .git_ignore(false)
+        .filter_entry(|entry| {
+            entry.depth() == 0
+                || !matches!(entry.file_name().to_str(), Some(".git" | "node_modules"))
+        });
+    for entry in builder.build() {
+        let entry = entry.wrap_err("failed to scan Node workspace packages")?;
+        if !entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_file())
+            || entry.file_name() != PACKAGE_JSON
+        {
+            continue;
+        }
+        let root = entry
+            .path()
+            .parent()
+            .expect("package.json has a parent")
+            .strip_prefix(workspace_root)
+            .expect("workspace walk stays beneath its root");
+        let root = if root.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            root
+        };
+        if included.is_match(root) && !excluded.is_match(root) {
+            roots.insert(root.to_path_buf());
+        }
+    }
+    Ok(roots)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn project_summary(projects: &[WorkspaceProject]) -> Vec<(&str, &Path, Option<&str>)> {
+        projects
+            .iter()
+            .map(|project| {
+                (
+                    project.id.as_str(),
+                    project.root.as_path(),
+                    project.metadata.get("package_manager").map(String::as_str),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn discovers_package_json_workspaces_for_npm_yarn_and_bun() {
+        for manager in ["npm", "yarn", "bun"] {
+            let temp = tempdir().unwrap();
+            write(
+                &temp.path().join(PACKAGE_JSON),
+                &format!(r#"{{"packageManager":"{manager}@1.0.0","workspaces":["packages/*"]}}"#),
+            );
+            write(
+                &temp.path().join("packages/app/package.json"),
+                r#"{"name":"@scope/app"}"#,
+            );
+            write(
+                &temp.path().join("packages/lib/package.json"),
+                r#"{"name":"lib"}"#,
+            );
+
+            let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+            assert_eq!(
+                project_summary(&projects),
+                vec![
+                    ("node:@scope/app", Path::new("packages/app"), Some(manager)),
+                    ("node:lib", Path::new("packages/lib"), Some(manager)),
+                ]
+            );
+            assert!(projects.iter().all(|project| {
+                project.metadata.get("workspace_source").map(String::as_str) == Some(PACKAGE_JSON)
+            }));
+        }
+    }
+
+    #[test]
+    fn supports_yarn_object_workspace_syntax() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":{"packages":["apps/*"],"nohoist":["**/react"]}}"#,
+        );
+        write(
+            &temp.path().join("apps/web/package.json"),
+            r#"{"name":"web"}"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert_eq!(
+            project_summary(&projects),
+            vec![("node:web", Path::new("apps/web"), None)]
+        );
+    }
+
+    #[test]
+    fn pnpm_workspace_takes_precedence_and_supports_exclusions() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"name":"root","workspaces":["ignored/*"]}"#,
+        );
+        write(
+            &temp.path().join(PNPM_WORKSPACE),
+            "packages:\n  - packages/*\n  - '!packages/private'\n",
+        );
+        write(
+            &temp.path().join("ignored/app/package.json"),
+            r#"{"name":"ignored"}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"app"}"#,
+        );
+        write(
+            &temp.path().join("packages/private/package.json"),
+            r#"{"name":"private"}"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert_eq!(
+            project_summary(&projects),
+            vec![
+                ("node:root", Path::new("."), Some("pnpm")),
+                ("node:app", Path::new("packages/app"), Some("pnpm")),
+            ]
+        );
+        assert_eq!(
+            projects[1]
+                .metadata
+                .get("workspace_source")
+                .map(String::as_str),
+            Some(PNPM_WORKSPACE)
+        );
+    }
+
+    #[test]
+    fn full_glob_patterns_ignore_installed_dependencies() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":["{apps,packages}/**","!**/excluded/**"]}"#,
+        );
+        write(
+            &temp.path().join("apps/web/package.json"),
+            r#"{"name":"web"}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"app"}"#,
+        );
+        write(
+            &temp.path().join("packages/excluded/test/package.json"),
+            r#"{"name":"excluded"}"#,
+        );
+        write(
+            &temp
+                .path()
+                .join("packages/app/node_modules/transitive/package.json"),
+            r#"{"name":"transitive"}"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert_eq!(
+            project_summary(&projects),
+            vec![
+                ("node:web", Path::new("apps/web"), None),
+                ("node:app", Path::new("packages/app"), None),
+            ]
+        );
+    }
+
+    #[test]
+    fn pnpm_skips_an_unnamed_root_package() {
+        let temp = tempdir().unwrap();
+        write(&temp.path().join(PACKAGE_JSON), r#"{"private":true}"#);
+        write(&temp.path().join(PNPM_WORKSPACE), "packages: []\n");
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert!(projects.is_empty());
+    }
+
+    #[test]
+    fn rejects_escaping_patterns_and_unnamed_packages() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":["../outside"]}"#,
+        );
+        let err = NodeWorkspaceProvider.discover(temp.path()).unwrap_err();
+        assert!(err.to_string().contains("cannot escape the workspace root"));
+
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":["packages/*"]}"#,
+        );
+        write(&temp.path().join("packages/app/package.json"), "{}");
+        let err = NodeWorkspaceProvider.discover(temp.path()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("missing the package.json \"name\"")
+        );
+    }
+}

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -70,7 +70,7 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
         if definition.include_named_root {
             let root_manifest_path = workspace_root.join(PACKAGE_JSON);
             if root_manifest_path.is_file()
-                && read_package_json(&root_manifest_path)?.name.is_some()
+                && read_package_name_if_valid(&root_manifest_path)?.is_some()
             {
                 roots.insert(PathBuf::from("."));
             }
@@ -104,13 +104,7 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
 }
 
 fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinition>> {
-    let root_manifest_path = workspace_root.join(PACKAGE_JSON);
-    let root_manifest = root_manifest_path
-        .is_file()
-        .then(|| read_package_json(&root_manifest_path))
-        .transpose()?;
     let pnpm_workspace_path = workspace_root.join(PNPM_WORKSPACE);
-
     if pnpm_workspace_path.is_file() {
         let contents = file::read_to_string(&pnpm_workspace_path)?;
         let workspace: PnpmWorkspace = serde_yaml::from_str(&contents).wrap_err_with(|| {
@@ -127,6 +121,11 @@ fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinit
         }));
     }
 
+    let root_manifest_path = workspace_root.join(PACKAGE_JSON);
+    let root_manifest = root_manifest_path
+        .is_file()
+        .then(|| read_package_json(&root_manifest_path))
+        .transpose()?;
     let Some(root_manifest) = root_manifest else {
         return Ok(None);
     };
@@ -147,6 +146,13 @@ fn read_package_json(path: &Path) -> Result<PackageJson> {
         .wrap_err_with(|| format!("failed to parse Node package manifest {}", path.display()))
 }
 
+fn read_package_name_if_valid(path: &Path) -> Result<Option<String>> {
+    let contents = file::read_to_string(path)?;
+    Ok(serde_json::from_str::<PackageJson>(&contents)
+        .ok()
+        .and_then(|manifest| manifest.name))
+}
+
 fn detect_package_manager(workspace_root: &Path, configured: Option<String>) -> Option<String> {
     configured
         .as_deref()
@@ -156,6 +162,7 @@ fn detect_package_manager(workspace_root: &Path, configured: Option<String>) -> 
         .or_else(|| {
             [
                 ("bun", ["bun.lock", "bun.lockb"].as_slice()),
+                ("pnpm", ["pnpm-lock.yaml"].as_slice()),
                 ("yarn", ["yarn.lock"].as_slice()),
                 (
                     "npm",
@@ -178,7 +185,7 @@ fn expand_workspace_patterns(
 ) -> Result<BTreeSet<PathBuf>> {
     let mut included = GlobSetBuilder::new();
     let mut excluded = GlobSetBuilder::new();
-    let mut has_includes = false;
+    let mut walk_roots = BTreeSet::new();
     for raw_pattern in patterns {
         let (target, pattern) = raw_pattern
             .strip_prefix('!')
@@ -195,13 +202,18 @@ fn expand_workspace_patterns(
                 .wrap_err_with(|| format!("invalid Node workspace pattern {pattern:?}"))?,
         );
         if !raw_pattern.starts_with('!') {
-            has_includes = true;
+            walk_roots.insert(literal_workspace_prefix(pattern));
         }
     }
-    if !has_includes {
+    if walk_roots.is_empty() {
         return Ok(BTreeSet::new());
     }
-    collect_matching_package_roots(workspace_root, &included.build()?, &excluded.build()?)
+    collect_matching_package_roots(
+        workspace_root,
+        &minimize_walk_roots(walk_roots),
+        &included.build()?,
+        &excluded.build()?,
+    )
 }
 
 fn validate_workspace_pattern(pattern: &str) -> Result<()> {
@@ -229,44 +241,85 @@ fn normalize_workspace_pattern(pattern: &str) -> &str {
     if pattern.is_empty() { "." } else { pattern }
 }
 
+fn literal_workspace_prefix(pattern: &str) -> PathBuf {
+    let mut prefix = PathBuf::new();
+    for component in pattern.split('/') {
+        if component
+            .chars()
+            .any(|character| matches!(character, '*' | '?' | '[' | '{'))
+        {
+            break;
+        }
+        if component != "." {
+            prefix.push(component);
+        }
+    }
+    if prefix.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        prefix
+    }
+}
+
+fn minimize_walk_roots(roots: BTreeSet<PathBuf>) -> BTreeSet<PathBuf> {
+    let mut minimized = BTreeSet::new();
+    for root in roots {
+        if minimized
+            .iter()
+            .any(|ancestor| ancestor == Path::new(".") || root.starts_with(ancestor))
+        {
+            continue;
+        }
+        minimized.insert(root);
+    }
+    minimized
+}
+
 fn collect_matching_package_roots(
     workspace_root: &Path,
+    walk_roots: &BTreeSet<PathBuf>,
     included: &GlobSet,
     excluded: &GlobSet,
 ) -> Result<BTreeSet<PathBuf>> {
     let mut roots = BTreeSet::new();
-    let mut builder = WalkBuilder::new(workspace_root);
-    builder
-        .hidden(false)
-        .git_exclude(false)
-        .git_global(false)
-        .git_ignore(false)
-        .filter_entry(|entry| {
-            entry.depth() == 0
-                || !matches!(entry.file_name().to_str(), Some(".git" | "node_modules"))
-        });
-    for entry in builder.build() {
-        let entry = entry.wrap_err("failed to scan Node workspace packages")?;
-        if !entry
-            .file_type()
-            .is_some_and(|file_type| file_type.is_file())
-            || entry.file_name() != PACKAGE_JSON
-        {
+    for walk_root in walk_roots {
+        let walk_root = workspace_root.join(walk_root);
+        if !walk_root.exists() {
             continue;
         }
-        let root = entry
-            .path()
-            .parent()
-            .expect("package.json has a parent")
-            .strip_prefix(workspace_root)
-            .expect("workspace walk stays beneath its root");
-        let root = if root.as_os_str().is_empty() {
-            Path::new(".")
-        } else {
-            root
-        };
-        if included.is_match(root) && !excluded.is_match(root) {
-            roots.insert(root.to_path_buf());
+        let mut builder = WalkBuilder::new(walk_root);
+        builder
+            .hidden(false)
+            .git_exclude(false)
+            .git_global(false)
+            .git_ignore(false)
+            .filter_entry(|entry| {
+                entry.depth() == 0
+                    || !matches!(entry.file_name().to_str(), Some(".git" | "node_modules"))
+            });
+        for entry in builder.build() {
+            let entry = entry.wrap_err("failed to scan Node workspace packages")?;
+            if !entry
+                .file_type()
+                .is_some_and(|file_type| file_type.is_file())
+                || entry.file_name() != PACKAGE_JSON
+            {
+                continue;
+            }
+            let root = entry
+                .path()
+                .parent()
+                .expect("package.json has a parent")
+                .strip_prefix(workspace_root)
+                .expect("workspace walk stays beneath its root");
+            let root = if root.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                root
+            };
+            if included.is_match(root) && !excluded.is_match(root) {
+                roots.insert(root.to_path_buf());
+            }
         }
     }
     Ok(roots)
@@ -440,6 +493,68 @@ mod tests {
         let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
 
         assert!(projects.is_empty());
+    }
+
+    #[test]
+    fn pnpm_discovery_does_not_require_a_valid_root_manifest() {
+        let temp = tempdir().unwrap();
+        write(&temp.path().join(PACKAGE_JSON), "{");
+        write(
+            &temp.path().join(PNPM_WORKSPACE),
+            "packages:\n  - packages/*\n",
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"app"}"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert_eq!(
+            project_summary(&projects),
+            vec![("node:app", Path::new("packages/app"), Some("pnpm"))]
+        );
+    }
+
+    #[test]
+    fn detects_pnpm_from_its_lockfile() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":["packages/*"]}"#,
+        );
+        write(
+            &temp.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: '9.0'\n",
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"app"}"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert_eq!(
+            project_summary(&projects),
+            vec![("node:app", Path::new("packages/app"), Some("pnpm"))]
+        );
+    }
+
+    #[test]
+    fn narrows_walk_roots_to_literal_pattern_prefixes() {
+        let roots = ["packages/*", "packages/nested/**", "apps/**/plugins/*"]
+            .into_iter()
+            .map(literal_workspace_prefix)
+            .collect();
+
+        assert_eq!(
+            minimize_walk_roots(roots),
+            BTreeSet::from([PathBuf::from("apps"), PathBuf::from("packages")])
+        );
+        assert_eq!(
+            literal_workspace_prefix("{apps,packages}/**"),
+            PathBuf::from(".")
+        );
     }
 
     #[test]

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -135,11 +135,13 @@ fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinit
     let Some(workspaces) = root_manifest.workspaces else {
         return Ok(None);
     };
+    let package_manager = detect_package_manager(workspace_root, root_manifest.package_manager);
+    let include_named_root = package_manager.as_deref() == Some("yarn");
     Ok(Some(WorkspaceDefinition {
         patterns: workspaces.patterns(),
         source: PACKAGE_JSON,
-        package_manager: detect_package_manager(workspace_root, root_manifest.package_manager),
-        include_named_root: false,
+        package_manager,
+        include_named_root,
     }))
 }
 
@@ -404,6 +406,29 @@ mod tests {
         assert_eq!(
             project_summary(&projects),
             vec![("node:web", Path::new("apps/web"), None)]
+        );
+    }
+
+    #[test]
+    fn yarn_includes_a_named_root_package() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"name":"root","packageManager":"yarn@4.0.0","workspaces":["packages/*"]}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"app"}"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert_eq!(
+            project_summary(&projects),
+            vec![
+                ("node:root", Path::new("."), Some("yarn")),
+                ("node:app", Path::new("packages/app"), Some("yarn")),
+            ]
         );
     }
 

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -294,6 +294,7 @@ fn collect_matching_package_roots(
             .git_exclude(false)
             .git_global(false)
             .git_ignore(false)
+            .ignore(false)
             .filter_entry(|entry| {
                 entry.depth() == 0
                     || !matches!(entry.file_name().to_str(), Some(".git" | "node_modules"))
@@ -482,6 +483,27 @@ mod tests {
                 ("node:web", Path::new("apps/web"), None),
                 ("node:app", Path::new("packages/app"), None),
             ]
+        );
+    }
+
+    #[test]
+    fn workspace_discovery_does_not_honor_dot_ignore_files() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":["packages/*"]}"#,
+        );
+        write(&temp.path().join(".ignore"), "packages/ignored\n");
+        write(
+            &temp.path().join("packages/ignored/package.json"),
+            r#"{"name":"ignored"}"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert_eq!(
+            project_summary(&projects),
+            vec![("node:ignored", Path::new("packages/ignored"), None)]
         );
     }
 

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -70,7 +70,9 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
         if definition.include_named_root {
             let root_manifest_path = workspace_root.join(PACKAGE_JSON);
             if root_manifest_path.is_file()
-                && read_package_name_if_valid(&root_manifest_path)?.is_some()
+                && read_package_json_if_valid(&root_manifest_path)?
+                    .and_then(|manifest| manifest.name)
+                    .is_some()
             {
                 roots.insert(PathBuf::from("."));
             }
@@ -124,8 +126,9 @@ fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinit
     let root_manifest_path = workspace_root.join(PACKAGE_JSON);
     let root_manifest = root_manifest_path
         .is_file()
-        .then(|| read_package_json(&root_manifest_path))
-        .transpose()?;
+        .then(|| read_package_json_if_valid(&root_manifest_path))
+        .transpose()?
+        .flatten();
     let Some(root_manifest) = root_manifest else {
         return Ok(None);
     };
@@ -146,11 +149,9 @@ fn read_package_json(path: &Path) -> Result<PackageJson> {
         .wrap_err_with(|| format!("failed to parse Node package manifest {}", path.display()))
 }
 
-fn read_package_name_if_valid(path: &Path) -> Result<Option<String>> {
+fn read_package_json_if_valid(path: &Path) -> Result<Option<PackageJson>> {
     let contents = file::read_to_string(path)?;
-    Ok(serde_json::from_str::<PackageJson>(&contents)
-        .ok()
-        .and_then(|manifest| manifest.name))
+    Ok(serde_json::from_str(&contents).ok())
 }
 
 fn detect_package_manager(workspace_root: &Path, configured: Option<String>) -> Option<String> {
@@ -514,6 +515,16 @@ mod tests {
             project_summary(&projects),
             vec![("node:app", Path::new("packages/app"), Some("pnpm"))]
         );
+    }
+
+    #[test]
+    fn ignores_an_invalid_root_manifest_without_a_workspace_definition() {
+        let temp = tempdir().unwrap();
+        write(&temp.path().join(PACKAGE_JSON), "{");
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+
+        assert!(projects.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- discover Node projects from npm, pnpm, Yarn, and Bun workspace definitions
- support package.json array/object forms, pnpm exclusions and implicit root membership, and recursive/brace glob patterns
- expose stable provider-namespaced project IDs plus workspace-source/package-manager metadata through `mise tasks graph`
- skip installed dependencies and reject workspace patterns that escape the monorepo root
- update the task-cache parity tracker and add focused unit/E2E coverage

## Context
- follows #11427, which introduced workspace graph inspection
- dependency-edge inference remains the next follow-up PR

## Validation
- `cargo test --bin mise 'task::workspace::'`
- `mise run test:e2e test_task_node_workspace_graph test_task_workspace_graph`
- `mise run lint-fix`
- `mise x rust@1.94.1 -- cargo clippy --all-features -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem scanning and manifest parsing on monorepo graph paths; behavior is gated behind experimental + monorepo root, with bounded walk rules and validation.
> 
> **Overview**
> Adds a **Node workspace provider** so the experimental `mise tasks graph` can infer projects from npm, pnpm, Yarn, and Bun workspace metadata—without requiring a `mise.toml` in every package.
> 
> Discovery reads `pnpm-workspace.yaml` (wins over root `package.json`), `package.json` `workspaces` (array or Yarn-style object), expands globs with include/exclude and brace patterns, and assigns stable IDs like `node:@scope/app` from each package’s `name`. Output includes `workspace_source`, inferred `package_manager`, and package roots. Scanning skips `.git` and `node_modules` but not `.ignore`; patterns that escape the repo root are rejected.
> 
> **Wiring:** `NodeWorkspaceProvider` is registered in monorepo graph discovery (`config/mod.rs`). Docs cover experimental setup, Node rules, and `[monorepo.projects]` overrides; the task-cache parity tracker marks the Node provider item done. Unit tests in `node.rs` and e2e `test_task_node_workspace_graph` cover Bun workspaces and JSON shape. Internal package **dependency edges** are explicitly out of scope for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0082cf44c5e565ecdc0ddbe192c77637f5633944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of Node.js workspace projects from npm, pnpm, Yarn, and Bun workspace definitions.
  * The experimental workspace project graph now uses Node-based workspace discovery and reports project identifiers, paths, workspace source, and inferred package manager details.
* **Bug Fixes**
  * Improved workspace pattern handling to avoid scanning installed dependency directories.
* **Tests**
  * Added end-to-end coverage validating workspace graph output and `--json` results.
* **Documentation**
  * Documented the experimental workspace project graph, Node discovery rules, and project overrides.  
  * Updated the parity tracker to reflect completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->