### PR TITLE
feat(bootstrap): add bs command alias

### DIFF
--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -2,6 +2,7 @@
 # `mise bootstrap`
 
 - **Usage**: `mise bootstrap [FLAGS] [SUBCOMMAND]`
+- **Aliases**: `bs`
 - **Effect**: modifies state
 - **Source code**: [`src/cli/bootstrap.rs`](https://github.com/jdx/mise/blob/main/src/cli/bootstrap.rs)
 

--- a/e2e/cli/test_bootstrap
+++ b/e2e/cli/test_bootstrap
@@ -5,6 +5,7 @@ cat <<EOF >mise.toml
 [tools]
 EOF
 assert_succeed "mise bootstrap --yes"
+assert_succeed "mise bs --yes"
 assert_succeed "MISE_EXPERIMENTAL=0 mise bootstrap --yes"
 assert_succeed "MISE_EXPERIMENTAL=0 mise bootstrap status"
 assert_not_contains "mise bootstrap --yes" "bootstrap: follow-up"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -144,6 +144,9 @@ List all the active runtime bin paths
 .TP
 \fBbootstrap\fR
 Set up a machine for the current config in one command
+.RS
+\fIAliases: \fRbs
+.RE
 .TP
 \fBbootstrap dotfiles\fR
 Manage dotfiles from `[dotfiles]`

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -281,6 +281,7 @@ e.g.: ruby@3
 """# required=#false var=#true
 }
 cmd bootstrap help="Set up a machine for the current config in one command" effect=write {
+    alias bs
     long_help #"""
 Set up a machine for the current config in one command
 

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -66,7 +66,11 @@ use clap::{Subcommand, ValueEnum};
 /// named parts. Both flags can be repeated or comma-separated, but they
 /// cannot be used together.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(
+    visible_alias = "bs",
+    verbatim_doc_comment,
+    after_long_help = AFTER_LONG_HELP
+)]
 pub struct Bootstrap {
     #[clap(subcommand)]
     command: Option<Commands>,


### PR DESCRIPTION
## Summary
- add `bs` as a visible alias for the `bootstrap` command
- cover the alias with an end-to-end invocation
- regenerate CLI usage, documentation, and the man page

## Impact
Users can run `mise bs` and `mise bs <subcommand>` as shorthand for `mise bootstrap`.

## Validation
- `cargo fmt --check`
- `mise run test:e2e cli/test_bootstrap`
- `mise run render`
- verified `mise --help` displays `[alias: bs]`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI alias and documentation only; no change to bootstrap behavior beyond accepting an additional command name.
> 
> **Overview**
> Adds **`bs`** as a visible shorthand for **`mise bootstrap`**, so users can run `mise bs` (and subcommands) the same way as the full command.
> 
> The alias is wired on the bootstrap CLI via clap’s `visible_alias`, and **usage/man/docs** are updated to list it. An **e2e** check asserts `mise bs --yes` succeeds alongside the existing bootstrap smoke test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed11e6048b5e4193c61338aa00d6a93614d1f62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->