### PR TITLE
fix(npm): route aube prompts through mise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc4c0319402cbef93e09f24b1163a165a4df9fc0d574072b671cce5f1986f27"
+checksum = "e2737cd03833117f398dc171b75c38fc6e831b7ae19e40550bb5721a5fe11b71"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7992439189bd31d0cab1ab4da560df1621dd9185a53e05ece4128a493b05ad"
+checksum = "7dcba682d96e508df23093ef85f39c9044290faf08b797ed319f516df5763ec4"
 dependencies = [
  "serde",
  "serde_json",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0b30b130870b8e97d310ee9453011cc75ffcffbb9fb9beb4c07a9d92eebf96"
+checksum = "4c305c220bc17ab93d344323a79720992b04eecdecbeb9fa4dbfc3dbaacec65c"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a0fddc7392b4827a342f19eba81e0ca03516df0a5adb1bf13cb5800521d58d"
+checksum = "1f970e9af2666c476ddf0dd97daf447f0d483601ef09c3b074a02b0c3a59005b"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c960a37f8161d6f434262b407991bc5bc45bdb06fb540a9f1d870d7429734d2"
+checksum = "eb90acfa7248f49bbee33b69c66681e46fd3de276ab54a8a59f8344d25c31122"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3a22649c17644fba5211d8d9d7c71db02f77a33b116b04d32ff19161f80c9b"
+checksum = "4f08d41526e20ffa76c00ac6dd2d7e8e3a2a4f87ecc7ce7dec1392d411a32009"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695c6ad662a5b00e160c0e416e27705cc6f4708b896a5c0dd18ae57fb7289b81"
+checksum = "ab4bf52b5f904b9e184689781a570b6c5e51c6006660490d17bc1fd90539ad09"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00cf26ebf3ff492bf99245f4c33c756c46f90e5d61ce7e65ac4726cc9d359be"
+checksum = "b7abeacedb6a72dcf19fd40dc2e29c586b358123be17fe82a77767f2b80aeb95"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce5c536d5819be028fdfac7e41e6f27a03d03ee019e5b87d71d5eed62993ceb"
+checksum = "d031825c5c9a93d086880398f0554d5c8160a4de230a71f952b2afa10c043068"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d590a426e63b890268af4d348ad2b3300f328b2e5aac5b55ad08979330acde"
+checksum = "2f6d8a84f1e8a672076373de8ba6716c780b6362d24345e80b4ab148161139b3"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0eb4cc552cb423197a164a46671e35ed296cfbceb15bd2a03afde4f8478b05f"
+checksum = "6e37cc3c5703a93a61bc42ca5eb04d6b8f2890c8e63f47b4e95e458179b084c9"
 dependencies = [
  "aube-util",
  "base64 0.22.1",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f054ebcdd13f940d3bdc67bc0b839fea4b9cfc667d49ec0bc2ef57541fe391bd"
+checksum = "3f2487257d07d108f9f290e9daab5f3348db35efb9b174cfb17447f0ee89bbc9"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83071f192fdc7e377e3b6867732384e24e9fc8f0c95a71393ad65622dcfd0c5a"
+checksum = "e869fe05450de6ec0267df610495e51f3ba95b855c98b5cb0d3879fb575afd2f"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -1472,7 +1472,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4277,7 +4277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -7233,7 +7233,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -9490,7 +9490,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,10 @@ opt-level = 3
 [dependencies]
 age = { version = "0.12", features = ["ssh"] }
 aho-corasick = "1"
-aube-registry = { version = "1.34", default-features = false, features = [
+aube-registry = { version = "1.35", default-features = false, features = [
   "rustls",
 ] }
-aube = { version = "1.34", default-features = false, features = ["rustls"] }
+aube = { version = "1.35", default-features = false, features = ["rustls"] }
 async-backtrace = "0.2"
 async-trait = "0.1"
 aws-config = { version = "1.5", default-features = false, features = [

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -952,7 +952,8 @@ impl NPMBackend {
             // `aube.allowBuilds`; only the "allow everything" case needs the
             // invocation flag. `None` leaves scripts skipped (aube's default).
             dangerously_allow_all_builds: matches!(allow_builds, AllowBuilds::All),
-            control: aube::embed::InstallControl::events(Arc::new(AubeProgressReporter { tx })),
+            control: aube::embed::InstallControl::events(Arc::new(AubeProgressReporter { tx }))
+                .with_prompt_handler(Arc::new(AubePromptHandler)),
             // Run dependency lifecycle scripts on the node mise resolved as a
             // dependency, so `allow_builds` installs work even when node isn't
             // on the ambient PATH (the in-process installer doesn't inherit the
@@ -1299,6 +1300,53 @@ impl aube::embed::InstallReporter for AubeProgressReporter {
     }
 }
 
+/// Routes confirmations requested by embedded aube through mise's prompt UI.
+///
+/// The prompt UI owns TTY detection and progress suspension, so unattended
+/// installs fail closed instead of waiting on stdin and interactive prompts
+/// cannot be overwritten by the progress renderer.
+#[derive(Debug)]
+struct AubePromptHandler;
+
+impl aube::embed::InstallPromptHandler for AubePromptHandler {
+    fn confirm(&self, prompt: aube::embed::InstallPrompt) -> aube::embed::InstallPromptFuture<'_> {
+        Box::pin(async move {
+            crate::ui::prompt::confirm_with_default(aube_prompt_message(&prompt), false)
+                .map_err(|err| miette::miette!("{err:#}"))
+        })
+    }
+}
+
+fn aube_prompt_message(prompt: &aube::embed::InstallPrompt) -> String {
+    use aube::embed::InstallPrompt;
+
+    match prompt {
+        InstallPrompt::SimilarPackageName {
+            package,
+            suggested_package,
+            popularity_rank,
+            edit_distance,
+        } => format!(
+            "{package} resembles {suggested_package} (top-100,000 rank #{popularity_rank}, edit distance {edit_distance}). Continue adding {package}?"
+        ),
+        InstallPrompt::LowDownloadPackage {
+            package,
+            weekly_downloads,
+            threshold,
+        } => format!(
+            "{package} looks suspicious: {weekly_downloads} downloads last week (threshold: {threshold}). Continue adding {package}?"
+        ),
+        InstallPrompt::NewPackageName {
+            package,
+            created_at,
+            minimum_age_minutes,
+        } => format!(
+            "{package} is newly registered (first published {created_at}; minimum age: {minimum_age_minutes} minutes). Continue adding {package}?"
+        ),
+        _ => "aube requires confirmation before adding this package. Continue?".to_string(),
+    }
+}
+
 /// Render one aube install event onto mise's progress job.
 ///
 /// Everything goes in the message; the progress bar is deliberately left
@@ -1642,6 +1690,35 @@ mod tests {
         assert_eq!(NPMBackend::build_aube_minimum_release_age(1), 1);
         assert_eq!(NPMBackend::build_aube_minimum_release_age(60), 1);
         assert_eq!(NPMBackend::build_aube_minimum_release_age(61), 2);
+    }
+
+    #[test]
+    fn test_aube_prompt_messages_preserve_security_context() {
+        assert_eq!(
+            aube_prompt_message(&aube::embed::InstallPrompt::LowDownloadPackage {
+                package: "tiny".to_string(),
+                weekly_downloads: 12,
+                threshold: 1000,
+            }),
+            "tiny looks suspicious: 12 downloads last week (threshold: 1000). Continue adding tiny?"
+        );
+        assert_eq!(
+            aube_prompt_message(&aube::embed::InstallPrompt::SimilarPackageName {
+                package: "loadsh".to_string(),
+                suggested_package: "lodash".to_string(),
+                popularity_rank: 42,
+                edit_distance: 2,
+            }),
+            "loadsh resembles lodash (top-100,000 rank #42, edit distance 2). Continue adding loadsh?"
+        );
+        assert_eq!(
+            aube_prompt_message(&aube::embed::InstallPrompt::NewPackageName {
+                package: "new-package".to_string(),
+                created_at: "2026-07-28T00:00:00Z".to_string(),
+                minimum_age_minutes: 43_200,
+            }),
+            "new-package is newly registered (first published 2026-07-28T00:00:00Z; minimum age: 43200 minutes). Continue adding new-package?"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- bump the embedded `aube` and `aube-registry` crates from 1.34 to 1.35
- attach a mise-owned prompt handler to embedded aube installs
- preserve the security context for low-download, similar-name, and newly registered package confirmations
- default confirmations to No and rely on mise's attended-terminal detection

## Why

Embedded aube previously owned stdin directly while mise owned the progress renderer. That could leave unattended installs waiting for input, and interactive warnings could be overwritten by progress output.

Aube 1.35 includes the host prompt API from jdx/aube#1154. This PR wires it into the shared mise prompt path added by #11421, so mise now owns TTY detection, prompt rendering, input, and progress suspension.

This addresses the broader behavior discussed in #11375 and the overwritten prompt reported in #11417.

## Validation

- `mise run format`
- `mise run test:unit` — 2,094 passed
- `mise run test:e2e e2e/backend/test_npm_aube`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm install behavior for embedded aube when confirmations are required—now tied to mise’s attended-terminal rules—but scope is limited to prompt routing and a dependency bump, not resolver or trust policy logic.
> 
> **Overview**
> **Embedded npm installs** now hand aube’s confirmation prompts to mise instead of letting aube read stdin directly. The embedded **`aube` / `aube-registry` crates are bumped from 1.34 to 1.35** so the host prompt API is available.
> 
> On the npm backend, **`InstallControl`** gains **`AubePromptHandler`**, which implements aube’s **`InstallPromptHandler`** and calls **`confirm_with_default(..., false)`**. That reuses mise’s TTY detection and progress suspension, so CI/non-interactive runs **fail closed** rather than hanging, and interactive typosquat / low-download / new-package warnings are not drawn under the progress spinner.
> 
> User-facing text for those three prompt kinds is built in **`aube_prompt_message`**; other prompt variants get a generic fallback. Unit tests lock in the security wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 944e28d42959998ffd7ea75c754b741bf0b33750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts for embedded package installations, including warnings for low downloads, similar package names, and newly registered packages.
  * Prompts are automatically declined when running unattended.

* **Updates**
  * Updated the Aube package integration to version 1.35.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->