### PR TITLE
fix(backend): resolve tool programs instead of hardcoding .cmd on Windows

### DIFF
--- a/e2e-win/npm_backend.Tests.ps1
+++ b/e2e-win/npm_backend.Tests.ps1
@@ -11,4 +11,40 @@ Describe 'npm_backend' {
             Remove-Item Env:MISE_NPM_PACKAGE_MANAGER -ErrorAction SilentlyContinue
         }
     }
+    It 'installs npm:prettier 3.5.3 with the node-bundled npm, which ships no npm.exe' {
+        # Covers the spawn that `NPM_PROGRAM = "npm.cmd"` used to hardcode. mise's node
+        # install ships `npm` (a `#!/usr/bin/env bash` script), `npm.cmd` and `npm.ps1` but
+        # no `npm.exe`, and on Windows the node plugin puts the install root itself on PATH.
+        # `executable_names` tries the bare name first, so mise's own lookup answers with
+        # the bash script -- which CreateProcess cannot launch. The resolver has to walk
+        # past it to npm.cmd.
+        #
+        # The default package manager is `auto` -> embedded aube, which never spawns npm,
+        # so pinning it is what makes this reach the npm program at all. 3.5.3 rather than
+        # the 3.6.2 the aube case above installs, so a cached install cannot let this skip
+        # the spawn entirely.
+        $previousPackageManager = [Environment]::GetEnvironmentVariable(
+            'MISE_NPM_PACKAGE_MANAGER', 'Process'
+        )
+        $env:MISE_NPM_PACKAGE_MANAGER = "npm"
+        try {
+            $out = mise install node@24.4.1 npm:prettier@3.5.3 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            # The pre-fix failure mode, from std only ever appending .exe to a bare name.
+            $out | Should -Not -Match 'program not found'
+            # Assert the result of that install, not just its exit code: the binary npm
+            # placed has to be the requested version.
+            mise x node@24.4.1 npm:prettier@3.5.3 -- prettier --version | Should -be "3.5.3"
+        }
+        finally {
+            # Restore rather than remove -- Pester shares one runspace, and $null does not
+            # round-trip through SetEnvironmentVariable, so branch on it.
+            if ($null -eq $previousPackageManager) {
+                Remove-Item Env:\MISE_NPM_PACKAGE_MANAGER -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:MISE_NPM_PACKAGE_MANAGER = $previousPackageManager
+            }
+        }
+    }
 }

--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -316,7 +316,11 @@ impl Backend for CargoBackend {
             );
         }
 
