### PR TITLE
feat(task): support optional dependencies

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -217,8 +217,9 @@ Supports the same argument, environment variable, and optional dependency syntax
 
 - **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string }, optional?: bool })[]`
 
-Similar to `depends`, it will wait for these tasks to complete before running however they won't be
-added to the list of tasks to run. This is essentially optional dependencies.
+Similar to `depends`, it will wait for these tasks to complete before running. Unlike `depends`,
+`wait_for` does not add matching tasks to the run; it only waits for them when they are already
+scheduled. To allow a task name or pattern to have no configured matches, use `optional = true`.
 
 ```mise-toml
 [tasks.lint]

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -76,7 +76,7 @@ run = "cargo build"
 
 ### `depends`
 
-- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string } })[]`
+- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string }, optional?: bool })[]`
 
 Tasks that must be run before this task. This is a list of task names or aliases. Arguments can be
 passed to the task, e.g.: `depends = ["build --release"]`. If multiple tasks have the same dependency,
@@ -140,6 +140,19 @@ run = "echo checks complete"
 
 Note: These environment variables are passed only to the specified dependency, not to the current task or other dependencies.
 
+#### Optional dependencies
+
+Set `optional = true` on a structured dependency to run matching tasks when they exist without
+failing when the task name or pattern has no matches. Invalid task patterns still produce an error.
+
+```mise-toml
+[tasks.test]
+depends = [
+  { task = "//...:test", optional = true },
+  { task = "//...:test:*", optional = true },
+]
+```
+
 #### Passing parent task arguments to dependencies
 
 You can forward a parent task's arguments to its dependencies using <span v-pre>`{{usage.*}}`</span> templates.
@@ -185,7 +198,7 @@ forward its resolved arguments to its own dependencies.
 
 ### `depends_post`
 
-- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string } })[]`
+- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string }, optional?: bool })[]`
 
 Like `depends` but these tasks run _after_ this task and its dependencies complete. For example, you
 may want a `postlint` task that you can run individually without also running `lint`:
@@ -198,11 +211,11 @@ depends_post = ["postlint"]
 run = "echo 'linting complete'"
 ```
 
-Supports the same argument and environment variable syntax as `depends`.
+Supports the same argument, environment variable, and optional dependency syntax as `depends`.
 
 ### `wait_for`
 
-- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string } })[]`
+- **Type**: `string | (string | string[] | { task: string, args?: string[], env?: { [key]: string }, optional?: bool })[]`
 
 Similar to `depends`, it will wait for these tasks to complete before running however they won't be
 added to the list of tasks to run. This is essentially optional dependencies.
