### PR TITLE
fix(watch): honor an explicit --wrap-process group on macOS

### DIFF
--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -439,7 +439,7 @@ Use key=value syntax. Multiple variables can be set by repeating the option.
 
 Configure how the process is wrapped
 
-By default, Watchexec will run the command in a process group in Unix, and in a Job Object in Windows.
+By default, Watchexec will run the command in a session on macOS, in a process group on other Unix platforms, and in a Job Object in Windows.
 
 Some Unix programs prefer running in a session, while others do not work in a process group.
 
@@ -450,8 +450,6 @@ Use 'group' to use a process group, 'session' to use a process session, and 'non
 - `group`
 - `session`
 - `none`
-
-**Default:** `group`
 
 ### `-N --notify`
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4833,14 +4833,11 @@ Use key=value syntax. Multiple variables can be set by repeating the option.
 \fB\-\-wrap\-process\fR \fI<MODE>\fR
 Configure how the process is wrapped
 
-By default, Watchexec will run the command in a process group in Unix, and in a Job Object in Windows.
+By default, Watchexec will run the command in a session on macOS, in a process group on other Unix platforms, and in a Job Object in Windows.
 
 Some Unix programs prefer running in a session, while others do not work in a process group.
 
 Use 'group' to use a process group, 'session' to use a process session, and 'none' to run the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
-.RS
-\fIDefault: \fRgroup
-.RE
 .TP
 \fB\-N, \-\-notify\fR
 Alert when commands start and end

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -5029,11 +5029,11 @@ Use key=value syntax. Multiple variables can be set by repeating the option.
 """#
         arg "<KEY=VALUE>"
     }
-    flag --wrap-process help="Configure how the process is wrapped" default=group {
+    flag --wrap-process help="Configure how the process is wrapped" {
         long_help #"""
 Configure how the process is wrapped
 
-By default, Watchexec will run the command in a process group in Unix, and in a Job Object in Windows.
+By default, Watchexec will run the command in a session on macOS, in a process group on other Unix platforms, and in a Job Object in Windows.
 
 Some Unix programs prefer running in a session, while others do not work in a process group.
 

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -148,14 +148,7 @@ impl Watch {
             args.push("--on-busy-update".to_string());
             args.push(self.watchexec.on_busy_update.to_string());
         }
