### PR TITLE
feat(task): add upstream task dependencies

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -49,7 +49,7 @@ outside this tracker.
 - [x] Infer Node project dependency edges from declared internal package dependencies
 - [x] Import package scripts as scoped mise tasks without requiring a `mise.toml` in every package
 - [x] Add root task defaults that apply by task name across inferred and explicit projects
-- [ ] Add dependency-scoped task relationships equivalent to building the same task in upstream
+- [x] Add dependency-scoped task relationships equivalent to building the same task in upstream
       projects first
 - [ ] Define deterministic precedence between provider inference, root task defaults, task
       templates, and project-local configuration

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -431,6 +431,8 @@ because those fields do not describe prerequisite work.
 Running `node:@acme/web#build` now runs `build` in each project that `@acme/web` depends on before
 building `@acme/web`. The relationship follows the complete project dependency graph, including
 through intermediate projects that do not define `build`. Missing upstream tasks are skipped.
+For a configured task root that is not represented in the detected project graph, the dependency
+is a no-op because that task has no upstream project relationship.
 
 Upstream dependencies work with both provider-inferred tasks and explicit mise tasks. They use the
 same task scheduler as ordinary `depends`, including cycle detection, deduplication, parallel

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -425,6 +425,9 @@ task default is the usual way to apply this relationship across the workspace:
 depends = ["^build"]
 ```
 
+The `^` prefix is supported only in `depends`. It is rejected in `depends_post` and `wait_for`
+because those fields do not describe prerequisite work.
+
 Running `node:@acme/web#build` now runs `build` in each project that `@acme/web` depends on before
 building `@acme/web`. The relationship follows the complete project dependency graph, including
 through intermediate projects that do not define `build`. Missing upstream tasks are skipped.

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -415,6 +415,25 @@ task uses `extends`, its template also takes precedence over the root default.
 
 Root task defaults are experimental and are ignored unless experimental features are enabled.
 
+### Upstream Task Dependencies
+
+Prefix a task dependency with `^` to run that task in upstream workspace projects first. A root
+task default is the usual way to apply this relationship across the workspace:
+
+```toml
+[monorepo.task_defaults.build]
+depends = ["^build"]
+```
+
+Running `node:@acme/web#build` now runs `build` in each project that `@acme/web` depends on before
+building `@acme/web`. The relationship follows the complete project dependency graph, including
+through intermediate projects that do not define `build`. Missing upstream tasks are skipped.
+
+Upstream dependencies work with both provider-inferred tasks and explicit mise tasks. They use the
+same task scheduler as ordinary `depends`, including cycle detection, deduplication, parallel
+execution, and dependency cache-key propagation. This syntax is available only for configured
+monorepo workspaces while experimental features are enabled.
+
 ### Project Overrides
 
 Use `[monorepo.projects]` in the root `mise.toml` to correct or extend provider inference. Project IDs containing `:` or scoped package names must be quoted:

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -7,10 +7,12 @@ cat <<'SH' >bin/npm
 #!/bin/sh
 printf '%s' "$*" >manager-args.txt
 printf '%s' "$ROOT_TASK_DEFAULT" >default.txt
+printf '%s:%s\n' "$(basename "$PWD")" "$*" >>"$WORKSPACE_TASK_LOG"
 printf inferred >result.txt
 SH
 chmod +x bin/npm
 export PATH="$PWD/bin:$PATH"
+export WORKSPACE_TASK_LOG="$PWD/workspace-task.log"
 
 cat <<'TOML' >mise.toml
 monorepo_root = true
@@ -20,6 +22,7 @@ config_roots = ["packages/*"]
 
 [monorepo.task_defaults.build]
 env = { ROOT_TASK_DEFAULT = "from-root", TASK_PRECEDENCE = "from-root" }
+depends = ["^build"]
 
 [monorepo.task_defaults.lint]
 env = { ROOT_TASK_DEFAULT = "from-executable-default" }
