### PR TITLE
chore: release 2026.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,98 @@
 # Changelog
 
+## [2026.8.0](https://github.com/jdx/mise/compare/v2026.7.18..v2026.8.0) - 2026-08-01
+
+### 🚀 Features
+
+- **(ruby)** make precompiled binaries the default by @jdx in [#11584](https://github.com/jdx/mise/pull/11584)
+- **(task)** configure vcs ignores for watch by @Marukome0743 in [#11535](https://github.com/jdx/mise/pull/11535)
+- **(task)** add provider task suggestions by @jdx in [#11543](https://github.com/jdx/mise/pull/11543)
+- **(task)** explain workspace inference provenance by @jdx in [#11547](https://github.com/jdx/mise/pull/11547)
+- **(task)** infer Cargo workspace dependencies by @jdx in [#11554](https://github.com/jdx/mise/pull/11554)
+- **(task)** infer uv workspace dependencies by @jdx in [#11556](https://github.com/jdx/mise/pull/11556)
+- **(task)** discover Go workspaces by @jdx in [#11559](https://github.com/jdx/mise/pull/11559)
+- **(task)** map changed files to workspace projects by @jdx in [#11569](https://github.com/jdx/mise/pull/11569)
+- **(task)** expand affected workspace projects by @jdx in [#11583](https://github.com/jdx/mise/pull/11583)
+- **(task)** resolve affected Git revisions by @jdx in [#11585](https://github.com/jdx/mise/pull/11585)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** read checksum files that carry a byte-order mark by @JamBalaya56562 in [#11552](https://github.com/jdx/mise/pull/11552)
+- **(aqua)** fetch the checksum manifest with get_text again by @JamBalaya56562 in [#11558](https://github.com/jdx/mise/pull/11558)
+- **(asdf)** expose dependencies to install scripts by @Marukome0743 in [#11531](https://github.com/jdx/mise/pull/11531)
+- **(asdf)** fail when bin/install installs nothing by @JamBalaya56562 in [#11553](https://github.com/jdx/mise/pull/11553)
+- **(brew-cask)** harden direct cask pours by @donbeave in [#11215](https://github.com/jdx/mise/pull/11215)
+- **(config)** make --path <dir> target that directory by @JamBalaya56562 in [#11575](https://github.com/jdx/mise/pull/11575)
+- **(dotfiles)** avoid scanning symlink-each targets by @jdx in [#11549](https://github.com/jdx/mise/pull/11549)
+- **(env)** allow redact false to override patterns by @jdx in [#11564](https://github.com/jdx/mise/pull/11564)
+- **(forgejo)** support new fj macos key path by @jdx in [#11545](https://github.com/jdx/mise/pull/11545)
+- **(github,gitlab)** find gh/glab config on Windows by @JamBalaya56562 in [#11508](https://github.com/jdx/mise/pull/11508)
+- **(hook-env)** restore modified managed environment by @Marukome0743 in [#11568](https://github.com/jdx/mise/pull/11568)
+- **(http)** handle client initialization failures by @Marukome0743 in [#11561](https://github.com/jdx/mise/pull/11561)
+- **(python)** honour --tool when creating a venv by @JamBalaya56562 in [#11567](https://github.com/jdx/mise/pull/11567)
+- **(task)** handle ctrl-c as task interruption by @Marukome0743 in [#11511](https://github.com/jdx/mise/pull/11511)
+- **(task)** support brace globs in sources and outputs by @Marukome0743 in [#11555](https://github.com/jdx/mise/pull/11555)
+- **(task)** preserve literal singleton braces in globs by @Marukome0743 in [#11565](https://github.com/jdx/mise/pull/11565)
+- **(unuse)** preserve unselected tool versions by @Marukome0743 in [#11563](https://github.com/jdx/mise/pull/11563)
+- **(vfox)** verify sha1 and md5 checksums instead of panicking by @JamBalaya56562 in [#11536](https://github.com/jdx/mise/pull/11536)
+
+### 🚜 Refactor
+
+- **(backend)** group clippy-heavy call contexts by @jdx in [#11525](https://github.com/jdx/mise/pull/11525)
+- **(config)** centralize interactive render options by @jdx in [#11522](https://github.com/jdx/mise/pull/11522)
+- **(env)** centralize directive resolution context by @jdx in [#11521](https://github.com/jdx/mise/pull/11521)
+- **(task)** group scheduler and cache state by @jdx in [#11527](https://github.com/jdx/mise/pull/11527)
+- **(task)** centralize execution context by @jdx in [#11528](https://github.com/jdx/mise/pull/11528)
+- clean up obsolete clippy exceptions by @jdx in [#11519](https://github.com/jdx/mise/pull/11519)
+- remove targeted clippy exceptions by @jdx in [#11524](https://github.com/jdx/mise/pull/11524)
+
+### 📚 Documentation
+
+- **(task)** define workspace task precedence by @jdx in [#11542](https://github.com/jdx/mise/pull/11542)
+- discourage clippy exclusions by @jdx in [#11529](https://github.com/jdx/mise/pull/11529)
+
+### ⚡ Performance
+
+- **(ci)** reduce repeated test setup by @jdx in [#11514](https://github.com/jdx/mise/pull/11514)
+- **(release)** optimize linux x64 binary with BOLT by @jdx in [#11533](https://github.com/jdx/mise/pull/11533)
+- **(shim)** reuse resolved toolset and config roots by @jdx in [#11534](https://github.com/jdx/mise/pull/11534)
+- **(task)** cache workspace discovery filesystem access by @jdx in [#11562](https://github.com/jdx/mise/pull/11562)
+- reduce release binary size by @jdx in [#11520](https://github.com/jdx/mise/pull/11520)
+
+### 🧪 Testing
+
+- **(parallel)** pin cancel-and-drain against the join_all panic by @JamBalaya56562 in [#11532](https://github.com/jdx/mise/pull/11532)
+
+### 📦️ Dependency Updates
+
+- bump aube to 1.37.0 by @jdx in [#11539](https://github.com/jdx/mise/pull/11539)
+
+### 📦 Registry
+
+- update herdr repository by @ogulcancelik in [#11518](https://github.com/jdx/mise/pull/11518)
+
+### Chore
+
+- **(clippy)** fix warnings surfaced by clippy 0.1.97 by @JamBalaya56562 in [#11516](https://github.com/jdx/mise/pull/11516)
+- **(clippy)** gate an already-unix-only binding in vfox by @JamBalaya56562 in [#11517](https://github.com/jdx/mise/pull/11517)
+- **(lint)** remove stale template exclusions by @jdx in [#11526](https://github.com/jdx/mise/pull/11526)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (2)
+
+- [`ProtonDriveApps/sdk/cli`](https://github.com/ProtonDriveApps/sdk)
+- [`asmz/agedir`](https://github.com/asmz/agedir)
+
+#### Updated Packages (6)
+
+- [`Byron/dua-cli`](https://github.com/Byron/dua-cli)
+- [`hadolint/hadolint`](https://github.com/hadolint/hadolint)
+- [`haskell/cabal/cabal-install`](https://github.com/haskell/cabal)
+- [`itamae-kitchen/mitamae`](https://github.com/itamae-kitchen/mitamae)
+- [`lintnet/lintnet`](https://github.com/lintnet/lintnet)
+- [`supabase/cli`](https://github.com/supabase/cli)
+
 ## [2026.7.18](https://github.com/jdx/mise/compare/v2026.7.17..v2026.7.18) - 2026-07-30
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6313,7 +6313,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.7.18"
+version = "2026.8.0"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.7.18"
+version = "2026.8.0"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.7.18 macos-arm64 (2026-07-30)
+2026.8.0 macos-arm64 (2026-08-01)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_18.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_0.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_7_18.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_0.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -p usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_7_18.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_0.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_7_18.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_0.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.7.18";
+  version = "2026.8.0";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "31.3k",
+      stars: "31.4k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.7.18
+Version: 2026.8.0
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.7.18"
+version: "2026.8.0"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "fccbf15163f3e04681c359444b69e79bcd7f1d36"
+  "tag": "c294d12eaa19030a91d9e84801d1f4575a9e5f3b"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -1742,6 +1742,25 @@ packages:
         supported_envs:
           - darwin
           - linux
+      - version_constraint: semver("<= 2.39.0")
+        asset: dua-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: dua
+            src: "{{.AssetWithoutExt}}/dua"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: dua-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -1761,6 +1780,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: Byron/dua-cli/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: ByteNess
     repo_name: aws-vault
@@ -6753,6 +6774,23 @@ packages:
           - goos: windows
             format: zip
             asset: PowerShell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+  - type: http
+    name: ProtonDriveApps/sdk/cli
+    repo_owner: ProtonDriveApps
+    repo_name: sdk
+    description: Manage your Proton Drive files from the CLI
+    link: https://proton.me/support/drive-cli
+    version_source: github_tag
+    version_prefix: cli/
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        url: https://proton.me/download/drive/cli/{{trimV .SemVer}}/{{.OS}}-{{.Arch}}/proton-drive
+        format: raw
+        files:
+          - name: proton-drive
+        replacements:
+          amd64: x64
   - type: github_release
     repo_owner: Qovery
     repo_name: Replibyte
@@ -16516,6 +16554,29 @@ packages:
         supported_envs:
           - linux
           - darwin
+  - type: github_release
+    repo_owner: asmz
+    repo_name: agedir
+    description: A CLI tool to bulk-encrypt, decrypt, and place multiple secret files across a project using age encryption and a simple YAML mapping config
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.0")
+        asset: agedir-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: agedir_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: assetnote
     repo_name: surf
@@ -47432,6 +47493,17 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
+      - version_constraint: semver("<= 2.14.0")
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
       - version_constraint: "true"
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
@@ -47443,6 +47515,8 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: hadolint/hadolint/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: hairyhenderson
     repo_name: gomplate
@@ -48047,7 +48121,7 @@ packages:
             format: zip
             url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
             replacements: {}
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.16.1.0")
         url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}-alpine3_12.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
@@ -48068,6 +48142,23 @@ packages:
             format: zip
             url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
             replacements: {}
+      - version_constraint: "true"
+        url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: linux-unknown
+          windows: mingw64
+        checksum:
+          type: http
+          url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: http
     repo_owner: haskell
     repo_name: ghcup-hs
@@ -51267,9 +51358,20 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.14.4")
         asset: mitamae-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        github_artifact_attestations:
+          signer_workflow: itamae-kitchen/mitamae/.github/workflows/build.yml
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: mitamae-{{.Arch}}-{{.OS}}
+        format: raw
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -62083,6 +62185,29 @@ packages:
     description: General Linter powered by Jsonnet
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.4.8-1")
+        asset: lintnet_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        checksum:
+          type: github_release
+          asset: lintnet_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --signature
+              - https://github.com/lintnet/lintnet/releases/download/{{.Version}}/lintnet_{{trimV .Version}}_checksums.txt.sig
+              - --certificate
+              - https://github.com/lintnet/lintnet/releases/download/{{.Version}}/lintnet_{{trimV .Version}}_checksums.txt.pem
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
       - version_constraint: semver("<= 0.4.11")
         asset: lintnet_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -62106,6 +62231,8 @@ packages:
               - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
               - --certificate-oidc-issuer
               - "https://token.actions.githubusercontent.com"
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/\.github/workflows/release\.yaml
       - version_constraint: "true"
         asset: lintnet_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -62128,6 +62255,8 @@ packages:
               - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
               - --certificate-oidc-issuer
               - "https://token.actions.githubusercontent.com"
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/\.github/workflows/release\.yaml
   - type: github_release
     repo_owner: linuxkit
     repo_name: linuxkit
@@ -88449,12 +88578,19 @@ packages:
           type: github_release
           asset: supabase_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.98.0")
         asset: supabase_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release
           asset: supabase_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: supabase_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
           algorithm: sha256
   - type: github_release
     repo_owner: superbrothers


### PR DESCRIPTION
### 🚀 Features

- **(ruby)** make precompiled binaries the default by @jdx in [#11584](https://github.com/jdx/mise/pull/11584)
- **(task)** configure vcs ignores for watch by @Marukome0743 in [#11535](https://github.com/jdx/mise/pull/11535)
- **(task)** add provider task suggestions by @jdx in [#11543](https://github.com/jdx/mise/pull/11543)
- **(task)** explain workspace inference provenance by @jdx in [#11547](https://github.com/jdx/mise/pull/11547)
- **(task)** infer Cargo workspace dependencies by @jdx in [#11554](https://github.com/jdx/mise/pull/11554)
- **(task)** infer uv workspace dependencies by @jdx in [#11556](https://github.com/jdx/mise/pull/11556)
- **(task)** discover Go workspaces by @jdx in [#11559](https://github.com/jdx/mise/pull/11559)
- **(task)** map changed files to workspace projects by @jdx in [#11569](https://github.com/jdx/mise/pull/11569)
- **(task)** expand affected workspace projects by @jdx in [#11583](https://github.com/jdx/mise/pull/11583)
- **(task)** resolve affected Git revisions by @jdx in [#11585](https://github.com/jdx/mise/pull/11585)

### 🐛 Bug Fixes

- **(aqua)** read checksum files that carry a byte-order mark by @JamBalaya56562 in [#11552](https://github.com/jdx/mise/pull/11552)
- **(aqua)** fetch the checksum manifest with get_text again by @JamBalaya56562 in [#11558](https://github.com/jdx/mise/pull/11558)
- **(asdf)** expose dependencies to install scripts by @Marukome0743 in [#11531](https://github.com/jdx/mise/pull/11531)
- **(asdf)** fail when bin/install installs nothing by @JamBalaya56562 in [#11553](https://github.com/jdx/mise/pull/11553)
- **(brew-cask)** harden direct cask pours by @donbeave in [#11215](https://github.com/jdx/mise/pull/11215)
- **(config)** make --path <dir> target that directory by @JamBalaya56562 in [#11575](https://github.com/jdx/mise/pull/11575)
- **(dotfiles)** avoid scanning symlink-each targets by @jdx in [#11549](https://github.com/jdx/mise/pull/11549)
- **(env)** allow redact false to override patterns by @jdx in [#11564](https://github.com/jdx/mise/pull/11564)
- **(forgejo)** support new fj macos key path by @jdx in [#11545](https://github.com/jdx/mise/pull/11545)
- **(github,gitlab)** find gh/glab config on Windows by @JamBalaya56562 in [#11508](https://github.com/jdx/mise/pull/11508)
- **(hook-env)** restore modified managed environment by @Marukome0743 in [#11568](https://github.com/jdx/mise/pull/11568)
- **(http)** handle client initialization failures by @Marukome0743 in [#11561](https://github.com/jdx/mise/pull/11561)
- **(python)** honour --tool when creating a venv by @JamBalaya56562 in [#11567](https://github.com/jdx/mise/pull/11567)
- **(task)** handle ctrl-c as task interruption by @Marukome0743 in [#11511](https://github.com/jdx/mise/pull/11511)
- **(task)** support brace globs in sources and outputs by @Marukome0743 in [#11555](https://github.com/jdx/mise/pull/11555)
- **(task)** preserve literal singleton braces in globs by @Marukome0743 in [#11565](https://github.com/jdx/mise/pull/11565)
- **(unuse)** preserve unselected tool versions by @Marukome0743 in [#11563](https://github.com/jdx/mise/pull/11563)
- **(vfox)** verify sha1 and md5 checksums instead of panicking by @JamBalaya56562 in [#11536](https://github.com/jdx/mise/pull/11536)

### 🚜 Refactor

- **(backend)** group clippy-heavy call contexts by @jdx in [#11525](https://github.com/jdx/mise/pull/11525)
- **(config)** centralize interactive render options by @jdx in [#11522](https://github.com/jdx/mise/pull/11522)
- **(env)** centralize directive resolution context by @jdx in [#11521](https://github.com/jdx/mise/pull/11521)
- **(task)** group scheduler and cache state by @jdx in [#11527](https://github.com/jdx/mise/pull/11527)
- **(task)** centralize execution context by @jdx in [#11528](https://github.com/jdx/mise/pull/11528)
- clean up obsolete clippy exceptions by @jdx in [#11519](https://github.com/jdx/mise/pull/11519)
- remove targeted clippy exceptions by @jdx in [#11524](https://github.com/jdx/mise/pull/11524)

### 📚 Documentation

- **(task)** define workspace task precedence by @jdx in [#11542](https://github.com/jdx/mise/pull/11542)
- discourage clippy exclusions by @jdx in [#11529](https://github.com/jdx/mise/pull/11529)

### ⚡ Performance

- **(ci)** reduce repeated test setup by @jdx in [#11514](https://github.com/jdx/mise/pull/11514)
- **(release)** optimize linux x64 binary with BOLT by @jdx in [#11533](https://github.com/jdx/mise/pull/11533)
- **(shim)** reuse resolved toolset and config roots by @jdx in [#11534](https://github.com/jdx/mise/pull/11534)
- **(task)** cache workspace discovery filesystem access by @jdx in [#11562](https://github.com/jdx/mise/pull/11562)
- reduce release binary size by @jdx in [#11520](https://github.com/jdx/mise/pull/11520)

### 🧪 Testing

- **(parallel)** pin cancel-and-drain against the join_all panic by @JamBalaya56562 in [#11532](https://github.com/jdx/mise/pull/11532)

### 📦️ Dependency Updates

- bump aube to 1.37.0 by @jdx in [#11539](https://github.com/jdx/mise/pull/11539)

### 📦 Registry

- update herdr repository by @ogulcancelik in [#11518](https://github.com/jdx/mise/pull/11518)

### Chore

- **(clippy)** fix warnings surfaced by clippy 0.1.97 by @JamBalaya56562 in [#11516](https://github.com/jdx/mise/pull/11516)
- **(clippy)** gate an already-unix-only binding in vfox by @JamBalaya56562 in [#11517](https://github.com/jdx/mise/pull/11517)
- **(lint)** remove stale template exclusions by @jdx in [#11526](https://github.com/jdx/mise/pull/11526)

## 📦 Aqua Registry Updates

### New Packages (2)

- [`ProtonDriveApps/sdk/cli`](https://github.com/ProtonDriveApps/sdk)
- [`asmz/agedir`](https://github.com/asmz/agedir)

### Updated Packages (6)

- [`Byron/dua-cli`](https://github.com/Byron/dua-cli)
- [`hadolint/hadolint`](https://github.com/hadolint/hadolint)
- [`haskell/cabal/cabal-install`](https://github.com/haskell/cabal)
- [`itamae-kitchen/mitamae`](https://github.com/itamae-kitchen/mitamae)
- [`lintnet/lintnet`](https://github.com/lintnet/lintnet)
- [`supabase/cli`](https://github.com/supabase/cli)