### PR TITLE
perf(ci): reduce redundant lint compilation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -32,3 +32,10 @@ self-hosted-runner:
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.
 config-variables: null
+
+paths:
+  .github/workflows/test.yml:
+    # actionlint 1.7.12 predates GitHub's native parallel step groups.
+    # Remove this once actionlint recognizes the `parallel` keyword.
+    ignore:
+      - 'step must run script with "run" section or run action with "uses" section'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,11 +219,6 @@ jobs:
             exit 1
           fi
       - run: rm -rf ~/.cargo/advisory-dbs && cargo deny check
-      # Keep MSRV artifacts from invalidating the stable artifacts reused by
-      # the render and Clippy steps.
-      - run: cargo msrv verify
-        env:
-          CARGO_TARGET_DIR: target/msrv
       - run: cargo machete --with-metadata
       - run: ./scripts/test-standalone.sh
       # The Clippy passes below compile the same Rust targets with stricter checks.
@@ -232,8 +227,29 @@ jobs:
       - run: mise run lint
         env:
           HK_SKIP_STEPS: cargo-check
-      - run: cargo clippy -- -D warnings
-      - run: cargo clippy --all-features --all-targets -- -D warnings
+      # MSRV uses a separate compiler and target directory, so it can run
+      # alongside the sequential stable Clippy checks without consuming
+      # another Namespace runner.
+      - name: Run MSRV and Clippy checks
+        run: |
+          set +e
+          CARGO_TARGET_DIR=target/msrv cargo msrv verify &
+          msrv_pid=$!
+
+          cargo clippy -- -D warnings
+          clippy_status=$?
+          if [ "$clippy_status" -eq 0 ]; then
+            cargo clippy --all-features --all-targets -- -D warnings
+            clippy_status=$?
+          fi
+
+          wait "$msrv_pid"
+          msrv_status=$?
+          if [ "$msrv_status" -ne 0 ]; then
+            echo "::error::MSRV verification failed"
+            exit "$msrv_status"
+          fi
+          exit "$clippy_status"
       - run: sccache --show-stats
         if: always()
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
             ~/.cache/sccache
-            target
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -190,7 +189,6 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
             ~/.cache/sccache
-            target
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -204,6 +202,10 @@ jobs:
             echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
           } >> "$GITHUB_ENV"
           sccache --zero-stats
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: mise-ubuntu-latest
+          path: target/debug
       - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
       - uses: ./.github/actions/mise-tools
       - run: mise x -- bun i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
             ~/.cache/sccache
+            target
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -189,6 +190,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
             ~/.cache/sccache
+            target
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with: { tool: sccache }
       - name: Configure sccache
@@ -202,10 +204,6 @@ jobs:
             echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
           } >> "$GITHUB_ENV"
           sccache --zero-stats
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: mise-ubuntu-latest
-          path: target/debug
       - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
       - uses: ./.github/actions/mise-tools
       - run: mise x -- bun i
@@ -219,10 +217,19 @@ jobs:
             exit 1
           fi
       - run: rm -rf ~/.cargo/advisory-dbs && cargo deny check
+      # Keep MSRV artifacts from invalidating the stable artifacts reused by
+      # the render and Clippy steps.
       - run: cargo msrv verify
+        env:
+          CARGO_TARGET_DIR: target/msrv
       - run: cargo machete --with-metadata
       - run: ./scripts/test-standalone.sh
+      # The Clippy passes below compile the same Rust targets with stricter checks.
+      # Keep cargo-check in the local lint task, but avoid compiling them a third
+      # time in CI.
       - run: mise run lint
+        env:
+          HK_SKIP_STEPS: cargo-check
       - run: cargo clippy -- -D warnings
       - run: cargo clippy --all-features --all-targets -- -D warnings
       - run: sccache --show-stats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
 
   nightly:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux-nightly
-    timeout-minutes: 10
+    timeout-minutes: 15
     # Track rolling nightly for early rustc regressions without blocking PRs on upstream compiler ICEs.
     continue-on-error: true
     steps:
@@ -160,11 +160,7 @@ jobs:
             echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
           } >> "$GITHUB_ENV"
           sccache --zero-stats