@@ -213,7 +226,7 @@ wait_for = ["render"] # creates some js files, so if it's running, wait for it t
 run = "eslint ."
 ```
 
-Supports the same argument and environment variable syntax as `depends`.
+Supports the same argument, environment variable, and optional dependency syntax as `depends`.
 
 `wait_for` matches tasks differently depending on whether args or env vars are specified:
 

--- a/e2e/tasks/test_task_optional_dependencies
+++ b/e2e/tasks/test_task_optional_dependencies
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks."test:unit"]
+run = "echo unit"
+
+[tasks."test:integration"]
+run = "echo integration"
+
+[tasks.test]
+depends = [
+  { task = "missing", optional = true },
+  { task = "missing:*", optional = true },
+  { task = "test:*", optional = true },
+]
+run = "echo test"
+EOF
+
+output="$(mise run test)"
+assert_contains_text "$output" "unit"
+assert_contains_text "$output" "integration"
+assert_contains_text "$output" "test"
+
+cat <<'EOF' >mise.toml
+[tasks.test]
+depends = [{ task = "missing", optional = true }]
+depends_post = [{ task = "missing-post", optional = true }]
+wait_for = [{ task = "missing-wait", optional = true }]
+run = "echo test"
+EOF
+
+assert "mise run test" "test"
+assert_contains "mise tasks validate" "validated successfully"
+
+cat <<'EOF' >mise.toml
+[tasks.test]
+depends = [{ task = "missing", optional = false }]
+run = "echo test"
+EOF
+
+assert_fail "mise run test" "task not found: missing"
+assert_contains "mise tasks validate 2>&1 || true" "Dependency 'missing' not found"
+
+cat <<'EOF' >mise.toml
+[tasks.test]
+depends = [{ task = "invalid/path:task", optional = true }]
+run = "echo test"
+EOF
+
+assert_fail "mise run test" "relative path syntax"

--- a/e2e/tasks/test_task_optional_dependencies
+++ b/e2e/tasks/test_task_optional_dependencies
@@ -48,3 +48,4 @@ run = "echo test"
 EOF
 
 assert_fail "mise run test" "relative path syntax"
+assert_contains "mise tasks validate 2>&1 || true" "relative path syntax"

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -963,6 +963,10 @@
               "additionalProperties": {
                 "type": "string"
               }
+            },
+            "optional": {
+              "description": "do not fail when the task name or pattern has no matches",
+              "type": "boolean"
             }
           },
           "required": ["task"],

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -33,6 +33,10 @@
               "additionalProperties": {
                 "type": "string"
               }
+            },
+            "optional": {
+              "description": "do not fail when the task name or pattern has no matches",
+              "type": "boolean"
             }
           },
           "required": ["task"],

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -293,6 +293,8 @@ impl TasksValidate {
 
         for (dep_type, dep) in all_deps {
             if dep.optional {
+                // Graph construction above still validates the selector and reports matcher
+                // errors. Only the later missing-reference check is skipped here.
                 continue;
             }
             let dep_name = &dep.task;

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -287,11 +287,15 @@ impl TasksValidate {
         let all_deps = task
             .depends
             .iter()
-            .map(|d| ("depends", &d.task))
-            .chain(task.depends_post.iter().map(|d| ("depends_post", &d.task)))
-            .chain(task.wait_for.iter().map(|d| ("wait_for", &d.task)));
+            .map(|d| ("depends", d))
+            .chain(task.depends_post.iter().map(|d| ("depends_post", d)))
+            .chain(task.wait_for.iter().map(|d| ("wait_for", d)));
 
-        for (dep_type, dep_name) in all_deps {
+        for (dep_type, dep) in all_deps {
+            if dep.optional {
+                continue;
+            }
+            let dep_name = &dep.task;
             // Skip pattern wildcards for now (they're resolved at runtime)
             if dep_name.contains('*') || dep_name.contains('?') {
                 continue;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2554,7 +2554,7 @@ fn match_tasks_with_context(
             Ok(t)
         })
         .collect::<Result<Vec<_>>>()?;
-    if matches.is_empty() {
+    if matches.is_empty() && !td.optional {
         let mut err_msg = format!("task not found: {}", td.task);
 
         // In monorepo mode, suggest similar tasks using fuzzy matching
@@ -3497,11 +3497,13 @@ exec proxy "$@"
                     task: "post1".to_string(),
                     args: vec![],
                     env: Default::default(),
+                    optional: false,
                 },
                 TaskDep {
                     task: "post2".to_string(),
                     args: vec![],
                     env: Default::default(),
+                    optional: false,
                 },
             ],
             ..Default::default()
@@ -3514,6 +3516,7 @@ exec proxy "$@"
                 task: "other_post".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };
@@ -3883,6 +3886,7 @@ echo "hello world"
                 task: "task_b".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };
@@ -3893,6 +3897,7 @@ echo "hello world"
                 task: "task_a".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };
@@ -3918,6 +3923,7 @@ echo "hello world"
                 task: "task_b".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };
@@ -3928,6 +3934,7 @@ echo "hello world"
                 task: "task_c".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };
@@ -3938,6 +3945,7 @@ echo "hello world"
                 task: "task_a".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };
@@ -3968,11 +3976,13 @@ echo "hello world"
                     task: "task_a".to_string(),
                     args: vec![],
                     env: Default::default(),
+                    optional: false,
                 },
                 crate::task::task_dep::TaskDep {
                     task: "task_b".to_string(),
                     args: vec![],
                     env: Default::default(),
+                    optional: false,
                 },
             ],
             ..Default::default()
@@ -3984,6 +3994,7 @@ echo "hello world"
                 task: "common".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };
@@ -3994,6 +4005,7 @@ echo "hello world"
                 task: "common".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };

--- a/src/task/task_dep.rs
+++ b/src/task/task_dep.rs
@@ -13,6 +13,7 @@ pub struct TaskDep {
     pub task: String,
     pub args: Vec<String>,
     pub env: IndexMap<String, String>,
+    pub optional: bool,
 }
 
 impl TaskDep {
@@ -124,6 +125,7 @@ impl FromStr for TaskDep {
             task: s.to_string(),
             args: Default::default(),
             env: Default::default(),
+            optional: false,
         })
     }
 }
@@ -144,6 +146,7 @@ impl<'de> Deserialize<'de> for TaskDep {
                     task: v.to_string(),
                     args: Default::default(),
                     env: Default::default(),
+                    optional: false,
                 })
             }
 
@@ -159,6 +162,7 @@ impl<'de> Deserialize<'de> for TaskDep {
                     task: items[0].clone(),
                     args: items[1..].to_vec(),
                     env: Default::default(),
+                    optional: false,
                 })
             }
 
@@ -166,14 +170,19 @@ impl<'de> Deserialize<'de> for TaskDep {
                 let mut task: Option<String> = None;
                 let mut args: Vec<String> = Vec::new();
                 let mut env: IndexMap<String, String> = IndexMap::new();
+                let mut optional = false;
 
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
                         "task" => task = Some(map.next_value()?),
                         "args" => args = map.next_value()?,
                         "env" => env = map.next_value()?,
+                        "optional" => optional = map.next_value()?,
                         _ => {
-                            return Err(de::Error::unknown_field(&key, &["task", "args", "env"]));
+                            return Err(de::Error::unknown_field(
+                                &key,
+                                &["task", "args", "env", "optional"],
+                            ));
                         }
                     }
                 }
@@ -182,6 +191,7 @@ impl<'de> Deserialize<'de> for TaskDep {
                     task: task.ok_or_else(|| de::Error::missing_field("task"))?,
                     args,
                     env,
+                    optional,
                 })
             }
         }
@@ -192,14 +202,19 @@ impl<'de> Deserialize<'de> for TaskDep {
 
 impl Serialize for TaskDep {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        if !self.env.is_empty() {
-            // Use object format when env is present
+        if !self.env.is_empty() || self.optional {
+            // Use object format when env or optional metadata is present
             let mut map = serializer.serialize_map(None)?;
             map.serialize_entry("task", &self.task)?;
             if !self.args.is_empty() {
                 map.serialize_entry("args", &self.args)?;
             }
-            map.serialize_entry("env", &self.env)?;
+            if !self.env.is_empty() {
+                map.serialize_entry("env", &self.env)?;
+            }
+            if self.optional {
+                map.serialize_entry("optional", &true)?;
+            }
             map.end()
         } else if self.args.is_empty() {
             serializer.serialize_str(&self.task)
@@ -234,6 +249,7 @@ mod tests {
             task: "task".to_string(),
             args: vec!["arg1".to_string(), "arg2".to_string()],
             env: Default::default(),
+            optional: false,
         };
         assert_eq!(td.to_string(), "task arg1 arg2");
 
@@ -244,6 +260,7 @@ mod tests {
             task: "task".to_string(),
             args: vec![],
             env,
+            optional: false,
         };
         assert_eq!(td.to_string(), "FOO=bar task");
     }
@@ -277,6 +294,20 @@ mod tests {
         assert_eq!(td.task, "mytask");
         assert_eq!(td.args, vec!["arg1"]);
         assert_eq!(td.env.get("FOO"), Some(&"bar".to_string()));
+        assert!(!td.optional);
+    }
+
+    #[test]
+    fn test_task_dep_optional_round_trip() {
+        let td: TaskDep = serde_json::from_str(r#"{"task":"missing:*","optional":true}"#).unwrap();
+        assert_eq!(td.task, "missing:*");
+        assert!(td.args.is_empty());
+        assert!(td.env.is_empty());
+        assert!(td.optional);
+        assert_eq!(
+            serde_json::to_string(&td).unwrap(),
+            r#"{"task":"missing:*","optional":true}"#
+        );
     }
 
     #[test]
@@ -298,6 +329,7 @@ mod tests {
             task: "mytask".to_string(),
             args: vec![],
             env,
+            optional: false,
         };
         let json = serde_json::to_string(&td).unwrap();
         assert!(json.contains(r#""task":"mytask""#));
@@ -351,6 +383,7 @@ mod tests {
                 String::new(),
             ],
             env: Default::default(),
+            optional: false,
         };
         let mut tera = TeraEngine::V2(Box::default());
         let mut ctx = tera::Context::new();
@@ -366,6 +399,7 @@ mod tests {
             task: "lint".to_string(),
             args: vec!["{% if usage.fix %}--fix{% endif %}".to_string()],
             env: Default::default(),
+            optional: false,
         };
         let mut tera = TeraEngine::V2(Box::default());
         let mut ctx = tera::Context::new();

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -371,6 +371,7 @@ mod tests {
                 task: "local-dep".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };
@@ -379,6 +380,7 @@ mod tests {
                 task: "template-dep".to_string(),
                 args: vec![],
                 env: Default::default(),
+                optional: false,
             }],
             ..Default::default()
         };


### PR DESCRIPTION
## Summary
- add `optional = true` to structured task dependencies
- skip zero-match optional dependencies while preserving errors for invalid selectors
- update task validation, schemas, documentation, and focused tests

This implements the behavior requested in https://github.com/jdx/mise/discussions/11461. Optional dependencies run all matches when present and are silently omitted when no task matches. The syntax applies consistently to `depends`, `depends_post`, and `wait_for`.

## Testing
- `mise run test:e2e test_task_optional_dependencies`
- `mise run test:unit -- task_dep`
- `mise run format`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task graph resolution and validation for all dependency kinds; behavior is well-covered by e2e/unit tests but misconfigured optional deps could hide missing tasks users expected to run.
> 
> **Overview**
> Structured task dependencies can now set **`optional = true`**, so mise runs all matching tasks when they exist and **does not error** when a name or wildcard has no matches. **Invalid selectors still fail** (e.g. bad monorepo path syntax).
> 
> Runtime resolution treats empty match sets as success when optional; **`mise tasks validate`** skips the “dependency not found” check for optional deps while still validating patterns. **`TaskDep`** gains an `optional` field (deserialize/serialize, JSON schemas, docs). Docs also clarify that **`wait_for`** only waits on already-scheduled work—use **`optional`** for “no matches is OK,” not as a substitute for **`depends`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ccaa8f5763399ad7f0c53b565dd0c3fd615cc92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for marking task dependencies as optional.
  - Optional dependencies run when matching tasks exist but do not fail when no matches are found.
  - Supported across `depends`, `depends_post`, and `wait_for`, including wildcard patterns.
- **Bug Fixes**
  - Validation now skips unresolved optional dependencies while still reporting missing required dependencies.
- **Documentation**
  - Updated task configuration guidance and examples for optional dependencies, including clarified `wait_for` behavior.
- **Tests**
  - Added end-to-end coverage for optional dependency behavior, including failure cases for non-optional and invalid optional dependency syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->