### PR TITLE
fix(monorepo): resolve idiomatic version files per config_root

### DIFF
--- a/e2e/cli/test_ls_monorepo_idiomatic_disable_files
+++ b/e2e/cli/test_ls_monorepo_idiomatic_disable_files
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Regression test: a config_root that only overrides
+# idiomatic_version_file_disable_files (not idiomatic_version_file_enable_tools) must
+# still have that override applied by `mise ls --monorepo`, instead of being ignored
+# because idiomatic_filenames_for_root() only tracked enable_tools overrides as
+# "overridden" and fell back to the cached global default otherwise.
+export MISE_EXPERIMENTAL=1
+export MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS=tiny
+
+# Install the tiny plugin, which supports idiomatic .tiny-version files
+mise plugin install tiny
+
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+
+# tiny is enabled globally, so this root's .tiny-version would normally be picked up --
+# but this root disables that specific file for tiny via disable_files alone, and its
+# version should NOT show up.
+mkdir -p packages/app1
+echo "9.9.9" >packages/app1/.tiny-version
+cat <<EOF >packages/app1/mise.toml
+[settings]
+idiomatic_version_file_disable_files = ["tiny:.tiny-version"]
+EOF
+
+# Control: a sibling root with no override still picks up its own .tiny-version normally.
+mkdir -p packages/app2
+echo "1.2.3" >packages/app2/.tiny-version
+
+echo "=== ls --monorepo applies a config_root-only idiomatic_version_file_disable_files override ==="
+output=$(mise ls --monorepo tiny 2>&1)
+assert_not_contains "echo '$output'" "9.9.9"
+assert_contains "echo '$output'" "1.2.3"

