### PR TITLE
fix(gitlab): send auth headers on paginated release/tag requests

### DIFF
--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -200,6 +200,27 @@ impl fmt::Display for TokenSource {
     }
 }
 
+#[cfg(test)]
+pub(crate) mod test_support {
+    //! Test-only hook that lets tests seed a token without mutating the environment.
+    //! Only consulted from [`super::resolve_token`] under `#[cfg(test)]`; production builds
+    //! never see it. Deliberately checked *before* the env-var branch so a developer's
+    //! ambient `FORGEJO_TOKEN` / `MISE_FORGEJO_ENTERPRISE_TOKEN` cannot change the outcome.
+    //! Mirrors the equivalent in [`crate::github`].
+
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+
+    /// Overrides the `forgejo_tokens.toml` source in [`super::resolve_token`], keyed by host.
+    pub(crate) static TOKENS_FILE_OVERRIDE: RwLock<Option<HashMap<String, String>>> =
+        RwLock::new(None);
+
+    pub(crate) fn lookup_tokens_file_override(host: &str) -> Option<String> {
+        let guard = TOKENS_FILE_OVERRIDE.read().ok()?;
+        guard.as_ref()?.get(host).cloned()
+    }
+}
+
 /// Resolve the Forgejo token for the given hostname.
 ///
 /// Priority:
@@ -210,6 +231,11 @@ impl fmt::Display for TokenSource {
 /// 5. fj CLI token (from `keys.json`)
 /// 6. `git credential fill` (if enabled)
 pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
+    #[cfg(test)]
+    if let Some(token) = test_support::lookup_tokens_file_override(host) {
+        return Some((token, TokenSource::TokensFile));
+    }
+
     let settings = Settings::get();
     let is_codeberg = host == "codeberg.org";
 
@@ -541,5 +567,71 @@ something_else = "value"
         p3.assert_async().await;
         p4.assert_async().await;
         assert_eq!(releases.len(), 3);
+    }
+
+    const TEST_TOKEN: &str = "forgejo_paginate_test";
+
+    /// Seeds a token for `host` for the lifetime of the guard.
+    struct TokensFileOverrideGuard;
+
+    impl TokensFileOverrideGuard {
+        fn set(host: &str) -> Self {
+            let mut tokens = std::collections::HashMap::new();
+            tokens.insert(host.to_string(), TEST_TOKEN.to_string());
+            *test_support::TOKENS_FILE_OVERRIDE.write().unwrap() = Some(tokens);
+            Self
+        }
+    }
+
+    impl Drop for TokensFileOverrideGuard {
+        fn drop(&mut self) {
+            *test_support::TOKENS_FILE_OVERRIDE.write().unwrap() = None;
+        }
+    }
+
+    // Regression: every paginated request must carry the Authorization header. This loop is
+    // already correct; the test exists because nothing pinned it -- gitlab had the same loop
+    // without the auth re-derivation and nobody noticed for a year.
+    #[tokio::test]
+    async fn test_list_releases_sends_auth_on_every_page() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let repo = "owner/auth-on-every-page";
+        let host = url::Url::parse(&base)
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let _token = TokensFileOverrideGuard::set(&host);
+        let auth = format!("Bearer {TEST_TOKEN}");
+
+        let page1 = server
+            .mock("GET", format!("/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "100".into()))
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/page2>; rel=\"next\"").as_str())
+            .with_body(
+                serde_json::to_string(&vec![release("v2.0.0-alpha.1", false, true)]).unwrap(),
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/page2")
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&vec![release("v1.0.0", false, false)]).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, repo).await.unwrap();
+        page1.assert_async().await;
+        page2.assert_async().await;
+        assert_eq!(releases.len(), 2);
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -197,7 +197,7 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GithubRelease>>
         {
             break;
         }
-        url = resolve_pagination_url(&url, &next)?;
+        url = crate::http::resolve_pagination_url(&url, &next)?;
         headers = get_headers(&url)?;
         let (more, h) = crate::http::HTTP_FETCH
             .json_headers_with_headers::<Vec<GithubRelease>, _>(&url, &headers)
@@ -216,7 +216,9 @@ pub async fn list_tags(repo: &str) -> Result<Vec<String>> {
     let cache = get_tags_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_tags_(API_URL, repo).await)
