### PR TITLE
fix(self-update): show a generic update hint when no packager instructions exist

### DIFF
--- a/e2e/cli/test_version_update_hint
+++ b/e2e/cli/test_version_update_hint
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# When a newer mise is available, the warning must always be followed by a way
+# to act on it. Installs that disable self-update without shipping an
+# instructions file (Homebrew, Arch, the AUR mise-bin package) previously got
+# "mise version X available" and nothing else.
+
+# show_latest() returns early under ci_info::is_ci(), so clear the CI markers
+unset CI GITHUB_ACTIONS GITHUB_ACTION 2>/dev/null || true
+
+# Pretend the daily check already found a newer release, so no network is needed
+echo "9999.0.0" >"$MISE_CACHE_DIR/latest-version"
+
+# self-update disabled, no packager instructions → generic hint
+assert_contains 'MISE_SELF_UPDATE_AVAILABLE=false mise version 2>&1' '9999.0.0 available'
+assert_contains 'MISE_SELF_UPDATE_AVAILABLE=false mise version 2>&1' 'self-update is disabled for this install'
+
+# packager instructions win over the generic hint
+cat >instructions.toml <<'TOML'
+message = "To update, run brew upgrade mise"
+TOML
+
+assert_contains 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTIONS=./instructions.toml mise version 2>&1' 'brew upgrade mise'
+assert_not_contains 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTIONS=./instructions.toml mise version 2>&1' 'self-update is disabled for this install'
+
+# self-update available → unchanged advice
+assert_contains 'MISE_SELF_UPDATE_AVAILABLE=true mise version 2>&1' 'mise self-update'
+assert_not_contains 'MISE_SELF_UPDATE_AVAILABLE=true mise version 2>&1' 'self-update is disabled for this install'

--- a/e2e/config/test_min_version
+++ b/e2e/config/test_min_version
@@ -11,6 +11,7 @@ TOML
 
 assert_contains 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTIONS=./instructions.toml MISE_LOG_LEVEL=warn mise ls 2>&1' 'recommended'
 assert_contains 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTIONS=./instructions.toml MISE_LOG_LEVEL=warn mise ls 2>&1' 'brew upgrade mise'
+assert_not_contains 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTIONS=./instructions.toml MISE_LOG_LEVEL=warn mise ls 2>&1' 'self-update is disabled for this install'
 
 # hard min_version: should fail and include instructions
 cat >mise.toml <<'TOML'
@@ -19,3 +20,17 @@ TOML
 
 assert_fail 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTIONS=./instructions.toml mise ls 2>&1' 'is required'
 assert_fail 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTIONS=./instructions.toml mise ls 2>&1' 'brew upgrade mise'
+
+# hard min_version without packager instructions: still has to say how to update
+assert_fail 'MISE_SELF_UPDATE_AVAILABLE=false mise ls 2>&1' 'self-update is disabled for this install'
+
+# soft min_version without packager instructions: same
+cat >mise.toml <<'TOML'
+min_version = { soft = "9999.0.0" }
+TOML
+
+assert_contains 'MISE_SELF_UPDATE_AVAILABLE=false MISE_LOG_LEVEL=warn mise ls 2>&1' 'self-update is disabled for this install'
+
+# self-update available: unchanged advice, no generic hint
+assert_contains 'MISE_SELF_UPDATE_AVAILABLE=true MISE_LOG_LEVEL=warn mise ls 2>&1' 'mise self-update'
+assert_not_contains 'MISE_SELF_UPDATE_AVAILABLE=true MISE_LOG_LEVEL=warn mise ls 2>&1' 'self-update is disabled for this install'

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -41,6 +41,22 @@ pub fn upgrade_instructions_text() -> Option<String> {
     None
 }
 
