### PR TITLE
registry: update herdr repository

### DIFF
--- a/registry/herdr.toml
+++ b/registry/herdr.toml
@@ -1,3 +1,3 @@
-backends = ["aqua:ogulcancelik/herdr", "github:ogulcancelik/herdr"]
+backends = ["aqua:herdrdev/herdr", "github:herdrdev/herdr"]
 description = "Agent multiplexer that lives in your terminal"
 test = { cmd = "herdr --version", expected = "herdr {{version}}" }


### PR DESCRIPTION
## Summary

- update Herdr’s Aqua and GitHub backends to the canonical `herdrdev/herdr` repository
- align mise’s registry entry with Aqua’s repository-transfer metadata

## Why

Herdr transferred from `ogulcancelik/herdr` to `herdrdev/herdr`.

The Aqua registry completed the corresponding migration in [aquaproj/aqua-registry#57930](https://github.com/aquaproj/aqua-registry/pull/57930) and retains `ogulcancelik/herdr` as a compatibility alias. GitHub also redirects the previous repository URL.

Using the canonical repository identity avoids relying on those compatibility redirects and keeps mise aligned with the current Aqua package metadata.

## Validation

- `mise ls-remote aqua:herdrdev/herdr`
- `mise ls-remote github:herdrdev/herdr`
- `mise x aqua:herdrdev/herdr@0.7.5 -- herdr --version`
- `taplo check registry/herdr.toml`

## Popularity

- GitHub: 22.6k stars and 1.5k forks
- Latest stable release: v0.7.5, published 2026-07-21
- v0.7.5 release assets: approximately 51k downloads

*AI-assisted — Tool: pi; model: openai-codex/gpt-5.6-sol; version: 0.83.0.*

Verified by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Herdr backend source reference to the new repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->