### PR TITLE
fix(prune): preserve untrusted version file references

### DIFF
--- a/e2e/cli/test_prune_tracked_config_trust
+++ b/e2e/cli/test_prune_tracked_config_trust
@@ -8,7 +8,7 @@ cat <<'EOF' >"$MISE_CONFIG_DIR/config.toml"
 idiomatic_version_file_enable_tools = ["dummy"]
 EOF
 
-mkdir idiomatic tool-versions templated other
+mkdir idiomatic tool-versions templated ignored other
 marker="$TMPDIR/mise-prune-tracked-config-pwned"
 
 echo "1.0.0" >idiomatic/.dummy-version
@@ -25,10 +25,17 @@ cat <<EOF >templated/.tool-versions
 dummy {{ exec(command="touch $marker") }}3.0.0
 EOF
 
+echo "4.0.0" >ignored/.dummy-version
+mise -C ignored install
+mise -C ignored trust --ignore .dummy-version
+
 cd other || exit 1
 output=$(MISE_YES=0 MISE_LOG_LEVEL=debug mise prune --dry-run --tools --raw 2>&1)
 
 assert_not_contains "echo '$output'" "dummy@1.0.0"
 assert_not_contains "echo '$output'" "dummy@2.0.0"
+assert_contains "echo '$output'" "dummy@3.0.0"
+assert_contains "echo '$output'" "dummy@4.0.0"
 assert_contains "echo '$output'" "skipping untrusted tracked config"
+assert_contains "echo '$output'" "skipping ignored tracked config"
 assert_fail "test -e '$marker'"

--- a/e2e/cli/test_prune_tracked_config_trust
+++ b/e2e/cli/test_prune_tracked_config_trust
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+export MISE_TRUSTED_CONFIG_PATHS=""
+unset CI GITHUB_ACTIONS GITHUB_ACTION 2>/dev/null || true
+
+cat <<'EOF' >"$MISE_CONFIG_DIR/config.toml"
+[settings]
+idiomatic_version_file_enable_tools = ["dummy"]
+EOF
+
+mkdir idiomatic tool-versions templated other
+marker="$TMPDIR/mise-prune-tracked-config-pwned"
+
+echo "1.0.0" >idiomatic/.dummy-version
+mise -C idiomatic install
+
+echo "dummy 2.0.0" >tool-versions/.tool-versions
+mise -C tool-versions install
+
+# Track a plain .tool-versions file, then make it require trust. Tracked-config
+# loading must skip it without rendering the template.
+echo "dummy 3.0.0" >templated/.tool-versions
+mise -C templated install
+cat <<EOF >templated/.tool-versions
+dummy {{ exec(command="touch $marker") }}3.0.0
+EOF
+
+cd other || exit 1
+output=$(MISE_YES=0 MISE_LOG_LEVEL=debug mise prune --dry-run --tools --raw 2>&1)
+
+assert_not_contains "echo '$output'" "dummy@1.0.0"
+assert_not_contains "echo '$output'" "dummy@2.0.0"
+assert_contains "echo '$output'" "skipping untrusted tracked config"
+assert_fail "test -e '$marker'"

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -301,6 +301,24 @@ pub async fn parse(path: &Path) -> Result<Arc<dyn ConfigFile>> {
     }
 }
 
