### PR TITLE
feat(task): add root task defaults

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -48,7 +48,7 @@ outside this tracker.
 - [x] Add a Node workspace provider for npm, pnpm, Yarn, and Bun workspace definitions
 - [x] Infer Node project dependency edges from declared internal package dependencies
 - [x] Import package scripts as scoped mise tasks without requiring a `mise.toml` in every package
-- [ ] Add root task defaults that apply by task name across inferred and explicit projects
+- [x] Add root task defaults that apply by task name across inferred and explicit projects
 - [ ] Add dependency-scoped task relationships equivalent to building the same task in upstream
       projects first
 - [ ] Define deterministic precedence between provider inference, root task defaults, task

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -394,6 +394,27 @@ This inference is currently experimental and only runs for a configured monorepo
 mise settings experimental=true
 ```
 
+### Root Task Defaults
+
+Use `[monorepo.task_defaults.<name>]` in the root `mise.toml` to define shared defaults for
+tasks with the same name in every workspace project:
+
+```toml
+[monorepo.task_defaults.build]
+sources = ["src/**", "package.json"]
+outputs = ["dist/**"]
+cache = true
+
+[monorepo.task_defaults.test]
+env = { NODE_ENV = "test" }
+```
+
+These defaults apply to both provider-inferred tasks such as `node:@acme/web#build` and explicit
+mise tasks such as `//apps/web:build`. Task-local configuration takes precedence. When an explicit
+task uses `extends`, its template also takes precedence over the root default.
+
+Root task defaults are experimental and are ignored unless experimental features are enabled.
+
 ### Project Overrides
 
 Use `[monorepo.projects]` in the root `mise.toml` to correct or extend provider inference. Project IDs containing `:` or scoped package names must be quoted:

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -403,7 +403,7 @@ tasks with the same name in every workspace project:
 [monorepo.task_defaults.build]
 sources = ["src/**", "package.json"]
 outputs = ["dist/**"]
-cache = true
+cache = { enabled = true }
 
 [monorepo.task_defaults.test]
 env = { NODE_ENV = "test" }

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -6,6 +6,7 @@ mkdir -p bin
 cat <<'SH' >bin/npm
 #!/bin/sh
 printf '%s' "$*" >manager-args.txt
+printf '%s' "$ROOT_TASK_DEFAULT" >default.txt
 printf inferred >result.txt
 SH
 chmod +x bin/npm
@@ -16,6 +17,12 @@ monorepo_root = true
 
 [monorepo]
 config_roots = ["packages/*"]
+
+[monorepo.task_defaults.build]
+env = { ROOT_TASK_DEFAULT = "from-root", TASK_PRECEDENCE = "from-root" }
+
+[task_templates.build-override]
+env = { TASK_PRECEDENCE = "from-template" }
 
 [tasks.local]
 run = "printf local > local-result.txt"
@@ -44,6 +51,7 @@ assert_contains "mise task info 'node:@scope/app#build'" "packages/app/package.j
 mise -q run 'node:@scope/app#build' -- forwarded
 assert "cat packages/app/result.txt" "inferred"
 assert "cat packages/app/manager-args.txt" "run build -- forwarded"
+assert "cat packages/app/default.txt" "from-root"
 
 printf stale >packages/app/result.txt
 mise -q run //packages/app:build
@@ -51,12 +59,15 @@ assert "cat packages/app/result.txt" "inferred"
 
 cat <<'TOML' >packages/app/mise.toml
 [tasks.build]
-run = "printf explicit > result.txt"
+extends = "build-override"
+run = "printf explicit > result.txt; printf '%s' \"$ROOT_TASK_DEFAULT\" > explicit-default.txt; printf '%s' \"$TASK_PRECEDENCE\" > precedence.txt"
 TOML
 
 printf stale >packages/app/result.txt
 mise -q run 'node:@scope/app#build'
 assert "cat packages/app/result.txt" "explicit"
