### PR TITLE
fix(asdf): pass config env to version scripts

### DIFF
--- a/docs/dev-tools/backends/asdf.md
+++ b/docs/dev-tools/backends/asdf.md
@@ -53,6 +53,13 @@ need to set env vars other than `PATH`.
 
 See the asdf documentation for more information on [writing plugins](https://asdf-vm.com/plugins/create.html).
 
+The `bin/list-all` and `bin/latest-stable` version scripts receive environment variables and PATH
+additions resolved from mise configuration before tools are loaded. This allows private plugins to
+use credentials, helper executables from `_.path`, or other project-specific values from `[env]`
+while listing versions. Because these values can change the available versions, mise stores
+version-list caches separately for each resolved configuration environment without writing the
+original values or paths to the cache.
+
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `asdf` backend—these

--- a/e2e/backend/test_asdf_version_env
+++ b/e2e/backend/test_asdf_version_env
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+plugin_dir="$MISE_DATA_DIR/plugins/env-listing"
+mkdir -p "$plugin_dir/bin"
+mkdir -p version-tools version-tools-alt
+
+cat >version-tools/version-list-helper <<'EOF'
+#!/usr/bin/env bash
+echo "$1"
+EOF
+
+cat >version-tools-alt/version-list-helper <<'EOF'
+#!/usr/bin/env bash
+echo 3.4.5
+EOF
+
+cat >"$plugin_dir/bin/list-all" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${FAIL_VERSION_SCRIPTS:-} == 1 ]]; then
+  exit 1
+fi
+version-list-helper "${VERSION_LIST_SECRET:-0.0.0}"
+EOF
+
+cat >"$plugin_dir/bin/latest-stable" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${FAIL_VERSION_SCRIPTS:-} == 1 ]]; then
+  exit 1
+fi
+version-list-helper "${VERSION_LIST_SECRET:-0.0.0}"
+EOF
+
+chmod +x \
+  "$plugin_dir/bin/list-all" \
+  "$plugin_dir/bin/latest-stable" \
+  version-tools/version-list-helper \
+  version-tools-alt/version-list-helper
+
+cat >mise.toml <<'EOF'
+[env]
+_.path = "./version-tools"
+VERSION_LIST_SECRET = "1.2.3"
+EOF
+
+assert "mise ls-remote env-listing" "1.2.3"
+assert "mise latest env-listing" "1.2.3"
+assert "FAIL_VERSION_SCRIPTS=1 MISE_OFFLINE=1 mise ls-remote env-listing" "1.2.3"
+assert "FAIL_VERSION_SCRIPTS=1 MISE_OFFLINE=1 mise latest env-listing" "1.2.3"
+
+cat >mise.toml <<'EOF'
+[env]
+_.path = "./version-tools"
+VERSION_LIST_SECRET = "2.3.4"
+EOF
+
+assert "MISE_OFFLINE=1 mise ls-remote env-listing" ""
+assert "mise ls-remote env-listing" "2.3.4"
+assert "mise latest env-listing" "2.3.4"
+
+cat >mise.toml <<'EOF'
+[env]
+_.path = "./version-tools-alt"
+VERSION_LIST_SECRET = "2.3.4"
+EOF
+
+assert "mise ls-remote env-listing" "3.4.5"
+assert "mise latest env-listing" "3.4.5"

--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -1,8 +1,10 @@
+use std::collections::{BTreeMap, HashMap};
+use std::ffi::OsString;
 use std::fmt::{Debug, Formatter};
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::{Arc, Mutex};
 
 use crate::backend::VersionInfo;
 use crate::backend::backend_type::BackendType;
@@ -10,6 +12,7 @@ use crate::backend::external_plugin_cache::ExternalPluginCache;
 use crate::backend::normalize_idiomatic_contents;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
+use crate::config::env_directive::EnvResults;
 use crate::config::{Config, Settings};
 use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvMap};
 use crate::hash::hash_to_str;
@@ -37,7 +40,7 @@ pub struct AsdfBackend {
     plugin: Arc<AsdfPlugin>,
     plugin_enum: PluginEnum,
     cache: ExternalPluginCache,
-    latest_stable_cache: CacheManager<Option<String>>,
+    latest_stable_caches: Mutex<HashMap<String, Arc<CacheManager<Option<String>>>>>,
     alias_cache: CacheManager<Vec<(String, String)>>,
     idiomatic_filename_cache: CacheManager<Vec<String>>,
 }
