### PR TITLE
feat(task): infer node workspace dependencies

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -46,7 +46,7 @@ outside this tracker.
 ## Workspace providers and task inference
 
 - [x] Add a Node workspace provider for npm, pnpm, Yarn, and Bun workspace definitions
-- [ ] Infer Node project dependency edges from declared internal package dependencies
+- [x] Infer Node project dependency edges from declared internal package dependencies
 - [ ] Import package scripts as scoped mise tasks without requiring a `mise.toml` in every package
 - [ ] Add root task defaults that apply by task name across inferred and explicit projects
 - [ ] Add dependency-scoped task relationships equivalent to building the same task in upstream

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -356,7 +356,7 @@ For every discovered Node package, mise checks these `package.json` fields:
 - `optionalDependencies`
 - `peerDependencies`
 
-When a declared dependency name exactly matches another discovered workspace package, mise adds an edge to that package's stable `node:` project ID. External package names are ignored.
+When a declared dependency name exactly matches another discovered workspace package, mise adds an edge to that package's stable `node:` project ID. External package names and declarations that refer back to the same project are ignored.
 
 Dependency version strings are treated as opaque. A matching internal name creates the same edge whether its value uses `workspace:*`, `catalog:`, `*`, a normal version range, or another package-manager-specific form. mise does not resolve or compare those values when constructing the project graph.
 

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -347,6 +347,21 @@ When both files exist, `pnpm-workspace.yaml` defines membership. For pnpm and de
 
 Each discovered package must have a `name` in its `package.json`. mise uses that stable ecosystem identity to create an ID such as `node:@acme/web`; moving the package to another directory does not change its ID. `mise tasks graph` also reports the package root, workspace-definition source, and detected package manager.
 
+### Node Dependency Inference
+
+For every discovered Node package, mise checks these `package.json` fields:
+
+- `dependencies`
+- `devDependencies`
+- `optionalDependencies`
+- `peerDependencies`
+
+When a declared dependency name exactly matches another discovered workspace package, mise adds an edge to that package's stable `node:` project ID. External package names are ignored.
+
+Dependency version strings are treated as opaque. A matching internal name creates the same edge whether its value uses `workspace:*`, `catalog:`, `*`, a normal version range, or another package-manager-specific form. mise does not resolve or compare those values when constructing the project graph.
+
+All four dependency kinds participate in the same project graph, including development dependencies. If the declarations produce a cycle, `mise tasks graph` reports the cycle instead of silently dropping an edge. Use `depends`, `depends_add`, or `depends_remove` in a project override when the inferred build relationship needs to differ from the package manifests.
+
 ### Project Overrides
 
 Use `[monorepo.projects]` in the root `mise.toml` to correct or extend provider inference. Project IDs containing `:` or scoped package names must be quoted:

--- a/e2e/tasks/test_task_node_workspace_graph
+++ b/e2e/tasks/test_task_node_workspace_graph
@@ -16,7 +16,10 @@ EOF
 mkdir -p packages/app packages/lib
 cat <<'EOF' >packages/app/package.json
 {
-  "name": "@scope/app"
+  "name": "@scope/app",
+  "dependencies": {
+    "lib": "workspace:*"
+  }
 }
 EOF
 cat <<'EOF' >packages/lib/package.json
@@ -29,14 +32,19 @@ assert_contains "mise tasks graph" "node:@scope/app"
 assert_contains "mise tasks graph" "packages/app"
 assert_contains "mise tasks graph" '"package_manager":"bun"'
 assert_contains "mise tasks graph" '"workspace_source":"package.json"'
+assert_contains "mise tasks graph" "node:lib"
 
-assert_json "mise tasks graph --json | jq '.projects | map({id, root})'" '[
+assert_json "mise tasks graph --json | jq '.projects | map({id, root, dependencies})'" '[
   {
     "id": "node:@scope/app",
-    "root": "packages/app"
+    "root": "packages/app",
+    "dependencies": [
+      "node:lib"
+    ]
   },
   {
     "id": "node:lib",
-    "root": "packages/lib"
+    "root": "packages/lib",
+    "dependencies": []
   }
 ]'

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use aube::embed::{ManifestError, PackageJson, WorkspaceDiscoveryOptions};
@@ -78,18 +78,37 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
             }
         }
 
