### PR TITLE
fix(aqua): include prefixed override candidates

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -994,9 +994,17 @@ impl AquaBackend {
         tv: &ToolVersion,
         versions: &[&str],
     ) -> Result<AquaPackage> {
+        let pkg = AQUA_REGISTRY.package(&self.id).await?;
+        Self::package_with_options_for_pkg(tv, pkg, versions)
+    }
+
+    fn package_with_options_for_pkg(
+        tv: &ToolVersion,
+        pkg: AquaPackage,
+        versions: &[&str],
+    ) -> Result<AquaPackage> {
         let target = PlatformTarget::from_current();
         let (target_os, target_arch) = Self::to_aqua_platform(&target);
-        let pkg = AQUA_REGISTRY.package(&self.id).await?;
         let target_libc = Self::target_variant_libc(&target);
         let pkg = pkg.with_version_libc(versions, target_os, target_arch, target_libc.as_deref());
         let pkg = Self::apply_aqua_libc_replacement(pkg, target_os, Self::target_libc(&target));
@@ -1006,9 +1014,10 @@ impl AquaBackend {
     }
 
     async fn package_with_version_candidates(&self, tv: &ToolVersion) -> Result<AquaPackage> {
-        let versions = version_candidates(&tv.version, None);
+        let pkg = AQUA_REGISTRY.package(&self.id).await?;
+        let versions = package_version_candidates(&tv.version, &pkg);
         let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
-        self.package_with_options(tv, &versions).await
+        Self::package_with_options_for_pkg(tv, pkg, &versions)
     }
 
     fn to_aqua_platform(target: &PlatformTarget) -> (&str, &str) {
@@ -3262,6 +3271,24 @@ fn version_candidates<'a>(version: &'a str, version_prefix: Option<&str>) -> Vec
     candidates.into_iter().unique().collect()
 }
 
+fn package_version_candidates<'a>(version: &'a str, pkg: &AquaPackage) -> Vec<Cow<'a, str>> {
+    let mut candidates = version_candidates(version, None);
+    let prefixes = pkg
+        .version_prefix
+        .iter()
+        .map(String::as_str)
+        .chain(
+            pkg.version_overrides
+                .iter()
+                .filter_map(|vo| vo.version_prefix.as_deref()),
+        )
+        .unique();
+    for prefix in prefixes {
+        candidates.extend(version_candidates(version, Some(prefix)));
+    }
+    candidates.into_iter().unique().collect()
+}
+
 fn github_release_tag_from_url(url: &str) -> Option<String> {
     let url = Url::parse(url).ok()?;
     if url.host_str()? != "github.com" {
@@ -3589,6 +3616,70 @@ mod tests {
             .collect_vec();
 
         assert_eq!(candidates, vec!["tool-v1.2.3"]);
+    }
+
+    #[test]
+    fn test_package_version_candidates_include_package_and_override_prefixes() {
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: github_release
+    repo_owner: example
+    repo_name: tool
+    version_prefix: maven-
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        version_prefix: lychee-v
+"#,
+        )
+        .unwrap();
+        let pkg = registry.package("example/tool").unwrap();
+        let candidates = package_version_candidates("1.2.3", &pkg)
+            .into_iter()
+            .map(Cow::into_owned)
+            .collect_vec();
+
+        assert_eq!(
+            candidates,
+            vec![
+                "1.2.3",
+                "v1.2.3",
+                "maven-1.2.3",
+                "maven-v1.2.3",
+                "lychee-v1.2.3"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_package_version_candidates_apply_prefixed_file_override() {
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: github_release
+    repo_owner: lycheeverse
+    repo_name: lychee
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        version_prefix: lychee-v
+        asset: lychee.tar.gz
+        format: tar.gz
+        files:
+          - name: lychee
+            src: lychee-x86_64-unknown-linux-musl/lychee
+"#,
+        )
+        .unwrap();
+        let pkg = registry.package("lycheeverse/lychee").unwrap();
+        let versions = package_version_candidates("0.24.2", &pkg);
+        let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
+        let pkg = pkg.with_version(&versions, "linux", "amd64");
+
+        assert_eq!(pkg.version_prefix.as_deref(), Some("lychee-v"));
+        assert_eq!(pkg.files.len(), 1);
+        assert_eq!(pkg.files[0].name, "lychee");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- include package-level and override-level Aqua prefixes when resolving normalized versions
- reuse the resolved package while applying platform and tool options
- add regression coverage for prefixed candidates and executable file mappings

## Root cause
Prefix-aware override matching requires the candidate version to start with the override's `version_prefix`. Runtime bin-path resolution only generated the normalized version and its plain `v` variant, so entries such as Maven (`maven-`) and Lychee (`lychee-v`) lost their `files` mappings after installation. Their executables remained inside extracted subdirectories and were not exposed on `PATH`.

## Impact
Aqua tools whose executable mapping lives in a prefixed version override retain the correct runtime bin paths. This fixes the Maven and Lychee failures blocking release PR #11464.

## Validation
- `cargo test backend::aqua::tests::test_package_version_candidates`
- `cargo test backend::aqua::tests::test_candidate_bin_paths_use_v_prefixed_package_override`
- `mise run lint-fix`
- `target/debug/mise test-tool --jobs 2 maven lychee` restored both executable paths; Lychee passed, while Maven reached `apache-maven-3.9.16/bin/mvn` and then stopped because the local environment has no `JAVA_HOME`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Aqua install and `list_bin_paths` resolution; wrong prefix handling could still mis-resolve assets, but scope is limited to version-candidate logic with new unit tests.
> 
> **Overview**
> Fixes Aqua tools whose executables are defined under **prefixed** `version_overrides` (e.g. Maven `maven-`, Lychee `lychee-v`) so installs expose the right binaries on `PATH`.
> 
> **Version candidate generation** now builds the list passed to `with_version_libc` from the package’s own `version_prefix` and every override’s `version_prefix`, not only the bare version and optional `v` prefix. That lets prefix-scoped overrides win and keeps their `files` / asset mappings.
> 
> **Package resolution** loads the registry package once per call: `package_with_version_candidates` and `package_with_options` share a new sync helper `package_with_options_for_pkg` so platform/options are applied on the same resolved package used for candidates.
> 
> Regression tests cover combined prefixes and prefixed overrides applying `files` correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c049e104bcf862be1a7c0b67a5465e0ea901fabc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Aqua package version selection when package or override version prefixes are configured.
  * Prefixed file overrides are now correctly applied during version resolution.

* **Bug Fixes**
  * Fixed package installation and locking to consistently apply platform, target, and version configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->