### PR TITLE
fix(plugins): continue batch operations after failures

### DIFF
--- a/e2e/plugins/test_plugin_batch_failures
+++ b/e2e/plugins/test_plugin_batch_failures
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+create_plugin_repo() {
+  local repo="$1"
+  mkdir -p "$repo/bin"
+  cat >"$repo/bin/list-all" <<'EOF'
+#!/usr/bin/env bash
+echo 1.0.0
+EOF
+  chmod +x "$repo/bin/list-all"
+  git -C "$repo" init -q
+  git -C "$repo" add .
+  git -C "$repo" commit -qm "initial plugin"
+}
+
+mkdir -p sources
+create_plugin_repo "$PWD/sources/install-good"
+
+git config --global \
+  url."file://$PWD/sources/missing-alpha".insteadOf \
+  "https://github.com/gr1m0h/asdf-act.git"
+git config --global \
+  url."file://$PWD/sources/install-good".insteadOf \
+  "https://github.com/mpalmer/action-validator.git"
+git config --global \
+  url."file://$PWD/sources/missing-zeta".insteadOf \
+  "https://gitlab.com/td7x/asdf/adr-tools"
+
+if output="$(mise plugins install adr-tools action-validator act --jobs 1 2>&1)"; then
+  fail "expected batch plugin install to fail"
+fi
+assert_contains_text "$output" \
+  "Failed to install plugins: act, adr-tools"
+[[ -d $MISE_DATA_DIR/plugins/action-validator/.git ]] ||
+  fail "expected successful plugin install to complete"
+
+create_plugin_repo "$PWD/sources/update-bad"
+create_plugin_repo "$PWD/sources/update-good"
+
+mise plugins install update-bad "file://$PWD/sources/update-bad"
+mise plugins install update-good "file://$PWD/sources/update-good"
+git -C "$MISE_DATA_DIR/plugins/update-bad" remote set-url origin \
+  "file://$PWD/sources/missing-update"
+
+echo updated >"$PWD/sources/update-good/updated"
+git -C "$PWD/sources/update-good" add updated
+git -C "$PWD/sources/update-good" commit -qm "update plugin"
+expected_sha="$(git -C "$PWD/sources/update-good" rev-parse HEAD)"
+
+if output="$(mise plugins update update-bad update-good --jobs 1 2>&1)"; then
+  fail "expected batch plugin update to fail"
+fi
+assert_contains_text "$output" "[update-bad] plugin update"
+assert "git -C \"$MISE_DATA_DIR/plugins/update-good\" rev-parse HEAD" "$expected_sha"

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -16,6 +16,8 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::style;
 use crate::{backend::unalias_backend, config::Settings};
 
+use super::{PluginTaskNames, PluginTaskResult, join_plugin_tasks, spawn_plugin_task};
+
 /// Install a plugin
 ///
 /// note that mise can automatically install plugins when you install a tool
