### PR TITLE
chore(lint): remove stale template exclusions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 // eyre 0.6.12 emits a trailing semicolon from bail!, which nightly rejects.
 #![allow(semicolon_in_expressions_from_macros)]
 

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 use std::fmt::Display;
 
 use shell_escape::unix::escape;

--- a/src/shell/elvish.rs
+++ b/src/shell/elvish.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 use std::fmt::Display;
 
 use crate::shell::{self, ActivateOptions, Shell};

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 use std::fmt::{Display, Formatter};
 
 use crate::config::Settings;

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 use std::fmt::Display;
 
 use indoc::formatdoc;

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 use crate::config::Settings;
 use std::borrow::Cow;
 use std::fmt::Display;

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 use std::borrow::Cow;
 use std::fmt::Display;
 

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 use std::fmt::Display;
 
 use indoc::formatdoc;

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(clippy::literal_string_with_formatting_args)]
 
 use std::{
     fmt::{Display, Formatter},


### PR DESCRIPTION
## Summary
- remove nine file-wide `clippy::literal_string_with_formatting_args` exclusions
- keep shell activation templates and progress rendering unchanged
- confirm the current Clippy toolchain accepts every affected file without narrower suppressions

## Validation
- `mise run lint`
- `cargo clippy --bin mise --all-features -- -D warnings`

This is a prerequisite cleanup in stack #11523; it targets #11525.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only attribute removals with no behavioral changes; risk is limited to CI failing if Clippy regresses on those files.
> 
> **Overview**
> Removes file-level `#![allow(clippy::literal_string_with_formatting_args)]` from **nine** modules (`main`, shell backends for bash/elvish/fish/nushell/pwsh/xonsh/zsh, and `ui/progress_report`). No runtime or template logic changes—only dropping suppressions that are no longer needed under the current Clippy toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be532a5c71cf18a5af1c776347e9c436ace470f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->