### PR TITLE
refactor: clean up obsolete clippy exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,8 +346,5 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(coverage,coverage_nightly)',
 ] }
 
-[lints.clippy]
-borrowed_box = "allow"
-
 [profile.dev]
 debug = 1

--- a/crates/vfox/src/bin.rs
+++ b/crates/vfox/src/bin.rs
@@ -5,7 +5,7 @@ extern crate log;
 #[cfg(feature = "cli")]
 mod cli;
 
-#[allow(clippy::disallowed_methods, clippy::needless_return)]
+#[allow(clippy::disallowed_methods)]
 #[cfg(feature = "cli")]
 #[tokio::main]
 async fn main() {

--- a/crates/vfox/src/hooks/available.rs
+++ b/crates/vfox/src/hooks/available.rs
@@ -5,7 +5,6 @@ use crate::Plugin;
 use crate::error::Result;
 
 impl Plugin {
-    #[allow(clippy::needless_return)] // seems to be a clippy bug
     #[tokio::main(flavor = "current_thread")]
     pub async fn available(&self) -> Result<Vec<AvailableVersion>> {
         self.available_async().await

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -102,7 +102,6 @@ pub fn get_parent_path() -> Result<PathBuf> {
         .wrap_err_with(|| eyre!("no {} file found", filenames.join(" or "),))
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn local(
     config: &Arc<Config>,
     path: &Path,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -609,7 +609,6 @@ impl<'a> CmdLineRunner<'a> {
         self
     }
 
-    #[allow(clippy::readonly_write_lock)]
     pub fn execute(mut self) -> Result<()> {
         let read_lock = raw_read_lock_blocking();
         debug!("$ {self}");

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -296,7 +296,6 @@ pub async fn parse(path: &Path) -> Result<Arc<dyn ConfigFile>> {
         Some(ConfigFileType::IdiomaticVersion(backends)) => Ok(Arc::new(
             IdiomaticVersionFile::parse(path.to_path_buf(), backends).await?,
         )),
-        #[allow(clippy::box_default)]
         _ => Ok(Arc::new(MiseToml::default())),
     }
 }

--- a/src/deps_graph.rs
+++ b/src/deps_graph.rs
@@ -291,15 +291,10 @@ where
 mod tests {
     use super::*;
 
-    #[allow(clippy::ptr_arg)]
-    fn string_key(s: &String) -> String {
-        s.clone()
-    }
-
     #[test]
     fn test_empty_graph() {
         let deps: DepsGraph<String, String> =
-            DepsGraph::new(vec![], Vec::<(String, String)>::new(), string_key).unwrap();
+            DepsGraph::new(vec![], Vec::<(String, String)>::new(), String::clone).unwrap();
         assert!(deps.is_empty());
     }
 
@@ -311,7 +306,7 @@ mod tests {
             ("c".into(), "c".into()),
         ];
         let mut deps: DepsGraph<String, String> =
-            DepsGraph::new(nodes, Vec::<(String, String)>::new(), string_key).unwrap();
+            DepsGraph::new(nodes, Vec::<(String, String)>::new(), String::clone).unwrap();
         let mut rx = deps.subscribe();
 
         let mut emitted = vec![];
@@ -329,7 +324,7 @@ mod tests {
             ("c".into(), "c".into()),
         ];
         let edges: Vec<(String, String)> = vec![("b".into(), "a".into()), ("c".into(), "b".into())];
-        let mut deps = DepsGraph::new(nodes, edges, string_key).unwrap();
+        let mut deps = DepsGraph::new(nodes, edges, String::clone).unwrap();
         let mut rx = deps.subscribe();
 
         let first = rx.try_recv().unwrap().unwrap();
@@ -358,7 +353,7 @@ mod tests {
             ("d".into(), "d".into()),
         ];
         let edges: Vec<(String, String)> = vec![("b".into(), "a".into()), ("c".into(), "b".into())];
-        let mut deps = DepsGraph::new(nodes, edges, string_key).unwrap();
+        let mut deps = DepsGraph::new(nodes, edges, String::clone).unwrap();
         let mut rx = deps.subscribe();
 
         let mut initial = vec![];
@@ -387,7 +382,7 @@ mod tests {
             ("c".into(), "c".into()),
         ];
         let edges: Vec<(String, String)> = vec![("a".into(), "b".into()), ("b".into(), "a".into())];
-        let mut deps = DepsGraph::new(nodes, edges, string_key).unwrap();
+        let mut deps = DepsGraph::new(nodes, edges, String::clone).unwrap();
 
         let blocked = deps.blocked_keys();
         assert!(blocked.contains(&"a".to_string()));
@@ -406,7 +401,7 @@ mod tests {
     fn test_unknown_dep_error() {
         let nodes: Vec<(String, String)> = vec![("a".into(), "a".into())];
         let edges: Vec<(String, String)> = vec![("a".into(), "nonexistent".into())];
-        let result = DepsGraph::new(nodes, edges, string_key);
+        let result = DepsGraph::new(nodes, edges, String::clone);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("unknown"));
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -2389,9 +2389,7 @@ mod tests {
             .into_iter()
             .map(|s| s.to_string())
             .collect_vec();
-        #[allow(clippy::needless_collect)]
-        let find_up = FindUp::new(path, &filenames).collect::<Vec<_>>();
-        let mut find_up = find_up.into_iter();
+        let mut find_up = FindUp::new(path, &filenames);
         assert_eq!(
             find_up.next(),
             Some(dirs::HOME.join("cwd/.test-tool-versions"))

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -271,13 +271,8 @@ fn parse_gemfile(body: &str) -> String {
     v
 }
 
-#[allow(clippy::if_same_then_else)]
 fn arch() -> &'static str {
-    if cfg!(target_arch = "aarch64") {
-        "x64"
-    } else {
-        "x64"
-    }
+    "x64"
 }
 
 #[cfg(test)]

--- a/src/ui/tree.rs
+++ b/src/ui/tree.rs
@@ -114,7 +114,6 @@ fn print_tree_item<T: TreeItem>(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn print_tree_item_compact<T, K, F>(
     item: &T,
     prefix: String,


### PR DESCRIPTION
## Summary
- remove the unused workspace-wide `borrowed_box` allowance
- remove stale function-level Clippy suppressions that no longer trigger
- replace test-only suppressions with direct iterator and clone-function usage
- simplify the Windows Ruby architecture helper with identical branches

## Why
These exceptions had accumulated after the underlying code or Clippy behavior changed. Removing them keeps lint policy explicit and prevents obsolete allowances from hiding future findings.

This is intentionally limited to behavior-preserving cleanup; larger argument-context refactors are left for separate changes.

## Validation
- `mise run lint`
- `mise --cd crates/vfox run lint`
- `cargo test --bin mise deps_graph::tests` (6 passed)
- `cargo test --bin mise test_find_up` (2 passed)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and comment-only cleanup with behavior-preserving test refactors; no functional logic changes beyond simplifying a dead Windows arch branch.
> 
> **Overview**
> This PR **tightens lint hygiene** by dropping Clippy suppressions and workspace allowances that no longer apply, without changing runtime behavior.
> 
> **Workspace policy:** The `[lints.clippy]` block is removed from `Cargo.toml`, including the unused `borrowed_box = "allow"` rule.
> 
> **Stale `#[allow(clippy::…)]` attributes** are removed from `local`, `CmdLineRunner::execute`, config parsing, vfox CLI/hooks, and tree printing where Clippy no longer fires.
> 
> **Test and helper cleanups:** `deps_graph` tests pass `String::clone` instead of a wrapper that needed `ptr_arg`; `test_find_up` iterates `FindUp` directly instead of collecting to a `Vec` first; Windows Ruby `arch()` is reduced to a constant `"x64"` after removing an `if_same_then_else` branch where both arms were identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5369e042c87b391ea6dd281c80230f38b51b6f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal code and removed outdated lint exceptions.
  * Streamlined architecture detection for Ruby on Windows without changing expected behavior.
  * Simplified test utilities and iterator usage while preserving test coverage and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->