### PR TITLE
registry: add ryl (aqua:owenlamont/ryl)

### DIFF
--- a/registry/ryl.toml
+++ b/registry/ryl.toml
@@ -1,0 +1,3 @@
+description = "Ryl is the Rust YAML linter"
+test = { cmd = "ryl --version", expected = "ryl {{version}}" }
+backends = ["aqua:owenlamont/ryl"]


### PR DESCRIPTION
Add [ryl](https://github.com/owenlamont/ryl) package with aqua backends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ryl, a Rust YAML linter, to the registry.
  - Included version verification and backend configuration for reliable tool detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->