### PR TITLE
chore: release 2026.7.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [2026.7.18](https://github.com/jdx/mise/compare/v2026.7.17..v2026.7.18) - 2026-07-30
+
+### 🚀 Features
+
+- **(task)** support relative monorepo dependency paths by @jdx in [#11503](https://github.com/jdx/mise/pull/11503)
+- **(task)** add compact dependency tree output by @jdx in [#11502](https://github.com/jdx/mise/pull/11502)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** preserve locked HTTP override metadata by @jdx in [#11499](https://github.com/jdx/mise/pull/11499)
+- **(asdf)** pass config env to version scripts by @Marukome0743 in [#11492](https://github.com/jdx/mise/pull/11492)
+- **(backend)** resolve a spawnable program on Windows instead of a bare name by @JamBalaya56562 in [#11486](https://github.com/jdx/mise/pull/11486)
+- **(backend)** resolve tool programs instead of hardcoding .cmd on Windows by @JamBalaya56562 in [#11489](https://github.com/jdx/mise/pull/11489)
+- **(cargo)** reinstall when install options change by @Marukome0743 in [#11480](https://github.com/jdx/mise/pull/11480)
+- **(env)** collapse duplicate PATH entries in computed environments by @JamBalaya56562 in [#11491](https://github.com/jdx/mise/pull/11491)
+- **(gitlab)** send auth headers on paginated release/tag requests by @JamBalaya56562 in [#11507](https://github.com/jdx/mise/pull/11507)
+- **(install)** preserve config file timestamps by @Marukome0743 in [#11495](https://github.com/jdx/mise/pull/11495)
+- **(lockfile)** cache monorepo legacy path discovery by @jdx in [#11500](https://github.com/jdx/mise/pull/11500)
+- **(monorepo)** resolve idiomatic version files per config_root by @kaii-zen in [#11463](https://github.com/jdx/mise/pull/11463)
+- **(plugins)** support local paths in config by @Marukome0743 in [#11487](https://github.com/jdx/mise/pull/11487)
+- **(plugins)** continue batch operations after failures by @Marukome0743 in [#11490](https://github.com/jdx/mise/pull/11490)
+- **(prune)** preserve untrusted version file references by @jdx in [#11501](https://github.com/jdx/mise/pull/11501)
+- **(watch)** honor an explicit --wrap-process group on macOS by @JamBalaya56562 in [#11512](https://github.com/jdx/mise/pull/11512)
+
+### ⚡ Performance
+
+- **(ci)** reduce redundant lint compilation by @jdx in [#11504](https://github.com/jdx/mise/pull/11504)
+
+### 🧪 Testing
+
+- **(system)** avoid flaky GNU mirror in brew source e2e by @jdx in [#11509](https://github.com/jdx/mise/pull/11509)
+
+### 📦 Registry
+
+- add witr by @Jelenkee in [#11505](https://github.com/jdx/mise/pull/11505)
+
+### New Contributors
+
+- @Jelenkee made their first contribution in [#11505](https://github.com/jdx/mise/pull/11505)
+- @kaii-zen made their first contribution in [#11463](https://github.com/jdx/mise/pull/11463)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (1)
+
+- [`herdrdev/herdr`](https://github.com/herdrdev/herdr)
+
+#### Updated Packages (1)
+
+- [`entireio/cli`](https://github.com/entireio/cli)
+
 ## [2026.7.17](https://github.com/jdx/mise/compare/v2026.7.16..v2026.7.17) - 2026-07-29
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6313,7 +6313,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.17"
+version = "2026.7.18"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.17"
+version = "2026.7.18"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.17 macos-arm64 (2026-07-29)
+2026.7.18 macos-arm64 (2026-07-30)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_17.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_18.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_17.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_18.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -p usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_17.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_18.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_17.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_18.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.17";
+  version = "2026.7.18";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.17
+Version: 2026.7.18
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.17"
+version: "2026.7.18"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "1fe11bab8687216fd804af41ff8ca6b54c5632b3"
+  "tag": "fccbf15163f3e04681c359444b69e79bcd7f1d36"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -36669,13 +36669,23 @@ packages:
   - type: github_release
     repo_owner: entireio
     repo_name: cli
-    description: Entire is a new developer platform that hooks into your git workflow to capture AI agent sessions on every push, unifying your code with its context and reasoning
+    description: Entire CLI hooks into your Git workflow to capture AI agent sessions as you work. Sessions are indexed alongside commits, creating a searchable record of how code was written in your repo
     files:
       - name: entire
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.3.9")
         asset: cli_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.5.1")
+        asset: entire_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release
@@ -36691,9 +36701,9 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: entireio
     repo_name: git-sync
@@ -48602,6 +48612,33 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: herdrdev
+    repo_name: herdr
+    aliases:
+      - name: ogulcancelik/herdr
+    description: agent multiplexer that lives in your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.4.0"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
         supported_envs:
           - linux
           - darwin
@@ -70398,31 +70435,6 @@ packages:
     files:
       - name: exa
         src: bin/exa
-  - type: github_release
-    repo_owner: ogulcancelik
-    repo_name: herdr
-    description: agent multiplexer that lives in your terminal
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: Version == "v0.4.0"
-        asset: herdr-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: macos
-        supported_envs:
-          - darwin
-      - version_constraint: "true"
-        asset: herdr-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: macos
-        supported_envs:
-          - linux
-          - darwin
   - type: github_release
     repo_owner: ohkrab
     repo_name: krab


### PR DESCRIPTION
### 🚀 Features

- **(task)** support relative monorepo dependency paths by @jdx in [#11503](https://github.com/jdx/mise/pull/11503)
- **(task)** add compact dependency tree output by @jdx in [#11502](https://github.com/jdx/mise/pull/11502)

### 🐛 Bug Fixes

- **(aqua)** preserve locked HTTP override metadata by @jdx in [#11499](https://github.com/jdx/mise/pull/11499)
- **(asdf)** pass config env to version scripts by @Marukome0743 in [#11492](https://github.com/jdx/mise/pull/11492)
- **(backend)** resolve a spawnable program on Windows instead of a bare name by @JamBalaya56562 in [#11486](https://github.com/jdx/mise/pull/11486)
- **(backend)** resolve tool programs instead of hardcoding .cmd on Windows by @JamBalaya56562 in [#11489](https://github.com/jdx/mise/pull/11489)
- **(cargo)** reinstall when install options change by @Marukome0743 in [#11480](https://github.com/jdx/mise/pull/11480)
- **(env)** collapse duplicate PATH entries in computed environments by @JamBalaya56562 in [#11491](https://github.com/jdx/mise/pull/11491)
- **(gitlab)** send auth headers on paginated release/tag requests by @JamBalaya56562 in [#11507](https://github.com/jdx/mise/pull/11507)
- **(install)** preserve config file timestamps by @Marukome0743 in [#11495](https://github.com/jdx/mise/pull/11495)
- **(lockfile)** cache monorepo legacy path discovery by @jdx in [#11500](https://github.com/jdx/mise/pull/11500)
- **(monorepo)** resolve idiomatic version files per config_root by @kaii-zen in [#11463](https://github.com/jdx/mise/pull/11463)
- **(plugins)** support local paths in config by @Marukome0743 in [#11487](https://github.com/jdx/mise/pull/11487)
- **(plugins)** continue batch operations after failures by @Marukome0743 in [#11490](https://github.com/jdx/mise/pull/11490)
- **(prune)** preserve untrusted version file references by @jdx in [#11501](https://github.com/jdx/mise/pull/11501)
- **(watch)** honor an explicit --wrap-process group on macOS by @JamBalaya56562 in [#11512](https://github.com/jdx/mise/pull/11512)

### ⚡ Performance

- **(ci)** reduce redundant lint compilation by @jdx in [#11504](https://github.com/jdx/mise/pull/11504)

### 🧪 Testing

- **(system)** avoid flaky GNU mirror in brew source e2e by @jdx in [#11509](https://github.com/jdx/mise/pull/11509)

### 📦 Registry

- add witr by @Jelenkee in [#11505](https://github.com/jdx/mise/pull/11505)

### New Contributors

- @Jelenkee made their first contribution in [#11505](https://github.com/jdx/mise/pull/11505)
- @kaii-zen made their first contribution in [#11463](https://github.com/jdx/mise/pull/11463)

## 📦 Aqua Registry Updates

### New Packages (1)

- [`herdrdev/herdr`](https://github.com/herdrdev/herdr)

### Updated Packages (1)

- [`entireio/cli`](https://github.com/entireio/cli)