### PR TITLE
chore: release 2026.7.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [2026.7.17](https://github.com/jdx/mise/compare/v2026.7.16..v2026.7.17) - 2026-07-29
+
+### 🚀 Features
+
+- **(config)** allow disabling individual idiomatic version files by @jdx in [#11470](https://github.com/jdx/mise/pull/11470)
+- **(dotfiles)** improve add and apply workflow by @jdx in [#11451](https://github.com/jdx/mise/pull/11451)
+- **(task)** infer node workspace dependencies by @jdx in [#11435](https://github.com/jdx/mise/pull/11435)
+- **(task)** import node workspace scripts by @jdx in [#11466](https://github.com/jdx/mise/pull/11466)
+- **(task)** support optional dependencies by @jdx in [#11471](https://github.com/jdx/mise/pull/11471)
+- **(task)** add root task defaults by @jdx in [#11473](https://github.com/jdx/mise/pull/11473)
+- **(task)** add upstream task dependencies by @jdx in [#11476](https://github.com/jdx/mise/pull/11476)
+
+### 🐛 Bug Fixes
+
+- **(activate)** support zsh POSIX_IDENTIFIERS by @jdx in [#11467](https://github.com/jdx/mise/pull/11467)
+- **(activate)** keep fish cd hook active during commands by @Marukome0743 in [#11478](https://github.com/jdx/mise/pull/11478)
+- **(aqua)** match version override prefixes by @jdx in [#11469](https://github.com/jdx/mise/pull/11469)
+- **(aqua)** include prefixed override candidates by @jdx in [#11482](https://github.com/jdx/mise/pull/11482)
+- **(brew)** support cask command wrappers and run steps by @jdx in [#11472](https://github.com/jdx/mise/pull/11472)
+- **(config)** preserve comments in alias and bootstrap writers by @JamBalaya56562 in [#11453](https://github.com/jdx/mise/pull/11453)
+- **(config)** match aliased tool keys when writing mise.toml by @JamBalaya56562 in [#11474](https://github.com/jdx/mise/pull/11474)
+- **(config)** preserve comments between version array elements by @JamBalaya56562 in [#11454](https://github.com/jdx/mise/pull/11454)
+- **(hook-env)** ensure fast-path-forced runs refresh the session by @Marukome0743 in [#11458](https://github.com/jdx/mise/pull/11458)
+- **(lockfile)** avoid config root scans during shim resolution by @jdx in [#11468](https://github.com/jdx/mise/pull/11468)
+- **(python)** respect UV_PROJECT_ENVIRONMENT for uv venvs by @Marukome0743 in [#11475](https://github.com/jdx/mise/pull/11475)
+- **(self-update)** show a generic update hint when no packager instructions exist by @JamBalaya56562 in [#11449](https://github.com/jdx/mise/pull/11449)
+- **(task)** include mtime in the source metadata hash by @JamBalaya56562 in [#11455](https://github.com/jdx/mise/pull/11455)
+
+### 📚 Documentation
+
+- update stephane-robert guide URL and external post dates by @Bartok9 in [#11252](https://github.com/jdx/mise/pull/11252)
+
+### 📦️ Dependency Updates
+
+- bump aube to 1.36.0 by @jdx in [#11479](https://github.com/jdx/mise/pull/11479)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (2)
+
+- [`Kotlin/ktfmt`](https://github.com/Kotlin/ktfmt)
+- [`grafana/otel-checker`](https://github.com/grafana/otel-checker)
+
+#### Updated Packages (3)
+
+- [`goss-org/goss`](https://github.com/goss-org/goss)
+- [`kubermatic/kubeone`](https://github.com/kubermatic/kubeone)
+- [`supernovae-st/nika`](https://github.com/supernovae-st/nika)
+
 ## [2026.7.16](https://github.com/jdx/mise/compare/v2026.7.15..v2026.7.16) - 2026-07-29
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6313,7 +6313,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.16"
+version = "2026.7.17"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.16"
+version = "2026.7.17"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.16 macos-arm64 (2026-07-29)
+2026.7.17 macos-arm64 (2026-07-29)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_16.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_17.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_16.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_17.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -p usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_16.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_17.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_16.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_17.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.16";
+  version = "2026.7.17";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "31.2k",
+      stars: "31.3k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.16
+Version: 2026.7.17
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.16"
+version: "2026.7.17"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "b18b6506f5c88356b2f7a902a154b9a90080358d"
+  "tag": "1fe11bab8687216fd804af41ff8ca6b54c5632b3"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -5154,6 +5154,16 @@ packages:
               - name: ki
                 src: ki/bin/ki.bat
   - type: github_release
+    repo_owner: Kotlin
+    repo_name: ktfmt
+    aliases:
+      - name: facebook/ktfmt
+      - name: fbtransfer/ktfmt
+    description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
+    asset: ktfmt-{{trimV .Version}}-with-dependencies.jar
+    format: raw
+    complete_windows_ext: false
+  - type: github_release
     repo_owner: KusionStack
     repo_name: kusion
     description: Deliver intentions to Kubernetes and Clouds
@@ -38446,15 +38456,6 @@ packages:
       asset: frp_sha256_checksums.txt
       algorithm: sha256
   - type: github_release
-    repo_owner: fbtransfer
-    repo_name: ktfmt
-    aliases:
-      - name: facebook/ktfmt
-    description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
-    asset: ktfmt-{{trimV .Version}}-with-dependencies.jar
-    format: raw
-    complete_windows_ext: false
-  - type: github_release
     repo_owner: fe3dback
     repo_name: go-arch-lint
     description: GoLang architecture linter (checker) tool. Will check all project import path and compare with arch rules defined in yml file. Useful for hexagonal / onion / ddd / mvc and other architectural patterns. Tool can by used in your CI
@@ -45889,22 +45890,94 @@ packages:
     aliases:
       - name: aelsabbahy/goss
     description: Quick and Easy server testing/validation
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    asset: goss-{{.OS}}-{{.Arch}}
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.sha256"
-      algorithm: sha256
-    version_constraint: semver(">= 0.4.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 0.4.0")
+      - version_constraint: Version == "v0.3.11"
+        asset: goss-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.3.10")
+        asset: goss-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.3.16")
+        asset: goss-alpha-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: goss-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
+      - version_constraint: semver("<= 0.3.23")
+        asset: goss-alpha-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: goss-{{.OS}}-{{.Arch}}
+      - version_constraint: semver("<= 0.4.0-rc.2")
+        asset: goss-alpha-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: goss-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: goss-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 0.4.9")
+        asset: goss-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: goss_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
-          windows: alpha-windows
-          darwin: alpha-darwin
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - name: goss-org/goss/dcgoss
     type: github_content
     repo_owner: goss-org
@@ -46398,6 +46471,26 @@ packages:
         format: tar.gz
         github_artifact_attestations:
           signer_workflow: grafana/oats/.github/workflows/release.yml
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: grafana
+    repo_name: otel-checker
+    description: Otel Me If It's Right project
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: otel-checker_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        github_artifact_attestations:
+          signer_workflow: grafana/otel-checker/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: checksums.txt
@@ -58357,20 +58450,38 @@ packages:
     repo_name: kubeone
     asset: kubeone_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
     description: Kubermatic KubeOne automate cluster operations on all your cloud, on-prem, edge, and IoT environments
-    supported_envs:
-      - linux
-      - darwin
-    checksum:
-      type: github_release
-      asset: kubeone_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
-    version_constraint: semver(">= 1.4.2")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.4.2")
         rosetta2: true
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("<= 1.13.5")
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubeone_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubeone_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: kubeone_{{trimV .Version}}_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/kubermatic/kubeone/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
   - type: github_release
     repo_owner: kubernetes-retired
     repo_name: kubefed
@@ -88564,6 +88675,21 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 0.105.0")
+        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
         format: tar.gz
@@ -88576,6 +88702,10 @@ packages:
           algorithm: sha256
         github_artifact_attestations:
           signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+          source_tag: "-"
         supported_envs:
           - linux
           - darwin


### PR DESCRIPTION
### 🚀 Features

- **(config)** allow disabling individual idiomatic version files by @jdx in [#11470](https://github.com/jdx/mise/pull/11470)
- **(dotfiles)** improve add and apply workflow by @jdx in [#11451](https://github.com/jdx/mise/pull/11451)
- **(task)** infer node workspace dependencies by @jdx in [#11435](https://github.com/jdx/mise/pull/11435)
- **(task)** import node workspace scripts by @jdx in [#11466](https://github.com/jdx/mise/pull/11466)
- **(task)** support optional dependencies by @jdx in [#11471](https://github.com/jdx/mise/pull/11471)
- **(task)** add root task defaults by @jdx in [#11473](https://github.com/jdx/mise/pull/11473)
- **(task)** add upstream task dependencies by @jdx in [#11476](https://github.com/jdx/mise/pull/11476)

### 🐛 Bug Fixes

- **(activate)** support zsh POSIX_IDENTIFIERS by @jdx in [#11467](https://github.com/jdx/mise/pull/11467)
- **(activate)** keep fish cd hook active during commands by @Marukome0743 in [#11478](https://github.com/jdx/mise/pull/11478)
- **(aqua)** match version override prefixes by @jdx in [#11469](https://github.com/jdx/mise/pull/11469)
- **(aqua)** include prefixed override candidates by @jdx in [#11482](https://github.com/jdx/mise/pull/11482)
- **(brew)** support cask command wrappers and run steps by @jdx in [#11472](https://github.com/jdx/mise/pull/11472)
- **(config)** preserve comments in alias and bootstrap writers by @JamBalaya56562 in [#11453](https://github.com/jdx/mise/pull/11453)
- **(config)** match aliased tool keys when writing mise.toml by @JamBalaya56562 in [#11474](https://github.com/jdx/mise/pull/11474)
- **(config)** preserve comments between version array elements by @JamBalaya56562 in [#11454](https://github.com/jdx/mise/pull/11454)
- **(hook-env)** ensure fast-path-forced runs refresh the session by @Marukome0743 in [#11458](https://github.com/jdx/mise/pull/11458)
- **(lockfile)** avoid config root scans during shim resolution by @jdx in [#11468](https://github.com/jdx/mise/pull/11468)
- **(python)** respect UV_PROJECT_ENVIRONMENT for uv venvs by @Marukome0743 in [#11475](https://github.com/jdx/mise/pull/11475)
- **(self-update)** show a generic update hint when no packager instructions exist by @JamBalaya56562 in [#11449](https://github.com/jdx/mise/pull/11449)
- **(task)** include mtime in the source metadata hash by @JamBalaya56562 in [#11455](https://github.com/jdx/mise/pull/11455)

### 📚 Documentation

- update stephane-robert guide URL and external post dates by @Bartok9 in [#11252](https://github.com/jdx/mise/pull/11252)

### 📦️ Dependency Updates

- bump aube to 1.36.0 by @jdx in [#11479](https://github.com/jdx/mise/pull/11479)

## 📦 Aqua Registry Updates

### New Packages (2)

- [`Kotlin/ktfmt`](https://github.com/Kotlin/ktfmt)
- [`grafana/otel-checker`](https://github.com/grafana/otel-checker)

### Updated Packages (3)

- [`goss-org/goss`](https://github.com/goss-org/goss)
- [`kubermatic/kubeone`](https://github.com/kubermatic/kubeone)
- [`supernovae-st/nika`](https://github.com/supernovae-st/nika)