### PR TITLE
docs: add trailing slash to node.mirror_url npmmirror example

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -65,6 +65,6 @@ $ mise settings always_keep_download
 # set the value of the setting "always_keep_download" to "true"
 $ mise settings always_keep_download=true
 
-# set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node"
-$ mise settings node.mirror_url https://npmmirror.com/mirrors/node
+# set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node/"
+$ mise settings node.mirror_url https://npmmirror.com/mirrors/node/
 ```

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3340,8 +3340,8 @@ Examples:
     # set the value of the setting "always_keep_download" to "true"
     $ mise settings always_keep_download=true
 
-    # set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node"
-    $ mise settings node.mirror_url https://npmmirror.com/mirrors/node
+    # set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node/"
+    $ mise settings node.mirror_url https://npmmirror.com/mirrors/node/
 
 """#
     flag "-a --all" help="List all settings"

--- a/src/cli/settings/mod.rs
+++ b/src/cli/settings/mod.rs
@@ -85,7 +85,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     # set the value of the setting "always_keep_download" to "true"
     $ <bold>mise settings always_keep_download=true</bold>
 
-    # set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node"
-    $ <bold>mise settings node.mirror_url https://npmmirror.com/mirrors/node</bold>
+    # set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node/"
+    $ <bold>mise settings node.mirror_url https://npmmirror.com/mirrors/node/</bold>
 "#
 );


### PR DESCRIPTION
The `node.mirror_url` help example used `https://npmmirror.com/mirrors/node` without a trailing slash. `Url::join` then drops the last path segment, so downloads resolve to `/mirrors/v...` (404) instead of `/mirrors/node/v...`. Add the slash to match `DEFAULT_NODE_MIRROR_URL` (`.../dist/`).

Proof: join without slash -> `.../mirrors/v22.17.1/SHASUMS256.txt` (404); with slash -> `.../mirrors/node/v22.17.1/SHASUMS256.txt` (200).

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 72h