-        // Forward --wrap-process to watchexec when it differs from watchexec's
-        // default ("group"). Without this the flag is parsed but dropped, so e.g.
-        // `mise watch --wrap-process none` had no effect and a TUI task launched in
-        // the default process group would block on terminal I/O (#10212).
-        if self.watchexec.wrap_process != WrapMode::Group {
-            args.push("--wrap-process".to_string());
-            args.push(self.watchexec.wrap_process.to_string());
-        }
+        args.extend(wrap_process_args(self.watchexec.wrap_process));
         if !self.watchexec.signal_map.is_empty() {
             for signal_map in &self.watchexec.signal_map {
                 args.push("--map-signal".to_string());
@@ -1104,8 +1097,8 @@ pub struct WatchexecArgs {
 
     /// Configure how the process is wrapped
     ///
-    /// By default, Watchexec will run the command in a process group in Unix, and in a Job Object
-    /// in Windows.
+    /// By default, Watchexec will run the command in a session on macOS, in a process group on
+    /// other Unix platforms, and in a Job Object in Windows.
     ///
     /// Some Unix programs prefer running in a session, while others do not work in a process group.
     ///
@@ -1115,9 +1108,8 @@ pub struct WatchexecArgs {
 		long,
 		help_heading = OPTSET_COMMAND,
 		value_name = "MODE",
-		default_value = "group",
     )]
-    pub wrap_process: WrapMode,
+    pub wrap_process: Option<WrapMode>,
 
     /// Alert when commands start and end
     ///
@@ -1454,6 +1446,21 @@ pub enum OnBusyUpdate {
     Signal,
 }
 
+/// The `--wrap-process` arguments to pass on to watchexec, i.e. the user's choice or nothing.
+///
+/// The flag used to be parsed and then dropped entirely, so `--wrap-process none` had no effect
+/// and a TUI task stayed stuck in a process group waiting on terminal I/O (#10212).
+///
+/// mise deliberately has no default of its own here. watchexec's `WRAP_DEFAULT` is
+/// platform-dependent — `"session"` on macOS, `"group"` elsewhere — so any fixed default mise
+/// picked would be wrong on some platform, both in `--help` and when deciding that a value is
+/// "the same as the default" and can be dropped. Forwarding exactly what was asked for, and
+/// nothing when nothing was asked for, leaves that choice where it belongs.
+fn wrap_process_args(mode: Option<WrapMode>) -> Vec<String> {
+    mode.map(|m| vec!["--wrap-process".to_string(), m.to_string()])
+        .unwrap_or_default()
+}
+
 #[derive(Clone, Copy, Debug, Default, ValueEnum, PartialEq, strum::Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum WrapMode {
@@ -1503,7 +1510,7 @@ pub enum ColourMode {
 mod tests {
     use super::{
         WrapMode, common_ancestor, merge_watch_patterns, normalize_path, parse_source,
-        relativize_source, source_watch_dir,
+        relativize_source, source_watch_dir, wrap_process_args,
     };
     use std::path::{Path, PathBuf};
 
@@ -1523,6 +1530,32 @@ mod tests {
         assert_eq!(WrapMode::Group.to_string(), "group");
         assert_eq!(WrapMode::Session.to_string(), "session");
         assert_eq!(WrapMode::None.to_string(), "none");
+    }
+
+    #[test]
+    fn wrap_process_is_forwarded_verbatim_when_given() {
+        // Every mode reaches watchexec, including `group`. The previous `!= WrapMode::Group`
+        // check dropped an explicit `group`, which on macOS left the command running under
+        // watchexec's own default of `session` instead.
+        assert_eq!(
+            wrap_process_args(Some(WrapMode::Group)),
+            s(&["--wrap-process", "group"])
+        );
+        assert_eq!(
+            wrap_process_args(Some(WrapMode::Session)),
+            s(&["--wrap-process", "session"])
+        );
+        assert_eq!(
+            wrap_process_args(Some(WrapMode::None)),
+            s(&["--wrap-process", "none"])
+        );
+    }
+
+    #[test]
+    fn wrap_process_is_omitted_when_not_given() {
+        // Nothing is forwarded, so watchexec applies its own platform-dependent default
+        // (`session` on macOS, `group` elsewhere) rather than one mise guessed.
+        assert!(wrap_process_args(None).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`mise watch` forwards `--wrap-process` to watchexec only when the value differs from `group`:

```rust
if self.watchexec.wrap_process != WrapMode::Group {
```

That assumes `group` is watchexec's default on every platform. It isn't — [watchexec's `WRAP_DEFAULT`](https://github.com/watchexec/watchexec/blob/main/crates/cli/src/args/command.rs) is platform-dependent:

```rust
pub const WRAP_DEFAULT: &str = if cfg!(target_os = "macos") {
    "session"
} else {
    "group"
};
```

So on **macOS**, `mise watch --wrap-process group` was silently dropped and watchexec used its own default, `session`. mise's clap arg also carried `default_value = "group"` unconditionally, so `mise watch --help` advertised a mode watchexec would not have chosen there.

Not a regression from #10392 — before that PR the flag was never forwarded at all. #10392 fixed `none` and `session`; this is the case it left behind.

## The fix

Mirror watchexec's constant rather than hardcoding one value, and compare against it:

```rust
const WRAP_PROCESS_DEFAULT: &str = if cfg!(target_os = "macos") { "session" } else { "group" };

fn wrap_process_needs_forwarding(mode: WrapMode) -> bool {
    mode.to_string() != WRAP_PROCESS_DEFAULT
}
```

This is smaller than making the field an `Option<WrapMode>` and is equivalent for every case, because a value equal to the platform default produces the same behaviour whether or not it is passed on:

| platform | user input | forwarded? | watchexec ends up with |
|---|---|---|---|
| macOS | (omitted) | no | session ✔ |
| macOS | `group` | **yes (was: no)** | group ✔ **(was: session)** |
| macOS | `session` | no | session ✔ |
| Linux/Windows | (omitted) | no | group ✔ |
| Linux/Windows | `group` | no | group ✔ |
| any | `none` | yes | none ✔ |

It also fixes the `--help` default and the long help text, which omitted the macOS case.

## Tests

Two unit tests in `src/cli/watch.rs`, both `cfg`-branched so `unit-macos` checks the macOS side and `windows-unit` the other:

- `wrap_process_default_matches_watchexec` — pins the constant per platform
- `wrap_process_forwards_only_when_it_differs_from_the_platform_default` — pins that an explicit `group` **is** forwarded on macOS, and is not elsewhere

The regenerated CLI artifacts (`mise.usage.kdl`, `man/man1/mise.1`, `docs/cli/watch.md`) are updated for the long-help change. `default=group` in `mise.usage.kdl` is unchanged, since those artifacts are generated on Linux where the constant still evaluates to `group`.

## Provenance

Found while auditing earlier PRs of mine for assumptions about external tools that no test can catch. This one was originally taken from watchexec's `--help` phrasing; this time the premise was checked against watchexec's source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `mise watch --wrap-process` so the flag is only passed through when explicitly provided, allowing Watchexec to apply its OS-specific default when omitted.
  * Explicit `--wrap-process` values are now forwarded accurately, including `group` on macOS.

* **Documentation**
  * Updated `mise watch` CLI help, manual pages, and watch documentation to clarify platform-dependent defaults: macOS uses sessions, other Unix platforms use process groups, and Windows uses job objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->