### PR TITLE
test(parallel): pin cancel-and-drain against the join_all panic

### DIFF
--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -43,6 +43,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
     use tokio::test;
 
     #[test]
@@ -50,5 +52,91 @@ mod tests {
         let input = vec![1, 2, 3, 4, 5];
         let results = parallel(input, |x| async move { Ok(x * 2) }).await.unwrap();
         assert_eq!(results, vec![2, 4, 6, 8, 10]);
+    }
+
+    /// Yield until `flag` is set, giving up after a bounded number of turns.
+    ///
+    /// The bound is what keeps these tests independent of the `jobs` setting. A permit is taken
+    /// *before* `spawn`, so with a budget of one — which `raw = true` forces, see
+    /// `Settings::try_get` — a task that waits unconditionally on a sibling stops that sibling
+    /// from ever being spawned, and the test hangs. Giving up early only weakens the interleaving;
+    /// it never changes what is asserted.
+    ///
+    /// Shared state is a `static` rather than a captured handle because `F` is bound by `Copy`,
+    /// which a closure holding an `Arc` would not satisfy.
+    async fn yield_until(flag: &AtomicBool) {
+        for _ in 0..1_000 {
+            if flag.load(Ordering::SeqCst) {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    static VICTIM_STARTED: AtomicBool = AtomicBool::new(false);
+    static VICTIM_FINISHED: AtomicBool = AtomicBool::new(false);
+
+    /// One task failing must abort its unfinished siblings and return the error — not panic.
+    ///
+    /// `JoinSet::join_all()` panics on any task that was cancelled rather than completed, which is
+    /// why the drain above uses `join_next()` (#7280). The panic it replaced reached users as
+    /// `task N was cancelled` out of `join_set.rs` (discussions #5263, #5369, #5414), and nothing
+    /// pinned the replacement.
+    ///
+    /// The failing task is item 0 so that it is spawned first and can never be starved of a
+    /// permit by the sibling. The sibling parks for far longer than the test takes, so it is
+    /// guaranteed to be unfinished when the drain reaches it — cancelled before its first poll
+    /// counts just the same, which is what makes this hold at any `jobs` budget.
+    #[test]
+    async fn a_failure_aborts_unfinished_siblings_without_panicking() {
+        let err = parallel(vec![0, 1], |i| async move {
+            if i == 0 {
+                // the trigger: nudge the sibling into actually running first, so the usual case is
+                // a cancelled *in-flight* task rather than one aborted before it was ever polled
+                yield_until(&VICTIM_STARTED).await;
+                Err(eyre::eyre!("task {i} failed"))
+            } else {
+                // the victim: finishing this would mean the abort never happened
+                VICTIM_STARTED.store(true, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                VICTIM_FINISHED.store(true, Ordering::SeqCst);
+                Ok(i)
+            }
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(format!("{err:#}"), "task 0 failed");
+        assert!(
+            !VICTIM_FINISHED.load(Ordering::SeqCst),
+            "sibling ran to completion, so it was never aborted"
+        );
+    }
+
+    static FAST_TASK_DONE: AtomicBool = AtomicBool::new(false);
+
+    /// Results are indexed by input position, not by completion order.
+    ///
+    /// `src/backend/conda.rs` zips its input vector against this function's output, which is only
+    /// correct while that holds. `test_parallel` cannot catch a regression here — `x * 2` over a
+    /// sorted input looks the same either way.
+    ///
+    /// The completion order is forced by a handshake rather than a timer: item 1 sets the flag as
+    /// its last act, and item 0 does not return until it observes that.
+    #[test]
+    async fn results_follow_input_order_not_completion_order() {
+        let results = parallel(vec![0, 1], |i| async move {
+            if i == 0 {
+                // first in the input, last to finish
+                yield_until(&FAST_TASK_DONE).await;
+            } else {
+                FAST_TASK_DONE.store(true, Ordering::SeqCst);
+            }
+            Ok(format!("item-{i}"))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(results, vec!["item-0", "item-1"]);
     }
 }


### PR DESCRIPTION
Test-only. `src/parallel.rs` aborts its `JoinSet` when a task fails and then drains with `join_next()`, with a comment saying exactly why:

```rust
jset.abort_all();
// Drain remaining tasks - don't use join_all() as it panics on cancelled tasks
while jset.join_next().await.is_some() {}
```

That is the fix from #7280. Nothing pins it. The file's only test is a happy path where no task fails, so anyone who "simplifies" the drain back to `join_all()` reintroduces the `task N was cancelled` panic — reported three separate times in #5263, #5369 and #5414 — and CI stays green.

## The tests

**`a_failure_aborts_unfinished_siblings_without_panicking`** — two inputs. Item 0 fails; item 1 parks for 10s, far longer than the test takes, so it is unfinished when the drain reaches it. `JoinSet::join_all()` panics on any task that was *cancelled rather than completed*, so that is the whole precondition — the sibling does not have to have been polled. Asserts: `Err` returned rather than a panic, and the sibling did **not** run to completion, i.e. it was cancelled.

**`results_follow_input_order_not_completion_order`** — `parallel` pre-fills `Vec<Option<U>>` and writes by the `enumerate` index, and `src/backend/conda.rs:423` zips its *input* vector against this function's *output* vector, which is correct only while that holds. The existing test can't detect a regression: `x * 2` over `1..=5` is monotonic, so completion order and input order coincide. Here item 1 signals completion and item 0 does not return until it observes that, so item 0 finishes last and the output is still in input order.

## Why neither test depends on `jobs`

A permit is taken *before* `spawn`, so a task that waits unconditionally on a sibling stops that sibling from ever being spawned. That matters because `jobs == 1` is reachable — `Settings::try_get` forces it when `raw = true`:

```rust
if settings.raw {
    settings.jobs = 1;
}
```

So: the failing task is item 0, spawned first, never starved of a permit by the sibling; and both handshakes go through a `yield_until` helper that gives up after a bounded number of turns. At `jobs == 1` the first task completes, releases its permit, the second is spawned, and `abort_all()` cancels it — the same drain path, no hang. At any larger budget both are in flight and the handshake decides the interleaving. Giving up early only weakens the interleaving; it never changes what is asserted.

Shared state is `static AtomicBool` rather than a captured handle because `F: Fn(T) -> Fut + Send + Copy + 'static` — `Copy` rules out a closure holding an `Arc`, which is how the rest of the repo sequences async tests.

## What I can and cannot claim

I can't demonstrate the test failing against the pre-#7280 code, since that would mean reverting the fix. The argument is structural: `join_all()` panics on a cancelled task, and the test guarantees an unfinished-then-cancelled task exists at drain time.

Known gap, deliberately left out: the `Err(e) => e.into()` `JoinError` arm, which needs a *panicking* task. There is prior art in `src/cli/plugins/mod.rs`, but it dumps a panic backtrace into test output for a branch no bug report has ever pointed at. Happy to add it if you'd rather have the coverage.

No local `cargo` run — `rustfmt --edition 2024` only. `lint`, linux `cargo test`, `unit-macos` and `windows-unit` cover compile and behaviour on all three platforms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parallel task execution now cancels remaining sibling tasks when one task fails, without causing a panic.
  * Successful parallel results consistently preserve the original input order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->