### PR TITLE
fix(config): match aliased tool keys when writing mise.toml

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,6 +24,10 @@ something with the aliasing is acting up, submit a ticket or just stick to using
 Under the hood, when mise reads a config file or takes CLI input it will swap out "nodejs" and
 "golang".
 
+When mise _writes_ to a `mise.toml` (`mise use`, `mise unuse`), it writes the canonical name — a
+`nodejs` entry becomes `node`, keeping its comments. `.tool-versions` files are unaffected and still
+use the asdf spellings.
+
 ## What does `mise activate` do?
 
 It registers a shell hook to run `mise hook-env` every time the shell prompt is displayed.

--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -51,6 +51,18 @@ assert_fail "mise use --dry-run --path package.json dummy@1" "cannot update idio
 mise use --rm dummy --path mise.local.toml
 assert "cat mise.local.toml" ""
 
+# `nodejs` is an alias for `node`, so --rm has to match the key however it is spelled.
+# It used to only look for the short name, leaving the entry in the file.
+cat >mise.local.toml <<EOF
+[tools]
+dummy = "1"
+nodejs = "20.0.0"
+EOF
+mise use --rm nodejs --path mise.local.toml
+assert "cat mise.local.toml" '[tools]
+dummy = "1"'
+rm -f mise.local.toml
+
 mise use dummy@1 --path .
 assert "cat mise.toml" '[tools]
 dummy = "1"'

--- a/e2e/core/test_node_slow
+++ b/e2e/core/test_node_slow
@@ -25,4 +25,15 @@ mise use nodejs@20.1.0
 mise ls
 assert "mise x -- node --version" "v20.1.0"
 assert_contains "mise ls-remote nodejs" "20.1.0"
+
+# a `nodejs` key is the same tool as `node`: rename it in place instead of adding a
+# second key, which would silently outvote the one just written
+cat >mise.toml <<EOF
+[tools]
+nodejs = "20.1.0" # keep me
+EOF
+mise use nodejs@20.1.0
+assert "cat mise.toml" '[tools]
+node = "20.1.0" # keep me'
+
 mise use --rm node

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -16,6 +16,7 @@ use tera::Context as TeraContext;
 use toml_edit::{Array, DocumentMut, InlineTable, Item, Key, Value, table, value};
 use versions::Versioning;
 
