### PR TITLE
fix(hook-env): ensure fast-path-forced runs refresh the session

### DIFF
--- a/e2e/cli/test_hook_env_unrelated_file_stabilizes
+++ b/e2e/cli/test_hook_env_unrelated_file_stabilizes
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# A file created in a config-search directory bumps that directory's mtime,
+# which only should_exit_early_fast checks. should_exit_early has no equivalent
+# check, so it used to return early before build_session ran. Config — and
+# therefore env._.source — is loaded before that early return, so the expensive
+# work happened on every prompt while the session timestamp stayed stale,
+# forcing the same thing again on the next prompt, indefinitely.
+#
+# test_hook_env_dir_mtime_stabilizes covers the case where the new file is
+# itself a config file; that also trips the slow path's watch-file check, so it
+# stabilized regardless. This covers the uncovered case: an unrelated file.
+#
+# Note that hook-env prints nothing when the slow path returns early, so an
+# empty stdout does not distinguish "fast-path skipped the work" from "the work
+# ran and was thrown away". Counting env._.source executions does.
+
+export MISE_ENV_CACHE=0
+
+cat >env.sh <<'EOF'
+echo ran >>"$COUNTER_FILE"
+export FROM_SOURCE=1
+EOF
+
+cat >mise.toml <<'EOF'
+[env]
+_.source = "env.sh"
+EOF
+
+export COUNTER_FILE="$PWD/source-runs.txt"
+: >"$COUNTER_FILE"
+
+eval "$(mise activate bash 2>/dev/null)"
+eval "$(mise hook-env -s bash 2>/dev/null)"
+before_touch=$(wc -l <"$COUNTER_FILE")
+
+# Creating a non-config file bumps the directory mtime, which legitimately
+# forces one more full run so the new state can be picked up.
+sleep 1
+touch unrelated.lock
+eval "$(mise hook-env -s bash 2>/dev/null)"
+settled=$(wc -l <"$COUNTER_FILE")
+if [[ $settled -le $before_touch ]]; then
+  fail "unrelated file did not trigger env._.source: $before_touch -> $settled"
+fi
+
+# That run must have refreshed the session. Every prompt after it should take
+# the fast path and leave env._.source alone.
+for _ in 1 2 3; do
+  eval "$(mise hook-env -s bash 2>/dev/null)"
+done
+after=$(wc -l <"$COUNTER_FILE")
+
+if [[ $after -eq $settled ]]; then
+  ok "env._.source stopped re-running after an unrelated file was created"
+else
+  fail "env._.source kept re-running: $settled -> $after over 3 prompts"
+fi
+
+# Belt and braces: a settled prompt takes the fast path, which exits before
+# logger init, so it emits nothing on either stream.
+output=$(mise hook-env -s bash 2>&1)
+if [[ -z $output ]]; then
+  ok "fast-path works once the session is stable"
+else
+  fail "expected fast-path (no output) but got: '$output'"
+fi

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -1,6 +1,7 @@
 use std::io::prelude::*;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::BTreeSet, sync::Arc};
 
@@ -57,6 +58,29 @@ fn write_last_full_check(timestamp: u128) {
     if let Err(e) = std::fs::write(last_check_file_for_dir(cwd), timestamp.to_string()) {
         trace!("failed to write last check file: {e}");
     }
+}
+
+/// Set when [`should_exit_early_fast`] determines a full hook-env run is
+/// required because something looks stale.
+///
+/// [`should_exit_early`] consults this so a run the fast path forced always
+/// reaches [`build_session`], which is what rewrites `latest_update`. The two
+/// checks are not identical — the fast path also compares config-search
+/// directory mtimes, which the slow path has no equivalent for — so without
+/// this the slow path could exit early on a run the fast path forced, leaving
+/// `latest_update` stale and forcing another full run on the next prompt,
+/// forever.
+///
+/// Both functions run in the same process for a given `mise hook-env`:
+/// `should_exit_early_fast` from `cli::run` before config is loaded, and
+/// `should_exit_early` from `cli::hook_env::HookEnv::run` after.
+static FAST_PATH_FORCED_FULL_RUN: AtomicBool = AtomicBool::new(false);
+
+/// Record that the fast path requires a full run and return `false`, so call
+/// sites can `return force_full_run();` in place of a bare `return false`.
+fn force_full_run() -> bool {
+    FAST_PATH_FORCED_FULL_RUN.store(true, Ordering::Relaxed);
+    false
 }
 
 /// Convert a SystemTime to milliseconds since Unix epoch
