### PR TITLE
perf: reduce release binary size

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,53 @@ jobs:
       - run: sccache --show-stats
         if: always()
 
+  # Temporary validation for PR #11520. Remove before merge.
+  abort-cleanup:
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    timeout-minutes: 60
+    if: github.event_name == 'pull_request' && github.event.pull_request.number == 11520
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/.global-cache
+      - name: Build abort-profile binary
+        run: >-
+          cargo build --profile serious --no-default-features
+          --features rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored
+      - name: Verify panics terminate spawned process groups
+        shell: bash
+        run: |
+          test_dir="$(mktemp -d)"
+          pid_file="$test_dir/child.pid"
+          trap 'if test -s "$pid_file"; then kill "$(cat "$pid_file")" 2>/dev/null || true; fi; rm -rf "$test_dir"' EXIT
+          cat > "$test_dir/mise.toml" <<'EOF'
+          [tasks.hold]
+          run = 'echo $$ > "$MISE_ABORT_PID_FILE"; sleep 300'
+          EOF
+
+          set +e
+          MISE_TEST_ABORT_AFTER_SPAWN=1 \
+            MISE_ABORT_PID_FILE="$pid_file" \
+            target/serious/mise --cd "$test_dir" run hold
+          status=$?
+          set -e
+
+          test "$status" -ne 0
+          test -s "$pid_file"
+          pid="$(cat "$pid_file")"
+          for _ in {1..50}; do
+            if ! kill -0 "$pid" 2>/dev/null; then
+              exit 0
+            fi
+            sleep 0.1
+          done
+          echo "spawned task process $pid survived mise abort" >&2
+          exit 1
+
   build-windows:
     runs-on: windows-latest
     timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,52 +101,6 @@ jobs:
       - run: sccache --show-stats
         if: always()
 
-  # Temporary validation for PR #11520. Remove before merge.
-  abort-cleanup:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    if: github.event_name == 'pull_request' && github.event.pull_request.number == 11520
-    env:
-      # LTO does not affect panic semantics and exhausted the one-off runner
-      # before the cleanup assertion could execute.
-      CARGO_PROFILE_SERIOUS_LTO: "false"
-      CARGO_PROFILE_SERIOUS_OPT_LEVEL: "0"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Build abort-profile binary
-        run: >-
-          cargo build --profile serious --no-default-features
-          --features rustls-native-roots,self_update,vfox/vendored-lua
-      - name: Verify panics terminate spawned process groups
-        shell: bash
-        run: |
-          test_dir="$(mktemp -d)"
-          pid_file="$test_dir/child.pid"
-          trap 'if test -s "$pid_file"; then kill "$(cat "$pid_file")" 2>/dev/null || true; fi; rm -rf "$test_dir"' EXIT
-          cat > "$test_dir/mise.toml" <<'EOF'
-          [tasks.hold]
-          run = 'echo $$ > "$MISE_ABORT_PID_FILE"; sleep 300'
-          EOF
-
-          set +e
-          MISE_TEST_ABORT_AFTER_SPAWN=1 \
-            MISE_ABORT_PID_FILE="$pid_file" \
-            target/serious/mise --cd "$test_dir" run hold
-          status=$?
-          set -e
-
-          test "$status" -ne 0
-          test -s "$pid_file"
-          pid="$(cat "$pid_file")"
-          for _ in {1..50}; do
-            if ! kill -0 "$pid" 2>/dev/null; then
-              exit 0
-            fi
-            sleep 0.1
-          done
-          echo "spawned task process $pid survived mise abort" >&2
-          exit 1
-
   build-windows:
     runs-on: windows-latest
     timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,10 @@ jobs:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
     timeout-minutes: 60
     if: github.event_name == 'pull_request' && github.event.pull_request.number == 11520
+    env:
+      # LTO does not affect panic semantics and exhausted the one-off runner
+      # before the cleanup assertion could execute.
+      CARGO_PROFILE_SERIOUS_LTO: "false"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,9 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
       - name: Build abort-profile binary
