### PR TITLE
feat(task): support relative monorepo dependency paths

### DIFF
--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -113,6 +113,19 @@ depends = ["lint"]   # Also works (for migration compatibility)
 run = "webpack build"
 ```
 
+Dependency paths beginning with `./` are resolved relative to the task that
+declares them. This makes it possible to reuse the same dependency declaration
+at different levels of a monorepo:
+
+```toml
+[tasks.test]
+depends = [{ task = "./...:groups:tests:*", optional = true }]
+```
+
+For example, when declared by `//apps/frontend:test`, this pattern resolves to
+`//apps/frontend/...:groups:tests:*` and matches the current project and its
+descendants without matching sibling projects.
+
 The bare name syntax (without `:`) is supported primarily to ease migration from non-monorepo to monorepo configurations. When migrating, you won't need to update all your task dependencies immediately - they'll continue to work. However, using the `:` prefix makes it clear you're referencing a task in the current config_root.
 :::
 

--- a/e2e/tasks/test_task_monorepo_wildcard_with_deps
+++ b/e2e/tasks/test_task_monorepo_wildcard_with_deps
@@ -160,6 +160,8 @@ assert_not_contains "mise run '//apps/frontend:relative-tests'" "root grouped te
 # ./ followed directly by a task separator stays in the declaring project
 assert_contains "mise run '//apps/frontend:relative-bootstrap'" "frontend bootstrap executed"
 assert_contains "mise run '//apps/frontend:relative-bootstrap'" "frontend relative bootstrap executed"
+assert_not_contains "mise run '//apps/frontend:relative-bootstrap'" "shared bootstrap executed"
+assert_not_contains "mise run '//apps/frontend:relative-bootstrap'" "backend bootstrap executed"
 
 assert_contains "mise run '//apps/frontend/child:relative-tests'" "child grouped test executed"
 assert_not_contains "mise run '//apps/frontend/child:relative-tests'" "frontend grouped test executed"

--- a/e2e/tasks/test_task_monorepo_wildcard_with_deps
+++ b/e2e/tasks/test_task_monorepo_wildcard_with_deps
@@ -11,10 +11,17 @@ cat <<'EOF' >mise.toml
 monorepo_root = true
 
 [monorepo]
-config_roots = ["libs/*", "apps/*", "tools/*"]
+config_roots = ["libs/*", "apps/*", "apps/*/*", "tools/*"]
 
 [settings]
 experimental = true
+
+[tasks."groups:tests:root"]
+run = 'echo "root grouped test executed"'
+
+[tasks.relative-tests]
+depends = [{ task = "./...:groups:tests:*", optional = true }]
+run = 'echo "root relative tests executed"'
 EOF
 
 # Create first project with format depending on bootstrap
@@ -45,6 +52,24 @@ run = 'echo "frontend format executed"'
 [tasks.build]
 depends = [":bootstrap"]
 run = 'echo "frontend build executed"'
+
+[tasks."groups:tests:frontend"]
+run = 'echo "frontend grouped test executed"'
+
+[tasks.relative-tests]
+depends = [{ task = "./...:groups:tests:*", optional = true }]
+run = 'echo "frontend relative tests executed"'
+EOF
+
+# Create a nested project using the same relative dependency declaration
+mkdir -p apps/frontend/child
+cat <<'EOF' >apps/frontend/child/mise.toml
+[tasks."groups:tests:child"]
+run = 'echo "child grouped test executed"'
+
+[tasks.relative-tests]
+depends = [{ task = "./...:groups:tests:*", optional = true }]
+run = 'echo "child relative tests executed"'
 EOF
 
 # Create third project with same pattern
@@ -60,6 +85,9 @@ run = 'echo "backend format executed"'
 [tasks.test]
 depends = [":format"]
 run = 'echo "backend test executed"'
+
+[tasks."groups:tests:backend"]
+run = 'echo "backend grouped test executed"'
 EOF
 
 # Create a project WITHOUT bootstrap to ensure it doesn't interfere
@@ -118,5 +146,20 @@ assert_contains "mise run '//apps/backend:test'" "backend test executed"
 assert_contains "mise run '//...:test'" "backend bootstrap executed"
 assert_contains "mise run '//...:test'" "backend format executed"
 assert_contains "mise run '//...:test'" "backend test executed"
