### PR TITLE
fix(cargo): reinstall when install options change

### DIFF
--- a/docs/dev-tools/backends/cargo.md
+++ b/docs/dev-tools/backends/cargo.md
@@ -100,6 +100,11 @@ For options that do not skip `cargo-binstall`, mise disables cargo-binstall's co
 runs `cargo install` itself only when cargo-binstall exits with code 94 to report that no prebuilt
 artifact is available.
 
+Mise records the effective `features`, `default-features`, `bin`, `crate`, and `locked` values with
+each installed Cargo version. Changing any of these options reinstalls the same version instead of
+reusing a binary built or selected with different options. Feature names are normalized, so changing
+their order or switching between a string and an array does not trigger an unnecessary reinstall.
+
 | Option                     | `cargo-binstall` behavior                                                                |
 | -------------------------- | ---------------------------------------------------------------------------------------- |
 | `features`                 | Skips `cargo-binstall`; requires `cargo install --features`.                             |

--- a/e2e/backend/test_cargo_binstall_token
+++ b/e2e/backend/test_cargo_binstall_token
@@ -30,6 +30,9 @@ assert_contains "MISE_GITHUB_TOKEN=foobar GITHUB_API_TOKEN=barquz GITHUB_TOKEN=b
 
 # compile and quick-install should be disabled by default
 assert_contains "mise install -f cargo:eza@0.18.24 2>&1" "args=-y --disable-strategies compile,quick-install eza@0.18.24"
+install_path="$(mise where cargo:eza@0.18.24)"
+assert_contains "cat '$install_path/.mise-cargo-install.toml'" "default_features = true"
+assert_contains "cat '$install_path/.mise-cargo-install.toml'" "locked = true"
 
 # The setting should allow quick-install while compile remains disabled
 assert_contains "MISE_CARGO_BINSTALL_QUICKINSTALL=1 mise install -f cargo:eza@0.18.24 2>&1" "args=-y --disable-strategies compile eza@0.18.24"

--- a/e2e/backend/test_cargo_install_options_slow
+++ b/e2e/backend/test_cargo_install_options_slow
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+require_cmd cargo
+require_cmd git
+
+crate_dir="$PWD/option-test-crate"
+mkdir -p "$crate_dir/src"
+cat >"$crate_dir/Cargo.toml" <<'EOF'
+[package]
+name = "mise-cargo-option-test"
+version = "1.0.0"
+edition = "2024"
+
+[features]
+extra = []
+
+[[bin]]
+name = "mise-cargo-option-test"
+path = "src/main.rs"
+EOF
+cat >"$crate_dir/src/main.rs" <<'EOF'
+fn main() {
+    if cfg!(feature = "extra") {
+        println!("extra");
+    } else {
+        println!("default");
+    }
+}
+EOF
+(
+  cd "$crate_dir"
+  cargo generate-lockfile
+  git init -q
+  git config user.email "mise-e2e@example.com"
+  git config user.name "mise e2e"
+  git add Cargo.toml Cargo.lock src/main.rs
+  git commit -qm "initial"
+  git tag v1.0.0
+)
+
+export MISE_CARGO_BINSTALL=0
+export CARGO_HOME="$PWD/cargo-home"
+tool="cargo:file://$crate_dir"
+cat >mise.toml <<EOF
+[tools]
+"$tool" = { version = "tag:v1.0.0", crate = "mise-cargo-option-test" }
+EOF
+mise install
+assert "mise x -- mise-cargo-option-test" "default"
+
+cat >mise.toml <<EOF
+[tools]
+"$tool" = { version = "tag:v1.0.0", crate = "mise-cargo-option-test", features = "extra" }
+EOF
+assert_contains "mise install '$tool' --dry-run 2>&1" "would install"
+mise install
+assert "mise x -- mise-cargo-option-test" "extra"
+assert_contains "mise install '$tool' --dry-run 2>&1" "already installed"

