### PR TITLE
perf(ci): reduce repeated test setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Prepare mise artifact
         run: |
           install -Dm755 target/debug/mise target/ci-artifacts/mise
-          strip target/ci-artifacts/mise
+          strip --strip-debug target/ci-artifacts/mise
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mise-ubuntu-latest
@@ -285,7 +285,7 @@ jobs:
     if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     needs: [build-ubuntu, classify-changes]
-    timeout-minutes: 30
+    timeout-minutes: 65
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -353,6 +353,8 @@ jobs:
               MISE_E2E_DOCKER: "1"
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
               TEST_TRANCHE_COUNT: 8
+              TRANCHE_A: 0
+              TRANCHE_B: 4
               TOKEN_A: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
               TOKEN_B: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: &e2e-retry
@@ -360,8 +362,8 @@ jobs:
               retry_wait_seconds: 30
               max_attempts: 2
               command: |
-                MISE_GITHUB_TOKEN="$TOKEN_A" GITHUB_TOKEN="$TOKEN_A" TEST_TRANCHE=0 ./e2e/run_all_tests
-                MISE_GITHUB_TOKEN="$TOKEN_B" GITHUB_TOKEN="$TOKEN_B" TEST_TRANCHE=4 ./e2e/run_all_tests
+                MISE_GITHUB_TOKEN="$TOKEN_A" GITHUB_TOKEN="$TOKEN_A" TEST_TRANCHE="$TRANCHE_A" ./e2e/run_all_tests
+                MISE_GITHUB_TOKEN="$TOKEN_B" GITHUB_TOKEN="$TOKEN_B" TEST_TRANCHE="$TRANCHE_B" ./e2e/run_all_tests
           - name: Test tranches 1 and 5
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
@@ -369,6 +371,8 @@ jobs:
               MISE_E2E_DOCKER: "1"
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
               TEST_TRANCHE_COUNT: 8
+              TRANCHE_A: 1
+              TRANCHE_B: 5
               TOKEN_A: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
               TOKEN_B: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
@@ -379,6 +383,8 @@ jobs:
               MISE_E2E_DOCKER: "1"
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
               TEST_TRANCHE_COUNT: 8
+              TRANCHE_A: 2
+              TRANCHE_B: 6
               TOKEN_A: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
               TOKEN_B: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
@@ -389,6 +395,8 @@ jobs:
               MISE_E2E_DOCKER: "1"
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
               TEST_TRANCHE_COUNT: 8
+              TRANCHE_A: 3
+              TRANCHE_B: 7
               TOKEN_A: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
               TOKEN_B: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,39 @@ permissions:
   contents: read
 
 jobs:
