### PR TITLE
test(system): avoid flaky GNU mirror in brew source e2e

### DIFF
--- a/e2e/cli/test_system_install_brew_source_slow
+++ b/e2e/cli/test_system_install_brew_source_slow
@@ -14,6 +14,10 @@ esac
 export MISE_SYSTEM_BREW_PREFIX="$HOME/brew-source-prefix"
 # hello has bottles everywhere; force it down the source-build path
 export MISE_SYSTEM_BREW_FORCE_SOURCE=hello
+# GNU's load-balancing mirror intermittently returns 502s. Use the canonical
+# archive host so this test exercises mise's source builder instead of mirror
+# availability; the Homebrew-provided sha256 still verifies the download.
+export MISE_URL_REPLACEMENTS='{"https://ftpmirror.gnu.org/gnu":"https://ftp.gnu.org/gnu"}'
 
 cat <<EOF >mise.toml
 [bootstrap.packages]


### PR DESCRIPTION
## Summary
- redirect the GNU hello source download from the flaky load-balancing mirror to the canonical GNU archive host in the slow brew source-build e2e test
- retain Homebrew's SHA-256 verification for the downloaded archive

## Why
`ftpmirror.gnu.org` intermittently returns HTTP 502 responses, causing the test to fail before it exercises mise's source-build pipeline. The canonical `ftp.gnu.org` archive serves the same checksum-verified tarball more reliably.

## Validation
- `mise run test:e2e test_system_install_brew_source_slow`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only URL rewrite for e2e; no runtime behavior or security-sensitive code paths change.
> 
> **Overview**
> The slow **brew source-build** e2e (`test_system_install_brew_source_slow`) sets **`MISE_URL_REPLACEMENTS`** so GNU hello tarballs are fetched from **`https://ftp.gnu.org/gnu`** instead of **`https://ftpmirror.gnu.org/gnu`**, which intermittently returns HTTP 502 and fails the test before mise’s source-build path runs.
> 
> Inline comments document that Homebrew’s **SHA-256** check still applies to the downloaded archive. No production or installer logic changes—only test stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff36f21395ec462c35f584682ee3a8c145279a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the GNU Hello system installation test to use a consistent download source.
  * Preserved checksum verification while ensuring the source-build installation path is exercised reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->