### PR TITLE
fix(config): preserve comments between version array elements

### DIFF
--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1033,6 +1033,14 @@ impl ConfigFile for MiseToml {
         let key = get_key_with_decor_from(tools, ba.short.as_str(), &existing);
         // and the same for the value, so a comment after the version survives the replacement
         let value_decor = get_value_decor(tools, &existing);
+        // keep the array as it was written so its layout — multi-line shape, trailing comma and any
+        // comments between the elements — can be reused when only the versions change. Read before
+        // the removal below, which drops the entry when it is stored under a long name.
+        let existing_arr = tools
+            .get(&existing)
+            .and_then(|i| i.as_value())
+            .and_then(|v| v.as_array())
+            .cloned();
 
         // drop the other spellings: they all deserialize to this one entry, so leaving one behind
         // means the file has two keys for one tool and the later one silently wins on read-back.
@@ -1059,11 +1067,18 @@ impl ConfigFile for MiseToml {
             set_value_decor(&mut item, &value_decor);
             tools.insert_formatted(&key, item);
         } else {
-            let mut arr = Array::new();
-            for tr in versions {
+            // Reuse the existing array when the version count is unchanged: swapping the values in
+            // place keeps the layout, including comments written between the elements. A comment
+            // after an element belongs to the decor of the element that follows it, so an array
+            // built from scratch always drops it. When the count changes there is no way to line
+            // the old decor up with the new elements, so build a fresh array as before.
+            let reused = existing_arr.filter(|a| a.len() == versions.len());
+            let reusing = reused.is_some();
+            let mut arr = reused.unwrap_or_else(Array::new);
+            for (i, tr) in versions.into_iter().enumerate() {
                 let v = tr.version();
-                if output_empty_opts(&tr.options()) {
-                    arr.push(v.to_string());
+                let val: Value = if output_empty_opts(&tr.options()) {
+                    v.to_string().into()
                 } else {
                     let mut table = InlineTable::new();
                     table.insert("version", v.to_string().into());
@@ -1072,7 +1087,16 @@ impl ConfigFile for MiseToml {
                         table.insert(k, toml_value_to_edit(v.clone()));
                     }
                     insert_core_options(&mut table, options);
-                    arr.push(table);
+                    table.into()
+                };
+                match reusing.then(|| arr.get_mut(i)).flatten() {
+                    Some(slot) => {
+                        let mut val = val;
+                        *val.decor_mut() = slot.decor().clone();
+                        *slot = val;
+                    }
+                    // `push` applies the default separators, exactly as before
+                    None => arr.push(val),
                 }
             }
             let mut item = Item::Value(Value::Array(arr));
@@ -3981,6 +4005,171 @@ run = 'echo "template"'
         assert!(
             dump.contains(r#"dummy = ["1.0.1", "2.0.0"] # keep me too"#),
             "comment after a multi-version tool should survive: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_preserves_array_element_comments() {
+        // https://github.com/jdx/mise/discussions/4797
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".array-comments.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            dummy = [
+              "1.0.0", # first
+              "2.0.0", # second
+            ]
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let dummy = "dummy".into();
+        cf.replace_versions(
+            &dummy,
+            vec![
+                ToolRequest::new(Arc::new("dummy".into()), "1.0.1", ToolSource::Unknown).unwrap(),
+                ToolRequest::new(Arc::new("dummy".into()), "2.0.1", ToolSource::Unknown).unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(indoc! {r#"
+                dummy = [
+                  "1.0.1", # first
+                  "2.0.1", # second
+                ]"#}),
+            "the array should keep its layout with each comment on its own element: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_array_comments_stay_positional() {
+        // A comment written after an array element belongs to the decor of the element that
+        // follows it, so it is tied to a position rather than to a version. Reordering the
+        // versions therefore leaves the comments where the user put them, which is the same rule
+        // the scalar case follows: a comment survives its value changing.
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".array-reorder.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            dummy = [
+              "1.0.0", # first
+              "2.0.0", # second
+            ]
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let dummy = "dummy".into();
+        cf.replace_versions(
+            &dummy,
+            vec![
+                ToolRequest::new(Arc::new("dummy".into()), "2.0.0", ToolSource::Unknown).unwrap(),
+                ToolRequest::new(Arc::new("dummy".into()), "1.0.0", ToolSource::Unknown).unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(indoc! {r#"
+                dummy = [
+                  "2.0.0", # first
+                  "1.0.0", # second
+                ]"#}),
+            "comments should stay at their position rather than follow a version: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_array_count_change_still_writes() {
+        // a different number of versions cannot reuse the old array's layout, so it falls back to
+        // building a fresh one — the versions themselves still have to be written
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".array-count.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            dummy = ["1.0.0", "2.0.0"]
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let dummy = "dummy".into();
+        cf.replace_versions(
+            &dummy,
+            vec![
+                ToolRequest::new(Arc::new("dummy".into()), "1.0.1", ToolSource::Unknown).unwrap(),
+                ToolRequest::new(Arc::new("dummy".into()), "2.0.1", ToolSource::Unknown).unwrap(),
+                ToolRequest::new(Arc::new("dummy".into()), "3.0.0", ToolSource::Unknown).unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(r#"dummy = ["1.0.1", "2.0.1", "3.0.0"]"#),
+            "all versions should be written: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_array_element_comments_survive_alias_rename() {
+        // an aliased entry is renamed to the short name, and the element comments have to come
+        // along. Nothing in the reuse itself states why this works: the array is looked up under
+        // the spelling the file actually uses, which the alias-aware key list supplies. Reading it
+        // from the short name instead would drop these comments again while every other test here
+        // still passed, so pin the combination.
+        let _config = Config::get().await.unwrap();
+        let p = CWD
+            .as_ref()
+            .unwrap()
+            .join(".aliased-array-comments.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            nodejs = [
+              "20.11.0", # first
+              "22.0.0", # second
+            ]
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let node: BackendArg = "node".into();
+        cf.replace_versions(
+            &node,
+            vec![
+                ToolRequest::new(Arc::new("node".into()), "20.11.1", ToolSource::Unknown).unwrap(),
+                ToolRequest::new(Arc::new("node".into()), "22.1.0", ToolSource::Unknown).unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(indoc! {r#"
+                node = [
+                  "20.11.1", # first
+                  "22.1.0", # second
+                ]"#}),
+            "the renamed key should keep the comments between its elements: {dump}"
+        );
+        assert!(
+            !dump.contains("nodejs"),
+            "the alias must not be left behind as a second key: {dump}"
         );
         file::remove_file(&p).unwrap();
     }


### PR DESCRIPTION
## Summary

- keep comments written between the elements of a multi-version tool when `mise use` / `mise up`
  rewrite the array
- last of the follow-ups listed in #11415 (see also #11453 for the alias and bootstrap writers)

## Problem

```toml
[tools]
dummy = [
  "1.0.0", # first
  "2.0.0", # second
]
```

After `mise up dummy` the comments — and the multi-line layout — are gone:

```toml
[tools]
dummy = ["1.0.1", "2.0.1"]
```

`replace_versions` builds the replacement with `Array::new()` and pushes the new elements, so nothing
of the old array survives. `set_value_decor` re-applies the decor of the array *as a whole*, which is
only the comment written after the closing `]`.

## Why not match elements by version

In `toml_edit` a comment written after an element is stored in the decor of the element that
*follows* it (and the one after the last element lives in the array's `trailing`). Carrying decor
across by matching version strings therefore moves comments to whichever position the matching
version happens to occupy, which silently re-attaches a comment to a different version whenever the
order changes.

## Approach

Reuse the existing array when the number of versions is unchanged, and swap the values in place:

- the array object is cloned, so the multi-line shape, the trailing comma and every inter-element
  comment are reproduced exactly — only the version strings change
- each new value inherits the decor of the slot it replaces, so nothing moves
- when the count *does* change there is no way to line the old decor up with the new elements, so it
  falls back to building a fresh array exactly as today — no behaviour change, no regression

This matches the rule #11415 already set for scalars: a comment stays where the user wrote it, even
though the value next to it changed.

The old array is captured before the `tools.remove(&ba.full())` a few lines below, which would
otherwise drop the entry when it is stored under a long name like `core:node`.

## Tests

Unit (`src/config/config_file/mise_toml.rs`), alongside the existing comment-preservation tests:

- `test_replace_versions_preserves_array_element_comments` — a multi-line array with a comment on
  each element, replaced by the same number of versions; both comments and both new versions survive
- `test_replace_versions_array_count_change_still_writes` — 2 versions replaced by 3, covering the
  fallback path

The existing `test_replace_versions_preserves_comments` already asserts the count-changing case
(`["1.0.0"]` → `["1.0.1", "2.0.0"]`) renders unchanged, so the fallback formatting is pinned too.

No e2e: producing a multi-version array through the CLI is a roundabout way to reach a code path the
unit tests can call directly.

## Verification

I cannot compile mise on this machine (3 GB RAM), so this has not been built or run locally and CI is
the check. Verified locally what needs no build: `rustfmt --check` reports nothing in the edited
regions (the remaining diffs my older toolchain reports are the same ones it reports for the
surrounding committed code).

Marking as draft until CI is green.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing TOML array formatting, including per-element comments, when updating tool version lists where the version count stays the same.
  * Maintained correct positional comment placement when versions are reordered within an array.
  * Continued rewriting the entire array when the version count changes to keep updates accurate.
* **Tests**
  * Extended coverage to verify per-element comment survival and correct positional accuracy during version replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->