### PR TITLE
fix(install): preserve config file timestamps

### DIFF
--- a/e2e/cli/test_install_preserves_config_mtime
+++ b/e2e/cli/test_install_preserves_config_mtime
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Installing a configured tool should notify hook-env through the mise data
+# directory without changing the config file's timestamp.
+
+cat >mise.toml <<EOF
+[tools]
+dummy = "1.0.0"
+EOF
+
+rm -rf "$MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# Establish a session while the configured tool is still uninstalled.
+eval "$(mise activate bash)"
+output=$(mise hook-env -s bash)
+if [[ -n $output ]]; then
+  fail "expected hook-env fast path before install but got: '$output'"
+fi
+
+# Use a deterministic old timestamp so the test detects an install touching the
+# config file without relying on filesystem timestamp resolution.
+touch -t 202001010000 mise.toml
+touch config-mtime-marker
+
+mise install dummy@1.0.0
+
+assert_succeed "test mise.toml -ot config-mtime-marker"
+
+# The data-directory update must still bypass hook-env's fast path and add the
+# newly installed tool to PATH.
+output=$(mise hook-env -s bash)
+assert_contains_text "$output" "$MISE_DATA_DIR/installs/dummy/1.0.0/bin"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2716,14 +2716,9 @@ pub trait Backend: Debug + Send + Sync {
         }
 
         self.cleanup_install_dirs(&tv);
-        // attempt to touch all the .tool-version files to trigger updates in hook-env
-        let mut touch_dirs = vec![dirs::DATA.to_path_buf()];
-        touch_dirs.extend(ctx.config.config_files.keys().cloned());
-        for path in touch_dirs {
-            let err = file::touch_dir(&path);
-            if let Err(err) = err {
-                trace!("error touching config file: {:?} {:?}", path, err);
-            }
+        // Touch the data directory to trigger updates in hook-env after PATH changes.
+        if let Err(err) = file::touch_dir(&dirs::DATA) {
+            trace!("error touching data directory: {:?}", err);
         }
         install_state::clear_incomplete_marker_best_effort(&tv.ba().short, &tv.tv_pathname());
         if let Some(script) = tv.request.options().get("postinstall") {


### PR DESCRIPTION
## Summary

- stop touching loaded config files after a successful tool installation
- keep touching the mise data directory so hook-env still detects installation and PATH changes
- add an offline regression test covering both config mtime preservation and hook-env refresh

## Root cause

After installing a tool, mise touched every loaded config file as well as the data directory to invalidate hook-env state. Updating the config mtimes caused editors to report that an open file had been modified externally, even though its contents were unchanged.

The current hook-env session already watches the mise data directory and includes its modification time in fast-path invalidation. Touching that directory alone preserves the required refresh behavior without mutating config file metadata.

## Testing

- `mise run test:e2e e2e/cli/test_install_preserves_config_mtime e2e/cli/test_hook_env_fast_path`
- `mise run test:e2e e2e/cli/test_install_preserves_config_mtime`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck -x e2e/cli/test_install_preserves_config_mtime`
- `mise exec -- shfmt -d -s -i 2 e2e/cli/test_install_preserves_config_mtime`

`mise run format` and `mise run lint` stop before checking files because hk cannot identify this Sapling working copy as a Git repository. The corresponding Rustfmt, ShellCheck, and shfmt checks above pass individually.

Addresses https://github.com/jdx/mise/discussions/4336

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Installing a configured tool now preserves the modification time of your `mise.toml` file.
  - Environment hooks correctly detect newly installed tools and update `PATH` without requiring configuration files to be modified.
  - Improved installation behavior avoids unnecessary updates to configuration file timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->