### PR TITLE
feat(config): allow disabling individual idiomatic version files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -455,6 +455,13 @@ In mise, these are disabled by default, see <https://github.com/jdx/mise/discuss
 
 - `mise settings add idiomatic_version_file_enable_tools python` for a specific tool such as Python ([docs](/configuration/settings.html#idiomatic_version_file_enable_tools))
 
+Individual files can be disabled for a tool with a `tool:filename` pair. For example, to use
+`.nvmrc` for node while leaving `package.json` available to package managers:
+
+```sh
+mise settings add idiomatic_version_file_disable_files node:package.json
+```
+
 There is a small performance cost to discovering and parsing these files. Registry parsers run
 in-process; plugin-provided files may invoke the plugin's parser. Results are [cached](/cache-behavior),
 so this is generally not noticeable.

--- a/docs/lang/node.md
+++ b/docs/lang/node.md
@@ -86,6 +86,13 @@ Or in `~/.config/mise/config.toml`:
 idiomatic_version_file_enable_tools = ["node"]
 ```
 
+To keep `.nvmrc` or `.node-version` enabled while preventing node from using
+`devEngines.runtime` in `package.json`:
+
+```sh
+mise settings add idiomatic_version_file_disable_files node:package.json
+```
+
 :::
 
 ## Default node packages

--- a/e2e/core/test_package_json
+++ b/e2e/core/test_package_json
@@ -53,3 +53,24 @@ EOF
 
 # Should not error, just no version detected
 assert "mise current node" ""
+
+# Test package.json can be disabled for node without disabling .nvmrc or pnpm
+mise settings set idiomatic_version_file_disable_files "node:package.json"
+echo "20.0.0" >.nvmrc
+cat >package.json <<'EOF'
+{
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    },
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.0.0"
+    }
+  }
+}
+EOF
+
+assert "mise current node" "20.0.0"
+assert "mise current pnpm" "10.0.0"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1106,19 +1106,19 @@
           "type": "boolean",
           "deprecated": true
         },
+        "idiomatic_version_file_disable_files": {
+          "default": [],
+          "description": "Specific idiomatic version files to disable for a tool.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "idiomatic_version_file_disable_tools": {
           "default": [],
           "description": "Specific tools to disable idiomatic version files for.",
           "type": "array",
           "deprecated": true,
-          "items": {
-            "type": "string"
-          }
-        },
-        "idiomatic_version_file_disable_files": {
-          "default": [],
-          "description": "Specific idiomatic version files to disable for a tool.",
-          "type": "array",
           "items": {
             "type": "string"
           }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1115,6 +1115,14 @@
             "type": "string"
           }
         },
+        "idiomatic_version_file_disable_files": {
+          "default": [],
+          "description": "Specific idiomatic version files to disable for a tool.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "idiomatic_version_file_enable_tools": {
           "default": [],
           "description": "Specific tools to enable idiomatic version files for like .node-version, .ruby-version, etc.",

--- a/settings.toml
+++ b/settings.toml
@@ -1247,16 +1247,6 @@ hide = true
 optional = true
 type = "Bool"
 
-[idiomatic_version_file_disable_tools]
-default = []
-deprecated = "This has been replaced with the idiomatic_version_file_enable_tools setting."
-description = "Specific tools to disable idiomatic version files for."
-env = "MISE_IDIOMATIC_VERSION_FILE_DISABLE_TOOLS"
-hide = true
-parse_env = "set_by_comma"
-rust_type = "BTreeSet<String>"
-type = "SetString"
-
 [idiomatic_version_file_disable_files]
 default = []
 description = "Specific idiomatic version files to disable for a tool."
@@ -1270,6 +1260,16 @@ For example, this keeps `.nvmrc` enabled for node while preventing node from rea
     mise settings add idiomatic_version_file_disable_files node:package.json
 """
 env = "MISE_IDIOMATIC_VERSION_FILE_DISABLE_FILES"
+parse_env = "set_by_comma"
+rust_type = "BTreeSet<String>"
+type = "SetString"
+
+[idiomatic_version_file_disable_tools]
+default = []
+deprecated = "This has been replaced with the idiomatic_version_file_enable_tools setting."
+description = "Specific tools to disable idiomatic version files for."
+env = "MISE_IDIOMATIC_VERSION_FILE_DISABLE_TOOLS"
+hide = true
 parse_env = "set_by_comma"
 rust_type = "BTreeSet<String>"
 type = "SetString"

--- a/settings.toml
+++ b/settings.toml
@@ -1257,6 +1257,23 @@ parse_env = "set_by_comma"
 rust_type = "BTreeSet<String>"
 type = "SetString"
 
+[idiomatic_version_file_disable_files]
+default = []
+description = "Specific idiomatic version files to disable for a tool."
+docs = """
+Use `tool:filename` pairs to exclude individual idiomatic version files without disabling
+other files for the tool or other tools that read the same file.
+
+For example, this keeps `.nvmrc` enabled for node while preventing node from reading
+`devEngines.runtime` in `package.json`:
+
+    mise settings add idiomatic_version_file_disable_files node:package.json
+"""
+env = "MISE_IDIOMATIC_VERSION_FILE_DISABLE_FILES"
+parse_env = "set_by_comma"
+rust_type = "BTreeSet<String>"
+type = "SetString"
+
 [idiomatic_version_file_enable_tools]
 default = []
 description = "Specific tools to enable idiomatic version files for like .node-version, .ruby-version, etc."

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -679,7 +679,7 @@ async fn path_is_idiomatic_with_disabled_files(
         match b.idiomatic_filenames().await {
             Ok(filenames) => {
                 for filename in filenames {
-                    if super::idiomatic_version_file_disabled(&disable_files, b.id(), &filename) {
+                    if super::idiomatic_version_file_disabled(disable_files, b.id(), &filename) {
                         continue;
                     }
                     backends_by_filename

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, Once};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -664,11 +664,24 @@ pub(crate) fn matching_idiomatic_filenames<'a>(
 }
 
 async fn path_is_idiomatic(path: &Path) -> Option<Vec<Arc<dyn Backend>>> {
+    let disable_files = Settings::try_get()
+        .map(|settings| settings.idiomatic_version_file_disable_files.clone())
+        .unwrap_or_default();
+    path_is_idiomatic_with_disabled_files(path, &disable_files).await
+}
+
+async fn path_is_idiomatic_with_disabled_files(
+    path: &Path,
+    disable_files: &BTreeSet<String>,
+) -> Option<Vec<Arc<dyn Backend>>> {
     let mut backends_by_filename = BTreeMap::<String, Vec<Arc<dyn Backend>>>::new();
     for b in backend::list() {
         match b.idiomatic_filenames().await {
             Ok(filenames) => {
                 for filename in filenames {
+                    if super::idiomatic_version_file_disabled(&disable_files, b.id(), &filename) {
+                        continue;
+                    }
                     backends_by_filename
                         .entry(filename)
                         .or_default()
@@ -815,6 +828,20 @@ mod tests {
             .expect("goreleaser should be parsed from its nested idiomatic path");
 
         assert_eq!(versions[0].version(), "2");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_path_is_idiomatic_respects_disabled_files() -> Result<()> {
+        backend::load_tools().await?;
+        let disabled = BTreeSet::from(["node:package.json".to_string()]);
+
+        let backends = path_is_idiomatic_with_disabled_files(Path::new("package.json"), &disabled)
+            .await
+            .expect("package.json should remain idiomatic for package managers");
+
+        assert!(!backends.iter().any(|backend| backend.id() == "node"));
+        assert!(backends.iter().any(|backend| backend.id() == "pnpm"));
         Ok(())
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1166,14 +1166,13 @@ fn find_monorepo_config(config_files: &ConfigMap) -> Option<&Arc<dyn ConfigFile>
 }
 
 async fn load_idiomatic_filenames() -> BTreeMap<String, Vec<String>> {
-    let enable_tools = Settings::get().idiomatic_version_file_enable_tools.clone();
+    let settings = Settings::get();
+    let enable_tools = settings.idiomatic_version_file_enable_tools.clone();
+    let disable_files = settings.idiomatic_version_file_disable_files.clone();
     if enable_tools.is_empty() {
         return BTreeMap::new();
     }
-    if !Settings::get()
-        .idiomatic_version_file_disable_tools
-        .is_empty()
-    {
+    if !settings.idiomatic_version_file_disable_tools.is_empty() {
         deprecated!(
             "idiomatic_version_file_disable_tools",
             "is deprecated, use idiomatic_version_file_enable_tools instead"
@@ -1182,6 +1181,7 @@ async fn load_idiomatic_filenames() -> BTreeMap<String, Vec<String>> {
     let mut jset = JoinSet::new();
     for tool in backend::list() {
         let enable_tools = enable_tools.clone();
+        let disable_files = disable_files.clone();
         jset.spawn(async move {
             if !enable_tools.contains(tool.id()) {
                 return vec![];
@@ -1189,6 +1189,9 @@ async fn load_idiomatic_filenames() -> BTreeMap<String, Vec<String>> {
             match tool.idiomatic_filenames().await {
                 Ok(filenames) => filenames
                     .iter()
+                    .filter(|filename| {
+                        !idiomatic_version_file_disabled(&disable_files, tool.id(), filename)
+                    })
                     .map(|f| (f.to_string(), tool.id().to_string()))
                     .collect::<Vec<_>>(),
                 Err(err) => {
@@ -1213,6 +1216,20 @@ async fn load_idiomatic_filenames() -> BTreeMap<String, Vec<String>> {
             .push(plugin);
     }
     idiomatic_filenames
+}
+
+fn idiomatic_version_file_disabled(
+    disable_files: &BTreeSet<String>,
+    tool: &str,
+    filename: &str,
+) -> bool {
+    disable_files.iter().any(|entry| {
+        entry
+            .rsplit_once(':')
+            .is_some_and(|(disabled_tool, disabled_filename)| {
+                disabled_tool == tool && disabled_filename == filename
+            })
+    })
 }
 
 static LOCAL_CONFIG_FILENAMES: Lazy<IndexSet<&'static str>> = Lazy::new(|| {
@@ -5077,6 +5094,34 @@ config_roots = ["apps/api", "apps/web"]
             ),
             vec!["nested-tool"]
         );
+    }
+
+    #[test]
+    fn test_idiomatic_version_file_disabled_is_tool_specific() {
+        let disabled = BTreeSet::from([
+            "aqua:owner/tool:tool.json".to_string(),
+            "node:package.json".to_string(),
+            "python:.python-version".to_string(),
+        ]);
+
+        assert!(idiomatic_version_file_disabled(
+            &disabled,
+            "aqua:owner/tool",
+            "tool.json"
+        ));
+        assert!(idiomatic_version_file_disabled(
+            &disabled,
+            "node",
+            "package.json"
+        ));
+        assert!(!idiomatic_version_file_disabled(
+            &disabled,
+            "pnpm",
+            "package.json"
+        ));
+        assert!(!idiomatic_version_file_disabled(
+            &disabled, "node", ".nvmrc"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add `idiomatic_version_file_disable_files` with tool-qualified `tool:filename` exclusions
- keep shared idiomatic files available to other tools when one tool opts out
- document and test using `.nvmrc` for node while pnpm continues reading `package.json`
- regenerate the settings schema

## Motivation

Enabling idiomatic version files for node currently enables `.nvmrc`, `.node-version`, and `package.json` together. Projects may use `.nvmrc` to select node while using `package.json#devEngines` as a compatibility constraint. Since both files are treated as version selectors, a semver range in `devEngines` can override the intended `.nvmrc` selection.

The new setting allows a targeted exclusion such as:

```sh
mise settings add idiomatic_version_file_disable_files node:package.json
```

This disables `package.json` only for node; package managers such as pnpm can continue reading it.

Refs #7379.

## Tests

- `cargo test config::tests::test_idiomatic_version_file_disabled_is_tool_specific`
- `mise run test:e2e e2e/core/test_package_json`
- `mise run render:schema`
- `mise run lint`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in setting that narrows idiomatic file parsing; wrong `tool:filename` pairs could surprise version selection but do not touch installs, auth, or data paths.
> 
> **Overview**
> Adds **`idiomatic_version_file_disable_files`**, a set of `tool:filename` entries so one tool can stop using a shared idiomatic file without turning off other files for that tool or other tools that read the same path.
> 
> Version discovery now skips only matching pairs in **`load_idiomatic_filenames`** and when resolving which backends own a path (**`path_is_idiomatic`**). Tool IDs that contain `:` (e.g. `aqua:owner/tool`) are handled via **`rsplit_once`** on the disable entry.
> 
> Docs and **`settings.toml`** / **`schema/mise.json`** describe the main case: keep **`.nvmrc`** for node while ignoring **`package.json`** `devEngines.runtime`, with pnpm still reading **`package.json`**. E2E and unit tests cover that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d8e2601b403d9be51bc9c6a42bd86f0e44fa0d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to selectively disable specific idiomatic version files per tool using `tool:filename` pairs.
  * Configurable via `MISE_IDIOMATIC_VERSION_FILE_DISABLE_FILES`.
* **Documentation**
  * Expanded configuration and Node guidance with examples to keep `.nvmrc`/`.node-version` active while excluding `package.json` engine fields.
* **Bug Fixes**
  * Version detection now skips only the explicitly disabled tool+file combinations while still using other available sources.
* **Tests**
  * Added end-to-end and unit test coverage for tool+filename-specific disable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->