### PR TITLE
docs: fix redactions glob example using removed nested syntax

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1180,7 +1180,7 @@ redactions = ["API_KEY", "PASSWORD"]
 
 Running the above task will output `echo [redacted]` instead.
 
-You can also specify these as a glob pattern, e.g.: `redactions.env = ["SECRETS_*"]`.
+You can also specify these as a glob pattern, e.g.: `redactions = ["SECRETS_*"]`.
 
 ## `[vars]` options
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -299,7 +299,7 @@ redactions = ["API_KEY", "PASSWORD"]
 Glob patterns are also supported:
 
 ```toml
-redactions.env = ["SECRETS_*"]
+redactions = ["SECRETS_*"]
 ```
 
 ## Software verification


### PR DESCRIPTION
The `redactions.env = [...]` form was removed in #3647, which flattened `Redactions` to a plain string set, but two docs still show it. Copying either example into a `mise.toml` fails to parse:

```
mise::config::parse_error

  × Invalid TOML in config file: .../mise.toml
   ╭─[.../mise.toml:1:1]
 1 │ redactions.env = ["SECRETS_*"]
   · ─────┬────
   ·      ╰── invalid type: map, expected a set
   ╰────
```

`docs/tasks/task-configuration.md` was missed when #3647 rewrote the surrounding examples — blame shows that line still at `3bc3f41` (2024-12-13) while the adjacent `redactions = ["API_KEY", "PASSWORD"]` was updated by `4ed4f02` (2024-12-17). The `docs/tips-and-tricks.md` block added later in #10370 copied the already-stale form.

`schema/mise.json` already matches the code (`properties.redactions` is `array` of `string`), so only the two doc lines needed changing.

## Test plan

- [x] Documented form works, including globs: with `redactions = ["SECRETS_*"]`, `SECRETS_A` is redacted and `OTHER` is not
- [x] Old nested form still fails to parse, confirming the docs were the outlier
- [x] `markdownlint docs/tasks/task-configuration.md docs/tips-and-tricks.md` clean
- [x] `mise run docs:build` succeeds
- [x] `grep -rn "redactions\.env" docs/ schema/` returns nothing

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated redaction configuration examples to use the current `redactions` setting with glob patterns.
  * Applied the corrected syntax consistently across task configuration and tips documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->