--- a/e2e/cli/test_ls_monorepo_idiomatic_tools
+++ b/e2e/cli/test_ls_monorepo_idiomatic_tools
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Test that `mise ls --monorepo` picks up idiomatic version files that are only
+# enabled via a config_root's own [settings] block, not the global/CLI settings
+# resolved from the invocation directory.
+#
+# Regression test for https://github.com/jdx/mise/discussions/8629 -- a config
+# root's `idiomatic_version_file_enable_tools` setting was silently ignored by
+# monorepo-wide commands because `load_idiomatic_filenames()` read the settings
+# snapshot resolved once from the monorepo root, before iterating config_roots,
+# so idiomatic files declared only inside a subproject's own config were never
+# even scanned for.
+export MISE_EXPERIMENTAL=1
+
+# Install the tiny plugin, which supports idiomatic .tiny-version files
+mise plugin install tiny
+
+# Note: intentionally NOT setting idiomatic_version_file_enable_tools globally here.
+# The whole point of this test is that app1 enables it for itself, in its own config.
+
+# Create monorepo root config with no idiomatic settings of its own
+cat <<EOF >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+
+# Subproject that enables idiomatic version files only in its own config
+mkdir -p packages/app1
+echo "1.0.1" >packages/app1/.tiny-version
+cat <<EOF >packages/app1/mise.toml
+[settings]
+idiomatic_version_file_enable_tools = ["tiny"]
+EOF
+
+# Subproject using explicit [tools], for comparison -- should keep working unaffected
+mkdir -p packages/app2
+cat <<EOF >packages/app2/mise.toml
+[tools]
+tiny = "2.0.1"
+EOF
+
+echo "=== ls --monorepo resolves an idiomatic version file enabled only by a config_root's own [settings] ==="
+output=$(mise ls --monorepo tiny 2>&1)
+assert_contains "echo '$output'" "1.0.1"
+assert_contains "echo '$output'" ".tiny-version"
+assert_contains "echo '$output'" "2.0.1"
+
+# Subproject identical to app1 (own [settings] enabling tiny), used to verify safe mode
+# ignores it -- an untrusted repo's own [settings] block must not influence resolution.
+mkdir -p packages/app3
+echo "3.0.1" >packages/app3/.tiny-version
+cat <<EOF >packages/app3/mise.toml
+[settings]
+idiomatic_version_file_enable_tools = ["tiny"]
+EOF
+
+echo "=== ls --monorepo in safe mode ignores a config_root's own [settings] override ==="
+safe_output=$(MISE_SAFE=1 mise ls --monorepo tiny 2>&1)
+assert_not_contains "echo '$safe_output'" "3.0.1"
+assert_not_contains "echo '$safe_output'" "app3"
+# app1's explicit [tools]-free case still isn't picked up either in safe mode, since it
+# relies on the same per-root [settings] override.
+assert_not_contains "echo '$safe_output'" "1.0.1"
+# app2's explicit [tools] declaration is unaffected by safe mode.
+assert_contains "echo '$safe_output'" "2.0.1"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -562,9 +562,16 @@ impl Config {
 
         let mut union = ToolRequestSet::new();
         for root in roots {
-            let root_paths = config_paths_in_dir_with_filenames(&root, &config_filenames);
+            let root_idiomatic_filenames =
+                idiomatic_filenames_for_root(&root, &idiomatic_filenames).await;
+            let root_config_filenames = root_idiomatic_filenames
+                .keys()
+                .chain(DEFAULT_CONFIG_FILENAMES.iter())
+                .cloned()
+                .collect_vec();
+            let root_paths = config_paths_in_dir_with_filenames(&root, &root_config_filenames);
             let mut root_config_files =
-                load_config_files_from_paths(&root_paths, &idiomatic_filenames).await?;
+                load_config_files_from_paths(&root_paths, &root_idiomatic_filenames).await?;
             for (path, cf) in root_config_files.clone() {
                 config_files.entry(path).or_insert(cf);
             }
@@ -1248,14 +1255,25 @@ async fn load_idiomatic_filenames() -> BTreeMap<String, Vec<String>> {
     let settings = Settings::get();
     let enable_tools = settings.idiomatic_version_file_enable_tools.clone();
     let disable_files = settings.idiomatic_version_file_disable_files.clone();
-    if enable_tools.is_empty() {
-        return BTreeMap::new();
-    }
     if !settings.idiomatic_version_file_disable_tools.is_empty() {
         deprecated!(
             "idiomatic_version_file_disable_tools",
             "is deprecated, use idiomatic_version_file_enable_tools instead"
         );
+    }
+    load_idiomatic_filenames_for_tools(&enable_tools, &disable_files).await
+}
+
+/// Same as [`load_idiomatic_filenames`] but for explicit `enable_tools`/`disable_files` rather
+/// than the process-wide `Settings::get()` snapshot. Used by monorepo union resolution, where a
+/// config root's own `idiomatic_version_file_enable_tools` can differ from the settings
+/// resolved from the invocation directory (see [`idiomatic_filenames_for_root`]).
+async fn load_idiomatic_filenames_for_tools(
+    enable_tools: &BTreeSet<String>,
+    disable_files: &BTreeSet<String>,
+) -> BTreeMap<String, Vec<String>> {
+    if enable_tools.is_empty() {
+        return BTreeMap::new();
     }
     let mut jset = JoinSet::new();
     for tool in backend::list() {
@@ -1309,6 +1327,47 @@ fn idiomatic_version_file_disabled(
                 disabled_tool == tool && disabled_filename == filename
             })
     })
+}
+
+/// Resolves idiomatic version filenames for a single monorepo config root, honoring that
+/// root's own `[settings].idiomatic_version_file_enable_tools`/`idiomatic_version_file_disable_files`
+/// if it sets either.
+///
+/// `Settings::get()` is a process-wide snapshot resolved once from the invocation directory
+/// (walking config files upward); it never walks *down* into `[monorepo].config_roots`, so a
+/// config root's own `[settings]` block is otherwise silently ignored by monorepo-wide
+/// commands (e.g. `mise ls --monorepo`) even though the same setting works fine when mise is
+/// actually invoked from within that root. See https://github.com/jdx/mise/discussions/8629.
+async fn idiomatic_filenames_for_root(
+    root: &Path,
+    default_idiomatic_filenames: &BTreeMap<String, Vec<String>>,
+) -> BTreeMap<String, Vec<String>> {
+    let settings = Settings::get();
+    let mut enable_tools = settings.idiomatic_version_file_enable_tools.clone();
+    let mut disable_files = settings.idiomatic_version_file_disable_files.clone();
+    let mut overridden = false;
+    let safe_mode = Settings::safe_mode();
+    for path in config_paths_in_dir_with_filenames(root, &DEFAULT_CONFIG_FILENAMES) {
+        if safe_mode && !is_global_config(&path) {
+            // Match all_settings_files()'s safe-mode boundary: an untrusted repo's own
+            // [settings] block must not influence resolution, including here.
+            continue;
+        }
+        if let Ok(partial) = Settings::parse_settings_file(&path) {
+            if let Some(tools) = partial.idiomatic_version_file_enable_tools {
+                enable_tools = tools;
+                overridden = true;
+            }
+            if let Some(files) = partial.idiomatic_version_file_disable_files {
+                disable_files = files;
+                overridden = true;
+            }
+        }
+    }
+    if !overridden {
+        return default_idiomatic_filenames.clone();
+    }
+    load_idiomatic_filenames_for_tools(&enable_tools, &disable_files).await
 }
 
 static LOCAL_CONFIG_FILENAMES: Lazy<IndexSet<&'static str>> = Lazy::new(|| {