+
+# Test 7: ./ paths in dependencies resolve relative to the declaring task
+assert_contains "mise run '//apps/frontend:relative-tests'" "frontend grouped test executed"
+assert_contains "mise run '//apps/frontend:relative-tests'" "child grouped test executed"
+assert_not_contains "mise run '//apps/frontend:relative-tests'" "backend grouped test executed"
+assert_not_contains "mise run '//apps/frontend:relative-tests'" "root grouped test executed"
+
+assert_contains "mise run '//apps/frontend/child:relative-tests'" "child grouped test executed"
+assert_not_contains "mise run '//apps/frontend/child:relative-tests'" "frontend grouped test executed"
+assert_not_contains "mise run '//apps/frontend/child:relative-tests'" "backend grouped test executed"
+
+assert_contains "mise run '//:relative-tests'" "root grouped test executed"
+assert_contains "mise run '//:relative-tests'" "frontend grouped test executed"
+assert_contains "mise run '//:relative-tests'" "child grouped test executed"
+assert_contains "mise run '//:relative-tests'" "backend grouped test executed"
 
 echo "=== All wildcard with dependencies tests passed! ==="

--- a/e2e/tasks/test_task_monorepo_wildcard_with_deps
+++ b/e2e/tasks/test_task_monorepo_wildcard_with_deps
@@ -59,6 +59,10 @@ run = 'echo "frontend grouped test executed"'
 [tasks.relative-tests]
 depends = [{ task = "./...:groups:tests:*", optional = true }]
 run = 'echo "frontend relative tests executed"'
+
+[tasks.relative-bootstrap]
+depends = ["./:bootstrap"]
+run = 'echo "frontend relative bootstrap executed"'
 EOF
 
 # Create a nested project using the same relative dependency declaration
@@ -152,6 +156,10 @@ assert_contains "mise run '//apps/frontend:relative-tests'" "frontend grouped te
 assert_contains "mise run '//apps/frontend:relative-tests'" "child grouped test executed"
 assert_not_contains "mise run '//apps/frontend:relative-tests'" "backend grouped test executed"
 assert_not_contains "mise run '//apps/frontend:relative-tests'" "root grouped test executed"
+
+# ./ followed directly by a task separator stays in the declaring project
+assert_contains "mise run '//apps/frontend:relative-bootstrap'" "frontend bootstrap executed"
+assert_contains "mise run '//apps/frontend:relative-bootstrap'" "frontend relative bootstrap executed"
 
 assert_contains "mise run '//apps/frontend/child:relative-tests'" "child grouped test executed"
 assert_not_contains "mise run '//apps/frontend/child:relative-tests'" "frontend grouped test executed"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -3025,6 +3025,9 @@ where
             .build()
             .ok()
             .map(|b| b.compile_matcher());
+        let trailing_ellipsis_base_matcher = trailing_ellipsis_base
+            .and_then(|base| GlobBuilder::new(base).literal_separator(true).build().ok())
+            .map(|glob| glob.compile_matcher());
 
         // Build task matcher if not wildcard
         let task_matcher = if task_glob != "*" {
@@ -3082,7 +3085,9 @@ where
             // Match path part with ellipsis support
             let path_matches = if let Some(ref matcher) = path_matcher {
                 matcher.is_match(key_path)
-                    || trailing_ellipsis_base.is_some_and(|base| base == key_path)
+                    || trailing_ellipsis_base_matcher
+                        .as_ref()
+                        .is_some_and(|base_matcher| base_matcher.is_match(key_path))
             } else {
                 false
             };
@@ -5407,6 +5412,14 @@ echo "test"
             tasks.get_matching("//...:test").unwrap(),
             vec![
                 &"//:test".to_string(),
+                &"//apps/api:test".to_string(),
+                &"//apps/web/e2e:test".to_string(),
+                &"//apps/web:test".to_string(),
+            ]
+        );
+        assert_eq!(
+            tasks.get_matching("//apps/*/...:test").unwrap(),
+            vec![
                 &"//apps/api:test".to_string(),
                 &"//apps/web/e2e:test".to_string(),
                 &"//apps/web:test".to_string(),

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2622,12 +2622,16 @@ where
         .collect()
 }
 
-/// Resolve a task dependency pattern, optionally relative to a parent task
-/// If pattern starts with ":" and parent_task is provided, resolve relative to parent's path
-/// For example: parent "//projects/frontend:test" with pattern ":build" -> "//projects/frontend:build"
+/// Resolve a task dependency pattern, optionally relative to a parent task.
+///
+/// `:build` and bare task names resolve within the parent's project, while
+/// `./...:build` and other `./`-prefixed paths resolve from the parent's
+/// monorepo path.
 pub(crate) fn resolve_task_pattern(pattern: &str, parent_task: Option<&Task>) -> String {
+    let is_relative_path = pattern.starts_with("./");
     // Check if this is a bare task name that should be treated as relative
-    let is_bare_name = !pattern.starts_with("//")
+    let is_bare_name = !is_relative_path
+        && !pattern.starts_with("//")
         && !pattern.starts_with("::")
         && !pattern.starts_with(':')
         && !is_workspace_project_task(pattern);
@@ -2635,8 +2639,10 @@ pub(crate) fn resolve_task_pattern(pattern: &str, parent_task: Option<&Task>) ->
         parent.name.starts_with("//") || is_workspace_project_task(&parent.name)
     });
 