-        roots
+        let manifests = roots
             .into_iter()
             .map(|root| {
                 let manifest_path = workspace_root.join(&root).join(PACKAGE_JSON);
                 let manifest = read_package_json(&manifest_path)?;
-                let name = manifest.name.ok_or_else(|| {
+                let name = manifest.name.clone().ok_or_else(|| {
                     eyre::eyre!(
                         "Node workspace package at {} is missing the package.json \"name\" field",
                         root.display()
                     )
                 })?;
-                let mut project = WorkspaceProject::new(ProjectId::new(self.id(), &name)?, root);
+                let id = ProjectId::new(self.id(), &name)?;
+                Ok((root, manifest, name, id))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let project_ids = manifests
+            .iter()
+            .map(|(_, _, name, id)| (name.clone(), id.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        manifests
+            .into_iter()
+            .map(|(root, manifest, _, id)| {
+                let mut project = WorkspaceProject::new(id, root);
+                project.dependencies = manifest
+                    .all_dependencies()
+                    .map(|(name, _)| name)
+                    .chain(manifest.optional_dependencies.keys().map(String::as_str))
+                    .chain(manifest.peer_dependencies.keys().map(String::as_str))
+                    .filter_map(|name| project_ids.get(name).cloned())
+                    .collect();
                 project.metadata.insert(
                     "workspace_source".to_string(),
                     definition.source.to_string(),
@@ -499,6 +518,47 @@ mod tests {
         assert_eq!(
             project_summary(&projects),
             vec![("node:app", Path::new("packages/app"), Some("pnpm"))]
+        );
+    }
+
+    #[test]
+    fn infers_edges_for_declared_internal_dependencies() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":["packages/*"]}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{
+                "name":"app",
+                "dependencies":{"runtime":"workspace:*","external":"^1.0.0"},
+                "devDependencies":{"build":"*"},
+                "optionalDependencies":{"optional":"catalog:"},
+                "peerDependencies":{"peer":"^2.0.0"}
+            }"#,
+        );
+        for name in ["runtime", "build", "optional", "peer"] {
+            write(
+                &temp.path().join(format!("packages/{name}/package.json")),
+                &format!(r#"{{"name":"{name}"}}"#),
+            );
+        }
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+        let app = projects
+            .iter()
+            .find(|project| project.id.as_str() == "node:app")
+            .unwrap();
+
+        assert_eq!(
+            app.dependencies,
+            BTreeSet::from([
+                ProjectId::new("node", "build").unwrap(),
+                ProjectId::new("node", "optional").unwrap(),
+                ProjectId::new("node", "peer").unwrap(),
+                ProjectId::new("node", "runtime").unwrap(),
+            ])
         );
     }
 

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -101,14 +101,16 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
         manifests
             .into_iter()
             .map(|(root, manifest, _, id)| {
-                let mut project = WorkspaceProject::new(id, root);
-                project.dependencies = manifest
+                let dependencies = manifest
                     .all_dependencies()
                     .map(|(name, _)| name)
                     .chain(manifest.optional_dependencies.keys().map(String::as_str))
                     .chain(manifest.peer_dependencies.keys().map(String::as_str))
                     .filter_map(|name| project_ids.get(name).cloned())
+                    .filter(|dependency| dependency != &id)
                     .collect();
+                let mut project = WorkspaceProject::new(id, root);
+                project.dependencies = dependencies;
                 project.metadata.insert(
                     "workspace_source".to_string(),
                     definition.source.to_string(),
@@ -560,6 +562,28 @@ mod tests {
                 ProjectId::new("node", "runtime").unwrap(),
             ])
         );
+    }
+
+    #[test]
+    fn ignores_declared_self_dependencies() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":["packages/*"]}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"app","dependencies":{"app":"*"}}"#,
+        );
+
+        let graph = crate::task::workspace::WorkspaceProjectGraph::discover(
+            &NodeWorkspaceProvider,
+            temp.path(),
+        )
+        .unwrap();
+        let app = graph.get(&ProjectId::new("node", "app").unwrap()).unwrap();
+
+        assert!(app.dependencies.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- infer Node workspace project edges by matching declared package names to discovered internal projects
- include runtime, development, optional, and peer dependency declarations
- keep dependency version strings opaque, supporting `workspace:`, catalog, wildcard, and ordinary range syntax without semver assumptions
- ignore external packages and deduplicate inferred edges deterministically
- expose inferred edges through `mise tasks graph` and update the parity tracker

## Stack
- depends on #11445
- targets `agent/node-workspace-aube-discovery` so this PR contains only dependency inference and its documentation

## Impact
Node workspaces now produce the package dependency graph needed for dependency-aware task ordering and affected-project analysis. This PR only infers project edges; importing package scripts remains the next tracker item.

## Validation
- `cargo test --bin mise 'task::workspace::'`
- `mise run test:e2e test_task_node_workspace_graph test_task_workspace_graph`
- `mise run lint-fix`
- `mise x rust@1.94.1 -- cargo clippy --all-features -- -D warnings`
- post-rebase: `cargo test task::workspace::node::tests` (14 passed)
- post-rebase: `mise run test:e2e test_task_node_workspace_graph`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive behavior on the experimental workspace graph with unit and e2e coverage; no changes to auth, installs, or task execution.
> 
> **Overview**
> **Node workspace packages now get dependency edges in the experimental project graph** by matching declared `package.json` dependency names to other discovered workspace packages.
> 
> The Node provider builds a name→`node:` project ID map during discovery, then wires `dependencies`, `devDependencies`, `optionalDependencies`, and `peerDependencies` into each project's `dependencies` set. External packages are skipped; version strings are not parsed. Self-references are dropped. Inferred edges surface in `mise tasks graph` / `--json` (e2e asserts `node:lib` from `workspace:*`).
> 
> Docs add a **Node Dependency Inference** section; the task-cache parity tracker marks internal package dependency inference as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6df6292778e35c6ee0091f14e6824a4a20201c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise tasks graph` now infers and displays dependency edges between packages in Node workspaces from declared internal package names (including `dependencies`, `devDependencies`, `optionalDependencies`, and `peerDependencies`), while excluding external packages.
  * Dependency cycles are now reported instead of being omitted.
* **Documentation**
  * Added guidance on Node workspace dependency inference under experimental workspace discovery, plus tips for overriding inferred relationships.
* **Tests**
  * Updated e2e graph assertions to include dependency information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->