-        run: cargo build --profile serious --no-default-features
+        run: >-
+          cargo build --profile serious --no-default-features
+          --features vfox/vendored-lua
       - name: Verify panics terminate spawned process groups
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Build abort-profile binary
         run: >-
           cargo build --profile serious --no-default-features
-          --features vfox/vendored-lua
+          --features rustls-native-roots,self_update,vfox/vendored-lua
       - name: Verify panics terminate spawned process groups
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,7 @@ jobs:
       # LTO does not affect panic semantics and exhausted the one-off runner
       # before the cleanup assertion could execute.
       CARGO_PROFILE_SERIOUS_LTO: "false"
+      CARGO_PROFILE_SERIOUS_OPT_LEVEL: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
@@ -119,9 +120,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/.global-cache
       - name: Build abort-profile binary
-        run: >-
-          cargo build --profile serious --no-default-features
-          --features rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored
+        run: cargo build --profile serious --no-default-features
       - name: Verify panics terminate spawned process groups
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
 
   # Temporary validation for PR #11520. Remove before merge.
   abort-cleanup:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     if: github.event_name == 'pull_request' && github.event.pull_request.number == 11520
     env:
@@ -113,12 +113,6 @@ jobs:
       CARGO_PROFILE_SERIOUS_OPT_LEVEL: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.global-cache
       - name: Build abort-profile binary
         run: >-
           cargo build --profile serious --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ path = "src/main.rs"
 inherits = "release"
 lto = true
 panic = "abort"
-strip = true
 
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ path = "src/main.rs"
 [profile.serious]
 inherits = "release"
 lto = true
