### PR TITLE
fix(task): include mtime in the source metadata hash

### DIFF
--- a/e2e/tasks/test_task_source_freshness
+++ b/e2e/tasks/test_task_source_freshness
@@ -36,6 +36,29 @@ touch sizeout.txt
 # Should rebuild because size changed in the metadata hash
 assert "mise run -q sizetest" "rebuilt"
 
+# Test same-size detection (a change that keeps the size but restores an older mtime, the way
+# tar/unzip/rsync -a/cp -p put an older tree back, must still trigger a rebuild)
+cat <<EOF >mise.toml
+[tasks.pintest]
+run = 'echo rebuilt'
+sources = ['pin.txt']
+outputs = ['pinout.txt']
+EOF
+
+echo 'version = "1.2.3"' >pin.txt
+echo "out" >pinout.txt
+sleep 0.1
+touch pinout.txt
+
+# First run should skip (output is newer)
+assert_empty "mise run -q pintest"
+
+# Same number of bytes as the line above, and older than the output, so neither the size nor the
+# mtime comparison can see the change on their own
+echo 'version = "1.2.4"' >pin.txt
+touch -t 202001010000 pin.txt
+assert "mise run -q pintest" "rebuilt"
+
 # Test that normal source/output freshness still works
 cat <<EOF >mise.toml
 [tasks.fresh]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -770,10 +770,23 @@ fn get_file_metadatas(
 }
 
 /// Convert file metadata to a hash string for comparison
-/// Includes path and file size to detect changes even when mtimes are unreliable
+///
+/// Includes path, file size and mtime. Without the mtime, a change that keeps the file size — a
+/// version bump from `1.2.3` to `1.2.4`, say — and lands an mtime no newer than the output falls
+/// through to the mtime comparison below, which then reports the task as fresh and leaves a stale
+/// output in place. That is what tar, unzip, `rsync -a` and `cp -p` do when they restore an older
+/// tree; `git checkout` is unaffected because it always writes with the current time.
+///
+/// The [`SystemTime`] is hashed as it is rather than as a duration since the epoch: converting
+/// would fold every pre-epoch mtime into the same value as "this filesystem reports no mtime",
+/// making two distinct timestamps indistinguishable. `None` therefore means only that the mtime is
+/// unavailable.
 fn file_metadatas_to_hash(metadatas: &[(PathBuf, fs::Metadata)]) -> String {
-    let path_and_sizes: Vec<_> = metadatas.iter().map(|(p, m)| (p, m.len())).collect();
-    hash::hash_to_str(&path_and_sizes)
+    let stat_info: Vec<_> = metadatas
+        .iter()
+        .map(|(p, m)| (p, m.len(), m.modified().ok()))
+        .collect();
+    hash::hash_to_str(&stat_info)
 }
 
 /// Per-file content hash cache entry. The `(size, mtime_secs, mtime_nanos)`
