### PR TITLE
fix(plugins): support local paths in config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,6 +220,21 @@ If you simply want to install a plugin from a specific URL once, it's better to 
 `mise plugin install <NAME> <GIT_URL>`. Add this section to `mise.toml` if you want
 to share the plugin location/revision with other developers in your project.
 
+Local plugin directories are also supported. Absolute paths and paths beginning
+with `~/` are used directly. Explicit relative paths beginning with `./` or `../`
+are resolved relative to the config root of the file that declares them:
+
+```toml
+[plugins]
+example = "./plugins/mise-example"
+```
+
+Local plugins are symlinked into mise's plugin directory, matching
+`mise plugins link`, so changes to the source directory are available immediately.
+As with remote entries, `[plugins]` only affects new installations. Run
+`mise plugins install --force <NAME>` to replace an existing plugin with the
+configured local source. `file://` sources remain Git repositories and are cloned.
+
 This replaces the deprecated `settings.shorthands_file` / `MISE_SHORTHANDS_FILE` mechanism: put the
 same `shortname = "backend-or-url"` entries under `[plugins]` instead of a separate TOML file.
 

--- a/docs/plugin-usage.md
+++ b/docs/plugin-usage.md
@@ -62,6 +62,20 @@ mise plugin install tiny https://github.com/mise-plugins/mise-tiny.git
 mise plugin link <plugin-name> /path/to/plugin/directory
 ```
 
+Local plugins can also be declared in `mise.toml`:
+
+```toml
+[plugins]
+my-plugin = "./plugins/my-plugin"
+```
+
+Absolute paths and `~/...` are supported. Explicit relative paths beginning with
+`./` or `../` are resolved from the config root of the file containing the
+declaration. Mise symlinks the directory just like `mise plugins link`, so local
+edits are reflected immediately. Existing plugin installations are not replaced
+automatically; use `mise plugins install --force my-plugin` when changing an
+existing installation to a local source.
+
 ## Using Plugins (Advanced)
 
 Once a plugin is installed, you can use it with the `plugin:tool` format:

--- a/e2e/plugins/test_plugins_section_local
+++ b/e2e/plugins/test_plugins_section_local
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+make_asdf_plugin() {
+  local plugin_dir=$1
+  local version=$2
+  mkdir -p "$plugin_dir/bin"
+  cat >"$plugin_dir/bin/list-all" <<EOF
+#!/usr/bin/env bash
+echo "$version"
+EOF
+  chmod +x "$plugin_dir/bin/list-all"
+}
+
+mkdir absolute-case
+(
+  cd absolute-case
+  make_asdf_plugin "$PWD/local-plugin" "1.0.0"
+  cat >mise.toml <<EOF
+[plugins]
+local-absolute = "$PWD/local-plugin"
+EOF
+
+  mise plugin install local-absolute
+  [[ -L "$MISE_DATA_DIR/plugins/local-absolute" ]]
+  assert "readlink '$MISE_DATA_DIR/plugins/local-absolute'" "$PWD/local-plugin"
+)
+
+mkdir relative-case
+(
+  cd relative-case
+  make_asdf_plugin "$PWD/local-plugin" "1.0.0"
+  cat >"$PWD/local-plugin/bin/post-plugin-add" <<'EOF'
+#!/usr/bin/env bash
+touch "$HOME/post-plugin-add-ran"
+EOF
+  chmod +x "$PWD/local-plugin/bin/post-plugin-add"
+  rm -f "$HOME/post-plugin-add-ran"
+  cat >mise.toml <<'EOF'
+[plugins]
+local-relative = "./local-plugin"
+EOF
+
+  mise plugin install local-relative
+  [[ -f "$HOME/post-plugin-add-ran" ]]
+  [[ -L "$MISE_DATA_DIR/plugins/local-relative" ]]
+  assert "readlink '$MISE_DATA_DIR/plugins/local-relative'" "$PWD/local-plugin"
+  assert "'$MISE_DATA_DIR/plugins/local-relative/bin/list-all'" "1.0.0"
+
+  make_asdf_plugin "$PWD/local-plugin" "2.0.0"
+  assert "'$MISE_DATA_DIR/plugins/local-relative/bin/list-all'" "2.0.0"
+)
+
+mkdir zip-directory-case
+(
+  cd zip-directory-case
+  make_asdf_plugin "$PWD/local-plugin.zip" "1.0.0"
+  cat >mise.toml <<EOF
+[plugins]
+local-zip-directory = "$PWD/local-plugin.zip"
+EOF
+
+  mise plugin install local-zip-directory
+  [[ -L "$MISE_DATA_DIR/plugins/local-zip-directory" ]]
+  assert "readlink '$MISE_DATA_DIR/plugins/local-zip-directory'" "$PWD/local-plugin.zip"
+)
+
+mkdir failed-hook-case
+(
+  cd failed-hook-case
+  make_asdf_plugin "$PWD/local-plugin" "1.0.0"
+  cat >"$PWD/local-plugin/bin/post-plugin-add" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$PWD/local-plugin/bin/post-plugin-add"
+  cat >mise.toml <<'EOF'
+[plugins]
+local-failed-hook = "./local-plugin"
+EOF
+
+  assert_fail "mise plugin install local-failed-hook"
+  [[ ! -e "$MISE_DATA_DIR/plugins/local-failed-hook" ]]
+  [[ ! -L "$MISE_DATA_DIR/plugins/local-failed-hook" ]]
+
+  rm "$PWD/local-plugin/bin/post-plugin-add"
+  mise plugin install local-failed-hook
+  [[ -L "$MISE_DATA_DIR/plugins/local-failed-hook" ]]
+)
+
+mkdir vfox-case
+(
+  cd vfox-case
+  mkdir local-vfox-plugin
+  touch local-vfox-plugin/metadata.lua
+  cat >mise.toml <<'EOF'
+[plugins]
+"vfox:local-vfox" = "./local-vfox-plugin"
+EOF
+
+  mise install
+  [[ -L "$MISE_DATA_DIR/plugins/local-vfox" ]]
+  assert "readlink '$MISE_DATA_DIR/plugins/local-vfox'" "$PWD/local-vfox-plugin"
+)
+
+mkdir missing-case
+(
+  cd missing-case
+  cat >mise.toml <<'EOF'
+[plugins]
+missing-local = "./does-not-exist"
+EOF
+
+  if output=$(mise plugin install missing-local 2>&1); then
+    echo "expected missing local plugin installation to fail"
+    exit 1
+  fi
+  [[ $output == *"local plugin directory does not exist"* ]]
+  [[ ! -e "$MISE_DATA_DIR/plugins/missing-local" ]]
+  [[ ! -L "$MISE_DATA_DIR/plugins/missing-local" ]]
+)
+
+mkdir file-url-case
+(
+  cd file-url-case
+  make_asdf_plugin "$PWD/plugin-repo" "1.0.0"
+  git -C plugin-repo init -q
+  git -C plugin-repo add .
+  git -C plugin-repo \
+    -c user.name=test \
+    -c user.email=test@example.com \
+    commit -qm "initial"
+  cat >mise.toml <<EOF
+[plugins]
+local-file-url = "file://$PWD/plugin-repo"
+local-path-ref = "$PWD/plugin-repo#HEAD"
+EOF
+
+  mise plugin install local-file-url
+  [[ ! -L "$MISE_DATA_DIR/plugins/local-file-url" ]]
+  [[ -d "$MISE_DATA_DIR/plugins/local-file-url/.git" ]]
+
+  mise plugin install local-path-ref
+  [[ ! -L "$MISE_DATA_DIR/plugins/local-path-ref" ]]
+  [[ -d "$MISE_DATA_DIR/plugins/local-path-ref/.git" ]]
+)

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -2,11 +2,12 @@ use eyre::{WrapErr, eyre};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
+use path_absolutize::Absolutize;
 use serde::Deserialize;
 use serde::de::Visitor;
 use serde::{Deserializer, de};
 use std::fmt::{Debug, Formatter};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -919,7 +920,7 @@ impl ConfigFile for MiseToml {
             .into_iter()
             .map(|(k, v)| {
                 let v = self.parse_template(&v)?;
-                Ok((k, v))
+                Ok((k, resolve_plugin_source_path(&self.path, v)?))
             })
             .collect()
     }
@@ -1376,6 +1377,27 @@ impl ConfigFile for MiseToml {
 
     fn dotfiles_config(&self) -> Option<DotfilesTomlConfig> {
         self.dotfiles.clone()
+    }
+}
+
+fn resolve_plugin_source_path(config_path: &Path, source: String) -> eyre::Result<String> {
+    let source_path = Path::new(&source);
+    let is_explicit_relative = matches!(
+        source_path.components().next(),
+        Some(Component::CurDir | Component::ParentDir)
+    );
+    let expanded = file::replace_path(source_path);
+    let path = if expanded.is_absolute() {
+        Some(expanded)
+    } else if is_explicit_relative {
+        Some(config_root::config_root(config_path).join(expanded))
+    } else {
+        None
+    };
+
+    match path {
+        Some(path) => Ok(path.absolutize()?.to_string_lossy().into_owned()),
+        None => Ok(source),
     }
 }
 
@@ -2653,6 +2675,43 @@ mod tests {
     use crate::{config::Config, dirs::CWD};
 
     use super::*;
+
+    #[test]
+    fn test_resolve_plugin_source_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_path = temp.path().join("project/mise.toml");
+        let absolute_plugin = temp.path().join("absolute/plugin");
+        let home_plugin = dirs::HOME.join("plugins/example");
+
+        for (source, expected) in [
+            (
+                absolute_plugin.to_string_lossy().into_owned(),
+                absolute_plugin,
+            ),
+            (
+                "./plugins/example".to_string(),
+                temp.path().join("project/plugins/example"),
+            ),
+            ("../example".to_string(), temp.path().join("example")),
+            ("~/plugins/example".to_string(), home_plugin),
+        ] {
+            assert_eq!(
+                resolve_plugin_source_path(&config_path, source).unwrap(),
+                expected.to_string_lossy()
+            );
+        }
+
+        for source in [
+            "https://github.com/example/plugin.git",
+            "file:///tmp/plugin",
+            "example/plugin",
+        ] {
+            assert_eq!(
+                resolve_plugin_source_path(&config_path, source.to_string()).unwrap(),
+                source
+            );
+        }
+    }
 
     #[test]
     fn test_parse_monorepo_project_overrides() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -413,6 +413,12 @@ impl Config {
     }
 
     pub fn get_repo_url(&self, plugin_name: &str) -> Option<String> {
+        if let Some(url) = self.repo_urls.get(plugin_name)
+            && (Path::new(url).is_absolute() || url.starts_with("file://"))
+        {
+            return Some(url.clone());
+        }
+
         let plugin_name = self
             .all_aliases
             .get(plugin_name)
@@ -428,7 +434,13 @@ impl Config {
             .find(|k| k.ends_with(&format!(":{plugin_name}")))
             .and_then(|k| self.repo_urls.get(k))
         {
-            return Some(url.clone());
+            return Some(
+                if Path::new(url).is_absolute() || url.starts_with("file://") {
+                    url.clone()
+                } else {
+                    registry::full_to_url(url)
+                },
+            );
         }
 
         self.shorthands
@@ -5368,6 +5380,66 @@ config_roots = ["apps/api", "apps/web"]
             );
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_get_repo_url_preserves_explicit_local_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let local_asdf = temp
+            .path()
+            .join("plugins/local-asdf")
+            .to_string_lossy()
+            .into_owned();
+        let local_vfox = temp
+            .path()
+            .join("plugins/local-vfox")
+            .to_string_lossy()
+            .into_owned();
+        let repo_urls = HashMap::from([
+            ("local-asdf".to_string(), local_asdf.clone()),
+            ("vfox:local-vfox".to_string(), local_vfox.clone()),
+            ("remote-asdf".to_string(), "owner/asdf-plugin".to_string()),
+            (
+                "vfox:remote-vfox".to_string(),
+                "owner/vfox-plugin".to_string(),
+            ),
+        ]);
+        let config = Config {
+            tera_ctx: BASE_CONTEXT.clone(),
+            config_files: Default::default(),
+            env: OnceCell::new(),
+            env_with_sources: OnceCell::new(),
+            shorthands: get_shorthands(&Settings::get()),
+            hooks: OnceCell::new(),
+            tasks_cache: Arc::new(DashMap::new()),
+            tool_request_set: OnceCell::new(),
+            toolset: OnceCell::new(),
+            all_aliases: Default::default(),
+            aliases: Default::default(),
+            project_root: Default::default(),
+            repo_urls,
+            shell_aliases: Default::default(),
+            tera_files: Default::default(),
+            vars: Default::default(),
+            vars_results: OnceCell::new(),
+        };
+
+        assert_eq!(
+            config.get_repo_url("local-asdf").as_deref(),
+            Some(local_asdf.as_str())
+        );
+        assert_eq!(
+            config.get_repo_url("local-vfox").as_deref(),
+            Some(local_vfox.as_str())
+        );
+        assert_eq!(
+            config.get_repo_url("remote-asdf").as_deref(),
+            Some("https://github.com/owner/asdf-plugin.git")
+        );
+        assert_eq!(
+            config.get_repo_url("remote-vfox").as_deref(),
+            Some("https://github.com/owner/vfox-plugin.git")
+        );
     }
 
     #[tokio::test]

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -5,7 +5,8 @@ use crate::git::Git;
 use crate::http::HTTP;
 use crate::plugins::{
     Plugin, PluginSource, PluginType, Script, ScriptManager, install_git_plugin_source,
-    managed_git_plugin_repo_path, remove_git_plugin_source,
+    install_local_plugin_source, local_plugin_source_path, managed_git_plugin_repo_path,
+    remove_git_plugin_source, validate_local_plugin_source,
 };
 use crate::result::Result;
 use crate::timeout::run_with_timeout;
@@ -360,11 +361,31 @@ impl Plugin for AsdfPlugin {
     async fn install(&self, config: &Arc<Config>, pr: &dyn SingleReport) -> eyre::Result<()> {
         Settings::ensure_not_safe("installing plugins")?;
         let repository = self.get_repo_url(config)?;
+        let local_source = local_plugin_source_path(&repository);
+        if let Some(source) = &local_source {
+            validate_local_plugin_source(source, &self.plugin_path)?;
+        }
         let source = PluginSource::parse(&repository);
         debug!("asdf_plugin[{}]:install {:?}", self.name, repository);
 
         if self.is_installed() {
             self.uninstall(pr).await?;
+        }
+
+        if let Some(source) = local_source {
+            install_local_plugin_source(&self.plugin_path, &source, pr)?;
+            if let Err(err) = self.exec_hook(pr, "post-plugin-add") {
+                if let Err(cleanup_err) =
+                    remove_git_plugin_source(&self.name, &self.plugin_path, pr)
+                {
+                    warn!(
+                        "failed to clean up local plugin link after post-plugin-add failed: {cleanup_err:#}"
+                    );
+                }
+                return Err(err);
+            }
+            pr.finish_with_message(format!("linked {}", display_path(source)));
+            return Ok(());
         }
 
         match source {
@@ -379,13 +400,6 @@ impl Plugin for AsdfPlugin {
                 git_ref,
                 subdir,
             } => {
-                if regex!(r"^[/~]").is_match(&repo_url) {
-                    Err(eyre!(
-                        r#"Invalid repository URL: {repo_url}
-If you are trying to link to a local directory, use `mise plugins link` instead.
-Plugins could support local directories in the future but for now a symlink is required which `mise plugins link` will create for you."#
-                    ))?;
-                }
                 let git = install_git_plugin_source(
                     &self.name,
                     &self.plugin_path,

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,5 +1,5 @@
 use crate::errors::Error::PluginNotInstalled;
-use crate::file;
+use crate::file::{self, display_path};
 use crate::git::{CloneOptions, Git};
 use crate::plugins::asdf_plugin::AsdfPlugin;
 use crate::plugins::vfox_plugin::VfoxPlugin;
@@ -11,7 +11,7 @@ use crate::ui::progress_report::SingleReport;
 use crate::{config::Config, dirs};
 use async_trait::async_trait;
 use clap::Command;
-use eyre::{Result, eyre};
+use eyre::{Result, bail, eyre};
 use heck::ToKebabCase;
 use regex::Regex;
 pub use script_manager::{Script, ScriptManager};
@@ -517,9 +517,167 @@ pub fn install_git_plugin_source(
     }
 }
 
+pub fn local_plugin_source_path(repository: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(repository);
+    let source = PluginSource::parse(repository);
+    if path.is_absolute() && path.is_dir() && matches!(&source, PluginSource::Zip { .. }) {
+        return Some(path);
+    }
+
+    match source {
+        PluginSource::Git {
+            url,
+            git_ref: None,
+            subdir: None,
+        } if url == repository => path.is_absolute().then_some(path),
+        _ => None,
+    }
+}
+
+pub fn validate_local_plugin_source(source: &Path, plugin_path: &Path) -> Result<()> {
+    if !source.exists() {
+        bail!(
+            "local plugin directory does not exist: {}",
+            display_path(source)
+        );
+    }
+    if !source.is_dir() {
+        bail!(
+            "local plugin source is not a directory: {}",
+            display_path(source)
+        );
+    }
+    let resolved_source = file::desymlink_path(source);
+    let resolved_plugin_path = match (plugin_path.parent(), plugin_path.file_name()) {
+        (Some(parent), Some(file_name)) => file::desymlink_path(parent).join(file_name),
+        _ => plugin_path.to_path_buf(),
+    };
+    if resolved_source
+        .ancestors()
+        .any(|path| file::paths_eq(path, &resolved_plugin_path))
+        || resolved_plugin_path
+            .ancestors()
+            .any(|path| file::paths_eq(path, &resolved_source))
+    {
+        bail!(
+            "local plugin source cannot contain, be, or be inside the plugin install path: {}",
+            display_path(source)
+        );
+    }
+    Ok(())
+}
+
+pub fn install_local_plugin_source(
+    plugin_path: &Path,
+    source: &Path,
+    pr: &dyn SingleReport,
+) -> Result<()> {
+    let parent = plugin_path.parent().ok_or_else(|| {
+        eyre!(
+            "plugin install path has no parent: {}",
+            display_path(plugin_path)
+        )
+    })?;
+    file::create_dir_all(parent)?;
+    pr.set_message(format!("link {}", display_path(source)));
+    file::make_symlink(source, plugin_path)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_local_plugin_source_path_requires_plain_absolute_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().to_string_lossy();
+
+        assert_eq!(
+            local_plugin_source_path(&source),
+            Some(temp.path().to_path_buf())
+        );
+        let source_with_ref = format!("{source}#main");
+        assert_eq!(local_plugin_source_path(&source_with_ref), None);
+        assert!(matches!(
+            PluginSource::parse(&source_with_ref),
+            PluginSource::Git {
+                url,
+                git_ref: Some(git_ref),
+                subdir: None,
+            } if url == source && git_ref == "main"
+        ));
+
+        let referenced_directory = temp.path().join("plugin#main");
+        fs::create_dir_all(&referenced_directory).unwrap();
+        assert_eq!(
+            local_plugin_source_path(&referenced_directory.to_string_lossy()),
+            None
+        );
+
+        let zip_directory = temp.path().join("plugin.zip");
+        fs::create_dir_all(&zip_directory).unwrap();
+        assert_eq!(
+            local_plugin_source_path(&zip_directory.to_string_lossy()),
+            Some(zip_directory)
+        );
+
+        let archive = temp.path().join("plugin-archive.zip");
+        fs::write(&archive, b"archive").unwrap();
+        let archive = archive.to_string_lossy();
+        assert_eq!(local_plugin_source_path(&archive), None);
+        assert!(matches!(
+            PluginSource::parse(&archive),
+            PluginSource::Zip { url } if url == archive
+        ));
+    }
+
+    #[test]
+    fn test_validate_local_plugin_source_rejects_recursive_layouts() {
+        let temp = tempfile::tempdir().unwrap();
+        let plugins_dir = temp.path().join("plugins");
+        let plugin_path = plugins_dir.join("example");
+        let descendant = plugin_path.join("source");
+        let separate_source = temp.path().join("source");
+        fs::create_dir_all(&descendant).unwrap();
+        fs::create_dir_all(&separate_source).unwrap();
+
+        assert!(validate_local_plugin_source(&plugins_dir, &plugin_path).is_err());
+        assert!(validate_local_plugin_source(&plugin_path, &plugin_path).is_err());
+        assert!(validate_local_plugin_source(&descendant, &plugin_path).is_err());
+        assert!(validate_local_plugin_source(&separate_source, &plugin_path).is_ok());
+    }
+
+    #[test]
+    fn test_validate_local_plugin_source_resolves_symlink_aliases() {
+        let temp = tempfile::tempdir().unwrap();
+        let plugins_dir = temp.path().join("plugins");
+        let plugin_path = plugins_dir.join("example");
+        let plugin_alias = temp.path().join("plugin-alias");
+        let parent_alias = temp.path().join("parent-alias");
+        fs::create_dir_all(&plugin_path).unwrap();
+        file::make_symlink(&plugin_path, &plugin_alias).unwrap();
+        file::make_symlink(&plugins_dir, &parent_alias).unwrap();
+
+        assert!(validate_local_plugin_source(&plugin_alias, &plugin_path).is_err());
+        assert!(validate_local_plugin_source(&parent_alias, &plugin_path).is_err());
+    }
+
+    #[test]
+    fn test_validate_local_plugin_source_preserves_symlinked_install_slot() {
+        let temp = tempfile::tempdir().unwrap();
+        let plugins_dir = temp.path().join("plugins");
+        let plugin_path = plugins_dir.join("example");
+        let old_source = temp.path().join("old-source");
+        let new_source = temp.path().join("new-source");
+        fs::create_dir_all(&plugins_dir).unwrap();
+        fs::create_dir_all(&old_source).unwrap();
+        fs::create_dir_all(&new_source).unwrap();
+        file::make_symlink(&old_source, &plugin_path).unwrap();
+
+        assert!(validate_local_plugin_source(&plugins_dir, &plugin_path).is_err());
+        assert!(validate_local_plugin_source(&new_source, &plugin_path).is_ok());
+    }
 
     #[test]
     fn test_plugin_source_parse_git() {

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -4,8 +4,9 @@ use crate::git::Git;
 use crate::http::HTTP;
 use crate::plugins::warn_if_env_plugin_shadows_registry;
 use crate::plugins::{
-    Plugin, PluginSource, PluginType, install_git_plugin_source, managed_git_plugin_repo_path,
-    remove_git_plugin_source,
+    Plugin, PluginSource, PluginType, install_git_plugin_source, install_local_plugin_source,
+    local_plugin_source_path, managed_git_plugin_repo_path, remove_git_plugin_source,
+    validate_local_plugin_source,
 };
 use crate::result::Result;
 use crate::toolset::install_state;
@@ -371,11 +372,21 @@ impl Plugin for VfoxPlugin {
     async fn install(&self, config: &Arc<Config>, pr: &dyn SingleReport) -> eyre::Result<()> {
         Settings::ensure_not_safe("installing plugins")?;
         let repository = self.get_repo_url(config)?;
+        let local_source = local_plugin_source_path(&repository);
+        if let Some(source) = &local_source {
+            validate_local_plugin_source(source, &self.plugin_path)?;
+        }
         let source = PluginSource::parse(repository.as_str());
         debug!("vfox_plugin[{}]:install {:?}", self.name, repository);
 
         if self.is_installed() {
             self.uninstall(pr).await?;
+        }
+
+        if let Some(source) = local_source {
+            install_local_plugin_source(&self.plugin_path, &source, pr)?;
+            pr.finish_with_message(format!("linked {}", file::display_path(source)));
+            return Ok(());
         }
 
         match source {
@@ -389,13 +400,6 @@ impl Plugin for VfoxPlugin {
                 git_ref,
                 subdir,
             } => {
-                if regex!(r"^[/~]").is_match(&repo_url) {
-                    Err(eyre!(
-                        r#"Invalid repository URL: {repo_url}
-If you are trying to link to a local directory, use `mise plugins link` instead.
-Plugins could support local directories in the future but for now a symlink is required which `mise plugins link` will create for you."#
-                    ))?;
-                }
                 let git = install_git_plugin_source(
                     &self.name,
                     &self.plugin_path,


### PR DESCRIPTION
## Summary

- preserve explicit `[plugins]` sources even when they are filesystem paths rather than URL-like values
- resolve absolute, `~/`, and explicit `./` or `../` paths, with relative paths anchored to the declaring config root
- install local asdf, vfox, vfox-backend, and package plugins as symlinks so source edits are reflected immediately
- keep `file://`, Git URLs, refs, zip archives, and subdirectory sources on the existing clone/install paths