+  classify-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      full-ci: ${{ steps.classify.outputs.full-ci }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+      - name: Classify changes
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          echo "full-ci=true" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            exit 0
+          fi
+
+          changed=0
+          while IFS= read -r path; do
+            changed=1
+            case "$path" in
+              docs/* | *.md) ;;
+              *) exit 0 ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          if [ "$changed" -eq 1 ]; then
+            echo "full-ci=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-ubuntu:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     timeout-minutes: 60
@@ -71,6 +104,8 @@ jobs:
   build-windows:
     runs-on: windows-latest
     timeout-minutes: 60
+    needs: [classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
     env:
       MISE_DATA_DIR: ~/.local/share/mise
       MISE_CACHE_DIR: ~/.cache/mise
@@ -85,18 +120,21 @@ jobs:
           cargo build --no-default-features --features rustls-native-roots,vfox/vendored-lua,self_update
           cargo build -p mise-shim
           Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE\target\debug"
-      - run: mise -v
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: mise-windows-latest
-          path: |
-            target/debug/mise.exe
-            target/debug/mise-shim.exe
+      - parallel:
+          - run: mise -v
+          - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: mise-windows-latest
+              path: |
+                target/debug/mise.exe
+                target/debug/mise-shim.exe
 
   unit:
     name: unit-macos
     runs-on: namespace-profile-endev-macos-arm64;overrides.cache-tag=mise-pr-rust-macos
     timeout-minutes: 30
+    needs: [classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -244,9 +282,9 @@ jobs:
     name: e2e
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
-    if: ${{ github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main' }}
+    if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
-    needs: [build-ubuntu]
+    needs: [build-ubuntu, classify-changes]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -300,17 +338,18 @@ jobs:
           name: mise-ubuntu-latest
           path: target/debug
       - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
-      - uses: ./.github/actions/mise-tools
-      - name: Pull e2e Docker image
-        run: docker pull ghcr.io/jdx/mise:e2e
+      - parallel:
+          - uses: ./.github/actions/mise-tools
+          - name: Pull e2e Docker image
+            run: docker pull ghcr.io/jdx/mise:e2e
       # Each test gets isolated host directories and an ephemeral container.
       # Run four branches on a standard runner; each branch handles two
-      # token-isolated tranches sequentially.
+      # token-isolated tranches sequentially, capped at eight containers total.
       - parallel:
           - name: Test tranches 0 and 4
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
-              E2E_JOBS: 1
+              E2E_JOBS: 2
               MISE_E2E_DOCKER: "1"
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
               TEST_TRANCHE_COUNT: 8
@@ -326,7 +365,7 @@ jobs:
           - name: Test tranches 1 and 5
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
-              E2E_JOBS: 1
+              E2E_JOBS: 2
               MISE_E2E_DOCKER: "1"
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
               TEST_TRANCHE_COUNT: 8
@@ -336,7 +375,7 @@ jobs:
           - name: Test tranches 2 and 6
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
-              E2E_JOBS: 1
+              E2E_JOBS: 2
               MISE_E2E_DOCKER: "1"
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
               TEST_TRANCHE_COUNT: 8
@@ -346,7 +385,7 @@ jobs:
           - name: Test tranches 3 and 7
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
-              E2E_JOBS: 1
+              E2E_JOBS: 2
               MISE_E2E_DOCKER: "1"
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
               TEST_TRANCHE_COUNT: 8
@@ -357,6 +396,8 @@ jobs:
   windows-unit:
     runs-on: windows-latest
     timeout-minutes: 30
+    needs: [classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
     env:
       MISE_DATA_DIR: ~/.local/share/mise
       MISE_CACHE_DIR: ~/.cache/mise
@@ -380,7 +421,8 @@ jobs:
   windows-e2e:
     runs-on: windows-latest
     timeout-minutes: 40
-    needs: [build-windows]
+    needs: [build-windows, classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
     env:
       MISE_DATA_DIR: ~/.local/share/mise
       MISE_CACHE_DIR: ~/.cache/mise
@@ -405,6 +447,7 @@ jobs:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     timeout-minutes: 1
     needs:
+      - classify-changes
       - build-ubuntu
       - build-windows
       - unit
@@ -422,37 +465,53 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
+          full_ci="${{ needs.classify-changes.outputs.full-ci }}"
           if [ "${{ needs.build-ubuntu.result }}" != "success" ]; then
             echo "build-ubuntu failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.build-windows.result }}" != "success" ]; then
-            echo "build-windows failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.unit.result }}" != "success" ]; then
-            echo "unit failed or was skipped"
             exit 1
           fi
           if [ "${{ needs.lint.result }}" != "success" ]; then
             echo "lint failed or was skipped"
             exit 1
           fi
-          if [ "${{ github.event_name }}" == "pull_request" ] && [ "$HEAD_REF" == "release" ] && [ "$BASE_REF" == "main" ]; then
-            if [ "${{ needs.e2e.result }}" != "skipped" ]; then
-              echo "e2e should be handled by the release workflow"
+
+          if [ "$full_ci" == "true" ]; then
+            if [ "${{ needs.build-windows.result }}" != "success" ]; then
+              echo "build-windows failed or was skipped"
               exit 1
             fi
-          elif [ "${{ needs.e2e.result }}" != "success" ]; then
-            echo "e2e failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.windows-unit.result }}" != "success" ]; then
-            echo "windows-unit failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.windows-e2e.result }}" != "success" ]; then
-            echo "windows-e2e failed or was skipped"
-            exit 1
+            if [ "${{ needs.unit.result }}" != "success" ]; then
+              echo "unit failed or was skipped"
+              exit 1
+            fi
+            if [ "${{ github.event_name }}" == "pull_request" ] && [ "$HEAD_REF" == "release" ] && [ "$BASE_REF" == "main" ]; then
+              if [ "${{ needs.e2e.result }}" != "skipped" ]; then
+                echo "e2e should be handled by the release workflow"
+                exit 1
+              fi
+            elif [ "${{ needs.e2e.result }}" != "success" ]; then
+              echo "e2e failed or was skipped"
+              exit 1
+            fi
+            if [ "${{ needs.windows-unit.result }}" != "success" ]; then
+              echo "windows-unit failed or was skipped"
+              exit 1
+            fi
+            if [ "${{ needs.windows-e2e.result }}" != "success" ]; then
+              echo "windows-e2e failed or was skipped"
+              exit 1
+            fi
+          else
+            for result in \
+              "${{ needs.build-windows.result }}" \
+              "${{ needs.unit.result }}" \
+              "${{ needs.e2e.result }}" \
+              "${{ needs.windows-unit.result }}" \
+              "${{ needs.windows-e2e.result }}"; do
+              if [ "$result" != "skipped" ]; then
+                echo "docs-only jobs should be skipped"
+                exit 1
+              fi
+            done
           fi
           echo "All CI jobs completed successfully"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,7 +245,7 @@ jobs:
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
     if: ${{ github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main' }}
-    runs-on: namespace-profile-endev-linux-amd64-xlarge
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     needs: [build-ubuntu]
     timeout-minutes: 30
     steps:
@@ -304,99 +304,54 @@ jobs:
       - name: Pull e2e Docker image
         run: docker pull ghcr.io/jdx/mise:e2e
       # Each test gets isolated host directories and an ephemeral container.
-      # Two tests per tranche caps this runner at 16 concurrent containers.
+      # Run four branches on a standard runner; each branch handles two
+      # token-isolated tranches sequentially.
       - parallel:
-          - name: Test tranche 0
+          - name: Test tranches 0 and 4
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
-              E2E_JOBS: 2
-              GITHUB_TOKEN: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              E2E_JOBS: 1
               MISE_E2E_DOCKER: "1"
-              MISE_GITHUB_TOKEN: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE: 0
               TEST_TRANCHE_COUNT: 8
+              TOKEN_A: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: &e2e-retry
               timeout_minutes: 30
               retry_wait_seconds: 30
               max_attempts: 2
-              command: ./e2e/run_all_tests
-          - name: Test tranche 1
+              command: |
+                MISE_GITHUB_TOKEN="$TOKEN_A" GITHUB_TOKEN="$TOKEN_A" TEST_TRANCHE=0 ./e2e/run_all_tests
+                MISE_GITHUB_TOKEN="$TOKEN_B" GITHUB_TOKEN="$TOKEN_B" TEST_TRANCHE=4 ./e2e/run_all_tests
+          - name: Test tranches 1 and 5
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
-              E2E_JOBS: 2
-              GITHUB_TOKEN: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              E2E_JOBS: 1
               MISE_E2E_DOCKER: "1"
-              MISE_GITHUB_TOKEN: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE: 1
               TEST_TRANCHE_COUNT: 8
+              TOKEN_A: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
-          - name: Test tranche 2
+          - name: Test tranches 2 and 6
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
-              E2E_JOBS: 2
-              GITHUB_TOKEN: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              E2E_JOBS: 1
               MISE_E2E_DOCKER: "1"
-              MISE_GITHUB_TOKEN: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE: 2
               TEST_TRANCHE_COUNT: 8
+              TOKEN_A: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
-          - name: Test tranche 3
+          - name: Test tranches 3 and 7
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
             env:
-              E2E_JOBS: 2
-              GITHUB_TOKEN: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              E2E_JOBS: 1
               MISE_E2E_DOCKER: "1"
-              MISE_GITHUB_TOKEN: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
               TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE: 3
               TEST_TRANCHE_COUNT: 8
-            with: *e2e-retry
-          - name: Test tranche 4
-            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-            env:
-              E2E_JOBS: 2
-              GITHUB_TOKEN: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              MISE_E2E_DOCKER: "1"
-              MISE_GITHUB_TOKEN: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE: 4
-              TEST_TRANCHE_COUNT: 8
-            with: *e2e-retry
-          - name: Test tranche 5
-            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-            env:
-              E2E_JOBS: 2
-              GITHUB_TOKEN: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              MISE_E2E_DOCKER: "1"
-              MISE_GITHUB_TOKEN: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE: 5
-              TEST_TRANCHE_COUNT: 8
-            with: *e2e-retry
-          - name: Test tranche 6
-            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-            env:
-              E2E_JOBS: 2
-              GITHUB_TOKEN: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              MISE_E2E_DOCKER: "1"
-              MISE_GITHUB_TOKEN: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE: 6
-              TEST_TRANCHE_COUNT: 8
-            with: *e2e-retry
-          - name: Test tranche 7
-            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-            env:
-              E2E_JOBS: 2
-              GITHUB_TOKEN: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              MISE_E2E_DOCKER: "1"
-              MISE_GITHUB_TOKEN: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-              TEST_TRANCHE: 7
-              TEST_TRANCHE_COUNT: 8
+              TOKEN_A: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
 
   windows-unit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,16 @@ jobs:
           cargo build --all-features
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - run: mise -v
+      # Downstream jobs only execute this binary, so keep full debug symbols in
+      # the build job while transferring a much smaller stripped copy.
+      - name: Prepare mise artifact
+        run: |
+          install -Dm755 target/debug/mise target/ci-artifacts/mise
+          strip target/ci-artifacts/mise
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mise-ubuntu-latest
-          path: target/debug/mise
-      - uses: ./.github/actions/mise-tools
+          path: target/ci-artifacts/mise
       - run: sccache --show-stats
         if: always()
 
@@ -87,7 +92,6 @@ jobs:
           path: |
             target/debug/mise.exe
             target/debug/mise-shim.exe
-      - uses: ./.github/actions/mise-tools
 
   unit:
     name: unit-macos
@@ -237,33 +241,60 @@ jobs:
         if: always()
 
   e2e:
-    name: e2e-${{matrix.tranche}}
+    name: e2e
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
     if: ${{ github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main' }}
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: namespace-profile-endev-linux-amd64-xlarge
     needs: [build-ubuntu]
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        tranche: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - name: Fetch token from pool
-        id: token
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Set GitHub token from pool
-        if: steps.token.outputs.token
-        run: |
-          {
-            echo "MISE_GITHUB_TOKEN=${{ steps.token.outputs.token }}"
-            echo "GITHUB_TOKEN=${{ steps.token.outputs.token }}"
-          } >> "$GITHUB_ENV"
+      # Preserve the matrix's separate rate-limit tokens while sharing the
+      # expensive runner setup below.
+      - parallel:
+          - name: Fetch token 0
+            id: token_0
+            uses: ./.github/actions/fetch-token
+            with:
+              api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+          - name: Fetch token 1
+            id: token_1
+            uses: ./.github/actions/fetch-token
+            with:
+              api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+          - name: Fetch token 2
+            id: token_2
+            uses: ./.github/actions/fetch-token
+            with:
+              api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+          - name: Fetch token 3
+            id: token_3
+            uses: ./.github/actions/fetch-token
+            with:
+              api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+          - name: Fetch token 4
+            id: token_4
+            uses: ./.github/actions/fetch-token
+            with:
+              api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+          - name: Fetch token 5
+            id: token_5
+            uses: ./.github/actions/fetch-token
+            with:
+              api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+          - name: Fetch token 6
+            id: token_6
+            uses: ./.github/actions/fetch-token
+            with:
+              api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
+          - name: Fetch token 7
+            id: token_7
+            uses: ./.github/actions/fetch-token
+            with:
+              api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: mise-ubuntu-latest
@@ -272,18 +303,101 @@ jobs:
       - uses: ./.github/actions/mise-tools
       - name: Pull e2e Docker image
         run: docker pull ghcr.io/jdx/mise:e2e
-      - name: Test in Docker
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        env:
-          MISE_E2E_DOCKER: "1"
-          TEST_TRANCHE: ${{matrix.tranche}}
-          TEST_TRANCHE_COUNT: 8
-          TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: 30
-          max_attempts: 2
-          command: ./e2e/run_all_tests
+      # Each test gets isolated host directories and an ephemeral container.
+      # Two tests per tranche caps this runner at 16 concurrent containers.
+      - parallel:
+          - name: Test tranche 0
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              GITHUB_TOKEN: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              MISE_E2E_DOCKER: "1"
+              MISE_GITHUB_TOKEN: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE: 0
+              TEST_TRANCHE_COUNT: 8
+            with: &e2e-retry
+              timeout_minutes: 30
+              retry_wait_seconds: 30
+              max_attempts: 2
+              command: ./e2e/run_all_tests
+          - name: Test tranche 1
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              GITHUB_TOKEN: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              MISE_E2E_DOCKER: "1"
+              MISE_GITHUB_TOKEN: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE: 1
+              TEST_TRANCHE_COUNT: 8
+            with: *e2e-retry
+          - name: Test tranche 2
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              GITHUB_TOKEN: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              MISE_E2E_DOCKER: "1"
+              MISE_GITHUB_TOKEN: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE: 2
+              TEST_TRANCHE_COUNT: 8
+            with: *e2e-retry
+          - name: Test tranche 3
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              GITHUB_TOKEN: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              MISE_E2E_DOCKER: "1"
+              MISE_GITHUB_TOKEN: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE: 3
+              TEST_TRANCHE_COUNT: 8
+            with: *e2e-retry
+          - name: Test tranche 4
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              GITHUB_TOKEN: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              MISE_E2E_DOCKER: "1"
+              MISE_GITHUB_TOKEN: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE: 4
+              TEST_TRANCHE_COUNT: 8
+            with: *e2e-retry
+          - name: Test tranche 5
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              GITHUB_TOKEN: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              MISE_E2E_DOCKER: "1"
+              MISE_GITHUB_TOKEN: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE: 5
+              TEST_TRANCHE_COUNT: 8
+            with: *e2e-retry
+          - name: Test tranche 6
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              GITHUB_TOKEN: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              MISE_E2E_DOCKER: "1"
+              MISE_GITHUB_TOKEN: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE: 6
+              TEST_TRANCHE_COUNT: 8
+            with: *e2e-retry
+          - name: Test tranche 7
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            env:
+              E2E_JOBS: 2
+              GITHUB_TOKEN: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              MISE_E2E_DOCKER: "1"
+              MISE_GITHUB_TOKEN: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TEST_ALL: ${{(github.head_ref == 'release' || github.ref == 'refs/heads/release') && '1' || '0'}}
+              TEST_TRANCHE: 7
+              TEST_TRANCHE_COUNT: 8
+            with: *e2e-retry
 
   windows-unit:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary

- upload a debug-stripped staging copy of the Linux binary while retaining local debug symbols in the build job and function symbols downstream
- remove redundant `mise-tools` cache restores from artifact-producing jobs
- replace eight Linux e2e runners with one standard runner that shares checkout, artifact download, tool setup, and Docker image pull
- preserve eight separately fetched GitHub tokens and all eight test tranches in four parallel branches (at most eight concurrent containers)
- skip macOS, Windows, unit, and e2e jobs only when every changed file is under `docs/` or is Markdown; Linux build/render/lint and nightly still run
- overlap safe read-only Windows post-build work and Linux e2e setup work

## Why

A representative run spent about 38 runner-minutes across the Linux e2e jobs, including roughly 21 minutes of repeated setup and cleanup. The 177 MB compressed binary artifact was also downloaded separately by every tranche. This keeps the same test coverage while reducing repeated work and namespace concurrency pressure.

Live validation showed:

- the symbol-preserving stripped artifact fell from about 177 MB to 74.2 MB compressed and downloaded in 7 seconds in the final run
- an xlarge runner remained queued at the namespace limit, while the standard e2e runner could start alongside lint
- all eight token fetches and four paired tranche branches expanded correctly through native parallel steps
- the consolidated e2e job passed in 10m33 on one runner; its four branches completed in 8m43–9m58
- lint passed in 7m15 and nightly passed in 4m29

## Safety

- e2e tests use isolated host directories and ephemeral Docker containers, with the repository mounted read-only
- each tranche retains its own token to avoid concentrating API rate-limit use
- docs-only classification is deliberately narrow; all non-PR runs and any non-doc file force full CI
- the required `test-ci` aggregate verifies that docs-only jobs were actually skipped
- perf and nightly checks remain unconditional
- Cargo checks are not parallelized against one another

## Validation

- `actionlint .github/workflows/test.yml`
- `bun x prettier --check .github/workflows/test.yml`
- `git diff --check`
- full GitHub Actions test workflow: https://github.com/jdx/mise/actions/runs/30577391980

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*