+        .get_or_try_init_async(async || {
+            list_tags_(API_URL, repo, *env::MISE_LIST_ALL_VERSIONS).await
+        })
         .await?
         .to_vec())
 }
@@ -226,21 +228,26 @@ pub async fn list_tags_from_url(api_url: &str, repo: &str) -> Result<Vec<String>
     let cache = get_tags_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_tags_(api_url, repo).await)
+        .get_or_try_init_async(async || {
+            list_tags_(api_url, repo, *env::MISE_LIST_ALL_VERSIONS).await
+        })
         .await?
         .to_vec())
 }
 
-async fn list_tags_(api_url: &str, repo: &str) -> Result<Vec<String>> {
+/// `list_all` is `MISE_LIST_ALL_VERSIONS`, taken as an argument rather than read here so
+/// tests can exercise the pagination loop: the env var is a process-wide `Lazy` that other
+/// modules' tests have already forced by the time this one runs.
+async fn list_tags_(api_url: &str, repo: &str, list_all: bool) -> Result<Vec<String>> {
     let mut url = format!("{api_url}/repos/{repo}/tags?per_page=100");
     let headers = get_headers(&url)?;
     let (mut tags, mut headers) = crate::http::HTTP_FETCH
         .json_headers_with_headers::<Vec<GithubTag>, _>(&url, &headers)
         .await?;
 
-    if *env::MISE_LIST_ALL_VERSIONS {
+    if list_all {
         while let Some(next) = next_page(&headers) {
-            url = resolve_pagination_url(&url, &next)?;
+            url = crate::http::resolve_pagination_url(&url, &next)?;
             headers = get_headers(&url)?;
             let (more, h) = crate::http::HTTP_FETCH
                 .json_headers_with_headers::<Vec<GithubTag>, _>(&url, &headers)
@@ -268,7 +275,7 @@ async fn list_tags_with_dates_(api_url: &str, repo: &str) -> Result<Vec<GithubTa
 
     // Fetch all pages when MISE_LIST_ALL_VERSIONS is set
     while let Some(next) = next_page(&response_headers) {
-        url = resolve_pagination_url(&url, &next)?;
+        url = crate::http::resolve_pagination_url(&url, &next)?;
         response_headers = get_headers(&url)?;
         let (more, h) = crate::http::HTTP_FETCH
             .json_headers_with_headers::<Vec<GithubTag>, _>(&url, &response_headers)
@@ -470,20 +477,6 @@ fn next_page(headers: &HeaderMap) -> Option<String> {
     regex!(r#"<([^>]+)>; rel="next""#)
         .captures(&link)
         .map(|c| c.get(1).unwrap().as_str().to_string())
-}
-
-fn resolve_pagination_url(current: &str, next: &str) -> Result<String> {
-    if next.starts_with("http://") || next.starts_with("https://") {
-        return Ok(next.to_string());
-    }
-    let base = url::Url::parse(current)
-        .wrap_err_with(|| format!("invalid pagination base URL: {current}"))?;
-    if next.starts_with('/') {
-        return Ok(format!("{}{next}", base.origin().ascii_serialization()));
-    }
-    base.join(next)
-        .map(|u| u.to_string())
-        .wrap_err_with(|| format!("invalid pagination URL: {next}"))
 }
 
 fn cache_dir() -> PathBuf {
@@ -1195,23 +1188,6 @@ something_else = "value"
         );
     }
 
-    #[test]
-    fn test_resolve_pagination_url() {
-        let base = "https://api.github.com/repos/jdx/aube/releases?per_page=100";
-        assert_eq!(
-            resolve_pagination_url(base, "/repos/jdx/aube/releases?page=2").unwrap(),
-            "https://api.github.com/repos/jdx/aube/releases?page=2"
-        );
-        assert_eq!(
-            resolve_pagination_url(
-                base,
-                "https://api.github.com/repos/jdx/aube/releases?page=2"
-            )
-            .unwrap(),
-            "https://api.github.com/repos/jdx/aube/releases?page=2"
-        );
-    }
-
     fn make_release(tag: &str) -> GithubRelease {
         GithubRelease {
             tag_name: tag.to_string(),
@@ -1534,5 +1510,165 @@ something_else = "value"
         p3.assert_async().await;
         p4.assert_async().await;
         assert_eq!(releases.len(), 3);
+    }
+
+    const PAGINATE_TEST_TOKEN: &str = "ghp_paginate_test";
+
+    /// A GHES-shaped base URL: `get_headers` only attaches auth to REST API URLs, and for a
+    /// host that is not api.github.com that means the path must sit under [`API_PATH`].
+    fn ghes_api_url(base: &str) -> String {
+        format!("{base}{API_PATH}")
+    }
+
+    fn tag_without_commit(name: &str) -> GithubTag {
+        GithubTag {
+            name: name.to_string(),
+            commit: None,
+        }
+    }
+
+    // Regression for #6318: every paginated request must carry the Authorization header.
+    // Before that fix page 2 was sent page 1's *response* headers and went out
+    // unauthenticated; nothing pinned the fix until now.
+    #[tokio::test]
+    async fn test_list_releases_sends_auth_on_every_page() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let api = ghes_api_url(&base);
+        let repo = "owner/auth-on-every-page";
+        let host = url::Url::parse(&base)
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let _token = TokensFileOverrideGuard::set(&host, PAGINATE_TEST_TOKEN);
+        let auth = format!("Bearer {PAGINATE_TEST_TOKEN}");
+
+        let page1 = server
+            .mock("GET", format!("{API_PATH}/repos/{repo}/releases").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{api}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::to_string(&vec![make_prerelease("v2.0.0-alpha.1")]).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", format!("{API_PATH}/page2").as_str())
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&vec![make_release("v1.0.0")]).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&api, repo).await.unwrap();
+        page1.assert_async().await;
+        page2.assert_async().await;
+        assert_eq!(releases.len(), 2);
+    }
+
+    // Same regression for the tags loop -- see the release test above.
+    #[tokio::test]
+    async fn test_list_tags_sends_auth_on_every_page() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let api = ghes_api_url(&base);
+        let repo = "owner/auth-on-every-page";
+        let host = url::Url::parse(&base)
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let _token = TokensFileOverrideGuard::set(&host, PAGINATE_TEST_TOKEN);
+        let auth = format!("Bearer {PAGINATE_TEST_TOKEN}");
+
+        let page1 = server
+            .mock("GET", format!("{API_PATH}/repos/{repo}/tags").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{api}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::to_string(&vec![tag_without_commit("v2.0.0")]).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", format!("{API_PATH}/page2").as_str())
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&vec![tag_without_commit("v1.0.0")]).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let tags = list_tags_(&api, repo, true).await.unwrap();
+        page1.assert_async().await;
+        page2.assert_async().await;
+        assert_eq!(tags, ["v2.0.0", "v1.0.0"]);
+    }
+
+    // `list_tags_with_dates_` paginates unconditionally, so it needs the same guarantee.
+    // Tags carry no `commit`, which keeps this to the two paginated requests.
+    #[tokio::test]
+    async fn test_list_tags_with_dates_sends_auth_on_every_page() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let api = ghes_api_url(&base);
+        let repo = "owner/auth-on-every-page-dates";
+        let host = url::Url::parse(&base)
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        let _token = TokensFileOverrideGuard::set(&host, PAGINATE_TEST_TOKEN);
+        let auth = format!("Bearer {PAGINATE_TEST_TOKEN}");
+
+        let page1 = server
+            .mock("GET", format!("{API_PATH}/repos/{repo}/tags").as_str())
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{api}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::to_string(&vec![tag_without_commit("v2.0.0")]).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", format!("{API_PATH}/page2").as_str())
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&vec![tag_without_commit("v1.0.0")]).unwrap())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let tags = list_tags_with_dates_(&api, repo).await.unwrap();
+        page1.assert_async().await;
+        page2.assert_async().await;
+        assert_eq!(
+            tags.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            ["v2.0.0", "v1.0.0"]
+        );
+        assert!(tags.iter().all(|t| t.date.is_none()));
     }
 }

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -108,7 +108,9 @@ pub async fn list_releases(repo: &str) -> Result<Vec<GitlabRelease>> {
     let cache = get_releases_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_releases_(API_URL, repo).await)
