### PR TITLE
fix(aqua): preserve locked HTTP override metadata

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -3704,9 +3704,16 @@ packages:
         )
         .unwrap();
         let pkg = registry.package("haskell/cabal").unwrap();
+        let backend = Arc::new(BackendArg::new(
+            "cabal".to_string(),
+            Some("aqua:haskell/cabal/cabal-install".to_string()),
+        ));
+        let request =
+            ToolRequest::new(backend, "3.16.1.0", crate::toolset::ToolSource::Unknown).unwrap();
+        let tv = ToolVersion::new(request, "3.16.1.0".to_string());
         let versions = install_package_version_candidates("3.16.1.0", None, &pkg);
         let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
-        let pkg = pkg.with_version(&versions, "linux", "amd64");
+        let pkg = AquaBackend::package_with_options_for_pkg(&tv, pkg, &versions).unwrap();
 
         assert_eq!(pkg.version_prefix.as_deref(), Some("cabal-install-v"));
         assert_eq!(pkg.format, "tar.xz");

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -451,11 +451,10 @@ impl Backend for AquaBackend {
         let mut v = tag.clone().unwrap_or_else(|| tv.version.clone());
         let mut v_prefixed =
             (tag.is_none() && !tv.version.starts_with('v')).then(|| format!("v{v}"));
-        let versions = match &v_prefixed {
-            Some(v_prefixed) => vec![v.as_str(), v_prefixed.as_str()],
-            None => vec![v.as_str()],
-        };
-        let pkg = self.package_with_options(&tv, &versions).await?;
+        let pkg = AQUA_REGISTRY.package(&self.id).await?;
+        let versions = install_package_version_candidates(&tv.version, tag.as_deref(), &pkg);
+        let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
+        let pkg = Self::package_with_options_for_pkg(&tv, pkg, &versions)?;
         if let Some(prefix) = &pkg.version_prefix
             && !v.starts_with(prefix)
         {
@@ -989,15 +988,6 @@ impl Backend for AquaBackend {
 }
 
 impl AquaBackend {
-    async fn package_with_options(
-        &self,
-        tv: &ToolVersion,
-        versions: &[&str],
-    ) -> Result<AquaPackage> {
-        let pkg = AQUA_REGISTRY.package(&self.id).await?;
-        Self::package_with_options_for_pkg(tv, pkg, versions)
-    }
-
     fn package_with_options_for_pkg(
         tv: &ToolVersion,
         pkg: AquaPackage,
@@ -3289,6 +3279,21 @@ fn package_version_candidates<'a>(version: &'a str, pkg: &AquaPackage) -> Vec<Co
     candidates.into_iter().unique().collect()
 }
 
+fn install_package_version_candidates<'a>(
+    version: &'a str,
+    tag: Option<&'a str>,
+    pkg: &AquaPackage,
+) -> Vec<Cow<'a, str>> {
+    if let Some(tag) = tag {
+        vec![Cow::Borrowed(tag)]
+    } else {
+        // Locked HTTP package URLs do not contain a GitHub release tag. Include the
+        // registry's prefixes so prefix-scoped overrides still provide metadata such
+        // as the archive format.
+        package_version_candidates(version, pkg)
+    }
+}
+
 fn github_release_tag_from_url(url: &str) -> Option<String> {
     let url = Url::parse(url).ok()?;
     if url.host_str()? != "github.com" {
@@ -3680,6 +3685,31 @@ packages:
         assert_eq!(pkg.version_prefix.as_deref(), Some("lychee-v"));
         assert_eq!(pkg.files.len(), 1);
         assert_eq!(pkg.files[0].name, "lychee");
+    }
+
+    #[test]
+    fn test_package_version_candidates_apply_inherited_prefix_format_override() {
+        let registry = ParsedRegistry::parse_yaml(
+            r#"
+packages:
+  - type: http
+    repo_owner: haskell
+    repo_name: cabal
+    version_prefix: cabal-install-v
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        format: tar.xz
+"#,
+        )
+        .unwrap();
+        let pkg = registry.package("haskell/cabal").unwrap();
+        let versions = install_package_version_candidates("3.16.1.0", None, &pkg);
+        let versions = versions.iter().map(|v| v.as_ref()).collect_vec();
+        let pkg = pkg.with_version(&versions, "linux", "amd64");
+
+        assert_eq!(pkg.version_prefix.as_deref(), Some("cabal-install-v"));
+        assert_eq!(pkg.format, "tar.xz");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- resolve Aqua install metadata with package- and override-prefixed version candidates when no exact release tag is available
- preserve exact release-tag selection when a GitHub lock URL provides one
- add regression coverage for Cabal-style locked HTTP packages whose archive format comes from a prefix-scoped override

## Root cause

Locked HTTP URLs such as Cabal's `downloads.haskell.org` artifacts do not contain a GitHub release tag, and mise skips tag discovery when a lockfile URL already exists. After prefix-aware Aqua override matching was introduced, install resolution still supplied only the bare version and its `v` variant. Cabal's `cabal-install-v` override therefore did not match, its `format: tar.xz` metadata was lost, and the archive was copied as the executable.

Fixes the regression reported in https://github.com/jdx/mise/discussions/11494.

## Impact

Locked Aqua HTTP installs retain prefix-scoped format and file metadata, so archives are extracted correctly. Packages with an exact release tag continue to use only that tag, preserving disambiguation between multiple prefix families.

## Validation

- `cargo test backend::aqua::tests::test_package_version_candidates -- --nocapture`
- `cargo test backend::aqua::lock_candidate_tests:: -- --nocapture`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time Aqua package/override resolution for locked installs; wrong candidate logic could mis-apply formats or overrides, but scope is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes Aqua installs where a **lockfile URL** exists but carries **no GitHub release tag** (e.g. Cabal on `downloads.haskell.org`). Install resolution no longer passes only the bare version and optional `v` variant into override matching; it uses **`install_package_version_candidates`**, which delegates to **`package_version_candidates`** so registry **`version_prefix`** values (like `cabal-install-v`) still match and inherit metadata such as **`format: tar.xz`**.
> 
> When the lock URL **does** encode a GitHub release tag, resolution still uses **only that tag**, avoiding ambiguity between prefix families. The redundant async **`package_with_options`** helper is removed in favor of loading the package once and calling **`package_with_options_for_pkg`** directly. A **Cabal-style HTTP** regression test asserts prefix and format are applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4708fe78a99fa461bf6e3b44e4a59ea7043e40fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation handling for packages that use version prefixes and format overrides.
  * Preserved inherited version metadata for HTTP packages during installs, including when a release tag is not available.
  * Corrected install-time version resolution to use the appropriate registry-derived candidate set for overrides.
* **Tests**
  * Updated coverage to validate inherited version-prefix behavior with install-time options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->