@@ -47,9 +50,32 @@ JSON
 cat <<'JSON' >packages/app/package.json
 {
   "name": "@scope/app",
+  "dependencies": {
+    "@scope/bridge": "workspace:*"
+  },
   "scripts": {
     "build": "printf inferred > result.txt",
     "test:unit": "printf tested > test-result.txt"
+  }
+}
+JSON
+
+mkdir -p packages/bridge
+cat <<'JSON' >packages/bridge/package.json
+{
+  "name": "@scope/bridge",
+  "dependencies": {
+    "@scope/core": "workspace:*"
+  }
+}
+JSON
+
+mkdir -p packages/core
+cat <<'JSON' >packages/core/package.json
+{
+  "name": "@scope/core",
+  "scripts": {
+    "build": "printf built > result.txt"
   }
 }
 JSON
@@ -71,6 +97,7 @@ mise -q run 'node:@scope/app#build' -- forwarded
 assert "cat packages/app/result.txt" "inferred"
 assert "cat packages/app/manager-args.txt" "run build -- forwarded"
 assert "cat packages/app/default.txt" "from-root"
+assert "cat workspace-task.log" $'core:run build --\napp:run build -- forwarded'
 
 printf stale >packages/app/result.txt
 mise -q run //packages/app:build
@@ -80,6 +107,11 @@ cat <<'TOML' >packages/app/mise.toml
 [tasks.build]
 extends = "build-override"
 run = "printf explicit > result.txt; printf '%s' \"$ROOT_TASK_DEFAULT\" > explicit-default.txt; printf '%s' \"$TASK_PRECEDENCE\" > precedence.txt"
+TOML
+
+cat <<'TOML' >packages/core/mise.toml
+[tasks.build]
+run = "printf explicit-upstream > explicit-result.txt"
 TOML
 
 mkdir -p packages/app/mise-tasks
@@ -94,6 +126,7 @@ mise -q run 'node:@scope/app#build'
 assert "cat packages/app/result.txt" "explicit"
 assert "cat packages/app/explicit-default.txt" "from-root"
 assert "cat packages/app/precedence.txt" "from-template"
+assert "cat packages/core/explicit-result.txt" "explicit-upstream"
 
 mise -q run //packages/app:lint
 assert "cat packages/app/executable-default.txt" "from-executable-default"

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -107,6 +107,11 @@ cat <<'TOML' >packages/app/mise.toml
 [tasks.build]
 extends = "build-override"
 run = "printf explicit > result.txt; printf '%s' \"$ROOT_TASK_DEFAULT\" > explicit-default.txt; printf '%s' \"$TASK_PRECEDENCE\" > precedence.txt"
+
+[tasks.deploy]
+usage = 'arg "<task>"'
+depends = ["^{{usage.task}}"]
+run = "printf deployed > deploy-result.txt"
 TOML
 
 cat <<'TOML' >packages/core/mise.toml
@@ -128,6 +133,11 @@ assert "cat packages/app/explicit-default.txt" "from-root"
 assert "cat packages/app/precedence.txt" "from-template"
 assert "cat packages/core/explicit-result.txt" "explicit-upstream"
 
+printf stale >packages/core/explicit-result.txt
+mise -q run //packages/app:deploy build
+assert "cat packages/app/deploy-result.txt" "deployed"
+assert "cat packages/core/explicit-result.txt" "explicit-upstream"
+
 mise -q run //packages/app:lint
 assert "cat packages/app/executable-default.txt" "from-executable-default"
 
@@ -140,6 +150,7 @@ mise -q run local
 assert "cat local-result.txt" "local"
 assert "cat local-default.txt" ""
 
-printf stale >packages/app/explicit-default.txt
-mise -q run //packages/app:build
-assert "cat packages/app/explicit-default.txt" "from-root"
+printf stale >packages/app/executable-default.txt
+mise -q run //packages/app:lint
+assert "cat packages/app/executable-default.txt" "from-executable-default"
+assert_fail_contains "mise run //packages/app:build" "failed to resolve upstream task dependencies"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -793,6 +793,14 @@ impl Config {
                 tasks.insert(task.name.clone(), task);
             }
         }
+        if let Some(monorepo_root) = config.monorepo_root() {
+            let graph = workspace_graph
+                .as_ref()
+                .and_then(|graph| graph.as_ref().ok());
+            for task in tasks.values_mut() {
+                task.resolve_workspace_task_dependencies(graph, &monorepo_root)?;
+            }
+        }
         let all_tasks = tasks.clone();
         for task in tasks.values_mut() {
             task.display_name = task.display_name(&all_tasks);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -793,11 +793,20 @@ impl Config {
                 tasks.insert(task.name.clone(), task);
             }
         }