-      - run: |
-          cargo build --all-features
-          echo "$PWD/target/debug" >> "$GITHUB_PATH"
-      - uses: ./.github/actions/mise-tools
-      - run: mise run test
+      - run: cargo test --all-features
       - run: sccache --show-stats
         if: always()
 
@@ -174,20 +170,23 @@ jobs:
     needs: [build-ubuntu]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Install mold
-        run: sudo apt-get update && sudo apt-get install -y mold
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-        with:
-          tool: cargo-deny,cargo-msrv,cargo-machete
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
-            ~/.cache/sccache
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
-        with: { tool: sccache }
+      - parallel:
+          - name: Install mold
+            run: sudo apt-get update && sudo apt-get install -y mold
+          - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
+            with:
+              tool: cargo-deny,cargo-msrv,cargo-machete,sccache
+          - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+            with:
+              path: |
+                ~/.cargo/registry
+                ~/.cargo/git
+                ~/.cargo/.global-cache
+                ~/.cache/sccache
+          - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+            with:
+              name: mise-ubuntu-latest
+              path: target/debug
       - name: Configure sccache
         run: |
           export RUSTC_WRAPPER=sccache
@@ -199,10 +198,6 @@ jobs:
             echo "SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
           } >> "$GITHUB_ENV"
           sccache --zero-stats
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: mise-ubuntu-latest
-          path: target/debug
       - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
       - uses: ./.github/actions/mise-tools
       - run: mise x -- bun i
@@ -218,17 +213,16 @@ jobs:
             git diff HEAD
             exit 1
           fi
-      - run: rm -rf ~/.cargo/advisory-dbs && cargo deny check
-      - run: cargo machete --with-metadata
-      - run: ./scripts/test-standalone.sh
-      # The Clippy passes below compile the same Rust targets with stricter checks.
-      # Keep cargo-check in the local lint task, but avoid compiling them a third
-      # time in CI.
-      - run: mise run lint
-        env:
-          HK_SKIP_STEPS: cargo-check
-      # Keep these checks on one Namespace runner while overlapping their work.
+      # Keep these independent checks on one Namespace runner while overlapping
+      # their work. Clippy is stricter than HK's cargo-check, so CI can skip that
+      # redundant compilation while retaining it for local lint runs.
       - parallel:
+          - run: rm -rf ~/.cargo/advisory-dbs && cargo deny check
+          - run: cargo machete --with-metadata
+          - run: ./scripts/test-standalone.sh
+          - run: mise run lint
+            env:
+              HK_SKIP_STEPS: cargo-check
           # MSRV uses a separate target directory so its older compiler cannot
           # invalidate stable's build artifacts.
           - name: Verify MSRV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,9 +174,6 @@ jobs:
     needs: [build-ubuntu]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
       - name: Install mold
         run: sudo apt-get update && sudo apt-get install -y mold
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
@@ -209,7 +206,10 @@ jobs:
       - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
       - uses: ./.github/actions/mise-tools
       - run: mise x -- bun i
+      # build-ubuntu produced this commit's binary, downloaded above.
       - run: mise run render
+        env:
+          MISE_TASK_SKIP: build
       - name: assert render produces no diff
         run: |
           if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,29 +227,18 @@ jobs:
       - run: mise run lint
         env:
           HK_SKIP_STEPS: cargo-check
-      # MSRV uses a separate compiler and target directory, so it can run
-      # alongside the sequential stable Clippy checks without consuming
-      # another Namespace runner.
-      - name: Run MSRV and Clippy checks
-        run: |
-          set +e
-          CARGO_TARGET_DIR=target/msrv cargo msrv verify &
-          msrv_pid=$!
-
-          cargo clippy -- -D warnings
-          clippy_status=$?
-          if [ "$clippy_status" -eq 0 ]; then
-            cargo clippy --all-features --all-targets -- -D warnings
-            clippy_status=$?
-          fi
-
-          wait "$msrv_pid"
-          msrv_status=$?
-          if [ "$msrv_status" -ne 0 ]; then
-            echo "::error::MSRV verification failed"
-            exit "$msrv_status"
-          fi
-          exit "$clippy_status"
+      # Keep these checks on one Namespace runner while overlapping their work.
+      - parallel:
+          # MSRV uses a separate target directory so its older compiler cannot
+          # invalidate stable's build artifacts.
+          - name: Verify MSRV
+            run: cargo msrv verify
+            env:
+              CARGO_TARGET_DIR: target/msrv
+          - name: Run Clippy
+            run: |
+              cargo clippy -- -D warnings
+              cargo clippy --all-features --all-targets -- -D warnings
       - run: sccache --show-stats
         if: always()
 


