### PR TITLE
chore(clippy): fix warnings surfaced by clippy 0.1.97

### DIFF
--- a/src/backend/dotnet.rs
+++ b/src/backend/dotnet.rs
@@ -65,7 +65,7 @@ impl Backend for DotnetBackend {
                 // version arrays of packages that are visible.
                 "{}?q={}&packageType=dotnettool&take=1&prerelease={}&semVerLevel=2.0.0",
                 feed_url,
-                &self.tool_name(),
+                self.tool_name(),
                 true
             ))
             .await?;

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -426,7 +426,7 @@ impl Doctor {
                 && !plugin.is_installed()
             {
                 self.errors
-                    .push(format!("plugin {} is not installed", &plugin.name()));
+                    .push(format!("plugin {} is not installed", plugin.name()));
                 continue;
             }
         }
@@ -823,7 +823,7 @@ impl Doctor {
 
             if is_core && matches!(plugin_type, Some(PluginType::Asdf | PluginType::Vfox)) {
                 self.warnings
-                    .push(format!("plugin {} overrides a core plugin", &plugin.id()));
+                    .push(format!("plugin {} overrides a core plugin", plugin.id()));
             }
         }
     }

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -207,7 +207,7 @@ impl Edit {
     async fn interactive(&self, path: &Path) -> Result<()> {
         use crate::ui::progress_report::ProgressReport;
 
-        let title = format!("mise {} by @jdx", &*VERSION_PLAIN);
+        let title = format!("mise {} by @jdx", *VERSION_PLAIN);
 
         // Show loading spinner while setting up
         let pr = ProgressReport::new("edit".into());

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -473,18 +473,16 @@ where
     // `mise exec -- cmd /c "echo one" two` is not reinterpreted as a shell body.
     // cwd is intentionally inherited from the process here, matching the duct
     // fallback below; the resolved `cwd` above governs program lookup only.
-    if shell_body_mode {
-        if let (Some(prog), [.., last]) = (program.to_str(), args.as_slice()) {
-            let flags: Vec<String> = args[..args.len() - 1]
-                .iter()
-                .map(|a| a.to_string_lossy().into_owned())
-                .collect();
-            let body = last.to_string_lossy();
-            if let Some(mut c) = crate::path::cmd_verbatim_command(prog, &flags, &body) {
-                match c.status()?.code() {
-                    Some(code) => return Err(crate::request_exit(code)),
-                    None => return Err(eyre!("command failed: terminated by signal")),
-                }
+    if shell_body_mode && let (Some(prog), [.., last]) = (program.to_str(), args.as_slice()) {
+        let flags: Vec<String> = args[..args.len() - 1]
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let body = last.to_string_lossy();
+        if let Some(mut c) = crate::path::cmd_verbatim_command(prog, &flags, &body) {
+            match c.status()?.code() {
+                Some(code) => return Err(crate::request_exit(code)),
+                None => return Err(eyre!("command failed: terminated by signal")),
             }
         }
     }

--- a/src/cli/generate/github_action.rs
+++ b/src/cli/generate/github_action.rs
@@ -27,7 +27,7 @@ impl GithubAction {
         if self.write {
             let path = Git::get_root()?
                 .join(".github/workflows")
-                .join(format!("{}.yml", &self.name));
+                .join(format!("{}.yml", self.name));
             file::write(&path, &output)?;
             miseprintln!("Wrote to {}", display_path(&path));
         } else {

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -160,7 +160,7 @@ async fn delete(
         }
         if !dry_run
             && !Settings::get().yes
-            && !prompt::confirm_with_all(format!("remove {} ?", &tv))?
+            && !prompt::confirm_with_all(format!("remove {} ?", tv))?
         {
             continue;
         }

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1491,7 +1491,7 @@ fn set_value_decor(item: &mut Item, decor: &Option<toml_edit::Decor>) {
 impl Debug for MiseToml {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let tools = self.to_tool_request_set().unwrap().to_string();
-        let title = format!("MiseToml({}): {tools}", &display_path(&self.path));
+        let title = format!("MiseToml({}): {tools}", display_path(&self.path));
         let mut d = f.debug_struct(&title);
         if let Some(min_version) = &self.min_version {
             d.field("min_version", min_version);
@@ -2808,7 +2808,7 @@ mod tests {
         )));
         assert_debug_snapshot!(cf.alias);
 
-        assert_snapshot!(replace_path(&format!("{:#?}", &cf)));
+        assert_snapshot!(replace_path(&format!("{:#?}", cf)));
     }
 
     #[tokio::test]

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -756,7 +756,7 @@ async fn detect_config_file_type(path: &Path) -> Option<ConfigFileType> {
 impl Display for dyn ConfigFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let toolset = self.to_toolset().unwrap().to_string();
-        write!(f, "{}: {toolset}", &display_path(self.get_path()))
+        write!(f, "{}: {toolset}", display_path(self.get_path()))
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -929,7 +929,7 @@ fn filename(path: &str) -> &str {
 fn get_token(keys: &[&str]) -> Option<String> {
     keys.iter()
         .find_map(|key| var(key).ok())
-        .and_then(|v| if v.trim().is_empty() { None } else { Some(v) })
+        .filter(|v| !v.trim().is_empty())
 }
 
 pub fn is_activated() -> bool {

--- a/src/plugins/asdf_plugin.rs
+++ b/src/plugins/asdf_plugin.rs
@@ -443,7 +443,7 @@ impl Plugin for AsdfPlugin {
         }
 
         let topic = Command::new(self.name.clone())
-            .about(format!("Commands provided by {} plugin", &self.name))
+            .about(format!("Commands provided by {} plugin", self.name))
             .subcommands(commands.into_iter().map(|cmd| {
                 Command::new(cmd.join("-"))
                     .about(format!("{} command", cmd.join("-")))

--- a/src/plugins/core/deno.rs
+++ b/src/plugins/core/deno.rs
@@ -196,7 +196,7 @@ impl Backend for DenoPlugin {
             .ok_or_else(|| eyre::eyre!("Failed to get deno tarball URL"))?;
 
         // Deno provides .sha256sum files alongside each zip
-        let checksum_url = format!("{}.sha256sum", &url);
+        let checksum_url = format!("{}.sha256sum", url);
         let checksum = fetch_checksum_from_file(&checksum_url, "sha256").await;
 
         Ok(PlatformInfo {

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -123,7 +123,7 @@ impl GoPlugin {
 
         let tarball_url_ = tarball_url.clone();
         let checksum_handle = tokio::spawn(async move {
-            let checksum_url = format!("{}.sha256", &tarball_url_);
+            let checksum_url = format!("{}.sha256", tarball_url_);
             HTTP.get_text(checksum_url).await
         });
         pr.set_message(format!("download {filename}"));
@@ -370,7 +370,7 @@ impl Backend for GoPlugin {
         };
         Ok(Some(format!(
             "{}/go{}.{}-{}.{}",
-            &settings.go.download_mirror, tv.version, platform, arch, ext
+            settings.go.download_mirror, tv.version, platform, arch, ext
         )))
     }
 
@@ -389,7 +389,7 @@ impl Backend for GoPlugin {
 
         // Go provides .sha256 files alongside each tarball
         let checksum = if !settings.go.skip_checksum {
-            let checksum_url = format!("{}.sha256", &url);
+            let checksum_url = format!("{}.sha256", url);
             fetch_checksum_from_file(&checksum_url, "sha256").await
         } else {
             None

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -500,7 +500,7 @@ impl PythonPlugin {
             cmd = cmd.arg("--patch").stdin_string(patch)
         }
         if let Some(patches_dir) = &Settings::get().python.patches_directory {
-            let patch_file = patches_dir.join(format!("{}.patch", &tv.version));
+            let patch_file = patches_dir.join(format!("{}.patch", tv.version));
             if patch_file.exists() {
                 ctx.pr
                     .set_message(format!("with patch file: {}", patch_file.display()));

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -86,8 +86,8 @@ impl RemoteTaskGit {
     fn get_cache_key(&self, repo_structure: &GitRepoStructure) -> String {
         let key = format!(
             "{}{}",
-            &repo_structure.url_without_path,
-            &repo_structure.branch.to_owned().unwrap_or("".to_string())
+            repo_structure.url_without_path,
+            repo_structure.branch.to_owned().unwrap_or("".to_string())
         );
         hash::hash_sha256_to_str(&key)
     }
@@ -150,7 +150,7 @@ impl TaskFileProvider for RemoteTaskGit {
             trace!("Cache mode disabled");
         }
 
-        let tmp_destination = self.storage_path.join(format!("{}.clone-tmp", &cache_key));
+        let tmp_destination = self.storage_path.join(format!("{}.clone-tmp", cache_key));
         if tmp_destination.exists() {
             crate::file::remove_all(&tmp_destination)?;
         }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -99,10 +99,10 @@ pub fn get_credential_command_token(provider: &str, cmd: &str, host: &str) -> Op
     // the plain Command::new(program).args(args). The command body is the last
     // element of args (see credential_command_shell_from).
     #[cfg(windows)]
-    if let Some((body, flags)) = args.split_last() {
-        if let Some(c) = crate::path::cmd_verbatim_command(&program, flags, body) {
-            command = c;
-        }
+    if let Some((body, flags)) = args.split_last()
+        && let Some(c) = crate::path::cmd_verbatim_command(&program, flags, body)
+    {
+        command = c;
     }
     let result = command
         .env("PATH", &path_without_shims)

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -611,7 +611,7 @@ pub fn version_sub(orig: &str, sub: &str) -> String {
 
 impl Display for ToolRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}@{}", &self.ba(), self.version())
+        write!(f, "{}@{}", self.ba(), self.version())
     }
 }
 

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -297,7 +297,7 @@ impl ToolVersion {
         format!(
             "{}{}",
             style(&self.ba().short).blue().for_stderr(),
-            style(&format!("@{}", &self.version)).for_stderr()
+            style(&format!("@{}", self.version)).for_stderr()
         )
     }
     pub fn tv_pathname(&self) -> String {
@@ -699,7 +699,7 @@ impl ToolVersion {
 
 impl Display for ToolVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}@{}", &self.ba().full(), &self.version)
+        write!(f, "{}@{}", self.ba().full(), self.version)
     }
 }
 


### PR DESCRIPTION
## What

25 clippy warnings across 17 files:

| lint | count |
|---|---|
| `clippy::useless_borrows_in_formatting` | 22 |
| `clippy::collapsible_if` | 2 |
| `clippy::manual_filter` | 1 |

All semantics-preserving. The edits are `cargo clippy --fix` output, reviewed rather than transcribed by hand — the only non-mechanical-looking ones are the two let-chain conversions and the `manual_filter`:

```diff
-    if shell_body_mode {
-        if let (Some(prog), [.., last]) = (program.to_str(), args.as_slice()) {
+    if shell_body_mode && let (Some(prog), [.., last]) = (program.to_str(), args.as_slice()) {
```

```diff
-        .and_then(|v| if v.trim().is_empty() { None } else { Some(v) })
+        .filter(|v| !v.trim().is_empty())
```

## Why these are not already caught

The `lint` job runs `cargo clippy -- -D warnings` on a Linux runner. Nothing runs clippy on Windows or macOS, so I ran `cargo clippy --all-targets` on `windows-latest` and `macos-latest` to see what was there. Two categories came back, and it is worth separating them:

**Three are genuinely platform-gated** — invisible to CI because the code is never compiled there:

- `src/cli/exec.rs` and `src/tokens.rs` — `collapsible_if` inside `#[cfg(windows)]` blocks
- `src/config/config_file/mise_toml.rs` — a test that is not compiled on Windows

This is the same drift #10149 ("clean up accumulated Windows-only clippy warnings") and #10425 cleaned up before.

**The other 22 are ordinary cross-platform code**, not behind any `cfg`. They are invisible for a different reason: the runners I used had **clippy 0.1.97 (rustc 1.97.1)**, which is newer than what the Linux `lint` runner is using. So these are not a platform problem at all — they are queued up to start failing the `lint` job the moment that toolchain moves. Fixing them now means that update is a non-event.

## Out of scope

`crates/*` warnings are left alone. Those crates sit outside the `lint` job's scope entirely (`cargo clippy` lints default members; `windows-unit`'s check is `-p mise`), and the findings there raise a separate question rather than a mechanical fix — `crates/mise-shim` calls `std::process::exit` five times, which the repo's own `clippy.toml` disallows, but a shim binary's `main` is exactly the outermost boundary that rule carves out. That deserves its own PR and its own discussion.

Also out of scope, but worth saying out loud: nothing here stops the drift recurring. Adding clippy to the existing `windows-unit` job (and a macOS equivalent) would, at the cost of build time. Happy to open that separately if you want it.

## Verification

The `lint` job here covers Linux as usual. For the two targets CI does not lint, I am re-running `cargo clippy --all-targets` on `windows-latest` and `macos-latest` against this branch and will post the result below — that re-run is the actual proof that the list is now empty, so I would rather report it than assert it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command execution handling without changing existing command behavior.
  * Continued to ignore empty or whitespace-only authentication tokens.
  * Preserved tool, plugin, configuration, and task formatting and path-generation behavior.

* **Refactor**
  * Simplified internal string formatting and conditional logic across tool management, plugins, task handling, and CLI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->