@@ -961,6 +974,61 @@ mod tests {
         let matcher = build_output_matcher(root.path(), &patterns).unwrap();
 
         assert!(is_output(&matcher, &output, false));
+    }
+
+    #[test]
+    fn metadata_hash_notices_a_same_size_change_with_an_older_mtime() {
+        // https://github.com/jdx/mise/discussions/4209 — restoring an older tree with tar,
+        // `rsync -a` or `cp -p` keeps the recorded mtime, so a same-size edit is invisible to a
+        // hash built from the path and size alone and the mtime comparison then calls it fresh.
+        let root = tempfile::tempdir().unwrap();
+        let p = root.path().join("pin.txt");
+        fs::write(&p, "1.2.3").unwrap();
+        let before = file_metadatas_to_hash(&[(p.clone(), fs::metadata(&p).unwrap())]);
+
+        fs::write(&p, "1.2.4").unwrap();
+        let restored = filetime::FileTime::from_unix_time(1_000_000, 0);
+        filetime::set_file_times(&p, restored, restored).unwrap();
+        let after = file_metadatas_to_hash(&[(p.clone(), fs::metadata(&p).unwrap())]);
+
+        assert_eq!(
+            fs::metadata(&p).unwrap().len(),
+            5,
+            "the fixture only exercises the bug while both versions are the same size"
+        );
+        assert_ne!(before, after, "the mtime change should be part of the hash");
+    }
+
+    #[test]
+    fn metadata_hash_separates_pre_epoch_mtimes() {
+        // mtimes from before 1970 must stay distinct from each other, and from "the filesystem
+        // reports no mtime" — folding them together would hide a change the same way the missing
+        // mtime did.
+        let root = tempfile::tempdir().unwrap();
+        let p = root.path().join("ancient.txt");
+        fs::write(&p, "x").unwrap();
+
+        let stamp = |secs: i64| {
+            let t = filetime::FileTime::from_unix_time(secs, 0);
+            // a filesystem that cannot store a pre-epoch timestamp is not what this pins down
+            filetime::set_file_times(&p, t, t).ok()?;
+            let metadata = fs::metadata(&p).unwrap();
+            let mtime = metadata.modified().ok()?;
+            Some((mtime, file_metadatas_to_hash(&[(p.clone(), metadata)])))
+        };
+        let (Some((first_mtime, first)), Some((second_mtime, second))) =
+            (stamp(-2_000_000), stamp(-1_000_000))
+        else {
+            return;
+        };
+        if first_mtime == second_mtime {
+            return;
+        }
+
+        assert_ne!(
+            first, second,
+            "two different pre-epoch mtimes should hash differently"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- include the mtime in the source metadata hash, so a same-size change that arrives with an older
  mtime is no longer reported as fresh
- costs nothing: the mtime is already in the `fs::Metadata` that has been stat'ed

## Problem

In the default (metadata) mode, `sources_are_fresh` compares a hash of the sources against the
stored baseline and, when it matches, falls back to comparing mtimes. The hash covered only
`(path, size)`, so a change that keeps the file size slipped through, and if its mtime was not newer
than the output the mtime comparison then declared the task fresh:

```console
$ tar czf snapshot.tgz src.txt          # version = "1.2.3", mtime 2026-07-01
$ printf 'version = "1.2.4"\n' >src.txt # same number of bytes
$ mise run build                        # out.txt is now newer than src.txt
$ tar xzf snapshot.tgz                  # restores 1.2.3 *and* its old mtime
$ mise run build
[build] sources up-to-date, skipping    # wrong
$ cat out.txt
version = "1.2.4"                       # stale output, silently
```

The failure is silent and looks like a successful build, which is what makes it worth fixing despite
the narrow trigger.

## Which paths actually hit it

Verified on 2026.7.15, one scenario per row:

| Scenario | Before |
| --- | --- |
| Size-changing edit + older mtime | detected (size is in the hash) |
| Same-size edit + older mtime | **missed** |
| `rsync -a` restoring an older tree | **missed** |
| `cp -p` restoring an older tree | **missed** |
| `tar xzf` restoring an older tree | **missed** |
| `git checkout` of an older revision | detected — git writes with the current time |
| Any of the above with `source_freshness_hash_contents = true` | detected |

Both conditions have to line up: the size must be unchanged *and* the mtime must not be newer than
the output. Same-size edits are ordinary in practice (a version pin `1.2.3` → `1.2.4`, a date, a
hash, a single character), and the tools that preserve mtimes — tar, unzip, `rsync -a`, `cp -p`, and
the tar-based CI cache actions — are exactly the ones used to restore or roll back a tree. Everyday
git work is unaffected, which is why this has stayed hidden.

## Changes

`src/task/task_source_checker.rs`:

- `file_metadatas_to_hash()` hashes `(path, size, mtime)` instead of `(path, size)`. The
  `SystemTime` is hashed as it is rather than as a duration since the epoch, so a pre-epoch mtime
  stays distinct instead of collapsing into the same value as "this filesystem reports no mtime"

Scope of the change:

- the hash has exactly two callers — `compute_source_hash` (which `save_checksum` writes) and
  `sources_are_fresh` (which compares) — so the baseline and the comparison move together
- **artifact cache keys are untouched**: `task_cache_inputs` builds its own blake3 content hash and
  never calls this function, so cache entries stay portable across machines and checkouts
- the epoch-timestamp guard stays: it still covers the first run, before any baseline exists
- existing users have a baseline written with the old hash, so the first run after upgrading rebuilds
  each task once and is stable from then on

## Tests

- unit `metadata_hash_notices_a_same_size_change_with_an_older_mtime` — rewrites a 5-byte pin as
  another 5 bytes, pushes the mtime back with `filetime::set_file_times`, and asserts the hash
  changes. On `main` the two hashes are identical.
- unit `metadata_hash_separates_pre_epoch_mtimes` — two different negative Unix timestamps must
  hash differently (skipped on a filesystem that cannot store them).
- e2e `e2e/tasks/test_task_source_freshness` — a new section next to the existing size- and
  rename-detection ones, using `touch -t` to reproduce the restore.

The existing e2e coverage is the other half of the check: `test_task_source_freshness`,
`test_task_run_sources` and the `test_task_source_freshness_hash_contents*` family all assert cases
that are *supposed* to be skipped, so they pin the extra mtime sensitivity to what is intended.

## Verification

I cannot compile mise on this machine (3 GB RAM), so this has not been built or run locally and CI is
the check. Verified locally what needs no build: `rustfmt --check` reports nothing in the edited
regions, and `bash -n` / `shellcheck -x` / `shfmt -l -s` are clean on the e2e file.

Marking as draft until CI is green.

## Notes

`task.source_freshness_hash_contents = true` already handled all of these cases; this brings the
default mode closer to it for free, without reading file contents.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task freshness detection to identify source changes even when file size remains unchanged.
  * Rebuilds now trigger correctly when a source file’s modification time is restored to an older value.
* **Tests**
  * Added end-to-end coverage for same-size source changes with older modification timestamps.
  * Added coverage to ensure different pre-epoch modification times produce distinct freshness results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->