+        .get_or_try_init_async(async || {
+            list_releases_(API_URL, repo, *env::MISE_LIST_ALL_VERSIONS).await
+        })
         .await?
         .to_vec())
 }
@@ -118,13 +120,18 @@ pub async fn list_releases_from_url(api_url: &str, repo: &str) -> Result<Vec<Git
     let cache = get_releases_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_releases_(api_url, repo).await)
+        .get_or_try_init_async(async || {
+            list_releases_(api_url, repo, *env::MISE_LIST_ALL_VERSIONS).await
+        })
         .await?
         .to_vec())
 }
 
-async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GitlabRelease>> {
-    let url = format!(
+/// `list_all` is `MISE_LIST_ALL_VERSIONS`, taken as an argument rather than read here so
+/// tests can exercise the pagination loop: the env var is a process-wide `Lazy` that other
+/// modules' tests have already forced by the time this one runs.
+async fn list_releases_(api_url: &str, repo: &str, list_all: bool) -> Result<Vec<GitlabRelease>> {
+    let mut url = format!(
         "{}/projects/{}/releases?per_page=100",
         api_url,
         urlencoding::encode(repo)
@@ -132,13 +139,19 @@ async fn list_releases_(api_url: &str, repo: &str) -> Result<Vec<GitlabRelease>>
 
     let headers = get_headers(&url);
     let (mut releases, mut headers) = crate::http::HTTP_FETCH
-        .json_headers_with_headers::<Vec<GitlabRelease>, _>(url, &headers)
+        .json_headers_with_headers::<Vec<GitlabRelease>, _>(&url, &headers)
         .await?;
 
-    if *env::MISE_LIST_ALL_VERSIONS {
+    if list_all {
         while let Some(next) = next_page(&headers) {
+            url = crate::http::resolve_pagination_url(&url, &next)?;
+            // Re-derive auth for every page. `headers` holds the *response* headers of the
+            // previous page at this point (that is how `next_page` reads `Link`), and
+            // `json_headers_with_headers` bypasses the automatic host auth, so reusing it
+            // would send page 2 onward unauthenticated. Same defect github had (#6318).
+            headers = get_headers(&url);
             let (more, h) = crate::http::HTTP_FETCH
-                .json_headers_with_headers::<Vec<GitlabRelease>, _>(next, &headers)
+                .json_headers_with_headers::<Vec<GitlabRelease>, _>(&url, &headers)
                 .await?;
             releases.extend(more);
             headers = h;
@@ -154,7 +167,9 @@ pub async fn list_tags(repo: &str) -> Result<Vec<String>> {
     let cache = get_tags_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_tags_(API_URL, repo).await)
+        .get_or_try_init_async(async || {
+            list_tags_(API_URL, repo, *env::MISE_LIST_ALL_VERSIONS).await
+        })
         .await?
         .to_vec())
 }
@@ -164,26 +179,32 @@ pub async fn list_tags_from_url(api_url: &str, repo: &str) -> Result<Vec<String>
     let cache = get_tags_cache(&key).await;
     let cache = cache.get(&key).unwrap();
     Ok(cache
-        .get_or_try_init_async(async || list_tags_(api_url, repo).await)
+        .get_or_try_init_async(async || {
+            list_tags_(api_url, repo, *env::MISE_LIST_ALL_VERSIONS).await
+        })
         .await?
         .to_vec())
 }
 
-async fn list_tags_(api_url: &str, repo: &str) -> Result<Vec<String>> {
-    let url = format!(
+/// See [`list_releases_`] for why `list_all` is a parameter.
+async fn list_tags_(api_url: &str, repo: &str, list_all: bool) -> Result<Vec<String>> {
+    let mut url = format!(
         "{}/projects/{}/repository/tags?per_page=100",
         api_url,
         urlencoding::encode(repo)
     );
     let headers = get_headers(&url);
     let (mut tags, mut headers) = crate::http::HTTP_FETCH
-        .json_headers_with_headers::<Vec<GitlabTag>, _>(url, &headers)
+        .json_headers_with_headers::<Vec<GitlabTag>, _>(&url, &headers)
         .await?;
 
-    if *env::MISE_LIST_ALL_VERSIONS {
+    if list_all {
         while let Some(next) = next_page(&headers) {
+            url = crate::http::resolve_pagination_url(&url, &next)?;
+            // Re-derive auth for every page — see the comment in `list_releases_`.
+            headers = get_headers(&url);
             let (more, h) = crate::http::HTTP_FETCH
-                .json_headers_with_headers::<Vec<GitlabTag>, _>(next, &headers)
+                .json_headers_with_headers::<Vec<GitlabTag>, _>(&url, &headers)
                 .await?;
             tags.extend(more);
             headers = h;
@@ -282,6 +303,27 @@ impl fmt::Display for TokenSource {
     }
 }
 
+#[cfg(test)]
+pub(crate) mod test_support {
+    //! Test-only hook that lets tests seed a token without mutating the environment.
+    //! Only consulted from [`super::resolve_token`] under `#[cfg(test)]`; production builds
+    //! never see it. Deliberately checked *before* the env-var branch so a developer's
+    //! ambient `GITLAB_TOKEN` / `MISE_GITLAB_ENTERPRISE_TOKEN` cannot change the outcome.
+    //! Mirrors the equivalent in [`crate::github`].
+
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+
+    /// Overrides the `gitlab_tokens.toml` source in [`super::resolve_token`], keyed by host.
+    pub(crate) static TOKENS_FILE_OVERRIDE: RwLock<Option<HashMap<String, String>>> =
+        RwLock::new(None);
+
+    pub(crate) fn lookup_tokens_file_override(host: &str) -> Option<String> {
+        let guard = TOKENS_FILE_OVERRIDE.read().ok()?;
+        guard.as_ref()?.get(host).cloned()
+    }
+}
+
 /// Resolve the GitLab token for the given hostname.
 ///
 /// Priority:
@@ -292,6 +334,11 @@ impl fmt::Display for TokenSource {
 /// 5. glab CLI token (from `config.yml`)
 /// 6. `git credential fill` (if enabled)
 pub fn resolve_token(host: &str) -> Option<(String, TokenSource)> {
+    #[cfg(test)]
+    if let Some(token) = test_support::lookup_tokens_file_override(host) {
+        return Some((token, TokenSource::TokensFile));
+    }
+
     let settings = Settings::get();
     let is_gitlab_com = host == "gitlab.com";
 
@@ -586,5 +633,142 @@ hosts:
     fn test_find_expired_glab_tokens_empty() {
         assert!(find_expired_glab_tokens("").is_empty());
         assert!(find_expired_glab_tokens("hosts: {}").is_empty());
+    }
+
+    const TEST_TOKEN: &str = "glpat_paginate_test";
+
+    /// Seeds a token for `host` for the lifetime of the guard.
+    struct TokensFileOverrideGuard;
+
+    impl TokensFileOverrideGuard {
+        fn set(host: &str) -> Self {
+            let mut tokens = HashMap::new();
+            tokens.insert(host.to_string(), TEST_TOKEN.to_string());
+            *test_support::TOKENS_FILE_OVERRIDE.write().unwrap() = Some(tokens);
+            Self
+        }
+    }
+
+    impl Drop for TokensFileOverrideGuard {
+        fn drop(&mut self) {
+            *test_support::TOKENS_FILE_OVERRIDE.write().unwrap() = None;
+        }
+    }
+
+    fn host_of(url: &str) -> String {
+        url::Url::parse(url)
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn tag_json(name: &str) -> serde_json::Value {
+        serde_json::json!({ "name": name })
+    }
+
+    fn release_json(tag: &str) -> serde_json::Value {
+        serde_json::json!({
+            "tag_name": tag,
+            "description": null,
+            "released_at": null,
+            "assets": { "sources": [], "links": [] },
+        })
+    }
+
+    // Regression: every paginated request must carry the Authorization header. Before the
+    // fix, page 2 was sent page 1's *response* headers, so it went out unauthenticated and
+    // hit the anonymous rate limit on private/rate-limited projects. github had the same
+    // defect until #6318; gitlab never got that fix.
+    #[tokio::test]
+    async fn test_list_releases_sends_auth_on_every_page() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let _token = TokensFileOverrideGuard::set(&host_of(&base));
+        let auth = format!("Bearer {TEST_TOKEN}");
+
+        // Regex rather than an exact path: the project is percent-encoded into the path
+        // (`owner%2Frepo`) and how that is normalized before matching is not this test's
+        // subject -- the Authorization header on page 2 is.
+        let page1 = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/projects/.+/releases$".to_string()),
+            )
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::json!([release_json("v2.0.0")]).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/page2")
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!([release_json("v1.0.0")]).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let releases = list_releases_(&base, "owner/repo", true).await.unwrap();
+        page1.assert_async().await;
+        page2.assert_async().await;
+        assert_eq!(
+            releases
+                .iter()
+                .map(|r| r.tag_name.as_str())
+                .collect::<Vec<_>>(),
+            ["v2.0.0", "v1.0.0"]
+        );
+    }
+
+    // Same regression for the tags loop -- see `test_list_releases_sends_auth_on_every_page`.
+    #[tokio::test]
+    async fn test_list_tags_sends_auth_on_every_page() {
+        let _config = crate::config::Config::get().await.unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let _token = TokensFileOverrideGuard::set(&host_of(&base));
+        let auth = format!("Bearer {TEST_TOKEN}");
+
+        let page1 = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/projects/.+/repository/tags$".to_string()),
+            )
+            .match_query(mockito::Matcher::UrlEncoded(
+                "per_page".into(),
+                "100".into(),
+            ))
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("link", format!("<{base}/page2>; rel=\"next\"").as_str())
+            .with_body(serde_json::json!([tag_json("v2.0.0")]).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/page2")
+            .match_header("authorization", auth.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!([tag_json("v1.0.0")]).to_string())
+            .expect(1)
+            .create_async()
+            .await;
+
+        let tags = list_tags_(&base, "owner/repo", true).await.unwrap();
+        page1.assert_async().await;
+        page2.assert_async().await;
+        assert_eq!(tags, ["v2.0.0", "v1.0.0"]);
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use eyre::{Report, Result, bail, ensure, eyre};
+use eyre::{Report, Result, WrapErr, bail, ensure, eyre};
 use regex::Regex;
 use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
@@ -1113,6 +1113,26 @@ fn netrc_headers(url: &Url) -> HeaderMap {
     headers
 }
 
+/// Resolve the `rel="next"` target of a `Link` header against the URL it came from.
+///
+/// Forge APIs are inconsistent about this: an absolute URL is the common case, but a
+/// root-relative or relative target is legal and appears from instances behind a proxy.
+/// Shared by [`crate::github`] and [`crate::gitlab`] so their pagination loops resolve
+/// the next page the same way — the two drifted apart once already (#6318).
+pub(crate) fn resolve_pagination_url(current: &str, next: &str) -> Result<String> {
+    if next.starts_with("http://") || next.starts_with("https://") {
+        return Ok(next.to_string());
+    }
+    let base = url::Url::parse(current)
+        .wrap_err_with(|| format!("invalid pagination base URL: {current}"))?;
+    if next.starts_with('/') {
+        return Ok(format!("{}{next}", base.origin().ascii_serialization()));
+    }
+    base.join(next)
+        .map(|u| u.to_string())
+        .wrap_err_with(|| format!("invalid pagination URL: {next}"))
+}
+
 /// Apply URL replacements based on settings configuration
 /// Supports both simple string replacement and regex patterns (prefixed with "regex:")
 pub fn apply_url_replacements(url: &mut Url) {
@@ -1377,6 +1397,23 @@ mod tests {
         crate::config::Settings::reset(None);
 
         result
+    }
+
+    #[test]
+    fn test_resolve_pagination_url() {
+        let base = "https://api.github.com/repos/jdx/aube/releases?per_page=100";
+        assert_eq!(
+            resolve_pagination_url(base, "/repos/jdx/aube/releases?page=2").unwrap(),
+            "https://api.github.com/repos/jdx/aube/releases?page=2"
+        );
+        assert_eq!(
+            resolve_pagination_url(
+                base,
+                "https://api.github.com/repos/jdx/aube/releases?page=2"
+            )
+            .unwrap(),
+            "https://api.github.com/repos/jdx/aube/releases?page=2"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The bug

`gitlab::list_releases_` and `gitlab::list_tags_` pass the **previous response's** `HeaderMap` as the **request** headers for page 2 onward, so `Authorization: Bearer <token>` is dropped from every page after the first:

```rust
let headers = get_headers(&url);
let (mut releases, mut headers) = ...json_headers_with_headers(url, &headers).await?;  // headers is now the RESPONSE map

if *env::MISE_LIST_ALL_VERSIONS {
    while let Some(next) = next_page(&headers) {
        let (more, h) = ...json_headers_with_headers(next, &headers).await?;           // <- sent as REQUEST headers
```

GitHub had the byte-identical defect until #6318 ("correctly paginate releases/tags for private repos", v2025.9.13). `src/forgejo.rs` is correct. **GitLab never got the fix.**

The shape invites it. [`json_headers_with_headers`](https://github.com/jdx/mise/blob/main/src/http.rs) returns the *response* headers, and the caller has to keep them so `next_page` can read `Link` — so the request-headers binding gets shadowed. And that method reaches `get_async_with_headers`, which deliberately **bypasses** `host_auth_headers`, so nothing re-adds the token. Both loops now re-derive `get_headers()` per page.

**Impact**: only with `MISE_LIST_ALL_VERSIONS` set, and only visible on private or rate-limited projects — where it turns page 2 into an anonymous request. Note that switching these calls to the auto-auth path would *not* be a fix: `is_gitlab_host()` only matches hosts listed in `gitlab_tokens.toml` or glab's config, so a self-hosted instance authenticated via `MISE_GITLAB_ENTERPRISE_TOKEN` or `credential_command` would silently lose its token.

Found while going through [discussion #5418](https://github.com/jdx/mise/discussions/5418), where this exact behaviour was diagnosed on the GitHub side in June 2025.

## Also in this PR

- **`resolve_pagination_url` moves from `github.rs` to `http.rs`** (with its unit test) so both callers resolve a relative `rel="next"` target the same way. GitLab had no equivalent and used the raw `Link` value.
- **`MISE_LIST_ALL_VERSIONS` becomes an argument** for the three loops gated only on it (`gitlab::list_releases_`, `gitlab::list_tags_`, `github::list_tags_`); the caching wrappers read the static as before. It is a process-wide `Lazy<bool>`, already forced to `false` by other modules' tests by the time these run, so without this seam the loops are unreachable from a test. No behavioural change.
- **A `#[cfg(test)]` token-override hook in `gitlab.rs` and `forgejo.rs`**, mirroring the one already in `github.rs`, so tests can seed a token without mutating the environment (no `set_var`, and immune to an ambient `GITLAB_TOKEN`).

## Tests

Six regression tests, one per pagination loop across all three forges, each asserting `authorization` on the **page-2** request via `.match_header(...)`:

| module | loop |
|---|---|
| `gitlab.rs` | `list_releases_`, `list_tags_` — the bug |
| `github.rs` | `list_releases_`, `list_tags_`, `list_tags_with_dates_` — pins #6318 |
| `forgejo.rs` | `list_releases_` — previously unpinned |

Nothing in the repo asserted a *sent* request header before this (`match_header` had zero hits in `src/`), which is precisely why #6318 could be fixed on one forge and stay broken on another for a year — that PR shipped without a test.

The GitLab tests fail on the pre-fix code: page 2 arrives without the header, the mock does not match, and `list_releases_`/`list_tags_` return `Err`.

## Out of scope

- `next_page` is byte-identical in all three modules and the loops are near-identical. A shared `paginate()` helper owning the header re-derivation would make this class of bug structurally impossible — that is the real root cause of the drift, but it is a refactor rather than this fix.
- `github::list_tags_with_dates_` names its request-headers variable `response_headers` — correct, confusingly named.
- `forgejo` still uses the raw `Link` value; unchanged from today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination requests so authentication headers are consistently included on every page for Forgejo, GitHub, and GitLab.
  * Improved handling of relative pagination links across supported hosting services.
  * Added validation for absolute and root-relative pagination URLs.
* **Tests**
  * Expanded regression coverage for authenticated multi-page release and tag requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->