### PR TITLE
refactor(backend): group clippy-heavy call contexts

### DIFF
--- a/crates/mise-sigstore/src/lib.rs
+++ b/crates/mise-sigstore/src/lib.rs
@@ -535,6 +535,17 @@ impl AttestationClient {
     }
 }
 
+pub struct GithubAttestationRequest<'a> {
+    pub artifact_path: &'a Path,
+    pub owner: &'a str,
+    pub repo: &'a str,
+    pub token: Option<&'a str>,
+    pub signer_workflow: Option<&'a str>,
+    pub base_url: Option<&'a str>,
+    pub digest: Option<&'a str>,
+    pub retry_config: RetryConfig,
+}
+
 pub async fn verify_github_attestation(
     artifact_path: &Path,
     owner: &str,
@@ -543,16 +554,16 @@ pub async fn verify_github_attestation(
     signer_workflow: Option<&str>,
     retry_config: RetryConfig,
 ) -> Result<bool> {
-    verify_github_attestation_inner(
+    verify_github_attestation_inner(GithubAttestationRequest {
         artifact_path,
         owner,
         repo,
         token,
         signer_workflow,
-        None,
-        None,
+        base_url: None,
+        digest: None,
         retry_config,
-    )
+    })
     .await
 }
 
@@ -565,41 +576,23 @@ pub async fn verify_github_attestation_with_base_url(
     base_url: &str,
     retry_config: RetryConfig,
 ) -> Result<bool> {
-    verify_github_attestation_inner(
+    verify_github_attestation_inner(GithubAttestationRequest {
         artifact_path,
         owner,
         repo,
         token,
         signer_workflow,
-        Some(base_url),
-        None,
+        base_url: Some(base_url),
+        digest: None,
         retry_config,
-    )
+    })
     .await
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn verify_github_attestation_with_base_url_and_digest(
-    artifact_path: &Path,
-    owner: &str,
-    repo: &str,
-    token: Option<&str>,
-    signer_workflow: Option<&str>,
-    base_url: &str,
-    digest: &str,
-    retry_config: RetryConfig,
+    request: GithubAttestationRequest<'_>,
 ) -> Result<bool> {
-    verify_github_attestation_inner(
-        artifact_path,
-        owner,
-        repo,
-        token,
-        signer_workflow,
-        Some(base_url),
-        Some(digest),
-        retry_config,
-    )
-    .await
+    verify_github_attestation_inner(request).await
 }
 
 pub async fn verify_github_attestation_with_attestations(
@@ -616,33 +609,23 @@ pub async fn verify_github_attestation_with_attestations(
     verify_attestation_bundles(attestations, &artifact, signer_workflow, &mut trust_roots).await
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn verify_github_attestation_inner(
-    artifact_path: &Path,
-    owner: &str,
-    repo: &str,
-    token: Option<&str>,
-    signer_workflow: Option<&str>,
-    base_url: Option<&str>,
-    digest: Option<&str>,
-    retry_config: RetryConfig,
-) -> Result<bool> {
-    let mut builder = AttestationClient::builder().retry_config(retry_config);
-    if let Some(token) = token {
+async fn verify_github_attestation_inner(request: GithubAttestationRequest<'_>) -> Result<bool> {
+    let mut builder = AttestationClient::builder().retry_config(request.retry_config);
+    if let Some(token) = request.token {
         builder = builder.github_token(token);
     }
-    if let Some(base_url) = base_url {
+    if let Some(base_url) = request.base_url {
         builder = builder.base_url(base_url);
     }
     let client = builder.build()?;
-    let digest = match digest {
+    let digest = match request.digest {
         Some(digest) => digest.to_string(),
-        None => calculate_file_digest(artifact_path).await?,
+        None => calculate_file_digest(request.artifact_path).await?,
     };
     let attestations = client
         .fetch_attestations(FetchParams {
-            owner: owner.to_string(),
-            repo: Some(format!("{owner}/{repo}")),
+            owner: request.owner.to_string(),
+            repo: Some(format!("{}/{}", request.owner, request.repo)),
             digest: format!("sha256:{digest}"),
             limit: 30,
             predicate_type: None,
@@ -653,9 +636,15 @@ async fn verify_github_attestation_inner(
         return Err(AttestationError::NoAttestations);
     }
 
-    let artifact = tokio::fs::read(artifact_path).await?;
+    let artifact = tokio::fs::read(request.artifact_path).await?;
     let mut trust_roots = TrustRoots::default();
-    verify_attestation_bundles(&attestations, &artifact, signer_workflow, &mut trust_roots).await
+    verify_attestation_bundles(
+        &attestations,
+        &artifact,
+        request.signer_workflow,
+        &mut trust_roots,
+    )
+    .await
 }
 
 pub async fn verify_cosign_signature(

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -57,6 +57,17 @@ struct AquaOptions<'a> {
     values: BackendOptions<'a>,
 }
 
+struct MinisignCheck<'a> {
+    artifact_path: &'a Path,
+    artifact_filename: &'a str,
+    pkg: &'a AquaPackage,
+    config: &'a AquaMinisign,
+    checksum: Option<&'a AquaChecksum>,
+    version: &'a str,
+    download_dir: &'a Path,
+    progress: Option<&'a dyn SingleReport>,
+}
+
 impl<'a> AquaOptions<'a> {
     fn new(raw: &'a ToolVersionOptions) -> Self {
         Self {
@@ -1303,16 +1314,16 @@ impl AquaBackend {
                     .as_ref()
                     .filter(|minisign| minisign.enabled != Some(false))
                 {
-                    self.run_minisign_check(
-                        &artifact_path,
-                        &filename,
+                    self.run_minisign_check(MinisignCheck {
+                        artifact_path: &artifact_path,
+                        artifact_filename: &filename,
                         pkg,
-                        minisign,
-                        None,
-                        v,
-                        tmp_dir.path(),
-                        None,
-                    )
+                        config: minisign,
+                        checksum: None,
+                        version: v,
+                        download_dir: tmp_dir.path(),
+                        progress: None,
+                    })
                     .await?;
                 } else {
                     let (checksum_config, minisign) = Self::checksum_minisign_config(pkg).wrap_err(
@@ -1325,16 +1336,16 @@ impl AquaBackend {
                         .file_name()
                         .and_then(|f| f.to_str())
                         .unwrap_or("checksum");
-                    self.run_minisign_check(
-                        &checksum_path,
-                        checksum_filename,
+                    self.run_minisign_check(MinisignCheck {
+                        artifact_path: &checksum_path,
+                        artifact_filename: checksum_filename,
                         pkg,
-                        minisign,
-                        Some(checksum_config),
-                        v,
-                        tmp_dir.path(),
-                        None,
-                    )
+                        config: minisign,
+                        checksum: Some(checksum_config),
+                        version: v,
+                        download_dir: tmp_dir.path(),
+                        progress: None,
+                    })
                     .await?;
                     self.verify_checksum_file_matches_expected(
                         checksum_config,
@@ -1537,67 +1548,74 @@ impl AquaBackend {
     }
 
     /// Download minisign signature and verify against an already-downloaded artifact.
-    #[allow(clippy::too_many_arguments)]
-    async fn run_minisign_check(
-        &self,
-        artifact_path: &Path,
-        artifact_filename: &str,
-        pkg: &AquaPackage,
-        minisign_config: &AquaMinisign,
-        checksum_config: Option<&AquaChecksum>,
-        v: &str,
-        download_dir: &Path,
-        pr: Option<&dyn SingleReport>,
-    ) -> Result<()> {
-        let template_ctx = checksum_config
-            .map(|checksum| checksum.template_ctx(pkg, v, os(), arch()))
+    async fn run_minisign_check(&self, check: MinisignCheck<'_>) -> Result<()> {
+        let template_ctx = check
+            .checksum
+            .map(|checksum| checksum.template_ctx(check.pkg, check.version, os(), arch()))
             .transpose()?;
-        let sig_path = match minisign_config._type() {
+        let sig_path = match check.config._type() {
             AquaMinisignType::GithubRelease => {
                 let asset = if let Some(ctx) = &template_ctx {
                     let mut overrides = ctx.clone();
-                    overrides.insert("Asset".to_string(), artifact_filename.to_string());
-                    pkg.parse_aqua_str(
-                        minisign_config.asset.as_ref().unwrap(),
-                        v,
+                    overrides.insert("Asset".to_string(), check.artifact_filename.to_string());
+                    check.pkg.parse_aqua_str(
+                        check.config.asset.as_ref().unwrap(),
+                        check.version,
                         &overrides,
                         os(),
                         arch(),
                     )?
                 } else {
-                    minisign_config.asset(pkg, artifact_filename, v, os(), arch())?
+                    check.config.asset(
+                        check.pkg,
+                        check.artifact_filename,
+                        check.version,
+                        os(),
+                        arch(),
+                    )?
                 };
                 let asset_strs = IndexSet::from([asset]);
                 let (repo_owner, repo_name) = resolve_repo_info(
-                    minisign_config.repo_owner.as_ref(),
-                    minisign_config.repo_name.as_ref(),
-                    pkg,
+                    check.config.repo_owner.as_ref(),
+                    check.config.repo_name.as_ref(),
+                    check.pkg,
                 );
-                let mut sig_pkg = pkg.clone();
+                let mut sig_pkg = check.pkg.clone();
                 sig_pkg.repo_owner = repo_owner;
                 sig_pkg.repo_name = repo_name;
                 let (url, download_url) = self
-                    .github_release_asset_urls(&sig_pkg, v, asset_strs)
+                    .github_release_asset_urls(&sig_pkg, check.version, asset_strs)
                     .await?;
-                let path = download_dir.join(get_filename_from_url(&url));
-                HTTP.download_file(&download_url, &path, pr).await?;
+                let path = check.download_dir.join(get_filename_from_url(&url));
+                HTTP.download_file(&download_url, &path, check.progress)
+                    .await?;
                 path
             }
             AquaMinisignType::Http => {
                 let url = if let Some(ctx) = &template_ctx {
-                    pkg.parse_aqua_str(minisign_config.url.as_ref().unwrap(), v, ctx, os(), arch())?
+                    check.pkg.parse_aqua_str(
+                        check.config.url.as_ref().unwrap(),
+                        check.version,
+                        ctx,
+                        os(),
+                        arch(),
+                    )?
                 } else {
-                    minisign_config.url(pkg, v, os(), arch())?
+                    check.config.url(check.pkg, check.version, os(), arch())?
                 };
-                let path = download_dir.join(format!("{artifact_filename}.minisig"));
-                HTTP.download_file(&url, &path, pr).await?;
+                let path = check
+                    .download_dir
+                    .join(format!("{}.minisig", check.artifact_filename));
+                HTTP.download_file(&url, &path, check.progress).await?;
                 path
             }
         };
-        let data = file::read(artifact_path)?;
+        let data = file::read(check.artifact_path)?;
         let sig = file::read_to_string(&sig_path)?;
         minisign::verify(
-            &minisign_config.public_key(pkg, v, os(), arch())?,
+            &check
+                .config
+                .public_key(check.pkg, check.version, os(), arch())?,
             &data,
             &sig,
         )?;
@@ -2461,16 +2479,16 @@ impl AquaBackend {
                     .is_some_and(|p| p.is_slsa() || p.is_github_attestations())
             {
                 let checksum_filename = checksum_asset_name;
-                self.run_minisign_check(
-                    &checksum_path,
-                    checksum_filename,
+                self.run_minisign_check(MinisignCheck {
+                    artifact_path: &checksum_path,
+                    artifact_filename: checksum_filename,
                     pkg,
-                    minisign,
-                    Some(checksum),
-                    v,
-                    &download_path,
-                    Some(ctx.pr.as_ref()),
-                )
+                    config: minisign,
+                    checksum: Some(checksum),
+                    version: v,
+                    download_dir: &download_path,
+                    progress: Some(ctx.pr.as_ref()),
+                })
                 .await?;
                 self.record_provenance(tv, ProvenanceType::Minisign);
             }
@@ -2570,16 +2588,17 @@ impl AquaBackend {
             ctx.pr.set_message("verify minisign".to_string());
             debug!("minisign: {:?}", minisign);
             let artifact_path = tv.download_path().join(filename);
-            self.run_minisign_check(
-                &artifact_path,
-                filename,
+            let download_path = tv.download_path();
+            self.run_minisign_check(MinisignCheck {
+                artifact_path: &artifact_path,
+                artifact_filename: filename,
                 pkg,
-                minisign,
-                None,
-                v,
-                &tv.download_path(),
-                Some(ctx.pr.as_ref()),
-            )
+                config: minisign,
+                checksum: None,
+                version: v,
+                download_dir: &download_path,
+                progress: Some(ctx.pr.as_ref()),
+            })
             .await?;
 
             // Record minisign provenance if no higher-priority verification already recorded

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -151,14 +151,16 @@ pub async fn verify_attestation(
     let base_url = routed_api_url(api_url.unwrap_or(crate::github::API_URL));
     if let Some(digest) = digest {
         mise_sigstore::verify_github_attestation_with_base_url_and_digest(
-            artifact_path,
-            owner,
-            repo,
-            token.as_deref(),
-            expected_workflow,
-            &base_url,
-            &digest,
-            mise_retry_config(),
+            mise_sigstore::GithubAttestationRequest {
+                artifact_path,
+                owner,
+                repo,
+                token: token.as_deref(),
+                signer_workflow: expected_workflow,
+                base_url: Some(&base_url),
+                digest: Some(&digest),
+                retry_config: mise_retry_config(),
+            },
         )
         .await
     } else {

--- a/src/system/packages/brew/resolve.rs
+++ b/src/system/packages/brew/resolve.rs
@@ -170,46 +170,42 @@ async fn resolve_closure_pairs(
     let mut sorted: Vec<ResolvedFormula> = vec![];
     let mut done: HashSet<FormulaKey> = HashSet::new();
     let mut visiting: Vec<FormulaKey> = vec![];
-    #[allow(clippy::too_many_arguments)]
-    fn visit(
-        key: &FormulaKey,
-        host_tag: &str,
-        formulae: &HashMap<FormulaKey, Formula>,
-        raw_bases: &HashMap<FormulaKey, Option<String>>,
-        canonical: &HashMap<FormulaKey, FormulaKey>,
-        done: &mut HashSet<FormulaKey>,
-        visiting: &mut Vec<FormulaKey>,
-        on_request: &HashSet<FormulaKey>,
-        sorted: &mut Vec<ResolvedFormula>,
-    ) -> Result<()> {
-        if done.contains(key) {
+    struct VisitContext<'a> {
+        host_tag: &'a str,
+        formulae: &'a HashMap<FormulaKey, Formula>,
+        raw_bases: &'a HashMap<FormulaKey, Option<String>>,
+        canonical: &'a HashMap<FormulaKey, FormulaKey>,
+        done: &'a mut HashSet<FormulaKey>,
+        visiting: &'a mut Vec<FormulaKey>,
+        on_request: &'a HashSet<FormulaKey>,
+        sorted: &'a mut Vec<ResolvedFormula>,
+    }
+    fn visit(key: &FormulaKey, ctx: &mut VisitContext<'_>) -> Result<()> {
+        if ctx.done.contains(key) {
             return Ok(());
         }
-        if visiting.iter().any(|n| n == key) {
+        if ctx.visiting.iter().any(|n| n == key) {
             // dependency cycles exist in homebrew/core (rare, e.g. mutual
             // optional deps); break the cycle rather than erroring
             debug!("dependency cycle involving {}, breaking", key.name);
             return Ok(());
         }
-        let Some(formula) = formulae.get(key) else {
+        let Some(formula) = ctx.formulae.get(key) else {
             bail!("unresolved dependency: {}", key.name);
         };
-        visiting.push(key.clone());
-        let tag = dep_tag(formula, host_tag);
+        ctx.visiting.push(key.clone());
+        let tag = dep_tag(formula, ctx.host_tag);
         for dep in install_deps(formula, &tag) {
             let dep_key = FormulaKey::new(dep.clone(), key.tap_name.clone(), key.tap_url.clone());
-            let dep_key = canonical.get(&dep_key).cloned().unwrap_or(dep_key);
-            visit(
-                &dep_key, host_tag, formulae, raw_bases, canonical, done, visiting, on_request,
-                sorted,
-            )?;
+            let dep_key = ctx.canonical.get(&dep_key).cloned().unwrap_or(dep_key);
+            visit(&dep_key, ctx)?;
         }
-        visiting.pop();
-        done.insert(key.clone());
-        sorted.push(ResolvedFormula {
-            formula: formulae[key].clone(),
-            tap_raw_base: raw_bases.get(key).cloned().flatten(),
-            on_request: on_request.contains(key),
+        ctx.visiting.pop();
+        ctx.done.insert(key.clone());
+        ctx.sorted.push(ResolvedFormula {
+            formula: ctx.formulae[key].clone(),
+            tap_raw_base: ctx.raw_bases.get(key).cloned().flatten(),
+            on_request: ctx.on_request.contains(key),
         });
         Ok(())
     }
@@ -220,18 +216,18 @@ async fn resolve_closure_pairs(
             .then_with(|| a.tap_url.cmp(&b.tap_url))
             .then_with(|| a.name.cmp(&b.name))
     }); // deterministic order
+    let mut visit_ctx = VisitContext {
+        host_tag: &host_tag,
+        formulae: &formulae,
+        raw_bases: &raw_bases,
+        canonical: &canonical,
+        done: &mut done,
+        visiting: &mut visiting,
+        on_request: &on_request,
+        sorted: &mut sorted,
+    };
     for key in keys {
-        visit(
-            &key,
-            &host_tag,
-            &formulae,
-            &raw_bases,
-            &canonical,
-            &mut done,
-            &mut visiting,
-            &on_request,
-            &mut sorted,
-        )?;
+        visit(&key, &mut visit_ctx)?;
     }
     Ok(sorted)
 }


### PR DESCRIPTION
## Summary
- group aqua minisign inputs in a typed verification context
- group GitHub attestation inputs in a public request type
- encapsulate Homebrew dependency traversal state
- remove four backend and sigstore `clippy::too_many_arguments` exclusions

## Validation
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p mise-sigstore` (26 passed)
- `cargo test --all-features backend::aqua::tests` (52 passed)
- `cargo test --all-features system::packages::brew` (139 passed)

This is a prerequisite refactor in stack #11523; it targets #11524.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical signature refactors with existing test coverage; no intended changes to verification or install resolution logic.
> 
> **Overview**
> Refactors several **long-argument** call sites into typed context structs so Clippy’s `too_many_arguments` allow-list can be dropped without changing behavior.
> 
> **mise-sigstore** introduces public **`GithubAttestationRequest`** and routes GitHub attestation verification (including the base-URL + digest path) through it; **`src/github/sigstore.rs`** is updated to build that struct at the digest-aware call site.
> 
> **Aqua** minisign verification now takes a **`MinisignCheck`** bundle (artifact, package, config, optional checksum, download dir, progress) instead of eight separate parameters at each **`run_minisign_check`** call.
> 
> **Homebrew formula resolution** replaces the recursive **`visit`** helper’s many parameters with a **`VisitContext`** that holds traversal state for dependency sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd61716dc21406fbfc710e87d504698082aa9d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->