-        if let Some(monorepo_root) = config.monorepo_root() {
+        if Settings::get().experimental
+            && let Some(monorepo_root) = config.monorepo_root()
+        {
             match workspace_graph.as_ref() {
                 Some(Ok(graph)) => {
+                    let mut project_ids_by_root = BTreeMap::new();
+                    for project in graph.projects() {
+                        project_ids_by_root
+                            .entry(file::desymlink_path(&monorepo_root.join(&project.root)))
+                            .or_insert_with(BTreeSet::new)
+                            .insert(project.id.clone());
+                    }
                     for task in tasks.values_mut() {
-                        task.resolve_workspace_task_dependencies(graph, &monorepo_root)?;
+                        task.resolve_workspace_task_dependencies(graph, &project_ids_by_root)?;
                     }
                 }
                 Some(Err(err)) => {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -794,11 +794,18 @@ impl Config {
             }
         }
         if let Some(monorepo_root) = config.monorepo_root() {
-            let graph = workspace_graph
-                .as_ref()
-                .and_then(|graph| graph.as_ref().ok());
-            for task in tasks.values_mut() {
-                task.resolve_workspace_task_dependencies(graph, &monorepo_root)?;
+            match workspace_graph.as_ref() {
+                Some(Ok(graph)) => {
+                    for task in tasks.values_mut() {
+                        task.resolve_workspace_task_dependencies(graph, &monorepo_root)?;
+                    }
+                }
+                Some(Err(err)) => {
+                    for task in tasks.values_mut() {
+                        task.set_workspace_task_dependency_error(err);
+                    }
+                }
+                _ => {}
             }
         }
         let all_tasks = tasks.clone();

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -695,6 +695,10 @@ pub struct Task {
     #[serde(skip)]
     pub wait_for_raw: Option<Vec<TaskDep>>,
 
+    /// Workspace graph error that prevents this task's `^task` dependencies from resolving.
+    #[serde(skip)]
+    pub(crate) workspace_dependency_error: Option<String>,
+
     /// Args supplied after a literal `--` separator on the command line.
     /// Tracked separately from `args` so the usage parser can be bypassed
     /// when these contain `--help`/`-h`, restoring the documented escape
@@ -1364,6 +1368,11 @@ impl Task {
         tasks: &BTreeMap<String, &Task>,
         visited: &mut HashSet<String>,
     ) -> Result<Vec<Task>> {
+        if !self.depends.is_empty()
+            && let Some(err) = &self.workspace_dependency_error
+        {
+            bail!("{err}");
+        }
         let mut depends: Vec<Task> = self
             .depends
             .iter()
@@ -1396,6 +1405,11 @@ impl Task {
     ) -> Result<(Vec<Task>, Vec<Task>)> {
         use crate::task::TaskLoadContext;
 
+        if !self.depends.is_empty()
+            && let Some(err) = &self.workspace_dependency_error
+        {
+            bail!("{err}");
+        }
         let tasks_to_run: HashSet<&Task> = tasks_to_run.iter().collect();
 
         // Build context with path hints from self, tasks_to_run, and dependency patterns
@@ -1482,17 +1496,12 @@ impl Task {
     /// through those projects so matching tasks farther upstream are retained.
     pub(crate) fn resolve_workspace_task_dependencies(
         &mut self,
-        graph: Option<&workspace::WorkspaceProjectGraph>,
+        graph: &workspace::WorkspaceProjectGraph,
         monorepo_root: &Path,
     ) -> Result<()> {
         if !self.depends.iter().any(|dep| dep.task.starts_with('^')) {
             return Ok(());
         }
-        let Some(graph) = graph else {
-            self.depends
-                .retain(|dependency| !dependency.task.starts_with('^'));
-            return Ok(());
-        };
 
         let mut project_ids = BTreeSet::new();
         let stable_task_names = once(self.name.as_str())
@@ -1528,6 +1537,9 @@ impl Task {
         if project_ids.is_empty() {
             self.depends
                 .retain(|dependency| !dependency.task.starts_with('^'));
+            if let Some(raw) = &mut self.depends_raw {
+                raw.retain(|dependency| !dependency.task.starts_with('^'));
+            }
             return Ok(());
         }
 
@@ -1541,31 +1553,47 @@ impl Task {
             );
         }
 
-        let mut expanded = Vec::new();
-        for dependency in &self.depends {
-            let Some(task_name) = dependency
-                .task
-                .strip_prefix('^')
-                .filter(|task_name| !task_name.is_empty())
-            else {
-                expanded.push(dependency.clone());
-                continue;
-            };
-
-            expanded.extend(upstream_roots.iter().map(|root| {
-                let mut dependency = dependency.clone();
-                let scope = if root.as_os_str().is_empty() || root == Path::new(".") {
-                    "//".to_string()
-                } else {
-                    format!("//{}", root.to_string_lossy().replace('\\', "/"))
+        fn expand(dependencies: &mut Vec<TaskDep>, upstream_roots: &BTreeSet<PathBuf>) {
+            let mut expanded = Vec::new();
+            for dependency in dependencies.iter() {
+                let Some(task_name) = dependency
+                    .task
+                    .strip_prefix('^')
+                    .filter(|task_name| !task_name.is_empty())
+                else {
+                    expanded.push(dependency.clone());
+                    continue;
                 };
-                dependency.task = format!("{scope}:{task_name}");
-                dependency.optional = true;
-                dependency
-            }));
+
+                expanded.extend(upstream_roots.iter().map(|root| {
+                    let mut dependency = dependency.clone();
+                    let scope = if root.as_os_str().is_empty() || root == Path::new(".") {
+                        "//".to_string()
+                    } else {
+                        format!("//{}", root.to_string_lossy().replace('\\', "/"))
+                    };
+                    dependency.task = format!("{scope}:{task_name}");
+                    dependency.optional = true;
+                    dependency
+                }));
+            }
+            *dependencies = expanded;
         }
-        self.depends = expanded;
+
+        expand(&mut self.depends, &upstream_roots);
+        if let Some(raw) = &mut self.depends_raw {
+            expand(raw, &upstream_roots);
+        }
         Ok(())
+    }
+
+    pub(crate) fn set_workspace_task_dependency_error(&mut self, error: &eyre::Report) {
+        if self.depends.iter().any(|dep| dep.task.starts_with('^')) {
+            self.workspace_dependency_error = Some(format!(
+                "failed to resolve upstream task dependencies because the workspace project graph \
+                 could not be loaded: {error:#}"
+            ));
+        }
     }
 
     /// True when mise should not run the usage parser against this task's
@@ -2753,6 +2781,7 @@ impl Default for Task {
             depends_raw: None,
             depends_post_raw: None,
             wait_for_raw: None,
+            workspace_dependency_error: None,
         }
     }
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1497,8 +1497,16 @@ impl Task {
     pub(crate) fn resolve_workspace_task_dependencies(
         &mut self,
         graph: &workspace::WorkspaceProjectGraph,
-        monorepo_root: &Path,
+        project_ids_by_root: &BTreeMap<PathBuf, BTreeSet<workspace::ProjectId>>,
     ) -> Result<()> {
+        if self
+            .depends_post
+            .iter()
+            .chain(&self.wait_for)
+            .any(|dep| dep.task.starts_with('^'))
+        {
+            bail!("^task dependencies are supported only in depends");
+        }
         if !self.depends.iter().any(|dep| dep.task.starts_with('^')) {
             return Ok(());
         }
@@ -1525,12 +1533,11 @@ impl Task {
         {
             let config_root = file::desymlink_path(config_root);
             project_ids.extend(
-                graph
-                    .projects()
-                    .filter(|project| {
-                        file::desymlink_path(&monorepo_root.join(&project.root)) == config_root
-                    })
-                    .map(|project| project.id.clone()),
+                project_ids_by_root
+                    .get(&config_root)
+                    .into_iter()
+                    .flatten()
+                    .cloned(),
             );
         }
 
@@ -3216,11 +3223,13 @@ pub async fn parse_usage_values_from_task(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
 
+    use crate::task::workspace;
     use crate::task::{RunEntry, Task};
     use crate::{config::Config, dirs};
     use indexmap::IndexMap;
@@ -3477,6 +3486,31 @@ exec proxy "$@"
         assert!(!tera_template_has_usage_ref("{# usage.app #}"));
         assert!(tera_tag_has_usage_ref("if(usage.run_post)"));
         assert!(!tera_tag_has_usage_ref("ifusage.run_post"));
+    }
+
+    #[test]
+    fn workspace_task_dependencies_reject_non_prerequisite_fields() {
+        let graph = workspace::WorkspaceProjectGraph::default();
+        let project_ids_by_root = BTreeMap::new();
+        for task in [
+            Task {
+                depends_post: vec!["^build".to_string().into()],
+                ..Default::default()
+            },
+            Task {
+                wait_for: vec!["^build".to_string().into()],
+                ..Default::default()
+            },
+        ] {
+            let mut task = task;
+            let err = task
+                .resolve_workspace_task_dependencies(&graph, &project_ids_by_root)
+                .unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "^task dependencies are supported only in depends"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1368,9 +1368,7 @@ impl Task {
         tasks: &BTreeMap<String, &Task>,
         visited: &mut HashSet<String>,
     ) -> Result<Vec<Task>> {
-        if !self.depends.is_empty()
-            && let Some(err) = &self.workspace_dependency_error
-        {
+        if let Some(err) = &self.workspace_dependency_error {
             bail!("{err}");
         }
         let mut depends: Vec<Task> = self
@@ -1405,9 +1403,7 @@ impl Task {
     ) -> Result<(Vec<Task>, Vec<Task>)> {
         use crate::task::TaskLoadContext;
 
-        if !self.depends.is_empty()
-            && let Some(err) = &self.workspace_dependency_error
-        {
+        if let Some(err) = &self.workspace_dependency_error {
             bail!("{err}");
         }
         let tasks_to_run: HashSet<&Task> = tasks_to_run.iter().collect();
@@ -1595,7 +1591,15 @@ impl Task {
     }
 
     pub(crate) fn set_workspace_task_dependency_error(&mut self, error: &eyre::Report) {
-        if self.depends.iter().any(|dep| dep.task.starts_with('^')) {
+        if self
+            .depends_post
+            .iter()
+            .chain(&self.wait_for)
+            .any(|dep| dep.task.starts_with('^'))
+        {
+            self.workspace_dependency_error =
+                Some("^task dependencies are supported only in depends".to_string());
+        } else if self.depends.iter().any(|dep| dep.task.starts_with('^')) {
             self.workspace_dependency_error = Some(format!(
                 "failed to resolve upstream task dependencies because the workspace project graph \
                  could not be loaded: {error:#}"
@@ -3511,6 +3515,17 @@ exec proxy "$@"
                 "^task dependencies are supported only in depends"
             );
         }
+
+        let mut task = Task {
+            wait_for: vec!["^build".to_string().into()],
+            ..Default::default()
+        };
+        task.set_workspace_task_dependency_error(&eyre::eyre!("invalid graph"));
+        let err = task.all_depends(&BTreeMap::new()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "^task dependencies are supported only in depends"
+        );
     }
 
     #[tokio::test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -17,8 +17,7 @@ use petgraph::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::iter::once;
@@ -1474,6 +1473,99 @@ impl Task {
             .filter_ok(|t| t.name != self.name)
             .collect::<Result<_>>()?;
         Ok((depends, depends_post))
+    }
+
+    /// Expands `^task` dependencies to the matching task in every upstream workspace project.
+    ///
+    /// Each expanded dependency is optional because not every project in the dependency closure
+    /// needs to implement the requested task. The workspace graph traversal still continues
+    /// through those projects so matching tasks farther upstream are retained.
+    pub(crate) fn resolve_workspace_task_dependencies(
+        &mut self,
+        graph: Option<&workspace::WorkspaceProjectGraph>,
+        monorepo_root: &Path,
+    ) -> Result<()> {
+        if !self.depends.iter().any(|dep| dep.task.starts_with('^')) {
+            return Ok(());
+        }
+        let Some(graph) = graph else {
+            self.depends
+                .retain(|dependency| !dependency.task.starts_with('^'));
+            return Ok(());
+        };
+
+        let mut project_ids = BTreeSet::new();
+        let stable_task_names = once(self.name.as_str())
+            .chain(self.aliases.iter().map(String::as_str))
+            .filter(|name| is_workspace_project_task(name))
+            .collect_vec();
+
+        for name in stable_task_names {
+            let (project_id, _) = name
+                .split_once('#')
+                .expect("workspace project task contains #");
+            if let Ok(project_id) = project_id.parse::<workspace::ProjectId>()
+                && graph.get(&project_id).is_some()
+            {
+                project_ids.insert(project_id);
+            }
+        }
+
+        if project_ids.is_empty()
+            && let Some(config_root) = self.config_root.as_deref()
+        {
+            let config_root = file::desymlink_path(config_root);
+            project_ids.extend(
+                graph
+                    .projects()
+                    .filter(|project| {
+                        file::desymlink_path(&monorepo_root.join(&project.root)) == config_root
+                    })
+                    .map(|project| project.id.clone()),
+            );
+        }
+
+        if project_ids.is_empty() {
+            self.depends
+                .retain(|dependency| !dependency.task.starts_with('^'));
+            return Ok(());
+        }
+
+        let mut upstream_roots = BTreeSet::new();
+        for project_id in &project_ids {
+            upstream_roots.extend(
+                graph
+                    .matching_dependency_projects(project_id, |_| true)?
+                    .into_iter()
+                    .map(|project| project.root.clone()),
+            );
+        }
+
+        let mut expanded = Vec::new();
+        for dependency in &self.depends {
+            let Some(task_name) = dependency
+                .task
+                .strip_prefix('^')
+                .filter(|task_name| !task_name.is_empty())
+            else {
+                expanded.push(dependency.clone());
+                continue;
+            };
+
+            expanded.extend(upstream_roots.iter().map(|root| {
+                let mut dependency = dependency.clone();
+                let scope = if root.as_os_str().is_empty() || root == Path::new(".") {
+                    "//".to_string()
+                } else {
+                    format!("//{}", root.to_string_lossy().replace('\\', "/"))
+                };
+                dependency.task = format!("{scope}:{task_name}");
+                dependency.optional = true;
+                dependency
+            }));
+        }
+        self.depends = expanded;
+        Ok(())
     }
 
     /// True when mise should not run the usage parser against this task's


### PR DESCRIPTION
## Summary

- add experimental `^task` dependency syntax for workspace-project tasks
- expand upstream relationships through the provider-neutral project graph
- skip projects that do not implement the requested task while continuing traversal
- support both inferred tasks and explicit mise tasks
- document the feature and advance the temporary parity tracker

## Why

Root task defaults can now define shared task configuration, but they could not yet express the common monorepo rule “build this task in upstream projects first.” This change maps `depends = ["^build"]` onto mise’s existing dependency scheduler so execution, deduplication, cycle detection, and dependency cache-key propagation remain consistent with ordinary task dependencies.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --all-features --all-targets`
- `mise run test:e2e tasks/test_task_node_workspace_scripts`
- `mise run lint`

The E2E coverage verifies inferred and explicit tasks, transitive traversal through a project without the requested task, and selection of an explicit upstream task over its inferred counterpart.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task loading and dependency expansion for experimental monorepos; failures are gated and surfaced at resolve time, but incorrect expansion could affect build order across projects.
> 
> **Overview**
> Adds experimental **`^task`** syntax in **`depends`** so a task can require the same named task in every upstream workspace project before it runs—typically via **`[monorepo.task_defaults]`** (e.g. `depends = ["^build"]`).
> 
> At load time (experimental monorepo only), each `^<name>` expands to optional **`//<project-root>:<name>`** dependencies using the workspace project graph, including transitive upstreams and projects that lack that task. **`^`** is rejected in **`depends_post`** and **`wait_for`**; if the graph fails to load, tasks with `^` deps fail with a clear error at dependency resolution.
> 
> Documented in **`docs/tasks/monorepo.md`**, parity tracker item checked, with expanded Node workspace e2e coverage (ordering, explicit upstream tasks, templated `^{{usage.task}}`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17a725981e9ec80a7d37057fdd7419c76a95951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental `^task` upstream dependencies for configured monorepo workspaces, running referenced tasks in upstream projects first (with optional expansion when tasks are missing).
  * Supported for `depends` only; entries in `depends_post` and `wait_for` are rejected.
* **Documentation**
  * Documented `^` dependency syntax and scheduling behavior, including cycle/dedup/parallel semantics.
* **Bug Fixes**
  * Improved task loading so workspace dependency graph failures are recorded early and prevent later resolution for `depends`.
* **Tests**
  * Extended end-to-end scenarios for task forwarding and upstream dependency ordering/failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->