@@ -244,16 +268,18 @@ pub fn should_exit_early_fast() -> bool {
         return true;
     }
 
+    // Every staleness check below returns via force_full_run() so the slow path
+    // knows this run must reach build_session and refresh the session.
     // Check if any loaded config files have been modified
     for config_path in &PREV_SESSION.loaded_configs {
         if let Ok(metadata) = config_path.metadata() {
             if let Ok(modified) = metadata.modified()
                 && mtime_to_millis(modified) > PREV_SESSION.latest_update
             {
-                return false;
+                return force_full_run();
             }
         } else if !config_path.exists() {
-            return false;
+            return force_full_run();
         }
     }
     // Check if any files accessed by tera template functions have been modified
@@ -262,10 +288,10 @@ pub fn should_exit_early_fast() -> bool {
             if let Ok(modified) = metadata.modified()
                 && mtime_to_millis(modified) > PREV_SESSION.latest_update
             {
-                return false;
+                return force_full_run();
             }
         } else if !path.exists() {
-            return false;
+            return force_full_run();
         }
     }
     // Check if any files from [[watch_files]] patterns have been modified
@@ -274,31 +300,33 @@ pub fn should_exit_early_fast() -> bool {
             if let Ok(modified) = metadata.modified()
                 && mtime_to_millis(modified) > PREV_SESSION.latest_update
             {
-                return false;
+                return force_full_run();
             }
         } else if !path.exists() {
-            return false;
+            return force_full_run();
         }
     }
     if have_trust_state_dirs_been_modified() {
-        return false;
+        return force_full_run();
     }
     // Check if data dir has been modified (new tools installed, etc.)
     // Also check if it's been deleted - this requires a full update
     if !dirs::DATA.exists() {
-        return false;
+        return force_full_run();
     }
     if let Ok(metadata) = dirs::DATA.metadata()
         && let Ok(modified) = metadata.modified()
         && mtime_to_millis(modified) > PREV_SESSION.latest_update
     {
-        return false;
+        return force_full_run();
     }
     // Check if any directory in the config search path has been modified
-    // This catches new config files created anywhere in the hierarchy
+    // This catches new config files created anywhere in the hierarchy.
+    // The slow path has no equivalent check, which is exactly why the
+    // FAST_PATH_FORCED_FULL_RUN handshake exists.
     for modified in config_search_dir_mtimes() {
         if mtime_to_millis(modified) > PREV_SESSION.latest_update {
-            return false;
+            return force_full_run();
         }
     }
     // Filesystem checks passed - update the last check timestamp so subsequent
@@ -344,6 +372,13 @@ pub fn should_exit_early(
         return false;
     }
     if have_mise_env_vars_been_modified() {
+        return false;
+    }
+    // The fast path already decided this run is necessary. Check it only after
+    // the slow-path checks above, since they also record modified watch files
+    // and schedule hooks as side effects.
+    if FAST_PATH_FORCED_FULL_RUN.load(Ordering::Relaxed) {
+        trace!("fast-path forced a full run, not exiting early");
         return false;
     }
     trace!("early-exit");
