### PR TITLE
fix(backend): resolve a spawnable program on Windows instead of a bare name

### DIFF
--- a/e2e-win/pipx.Tests.ps1
+++ b/e2e-win/pipx.Tests.ps1
@@ -1,0 +1,163 @@
+Describe 'pipx' {
+    # Regression test for https://github.com/jdx/mise/discussions/5333.
+    #
+    # pipx is commonly on PATH only as pipx.cmd -- that is what scoop's shims and
+    # `pip install pipx` leave behind. mise's dependency check finds it, because
+    # executable_names expands windows_executable_extensions, but Command::new does
+    # not: std only ever appends .exe to a bare name. So the install used to clear
+    # the check and then die with "program not found".
+
+    BeforeAll {
+        $script:originalPath = Get-Location
+        $script:originalEnvPath = $env:PATH
+        # Pester runs every file in one runspace, so restore rather than remove: a value
+        # set outside this file has to survive it. Same idiom as github_token.Tests.ps1.
+        $script:originalPipxUvx = [Environment]::GetEnvironmentVariable('MISE_PIPX_UVX', 'Process')
+        $script:miseDir = Split-Path (
+            Get-Command -Type Application mise -All | Select-Object -First 1
+        ).Source
+
+        Set-Location TestDrive:
+
+        $script:toolDir = Join-Path $TestDrive "pipxbin"
+        New-Item -ItemType Directory -Path $script:toolDir -Force | Out-Null
+        $script:markerFile = Join-Path $script:toolDir "pipx-ran.txt"
+
+        # The stub records that it ran into a file beside itself rather than relying on
+        # its stdout: piping a batch-file child through the PowerShell pipeline captures
+        # nothing on these runners (see the note in python.Tests.ps1). A marker file is
+        # a filesystem fact and is immune to that. No -NoNewline here, unlike
+        # shim_recursion.Tests.ps1, because the last line must be terminated.
+        @'
+@echo off
+> "%~dp0pipx-ran.txt" echo FAKE_PIPX_RAN %*
+echo FAKE_PIPX_RAN
+exit /b 42
+'@ | Out-File -FilePath (Join-Path $script:toolDir "pipx.cmd") -Encoding ascii
+
+        # uv would win the branch in install_version_ and the pipx spawn would never
+        # be exercised at all.
+        $env:MISE_PIPX_UVX = '0'
+
+        # Trim PATH to the stub, mise and the system dirs so nothing else can answer.
+        # Resolution is directory-major, so the stub dir being first is already decisive
+        # here -- but the later Its deliberately drop the stub dir, and trimming keeps a
+        # runner-installed pipx from answering there.
+        $env:PATH = "$($script:toolDir);$($script:miseDir);$env:SystemRoot\System32;$env:SystemRoot"
+    }
+
+    AfterAll {
+        $env:PATH = $script:originalEnvPath
+        # Branch on purpose: passing $null to SetEnvironmentVariable does not restore the
+        # unset state, because PowerShell binds it to the string parameter as '' instead.
+        if ($null -eq $script:originalPipxUvx) {
+            Remove-Item -Path Env:\MISE_PIPX_UVX -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:MISE_PIPX_UVX = $script:originalPipxUvx
+        }
+        Set-Location $script:originalPath
+        Remove-Item -Path $script:toolDir -Recurse -ErrorAction SilentlyContinue
+    }
+
+    It 'spawns a pipx that exists only as a .cmd shim' {
+        Remove-Item -Path $script:markerFile -ErrorAction SilentlyContinue
+
+        # black 24.3.0 is exact semver, so resolve_exact_version answers locally and no
+        # PyPI request is made. --force so a cached install cannot skip the spawn.
+        $result = mise install --force pipx:black@24.3.0 2>&1
+        # The stub always exits 42, so the install is expected to fail.
+        $LASTEXITCODE | Should -Not -Be 0
+
+        # The regression: before the fix this file never appears, because the spawn
+        # failed before cmd.exe ever ran the stub.
+        $script:markerFile | Should -Exist
+        $marker = Get-Content -Path $script:markerFile -Raw
+        $marker | Should -Match 'FAKE_PIPX_RAN install'
+        # ...and the arguments survived std's cmd.exe routing.
+        $marker | Should -Match 'black==24\.3\.0'
+
+        $output = ($result | Out-String)
+        $output | Should -Not -Match 'program not found'
+    }
+
+    It 'reports a missing pipx when the only candidate is a .ps1' {
+        # The general fix, stated as a test. A .ps1 needs `pwsh -File`, so CreateProcess
+        # cannot launch it -- but `.ps1` is in the default windows_executable_extensions
+        # list, so mise's plain dependency lookup accepted it as evidence that pipx
+        # existed. The install then reached the spawn and died with "program not found".
+        # The gate and the spawn now ask the same question, and the resolver walks past a
+        # candidate it cannot launch instead of stopping there, so a .ps1-only pipx is
+        # simply not found -- and "not found" carries the actionable instructions.
+        $ps1Dir = Join-Path $TestDrive "pipxps1"
+        New-Item -ItemType Directory -Path $ps1Dir -Force | Out-Null
+        'exit 42' | Out-File -FilePath (Join-Path $ps1Dir "pipx.ps1") -Encoding ascii
+        $previousPath = $env:PATH
+        try {
+            $env:PATH = "$ps1Dir;$($script:miseDir);$env:SystemRoot\System32;$env:SystemRoot"
+            $result = mise install --force pipx:black@24.3.0 2>&1
+            $LASTEXITCODE | Should -Not -Be 0
+            $output = ($result | Out-String)
+            $output | Should -Match 'mise use pipx@latest'
+            $output | Should -Not -Match 'program not found'
+        }
+        finally {
+            $env:PATH = $previousPath
+            Remove-Item -Path $ps1Dir -Recurse -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'does not commit to the uv branch when uv is only a .ps1' {
+        # The same question on the other side of the branch. `uv` decides whether the
+        # install goes through `uv tool install` or through pipx, and the resolved path is
+        # also the program handed to CmdLineRunner. A uv.ps1 satisfies the plain lookup, so
+        # mise would pick the uv branch and then fail at process creation; treating it as
+        # absent falls through to pipx, and with no pipx here that surfaces as the
+        # instructions rather than a spawn error. uvx is left enabled on purpose -- this is
+        # the branch the other Its suppress with MISE_PIPX_UVX=0.
+        $uvDir = Join-Path $TestDrive "uvps1"
+        New-Item -ItemType Directory -Path $uvDir -Force | Out-Null
+        'exit 42' | Out-File -FilePath (Join-Path $uvDir "uv.ps1") -Encoding ascii
+        $previousPath = $env:PATH
+        $previousUvx = $env:MISE_PIPX_UVX
+        try {
+            Remove-Item -Path Env:\MISE_PIPX_UVX -ErrorAction SilentlyContinue
+            $env:PATH = "$uvDir;$($script:miseDir);$env:SystemRoot\System32;$env:SystemRoot"
+            $result = mise install --force pipx:black@24.3.0 2>&1
+            $LASTEXITCODE | Should -Not -Be 0
+            $output = ($result | Out-String)
+            $output | Should -Match 'mise use pipx@latest'
+            $output | Should -Not -Match 'program not found'
+        }
+        finally {
+            $env:PATH = $previousPath
+            # Same branch as AfterAll: assigning $null would leave an empty value behind
+            # rather than restoring the unset state.
+            if ($null -eq $previousUvx) {
+                Remove-Item -Path Env:\MISE_PIPX_UVX -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:MISE_PIPX_UVX = $previousUvx
+            }
+            Remove-Item -Path $uvDir -Recurse -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'still reports a missing pipx with install instructions' {
+        # Guards the fallback arm of Backend::spawn_program, where nothing resolves at all,
+        # together with the spawnable_dependency gate. The Windows counterpart of
+        # e2e/backend/test_pipx_missing_dependency.
+        $previousPath = $env:PATH
+        try {
+            $env:PATH = "$($script:miseDir);$env:SystemRoot\System32;$env:SystemRoot"
+            $result = mise install --force pipx:black@24.3.0 2>&1
+            $LASTEXITCODE | Should -Not -Be 0
+            $output = ($result | Out-String)
+            $output | Should -Match 'mise use pipx@latest'
+            $output | Should -Not -Match 'program not found'
+        }
+        finally {
+            $env:PATH = $previousPath
+        }
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -618,6 +618,94 @@ fn which_non_pristine_executable(bin: &str) -> Option<PathBuf> {
         .find_map(file::which_non_pristine)
 }
 
+/// True when the OS will accept `path` as the program argument of a spawn.
+///
+/// [`file::can_execute_directly`] is *pure extension inspection* on Windows — it never
+/// touches the filesystem, so it answers true for a `foo.exe` that is not there. The
+/// `is_file()` guard supplies the existence check that [`file::is_executable`] performs
+/// inline; without it a lookup built on this would hand back paths to missing files.
+///
+/// The guard is `cfg!(windows)`-gated deliberately. On unix `can_execute_directly`
+/// delegates to `is_executable`, which stats already — and which answers true for a
+/// mode-0755 *directory*. Adding `is_file()` unconditionally would silently narrow every
+/// unix lookup below it, so unix keeps today's answer exactly.
+fn is_spawnable(path: &Path) -> bool {
+    if cfg!(windows) && !path.is_file() {
+        return false;
+    }
+    file::can_execute_directly(path)
+}
+
+/// Resolve `bin` inside `dirs`, in the order the OS itself resolves: directory-major,
+/// extension-minor.
+///
+/// `spawnable` picks the predicate, and the distinction is the whole point:
+///
+/// * `false` — the historical "looks executable" test. On Windows that deliberately
+///   accepts a shebang-only script and a `.ps1`, because it answers *"does this tool
+///   provide this bin"* for `mise which`, shims, auto-install and tool-stubs. Not to be
+///   narrowed.
+/// * `true` — [`is_spawnable`], i.e. *"can the OS launch this"*. Crucially it keeps
+///   searching **past** a candidate it rejects, so `None` means "nothing spawnable
+///   exists" rather than "the first thing I looked at was not spawnable".
+///
+/// Directory-major only matters on Windows, where [`executable_names`] yields several
+/// candidates per directory. It is the order `CreateProcess`+`PATHEXT`, `cmd.exe` and the
+/// `which` crate all use, and the order [`Backend::which`] has always used. It diverges
+/// from [`which_non_pristine_executable`], which is *name-major* — the bare name is tried
+/// across the whole PATH before any extension — and that one is left alone. Only
+/// directory-major resolves the case this exists for: mise's own node install ships a
+/// shebang `npm` and an `npm.cmd` side by side in one directory, with no `npm.exe`.
+///
+/// On unix `executable_names` returns exactly one name, so both orders are the same
+/// traversal and this degenerates to `file::_which` with a different predicate.
+fn which_in_dirs<I>(dirs: I, bin: &str, spawnable: bool) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    let names = executable_names(bin);
+    dirs.into_iter().find_map(|dir| {
+        names.iter().map(|name| dir.join(name)).find(|candidate| {
+            if spawnable {
+                is_spawnable(candidate)
+            } else {
+                candidate.exists() && file::is_executable(candidate)
+            }
+        })
+    })
+}
+
+/// PATH-side counterpart of [`which_non_pristine_executable`], narrowed to what the OS can
+/// actually spawn.
+///
+/// Non-pristine to match that function, which is what [`Backend::dependency_which`] uses.
+/// The "a mise-managed tool beats a system one" contract that
+/// `e2e/backend/test_pipx_direct_dependencies` asserts comes from consulting the toolset
+/// first in [`Backend::spawnable_dependency`], not from the PATH flavor, so it is kept.
+///
+/// mise's shim directories are skipped on Windows. A shim re-enters mise, and once a
+/// resolved absolute path is handed to `Command::new` the child PATH no longer gets a
+/// vote, so a shim that the child PATH would have shadowed must not win —
+/// [`file::which_no_shims`] exists for the same reason. Windows-gated so the unix answer
+/// stays identical to `which_non_pristine_executable`'s.
+///
+/// The skip is not free for callers that treat `None` as fatal. Through
+/// [`Backend::spawn_program`] a miss falls back to the bare name, i.e. today's code path.
+/// Through [`Backend::spawnable_dependency`] it is a gate, so a tool reachable *only* via a
+/// mise shim — installed by mise yet declared in no active config, so the dependency
+/// toolset does not have it either — now reports its install instructions instead of
+/// re-entering mise through the shim. That trade is deliberate: the alternative is
+/// spawning our own shim from inside an install, and the instructions are correct advice
+/// for a tool that is installed but unconfigured.
+fn which_non_pristine_spawnable(bin: &str) -> Option<PathBuf> {
+    let skip_shims = cfg!(windows);
+    let dirs = env::PATH_NON_PRISTINE
+        .iter()
+        .filter(|p| !skip_shims || !file::is_mise_shims_dir(p))
+        .cloned();
+    which_in_dirs(dirs, bin, true)
+}
+
 pub(crate) async fn configured_toolset_or_path_which(
     config: &Arc<Config>,
     tools: impl IntoIterator<Item = String>,
@@ -685,6 +773,177 @@ mod tests {
         assert_eq!(
             normalize_idiomatic_contents("# full line comment\n3.14.2 # inline comment\n   \n\n"),
             "3.14.2"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn which_in_dirs_skips_shebang_script_for_node_npm_layout() {
+        // The exact on-disk shape of installs\node\<version>: a bare `npm` that is a
+        // `#!/usr/bin/env bash` script, an `npm.cmd`, an `npm.ps1`, and no `npm.exe`. On
+        // Windows the node plugin puts that directory itself on PATH.
+        //
+        // The paired assertion is the point. The permissive predicate answers with the
+        // bash script, because `executable_names` puts the bare name first and
+        // `file::is_executable` accepts a shebang — and that is precisely why
+        // `NPM_PROGRAM = "npm.cmd"` had to be hardcoded. The spawnable predicate walks
+        // past it to `npm.cmd`, which is what makes the hardcode removable.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("npm"), "#!/usr/bin/env bash\nexit 0\n").unwrap();
+        fs::write(dir.path().join("npm.cmd"), "@echo off\n").unwrap();
+        fs::write(dir.path().join("npm.ps1"), "exit 0\n").unwrap();
+        fs::write(dir.path().join("node.exe"), "MZ").unwrap();
+
+        let dirs = || vec![dir.path().to_path_buf()];
+        assert_eq!(
+            which_in_dirs(dirs(), "npm", false),
+            Some(dir.path().join("npm")),
+            "the permissive predicate still answers with the shebang script"
+        );
+        assert_eq!(
+            which_in_dirs(dirs(), "npm", true),
+            Some(dir.path().join("npm.cmd")),
+            "the spawnable predicate has to walk past it to npm.cmd"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn which_in_dirs_rejects_interpreter_only_extensions() {
+        // A .ps1 needs `pwsh -File` and a .vbs needs wscript/cscript, so neither can be
+        // handed to Command::new — but both extensions are in the default
+        // windows_executable_extensions list, so the permissive predicate accepts them.
+        //
+        // Casing is deliberately not exercised here: `which_in_dirs` builds its candidates
+        // from `executable_names`, whose entries are always lowercase, so the guard would
+        // never see an uppercase extension through this path however the file is named on a
+        // case-insensitive filesystem. See
+        // `is_spawnable_rejects_interpreter_only_extensions_case_insensitively`.
+        for name in ["pipx.ps1", "pipx.vbs"] {
+            let dir = tempfile::tempdir().unwrap();
+            fs::write(dir.path().join(name), "exit 42\n").unwrap();
+            let dirs = || vec![dir.path().to_path_buf()];
+            assert!(
+                which_in_dirs(dirs(), "pipx", false).is_some(),
+                "{name} must still satisfy the permissive predicate"
+            );
+            assert_eq!(
+                which_in_dirs(dirs(), "pipx", true),
+                None,
+                "{name} cannot be spawned directly"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn which_in_dirs_prefers_exe_over_cmd_within_a_directory() {
+        // `executable_names` orders by the settings list, where `exe` precedes `cmd`.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("tool.cmd"), "@echo off\n").unwrap();
+        fs::write(dir.path().join("tool.exe"), "MZ").unwrap();
+        assert_eq!(
+            which_in_dirs(vec![dir.path().to_path_buf()], "tool", true),
+            Some(dir.path().join("tool.exe"))
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn which_in_dirs_is_directory_major() {
+        // Pins the ordering decision. `which_non_pristine_executable` is name-major and
+        // would answer dir_b/tool.exe here, because it tries every directory for one name
+        // before moving to the next name. This resolver is directory-major, like
+        // CreateProcess+PATHEXT and like Backend::which, so the earlier directory wins even
+        // though its candidate has a later extension.
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        fs::write(dir_a.path().join("tool.cmd"), "@echo off\n").unwrap();
+        fs::write(dir_b.path().join("tool.exe"), "MZ").unwrap();
+        assert_eq!(
+            which_in_dirs(
+                vec![dir_a.path().to_path_buf(), dir_b.path().to_path_buf()],
+                "tool",
+                true
+            ),
+            Some(dir_a.path().join("tool.cmd"))
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn is_spawnable_rejects_interpreter_only_extensions_case_insensitively() {
+        // The casing guard inside `can_execute_directly`, exercised where it is actually
+        // reachable: with a path read off disk rather than one built from
+        // `executable_names`. `task::task_executor` hands it exactly such a path when
+        // deciding whether a file task can be executed directly, so an uppercase `.PS1`
+        // there must be rejected — Windows extensions are case-insensitive while the guard
+        // compares strings.
+        //
+        // The paired `is_executable` assertion is the point: these files do look executable
+        // (their extensions are in windows_executable_extensions), which is why the spawn
+        // side needs a predicate of its own.
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["a.ps1", "b.PS1", "c.vbs", "d.VBS"] {
+            let path = dir.path().join(name);
+            fs::write(&path, "exit 0\n").unwrap();
+            assert!(!is_spawnable(&path), "{name} must not be spawnable");
+            assert!(
+                file::is_executable(&path),
+                "{name} should still satisfy the permissive predicate"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn which_in_dirs_ignores_missing_candidates() {
+        // Guards the is_file() composition in `is_spawnable`. `can_execute_directly` is
+        // pure extension inspection on Windows, so without that guard the `tool.exe`
+        // candidate answers true for a file that was never created. Removing the guard
+        // breaks this test and the node-layout one above, both by returning a path to a
+        // file that does not exist.
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            which_in_dirs(vec![dir.path().to_path_buf()], "tool", true),
+            None
+        );
+        assert_eq!(
+            which_in_dirs(vec![dir.path().to_path_buf()], "tool", false),
+            None
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn is_spawnable_matches_is_executable_on_unix() {
+        // "unix stays byte-identical" as a checked claim rather than a comment. The
+        // directory case is the sharp one: `is_executable` answers true for a mode-0755
+        // directory, so an ungated is_file() in `is_spawnable` would silently narrow every
+        // unix lookup built on it.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let tool = dir.path().join("tool");
+        fs::write(&tool, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&tool, fs::Permissions::from_mode(0o755)).unwrap();
+        let plain = dir.path().join("plain");
+        fs::write(&plain, "not executable\n").unwrap();
+        fs::set_permissions(&plain, fs::Permissions::from_mode(0o644)).unwrap();
+        let subdir = dir.path().join("subdir");
+        fs::create_dir(&subdir).unwrap();
+
+        assert!(is_spawnable(&tool));
+        assert!(!is_spawnable(&plain));
+        assert_eq!(
+            is_spawnable(&subdir),
+            file::is_executable(&subdir),
+            "a mode-0755 directory must be answered the same either way"
+        );
+        assert_eq!(
+            which_in_dirs(vec![dir.path().to_path_buf()], "tool", true),
+            which_in_dirs(vec![dir.path().to_path_buf()], "tool", false),
+            "both predicates agree on unix"
         );
     }
 
@@ -2713,22 +2972,40 @@ pub trait Backend: Debug + Send + Sync {
         tv: &ToolVersion,
         bin_name: &str,
     ) -> eyre::Result<Option<PathBuf>> {
-        let bin_paths = self
-            .list_bin_paths(config, tv)
-            .await?
-            .into_iter()
-            .filter(|p| p.parent().is_some());
-        for bin_path in bin_paths {
-            for bin_path in executable_names(bin_name)
+        Ok(which_in_dirs(
+            self.list_bin_paths(config, tv)
+                .await?
                 .into_iter()
-                .map(|bin| bin_path.join(bin))
-            {
-                if bin_path.exists() && file::is_executable(&bin_path) {
-                    return Ok(Some(bin_path));
-                }
-            }
-        }
-        Ok(None)
+                .filter(|p| p.parent().is_some()),
+            bin_name,
+            false,
+        ))
+    }
+
+    /// [`Self::which`] narrowed to a path the OS can spawn.
+    ///
+    /// Same bin paths, same directory-major traversal, stricter predicate: a shebang-only
+    /// `npm` or an `npm.ps1` is skipped and the search *continues*, so an `npm.cmd` beside
+    /// them wins. `None` here is a stronger statement than [`Self::which`]'s — "this tool
+    /// provides nothing spawnable for `bin_name`" — which is what makes a gate built on it
+    /// trustworthy.
+    ///
+    /// No backend overrides [`Self::which`], so the two can never disagree about which
+    /// directories they searched.
+    async fn which_spawnable(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+        bin_name: &str,
+    ) -> eyre::Result<Option<PathBuf>> {
+        Ok(which_in_dirs(
+            self.list_bin_paths(config, tv)
+                .await?
+                .into_iter()
+                .filter(|p| p.parent().is_some()),
+            bin_name,
+            true,
+        ))
     }
 
     fn create_install_dirs(&self, tv: &ToolVersion) -> eyre::Result<()> {
@@ -2890,6 +3167,83 @@ pub trait Backend: Debug + Send + Sync {
             return Some(bin);
         }
         self.dependency_which(config, bin).await
+    }
+
+    /// The spawnable path for a dependency program: the same three sources in the same
+    /// preference order as [`Self::dependency_path_for_install`] — the install's own
+    /// toolset, then PATH, then the dependency toolset — except every candidate must be
+    /// something the OS can launch.
+    ///
+    /// Returns `None` only when *nothing spawnable* exists in any of them, which is
+    /// strictly stronger than `dependency_path_for_install`'s `None`: a `pipx.ps1`, a
+    /// `pipx.vbs` or a shebang-only `pipx.pyz` satisfies that one, while this one steps
+    /// past it and keeps looking. Use this for gate and bail decisions so that "we found
+    /// it" and "we can run it" stop being two different questions.
+    ///
+    /// On unix this is identical to `dependency_path_for_install`: `executable_names`
+    /// yields one name, `can_execute_directly` *is* `is_executable`, and both the
+    /// `is_file()` and shim filters are `cfg!(windows)`-gated.
+    async fn spawnable_dependency(
+        &self,
+        config: &Arc<Config>,
+        ts: Option<&Toolset>,
+        bin: &str,
+    ) -> Option<PathBuf> {
+        if let Some(ts) = ts
+            && let Some(bin) = ts.which_bin_spawnable(config, bin).await
+        {
+            return Some(bin);
+        }
+        if let Some(bin) = which_non_pristine_spawnable(bin) {
+            return Some(bin);
+        }
+        let ts = self.dependency_toolset(config).await.ok()?;
+        ts.which_bin_spawnable(config, bin).await
+    }
+
+    /// The program to hand `CmdLineRunner::new` or `cmd!` for `bin`.
+    ///
+    /// On Windows: a resolved absolute path when one spawnable candidate was found. mise's
+    /// own lookup is PATHEXT-aware — `executable_names` expands the
+    /// `windows_executable_extensions` setting — but `Command::new` is not: std only ever
+    /// appends `.exe` to a bare name and then reports "program not found". mise's node
+    /// install ships `npm` (a `#!/usr/bin/env bash` script), `npm.cmd` and `npm.ps1` but no
+    /// `npm.exe`, and on Windows the node plugin puts the install root itself on PATH;
+    /// pipx from scoop or `pip install pipx` is only ever `pipx.cmd` (discussion #5333).
+    /// Handing over the resolved path skips std's weaker second lookup — std routes
+    /// `.cmd`/`.bat` through cmd.exe with escaped arguments, the same way the `pip.cmd`
+    /// wrappers mise synthesizes for Windows python are already run.
+    ///
+    /// Falls back to the bare name — today's behavior on every platform — when nothing
+    /// spawnable resolved. The child still receives a PATH built from the toolset, so the
+    /// fallback *is* the old code path and a genuinely missing program produces exactly the
+    /// error it produces today.
+    ///
+    /// Unix keeps the bare name on purpose, and `cfg!(windows)` short-circuits so it does
+    /// no filesystem work to get there. The unix spawn already works, and it is the child
+    /// PATH that decides between a mise-managed tool and a system one
+    /// (`e2e/backend/test_pipx_direct_dependencies` asserts that preference). Resolving
+    /// there would move that decision out of the child's PATH and into mise.
+    ///
+    /// Returns `OsString`, and that is load-bearing rather than cosmetic: duct implements
+    /// `IntoExecutablePath for PathBuf` as `Path::new(".").join(path)`, so a `PathBuf` in a
+    /// `cmd!` program position becomes `./npm` and stops being a PATH lookup at all. duct's
+    /// `OsString` impl returns the value verbatim, and std's `Command::new` never dotifies.
+    async fn spawn_program(
+        &self,
+        config: &Arc<Config>,
+        ts: Option<&Toolset>,
+        bin: &str,
+    ) -> OsString {
+        let resolved = if cfg!(windows) {
+            self.spawnable_dependency(config, ts, bin).await
+        } else {
+            None
+        };
+        match resolved {
+            Some(path) => path.into_os_string(),
+            None => OsString::from(bin),
+        }
     }
 
     /// Check if a required dependency is available and show a warning if not.

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -286,9 +286,16 @@ impl Backend for PIPXBackend {
         let options = PipxOptions::new(&request_options);
 
         // Check if pipx is available (unless uvx is being used)
+        //
+        // Asks for a *spawnable* uv, because this both picks the branch and supplies the
+        // program `uvx_cmd` hands to `CmdLineRunner`. A `uv.ps1` or a shebang-only `uv`
+        // satisfies the plain lookup, so mise would commit to the uv branch and then fail
+        // at process creation; treating it as absent falls through to pipx, which either
+        // works or reports the install instructions below. The branch only changes in the
+        // case where the branch it would have taken cannot run.
         let uvx_allowed = Settings::get().pipx.uvx != Some(false) && !options.uvx_disabled();
         let uv_program = if uvx_allowed {
-            self.dependency_path_for_install(&ctx.config, Some(&ctx.ts), "uv")
+            self.spawnable_dependency(&ctx.config, Some(&ctx.ts), "uv")
                 .await
         } else {
             None
@@ -321,13 +328,19 @@ impl Backend for PIPXBackend {
             // Fail with the instructions above rather than letting `pipx install` die with a
             // bare "No such file or directory (os error 2)". Skipped when a configured tool
             // provides pipx, since mise installs that first — same rule as the warning.
+            //
+            // The gate asks `spawnable_dependency`, the same question `spawn_program` asks
+            // below, so it cannot pass on evidence the spawn will then reject. On Windows a
+            // `pipx.ps1` or a shebang-only `pipx.pyz` satisfies the plain lookup but cannot
+            // be launched, and it used to reach `pipx install` and die with
+            // "program not found" instead of these instructions.
             let pipx_configured = match self.dependency_toolset(&ctx.config).await {
                 Ok(ts) => ts.versions.keys().any(|ba| ba.short == "pipx"),
                 Err(_) => false,
             };
             if !pipx_configured
                 && self
-                    .dependency_path_for_install(&ctx.config, Some(&ctx.ts), "pipx")
+                    .spawnable_dependency(&ctx.config, Some(&ctx.ts), "pipx")
                     .await
                     .is_none()
             {
@@ -612,7 +625,11 @@ impl PIPXBackend {
         ts: &Toolset,
         pr: &'a dyn SingleReport,
     ) -> Result<CmdLineRunner<'a>> {
-        let mut cmd = CmdLineRunner::new("pipx");
+        // Resolved rather than a bare "pipx": on Windows std only appends `.exe`, so a
+        // pipx that exists only as `pipx.cmd` — how scoop and `pip install pipx` leave it —
+        // cleared mise's dependency check and then died at the spawn (discussion #5333).
+        // Same question the `bail!` gate in `install_version_` asks, so the two agree.
+        let mut cmd = CmdLineRunner::new(b.spawn_program(config, Some(ts), "pipx").await);
         for arg in args {
             cmd = cmd.arg(arg);
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -792,6 +792,54 @@ pub fn has_shebang(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Extensions that `windows_executable_extensions` lists but `CreateProcess` cannot
+/// launch: they need an interpreter (`pwsh -File`, `wscript`/`cscript`). `.bat` and
+/// `.cmd` are not here — std routes those through cmd.exe with escaped arguments.
+///
+/// `pub(crate)` so `task::task_executor` can assert that its `shell_from_extension` names
+/// an interpreter for every entry. That function is not `cfg(windows)`-gated, so it cannot
+/// match against this list directly; the correspondence is enforced by a test instead.
+#[cfg(windows)]
+pub(crate) const INTERPRETER_ONLY_EXTENSIONS: [&str; 2] = ["ps1", "vbs"];
+
+/// Check if a file can be executed directly by the OS without a shell wrapper.
+/// On Unix, this checks the executable permission bit.
+/// On Windows, this checks for a known executable extension (.bat, .cmd, .exe, ...)
+/// minus the ones that only an interpreter can run.
+///
+/// Distinct from [`is_executable`], which on Windows deliberately also accepts a
+/// shebang-only file. Callers that hand the path to `Command::new` need this one:
+/// `CreateProcess` can run `.exe`/`.com`/`.cmd`/`.bat`, but not a `.ps1`, a `.vbs`,
+/// or a script that only carries a shebang.
+///
+/// Note that on Windows this never touches the filesystem — it is pure extension
+/// inspection, so it answers true for a `foo.exe` that does not exist. `is_executable`
+/// checks `is_file()` inline; this one does not. A lookup that walks candidate paths must
+/// compose the two, which is what `backend::is_spawnable` does.
+pub fn can_execute_directly(path: &Path) -> bool {
+    #[cfg(windows)]
+    {
+        // Compared case-insensitively, the way has_known_executable_extension does:
+        // Windows extensions are not case-sensitive, so PIPX.PS1 is the same file.
+        if path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| {
+                INTERPRETER_ONLY_EXTENSIONS
+                    .iter()
+                    .any(|only| ext.eq_ignore_ascii_case(only))
+            })
+        {
+            return false;
+        }
+        has_known_executable_extension(path)
+    }
+    #[cfg(not(windows))]
+    {
+        is_executable(path)
+    }
+}
+
 #[cfg(unix)]
 pub fn make_executable<P: AsRef<Path>>(path: P) -> Result<()> {
     trace!("chmod +x {}", display_path(&path));

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -3,9 +3,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings, env_directive::EnvDirective};
 use crate::duration;
 use crate::env_diff::EnvDiff;
-#[cfg(not(windows))]
-use crate::file::is_executable;
-use crate::file::{display_path, replace_path};
+use crate::file::{can_execute_directly, display_path, replace_path};
 use crate::sandbox::SandboxConfig;
 use crate::task::TaskArtifactCache;
 use crate::task::task_cache::CommandInput;
@@ -1800,30 +1798,31 @@ impl TaskExecutor {
     }
 }
 
-/// Check if a file can be executed directly by the OS without a shell wrapper.
-/// On Unix, this checks the executable permission bit.
-/// On Windows, this checks for a known executable extension (.bat, .ps1, etc.)
-/// — shebang-only files need to be run through a shell.
-fn can_execute_directly(path: &Path) -> bool {
-    #[cfg(windows)]
-    {
-        // .ps1 files need pwsh -File, they can't be executed directly
-        if path.extension().is_some_and(|e| e == "ps1") {
-            return false;
-        }
-        crate::file::has_known_executable_extension(path)
-    }
-    #[cfg(not(windows))]
-    {
-        is_executable(path)
-    }
-}
-
 /// Determine the shell from a file's extension.
 /// e.g. `.ps1` → `["pwsh", "-File"]`
+///
+/// This covers exactly the extensions [`crate::file::can_execute_directly`] rejects as
+/// interpreter-only, so every file the spawn predicate turns down has an explicit
+/// interpreter here rather than falling through to `windows_default_file_shell_args`.
+///
+/// `.vbs` names `cscript`, the *console* script host, instead of letting `cmd /c` resolve
+/// the file association: the registered handler is whichever host the machine has, and
+/// `wscript` — the Windows-based host — writes its output to message boxes rather than the
+/// pipes mise reads. Naming the console host keeps task output capturable, the same reason
+/// `.ps1` names `pwsh -File`. `//nologo` keeps the banner out of the task's output.
+///
+/// That arm is `cfg(windows)`-only because `cscript` does not exist elsewhere, and this
+/// function is not gated — selecting it on unix would replace the configured default file
+/// shell with a program that cannot be found. `.ps1` needs no gate: `pwsh` is
+/// cross-platform, which is why that arm predates this and was never gated.
+///
+/// Matched case-insensitively because `can_execute_directly` is, so `TASK.PS1` cannot be
+/// rejected there and then miss its interpreter here.
 fn shell_from_extension(path: &Path) -> Option<Vec<String>> {
-    match path.extension()?.to_str()? {
+    match path.extension()?.to_str()?.to_lowercase().as_str() {
         "ps1" => Some(vec!["pwsh".to_string(), "-File".to_string()]),
+        #[cfg(windows)]
+        "vbs" => Some(vec!["cscript".to_string(), "//nologo".to_string()]),
         _ => None,
     }
 }
@@ -1956,6 +1955,62 @@ mod tests {
         env.insert((*crate::env::PATH_KEY).to_string(), path.to_string());
         env.insert("OTHER".to_string(), "unchanged".to_string());
         env
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_shell_from_extension_has_a_mapping_for_every_interpreter_only_extension() {
+        // The invariant, enforced rather than merely documented: an extension that
+        // `file::can_execute_directly` rejects as interpreter-only must be named in
+        // `shell_from_extension`, or the task silently falls through to
+        // `windows_default_file_shell_args` — and for .vbs that means whichever script host
+        // the machine's file association points at, where `wscript` writes to message boxes
+        // instead of the pipes mise reads.
+        //
+        // Iterating the list is the point. `shell_from_extension` cannot match against it
+        // directly because that function is not cfg(windows)-gated while the list is, so
+        // adding an entry there without a mapping here would otherwise go unnoticed.
+        for ext in crate::file::INTERPRETER_ONLY_EXTENSIONS {
+            let path = PathBuf::from(format!("task.{ext}"));
+            assert!(
+                shell_from_extension(&path).is_some(),
+                "{ext} is rejected as interpreter-only but has no interpreter mapping"
+            );
+        }
+        // The console host specifically, and case-insensitively.
+        for name in ["task.vbs", "task.VBS"] {
+            assert_eq!(
+                shell_from_extension(Path::new(name)),
+                Some(vec!["cscript".to_string(), "//nologo".to_string()])
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_shell_from_extension_leaves_vbs_to_the_default_shell_off_windows() {
+        // `cscript` is Windows-only, so selecting it here would swap the configured default
+        // file shell for a program that does not exist. `shell_from_extension` is not
+        // cfg-gated, so the arm has to be.
+        assert_eq!(shell_from_extension(Path::new("task.vbs")), None);
+        assert_eq!(shell_from_extension(Path::new("task.VBS")), None);
+    }
+
+    #[test]
+    fn test_shell_from_extension_maps_ps1_on_every_platform() {
+        // `pwsh` is cross-platform, so this arm is deliberately ungated. Case-insensitive
+        // because the predicate that rejects `.ps1` for direct execution is.
+        assert_eq!(
+            shell_from_extension(Path::new("task.ps1")),
+            Some(vec!["pwsh".to_string(), "-File".to_string()])
+        );
+        assert_eq!(
+            shell_from_extension(Path::new("task.PS1")),
+            Some(vec!["pwsh".to_string(), "-File".to_string()])
+        );
+        // Anything else keeps using the configured default file shell.
+        assert_eq!(shell_from_extension(Path::new("task.sh")), None);
+        assert_eq!(shell_from_extension(Path::new("task")), None);
     }
 
     #[test]

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -580,6 +580,25 @@ impl Toolset {
         None
     }
 
+    /// [`Self::which_bin`] narrowed to a path the OS can spawn, for
+    /// [`Backend::spawn_program`] and [`Backend::spawnable_dependency`]. `which_bin` itself
+    /// is untouched because `mise which`, shim dispatch and auto-install all depend on its
+    /// answer.
+    pub async fn which_bin_spawnable(
+        &self,
+        config: &Arc<Config>,
+        bin_name: &str,
+    ) -> Option<PathBuf> {
+        let mut installed = self.list_current_installed_versions(config);
+        Self::sort_by_overrides(&mut installed).unwrap();
+        for (p, tv) in installed {
+            if let Ok(Some(bin)) = Box::pin(p.which_spawnable(config, &tv, bin_name)).await {
+                return Some(bin);
+            }
+        }
+        None
+    }
+
     pub async fn list_rtvs_with_bin(
         &self,
         config: &Arc<Config>,


### PR DESCRIPTION
## Summary

Adds the resolution step mise was missing on Windows, and routes pipx through it. Fixes https://github.com/jdx/mise/discussions/5333 (open and unanswered since 2025-06-12).

- `which_in_dirs(dirs, bin, spawnable)` — one resolver, directory-major, that with `spawnable = true` keeps searching past a candidate the OS cannot launch
- `Backend::spawn_program` / `Backend::spawnable_dependency` — what a spawn site and a gate ask, so they can no longer disagree
- `Backend::which` re-expressed through the same helper, **predicate and traversal unchanged**
- pipx migrated; its local helper deleted

Windows-only. On unix the program handed to the spawn is byte-identical.

## Root cause

mise has a lookup that answers **"is there a file here that looks executable"** — `executable_names` plus `file::is_executable` — and nothing that answers **"what can I actually spawn"**. On Windows those are different questions. `file::is_executable` deliberately accepts a shebang-only file, and the `windows_executable_extensions` default includes `ps1` and `vbs`; `CreateProcess` can launch none of those. Meanwhile `Command::new` only ever appends `.exe` to a bare name and then reports `program not found`.

So every spawn site improvised: `npm.rs` and `gem.rs` hardcoded `.cmd`, pipx did nothing (#5333), and a dozen sites in cargo/go/dotnet/spm just passed a bare name.

Reproduced on **v2026.7.16** with pipx present only as `pipx.cmd` — the form scoop and `pip install pipx` leave behind — in an isolated env:

```console
$ (Get-Command pipx).Source
...\pipxbin\pipx.cmd

$ mise install pipx:toml-sort
mise pipx:toml-sort@0.24.4 [1/3] pipx install toml-sort==0.24.4
mise ERROR Failed to install pipx:toml-sort@latest: failed to execute command:
           pipx install toml-sort==0.24.4 --pip-args=...: program not found
```

A control run pins the split:

| pipx on PATH | behavior |
|---|---|
| absent | check fails → early bail with `mise use pipx@latest` |
| `pipx.cmd` | check passes → dies at the spawn with `program not found` |

**The hardcodes are not incidental.** mise's own node install ships `npm` (a `#!/usr/bin/env bash` script), `npm.cmd` and `npm.ps1` but **no `npm.exe`**, and on Windows the node plugin puts the install root itself on PATH. `executable_names` tries the bare name first, so `Backend::which("npm")` answers with the bash script — which is exactly why `NPM_PROGRAM = "npm.cmd"` had to exist. A unit test pins both halves of that so the follow-up can delete the constant with evidence.

## Why a resolver rather than another special case

The first version of this PR guarded pipx locally: take whatever the lookup returned, and if it is not directly spawnable, fall back to the bare name. Both reviewers found holes in it — a case-sensitivity gap on `.ps1`, and `.vbs` being accepted — and Greptile named the structural problem:

> a resolved VBS dependency is still treated as evidence that pipx exists, but program selection discards that path and retries the bare name

That is correct and **unfixable at the program-selection layer**: a function handed one path can accept it or discard it, but cannot go look for a better one. Moving the decision into the search removes the premise. `which_in_dirs(…, true)` steps past a rejected candidate and continues, so `None` genuinely means "nothing spawnable exists anywhere mise looked", and the gate and the spawn are driven by the same predicate over the same traversal. The only value the spawn discards is one the gate also discards.

`.ps1`-only pipx therefore now produces mise's install instructions instead of a `CreateProcess` failure, which is what the new e2e case asserts.

## What is deliberately not narrowed

`file::is_executable`, `file::which*`, `Toolset::which`/`which_bin`, `executable_names`, `Backend::which`'s *meaning*, and both shim-inventory predicates. That list matters:

- `Backend::which` has 11 callers, including `mise which`, shim dispatch, auto-install candidate selection and tool-stubs.
- `shims.rs`'s desired-shim and actual-shim scans use **different** predicates (the latter has an extra `extension().is_none()` disjunct). Narrowing one and not the other would make `get_shim_diffs` permanently non-empty, so every `mise reshim` would delete and recreate the same shims forever.
- `file::is_executable` is also the predicate for file-task discovery and post-install bin detection.

`src/shims.rs` and `src/config/mod.rs` have zero changes; `src/file.rs` is a doc addendum only.

## Notes on the implementation

- **Directory-major, extension-minor.** The order `CreateProcess`+`PATHEXT`, `cmd.exe`, the `which` crate and `Backend::which` all use. It diverges from `which_non_pristine_executable`, which is name-major (bare name across the whole PATH first) and is left alone. Only directory-major resolves the case this exists for, since the shebang `npm` and `npm.cmd` sit in one directory.
- **`is_file()` is composed in, not moved into `can_execute_directly`.** That predicate is pure extension inspection on Windows, so on its own it answers true for a `foo.exe` that is not there. The guard is `cfg!(windows)`-gated because on unix `can_execute_directly` delegates to `is_executable`, which answers true for a mode-0755 *directory* — adding `is_file()` unconditionally would silently narrow every unix lookup.
- **`OsString`, not `PathBuf`, is load-bearing.** duct implements `IntoExecutablePath for PathBuf` as `Path::new(".").join(path)`, so a `PathBuf` in a `cmd!` program position becomes `./npm` and stops being a PATH lookup. duct's `OsString` impl is verbatim and std's `Command::new` never dotifies. Please don't "simplify" the return type.
- Shim directories are skipped on the Windows PATH search: a shim re-enters mise, and once an absolute path is handed over the child PATH no longer gets a vote. Skipping is monotone-safe — it can only move a hit later or to `None`, and `None` is the bare-name fallback, i.e. today's path.

### The one user-visible change outside backend spawning: `.vbs` file tasks

`can_execute_directly` is shared with the file-task path, so adding `vbs` to the interpreter-only list changes what happens to a shebang-less `.vbs` file task. Measured on Windows 11: `CreateProcess` cannot launch one at all (`The specified executable is not a valid application for this OS platform`), so these tasks were already broken before this PR rather than working — there is no regression available here.

They now route explicitly to `cscript //nologo`, added to `shell_from_extension` alongside the existing `.ps1` → `pwsh -File`. Not just to have *an* interpreter: leaving it to `cmd /c` would resolve the file association, and the registered handler may be `wscript` — `Microsoft (R) Windows Based Script Host` — whose output goes to message boxes rather than the pipes mise reads. `cscript` is `Microsoft (R) Console Based Script Host`, so task output stays capturable. The match is case-insensitive because the predicate that rejects these files is, and the mapped set is deliberately exactly `INTERPRETER_ONLY_EXTENSIONS`, with a unit test pinning that correspondence.

This still will not run on a machine without the engine: Windows 11 ships VBScript as a deprecated on-demand component, and here `assoc .vbs` reports no association and `cscript` reports `There is no script engine for file extension ".vbs"`. Where the engine is installed, the console host now runs the task and mise captures its output.

## Tests

Six unit tests on the resolver, replacing the four narrow ones from the previous revision:

| test | platform | pins |
|---|---|---|
| `which_in_dirs_skips_shebang_script_for_node_npm_layout` | windows | the real node layout: permissive → `npm`, spawnable → `npm.cmd` |
| `which_in_dirs_rejects_interpreter_only_extensions` | windows | `.ps1` / `.vbs` / `.PS1`, each paired against the permissive answer |
| `which_in_dirs_prefers_exe_over_cmd_within_a_directory` | windows | candidate order within one directory |
| `which_in_dirs_is_directory_major` | windows | the ordering decision itself |
| `which_in_dirs_ignores_missing_candidates` | windows | the `is_file()` composition — delete the guard and only this fails |
| `is_spawnable_matches_is_executable_on_unix` | unix | unix byte-identity, incl. the mode-0755 directory |

`e2e-win/pipx.Tests.ps1` covers the reported setup end to end: a `pipx.cmd` stub as the only pipx on a trimmed PATH, with a marker file rather than the stub's stdout (piping a batch child through the PowerShell pipeline captures nothing on these runners — documented in `python.Tests.ps1`). Plus the new `.ps1`-only case, and the nothing-resolves case.

## Out of scope

- **Deleting `NPM_PROGRAM` / `GEM_PROGRAM` and migrating cargo/go/dotnet/spm/bun/pnpm** onto `spawn_program`. That is the point of the mechanism and it is next, but the npm spawn has **zero Windows test coverage** today (`npm_backend.Tests.ps1` exercises the embedded aube path and the `bun` literal, never `NPM_PROGRAM`), gem and swift are not installable on my machine, and all the gem/cargo e2e tests are `_slow` and skipped on PRs. Keeping this PR to the mechanism plus one migration means a year-old report is not blocked on that risk. Follow-up PR will carry its own e2e-win npm case.
- **Resolution inside `CmdLineRunner`.** `new()` builds the `Command` immediately and neither std nor tokio exposes a program setter. The only precedent for late substitution is the macOS sandbox path, which builds a fresh `Command` and hand-copies state — and that rebuild demonstrably loses the raw-vs-regular argument classification (`raw_arg`/`cmd_body_args`, needed so `cmd.exe /c` bodies survive, #9355), `OsStr` fidelity, stdio settings and every registered `pre_exec` closure. That is why this lives at the caller layer.
- **`AUBE_PROGRAM` and `cargo-binstall`.** Both already resolve, and both already hand an absolute path to `CmdLineRunner` on unix too. Routing them through `spawn_program` would drop unix back to the bare name and change which binary runs.
- **`env_directive/venv.rs`'s `python3` fallback.** Windows CPython ships `python.exe`, not `python3.exe`, so there is no candidate for any resolver to find. Separate bug.
- **`warn_if_dependency_missing`** keeps its permissive predicate — it is shared by five backends and warning-only, and the `bail!` immediately after carries the same instructions.
- **`cli/which.rs`'s `.unwrap()`**, which panics if its two independent `Backend::which` calls ever disagree. Untouched here, but worth fixing.

## Verification

Locally: `rustfmt --edition 2024 --check` on all five Rust files, a PowerShell parse check on the Pester file, and a read-through confirming the `Backend::which` rewrite is 1:1. No local build — CI covers the rest: `windows-unit` (`cargo check --all-targets` with `-D unused`, then `cargo test`) for tests 1-5, `unit-macos` and the Linux tranches for test 6 and the three pipx e2e tests that assert the mise-managed-pipx-wins contract, `windows-e2e` for the Pester cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows executable discovery to distinguish launchable programs from scripts that require an interpreter.
  * Fixed `pipx` command resolution for Windows shims and supported executable formats.
  * Added clearer guidance when `pipx` cannot be found, including a suggested fallback command.
  * Improved handling of PowerShell and VBScript-based task executables.
* **Tests**
  * Added Windows end-to-end coverage for `pipx` resolution, missing executables, shims, and interpreter-only scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->