### PR TITLE
fix(activate): support zsh POSIX_IDENTIFIERS

### DIFF
--- a/e2e/env/test_zsh_consecutive_precmd_runs
+++ b/e2e/env/test_zsh_consecutive_precmd_runs
@@ -7,6 +7,9 @@ set -eu
 # variables change. Stub _mise_hook after activation so invocation detection is
 # independent of hook-env's output and early-exit behavior.
 
+# POSIX_IDENTIFIERS changes how zsh parses $#array in arithmetic expressions.
+setopt POSIX_IDENTIFIERS
+
 eval "$(mise activate zsh --status)"
 
 mise_hook_calls=0

--- a/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__zsh__tests__activate.snap
@@ -40,7 +40,7 @@ _mise_hook_env_state() {
   # zsh/parameter module via dlopen, which can deadlock under
   # Rosetta in login shells (https://github.com/jdx/mise/discussions/11187)
   local -a keys=(${(o)${(f)"$(typeset +m 'MISE_*' 2>/dev/null)"}##* })
-  if (( $#keys > 0 )); then
+  if (( ${#keys} > 0 )); then
     typeset -p "${keys[@]}" 2>/dev/null
   fi
 }

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -71,7 +71,7 @@ impl Shell for Zsh {
               # zsh/parameter module via dlopen, which can deadlock under
               # Rosetta in login shells (https://github.com/jdx/mise/discussions/11187)
               local -a keys=(${{(o)${{(f)"$(typeset +m 'MISE_*' 2>/dev/null)"}}##* }})
-              if (( $#keys > 0 )); then
+              if (( ${{#keys}} > 0 )); then
                 typeset -p "${{keys[@]}}" 2>/dev/null
               fi
             }}


### PR DESCRIPTION
## Summary
- use the braced zsh array-length expansion in the activation hook state check
- exercise zsh activation with `POSIX_IDENTIFIERS` enabled
- update the generated activation snapshot

## Root cause

With `POSIX_IDENTIFIERS` enabled, zsh parses `$#keys` in an arithmetic expression as the positional-parameter count followed by the bare token `keys`. This prints a `bad math expression` error and prevents `_mise_hook_env_state` from capturing `MISE_*` changes.

`${#keys}` is unambiguous under both the default zsh options and `POSIX_IDENTIFIERS`.

Reported in https://github.com/jdx/mise/discussions/11452#discussioncomment-17824170.

## Testing
- `mise run test:e2e e2e/env/test_zsh_consecutive_precmd_runs`
- `mise run format`
- `cargo test --all-features shell::zsh::tests::test_activate -- --exact`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to zsh hook string generation plus test/snapshot updates; no auth, data, or core runtime logic changes.
> 
> **Overview**
> Fixes zsh activation when **`POSIX_IDENTIFIERS`** is enabled by changing the `_mise_hook_env_state` empty-array check from `$#keys` to **`${#keys}`** in generated hook code. Under that option, `$#keys` in arithmetic is parsed as positional count plus `keys`, which triggers **bad math expression** and breaks capturing `MISE_*` state for precmd skip logic.
> 
> The zsh activation snapshot is updated to match. The consecutive-precmd e2e script now runs with **`setopt POSIX_IDENTIFIERS`** so this parsing mode is covered in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23863e7b14237759fd424780e0e7b27cbf9124ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zsh environment activation so `MISE_*` variables are correctly detected and exported.
  * Improved compatibility with Zsh array-length parsing and consecutive `precmd` hook execution.

* **Tests**
  * Updated Zsh integration coverage to validate the corrected parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->