### PR TITLE
refactor(task): group scheduler and cache state

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -13,6 +13,7 @@ use crate::duration;
 use crate::env;
 use crate::file::display_path;
 use crate::task::has_any_usage_spec;
+use crate::task::task_executor::TaskRunContext;
 use crate::task::task_helpers::task_needs_permit;
 use crate::task::task_list::{get_task_lists, resolve_depends};
 use crate::task::task_output::TaskOutput;
@@ -667,16 +668,16 @@ impl Run {
                 let deps = deps_for_remove.lock().await;
                 (deps.completion_state(), deps.dependency_state(&task))
             };
-            let (result, panicked) = match AssertUnwindSafe(this.run_task_sched(
-                &task,
-                &ctx.config,
-                ctx.sched_tx.clone(),
+            let (result, panicked) = match AssertUnwindSafe(this.run_task_sched(TaskRunContext {
+                task: &task,
+                config: &ctx.config,
+                sched_tx: ctx.sched_tx.clone(),
                 completion_state,
                 dependency_state,
                 semaphore,
-                &mut permit,
+                permit: &mut permit,
                 allow_during_interruption,
-            ))
+            }))
             .catch_unwind()
             .await
             {
@@ -950,31 +951,14 @@ impl Run {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn run_task_sched(
         &self,
-        task: &Task,
-        config: &Arc<Config>,
-        sched_tx: Arc<tokio::sync::mpsc::UnboundedSender<crate::task::task_scheduler::SchedMsg>>,
-        completion_state: crate::task::TaskCompletionState,
-        dependency_state: crate::task::TaskDependencyState,
-        semaphore: Arc<tokio::sync::Semaphore>,
-        permit: &mut Option<tokio::sync::OwnedSemaphorePermit>,
-        allow_during_interruption: bool,
+        ctx: TaskRunContext<'_>,
     ) -> Result<crate::task::task_executor::TaskRunOutcome> {
         self.executor
             .as_ref()
             .expect("executor must be initialized before running tasks")
-            .run_task_sched(
-                task,
-                config,
-                sched_tx,
-                completion_state,
-                dependency_state,
-                semaphore,
-                permit,
-                allow_during_interruption,
-            )
+            .run_task_sched(ctx)
             .await
     }
 

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -132,6 +132,16 @@ pub(crate) struct TaskArtifactCacheBuilder {
     inputs: TaskCacheInputs,
 }
 
+pub(crate) struct TaskCacheContext<'a> {
+    pub(crate) task: &'a Task,
+    pub(crate) config: &'a Arc<Config>,
+    pub(crate) toolset: &'a Toolset,
+    pub(crate) resolved_env: &'a BTreeMap<String, String>,
+    pub(crate) declared_env: &'a [(String, String)],
+    pub(crate) dependency_keys: &'a [String],
+    pub(crate) command_inputs: Vec<CommandInput>,
+}
+
 impl TaskArtifactCache {
     pub(crate) async fn prepare(
         task: &Task,
@@ -171,17 +181,16 @@ impl TaskArtifactCache {
 impl TaskArtifactCacheBuilder {
     /// Finishes cache-key construction after task tools, environment, and
     /// dependency artifacts have been resolved.
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn finish(
-        self,
-        task: &Task,
-        config: &Arc<Config>,
-        toolset: &Toolset,
-        resolved_env: &BTreeMap<String, String>,
-        declared_env: &[(String, String)],
-        dependency_keys: &[String],
-        command_inputs: Vec<CommandInput>,
-    ) -> Result<TaskArtifactCache> {
+    pub(crate) async fn finish(self, ctx: TaskCacheContext<'_>) -> Result<TaskArtifactCache> {
+        let TaskCacheContext {
+            task,
+            config,
+            toolset,
+            resolved_env,
+            declared_env,
+            dependency_keys,
+            command_inputs,
+        } = ctx;
         let Self { root, inputs } = self;
         let mut environment = declared_env
             .iter()

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -6,7 +6,7 @@ use crate::env_diff::EnvDiff;
 use crate::file::{can_execute_directly, display_path, replace_path};
 use crate::sandbox::SandboxConfig;
 use crate::task::TaskArtifactCache;
-use crate::task::task_cache::CommandInput;
+use crate::task::task_cache::{CommandInput, TaskCacheContext};
 use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_list::split_task_spec;
 use crate::task::task_output::{TaskOutput, trunc};
@@ -46,6 +46,17 @@ static TASK_RUNTIME_LOCK: LazyLock<RwLock<()>> = LazyLock::new(|| RwLock::new(()
 type TaskOutputCapture = Arc<StdMutex<Vec<TaskCacheOutput>>>;
 const COMMAND_INPUT_TIMEOUT: Duration = Duration::from_secs(30);
 const COMMAND_INPUT_MAX_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
+
+pub(crate) struct TaskRunContext<'a> {
+    pub(crate) task: &'a Task,
+    pub(crate) config: &'a Arc<Config>,
+    pub(crate) sched_tx: Arc<mpsc::UnboundedSender<SchedMsg>>,
+    pub(crate) completion_state: TaskCompletionState,
+    pub(crate) dependency_state: TaskDependencyState,
+    pub(crate) semaphore: Arc<Semaphore>,
+    pub(crate) permit: &'a mut Option<OwnedSemaphorePermit>,
+    pub(crate) allow_during_interruption: bool,
+}
 
 #[allow(dead_code)] // Guards are held for their Drop impl, not read
 enum RuntimeLockGuard<'a> {
@@ -342,18 +353,17 @@ impl TaskExecutor {
 
     /// Run a task, returning whether it did work and any stable artifact identity
     /// it produced or reused.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn run_task_sched(
-        &self,
-        task: &Task,
-        config: &Arc<Config>,
-        sched_tx: Arc<mpsc::UnboundedSender<SchedMsg>>,
-        completion_state: TaskCompletionState,
-        dependency_state: TaskDependencyState,
-        semaphore: Arc<Semaphore>,
-        permit: &mut Option<OwnedSemaphorePermit>,
-        allow_during_interruption: bool,
-    ) -> Result<TaskRunOutcome> {
+    pub async fn run_task_sched(&self, ctx: TaskRunContext<'_>) -> Result<TaskRunOutcome> {
+        let TaskRunContext {
+            task,
+            config,
+            sched_tx,
+            completion_state,
+            dependency_state,
+            semaphore,
+            permit,
+            allow_during_interruption,
+        } = ctx;
         let prefix = task.estyled_prefix();
         let total_start = std::time::Instant::now();
         Self::check_interruption(allow_during_interruption)?;
@@ -581,15 +591,15 @@ impl TaskExecutor {
                         .resolve_cache_command_inputs(task, config, &env)
                         .await?;
                     let cache = prepared
-                        .finish(
+                        .finish(TaskCacheContext {
                             task,
                             config,
-                            &ts,
-                            &env,
-                            &task_env,
-                            &dependency_state.cache_keys,
+                            toolset: &ts,
+                            resolved_env: &env,
+                            declared_env: &task_env,
+                            dependency_keys: &dependency_state.cache_keys,
                             command_inputs,
-                        )
+                        })
                         .await?;
                     let current_output = if self.task_cache.reads()
                         && !self.force


### PR DESCRIPTION
## Summary
- introduce `TaskRunContext` for scheduler state passed from the CLI into the executor
- introduce `TaskCacheContext` for cache-key material
- remove three task scheduling/cache `clippy::too_many_arguments` exclusions
- preserve task scheduling and artifact-cache behavior

## Validation
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --all-features task::task_cache` (8 passed)
- `mise run test:e2e e2e/tasks/test_task_artifact_cache` (all matching artifact-cache suites passed)

This is a prerequisite refactor in stack #11523; it targets #11526.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical signature refactor with no logic changes; validated by clippy and task cache tests.
> 
> **Overview**
> Introduces **`TaskRunContext`** so scheduler-related inputs (task, config, `sched_tx`, completion/dependency state, semaphore, permit, interruption flag) are passed as one struct from `mise run` through the CLI wrapper into **`TaskExecutor::run_task_sched`**, replacing an eight-argument signature.
> 
> Introduces **`TaskCacheContext`** so **`TaskArtifactCacheBuilder::finish`** takes a single bundle of cache-key inputs (task, config, toolset, env, dependency keys, command inputs) instead of seven separate parameters.
> 
> Removes **`clippy::too_many_arguments`** suppressions on those two call paths; scheduling and artifact-cache behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4c17d9de618b8f7946210c5481165b16440cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->