### PR TITLE
fix(activate): keep fish cd hook active during commands

### DIFF
--- a/e2e/shell/fish_cd_hook.fish
+++ b/e2e/shell/fish_cd_hook.fish
@@ -1,0 +1,61 @@
+#!/usr/bin/env fish
+
+mkdir project-one project-two
+printf '[env]\nMISE_FISH_CD_TEST = "one"\n' >project-one/mise.toml
+printf '[env]\nMISE_FISH_CD_TEST = "two"\n' >project-two/mise.toml
+
+mise activate fish | source
+
+# Reproduce an interactive prompt followed by a separate command.
+emit fish_prompt
+emit fish_preexec 'cd project-one; cd ../project-two'
+
+functions -q __mise_cd_hook
+or begin
+    echo "expected the default PWD hook to remain active during command execution"
+    exit 1
+end
+
+cd project-one
+test "$MISE_FISH_CD_TEST" = one
+or begin
+    echo "expected the first directory change to update the environment"
+    exit 1
+end
+
+cd ../project-two
+test "$MISE_FISH_CD_TEST" = two
+or begin
+    echo "expected the second directory change to update the environment"
+    exit 1
+end
+
+cd ..
+mise deactivate
+
+set -g mise_fish_mode eval_after_arrow
+mise activate fish | source
+emit fish_prompt
+emit fish_preexec 'cd project-one'
+
+functions -q __mise_cd_hook
+and begin
+    echo "expected eval_after_arrow to retain its delayed PWD hook behavior"
+    exit 1
+end
+
+cd project-one
+set -q MISE_FISH_CD_TEST
+and begin
+    echo "expected eval_after_arrow to defer the environment update until the prompt"
+    exit 1
+end
+
+emit fish_prompt
+test "$MISE_FISH_CD_TEST" = one
+or begin
+    echo "expected the prompt to apply the deferred environment update"
+    exit 1
+end
+
+mise deactivate

--- a/e2e/shell/test_fish_cd_hook
+++ b/e2e/shell/test_fish_cd_hook
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+require_cmd fish
+exec fish --no-config "$TEST_DIR/fish_cd_hook.fish"

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -101,7 +101,9 @@ impl Shell for Fish {
                     echo;
                 end;
 
-                functions --erase __mise_cd_hook;
+                if test "$mise_fish_mode" = "eval_after_arrow";
+                    functions --erase __mise_cd_hook;
+                end;
             end;
 
             __mise_env_eval

--- a/src/shell/snapshots/mise__shell__fish__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__fish__tests__activate.snap
@@ -69,7 +69,9 @@ function __mise_env_eval_2 --on-event fish_preexec --description 'Update mise en
         echo;
     end;
 
-    functions --erase __mise_cd_hook;
+    if test "$mise_fish_mode" = "eval_after_arrow";
+        functions --erase __mise_cd_hook;
+    end;
 end;
 
 __mise_env_eval


### PR DESCRIPTION
## Summary

- keep the Fish PWD hook active while commands run in the default mode
- preserve the existing delayed behavior for `eval_after_arrow` and prompt-only behavior for `disable_arrow`
- add Fish end-to-end coverage for consecutive directory changes after a separate activation command

## Problem

Fish erased `__mise_cd_hook` on every `fish_preexec` event. After activation was evaluated as a separate command, the next command removed the hook before `cd` changed `PWD`, so mise did not update the environment until a later prompt. This differed from the Bash and Zsh activation behavior.

## Solution

Only erase the PWD hook in `eval_after_arrow` mode. The default mode now keeps the hook active during command execution, allowing each directory change in a compound command to apply the matching mise environment immediately. The first-prompt optimization and the explicit Fish modes retain their existing behavior.

## Testing

- `cargo test shell::fish::tests`
- `cargo check --all-features`
- `cargo fmt --all -- --check`
- `shellcheck e2e/shell/test_fish_cd_hook`
- `shfmt -d e2e/shell/test_fish_cd_hook`
- Fish 4.2.1 syntax check for the new E2E script
- Docker/Linux: `shell/test_fish_cd_hook`
- Docker/Linux: `shell/test_fish_first_prompt`
- `cargo clippy --all-features --all-targets -- -A clippy::useless_borrows_in_formatting -A clippy::manual_filter -D warnings`

`mise run format` and `mise run lint` could not complete because hk does not recognize this Sapling working copy as a Git repository. The relevant format, shell, Rust, Clippy, and E2E checks above were run directly. Unsuppressed Clippy also reports only the two pre-existing Rust 1.97 diagnostics listed above on current main.

Addresses https://github.com/jdx/mise/discussions/3886

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*