### PR DESCRIPTION
## Summary

`idiomatic_version_file_enable_tools` set only in a config_root's own `[settings]` block is silently ignored by monorepo-wide commands (e.g. `mise ls --monorepo`), even though the same setting works as expected when mise is invoked from inside that config_root directly.

## Root cause

`Config::monorepo_union()` calls `load_idiomatic_filenames()` once, before iterating `[monorepo].config_roots`. That function reads `Settings::get()`, a process-wide snapshot resolved once from the invocation directory (walking config files upward) — it never walks *down* into a config_root. So if a config_root's own `.mise.toml` sets `idiomatic_version_file_enable_tools` (e.g. `["node", "pnpm"]`), that file is never even added to the set of filenames scanned for in that root, and the corresponding idiomatic version file (e.g. `package.json`) is never discovered.

## Fix

Resolve idiomatic filenames per config_root instead of once globally: for each root, check whether its own config files override `idiomatic_version_file_enable_tools`, and if so recompute idiomatic filenames for that root specifically. Falls back to the existing global snapshot when a root doesn't override the setting, so behavior for existing setups (global/CLI-level `idiomatic_version_file_enable_tools`) is unchanged.

Related: #8629 (same general area -- idiomatic version files in monorepos -- but that issue was about `mise run` task resolution and was already fixed; this is a distinct gap in `mise ls`/`mise install --monorepo` union resolution specifically).

## Testing

- Added `e2e/cli/test_ls_monorepo_idiomatic_tools`, confirmed it fails on the pre-fix code and passes after.
- Re-ran the existing `e2e/cli/test_install_monorepo` (covers the global/env-var-scoped idiomatic path) to confirm no regression.
- `cargo check --all-features` passes.
- `cargo fmt --check` clean on the changed Rust file.
- `shellcheck -x` and `shfmt -l -s` clean on the new e2e test script.

## Checklist

- [x] Conventional commit title
- [x] `cargo check --all-features` passes
- [x] Lint checks (cargo fmt, shellcheck, shfmt) pass on changed files
- [x] New e2e regression test added and verified against pre-fix code
- [x] No new dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Monorepo tool discovery now honors root-specific idiomatic version file settings.
  - `mise ls --monorepo` reflects idiomatic version resolution from local `.tiny-version` files inside subprojects.

- **Bug Fixes**
  - Fixed monorepo version resolution when different subprojects/config roots define different idiomatic enable/disable rules.
  - Improved safe mode to exclude idiomatic versions that should not be trusted while keeping explicitly pinned versions.

- **Tests**
  - Added E2E coverage for monorepo idiomatic resolution, safe mode filtering, and idiomatic version file disabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->