### PR TITLE
fix(task): handle ctrl-c as task interruption

### DIFF
--- a/e2e/cli/test_exit_status
+++ b/e2e/cli/test_exit_status
@@ -12,6 +12,14 @@ assert_exit_code() {
   assert_not_contains_text "$output" "exit with status"
 }
 
+run_in_new_session() {
+  if command -v setsid >/dev/null 2>&1; then
+    exec setsid "$@"
+  fi
+  exec python3 -c \
+    'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' "$@"
+}
+
 # Clap help and errors should keep their conventional statuses without exposing
 # the internal exit request used to unwind the command.
 assert_exit_code 0 mise --help
@@ -31,8 +39,108 @@ touch "$READY_FILE"
 trap '' INT TERM
 while true; do sleep 1; done
 """
+
+[tasks.interrupt]
+run = """
+touch "$READY_FILE"
+sleep 30
+"""
+
+[tasks.handle-interrupt]
+run = """
+touch "$READY_FILE"
+trap 'exit 0' INT
+while true; do sleep 1; done
+"""
+
+[tasks.after-interrupt]
+depends = ["interrupt"]
+run = 'touch "$AFTER_FILE"'
+
+[tasks.after-handled-interrupt]
+depends = ["handle-interrupt"]
+run = 'touch "$AFTER_FILE"'
+
+[tasks.fail-before-interrupt]
+run = """
+touch "$FAILED_FILE"
+exit 23
+"""
+
+[tasks.wait-for-interrupt]
+run = """
+touch "$READY_FILE"
+sleep 30
+"""
 EOF
 assert_exit_code 23 mise run fail
+
+# A task stopped by the first Ctrl-C is a user interruption, not a task
+# failure. It should exit with the conventional status without printing an
+# error report or launching later work, even with --continue-on-error.
+ready_file="$TMPDIR/exit-status-interrupt-ready"
+after_file="$TMPDIR/exit-status-after-interrupt"
+output_file="$TMPDIR/exit-status-interrupt-output"
+READY_FILE="$ready_file" AFTER_FILE="$after_file" \
+  mise run --continue-on-error after-interrupt >"$output_file" 2>&1 &
+mise_pid=$!
+wait_for_file "$ready_file" "interruptible task child" 30 "$mise_pid"
+kill -INT "$mise_pid"
+
+status=0
+wait "$mise_pid" || status=$?
+output="$(cat "$output_file")"
+if [[ $status -ne 130 ]]; then
+  fail "mise run expected exit code 130 after Ctrl-C, got $status: $output"
+fi
+assert_not_contains_text "$output" "exited with non-zero status"
+assert_not_contains_text "$output" "task failed"
+assert_not_contains_text "$output" "task(s) failed"
+if [[ -e $after_file ]]; then
+  fail "dependent task ran after Ctrl-C with --continue-on-error"
+fi
+
+# Cancellation is authoritative even if the task handles SIGINT and exits
+# successfully. Dependents must remain stopped and mise must still return 130.
+ready_file="$TMPDIR/exit-status-handled-ready"
+after_file="$TMPDIR/exit-status-after-handled"
+output_file="$TMPDIR/exit-status-handled-output"
+READY_FILE="$ready_file" AFTER_FILE="$after_file" \
+  mise run --continue-on-error after-handled-interrupt >"$output_file" 2>&1 &
+mise_pid=$!
+wait_for_file "$ready_file" "SIGINT-handling task child" 30 "$mise_pid"
+kill -INT "$mise_pid"
+
+status=0
+wait "$mise_pid" || status=$?
+output="$(cat "$output_file")"
+if [[ $status -ne 130 ]]; then
+  fail "mise run expected exit code 130 after handled Ctrl-C, got $status: $output"
+fi
+if [[ -e $after_file ]]; then
+  fail "dependent task ran after handled Ctrl-C with --continue-on-error"
+fi
+
+# Ctrl-C takes precedence over a task failure that was already recorded while
+# another task was still running.
+ready_file="$TMPDIR/exit-status-after-failure-ready"
+failed_file="$TMPDIR/exit-status-prior-failure"
+output_file="$TMPDIR/exit-status-after-failure-output"
+READY_FILE="$ready_file" FAILED_FILE="$failed_file" \
+  mise run --continue-on-error --jobs 2 \
+  fail-before-interrupt ::: wait-for-interrupt >"$output_file" 2>&1 &
+mise_pid=$!
+wait_for_file "$ready_file" "task running after a sibling failure" 30 "$mise_pid"
+wait_for_file "$failed_file" "failed task marker" 30 "$mise_pid"
+kill -INT "$mise_pid"
+
+status=0
+wait "$mise_pid" || status=$?
+output="$(cat "$output_file")"
+if [[ $status -ne 130 ]]; then
+  fail "mise run expected Ctrl-C to override a prior task failure, got $status: $output"
+fi
+assert_not_contains_text "$output" "task(s) failed"
 
 # Task execution handles the first Ctrl-C gracefully and force-exits on the
 # second. The forced path should still unwind command-scoped destructors.
@@ -40,7 +148,7 @@ ready_file="$TMPDIR/exit-status-child-ready"
 output_file="$TMPDIR/exit-status-child-output"
 # Isolate the process tree so the failure fallback can reap a child that
 # deliberately ignores INT and TERM.
-READY_FILE="$ready_file" setsid mise run wait >"$output_file" 2>&1 &
+READY_FILE="$ready_file" run_in_new_session mise run wait >"$output_file" 2>&1 &
 mise_pid=$!
 wait_for_file "$ready_file" "task child" 30 "$mise_pid"
 kill -INT "$mise_pid"

--- a/e2e/tasks/test_task_interrupt_cleanup
+++ b/e2e/tasks/test_task_interrupt_cleanup
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.interrupt]
+run = """
+touch "$READY_FILE"
+sleep 30
+"""
+depends_post = ["cleanup"]
+
+[tasks.cleanup]
+run = [{ task = "cleanup-child" }]
+
+[tasks.cleanup-child]
+run = 'touch "$CLEANUP_FILE"'
+EOF
+
+ready_file="$TMPDIR/task-interrupt-cleanup-ready"
+cleanup_file="$TMPDIR/task-interrupt-cleanup-ran"
+output_file="$TMPDIR/task-interrupt-cleanup-output"
+READY_FILE="$ready_file" CLEANUP_FILE="$cleanup_file" \
+  mise run interrupt >"$output_file" 2>&1 &
+mise_pid=$!
+wait_for_file "$ready_file" "interruptible task child" 30 "$mise_pid"
+kill -INT "$mise_pid"
+
+status=0
+wait "$mise_pid" || status=$?
+output="$(cat "$output_file")"
+if [[ $status -ne 130 ]]; then
+  fail "mise run expected exit code 130 after Ctrl-C, got $status: $output"
+fi
+if [[ ! -e $cleanup_file ]]; then
+  fail "post-dependency cleanup did not run after Ctrl-C: $output"
+fi

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -559,12 +559,20 @@ impl Run {
                 &mut main_done_rx,
                 main_deps.clone(),
                 || this.is_stopping(),
+                || this.is_interrupted(),
                 this.continue_on_error,
-                |task, deps_for_remove| {
+                |task, deps_for_remove, allow_during_interruption| {
                     let this = this.clone();
                     let spawn_context = spawn_context.clone();
                     async move {
-                        Self::spawn_sched_job(this, task, deps_for_remove, spawn_context).await
+                        Self::spawn_sched_job(
+                            this,
+                            task,
+                            deps_for_remove,
+                            allow_during_interruption,
+                            spawn_context,
+                        )
+                        .await
                     }
                 },
             )
@@ -578,6 +586,7 @@ impl Run {
             this.executor.as_ref().unwrap().failed_tasks.clone(),
             this.continue_on_error,
             this.timings(),
+            this.is_interrupted(),
         );
         results_display.display_results(num_tasks, timer)?;
         time!("parallelize_tasks done");
@@ -589,23 +598,23 @@ impl Run {
         this: Arc<Self>,
         task: Task,
         deps_for_remove: Arc<Mutex<Deps>>,
+        inherited_allow_during_interruption: bool,
         ctx: crate::task::task_scheduler::SpawnContext,
     ) -> Result<()> {
-        // If we're already stopping due to a previous failure and not in
-        // continue-on-error mode, do not launch this task unless it's a
-        // post-dependency (cleanup task that should run even on failure).
-        if this.is_stopping() && !this.continue_on_error {
-            let mut deps = deps_for_remove.lock().await;
-            if !deps.is_runnable_post_dep(&task) {
-                trace!(
-                    "aborting spawn before start (not continue-on-error): {} {}",
-                    task.name,
-                    task.args.join(" ")
-                );
-                deps.remove(&task);
-                return Ok(());
-            }
-            drop(deps);
+        if Self::should_abort_while_stopping(
+            &this,
+            &task,
+            &deps_for_remove,
+            inherited_allow_during_interruption,
+        )
+        .await
+        {
+            trace!(
+                "aborting spawn before start while stopping: {} {}",
+                task.name,
+                task.args.join(" ")
+            );
+            return Ok(());
         }
         let needs_permit = task_needs_permit(&task);
         let permit_opt = if needs_permit {
@@ -616,23 +625,23 @@ impl Run {
                 task.name,
                 wait_start.elapsed().as_millis()
             );
-            // If a failure occurred while we were waiting for a permit and we're not
-            // in continue-on-error mode, skip launching this task unless it's a
-            // post-dependency (cleanup task). This prevents subsequently queued
-            // tasks from running after failure, while still allowing cleanup.
-            if this.is_stopping() && !this.continue_on_error {
-                let mut deps = deps_for_remove.lock().await;
-                if !deps.is_runnable_post_dep(&task) {
-                    trace!(
-                        "aborting spawn after failure (not continue-on-error): {} {}",
-                        task.name,
-                        task.args.join(" ")
-                    );
-                    // Remove from deps so the scheduler can drain and not hang
-                    deps.remove(&task);
-                    return Ok(());
-                }
-                drop(deps);
+            // If a failure or interruption occurred while waiting for a permit,
+            // skip this task unless failures may continue or it is a
+            // post-dependency. Interruption always stops new normal tasks.
+            if Self::should_abort_while_stopping(
+                &this,
+                &task,
+                &deps_for_remove,
+                inherited_allow_during_interruption,
+            )
+            .await
+            {
+                trace!(
+                    "aborting spawn after wait while stopping: {} {}",
+                    task.name,
+                    task.args.join(" ")
+                );
+                return Ok(());
             }
             p
         } else {
@@ -644,6 +653,8 @@ impl Run {
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let in_flight_c = ctx.in_flight.clone();
         trace!("running task: {task}");
+        let allow_during_interruption = inherited_allow_during_interruption
+            || deps_for_remove.lock().await.is_runnable_post_dep(&task);
         // Mark task as executed synchronously before spawning so that the
         // scheduler's failure-cleanup path (which checks is_runnable_post_dep)
         // always sees the parent in `executed` — avoiding a race where a
@@ -664,6 +675,7 @@ impl Run {
                 dependency_state,
                 semaphore,
                 &mut permit,
+                allow_during_interruption,
             ))
             .catch_unwind()
             .await
@@ -686,13 +698,19 @@ impl Run {
                     deps.mark_cache_key(&task, cache_key.clone());
                 }
             }
+            let interrupted = result.as_ref().is_err_and(|err| {
+                !panicked && ctrlc::is_cancelled() && Error::is_task_interrupted(err)
+            });
             if let Err(err) = &result {
+                if interrupted {
+                    this.mark_interrupted();
+                }
                 let status = if panicked {
                     Some(1)
                 } else {
                     Error::get_exit_status(err)
                 };
-                if !this.is_stopping() && (panicked || status.is_none()) {
+                if !interrupted && !this.is_stopping() && (panicked || status.is_none()) {
                     let prefix = task.estyled_prefix();
                     if Settings::get().verbose {
                         this.eprint(&task, &prefix, &format!("{} {err:?}", style::ered("ERROR")));
@@ -705,13 +723,15 @@ impl Run {
                         }
                     };
                 }
-                this.add_failed_task(task.clone(), status);
+                if !interrupted {
+                    this.add_failed_task(task.clone(), status);
+                }
                 // SIGTERM any still-running siblings so we exit promptly on
                 // failure instead of waiting for them to finish naturally.
                 // run_loop only sees `is_stopping` when it next iterates,
                 // which doesn't happen while it's awaiting an idle select —
                 // so the kill has to be triggered from here.
-                if !this.continue_on_error {
+                if !interrupted && !this.continue_on_error {
                     debug!("task {} failed, killing siblings", task.name);
                     #[cfg(unix)]
                     crate::cmd::CmdLineRunner::kill_all(nix::sys::signal::SIGTERM);
@@ -724,13 +744,45 @@ impl Run {
             {
                 oh.keep_order_state.lock().unwrap().on_task_finished(&task);
             }
-            deps_for_remove.lock().await.remove(&task);
+            let mut deps = deps_for_remove.lock().await;
+            if result
+                .as_ref()
+                .is_err_and(Error::is_task_interrupted_before_start)
+            {
+                deps.unmark_executed(&task);
+            }
+            deps.remove(&task);
+            drop(deps);
             trace!("deps removed: {} {}", task.name, task.args.join(" "));
             in_flight_c.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
-            result.map(|_| ())
+            if interrupted {
+                Ok(())
+            } else {
+                result.map(|_| ())
+            }
         });
 
         Ok(())
+    }
+
+    async fn should_abort_while_stopping(
+        this: &Self,
+        task: &Task,
+        deps_for_remove: &Arc<Mutex<Deps>>,
+        inherited_allow_during_interruption: bool,
+    ) -> bool {
+        if !this.is_stopping()
+            || (this.continue_on_error && !this.is_interrupted())
+            || inherited_allow_during_interruption
+        {
+            return false;
+        }
+        let mut deps = deps_for_remove.lock().await;
+        if deps.is_runnable_post_dep(task) {
+            return false;
+        }
+        deps.remove(task);
+        true
     }
 
     // ============================================================================
@@ -875,10 +927,27 @@ impl Run {
     }
 
     fn is_stopping(&self) -> bool {
-        self.executor
-            .as_ref()
-            .map(|e| e.is_stopping())
-            .unwrap_or(false)
+        ctrlc::is_cancelled()
+            || self
+                .executor
+                .as_ref()
+                .map(|e| e.is_stopping())
+                .unwrap_or(false)
+    }
+
+    fn is_interrupted(&self) -> bool {
+        ctrlc::is_cancelled()
+            || self
+                .executor
+                .as_ref()
+                .map(|e| e.is_interrupted())
+                .unwrap_or(false)
+    }
+
+    fn mark_interrupted(&self) {
+        if let Some(executor) = &self.executor {
+            executor.mark_interrupted();
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -886,11 +955,12 @@ impl Run {
         &self,
         task: &Task,
         config: &Arc<Config>,
-        sched_tx: Arc<tokio::sync::mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
+        sched_tx: Arc<tokio::sync::mpsc::UnboundedSender<crate::task::task_scheduler::SchedMsg>>,
         completion_state: crate::task::TaskCompletionState,
         dependency_state: crate::task::TaskDependencyState,
         semaphore: Arc<tokio::sync::Semaphore>,
         permit: &mut Option<tokio::sync::OwnedSemaphorePermit>,
+        allow_during_interruption: bool,
     ) -> Result<crate::task::task_executor::TaskRunOutcome> {
         self.executor
             .as_ref()
@@ -903,6 +973,7 @@ impl Run {
                 dependency_state,
                 semaphore,
                 permit,
+                allow_during_interruption,
             )
             .await
     }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -797,13 +797,25 @@ impl<'a> CmdLineRunner<'a> {
         Ok(())
     }
 
-    pub async fn execute_async(mut self) -> Result<()> {
+    pub async fn execute_async(self) -> Result<()> {
+        self.execute_async_with_cancel_check(|| false).await
+    }
+
+    /// Execute a command while preventing cancellation from being lost between
+    /// the pre-spawn check and PID registration.
+    pub async fn execute_async_with_cancel_check(
+        mut self,
+        is_cancelled: impl Fn() -> bool + Send + Sync,
+    ) -> Result<()> {
+        if is_cancelled() {
+            return Err(crate::errors::Error::TaskInterrupted.into());
+        }
         let read_lock = RAW_LOCK.read().await;
         debug!("$ {self}");
         if Settings::get().raw || self.raw {
             drop(read_lock);
             let _write_lock = RAW_LOCK.write().await;
-            return self.execute_raw_async().await;
+            return self.execute_raw_async_with_cancel_check(is_cancelled).await;
         }
         #[cfg(unix)]
         if should_use_pgroup() {
@@ -827,6 +839,12 @@ impl<'a> CmdLineRunner<'a> {
             .wrap_err_with(|| format!("failed to execute command: {self}"))?;
         let id = cp.id().unwrap_or_default();
         RUNNING_PIDS.lock().unwrap().insert(id);
+        if is_cancelled() {
+            #[cfg(unix)]
+            signal_process_tree(id, nix::sys::signal::SIGINT);
+            #[cfg(windows)]
+            kill_process_tree(id);
+        }
         trace!("Started process: {id} for {}", self.get_program());
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         if let Some(stdout) = cp.stdout.take() {
@@ -1270,7 +1288,10 @@ impl<'a> CmdLineRunner<'a> {
         Ok(())
     }
 
-    async fn execute_raw_async(mut self) -> Result<()> {
+    async fn execute_raw_async_with_cancel_check(
+        mut self,
+        is_cancelled: impl Fn() -> bool + Send + Sync,
+    ) -> Result<()> {
         if self.stdin.is_none() {
             self.cmd.stdin(Stdio::inherit());
         }
@@ -1278,6 +1299,12 @@ impl<'a> CmdLineRunner<'a> {
         self.cmd.stderr(Stdio::inherit());
         let mut cp = self.spawn_async_with_etxtbsy_retry().await?;
         let id = cp.id().unwrap_or_default();
+        if is_cancelled() {
+            #[cfg(unix)]
+            signal_process_tree(id, nix::sys::signal::SIGINT);
+            #[cfg(windows)]
+            kill_process_tree(id);
+        }
         let timeout_guard = self.timeout.map(|t| TimeoutGuard::new(t, id));
         let status = cp.wait().await?;
         if let Some(g) = &timeout_guard {
@@ -1695,6 +1722,7 @@ where
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use pretty_assertions::assert_eq;
@@ -1735,6 +1763,46 @@ mod tests {
         assert_eq!(stderr.lock().unwrap().as_slice(), ["err"]);
         assert_eq!(observed_stdout.lock().unwrap().as_slice(), ["out"]);
         assert_eq!(observed_stderr.lock().unwrap().as_slice(), ["err"]);
+    }
+
+    #[tokio::test]
+    async fn test_execute_async_skips_pre_cancelled_command() {
+        let err = super::CmdLineRunner::new("sh")
+            .args(["-c", "exit 0"])
+            .execute_async_with_cancel_check(|| true)
+            .await
+            .unwrap_err();
+
+        assert!(crate::errors::Error::is_task_interrupted(&err));
+    }
+
+    #[tokio::test]
+    async fn test_execute_async_catches_cancellation_after_spawn() {
+        let checks = Arc::new(AtomicUsize::new(0));
+        let checks_c = checks.clone();
+        let err = super::CmdLineRunner::new("sh")
+            .args(["-c", "sleep 30"])
+            .execute_async_with_cancel_check(move || checks_c.fetch_add(1, Ordering::SeqCst) > 0)
+            .await
+            .unwrap_err();
+
+        assert!(crate::errors::Error::is_sigint(&err));
+        assert!(checks.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[tokio::test]
+    async fn test_execute_raw_async_catches_cancellation_after_spawn() {
+        let checks = Arc::new(AtomicUsize::new(0));
+        let checks_c = checks.clone();
+        let err = super::CmdLineRunner::new("sh")
+            .args(["-c", "sleep 30"])
+            .raw(true)
+            .execute_async_with_cancel_check(move || checks_c.fetch_add(1, Ordering::SeqCst) > 0)
+            .await
+            .unwrap_err();
+
+        assert!(crate::errors::Error::is_sigint(&err));
+        assert!(checks.load(Ordering::SeqCst) >= 2);
     }
 
     #[tokio::test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,8 @@ pub enum Error {
     VersionNotInstalled(Box<BackendArg>, String),
     #[error("{} exited with non-zero status: {}", .0, render_exit_status(.1))]
     ScriptFailed(String, Option<ExitStatus>),
+    #[error("task interrupted before process start")]
+    TaskInterrupted,
     #[error(
         "Config files in {} are not trusted.\nTrust them with `mise trust`. See https://mise.en.dev/cli/trust.html for more information.",
         display_path(.0)
@@ -115,6 +117,32 @@ impl Error {
         }
     }
 
+    #[cfg(unix)]
+    pub fn is_sigint(err: &Report) -> bool {
+        use std::os::unix::process::ExitStatusExt;
+
+        err.downcast_ref::<Error>().is_some_and(|err| {
+            matches!(
+                err,
+                Error::ScriptFailed(_, Some(status))
+                    if status.signal() == Some(nix::sys::signal::SIGINT as i32)
+            )
+        })
+    }
+
+    #[cfg(not(unix))]
+    pub fn is_sigint(_err: &Report) -> bool {
+        false
+    }
+
+    pub fn is_task_interrupted(err: &Report) -> bool {
+        Self::is_task_interrupted_before_start(err) || Self::is_sigint(err)
+    }
+
+    pub fn is_task_interrupted_before_start(err: &Report) -> bool {
+        matches!(err.downcast_ref::<Error>(), Some(Error::TaskInterrupted))
+    }
+
     pub fn is_argument_err(err: &Report) -> bool {
         err.downcast_ref::<Error>()
             .map(|e| {
@@ -127,5 +155,34 @@ impl Error {
                 )
             })
             .unwrap_or(false)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::process::ExitStatusExt;
+
+    #[test]
+    fn detects_sigint_script_failure() {
+        let status = ExitStatus::from_raw(nix::sys::signal::SIGINT as i32);
+        let err = Report::new(Error::ScriptFailed("sh".into(), Some(status)));
+
+        assert!(Error::is_sigint(&err));
+    }
+
+    #[test]
+    fn does_not_treat_exit_code_as_sigint() {
+        let status = ExitStatus::from_raw(2 << 8);
+        let err = Report::new(Error::ScriptFailed("sh".into(), Some(status)));
+
+        assert!(!Error::is_sigint(&err));
+    }
+
+    #[test]
+    fn detects_interruption_before_process_start() {
+        let err = Report::new(Error::TaskInterrupted);
+
+        assert!(Error::is_task_interrupted(&err));
     }
 }

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -344,6 +344,12 @@ impl Deps {
         self.executed.insert(task_key(task));
     }
 
+    /// Clear the execution marker when cancellation prevents a scheduled task
+    /// from reaching process startup.
+    pub fn unmark_executed(&mut self, task: &Task) {
+        self.executed.remove(&task_key(task));
+    }
+
     /// Mark a task as having executed or restored outputs.
     /// Used to invalidate dependent tasks' source freshness checks.
     pub fn mark_did_work(&mut self, task: &Task) {
@@ -587,6 +593,22 @@ mod tests {
             post_dep_parents,
             tx,
         }
+    }
+
+    #[test]
+    fn unmark_executed_disables_post_dependency_cleanup() {
+        let parent = task("parent");
+        let cleanup = task("cleanup");
+        let mut deps = deps_with_relationships(
+            HashMap::new(),
+            HashMap::from([(task_key(&cleanup), HashSet::from([task_key(&parent)]))]),
+        );
+
+        deps.mark_executed(&parent);
+        assert!(deps.is_runnable_post_dep(&cleanup));
+
+        deps.unmark_executed(&parent);
+        assert!(!deps.is_runnable_post_dep(&cleanup));
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -11,6 +11,7 @@ use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_list::split_task_spec;
 use crate::task::task_output::{TaskOutput, trunc};
 use crate::task::task_output_handler::OutputHandler;
+use crate::task::task_scheduler::SchedMsg;
 use crate::task::task_script_parser::subcommand_name_from_parse;
 use crate::task::task_source_checker::{
     remove_auto_output, save_checksum, sources_are_fresh, task_cwd,
@@ -31,6 +32,7 @@ use std::iter::once;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 use std::time::{Duration, SystemTime};
 use tokio::sync::Mutex;
@@ -176,6 +178,7 @@ pub struct TaskExecutor {
     pub context_builder: TaskContextBuilder,
     pub output_handler: OutputHandler,
     pub failed_tasks: FailedTasks,
+    interrupted: AtomicBool,
 
     // CLI flags
     pub force: bool,
@@ -206,6 +209,7 @@ impl TaskExecutor {
             context_builder,
             output_handler,
             failed_tasks: Arc::new(StdMutex::new(Vec::new())),
+            interrupted: AtomicBool::new(false),
             force: config.force,
             cd: config.cd,
             shell: config.shell,
@@ -220,7 +224,22 @@ impl TaskExecutor {
     }
 
     pub fn is_stopping(&self) -> bool {
-        !self.failed_tasks.lock().unwrap().is_empty()
+        self.is_interrupted() || !self.failed_tasks.lock().unwrap().is_empty()
+    }
+
+    pub fn is_interrupted(&self) -> bool {
+        self.interrupted.load(Ordering::Relaxed)
+    }
+
+    pub fn mark_interrupted(&self) {
+        self.interrupted.store(true, Ordering::Relaxed);
+    }
+
+    fn check_interruption(allow_during_interruption: bool) -> Result<()> {
+        if !allow_during_interruption && crate::ui::ctrlc::is_cancelled() {
+            return Err(crate::errors::Error::TaskInterrupted.into());
+        }
+        Ok(())
     }
 
     pub fn add_failed_task(&self, task: Task, status: Option<i32>) {
@@ -328,14 +347,16 @@ impl TaskExecutor {
         &self,
         task: &Task,
         config: &Arc<Config>,
-        sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
+        sched_tx: Arc<mpsc::UnboundedSender<SchedMsg>>,
         completion_state: TaskCompletionState,
         dependency_state: TaskDependencyState,
         semaphore: Arc<Semaphore>,
         permit: &mut Option<OwnedSemaphorePermit>,
+        allow_during_interruption: bool,
     ) -> Result<TaskRunOutcome> {
         let prefix = task.estyled_prefix();
         let total_start = std::time::Instant::now();
+        Self::check_interruption(allow_during_interruption)?;
         if Settings::get().task.skip.contains(&task.name) {
             if !self.quiet(Some(task)) {
                 self.eprint(task, &prefix, "skipping task");
@@ -593,40 +614,42 @@ impl TaskExecutor {
                     if self.task_cache.reads()
                         && !self.force
                         && !dependency_state.any_unkeyed_did_work
-                        && let Some(output) = cache.restore(task)?
                     {
-                        if !self.quiet(Some(task)) {
-                            let kind = if task.outputs.is_no_files() {
-                                "result"
-                            } else {
-                                "outputs"
-                            };
-                            self.eprint(
-                                task,
-                                &prefix,
-                                &format!("restored {kind} from cache {}", cache.key()),
-                            );
+                        Self::check_interruption(allow_during_interruption)?;
+                        if let Some(output) = cache.restore(task)? {
+                            if !self.quiet(Some(task)) {
+                                let kind = if task.outputs.is_no_files() {
+                                    "result"
+                                } else {
+                                    "outputs"
+                                };
+                                self.eprint(
+                                    task,
+                                    &prefix,
+                                    &format!("restored {kind} from cache {}", cache.key()),
+                                );
+                            }
+                            self.output_handler
+                                .replay_cached_output(task, &prefix, &output);
+                            if let Err(err) = save_checksum(task, config).await {
+                                warn!(
+                                    "task {} artifact cache checksum update failed: {err}",
+                                    task.name
+                                );
+                            }
+                            if self.task_cache.writes()
+                                && let Err(err) = cache.mark_current()
+                            {
+                                warn!(
+                                    "task {} artifact cache state update failed: {err}",
+                                    task.name
+                                );
+                            }
+                            return Ok(TaskRunOutcome {
+                                did_work: true,
+                                cache_key: Some(cache.key().to_string()),
+                            });
                         }
-                        self.output_handler
-                            .replay_cached_output(task, &prefix, &output);
-                        if let Err(err) = save_checksum(task, config).await {
-                            warn!(
-                                "task {} artifact cache checksum update failed: {err}",
-                                task.name
-                            );
-                        }
-                        if self.task_cache.writes()
-                            && let Err(err) = cache.mark_current()
-                        {
-                            warn!(
-                                "task {} artifact cache state update failed: {err}",
-                                task.name
-                            );
-                        }
-                        return Ok(TaskRunOutcome {
-                            did_work: true,
-                            cache_key: Some(cache.key().to_string()),
-                        });
                     }
                     Some(cache)
                 }
@@ -644,6 +667,7 @@ impl TaskExecutor {
 
         if let Some(file) = task_file {
             let exec_start = std::time::Instant::now();
+            Self::check_interruption(allow_during_interruption)?;
             remove_auto_output(task, config).await?;
             self.exec_file(
                 config,
@@ -653,6 +677,7 @@ impl TaskExecutor {
                 &prefix,
                 confirm_guard,
                 output_capture.as_ref(),
+                allow_during_interruption,
             )
             .await?;
             trace!(
@@ -673,6 +698,7 @@ impl TaskExecutor {
                 .await?;
 
             let exec_start = std::time::Instant::now();
+            Self::check_interruption(allow_during_interruption)?;
             remove_auto_output(task, config).await?;
             self.exec_task_run_entries(
                 config,
@@ -686,6 +712,7 @@ impl TaskExecutor {
                 semaphore,
                 permit,
                 output_capture.as_ref(),
+                allow_during_interruption,
             )
             .await?;
             trace!(
@@ -771,12 +798,13 @@ impl TaskExecutor {
         full_env: (&BTreeMap<String, String>, &[(String, String)]),
         prefix: &str,
         rendered_scripts: Vec<(String, Vec<String>)>,
-        sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
+        sched_tx: Arc<mpsc::UnboundedSender<SchedMsg>>,
         existing_guard: Option<RuntimeLockGuard<'static>>,
         completion_state: &TaskCompletionState,
         semaphore: Arc<Semaphore>,
         permit: &mut Option<OwnedSemaphorePermit>,
         output_capture: Option<&TaskOutputCapture>,
+        allow_during_interruption: bool,
     ) -> Result<()> {
         let (env, task_env) = full_env;
         use crate::task::RunEntry;
@@ -821,8 +849,16 @@ impl TaskExecutor {
                         if guard.is_none() {
                             guard = Some(acquire_runtime_lock(task.interactive).await);
                         }
-                        self.exec_script(&script, &args, task, env, prefix, output_capture)
-                            .await?;
+                        self.exec_script(
+                            &script,
+                            &args,
+                            task,
+                            env,
+                            prefix,
+                            output_capture,
+                            allow_during_interruption,
+                        )
+                        .await?;
                     }
                 }
                 RunEntry::SingleTask {
@@ -860,6 +896,7 @@ impl TaskExecutor {
                             override_env_ref,
                             sched_tx.clone(),
                             &completion_state,
+                            allow_during_interruption,
                         )
                         .await?;
                     completion_state.merge(completed);
@@ -884,6 +921,7 @@ impl TaskExecutor {
                             None,
                             sched_tx.clone(),
                             &completion_state,
+                            allow_during_interruption,
                         )
                         .await?;
                     completion_state.merge(completed);
@@ -904,8 +942,9 @@ impl TaskExecutor {
         task_env: &[(String, String)],
         override_args: Option<&[String]>,
         override_env: Option<&[(String, String)]>,
-        sched_tx: Arc<mpsc::UnboundedSender<(Task, Arc<Mutex<Deps>>)>>,
+        sched_tx: Arc<mpsc::UnboundedSender<SchedMsg>>,
         completion_state: &TaskCompletionState,
+        allow_during_interruption: bool,
     ) -> Result<TaskCompletionState> {
         use crate::task::TaskLoadContext;
         trace!("inject start: {}", specs.join(", "));
@@ -987,7 +1026,11 @@ impl TaskExecutor {
                             any = true;
                             let task = task.derive_env(&task_env_directives);
                             trace!("inject initial leaf: {} {}", task.name, task.args.join(" "));
-                            let _ = sched_tx.send((task, sub_deps_clone.clone()));
+                            let _ = sched_tx.send(SchedMsg::new(
+                                task,
+                                sub_deps_clone.clone(),
+                                allow_during_interruption,
+                            ));
                         }
                         Ok(None) => {
                             trace!("inject initial done");
@@ -1017,7 +1060,11 @@ impl TaskExecutor {
                                 task.args.join(" ")
                             );
                             let task = task.derive_env(&task_env_directives);
-                            let _ = sched_tx.send((task, sub_deps_clone.clone()));
+                            let _ = sched_tx.send(SchedMsg::new(
+                                task,
+                                sub_deps_clone.clone(),
+                                allow_during_interruption,
+                            ));
                         }
                         None => {
                             let _ = done_tx.send(());
@@ -1032,7 +1079,7 @@ impl TaskExecutor {
         // Wait for completion with a check for early stopping
         loop {
             // Check if we should stop early due to failure
-            if self.is_stopping() && !self.continue_on_error {
+            if self.is_stopping() && !self.continue_on_error && !allow_during_interruption {
                 trace!("inject_and_wait: stopping early due to failure");
                 // Clean up the dependency graph to ensure completion
                 let mut deps = sub_deps.lock().await;
@@ -1063,7 +1110,7 @@ impl TaskExecutor {
         }
 
         // Final check if we failed during the execution
-        if self.is_stopping() && !self.continue_on_error {
+        if self.is_stopping() && !self.continue_on_error && !allow_during_interruption {
             return Err(eyre!("task sequence aborted due to failure"));
         }
 
@@ -1071,6 +1118,7 @@ impl TaskExecutor {
         Ok(completion_state)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn exec_script(
         &self,
         script: &str,
@@ -1079,6 +1127,7 @@ impl TaskExecutor {
         env: &BTreeMap<String, String>,
         prefix: &str,
         output_capture: Option<&TaskOutputCapture>,
+        allow_during_interruption: bool,
     ) -> Result<()> {
         let config = Config::get().await?;
         let script = script.trim_start();
@@ -1109,8 +1158,16 @@ impl TaskExecutor {
             let file = dir.path().join("script");
             tokio::fs::write(&file, script.as_bytes()).await?;
             file::make_executable(&file)?;
-            self.exec_with_text_file_busy_retry(&file, args, task, env, prefix, output_capture)
-                .await
+            self.exec_with_text_file_busy_retry(
+                &file,
+                args,
+                task,
+                env,
+                prefix,
+                output_capture,
+                allow_during_interruption,
+            )
+            .await
         } else {
             let (program, args, cmd_verbatim) =
                 self.get_cmd_program_and_args(script, task, args)?;
@@ -1122,6 +1179,7 @@ impl TaskExecutor {
                 prefix,
                 cmd_verbatim,
                 output_capture,
+                allow_during_interruption,
             )
             .await
         }
@@ -1331,6 +1389,7 @@ impl TaskExecutor {
         prefix: &str,
         guard: Option<RuntimeLockGuard<'static>>,
         output_capture: Option<&TaskOutputCapture>,
+        allow_during_interruption: bool,
     ) -> Result<()> {
         let args = task.args.iter().cloned().collect_vec();
 
@@ -1348,10 +1407,19 @@ impl TaskExecutor {
         } else {
             Some(acquire_runtime_lock(task.interactive).await)
         };
-        self.exec(file, &args, task, env, prefix, output_capture)
-            .await
+        self.exec(
+            file,
+            &args,
+            task,
+            env,
+            prefix,
+            output_capture,
+            allow_during_interruption,
+        )
+        .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn exec(
         &self,
         file: &Path,
@@ -1360,12 +1428,23 @@ impl TaskExecutor {
         env: &BTreeMap<String, String>,
         prefix: &str,
         output_capture: Option<&TaskOutputCapture>,
+        allow_during_interruption: bool,
     ) -> Result<()> {
         let (program, args) = self.get_file_program_and_args(file, task, args)?;
-        self.exec_program(&program, &args, task, env, prefix, false, output_capture)
-            .await
+        self.exec_program(
+            &program,
+            &args,
+            task,
+            env,
+            prefix,
+            false,
+            output_capture,
+            allow_during_interruption,
+        )
+        .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn exec_with_text_file_busy_retry(
         &self,
         file: &Path,
@@ -1374,6 +1453,7 @@ impl TaskExecutor {
         env: &BTreeMap<String, String>,
         prefix: &str,
         output_capture: Option<&TaskOutputCapture>,
+        allow_during_interruption: bool,
     ) -> Result<()> {
         const ETXTBUSY_RETRIES: usize = 3;
         const ETXTBUSY_SLEEP_MS: u64 = 50;
@@ -1381,7 +1461,15 @@ impl TaskExecutor {
         let mut attempt = 0;
         loop {
             match self
-                .exec(file, args, task, env, prefix, output_capture)
+                .exec(
+                    file,
+                    args,
+                    task,
+                    env,
+                    prefix,
+                    output_capture,
+                    allow_during_interruption,
+                )
                 .await
             {
                 Ok(()) => break Ok(()),
@@ -1412,6 +1500,7 @@ impl TaskExecutor {
         prefix: &str,
         cmd_verbatim: bool,
         output_capture: Option<&TaskOutputCapture>,
+        allow_during_interruption: bool,
     ) -> Result<()> {
         #[cfg(not(windows))]
         let _ = cmd_verbatim;
@@ -1673,7 +1762,10 @@ impl TaskExecutor {
         }
         // Apply sandbox async (DNS resolution for macOS) before spawning.
         cmd.apply_sandbox().await?;
-        cmd.execute_async().await?;
+        cmd.execute_async_with_cancel_check(|| {
+            !allow_during_interruption && crate::ui::ctrlc::is_cancelled()
+        })
+        .await?;
         trace!("{prefix} exited successfully");
         Ok(())
     }

--- a/src/task/task_results_display.rs
+++ b/src/task/task_results_display.rs
@@ -9,6 +9,7 @@ pub struct TaskResultsDisplay {
     failed_tasks: FailedTasks,
     continue_on_error: bool,
     show_timings: bool,
+    interrupted: bool,
 }
 
 impl TaskResultsDisplay {
@@ -17,12 +18,14 @@ impl TaskResultsDisplay {
         failed_tasks: FailedTasks,
         continue_on_error: bool,
         show_timings: bool,
+        interrupted: bool,
     ) -> Self {
         Self {
             output_handler,
             failed_tasks,
             continue_on_error,
             show_timings,
+            interrupted,
         }
     }
 
@@ -30,8 +33,12 @@ impl TaskResultsDisplay {
     pub fn display_results(&self, num_tasks: usize, timer: std::time::Instant) -> Result<()> {
         self.display_keep_order_output();
         self.display_timing_summary(num_tasks, timer);
+        if self.interrupted {
+            return Err(request_exit(130));
+        }
         self.maybe_print_failure_summary();
-        self.exit_if_failed()
+        self.exit_if_failed()?;
+        Ok(())
     }
 
     /// Flush any remaining keep-order output (safety net).

--- a/src/task/task_scheduler.rs
+++ b/src/task/task_scheduler.rs
@@ -10,7 +10,21 @@ use tokio::task::JoinSet;
 #[cfg(unix)]
 use nix::sys::signal::SIGTERM;
 
-pub type SchedMsg = (Task, Arc<Mutex<Deps>>);
+pub struct SchedMsg {
+    pub task: Task,
+    pub deps: Arc<Mutex<Deps>>,
+    pub allow_during_interruption: bool,
+}
+
+impl SchedMsg {
+    pub fn new(task: Task, deps: Arc<Mutex<Deps>>, allow_during_interruption: bool) -> Self {
+        Self {
+            task,
+            deps,
+            allow_during_interruption,
+        }
+    }
+}
 
 /// Schedules and executes tasks with concurrency control
 pub struct Scheduler {
@@ -103,7 +117,7 @@ impl Scheduler {
                             task.name,
                             task.args.join(" ")
                         );
-                        let _ = sched_tx.send((task, deps_clone.clone()));
+                        let _ = sched_tx.send(SchedMsg::new(task, deps_clone.clone(), false));
                     }
                     Ok(None) => {
                         trace!("main deps initial done");
@@ -130,7 +144,7 @@ impl Scheduler {
                             task.name,
                             task.args.join(" ")
                         );
-                        let _ = sched_tx.send((task, deps_clone.clone()));
+                        let _ = sched_tx.send(SchedMsg::new(task, deps_clone.clone(), false));
                     }
                     None => {
                         trace!("main deps completed");
@@ -151,51 +165,58 @@ impl Scheduler {
     /// - no tasks are in-flight AND
     /// - no tasks were recently drained
     ///
-    /// Or if should_stop returns true (for early exit due to failures)
+    /// Or if should_stop returns true (for early exit due to failures or interruption).
+    /// An interruption always stops new work, even in continue-on-error mode.
     pub async fn run_loop<F, Fut>(
         &mut self,
         main_done_rx: &mut tokio::sync::watch::Receiver<bool>,
         main_deps: Arc<Mutex<Deps>>,
         should_stop: impl Fn() -> bool,
+        was_interrupted: impl Fn() -> bool,
         continue_on_error: bool,
         mut spawn_job: F,
     ) -> Result<()>
     where
-        F: FnMut(Task, Arc<Mutex<Deps>>) -> Fut,
+        F: FnMut(Task, Arc<Mutex<Deps>>, bool) -> Fut,
         Fut: std::future::Future<Output = Result<()>>,
     {
         let mut sched_rx = self.take_receiver().expect("receiver already taken");
-        let mut failure_cleanup_done = false;
+        let mut stop_cleanup_done = false;
 
         loop {
             // Drain ready tasks without awaiting
             let mut drained_any = false;
             loop {
                 match sched_rx.try_recv() {
-                    Ok((task, deps_for_remove)) => {
+                    Ok(SchedMsg {
+                        task,
+                        deps: deps_for_remove,
+                        allow_during_interruption,
+                    }) => {
                         drained_any = true;
                         trace!("scheduler received: {} {}", task.name, task.args.join(" "));
-                        if should_stop() && !continue_on_error {
+                        if should_stop() && (!continue_on_error || was_interrupted()) {
                             // Still allow post-dep (cleanup) tasks to run on failure,
                             // but only if their parent was actually started
                             let mut deps = deps_for_remove.lock().await;
-                            if !deps.is_runnable_post_dep(&task) {
+                            if !allow_during_interruption && !deps.is_runnable_post_dep(&task) {
                                 deps.remove(&task);
                                 continue;
                             }
                             drop(deps);
                         }
-                        spawn_job(task, deps_for_remove).await?;
+                        spawn_job(task, deps_for_remove, allow_during_interruption).await?;
                     }
                     Err(mpsc::error::TryRecvError::Empty) => break,
                     Err(mpsc::error::TryRecvError::Disconnected) => break,
                 }
             }
 
-            // Check if we should stop early due to failure (run cleanup only once)
-            if should_stop() && !continue_on_error && !failure_cleanup_done {
-                failure_cleanup_done = true;
-                trace!("scheduler: stopping early due to failure, cleaning up non-post-dep tasks");
+            // Check if we should stop early due to failure or interruption
+            // (run cleanup only once).
+            if should_stop() && (!continue_on_error || was_interrupted()) && !stop_cleanup_done {
+                stop_cleanup_done = true;
+                trace!("scheduler: stopping early, cleaning up non-post-dep tasks");
                 // Clean up tasks that shouldn't run: non-post-deps and post-deps whose
                 // parent was never started. Use batch removal so intermediate emit_leaves
                 // calls don't schedule post-deps of never-started tasks.
@@ -223,17 +244,23 @@ impl Scheduler {
             // Await either new work or main_done change
             tokio::select! {
                 m = sched_rx.recv() => {
-                    if let Some((task, deps_for_remove)) = m {
+                    if let Some(SchedMsg {
+                        task,
+                        deps: deps_for_remove,
+                        allow_during_interruption,
+                    }) = m {
                         trace!("scheduler received: {} {}", task.name, task.args.join(" "));
-                        if should_stop() && !continue_on_error {
+                        if should_stop() && (!continue_on_error || was_interrupted()) {
                             let mut deps = deps_for_remove.lock().await;
-                            if !deps.is_runnable_post_dep(&task) {
+                            if !allow_during_interruption
+                                && !deps.is_runnable_post_dep(&task)
+                            {
                                 deps.remove(&task);
                                 continue;
                             }
                             drop(deps);
                         }
-                        spawn_job(task, deps_for_remove).await?;
+                        spawn_job(task, deps_for_remove, allow_during_interruption).await?;
                     } else {
                         // channel closed; rely on main_done/in_flight to exit soon
                     }

--- a/src/ui/ctrlc.rs
+++ b/src/ui/ctrlc.rs
@@ -14,14 +14,14 @@ pub async fn exit_signal() -> i32 {
         if SHOW_CURSOR.load(Ordering::Relaxed) {
             let _ = Term::stderr().show_cursor();
         }
+        // Record the first task-mode interrupt before signalling children so
+        // their exit handlers can distinguish cancellation from task failure.
+        let should_exit = EXIT.load(Ordering::Relaxed) || CANCELLED.swap(true, Ordering::Relaxed);
         CmdLineRunner::kill_all(nix::sys::signal::SIGINT);
-        if EXIT.load(Ordering::Relaxed) || CANCELLED.load(Ordering::Relaxed) {
+        if should_exit {
             debug!("Ctrl-C pressed, exiting...");
             return 1;
         }
-        // First ctrl-c when EXIT is false: mark as cancelled so a second
-        // ctrl-c will end the command and in-process operations can check the flag.
-        CANCELLED.store(true, Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
## Summary

- classify task processes terminated by SIGINT after Ctrl+C as user interruptions instead of task failures
- return exit status 130 without printing `no exit status`, `task failed`, or a failure summary
- stop scheduling normal work after interruption even with `--continue-on-error`, while preserving cleanup post-dependencies
- keep the existing behavior for interactive tasks that handle SIGINT and for a second Ctrl+C that force-exits mise

## Root cause

During `mise run`, the first Ctrl+C was forwarded to child processes, but the cancellation flag was recorded only after signalling them. A child could therefore exit from SIGINT before mise knew that cancellation was in progress. Its signal-only `ExitStatus` has no numeric code, so the task runner classified it as an ordinary failure and rendered `no exit status` followed by `task failed`.

This change records cancellation before forwarding SIGINT, recognizes only the matching SIGINT task result as an interruption, and tracks interruption separately from failed tasks. Genuine non-zero exits and panics continue to use the existing failure path.

## Test plan

- [x] `mise exec -- cargo test --all-features errors::tests -- --nocapture`
- [x] `mise exec -- cargo test --all-features task::task_scheduler::tests -- --nocapture`
- [x] `mise run test:e2e e2e/cli/test_exit_status`
- [x] `mise run test:e2e e2e/tasks/test_task_sequence_failure e2e/tasks/test_task_parallel_fail_fast`
- [x] `mise exec -- cargo check --all-features`
- [x] `mise exec -- cargo fmt --all -- --check`
- [x] `mise exec -- shellcheck -x e2e/cli/test_exit_status`
- [x] `mise exec -- shfmt -d -i 2 -ci -s e2e/cli/test_exit_status`

`mise run lint` could not invoke `hk` because `hk` does not recognize this Sapling working copy as a Git repository. The relevant Rust and shell checks were run individually above.

Addresses https://github.com/jdx/mise/discussions/3972

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl-C/SIGINT interruption is now handled as a distinct “interrupted” state: `mise run` stops starting new work, marks the run interrupted, and exits with status **130**.
  * Interruption suppresses failure/error reporting and prevents dependent “after-*” tasks from running (even with `--continue-on-error`), while allowing configured post-dependency cleanup to proceed.
* **Tests**
  * Added/updated e2e Ctrl-C scenarios (including cleanup and cancellation precedence) and expanded unit/Tokio coverage for interruption detection and cancel checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->