+/// Shown when mise cannot update itself and the packager shipped no instructions
+/// file. Without it, telling the user their mise is out of date is a dead end on
+/// every install that disables self-update: a marker file (Homebrew, the AUR
+/// `mise-bin` package), a build without the `self_update` feature (Arch), or
+/// `MISE_SELF_UPDATE_AVAILABLE=false`. The wording stays neutral about which of
+/// those applies — being unable to self-update is not by itself proof that a
+/// package manager owns the install.
+pub const SELF_UPDATE_DISABLED_HINT: &str =
+    "self-update is disabled for this install, update mise the same way you installed it";
+
+/// How to update mise when `mise self-update` is not available: the packager's
+/// instructions when they shipped some, otherwise the generic hint.
+pub fn upgrade_instructions_or_hint() -> String {
+    upgrade_instructions_text().unwrap_or_else(|| SELF_UPDATE_DISABLED_HINT.to_string())
+}
+
 /// Appends self-update guidance and packaging instructions (if any) to a message.
 pub fn append_self_update_instructions(mut message: String) -> String {
     if SelfUpdate::is_available() {
@@ -49,6 +65,9 @@ pub fn append_self_update_instructions(mut message: String) -> String {
     if let Some(instructions) = upgrade_instructions_text() {
         message.push('\n');
         message.push_str(&instructions);
+    } else if !SelfUpdate::is_available() {
+        message.push('\n');
+        message.push_str(SELF_UPDATE_DISABLED_HINT);
     }
     message
 }

--- a/src/cli/self_update_stub.rs
+++ b/src/cli/self_update_stub.rs
@@ -62,10 +62,22 @@ pub fn upgrade_instructions_text() -> Option<String> {
     None
 }
 
+/// Shown when mise cannot update itself and the packager shipped no instructions
+/// file. Self-update is always unavailable in this build, so without the hint
+/// telling the user their mise is out of date is a dead end. Kept neutral about
+/// how mise was installed: a build without the `self_update` feature is usually
+/// a distro package, but it can equally be a local `--no-default-features` build.
+pub const SELF_UPDATE_DISABLED_HINT: &str =
+    "self-update is disabled for this install, update mise the same way you installed it";
+
+/// How to update mise: the packager's instructions when they shipped some,
+/// otherwise the generic hint.
+pub fn upgrade_instructions_or_hint() -> String {
+    upgrade_instructions_text().unwrap_or_else(|| SELF_UPDATE_DISABLED_HINT.to_string())
+}
+
 pub fn append_self_update_instructions(mut message: String) -> String {
-    if let Some(instructions) = upgrade_instructions_text() {
-        message.push('\n');
-        message.push_str(&instructions);
-    }
+    message.push('\n');
+    message.push_str(&upgrade_instructions_or_hint());
     message
 }

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock as Lazy;
 use versions::Versioning;
 
 use crate::build_time::BUILD_TIME;
-use crate::cli::self_update::SelfUpdate;
+use crate::cli::self_update::{SelfUpdate, upgrade_instructions_or_hint};
 use crate::file::modified_duration;
 use crate::ui::style;
 use crate::{dirs, duration, env, file};
@@ -125,8 +125,8 @@ pub async fn show_latest() {
         if SelfUpdate::is_available() {
             let cmd = style("mise self-update").bright().yellow().for_stderr();
             warn!("To update, run {}", cmd);
-        } else if let Some(instructions) = crate::cli::self_update::upgrade_instructions_text() {
-            warn!("{}", instructions);
+        } else {
+            warn!("{}", upgrade_instructions_or_hint());
         }
     }
 }


### PR DESCRIPTION
## Summary

- when mise cannot update itself and the packager shipped no instructions file, say how to update
  anyway instead of saying nothing
- applies to both places that report an out-of-date mise: the version check and `min_version`

No change to when or whether mise checks for a new version — this is only the advice that follows.

## Problem

Two code paths tell the user their mise is out of date, and both pick the follow-up advice the same
way:

| | self-update available | instructions file shipped | neither |
| --- | --- | --- | --- |
| `show_latest()` (`src/cli/version.rs`) | `mise self-update` | packager's message | **nothing** |
| `min_version` (`src/config/mod.rs` → `append_self_update_instructions`) | `mise self-update` | packager's message | **nothing** |

"Neither" is not a corner case. Homebrew, Arch `extra/mise` and the AUR `mise-bin` package all
disable self-update through a `.disable-self-update` marker or a build without the `self_update`
feature, and none of them ship `mise-self-update-instructions.toml`. deb/rpm/copr/snap do ship one,
so those users are fine — which is why this is easy to miss.

On a Homebrew install (`mise doctor` reports `self_update_available: no`):

```console
$ mise version
2026.7.15 linux-x64 (2026-07-27)
mise WARN  mise version 2099.1.1 available
```

That is the whole output. `mise self-update` is not available, and nothing says what is.

The `min_version` path is worse, because a hard violation aborts:

```console
$ mise ls
mise ERROR mise version 9999.0.0 is required, but you are using 2026.7.15
```

The command stops and the user is not told how to move forward.

## Changes

`src/cli/self_update.rs` (and the matching `src/cli/self_update_stub.rs` for
`--no-default-features` builds):

- `SELF_UPDATE_DISABLED_HINT` — "self-update is disabled for this install, update mise the same way
  you installed it". Deliberately neutral about *why* self-update is off: a marker file and a
  feature-less build both usually mean a package manager, but `MISE_SELF_UPDATE_AVAILABLE=false` and
  a local `--no-default-features` build reach the same branch, and being unable to self-update is
  not proof that a package manager owns the install
- `upgrade_instructions_or_hint()` — the packager's instructions when present, else the hint
- `append_self_update_instructions()` gains one `else if` branch; every existing output is
  byte-identical

`src/cli/version.rs` — `show_latest()` uses the helper, folding `else if let Some(instructions)`
into `else`.

## Tests

`e2e/cli/test_version_update_hint` (new): seeds the daily cache file with a high version so no
network is involved, then checks the hint appears with self-update disabled, that a packager
instructions file still wins, and that `mise self-update` is still advised when self-update is
available. CI markers are cleared first because `show_latest()` returns early under
`ci_info::is_ci()` (same approach as `e2e/cli/test_bash_duplicate_trust_warning`).

`e2e/config/test_min_version` (extended): the existing assertions always set an instructions file;
added soft and hard cases without one, plus a check that the self-update-available output is
unchanged.

## Verification

I cannot compile mise on this machine (3 GB RAM), so this has not been built or run locally — CI is
the check. Verified locally what needs no build: `shellcheck -x` and `shfmt -l -s` clean on both e2e
files, `bash -n` clean, and `rustfmt --check` clean on all three Rust files.

Marking as draft until CI is green.

## Notes

From https://github.com/jdx/mise/discussions/4077, whose second half is that the version check runs
even when mise cannot self-update. Deliberately **not** in this PR, since both are behaviour changes
rather than gaps:

- skipping or conditionalising the version check itself
- a setting to disable update checks without `offline = true`, which blocks all HTTP

`mise self-update`'s own error and `mise doctor` are also left alone: the first already says "mise is
installed via a package manager, cannot update", and the second already prints
`self_update_available: no`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the CLI “version update available” messaging when self-updating is disabled/unavailable by showing a consistent generic upgrade hint when no packager instructions are provided.
  * Ensured packager-provided upgrade instructions are shown when available, with consistent guidance across hard/soft minimum-version modes and self-update enabled/disabled cases.
* **Tests**
  * Added/updated end-to-end assertions to verify the hint text across scenarios, including no-network behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->