### PR TITLE
perf(ci): avoid duplicate release e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,7 +240,7 @@ jobs:
     name: e2e-${{matrix.tranche}}
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
-    if: ${{ github.event_name != 'pull_request' || github.head_ref != 'release' }}
+    if: ${{ github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main' }}
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     needs: [build-ubuntu]
     timeout-minutes: 30
@@ -344,12 +344,13 @@ jobs:
       - e2e
       - windows-unit
       - windows-e2e
-    # Run on success or upstream failure but skip when the workflow is cancelled
-    # — `always()` would override `cancel-in-progress` and waste a runner.
-    if: ${{ !cancelled() }}
+    # Evaluate skipped and failed dependencies, but do not waste a runner when
+    # the workflow is cancelled.
+    if: ${{ always() && !cancelled() }}
     steps:
       - name: Check CI job results
         env:
+          BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ "${{ needs.build-ubuntu.result }}" != "success" ]; then
@@ -368,7 +369,7 @@ jobs:
             echo "lint failed or was skipped"
             exit 1
           fi
-          if [ "${{ github.event_name }}" == "pull_request" ] && [ "$HEAD_REF" == "release" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ] && [ "$HEAD_REF" == "release" ] && [ "$BASE_REF" == "main" ]; then
             if [ "${{ needs.e2e.result }}" != "skipped" ]; then
               echo "e2e should be handled by the release workflow"
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,6 +238,9 @@ jobs:
 
   e2e:
     name: e2e-${{matrix.tranche}}
+    # The release PR runs the full suite against the packaged release tarball.
+    # Keep that stronger signal instead of also testing the debug artifact.
+    if: ${{ github.event_name != 'pull_request' || github.head_ref != 'release' }}
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     needs: [build-ubuntu]
     timeout-minutes: 30
@@ -346,6 +349,8 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - name: Check CI job results
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ "${{ needs.build-ubuntu.result }}" != "success" ]; then
             echo "build-ubuntu failed or was skipped"
@@ -363,7 +368,12 @@ jobs:
             echo "lint failed or was skipped"
             exit 1
           fi
-          if [ "${{ needs.e2e.result }}" != "success" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ] && [ "$HEAD_REF" == "release" ]; then
+            if [ "${{ needs.e2e.result }}" != "skipped" ]; then
+              echo "e2e should be handled by the release workflow"
+              exit 1
+            fi
+          elif [ "${{ needs.e2e.result }}" != "success" ]; then
             echo "e2e failed or was skipped"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- skip the normal Linux e2e matrix on the `release → main` pull request
- keep the release workflow's full e2e suite against the packaged tarball as the authoritative release signal
- make the `test-ci` aggregator require the normal e2e matrix to be skipped only for that release PR

## Why
Both workflows currently run eight tranches with `TEST_ALL=1` on the release pull request. The normal test workflow exercises a debug artifact, while the release workflow exercises the packaged tarball that will actually ship. Keeping the latter preserves the stronger coverage while avoiding duplicate work.

A representative release PR spent 66.4 runner-minutes on the normal workflow's eight Linux e2e shards alone.

Stable unit, lint, Windows unit, and Windows e2e coverage remain unchanged.

## Validation
- `actionlint .github/workflows/test.yml`
- `bun x prettier --check .github/workflows/test.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow conditions; no application or release artifact logic changes.
> 
> **Overview**
> **Skips the normal test workflow’s Linux e2e matrix** on pull requests from `release` into `main`, so the eight debug-artifact shards don’t rerun work already covered by the release workflow’s e2e against the packaged tarball.
> 
> The **`test-ci` aggregator** now uses `always() && !cancelled()` so it still runs when `e2e` is intentionally skipped. Its result check treats release→main PRs specially: `e2e` must be **skipped** (otherwise it fails with “e2e should be handled by the release workflow”); all other events still require `e2e` to succeed. Unit, lint, and Windows jobs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43a9fe89aa39fc193bf1cf6656db101f91f6ba17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined release pull request validation: end-to-end checks are skipped only when the pull request targets `main` and originates from `release`.
  * Updated CI aggregation behavior so the “Check CI job results” step evaluates required outcomes even if earlier jobs fail (while still respecting cancellations).
  * Release-PR assertions were tightened to confirm the expected skipped behavior; all other pull requests keep the same end-to-end result enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->