@@ -56,13 +59,7 @@ impl AsdfBackend {
         let plugin_enum = PluginEnum::Asdf(plugin.clone());
         Self {
             cache: ExternalPluginCache::default(),
-            latest_stable_cache: CacheManagerBuilder::new(
-                ba.cache_path.join("latest_stable.msgpack.z"),
-            )
-            .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
-            .with_fresh_file(plugin_path.clone())
-            .with_fresh_file(plugin_path.join("bin/latest-stable"))
-            .build(),
+            latest_stable_caches: Mutex::new(HashMap::new()),
             alias_cache: CacheManagerBuilder::new(ba.cache_path.join("aliases.msgpack.z"))
                 .with_fresh_file(plugin_path.clone())
                 .with_fresh_file(plugin_path.join("bin/list-aliases"))
@@ -106,6 +103,65 @@ impl AsdfBackend {
         file::create_dir_all(fp.parent().unwrap())?;
         file::write(fp, idiomatic_version)?;
         Ok(())
+    }
+
+    fn version_listing_cache_context(env_results: &EnvResults) -> Option<String> {
+        if env_results.env.is_empty()
+            && env_results.env_remove.is_empty()
+            && env_results.env_paths.is_empty()
+        {
+            return None;
+        }
+        let env = env_results
+            .env
+            .iter()
+            .map(|(key, (value, _))| (key, value))
+            .collect::<BTreeMap<_, _>>();
+        Some(hash_to_str(&(
+            env,
+            &env_results.env_remove,
+            &env_results.env_paths,
+        )))
+    }
+
+    fn script_man_for_version_listing(&self, env_results: &EnvResults) -> Result<ScriptManager> {
+        let mut sm = self.plugin.script_man.clone();
+        for key in &env_results.env_remove {
+            sm = sm.without_env(key);
+        }
+        for (key, (value, _)) in &env_results.env {
+            sm = sm.with_env(key, value);
+        }
+        if !env_results.env_paths.is_empty() {
+            let path_key = OsString::from(&*env::PATH_KEY);
+            let current_path = sm.env.get(&path_key).cloned().unwrap_or_default();
+            let mut paths = env_results.env_paths.clone();
+            if !current_path.is_empty() {
+                paths.extend(env::split_paths(&current_path));
+            }
+            sm = sm.with_env(path_key, env::join_paths(paths)?);
+        }
+        Ok(sm)
+    }
+
+    fn latest_stable_cache(&self, context: Option<&str>) -> Arc<CacheManager<Option<String>>> {
+        let map_key = context.unwrap_or_default().to_string();
+        self.latest_stable_caches
+            .lock()
+            .unwrap()
+            .entry(map_key)
+            .or_insert_with(|| {
+                let mut cm =
+                    CacheManagerBuilder::new(self.ba.cache_path.join("latest_stable.msgpack.z"))
+                        .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
+                        .with_fresh_file(self.plugin_path.clone())
+                        .with_fresh_file(self.plugin_path.join("bin/latest-stable"));
+                if let Some(context) = context {
+                    cm = cm.with_cache_key(context.to_string());
+                }
+                Arc::new(cm.build())
+            })
+            .clone()
     }
 
     async fn fetch_bin_paths(&self, config: &Arc<Config>, tv: &ToolVersion) -> Result<Vec<String>> {
@@ -262,8 +318,16 @@ impl Backend for AsdfBackend {
         false
     }
 
-    async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-        let versions = self.plugin.fetch_remote_versions()?;
+    async fn remote_version_cache_context(&self, config: &Arc<Config>) -> Result<Option<String>> {
+        Ok(Self::version_listing_cache_context(
+            config.env_results().await?,
+        ))
+    }
+
+    async fn _list_remote_versions(&self, config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
+        let env_results = config.env_results().await?;
+        let sm = self.script_man_for_version_listing(env_results)?;
+        let versions = self.plugin.fetch_remote_versions(&sm)?;
         Ok(versions
             .into_iter()
             .map(|v| VersionInfo {
@@ -273,14 +337,18 @@ impl Backend for AsdfBackend {
             .collect())
     }
 
-    async fn latest_stable_version(&self, _config: &Arc<Config>) -> Result<Option<String>> {
+    async fn latest_stable_version(&self, config: &Arc<Config>) -> Result<Option<String>> {
+        let env_results = config.env_results().await?;
+        let context = Self::version_listing_cache_context(env_results);
+        let sm = self.script_man_for_version_listing(env_results)?;
+        let cache = self.latest_stable_cache(context.as_deref());
         timeout::run_with_timeout_async(
             || async {
                 if !self.plugin.has_latest_stable_script() {
                     return Ok(None);
                 }
-                self.latest_stable_cache
-                    .get_or_try_init(|| self.plugin.fetch_latest_stable())
+                cache
+                    .get_or_try_init(|| self.plugin.fetch_latest_stable(&sm))
                     .wrap_err_with(|| {
                         eyre!(
                             "Failed fetching latest stable version for plugin {}",
@@ -458,6 +526,106 @@ impl Debug for AsdfBackend {
 mod tests {
 
     use super::*;
+    use std::ffi::OsString;
+
+    fn env_results(entries: &[(&str, &str)], removals: &[&str], paths: &[&str]) -> EnvResults {
+        let mut results = EnvResults::default();
+        for (key, value) in entries {
+            results.env.insert(
+                (*key).to_string(),
+                ((*value).to_string(), PathBuf::from("mise.toml")),
+            );
+        }
+        results.env_remove = removals.iter().map(|key| (*key).to_string()).collect();
+        results.env_paths = paths.iter().map(PathBuf::from).collect();
+        results
+    }
+
+    #[test]
+    fn version_listing_cache_context_is_stable_and_tracks_changes() {
+        let first = env_results(
+            &[("TOKEN", "secret"), ("CHANNEL", "stable")],
+            &["REMOVE_ME"],
+            &["/first/bin"],
+        );
+        let reordered = env_results(
+            &[("CHANNEL", "stable"), ("TOKEN", "secret")],
+            &["REMOVE_ME"],
+            &["/first/bin"],
+        );
+        let changed = env_results(
+            &[("TOKEN", "other"), ("CHANNEL", "stable")],
+            &["REMOVE_ME"],
+            &["/first/bin"],
+        );
+        let changed_removal = env_results(
+            &[("TOKEN", "secret"), ("CHANNEL", "stable")],
+            &["OTHER"],
+            &["/first/bin"],
+        );
+        let changed_path = env_results(
+            &[("TOKEN", "secret"), ("CHANNEL", "stable")],
+            &["REMOVE_ME"],
+            &["/other/bin"],
+        );
+
+        assert_eq!(
+            AsdfBackend::version_listing_cache_context(&first),
+            AsdfBackend::version_listing_cache_context(&reordered)
+        );
+        assert_ne!(
+            AsdfBackend::version_listing_cache_context(&first),
+            AsdfBackend::version_listing_cache_context(&changed)
+        );
+        assert_ne!(
+            AsdfBackend::version_listing_cache_context(&first),
+            AsdfBackend::version_listing_cache_context(&changed_removal)
+        );
+        assert_ne!(
+            AsdfBackend::version_listing_cache_context(&first),
+            AsdfBackend::version_listing_cache_context(&changed_path)
+        );
+        assert_eq!(
+            AsdfBackend::version_listing_cache_context(&EnvResults::default()),
+            None
+        );
+    }
+
+    #[test]
+    fn version_listing_script_manager_applies_config_env() {
+        let backend = AsdfBackend::from_arg("dummy".into());
+        let results = env_results(
+            &[("MISE_TEST_VERSION_CHANNEL", "private")],
+            &["REMOVE_ME"],
+            &["/first/bin", "/second/bin"],
+        );
+
+        let sm = backend.script_man_for_version_listing(&results).unwrap();
+
+        assert_eq!(
+            sm.env.get(&OsString::from("MISE_TEST_VERSION_CHANNEL")),
+            Some(&OsString::from("private"))
+        );
+        assert!(!sm.env.contains_key(&OsString::from("REMOVE_ME")));
+        let paths = env::split_paths(sm.env.get(&OsString::from(&*env::PATH_KEY)).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            &paths[..2],
+            &[PathBuf::from("/first/bin"), PathBuf::from("/second/bin")]
+        );
+    }
+
+    #[test]
+    fn version_listing_script_manager_can_add_paths_after_path_removal() {
+        let backend = AsdfBackend::from_arg("dummy".into());
+        let results = env_results(&[], &["PATH"], &["/only/bin"]);
+
+        let sm = backend.script_man_for_version_listing(&results).unwrap();
+        let paths = env::split_paths(sm.env.get(&OsString::from(&*env::PATH_KEY)).unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(paths, vec![PathBuf::from("/only/bin")]);
+    }
 
     #[tokio::test]
     async fn test_debug() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1410,6 +1410,15 @@ pub trait Backend: Debug + Send + Sync {
         &[]
     }
 
+    /// Opaque context that affects this backend's remote version listing.
+    ///
+    /// Backends should return a digest rather than raw values. A non-empty
+    /// context partitions the remote-version cache and disables the shared
+    /// versions host, whose response cannot account for local context.
+    async fn remote_version_cache_context(&self, _config: &Arc<Config>) -> Result<Option<String>> {
+        Ok(None)
+    }
+
     /// dependencies which wait for install but do not warn, like cargo-binstall
     fn get_optional_dependencies(&self) -> Result<Vec<&str>> {
         Ok(vec![])
@@ -1488,7 +1497,11 @@ pub trait Backend: Debug + Send + Sync {
         config: &Arc<Config>,
         refresh: bool,
     ) -> eyre::Result<Vec<VersionInfo>> {
-        let remote_versions = self.get_remote_version_cache();
+        let cache_context = self.remote_version_cache_context(config).await?;
+        let remote_versions = match cache_context.as_deref() {
+            Some(context) => self.get_remote_version_cache_with_context(Some(context)),
+            None => self.get_remote_version_cache(),
+        };
         let mut remote_versions = remote_versions.lock().await;
         let ba = self.ba().clone();
         let id = self.id();
@@ -1532,6 +1545,12 @@ pub trait Backend: Debug + Send + Sync {
             trace!(
                 "Skipping versions host for {} because {} backend has a direct source",
                 ba.short, backend_type
+            );
+            false
+        } else if cache_context.is_some() {
+            trace!(
+                "Skipping versions host for {} because local context affects remote version listing",
+                ba.short,
             );
             false
         } else if has_local_version_listing_override {
@@ -2980,20 +2999,34 @@ pub trait Backend: Debug + Send + Sync {
     }
 
     fn get_remote_version_cache(&self) -> Arc<TokioMutex<VersionCacheManager>> {
+        self.get_remote_version_cache_with_context(None)
+    }
+
+    fn get_remote_version_cache_with_context(
+        &self,
+        context: Option<&str>,
+    ) -> Arc<TokioMutex<VersionCacheManager>> {
         // use a mutex to prevent deadlocks that occurs due to reentrant cache access
         static REMOTE_VERSION_CACHE: Lazy<
             Mutex<HashMap<String, Arc<TokioMutex<VersionCacheManager>>>>,
         > = Lazy::new(Default::default);
 
+        let map_key = match context {
+            Some(context) => format!("{}\0{context}", self.ba().full()),
+            None => self.ba().full(),
+        };
         REMOTE_VERSION_CACHE
             .lock()
             .unwrap()
-            .entry(self.ba().full())
+            .entry(map_key)
             .or_insert_with(|| {
                 let mut cm = CacheManagerBuilder::new(
                     self.ba().cache_path.join("remote_versions.msgpack.z"),
                 )
                 .with_fresh_duration(Settings::get().fetch_remote_versions_cache());
+                if let Some(context) = context {
+                    cm = cm.with_cache_key(context.to_string());
+                }
                 if let Some(plugin_path) = self.plugin().map(|p| p.path()) {
                     cm = cm
                         .with_fresh_file(plugin_path.clone())
@@ -3623,6 +3656,37 @@ mod latest_version_tests {
 
         assert_eq!(versions, vec!["1.0.0".to_string(), "2.0.0".to_string()]);
         assert_eq!(backend.list_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_remote_version_cache_contexts_are_isolated() {
+        let _config = Config::get().await.unwrap();
+        let backend = LatestBackend::new("test-context-cache");
+        let first = backend.get_remote_version_cache_with_context(Some("first"));
+        let second = backend.get_remote_version_cache_with_context(Some("second"));
+
+        first
+            .lock()
+            .await
+            .write(&vec![VersionInfo {
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            }])
+            .unwrap();
+        second
+            .lock()
+            .await
+            .write(&vec![VersionInfo {
+                version: "2.0.0".to_string(),
+                ..Default::default()
+            }])
+            .unwrap();
+
+        assert_eq!(first.lock().await.get_cached().unwrap()[0].version, "1.0.0");
+        assert_eq!(
+            second.lock().await.get_cached().unwrap()[0].version,
+            "2.0.0"
+        );
     }
 
     #[tokio::test]

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -101,9 +101,9 @@ impl AsdfPlugin {
         }
         Ok(())
     }
-    pub fn fetch_remote_versions(&self) -> eyre::Result<Vec<String>> {
+    pub fn fetch_remote_versions(&self, script_man: &ScriptManager) -> eyre::Result<Vec<String>> {
         Settings::ensure_not_safe("executing asdf plugin scripts")?;
-        let cmd = self.script_man.cmd(&Script::ListAll);
+        let cmd = script_man.cmd(&Script::ListAll);
         let result = run_with_timeout(
             move || {
                 let result = cmd.stdout_capture().stderr_capture().unchecked().run()?;
@@ -112,7 +112,7 @@ impl AsdfPlugin {
             Settings::get().fetch_remote_versions_timeout(),
         )
         .wrap_err_with(|| {
-            let script = self.script_man.get_script_path(&Script::ListAll);
+            let script = script_man.get_script_path(&Script::ListAll);
             eyre!("Failed to run {}", display_path(script))
         })?;
         let stdout = String::from_utf8(result.stdout).unwrap();
@@ -138,12 +138,8 @@ impl AsdfPlugin {
             .map(|v| regex!(r"^v(\d+)").replace(v, "$1").to_string())
             .collect())
     }
-    pub fn fetch_latest_stable(&self) -> eyre::Result<Option<String>> {
-        let latest_stable = self
-            .script_man
-            .read(&Script::LatestStable)?
-            .trim()
-            .to_string();
+    pub fn fetch_latest_stable(&self, script_man: &ScriptManager) -> eyre::Result<Option<String>> {
+        let latest_stable = script_man.read(&Script::LatestStable)?.trim().to_string();
         Ok(if latest_stable.is_empty() {
             None
         } else {


### PR DESCRIPTION
## Summary

- pass mise configuration environment values, removals, and `_.path` additions to asdf `bin/list-all` and `bin/latest-stable` scripts
- partition remote-version and latest-stable caches by an opaque digest of the resolved configuration environment and PATH additions
- bypass the shared mise versions host when local configuration can affect an asdf plugin's version list

## Problem

An asdf plugin that needs a credential, helper executable, or another value from mise `[env]` could not use it while resolving versions. Both `bin/list-all` and `bin/latest-stable` were launched from the plugin's base `ScriptManager`, before the resolved configuration environment was applied. Reusing the ordinary cache or shared versions host would also return results produced for a different environment.

## Implementation

The asdf backend now builds one environment-aware script manager for both version scripts. It starts with the normal process environment, applies configuration removals, overlays resolved non-tool configuration values, and prepends resolved `_.path` entries in configuration order. Directives requiring tools remain excluded to avoid a dependency cycle during tool resolution.

When configuration contributes environment additions, removals, or PATH entries, mise computes an opaque, deterministic context digest. The digest partitions both in-memory and on-disk caches, so the same environment retains offline and prefer-offline reuse while changed values or paths do not reuse stale results. Raw variable names, values, credentials, and paths are not written to cache filenames, cache contents, or logs. With no configuration environment, the existing cache identity remains unchanged.

The shared mise versions host is skipped for context-dependent asdf listings because it cannot represent a user-specific environment. Other backends and asdf plugin hooks are unchanged.

## Validation

- `mise exec -- cargo test --all-features version_listing_ -- --nocapture`
- `mise exec -- cargo test --all-features test_remote_version_cache_contexts_are_isolated -- --nocapture`
- `mise run test:e2e e2e/backend/test_asdf_version_env`
- `mise run test:e2e e2e/cli/test_install_prefer_offline_no_refresh`
- `mise run test:e2e e2e/plugins/test_tiny`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck -x e2e/backend/test_asdf_version_env`
- `mise exec -- shfmt -d -s -i 2 e2e/backend/test_asdf_version_env`
- `mise x prettier -- prettier --check docs/dev-tools/backends/asdf.md`
- `mise exec -- markdownlint docs/dev-tools/backends/asdf.md`

`mise run lint` cannot enter its checks in this Sapling working copy because the `hk` wrapper reports `failed to find git repository`; the relevant checks above were run directly and passed.

Addresses https://github.com/jdx/mise/discussions/4837

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version listings and latest-version lookups now respect configured environment variables, removed variables, and PATH entries.
  * Version information is cached separately for each configuration, preventing results from one environment affecting another.
  * Offline lookups now reliably use matching cached results when available.

* **Documentation**
  * Added guidance explaining how environment settings affect version scripts and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->