--- a/e2e/backend/test_cargo_install_options_stub_slow
+++ b/e2e/backend/test_cargo_install_options_stub_slow
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+cat >~/bin/cargo <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$MISE_DATA_DIR/cargo-install.log"
+while (($#)); do
+  if [[ $1 == "--root" ]]; then
+    mkdir -p "$2/bin"
+    exit 0
+  fi
+  shift
+done
+EOF
+chmod u+x ~/bin/cargo
+export PATH="$HOME/bin:$PATH"
+export MISE_CARGO_BINSTALL=0
+
+assert_install_state() {
+  assert_contains "mise install '$tool' --dry-run 2>&1" "$1"
+}
+
+tool="cargo:option-test"
+cat >mise.toml <<'EOF'
+[tools]
+"cargo:option-test" = "1.0.0"
+EOF
+mise install
+assert_install_state "already installed"
+
+cat >mise.toml <<'EOF'
+[tools]
+"cargo:option-test" = { version = "1.0.0", features = "beta, alpha beta" }
+EOF
+assert_install_state "would install"
+mise install
+assert_install_state "already installed"
+
+# Equivalent feature spelling, ordering, and array syntax must reuse the install.
+cat >mise.toml <<'EOF'
+[tools]
+"cargo:option-test" = { version = "1.0.0", features = ["alpha", "beta"] }
+EOF
+assert_install_state "already installed"
+
+# Removing a non-default option must restore and record the default state.
+cat >mise.toml <<'EOF'
+[tools]
+"cargo:option-test" = "1.0.0"
+EOF
+assert_install_state "would install"
+mise install
+assert_install_state "already installed"
+
+for option in \
+  "default-features = false" \
+  'bin = "alternate-bin"' \
+  'crate = "alternate-crate"' \
+  "locked = false"; do
+  cat >mise.toml <<EOF
+[tools]
+"cargo:option-test" = { version = "1.0.0", $option }
+EOF
+  assert_install_state "would install"
+  mise install
+  assert_install_state "already installed"
+
+  cat >mise.toml <<'EOF'
+[tools]
+"cargo:option-test" = "1.0.0"
+EOF
+  assert_install_state "would install"
+  mise install
+  assert_install_state "already installed"
+done
+
+install_path="$(mise where cargo:option-test@1.0.0)"
+assert_contains "cat '$install_path/.mise-cargo-install.toml'" "default_features = true"
+assert_contains "cat '$install_path/.mise-cargo-install.toml'" "locked = true"
+
+# An incompatible shared install must be shadowed in the primary installs dir.
+tool="cargo:shared-option-test"
+cat >mise.toml <<'EOF'
+[tools]
+"cargo:shared-option-test" = "1.0.0"
+EOF
+mise install
+primary_path="$(mise where cargo:shared-option-test@1.0.0)"
+relative_path="${primary_path#"$MISE_DATA_DIR/installs/"}"
+shared_dir="$PWD/shared-installs"
+shared_path="$shared_dir/$relative_path"
+mkdir -p "$(dirname "$shared_path")"
+mv "$primary_path" "$shared_path"
+shared_state="$(cat "$shared_path/.mise-cargo-install.toml")"
+export MISE_SHARED_INSTALL_DIRS="$shared_dir"
+
+cat >mise.toml <<'EOF'
+[tools]
+"cargo:shared-option-test" = { version = "1.0.0", features = "extra" }
+EOF
+assert_install_state "would install"
+mise install
+assert "test -d '$primary_path'"
+assert_contains "cat '$primary_path/.mise-cargo-install.toml'" 'features = ["extra"]'
+assert "cat '$shared_path/.mise-cargo-install.toml'" "$shared_state"

--- a/e2e/backend/test_vfox_rolling_install
+++ b/e2e/backend/test_vfox_rolling_install
@@ -68,8 +68,19 @@ EOF
 
 # --- step 1: initial install ---
 mise install
-INSTALL_PATH=$(mise where "vfox:file://$PLUGIN_DIR")
-assert "cat '$INSTALL_PATH/version.txt'" "content-v1"
+PRIMARY_INSTALL_PATH=$(mise where "vfox:file://$PLUGIN_DIR")
+assert "cat '$PRIMARY_INSTALL_PATH/version.txt'" "content-v1"
+
+# Move the install into a shared fallback directory. Rolling checksum checks
+# must follow the resolved install path, and an update must shadow this install
+# in the primary directory rather than modifying the shared copy.
+RELATIVE_INSTALL_PATH="${PRIMARY_INSTALL_PATH#"$MISE_DATA_DIR/installs/"}"
+SHARED_INSTALLS="$PWD/shared-installs"
+SHARED_INSTALL_PATH="$SHARED_INSTALLS/$RELATIVE_INSTALL_PATH"
+mkdir -p "$(dirname "$SHARED_INSTALL_PATH")"
+mv "$PRIMARY_INSTALL_PATH" "$SHARED_INSTALL_PATH"
+export MISE_SHARED_INSTALL_DIRS="$SHARED_INSTALLS"
+assert "mise where 'vfox:file://$PLUGIN_DIR'" "$SHARED_INSTALL_PATH"
 
 # --- step 2: same checksum → no upgrade needed ---
 # mise upgrade --dry-run must produce no "Would install" output when the
@@ -114,9 +125,12 @@ mise plugins update
 # test does not distinguish a key mismatch between those two fields.
 assert_contains "mise upgrade --dry-run" "Would install"
 
-# mise upgrade detects the checksum change and reinstalls in place.
+# mise upgrade detects the checksum change, leaves the shared install alone,
+# and installs the updated rolling release into the primary directory.
 mise upgrade
-assert "cat '$INSTALL_PATH/version.txt'" "content-v2"
+assert "cat '$PRIMARY_INSTALL_PATH/version.txt'" "content-v2"
+assert "cat '$SHARED_INSTALL_PATH/version.txt'" "content-v1"
+assert "cat '$SHARED_INSTALL_PATH/.mise.checksum'" "sha256:aaa111"
 
 # --- step 4: checksum now matches → no further upgrade ---
 assert_not_contains "mise upgrade --dry-run" "Would install"

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -5,6 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 use async_trait::async_trait;
 use color_eyre::Section;
 use eyre::{bail, eyre};
+use serde::{Deserialize, Serialize};
 use serde_json::Deserializer;
 use url::Url;
 
@@ -23,6 +24,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
 use crate::env::GITHUB_TOKEN;
 use crate::errors::Error;
+use crate::file;
 use crate::http::HTTP_FETCH;
 use crate::install_context::InstallContext;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
@@ -34,6 +36,18 @@ pub struct CargoBackend {
 
 const CARGO_BINSTALL_NO_FALLBACK_EXIT_CODE: i32 = 94;
 const CARGO_BINSTALL_DEFAULT_DISABLED_STRATEGIES: &[&str] = &["compile"];
+const CARGO_INSTALL_STATE_FILENAME: &str = ".mise-cargo-install.toml";
+
+#[derive(Debug, Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(default)]
+struct CargoInstallState {
+    features: Vec<String>,
+    default_features: bool,
+    bin: Option<String>,
+    #[serde(rename = "crate")]
+    crate_name: Option<String>,
+    locked: bool,
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct CargoOptions<'a> {
@@ -97,6 +111,26 @@ impl<'a> CargoOptions<'a> {
         self.values.raw().get_string("crate")
     }
 
+    fn install_state(&self) -> CargoInstallState {
+        let mut features = self
+            .features()
+            .unwrap_or_default()
+            .split([',', ' ', '\t', '\r', '\n'])
+            .filter(|feature| !feature.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        features.sort();
+        features.dedup();
+
+        CargoInstallState {
+            features,
+            default_features: !self.default_features_disabled(),
+            bin: self.bin(),
+            crate_name: self.crate_arg(),
+            locked: self.locked(),
+        }
+    }
+
     fn lockfile_options(&self, target: &PlatformTarget) -> BTreeMap<String, String> {
         let mut result = BTreeMap::new();
         if let Some(features) = self.features() {
@@ -147,6 +181,18 @@ impl Backend for CargoBackend {
 
     fn mark_prereleases_from_version_pattern(&self) -> bool {
         true
+    }
+
+    async fn is_install_satisfied(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        check_symlink: bool,
+    ) -> Result<bool> {
+        if !self.is_version_installed(config, tv, check_symlink) {
+            return Ok(false);
+        }
+        Ok(self.install_state_matches(tv))
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
@@ -216,6 +262,7 @@ impl Backend for CargoBackend {
                         .execute_install_command(ctx, &tv, cmd.arg(&install_arg))
                         .await;
                     if result.as_ref().is_ok() {
+                        self.write_install_state_best_effort(&tv);
                         return Ok(tv.clone());
                     }
                     if Settings::get().cargo.binstall_only
@@ -240,6 +287,7 @@ impl Backend for CargoBackend {
                             .native_binstall(ctx, &tv, NativeBinstallAction::Install)
                             .await?
                         {
+                            self.write_install_state_best_effort(&tv);
                             return Ok(tv.clone());
                         }
                     }
@@ -288,6 +336,7 @@ impl Backend for CargoBackend {
             cmd = cmd.arg(&install_arg);
         }
         self.execute_install_command(ctx, &tv, cmd).await?;
+        self.write_install_state_best_effort(&tv);
 
         Ok(tv.clone())
     }
@@ -316,6 +365,44 @@ pub fn install_time_option_keys() -> Vec<String> {
 impl CargoBackend {
     pub fn from_arg(ba: BackendArg) -> Self {
         Self { ba: Arc::new(ba) }
+    }
+
+    fn requested_install_state(&self, tv: &ToolVersion) -> CargoInstallState {
+        CargoOptions::new(&tv.request.options()).install_state()
+    }
+
+    fn install_state_matches(&self, tv: &ToolVersion) -> bool {
+        let expected = self.requested_install_state(tv);
+        let state_path = tv.install_path().join(CARGO_INSTALL_STATE_FILENAME);
+        if !state_path.exists() {
+            return expected
+                == CargoInstallState {
+                    default_features: true,
+                    locked: true,
+                    ..Default::default()
+                };
+        }
+        file::read_to_string(&state_path)
+            .ok()
+            .and_then(|body| toml::from_str::<CargoInstallState>(&body).ok())
+            .is_some_and(|state| state == expected)
+    }
+
+    fn write_install_state(&self, tv: &ToolVersion) -> Result<()> {
+        let state = self.requested_install_state(tv);
+        file::write(
+            tv.install_path().join(CARGO_INSTALL_STATE_FILENAME),
+            toml::to_string(&state)?,
+        )
+    }
+
+    fn write_install_state_best_effort(&self, tv: &ToolVersion) {
+        if let Err(err) = self.write_install_state(tv) {
+            warn!(
+                "failed to persist cargo install state for {}: {err:#}",
+                tv.style()
+            );
+        }
     }
 
     async fn execute_install_command<'a>(
@@ -470,7 +557,22 @@ struct CrateVersion {
 mod tests {
     use super::*;
     use crate::platform::Platform;
-    use crate::toolset::parse_tool_options;
+    use crate::toolset::{ToolSource, parse_tool_options};
+
+    fn test_tool_version(
+        install_path: &std::path::Path,
+        options: ToolVersionOptions,
+    ) -> ToolVersion {
+        let backend = Arc::new(BackendArg::new(
+            "cargo:tool".to_string(),
+            Some("cargo:tool".to_string()),
+        ));
+        let request =
+            ToolRequest::new_opts(backend, "1.0.0", options, ToolSource::Unknown).unwrap();
+        let mut tv = ToolVersion::new(request, "1.0.0".to_string());
+        tv.install_path = Some(install_path.to_path_buf());
+        tv
+    }
 
     #[tokio::test]
     async fn exact_semver_versions_resolve_without_remote_discovery() {
@@ -589,6 +691,92 @@ mod tests {
         let opts = ToolVersionOptions::default();
 
         assert!(CargoOptions::new(&opts).locked());
+    }
+
+    #[test]
+    fn cargo_install_state_normalizes_features_and_defaults() {
+        let string_opts = parse_tool_options(
+            "features='rustls, postgres rustls',default-features=true,locked=true",
+        );
+        let mut array_opts = ToolVersionOptions::default();
+        array_opts.opts.insert(
+            "features".into(),
+            toml::Value::Array(vec![
+                toml::Value::String("postgres".into()),
+                toml::Value::String("rustls".into()),
+            ]),
+        );
+
+        let expected = CargoInstallState {
+            features: vec!["postgres".into(), "rustls".into()],
+            default_features: true,
+            locked: true,
+            ..Default::default()
+        };
+        assert_eq!(CargoOptions::new(&string_opts).install_state(), expected);
+        assert_eq!(CargoOptions::new(&array_opts).install_state(), expected);
+        assert_eq!(
+            CargoOptions::new(&ToolVersionOptions::default()).install_state(),
+            CargoInstallState {
+                default_features: true,
+                locked: true,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn cargo_install_state_round_trips() {
+        let opts = parse_tool_options(
+            "features='rustls postgres',default-features=false,bin=sqlx,crate=sqlx-cli,locked=false",
+        );
+        let state = CargoOptions::new(&opts).install_state();
+
+        assert_eq!(
+            toml::from_str::<CargoInstallState>(&toml::to_string(&state).unwrap()).unwrap(),
+            state
+        );
+    }
+
+    #[test]
+    fn cargo_install_state_matches_legacy_default_and_tracks_changes() {
+        let backend = CargoBackend::from_arg("cargo:tool".into());
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("install");
+        file::create_dir_all(&install_path).unwrap();
+
+        let default_tv = test_tool_version(&install_path, ToolVersionOptions::default());
+        let feature_tv = test_tool_version(&install_path, parse_tool_options("features=extra"));
+        assert!(backend.install_state_matches(&default_tv));
+        assert!(!backend.install_state_matches(&feature_tv));
+
+        backend.write_install_state(&feature_tv).unwrap();
+        assert!(backend.install_state_matches(&feature_tv));
+        assert!(!backend.install_state_matches(&default_tv));
+
+        file::write(
+            install_path.join(CARGO_INSTALL_STATE_FILENAME),
+            "not valid toml =",
+        )
+        .unwrap();
+        assert!(!backend.install_state_matches(&feature_tv));
+        assert!(!backend.install_state_matches(&default_tv));
+
+        backend.write_install_state(&default_tv).unwrap();
+        assert!(backend.install_state_matches(&default_tv));
+        assert!(!backend.install_state_matches(&feature_tv));
+    }
+
+    #[test]
+    fn cargo_install_state_write_failure_is_best_effort() {
+        let backend = CargoBackend::from_arg("cargo:tool".into());
+        let tmp = tempfile::tempdir().unwrap();
+        let install_path = tmp.path().join("missing").join("install");
+        let tv = test_tool_version(&install_path, parse_tool_options("features=extra"));
+
+        backend.write_install_state_best_effort(&tv);
+
+        assert!(!install_path.join(CARGO_INSTALL_STATE_FILENAME).exists());
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2146,11 +2146,13 @@ pub trait Backend: Debug + Send + Sync {
 
     /// Check if a rolling version has changed (by comparing checksums)
     /// Returns true if the version should be updated
-    async fn is_rolling_version_outdated(&self, config: &Arc<Config>, version: &str) -> bool {
+    async fn is_rolling_version_outdated(&self, config: &Arc<Config>, tv: &ToolVersion) -> bool {
         use crate::toolset::install_state;
 
+        let version = tv.request.version();
+
         // Get the latest version info
-        let version_info = match self.get_version_info(config, version).await {
+        let version_info = match self.get_version_info(config, &version).await {
             Some(v) if v.rolling => v,
             _ => return false, // Not rolling or not found
         };
@@ -2165,7 +2167,7 @@ pub trait Backend: Debug + Send + Sync {
         };
 
         // Compare with stored checksum
-        let stored_checksum = install_state::read_checksum(&self.ba().short, version);
+        let stored_checksum = install_state::read_checksum(&tv.install_path());
         match stored_checksum {
             Some(stored) if stored == latest_checksum => {
                 trace!("Rolling version {} checksum unchanged", version);
@@ -2353,9 +2355,7 @@ pub trait Backend: Debug + Send + Sync {
         // so its install dir already existing does NOT mean it's up-to-date.
         let rolling_reinstall = !ctx.force
             && self.is_version_installed(&ctx.config, &tv, true)
-            && self
-                .is_rolling_version_outdated(&ctx.config, &tv.request.version())
-                .await;
+            && self.is_rolling_version_outdated(&ctx.config, &tv).await;
 
         // Handle dry-run mode early to avoid plugin installation
         if ctx.dry_run {
@@ -2379,21 +2379,28 @@ pub trait Backend: Debug + Send + Sync {
             plugin.is_installed_err()?;
         }
 
-        // If --force and the install path resolved to a shared dir (but wasn't explicitly
-        // set via --system/--shared), redirect to primary dir to avoid modifying shared installs.
-        if ctx.force
-            && tv.install_path.is_none()
-            && env::install_path_category(&tv.install_path()) != env::InstallPathCategory::Local
-        {
-            tv.install_path = Some(tv.ba().installs_path.join(tv.tv_pathname()));
-        }
-
         // Incomplete markers are keyed by logical tool/version rather than by
         // the physical install path. Use the same logical key as link and
         // uninstall so shared and system installs cannot have their marker
         // cleared while an install is still in progress.
         let state_version = tv.tv_pathname();
         let _state_lock = install_state::lock_tool_version(&tv.ba().short, &state_version)?;
+
+        let mut install_satisfied = self
+            .is_install_satisfied_or_false(&ctx.config, &tv, true)
+            .await
+            && !rolling_reinstall;
+
+        // If the install path resolved to a shared dir (but wasn't explicitly set via
+        // --system/--shared), redirect forced or incompatible installs to the primary dir
+        // to avoid modifying shared installs.
+        if (ctx.force || !install_satisfied)
+            && tv.install_path.is_none()
+            && env::install_path_category(&tv.install_path()) != env::InstallPathCategory::Local
+        {
+            tv.install_path = Some(tv.ba().installs_path.join(tv.tv_pathname()));
+            install_satisfied = false;
+        }
 
         let will_uninstall =
             (ctx.force || rolling_reinstall) && self.is_version_installed(&ctx.config, &tv, true);
@@ -2411,11 +2418,7 @@ pub trait Backend: Debug + Send + Sync {
             self.uninstall_version_unlocked(&ctx.config, &tv, ctx.pr.as_ref(), false)
                 .await?;
             ctx.pr.next_operation();
-        } else if self
-            .is_install_satisfied_or_false(&ctx.config, &tv, true)
-            .await
-            && !rolling_reinstall
-        {
+        } else if install_satisfied {
             return Ok(tv);
         }
 

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -322,7 +322,7 @@ impl Backend for VfoxBackend {
 
         // Store checksum for rolling version tracking
         if let Some(sha256) = result.sha256
-            && let Err(e) = install_state::write_checksum(&self.ba.short, &tv.version, &sha256)
+            && let Err(e) = install_state::write_checksum(&tv.install_path(), &sha256)
         {
             warn!("failed to write checksum for {}: {e}", tv);
         }

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -652,25 +652,22 @@ pub fn clear_incomplete_marker_best_effort(short: &str, v: &str) {
     }
 }
 
-/// Path to the checksum file for a specific tool version
-/// Used to track changes in rolling releases (like "nightly")
-fn checksum_file_path(short: &str, v: &str) -> PathBuf {
-    dirs::INSTALLS
-        .join(short.to_kebab_case())
-        .join(v)
-        .join(".mise.checksum")
+/// Path to the checksum file for a specific tool version.
+/// Used to track changes in rolling releases (like "nightly").
+fn checksum_file_path(install_path: &Path) -> PathBuf {
+    install_path.join(".mise.checksum")
 }
 
 /// Store the checksum for a tool version (used for rolling release tracking)
-pub fn write_checksum(short: &str, v: &str, checksum: &str) -> Result<()> {
-    let path = checksum_file_path(short, v);
+pub fn write_checksum(install_path: &Path, checksum: &str) -> Result<()> {
+    let path = checksum_file_path(install_path);
     file::write(&path, checksum)?;
     Ok(())
 }
 
 /// Read the stored checksum for a tool version
-pub fn read_checksum(short: &str, v: &str) -> Option<String> {
-    let path = checksum_file_path(short, v);
+pub fn read_checksum(install_path: &Path) -> Option<String> {
+    let path = checksum_file_path(install_path);
     if path.exists() {
         file::read_to_string(&path).ok()
     } else {

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -141,7 +141,7 @@ impl OutdatedInfo {
         {
             // Check if this is a rolling version (like "nightly") with a new checksum
             let rolling_outdated = t
-                .is_rolling_version_outdated(config, &oi.tool_version.request.version())
+                .is_rolling_version_outdated(config, &oi.tool_version)
                 .await;
             if !rolling_outdated {
                 trace!("skipping up-to-date version {}", oi.tool_version);


### PR DESCRIPTION
## Summary

- record the effective Cargo install options in `.mise-cargo-install.toml` for each installed version
- reinstall when `features`, `default-features`, `bin`, `crate`, or `locked` changes
- preserve legacy default installs and shadow incompatible shared installs in the primary install directory

## Problem

Cargo artifacts are identified by more than the package version. The selected crate and binary determine what is installed, feature flags determine which code is compiled, and locked mode determines dependency resolution. Previously mise only checked whether the version directory existed, so changing any of these options could silently reuse the wrong artifact.

## Approach

The Cargo backend now derives a normalized install state from the exact options passed to the installer. Feature strings and arrays are split on commas or whitespace, then sorted and deduplicated. Omitted `locked` and `default-features` values normalize to their existing true defaults, while `bin` is resolved for the current platform and `crate` records the selected override.

All successful external cargo-binstall, native binstall, and cargo install paths attempt to write the state file. A metadata write failure logs a warning and preserves the successfully installed artifact; the missing state then causes a non-default request to retry on the next install. A missing state file remains compatible with an all-default legacy install; missing state for non-default options, malformed state, option mismatches, and removal of non-default options trigger one reinstall.

When an incompatible artifact comes from a shared or system fallback, mise leaves that directory untouched and installs the requested variant into the primary user install directory instead.

`install_env`, registry selection, and cargo-binstall settings are intentionally excluded because they are execution inputs rather than public artifact-selection options and may contain secrets.

## Benefits of tracking all five options

- `features` and `default-features` select compiled code and capabilities.
- `bin` selects which executable Cargo installs from a multi-binary package.
- `crate` selects the workspace package for Git sources.
- `locked` controls whether Cargo uses the committed dependency graph.

Treating the complete selection as the artifact identity prevents stale binaries without requiring users to remember `--force`.

## Verification

- `mise exec -- cargo test backend::cargo::tests` — 19 passed
- `mise run test:e2e e2e/backend/test_cargo_install_options_stub_slow` — passed; covers all five changes, option removal, feature normalization, and shared shadowing
- `mise run test:e2e e2e/backend/test_cargo_install_options_slow` — passed; recompiles the same local Git tag and changes runtime output after enabling a feature
- `mise run test:e2e e2e/backend/test_cargo_binstall_token` — passed
- `mise run test:e2e e2e/cli/test_shared_install_dirs` — passed
- `mise exec -- cargo check --all-features` — passed
- Cargo fmt, ShellCheck, shfmt, Markdownlint, and Prettier checks for changed files — passed
- `mise run lint` cannot run as a wrapper in this Sapling working copy because hk reports `failed to find git repository`; the applicable checks above were run individually

Addresses https://github.com/jdx/mise/discussions/5235

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cargo tool installs now record and reuse installation configuration (including selected features and flags) to ensure the requested variant is what’s installed.
  * Feature names are normalized so different orderings/representations are treated as equivalent, preventing unnecessary reinstalls.
* **Bug Fixes**
  * Rolling-release upgrades now correctly shadow shared installs, leaving the shared copy unchanged.
* **Documentation**
  * Updated Cargo backend docs to clarify how effective Cargo options are tracked and when reinstalls occur.
* **Tests**
  * Added/expanded end-to-end coverage for Cargo install option determinism and rolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->