### PR DESCRIPTION
## Summary
- reuse the `build-ubuntu` artifact for render and skip render's already-satisfied `build` dependency
- align lint's checkout with `build-ubuntu` so the artifact and source refer to the same merge commit
- use GitHub Actions native `parallel` step groups to overlap lint setup and independent post-render checks on one runner
- skip HK's redundant `cargo-check` in CI while retaining it for local lint runs
- keep the build artifact as the reliable cross-job binary handoff
- focus nightly on `cargo test --all-features` and allow 15 minutes for cold nightly compiler caches

## Why
The lint job compiled the project repeatedly. Render rebuilt the project despite downloading the `build-ubuntu` binary, HK's `cargo check --all-features` was immediately followed by stricter Clippy passes, and MSRV ran serially even though it uses a separate compiler and target directory from stable Clippy.

On the latest run before concurrency, render dropped to 13s, but lint still took 10m21s: MSRV was 3m17s and the two Clippy passes totaled 4m52s. Overlapping those independent compiler workloads should make the Rust-check phase approximately the duration of Clippy rather than MSRV plus Clippy, without using another Namespace runner slot.

Raw `target` persistence is intentionally avoided: Namespace cache volumes are best-effort across job invocations and cannot replace an artifact dependency.

Nightly previously rebuilt the project, installed the full mise toolset, and ran the complete unit and e2e task under a 10-minute limit. It now runs the nightly compiler compatibility signal directly; stable CI retains the full e2e coverage.

## Validation
- `mise run lint-fix`
- `actionlint .github/workflows/test.yml`
- `mise x prettier -- prettier --check .github/workflows/test.yml`
- `git diff --check`
- verified `MISE_TASK_SKIP=build mise run --dry-run render` skips `build` and schedules no `cargo build`
- verified HK marks `cargo-check` skipped when `HK_SKIP_STEPS=cargo-check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflows and actionlint config; no application runtime behavior, with intentional tradeoffs (skipped HK cargo-check in CI) documented and offset by Clippy.
> 
> **Overview**
> **CI lint** is restructured to cut duplicate Rust work and overlap independent checks on one runner.
> 
> The **lint** job now uses GitHub Actions **`parallel`** step groups: setup steps (mold, tool install, cache restore, **`build-ubuntu`** artifact download) run together; later, **cargo deny**, **machete**, standalone tests, **`mise run lint`**, **MSRV**, and **Clippy** run in parallel. **`mise run render`** sets **`MISE_TASK_SKIP=build`** so render reuses the downloaded binary instead of rebuilding. **`mise run lint`** sets **`HK_SKIP_STEPS=cargo-check`** in CI only (Clippy still runs). **MSRV** uses **`CARGO_TARGET_DIR=target/msrv`** so it does not stomp stable artifacts. Lint **checkout** no longer pins PR head repo/ref, matching the artifact’s commit context.
> 
> **Nightly** drops the full **`cargo build`** + **`mise run test`** path in favor of **`cargo test --all-features`** only, with timeout raised **10 → 15** minutes.
> 
> **actionlint** ignores a false positive on **`parallel`** steps in **`test.yml`** until actionlint supports the keyword.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ea2edc5aa89edb53e911bf73835142ee6fa2ba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI lint workflow behavior by relying on the workflow’s default checkout context in the lint job.
  * Updated the render stage to skip rebuilding and instead use the already downloaded build artifact for subsequent steps.
  * Refined the MSRV and stable lint flow so MSRV verification runs separately with a dedicated output directory, while stable Clippy runs alongside it, ensuring failures are correctly reported. 
  * Suppressed a known non-action-related warning in action linting configuration for the test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

