### PR TITLE
fix(aqua): resolve versions by semantic precedence

### DIFF
--- a/docs/dev-tools/backends/aqua.md
+++ b/docs/dev-tools/backends/aqua.md
@@ -136,6 +136,21 @@ Set them via tool options using either top-level keys or a nested `vars` table:
 Vars with defaults are filled automatically. Vars marked as required in the aqua registry must be set
 unless the registry also provides a default.
 
+### `version_sort`
+
+Aqua normally preserves the order returned by the upstream version source. For repositories that
+publish backports after newer releases, set `version_sort = "semver"` to resolve `latest` and
+version prefixes using [semantic version precedence](https://semver.org/):
+
+```toml
+[tools]
+"aqua:owner/tool" = { version = "latest", version_sort = "semver" }
+```
+
+If any matching version is not a valid semantic version, mise preserves the upstream order. The
+option is therefore intended only for tools whose release tags consistently follow semantic
+versioning.
+
 ### `prerelease`
 
 By default, releases flagged `prerelease: true` on GitHub are excluded from `mise ls-remote` and from `latest` resolution. Set `prerelease = true` to include them:

--- a/registry/tuist.toml
+++ b/registry/tuist.toml
@@ -1,4 +1,7 @@
-backends = ["aqua:tuist/tuist", "asdf:mise-plugins/mise-tuist"]
+backends = [
+  { full = "aqua:tuist/tuist", options = { version_sort = "semver" } },
+  "asdf:mise-plugins/mise-tuist",
+]
 description = "A toolchain to generate Xcode projects from Swift packages"
 os = ["macos", "linux"]
 test = { cmd = "tuist version", expected = "{{version}}" }

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -722,6 +722,7 @@ impl Backend for AquaBackend {
         versions: Vec<String>,
         query: &str,
         filter_prereleases: bool,
+        opts: &ToolVersionOptions,
     ) -> Vec<String> {
         let escaped_query = regex::escape(query);
         let query = if query == "latest" {
@@ -742,8 +743,7 @@ impl Backend for AquaBackend {
                 query_regex.is_match(v)
             })
             .collect();
-        let opts = self.ba.opts();
-        if AquaOptions::new(&opts).uses_semantic_version_sort() {
+        if AquaOptions::new(opts).uses_semantic_version_sort() {
             sort_versions_semantically(versions)
         } else {
             versions
@@ -3354,7 +3354,7 @@ fn sort_versions_semantically(versions: Vec<String>) -> Vec<String> {
         }
     };
     let mut versions = versions.into_iter().zip(parsed).collect::<Vec<_>>();
-    versions.sort_by(|(_, left), (_, right)| left.cmp(right));
+    versions.sort_by(|(_, left), (_, right)| left.cmp_precedence(right));
     versions.into_iter().map(|(version, _)| version).collect()
 }
 
@@ -4026,16 +4026,30 @@ packages:
     }
 
     #[test]
-    fn test_semantic_version_sort_orders_backports_by_version_precedence() {
+    fn test_semantic_version_sort_uses_tool_request_options() {
         let backend = AquaBackend::from_arg(BackendArg::new(
-            "tuist".to_string(),
-            Some("aqua:tuist/tuist".to_string()),
+            "tool".to_string(),
+            Some("aqua:owner/tool".to_string()),
         ));
+        let mut opts = ToolVersionOptions::default();
+        opts.opts.insert(
+            VERSION_SORT_OPTION.to_string(),
+            toml::Value::String("semver".to_string()),
+        );
+        let request = ToolRequest::new_opts(
+            backend.ba.clone(),
+            "latest",
+            opts,
+            crate::toolset::ToolSource::MiseToml(PathBuf::from("mise.toml")),
+        )
+        .unwrap();
+        let request_opts = request.options();
 
         let versions = backend.fuzzy_match_filter(
             vec!["4.202.6".to_string(), "4.197.3".to_string()],
             "latest",
             true,
+            &request_opts,
         );
 
         assert_eq!(versions, vec!["4.197.3", "4.202.6"]);
@@ -4052,6 +4066,7 @@ packages:
             vec!["4.202.6".to_string(), "4.197.3".to_string()],
             "latest",
             true,
+            &ToolVersionOptions::default(),
         );
 
         assert_eq!(versions, vec!["4.202.6", "4.197.3"]);
@@ -4063,6 +4078,16 @@ packages:
             sort_versions_semantically(vec!["1.0.0".to_string(), "not-semver".to_string()]);
 
         assert_eq!(versions, vec!["1.0.0", "not-semver"]);
+    }
+
+    #[test]
+    fn test_semantic_version_sort_ignores_build_metadata() {
+        let versions = sort_versions_semantically(vec![
+            "1.0.0-alpha+002".to_string(),
+            "1.0.0-alpha+001".to_string(),
+        ]);
+
+        assert_eq!(versions, vec!["1.0.0-alpha+002", "1.0.0-alpha+001"]);
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -45,6 +45,8 @@ use std::{
 };
 use url::Url;
 
+const VERSION_SORT_OPTION: &str = "version_sort";
+
 #[derive(Debug)]
 pub struct AquaBackend {
     ba: Arc<BackendArg>,
@@ -68,6 +70,10 @@ impl<'a> AquaOptions<'a> {
         self.values.bool("symlink_bins")
     }
 
+    fn uses_semantic_version_sort(&self) -> bool {
+        self.values.str(VERSION_SORT_OPTION) == Some("semver")
+    }
+
     fn var(&self, name: &str) -> Result<Option<String>> {
         self.canonical_var_options()?
             .get(name)
@@ -88,7 +94,10 @@ impl<'a> AquaOptions<'a> {
     fn canonical_var_options(&self) -> Result<BTreeMap<String, &toml::Value>> {
         let mut vars = BTreeMap::new();
         for (key, value) in self.values.raw().iter() {
-            if key == "symlink_bins" || EPHEMERAL_OPT_KEYS.contains(&key.as_str()) {
+            if key == "symlink_bins"
+                || key == VERSION_SORT_OPTION
+                || EPHEMERAL_OPT_KEYS.contains(&key.as_str())
+            {
                 continue;
             }
 
@@ -393,7 +402,7 @@ impl Backend for AquaBackend {
 
     async fn latest_stable_version(&self, config: &Arc<Config>) -> Result<Option<String>> {
         let opts = config.get_tool_opts_with_overrides(&self.ba).await?;
-        if self.include_prereleases(&opts) {
+        if self.include_prereleases(&opts) || AquaOptions::new(&opts).uses_semantic_version_sort() {
             return Ok(None);
         }
         self.latest_marked_release_version().await
@@ -721,7 +730,7 @@ impl Backend for AquaBackend {
             &escaped_query
         };
         let query_regex = Regex::new(&format!("^{query}([-.].+)?$")).unwrap();
-        versions
+        let versions = versions
             .into_iter()
             .filter(|v| {
                 if query == v {
@@ -732,7 +741,13 @@ impl Backend for AquaBackend {
                 }
                 query_regex.is_match(v)
             })
-            .collect()
+            .collect();
+        let opts = self.ba.opts();
+        if AquaOptions::new(&opts).uses_semantic_version_sort() {
+            sort_versions_semantically(versions)
+        } else {
+            versions
+        }
     }
 
     /// Resolve platform-specific lock information for any target platform.
@@ -3321,7 +3336,26 @@ pub fn install_time_option_keys() -> Vec<String> {
 }
 
 pub fn is_install_time_option_key(key: &str) -> bool {
-    key != "symlink_bins"
+    key != "symlink_bins" && key != VERSION_SORT_OPTION
+}
+
+fn sort_versions_semantically(versions: Vec<String>) -> Vec<String> {
+    let parsed = match versions
+        .iter()
+        .map(|version| semver::Version::parse(version))
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            warn_once!(
+                "aqua `{VERSION_SORT_OPTION}=semver` requires valid semantic versions: {error}; preserving upstream order"
+            );
+            return versions;
+        }
+    };
+    let mut versions = versions.into_iter().zip(parsed).collect::<Vec<_>>();
+    versions.sort_by(|(_, left), (_, right)| left.cmp(right));
+    versions.into_iter().map(|(version, _)| version).collect()
 }
 
 #[cfg(test)]
@@ -3882,6 +3916,10 @@ packages:
             toml::Value::String("true".to_string()),
         );
         opts.opts.insert(
+            VERSION_SORT_OPTION.to_string(),
+            toml::Value::String("semver".to_string()),
+        );
+        opts.opts.insert(
             "postinstall".to_string(),
             toml::Value::String("echo ok".to_string()),
         );
@@ -3895,6 +3933,7 @@ packages:
         assert_eq!(lock_opts.get("vars.channel"), Some(&"stable".to_string()));
         assert_eq!(lock_opts.get("vars.go_version"), Some(&"1.24".to_string()));
         assert!(!lock_opts.contains_key("symlink_bins"));
+        assert!(!lock_opts.contains_key(VERSION_SORT_OPTION));
         assert!(!lock_opts.contains_key("postinstall"));
     }
 
@@ -3983,6 +4022,47 @@ packages:
         assert!(is_install_time_option_key("vars.channel"));
         assert!(is_install_time_option_key("vars"));
         assert!(!is_install_time_option_key("symlink_bins"));
+        assert!(!is_install_time_option_key(VERSION_SORT_OPTION));
+    }
+
+    #[test]
+    fn test_semantic_version_sort_orders_backports_by_version_precedence() {
+        let backend = AquaBackend::from_arg(BackendArg::new(
+            "tuist".to_string(),
+            Some("aqua:tuist/tuist".to_string()),
+        ));
+
+        let versions = backend.fuzzy_match_filter(
+            vec!["4.202.6".to_string(), "4.197.3".to_string()],
+            "latest",
+            true,
+        );
+
+        assert_eq!(versions, vec!["4.197.3", "4.202.6"]);
+    }
+
+    #[test]
+    fn test_default_version_sort_preserves_upstream_order() {
+        let backend = AquaBackend::from_arg(BackendArg::new(
+            "tool".to_string(),
+            Some("aqua:owner/tool".to_string()),
+        ));
+
+        let versions = backend.fuzzy_match_filter(
+            vec!["4.202.6".to_string(), "4.197.3".to_string()],
+            "latest",
+            true,
+        );
+
+        assert_eq!(versions, vec!["4.202.6", "4.197.3"]);
+    }
+
+    #[test]
+    fn test_semantic_version_sort_preserves_upstream_order_for_invalid_versions() {
+        let versions =
+            sort_versions_semantically(vec!["1.0.0".to_string(), "not-semver".to_string()]);
+
+        assert_eq!(versions, vec!["1.0.0", "not-semver"]);
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1922,8 +1922,9 @@ pub trait Backend: Debug + Send + Sync {
         let versions = self.list_installed_versions();
         // No async config lookup available here; fall back to inline/registry
         // opts, which is the best we have for a sync path.
-        let filter = !self.include_prereleases(&self.ba().opts());
-        self.fuzzy_match_filter(versions, query, filter)
+        let opts = self.ba().opts();
+        let filter = !self.include_prereleases(&opts);
+        self.fuzzy_match_filter(versions, query, filter, &opts)
     }
     async fn list_versions_matching(
         &self,
@@ -1933,7 +1934,7 @@ pub trait Backend: Debug + Send + Sync {
         let versions = self.list_remote_versions(config).await?;
         let opts = config.get_tool_opts_with_overrides(self.ba()).await?;
         let filter = !self.include_prereleases(&opts);
-        Ok(self.fuzzy_match_filter(versions, query, filter))
+        Ok(self.fuzzy_match_filter(versions, query, filter, &opts))
     }
 
     /// List versions matching a query, optionally filtered by release date.
@@ -1968,7 +1969,7 @@ pub trait Backend: Debug + Send + Sync {
         };
         let opts = config.get_tool_opts_with_overrides(self.ba()).await?;
         let filter = !self.include_prereleases(&opts);
-        Ok(self.fuzzy_match_filter(versions, query, filter))
+        Ok(self.fuzzy_match_filter(versions, query, filter, &opts))
     }
 
     async fn latest_version_for_query(
@@ -2975,6 +2976,7 @@ pub trait Backend: Debug + Send + Sync {
         versions: Vec<String>,
         query: &str,
         filter_prereleases: bool,
+        _opts: &ToolVersionOptions,
     ) -> Vec<String> {
         fuzzy_match_versions(versions, query, filter_prereleases)
     }

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -123,6 +123,7 @@ impl Backend for PIPXBackend {
         versions: Vec<String>,
         query: &str,
         filter_prereleases: bool,
+        _opts: &ToolVersionOptions,
     ) -> Vec<String> {
         crate::backend::fuzzy_match_versions_pep440(versions, query, filter_prereleases)
     }

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -353,6 +353,7 @@ impl Backend for UbiBackend {
         versions: Vec<String>,
         query: &str,
         filter_prereleases: bool,
+        _opts: &ToolVersionOptions,
     ) -> Vec<String> {
         let escaped_query = regex::escape(query);
         let query = if query == "latest" {

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -474,7 +474,7 @@ impl Backend for JavaPlugin {
     fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {
         let versions = self.list_installed_versions();
         // Java doesn't support the `prerelease` opt-in; always filter.
-        self.fuzzy_match_filter(versions, query, true)
+        self.fuzzy_match_filter(versions, query, true, &self.ba.opts())
     }
 
     async fn list_versions_matching(
@@ -483,7 +483,8 @@ impl Backend for JavaPlugin {
         query: &str,
     ) -> eyre::Result<Vec<String>> {
         let versions = self.list_remote_versions(config).await?;
-        Ok(self.fuzzy_match_filter(versions, query, true))
+        let opts = config.get_tool_opts_with_overrides(&self.ba).await?;
+        Ok(self.fuzzy_match_filter(versions, query, true, &opts))
     }
 
     fn get_aliases(&self) -> Result<BTreeMap<String, String>> {
@@ -639,6 +640,7 @@ impl Backend for JavaPlugin {
         versions: Vec<String>,
         query: &str,
         filter_prereleases: bool,
+        _opts: &ToolVersionOptions,
     ) -> Vec<String> {
         // remove -musl feature in favour of alpine-linux OS
         let query = if Platform::current().libc() == Some("musl") && query.contains("-musl") {

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -886,6 +886,7 @@ impl Backend for PythonPlugin {
         versions: Vec<String>,
         query: &str,
         filter_prereleases: bool,
+        _opts: &ToolVersionOptions,
     ) -> Vec<String> {
         crate::backend::fuzzy_match_versions_pep440(versions, query, filter_prereleases)
     }


### PR DESCRIPTION
## What changed

- Added an opt-in Aqua backend option, `version_sort = "semver"`, that orders matching releases by [semantic versioning](https://semver.org/) precedence.
- Configured Tuist's Aqua registry entry to use semantic version ordering.
- Documented the option and its fallback behavior.

## Why

`mise latest tuist` should resolve to the highest stable Tuist version even when an older release line receives a newer backport.

## Root cause

The Aqua backend normally preserves the order returned by the upstream release source. When GitHub's marked latest release belongs to another package in the Tuist repository, mise falls back to release chronology. Tuist `4.197.3` was published after `4.202.6`, so the chronological fallback selected the lower version.

## Approach

The new behavior is opt-in because Aqua packages do not all use semantic versioning. When enabled, mise skips the marked-latest shortcut, collects matching release candidates, and orders valid semantic versions by precedence. If any candidate is not a valid semantic version, mise preserves the upstream order.

## Impact

Tuist now resolves `latest` and version prefixes by semantic version precedence. Existing Aqua tools keep their current ordering unless they explicitly enable the option.

## Validation

- `/Users/pepicrft/.cargo/bin/cargo fmt --all -- --check`
- `/Users/pepicrft/.cargo/bin/cargo test backend::aqua::tests::` with 52 tests passed
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `version_sort="semver"` behavior for Aqua-managed tools, using semantic version precedence for `latest` and version-prefix matching.
  * When semver parsing succeeds, matching results are semver-sorted; when parsing fails, the original upstream ordering is preserved.
  * Enabled semantic version sorting for the Tuist Aqua backend in the registry configuration.

* **Documentation**
  * Documented the Aqua `version_sort` option, including the semver-based resolution and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->