@@ -101,30 +103,21 @@ impl PluginsInstall {
         config: &Arc<Config>,
         plugins: Vec<String>,
     ) -> Result<()> {
-        let mut jset: JoinSet<Result<()>> = JoinSet::new();
+        let mut jset: JoinSet<PluginTaskResult> = JoinSet::new();
+        let mut task_names = PluginTaskNames::new();
         let semaphore = Arc::new(Semaphore::new(self.jobs.unwrap_or(Settings::get().jobs)));
         for plugin in plugins {
             let this = self.clone();
             let config = config.clone();
-            let permit = semaphore.clone().acquire_owned().await?;
-            jset.spawn(async move {
-                let _permit = permit;
+            let semaphore = semaphore.clone();
+            let plugin_name = plugin.clone();
+            spawn_plugin_task(&mut jset, &mut task_names, plugin_name, async move {
+                let _permit = semaphore.acquire_owned().await?;
                 println!("installing {plugin}");
                 this.install_one(&config, plugin, None).await
             });
         }
-        while let Some(result) = jset.join_next().await {
-            match result {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
-                    return Err(e);
-                }
-                Err(e) => {
-                    return Err(eyre!(e));
-                }
-            }
-        }
-        Ok(())
+        join_plugin_tasks(jset, task_names, "install").await
     }
 
     async fn install_one(

--- a/src/cli/plugins/mod.rs
+++ b/src/cli/plugins/mod.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 
 use clap::Subcommand;
-use eyre::Result;
+use eyre::{Report, Result, WrapErr, eyre};
+use tokio::task::{Id, JoinSet};
 
 use crate::config::Config;
 
@@ -11,6 +14,73 @@ mod ls;
 mod ls_remote;
 mod uninstall;
 mod update;
+
+type PluginTaskResult = Result<()>;
+type PluginTaskNames = HashMap<Id, String>;
+
+fn take_plugin_name(task_names: &mut PluginTaskNames, id: Id) -> String {
+    task_names
+        .remove(&id)
+        .expect("plugin task name should be registered before spawning")
+}
+
+fn spawn_plugin_task<F>(
+    tasks: &mut JoinSet<PluginTaskResult>,
+    task_names: &mut PluginTaskNames,
+    plugin: impl Into<String>,
+    task: F,
+) where
+    F: Future<Output = PluginTaskResult> + Send + 'static,
+{
+    let task = tasks.spawn(task);
+    task_names.insert(task.id(), plugin.into());
+}
+
+async fn join_plugin_tasks(
+    mut tasks: JoinSet<PluginTaskResult>,
+    mut task_names: PluginTaskNames,
+    operation: &'static str,
+) -> Result<()> {
+    let mut failures: Vec<(String, Report)> = Vec::new();
+
+    while let Some(result) = tasks.join_next_with_id().await {
+        match result {
+            Ok((id, Ok(()))) => {
+                take_plugin_name(&mut task_names, id);
+            }
+            Ok((id, Err(err))) => {
+                let plugin = take_plugin_name(&mut task_names, id);
+                failures.push((plugin, err));
+            }
+            Err(err) => {
+                let plugin = take_plugin_name(&mut task_names, err.id());
+                failures.push((plugin, err.into()));
+            }
+        }
+    }
+
+    match failures.len() {
+        0 => Ok(()),
+        1 => {
+            let (plugin, err) = failures.pop().unwrap();
+            Err(err).wrap_err_with(|| format!("[{plugin}] plugin {operation}"))
+        }
+        _ => {
+            failures.sort_by(|(a, _), (b, _)| a.cmp(b));
+            let names = failures
+                .iter()
+                .map(|(plugin, _)| plugin.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let details = failures
+                .iter()
+                .map(|(plugin, err)| format!("{plugin}: {err:#}"))
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            Err(eyre!("Failed to {operation} plugins: {names}\n\n{details}"))
+        }
+    }
+}
 
 #[derive(Debug, clap::Args)]
 #[clap(about = "Manage plugins", visible_alias = "p", aliases = ["plugin", "plugin-list"])]
@@ -83,5 +153,114 @@ impl Plugins {
         }));
 
         cmd.run(&config).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn plugin_tasks_finish_after_an_earlier_failure() {
+        let completed = Arc::new(AtomicBool::new(false));
+        let mut tasks = JoinSet::new();
+        let mut task_names = PluginTaskNames::new();
+        spawn_plugin_task(&mut tasks, &mut task_names, "failed", async {
+            Err(eyre!("failed immediately"))
+        });
+        spawn_plugin_task(&mut tasks, &mut task_names, "completed", {
+            let completed = completed.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                completed.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+        });
+
+        let err = join_plugin_tasks(tasks, task_names, "update")
+            .await
+            .unwrap_err();
+
+        assert!(completed.load(Ordering::SeqCst));
+        assert_eq!(
+            format!("{err:#}"),
+            "[failed] plugin update: failed immediately"
+        );
+    }
+
+    #[tokio::test]
+    async fn plugin_task_failures_are_reported_in_name_order() {
+        let mut tasks = JoinSet::new();
+        let mut task_names = PluginTaskNames::new();
+        spawn_plugin_task(&mut tasks, &mut task_names, "zeta", async {
+            Err(eyre!("zeta detail"))
+        });
+        spawn_plugin_task(&mut tasks, &mut task_names, "alpha", async {
+            Err(eyre!("alpha detail"))
+        });
+
+        let err = join_plugin_tasks(tasks, task_names, "install")
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            format!("{err:#}"),
+            "Failed to install plugins: alpha, zeta\n\n\
+             alpha: alpha detail\n\n\
+             zeta: zeta detail"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_plugin_failure_preserves_the_error_chain() {
+        let mut tasks = JoinSet::new();
+        let mut task_names = PluginTaskNames::new();
+        spawn_plugin_task(&mut tasks, &mut task_names, "tiny", async {
+            Err(eyre!("inner failure").wrap_err("outer context"))
+        });
+
+        let err = join_plugin_tasks(tasks, task_names, "update")
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            format!("{err:#}"),
+            "[tiny] plugin update: outer context: inner failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn panicked_plugin_task_does_not_cancel_other_tasks() {
+        async fn panic_plugin_task() -> Result<()> {
+            panic!("plugin task panic");
+        }
+
+        let completed = Arc::new(AtomicBool::new(false));
+        let mut tasks = JoinSet::new();
+        let mut task_names = PluginTaskNames::new();
+        spawn_plugin_task(
+            &mut tasks,
+            &mut task_names,
+            "panicked-plugin",
+            panic_plugin_task(),
+        );
+        spawn_plugin_task(&mut tasks, &mut task_names, "completed", {
+            let completed = completed.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                completed.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+        });
+
+        let err = join_plugin_tasks(tasks, task_names, "update")
+            .await
+            .unwrap_err();
+
+        assert!(completed.load(Ordering::SeqCst));
+        assert!(format!("{err:#}").contains("[panicked-plugin] plugin update"));
     }
 }

--- a/src/cli/plugins/update.rs
+++ b/src/cli/plugins/update.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
 use console::style;
-use eyre::{Result, WrapErr, eyre};
+use eyre::Result;
 use tokio::{sync::Semaphore, task::JoinSet};
 
 use crate::config::Settings;
 use crate::plugins;
 use crate::toolset::install_state;
 use crate::ui::multi_progress_report::MultiProgressReport;
+
+use super::{PluginTaskNames, PluginTaskResult, join_plugin_tasks, spawn_plugin_task};
 
 /// Updates a plugin to the latest version
 ///
@@ -42,37 +44,24 @@ impl Update {
         };
 
         let settings = Settings::try_get()?;
-        let mut jset: JoinSet<Result<()>> = JoinSet::new();
+        let mut jset: JoinSet<PluginTaskResult> = JoinSet::new();
+        let mut task_names = PluginTaskNames::new();
         let semaphore = Arc::new(Semaphore::new(self.jobs.unwrap_or(settings.jobs)));
         for (short, ref_) in plugins {
-            let permit = semaphore.clone().acquire_owned().await?;
-            jset.spawn(async move {
-                let _permit = permit;
+            let semaphore = semaphore.clone();
+            let plugin_name = short.clone();
+            spawn_plugin_task(&mut jset, &mut task_names, plugin_name, async move {
+                let _permit = semaphore.acquire_owned().await?;
                 let plugin = plugins::get(&short)?;
                 let prefix = format!("plugin:{}", style(plugin.name()).blue().for_stderr());
                 let mpr = MultiProgressReport::get();
                 let pr = mpr.add(&prefix);
-                plugin
-                    .update(pr.as_ref(), ref_)
-                    .await
-                    .wrap_err_with(|| format!("[{plugin}] plugin update"))?;
+                plugin.update(pr.as_ref(), ref_).await?;
                 Ok(())
             });
         }
 
-        while let Some(result) = jset.join_next().await {
-            match result {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
-                    return Err(e);
-                }
-                Err(e) => {
-                    return Err(eyre!(e));
-                }
-            }
-        }
-
-        Ok(())
+        join_plugin_tasks(jset, task_names, "update").await
     }
 }
 


