### PR TITLE
fix(task): treat missing content-hash baseline as stale

### DIFF
--- a/e2e/tasks/test_task_source_freshness_hash_contents_no_baseline
+++ b/e2e/tasks/test_task_source_freshness_hash_contents_no_baseline
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Enabling source_freshness_hash_contents on a task that already has an mtime
+# baseline must not skip the first run. Until a content hash is stored there is
+# nothing to compare against, so the task is stale — previously the hash branch
+# was gated on the baseline existing, and control fell through to the mtime
+# comparison, which reported "fresh" and left a stale output in place.
+#
+# The setting is toggled with an env var rather than by editing mise.toml so the
+# task keeps the same state key; rewriting the config would invalidate the
+# baseline on its own and hide the regression.
+
+cat <<EOF >mise.toml
+[tasks.build]
+run = 'cat src.txt >out.txt && echo built'
+sources = ['src.txt']
+outputs = ['out.txt']
+EOF
+
+echo "hello" >src.txt
+
+# Metadata mode: first run has no baseline and no output → stale → runs
+assert "mise run -q build" "built"
+
+# Metadata mode: nothing changed and out.txt is newer than src.txt → fresh
+assert_empty "mise run -q build"
+
+# Switching to hash mode: no content baseline exists yet, so the task must run
+# instead of trusting the mtime ordering left over from the runs above.
+assert "MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=1 mise run -q build" "built"
+
+# The baseline is stored now, so hash mode settles and stops rebuilding
+assert_empty "MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=1 mise run -q build"
+
+# Content change that mtime cannot see: same size, mtime older than the output.
+# Hash mode must still rebuild.
+echo "world" >src.txt
+touch -t 202001010000 src.txt
+assert "MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=1 mise run -q build" "built"
+assert "cat out.txt" "world"

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -413,8 +413,17 @@ pub async fn sources_are_fresh(task: &Task, config: &Arc<Config>) -> Result<bool
             // hash after a successful run.
             return Ok(false);
         }
-        if use_content_hash && existing_hash.is_some() {
+        if use_content_hash {
             // In hash mode, content alone determines freshness — no mtime check.
+            // With no stored baseline there is nothing to compare the content
+            // against, so the task is stale. Falling through to the mtime
+            // comparison here would let an edit whose mtime is older than the
+            // output masquerade as fresh — exactly what hash mode exists to
+            // prevent — on the first run after the setting is enabled.
+            if existing_hash.is_none() {
+                debug!("no stored content hash in {}", source_hash_path.display());
+                return Ok(false);
+            }
             // Compare against the stored output hash to catch partial/missing outputs.
             let current_output_hash = compute_output_hash(task, &root)?;
             let stored_output_hash = output_existing_hash(task, &root);


### PR DESCRIPTION
## Summary

- with `task.source_freshness_hash_contents` enabled, a missing content baseline no longer falls
  back to the mtime comparison — it is treated as stale
- e2e coverage for the transition into hash mode

## Problem

`sources_are_fresh` gated the hash branch on a stored baseline existing:

```rust
if use_content_hash && existing_hash.is_some() {
```

With the setting enabled but no `<key>-content` baseline yet, that branch is skipped and control
reaches the mtime comparison — the exact thing #11319 removed from hash mode. The first run after
enabling the setting can therefore report "sources up-to-date" and leave a stale output in place.

Reproduced on 2026.7.15:

```console
$ cat mise.toml
[tasks.build]
run = 'cat src.txt >out.txt && echo built'
sources = ['src.txt']
outputs = ['out.txt']

$ echo hello >src.txt
$ mise run build          # metadata mode; out.txt ends up newer than src.txt
$ echo world >src.txt     # same size as "hello"
$ touch -t 202001010000 src.txt

$ MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=1 mise run build
[build] sources up-to-date, skipping    # wrong — out.txt still holds "hello"

$ MISE_TASK_SOURCE_FRESHNESS_HASH_CONTENTS=1 mise run build
[build] $ cat src.txt >out.txt          # only the second run rebuilds
```

The same shape shows up whenever the baseline is absent for another reason, e.g. after the state
directory is cleared.

## Changes

`src/task/task_source_checker.rs` — split the guard so hash mode never reaches the mtime path:

```rust
if use_content_hash {
    if existing_hash.is_none() {
        return Ok(false);
    }
    ...
}
```

The early return happens before `file::write`, matching the convention a few lines above: the
baseline is persisted by `save_checksum` only after a successful run, so a failed run never
advances it.

Behavior changes only in the "hash mode, no baseline" case — one extra run per task the first time
the setting is enabled or after state is cleared. Every path that has a baseline is untouched, and
this is the same conservative answer the three existing hash-mode e2e tests already assume in their
opening assertion ("First run: no stored hash, no output → stale → runs").

## Tests

`e2e/tasks/test_task_source_freshness_hash_contents_no_baseline`:

1. metadata mode runs, then reports fresh (output newer than source)
2. switching to hash mode must run — fails on `main`, where mtime wins and the task is skipped
3. the next hash-mode run is fresh, so it does not rebuild forever
4. a same-size content change with an older mtime still rebuilds in hash mode

The setting is toggled with an env var rather than by editing `mise.toml`, so the task keeps the
same state key — rewriting the config would invalidate the baseline on its own and hide the
regression.

## Verification

I cannot compile mise on this machine (3 GB RAM), so this has not been built or run locally and CI
is the check. Locally verified what does not need a build: `shellcheck -x` and `shfmt -l -s` clean
on the new test, `bash -n` clean, and `rustfmt --check` reports no diff in the edited region.

Marking as draft until CI is green.

## Notes

From https://github.com/jdx/mise/discussions/4209. The original report there — a deleted source not
triggering a rebuild — is already fixed (#7932), as are renames, `git checkout`, and task-definition
changes; I re-tested each on 2026.7.15.

One gap from that discussion is deliberately **not** addressed here: in the default metadata mode,
a same-size content change whose mtime is not newer than the output is still skipped, because
`file_metadatas_to_hash` hashes only `(path, size)`. `task.source_freshness_hash_contents` is the
existing opt-in answer for that, and changing the default is a behavior/perf trade-off worth its own
discussion.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task freshness checks in content-hash mode when no prior content baseline exists.
  * Tasks now run as expected when switching from modification-time tracking to content tracking, preventing stale outputs from being incorrectly reused.
  * Subsequent runs remain skipped when source content is unchanged and rebuild correctly when content changes without a detectable timestamp change.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->