### PR TITLE
refactor: remove targeted clippy exceptions

### DIFF
--- a/crates/mise-shim/src/main.rs
+++ b/crates/mise-shim/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 use std::path::Path;
-use std::process::{Command, exit};
+use std::process::{Command, ExitCode};
 
 const MISE_SHIM_PATH_ENV: &str = "__MISE_SHIM_PATH";
 
@@ -24,29 +24,32 @@ fn paths_eq(a: &Path, b: &Path) -> bool {
     }
 }
 
-fn main() {
-    let exe = env::current_exe().unwrap_or_else(|e| {
-        eprintln!("mise-shim: failed to determine executable path: {e}");
-        exit(1);
-    });
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => ExitCode::from(code as u8),
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<i32, String> {
+    let exe = env::current_exe()
+        .map_err(|err| format!("mise-shim: failed to determine executable path: {err}"))?;
     let tool = exe
         .file_stem()
-        .unwrap_or_else(|| {
-            eprintln!("mise-shim: failed to determine tool name from executable path");
-            exit(1);
-        })
+        .ok_or_else(|| "mise-shim: failed to determine tool name from executable path".to_string())?
         .to_os_string();
-
     if env::var_os(MISE_SHIM_PATH_ENV)
         .as_deref()
         .is_some_and(|previous| paths_eq(Path::new(previous), &exe))
     {
-        eprintln!(
+        return Err(format!(
             "mise-shim: recursive shim invocation detected for {}: {}",
             tool.to_string_lossy(),
             exe.display()
-        );
-        exit(1);
+        ));
     }
 
     let args = env::args_os().skip(1);
@@ -60,12 +63,11 @@ fn main() {
         .status();
 
     match status {
-        Ok(s) => exit(s.code().unwrap_or(1)),
-        Err(e) => {
-            eprintln!("mise-shim: failed to execute mise: {e}");
-            eprintln!("Ensure `mise` is installed and available on your PATH.");
-            eprintln!("See https://mise.en.dev for installation instructions.");
-            exit(1);
-        }
+        Ok(status) => Ok(status.code().unwrap_or(1)),
+        Err(err) => Err(format!(
+            "mise-shim: failed to execute mise: {err}\n\
+             Ensure `mise` is installed and available on your PATH.\n\
+             See https://mise.en.dev for installation instructions."
+        )),
     }
 }

--- a/crates/vfox/src/bin.rs
+++ b/crates/vfox/src/bin.rs
@@ -5,15 +5,15 @@ extern crate log;
 #[cfg(feature = "cli")]
 mod cli;
 
-#[allow(clippy::disallowed_methods)]
 #[cfg(feature = "cli")]
 #[tokio::main]
-async fn main() {
+async fn main() -> std::process::ExitCode {
     env_logger::init_from_env(env_logger::Env::default().filter_or("VFOX_LOG", "info"));
     if let Err(err) = cli::run().await {
         error!("{err}");
-        std::process::exit(1);
+        return std::process::ExitCode::FAILURE;
     }
+    std::process::ExitCode::SUCCESS
 }
 
 #[cfg(not(feature = "cli"))]

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -140,7 +140,7 @@ impl Activate {
         // This key is session-scoped and lost when the shell closes
         if Settings::get().env_cache {
             let key = CachedEnv::ensure_encryption_key();
-            prelude.push(ActivatePrelude::SetEnv(
+            prelude.push(ActivatePrelude::Set(
                 "__MISE_ENV_CACHE_KEY".to_string(),
                 key,
             ));
@@ -160,7 +160,7 @@ impl Activate {
 
     fn prepend_path(&self, p: &Path) -> Option<ActivatePrelude> {
         if is_dir_not_in_nix(p) && !is_dir_in_path(p) && !p.is_relative() {
-            Some(ActivatePrelude::PrependEnv(
+            Some(ActivatePrelude::Prepend(
                 PATH_KEY.to_string(),
                 p.to_string_lossy().to_string(),
             ))
@@ -172,18 +172,18 @@ impl Activate {
     /// Used by activate_shims for the shims directory. Always prepends the path to
     /// the front, even if already present (accepting a duplicate entry), so the
     /// shims dir wins on re-source. For shells with native path dedup (fish), uses
-    /// MovePrependEnv to reorder without duplicating.
+    /// MovePrepend to reorder without duplicating.
     fn shims_prepend_path(&self, shell: &dyn Shell, p: &Path) -> Option<ActivatePrelude> {
         if !is_dir_not_in_nix(p) || p.is_relative() {
             return None;
         }
         if shell.supports_move_path() {
-            Some(ActivatePrelude::MovePrependEnv(
+            Some(ActivatePrelude::MovePrepend(
                 PATH_KEY.to_string(),
                 p.to_string_lossy().to_string(),
             ))
         } else {
-            Some(ActivatePrelude::PrependEnv(
+            Some(ActivatePrelude::Prepend(
                 PATH_KEY.to_string(),
                 p.to_string_lossy().to_string(),
             ))
@@ -209,7 +209,7 @@ fn remove_shims() -> std::io::Result<Option<ActivatePrelude>> {
         // goes back into the user's live shell: a duplicate entry the user put there is
         // theirs to keep, and only the shims dir may be dropped here.
         let path = path_env.join_verbatim().to_string_lossy().to_string();
-        Ok(Some(ActivatePrelude::SetEnv(PATH_KEY.to_string(), path)))
+        Ok(Some(ActivatePrelude::Set(PATH_KEY.to_string(), path)))
     } else {
         Ok(None)
     }

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -86,7 +86,7 @@ impl Completion {
         match shell {
             Shell::Bash => include_str!("../../completions/mise.bash"),
             Shell::Fish => include_str!("../../completions/mise.fish"),
-            Shell::PowerShell => include_str!("../../completions/mise.ps1"),
+            Shell::Powershell => include_str!("../../completions/mise.ps1"),
             Shell::Zsh => include_str!("../../completions/_mise"),
         }
         .to_string()
@@ -105,18 +105,17 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
 #[derive(Debug, Clone, Copy, EnumString, strum::Display)]
 #[strum(serialize_all = "snake_case")]
-#[allow(clippy::enum_variant_names)] // PowerShell is a proper noun
 enum Shell {
     Bash,
     Fish,
     #[strum(serialize = "powershell")]
-    PowerShell,
+    Powershell,
     Zsh,
 }
 
 impl ValueEnum for Shell {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Bash, Self::Fish, Self::PowerShell, Self::Zsh]
+        &[Self::Bash, Self::Fish, Self::Powershell, Self::Zsh]
     }
     fn to_possible_value(&self) -> Option<PossibleValue> {
         Some(PossibleValue::new(self.to_string()))

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -35,11 +35,10 @@ pub fn kill_all() {
     CmdLineRunner::kill_all();
 }
 
-/// Terminate only after command scopes and their destructors have unwound.
-#[allow(clippy::disallowed_methods)]
-pub fn terminate(code: i32) -> ! {
+/// Convert a requested process status after command scopes have unwound.
+pub fn status(code: i32) -> std::process::ExitCode {
     debug!("exiting with code: {code}");
-    std::process::exit(code)
+    std::process::ExitCode::from(code as u8)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 use std::{
     panic,
+    process::ExitCode,
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
@@ -105,7 +106,7 @@ pub(crate) use crate::exit::request as request_exit;
 pub(crate) use crate::result::Result;
 use crate::ui::multi_progress_report::MultiProgressReport;
 
-fn main() {
+fn main() -> ExitCode {
     let nprocs = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or_default();
@@ -126,7 +127,7 @@ fn main() {
         Ok(runtime) => runtime,
         Err(err) => {
             eprintln!("Error: {err:?}");
-            exit::terminate(1);
+            return exit::status(1);
         }
     };
     let result = runtime.block_on(main_());
@@ -150,8 +151,10 @@ fn main() {
     } else {
         drop(runtime);
     }
-    if code != 0 {
-        exit::terminate(code);
+    if code == 0 {
+        ExitCode::SUCCESS
+    } else {
+        exit::status(code)
     }
 }
 

--- a/src/sandbox/seccomp.rs
+++ b/src/sandbox/seccomp.rs
@@ -6,6 +6,10 @@ use seccompiler::{
 };
 use std::collections::BTreeMap;
 
+fn syscall_number<T: Into<i64>>(number: T) -> i64 {
+    number.into()
+}
+
 /// Apply a seccomp-bpf filter that blocks network syscalls.
 ///
 /// Blocks AF_INET and AF_INET6 sockets while allowing AF_UNIX (needed by many tools).
@@ -47,8 +51,10 @@ pub fn apply_seccomp_net_filter() -> Result<()> {
 
     // Block socket() and socketpair() for inet families
     // This is sufficient — if you can't create an inet socket, you can't do networking
-    #[allow(clippy::useless_conversion)]
-    for syscall in [libc::SYS_socket, libc::SYS_socketpair].map(i64::from) {
+    for syscall in [
+        syscall_number(libc::SYS_socket),
+        syscall_number(libc::SYS_socketpair),
+    ] {
         rules.insert(
             syscall,
             vec![socket_rule_inet.clone(), socket_rule_inet6.clone()],

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -83,7 +83,7 @@ pub trait Shell: Display {
     }
     /// Whether this shell natively deduplicates/reorders PATH entries.
     /// When true, activate_shims skips the is_dir_in_path guard and uses
-    /// MovePrependEnv to ensure correct ordering on re-source.
+    /// MovePrepend to ensure correct ordering on re-source.
     fn supports_move_path(&self) -> bool {
         false
     }
@@ -107,21 +107,20 @@ pub trait Shell: Display {
         prelude
             .iter()
             .map(|p| match p {
-                ActivatePrelude::SetEnv(k, v) => self.set_env(k, v),
-                ActivatePrelude::PrependEnv(k, v) => self.prepend_env(k, v),
-                ActivatePrelude::MovePrependEnv(k, v) => self.move_prepend_env(k, v),
+                ActivatePrelude::Set(k, v) => self.set_env(k, v),
+                ActivatePrelude::Prepend(k, v) => self.prepend_env(k, v),
+                ActivatePrelude::MovePrepend(k, v) => self.move_prepend_env(k, v),
             })
             .join("")
     }
 }
 
-#[allow(clippy::enum_variant_names)]
 pub enum ActivatePrelude {
-    SetEnv(String, String),
-    PrependEnv(String, String),
-    /// Like PrependEnv but moves existing entries to the front (for fish --move).
+    Set(String, String),
+    Prepend(String, String),
+    /// Like Prepend but moves existing entries to the front (for fish --move).
     /// Used only by activate_shims to reorder paths on re-source.
-    MovePrependEnv(String, String),
+    MovePrepend(String, String),
 }
 
 pub struct ActivateOptions {

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -37,8 +37,8 @@ impl Nushell {
         prelude
             .iter()
             .map(|p| match p {
-                ActivatePrelude::SetEnv(k, v) => format!("$env.{k} = r#'{v}'#\n"),
-                ActivatePrelude::PrependEnv(k, v) | ActivatePrelude::MovePrependEnv(k, v) => {
+                ActivatePrelude::Set(k, v) => format!("$env.{k} = r#'{v}'#\n"),
+                ActivatePrelude::Prepend(k, v) | ActivatePrelude::MovePrepend(k, v) => {
                     self.prepend_env(k, v)
                 }
             })

--- a/src/system/packages/brew/pour.rs
+++ b/src/system/packages/brew/pour.rs
@@ -648,11 +648,10 @@ pub fn link_keg(name: &str, pkg_version: &str, keg_only: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
     use super::*;
+    use tokio::sync::Mutex;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
     struct BrewPrefixGuard {
         previous: Option<String>,
@@ -729,7 +728,7 @@ mod tests {
     /// inside the Cellar and must still be recognized as brew's
     #[test]
     fn test_upgrade_over_brew_file_links() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         write_lib_keg(&prefix, "foo", "1.0")?;
@@ -748,7 +747,7 @@ mod tests {
     /// relink without conflicts or modifying the old keg
     #[test]
     fn test_upgrade_over_brew_dir_symlink() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         let old_keg = write_lib_keg(&prefix, "foo", "1.0")?;
@@ -776,7 +775,7 @@ mod tests {
     /// ship symlinks to system libraries) is still brew's own link
     #[test]
     fn test_upgrade_over_link_whose_cellar_target_leaves_the_cellar() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         for version in ["1.0", "2.0"] {
@@ -811,7 +810,7 @@ mod tests {
     /// and must still be reported as a conflict
     #[test]
     fn test_foreign_regular_file_still_conflicts() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         write_lib_keg(&prefix, "foo", "2.0")?;
@@ -831,7 +830,7 @@ mod tests {
     /// directory keeping that keg's entries visible, like brew does
     #[test]
     fn test_materialize_shared_dir_owned_by_other_keg() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         // other keg owns share/xml via a dir symlink
@@ -861,7 +860,7 @@ mod tests {
 
     #[test]
     fn test_nested_relative_link_is_brew_owned() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         let keg = prefix.join("Cellar/foo/1.0/lib");
@@ -879,7 +878,7 @@ mod tests {
 
     #[test]
     fn test_link_keg_maintains_homebrew_linked_record() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         write_lib_keg(&prefix, "foo", "1.0")?;
@@ -924,7 +923,7 @@ mod tests {
 
     #[test]
     fn test_repairs_active_records_without_relinking_the_keg() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         write_lib_keg(&prefix, "foo", "1.0")?;
@@ -953,7 +952,7 @@ mod tests {
 
     #[test]
     fn test_repairs_dangling_owned_records_but_not_foreign_records() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         write_lib_keg(&prefix, "foo", "1.0")?;
@@ -989,7 +988,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(clippy::await_holding_lock)] // guards the process-global brew prefix for this test
     async fn test_manager_repairs_linked_record_without_repouring() -> Result<()> {
         use std::os::unix::fs::MetadataExt;
 
@@ -997,7 +995,7 @@ mod tests {
             InstallOpts, PackageRequest, PackageState, SystemPackageManager,
         };
 
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.lock().await;
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         let keg = write_lib_keg(&prefix, "foo", "1.0")?;
@@ -1058,7 +1056,7 @@ mod tests {
 
     #[test]
     fn test_does_not_infer_a_linked_record_without_public_links() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         write_lib_keg(&prefix, "foo", "1.0")?;
@@ -1073,7 +1071,7 @@ mod tests {
 
     #[test]
     fn test_runtime_loader_does_not_make_glibc_look_linked() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         let keg = prefix.join("Cellar/glibc/1.0");
@@ -1099,7 +1097,7 @@ mod tests {
 
     #[test]
     fn test_foreign_linked_record_blocks_linking_before_changes() -> Result<()> {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = ENV_LOCK.blocking_lock();
         let (_tmp, prefix) = canonical_tempdir()?;
         let _guard = BrewPrefixGuard::set(&prefix);
         write_lib_keg(&prefix, "foo", "1.0")?;


### PR DESCRIPTION
## Summary
- return process statuses through `ExitCode` instead of calling the disallowed `std::process::exit`
- rename enum variants so they satisfy Clippy without suppressions
- normalize seccomp syscall constants across integer widths
- use an async-aware mutex in the brew test that holds a guard across `await`
- remove six targeted Clippy exclusions and fix the uncovered `mise-shim` warnings

## Validation
- `mise run lint`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p mise-shim -p vfox --all-features` (91 passed, 2 ignored)
- `cargo test --all-features test_manager_repairs_linked_record_without_repouring`

This is a prerequisite refactor in stack #11523; it targets #11522.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is mainly exit path ordering (destructors run before exit); exit codes and shell activation semantics are preserved.
> 
> **Overview**
> This PR clears several Clippy suppressions by adjusting how binaries exit, renaming a few enums, and tightening test synchronization.
> 
> **Process exit:** `mise`, `mise-shim`, and `vfox` no longer call `std::process::exit`. They return `ExitCode` from `main` (with `exit::status` replacing `exit::terminate`), so teardown can run before the process ends.
> 
> **Naming:** `ActivatePrelude` variants drop the `Env` suffix (`Set`, `Prepend`, `MovePrepend`), and the completion CLI shell enum uses `Powershell` instead of `PowerShell`, removing `enum_variant_names` allowances.
> 
> **Other:** Seccomp rule keys use a small `syscall_number` helper instead of a conversion lint allow. Brew pour tests switch from `std::sync::Mutex` to `tokio::sync::Mutex` with `blocking_lock` / `.await` so the async test can hold the env lock across `await` without a clippy exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479c2ea04d4981bbb607dd1fd483c02b60264abc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->