### PR TITLE
chore(clippy): gate an already-unix-only binding in vfox

### DIFF
--- a/crates/vfox/src/lua_mod/file.rs
+++ b/crates/vfox/src/lua_mod/file.rs
@@ -219,6 +219,8 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let file_path = temp_dir.path().join("stat-file.txt");
         let file_path_str = file_path.to_string_lossy().to_string();
+        // only read by the `#[cfg(unix)]` permissions assertion further down
+        #[cfg(unix)]
         let file_path_str_clone = file_path_str.clone();
         let dir_path = temp_dir.path().join("stat-dir");
         let dir_path_str = dir_path.to_string_lossy().to_string();


### PR DESCRIPTION
One line, plus a comment.

```rust
         let file_path_str = file_path.to_string_lossy().to_string();
+        // only read by the `#[cfg(unix)]` permissions assertion further down
+        #[cfg(unix)]
         let file_path_str_clone = file_path_str.clone();
```

`file_path_str_clone` is read only inside the `#[cfg(unix)]` block later in `test_stat`, so on Windows it is an unused binding. Gated to match its single use rather than silenced — no `allow` attribute, no behaviour change.

## Why it is invisible today

Neither clippy path in CI reaches it. The `lint` job's `cargo clippy` lints the default workspace members on Linux, and `windows-unit`'s `-D unused` check is scoped with `-p mise`, so `crates/vfox` on Windows falls through both. I found it by running `cargo clippy --workspace --all-targets` on `windows-latest`, which is also where the fixes in #11516 came from.

That matters for **#11529**, which widens CI clippy to the whole workspace with `--all-features --all-targets`. Once that lands, this warning becomes a failure on the Windows leg — assuming clippy runs there. If #11529 stays Linux-only it will not, and this is simply a latent tidy-up.

## Scope, and how this relates to your clippy stack

This PR started life larger and has been cut down deliberately, because your stack overtook most of it:

- It also added `#[allow(clippy::disallowed_methods)]` to `crates/mise-shim` for its five `std::process::exit` calls. **#11524** removes those calls entirely by restructuring around `ExitCode` and a `run() -> Result<i32, String>`, which is strictly better than an allow — dropped from here.
- **#11529** bans `allow`/`expect` attributes for clippy outright, so that half was pointing the wrong way regardless.
- **#11519** cleaned up obsolete exceptions; nothing there overlaps this file.

What is left is the one finding none of those touch: a genuinely unused binding on Windows, fixed without an exclusion. If you would rather fold it into your stack, feel free to take the two lines and close this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform test compatibility by ensuring Unix-specific file permission checks are only compiled on Unix systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->