-        let mut cmd = CmdLineRunner::new("cargo").arg("install");
+        let mut cmd = CmdLineRunner::new(
+            self.spawn_program(&ctx.config, Some(&ctx.ts), "cargo")
+                .await,
+        )
+        .arg("install");
         if let Some(url) = self.git_url() {
             cmd = cmd.arg(format!("--git={url}"));
             if let Some(rev) = tv.version.strip_prefix("rev:") {

--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -119,12 +119,15 @@ impl Backend for DotnetBackend {
         )
         .await;
 
-        let mut cli = CmdLineRunner::new("dotnet")
-            .arg("tool")
-            .arg("install")
-            .arg(self.tool_name())
-            .arg("--tool-path")
-            .arg(tv.install_path().join("bin"));
+        let mut cli = CmdLineRunner::new(
+            self.spawn_program(&ctx.config, Some(&ctx.ts), "dotnet")
+                .await,
+        )
+        .arg("tool")
+        .arg("install")
+        .arg(self.tool_name())
+        .arg("--tool-path")
+        .arg(tv.install_path().join("bin"));
 
         if &tv.version != "latest" {
             cli = cli.arg("--version").arg(&tv.version);

--- a/src/backend/gem.rs
+++ b/src/backend/gem.rs
@@ -17,8 +17,6 @@ use std::path::Path;
 use std::{fmt::Debug, sync::Arc};
 use tokio::sync::OnceCell as TokioOnceCell;
 
-const GEM_PROGRAM: &str = if cfg!(windows) { "gem.cmd" } else { "gem" };
-
 /// Cached gem source URL, memoized globally after first successful detection
 static GEM_SOURCE: TokioOnceCell<String> = TokioOnceCell::const_new();
 
@@ -97,7 +95,7 @@ impl Backend for GemBackend {
         )
         .await;
 
-        CmdLineRunner::new(GEM_PROGRAM)
+        CmdLineRunner::new(self.spawn_program(&ctx.config, Some(&ctx.ts), "gem").await)
             .arg("install")
             .arg(self.tool_name())
             .arg("--version")
@@ -142,11 +140,12 @@ impl GemBackend {
 
         // Get the mise-managed Ruby environment
         let env = self.dependency_env(config).await.unwrap_or_default();
+        let gem = self.spawn_program(config, None, "gem").await;
 
         // Try to initialize the source - only memoize on success
         match GEM_SOURCE
             .get_or_try_init(|| async {
-                let output = crate::cmd::cmd_read_async(GEM_PROGRAM, &["sources"], &env)
+                let output = crate::cmd::cmd_read_async(&gem, &["sources"], &env)
                     .await
                     .map_err(|e| eyre::eyre!("failed to run `gem sources`: {e}"))?;
 

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -157,8 +157,12 @@ impl Backend for GoBackend {
         let raw_opts = tv.request.options();
         let opts = GoOptions::new(&raw_opts);
 
+        // Hoisted: the closure below runs twice (with and without a `v` prefix), and the
+        // program does not change between attempts.
+        let go = self.spawn_program(&ctx.config, Some(&ctx.ts), "go").await;
+
         let install = async |v| {
-            let mut cmd = CmdLineRunner::new("go").arg("install").arg("-mod=readonly");
+            let mut cmd = CmdLineRunner::new(&go).arg("install").arg("-mod=readonly");
 
             if let Some(tags) = opts.tags() {
                 cmd = cmd.arg("-tags").arg(tags);
@@ -323,8 +327,9 @@ impl GoBackend {
 
         cache
             .get_or_try_init_async(async || {
+                let go = self.spawn_program(config, None, "go").await;
                 let raw = match cmd!(
-                    "go",
+                    go,
                     "list",
                     "-mod=readonly",
                     "-m",
@@ -364,8 +369,9 @@ impl GoBackend {
         mod_path: &str,
     ) -> eyre::Result<Option<Vec<VersionInfo>>> {
         let env = self.go_list_env(config).await?;
+        let go = self.spawn_program(config, None, "go").await;
         let raw = cmd!(
-            "go",
+            go,
             "list",
             "-mod=readonly",
             "-m",
@@ -400,6 +406,12 @@ impl GoBackend {
             }
         };
 
+        // Resolved once for every batch below. Metadata is best-effort — a failed batch
+        // leaves those versions with defaults rather than failing the listing — so without
+        // this the whole enrichment step would silently no-op on a Windows go that is not
+        // spawnable by bare name.
+        let go = self.spawn_program(config, None, "go").await;
+
         let mut metadata_by_version = HashMap::with_capacity(versions.len());
         for chunk in versions.chunks(GO_LIST_VERSION_INFO_BATCH_SIZE) {
             let mut args = vec![
@@ -411,7 +423,7 @@ impl GoBackend {
             for version in chunk {
                 args.push(format!("{mod_path}@{version}").into());
             }
-            let Ok(raw) = cmd("go", args).full_env(&env).read() else {
+            let Ok(raw) = cmd(&go, args).full_env(&env).read() else {
                 continue;
             };
             let Ok(infos) = Deserializer::from_str(&raw)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -172,16 +172,21 @@ pub(crate) async fn semver_version_from_toolsets_or_path(
     {
         return Some(version);
     }
-    semver_version_from_path(backend, config, tool).await
+    semver_version_from_path(backend, config, ts, tool).await
 }
 
+/// `ts` is threaded through only so the probe can resolve `tool` the same way the install
+/// spawns it — a bare name would be looked up by `Command::new`, which on Windows appends
+/// only `.exe` and so misses the `.cmd` shim the install itself would have used.
 async fn semver_version_from_path(
     backend: &dyn Backend,
     config: &Arc<Config>,
+    ts: &Toolset,
     tool: &str,
 ) -> Option<String> {
     let env = backend.dependency_env(config).await.ok()?;
-    let output = cmd!(tool, "--version").full_env(env).read().ok()?;
+    let program = backend.spawn_program(config, Some(ts), tool).await;
+    let output = cmd!(program, "--version").full_env(env).read().ok()?;
     parse_cli_version_output(&output)
 }
 
@@ -3172,10 +3177,19 @@ pub trait Backend: Debug + Send + Sync {
         self.dependency_which(config, bin).await
     }
 
-    /// The spawnable path for a dependency program: the same three sources in the same
-    /// preference order as [`Self::dependency_path_for_install`] — the install's own
-    /// toolset, then PATH, then the dependency toolset — except every candidate must be
-    /// something the OS can launch.
+    /// The spawnable path for a dependency program: the same three sources as
+    /// [`Self::dependency_path_for_install`] — the install's own toolset, the dependency
+    /// toolset, and PATH — except every candidate must be something the OS can launch.
+    ///
+    /// The preference order deliberately differs from `dependency_path_for_install`,
+    /// which consults PATH before the dependency toolset. This resolver stands in for
+    /// the search `Command::spawn` used to perform itself: every spawn site hands the
+    /// child an environment whose PATH has the dependency toolset's dirs *prepended*
+    /// (`dependency_env`/`prepend_path`), and std resolves a bare program against that
+    /// child PATH — so the mise-managed tool won. Resolving host PATH first here would
+    /// flip that, and a system npm would beat the node-bundled one for the `ts: None`
+    /// metadata probes (`npm view`, `gem sources`, `go list`). Dependency toolset first
+    /// preserves the old selection.
     ///
     /// Returns `None` only when *nothing spawnable* exists in any of them, which is
     /// strictly stronger than `dependency_path_for_install`'s `None`: a `pipx.ps1`, a
@@ -3183,9 +3197,10 @@ pub trait Backend: Debug + Send + Sync {
     /// past it and keeps looking. Use this for gate and bail decisions so that "we found
     /// it" and "we can run it" stop being two different questions.
     ///
-    /// On unix this is identical to `dependency_path_for_install`: `executable_names`
-    /// yields one name, `can_execute_directly` *is* `is_executable`, and both the
-    /// `is_file()` and shim filters are `cfg!(windows)`-gated.
+    /// On unix the predicate degenerates to today's: `executable_names` yields one name,
+    /// `can_execute_directly` *is* `is_executable`, and both the `is_file()` and shim
+    /// filters are `cfg!(windows)`-gated. (`spawn_program` additionally short-circuits
+    /// on unix and never calls this at all.)
     async fn spawnable_dependency(
         &self,
         config: &Arc<Config>,
@@ -3197,11 +3212,12 @@ pub trait Backend: Debug + Send + Sync {
         {
             return Some(bin);
         }
-        if let Some(bin) = which_non_pristine_spawnable(bin) {
+        if let Ok(dts) = self.dependency_toolset(config).await
+            && let Some(bin) = dts.which_bin_spawnable(config, bin).await
+        {
             return Some(bin);
         }
-        let ts = self.dependency_toolset(config).await.ok()?;
-        ts.which_bin_spawnable(config, bin).await
+        which_non_pristine_spawnable(bin)
     }
 
     /// The program to hand `CmdLineRunner::new` or `cmd!` for `bin`.

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -260,8 +260,6 @@ impl<'a> NpmOptions<'a> {
     }
 }
 
-const NPM_PROGRAM: &str = if cfg!(windows) { "npm.cmd" } else { "npm" };
-
 #[async_trait]
 impl Backend for NPMBackend {
     fn get_type(&self) -> BackendType {
@@ -421,28 +419,29 @@ impl Backend for NPMBackend {
                 self.install_via_aube_cli(ctx, &tv, &options).await?;
             }
             NpmPackageManager::Bun => {
-                let mut cmd = CmdLineRunner::new("bun")
-                    .arg("install")
-                    .arg(format!("{}@{}", self.tool_name(), tv.version))
-                    .arg("--global")
-                    // Isolated linker does not symlink binaries into BUN_INSTALL_BIN properly.
-                    // https://github.com/jdx/mise/discussions/7541
-                    .arg("--linker")
-                    .arg("hoisted")
-                    .args(install_before_args)
-                    .with_pr(ctx.pr.as_ref())
-                    .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .env_values(tv.install_env())
-                    .env("BUN_INSTALL_GLOBAL_DIR", tv.install_path())
-                    .env("BUN_INSTALL_BIN", tv.install_path().join("bin"))
-                    .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
-                    .prepend_path(
-                        self.dependency_toolset(&ctx.config)
-                            .await?
-                            .list_paths(&ctx.config)
-                            .await,
-                    )?
-                    .current_dir(tv.install_path());
+                let mut cmd =
+                    CmdLineRunner::new(self.spawn_program(&ctx.config, Some(&ctx.ts), "bun").await)
+                        .arg("install")
+                        .arg(format!("{}@{}", self.tool_name(), tv.version))
+                        .arg("--global")
+                        // Isolated linker does not symlink binaries into BUN_INSTALL_BIN properly.
+                        // https://github.com/jdx/mise/discussions/7541
+                        .arg("--linker")
+                        .arg("hoisted")
+                        .args(install_before_args)
+                        .with_pr(ctx.pr.as_ref())
+                        .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+                        .env_values(tv.install_env())
+                        .env("BUN_INSTALL_GLOBAL_DIR", tv.install_path())
+                        .env("BUN_INSTALL_BIN", tv.install_path().join("bin"))
+                        .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
+                        .prepend_path(
+                            self.dependency_toolset(&ctx.config)
+                                .await?
+                                .list_paths(&ctx.config)
+                                .await,
+                        )?
+                        .current_dir(tv.install_path());
                 if let Some(args) = options.bun_args() {
                     cmd = cmd.args(shell_words::split(args)?);
                 }
@@ -451,28 +450,30 @@ impl Backend for NPMBackend {
             NpmPackageManager::Pnpm => {
                 let bin_dir = tv.install_path().join("bin");
                 crate::file::create_dir_all(&bin_dir)?;
-                let mut cmd = CmdLineRunner::new("pnpm")
-                    .arg("add")
-                    .arg("--global")
-                    .arg(format!("{}@{}", self.tool_name(), tv.version))
-                    .arg("--global-dir")
-                    .arg(tv.install_path())
-                    .arg("--global-bin-dir")
-                    .arg(&bin_dir)
-                    .args(install_before_args)
-                    .with_pr(ctx.pr.as_ref())
-                    .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .env_values(tv.install_env())
-                    .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
-                    .prepend_path(
-                        self.dependency_toolset(&ctx.config)
-                            .await?
-                            .list_paths(&ctx.config)
-                            .await,
-                    )?
-                    // required to avoid pnpm error "global bin dir isn't in PATH"
-                    // https://github.com/pnpm/pnpm/issues/9333
-                    .prepend_path(vec![bin_dir])?;
+                let mut cmd = CmdLineRunner::new(
+                    self.spawn_program(&ctx.config, Some(&ctx.ts), "pnpm").await,
+                )
+                .arg("add")
+                .arg("--global")
+                .arg(format!("{}@{}", self.tool_name(), tv.version))
+                .arg("--global-dir")
+                .arg(tv.install_path())
+                .arg("--global-bin-dir")
+                .arg(&bin_dir)
+                .args(install_before_args)
+                .with_pr(ctx.pr.as_ref())
+                .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+                .env_values(tv.install_env())
+                .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
+                .prepend_path(
+                    self.dependency_toolset(&ctx.config)
+                        .await?
+                        .list_paths(&ctx.config)
+                        .await,
+                )?
+                // required to avoid pnpm error "global bin dir isn't in PATH"
+                // https://github.com/pnpm/pnpm/issues/9333
+                .prepend_path(vec![bin_dir])?;
                 if let Some(args) = options.pnpm_args() {
                     cmd = cmd.args(shell_words::split(args)?);
                 }
@@ -498,24 +499,25 @@ impl Backend for NPMBackend {
                     NpmOptions::npm_lifecycle_script_args(allow_builds, supports_allow_scripts);
                 let skipped_lifecycle_scripts =
                     Self::effective_npm_ignore_scripts(default_ignore_scripts, &npm_args);
-                let mut cmd = CmdLineRunner::new(NPM_PROGRAM)
-                    .arg("install")
-                    .arg("-g")
-                    .arg(format!("{}@{}", self.tool_name(), tv.version))
-                    .arg("--prefix")
-                    .arg(tv.install_path())
-                    .args(install_before_args)
-                    .with_pr(ctx.pr.as_ref())
-                    .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
-                    .env_values(tv.install_env())
-                    .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-                    .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
-                    .prepend_path(
-                        self.dependency_toolset(&ctx.config)
-                            .await?
-                            .list_paths(&ctx.config)
-                            .await,
-                    )?;
+                let mut cmd =
+                    CmdLineRunner::new(self.spawn_program(&ctx.config, Some(&ctx.ts), "npm").await)
+                        .arg("install")
+                        .arg("-g")
+                        .arg(format!("{}@{}", self.tool_name(), tv.version))
+                        .arg("--prefix")
+                        .arg(tv.install_path())
+                        .args(install_before_args)
+                        .with_pr(ctx.pr.as_ref())
+                        .envs(ctx.ts.env_with_path_without_tools(&ctx.config).await?)
+                        .env_values(tv.install_env())
+                        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+                        .prepend_path(ctx.ts.list_paths(&ctx.config).await)?
+                        .prepend_path(
+                            self.dependency_toolset(&ctx.config)
+                                .await?
+                                .list_paths(&ctx.config)
+                                .await,
+                        )?;
                 cmd = cmd.args(lifecycle_script_args);
                 if let Some(args) = &npm_args {
                     cmd = cmd.args(args);
@@ -580,9 +582,10 @@ impl NPMBackend {
             async || {
                 let env = self.dependency_env(config).await?;
                 let prefix = Self::npm_meta_prefix()?;
+                let npm = self.spawn_program(config, None, "npm").await;
 
                 let raw = cmd!(
-                    NPM_PROGRAM,
+                    npm,
                     "view",
                     self.tool_name(),
                     "versions",
@@ -607,8 +610,9 @@ impl NPMBackend {
     /// Legacy `npm view` dist-tags lookup, see [`Self::list_remote_versions_npm_view`].
     async fn latest_dist_tag_npm_view(&self, config: &Arc<Config>) -> eyre::Result<Option<String>> {
         let prefix = Self::npm_meta_prefix()?;
+        let npm = self.spawn_program(config, None, "npm").await;
         let raw = cmd!(
-            NPM_PROGRAM,
+            npm,
             "view",
             self.tool_name(),
             "dist-tags",
@@ -778,7 +782,8 @@ impl NPMBackend {
                 return false;
             }
         };
-        let output = match cmd!(NPM_PROGRAM, "--version")
+        let npm = self.spawn_program(config, None, "npm").await;
+        let output = match cmd!(npm, "--version")
             .full_env(env)
             .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
             .read()
@@ -808,7 +813,9 @@ impl NPMBackend {
         // TODO: Once bun supports querying packages without package.json, this can be updated
         self.warn_if_dependency_missing(
             config,
-            "npm", // Use "npm" for dependency check, which will check npm.cmd on Windows
+            // The bare name: `executable_names` expands it across
+            // `windows_executable_extensions`, so the node-bundled `npm.cmd` is found.
+            "npm",
             &["node", "npm"],
             "To use npm packages with mise, you need to install Node.js first:\n\
               mise use node@latest\n\n\

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -421,9 +421,12 @@ impl SPMBackend {
         repo_dir: &PathBuf,
         tv: &ToolVersion,
     ) -> Result<Vec<String>, eyre::Error> {
+        let swift = self
+            .spawn_program(&ctx.config, Some(&ctx.ts), "swift")
+            .await;
         let package_json = with_install_env(
             cmd!(
-                "swift",
+                swift,
                 "package",
                 "dump-package",
                 "--package-path",
@@ -456,7 +459,11 @@ impl SPMBackend {
         tv: &ToolVersion,
     ) -> Result<PathBuf, eyre::Error> {
         debug!("Building swift package");
-        CmdLineRunner::new("swift")
+        // Resolved once: both the build and the --show-bin-path query below use it.
+        let swift = self
+            .spawn_program(&ctx.config, Some(&ctx.ts), "swift")
+            .await;
+        CmdLineRunner::new(&swift)
             .arg("build")
             .arg("--configuration")
             .arg("release")
@@ -480,7 +487,7 @@ impl SPMBackend {
 
         let bin_path = with_install_env(
             cmd!(
-                "swift",
+                &swift,
                 "build",
                 "--configuration",
                 "release",
@@ -755,8 +762,11 @@ async fn swift_target_triples(
     backend: &SPMBackend,
     tv: &ToolVersion,
 ) -> eyre::Result<Vec<String>> {
+    let swift = backend
+        .spawn_program(&ctx.config, Some(&ctx.ts), "swift")
+        .await;
     let target_info = with_install_env(
-        cmd!("swift", "-print-target-info").full_env(backend.dependency_env(&ctx.config).await?),
+        cmd!(swift, "-print-target-info").full_env(backend.dependency_env(&ctx.config).await?),
         tv,
     )
     .read()?;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1609,14 +1609,20 @@ enum ChildProcessOutput {
 ///
 /// This variant **clears** the environment and sets only the provided `env` —
 /// use it for backends that pass a full env from `dependency_env()`.
-pub async fn cmd_read_async<I, K, V>(program: &str, args: &[&str], env: I) -> Result<String>
+/// `program` is `AsRef<OsStr>` rather than `&str` so callers can pass a resolved path
+/// straight through — `Backend::spawn_program` returns an `OsString`, and forcing it
+/// through `to_string_lossy()` here would mangle a Windows path that is not valid UTF-8.
+pub async fn cmd_read_async<P, I, K, V>(program: P, args: &[&str], env: I) -> Result<String>
 where
+    P: AsRef<OsStr>,
     I: IntoIterator<Item = (K, V)>,
     K: AsRef<OsStr>,
     V: AsRef<OsStr>,
 {
+    let program = program.as_ref();
+    let display_program = program.to_string_lossy();
     let display_args = args.join(" ");
-    debug!("$ {program} {display_args}");
+    debug!("$ {display_program} {display_args}");
 
     let output = tokio::process::Command::new(program)
         .args(args)
@@ -1628,19 +1634,19 @@ where
         .kill_on_drop(true)
         .output()
         .await
-        .wrap_err_with(|| format!("failed to execute command: {program} {display_args}"))?;
+        .wrap_err_with(|| format!("failed to execute command: {display_program} {display_args}"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "{program} {display_args} failed: exit code {}\n{}",
+            "{display_program} {display_args} failed: exit code {}\n{}",
             output.status.code().unwrap_or(-1),
             stderr.trim()
         );
     }
 
     let stdout = String::from_utf8(output.stdout)
-        .wrap_err_with(|| format!("{program} produced invalid UTF-8 output"))?;
+        .wrap_err_with(|| format!("{display_program} produced invalid UTF-8 output"))?;
     Ok(stdout.trim_end().to_string())
 }
 


### PR DESCRIPTION
> [!NOTE]
> Rebased onto `main` after #11486 merged — the diff is now this follow-up alone, one commit.

## Summary

Deletes the two hardcoded Windows program names and routes every remaining bare-name tool spawn through the `Backend::spawn_program` resolver added in #11486.

- `NPM_PROGRAM = "npm.cmd"` and `GEM_PROGRAM = "gem.cmd"` — **removed**
- 17 spawn sites migrated across npm, gem, cargo, go, dotnet and spm
- `cmd_read_async`'s `program` becomes `impl AsRef<OsStr>` (one caller)
- `npm_backend.Tests.ps1` gains the first Windows coverage of the npm spawn

Windows-only in effect: `spawn_program` short-circuits on `cfg!(windows)`, so the program string handed to every spawn on unix is unchanged.

## Why the hardcodes existed, and why they can go

mise's own lookup answers *"is there a file here that looks executable"*. On Windows that is the wrong question for a spawn, and npm is the sharpest case. The node install directory contains:

```
npm          2073 bytes, starts with #!/usr/bin/env bash
npm.cmd
npm.ps1
node.exe
```

There is **no `npm.exe`**, and on Windows the node plugin puts that directory itself on PATH. `executable_names` tries the bare name first and `file::is_executable` accepts a shebang, so `Backend::which("npm")` returns the bash script — which `CreateProcess` cannot launch. Hardcoding `npm.cmd` worked around exactly that.

The reason not to keep it is the objection raised in https://github.com/jdx/mise/discussions/5333: a hardcoded `.cmd` misses an `npm.exe` or `npm.bat` install. The resolver from #11486 does not stop at the first candidate that merely looks executable — it walks past anything it cannot spawn — so it reaches `npm.cmd` on its own, and would reach `npm.exe` first if one existed. The unit test that pins this shipped in #11486 (`which_in_dirs_skips_shebang_script_for_node_npm_layout`), asserting both halves: the permissive predicate still answers with the bash script, the spawnable one answers with `npm.cmd`.

## Sites migrated

| File | Sites |
|---|---|
| `npm.rs` | `npm install -g`; both `npm view` queries; the `npm --version` probe; the `bun` and `pnpm` install paths |
| `gem.rs` | `gem install`; `gem sources` |
| `cargo.rs` | `cargo install` |
| `go.rs` | `go install` (hoisted out of the retry closure, which runs twice); both `go list` queries |
| `dotnet.rs` | `dotnet tool install` |
| `spm.rs` | `swift package dump-package`; `swift build`; `swift build --show-bin-path`; `swift -print-target-info` |
| `mod.rs` | `semver_version_from_path`, which probes `<tool> --version` for bun/pnpm/uv — now takes the toolset so the probe resolves the same program the install spawns |

**Only npm and gem are fixes.** cargo, go, dotnet, swift, bun and pnpm all ship a plain `.exe` on Windows today (verified on disk), so those conversions are behavior-preserving; they are here so the class cannot reappear when one of them starts shipping a `.cmd`-only shim, and so there is no bare-name spawn left for the next person to copy. Every site falls back to the bare name when nothing spawnable resolves, so the worst case at any of them is exactly today's behavior.

## Deliberately not migrated

- **`AUBE_PROGRAM` (`npm.rs`) and `cargo-binstall` (`cargo.rs`).** Both already resolve, and both already hand an absolute `PathBuf` to `CmdLineRunner` **on unix as well**. Routing them through `spawn_program` would drop unix back to the bare name and change which binary runs. `AUBE_PROGRAM` is additionally extension-carrying (`aube.exe`) and doubles as a toolset lookup key, so `executable_names` short-circuits on it; the separable follow-up is dropping the `.exe` from the literal.
- **`env_directive/venv.rs`'s `python3` fallback.** Windows CPython ships `python.exe` and no `python3.*` at all, so there is no candidate for any resolver to find. The fix there is adding `python` to the fallback chain — a decision about *which* python. Separate bug.
- **`warn_if_dependency_missing`** keeps the permissive predicate. It is shared by five backends and is warning-only.

## Resolution order: dependency toolset before host PATH

Review caught that `spawnable_dependency` mirrored `dependency_path_for_install`'s host-PATH-first order, which is wrong for what this resolver is *for*. It stands in for the search `Command::spawn` used to perform itself: every spawn site hands the child an environment whose PATH has the dependency toolset's dirs prepended (`dependency_env` / `prepend_path`), and on Windows std resolves a bare program against that child PATH — so the mise-managed tool won. Host-PATH-first would have flipped that for the `ts: None` metadata probes (`npm view`, `gem sources`, `go list`) whenever a system copy also exists. The order is now: explicit install toolset → dependency toolset → host PATH, with the rationale in the doc comment. Unix is unaffected (`spawn_program` short-circuits before ever calling this).

## `cmd_read_async`

```rust
pub async fn cmd_read_async<P, I, K, V>(program: P, args: &[&str], env: I) -> Result<String>
where
    P: AsRef<OsStr>,
```

`gem.rs` is its only caller, so this is a one-line call-site change. `&str` would have forced `to_string_lossy()` at the call site, which can mangle a Windows path that is not valid UTF-8 — the same fidelity loss `CmdLineRunner::get_args` already suffers.

## Tests

`e2e-win/npm_backend.Tests.ps1` gains a case pinned to `MISE_NPM_PACKAGE_MANAGER=npm`. That pin is what makes it reach the npm program at all — the default is `auto` → embedded aube, which never spawns npm, which is why the existing two cases in that file exercise neither `NPM_PROGRAM` nor any npm spawn. `is-odd@3.0.1` keeps the install small.

No new Rust unit tests: the resolver's behavior is already pinned by the six tests in #11486, and these sites are call-site substitutions with nothing new to assert that would not just re-test `spawn_program`.

Coverage gaps worth naming, since I cannot run them locally: gem, swift and dotnet have no Windows e2e coverage at all, and the Linux gem/cargo/swift e2e tests are `_slow`, so they only run on the `release` branch. The mitigations are the bare-name fallback at every site and the `cfg!(windows)` gate keeping unix byte-identical.

## Verification

`rustfmt --edition 2024 --check` on all eight Rust files, PowerShell parse check on the Pester file, and a grep confirming no bare-name tool spawn remains in the migrated set and that `NPM_PROGRAM`/`GEM_PROGRAM` have no remaining references. No local build — CI covers the rest, in particular the Linux `e2e` tranches for `test_npm_package_manager` (the only automated exercise of the npm spawn) and `windows-e2e` for the new case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows executable resolution, including `.exe` and `.cmd` tools, dependency lookup, and npm shim handling.
  * Fixed command execution across supported package and language managers to consistently use the correct installed executable.
  * Improved command failure messages with clearer exit codes and error output.
  * Cargo installs now detect changes to installation options and avoid incorrectly reusing incompatible installations.

* **Tests**
  * Added end-to-end coverage for installing and running Prettier through npm on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->