+panic = "abort"
+strip = true
 
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use crate::cmd::{RunningPidGuard, prepare_noninteractive_child};
 use crate::config::Config;
 use clap::Parser;
 use rmcp::{
@@ -175,20 +176,22 @@ impl MiseServer {
             cmd_args.extend(args);
         }
 
-        let child = tokio::process::Command::new(exe)
+        let mut command = tokio::process::Command::new(exe);
+        command
             .args(&cmd_args)
             .env("NO_COLOR", "1")
             .env("MISE_YES", "1")
             .kill_on_drop(true)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|e| ErrorData {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: Cow::Owned(format!("Failed to spawn mise run: {e}")),
-                data: None,
-            })?;
+            .stderr(std::process::Stdio::piped());
+        prepare_noninteractive_child(command.as_std_mut());
+        let child = command.spawn().map_err(|e| ErrorData {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: Cow::Owned(format!("Failed to spawn mise run: {e}")),
+            data: None,
+        })?;
+        let _running_pid = RunningPidGuard::new(child.id());
 
         let output = match crate::config::Settings::get().task_timeout_duration() {
             Some(timeout) => tokio::time::timeout(timeout, child.wait_with_output())

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -4,6 +4,8 @@ use std::fmt::{Debug, Display, Formatter};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
+#[cfg(panic = "abort")]
+use std::sync::TryLockError;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::mpsc::{RecvTimeoutError, channel};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
@@ -250,6 +252,48 @@ static OUTPUT_LOCK: Mutex<()> = Mutex::new(());
 static RAW_LOCK: Lazy<tokio::sync::RwLock<()>> = Lazy::new(|| tokio::sync::RwLock::new(()));
 
 static RUNNING_PIDS: Lazy<Mutex<HashSet<u32>>> = Lazy::new(Default::default);
+
+#[cfg(all(panic = "abort", unix))]
+fn kill_pids_immediately(pids: &HashSet<u32>) {
+    let use_pgroup = should_use_pgroup();
+    for pid in pids {
+        let pid = nix::unistd::Pid::from_raw(*pid as i32);
+        if use_pgroup {
+            if nix::sys::signal::killpg(pid, nix::sys::signal::SIGKILL).is_err() {
+                let _ = nix::sys::signal::kill(pid, nix::sys::signal::SIGKILL);
+            }
+        } else {
+            let _ = nix::sys::signal::kill(pid, nix::sys::signal::SIGKILL);
+        }
+    }
+}
+
+#[cfg(all(panic = "abort", windows))]
+fn kill_pids_immediately(pids: &HashSet<u32>) {
+    for pid in pids {
+        let _ = std::process::Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+/// Best-effort synchronous cleanup for the panic hook.
+///
+/// An aborting panic does not run destructors, and there is no time for the
+/// normal TERM/grace-period/KILL sequence. Avoid blocking if the panic occurred
+/// while the PID registry was locked; a deadlocked panic hook would prevent the
+/// process from ever reaching abort.
+#[cfg(panic = "abort")]
+pub fn kill_all_on_panic() {
+    let pids = match RUNNING_PIDS.try_lock() {
+        Ok(pids) => pids,
+        Err(TryLockError::Poisoned(err)) => err.into_inner(),
+        Err(TryLockError::WouldBlock) => return,
+    };
+    kill_pids_immediately(&pids);
+}
 
 struct RunningPidGuard(Option<u32>);
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -295,10 +295,10 @@ pub fn kill_all_on_panic() {
     kill_pids_immediately(&pids);
 }
 
-struct RunningPidGuard(Option<u32>);
+pub(crate) struct RunningPidGuard(Option<u32>);
 
 impl RunningPidGuard {
-    fn new(pid: Option<u32>) -> Self {
+    pub(crate) fn new(pid: Option<u32>) -> Self {
         if let Some(pid) = pid {
             RUNNING_PIDS.lock().unwrap().insert(pid);
         }
@@ -361,6 +361,25 @@ fn should_use_pgroup() -> bool {
         true
     });
     *CACHED
+}
+
+/// Put a non-interactive child in the process tree managed by mise.
+///
+/// Callers must retain a [`RunningPidGuard`] after spawning the command.
+pub(crate) fn prepare_noninteractive_child(cmd: &mut std::process::Command) {
+    #[cfg(unix)]
+    if should_use_pgroup() {
+        cmd.env(TASK_PGID_MANAGED_ENV, "1");
+        unsafe {
+            cmd.pre_exec(|| {
+                let _ = nix::unistd::setpgid(
+                    nix::unistd::Pid::from_raw(0),
+                    nix::unistd::Pid::from_raw(0),
+                );
+                Ok(())
+            });
+        }
+    }
 }
 
 /// Grace period after a child's ExitStatus arrives during which we keep

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -711,11 +711,6 @@ impl<'a> CmdLineRunner<'a> {
         let id = cp.id();
         RUNNING_PIDS.lock().unwrap().insert(id);
         trace!("Started process: {id} for {}", self.get_program());
-        #[cfg(panic = "abort")]
-        if std::env::var_os("MISE_TEST_ABORT_AFTER_SPAWN").is_some() {
-            thread::sleep(Duration::from_millis(500));
-            panic!("intentional abort-profile child cleanup test");
-        }
         let (tx, rx) = channel();
         if let Some(stdout) = cp.stdout.take() {
             thread::spawn({
@@ -907,11 +902,6 @@ impl<'a> CmdLineRunner<'a> {
             .wrap_err_with(|| format!("failed to execute command: {self}"))?;
         let id = cp.id().unwrap_or_default();
         RUNNING_PIDS.lock().unwrap().insert(id);
-        #[cfg(panic = "abort")]
-        if std::env::var_os("MISE_TEST_ABORT_AFTER_SPAWN").is_some() {
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            panic!("intentional abort-profile child cleanup test");
-        }
         if is_cancelled() {
             #[cfg(unix)]
             signal_process_tree(id, nix::sys::signal::SIGINT);

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -907,6 +907,11 @@ impl<'a> CmdLineRunner<'a> {
             .wrap_err_with(|| format!("failed to execute command: {self}"))?;
         let id = cp.id().unwrap_or_default();
         RUNNING_PIDS.lock().unwrap().insert(id);
+        #[cfg(panic = "abort")]
+        if std::env::var_os("MISE_TEST_ABORT_AFTER_SPAWN").is_some() {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            panic!("intentional abort-profile child cleanup test");
+        }
         if is_cancelled() {
             #[cfg(unix)]
             signal_process_tree(id, nix::sys::signal::SIGINT);

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -692,6 +692,11 @@ impl<'a> CmdLineRunner<'a> {
         let id = cp.id();
         RUNNING_PIDS.lock().unwrap().insert(id);
         trace!("Started process: {id} for {}", self.get_program());
+        #[cfg(panic = "abort")]
+        if std::env::var_os("MISE_TEST_ABORT_AFTER_SPAWN").is_some() {
+            thread::sleep(Duration::from_millis(500));
+            panic!("intentional abort-profile child cleanup test");
+        }
         let (tx, rx) = channel();
         if let Some(stdout) = cp.stdout.take() {
             thread::spawn({

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -366,12 +366,12 @@ fn should_use_pgroup() -> bool {
 /// Put a non-interactive child in the process tree managed by mise.
 ///
 /// Callers must retain a [`RunningPidGuard`] after spawning the command.
-pub(crate) fn prepare_noninteractive_child(cmd: &mut std::process::Command) {
+pub(crate) fn prepare_noninteractive_child(_cmd: &mut std::process::Command) {
     #[cfg(unix)]
     if should_use_pgroup() {
-        cmd.env(TASK_PGID_MANAGED_ENV, "1");
+        _cmd.env(TASK_PGID_MANAGED_ENV, "1");
         unsafe {
-            cmd.pre_exec(|| {
+            _cmd.pre_exec(|| {
                 let _ = nix::unistd::setpgid(
                     nix::unistd::Pid::from_raw(0),
                     nix::unistd::Pid::from_raw(0),

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,10 @@ pub fn install_panic_hook(panic_hook: color_eyre::config::PanicHook) {
             } else {
                 bt_buffer.push_str("[no accessible async backtrace]");
             }
-            let all = async_backtrace::taskdump_tree(true);
+            // An aborting panic cannot wait for every running task to reach a
+            // frame boundary: some may be blocked on the panicking task, and
+            // the process must return from this hook to reach abort.
+            let all = async_backtrace::taskdump_tree(cfg!(panic = "unwind"));
             // A panic hook must never panic: a panic while the hook runs
             // aborts the process with SIGABRT.
             safe_eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,12 @@ static ASYNC_PANIC_OCCURRED: AtomicBool = AtomicBool::new(false);
 
 pub fn install_panic_hook(panic_hook: color_eyre::config::PanicHook) {
     panic::set_hook(Box::new(move |panic_info| {
+        // Serious release builds abort after this hook returns, so destructors
+        // and catch_unwind cleanup will not run. Terminate registered child
+        // process trees synchronously while we still can.
+        #[cfg(panic = "abort")]
+        cmd::kill_all_on_panic();
+
         if tokio::runtime::Handle::try_current().is_ok()
             && !ASYNC_PANIC_OCCURRED.swap(true, Ordering::SeqCst)
         {

--- a/src/oci/auth.rs
+++ b/src/oci/auth.rs
@@ -21,6 +21,7 @@ use base64::prelude::BASE64_STANDARD;
 use eyre::{Context, Result, bail};
 use serde::Deserialize;
 
+use crate::cmd::{RunningPidGuard, prepare_noninteractive_child};
 use crate::env;
 
 /// A username/secret pair for registry auth. `username == "<token>"` is the
@@ -239,13 +240,17 @@ fn run_credential_helper(helper: &str, registry: &str) -> Result<Credential> {
         registry
     };
     debug!("running {bin} get for {server}");
-    let mut child = Command::new(&bin)
+    let mut command = Command::new(&bin);
+    command
         .arg("get")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    prepare_noninteractive_child(&mut command);
+    let mut child = command
         .spawn()
         .wrap_err_with(|| format!("spawning {bin} (from credHelpers/credsStore)"))?;
+    let _running_pid = RunningPidGuard::new(Some(child.id()));
     {
         use std::io::Write;
         let mut stdin = child.stdin.take().expect("stdin piped");

--- a/src/oci/docker_archive.rs
+++ b/src/oci/docker_archive.rs
@@ -19,6 +19,7 @@ use eyre::{Context, Result, bail};
 use jdx_tar::{Builder, EntryType, Header};
 use serde::Serialize;
 
+use crate::cmd::{RunningPidGuard, prepare_noninteractive_child};
 use crate::oci::layout::ImageLayout;
 use crate::oci::manifest::{ImageIndex, ImageManifest};
 
@@ -60,13 +61,15 @@ pub fn load_into_docker(image_dir: &Path, tag: &str) -> Result<()> {
         crate::oci::layout::validate_sha256_digest(&layer.digest)?;
     }
 
-    let mut child = Command::new("docker")
+    let mut command = Command::new("docker");
+    command
         .args(["load", "--quiet"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .wrap_err("spawning `docker load`")?;
+        .stderr(Stdio::piped());
+    prepare_noninteractive_child(&mut command);
+    let mut child = command.spawn().wrap_err("spawning `docker load`")?;
+    let _running_pid = RunningPidGuard::new(Some(child.id()));
     let stdin = child.stdin.take().expect("stdin piped");
 
     // Write the archive on a separate thread so the parent can drain docker's

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,3 +1,4 @@
+use crate::cmd::{RunningPidGuard, prepare_noninteractive_child};
 use crate::config::Settings;
 use crate::env;
 use serde::Deserialize;
@@ -195,29 +196,30 @@ pub fn get_git_credential_token(provider: &str, host: &str) -> Option<String> {
 
     let path_without_shims = path_env_without_shims();
     let input = format!("protocol=https\nhost={host}\n\n");
-    let result = std::process::Command::new("git")
+    let mut command = std::process::Command::new("git");
+    command
         .args(["credential", "fill"])
         .env("PATH", &path_without_shims)
         .env("GIT_TERMINAL_PROMPT", "0")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .ok()
-        .and_then(|mut child| {
-            use std::io::Write;
-            child.stdin.take()?.write_all(input.as_bytes()).ok()?;
-            let output = child.wait_with_output().ok()?;
-            if !output.status.success() {
-                return None;
-            }
-            String::from_utf8(output.stdout)
-                .ok()?
-                .lines()
-                .find_map(|line| line.strip_prefix("password="))
-                .map(|p| p.to_string())
-                .filter(|s| !s.is_empty())
-        });
+        .stderr(std::process::Stdio::null());
+    prepare_noninteractive_child(&mut command);
+    let result = command.spawn().ok().and_then(|mut child| {
+        let _running_pid = RunningPidGuard::new(Some(child.id()));
+        use std::io::Write;
+        child.stdin.take()?.write_all(input.as_bytes()).ok()?;
+        let output = child.wait_with_output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8(output.stdout)
+            .ok()?
+            .lines()
+            .find_map(|line| line.strip_prefix("password="))
+            .map(|p| p.to_string())
+            .filter(|s| !s.is_empty())
+    });
 
     trace!(
         "{provider} git credential fill for {host}: {}",

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Once};
 
 use clx::progress::{self, ProgressJobBuilder, ProgressOutput};
 
@@ -107,9 +107,11 @@ impl MultiProgressReport {
         // Configure OSC progress based on settings
         if !settings.terminal_progress {
             // Disable OSC progress if terminal_progress is disabled
-            // clx::osc::configure panics if called more than once (singleton pattern),
-            // so we use catch_unwind to safely ignore duplicate calls
-            let _ = std::panic::catch_unwind(|| {
+            // clx configuration is write-once. MultiProgressReport may be
+            // reconstructed, so ensure the initializer is called only once
+            // without using a caught panic as control flow.
+            static DISABLE_OSC_PROGRESS: Once = Once::new();
+            DISABLE_OSC_PROGRESS.call_once(|| {
                 clx::osc::configure(false);
             });
         }


### PR DESCRIPTION
## Summary

- abort instead of unwind on panics in binaries built with the `serious` release profile
- preserve release symbols for useful native backtraces and crash reports
- synchronously terminate registered child process groups from the panic hook before aborting
- register direct subprocesses used by tasks, dependency commands, MCP tasks, Docker/OCI operations, and credential helpers
- avoid panic-based duplicate initialization in the clx progress integration
- use a non-blocking async task snapshot in abort builds so the panic hook cannot wait indefinitely

This follows the panic-profile optimization used by uv, while retaining mise's release symbols and accounting for mise's broader subprocess-management responsibilities.

## Size impact

### Linux x86_64

Measured from the same source revision and release feature set:

```console
cargo build --profile serious --no-default-features \
  --features rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored
```

| Configuration | Binary | gzip -9 |
| --- | ---: | ---: |
| unwind, symbols retained | 128,302,544 bytes | 43,364,242 bytes |
| abort, symbols retained | 105,031,328 bytes | 34,685,998 bytes |
| reduction | 23,271,216 bytes (18.1%) | 8,678,244 bytes (20.0%) |

The final proposal deliberately does not strip symbols. Earlier combined strip+abort measurements are not representative of the mergeable configuration.

An updated macOS arm64 measurement is pending; the earlier result included stripping.

## Panic and subprocess behavior

A panic in a published Unix release artifact terminates the process instead of unwinding. Consequently, `catch_unwind` does not recover and Rust destructors do not run after an internal panic.

Before returning from the panic hook, abort builds synchronously force-terminate every registered child process group. Direct spawn sites now use the same registry and process-group setup as task and dependency commands. The registry uses `try_lock` in the panic hook: if the panic itself occurs while that registry is locked, cleanup is skipped rather than deadlocking the abort forever.

Development and test profiles continue to unwind. Normal `Result`-based error handling is unchanged.

## Validation

- built the exact final release feature set with symbols retained on Linux x86_64
- ran `--version` and `--help` against the final Linux `serious` binary
- ran a temporary process-level CI check that:
  - built with `panic = "abort"`
  - deliberately panicked immediately after spawning a task command
  - asserted that the spawned process group no longer existed after mise exited
- confirmed that check passed in [the one-off GitHub Actions job](https://github.com/jdx/mise/actions/runs/30591062446/job/91033320992)
- removed the temporary workflow and injected panic trigger after validation; neither is present in the final diff
- ran `cargo check --all-features`
- ran an abort-profile `cargo check` with the release feature set
- ran the focused PID-registry unit test

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes panic semantics and synchronous child teardown in production binaries; dev/unwind profiles and normal `Result` errors are unchanged, but internal panics no longer unwind or run destructors.
> 
> **Overview**
> Sets **`panic = "abort"`** on the `serious` release profile to shrink release binaries (~18% on Linux) while keeping debug symbols for backtraces.
> 
> Because abort skips destructors and `catch_unwind`, the panic hook now calls **`kill_all_on_panic()`** to SIGKILL (or `taskkill /F /T`) every PID in the shared registry using a **non-blocking `try_lock`**, so the hook cannot deadlock if the panic happened while holding that mutex. Async task dumps in the hook use a **non-blocking snapshot** when `panic = "abort"`.
> 
> Direct spawns that previously bypassed task-style cleanup—**MCP `run_task`**, **docker credential helpers**, **`docker load`**, and **`git credential fill`**—now go through **`prepare_noninteractive_child`** (process groups where applicable) and **`RunningPidGuard`** so they participate in the same registry.
> 
> **`clx::osc::configure(false)`** is initialized with **`std::sync::Once`** instead of **`catch_unwind`**, since duplicate configure used to panic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 303bdd162cae4cd60427e27203baaf9257a19971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->