### PR TITLE
fix(python): respect UV_PROJECT_ENVIRONMENT for uv venvs

### DIFF
--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -80,7 +80,7 @@ mise has two ways to manage Python virtualenvs:
 | `python.uv_venv_auto` | uv projects (with `uv.lock`) | `[settings]` section |
 | `_.python.venv`       | Projects not using uv        | `[env]` section      |
 
-**`python.uv_venv_auto`** detects and sources the `.venv` managed by `uv`. Use `"source"` to only activate existing venvs, or `"create|source"` to create if missing. mise locates the uv project by walking up for a `uv.lock` file, so a `uv.lock` must be present — without one the setting does nothing. See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for full examples.
+**`python.uv_venv_auto`** detects and sources the virtual environment managed by `uv` (`.venv` by default, or the path configured by `UV_PROJECT_ENVIRONMENT`). Use `"source"` to only activate existing venvs, or `"create|source"` to create if missing. mise locates the uv project by walking up for a `uv.lock` file, so a `uv.lock` must be present — without one the setting does nothing. See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for full examples.
 
 **`_.python.venv`** creates/activates a venv and adds it to PATH. It works with both `mise activate` and `mise exec`. Use this for projects that don't use uv.
 
@@ -127,13 +127,25 @@ Virtualenv activation requires `mise activate` or `mise exec`. When using [shims
 
 ### `python.uv_venv_auto` setting
 
-For uv-managed projects (those with a `uv.lock` file), you can use the `python.uv_venv_auto` setting to automatically source or create the `.venv` that uv manages. mise finds the project root by walking up for a `uv.lock`; the presence of that lockfile is how mise knows the project uses uv, so a `uv.lock` must be present. If no `uv.lock` is found the setting is a no-op — run `uv sync` (or `uv lock`) to generate one first. See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for full examples.
+For uv-managed projects (those with a `uv.lock` file), you can use the `python.uv_venv_auto` setting to automatically source or create the virtual environment that uv manages. mise finds the project root by walking up for a `uv.lock`; the presence of that lockfile is how mise knows the project uses uv, so a `uv.lock` must be present. If no `uv.lock` is found the setting is a no-op — run `uv sync` (or `uv lock`) to generate one first. See the [mise + uv Cookbook](/mise-cookbook/python.html#mise-uv) for full examples.
 
 ```toml [mise.toml]
 [settings]
 python.uv_venv_auto = "source"        # activate existing .venv
 # or
 python.uv_venv_auto = "create|source" # create .venv if missing, then activate
+```
+
+mise respects uv's `UV_PROJECT_ENVIRONMENT` variable when choosing the environment path. A relative
+path is resolved from the uv project root (the directory containing `uv.lock`), while an absolute
+path is used as-is. When the variable is unset or empty, mise uses `.venv`.
+
+```toml [mise.toml]
+[env]
+UV_PROJECT_ENVIRONMENT = "my.venv"
+
+[settings]
+python.uv_venv_auto = "create|source"
 ```
 
 ## mise & uv

--- a/e2e/core/test_python_uv_venv
+++ b/e2e/core/test_python_uv_venv
@@ -86,8 +86,60 @@ assert "mise x -- which python" "$PWD/.venv/bin/python"
 # legacy true mode SHOULD set UV_PYTHON
 assert_contains "mise env -s bash" "UV_PYTHON"
 
+# Test UV_PROJECT_ENVIRONMENT from mise config in source mode
+rm -rf .venv my.venv
+
+cat >mise.toml <<EOF
+[tools]
+python = "3.12.3"
+uv = "0.5.4"
+
+[env]
+UV_PROJECT_ENVIRONMENT = "my.venv"
+
+[settings]
+python.uv_venv_auto = "source"
+EOF
+
+# Create the fixture with an explicit path so this test isolates mise's
+# UV_PROJECT_ENVIRONMENT sourcing behavior from the pinned uv version.
+mise x -- uv venv my.venv
+assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/my.venv"
+assert_directory_not_exists ".venv"
+
+# Test create|source creates the configured environment instead of .venv
+rm -rf my.venv
+sed -i.bak 's/uv_venv_auto = "source"/uv_venv_auto = "create|source"/' mise.toml
+rm mise.toml.bak
+assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/my.venv"
+assert_directory_exists "my.venv"
+assert_directory_not_exists ".venv"
+
+# Test UV_PROJECT_ENVIRONMENT from the process environment
+cat >mise.toml <<EOF
+[tools]
+python = "3.12.3"
+uv = "0.5.4"
+
+[settings]
+python.uv_venv_auto = "source"
+EOF
+
+mkdir -p process.venv/bin absolute.venv/bin
+UV_PROJECT_ENVIRONMENT=process.venv assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/process.venv"
+UV_PROJECT_ENVIRONMENT="$PWD/absolute.venv" assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/absolute.venv"
+
+# Explicitly removing the config value must not fall back to the process environment
+cat >>mise.toml <<EOF
+
+[env]
+UV_PROJECT_ENVIRONMENT = false
+EOF
+mkdir -p .venv/bin
+UV_PROJECT_ENVIRONMENT=process.venv assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/.venv"
+
 # Test boolean parsing from env vars - "true","1", "yes",  should all work
-rm -rf .venv
+rm -rf .venv my.venv process.venv absolute.venv
 
 cat >mise.toml <<EOF
 [tools]

--- a/e2e/env/test_env_cache_venv
+++ b/e2e/env/test_env_cache_venv
@@ -58,3 +58,30 @@ assert_not_contains "mise env -s bash" "VIRTUAL_ENV"
 cd ../proj
 assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/.venv"
 cd ..
+
+# A custom uv environment path must participate in the cache key too. Changing
+# UV_PROJECT_ENVIRONMENT must select the new venv rather than reuse the previous
+# cached environment, and the custom venv must not leak into a sibling.
+rm -rf "${MISE_STATE_DIR:?}/env-cache"
+mkdir -p proj/custom-a/bin proj/custom-b/bin
+cd proj
+UV_PROJECT_ENVIRONMENT=custom-a assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/custom-a"
+UV_PROJECT_ENVIRONMENT=custom-b assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/custom-b"
+cd ../other
+UV_PROJECT_ENVIRONMENT=custom-a assert_not_contains "mise env -s bash" "VIRTUAL_ENV"
+cd ..
+
+# A config-defined custom environment must produce the same key for cache save
+# and lookup, so the second invocation gets a full environment cache hit.
+rm -rf "${MISE_STATE_DIR:?}/env-cache"
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[env]
+UV_PROJECT_ENVIRONMENT = "configured"
+
+[settings]
+python.uv_venv_auto = "source"
+EOF
+mkdir -p proj/configured/bin
+cd proj
+assert_contains "mise env -s bash" "VIRTUAL_ENV=$PWD/configured"
+assert_contains "MISE_TRACE=1 mise env -s bash 2>&1" "env_cache: using cached environment"

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -95,7 +95,7 @@ impl HookEnv {
         // Try to use cached watch_files for early exit check if env_cache is enabled
         // This avoids executing plugins just to get watch_files
         let watch_files = if Settings::get().env_cache {
-            if let Ok(Some(cached)) = ts.try_load_env_cache_full(&config) {
+            if let Ok(Some(cached)) = ts.try_load_env_cache_full(&config).await {
                 trace!("env_cache: using cached watch_files for early exit check");
                 cached
                     .watch_files

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -70,7 +70,7 @@ impl Toolset {
     pub async fn env_with_path(&self, config: &Arc<Config>) -> Result<EnvMap> {
         // Try to load from cache if enabled
         if CachedEnv::is_enabled()
-            && let Some(mut cached) = self.try_load_env_cache(config)?
+            && let Some(mut cached) = self.try_load_env_cache(config).await?
         {
             trace!("env_cache: using cached environment");
             github::oauth::inject_token_env(&mut cached);
@@ -114,7 +114,7 @@ impl Toolset {
     ) -> Result<(EnvMap, Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>)> {
         // Try to load from cache if enabled
         if CachedEnv::is_enabled()
-            && let Some(cached) = self.try_load_env_cache_full(config)?
+            && let Some(cached) = self.try_load_env_cache_full(config).await?
         {
             trace!("env_cache: using cached environment with split paths");
             let mut env = cached.env;
@@ -163,17 +163,18 @@ impl Toolset {
     }
 
     /// Try to load environment from cache (returns full CachedEnv)
-    pub(crate) fn try_load_env_cache_full(
+    pub(crate) async fn try_load_env_cache_full(
         &self,
         config: &Arc<Config>,
     ) -> Result<Option<CachedEnv>> {
+        config.env_results().await?;
         let cache_key = self.compute_env_cache_key(config)?;
         CachedEnv::load(&cache_key)
     }
 
     /// Try to load environment from cache (returns reconstructed EnvMap)
-    fn try_load_env_cache(&self, config: &Arc<Config>) -> Result<Option<EnvMap>> {
-        match self.try_load_env_cache_full(config)? {
+    async fn try_load_env_cache(&self, config: &Arc<Config>) -> Result<Option<EnvMap>> {
+        match self.try_load_env_cache_full(config).await? {
             Some(cached) => {
                 let mut env = cached.env;
                 // Reconstruct PATH from cached paths
@@ -283,7 +284,7 @@ impl Toolset {
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
 
-        // Include the auto-sourced uv venv (uv.lock + .venv) in the key so a venv
+        // Include the auto-sourced uv venv (uv.lock + resolved venv) in the key so a venv
         // dir and a sibling sharing the same config files don't collide on one
         // cache entry, which would leak the venv across directories.
         let mut uv_venv_inputs: Vec<(PathBuf, u64)> = Vec::new();
@@ -291,7 +292,7 @@ impl Toolset {
             && let Some(uv_root) = uv::uv_root()
         {
             let lock = uv_root.join("uv.lock");
-            let venv = uv_root.join(".venv");
+            let venv = uv::uv_venv_path(config, &uv_root);
             let lock_mtime = get_file_mtime(&lock).unwrap_or(0);
             let venv_mtime = get_file_mtime(&venv).unwrap_or(0);
             uv_venv_inputs.push((lock, lock_mtime));

--- a/src/uv.rs
+++ b/src/uv.rs
@@ -4,7 +4,7 @@ use crate::config::{Config, Settings};
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
 use crate::toolset::Toolset;
-use crate::{dirs, file};
+use crate::{dirs, env, file};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 use std::{collections::HashMap, sync::Arc};
@@ -13,6 +13,7 @@ use tokio::sync::OnceCell;
 // use a mutex to prevent deadlocks that occurs due to reentrantly initialization
 // when resolving the venv path or env vars
 static UV_VENV: Lazy<OnceCell<Option<Venv>>> = Lazy::new(Default::default);
+const UV_PROJECT_ENVIRONMENT: &str = "UV_PROJECT_ENVIRONMENT";
 
 pub async fn uv_venv(config: &Arc<Config>, ts: &Toolset) -> &'static Option<Venv> {
     UV_VENV
@@ -23,7 +24,7 @@ pub async fn uv_venv(config: &Arc<Config>, ts: &Toolset) -> &'static Option<Venv
                 return None;
             }
             let uv_root = uv_root()?;
-            let venv_path = uv_root.join(".venv");
+            let venv_path = uv_venv_path(config, &uv_root);
             if !venv_path.exists() {
                 if uv_auto.should_create() {
                     match create_python_venv(
@@ -78,6 +79,38 @@ pub(crate) fn uv_root() -> Option<PathBuf> {
     file::find_up(dirs::CWD.as_ref()?, &["uv.lock"]).map(|p| p.parent().unwrap().to_path_buf())
 }
 
+pub(crate) fn uv_venv_path(config: &Config, uv_root: &Path) -> PathBuf {
+    let project_environment = if let Some(env_results) = config.env_results_cached() {
+        if let Some((value, _)) = env_results.env.get(UV_PROJECT_ENVIRONMENT) {
+            Some(value.as_str())
+        } else if env_results.env_remove.contains(UV_PROJECT_ENVIRONMENT) {
+            None
+        } else {
+            env::PRISTINE_ENV
+                .get(UV_PROJECT_ENVIRONMENT)
+                .map(String::as_str)
+        }
+    } else {
+        env::PRISTINE_ENV
+            .get(UV_PROJECT_ENVIRONMENT)
+            .map(String::as_str)
+    };
+
+    resolve_uv_venv_path(uv_root, project_environment)
+}
+
+fn resolve_uv_venv_path(uv_root: &Path, project_environment: Option<&str>) -> PathBuf {
+    let path = project_environment
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(".venv"));
+    if path.is_absolute() {
+        path
+    } else {
+        uv_root.join(path)
+    }
+}
+
 fn deps_uv_enabled(config: &Config, uv_root: &Path) -> bool {
     config.config_files.values().any(|cf| {
         if cf.config_root() != uv_root {
@@ -86,4 +119,26 @@ fn deps_uv_enabled(config: &Config, uv_root: &Path) -> bool {
         cf.deps_config()
             .is_some_and(|deps| deps.providers.contains_key("uv"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_uv_venv_path() {
+        let root = std::env::current_dir().unwrap().join("project");
+        let absolute = std::env::current_dir().unwrap().join("absolute-venv");
+
+        assert_eq!(resolve_uv_venv_path(&root, None), root.join(".venv"));
+        assert_eq!(
+            resolve_uv_venv_path(&root, Some("custom-venv")),
+            root.join("custom-venv")
+        );
+        assert_eq!(
+            resolve_uv_venv_path(&root, Some(absolute.to_str().unwrap())),
+            absolute
+        );
+        assert_eq!(resolve_uv_venv_path(&root, Some("")), root.join(".venv"));
+    }
 }


### PR DESCRIPTION
## Summary

- respect `UV_PROJECT_ENVIRONMENT` when `python.uv_venv_auto` selects, creates, and activates a uv virtual environment
- resolve relative paths from the uv workspace root and preserve absolute paths, while retaining `.venv` as the empty or unset fallback
- initialize resolved config environment values before cache lookup and include the selected virtual environment path in cache keys
- document the supported behavior

## Root cause

The uv auto-venv path was hardcoded to `<uv-root>/.venv` in both activation and env cache invalidation. As a result, mise ignored the environment path selected by uv and could activate or cache the wrong virtual environment. Cache lookup also did not guarantee that config environment values were initialized before deriving the key, so alternate config construction paths could derive different lookup and save keys.

## Testing

- `mise exec -- cargo test uv::tests::test_resolve_uv_venv_path`
- `mise run test:e2e e2e/core/test_python_uv_venv e2e/env/test_env_cache_venv`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck -x e2e/core/test_python_uv_venv e2e/env/test_env_cache_venv`
- `mise exec -- shfmt -d -s e2e/core/test_python_uv_venv e2e/env/test_env_cache_venv`
- `mise exec -- markdownlint docs/lang/python.md`
- `mise x prettier -- prettier --check docs/lang/python.md`

`mise run lint` could not start because hk does not recognize the Sapling working copy as a Git repository; all checks applicable to the changed files were run individually above.

Addresses https://github.com/jdx/mise/discussions/7142

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python projects can now use a custom virtual environment path via `UV_PROJECT_ENVIRONMENT`, including relative and absolute locations.
  * Virtual environment create/activate behavior now consistently honors the configured path (not just the default directory).

* **Bug Fixes**
  * Improved env-cache behavior so cache keys and reuse reflect custom virtual environment locations.
  * Prevented virtual environment settings from leaking between projects when using custom paths.

* **Documentation**
  * Updated Python documentation with clearer `UV_PROJECT_ENVIRONMENT` guidance and examples.

* **Tests**
  * Expanded end-to-end coverage for `UV_PROJECT_ENVIRONMENT` interactions and caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->