## Root cause

`Config::get_repo_url` only returned explicit plugin values after URL-like resolution, so filesystem paths could be discarded. Even when a path reached plugin installation, the asdf and vfox installers rejected it as an invalid repository URL.

## Behavior

Local sources are validated before any existing installation is removed, then linked into the mise plugins directory using the same symlink mechanism as `mise plugins link`. Existing plugins are not replaced during ordinary `mise install`; `mise plugins install --force <name>` retains the established replacement behavior.

Bare values such as `owner/repo` remain remote plugin references, while `file://` remains a Git clone source.

## Validation

- `cargo test test_resolve_plugin_source_path --all-features`
- `cargo test test_get_repo_url_preserves_explicit_local_paths --all-features`
- `mise run test:e2e ^test_plugins_section_local$`
- `mise run test:e2e ^test_install$ ^test_plugin_link$ ^test_plugins_section_auto_install$`
- `cargo check --all-features`
- `cargo fmt --all -- --check`
- ShellCheck and shfmt on the new E2E test
- markdownlint and Prettier checks on the updated documentation

`mise run format` and `mise run lint` stop in the `hk` wrapper because this Sapling working copy is not detected as a Git repository; the applicable format and lint commands were run individually as listed above.

Addresses https://github.com/jdx/mise/discussions/4035

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing plugins from local filesystem directories, including `vfox:` mappings, with automatic symlinking for immediate availability.
* **Bug Fixes**
  * Improved local source handling to preserve explicitly configured local URLs/`file://` values and validate safe source-to-install layouts.
  * Enhanced `post-plugin-add` failure behavior to avoid leaving partial installs.
* **Documentation**
  * Documented local plugin path formats and how overrides (such as `--force`) affect existing installations.
* **Tests**
  * Added end-to-end coverage for local plugin installation across multiple path reference formats and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->