### PR TITLE
fix(config): preserve comments in alias and bootstrap writers

### DIFF
--- a/e2e/cli/test_alias
+++ b/e2e/cli/test_alias
@@ -7,3 +7,11 @@ assert_not_contains "mise alias ls" "tiny  xxx"
 
 assert "mise alias set nushell aqua:nushell/nushell"
 assert "mise x nushell -- nu --version"
+
+# comments around an alias survive the value being replaced
+# See: https://github.com/jdx/mise/discussions/4797
+printf '[tool_alias.tiny.versions]\n# keep this comment\nxxx = "1" # keep me\n' >"$MISE_CONFIG_DIR/config.toml"
+assert "mise alias set tiny xxx 2"
+assert "cat '$MISE_CONFIG_DIR/config.toml'" '[tool_alias.tiny.versions]
+# keep this comment
+xxx = "2" # keep me'

--- a/e2e/cli/test_shell_alias
+++ b/e2e/cli/test_shell_alias
@@ -73,3 +73,11 @@ assert "mise shell-alias get myalias2" "echo test2"
 
 # shell-alias set with no value and no = fails
 assert_fail "mise shell-alias set myalias3"
+
+# comments around a shell alias survive the value being replaced
+# See: https://github.com/jdx/mise/discussions/4797
+printf '[shell_alias]\n# keep this comment\nll = "ls -l" # keep me\n' >"$MISE_CONFIG_DIR/config.toml"
+mise shell-alias set ll "ls -la"
+assert "cat '$MISE_CONFIG_DIR/config.toml'" '[shell_alias]
+# keep this comment
+ll = "ls -la" # keep me'

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -499,7 +499,8 @@ impl MiseToml {
             .or_default()
             .versions
             .insert(from.into(), to.into());
-        self.doc_mut()?
+        let mut doc = self.doc_mut()?;
+        let versions = doc
             .get_mut()
             .unwrap()
             .entry("tool_alias")
@@ -511,10 +512,8 @@ impl MiseToml {
             .as_table_like_mut()
             .unwrap()
             .entry("versions")
-            .or_insert_with(table)
-            .as_table_like_mut()
-            .unwrap()
-            .insert(from, value(to));
+            .or_insert_with(table);
+        insert_preserving_decor(versions, from, value(to));
         Ok(())
     }
 
@@ -573,14 +572,13 @@ impl MiseToml {
 
     pub fn set_shell_alias(&mut self, name: &str, command: &str) -> eyre::Result<()> {
         self.shell_alias.insert(name.into(), command.into());
-        self.doc_mut()?
+        let mut doc = self.doc_mut()?;
+        let shell_alias = doc
             .get_mut()
             .unwrap()
             .entry("shell_alias")
-            .or_insert_with(table)
-            .as_table_like_mut()
-            .unwrap()
-            .insert(name, value(command));
+            .or_insert_with(table);
+        insert_preserving_decor(shell_alias, name, value(command));
         Ok(())
     }
 
@@ -646,7 +644,10 @@ impl MiseToml {
             .as_table_mut()
             .unwrap();
         let key = get_key_with_decor(packages, spec);
-        packages.insert_formatted(&key, toml_edit::value(version));
+        let value_decor = get_value_decor(packages, spec);
+        let mut item = toml_edit::value(version);
+        set_value_decor(&mut item, &value_decor);
+        packages.insert_formatted(&key, item);
         Ok(())
     }
 
@@ -680,7 +681,10 @@ impl MiseToml {
             .as_table_mut()
             .unwrap();
         let key = get_key_with_decor(taps, tap);
-        taps.insert_formatted(&key, toml_edit::value(url));
+        let value_decor = get_value_decor(taps, tap);
+        let mut item = toml_edit::value(url);
+        set_value_decor(&mut item, &value_decor);
+        taps.insert_formatted(&key, item);
         Ok(())
     }
 
@@ -1360,6 +1364,22 @@ fn get_key_with_decor_from(table: &toml_edit::Table, key: &str, existing: &str) 
 fn get_value_decor(table: &toml_edit::Table, key: &str) -> Option<toml_edit::Decor> {
     let value = table.get(key)?.as_value()?;
     Some(value.decor().clone())
+}
+
+/// Inserts `item` under `key` in `target`, carrying over the decor of the entry being replaced:
+/// the comment above the line lives on the key, the one after the value on the value.
+///
+/// Inline tables have no `insert_formatted`, so they fall back to a plain insert — which is what
+/// every caller here did unconditionally before, so nothing regresses for them.
+fn insert_preserving_decor(target: &mut Item, key: &str, mut item: Item) {
+    if let Some(tbl) = target.as_table_mut() {
+        let k = get_key_with_decor(tbl, key);
+        let value_decor = get_value_decor(tbl, key);
+        set_value_decor(&mut item, &value_decor);
+        tbl.insert_formatted(&k, item);
+    } else if let Some(tbl) = target.as_table_like_mut() {
+        tbl.insert(key, item);
+    }
 }
 
 /// Applies decor captured by [`get_value_decor`] to the value that replaces it.
@@ -3974,6 +3994,122 @@ run = 'echo "template"'
         assert!(
             dump.contains(r#"FOO = "baz" # keep me"#),
             "comment after the value should survive: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_set_alias_preserves_comments() {
+        // https://github.com/jdx/mise/discussions/4797
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".alias-comments.mise.toml");
+        let node: BackendArg = "node".into();
+        let contents = formatdoc! {r#"
+            [tool_alias.{node}.versions]
+            # keep this comment
+            lts = "20" # keep me
+            "#};
+        file::write(&p, contents).unwrap();
+        let mut cf = MiseToml::from_file(&p).unwrap();
+        cf.set_alias(&node, "lts", "22").unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains("# keep this comment"),
+            "comment above the alias should survive: {dump}"
+        );
+        assert!(
+            dump.contains(r#"lts = "22" # keep me"#),
+            "comment after the alias should survive: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_set_shell_alias_preserves_comments() {
+        // https://github.com/jdx/mise/discussions/4797
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".shell-alias.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [shell_alias]
+            # keep this comment
+            ll = "ls -l" # keep me
+            "#},
+        )
+        .unwrap();
+        let mut cf = MiseToml::from_file(&p).unwrap();
+        cf.set_shell_alias("ll", "ls -la").unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains("# keep this comment"),
+            "comment above the shell alias should survive: {dump}"
+        );
+        assert!(
+            dump.contains(r#"ll = "ls -la" # keep me"#),
+            "comment after the shell alias should survive: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_bootstrap_package_preserves_comments() {
+        // https://github.com/jdx/mise/discussions/4797
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".bootstrap-comments.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [bootstrap.packages]
+            # keep this comment
+            "apt:curl" = "8.5.0" # keep me
+            "#},
+        )
+        .unwrap();
+        let mut cf = MiseToml::from_file(&p).unwrap();
+        cf.update_bootstrap_package("apt:curl", "8.6.0").unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains("# keep this comment"),
+            "comment above the package should survive: {dump}"
+        );
+        assert!(
+            dump.contains(r#""apt:curl" = "8.6.0" # keep me"#),
+            "comment after the package version should survive: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_update_bootstrap_brew_tap_preserves_comments() {
+        // https://github.com/jdx/mise/discussions/4797
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".brew-tap-comments.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [bootstrap.brew.taps]
+            # keep this comment
+            "acme/tools" = "https://example.com/old.git" # keep me
+            "#},
+        )
+        .unwrap();
+        let mut cf = MiseToml::from_file(&p).unwrap();
+        cf.update_bootstrap_brew_tap("acme/tools", "https://example.com/new.git")
+            .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains("# keep this comment"),
+            "comment above the tap should survive: {dump}"
+        );
+        assert!(
+            dump.contains(r#""acme/tools" = "https://example.com/new.git" # keep me"#),
+            "comment after the tap url should survive: {dump}"
         );
         file::remove_file(&p).unwrap();
     }


### PR DESCRIPTION
## Summary

- keep comments when `mise alias set` / `mise shell-alias set` rewrite an entry — today both the
  comment above the line and the one after the value are lost
- keep the trailing comment when the `[bootstrap.packages]` / `[bootstrap.brew.taps]` writers replace
  a value

Follow-up to #11415, which fixed the same class of bug for `[tools]` and `[env]` and listed these
four writers as the remaining work.

## Context

From https://github.com/jdx/mise/discussions/4797. Reproduced on 2026.7.15:

```console
$ cat ~/.config/mise/config.toml
[tool_alias.node.versions]
# above comment
lts = "20" # keep me

[shell_alias]
# above comment
ll = "ls -l" # keep me too

$ mise alias set node lts 22
$ mise shell-alias set ll "ls -la"
$ cat ~/.config/mise/config.toml
[tool_alias.node.versions]
lts = "22"

[shell_alias]
ll = "ls -la"
```

Both comments are gone. This is worse than the `[tools]` case #11415 fixed, where the comment above
the line at least survived.

The cause differs slightly between the two groups:

- `set_alias` and `set_shell_alias` end their chain in `as_table_like_mut().unwrap().insert(key,
  value(..))`. That never went through `get_key_with_decor`, so *both* decors are dropped.
- `update_bootstrap_package` and `update_bootstrap_brew_tap` do use `get_key_with_decor`, but not
  `get_value_decor`, so `insert_formatted` replaces the value and takes the trailing comment with it
  — exactly the `[tools]` bug before #11415.

## Changes

`src/config/config_file/mise_toml.rs`:

- `insert_preserving_decor()` next to the existing decor helpers: captures the key decor and the
  value decor of the entry being replaced and re-applies both. Inline tables have no
  `insert_formatted`, so they fall back to a plain insert — which is what all of these callers did
  unconditionally before, so nothing regresses there.
- `set_alias` / `set_shell_alias` now go through it.
- `update_bootstrap_package` / `update_bootstrap_brew_tap` apply the existing `get_value_decor` /
  `set_value_decor` pair, matching what `replace_versions` and `update_env` already do.

This is formatting-only: the values written are unchanged, and an entry that did not exist before is
unaffected because there is no decor to carry over.

## Tests

Unit (`src/config/config_file/mise_toml.rs`), following the shape of the existing
`test_replace_versions_preserves_comments`:

- `test_set_alias_preserves_comments`
- `test_set_shell_alias_preserves_comments`
- `test_update_bootstrap_package_preserves_comments`
- `test_update_bootstrap_brew_tap_preserves_comments` (`#[cfg(unix)]`, matching the writer)

e2e:

- `e2e/cli/test_alias` — `mise alias set tiny xxx 2` over `xxx = "1" # keep me`
- `e2e/cli/test_shell_alias` — `mise shell-alias set ll "ls -la"` over `ll = "ls -l" # keep me`

The bootstrap writers are not covered by e2e because exercising them needs a real package manager
(apt/brew); the unit tests call them directly instead.

## Verification

I cannot compile mise on this machine (3 GB RAM), so this has not been built or run locally and CI is
the check. Verified locally what needs no build: `rustfmt --check` reports nothing in the edited
regions, and `bash -n` / `shellcheck -x` / `shfmt -l -s` are clean on both e2e files.

Marking as draft until CI is green.

## Notes

Still not covered, and deliberately out of scope here: comments *inside* a multi-line version array
(one per element). Those elements are regenerated wholesale by `replace_versions`, so there is
nothing to re-attach a per-element comment to — fixing it needs a design decision rather than
another application of these helpers.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved comments and formatting in `config.toml` when updating tool aliases and shell aliases.
  * Preserved inline comments when changing bootstrap package versions or brew tap URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->