### PR TITLE
feat(task): import node workspace scripts

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -47,7 +47,7 @@ outside this tracker.
 
 - [x] Add a Node workspace provider for npm, pnpm, Yarn, and Bun workspace definitions
 - [x] Infer Node project dependency edges from declared internal package dependencies
-- [ ] Import package scripts as scoped mise tasks without requiring a `mise.toml` in every package
+- [x] Import package scripts as scoped mise tasks without requiring a `mise.toml` in every package
 - [ ] Add root task defaults that apply by task name across inferred and explicit projects
 - [ ] Add dependency-scoped task relationships equivalent to building the same task in upstream
       projects first

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -362,6 +362,38 @@ Dependency version strings are treated as opaque. A matching internal name creat
 
 All four dependency kinds participate in the same project graph, including development dependencies. If the declarations produce a cycle, `mise tasks graph` reports the cycle instead of silently dropping an edge. Use `depends`, `depends_add`, or `depends_remove` in a project override when the inferred build relationship needs to differ from the package manifests.
 
+### Node Package Scripts
+
+When experimental features are enabled, mise imports scripts from each discovered Node workspace
+package as tasks. Packages do not need their own `mise.toml`.
+
+An imported task uses the stable project ID followed by `#` and the package script name:
+
+```bash
+mise run 'node:@acme/web#build'
+```
+
+The equivalent monorepo path is available as an alias, so existing path patterns also work:
+
+```bash
+mise run //apps/web:build
+mise //...:test
+```
+
+The task runs in the package directory through the workspace package manager (`npm`, `pnpm`,
+`yarn`, or `bun`) and passes task arguments through to it. mise uses the root `packageManager`
+declaration or lockfile to select the manager and falls back to npm when neither identifies one.
+`mise task info` reports the package's `package.json` as the task source.
+
+An explicit mise task at the package's monorepo path takes precedence over the imported script.
+Both names continue to resolve to that explicit task.
+
+This inference is currently experimental and only runs for a configured monorepo root:
+
+```bash
+mise settings experimental=true
+```
+
 ### Project Overrides
 
 Use `[monorepo.projects]` in the root `mise.toml` to correct or extend provider inference. Project IDs containing `:` or scoped package names must be quoted:

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+mkdir -p bin
+cat <<'SH' >bin/npm
+#!/bin/sh
+printf '%s' "$*" >manager-args.txt
+printf inferred >result.txt
+SH
+chmod +x bin/npm
+export PATH="$PWD/bin:$PATH"
+
+cat <<'TOML' >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+TOML
+
+mkdir -p packages/app
+cat <<'JSON' >package.json
+{
+  "packageManager": "npm@11.0.0",
+  "workspaces": ["packages/*"]
+}
+JSON
+cat <<'JSON' >packages/app/package.json
+{
+  "name": "@scope/app",
+  "scripts": {
+    "build": "printf inferred > result.txt",
+    "test:unit": "printf tested > test-result.txt"
+  }
+}
+JSON
+
+assert_contains "mise tasks --all" "node:@scope/app#build"
+assert_contains "mise task info 'node:@scope/app#build'" "packages/app/package.json"
+
+mise -q run 'node:@scope/app#build' -- forwarded
+assert "cat packages/app/result.txt" "inferred"
+assert "cat packages/app/manager-args.txt" "run build forwarded"
+
+printf stale >packages/app/result.txt
+mise -q run //packages/app:build
+assert "cat packages/app/result.txt" "inferred"
+
+cat <<'TOML' >packages/app/mise.toml
+[tasks.build]
+run = "printf explicit > result.txt"
+TOML
+
+printf stale >packages/app/result.txt
+mise -q run 'node:@scope/app#build'
+assert "cat packages/app/result.txt" "explicit"
+
+assert_not_contains "MISE_EXPERIMENTAL=0 mise tasks --all" "node:@scope/app#test:unit"

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -56,3 +56,4 @@ mise -q run 'node:@scope/app#build'
 assert "cat packages/app/result.txt" "explicit"
 
 assert_not_contains "MISE_EXPERIMENTAL=0 mise tasks --all" "node:@scope/app#test:unit"
+assert_fail_contains "MISE_EXPERIMENTAL=0 mise run 'node:@scope/missing#build'" "no task"

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -16,6 +16,9 @@ monorepo_root = true
 
 [monorepo]
 config_roots = ["packages/*"]
+
+[tasks.local]
+run = "printf local > local-result.txt"
 TOML
 
 mkdir -p packages/app