-    // If pattern starts with ":" or is a bare name in monorepo context, resolve relatively
+    // If pattern starts with ":", is an explicit relative path, or is a bare
+    // name in monorepo context, resolve it relative to the parent.
     let should_resolve_relatively = pattern.starts_with(':') && !pattern.starts_with("::")
+        || (is_relative_path && parent_task.is_some_and(|parent| parent.name.starts_with("//")))
         || (is_bare_name && parent_is_scoped);
 
     if should_resolve_relatively && let Some(parent) = parent_task {
@@ -2653,7 +2659,12 @@ pub(crate) fn resolve_task_pattern(pattern: &str, parent_task: Option<&Task>) ->
         if let Some(stripped) = parent.name.strip_prefix("//") {
             // Find the first colon after "//" prefix
             if let Some(colon_idx) = stripped.find(':') {
-                let path = format!("//{}", &stripped[..colon_idx]);
+                let parent_path = &stripped[..colon_idx];
+                if let Some(relative_path) = pattern.strip_prefix("./") {
+                    let separator = if parent_path.is_empty() { "" } else { "/" };
+                    return format!("//{parent_path}{separator}{relative_path}");
+                }
+                let path = format!("//{parent_path}");
                 // If pattern is a bare name, add the colon prefix
                 return if is_bare_name {
                     format!("{}:{}", path, pattern)
@@ -2995,6 +3006,9 @@ where
         // Convert ellipsis (...) to glob pattern (**)
         // //... matches everything, //foo/... matches foo and all subdirs
         let path_glob = path_pattern.replace("...", "**");
+        let trailing_ellipsis_base = path_pattern
+            .strip_suffix("/...")
+            .map(|base| if base == "/" { "//" } else { base });
 
         // For task patterns, * only matches within the task name portion (after final :)
         // e.g., test:* matches test:unit, test:integration, etc.
@@ -3064,6 +3078,7 @@ where
             // Match path part with ellipsis support
             let path_matches = if let Some(ref matcher) = path_matcher {
                 matcher.is_match(key_path)
+                    || trailing_ellipsis_base.is_some_and(|base| base == key_path)
             } else {
                 false
             };
@@ -4005,6 +4020,37 @@ echo "hello world"
             resolve_task_pattern("::global", Some(&parent_task)),
             "::global"
         );
+
+        // Explicit relative paths resolve from the declaring task's monorepo path.
+        assert_eq!(
+            resolve_task_pattern("./...:test:*", Some(&parent_task)),
+            "//projects/frontend/...:test:*"
+        );
+        assert_eq!(
+            resolve_task_pattern("./child:build", Some(&parent_task)),
+            "//projects/frontend/child:build"
+        );
+
+        // Root tasks resolve ./ directly beneath the monorepo root.
+        let root_task = Task {
+            name: "//:test".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_task_pattern("./...:test:*", Some(&root_task)),
+            "//...:test:*"
+        );
+
+        // Explicit relative paths need a monorepo parent.
+        let regular_task = Task {
+            name: "test".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_task_pattern("./...:test:*", Some(&regular_task)),
+            "./...:test:*"
+        );
+        assert_eq!(resolve_task_pattern("./...:test:*", None), "./...:test:*");
     }
 
     #[test]
@@ -5320,6 +5366,40 @@ echo "test"
         );
         let matches = only_file.get_matching("//pkg:migrate").unwrap();
         assert_eq!(matches, vec![&"//pkg:migrate.sh".to_string()]);
+    }
+
+    #[test]
+    fn test_get_matching_trailing_ellipsis_includes_base_path() {
+        use std::collections::BTreeMap;
+
+        use super::GetMatchingExt;
+
+        let tasks = BTreeMap::from([
+            ("//:test".to_string(), "//:test".to_string()),
+            ("//apps/web:test".to_string(), "//apps/web:test".to_string()),
+            (
+                "//apps/web/e2e:test".to_string(),
+                "//apps/web/e2e:test".to_string(),
+            ),
+            ("//apps/api:test".to_string(), "//apps/api:test".to_string()),
+        ]);
+
+        assert_eq!(
+            tasks.get_matching("//apps/web/...:test").unwrap(),
+            vec![
+                &"//apps/web/e2e:test".to_string(),
+                &"//apps/web:test".to_string(),
+            ]
+        );
+        assert_eq!(
+            tasks.get_matching("//...:test").unwrap(),
+            vec![
+                &"//:test".to_string(),
+                &"//apps/api:test".to_string(),
+                &"//apps/web/e2e:test".to_string(),
+                &"//apps/web:test".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2661,7 +2661,11 @@ pub(crate) fn resolve_task_pattern(pattern: &str, parent_task: Option<&Task>) ->
             if let Some(colon_idx) = stripped.find(':') {
                 let parent_path = &stripped[..colon_idx];
                 if let Some(relative_path) = pattern.strip_prefix("./") {
-                    let separator = if parent_path.is_empty() { "" } else { "/" };
+                    let separator = if parent_path.is_empty() || relative_path.starts_with(':') {
+                        ""
+                    } else {
+                        "/"
+                    };
                     return format!("//{parent_path}{separator}{relative_path}");
                 }
                 let path = format!("//{parent_path}");
@@ -4030,6 +4034,10 @@ echo "hello world"
             resolve_task_pattern("./child:build", Some(&parent_task)),
             "//projects/frontend/child:build"
         );
+        assert_eq!(
+            resolve_task_pattern("./:build", Some(&parent_task)),
+            "//projects/frontend:build"
+        );
 
         // Root tasks resolve ./ directly beneath the monorepo root.
         let root_task = Task {
@@ -4039,6 +4047,10 @@ echo "hello world"
         assert_eq!(
             resolve_task_pattern("./...:test:*", Some(&root_task)),
             "//...:test:*"
+        );
+        assert_eq!(
+            resolve_task_pattern("./:build", Some(&root_task)),
+            "//:build"
         );
 
         // Explicit relative paths need a monorepo parent.


### PR DESCRIPTION
## Summary

- support `./`-prefixed monorepo dependency paths relative to the declaring task
- make trailing `...` path patterns include the base project as well as descendants
- document the syntax and cover root, nested, and sibling-scoping behavior

## Motivation

Discussion https://github.com/jdx/mise/discussions/11496 describes repeated aggregate task declarations that currently require hard-coded absolute monorepo paths.

Bare dependency patterns are treated as task names, so `./...:groups:tests:*` was previously appended after the parent's task separator instead of being resolved as a path. Additionally, `//path/...` matched descendants but omitted `//path` itself despite the documented behavior.

With this change, the same declaration works at every monorepo level:

```toml
[tasks.test]
depends = [{ task = "./...:groups:tests:*", optional = true }]
```

## Validation

- `cargo test test_resolve_task_pattern`
- `cargo test test_get_matching_trailing_ellipsis_includes_base_path`
- `mise run test:e2e test_task_monorepo_wildcard_with_deps`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes monorepo dependency resolution and wildcard matching used when scheduling tasks; scope is limited and covered by new tests, but incorrect resolution could affect aggregate task graphs across projects.
> 
> **Overview**
> Adds **`./`-prefixed task dependencies** so patterns like `./...:groups:tests:*` resolve from the declaring task’s monorepo path (e.g. `//apps/frontend:test` → `//apps/frontend/...:groups:tests:*`), enabling one reusable aggregate declaration at root, nested apps, and leaves without hard-coded absolute paths. **`./:build`** keeps the match in the same project instead of treating `./` as a task name.
> 
> Fixes **trailing `...` path matching** so patterns such as `//apps/web/...:test` include the base project (`//apps/web:test`) as well as descendants, aligning runtime behavior with documented ellipsis semantics.
> 
> Documentation and e2e/unit tests cover sibling exclusion, root vs nested scope, and wildcard dependency chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe38bc1a6ae4539619de90663ebdbb2f941851d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relative task dependency resolution so `./`-prefixed patterns are interpreted from the declaring project’s location.
  * Ensured `./...` wildcard dependencies expand only within the declaring project subtree (including descendants, excluding siblings).
* **New Features**
  * Added coverage for `./` patterns that reference tasks directly (for example `./:build`) to keep matches correctly scoped.
* **Documentation**
  * Documented monorepo `./` dependency behavior with clear TOML examples.
* **Tests**
  * Expanded end-to-end and unit tests to validate `./` wildcard and non-wildcard expansion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->