+/// Whether parsing `path` requires a trust record.
+///
+/// Tracked config loading uses this to avoid interactive prompts without
+/// discarding plain version files that never require trust.
+pub async fn path_requires_trust(path: &Path) -> bool {
+    if Settings::safe_mode() {
+        return false;
+    }
+    if Settings::try_get().is_ok_and(|settings| settings.paranoid) {
+        return true;
+    }
+    match detect_config_file_type(path).await {
+        Some(ConfigFileType::MiseToml) => !MiseToml::path_is_trust_exempt(path),
+        Some(ConfigFileType::ToolVersions) => ToolVersions::path_requires_trust(path),
+        Some(ConfigFileType::IdiomaticVersion(_)) | None => false,
+    }
+}
+
 pub fn config_trust_root(path: &Path) -> PathBuf {
     if settings::is_loaded() && Settings::get().paranoid {
         path.to_path_buf()

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -55,6 +55,13 @@ impl ToolVersions {
         Self::parse_str(&file::read_to_string(path)?, path.to_path_buf())
     }
 
+    pub fn path_requires_trust(path: &Path) -> bool {
+        match file::read_to_string(path) {
+            Ok(body) => contains_template_syntax(&body),
+            Err(_) => true,
+        }
+    }
+
     pub fn parse_str(s: &str, path: PathBuf) -> Result<Self> {
         let mut cf = Self::init(&path);
         let dir = path.parent();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -828,22 +828,14 @@ impl Config {
     pub async fn get_tracked_config_files(&self) -> Result<ConfigMap> {
         let mut config_files: ConfigMap = ConfigMap::default();
         for path in Tracker::list_all()?.into_iter() {
-            // Pre-check trust to avoid interactive prompts when loading
-            // tracked configs (e.g., during `mise upgrade`). Only MiseToml files
-            // call trust_check during parsing, but we can't cheaply distinguish
-            // file types here, so we check trust for all files and fall through
-            // to parse for trusted files. Untrusted non-MiseToml files (like
-            // .tool-versions) don't need trust and will parse fine regardless.
+            // Pre-check trust for config files that require it so tracked
+            // config loading (e.g., during `mise upgrade`) never prompts.
+            // Plain .tool-versions and idiomatic version files are safe to
+            // parse without trust and must still protect their tool versions.
             let trust_root = config_file::config_trust_root(&path);
-            // In safe mode, config is inert and trust is not required, so don't
-            // skip untrusted tracked configs — load them like trusted ones.
-            let safe_mode = Settings::safe_mode();
-            if !safe_mode
+            if config_file::path_requires_trust(&path).await
                 && !config_file::is_trusted(&trust_root)
                 && !config_file::is_trusted(&path)
-                // safe mise.toml files load without a trust marker, so a missing
-                // marker doesn't mean they should be skipped here
-                && !MiseToml::path_is_trust_exempt(&path)
             {
                 debug!("skipping untrusted tracked config: {}", display_path(&path));
                 continue;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -828,6 +828,10 @@ impl Config {
     pub async fn get_tracked_config_files(&self) -> Result<ConfigMap> {
         let mut config_files: ConfigMap = ConfigMap::default();
         for path in Tracker::list_all()?.into_iter() {
+            if config_path_is_ignored(&path, false) {
+                debug!("skipping ignored tracked config: {}", display_path(&path));
+                continue;
+            }
             // Pre-check trust for config files that require it so tracked
             // config loading (e.g., during `mise upgrade`) never prompts.
             // Plain .tool-versions and idiomatic version files are safe to

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -834,8 +834,8 @@ impl Config {
             // parse without trust and must still protect their tool versions.
             let trust_root = config_file::config_trust_root(&path);
             if config_file::path_requires_trust(&path).await
+                && !is_global_config(&path)
                 && !config_file::is_trusted(&trust_root)
-                && !config_file::is_trusted(&path)
             {
                 debug!("skipping untrusted tracked config: {}", display_path(&path));
                 continue;


### PR DESCRIPTION
## Summary

- preserve installed versions referenced by untrusted tracked idiomatic version files and plain `.tool-versions`
- classify tracked configs with the same file-type and content rules used by parsing before applying the trust pre-check
- consult config-root trust only, without carrying forward legacy individual-file trust checks
- continue skipping executable templated `.tool-versions` without prompting or rendering them

## Root cause

Tracked-config loading applied a blanket trust pre-check before parsing every tracked file. Idiomatic version files do not create trust records, so commands such as `mise prune --tools` silently discarded their references and could remove versions still used by other projects.

Reported in [discussion #11483](https://github.com/jdx/mise/discussions/11483).

## Validation

- `mise run format`
- `cargo fmt --all -- --check`
- `mise run test:e2e cli/test_prune_tracked_config_trust`
- `mise run test:e2e config/test_tool_versions_trust_check config/test_trust_safe_config_tracked`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust gating for all tracked-config consumers (prune, upgrade, ls), affecting which tool versions stay protected; logic is narrower and covered by new e2e tests.
> 
> **Overview**
> **Tracked config loading** no longer treats every tracked path as trust-gated before parse. Commands like **`mise prune --tools`** were dropping references from idiomatic version files and plain **`.tool-versions`** because those files never get trust records, so installed versions could be pruned while still in use elsewhere.
> 
> Loading now **skips ignored tracked configs** up front and uses **`path_requires_trust`** so only configs that actually need trust (non-exempt **`mise.toml`**, templated **`.tool-versions`**) are skipped when untrusted. Plain **`.tool-versions`** and idiomatic files are still parsed without trust; templated untrusted files are skipped **without** rendering templates. Trust is checked against the **config root** only (legacy per-file trust checks removed from this path).
> 
> An e2e test covers idiomatic, plain, templated, and ignored tracked configs during **`mise prune --dry-run`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fecefb2796910a1d01aaad096a392fae2a1493d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pruning of tracked configuration files by skipping ignored paths before trust evaluation.
  * Tightened trust enforcement so untrusted configs are skipped only when trust is required (and the config is not global).
  * Untrusted `.tool-versions` files containing template expressions are no longer processed, preventing template evaluation side effects.
  * Safe/idiomatic configs that don’t require trust continue to be processed normally.
* **Tests**
  * Added an end-to-end test validating that ignored/untrusted tracked configs are skipped during prune dry-runs, with no template side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->