### PR TITLE
fix(lockfile): avoid config root scans during shim resolution

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -485,28 +485,19 @@ impl Config {
             return None;
         }
         let monorepo_root = cf.project_root().map(|p| p.to_path_buf())?;
+
+        // An explicit opt-in always routes descendant configs to the root
+        // lockfile, even when config_roots cannot be resolved. Avoid expanding
+        // config_roots here because this method is called for every tool during
+        // lockfile resolution, including on every shim invocation. Commands
+        // that migrate legacy lockfiles validate config_roots separately.
+        if setting == Some(true) {
+            return Some(monorepo_root);
+        }
+
         match self.monorepo_config_root_dirs(None) {
             Ok(config_roots) if !config_roots.is_empty() => Some(monorepo_root),
-            Ok(_) => {
-                if setting == Some(true) {
-                    warn_once!(
-                        "[monorepo] lockfile = true is set, but [monorepo].config_roots did not match any directories; using root lockfiles without migration"
-                    );
-                    Some(monorepo_root)
-                } else {
-                    None
-                }
-            }
-            Err(err) => {
-                if setting == Some(true) {
-                    warn_once!(
-                        "[monorepo] lockfile = true is set, but [monorepo].config_roots could not be resolved: {err:#}; using root lockfiles without migration"
-                    );
-                    Some(monorepo_root)
-                } else {
-                    None
-                }
-            }
+            Ok(_) | Err(_) => None,
         }
     }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1553,8 +1553,14 @@ fn monorepo_legacy_lockfile_paths(config: &Config) -> IndexSet<PathBuf> {
     let Some(monorepo_root) = config.monorepo_lockfile_root() else {
         return IndexSet::new();
     };
-    let Ok(config_roots) = config.monorepo_config_root_dirs_for_lockfiles() else {
-        return IndexSet::new();
+    let config_roots = match config.monorepo_config_root_dirs_for_lockfiles() {
+        Ok(config_roots) => config_roots,
+        Err(err) => {
+            warn_once!(
+                "[monorepo] lockfile = true is set, but [monorepo].config_roots could not be resolved: {err:#}; using root lockfiles without migration"
+            );
+            return IndexSet::new();
+        }
     };
     let mut source_lockfiles = IndexSet::new();
 
@@ -1568,9 +1574,7 @@ fn monorepo_legacy_lockfile_paths(config: &Config) -> IndexSet<PathBuf> {
             }
         }
         for config_path in crate::config::config_paths_in_dir(&config_root) {
-            if let Some(source) =
-                legacy_lockfile_path_for_config(config, &config_path, &monorepo_root)
-            {
+            if let Some(source) = legacy_lockfile_path_for_config(&config_path, &monorepo_root) {
                 source_lockfiles.insert(source);
             }
         }
@@ -1595,12 +1599,8 @@ pub(crate) fn lockfile_variant_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
     paths.into_iter().collect()
 }
 
-fn legacy_lockfile_path_for_config(
-    config: &Config,
-    config_path: &Path,
-    monorepo_root: &Path,
-) -> Option<PathBuf> {
-    if !config_path.starts_with(monorepo_root) || config.monorepo_lockfile_root().is_none() {
+fn legacy_lockfile_path_for_config(config_path: &Path, monorepo_root: &Path) -> Option<PathBuf> {
+    if !config_path.starts_with(monorepo_root) {
         return None;
     }
     let (source, _) = lockfile_path_for_config(config_path, None);
@@ -3001,7 +3001,7 @@ fn read_lockfile_for(config: &Config, path: &Path) -> Arc<Lockfile> {
     let (lockfile_path, _is_local) = lockfile_path_for_config(path, monorepo_root.as_deref());
     let legacy_path = monorepo_root
         .as_deref()
-        .and_then(|root| legacy_lockfile_path_for_config(config, path, root));
+        .and_then(|root| legacy_lockfile_path_for_config(path, root));
 
     read_lockfile_at(lockfile_path, legacy_path)
 }


### PR DESCRIPTION
## Summary

- return the monorepo lockfile root immediately for an explicit `[monorepo] lockfile = true` opt-in
- validate `config_roots` only when legacy subproject lockfiles actually need to be discovered or migrated
- remove a redundant monorepo lockfile root lookup from per-config lockfile resolution

## Root cause

`Config::monorepo_lockfile_root()` expanded every `[monorepo].config_roots` pattern each time it was called. Lockfile resolution calls this method repeatedly while resolving configured tools, and every shim invocation starts a fresh mise process, so unified monorepo lockfiles multiplied filesystem traversal work across tools.

An explicit `lockfile = true` already routed configs to the root lockfile when `config_roots` could not be resolved. The scans therefore did not affect routing; they only produced migration validation that belongs on commands which discover legacy lockfiles.

This addresses the slowdown reported in https://github.com/jdx/mise/discussions/11456.

## Impact

Shim resolution with explicitly enabled unified monorepo lockfiles no longer expands all configured monorepo roots once or twice per tool. Install, lock, and upgrade flows continue to validate roots when performing legacy lockfile migration, including the existing warning for invalid roots.

## Validation

- `mise run format` (includes `cargo check --all-features`)
- `mise run test:e2e e2e/lockfile/test_lockfile_monorepo`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior on a frequently called lockfile hot path, but routing for explicit `lockfile = true` is preserved and validation moves to migration-only code.
> 
> **Overview**
> **Shim and per-tool lockfile resolution** no longer walks `[monorepo].config_roots` on every call to `Config::monorepo_lockfile_root()`. With an explicit **`[monorepo] lockfile = true`**, the monorepo project root is returned immediately so descendant configs still use the unified root lockfile even when `config_roots` cannot be resolved.
> 
> For other lockfile modes, that helper now only returns a root when `config_roots` expands to at least one directory; empty or failed expansion yields `None` here instead of running scans (and warnings) on the hot path.
> 
> **Legacy subproject lockfile discovery** (`monorepo_legacy_lockfile_paths`) is where `config_roots` are resolved and validated now. Failed resolution still emits the existing `warn_once` about using root lockfiles without migration, but only when migration actually needs those roots. `legacy_lockfile_path_for_config` drops a redundant `monorepo_lockfile_root()` check per config path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5316b9011c807da132dd9bdaa82d97d3dd8f8795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monorepo lockfile handling when lockfile configuration is explicitly enabled.
  * Prevented warnings and incorrect lockfile resolution when configuration roots are missing or cannot be resolved.
  * Improved fallback behavior when legacy lockfile paths cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->