### PR TITLE
docs(self-update): document how packagers disable self-update

### DIFF
--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -11,7 +11,9 @@ Uses the GitHub Releases API to find the latest release and binary.
 By default, this will also update any installed plugins.
 Uses mise's GitHub token resolution chain for authenticated requests.
 
-This command is not available if mise is installed via a package manager.
+Packagers can disable this command so that mise is updated through the
+package manager instead. See
+<https://mise.en.dev/contributing.html#packaging-and-self-update-instructions>
 
 ## Arguments
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,37 @@ respond to every PR with detailed context. A rejection may be brief.
 
 ## Packaging and Self-Update Instructions
 
-When mise is installed via a package manager, in-app self-update is disabled and users should update via their package manager. Packaging should install a TOML file with platform-specific instructions at `lib/mise-self-update-instructions.toml` (or `lib/mise/mise-self-update-instructions.toml`). Example contents:
+When mise is installed via a package manager, `mise self-update` should not replace the binary the package manager owns; users should update through the package manager instead. This is opt-in: a package that does none of the following keeps self-update fully enabled. Packagers have three ways to turn it off, and any of them makes `mise doctor` report `self_update_available: no`.
+
+The paths below are relative to the install prefix, which mise derives from its own binary: the path is canonicalized (symlinks resolved) and then taken two levels up, so `/usr/bin/mise` gives `/usr`.
+
+### Disable at build time
+
+Build without the `self_update` Cargo feature, as the Arch Linux package does:
+
+```bash
+cargo build --release --no-default-features --features native-tls
+```
+
+The subcommand still exists, so scripts that call it get a clear error rather than "unknown command", but it always fails with `mise's self-update feature has been disabled at build time, cannot update`.
+
+### Disable with a marker file
+
+Install an empty `.disable-self-update` file at any one of:
+
+- `lib/.disable-self-update` (used by Homebrew)
+- `lib/mise/.disable-self-update` (used by the AUR `mise-bin` package)
+- `lib64/mise/.disable-self-update`
+
+### Ship update instructions
+
+Installing a TOML file with platform-specific instructions also disables self-update, and mise prints its message when `mise self-update` is run and when a newer release is detected. Install it at any one of:
+
+- `lib/mise-self-update-instructions.toml`
+- `lib/mise/mise-self-update-instructions.toml`
+- `lib64/mise/mise-self-update-instructions.toml`
+
+Example contents:
 
 ```toml
 # Debian/Ubuntu (APT)
@@ -61,6 +91,14 @@ message = "To update mise from the APT repository, run:\n\n  sudo apt update && 
 # Fedora/CentOS Stream (DNF)
 message = "To update mise from COPR, run:\n\n  sudo dnf upgrade mise\n"
 ```
+
+Setting `MISE_SELF_UPDATE_INSTRUCTIONS` to a file path overrides the search.
+
+### Overriding the outcome
+
+`MISE_SELF_UPDATE_AVAILABLE=false` disables self-update without installing anything, and `MISE_SELF_UPDATE_AVAILABLE=true` re-enables it even when a marker or instructions file is present. Both are useful for testing a package build. Neither has any effect on a binary built without the `self_update` feature, where self-update is always unavailable.
+
+`mise self-update --force` also bypasses the availability check, so a user who passes it updates the binary in place even when a marker file, an instructions file, or `MISE_SELF_UPDATE_AVAILABLE=false` is in effect. Treat the runtime mechanisms as "do not update by default" rather than a hard block. A build without the `self_update` feature is the only variant `--force` cannot get past.
 
 ## Testing
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3178,7 +3178,9 @@ Uses the GitHub Releases API to find the latest release and binary.
 By default, this will also update any installed plugins.
 Uses mise's GitHub token resolution chain for authenticated requests.
 
-This command is not available if mise is installed via a package manager.
+Packagers can disable this command so that mise is updated through the
+package manager instead. See
+https://mise.en.dev/contributing.html#packaging\-and\-self\-update\-instructions
 .PP
 \fBUsage:\fR mise self\-update [OPTIONS] [<VERSION>]
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3205,7 +3205,9 @@ Uses the GitHub Releases API to find the latest release and binary.
 By default, this will also update any installed plugins.
 Uses mise's GitHub token resolution chain for authenticated requests.
 