+assert "cat packages/app/explicit-default.txt" "from-root"
+assert "cat packages/app/precedence.txt" "from-template"
 
 assert_not_contains "MISE_EXPERIMENTAL=0 mise tasks --all" "node:@scope/app#test:unit"
 assert_fail_contains "MISE_EXPERIMENTAL=0 mise run 'node:@scope/missing#build'" "no task"

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -21,11 +21,20 @@ config_roots = ["packages/*"]
 [monorepo.task_defaults.build]
 env = { ROOT_TASK_DEFAULT = "from-root", TASK_PRECEDENCE = "from-root" }
 
+[monorepo.task_defaults.lint]
+env = { ROOT_TASK_DEFAULT = "from-executable-default" }
+
+[monorepo.task_defaults.local]
+env = { ROOT_TASK_DEFAULT = "must-not-apply" }
+
+[monorepo.task_defaults."test:unit"]
+dir = "{{ invalid"
+
 [task_templates.build-override]
 env = { TASK_PRECEDENCE = "from-template" }
 
 [tasks.local]
-run = "printf local > local-result.txt"
+run = "printf local > local-result.txt; printf '%s' \"$ROOT_TASK_DEFAULT\" > local-default.txt"
 TOML
 
 mkdir -p packages/app
@@ -46,6 +55,7 @@ cat <<'JSON' >packages/app/package.json
 JSON
 
 assert_contains "mise tasks --all" "node:@scope/app#build"
+assert_not_contains "mise tasks --all" "node:@scope/app#test:unit"
 assert_contains "mise task info 'node:@scope/app#build'" "packages/app/package.json"
 
 mise -q run 'node:@scope/app#build' -- forwarded
@@ -63,11 +73,21 @@ extends = "build-override"
 run = "printf explicit > result.txt; printf '%s' \"$ROOT_TASK_DEFAULT\" > explicit-default.txt; printf '%s' \"$TASK_PRECEDENCE\" > precedence.txt"
 TOML
 
+mkdir -p packages/app/mise-tasks
+cat <<'SH' >packages/app/mise-tasks/lint
+#!/bin/sh
+printf '%s' "$ROOT_TASK_DEFAULT" >executable-default.txt
+SH
+chmod +x packages/app/mise-tasks/lint
+
 printf stale >packages/app/result.txt
 mise -q run 'node:@scope/app#build'
 assert "cat packages/app/result.txt" "explicit"
 assert "cat packages/app/explicit-default.txt" "from-root"
 assert "cat packages/app/precedence.txt" "from-template"
+
+mise -q run //packages/app:lint
+assert "cat packages/app/executable-default.txt" "from-executable-default"
 
 assert_not_contains "MISE_EXPERIMENTAL=0 mise tasks --all" "node:@scope/app#test:unit"
 assert_fail_contains "MISE_EXPERIMENTAL=0 mise run 'node:@scope/missing#build'" "no task"
@@ -76,3 +96,4 @@ mkdir -p packages/bad
 printf '{' >packages/bad/package.json
 mise -q run local
 assert "cat local-result.txt" "local"
+assert "cat local-default.txt" ""

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -97,3 +97,7 @@ printf '{' >packages/bad/package.json
 mise -q run local
 assert "cat local-result.txt" "local"
 assert "cat local-default.txt" ""
+
+printf stale >packages/app/explicit-default.txt
+mise -q run //packages/app:build
+assert "cat packages/app/explicit-default.txt" "from-root"

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -54,9 +54,18 @@ cat <<'JSON' >packages/app/package.json
 }
 JSON
 
+mkdir -p packages/tool
+cat <<'TOML' >packages/tool/mise.toml
+[tasks.build]
+run = "printf '%s' \"$ROOT_TASK_DEFAULT\" > config-root-default.txt"
+TOML
+
 assert_contains "mise tasks --all" "node:@scope/app#build"
 assert_not_contains "mise tasks --all" "node:@scope/app#test:unit"
 assert_contains "mise task info 'node:@scope/app#build'" "packages/app/package.json"
