### PR TITLE
feat(dotfiles): improve add and apply workflow

### DIFF
--- a/docs/cli/bootstrap/dotfiles/add.md
+++ b/docs/cli/bootstrap/dotfiles/add.md
@@ -39,6 +39,10 @@ Dotfile mode to write
 
 Print the config/source updates without writing anything
 
+### `--no-apply`
+
+Add the entry without applying it
+
 ### `-p --path <PATH>`
 
 Write to this config file or directory

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -25,9 +25,11 @@ dotfiles.default_mode = "symlink"
 "~/hosts/dev" = { line = "127.0.0.1 dev.local" }                     # edit one line in ~/hosts
 ```
 
-Dotfiles are only applied when explicitly requested with
-`mise bootstrap dotfiles apply` or as part of [`mise bootstrap`](/bootstrap.html). They
-are never applied implicitly by `mise install` or `mise bootstrap packages`.
+New entries are captured and applied by `mise bootstrap dotfiles add`; pass
+`--no-apply` to only capture them. Existing entries can be applied explicitly
+with `mise bootstrap dotfiles apply` or as part of
+[`mise bootstrap`](/bootstrap.html). They are never applied implicitly by
+`mise install` or `mise bootstrap packages`.
 The nested apply command runs the configured `pre-dotfiles` and
 `post-dotfiles` bootstrap hooks.
 
@@ -41,12 +43,13 @@ uses `~/.dotfiles/.zshrc`, and `~/.config/foo.toml` uses
 `source`.
 
 String entries are shorthand for an explicit source with
-`dotfiles.default_mode`. Commands that write `[dotfiles]` always write table
-form with `mode`, even when it is the default:
+`dotfiles.default_mode`. `mise bootstrap dotfiles add` omits an implied source
+and the built-in `symlink` mode, while preserving a mode explicitly selected
+with `--mode`:
 
 ```toml
 [dotfiles]
