### PR TITLE
refactor(env): centralize directive resolution context

### DIFF
--- a/src/config/env_directive/file.rs
+++ b/src/config/env_directive/file.rs
@@ -1,4 +1,7 @@
-use crate::config::{Config, env_directive::EnvResults};
+use crate::config::{
+    Config,
+    env_directive::{EnvDirectiveContext, EnvResults},
+};
 use crate::env_diff::EnvMap as TeraEnvMap;
 use crate::file::display_path;
 use crate::{Result, file, sops};
@@ -22,27 +25,21 @@ struct Env<V> {
 }
 
 impl EnvResults {
-    #[allow(clippy::too_many_arguments)]
-    pub async fn file(
-        config: &Arc<Config>,
-        ctx: &mut tera::Context,
-        tera: &mut Option<crate::tera::TeraEngine>,
-        r: &mut EnvResults,
-        normalize_path: fn(&Path, PathBuf) -> PathBuf,
-        source: &Path,
-        exec_env: &TeraEnvMap,
-        config_root: &Path,
+    pub(super) async fn file(
+        ctx: &mut EnvDirectiveContext<'_>,
         input: String,
         expand: bool,
     ) -> Result<IndexMap<PathBuf, EnvMap>> {
         let mut out = IndexMap::new();
-        let s = r.parse_template(ctx, tera, source, exec_env, &input)?;
+        let s = ctx.parse_template(&input)?;
         let expand = expand && crate::config::Settings::get().env_shell_expand;
         // Accumulate loaded vars so opted-in expansion can reference values from
         // an earlier file in the same directive or an earlier env block.
-        let mut acc: TeraEnvMap = exec_env.clone();
-        for p in xx::file::glob(normalize_path(config_root, s.into())).unwrap_or_default() {
-            let parse_template = |s: String| r.parse_template(ctx, tera, source, exec_env, &s);
+        let mut acc: TeraEnvMap = ctx.exec_env.clone();
+        for p in xx::file::glob(ctx.normalize_path(s.into())).unwrap_or_default() {
+            let config = ctx.config;
+            let exec_env = ctx.exec_env;
+            let parse_template = |s: String| ctx.parse_template(&s);
             let ext = p
                 .extension()
                 .map(|e| e.to_string_lossy().to_string())

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -327,6 +327,28 @@ pub struct EnvResults {
     pub has_uncacheable: bool,
 }
 
+pub(super) struct EnvDirectiveContext<'a> {
+    config: &'a Arc<Config>,
+    tera_ctx: &'a mut tera::Context,
+    tera: &'a mut Option<TeraEngine>,
+    results: &'a mut EnvResults,
+    normalize_path: fn(&Path, PathBuf) -> PathBuf,
+    source: &'a Path,
+    exec_env: &'a EnvMap,
+    config_root: &'a Path,
+}
+
+impl EnvDirectiveContext<'_> {
+    fn parse_template(&mut self, input: &str) -> eyre::Result<String> {
+        self.results
+            .parse_template(self.tera_ctx, self.tera, self.source, self.exec_env, input)
+    }
+
+    fn normalize_path(&self, path: PathBuf) -> PathBuf {
+        (self.normalize_path)(self.config_root, path)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub enum ToolsFilter {
     ToolsOnly,
@@ -592,27 +614,33 @@ impl EnvResults {
                     }
                 }
                 EnvDirective::Path(input_str, _opts) => {
-                    let path =
-                        Self::path(&mut ctx, &mut tera, &mut r, &source, &env_vars, input_str)
-                            .await?;
+                    let mut directive_ctx = EnvDirectiveContext {
+                        config,
+                        tera_ctx: &mut ctx,
+                        tera: &mut tera,
+                        results: &mut r,
+                        normalize_path,
+                        source: &source,
+                        exec_env: &env_vars,
+                        config_root: &config_root,
+                    };
+                    let path = Self::path(&mut directive_ctx, input_str).await?;
                     paths.push((path.clone(), source.clone()));
                     // Don't modify PATH in env - just add to env_paths
                     // This allows consumers to control PATH ordering
                 }
                 EnvDirective::File(input, opts) => {
-                    let files = Self::file(
+                    let mut directive_ctx = EnvDirectiveContext {
                         config,
-                        &mut ctx,
-                        &mut tera,
-                        &mut r,
+                        tera_ctx: &mut ctx,
+                        tera: &mut tera,
+                        results: &mut r,
                         normalize_path,
-                        &source,
-                        &env_vars,
-                        &config_root,
-                        input,
-                        opts.expand,
-                    )
-                    .await?;
+                        source: &source,
+                        exec_env: &env_vars,
+                        config_root: &config_root,
+                    };
+                    let files = Self::file(&mut directive_ctx, input, opts.expand).await?;
                     for (f, new_env) in files {
                         r.env_files.push(f.clone());
                         for (k, v) in new_env {
@@ -631,18 +659,17 @@ impl EnvResults {
                     }
                 }
                 EnvDirective::Source(input, _opts) => {
-                    let files = Self::source(
-                        &mut ctx,
-                        &mut tera,
-                        &mut paths,
-                        &mut r,
+                    let mut directive_ctx = EnvDirectiveContext {
+                        config,
+                        tera_ctx: &mut ctx,
+                        tera: &mut tera,
+                        results: &mut r,
                         normalize_path,
-                        &source,
-                        &env_vars,
-                        &config_root,
-                        &env_vars,
-                        input,
-                    )?;
+                        source: &source,
+                        exec_env: &env_vars,
+                        config_root: &config_root,
+                    };
+                    let files = Self::source(&mut directive_ctx, &mut paths, input)?;
                     for (f, new_env) in files {
                         r.env_scripts.push(f.clone());
                         for (k, v) in new_env {
@@ -668,22 +695,27 @@ impl EnvResults {
                     python_create_args,
                     options: _opts,
                 } => {
-                    Self::venv(
+                    let mut directive_ctx = EnvDirectiveContext {
                         config,
-                        &mut ctx,
-                        &mut tera,
-                        &mut env,
-                        &mut r,
+                        tera_ctx: &mut ctx,
+                        tera: &mut tera,
+                        results: &mut r,
                         normalize_path,
-                        &source,
-                        &env_vars,
-                        &config_root,
-                        env_vars.clone(),
+                        source: &source,
+                        exec_env: &env_vars,
+                        config_root: &config_root,
+                    };
+                    Self::venv(
+                        &mut directive_ctx,
+                        &mut env,
                         path,
                         create,
-                        python,
-                        uv_create_args,
-                        python_create_args,
+                        venv::PythonVenvOptions {
+                            python,
+                            uv_create_args,
+                            python_create_args,
+                            require_uv: false,
+                        },
                     )
                     .await?;
                 }

--- a/src/config/env_directive/path.rs
+++ b/src/config/env_directive/path.rs
@@ -1,19 +1,13 @@
-use crate::config::env_directive::EnvResults;
-use crate::env_diff::EnvMap;
+use crate::config::env_directive::{EnvDirectiveContext, EnvResults};
 use crate::result;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 impl EnvResults {
-    pub async fn path(
-        ctx: &mut tera::Context,
-        tera: &mut Option<crate::tera::TeraEngine>,
-        r: &mut EnvResults,
-        source: &Path,
-        exec_env: &EnvMap,
+    pub(super) async fn path(
+        ctx: &mut EnvDirectiveContext<'_>,
         input: String,
     ) -> result::Result<PathBuf> {
-        r.parse_template(ctx, tera, source, exec_env, &input)
-            .map(PathBuf::from)
+        ctx.parse_template(&input).map(PathBuf::from)
     }
 }
 

--- a/src/config/env_directive/source.rs
+++ b/src/config/env_directive/source.rs
@@ -1,38 +1,38 @@
 use crate::Result;
-use crate::config::env_directive::EnvResults;
+use crate::config::env_directive::{EnvDirectiveContext, EnvResults};
 use crate::env;
-use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvDiffOptions, EnvMap};
+use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvDiffOptions};
 use indexmap::IndexMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 impl EnvResults {
-    #[allow(clippy::too_many_arguments)]
-    pub fn source(
-        ctx: &mut tera::Context,
-        tera: &mut Option<crate::tera::TeraEngine>,
+    pub(super) fn source(
+        ctx: &mut EnvDirectiveContext<'_>,
         paths: &mut Vec<(PathBuf, PathBuf)>,
-        r: &mut EnvResults,
-        normalize_path: fn(&Path, PathBuf) -> PathBuf,
-        source: &Path,
-        exec_env: &EnvMap,
-        config_root: &Path,
-        env_vars: &EnvMap,
         input: String,
     ) -> Result<IndexMap<PathBuf, IndexMap<String, String>>> {
         // Note: in safe mode `_.source` directives are dropped during env
         // resolution (see EnvResults::resolve), so this is never reached.
         let mut out = IndexMap::new();
-        let s = r.parse_template(ctx, tera, source, exec_env, &input)?;
-        let orig_path = env_vars.get(&*env::PATH_KEY).cloned().unwrap_or_default();
+        let s = ctx.parse_template(&input)?;
+        let orig_path = ctx
+            .exec_env
+            .get(&*env::PATH_KEY)
+            .cloned()
+            .unwrap_or_default();
         let mut env_diff_opts = EnvDiffOptions::default();
         env_diff_opts.ignore_keys.shift_remove(&*env::PATH_KEY); // allow modifying PATH
-        for p in xx::file::glob(normalize_path(config_root, s.into())).unwrap_or_default() {
+        for p in xx::file::glob(ctx.normalize_path(s.into())).unwrap_or_default() {
             if !p.exists() {
                 continue;
             }
             let env = out.entry(p.clone()).or_insert_with(IndexMap::new);
-            let env_diff =
-                EnvDiff::from_bash_script(&p, config_root, env_vars.clone(), &env_diff_opts)?;
+            let env_diff = EnvDiff::from_bash_script(
+                &p,
+                ctx.config_root,
+                ctx.exec_env.clone(),
+                &env_diff_opts,
+            )?;
             for p in env_diff.to_patches() {
                 match p {
                     EnvDiffOperation::Add(k, v) | EnvDiffOperation::Change(k, v) => {
@@ -43,17 +43,17 @@ impl EnvResults {
                                     if p.as_os_str().is_empty() {
                                         continue;
                                     }
-                                    paths.push((p, source.to_path_buf()));
+                                    paths.push((p, ctx.source.to_path_buf()));
                                 }
                             }
                         } else {
-                            r.env_remove.remove(&k);
+                            ctx.results.env_remove.remove(&k);
                             env.insert(k.clone(), v.clone());
                         }
                     }
                     EnvDiffOperation::Remove(k) => {
                         env.shift_remove(&k);
-                        r.env_remove.insert(k);
+                        ctx.results.env_remove.insert(k);
                     }
                 }
             }

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -2,7 +2,7 @@ use crate::Result;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::config_file::trust_check;
-use crate::config::env_directive::EnvResults;
+use crate::config::env_directive::{EnvDirectiveContext, EnvResults};
 use crate::config::{Config, Settings};
 use crate::env_diff::EnvMap;
 use crate::file::{display_path, which_no_shims};
@@ -20,6 +20,14 @@ use std::{
 pub struct Venv {
     pub venv_path: PathBuf,
     pub env: HashMap<String, String>,
+}
+
+#[derive(Default)]
+pub(crate) struct PythonVenvOptions {
+    pub(crate) python: Option<String>,
+    pub(crate) uv_create_args: Option<Vec<String>>,
+    pub(crate) python_create_args: Option<Vec<String>>,
+    pub(crate) require_uv: bool,
 }
 
 pub(crate) fn load_venv(
@@ -92,17 +100,20 @@ fn build_stdlib_venv_command<'a>(
         .args(extra)
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn create_python_venv(
     config: &Arc<Config>,
     ts: &Toolset,
     venv: &Path,
     env_vars: EnvMap,
-    python: Option<&str>,
-    uv_create_args: Option<Vec<String>>,
-    python_create_args: Option<Vec<String>>,
-    require_uv: bool,
+    options: PythonVenvOptions,
 ) -> Result<bool> {
+    let PythonVenvOptions {
+        python,
+        uv_create_args,
+        python_create_args,
+        require_uv,
+    } = options;
+    let python = python.as_deref();
     let ba = BackendArg::from("python");
     let tv = ts.versions.get(&ba).and_then(|tv| {
         // if a python version is specified, check if that version is installed
@@ -169,28 +180,17 @@ pub(crate) async fn create_python_venv(
 }
 
 impl EnvResults {
-    #[allow(clippy::too_many_arguments)]
-    pub async fn venv(
-        config: &Arc<Config>,
-        ctx: &mut tera::Context,
-        tera: &mut Option<crate::tera::TeraEngine>,
+    pub(super) async fn venv(
+        ctx: &mut EnvDirectiveContext<'_>,
         env: &mut IndexMap<String, (String, Option<PathBuf>)>,
-        r: &mut EnvResults,
-        normalize_path: fn(&Path, PathBuf) -> PathBuf,
-        source: &Path,
-        exec_env: &EnvMap,
-        config_root: &Path,
-        env_vars: EnvMap,
         path: String,
         create: bool,
-        python: Option<String>,
-        uv_create_args: Option<Vec<String>>,
-        python_create_args: Option<Vec<String>>,
+        options: PythonVenvOptions,
     ) -> Result<()> {
         trace!("python venv: {} create={create}", display_path(&path));
-        trust_check(source)?;
-        let venv = r.parse_template(ctx, tera, source, exec_env, &path)?;
-        let venv = normalize_path(config_root, venv.into());
+        trust_check(ctx.source)?;
+        let venv = ctx.parse_template(&path)?;
+        let venv = ctx.normalize_path(venv.into());
         let venv_lock = LockFile::new(&venv).lock()?;
         if !venv.exists() && create {
             // TODO: the toolset stuff doesn't feel like it's in the right place here
@@ -202,7 +202,7 @@ impl EnvResults {
             // directive as part of config.env().
             // By filtering to only Python/UV BEFORE resolution, we avoid resolving unrelated tools
             // that have their own dependencies and environment requirements.
-            let trs = config.get_tool_request_set().await?;
+            let trs = ctx.config.get_tool_request_set().await?;
             let mut filter = HashSet::new();
             filter.insert("python".to_string());
             filter.insert("uv".to_string());
@@ -211,18 +211,8 @@ impl EnvResults {
             // Convert the filtered tool request set to a toolset and resolve only these tools
             let mut ts: Toolset = filtered_trs.into();
             // Ignore resolution errors for venv creation - if tools aren't available, we'll warn below
-            let _ = ts.resolve(config).await;
-            create_python_venv(
-                config,
-                &ts,
-                &venv,
-                env_vars,
-                python.as_deref(),
-                uv_create_args,
-                python_create_args,
-                false,
-            )
-            .await?;
+            let _ = ts.resolve(ctx.config).await;
+            create_python_venv(ctx.config, &ts, &venv, ctx.exec_env.clone(), options).await?;
         }
         drop(venv_lock);
         if venv.exists() {
@@ -230,9 +220,9 @@ impl EnvResults {
                 venv_path,
                 env: venv_env,
             } = load_venv(&venv, HashMap::new());
-            r.env_paths.insert(0, venv_path);
+            ctx.results.env_paths.insert(0, venv_path);
             for (k, v) in venv_env {
-                env.insert(k, (v, Some(source.to_path_buf())));
+                env.insert(k, (v, Some(ctx.source.to_path_buf())));
             }
         } else if !create {
             // The create "no venv found" warning is handled elsewhere

--- a/src/uv.rs
+++ b/src/uv.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::BackendArg;
-use crate::config::env_directive::venv::{Venv, create_python_venv, load_venv};
+use crate::config::env_directive::venv::{PythonVenvOptions, Venv, create_python_venv, load_venv};
 use crate::config::{Config, Settings};
 use crate::env_diff::EnvMap;
 use crate::file::display_path;
@@ -32,10 +32,10 @@ pub async fn uv_venv(config: &Arc<Config>, ts: &Toolset) -> &'static Option<Venv
                         ts,
                         &venv_path,
                         EnvMap::new(),
-                        None,
-                        None,
-                        None,
-                        true,
+                        PythonVenvOptions {
+                            require_uv: true,
+                            ..Default::default()
+                        },
                     )
                     .await
                     {


### PR DESCRIPTION
## Summary
- add a shared environment-directive context for config, template, path, source, and environment state
- use the context across path, file, source, and Python virtualenv resolution
- group Python virtualenv creation settings into a typed options value
- remove four `too_many_arguments` exceptions

## Why
Environment directive helpers individually threaded the same resolution state through long parameter lists. That obscured which values belong to the current directive and required Clippy exceptions on signatures with up to 15 arguments.

Centralizing that shared state makes the helper boundaries smaller while preserving directive behavior. The helper visibility is also narrowed to the environment-directive module where appropriate.

## Validation
- `mise run lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin mise config::env_directive` (9 passed)
- `mise run test:e2e e2e/config/test_config_env e2e/core/test_python_venv`
- `mise run test:e2e e2e/env/test_env_file e2e/env/test_env_file_expand e2e/env/test_env_file_glob e2e/env/test_env_source e2e/env/test_env_source_glob e2e/env/test_env_path_resolution`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with no intended behavior change; env resolution and venv creation paths are sensitive but the PR only reshapes how existing state is passed.
> 
> **Overview**
> Introduces **`EnvDirectiveContext`** to hold shared env-directive resolution state (config, Tera, `EnvResults`, path normalization, source path, exec env, config root) and adds **`parse_template`** / **`normalize_path`** helpers on it.
> 
> **Path**, **file**, **source**, and **Python venv** handlers now take `&mut EnvDirectiveContext` instead of long parallel parameter lists; **`EnvResults::resolve`** builds that context for each matching directive. Helper visibility is tightened to **`pub(super)`** within the env-directive module.
> 
> Python venv creation is grouped into **`PythonVenvOptions`** (python version, uv/stdlib args, **`require_uv`**); **`create_python_venv`** and **`uv.rs`** call sites use that struct instead of four trailing booleans/options. Four **`clippy::too_many_arguments`** suppressions are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54361178bbbd1face0be842b30bc7a3bc3d01cd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined environment directive processing for paths, files, sourced scripts, and Python virtual environments.
  * Improved handling of configured Python and UV options when creating virtual environments.
  * Preserved existing environment loading, path expansion, and shell expansion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->