@@ -57,3 +60,8 @@ assert "cat packages/app/result.txt" "explicit"
 
 assert_not_contains "MISE_EXPERIMENTAL=0 mise tasks --all" "node:@scope/app#test:unit"
 assert_fail_contains "MISE_EXPERIMENTAL=0 mise run 'node:@scope/missing#build'" "no task"
+
+mkdir -p packages/bad
+printf '{' >packages/bad/package.json
+mise -q run local
+assert "cat local-result.txt" "local"

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -40,7 +40,7 @@ assert_contains "mise task info 'node:@scope/app#build'" "packages/app/package.j
 
 mise -q run 'node:@scope/app#build' -- forwarded
 assert "cat packages/app/result.txt" "inferred"
-assert "cat packages/app/manager-args.txt" "run build forwarded"
+assert "cat packages/app/manager-args.txt" "run build -- forwarded"
 
 printf stale >packages/app/result.txt
 mise -q run //packages/app:build

--- a/src/cli/tasks/info.rs
+++ b/src/cli/tasks/info.rs
@@ -32,6 +32,9 @@ impl TasksInfo {
         let tasks = if task_name.starts_with("//") {
             let ctx = crate::task::TaskLoadContext::from_pattern(&task_name);
             config.tasks_with_context(Some(&ctx)).await?
+        } else if crate::task::is_workspace_project_task(&task_name) {
+            let ctx = crate::task::TaskLoadContext::all();
+            config.tasks_with_context(Some(&ctx)).await?
         } else {
             config.tasks().await?
         };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,7 +30,7 @@ use crate::file::display_path;
 use crate::shorthands::{Shorthands, get_shorthands};
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
 use crate::task::task_sources::TaskOutputs;
-use crate::task::{Task, TaskCacheConfig, TaskTemplate, monorepo_scope, strip_extension};
+use crate::task::{RunEntry, Task, TaskCacheConfig, TaskTemplate, monorepo_scope, strip_extension};
 use crate::tera::{contains_template_syntax, get_empty_tera, render_str, take_tera_accessed_files};
 use crate::toolset::env_cache::{CachedNonToolEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::{
@@ -738,6 +738,49 @@ impl Config {
             })
             .map(|t| (t.name.clone(), t))
             .collect();
+        if Settings::get().experimental {
+            for task in inferred_workspace_tasks(&config)? {
+                if tasks.contains_key(&task.name) {
+                    let available_aliases = task
+                        .aliases
+                        .into_iter()
+                        .filter(|alias| {
+                            !tasks.contains_key(alias)
+                                && !tasks
+                                    .values()
+                                    .any(|explicit| explicit.aliases.contains(alias))
+                        })
+                        .collect::<Vec<_>>();
+                    tasks
+                        .get_mut(&task.name)
+                        .expect("explicit task name was just found")
+                        .aliases
+                        .extend(available_aliases);
+                    continue;
+                }
+                let explicit_name = task
+                    .aliases
+                    .iter()
+                    .find(|alias| tasks.contains_key(*alias))
+                    .cloned();
+                if let Some(explicit_name) = explicit_name {
+                    let explicit = tasks
+                        .get_mut(&explicit_name)
+                        .expect("explicit task name was just found");
+                    if !explicit.aliases.contains(&task.name) {
+                        explicit.aliases.push(task.name);
+                    }
+                    continue;
+                }
+                if tasks
+                    .values()
+                    .any(|explicit| explicit.aliases.contains(&task.name))
+                {
+                    continue;
+                }
+                tasks.insert(task.name.clone(), task);
+            }
+        }
         let all_tasks = tasks.clone();
         for task in tasks.values_mut() {
             task.display_name = task.display_name(&all_tasks);
@@ -2619,6 +2662,37 @@ fn prefix_monorepo_task_names(tasks: &mut [Task], dir: &Path, monorepo_root: &Pa
             task.name = format!("{scope}:{}", task.name);
         }
     }
+}
+
+fn inferred_workspace_tasks(config: &Config) -> Result<Vec<Task>> {
+    let Some(monorepo_root) = config.monorepo_root() else {
+        return Ok(Vec::new());
+    };
+    let graph = config.workspace_project_graph()?;
+    let mut tasks = Vec::new();
+
+    for project in graph.projects() {
+        let project_root = monorepo_root.join(&project.root);
+        let path_scope = monorepo_scope(&monorepo_root, &project_root);
+        for (name, inferred) in &project.tasks {
+            let aliases = path_scope
+                .as_ref()
+                .map(|scope| vec![format!("{scope}:{name}")])
+                .unwrap_or_default();
+            tasks.push(Task {
+                name: format!("{}#{name}", project.id),
+                description: inferred.description.clone(),
+                aliases,
+                config_source: monorepo_root.join(&inferred.source),
+                config_root: Some(project_root.clone()),
+                raw_args: true,
+                run: vec![RunEntry::Script(inferred.command.clone())],
+                ..Default::default()
+            });
+        }
+    }
+
+    Ok(tasks)
 }
 
 /// Monorepo roots that enclose the selected one.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -739,7 +739,14 @@ impl Config {
             .map(|t| (t.name.clone(), t))
             .collect();
         if Settings::get().experimental {
-            for task in inferred_workspace_tasks(&config)? {
+            let inferred_tasks = match inferred_workspace_tasks(&config) {
+                Ok(tasks) => tasks,
+                Err(err) => {
+                    warn!("failed to infer workspace tasks: {err:#}");
+                    Vec::new()
+                }
+            };
+            for task in inferred_tasks {
                 if tasks.contains_key(&task.name) {
                     let available_aliases = task
                         .aliases

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2498,12 +2498,22 @@ pub(crate) fn resolve_task_pattern(pattern: &str, parent_task: Option<&Task>) ->
     // Check if this is a bare task name that should be treated as relative
     let is_bare_name =
         !pattern.starts_with("//") && !pattern.starts_with("::") && !pattern.starts_with(':');
+    let parent_is_scoped = parent_task.is_some_and(|parent| {
+        parent.name.starts_with("//") || is_workspace_project_task(&parent.name)
+    });
 
     // If pattern starts with ":" or is a bare name in monorepo context, resolve relatively
     let should_resolve_relatively = pattern.starts_with(':') && !pattern.starts_with("::")
-        || (is_bare_name && parent_task.is_some_and(|p| p.name.starts_with("//")));
+        || (is_bare_name && parent_is_scoped);
 
     if should_resolve_relatively && let Some(parent) = parent_task {
+        if let Some((project, _)) = parent
+            .name
+            .split_once('#')
+            .filter(|_| is_workspace_project_task(&parent.name))
+        {
+            return format!("{project}#{}", pattern.strip_prefix(':').unwrap_or(pattern));
+        }
         // Extract the path portion from the parent task name
         // For monorepo tasks like "//projects/frontend:test:nested", we need to extract "//projects/frontend"
         // by finding the FIRST colon after the "//" prefix, not the last one
@@ -2767,6 +2777,19 @@ where
         // (for example, `node:@scope/app#build`) without being monorepo paths.
         if let Some(exact) = self.get(pat) {
             return Ok(vec![exact]);
+        }
+        if is_workspace_project_task(pat) {
+            let matcher = GlobBuilder::new(pat)
+                .literal_separator(false)
+                .build()
+                .map_err(|err| eyre!("invalid workspace task pattern {pat:?}: {err}"))?
+                .compile_matcher();
+            return Ok(self
+                .iter()
+                .filter(|(name, _)| matcher.is_match(name))
+                .map(|(_, task)| task)
+                .unique()
+                .collect());
         }
 
         // === Monorepo pattern matching ===
@@ -3697,6 +3720,21 @@ echo "hello world"
         assert_eq!(
             resolve_task_pattern("::global", Some(&parent_task)),
             "::global"
+        );
+
+        // Stable workspace task IDs resolve relative dependencies within the
+        // same project rather than treating the provider prefix as a path.
+        let parent_task = Task {
+            name: "node:@scope/app#build".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_task_pattern(":test", Some(&parent_task)),
+            "node:@scope/app#test"
+        );
+        assert_eq!(
+            resolve_task_pattern("lint", Some(&parent_task)),
+            "node:@scope/app#lint"
         );
 
         // Test 9: Pattern with wildcards
@@ -5111,6 +5149,35 @@ echo "test"
 
         let matches = tasks.get_matching("pr:remove").unwrap();
         assert_eq!(matches, vec![&"pr:remove".to_string()]);
+    }
+
+    #[test]
+    fn test_get_matching_workspace_task_ids() {
+        use std::collections::BTreeMap;
+
+        use super::GetMatchingExt;
+
+        let tasks = BTreeMap::from([
+            (
+                "node:@scope/app#build".to_string(),
+                "node:@scope/app#build".to_string(),
+            ),
+            (
+                "node:@scope/app#test:unit".to_string(),
+                "node:@scope/app#test:unit".to_string(),
+            ),
+        ]);
+
+        assert!(
+            tasks
+                .get_matching("node:@scope/missing#build")
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            tasks.get_matching("node:@scope/app#test:*").unwrap(),
+            vec![&"node:@scope/app#test:unit".to_string()]
+        );
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -62,7 +62,8 @@ pub mod task_source_checker;
 pub mod task_sources;
 pub mod task_template;
 pub mod task_tool_installer;
-// Consumed by workspace providers introduced in follow-up changes.
+// Some graph traversal APIs are currently consumed only by tests and follow-up
+// workspace-task features.
 #[allow(dead_code)]
 pub mod workspace;
 
@@ -70,7 +71,7 @@ pub(crate) use task_cache::TaskCacheOutput;
 pub use task_cache::{TaskArtifactCache, TaskCacheConfig, TaskCacheMode};
 pub use task_confirm::TaskConfirm;
 pub(crate) use task_load_context::monorepo_scope;
-pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax};
+pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax, is_workspace_project_task};
 pub use task_output::TaskOutput;
 pub use task_script_parser::{has_any_args_defined, has_any_usage_spec};
 pub use task_template::TaskTemplate;
@@ -2761,6 +2762,13 @@ where
     T: Eq + Hash,
 {
     fn get_matching(&self, pat: &str) -> Result<Vec<&T>> {
+        // Exact task identities and aliases take precedence over syntax-based
+        // pattern parsing. Workspace task IDs can contain both `:` and `/`
+        // (for example, `node:@scope/app#build`) without being monorepo paths.
+        if let Some(exact) = self.get(pat) {
+            return Ok(vec![exact]);
+        }
+
         // === Monorepo pattern matching ===
         // Only patterns starting with '//' or ':' are monorepo patterns
         // Reject patterns that look like monorepo paths but use wrong syntax (have / and : but don't start with // or :)

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2496,8 +2496,10 @@ where
 /// For example: parent "//projects/frontend:test" with pattern ":build" -> "//projects/frontend:build"
 pub(crate) fn resolve_task_pattern(pattern: &str, parent_task: Option<&Task>) -> String {
     // Check if this is a bare task name that should be treated as relative
-    let is_bare_name =
-        !pattern.starts_with("//") && !pattern.starts_with("::") && !pattern.starts_with(':');
+    let is_bare_name = !pattern.starts_with("//")
+        && !pattern.starts_with("::")
+        && !pattern.starts_with(':')
+        && !is_workspace_project_task(pattern);
     let parent_is_scoped = parent_task.is_some_and(|parent| {
         parent.name.starts_with("//") || is_workspace_project_task(&parent.name)
     });
@@ -3735,6 +3737,10 @@ echo "hello world"
         assert_eq!(
             resolve_task_pattern("lint", Some(&parent_task)),
             "node:@scope/app#lint"
+        );
+        assert_eq!(
+            resolve_task_pattern("node:@scope/other#test", Some(&parent_task)),
+            "node:@scope/other#test"
         );
 
         // Test 9: Pattern with wildcards

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -1,7 +1,8 @@
 use crate::config::{self, Config};
 use crate::file::display_path;
 use crate::task::{
-    GetMatchingExt, Task, TaskLoadContext, extract_monorepo_path, resolve_task_pattern,
+    GetMatchingExt, Task, TaskLoadContext, extract_monorepo_path, is_workspace_project_task,
+    resolve_task_pattern,
 };
 use crate::ui::ctrlc;
 use crate::ui::{prompt, style};
@@ -432,7 +433,11 @@ pub async fn get_task_lists(
         let monorepo_patterns: Vec<&str> = args
             .iter()
             .filter_map(|(t, _)| {
-                if t.starts_with("//") || t.contains("...") || t.starts_with(':') {
+                if t.starts_with("//")
+                    || t.contains("...")
+                    || t.starts_with(':')
+                    || is_workspace_project_task(t)
+                {
                     Some(t.as_str())
                 } else {
                     None

--- a/src/task/task_load_context.rs
+++ b/src/task/task_load_context.rs
@@ -14,6 +14,12 @@ pub(crate) fn monorepo_scope(monorepo_root: &Path, dir: &Path) -> Option<String>
     }
 }
 
+/// Whether a task uses the stable `<provider>:<project>#<task>` workspace identity.
+pub fn is_workspace_project_task(task: &str) -> bool {
+    task.split_once('#')
+        .is_some_and(|(project, name)| project.contains(':') && !name.is_empty())
+}
+
 /// Context for loading tasks with optional filtering hints
 #[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
 pub struct TaskLoadContext {
@@ -171,7 +177,7 @@ pub fn expand_colon_task_syntax(
     config: &crate::config::Config,
 ) -> eyre::Result<String> {
     // Skip expansion for absolute monorepo paths or explicit global tasks
-    if task.starts_with("//") || task.starts_with("::") {
+    if task.starts_with("//") || task.starts_with("::") || is_workspace_project_task(task) {
         return Ok(task.to_string());
     }
 

--- a/src/task/task_load_context.rs
+++ b/src/task/task_load_context.rs
@@ -16,8 +16,12 @@ pub(crate) fn monorepo_scope(monorepo_root: &Path, dir: &Path) -> Option<String>
 
 /// Whether a task uses the stable `<provider>:<project>#<task>` workspace identity.
 pub fn is_workspace_project_task(task: &str) -> bool {
-    task.split_once('#')
-        .is_some_and(|(project, name)| project.contains(':') && !name.is_empty())
+    task.split_once('#').is_some_and(|(project, name)| {
+        !project.starts_with('/')
+            && !project.starts_with(':')
+            && project.contains(':')
+            && !name.is_empty()
+    })
 }
 
 /// Context for loading tasks with optional filtering hints
@@ -250,6 +254,14 @@ mod tests {
             Some("//apps/api".to_string())
         );
         assert_eq!(monorepo_scope(root, Path::new("other")), None);
+    }
+
+    #[test]
+    fn test_is_workspace_project_task() {
+        assert!(is_workspace_project_task("node:@scope/app#build"));
+        assert!(!is_workspace_project_task("//packages/app:release#v2"));
+        assert!(!is_workspace_project_task(":release#v2"));
+        assert!(!is_workspace_project_task("::release#v2"));
     }
 
     #[test]

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -276,7 +276,11 @@ impl WorkspaceProjectGraph {
 
             let project = self.projects.get_mut(&id).expect("project was inserted");
             if let Some(root) = &config.root {
-                project.root = normalize_project_root(&id, root)?;
+                let root = normalize_project_root(&id, root)?;
+                if root != project.root {
+                    project.tasks.clear();
+                    project.root = root;
+                }
             }
             if let Some(metadata) = &config.metadata {
                 project.metadata.clone_from(metadata);
@@ -685,6 +689,14 @@ mod tests {
         let old_id = ProjectId::new("node", "old").unwrap();
         let mut app = project("node", "app", "apps/app");
         app.dependencies = BTreeSet::from([lib_id.clone(), old_id.clone()]);
+        app.tasks.insert(
+            "build".to_string(),
+            WorkspaceTask {
+                command: "npm run build --".to_string(),
+                description: "vite build".to_string(),
+                source: "apps/app/package.json".into(),
+            },
+        );
         let node = TestProvider {
             id: "node",
             projects: vec![
@@ -738,6 +750,7 @@ mod tests {
 
         assert!(graph.get(&lib_id).is_none());
         assert_eq!(app.root, Path::new("apps/web"));
+        assert!(app.tasks.is_empty());
         assert_eq!(
             app.metadata,
             BTreeMap::from([("kind".to_string(), "frontend".to_string())])

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -73,18 +73,33 @@ pub struct WorkspaceProject {
     pub metadata: BTreeMap<String, String>,
     /// Projects that this project directly depends on.
     pub dependencies: BTreeSet<ProjectId>,
+    /// Tasks inferred from ecosystem-specific project metadata.
+    #[serde(skip)]
+    pub tasks: BTreeMap<String, WorkspaceTask>,
 }
 
 impl WorkspaceProject {
-    /// Creates a project with no metadata or dependencies.
+    /// Creates a project with no metadata, dependencies, or inferred tasks.
     pub fn new(id: ProjectId, root: impl Into<PathBuf>) -> Self {
         Self {
             id,
             root: root.into(),
             metadata: BTreeMap::new(),
             dependencies: BTreeSet::new(),
+            tasks: BTreeMap::new(),
         }
     }
+}
+
+/// A provider-neutral task inferred for a workspace project.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceTask {
+    /// Command to execute in the project root.
+    pub command: String,
+    /// Human-readable description of the inferred task.
+    pub description: String,
+    /// File relative to the workspace root that supplied the task.
+    pub source: PathBuf,
 }
 
 /// Explicit changes applied after workspace providers discover their projects.

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -233,8 +233,16 @@ impl WorkspaceProjectGraph {
                 .projects
                 .get_mut(&id)
                 .expect("non-removed override project exists");
-            project.tasks =
-                provider.discover_project_tasks(workspace_root, project.root.as_path())?;
+            match provider.discover_project_tasks(workspace_root, project.root.as_path()) {
+                Ok(tasks) => project.tasks = tasks,
+                Err(error) => {
+                    warn!(
+                        "failed to infer workspace tasks for {id} at {}: {error:#}",
+                        project.root.display()
+                    );
+                    project.tasks.clear();
+                }
+            }
         }
         Ok(graph)
     }
@@ -550,6 +558,36 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct FailingTaskProvider;
+
+    impl WorkspaceProvider for FailingTaskProvider {
+        fn id(&self) -> &str {
+            "test"
+        }
+
+        fn discover(&self, _workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+            let mut project = WorkspaceProject::new(ProjectId::new("test", "app").unwrap(), "old");
+            project.tasks.insert(
+                "build".to_string(),
+                WorkspaceTask {
+                    command: "old build".to_string(),
+                    description: "old build".to_string(),
+                    source: "old/manifest".into(),
+                },
+            );
+            Ok(vec![project])
+        }
+
+        fn discover_project_tasks(
+            &self,
+            _workspace_root: &Path,
+            _project_root: &Path,
+        ) -> Result<BTreeMap<String, WorkspaceTask>> {
+            bail!("task discovery failed")
+        }
+    }
+
     fn project(provider: &str, name: &str, root: &str) -> WorkspaceProject {
         WorkspaceProject::new(ProjectId::new(provider, name).unwrap(), root)
     }
@@ -829,6 +867,28 @@ mod tests {
                 .dependencies,
             BTreeSet::from([ProjectId::new("node", "explicit").unwrap()])
         );
+    }
+
+    #[test]
+    fn override_task_inference_errors_are_isolated() {
+        let overrides = BTreeMap::from([(
+            "test:app".to_string(),
+            WorkspaceProjectOverride {
+                root: Some("new".into()),
+                ..Default::default()
+            },
+        )]);
+
+        let graph = WorkspaceProjectGraph::discover_all_with_overrides(
+            &[&FailingTaskProvider],
+            Path::new("/workspace"),
+            &overrides,
+        )
+        .unwrap();
+        let project = graph.get(&ProjectId::new("test", "app").unwrap()).unwrap();
+
+        assert_eq!(project.root, Path::new("new"));
+        assert!(project.tasks.is_empty());
     }
 
     #[test]

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -130,6 +130,15 @@ pub trait WorkspaceProvider: Debug + Send + Sync {
     /// The returned order is ignored. Project IDs, metadata, and dependency
     /// sets determine the canonical graph order instead.
     fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>>;
+
+    /// Re-discovers location-derived tasks after an explicit root override.
+    fn discover_project_tasks(
+        &self,
+        _workspace_root: &Path,
+        _project_root: &Path,
+    ) -> Result<BTreeMap<String, WorkspaceTask>> {
+        Ok(BTreeMap::new())
+    }
 }
 
 /// A validated, deterministically ordered project graph from workspace providers.
@@ -204,7 +213,30 @@ impl WorkspaceProjectGraph {
         workspace_root: &Path,
         overrides: &BTreeMap<String, WorkspaceProjectOverride>,
     ) -> Result<WorkspaceProjectGraph> {
-        Self::collect_provider_projects(providers, workspace_root)?.with_overrides(overrides)
+        let mut graph = Self::collect_provider_projects(providers, workspace_root)?
+            .with_overrides(overrides)?;
+        for (raw_id, config) in overrides {
+            if config.remove || config.root.is_none() {
+                continue;
+            }
+            let id = raw_id.parse::<ProjectId>()?;
+            let Some((provider_id, _)) = id.as_str().split_once(':') else {
+                continue;
+            };
+            let Some(provider) = providers
+                .iter()
+                .find(|provider| provider.id() == provider_id)
+            else {
+                continue;
+            };
+            let project = graph
+                .projects
+                .get_mut(&id)
+                .expect("non-removed override project exists");
+            project.tasks =
+                provider.discover_project_tasks(workspace_root, project.root.as_path())?;
+        }
+        Ok(graph)
     }
 
     fn collect_provider_projects(

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -137,7 +137,13 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
             return Ok(BTreeMap::new());
         };
         let source = project_root.join(PACKAGE_JSON);
-        let manifest = read_package_json(&workspace_root.join(&source))?;
+        let manifest_path = workspace_root.join(&source);
+        if !manifest_path.is_file() {
+            return Ok(BTreeMap::new());
+        }
+        let Some(manifest) = read_package_json_if_valid(&manifest_path)? else {
+            return Ok(BTreeMap::new());
+        };
         let package_manager = definition.package_manager.as_deref().unwrap_or("npm");
         Ok(workspace_tasks(&manifest, package_manager, &source))
     }
@@ -352,6 +358,52 @@ mod tests {
                 description: "new command".to_string(),
                 source: PathBuf::from("overrides/app/package.json"),
             })
+        );
+    }
+
+    #[test]
+    fn root_overrides_without_valid_manifests_have_no_scripts() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"workspaces":["packages/*"]}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"app","scripts":{"old":"old command"}}"#,
+        );
+        let overrides = BTreeMap::from([(
+            "node:app".to_string(),
+            super::super::WorkspaceProjectOverride {
+                root: Some("overrides/app".into()),
+                ..Default::default()
+            },
+        )]);
+
+        let discover = || {
+            super::super::WorkspaceProjectGraph::discover_all_with_overrides(
+                &[&NodeWorkspaceProvider],
+                temp.path(),
+                &overrides,
+            )
+            .unwrap()
+        };
+
+        assert!(
+            discover()
+                .get(&ProjectId::new("node", "app").unwrap())
+                .unwrap()
+                .tasks
+                .is_empty()
+        );
+
+        write(&temp.path().join("overrides/app/package.json"), "{");
+        assert!(
+            discover()
+                .get(&ProjectId::new("node", "app").unwrap())
+                .unwrap()
+                .tasks
+                .is_empty()
         );
     }
 

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -122,25 +122,47 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
                         .insert("package_manager".to_string(), package_manager.clone());
                 }
                 let package_manager = definition.package_manager.as_deref().unwrap_or("npm");
-                project.tasks = manifest
-                    .scripts
-                    .into_iter()
-                    .map(|(name, script)| {
-                        let command = shell_words::join([package_manager, "run", &name, "--"]);
-                        (
-                            name,
-                            WorkspaceTask {
-                                command,
-                                description: script,
-                                source: source.clone(),
-                            },
-                        )
-                    })
-                    .collect();
+                project.tasks = workspace_tasks(&manifest, package_manager, &source);
                 Ok(project)
             })
             .collect()
     }
+
+    fn discover_project_tasks(
+        &self,
+        workspace_root: &Path,
+        project_root: &Path,
+    ) -> Result<BTreeMap<String, WorkspaceTask>> {
+        let Some(definition) = workspace_definition(workspace_root)? else {
+            return Ok(BTreeMap::new());
+        };
+        let source = project_root.join(PACKAGE_JSON);
+        let manifest = read_package_json(&workspace_root.join(&source))?;
+        let package_manager = definition.package_manager.as_deref().unwrap_or("npm");
+        Ok(workspace_tasks(&manifest, package_manager, &source))
+    }
+}
+
+fn workspace_tasks(
+    manifest: &PackageJson,
+    package_manager: &str,
+    source: &Path,
+) -> BTreeMap<String, WorkspaceTask> {
+    manifest
+        .scripts
+        .iter()
+        .map(|(name, script)| {
+            let command = shell_words::join([package_manager, "run", name, "--"]);
+            (
+                name.clone(),
+                WorkspaceTask {
+                    command,
+                    description: script.clone(),
+                    source: source.to_path_buf(),
+                },
+            )
+        })
+        .collect()
 }
 
 fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinition>> {
@@ -287,6 +309,49 @@ mod tests {
                 .get("test:unit")
                 .map(|task| task.command.as_str()),
             Some("pnpm run test:unit --")
+        );
+    }
+
+    #[test]
+    fn root_overrides_reload_package_scripts() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"packageManager":"pnpm@10.0.0","workspaces":["packages/*"]}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"app","scripts":{"old":"old command"}}"#,
+        );
+        write(
+            &temp.path().join("overrides/app/package.json"),
+            r#"{"name":"app","scripts":{"new":"new command"}}"#,
+        );
+        let overrides = BTreeMap::from([(
+            "node:app".to_string(),
+            super::super::WorkspaceProjectOverride {
+                root: Some("overrides/app".into()),
+                ..Default::default()
+            },
+        )]);
+
+        let graph = super::super::WorkspaceProjectGraph::discover_all_with_overrides(
+            &[&NodeWorkspaceProvider],
+            temp.path(),
+            &overrides,
+        )
+        .unwrap();
+        let project = graph.get(&ProjectId::new("node", "app").unwrap()).unwrap();
+
+        assert_eq!(project.root, Path::new("overrides/app"));
+        assert!(!project.tasks.contains_key("old"));
+        assert_eq!(
+            project.tasks.get("new"),
+            Some(&WorkspaceTask {
+                command: "pnpm run new --".to_string(),
+                description: "new command".to_string(),
+                source: PathBuf::from("overrides/app/package.json"),
+            })
         );
     }
 

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -126,7 +126,7 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
                     .scripts
                     .into_iter()
                     .map(|(name, script)| {
-                        let command = shell_words::join([package_manager, "run", &name]);
+                        let command = shell_words::join([package_manager, "run", &name, "--"]);
                         (
                             name,
                             WorkspaceTask {
@@ -276,7 +276,7 @@ mod tests {
         assert_eq!(
             project.tasks.get("build"),
             Some(&WorkspaceTask {
-                command: "pnpm run build".to_string(),
+                command: "pnpm run build --".to_string(),
                 description: "vite build".to_string(),
                 source: PathBuf::from("packages/app/package.json"),
             })
@@ -286,7 +286,7 @@ mod tests {
                 .tasks
                 .get("test:unit")
                 .map(|task| task.command.as_str()),
-            Some("pnpm run test:unit")
+            Some("pnpm run test:unit --")
         );
     }
 

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use aube::embed::{ManifestError, PackageJson, WorkspaceDiscoveryOptions};
 use eyre::{Context, Result};
 
-use super::{ProjectId, WorkspaceProject, WorkspaceProvider};
+use super::{ProjectId, WorkspaceProject, WorkspaceProvider, WorkspaceTask};
 
 const PACKAGE_JSON: &str = "package.json";
 const PNPM_WORKSPACE: &str = "pnpm-workspace.yaml";
@@ -109,6 +109,7 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
                     .filter_map(|name| project_ids.get(name).cloned())
                     .filter(|dependency| dependency != &id)
                     .collect();
+                let source = root.join(PACKAGE_JSON);
                 let mut project = WorkspaceProject::new(id, root);
                 project.dependencies = dependencies;
                 project.metadata.insert(
@@ -120,6 +121,22 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
                         .metadata
                         .insert("package_manager".to_string(), package_manager.clone());
                 }
+                let package_manager = definition.package_manager.as_deref().unwrap_or("npm");
+                project.tasks = manifest
+                    .scripts
+                    .into_iter()
+                    .map(|(name, script)| {
+                        let command = shell_words::join([package_manager, "run", &name]);
+                        (
+                            name,
+                            WorkspaceTask {
+                                command,
+                                description: script,
+                                source: source.clone(),
+                            },
+                        )
+                    })
+                    .collect();
                 Ok(project)
             })
             .collect()
@@ -239,6 +256,38 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    #[test]
+    fn infers_package_scripts_as_workspace_tasks() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"packageManager":"pnpm@10.0.0","workspaces":["packages/*"]}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"@scope/app","scripts":{"build":"vite build","test:unit":"vitest"}}"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+        let project = &projects[0];
+
+        assert_eq!(
+            project.tasks.get("build"),
+            Some(&WorkspaceTask {
+                command: "pnpm run build".to_string(),
+                description: "vite build".to_string(),
+                source: PathBuf::from("packages/app/package.json"),
+            })
+        );
+        assert_eq!(
+            project
+                .tasks
+                .get("test:unit")
+                .map(|task| task.command.as_str()),
+            Some("pnpm run test:unit")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add provider-neutral inferred task records to workspace projects
- import Node package scripts as stable node:<package>#<script> tasks with native monorepo path aliases
- run scripts in their package roots through the detected package manager with raw argument pass-through
- let explicit project tasks replace inferred scripts while preserving both task names
- document the experimental behavior and update the parity tracker

## Tests
- cargo test task::workspace::node::tests
- cargo test task::task_load_context::tests
- mise run test:e2e tasks/test_task_node_workspace_scripts
- mise run lint

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task discovery, naming, and resolution for monorepos behind an experimental flag; incorrect precedence or pattern handling could affect which task runs.
> 
> **Overview**
> **Experimental** Node workspace packages can expose `package.json` scripts as mise tasks without a per-package `mise.toml`, using stable IDs like `node:@scope/app#build` and monorepo path aliases such as `//packages/app:build`.
> 
> The Node workspace provider maps each script to a `pnpm|npm|yarn|bun run <script> --` command in the package root with **raw argument passthrough**; `mise task info`, task listing, and pattern matching treat these IDs distinctly from `//` monorepo paths. **Explicit** tasks at the package path win while keeping both names linked as aliases.
> 
> Task loading merges inferred tasks when `experimental` is on, with override roots re-inferring scripts from the new `package.json`. Docs and the parity tracker are updated; e2e covers discovery, execution, aliases, overrides, and disabling experimental mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7bc57d92b08298d3a6d0d320201f2bb1439b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node workspace packages now expose `package.json` scripts as executable mise tasks without requiring per-package `mise.toml`.
  * Stable task naming supports monorepo-path aliases, argument passthrough, and correct precedence when explicit package tasks exist.
  * Enabled via the experimental workspace task inference setting.
* **Documentation**
  * Documented Node Package Scripts behavior in the experimental workspace project graph.
  * Updated the task cache parity checklist.
* **Bug Fixes**
  * Improved `mise task info` resolution for workspace project tasks.
* **Tests**
  * Added end-to-end coverage for discovery, execution, aliases, passthrough, overrides, and experimental disable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->