### PR TITLE
docs: discourage clippy exclusions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,12 @@ Users can still install via any backend themselves with explicit syntax (`mise u
 - `mise --cd crates/vfox run lint-fix` - Run linting and fix issues for the vfox crate
 - `mise task ls` - List all available tasks
 
+### Clippy Exclusions
+
+- Do not add `#[allow(clippy::...)]`, `#[expect(clippy::...)]`, Cargo lint levels set to `allow`, or `-A clippy::...` command-line flags.
+- Refactor the code so `cargo clippy --workspace --all-features --all-targets -- -D warnings` passes without exclusions.
+- If a feature or fix needs a preparatory refactor to satisfy Clippy cleanly, put that refactor in a prerequisite PR and stack the behavior change on top of it.
+
 ### Documentation and Generation
 - `mise run render` - Generate all documentation and completions
 - `mise run render:usage` - Generate CLI usage documentation


### PR DESCRIPTION
## Summary
- document that Clippy allowances and expectations should not be added
- direct contributors to refactor warnings instead of suppressing them
- recommend prerequisite PRs when a clean Clippy fix requires preparatory refactoring

## Validation
- `mise run render`
- `mise run lint`

This keeps the policy advisory rather than adding a repository scanner or CI enforcement.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor guidance with no runtime, CI, or code behavior impact.
> 
> **Overview**
> Adds a **Clippy Exclusions** subsection under **Code Quality and Testing** in `AGENTS.md` so agents and contributors treat Clippy warnings as fixable rather than suppressible.
> 
> The policy forbids `#[allow(clippy::...)]`, `#[expect(clippy::...)]`, Cargo `allow` lint levels, and `-A clippy::...` flags. It points people at `cargo clippy --workspace --all-features --all-targets -- -D warnings` as the bar and suggests stacking behavior changes on a prerequisite refactor PR when a clean fix needs prep work.
> 
> This is documentation-only; it does not add CI checks or scanners beyond existing Clippy jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 306a54f160fcdce327409496c9fff7d1ab05c65f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring code improvements instead of suppressing Clippy warnings.
  * Clarified that preparatory refactoring should be submitted separately when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->