### PR DESCRIPTION
## Summary

- let every plugin in a batch install or update attempt finish even when a sibling fails
- preserve successful plugin changes while returning a failing exit status when any operation fails
- report one failure with its original error chain and aggregate multiple failures in deterministic plugin-name order
- apply the same behavior to `plugins update`, multi-plugin `plugins install`, and `plugins install --all`

## Root cause

Both plugin batch paths returned from their `JoinSet` loop as soon as the first error was observed. Dropping the set could cancel tasks that were still queued or running, so one broken plugin prevented unrelated plugins from completing.

## Behavior

All plugin tasks are now queued before execution and acquire the existing `--jobs` semaphore inside each task. The shared completion helper drains the full task set, retains successful installs or updates, and reports failures only after every plugin has finished. Panicked tasks are also recorded without cancelling their siblings.

Single-plugin URL installs remain on their existing direct path, and no CLI options or configuration formats change.

## Validation

- `mise exec -- cargo test --all-features cli::plugins::tests --no-fail-fast`
- `mise run test:e2e e2e/plugins/test_plugin_batch_failures`
- `mise run test:e2e e2e/plugins/test_plugin_update e2e/plugins/test_plugin_install`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck -x e2e/plugins/test_plugin_batch_failures`
- `mise exec -- shfmt -d -s e2e/plugins/test_plugin_batch_failures`

`mise run format` and `mise run lint` stop in the `hk` wrapper because this Sapling working copy is not detected as a Git repository; the applicable format and lint commands were run individually as listed above.

Addresses https://github.com/jdx/mise/discussions/4803

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch plugin installation and update behavior when one or more plugin sources are unavailable.
  * Plugin operations now report all failed plugins together with clearer, plugin-specific error details.
  * Batch operations continue processing other plugins even if one plugin fails, preventing misleading or incomplete results.
  * Prevents partial updates for remaining plugins when one update target fails, including resilience to unexpected task failures.

* **Tests**
  * Added an end-to-end test covering Git-backed rewrite scenarios for failing batch plugin installs and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->