### PR TITLE
registry: add witr

### DIFF
--- a/registry/witr.toml
+++ b/registry/witr.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:pranshuparmar/witr"]
+description = "Why is this running? Trace any process, port, container, or file back to what started it - CLI + TUI."
+test = { cmd = "witr --version", expected = "witr v{{version}}" }


### PR DESCRIPTION
# registry: add witr

Adds [`witr`](https://github.com/pranshuparmar/witr) to the mise registry as a shorthand for `aqua:pranshuparmar/witr`.

[witr](https://github.com/pranshuparmar/witr) (Why is this running?) traces any process, port, container, or file back to what started it via a CLI + TUI.

## Entry

```toml
# registry/witr.toml
backends = ["aqua:pranshuparmar/witr"]
description = "Why is this running? Trace any process, port, container, or file back to what started it - CLI + TUI."
test = { cmd = "witr --version", expected = "witr v{{version}}" }
```

## Popularity

- **GitHub:** [pranshuparmar/witr](https://github.com/pranshuparmar/witr) — 18,355 stars, 578 forks, last release `v0.3.3` (2026-06-24)
- **Aqua registry:** entry present at [`aqua-registry/pkgs/pranshuparmar/witr/registry.yaml`](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/pranshuparmar/witr/registry.yaml)
- **License:** Apache-2.0
- **Version listing verified:** `mise ls-remote aqua:pranshuparmar/witr` returns 21 versions (0.1.0 → 0.3.3)
- **Test verified locally:** `witr --version` outputs `witr v0.3.3 (commit ..., built ...)`, which contains the templated substring `witr v{{version}}`

## Notes

- Single backend (`aqua:`) — witr is in the aqua registry, so the preferred tier-1 backend is used.
- Includes a `test` field as required by `.github/workflows/registry.yml` for new tools.

*AI-assisted — Tool: pi; model: MiniMax/MiniMax-M3; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a registry configuration for the `witr` backend.
  * Added a version verification test to confirm the command reports its version correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->