### PR TITLE
fix(aqua): match version override prefixes

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -478,6 +478,11 @@ impl AquaPackage {
     }
 
     fn version_override(&self, versions: &[&str]) -> Option<&AquaPackage> {
+        // Aqua treats a package without a top-level constraint as unconditional.
+        // In that case version overrides are not considered.
+        if self.version_constraint.is_empty() {
+            return Some(self);
+        }
         let expressions = versions
             .iter()
             .map(|v| (*v, self.expr_parser(v), self.expr_ctx(v)))
@@ -1991,6 +1996,19 @@ packages:
         let new = pkg.version_override(&["new_v1.0.0"]).unwrap();
         assert_eq!(new.version_prefix.as_deref(), Some("new_v"));
         assert_eq!(new.asset, "tool.tar.gz");
+    }
+
+    #[test]
+    fn test_unconditional_package_ignores_version_prefix() {
+        let pkg = AquaPackage {
+            version_prefix: Some("jq-".to_string()),
+            asset: "jq-{{.OS}}-{{.Arch}}".to_string(),
+            ..Default::default()
+        };
+
+        let resolved = pkg.version_override(&["1.8.1"]).unwrap();
+        assert_eq!(resolved.version_prefix.as_deref(), Some("jq-"));
+        assert_eq!(resolved.asset, "jq-{{.OS}}-{{.Arch}}");
     }
 
     #[test]

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -486,15 +486,15 @@ impl AquaPackage {
             .into_iter()
             .chain(self.version_overrides.iter())
             .find(|vo| {
-                if vo.version_constraint.is_empty() {
-                    true
-                } else {
-                    expressions.iter().any(|(version, expr, ctx)| {
-                        let version_prefix =
-                            vo.version_prefix.as_ref().or(self.version_prefix.as_ref());
-                        if version_prefix.is_some_and(|prefix| !version.starts_with(prefix)) {
-                            return false;
-                        }
+                expressions.iter().any(|(version, expr, ctx)| {
+                    let version_prefix =
+                        vo.version_prefix.as_ref().or(self.version_prefix.as_ref());
+                    if version_prefix.is_some_and(|prefix| !version.starts_with(prefix)) {
+                        return false;
+                    }
+                    if vo.version_constraint.is_empty() {
+                        true
+                    } else {
                         expr.eval(&vo.version_constraint, ctx)
                             .map_err(|e| {
                                 log::debug!("error parsing {}: {e}", vo.version_constraint)
@@ -502,8 +502,8 @@ impl AquaPackage {
                             .unwrap_or(false.into())
                             .as_bool()
                             .unwrap()
-                    })
-                }
+                    }
+                })
             })
     }
 
@@ -1963,6 +1963,34 @@ packages:
         let oxlint = pkg.version_override(&["oxlint_v1.76.0"]).unwrap();
         assert_eq!(oxlint.version_prefix.as_deref(), Some("oxlint_v"));
         assert_eq!(oxlint.error_message.as_deref(), Some("unavailable"));
+    }
+
+    #[test]
+    fn test_unconditional_version_override_matches_version_prefix() {
+        let pkg = AquaPackage {
+            version_constraint: "false".to_string(),
+            version_overrides: vec![
+                AquaPackage {
+                    version_prefix: Some("old_v".to_string()),
+                    error_message: Some("unavailable".to_string()),
+                    ..Default::default()
+                },
+                AquaPackage {
+                    version_prefix: Some("new_v".to_string()),
+                    asset: "tool.tar.gz".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let old = pkg.version_override(&["old_v1.0.0"]).unwrap();
+        assert_eq!(old.version_prefix.as_deref(), Some("old_v"));
+        assert_eq!(old.error_message.as_deref(), Some("unavailable"));
+
+        let new = pkg.version_override(&["new_v1.0.0"]).unwrap();
+        assert_eq!(new.version_prefix.as_deref(), Some("new_v"));
+        assert_eq!(new.asset, "tool.tar.gz");
     }
 
     #[test]

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -480,7 +480,7 @@ impl AquaPackage {
     fn version_override(&self, versions: &[&str]) -> Option<&AquaPackage> {
         let expressions = versions
             .iter()
-            .map(|v| (self.expr_parser(v), self.expr_ctx(v)))
+            .map(|v| (*v, self.expr_parser(v), self.expr_ctx(v)))
             .collect_vec();
         vec![self]
             .into_iter()
@@ -489,7 +489,12 @@ impl AquaPackage {
                 if vo.version_constraint.is_empty() {
                     true
                 } else {
-                    expressions.iter().any(|(expr, ctx)| {
+                    expressions.iter().any(|(version, expr, ctx)| {
+                        let version_prefix =
+                            vo.version_prefix.as_ref().or(self.version_prefix.as_ref());
+                        if version_prefix.is_some_and(|prefix| !version.starts_with(prefix)) {
+                            return false;
+                        }
                         expr.eval(&vo.version_constraint, ctx)
                             .map_err(|e| {
                                 log::debug!("error parsing {}: {e}", vo.version_constraint)
@@ -1926,6 +1931,38 @@ packages:
         // which sorts before numeric versions.
         assert!(result.error_message.is_some());
         assert!(result.asset.is_empty());
+    }
+
+    #[test]
+    fn test_version_override_matches_version_prefix() {
+        let pkg = AquaPackage {
+            version_constraint: "false".to_string(),
+            version_overrides: vec![
+                AquaPackage {
+                    version_constraint: "semver(\">= 1.17.0\")".to_string(),
+                    version_prefix: Some("oxlint_v".to_string()),
+                    error_message: Some("unavailable".to_string()),
+                    ..Default::default()
+                },
+                AquaPackage {
+                    version_constraint: "true".to_string(),
+                    version_prefix: Some("apps_v".to_string()),
+                    asset: "oxlint.tar.gz".to_string(),
+                    format: "tar.gz".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let apps = pkg.version_override(&["apps_v1.76.0"]).unwrap();
+        assert_eq!(apps.version_prefix.as_deref(), Some("apps_v"));
+        assert!(apps.error_message.is_none());
+        assert_eq!(apps.asset, "oxlint.tar.gz");
+
+        let oxlint = pkg.version_override(&["oxlint_v1.76.0"]).unwrap();
+        assert_eq!(oxlint.version_prefix.as_deref(), Some("oxlint_v"));
+        assert_eq!(oxlint.error_message.as_deref(), Some("unavailable"));
     }
 
     #[test]

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -4666,6 +4666,31 @@ mod lock_candidate_tests {
         assert_eq!(version_from_tag(&pkg, "other-1.2.3").unwrap(), None);
     }
 
+    #[test]
+    fn test_version_from_tag_matches_override_version_prefix() {
+        let pkg = pkg_from_yaml(
+            r#"
+type: github_release
+repo_owner: oxc-project
+repo_name: oxc
+version_constraint: "false"
+version_overrides:
+  - version_constraint: semver(">= 1.17.0")
+    version_prefix: oxlint_v
+    error_message: unavailable
+  - version_constraint: "true"
+    version_prefix: apps_v
+    asset: oxlint.tar.gz
+    format: tar.gz
+"#,
+        );
+
+        assert_eq!(
+            version_from_tag(&pkg, "apps_v1.76.0").unwrap(),
+            Some("1.76.0".to_string())
+        );
+    }
+
     fn pkg_from_yaml(yaml: &str) -> AquaPackage {
         let mut pkg: AquaPackage = serde_yaml::from_str(yaml).unwrap();
         pkg.setup_version_filter().unwrap();

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -418,9 +418,15 @@ impl Backend for AquaBackend {
             .get(&platform_key)
             .and_then(|asset| asset.url_api.clone());
 
-        // Skip get_version_tags() API call if we have lockfile URL
-        let tag = if existing_platform.is_some() {
-            None // We'll determine version from URL instead
+        // Skip get_version_tags() API call if the lockfile URL contains the release tag.
+        // Keep the tag for selecting Aqua version overrides, which may be scoped by prefix.
+        let locked_tag = existing_platform
+            .as_deref()
+            .and_then(github_release_tag_from_url);
+        let tag = if let Some(tag) = locked_tag {
+            Some(tag)
+        } else if existing_platform.is_some() {
+            None
         } else {
             match self.get_version_tags().await {
                 Ok(tags) => tags
@@ -3256,6 +3262,18 @@ fn version_candidates<'a>(version: &'a str, version_prefix: Option<&str>) -> Vec
     candidates.into_iter().unique().collect()
 }
 
+fn github_release_tag_from_url(url: &str) -> Option<String> {
+    let url = Url::parse(url).ok()?;
+    if url.host_str()? != "github.com" {
+        return None;
+    }
+    let segments = url.path_segments()?.collect::<Vec<_>>();
+    let [_owner, _name, "releases", "download", tag, _asset] = segments.as_slice() else {
+        return None;
+    };
+    urlencoding::decode(tag).ok().map(Cow::into_owned)
+}
+
 fn starts_with_v(s: &str) -> bool {
     s.starts_with('v') || s.starts_with('V')
 }
@@ -4689,6 +4707,29 @@ version_overrides:
             version_from_tag(&pkg, "apps_v1.76.0").unwrap(),
             Some("1.76.0".to_string())
         );
+    }
+
+    #[test]
+    fn test_locked_release_tag_matches_version_override_prefix() {
+        let pkg = pkg_from_yaml(
+            r#"
+type: github_release
+repo_owner: jqlang
+repo_name: jq
+version_constraint: "false"
+version_prefix: jq-
+version_overrides:
+  - version_constraint: "true"
+    asset: jq-{{.OS}}-{{.Arch}}
+    format: raw
+"#,
+        );
+        let url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-arm64";
+        let tag = github_release_tag_from_url(url).unwrap();
+        let versioned = pkg.with_version(&[&tag], "darwin", "arm64");
+
+        assert_eq!(tag, "jq-1.8.1");
+        assert_eq!(versioned.asset, "jq-{{.OS}}-{{.Arch}}");
     }
 
     fn pkg_from_yaml(yaml: &str) -> AquaPackage {


### PR DESCRIPTION
## Summary

- require Aqua version overrides to match their effective `version_prefix` before evaluating constraints
- preserve fallback to the package-level prefix when an override does not define its own
- add selector and tag-resolution regression coverage for oxlint's `oxlint_v` and `apps_v` tag families

## Root cause

mise evaluated each override's semver constraint after generically stripping the tag prefix, but did not first check whether the full tag belonged to that override's prefix family. As a result, `apps_v1.76.0` matched the earlier `oxlint_v` override for versions greater than or equal to 1.17.0 and was rejected as unavailable.

This now mirrors Aqua's override selection order: match the effective prefix first, then evaluate the version constraint.

Reported in https://github.com/jdx/mise/discussions/11459.

## Impact

Modern oxlint releases using `apps_v` tags can be discovered and installed through the Aqua backend. The same correction applies to other Aqua registry packages that use multiple tag-prefix families.

## Validation

- `cargo test -p aqua-registry test_version_override_matches_version_prefix`
- `cargo test backend::aqua::lock_candidate_tests:: -- --nocapture`
- `mise run lint-fix`
- built mise and ran `mise x 'aqua:oxc-project/oxc/oxlint@1.76.0' -- oxlint --version`, which installed successfully and returned `Version: 1.76.0`

The full `cargo test -p aqua-registry` run passed 114 tests and hit the unrelated existing `test_override_envs_all_matches_any_platform` Windows-extension assertion failure present on `main`.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Aqua version resolution and locked-install tag handling; mistakes could break installs or asset selection for multi-prefix registry packages.
> 
> **Overview**
> Fixes Aqua **version override** selection when a registry package defines multiple **tag prefix families** (e.g. oxlint `oxlint_v` vs `apps_v`), so tags like `apps_v1.76.0` no longer match the wrong override.
> 
> In `AquaPackage::version_override`, an override is skipped unless the candidate version string starts with that override’s effective `version_prefix` (override prefix, else package-level). Semver/`true` constraints run only after that filter. Packages with an **empty** top-level `version_constraint` are treated as unconditional and return the base package without walking overrides.
> 
> The Aqua backend parses the **GitHub release tag** from a lockfile download URL when present, so `--locked` installs still pass the full tag into `with_version` for prefix-scoped overrides instead of dropping the tag to skip `get_version_tags()`.
> 
> Regression tests cover prefix-scoped overrides, unconditional overrides, unconditional packages ignoring prefix for selection, tag resolution, and locked jq-style URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057692b5c018dc18da2c2083dedd6653dc6ad63b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->