### PR TITLE
fix(env): collapse duplicate PATH entries in computed environments

### DIFF
--- a/e2e/env/test_bash_reactivate_computed_env_dedups_stale_user_path
+++ b/e2e/env/test_bash_reactivate_computed_env_dedups_stale_user_path
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# From https://github.com/jdx/mise/discussions/5397: `mise doctor` showed the
+# same PATH entries four and five deep.
+#
+# The accumulation happens when a session inherits an activated PATH but not the
+# __MISE_* state vars (nested shells, IDE integrated terminals). hook-env then
+# has no way to tell a stale copy of a `_.path` entry from one the user put on
+# PATH themselves, and the user's copies are contractually preserved verbatim —
+# cli/test_deactivate pins that a deliberate user duplicate survives
+# reactivation. So the live shell PATH is left alone.
+#
+# What mise *computes* is mise's to normalize: `mise env`, `mise x` child PATHs
+# and `mise doctor`'s `path:` section all build PATH via PathEnv, which now
+# collapses exact duplicates first-wins. The fresh copy in the mise-managed
+# section wins over stale copies in the inherited portion, so every computed
+# surface shows the entry exactly once no matter how polluted the inherited
+# PATH is.
+
+mkdir -p extra
+
+# global config, like the sibling zsh test: no local-config trust in play
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[env]
+_.path = ["$PWD/extra"]
+EOF
+
+count_live() {
+  # -F: the workdir path is data, not a regex; -x: whole components only, so a
+  # sibling like extra-old can never count
+  echo "$PATH" | tr : '\n' | grep -Fxc "$PWD/extra" || true
+}
+
+count_computed() {
+  # --json rather than -s bash: jq yields the raw PATH value, so exact component
+  # matching works without peeling shell quoting off an `export PATH='...'` line
+  mise env --json | jq -r .PATH | tr : '\n' | grep -Fxc "$PWD/extra" || true
+}
+
+drop_mise_state() {
+  # what a child process keeps (PATH) vs. loses (shell-session state vars)
+  unset __MISE_DIFF __MISE_ORIG_PATH __MISE_SESSION __MISE_WATCH
+}
+
+eval "$(mise hook-env -s bash)"
+[[ $(count_live) == "1" ]] || {
+  echo "expected 1 copy after first activation, got: $(count_live)"
+  exit 1
+}
+
+# Two state-loss rounds pollute the live PATH with stale copies.
+drop_mise_state
+eval "$(mise hook-env -s bash)"
+drop_mise_state
+eval "$(mise hook-env -s bash)"
+
+[[ $(count_live) -ge 2 ]] || {
+  echo "test setup failed: expected the live PATH to carry stale copies, got: $(count_live)"
+  exit 1
+}
+
+# The computed environment collapses them to exactly one.
+[[ $(count_computed) == "1" ]] || {
+  echo "expected mise env to show exactly 1 copy, got: $(count_computed)"
+  mise env --json | jq -r .PATH
+  exit 1
+}

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -205,8 +205,10 @@ fn remove_shims() -> std::io::Result<Option<ActivatePrelude>> {
         .contains(&shims)
     {
         let path_env = PathEnv::from_iter(env::PATH.clone());
-        // PathEnv automatically removes the shims directory
-        let path = path_env.join().to_string_lossy().to_string();
+        // PathEnv automatically removes the shims directory. Verbatim, because this PATH
+        // goes back into the user's live shell: a duplicate entry the user put there is
+        // theirs to keep, and only the shims dir may be dropped here.
+        let path = path_env.join_verbatim().to_string_lossy().to_string();
         Ok(Some(ActivatePrelude::SetEnv(PATH_KEY.to_string(), path)))
     } else {
         Ok(None)

--- a/src/path_env.rs
+++ b/src/path_env.rs
@@ -1,5 +1,6 @@
 use crate::config::Settings;
 use crate::dirs;
+use std::collections::HashSet;
 use std::env::{join_paths, split_paths};
 use std::ffi::OsString;
 use std::fmt;
@@ -30,7 +31,34 @@ impl PathEnv {
         }
     }
 
+    /// First occurrence wins; later exact duplicates are dropped. A later duplicate of
+    /// an earlier PATH entry can never win a lookup, so removing it changes nothing for
+    /// resolution — but it keeps stale copies left by a previous activation (a session
+    /// that inherited PATH without the `__MISE_*` state vars) from surfacing in every
+    /// computed environment: `mise env`/`mise x` child PATHs and `mise doctor`'s `path:`
+    /// section (#5397). mise re-adds its managed dirs on each activation, so the fresh
+    /// copy in `mise` outranks a stale one in `post` and supplies the surviving entry.
+    ///
+    /// Only for environments mise computes — children and display. A surface that hands
+    /// PATH back to the user's live shell must use [`Self::join_verbatim`] instead:
+    /// user-owned duplicates there are preserved exactly as written.
     pub fn to_vec(&self) -> Vec<PathBuf> {
+        let mut seen = HashSet::new();
+        self.pre
+            .iter()
+            .chain(self.mise.iter())
+            .chain(self.post.iter())
+            .filter(|p| seen.insert(*p))
+            .map(|p| p.to_path_buf())
+            .collect()
+    }
+
+    /// Every entry, duplicates included, in order. The projection for the one surface
+    /// that writes PATH back into the user's live shell — `mise activate`'s shim
+    /// removal — where a duplicate the user put there deliberately is theirs to keep
+    /// (`cli/test_deactivate` pins that contract, three copies and all). Deduplicating
+    /// here would silently rewrite the user's PATH as a side effect of removing shims.
+    pub fn to_vec_verbatim(&self) -> Vec<PathBuf> {
         self.pre
             .iter()
             .chain(self.mise.iter())
@@ -41,6 +69,11 @@ impl PathEnv {
 
     pub fn join(&self) -> OsString {
         join_paths(self.to_vec()).unwrap()
+    }
+
+    /// [`Self::join`] over the verbatim projection — see [`Self::to_vec_verbatim`].
+    pub fn join_verbatim(&self) -> OsString {
+        join_paths(self.to_vec_verbatim()).unwrap()
     }
 }
 
@@ -123,6 +156,71 @@ pub(crate) fn is_mise_install_path(path: &std::path::Path, install_dirs: &[PathB
         .iter()
         .filter_map(|d| crate::file::canonicalize_cached(d))
         .any(|d| path.starts_with(d))
+}
+
+// Platform-neutral, unlike `tests` below: dedup touches no filesystem and joins nothing,
+// so these also run in the windows-unit job.
+#[cfg(test)]
+mod dedup_tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn to_vec_drops_later_exact_duplicates() {
+        // The reactivation residue shape from #5397: a stale copy of a mise-managed dir
+        // sits in the inherited PATH (post), and mise adds a fresh copy (mise). The fresh
+        // copy comes first in pre+mise+post order, so it wins and the stale one drops.
+        let mut path_env = PathEnv::from_iter(
+            ["/stale-extra", "/usr/bin", "/stale-extra", "/bin"].map(PathBuf::from),
+        );
+        path_env.add("/stale-extra".into());
+        path_env.add("/tool".into());
+        assert_eq!(
+            path_env.to_vec(),
+            ["/stale-extra", "/tool", "/usr/bin", "/bin"].map(PathBuf::from)
+        );
+    }
+
+    #[test]
+    fn to_vec_verbatim_preserves_user_duplicates() {
+        // The live-shell projection: `mise activate`'s shim removal writes this PATH
+        // back into the user's shell, and a duplicate the user put there deliberately
+        // must survive exactly as written — the boundary cli/test_deactivate pins.
+        let mut path_env =
+            PathEnv::from_iter(["/shared", "/usr/bin", "/shared"].map(PathBuf::from));
+        path_env.add("/tool".into());
+        assert_eq!(
+            path_env.to_vec_verbatim(),
+            ["/tool", "/shared", "/usr/bin", "/shared"].map(PathBuf::from)
+        );
+    }
+
+    #[test]
+    fn to_vec_dedups_by_path_components_not_bytes() {
+        // `PathBuf` equality is component-wise, so a trailing-separator variant is the
+        // same entry (`/dir/` == `/dir`) and collapses too — those resolve to identical
+        // lookups, so dropping one is still semantics-preserving. The casing of a normal
+        // component is compared byte-wise and is NOT collapsed, on every platform
+        // including Windows: whether `/Dir` and `/dir` are the same place is a filesystem
+        // property mise does not assume.
+        let path_env = PathEnv::from_iter(["/dir", "/dir/", "/Dir", "/dir-2"].map(PathBuf::from));
+        assert_eq!(
+            path_env.to_vec(),
+            ["/dir", "/Dir", "/dir-2"].map(PathBuf::from)
+        );
+    }
+
+    /// The prefix is the one component Windows compares case-insensitively, so
+    /// drive-letter variants *are* one entry and do collapse. Pinned because it is the
+    /// exception to the case rule above rather than a contradiction of it — the two are
+    /// easy to conflate when reading `to_vec()`.
+    #[cfg(windows)]
+    #[test]
+    fn to_vec_collapses_drive_letter_case() {
+        let path_env = PathEnv::from_iter([r"C:\x", r"c:\x", r"C:\y"].map(PathBuf::from));
+        assert_eq!(path_env.to_vec(), [r"C:\x", r"C:\y"].map(PathBuf::from));
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Fixes the duplicate `path:` entries from https://github.com/jdx/mise/discussions/5397 on every surface mise computes — `mise env`, `mise x` child PATHs, `mise doctor` — by making `PathEnv::to_vec` collapse exact duplicates first-wins. The live shell PATH is deliberately not touched; see below for why that is a contract, not an omission.

## The bug, measured

When a session inherits an activated PATH **without** the `__MISE_*` state vars — nested shells, IDE integrated terminals — hook-env cannot tell which entries a previous activation added. Each such round prepends the config's `_.path` entries again while the previous copies are never removed.

Measured on v2026.7.16 (isolated env, `_.path = ["…/extra"]`, `jq@latest`):

| round | condition | `extra` copies | `installs/jq/1.8.2` copies |
|---|---|---|---|
| 1–2 | normal prompt cycles, state vars present | 1 | 1 |
| 3 | PATH kept, `__MISE_*` dropped, re-hooked | 2 | 1 |
| 4 | same again | 3 | 1 |
| 5 | same again | 4 | 1 |

`mise doctor` then prints the accumulation verbatim — `extra` four deep, exactly the shape of the report. Install dirs stay at one copy because the reactivation filter (#10162, #10345) hard-drops them from the inherited PATH; `_.path` and other env-directive paths were left out of that filter and are what still accumulates. (The reporter was on 2025.6.5, which predates that filter, so their duplicates were install dirs.)

## Why the live PATH is left alone

The first revision of this PR also collapsed exact duplicates in hook-env's presumed-user PATH, on the reasoning that a later duplicate can never win a lookup. CI rejected it, and rightly: `cli/test_deactivate` (and its fish/zsh siblings) pin that a duplicate the **user** deliberately put on PATH — the same directory before *and* after mise's entries — survives deactivation and reactivation verbatim, three copies and all. The test's own comment calls the three-copy outcome correct behavior.

That is the constraint in full: once the state vars are gone, a stale mise-added copy is genuinely indistinguishable from a user-owned one, and user-owned PATH is preserved verbatim by contract. So the live PATH cannot be safely deduped at all — not bounded, not capped — and this PR no longer tries.

What mise *computes* is mise's to normalize. `mise env`, `mise x` children and doctor already rebuild PATH from the pristine view via `PathEnv`; collapsing exact duplicates there changes resolution for no one (later exact duplicates are dead for lookup) and fixes the reported symptom at its display surface:

- first-wins across `pre + mise + post`, so the fresh copy in the mise-managed section outranks stale copies in the inherited portion — the surviving entry is also in the right position
- `PathBuf` equality is component-wise, so a trailing-separator variant collapses too (`/dir/` == `/dir`, identical lookups); casing differences are byte-distinct and kept, since whether `/Dir` and `/dir` name the same place is a filesystem property mise does not assume

The reporter's `C:\Program Files\PowerShell\7` pair (one with a trailing slash) collapses in computed environments as a side effect; their system PATH itself is out of scope.

## Tests

- `e2e/env/test_bash_reactivate_computed_env_dedups_stale_user_path` — the state-loss scenario end to end: two `__MISE_*`-loss rounds pollute the live PATH (asserted as setup), then `mise env` shows exactly **1** copy of the `_.path` dir. Fails pre-fix, where the computed PATH carries every stale copy.
- `path_env.rs` unit tests in a platform-neutral module (no filesystem access, so they also run in `windows-unit`): the reactivation-residue shape resolves to the fresh copy first, and component-vs-byte equality behaves as documented above.
- The deactivate trio and the activate/path e2e suite pass unchanged — `src/cli/hook_env.rs` is untouched in this revision.

## Out of scope

- Deduplicating the live shell PATH (contractually user-owned, see above).
- Smarter `__MISE_ORIG_PATH` recovery (persisting state outside env vars). Different design, different risks.

## Verification

`rustfmt --check`, `shellcheck -x` + `shfmt -d` on the e2e script. No local build — CI verifies: the new e2e discriminates the fix, the unit tests run on all three platforms, and the deactivate trio guards the boundary this PR deliberately respects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate PATH entries from reappearing in computed environments, including across repeated activation/reactivation cycles.
  * Ensures “first occurrence wins” for exact PATH entries (drops later exact duplicates); normalizes component-equivalent variants while keeping case differences distinct.
  * Improved PATH handling during shim removal to better preserve user-introduced PATH formatting/duplicates in the active session.
* **Tests**
  * Added unit tests covering PATH deduplication, including stale/reactivation scenarios and component-equivalent handling.
  * Added an end-to-end bash test verifying computed PATH collapses stale duplicates after reactivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->