-"~/.zshrc" = { mode = "symlink" }
+"~/.zshrc" = {}
 "~/.ssh/config" = { source = "ssh/config", mode = "copy" }
 ```
 

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -161,9 +161,9 @@ multi-line content.
 - **Declarative and additive** — entries merge across the
   [config hierarchy](/configuration.html) (global → project). Whole-file
   entries merge by target path; edit entries merge by `(path, id)`.
-- **Manual application only** — nothing is written implicitly. Only
-  `mise bootstrap dotfiles apply` or [`mise bootstrap`](/bootstrap.html) applies
-  dotfiles.
+- **Explicit application** — `mise bootstrap dotfiles add` applies the entries
+  it captures unless `--no-apply` is set. Existing entries are applied only by
+  `mise bootstrap dotfiles apply` or [`mise bootstrap`](/bootstrap.html).
 - **Idempotent** — entries already in their desired state are skipped;
   re-running is always safe.
 - **Unknown modes and operations are ignored with a warning** so configs
@@ -179,6 +179,12 @@ is an error listing the conflicting paths. Pass
 For symlink entries, an existing regular file with identical content to the
 source is converged without `--force` by replacing it with the requested
 symlink. If the content differs, mise still treats it as a conflict.
+Real directories always require `--force` during a standalone apply because
+portable filesystem APIs cannot compare ownership, ACLs, extended attributes,
+flags, and security labels. `mise bootstrap dotfiles add` avoids that
+destructive comparison by moving a captured directory to its source before
+creating the symlink; cross-filesystem moves fall back to a symlink- and
+permission-preserving copy.
 
 Content updates are not conflicts: a `copy` or `template` entry overwrites
 the target file's content without `--force` — that is the declared intent of

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -162,8 +162,8 @@ multi-line content.
   [config hierarchy](/configuration.html) (global → project). Whole-file
   entries merge by target path; edit entries merge by `(path, id)`.
 - **Explicit application** — `mise bootstrap dotfiles add` applies the entries
-  it captures unless `--no-apply` is set. Existing entries are applied only by
-  `mise bootstrap dotfiles apply` or [`mise bootstrap`](/bootstrap.html).
+  it captures unless `--no-apply` is set. Entries not captured by `add` are
+  applied by `mise bootstrap dotfiles apply` or [`mise bootstrap`](/bootstrap.html).
 - **Idempotent** — entries already in their desired state are skipped;
   re-running is always safe.
 - **Unknown modes and operations are ignored with a warning** so configs

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -176,14 +176,12 @@ directory where a symlink should go, or a directory where a file should go,
 is an error listing the conflicting paths. Pass
 `mise bootstrap dotfiles apply --force` to replace them.
 
-For symlink entries, an existing regular file with identical content to the
-source is converged without `--force` by replacing it with the requested
-symlink. If the content differs, mise still treats it as a conflict.
-Real directories always require `--force` during a standalone apply because
-portable filesystem APIs cannot compare ownership, ACLs, extended attributes,
-flags, and security labels. `mise bootstrap dotfiles add` avoids that
-destructive comparison by moving a captured directory to its source before
-creating the symlink; cross-filesystem moves fall back to a symlink- and
+Real files and directories always require `--force` during a standalone
+symlink apply, even when their visible content and permissions match. Portable
+filesystem APIs cannot compare ownership, ACLs, extended attributes, flags,
+and security labels. `mise bootstrap dotfiles add` avoids that destructive
+comparison by moving each captured real path to its source before creating the
+symlink; cross-filesystem moves fall back to a symlink- and
 permission-preserving copy.
 
 Content updates are not conflicts: a `copy` or `template` entry overwrites

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -342,7 +342,7 @@ mkdir ~/.captured-dir/empty
 ln -s file ~/.captured-dir/link
 chmod 600 ~/.captured-dir/file
 captured_out="$(MISE_DOTFILES_ROOT="$PWD/captured-root" MISE_DOTFILES_DEFAULT_MODE=symlink mise dotfiles add "$HOME/.captured-dir/" "$HOME/.captured" --yes 2>&1)"
-assert_contains_text "$captured_out" "copied ~/.captured-dir to"
+assert_contains_text "$captured_out" "moved ~/.captured-dir to"
 assert_contains_text "$captured_out" "added ~/.captured to ~/.config/mise/config.toml"
 assert_contains_text "$captured_out" "created symlink ~/.captured ->"
 assert "cat captured-root/.captured" "captured content"
@@ -381,7 +381,8 @@ ln -s second same-dir-target/link
 assert_fail "mise dotfiles apply --yes"
 rm same-dir-target/link
 ln -s first same-dir-target/link
-assert_succeed "mise dotfiles apply --yes"
+assert_fail "mise dotfiles apply --yes"
+assert_succeed "mise dotfiles apply --yes --force"
 assert "readlink same-dir-target" "$PWD/same-dir-source"
 
 # parent-directory components normalize to the canonical target key
@@ -400,28 +401,43 @@ assert_fail "mise dotfiles add ~/.invalid-template --source \"$PWD/template-sour
 assert "cat template-source" "original template"
 assert_fail "test -e ~/.config/mise/config.toml"
 
-# capture failures roll back sources changed earlier in the same invocation
-echo "live rollback one" >~/.rollback-one
-echo "live rollback two" >~/.rollback-two
-echo "source rollback one" >captured-root/.rollback-one
-echo "source rollback two" >captured-root/.rollback-two
-chmod 400 captured-root/.rollback-two
-assert_fail "MISE_DOTFILES_ROOT=\"$PWD/captured-root\" mise dotfiles add ~/.rollback-one ~/.rollback-two --yes"
-chmod 600 captured-root/.rollback-two
-assert "cat captured-root/.rollback-one" "source rollback one"
-assert "cat captured-root/.rollback-two" "source rollback two"
-assert_fail "test -e ~/.config/mise/config.toml"
+if [ "$(id -u)" != 0 ]; then
+  # capture failures roll back sources changed earlier in the same invocation
+  echo "live rollback one" >~/.rollback-one
+  echo "live rollback two" >~/.rollback-two
+  echo "source rollback one" >captured-root/.rollback-one
+  echo "source rollback two" >captured-root/.rollback-two
+  chmod 400 captured-root/.rollback-two
+  assert_fail "MISE_DOTFILES_ROOT=\"$PWD/captured-root\" mise dotfiles add ~/.rollback-one ~/.rollback-two --yes"
+  chmod 600 captured-root/.rollback-two
+  assert "cat captured-root/.rollback-one" "source rollback one"
+  assert "cat captured-root/.rollback-two" "source rollback two"
+  assert_fail "test -e ~/.config/mise/config.toml"
 
-# execution failures restore source/config state after planning has succeeded
-mkdir apply-failure-parent
-echo "live execution rollback" >apply-failure-parent/target
-echo "source execution rollback" >apply-failure-source
-chmod 500 apply-failure-parent
-assert_fail "mise dotfiles add \"$PWD/apply-failure-parent/target\" --source \"$PWD/apply-failure-source\" --yes"
-chmod 700 apply-failure-parent
-assert "cat apply-failure-parent/target" "live execution rollback"
-assert "cat apply-failure-source" "source execution rollback"
-assert_fail "test -e ~/.config/mise/config.toml"
+  # execution failures restore source/config state after planning has succeeded
+  mkdir apply-failure-parent
+  echo "live execution rollback" >apply-failure-parent/target
+  echo "source execution rollback" >apply-failure-source
+  chmod 500 apply-failure-parent
+  assert_fail "mise dotfiles add \"$PWD/apply-failure-parent/target\" --source \"$PWD/apply-failure-source\" --yes"
+  chmod 700 apply-failure-parent
+  assert "cat apply-failure-parent/target" "live execution rollback"
+  assert "cat apply-failure-source" "source execution rollback"
+  assert_fail "test -e ~/.config/mise/config.toml"
+fi
+
+# config failures restore a newly created source to its missing state
+echo "not a directory" >config-path-blocker
+assert_fail "MISE_DOTFILES_ROOT=\"$PWD/captured-root\" mise dotfiles add ~/.missing-rollback --path \"$PWD/config-path-blocker/config.toml\" --yes"
+assert_fail "test -e captured-root/.missing-rollback"
+
+# directory auto-add moves the original into place so a later failure can
+# restore its complete filesystem metadata without reconstructing it
+mkdir ~/.moved-rollback
+echo "moved rollback" >~/.moved-rollback/file
+assert_fail "MISE_DOTFILES_ROOT=\"$PWD/captured-root\" mise dotfiles add ~/.moved-rollback --path \"$PWD/config-path-blocker/config.toml\" --yes"
+assert "cat ~/.moved-rollback/file" "moved rollback"
+assert_fail "test -e captured-root/.moved-rollback"
 
 # --no-apply leaves the captured target in place
 echo "capture only" >~/.capture-only

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -183,9 +183,10 @@ assert "cat ~/.local/copydir/unmanaged" "keep me"
 
 # a real file where a symlink should go is a conflict: not clobbered
 rm ~/.gitconfig
-# identical content: regular file converges to symlink without --force
+# identical visible content can still hide ownership, ACL, or xattr differences
 cat dotfiles/gitconfig >~/.gitconfig
-assert_succeed "mise dotfiles apply --yes"
+assert_fail "mise dotfiles apply --yes"
+assert_succeed "mise dotfiles apply --yes --force"
 assert "readlink ~/.gitconfig" "$PWD/dotfiles/gitconfig"
 rm ~/.gitconfig
 echo "precious" >~/.gitconfig
@@ -408,7 +409,7 @@ if [ "$(id -u)" != 0 ]; then
   echo "source rollback one" >captured-root/.rollback-one
   echo "source rollback two" >captured-root/.rollback-two
   chmod 400 captured-root/.rollback-two
-  assert_fail "MISE_DOTFILES_ROOT=\"$PWD/captured-root\" mise dotfiles add ~/.rollback-one ~/.rollback-two --yes"
+  assert_fail "MISE_DOTFILES_ROOT=\"$PWD/captured-root\" mise dotfiles add ~/.rollback-one ~/.rollback-two --mode copy --yes"
   chmod 600 captured-root/.rollback-two
   assert "cat captured-root/.rollback-one" "source rollback one"
   assert "cat captured-root/.rollback-two" "source rollback two"

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -400,6 +400,29 @@ assert_fail "mise dotfiles add ~/.invalid-template --source \"$PWD/template-sour
 assert "cat template-source" "original template"
 assert_fail "test -e ~/.config/mise/config.toml"
 
+# capture failures roll back sources changed earlier in the same invocation
+echo "live rollback one" >~/.rollback-one
+echo "live rollback two" >~/.rollback-two
+echo "source rollback one" >captured-root/.rollback-one
+echo "source rollback two" >captured-root/.rollback-two
+chmod 400 captured-root/.rollback-two
+assert_fail "MISE_DOTFILES_ROOT=\"$PWD/captured-root\" mise dotfiles add ~/.rollback-one ~/.rollback-two --yes"
+chmod 600 captured-root/.rollback-two
+assert "cat captured-root/.rollback-one" "source rollback one"
+assert "cat captured-root/.rollback-two" "source rollback two"
+assert_fail "test -e ~/.config/mise/config.toml"
+
+# execution failures restore source/config state after planning has succeeded
+mkdir apply-failure-parent
+echo "live execution rollback" >apply-failure-parent/target
+echo "source execution rollback" >apply-failure-source
+chmod 500 apply-failure-parent
+assert_fail "mise dotfiles add \"$PWD/apply-failure-parent/target\" --source \"$PWD/apply-failure-source\" --yes"
+chmod 700 apply-failure-parent
+assert "cat apply-failure-parent/target" "live execution rollback"
+assert "cat apply-failure-source" "source execution rollback"
+assert_fail "test -e ~/.config/mise/config.toml"
+
 # --no-apply leaves the captured target in place
 echo "capture only" >~/.capture-only
 MISE_DOTFILES_ROOT="$PWD/captured-root" mise dotfiles add ~/.capture-only --no-apply --yes

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -359,8 +359,8 @@ captured_dir_line="$(grep -nF '"~/.captured-dir" = {}' ~/.config/mise/config.tom
 assert_succeed "test $captured_file_line -lt $captured_dir_line"
 rm ~/.config/mise/config.toml
 
-# apply only replaces an existing directory without --force when its complete
-# file set matches the source
+# standalone apply never replaces an existing real directory without --force,
+# even when its visible contents match the source
 mkdir -p same-dir-source same-dir-target
 echo "same" >same-dir-source/file
 echo "same" >same-dir-target/file

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -338,12 +338,17 @@ assert_contains_text "$verbose_out" "content differs"
 echo "captured content" >~/.captured
 mkdir -p ~/.captured-dir
 echo "captured dir content" >~/.captured-dir/file
+mkdir ~/.captured-dir/empty
+ln -s file ~/.captured-dir/link
+chmod 600 ~/.captured-dir/file
 captured_out="$(MISE_DOTFILES_ROOT="$PWD/captured-root" MISE_DOTFILES_DEFAULT_MODE=symlink mise dotfiles add "$HOME/.captured-dir/" "$HOME/.captured" --yes 2>&1)"
 assert_contains_text "$captured_out" "copied ~/.captured-dir to"
 assert_contains_text "$captured_out" "added ~/.captured to ~/.config/mise/config.toml"
 assert_contains_text "$captured_out" "created symlink ~/.captured ->"
 assert "cat captured-root/.captured" "captured content"
 assert "cat captured-root/.captured-dir/file" "captured dir content"
+assert_directory_exists "captured-root/.captured-dir/empty"
+assert "readlink captured-root/.captured-dir/link" "file"
 assert_contains "cat ~/.config/mise/config.toml" '"~/.captured" = {}'
 assert_contains "cat ~/.config/mise/config.toml" '"~/.captured-dir" = {}'
 assert_not_contains "cat ~/.config/mise/config.toml" "$HOME"
@@ -359,16 +364,41 @@ rm ~/.config/mise/config.toml
 mkdir -p same-dir-source same-dir-target
 echo "same" >same-dir-source/file
 echo "same" >same-dir-target/file
-echo "extra" >same-dir-target/extra
 cat <<EOF >mise.toml
 [dotfiles]
 "$PWD/same-dir-target" = { source = "same-dir-source", mode = "symlink" }
 EOF
+mkdir same-dir-target/extra-empty
 assert_fail "mise dotfiles apply --yes"
-assert "cat same-dir-target/extra" "extra"
-rm same-dir-target/extra
+assert_directory_exists "same-dir-target/extra-empty"
+rmdir same-dir-target/extra-empty
+chmod 755 same-dir-source
+chmod 700 same-dir-target
+assert_fail "mise dotfiles apply --yes"
+chmod --reference=same-dir-source same-dir-target
+ln -s first same-dir-source/link
+ln -s second same-dir-target/link
+assert_fail "mise dotfiles apply --yes"
+rm same-dir-target/link
+ln -s first same-dir-target/link
 assert_succeed "mise dotfiles apply --yes"
 assert "readlink same-dir-target" "$PWD/same-dir-source"
+
+# parent-directory components normalize to the canonical target key
+echo "normalized" >~/.normalized
+mkdir -p ~/.normalization-parent
+MISE_DOTFILES_ROOT="$PWD/captured-root" mise dotfiles add ~/.normalization-parent/../.normalized --no-apply --yes
+assert_contains "cat ~/.config/mise/config.toml" '"~/.normalized" = {}'
+assert_not_contains "cat ~/.config/mise/config.toml" "normalization-parent"
+rm ~/.config/mise/config.toml
+
+# failed automatic apply validation restores overwritten sources and does not
+# write a config entry
+echo "original template" >template-source
+echo "{{ invalid template" >~/.invalid-template
+assert_fail "mise dotfiles add ~/.invalid-template --source \"$PWD/template-source\" --mode template --yes"
+assert "cat template-source" "original template"
+assert_fail "test -e ~/.config/mise/config.toml"
 
 # --no-apply leaves the captured target in place
 echo "capture only" >~/.capture-only
@@ -421,6 +451,12 @@ EOF
 assert_succeed "mise dotfiles apply --yes"
 EDITOR="$PWD/editor-write" mise dotfiles edit --apply ~/.edit-copy
 assert "cat ~/.edit-copy" "edited source"
+
+# unmanaged edits are not applied unless --apply is requested
+echo "unmanaged before edit" >~/.edit-unmanaged
+EDITOR="$PWD/editor-write" mise dotfiles edit ~/.edit-unmanaged --yes
+assert "cat ~/.edit-unmanaged" "unmanaged before edit"
+assert "cat ~/.dotfiles/.edit-unmanaged" "edited source"
 
 # inline edit entries open the owning mise config file
 cat <<'EOF' >editor-append

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -358,6 +358,14 @@ assert "readlink ~/.captured-dir" "$PWD/captured-root/.captured-dir"
 captured_file_line="$(grep -nF '"~/.captured" = {}' ~/.config/mise/config.toml | cut -d: -f1)"
 captured_dir_line="$(grep -nF '"~/.captured-dir" = {}' ~/.config/mise/config.toml | cut -d: -f1)"
 assert_succeed "test $captured_file_line -lt $captured_dir_line"
+
+# a new symlink-each target is moved out of the way before automatic apply
+mkdir ~/.captured-each
+echo "captured each" >~/.captured-each/file
+MISE_DOTFILES_ROOT="$PWD/captured-root" mise dotfiles add ~/.captured-each --mode symlink-each --yes
+assert "cat captured-root/.captured-each/file" "captured each"
+assert "readlink ~/.captured-each/file" "$PWD/captured-root/.captured-each/file"
+assert_contains "cat ~/.config/mise/config.toml" '"~/.captured-each" = { mode = "symlink-each" }'
 rm ~/.config/mise/config.toml
 
 # standalone apply never replaces an existing real directory without --force,

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -333,11 +333,48 @@ echo "implied content v2" >implied-root/.implied
 verbose_out="$(mise dotfiles apply ~/.implied --dry-run --verbose 2>&1)"
 assert_contains_text "$verbose_out" "content differs"
 
-# add captures live files into dotfiles.root and writes explicit mode
+# add captures live files into dotfiles.root, writes normalized/sorted entries,
+# and applies them by default
 echo "captured content" >~/.captured
-MISE_DOTFILES_ROOT="$PWD/captured-root" MISE_DOTFILES_DEFAULT_MODE=symlink mise dotfiles add '~/.captured' --yes
+mkdir -p ~/.captured-dir
+echo "captured dir content" >~/.captured-dir/file
+captured_out="$(MISE_DOTFILES_ROOT="$PWD/captured-root" MISE_DOTFILES_DEFAULT_MODE=symlink mise dotfiles add "$HOME/.captured-dir/" "$HOME/.captured" --yes 2>&1)"
+assert_contains_text "$captured_out" "copied ~/.captured-dir to"
+assert_contains_text "$captured_out" "added ~/.captured to ~/.config/mise/config.toml"
+assert_contains_text "$captured_out" "created symlink ~/.captured ->"
 assert "cat captured-root/.captured" "captured content"
-assert_contains "cat ~/.config/mise/config.toml" '"~/.captured" = { mode = "symlink" }'
+assert "cat captured-root/.captured-dir/file" "captured dir content"
+assert_contains "cat ~/.config/mise/config.toml" '"~/.captured" = {}'
+assert_contains "cat ~/.config/mise/config.toml" '"~/.captured-dir" = {}'
+assert_not_contains "cat ~/.config/mise/config.toml" "$HOME"
+assert "readlink ~/.captured" "$PWD/captured-root/.captured"
+assert "readlink ~/.captured-dir" "$PWD/captured-root/.captured-dir"
+captured_file_line="$(grep -nF '"~/.captured" = {}' ~/.config/mise/config.toml | cut -d: -f1)"
+captured_dir_line="$(grep -nF '"~/.captured-dir" = {}' ~/.config/mise/config.toml | cut -d: -f1)"
+assert_succeed "test $captured_file_line -lt $captured_dir_line"
+rm ~/.config/mise/config.toml
+
+# apply only replaces an existing directory without --force when its complete
+# file set matches the source
+mkdir -p same-dir-source same-dir-target
+echo "same" >same-dir-source/file
+echo "same" >same-dir-target/file
+echo "extra" >same-dir-target/extra
+cat <<EOF >mise.toml
+[dotfiles]
+"$PWD/same-dir-target" = { source = "same-dir-source", mode = "symlink" }
+EOF
+assert_fail "mise dotfiles apply --yes"
+assert "cat same-dir-target/extra" "extra"
+rm same-dir-target/extra
+assert_succeed "mise dotfiles apply --yes"
+assert "readlink same-dir-target" "$PWD/same-dir-source"
+
+# --no-apply leaves the captured target in place
+echo "capture only" >~/.capture-only
+MISE_DOTFILES_ROOT="$PWD/captured-root" mise dotfiles add ~/.capture-only --no-apply --yes
+assert_fail "test -L ~/.capture-only"
+assert "cat captured-root/.capture-only" "capture only"
 rm ~/.config/mise/config.toml
 
 # add on an already-managed copied file stores live changes back to the source

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -941,6 +941,9 @@ Dotfile mode to write
 \fB\-n, \-\-dry\-run\fR
 Print the config/source updates without writing anything
 .TP
+\fB\-\-no\-apply\fR
+Add the entry without applying it
+.TP
 \fB\-p, \-\-path\fR \fI<PATH>\fR
 Write to this config file or directory
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -390,6 +390,7 @@ Examples:
                 arg <MODE>
             }
             flag "-n --dry-run" help="Print the config/source updates without writing anything"
+            flag --no-apply help="Add the entry without applying it"
             flag "-p --path" help="Write to this config file or directory" {
                 arg <PATH>
             }
@@ -1066,6 +1067,7 @@ Examples:
             arg <MODE>
         }
         flag "-n --dry-run" help="Print the config/source updates without writing anything"
+        flag --no-apply help="Add the entry without applying it"
         flag "-p --path" help="Write to this config file or directory" {
             arg <PATH>
         }

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -405,7 +405,7 @@ fn inline_entry(item: &PlannedAdd) -> Value {
 
 fn normalized_target_raw(target: &std::path::Path) -> String {
     let normalized = target.components().collect::<PathBuf>();
-    match normalized.strip_prefix(&*dirs::HOME) {
+    match normalized.strip_prefix(*dirs::HOME) {
         Ok(rel) if !rel.as_os_str().is_empty() => format!("~/{}", rel.display()),
         Ok(_) => "~".to_string(),
         Err(_) => normalized.to_string_lossy().to_string(),

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -211,15 +211,34 @@ impl DotfilesAdd {
                         }
                         match file::try_rename(&item.target, &item.source) {
                             Ok(()) => {
-                                moved_targets.push((item.target.clone(), item.source.clone()));
+                                moved_targets.push(MovedTarget {
+                                    target: item.target.clone(),
+                                    source: item.source.clone(),
+                                    recovery: None,
+                                });
                             }
                             Err(err) if err.kind() == std::io::ErrorKind::CrossesDevices => {
-                                system::files::copy_path(&item.target, &item.source)?;
-                                // Record the completed copy before removing the
-                                // original so rollback can restore the target
-                                // even when removal fails partway through.
-                                moved_targets.push((item.target.clone(), item.source.clone()));
-                                file::remove_all(&item.target)?;
+                                let parent = item.target.parent().ok_or_else(|| {
+                                    eyre::eyre!(
+                                        "cannot stage target without a parent: {}",
+                                        item.target.display_user()
+                                    )
+                                })?;
+                                let recovery = tempfile::Builder::new()
+                                    .prefix(".mise-dotfiles-rollback-")
+                                    .tempdir_in(parent)?;
+                                let recovery_path = recovery.path().join("target");
+                                // Keep the original on its own filesystem until
+                                // the entire transaction succeeds. This makes
+                                // rollback an atomic rename instead of another
+                                // potentially failing recursive removal.
+                                file::rename(&item.target, &recovery_path)?;
+                                moved_targets.push(MovedTarget {
+                                    target: item.target.clone(),
+                                    source: item.source.clone(),
+                                    recovery: Some(recovery),
+                                });
+                                system::files::copy_path(&recovery_path, &item.source)?;
                             }
                             Err(err) => bail!(
                                 "failed rename: {} -> {}: {err}",
@@ -497,28 +516,40 @@ fn remove_path(path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+struct MovedTarget {
+    target: PathBuf,
+    source: PathBuf,
+    /// A same-filesystem staging directory used by cross-device captures.
+    /// Keeping it alive preserves the original until the transaction commits.
+    recovery: Option<tempfile::TempDir>,
+}
+
 fn rollback_add(
     source_backups: &[(PathBuf, PathBackup)],
     target_backups: &[(PathBuf, PathBackup)],
-    moved_targets: &[(PathBuf, PathBuf)],
+    moved_targets: &[MovedTarget],
     restore_targets: bool,
     config_path: &std::path::Path,
     original_config: Option<&[u8]>,
 ) -> Result<()> {
     let mut errors = vec![];
-    for (target, source) in moved_targets.iter().rev() {
+    for moved in moved_targets.iter().rev() {
         let result = (|| -> Result<()> {
-            remove_path(target)?;
-            if let Some(parent) = target.parent() {
+            remove_path(&moved.target)?;
+            if let Some(parent) = moved.target.parent() {
                 file::create_dir_all(parent)?;
             }
-            file::move_file(source, target)
+            if let Some(recovery) = &moved.recovery {
+                file::rename(recovery.path().join("target"), &moved.target)
+            } else {
+                file::move_file(&moved.source, &moved.target)
+            }
         })();
         if let Err(err) = result {
             errors.push(format!(
                 "moved target {} from {}: {err}",
-                target.display_user(),
-                source.display_user()
+                moved.target.display_user(),
+                moved.source.display_user()
             ));
         }
     }
@@ -549,3 +580,48 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig</bold>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rollback_uses_staged_cross_device_original() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("target");
+        let source = root.path().join("source");
+        let source_backup = root.path().join("source-backup");
+        let recovery = tempfile::tempdir_in(root.path()).unwrap();
+        let recovery_target = recovery.path().join("target");
+
+        file::create_dir_all(&recovery_target).unwrap();
+        file::write(recovery_target.join("file"), "live target").unwrap();
+        file::create_dir_all(&source).unwrap();
+        file::write(source.join("file"), "captured copy").unwrap();
+        file::create_dir_all(&source_backup).unwrap();
+        file::write(source_backup.join("file"), "old source").unwrap();
+
+        rollback_add(
+            &[(source.clone(), PathBackup::Copied(source_backup))],
+            &[],
+            &[MovedTarget {
+                target: target.clone(),
+                source: source.clone(),
+                recovery: Some(recovery),
+            }],
+            false,
+            &root.path().join("config.toml"),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            file::read_to_string(target.join("file")).unwrap(),
+            "live target"
+        );
+        assert_eq!(
+            file::read_to_string(source.join("file")).unwrap(),
+            "old source"
+        );
+    }
+}

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -165,24 +165,16 @@ impl DotfilesAdd {
             return Ok(());
         }
 
-        let writes_config = planned.iter().any(|item| item.already_managed.is_none());
-        let mut doc = if writes_config {
-            if !config_path.exists() {
-                let cf = MiseToml::init(&config_path);
-                cf.save()?;
-            }
-            let raw = file::read_to_string(&config_path)?;
-            let mut doc: DocumentMut = raw.parse()?;
-            ensure_dotfiles_table(&mut doc);
-            Some(doc)
-        } else {
+        let backup_dir = if self.no_apply {
             None
+        } else {
+            Some(tempfile::tempdir()?)
         };
-
-        let mut added_targets = vec![];
+        let mut source_backups = vec![];
+        let mut accepted = vec![];
         let mut updated_targets = vec![];
         let mut apply_requests = vec![];
-        for item in &planned {
+        for (index, item) in planned.iter().enumerate() {
             if item.target.exists() && !same_file(&item.target, &item.source) {
                 if item.source.exists()
                     && !self.force
@@ -199,6 +191,15 @@ impl DotfilesAdd {
                         continue;
                     }
                 }
+                if let Some(backup_dir) = &backup_dir {
+                    let backup = backup_dir.path().join(index.to_string());
+                    if item.source.exists() || item.source.is_symlink() {
+                        system::files::copy_path(&item.source, &backup)?;
+                        source_backups.push((item.source.clone(), Some(backup)));
+                    } else {
+                        source_backups.push((item.source.clone(), None));
+                    }
+                }
                 system::files::copy_path(&item.target, &item.source)?;
                 info!(
                     "dotfiles: copied {} to {}",
@@ -206,30 +207,62 @@ impl DotfilesAdd {
                     item.source.display_user()
                 );
             } else if !item.source.exists() {
+                if backup_dir.is_some() {
+                    source_backups.push((item.source.clone(), None));
+                }
                 if let Some(parent) = item.source.parent() {
                     file::create_dir_all(parent)?;
                 }
                 file::write(&item.source, "")?;
                 info!("dotfiles: created {}", item.source.display_user());
             }
-            if item.already_managed.is_none()
-                && let Some(doc) = &mut doc
-            {
-                write_entry(doc, item);
-                added_targets.push(item.target_raw.as_str());
-            } else {
+            if item.already_managed.is_some() {
                 updated_targets.push(item.target_raw.as_str());
             }
+            accepted.push(item);
             apply_requests.push(item.as_request(&config_path));
         }
 
-        if let Some(mut doc) = doc {
+        let apply_opts = system::files::ApplyOpts {
+            dry_run: false,
+            verbose: false,
+            force: false,
+            force_hint: "run `mise bootstrap dotfiles apply --force`",
+            yes: true,
+        };
+        let apply_plan = if !self.no_apply && !apply_requests.is_empty() {
+            match system::files::plan_apply(&config, &apply_requests, &apply_opts) {
+                Ok(plan) => Some(plan),
+                Err(err) => {
+                    restore_sources(&source_backups)?;
+                    return Err(err);
+                }
+            }
+        } else {
+            None
+        };
+
+        let added_targets = accepted
+            .iter()
+            .filter(|item| item.already_managed.is_none())
+            .collect::<Vec<_>>();
+        if !added_targets.is_empty() {
+            if !config_path.exists() {
+                let cf = MiseToml::init(&config_path);
+                cf.save()?;
+            }
+            let raw = file::read_to_string(&config_path)?;
+            let mut doc: DocumentMut = raw.parse()?;
+            ensure_dotfiles_table(&mut doc);
+            for item in &added_targets {
+                write_entry(&mut doc, item);
+            }
             sort_dotfiles_table(&mut doc);
             file::write(&config_path, doc.to_string())?;
-            for target in &added_targets {
+            for item in &added_targets {
                 info!(
                     "dotfiles: added {} to {}",
-                    target,
+                    item.target_raw,
                     config_path.display_user()
                 );
             }
@@ -237,15 +270,8 @@ impl DotfilesAdd {
         if !updated_targets.is_empty() {
             info!("dotfiles: updated {}", updated_targets.join(", "));
         }
-        if !self.no_apply && !apply_requests.is_empty() {
-            let opts = system::files::ApplyOpts {
-                dry_run: false,
-                verbose: false,
-                force: false,
-                force_hint: "use --force",
-                yes: true,
-            };
-            system::files::apply(&config, &apply_requests, &opts)?;
+        if let Some(plan) = apply_plan {
+            system::files::execute_apply(plan, &apply_opts)?;
         }
         Ok(())
     }
@@ -348,6 +374,20 @@ fn same_file(a: &std::path::Path, b: &std::path::Path) -> bool {
         (Ok(a), Ok(b)) => a == b,
         _ => false,
     }
+}
+
+fn restore_sources(backups: &[(PathBuf, Option<PathBuf>)]) -> Result<()> {
+    for (source, backup) in backups.iter().rev() {
+        if source.is_symlink() || source.is_file() {
+            file::remove_file(source)?;
+        } else if source.is_dir() {
+            file::remove_all(source)?;
+        }
+        if let Some(backup) = backup {
+            system::files::copy_path(backup, source)?;
+        }
+    }
+    Ok(())
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -165,113 +165,148 @@ impl DotfilesAdd {
             return Ok(());
         }
 
-        let backup_dir = if self.no_apply {
-            None
+        let backup_dir = tempfile::tempdir()?;
+        let original_config = if config_path.exists() {
+            Some(file::read(&config_path)?)
         } else {
-            Some(tempfile::tempdir()?)
+            None
         };
         let mut source_backups = vec![];
-        let mut accepted = vec![];
-        let mut updated_targets = vec![];
-        let mut apply_requests = vec![];
-        for (index, item) in planned.iter().enumerate() {
-            if item.target.exists() && !same_file(&item.target, &item.source) {
-                if item.source.exists()
-                    && !self.force
-                    && !self.yes
-                    && console::user_attended_stderr()
-                {
-                    let ok = prompt::confirm(format!(
-                        "dotfiles: overwrite source {} from {}?",
-                        item.source.display_user(),
-                        item.target.display_user()
-                    ))?;
-                    if !ok {
-                        info!("dotfiles: skipped {}", item.target_raw);
-                        continue;
+        let mut target_backups = vec![];
+        let mut apply_started = false;
+        let result = (|| -> Result<()> {
+            let mut accepted = vec![];
+            let mut updated_targets = vec![];
+            let mut apply_requests = vec![];
+            for (index, item) in planned.iter().enumerate() {
+                if item.target.exists() && !same_file(&item.target, &item.source) {
+                    if item.source.exists()
+                        && !self.force
+                        && !self.yes
+                        && console::user_attended_stderr()
+                    {
+                        let ok = prompt::confirm(format!(
+                            "dotfiles: overwrite source {} from {}?",
+                            item.source.display_user(),
+                            item.target.display_user()
+                        ))?;
+                        if !ok {
+                            info!("dotfiles: skipped {}", item.target_raw);
+                            continue;
+                        }
                     }
-                }
-                if let Some(backup_dir) = &backup_dir {
-                    let backup = backup_dir.path().join(index.to_string());
-                    if item.source.exists() || item.source.is_symlink() {
-                        system::files::copy_path(&item.source, &backup)?;
-                        source_backups.push((item.source.clone(), Some(backup)));
-                    } else {
-                        source_backups.push((item.source.clone(), None));
+                    target_backups.push((
+                        item.target.clone(),
+                        backup_path(
+                            &item.target,
+                            &backup_dir.path().join("targets").join(index.to_string()),
+                        )?,
+                    ));
+                    source_backups.push((
+                        item.source.clone(),
+                        backup_path(
+                            &item.source,
+                            &backup_dir.path().join("sources").join(index.to_string()),
+                        )?,
+                    ));
+                    system::files::copy_path(&item.target, &item.source)?;
+                    info!(
+                        "dotfiles: copied {} to {}",
+                        item.target.display_user(),
+                        item.source.display_user()
+                    );
+                } else if !item.source.exists() {
+                    target_backups.push((
+                        item.target.clone(),
+                        backup_path(
+                            &item.target,
+                            &backup_dir.path().join("targets").join(index.to_string()),
+                        )?,
+                    ));
+                    source_backups.push((item.source.clone(), PathBackup::Missing));
+                    if let Some(parent) = item.source.parent() {
+                        file::create_dir_all(parent)?;
                     }
+                    file::write(&item.source, "")?;
+                    info!("dotfiles: created {}", item.source.display_user());
+                } else if !self.no_apply {
+                    target_backups.push((
+                        item.target.clone(),
+                        backup_path(
+                            &item.target,
+                            &backup_dir.path().join("targets").join(index.to_string()),
+                        )?,
+                    ));
                 }
-                system::files::copy_path(&item.target, &item.source)?;
-                info!(
-                    "dotfiles: copied {} to {}",
-                    item.target.display_user(),
-                    item.source.display_user()
-                );
-            } else if !item.source.exists() {
-                if backup_dir.is_some() {
-                    source_backups.push((item.source.clone(), None));
+                if item.already_managed.is_some() {
+                    updated_targets.push(item.target_raw.as_str());
                 }
-                if let Some(parent) = item.source.parent() {
-                    file::create_dir_all(parent)?;
-                }
-                file::write(&item.source, "")?;
-                info!("dotfiles: created {}", item.source.display_user());
+                accepted.push(item);
+                apply_requests.push(item.as_request(&config_path));
             }
-            if item.already_managed.is_some() {
-                updated_targets.push(item.target_raw.as_str());
-            }
-            accepted.push(item);
-            apply_requests.push(item.as_request(&config_path));
-        }
 
-        let apply_opts = system::files::ApplyOpts {
-            dry_run: false,
-            verbose: false,
-            force: false,
-            force_hint: "run `mise bootstrap dotfiles apply --force`",
-            yes: true,
-        };
-        let apply_plan = if !self.no_apply && !apply_requests.is_empty() {
-            match system::files::plan_apply(&config, &apply_requests, &apply_opts) {
-                Ok(plan) => Some(plan),
-                Err(err) => {
-                    restore_sources(&source_backups)?;
-                    return Err(err);
+            let apply_opts = system::files::ApplyOpts {
+                dry_run: false,
+                verbose: false,
+                force: false,
+                force_hint: "run `mise bootstrap dotfiles apply --force`",
+                yes: true,
+            };
+            let apply_plan = if !self.no_apply && !apply_requests.is_empty() {
+                Some(system::files::plan_apply(
+                    &config,
+                    &apply_requests,
+                    &apply_opts,
+                )?)
+            } else {
+                None
+            };
+
+            let added_targets = accepted
+                .iter()
+                .filter(|item| item.already_managed.is_none())
+                .collect::<Vec<_>>();
+            if !added_targets.is_empty() {
+                if !config_path.exists() {
+                    let cf = MiseToml::init(&config_path);
+                    cf.save()?;
+                }
+                let raw = file::read_to_string(&config_path)?;
+                let mut doc: DocumentMut = raw.parse()?;
+                ensure_dotfiles_table(&mut doc);
+                for item in &added_targets {
+                    write_entry(&mut doc, item);
+                }
+                sort_dotfiles_table(&mut doc);
+                file::write(&config_path, doc.to_string())?;
+                for item in &added_targets {
+                    info!(
+                        "dotfiles: added {} to {}",
+                        item.target_raw,
+                        config_path.display_user()
+                    );
                 }
             }
-        } else {
-            None
-        };
-
-        let added_targets = accepted
-            .iter()
-            .filter(|item| item.already_managed.is_none())
-            .collect::<Vec<_>>();
-        if !added_targets.is_empty() {
-            if !config_path.exists() {
-                let cf = MiseToml::init(&config_path);
-                cf.save()?;
+            if !updated_targets.is_empty() {
+                info!("dotfiles: updated {}", updated_targets.join(", "));
             }
-            let raw = file::read_to_string(&config_path)?;
-            let mut doc: DocumentMut = raw.parse()?;
-            ensure_dotfiles_table(&mut doc);
-            for item in &added_targets {
-                write_entry(&mut doc, item);
+            if let Some(plan) = apply_plan {
+                apply_started = true;
+                system::files::execute_apply(plan, &apply_opts)?;
             }
-            sort_dotfiles_table(&mut doc);
-            file::write(&config_path, doc.to_string())?;
-            for item in &added_targets {
-                info!(
-                    "dotfiles: added {} to {}",
-                    item.target_raw,
-                    config_path.display_user()
-                );
+            Ok(())
+        })();
+        if let Err(err) = result {
+            if let Err(rollback_err) = rollback_add(
+                &source_backups,
+                &target_backups,
+                apply_started,
+                &config_path,
+                original_config.as_deref(),
+            ) {
+                bail!("{err}\ndotfiles: rollback failed: {rollback_err}");
             }
-        }
-        if !updated_targets.is_empty() {
-            info!("dotfiles: updated {}", updated_targets.join(", "));
-        }
-        if let Some(plan) = apply_plan {
-            system::files::execute_apply(plan, &apply_opts)?;
+            return Err(err);
         }
         Ok(())
     }
@@ -376,16 +411,82 @@ fn same_file(a: &std::path::Path, b: &std::path::Path) -> bool {
     }
 }
 
-fn restore_sources(backups: &[(PathBuf, Option<PathBuf>)]) -> Result<()> {
-    for (source, backup) in backups.iter().rev() {
-        if source.is_symlink() || source.is_file() {
-            file::remove_file(source)?;
-        } else if source.is_dir() {
-            file::remove_all(source)?;
+enum PathBackup {
+    Missing,
+    Copied(PathBuf),
+    Symlink(PathBuf),
+}
+
+fn backup_path(path: &std::path::Path, backup: &std::path::Path) -> Result<PathBackup> {
+    if path.is_symlink() {
+        Ok(PathBackup::Symlink(std::fs::read_link(path)?))
+    } else if path.exists() {
+        system::files::copy_path(path, backup)?;
+        Ok(PathBackup::Copied(backup.to_path_buf()))
+    } else {
+        Ok(PathBackup::Missing)
+    }
+}
+
+fn restore_paths(backups: &[(PathBuf, PathBackup)]) -> Result<()> {
+    let mut errors = vec![];
+    for (path, backup) in backups.iter().rev() {
+        let result = (|| -> Result<()> {
+            remove_path(path)?;
+            match backup {
+                PathBackup::Missing => {}
+                PathBackup::Copied(backup) => system::files::copy_path(backup, path)?,
+                PathBackup::Symlink(target) => {
+                    if let Some(parent) = path.parent() {
+                        file::create_dir_all(parent)?;
+                    }
+                    file::make_symlink(target, path)?;
+                }
+            }
+            Ok(())
+        })();
+        if let Err(err) = result {
+            errors.push(format!("{}: {err}", path.display_user()));
         }
-        if let Some(backup) = backup {
-            system::files::copy_path(backup, source)?;
-        }
+    }
+    if !errors.is_empty() {
+        bail!("{}", errors.join("\n"));
+    }
+    Ok(())
+}
+
+fn remove_path(path: &std::path::Path) -> Result<()> {
+    if path.is_symlink() || path.is_file() {
+        file::remove_file(path)?;
+    } else if path.is_dir() {
+        file::remove_all(path)?;
+    }
+    Ok(())
+}
+
+fn rollback_add(
+    source_backups: &[(PathBuf, PathBackup)],
+    target_backups: &[(PathBuf, PathBackup)],
+    restore_targets: bool,
+    config_path: &std::path::Path,
+    original_config: Option<&[u8]>,
+) -> Result<()> {
+    let mut errors = vec![];
+    if restore_targets && let Err(err) = restore_paths(target_backups) {
+        errors.push(format!("targets: {err}"));
+    }
+    if let Err(err) = restore_paths(source_backups) {
+        errors.push(format!("sources: {err}"));
+    }
+    let config_result = match original_config {
+        Some(contents) => file::write(config_path, contents),
+        None => remove_path(config_path),
+    };
+    if let Err(err) = config_result {
+        errors.push(format!("config: {err}"));
+    }
+    if !errors.is_empty() {
+        bail!("{}", errors.join("\n"));
     }
     Ok(())
 }

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -203,17 +203,30 @@ impl DotfilesAdd {
                             &backup_dir.path().join("sources").join(index.to_string()),
                         )?,
                     ));
-                    if !self.no_apply
-                        && item.mode == FileMode::Symlink
-                        && item.target.is_dir()
-                        && !item.target.is_symlink()
+                    if !self.no_apply && item.mode == FileMode::Symlink && !item.target.is_symlink()
                     {
                         remove_path(&item.source)?;
                         if let Some(parent) = item.source.parent() {
                             file::create_dir_all(parent)?;
                         }
-                        file::move_file(&item.target, &item.source)?;
-                        moved_targets.push((item.target.clone(), item.source.clone()));
+                        match file::try_rename(&item.target, &item.source) {
+                            Ok(()) => {
+                                moved_targets.push((item.target.clone(), item.source.clone()));
+                            }
+                            Err(err) if err.kind() == std::io::ErrorKind::CrossesDevices => {
+                                system::files::copy_path(&item.target, &item.source)?;
+                                // Record the completed copy before removing the
+                                // original so rollback can restore the target
+                                // even when removal fails partway through.
+                                moved_targets.push((item.target.clone(), item.source.clone()));
+                                file::remove_all(&item.target)?;
+                            }
+                            Err(err) => bail!(
+                                "failed rename: {} -> {}: {err}",
+                                item.target.display_user(),
+                                item.source.display_user()
+                            ),
+                        }
                         info!(
                             "dotfiles: moved {} to {}",
                             item.target.display_user(),

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -212,7 +212,7 @@ impl DotfilesAdd {
                         if let Some(parent) = item.source.parent() {
                             file::create_dir_all(parent)?;
                         }
-                        file::rename(&item.target, &item.source)?;
+                        file::move_file(&item.target, &item.source)?;
                         moved_targets.push((item.target.clone(), item.source.clone()));
                         info!(
                             "dotfiles: moved {} to {}",
@@ -499,7 +499,7 @@ fn rollback_add(
             if let Some(parent) = target.parent() {
                 file::create_dir_all(parent)?;
             }
-            file::rename(source, target)
+            file::move_file(source, target)
         })();
         if let Err(err) = result {
             errors.push(format!(

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -203,8 +203,9 @@ impl DotfilesAdd {
                             &backup_dir.path().join("sources").join(index.to_string()),
                         )?,
                     ));
-                    if !self.no_apply && item.mode == FileMode::Symlink && !item.target.is_symlink()
-                    {
+                    let move_before_apply = item.mode == FileMode::Symlink
+                        || (item.mode == FileMode::SymlinkEach && item.already_managed.is_none());
+                    if !self.no_apply && move_before_apply && !item.target.is_symlink() {
                         remove_path(&item.source)?;
                         if let Some(parent) = item.source.parent() {
                             file::create_dir_all(parent)?;
@@ -351,7 +352,7 @@ impl DotfilesAdd {
             if let Err(rollback_err) = rollback_add(
                 &source_backups,
                 &target_backups,
-                &moved_targets,
+                &mut moved_targets,
                 apply_started,
                 &config_path,
                 original_config.as_deref(),
@@ -524,16 +525,24 @@ struct MovedTarget {
     recovery: Option<tempfile::TempDir>,
 }
 
+impl MovedTarget {
+    fn keep_recovery(&mut self) -> Option<PathBuf> {
+        self.recovery
+            .take()
+            .map(|recovery| recovery.keep().join("target"))
+    }
+}
+
 fn rollback_add(
     source_backups: &[(PathBuf, PathBackup)],
     target_backups: &[(PathBuf, PathBackup)],
-    moved_targets: &[MovedTarget],
+    moved_targets: &mut [MovedTarget],
     restore_targets: bool,
     config_path: &std::path::Path,
     original_config: Option<&[u8]>,
 ) -> Result<()> {
     let mut errors = vec![];
-    for moved in moved_targets.iter().rev() {
+    for moved in moved_targets.iter_mut().rev() {
         let result = (|| -> Result<()> {
             remove_path(&moved.target)?;
             if let Some(parent) = moved.target.parent() {
@@ -546,11 +555,18 @@ fn rollback_add(
             }
         })();
         if let Err(err) = result {
-            errors.push(format!(
+            let mut message = format!(
                 "moved target {} from {}: {err}",
                 moved.target.display_user(),
                 moved.source.display_user()
-            ));
+            );
+            if let Some(recovery) = moved.keep_recovery() {
+                message.push_str(&format!(
+                    "; original preserved at {}",
+                    recovery.display_user()
+                ));
+            }
+            errors.push(message);
         }
     }
     if restore_targets && let Err(err) = restore_paths(target_backups) {
@@ -601,14 +617,15 @@ mod tests {
         file::create_dir_all(&source_backup).unwrap();
         file::write(source_backup.join("file"), "old source").unwrap();
 
+        let mut moved_targets = vec![MovedTarget {
+            target: target.clone(),
+            source: source.clone(),
+            recovery: Some(recovery),
+        }];
         rollback_add(
             &[(source.clone(), PathBackup::Copied(source_backup))],
             &[],
-            &[MovedTarget {
-                target: target.clone(),
-                source: source.clone(),
-                recovery: Some(recovery),
-            }],
+            &mut moved_targets,
             false,
             &root.path().join("config.toml"),
             None,
@@ -623,5 +640,23 @@ mod tests {
             file::read_to_string(source.join("file")).unwrap(),
             "old source"
         );
+    }
+
+    #[test]
+    fn failed_rollback_can_keep_staged_original() {
+        let root = tempfile::tempdir().unwrap();
+        let recovery = tempfile::tempdir_in(root.path()).unwrap();
+        let recovery_target = recovery.path().join("target");
+        file::write(&recovery_target, "original").unwrap();
+        let mut moved = MovedTarget {
+            target: root.path().join("target"),
+            source: root.path().join("source"),
+            recovery: Some(recovery),
+        };
+
+        let kept = moved.keep_recovery().unwrap();
+        drop(moved);
+
+        assert_eq!(file::read_to_string(kept).unwrap(), "original");
     }
 }

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -173,6 +173,7 @@ impl DotfilesAdd {
         };
         let mut source_backups = vec![];
         let mut target_backups = vec![];
+        let mut moved_targets = vec![];
         let mut apply_started = false;
         let result = (|| -> Result<()> {
             let mut accepted = vec![];
@@ -195,13 +196,6 @@ impl DotfilesAdd {
                             continue;
                         }
                     }
-                    target_backups.push((
-                        item.target.clone(),
-                        backup_path(
-                            &item.target,
-                            &backup_dir.path().join("targets").join(index.to_string()),
-                        )?,
-                    ));
                     source_backups.push((
                         item.source.clone(),
                         backup_path(
@@ -209,12 +203,37 @@ impl DotfilesAdd {
                             &backup_dir.path().join("sources").join(index.to_string()),
                         )?,
                     ));
-                    system::files::copy_path(&item.target, &item.source)?;
-                    info!(
-                        "dotfiles: copied {} to {}",
-                        item.target.display_user(),
-                        item.source.display_user()
-                    );
+                    if !self.no_apply
+                        && item.mode == FileMode::Symlink
+                        && item.target.is_dir()
+                        && !item.target.is_symlink()
+                    {
+                        remove_path(&item.source)?;
+                        if let Some(parent) = item.source.parent() {
+                            file::create_dir_all(parent)?;
+                        }
+                        file::rename(&item.target, &item.source)?;
+                        moved_targets.push((item.target.clone(), item.source.clone()));
+                        info!(
+                            "dotfiles: moved {} to {}",
+                            item.target.display_user(),
+                            item.source.display_user()
+                        );
+                    } else {
+                        target_backups.push((
+                            item.target.clone(),
+                            backup_path(
+                                &item.target,
+                                &backup_dir.path().join("targets").join(index.to_string()),
+                            )?,
+                        ));
+                        system::files::copy_path(&item.target, &item.source)?;
+                        info!(
+                            "dotfiles: copied {} to {}",
+                            item.target.display_user(),
+                            item.source.display_user()
+                        );
+                    }
                 } else if !item.source.exists() {
                     target_backups.push((
                         item.target.clone(),
@@ -300,6 +319,7 @@ impl DotfilesAdd {
             if let Err(rollback_err) = rollback_add(
                 &source_backups,
                 &target_backups,
+                &moved_targets,
                 apply_started,
                 &config_path,
                 original_config.as_deref(),
@@ -467,11 +487,28 @@ fn remove_path(path: &std::path::Path) -> Result<()> {
 fn rollback_add(
     source_backups: &[(PathBuf, PathBackup)],
     target_backups: &[(PathBuf, PathBackup)],
+    moved_targets: &[(PathBuf, PathBuf)],
     restore_targets: bool,
     config_path: &std::path::Path,
     original_config: Option<&[u8]>,
 ) -> Result<()> {
     let mut errors = vec![];
+    for (target, source) in moved_targets.iter().rev() {
+        let result = (|| -> Result<()> {
+            remove_path(target)?;
+            if let Some(parent) = target.parent() {
+                file::create_dir_all(parent)?;
+            }
+            file::rename(source, target)
+        })();
+        if let Err(err) = result {
+            errors.push(format!(
+                "moved target {} from {}: {err}",
+                target.display_user(),
+                source.display_user()
+            ));
+        }
+    }
     if restore_targets && let Err(err) = restore_paths(target_backups) {
         errors.push(format!("targets: {err}"));
     }

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -6,6 +6,7 @@ use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
 use crate::config::config_file::ConfigFile;
 use crate::config::config_file::mise_toml::MiseToml;
 use crate::config::{Config, ConfigPathOptions, resolve_target_config_path};
+use crate::dirs;
 use crate::file;
 use crate::path::PathExt;
 use crate::system;
@@ -43,6 +44,10 @@ pub struct DotfilesAdd {
     /// Print the config/source updates without writing anything
     #[clap(long, short = 'n')]
     pub(super) dry_run: bool,
+
+    /// Add the entry without applying it
+    #[clap(long)]
+    pub(super) no_apply: bool,
 
     /// Write to this config file or directory
     #[clap(long, short, value_name = "PATH", conflicts_with_all = ["global", "local"])]
@@ -82,7 +87,9 @@ impl DotfilesAdd {
         let mut planned = vec![];
         let managed_edits = system::edits::edits_from_config(&config);
         for target_raw in &self.targets {
-            let target = system::files::resolve_target_arg(target_raw);
+            let target = system::files::resolve_target_arg(target_raw)
+                .components()
+                .collect::<PathBuf>();
             if target.is_relative() {
                 bail!("{target_raw}: target must be absolute or start with ~/");
             }
@@ -124,11 +131,12 @@ impl DotfilesAdd {
                 );
             }
             planned.push(PlannedAdd {
-                target_raw: target_raw.clone(),
+                target_raw: normalized_target_raw(&target),
                 target,
                 source,
                 mode: write_mode,
                 implied_source: self.source.is_none(),
+                explicit_mode: self.mode.is_some(),
                 already_managed: existing.cloned(),
             });
         }
@@ -150,6 +158,9 @@ impl DotfilesAdd {
                         item.source.display_user()
                     );
                 }
+                if !self.no_apply {
+                    miseprintln!("{}", describe_apply(item));
+                }
             }
             return Ok(());
         }
@@ -170,6 +181,7 @@ impl DotfilesAdd {
 
         let mut added_targets = vec![];
         let mut updated_targets = vec![];
+        let mut apply_requests = vec![];
         for item in &planned {
             if item.target.exists() && !same_file(&item.target, &item.source) {
                 if item.source.exists()
@@ -188,11 +200,17 @@ impl DotfilesAdd {
                     }
                 }
                 system::files::copy_path(&item.target, &item.source)?;
+                info!(
+                    "dotfiles: copied {} to {}",
+                    item.target.display_user(),
+                    item.source.display_user()
+                );
             } else if !item.source.exists() {
                 if let Some(parent) = item.source.parent() {
                     file::create_dir_all(parent)?;
                 }
                 file::write(&item.source, "")?;
+                info!("dotfiles: created {}", item.source.display_user());
             }
             if item.already_managed.is_none()
                 && let Some(doc) = &mut doc
@@ -202,20 +220,32 @@ impl DotfilesAdd {
             } else {
                 updated_targets.push(item.target_raw.as_str());
             }
+            apply_requests.push(item.as_request(&config_path));
         }
 
-        if let Some(doc) = doc {
+        if let Some(mut doc) = doc {
+            sort_dotfiles_table(&mut doc);
             file::write(&config_path, doc.to_string())?;
-            if !added_targets.is_empty() {
+            for target in &added_targets {
                 info!(
-                    "{}: added {}",
-                    config_path.display_user(),
-                    added_targets.join(", ")
+                    "dotfiles: added {} to {}",
+                    target,
+                    config_path.display_user()
                 );
             }
         }
         if !updated_targets.is_empty() {
             info!("dotfiles: updated {}", updated_targets.join(", "));
+        }
+        if !self.no_apply && !apply_requests.is_empty() {
+            let opts = system::files::ApplyOpts {
+                dry_run: false,
+                verbose: false,
+                force: false,
+                force_hint: "use --force",
+                yes: true,
+            };
+            system::files::apply(&config, &apply_requests, &opts)?;
         }
         Ok(())
     }
@@ -228,12 +258,35 @@ struct PlannedAdd {
     source: PathBuf,
     mode: FileMode,
     implied_source: bool,
+    explicit_mode: bool,
     already_managed: Option<FileRequest>,
+}
+
+impl PlannedAdd {
+    fn as_request(&self, config_path: &std::path::Path) -> FileRequest {
+        FileRequest {
+            target_raw: self.target_raw.clone(),
+            target: self.target.clone(),
+            source: self.source.clone(),
+            mode: self.mode,
+            exclude: vec![],
+            base: config_path
+                .parent()
+                .unwrap_or(std::path::Path::new("."))
+                .to_path_buf(),
+        }
+    }
 }
 
 fn ensure_dotfiles_table(doc: &mut DocumentMut) {
     if !doc.as_table().contains_key("dotfiles") {
         doc["dotfiles"] = Item::Table(Table::new());
+    }
+}
+
+fn sort_dotfiles_table(doc: &mut DocumentMut) {
+    if let Some(table) = doc["dotfiles"].as_table_mut() {
+        table.sort_values();
     }
 }
 
@@ -260,11 +313,34 @@ fn inline_entry(item: &PlannedAdd) -> Value {
             )),
         );
     }
-    table.insert(
-        "mode",
-        Value::String(toml_edit::Formatted::new(item.mode.name().to_string())),
-    );
+    if item.explicit_mode || item.mode != FileMode::Symlink {
+        table.insert(
+            "mode",
+            Value::String(toml_edit::Formatted::new(item.mode.name().to_string())),
+        );
+    }
     Value::InlineTable(table)
+}
+
+fn normalized_target_raw(target: &std::path::Path) -> String {
+    let normalized = target.components().collect::<PathBuf>();
+    match normalized.strip_prefix(&*dirs::HOME) {
+        Ok(rel) if !rel.as_os_str().is_empty() => format!("~/{}", rel.display()),
+        Ok(_) => "~".to_string(),
+        Err(_) => normalized.to_string_lossy().to_string(),
+    }
+}
+
+fn describe_apply(item: &PlannedAdd) -> String {
+    let source = item.source.display_user();
+    let target = item.target.display_user();
+    match item.mode {
+        FileMode::Symlink => format!("ln -sf {source} {target}"),
+        FileMode::SymlinkEach => format!("ln -sf {source}/* into {target}/"),
+        FileMode::Copy if item.source.is_dir() => format!("cp -r {source} {target}"),
+        FileMode::Copy => format!("cp {source} {target}"),
+        FileMode::Template => format!("render {source} -> {target}"),
+    }
 }
 
 fn same_file(a: &std::path::Path, b: &std::path::Path) -> bool {

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -66,6 +66,7 @@ impl DotfilesEdit {
             local: false,
             path: None,
             dry_run: false,
+            no_apply: false,
             force: false,
             yes: true,
         }

--- a/src/cli/dotfiles/edit.rs
+++ b/src/cli/dotfiles/edit.rs
@@ -66,7 +66,7 @@ impl DotfilesEdit {
             local: false,
             path: None,
             dry_run: false,
-            no_apply: false,
+            no_apply: true,
             force: false,
             yes: true,
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -187,14 +187,20 @@ pub fn remove_all_with_progress<P: AsRef<Path>>(path: P, pr: &dyn SingleReport) 
 pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
-    trace!("mv {} {}", from.display(), to.display());
-    do_rename(from, to).wrap_err_with(|| {
+    try_rename(from, to).wrap_err_with(|| {
         format!(
             "failed rename: {} -> {}",
             display_path(from),
             display_path(to)
         )
     })
+}
+
+pub(crate) fn try_rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> std::io::Result<()> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    trace!("mv {} {}", from.display(), to.display());
+    do_rename(from, to)
 }
 
 #[cfg(windows)]
@@ -234,7 +240,7 @@ pub fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
 
-    match do_rename(from, to) {
+    match try_rename(from, to) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::CrossesDevices => {
             if from.is_dir() {

--- a/src/file.rs
+++ b/src/file.rs
@@ -284,14 +284,16 @@ pub fn copy_dir_all<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()
     })
 }
 
-fn copy_dir_all_preserve_symlinks(from: &Path, to: &Path) -> Result<()> {
+pub fn copy_dir_all_preserve_symlinks(from: &Path, to: &Path) -> Result<()> {
     trace!("cp -a {} {}", from.display(), to.display());
+    let mut directory_permissions = vec![(to.to_path_buf(), fs::metadata(from)?.permissions())];
     for entry in WalkDir::new(from).follow_links(false).min_depth(1) {
         let entry = entry?;
         let relative = entry.path().strip_prefix(from)?;
         let dest = to.join(relative);
         if entry.file_type().is_dir() {
             create_dir_all(&dest)?;
+            directory_permissions.push((dest, entry.metadata()?.permissions()));
         } else if entry.file_type().is_symlink() {
             create_dir_all(dest.parent().unwrap())?;
             make_symlink(&fs::read_link(entry.path())?, &dest)?;
@@ -299,6 +301,11 @@ fn copy_dir_all_preserve_symlinks(from: &Path, to: &Path) -> Result<()> {
             create_dir_all(dest.parent().unwrap())?;
             copy(entry.path(), &dest)?;
         }
+    }
+    // Apply directory permissions after copying children so read-only source
+    // directories do not prevent populating their destination.
+    for (path, permissions) in directory_permissions.into_iter().rev() {
+        fs::set_permissions(path, permissions)?;
     }
     Ok(())
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -228,7 +228,8 @@ fn do_rename(from: &Path, to: &Path) -> std::io::Result<()> {
 ///
 /// This preserves the normal `rename` behavior when possible, but avoids cross-device failures
 /// (`ErrorKind::CrossesDevices`) when `from` and `to` live on separate mounts (for example, when
-/// downloads are cached on one volume and installs are written to another).
+/// downloads are cached on one volume and installs are written to another). Directory fallbacks
+/// preserve symlinks and file/directory permissions.
 pub fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
@@ -238,7 +239,7 @@ pub fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
         Err(err) if err.kind() == std::io::ErrorKind::CrossesDevices => {
             if from.is_dir() {
                 create_dir_all(to)?;
-                copy_dir_all(from, to)?;
+                copy_dir_all_preserve_symlinks(from, to)?;
                 remove_all(from)?;
             } else {
                 copy(from, to)?;

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -1474,7 +1474,9 @@ fn paths_have_same_content(source: &Path, target: &Path) -> Result<bool> {
     if !source.is_dir() || !target.is_dir() {
         return Ok(false);
     }
-    // The caller can still replace the directory with an explicit --force.
+    // A standalone apply can still replace the directory with an explicit
+    // --force. `dotfiles add` avoids this comparison by moving the live
+    // directory to its source before applying the symlink.
     Ok(false)
 }
 

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -1459,8 +1459,9 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
 }
 
 /// Whether replacing `target` with a symlink to `source` preserves all of the
-/// target's filesystem state. Directory comparisons include empty directories,
-/// symlink identity, and permissions as well as regular-file contents.
+/// target's filesystem state. Real directories are never considered
+/// equivalent because portable filesystem APIs cannot compare all ownership,
+/// ACL, extended-attribute, flag, and security-label metadata.
 fn paths_have_same_content(source: &Path, target: &Path) -> Result<bool> {
     if source.is_file() && target.is_file() {
         if !permissions_match(source, target)?
@@ -1473,61 +1474,8 @@ fn paths_have_same_content(source: &Path, target: &Path) -> Result<bool> {
     if !source.is_dir() || !target.is_dir() {
         return Ok(false);
     }
-    // Windows ACLs are not represented by std::fs::Permissions. Refuse to
-    // destructively replace a real directory unless the user explicitly
-    // accepts that risk with --force.
-    #[cfg(not(unix))]
-    return Ok(false);
-    if !permissions_match(source, target)? {
-        return Ok(false);
-    }
-    let relative_entries = |root: &Path| -> Result<Vec<PathBuf>> {
-        let mut entries = walkdir::WalkDir::new(root)
-            .follow_links(false)
-            .min_depth(1)
-            .into_iter()
-            .map(|entry| {
-                let entry = entry?;
-                Ok(entry.path().strip_prefix(root)?.to_path_buf())
-            })
-            .collect::<Result<Vec<_>>>()?;
-        entries.sort();
-        Ok(entries)
-    };
-    let source_entries = relative_entries(source)?;
-    if source_entries != relative_entries(target)? {
-        return Ok(false);
-    }
-    for rel in source_entries {
-        let source_entry = source.join(&rel);
-        let target_entry = target.join(rel);
-        let source_metadata = source_entry.symlink_metadata()?;
-        let target_metadata = target_entry.symlink_metadata()?;
-        let source_type = source_metadata.file_type();
-        let target_type = target_metadata.file_type();
-        if source_type.is_dir() != target_type.is_dir()
-            || source_type.is_file() != target_type.is_file()
-            || source_type.is_symlink() != target_type.is_symlink()
-            || !permissions_match(&source_entry, &target_entry)?
-        {
-            return Ok(false);
-        }
-        if source_type.is_file()
-            && (source_metadata.len() != target_metadata.len()
-                || file::read(&source_entry)? != file::read(&target_entry)?)
-        {
-            return Ok(false);
-        }
-        if source_type.is_symlink()
-            && std::fs::read_link(&source_entry)? != std::fs::read_link(&target_entry)?
-        {
-            return Ok(false);
-        }
-        if !source_type.is_dir() && !source_type.is_file() && !source_type.is_symlink() {
-            return Ok(false);
-        }
-    }
-    Ok(true)
+    // The caller can still replace the directory with an explicit --force.
+    Ok(false)
 }
 
 #[cfg(unix)]

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -955,6 +955,7 @@ pub fn apply(config: &Config, requests: &[FileRequest], opts: &ApplyOpts) -> Res
     }
     for (req, rendered) in &todo {
         apply_one(req, rendered.as_deref())?;
+        info!("files: {}", describe_applied(req)?);
     }
     info!(
         "files: applied {}",
@@ -1376,16 +1377,6 @@ fn unapply_one(plan: &UnapplyPlan<'_>) -> Result<()> {
 /// content overwrites by copy/template (those are the declared intent) or
 /// re-pointing symlinks (always mise-owned territory)
 fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
-    let regular_files_have_same_content = |source: &Path, target: &Path| -> Result<bool> {
-        if !source.is_file() || !target.is_file() {
-            return Ok(false);
-        }
-        if source.metadata()?.len() != target.metadata()?.len() {
-            return Ok(false);
-        }
-        Ok(file::read(source)? == file::read(target)?)
-    };
-
     // on Windows, file "symlinks" are applied as copies (see `link_path`),
     // so existing regular-file targets are routine content updates there,
     // not conflicts — only a type mismatch blocks
@@ -1398,7 +1389,7 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
             }
             // If this equality check cannot read either side, keep the
             // conservative conflict path so --force can still handle it.
-            Ok(!regular_files_have_same_content(source, target).unwrap_or(false))
+            Ok(!paths_have_same_content(source, target).unwrap_or(false))
         }
     };
     let mut out = vec![];
@@ -1433,6 +1424,41 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
     Ok(out)
 }
 
+/// Whether replacing `target` with a symlink to `source` preserves all of the
+/// target's file data. Directory comparisons are exact: target-only files
+/// remain conflicts rather than being silently removed.
+fn paths_have_same_content(source: &Path, target: &Path) -> Result<bool> {
+    if source.is_file() && target.is_file() {
+        if source.metadata()?.len() != target.metadata()?.len() {
+            return Ok(false);
+        }
+        return Ok(file::read(source)? == file::read(target)?);
+    }
+    if !source.is_dir() || !target.is_dir() {
+        return Ok(false);
+    }
+    let relative_files = |root: &Path| -> Result<Vec<PathBuf>> {
+        Ok(file::recursive_ls(root)?
+            .into_iter()
+            .map(|path| path.strip_prefix(root).map(Path::to_path_buf))
+            .collect::<std::result::Result<Vec<_>, _>>()?)
+    };
+    let source_files = relative_files(source)?;
+    if source_files != relative_files(target)? {
+        return Ok(false);
+    }
+    for rel in source_files {
+        let source_file = source.join(&rel);
+        let target_file = target.join(rel);
+        if source_file.metadata()?.len() != target_file.metadata()?.len()
+            || file::read(source_file)? != file::read(target_file)?
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 fn describe(req: &FileRequest) -> Result<String> {
     let src = req.source.display_user();
     let tgt = req.target.display_user();
@@ -1452,6 +1478,20 @@ fn describe(req: &FileRequest) -> Result<String> {
         FileMode::Copy if req.source.is_dir() => format!("cp -r {src} {tgt}"),
         FileMode::Copy => format!("cp {src} {tgt}"),
         FileMode::Template => format!("render {src} -> {tgt}"),
+    })
+}
+
+fn describe_applied(req: &FileRequest) -> Result<String> {
+    let src = req.source.display_user();
+    let tgt = req.target.display_user();
+    Ok(match req.mode {
+        FileMode::Symlink => format!("created symlink {tgt} -> {src}"),
+        FileMode::SymlinkEach => format!(
+            "created {} symlink(s) from {src} in {tgt}",
+            walk_source_files(req)?.len()
+        ),
+        FileMode::Copy => format!("copied {src} to {tgt}"),
+        FileMode::Template => format!("rendered {src} to {tgt}"),
     })
 }
 

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -285,7 +285,21 @@ pub fn source_is_implied(req: &FileRequest) -> bool {
 }
 
 pub fn resolve_target_arg(target: &str) -> PathBuf {
-    file::replace_path(target)
+    lexical_normalize(&file::replace_path(target))
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 pub fn matches_target(req_target: &Path, req_raw: &str, filters: &[String]) -> bool {
@@ -303,11 +317,11 @@ pub fn copy_path(source: &Path, target: &Path) -> Result<()> {
         file::create_dir_all(parent)?;
     }
     if source.is_dir() {
-        if target.exists() && !target.is_dir() {
+        if target.exists() || target.is_symlink() {
             remove_existing(target)?;
         }
         file::create_dir_all(target)?;
-        file::copy_dir_all(source, target)?;
+        file::copy_dir_all_preserve_symlinks(source, target)?;
     } else {
         if target.is_symlink() {
             file::remove_file(target)?;
@@ -849,12 +863,71 @@ pub struct ApplyOpts {
     pub yes: bool,
 }
 
+pub struct ApplyPlan<'a> {
+    todo: Vec<(&'a FileRequest, Option<String>)>,
+}
+
 /// Apply all entries that aren't already in the desired state. Conflicting
 /// targets (a real file where a symlink should go, a directory where a file
 /// should go) are an error unless `force` is set — content updates for
 /// copy/template entries are not conflicts, overwriting is their job. Returns
 /// `false` when the user declines the confirmation prompt.
 pub fn apply(config: &Config, requests: &[FileRequest], opts: &ApplyOpts) -> Result<bool> {
+    execute_apply(plan_apply(config, requests, opts)?, opts)
+}
+
+pub fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<bool> {
+    if plan.todo.is_empty() {
+        info!("files: all files are applied");
+        return Ok(true);
+    }
+    if opts.dry_run {
+        for (req, rendered) in &plan.todo {
+            // template state wasn't computed (no rendering on dry runs), so
+            // the entry may already be converged
+            let conditional = req.mode == FileMode::Template && rendered.is_none();
+            let suffix = if conditional { " (if changed)" } else { "" };
+            miseprintln!("{}{suffix}", describe(req)?);
+            if opts.verbose && !conditional {
+                print_diff(req, rendered.as_deref())?;
+            }
+        }
+        return Ok(true);
+    }
+    if !opts.yes && console::user_attended_stderr() {
+        let list = plan
+            .todo
+            .iter()
+            .map(|(r, _)| r.target_raw.clone())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if !prompt::confirm(format!("files: apply {list}?"))? {
+            info!("files: skipped");
+            return Ok(false);
+        }
+    }
+    for (req, rendered) in &plan.todo {
+        apply_one(req, rendered.as_deref())?;
+        info!("files: {}", describe_applied(req)?);
+    }
+    info!(
+        "files: applied {}",
+        plan.todo
+            .iter()
+            .map(|(r, _)| r.target_raw.clone())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    Ok(true)
+}
+
+/// Plan and validate an apply without changing targets. Templates are rendered
+/// here so execution writes exactly the content that was validated.
+pub fn plan_apply<'a>(
+    config: &Config,
+    requests: &'a [FileRequest],
+    opts: &ApplyOpts,
+) -> Result<ApplyPlan<'a>> {
     // pre-rendered template output rides along so it's written as compared,
     // and exec() in templates runs once per apply
     let mut todo: Vec<(&FileRequest, Option<String>)> = vec![];
@@ -925,46 +998,7 @@ pub fn apply(config: &Config, requests: &[FileRequest], opts: &ApplyOpts) -> Res
     if !problems.is_empty() {
         bail!("files: {}", problems.join("\nfiles: "));
     }
-    if todo.is_empty() {
-        info!("files: all files are applied");
-        return Ok(true);
-    }
-    if opts.dry_run {
-        for (req, rendered) in &todo {
-            // template state wasn't computed (no rendering on dry runs), so
-            // the entry may already be converged
-            let conditional = req.mode == FileMode::Template && rendered.is_none();
-            let suffix = if conditional { " (if changed)" } else { "" };
-            miseprintln!("{}{suffix}", describe(req)?);
-            if opts.verbose && !conditional {
-                print_diff(req, rendered.as_deref())?;
-            }
-        }
-        return Ok(true);
-    }
-    if !opts.yes && console::user_attended_stderr() {
-        let list = todo
-            .iter()
-            .map(|(r, _)| r.target_raw.clone())
-            .collect::<Vec<_>>()
-            .join(", ");
-        if !prompt::confirm(format!("files: apply {list}?"))? {
-            info!("files: skipped");
-            return Ok(false);
-        }
-    }
-    for (req, rendered) in &todo {
-        apply_one(req, rendered.as_deref())?;
-        info!("files: {}", describe_applied(req)?);
-    }
-    info!(
-        "files: applied {}",
-        todo.iter()
-            .map(|(r, _)| r.target_raw.clone())
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
-    Ok(true)
+    Ok(ApplyPlan { todo })
 }
 
 pub struct UnapplyOpts {
@@ -1425,11 +1459,13 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
 }
 
 /// Whether replacing `target` with a symlink to `source` preserves all of the
-/// target's file data. Directory comparisons are exact: target-only files
-/// remain conflicts rather than being silently removed.
+/// target's filesystem state. Directory comparisons include empty directories,
+/// symlink identity, and permissions as well as regular-file contents.
 fn paths_have_same_content(source: &Path, target: &Path) -> Result<bool> {
     if source.is_file() && target.is_file() {
-        if source.metadata()?.len() != target.metadata()?.len() {
+        if !permissions_match(source, target)?
+            || source.metadata()?.len() != target.metadata()?.len()
+        {
             return Ok(false);
         }
         return Ok(file::read(source)? == file::read(target)?);
@@ -1437,26 +1473,69 @@ fn paths_have_same_content(source: &Path, target: &Path) -> Result<bool> {
     if !source.is_dir() || !target.is_dir() {
         return Ok(false);
     }
-    let relative_files = |root: &Path| -> Result<Vec<PathBuf>> {
-        Ok(file::recursive_ls(root)?
-            .into_iter()
-            .map(|path| path.strip_prefix(root).map(Path::to_path_buf))
-            .collect::<std::result::Result<Vec<_>, _>>()?)
-    };
-    let source_files = relative_files(source)?;
-    if source_files != relative_files(target)? {
+    if !permissions_match(source, target)? {
         return Ok(false);
     }
-    for rel in source_files {
-        let source_file = source.join(&rel);
-        let target_file = target.join(rel);
-        if source_file.metadata()?.len() != target_file.metadata()?.len()
-            || file::read(source_file)? != file::read(target_file)?
+    let relative_entries = |root: &Path| -> Result<Vec<PathBuf>> {
+        let mut entries = walkdir::WalkDir::new(root)
+            .follow_links(false)
+            .min_depth(1)
+            .into_iter()
+            .map(|entry| {
+                let entry = entry?;
+                Ok(entry.path().strip_prefix(root)?.to_path_buf())
+            })
+            .collect::<Result<Vec<_>>>()?;
+        entries.sort();
+        Ok(entries)
+    };
+    let source_entries = relative_entries(source)?;
+    if source_entries != relative_entries(target)? {
+        return Ok(false);
+    }
+    for rel in source_entries {
+        let source_entry = source.join(&rel);
+        let target_entry = target.join(rel);
+        let source_metadata = source_entry.symlink_metadata()?;
+        let target_metadata = target_entry.symlink_metadata()?;
+        let source_type = source_metadata.file_type();
+        let target_type = target_metadata.file_type();
+        if source_type.is_dir() != target_type.is_dir()
+            || source_type.is_file() != target_type.is_file()
+            || source_type.is_symlink() != target_type.is_symlink()
+            || !permissions_match(&source_entry, &target_entry)?
         {
+            return Ok(false);
+        }
+        if source_type.is_file()
+            && (source_metadata.len() != target_metadata.len()
+                || file::read(&source_entry)? != file::read(&target_entry)?)
+        {
+            return Ok(false);
+        }
+        if source_type.is_symlink()
+            && std::fs::read_link(&source_entry)? != std::fs::read_link(&target_entry)?
+        {
+            return Ok(false);
+        }
+        if !source_type.is_dir() && !source_type.is_file() && !source_type.is_symlink() {
             return Ok(false);
         }
     }
     Ok(true)
+}
+
+#[cfg(unix)]
+fn permissions_match(source: &Path, target: &Path) -> Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+    Ok(source.symlink_metadata()?.permissions().mode()
+        == target.symlink_metadata()?.permissions().mode())
+}
+
+#[cfg(not(unix))]
+fn permissions_match(source: &Path, target: &Path) -> Result<bool> {
+    Ok(source.symlink_metadata()?.permissions().readonly()
+        == target.symlink_metadata()?.permissions().readonly())
 }
 
 fn describe(req: &FileRequest) -> Result<String> {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -1418,12 +1418,7 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
         if cfg!(windows) && source.is_file() {
             Ok(target.exists() && target.is_dir())
         } else {
-            if !target.exists() || target.is_symlink() {
-                return Ok(false);
-            }
-            // If this equality check cannot read either side, keep the
-            // conservative conflict path so --force can still handle it.
-            Ok(!paths_have_same_content(source, target).unwrap_or(false))
+            Ok(target.exists() && !target.is_symlink())
         }
     };
     let mut out = vec![];
@@ -1456,41 +1451,6 @@ fn find_conflicts(req: &FileRequest) -> Result<Vec<PathBuf>> {
         }
     }
     Ok(out)
-}
-
-/// Whether replacing `target` with a symlink to `source` preserves all of the
-/// target's filesystem state. Real directories are never considered
-/// equivalent because portable filesystem APIs cannot compare all ownership,
-/// ACL, extended-attribute, flag, and security-label metadata.
-fn paths_have_same_content(source: &Path, target: &Path) -> Result<bool> {
-    if source.is_file() && target.is_file() {
-        if !permissions_match(source, target)?
-            || source.metadata()?.len() != target.metadata()?.len()
-        {
-            return Ok(false);
-        }
-        return Ok(file::read(source)? == file::read(target)?);
-    }
-    if !source.is_dir() || !target.is_dir() {
-        return Ok(false);
-    }
-    // A standalone apply can still replace the directory with an explicit
-    // --force. `dotfiles add` avoids this comparison by moving the live
-    // directory to its source before applying the symlink.
-    Ok(false)
-}
-
-#[cfg(unix)]
-fn permissions_match(source: &Path, target: &Path) -> Result<bool> {
-    use std::os::unix::fs::PermissionsExt;
-    Ok(source.symlink_metadata()?.permissions().mode()
-        == target.symlink_metadata()?.permissions().mode())
-}
-
-#[cfg(not(unix))]
-fn permissions_match(source: &Path, target: &Path) -> Result<bool> {
-    Ok(source.symlink_metadata()?.permissions().readonly()
-        == target.symlink_metadata()?.permissions().readonly())
 }
 
 fn describe(req: &FileRequest) -> Result<String> {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -1473,6 +1473,11 @@ fn paths_have_same_content(source: &Path, target: &Path) -> Result<bool> {
     if !source.is_dir() || !target.is_dir() {
         return Ok(false);
     }
+    // Windows ACLs are not represented by std::fs::Permissions. Refuse to
+    // destructively replace a real directory unless the user explicitly
+    // accepts that risk with --force.
+    #[cfg(not(unix))]
+    return Ok(false);
     if !permissions_match(source, target)? {
         return Ok(false);
     }


### PR DESCRIPTION
## Summary
- normalize added targets to `~/...`, remove trailing separators, and sort `[dotfiles]` entries
- omit implicit `mode = "symlink"` while preserving explicitly selected modes
- apply added dotfiles by default, with `--no-apply` for capture-only workflows
- capture real paths by moving them into the dotfiles source, including across filesystems, while keeping standalone real-path replacement behind `--force`
- report config writes, source captures, and concrete apply actions

Implements the QoL ideas from [Discussion #11450](https://github.com/jdx/mise/discussions/11450).

## Validation
- `mise run test:e2e e2e/cli/test_dotfiles_files`
- `mise run lint-fix`
- `cargo check --workspace --all-targets`
- `mise run render:usage`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default `add` behavior and filesystem semantics (moves, rollback, stricter symlink apply), which can surprise users and affect home-directory files, though e2e coverage is extensive.
> 
> **Overview**
> **`mise bootstrap dotfiles add`** applies captured entries by default; **`--no-apply`** records config and sources only. Symlink and new **`symlink-each`** captures **move** live paths into `dotfiles.root` before linking (cross-device fallback preserves metadata), with **rollback** on capture, config, or apply failures.
> 
> **Config writes** normalize target keys (`~/...`, lexical `..`), **sort** `[dotfiles]` keys, and omit implied **`mode = "symlink"`** unless **`--mode`** was used. **`dotfiles edit`** delegates to add with **`no_apply: true`** so edits stay capture-only unless **`--apply`**.
> 
> **Standalone `dotfiles apply`** no longer auto-replaces a real file or directory with a symlink when visible content matches; **`--force`** is always required. **`add`** sidesteps that by moving the real path first.
> 
> Apply logic is split into **`plan_apply`** / **`execute_apply`** for reuse from add. Directory copies use **symlink- and permission-preserving** copies; conflict detection drops content-equality shortcuts for symlink targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b84ddaa7d2e99a293f567f7483c3872c2866a216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--no-apply` to record/update dotfile entries without applying them (`bootstrap dotfiles add` and deprecated `dotfiles add`).
* **Bug Fixes**
  * Improved dotfile target normalization, safer conflict handling, and clearer per-entry apply reporting; enhanced rollback to preserve pre-invocation filesystem state on failures.
  * Improved directory replacement/copy behavior by preserving directory permission metadata and symlinks.
* **Documentation**
  * Clarified dotfiles capture vs apply semantics; updated CLI and man pages for `--no-apply`.
* **Tests**
  * Expanded end-to-end coverage for `--no-apply`, rollback edge cases, directory handling with/without `--force`, canonical key normalization, and edit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