-This command is not available if mise is installed via a package manager.
+Packagers can disable this command so that mise is updated through the
+package manager instead. See
+https://mise.en.dev/contributing.html#packaging-and-self-update-instructions
 """#
     flag "-f --force" help="Update even if already up to date"
     flag "-y --yes" help="Skip confirmation prompt"

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -59,7 +59,9 @@ pub fn append_self_update_instructions(mut message: String) -> String {
 /// By default, this will also update any installed plugins.
 /// Uses mise's GitHub token resolution chain for authenticated requests.
 ///
-/// This command is not available if mise is installed via a package manager.
+/// Packagers can disable this command so that mise is updated through the
+/// package manager instead. See
+/// https://mise.en.dev/contributing.html#packaging-and-self-update-instructions
 #[derive(Debug, Default, clap::Args)]
 #[clap(verbatim_doc_comment)]
 pub struct SelfUpdate {


### PR DESCRIPTION
## Summary

- document the three ways a packager can turn off `mise self-update`, none of which were in `docs/`
- replace the `self-update` help text, which asserted something that is not true in general

Docs only — no runtime behavior changes.

## Context

From https://github.com/jdx/mise/discussions/4077, which asked for "a build option to disable it
when building for a package, or at least a config option". The build option has existed since
2025.1.16 (#4230), and two runtime mechanisms exist as well — but none of them are documented:

| Package | Mechanism it uses | Documented before this PR |
| --- | --- | --- |
| Arch `extra/mise` | `--no-default-features` build | no |
| Homebrew | `lib/.disable-self-update` | no |
| AUR `mise-bin` | `lib/mise/.disable-self-update` | no |
| deb / rpm / copr / snap | `mise-self-update-instructions.toml` | yes |

`grep -rn "MISE_SELF_UPDATE_AVAILABLE\|\.disable-self-update" docs/` returned nothing on `main`, so
the only documented mechanism was the one the three source-of-truth package managers do not use.

The help text is the other half of the problem: `This command is not available if mise is installed
via a package manager.` reads as a guarantee, but nothing enforces it — a package that ships no
marker, no instructions file, and builds with default features keeps `self-update` fully enabled.

## Changes

`docs/contributing.md` — the "Packaging and Self-Update Instructions" section now covers:

- the install-prefix rule the lookups use (`src/env.rs`: canonicalize the binary path, two levels up,
  so `/usr/bin/mise` gives `/usr`)
- disabling at build time via `--no-default-features`, and what the stub then reports
- the `.disable-self-update` marker file and all three searched paths
- the instructions TOML, its three searched paths, that it also disables self-update, and
  `MISE_SELF_UPDATE_INSTRUCTIONS`
- `MISE_SELF_UPDATE_AVAILABLE=true|false` as an override for testing a package build
- that `mise doctor` reports the result as `self_update_available`

`src/cli/self_update.rs` — the last line of the doc comment now points at that section instead of
claiming the command is unavailable under package managers. Regenerated artifacts follow:
`mise.usage.kdl`, `docs/cli/self-update.md`, `man/man1/mise.1`. The short help is unchanged, so
completions, `README.md` and `docs/public/llms.txt` are untouched.

## Verification

I cannot compile mise on this machine, so `mise run render` could not be run end-to-end; CI's
`assert render produces no diff` step is the check for the doc comment → `mise.usage.kdl` step.

Everything downstream of the kdl was verified locally with the pinned tools, since
`docs/cli/*.md` and the man page are produced by `usage` from `mise.usage.kdl`:

- `usage@4.0.0 generate markdown` + `markdownlint-cli@0.48.0 --fix` over the whole `docs/cli` tree
  reproduces every committed file byte-for-byte, with `docs/cli/self-update.md` as the only
  difference (`docs/cli/watch.md` is in `.markdownlintignore`, which accounts for the other one)
- `usage@4.0.0 generate manpage` reproduces `man/man1/mise.1` with the expected single hunk
- `markdownlint` and `prettier@3.9.6 --check` pass on `docs/contributing.md`

## Notes

The discussion also asks for the `mise version` update check to be skipped when self-update is
unavailable, and for a `settings.toml` option to disable it. Both are behavior changes rather than
documentation gaps, so they are deliberately not in this PR.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that package maintainers can disable `mise self-update`, directing updates to be handled via the package manager instead.
  - Added detailed guidance for disabling self-updates (build options, marker files, and platform-specific instructions).
  - Documented environment-based overrides and how self-update availability is reflected in `mise doctor`.
  - Updated CLI help text and related man page and contributing documentation, including a link to the packaging/self-update instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->