+
+mise -q run //packages/tool:build
+assert "cat packages/tool/config-root-default.txt" "from-root"
 
 mise -q run 'node:@scope/app#build' -- forwarded
 assert "cat packages/app/result.txt" "inferred"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2365,6 +2365,13 @@
           "description": "Use a single lockfile at the monorepo root for descendant config roots. true opts in now, false keeps lockfiles next to subproject configs, and unset keeps the current behavior until the scheduled default flip.",
           "type": "boolean"
         },
+        "task_defaults": {
+          "description": "Experimental task defaults applied by task name across inferred and explicit workspace projects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/task_template"
+          }
+        },
         "projects": {
           "description": "Experimental explicit additions, removals, and overrides applied to provider-inferred workspace projects",
           "type": "object",

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -310,6 +310,9 @@ pub struct MonorepoConfig {
     #[allow(dead_code)]
     #[serde(default)]
     pub projects: BTreeMap<String, WorkspaceProjectOverride>,
+    /// Experimental task defaults applied by task name across workspace projects.
+    #[serde(default)]
+    pub task_defaults: IndexMap<String, TaskTemplate>,
 }
 
 impl EnvList {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -744,7 +744,10 @@ impl Config {
                     inferred_workspace_tasks(&config, &task_definitions, graph).await
                 }
                 Some(Err(err)) => {
-                    warn!("failed to infer workspace tasks: {err:#}");
+                    warn!(
+                        "failed to load workspace project graph; inferred tasks and root task \
+                         defaults are unavailable: {err:#}"
+                    );
                     Vec::new()
                 }
                 None => Vec::new(),
@@ -3828,16 +3831,17 @@ pub async fn load_tasks_in_dir(
     config_files: &ConfigMap,
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
-    load_tasks_in_dir_with_definitions(
-        config,
-        dir,
+    let workspace_graph = Settings::get()
+        .experimental
+        .then(|| config.workspace_project_graph());
+    let mut definitions = collect_task_definitions(
         config_files,
-        &TaskDefinitions {
-            templates: templates.clone(),
-            workspace_defaults: None,
-        },
-    )
-    .await
+        workspace_graph
+            .as_ref()
+            .and_then(|graph| graph.as_ref().ok()),
+    );
+    definitions.templates = templates.clone();
+    load_tasks_in_dir_with_definitions(config, dir, config_files, &definitions).await
 }
 
 async fn load_tasks_in_dir_with_definitions(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2338,12 +2338,31 @@ fn collect_task_definitions(
         .then(|| {
             let cf = find_monorepo_config(config_files)?;
             let root = cf.project_root()?.to_path_buf();
-            let tasks = cf.monorepo()?.task_defaults.clone();
-            let graph = workspace_graph?;
-            let project_roots = graph
-                .projects()
-                .map(|project| file::desymlink_path(&root.join(&project.root)))
-                .collect();
+            let monorepo = cf.monorepo()?;
+            let tasks = monorepo.task_defaults.clone();
+            let mut project_roots = BTreeSet::new();
+            if let Some(graph) = workspace_graph {
+                project_roots.extend(
+                    graph
+                        .projects()
+                        .map(|project| file::desymlink_path(&root.join(&project.root))),
+                );
+            } else {
+                project_roots.extend(
+                    expand_config_root_dirs(&root, &monorepo.config_roots, None)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|project_root| file::desymlink_path(&project_root)),
+                );
+                project_roots.extend(
+                    monorepo
+                        .projects
+                        .values()
+                        .filter(|project| !project.remove)
+                        .filter_map(|project| project.root.as_ref())
+                        .map(|project_root| file::desymlink_path(&root.join(project_root))),
+                );
+            }
             (!tasks.is_empty()).then_some(WorkspaceTaskDefaults {
                 project_roots,
                 tasks,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -707,8 +707,7 @@ impl Config {
         let config = Config::get().await?;
         time!("load_all_tasks");
 
-        let workspace_graph = Settings::get()
-            .experimental
+        let workspace_graph = (Settings::get().experimental && config.monorepo_root().is_some())
             .then(|| config.workspace_project_graph());
         let task_definitions = collect_task_definitions(
             &config.config_files,
@@ -2340,27 +2339,24 @@ fn collect_task_definitions(
             let root = cf.project_root()?.to_path_buf();
             let monorepo = cf.monorepo()?;
             let tasks = monorepo.task_defaults.clone();
-            let mut project_roots = BTreeSet::new();
+            let mut project_roots = expand_config_root_dirs(&root, &monorepo.config_roots, None)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|project_root| file::desymlink_path(&project_root))
+                .collect::<BTreeSet<_>>();
+            project_roots.extend(
+                monorepo
+                    .projects
+                    .values()
+                    .filter(|project| !project.remove)
+                    .filter_map(|project| project.root.as_ref())
+                    .map(|project_root| file::desymlink_path(&root.join(project_root))),
+            );
             if let Some(graph) = workspace_graph {
                 project_roots.extend(
                     graph
                         .projects()
                         .map(|project| file::desymlink_path(&root.join(&project.root))),
-                );
-            } else {
-                project_roots.extend(
-                    expand_config_root_dirs(&root, &monorepo.config_roots, None)
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(|project_root| file::desymlink_path(&project_root)),
-                );
-                project_roots.extend(
-                    monorepo
-                        .projects
-                        .values()
-                        .filter(|project| !project.remove)
-                        .filter_map(|project| project.root.as_ref())
-                        .map(|project_root| file::desymlink_path(&root.join(project_root))),
                 );
             }
             (!tasks.is_empty()).then_some(WorkspaceTaskDefaults {
@@ -3850,8 +3846,7 @@ pub async fn load_tasks_in_dir(
     config_files: &ConfigMap,
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
-    let workspace_graph = Settings::get()
-        .experimental
+    let workspace_graph = (Settings::get().experimental && config.monorepo_root().is_some())
         .then(|| config.workspace_project_graph());
     let mut definitions = collect_task_definitions(
         config_files,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -707,7 +707,15 @@ impl Config {
         let config = Config::get().await?;
         time!("load_all_tasks");
 
-        let task_definitions = collect_task_definitions(&config.config_files);
+        let workspace_graph = Settings::get()
+            .experimental
+            .then(|| config.workspace_project_graph());
+        let task_definitions = collect_task_definitions(
+            &config.config_files,
+            workspace_graph
+                .as_ref()
+                .and_then(|graph| graph.as_ref().ok()),
+        );
 
         let mut local_tasks =
             load_local_tasks_with_context(&config, ctx, &task_definitions).await?;
@@ -731,12 +739,15 @@ impl Config {
             .map(|t| (t.name.clone(), t))
             .collect();
         if Settings::get().experimental {
-            let inferred_tasks = match inferred_workspace_tasks(&config, &task_definitions).await {
-                Ok(tasks) => tasks,
-                Err(err) => {
+            let inferred_tasks = match workspace_graph.as_ref() {
+                Some(Ok(graph)) => {
+                    inferred_workspace_tasks(&config, &task_definitions, graph).await
+                }
+                Some(Err(err)) => {
                     warn!("failed to infer workspace tasks: {err:#}");
                     Vec::new()
                 }
+                None => Vec::new(),
             };
             for task in inferred_tasks {
                 if tasks.contains_key(&task.name) {
@@ -2299,14 +2310,17 @@ struct TaskDefinitions {
 
 #[derive(Clone, Debug)]
 struct WorkspaceTaskDefaults {
-    root: PathBuf,
+    project_roots: BTreeSet<PathBuf>,
     tasks: IndexMap<String, TaskTemplate>,
 }
 
 /// Collect all task templates from the config file hierarchy and task-name defaults from the
 /// selected monorepo root.
 /// Templates from child configs (closer to cwd) override templates from parent configs.
-fn collect_task_definitions(config_files: &ConfigMap) -> TaskDefinitions {
+fn collect_task_definitions(
+    config_files: &ConfigMap,
+    workspace_graph: Option<&crate::task::workspace::WorkspaceProjectGraph>,
+) -> TaskDefinitions {
     let mut templates = IndexMap::new();
 
     // Iterate in reverse order (global -> local) so child directories override parent configs
@@ -2322,7 +2336,15 @@ fn collect_task_definitions(config_files: &ConfigMap) -> TaskDefinitions {
             let cf = find_monorepo_config(config_files)?;
             let root = cf.project_root()?.to_path_buf();
             let tasks = cf.monorepo()?.task_defaults.clone();
-            (!tasks.is_empty()).then_some(WorkspaceTaskDefaults { root, tasks })
+            let graph = workspace_graph?;
+            let project_roots = graph
+                .projects()
+                .map(|project| file::desymlink_path(&root.join(&project.root)))
+                .collect();
+            (!tasks.is_empty()).then_some(WorkspaceTaskDefaults {
+                project_roots,
+                tasks,
+            })
         })
         .flatten();
 
@@ -2358,7 +2380,8 @@ fn resolve_task_template(task: &mut Task, definitions: &TaskDefinitions) -> Resu
         && task
             .config_root
             .as_deref()
-            .is_some_and(|root| file::path_starts_with_resolved(root, &defaults.root))
+            .map(file::desymlink_path)
+            .is_some_and(|root| defaults.project_roots.contains(&root))
     {
         let task_name = task
             .name
@@ -2706,11 +2729,11 @@ fn prefix_monorepo_task_names(tasks: &mut [Task], dir: &Path, monorepo_root: &Pa
 async fn inferred_workspace_tasks(
     config: &Arc<Config>,
     task_definitions: &TaskDefinitions,
-) -> Result<Vec<Task>> {
+    graph: &crate::task::workspace::WorkspaceProjectGraph,
+) -> Vec<Task> {
     let Some(monorepo_root) = config.monorepo_root() else {
-        return Ok(Vec::new());
+        return Vec::new();
     };
-    let graph = config.workspace_project_graph()?;
     let mut tasks = Vec::new();
 
     for project in graph.projects() {
@@ -2731,13 +2754,27 @@ async fn inferred_workspace_tasks(
                 run: vec![RunEntry::Script(inferred.command.clone())],
                 ..Default::default()
             };
-            resolve_task_template(&mut task, task_definitions)?;
-            task.render(config, &project_root).await?;
+            if let Err(err) = resolve_task_template(&mut task, task_definitions) {
+                warn!(
+                    "Failed to resolve inferred task {} in {}: {err:#}. Task will not be available.",
+                    task.name,
+                    display_path(&task.config_source)
+                );
+                continue;
+            }
+            if let Err(err) = task.render(config, &project_root).await {
+                warn!(
+                    "Failed to render inferred task {} in {}: {err:#}. Task will not be available.",
+                    task.name,
+                    display_path(&task.config_source)
+                );
+                continue;
+            }
             tasks.push(task);
         }
     }
 
-    Ok(tasks)
+    tasks
 }
 
 /// Monorepo roots that enclose the selected one.
@@ -3574,6 +3611,18 @@ async fn load_tasks_includes(
                 &config_root,
                 monorepo_cf.cloned(),
             )?;
+            if let Err(err) = resolve_task_template(&mut task, templates) {
+                if monorepo_cf.is_some() {
+                    warn!(
+                        "Failed to resolve task {} in {}: {err:#}. Task will not be available.",
+                        task.name,
+                        display_path(&path)
+                    );
+                    continue;
+                } else {
+                    return Err(err);
+                }
+            }
             let cache_key = rendered_task_cache_key(&task);
             if let Some(cached) = rendered_file_tasks
                 .as_deref()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -707,10 +707,11 @@ impl Config {
         let config = Config::get().await?;
         time!("load_all_tasks");
 
-        let templates = collect_task_templates(&config.config_files);
+        let task_definitions = collect_task_definitions(&config.config_files);
 
-        let mut local_tasks = load_local_tasks_with_context(&config, ctx, &templates).await?;
-        let global_tasks = load_global_tasks(&config, &templates).await?;
+        let mut local_tasks =
+            load_local_tasks_with_context(&config, ctx, &task_definitions).await?;
+        let global_tasks = load_global_tasks(&config, &task_definitions).await?;
         local_tasks.retain(|local| {
             !global_tasks
                 .iter()
@@ -730,7 +731,7 @@ impl Config {
             .map(|t| (t.name.clone(), t))
             .collect();
         if Settings::get().experimental {
-            let inferred_tasks = match inferred_workspace_tasks(&config) {
+            let inferred_tasks = match inferred_workspace_tasks(&config, &task_definitions).await {
                 Ok(tasks) => tasks,
                 Err(err) => {
                     warn!("failed to infer workspace tasks: {err:#}");
@@ -2290,9 +2291,22 @@ impl Debug for Config {
     }
 }
 
-/// Collect all task templates from the config file hierarchy.
+#[derive(Clone, Debug, Default)]
+struct TaskDefinitions {
+    templates: IndexMap<String, TaskTemplate>,
+    workspace_defaults: Option<WorkspaceTaskDefaults>,
+}
+
+#[derive(Clone, Debug)]
+struct WorkspaceTaskDefaults {
+    root: PathBuf,
+    tasks: IndexMap<String, TaskTemplate>,
+}
+
+/// Collect all task templates from the config file hierarchy and task-name defaults from the
+/// selected monorepo root.
 /// Templates from child configs (closer to cwd) override templates from parent configs.
-fn collect_task_templates(config_files: &ConfigMap) -> IndexMap<String, TaskTemplate> {
+fn collect_task_definitions(config_files: &ConfigMap) -> TaskDefinitions {
     let mut templates = IndexMap::new();
 
     // Iterate in reverse order (global -> local) so child directories override parent configs
@@ -2302,31 +2316,58 @@ fn collect_task_templates(config_files: &ConfigMap) -> IndexMap<String, TaskTemp
         }
     }
 
-    templates
+    let workspace_defaults = Settings::get()
+        .experimental
+        .then(|| {
+            let cf = find_monorepo_config(config_files)?;
+            let root = cf.project_root()?.to_path_buf();
+            let tasks = cf.monorepo()?.task_defaults.clone();
+            (!tasks.is_empty()).then_some(WorkspaceTaskDefaults { root, tasks })
+        })
+        .flatten();
+
+    TaskDefinitions {
+        templates,
+        workspace_defaults,
+    }
 }
 
-/// Resolve a task template and merge it into the task.
+/// Resolve a task template and merge it into the task, then fill remaining fields from any
+/// workspace-root default matching the task's unscoped name.
 /// Returns an error if the template is not found.
-fn resolve_task_template(
-    task: &mut Task,
-    templates: &IndexMap<String, TaskTemplate>,
-) -> Result<()> {
+fn resolve_task_template(task: &mut Task, definitions: &TaskDefinitions) -> Result<()> {
     if let Some(template_name) = &task.extends {
-        let template = templates.get(template_name).ok_or_else(|| {
+        let template = definitions.templates.get(template_name).ok_or_else(|| {
             eyre!(
                 "Task '{}' extends template '{}' which was not found. \
                  Available templates: {}",
                 task.name,
                 template_name,
-                if templates.is_empty() {
+                if definitions.templates.is_empty() {
                     "(none)".to_string()
                 } else {
-                    templates.keys().join(", ")
+                    definitions.templates.keys().join(", ")
                 }
             )
         })?;
 
         task.merge_template(template);
+    }
+    if let Some(defaults) = &definitions.workspace_defaults
+        && !task.global
+        && task
+            .config_root
+            .as_deref()
+            .is_some_and(|root| file::path_starts_with_resolved(root, &defaults.root))
+    {
+        let task_name = task
+            .name
+            .split_once('#')
+            .filter(|_| crate::task::is_workspace_project_task(&task.name))
+            .map_or(task.name.as_str(), |(_, name)| name);
+        if let Some(default) = defaults.tasks.get(task_name) {
+            task.merge_template(default);
+        }
     }
     Ok(())
 }
@@ -2662,7 +2703,10 @@ fn prefix_monorepo_task_names(tasks: &mut [Task], dir: &Path, monorepo_root: &Pa
     }
 }
 
-fn inferred_workspace_tasks(config: &Config) -> Result<Vec<Task>> {
+async fn inferred_workspace_tasks(
+    config: &Arc<Config>,
+    task_definitions: &TaskDefinitions,
+) -> Result<Vec<Task>> {
     let Some(monorepo_root) = config.monorepo_root() else {
         return Ok(Vec::new());
     };
@@ -2677,7 +2721,7 @@ fn inferred_workspace_tasks(config: &Config) -> Result<Vec<Task>> {
                 .as_ref()
                 .map(|scope| vec![format!("{scope}:{name}")])
                 .unwrap_or_default();
-            tasks.push(Task {
+            let mut task = Task {
                 name: format!("{}#{name}", project.id),
                 description: inferred.description.clone(),
                 aliases,
@@ -2686,7 +2730,10 @@ fn inferred_workspace_tasks(config: &Config) -> Result<Vec<Task>> {
                 raw_args: true,
                 run: vec![RunEntry::Script(inferred.command.clone())],
                 ..Default::default()
-            });
+            };
+            resolve_task_template(&mut task, task_definitions)?;
+            task.render(config, &project_root).await?;
+            tasks.push(task);
         }
     }
 
@@ -2743,7 +2790,7 @@ fn dir_is_in_enclosing_monorepo(
 async fn load_local_tasks_with_context(
     config: &Arc<Config>,
     ctx: Option<&crate::task::TaskLoadContext>,
-    templates: &IndexMap<String, TaskTemplate>,
+    templates: &TaskDefinitions,
 ) -> Result<Vec<Task>> {
     let mut tasks = vec![];
     let monorepo_config = find_monorepo_config(&config.config_files);
@@ -2775,7 +2822,8 @@ async fn load_local_tasks_with_context(
             );
             continue;
         }
-        let mut dir_tasks = load_tasks_in_dir(config, &d, &local_config_files, templates).await?;
+        let mut dir_tasks =
+            load_tasks_in_dir_with_definitions(config, &d, &local_config_files, templates).await?;
 
         if let Some(ref monorepo_root) = monorepo_root {
             prefix_monorepo_task_names(&mut dir_tasks, &d, monorepo_root);
@@ -3195,10 +3243,7 @@ fn discover_monorepo_subdirs(
     Ok(subdirs)
 }
 
-async fn load_global_tasks(
-    config: &Arc<Config>,
-    templates: &IndexMap<String, TaskTemplate>,
-) -> Result<Vec<Task>> {
+async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) -> Result<Vec<Task>> {
     // User-global config overrides system config. Within each group the path
     // lists are lowest-first, so reverse them before applying first-wins task
     // precedence.
@@ -3392,7 +3437,7 @@ async fn load_config_tasks(
     config: &Arc<Config>,
     cf: Arc<dyn ConfigFile>,
     config_root: &Path,
-    templates: &IndexMap<String, TaskTemplate>,
+    templates: &TaskDefinitions,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     task_config: &ResolvedTaskConfig,
 ) -> Result<Vec<Task>> {
@@ -3454,7 +3499,7 @@ async fn load_tasks_includes(
     root: &Path,
     config_root: &Path,
     task_config: &ResolvedTaskConfig,
-    templates: &IndexMap<String, TaskTemplate>,
+    templates: &TaskDefinitions,
     options: LoadTaskIncludesOptions<'_>,
 ) -> Result<Vec<Task>> {
     let LoadTaskIncludesOptions {
@@ -3734,6 +3779,24 @@ pub async fn load_tasks_in_dir(
     config_files: &ConfigMap,
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
+    load_tasks_in_dir_with_definitions(
+        config,
+        dir,
+        config_files,
+        &TaskDefinitions {
+            templates: templates.clone(),
+            workspace_defaults: None,
+        },
+    )
+    .await
+}
+
+async fn load_tasks_in_dir_with_definitions(
+    config: &Arc<Config>,
+    dir: &Path,
+    config_files: &ConfigMap,
+    templates: &TaskDefinitions,
+) -> Result<Vec<Task>> {
     let configs = configs_at_root(dir, config_files);
     let cascaded_task_config = cascaded_task_config_for_dir(dir, config_files)?;
     load_tasks_from_configs(
@@ -3887,7 +3950,7 @@ async fn load_tasks_from_configs(
     config: &Arc<Config>,
     dir: &Path,
     configs: Vec<&Arc<dyn ConfigFile>>,
-    templates: &IndexMap<String, TaskTemplate>,
+    templates: &TaskDefinitions,
     monorepo_context: bool,
     cascaded_task_config: Option<&CascadedTaskConfig>,
 ) -> Result<Vec<Task>> {
@@ -3913,7 +3976,7 @@ async fn load_task_sources_from_configs(
     config: &Arc<Config>,
     dir: &Path,
     configs: Vec<&Arc<dyn ConfigFile>>,
-    templates: &IndexMap<String, TaskTemplate>,
+    templates: &TaskDefinitions,
     monorepo_context: bool,
     cascaded_task_config: Option<&CascadedTaskConfig>,
     mut rendered_file_tasks: Option<&mut RenderedTaskCache>,
@@ -4059,7 +4122,7 @@ async fn load_task_file(
     path: &Path,
     config_root: &Path,
     task_config: &ResolvedTaskConfig,
-    templates: &IndexMap<String, TaskTemplate>,
+    templates: &TaskDefinitions,
     monorepo_cf: Option<&Arc<dyn ConfigFile>>,
     mut rendered_file_tasks: Option<&mut RenderedTaskCache>,
 ) -> Result<Vec<Task>> {
@@ -5191,7 +5254,7 @@ vars = { target = "linux" }
             &tasks_toml,
             temp_dir.path(),
             &ResolvedTaskConfig::default(),
-            &IndexMap::new(),
+            &TaskDefinitions::default(),
             None,
             None,
         )


### PR DESCRIPTION
## Summary

- add experimental `[monorepo.task_defaults.<name>]` configuration
- apply shared defaults to inferred and explicit tasks across workspace projects
- preserve precedence for task-local fields and explicit task templates
- document the feature, update the schema, and advance the parity tracker

## Testing

- `mise run lint`
- `cargo check --all-features --all-targets`
- `mise run test:e2e tasks/test_task_node_workspace_scripts`
- `cargo clippy --all-features --all-targets -- -A clippy::useless_borrows_in_formatting -A clippy::manual_filter -D warnings`

Unsuppressed Clippy currently reports pre-existing Rust 1.97 `useless_borrows_in_formatting`
and `manual_filter` diagnostics outside this change.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches central task-loading and merge precedence for all monorepo workspace tasks; mis-scoped defaults could change env/cache behavior broadly, though the feature is experimental and gated.
> 
> **Overview**
> Adds experimental **`[monorepo.task_defaults.<name>]`** on the monorepo root so shared task settings (env, sources, cache, etc.) apply by **task name** across workspace projects—both Node-inferred tasks (`node:…#build`) and path-scoped mise tasks (`//packages/app:build`).
> 
> Task loading now collects **`TaskDefinitions`** (templates plus workspace defaults) using the workspace project graph when experimental mode is on. **`resolve_task_template`** merges `extends` templates first, then root defaults for tasks whose `config_root` is a known project; task-local fields and explicit templates still win. Inferred workspace tasks go through the same resolution/render path, with broken defaults dropping the task from the list instead of failing the whole load. File tasks in monorepo subdirs get the same template resolution with warn-and-skip on failure.
> 
> Docs, JSON schema, parity tracker, and e2e coverage document precedence, experimental gating, and invalid-default behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 183daf6c791a9ede6b39a578c35499f202ac161e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental **root task defaults** for monorepo tasks.
  * Configure defaults by task name via `monorepo.task_defaults`, applied to both inferred workspace tasks and explicitly defined projects.
  * Task-local settings and `extends` templates still override root defaults (including task precedence).
* **Documentation**
  * Added “Root Task Defaults” guidance, including precedence and experimental enablement notes.
  * Updated the parity tracker to reflect completion for root task defaults by task name.
* **Tests**
  * Expanded e2e coverage to verify default environment propagation across inferred and explicit task definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->