+use crate::backend::unalias_backend;
 use crate::cli::args::{BackendArg, ToolVersionType};
 use crate::config::config_file::{
     ConfigFile, TaskConfig, config_trust_root, is_ignored, trust, trust_check,
@@ -965,7 +966,13 @@ impl ConfigFile for MiseToml {
         if let Some(tools) = doc.get_mut("tools")
             && let Some(tools) = tools.as_table_like_mut()
         {
-            tools.remove(&fa.to_string());
+            // the tool may be written as an alias ("nodejs"), a qualified name ("core:node") or the
+            // fully-qualified backend rather than as fa.short; removing only the short name leaves
+            // the entry in the document and save() writes it straight back out
+            let keys = tool_keys_for(&*tools, fa);
+            for key in &keys {
+                tools.remove(key);
+            }
             if tools.is_empty() {
                 doc.as_table_mut().remove("tools");
             }
@@ -1008,21 +1015,32 @@ impl ConfigFile for MiseToml {
             .as_table_mut()
             .unwrap();
 
-        // the entry may be stored under a long name like "core:node" that is replaced by its short
-        // name below, so read the decorations off whichever key is actually there
-        let existing = if tools.contains_key(ba.short.as_str()) {
-            ba.short.to_string()
-        } else {
-            ba.full()
-        };
+        // the entry may be written under any spelling of this tool — an alias like "nodejs", a
+        // qualified "core:node", or the fully-qualified backend — so collect every key in the
+        // document that refers to it. The first one is the entry the file appears to define, so it
+        // supplies the decorations; the rest are duplicates of it and are dropped below.
+        let keys = tool_keys_for(&*tools, ba);
+        let existing = keys.first().cloned().unwrap_or_else(|| ba.short.clone());
+        if keys.len() > 1 {
+            let dupes = keys.iter().map(|k| format!("`{k}`")).join(", ");
+            warn!(
+                "{}: {dupes} are the same tool; collapsing them into a single `{}` entry",
+                display_path(&self.path),
+                ba.short
+            );
+        }
         // create a key from the short name preserving any decorations like prefix/suffix if the key already exists
         let key = get_key_with_decor_from(tools, ba.short.as_str(), &existing);
         // and the same for the value, so a comment after the version survives the replacement
         let value_decor = get_value_decor(tools, &existing);
 
-        // if a short name is used like "node", make sure we remove any long names like "core:node"
-        if ba.short != ba.full() {
-            tools.remove(&ba.full());
+        // drop the other spellings: they all deserialize to this one entry, so leaving one behind
+        // means the file has two keys for one tool and the later one silently wins on read-back.
+        // ba.short itself is kept so insert_formatted overwrites it in place instead of appending.
+        for k in &keys {
+            if k != &ba.short {
+                tools.remove(k);
+            }
         }
 
         if versions.len() == 1 {
@@ -1357,6 +1375,33 @@ fn get_key_with_decor_from(table: &toml_edit::Table, key: &str, existing: &str) 
         }
     }
     key
+}
+
+/// Every key in a `[tools]` table that refers to `ba`, in document order.
+///
+/// The same tool can be written under several spellings: its short name (`node`), one of the
+/// hardcoded aliases (`nodejs`, `golang`, `dotnet-core`), a `core:`-qualified name (`core:node`),
+/// or the fully-qualified backend the short name resolves to. [`unalias_backend`] folds the first
+/// three onto the short name, and that is what happens when the file is deserialized — so mise's
+/// own view of `[tools]` holds a single entry no matter how many of those keys the document has,
+/// and when there is more than one the later one silently wins. A writer therefore has to find all
+/// of them and not just the one it would write itself, or it leaves a second key behind that
+/// outvotes the one it just wrote.
+///
+/// Registry aliases (`rg` for `ripgrep`) are a different mechanism: they resolve to *different*
+/// short names, mise keeps them as separate entries and writes each back as the user spelled it,
+/// so they are deliberately not matched here. Keys carrying inline options
+/// (`"go:example.com/x[tags=y]"`) are likewise left alone — collapsing those would have to decide
+/// what happens to the options.
+///
+/// The keys are returned owned so the caller can go on to mutate the table.
+fn tool_keys_for(tools: &dyn toml_edit::TableLike, ba: &BackendArg) -> Vec<String> {
+    let full = ba.full();
+    tools
+        .iter()
+        .filter(|&(k, _)| unalias_backend(k) == ba.short.as_str() || k == full.as_str())
+        .map(|(k, _)| k.to_string())
+        .collect()
 }
 
 /// Captures the decor of the value `key` currently holds, if any.
@@ -3968,6 +4013,217 @@ run = 'echo "template"'
         assert!(
             dump.contains(r#"node = "18.0.0" # keep me"#),
             "comment after the version should survive the rename: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_renames_aliased_key() {
+        // `nodejs` is an alias for `node`, so the file defines one tool and not two: the entry has
+        // to be renamed in place rather than a second key added beside it, or the file ends up
+        // with two keys for one tool and the later one silently wins when it is read back
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".aliased-key.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            # renovate: datasource=github-releases depName=node
+            nodejs = "20.11.0" # keep me
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let node: BackendArg = "node".into();
+        cf.replace_versions(
+            &node,
+            vec![
+                ToolRequest::new(Arc::new("node".into()), "24.16.0", ToolSource::Unknown).unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(r#"node = "24.16.0" # keep me"#),
+            "the aliased key should be renamed and keep its comment: {dump}"
+        );
+        assert!(
+            dump.contains("# renovate: datasource=github-releases depName=node"),
+            "the comment above should survive the rename: {dump}"
+        );
+        assert!(
+            !dump.contains("nodejs"),
+            "the alias must not be left behind as a second key: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_renames_aliased_key_with_array() {
+        // same for a multi-version entry: the array moves to the short name rather than being
+        // written out a second time
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".aliased-array.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            nodejs = ["20.11.0", "22.0.0"] # keep me
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let node: BackendArg = "node".into();
+        cf.replace_versions(
+            &node,
+            vec![
+                ToolRequest::new(Arc::new("node".into()), "20.11.1", ToolSource::Unknown).unwrap(),
+                ToolRequest::new(Arc::new("node".into()), "22.1.0", ToolSource::Unknown).unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(r#"node = ["20.11.1", "22.1.0"] # keep me"#),
+            "the array should move to the short name: {dump}"
+        );
+        assert!(
+            !dump.contains("nodejs"),
+            "the alias must not be left behind as a second key: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_collapses_duplicate_spellings() {
+        // a file damaged by the old behavior has both keys; they deserialize to one entry and the
+        // later one silently wins, so the write has to leave exactly one key behind. The first key
+        // in the file is the entry the file appears to define, so it supplies the decorations.
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".dupe-spellings.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            nodejs = "20.11.0" # keep me
+            node = "24.16.0"
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let node: BackendArg = "node".into();
+        cf.replace_versions(
+            &node,
+            vec![
+                ToolRequest::new(Arc::new("node".into()), "24.17.0", ToolSource::Unknown).unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(r#"node = "24.17.0" # keep me"#),
+            "the first key in the file supplies the decor: {dump}"
+        );
+        assert!(
+            !dump.contains("nodejs"),
+            "the duplicate spelling should be removed: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_keeps_registry_alias_key() {
+        // `rg` is a registry alias for `ripgrep`, not one of the hardcoded backend aliases: the two
+        // resolve to different short names, mise treats them as separate entries, and each is
+        // written back under the name it was asked for
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".registry-alias.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            ripgrep = "14.1.0"
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let rg: BackendArg = "rg".into();
+        cf.replace_versions(
+            &rg,
+            vec![ToolRequest::new(Arc::new("rg".into()), "14.1.1", ToolSource::Unknown).unwrap()],
+        )
+        .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(r#"ripgrep = "14.1.0""#),
+            "a registry alias is a different entry and must be left as written: {dump}"
+        );
+        assert!(
+            dump.contains(r#"rg = "14.1.1""#),
+            "the tool should be written under the name it was asked for: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_remove_tool_removes_aliased_key() {
+        // `mise unuse nodejs` used to report success and prune the install while leaving the
+        // `nodejs` key in the file, because it only ever looked for the short name
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".remove-aliased.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            dummy = "1.0.0"
+            nodejs = "20.11.0"
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        cf.remove_tool(&"nodejs".into()).unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            !dump.contains("nodejs"),
+            "the aliased key should be removed: {dump}"
+        );
+        assert!(
+            dump.contains(r#"dummy = "1.0.0""#),
+            "other tools should be left alone: {dump}"
+        );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_remove_tool_removes_qualified_key() {
+        // matching is done on the key as written, so this holds whatever the registry currently
+        // reports as node's backend
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".remove-qualified.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [tools]
+            "core:node" = "20.11.0"
+            "#},
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        cf.remove_tool(&"node".into()).unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            !dump.contains("node"),
+            "the qualified key should be removed: {dump}"
+        );
+        assert!(
+            !dump.contains("[tools]"),
+            "the now-empty tools table should be dropped: {dump}"
         );
         file::remove_file(&p).unwrap();
     }


### PR DESCRIPTION
## Summary
- find every key in `[tools]` that refers to a tool, instead of only the short name, so `mise use` renames an aliased entry in place instead of adding a second key beside it
- fix `mise unuse nodejs`, which reported success and pruned the install while leaving the entry in the file
- registry aliases (`rg`/`ripgrep`) and `.tool-versions` are deliberately untouched

## Problem

`BackendArg::short` is `unalias_backend(name)` — `nodejs`→`node`, `golang`→`go`, `dotnet-core`→`dotnet`, plus stripping a `core:` prefix. The `[tools]` writers only ever looked up the short name, so a config written with any other spelling of the same tool was invisible to them.

**`mise use` duplicates the entry** (v2026.7.15):

```toml
# before                          # after `mise use nodejs@24.16.0`
[tools]                           [tools]
nodejs = "24.16.0" # keep me      node = "24.16.0"
                                  nodejs = "24.16.0" # keep me
```

**`mise unuse` removes nothing** — it looks the tool up in mise's in-memory map (already unaliased, so it matches), pushes it to the removal list, saves, reports success, and prunes the installed version. Only the document write is a no-op:

```console
$ mise unuse nodejs --no-prune
mise removed: node from …/mise.toml
$ cat mise.toml
[tools]
nodejs = "24.16.0"        # still there
```

Without `--no-prune` the version is uninstalled too, so the config ends up requesting a tool that is no longer on disk.

## Why this is worse than a stray line

TOML parses `node` and `nodejs` as two keys, but both deserialize to the same `BackendArg` (`Eq`/`Hash` are `short`-only), and `IndexMap::insert` keeps the **first** key's position while overwriting with the **last** value. So the duplicate silently changes which version applies:

```toml
[tools]
node = "24.16.0"
nodejs = "20.11.0"
```
```console
$ mise ls --current
node  20.11.0 …
```

No warning anywhere. And because `replace_versions` sorts the table and `node` < `nodejs`, the stale alias always ends up **last** — so after the duplication every later `mise use node@X` writes the right value into a key that is then overridden, and the upgrade appears to do nothing.

## Fix

One helper answers "which keys in this document refer to this tool" (`unalias_backend(key) == ba.short`, plus the fully-qualified backend), and both writers use it. The rule, in one sentence:

> **the first matching key supplies the decorations, its key is rewritten to the canonical name, and the other spellings are removed.**

First-in-document rather than "prefer the short name" preserves strictly more of what the user wrote (a comment on the `nodejs` line survives even when a bare `node` line exists below it), and matches which entry a human reading the file would consider authoritative. For every single-key case — `node`, `nodejs`, or `core:node` alone — it picks exactly what the old code picked, so existing behavior and tests are unchanged. `ba.short` itself is never removed, so `insert_formatted` still overwrites it in place and does not move the line.

This also subsumes the old `if ba.short != ba.full() { tools.remove(&ba.full()) }`, and gives `remove_tool` the `core:`-qualified handling it never had.

## Please note: this can delete a line you wrote

If a config already contains both spellings (`node` **and** `nodejs`), `mise use`/`mise unuse` now collapse them into one entry and **delete the other line, including any comment on it**. That is intentional: TOML saw two keys, mise saw one tool, and which version actually applied depended on line order with no warning. The surviving version is the one you just asked for — the other was already being ignored. mise prints a warning naming every key it collapses, and only in that multi-key case; the plain rename (`nodejs` alone → `node`) is silent, since nothing is lost.

## Origin

`06a6aa81b44c` (#2470, 2024-08-18) switched the written key to the registry shortname and added the cleanup beside it:

```diff
+        // if a short name is used like "node", make sure we remove any long names like "core:node"
+        tools.remove(&fa.full.to_string());
+
         if versions.len() == 1 {
-            tools.insert(&fa.to_string(), value(versions[0].clone()));
+            tools.insert(&fa.short, value(versions[0].clone()));
```

Before that the key was written back exactly as the user spelled it, so nothing could duplicate. The cleanup only covers the `core:`-qualified form, and `full()` never yields an alias spelling — the aliases themselves predate it (`ee923bedd44a`, 2024-05-31). `2592f8429a0b` (#3015) only added the `if ba.short != ba.full()` guard.

## Tests
Six unit tests: the alias rename (scalar and array), the damaged both-keys state, `remove_tool` on an aliased key and on a `core:`-qualified key, and a guard that a **registry** alias is *not* collapsed (`ripgrep` stays as written while `rg` is added — that mechanism resolves to different short names and is already pinned by `e2e/cli/test_use`).

Two e2e blocks: `--rm nodejs` in `e2e/cli/test_use` (installs nothing), and the rename in `e2e/core/test_node_slow`, which reuses the node install that test already does — no added CI time in either.

## Not changed
- **Registry aliases** (`rg`/`ripgrep`, `gh`) are a separate mechanism resolving to different short names; each is still written back as spelled.
- **`.tool-versions`** still writes `nodejs`/`golang` for asdf compatibility.
- **Keys carrying inline options** (`"go:example.com/x[tags=y]"`) are a third spelling with the same duplication problem, but collapsing them has to decide what happens to the options, so that is deliberately left for a separate change.
- A renamed key still moves to the end of `[tools]` when the table was not already sorted — `toml_edit` has no position-preserving rename. Pre-existing for `core:node`.

## Notes
I could not compile locally (memory-constrained machine), so the change is validated by CI; the before-states above were all reproduced against the released 2026.7.15 binary. This touches the same block as #11454, so whichever lands second will need a trivial rebase.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mise.toml` tool key handling to treat equivalent spellings (aliases and qualified forms) as the same tool, rewriting to the canonical short key.
  * Consolidates duplicate tool entries into a single key while preserving related comments and decorations.
  * `--rm`-style removals now delete all matching `[tools]` entries and remove the `[tools]` section when it becomes empty.
  * Ensures registry aliases (e.g., `rg`) remain separate.
* **Documentation**
  * Updated the FAQ to clarify canonical naming and confirm `.tool-versions` is unchanged.
* **Tests**
  * Added e2e/core coverage for alias removal and in-place key normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->