@@ -757,10 +792,23 @@ pub fn build_alias_commands(
 
 #[cfg(test)]
 mod tests {
-    use super::has_preclap_logging_flag;
+    use super::{FAST_PATH_FORCED_FULL_RUN, force_full_run, has_preclap_logging_flag};
+    use std::sync::atomic::Ordering;
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn force_full_run_records_the_decision_and_reports_not_exiting_early() {
+        let prev = FAST_PATH_FORCED_FULL_RUN.swap(false, Ordering::Relaxed);
+
+        // Returns false so callers can `return force_full_run();` directly, and
+        // leaves the flag set for should_exit_early to observe.
+        assert!(!force_full_run());
+        assert!(FAST_PATH_FORCED_FULL_RUN.load(Ordering::Relaxed));
+
+        FAST_PATH_FORCED_FULL_RUN.store(prev, Ordering::Relaxed);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`env._.source` (and everything else config loading does) re-runs on **every prompt**, indefinitely, once any file is created in a config-search ancestor directory. Reported in #4580 and #5433 — one reporter measured ~1s of added latency per prompt from a 1Password lookup.

## Root cause

`hook-env` decides twice whether it can skip work:

```
should_exit_early_fast()   <- before config is loaded; cheap checks only
      | false
  config is loaded         <- env._.source runs here
      |
should_exit_early()        <- after config is loaded
      | false
  build_session()          <- this is what rewrites latest_update
```

`should_exit_early_fast` compares **config-search directory mtimes** (`config_search_dir_mtimes()`), which catches config files created anywhere in the hierarchy. `should_exit_early` has no equivalent check.

Creating any file in one of those directories bumps its mtime, so:

1. the fast path sees `dir_mtime > latest_update` and forces a full run
2. config is loaded — `env._.source` executes
3. the slow path sees nothing it knows about and returns early
4. `build_session()` is never reached, so `latest_update` stays stale
5. next prompt goes back to 1

I instrumented both functions and ran it in CI. Every prompt produced the same three lines:

```
DIAG fast: latest_update=1785311235208            <- never advances
DIAG fast: RETRIGGER config_search_dir mtime=1785311235266
DIAG slow: should_exit_early TRUE -> return before build_session
```

`build_session: REACHED` appeared once, at activation, and never again.

Touching an *existing* file does not trigger this (no directory mtime change), and neither does a file created outside the config-search ancestors — which matches the reports, where a `bun install` writing out a lockfile was enough to put the shell into this state for the rest of the session.

## Fix

The fast path now records that it forced a run, and the slow path honors that:

```rust
static FAST_PATH_FORCED_FULL_RUN: AtomicBool = AtomicBool::new(false);

fn force_full_run() -> bool {
    FAST_PATH_FORCED_FULL_RUN.store(true, Ordering::Relaxed);
    false
}
```

Every staleness check in `should_exit_early_fast` returns via `force_full_run()`, and `should_exit_early` refuses to exit early when the flag is set. A run the fast path forced therefore always reaches `build_session`.

### Why this rather than duplicating the check

The obvious alternative is to add `config_search_dir_mtimes()` to `should_exit_early` as well. That is a smaller diff, and it would fix this particular symptom. I went the other way for two reasons:

- It would stat every config-search ancestor directory a second time per prompt. `hook_env.cache_ttl` exists specifically because those stats are expensive on slow filesystems, so doubling them seemed like the wrong direction.
- It leaves the underlying asymmetry in place. This bug exists because a check was added to one path and not the other; keeping the two lists in sync by hand invites the same class of bug the next time the fast path gains a check. The handshake establishes an invariant instead: *if the fast path decided a run is needed, that run refreshes the session.*

The trade-off is a process-global `AtomicBool` and an implicit ordering assumption — `should_exit_early_fast` runs in `cli::run` before config load, `should_exit_early` in `HookEnv::run` after, always in that order within one process. That is documented on the static. `PREFER_OFFLINE` in `src/env.rs` is the same pattern. If you would rather have the duplicated check, I am happy to switch.

One behavioral note: when the fast path fires on a condition the slow path *would* also have caught, the slow path no longer gets to exit early. That costs one full run, after which the session is refreshed and subsequent prompts fast-path normally — it cannot loop.

## Tests

`e2e/cli/test_hook_env_dir_mtime_stabilizes` already covers "directory mtime changed, then stabilizes" — but it creates a **config file**, which also trips the slow path's watch-file check, so it passed either way. The uncovered case was a file that mise does not care about.

`e2e/cli/test_hook_env_unrelated_file_stabilizes` adds it: create `unrelated.lock`, then run several prompts and assert `env._.source` stops executing.

It counts `env._.source` executions rather than inspecting stdout, which matters here — when the slow path returns early, hook-env prints *nothing*, so empty output does not distinguish "the fast path skipped the work" from "the work ran and was thrown away". My first attempt at this test asserted on stdout and failed for the wrong reason.

I pushed the test on its own first to confirm it fails without the fix:

```
ERROR: E2E assertion failed: env._.source kept re-running: 3 -> 6 over 3 prompts
```

and then the fix on top, after which both it and `test_hook_env_dir_mtime_stabilizes` pass. Also added a unit test for `force_full_run()`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the environment hook when unrelated files change in config-search directories.
  * Ensured forced full updates aren’t accidentally skipped, preventing repeated environment reloads and avoiding stuck “stale” detection loops.
  * Confirmed that, after settling into the stable fast-path, subsequent runs produce no unexpected output.
* **Tests**
  * Added an end-to-end regression test validating fast/slow-path settling after unrelated file changes.
  * Added/updated a unit test to cover the internal coordination used during staleness detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->