### PR TITLE
perf(release): optimize linux x64 binary with BOLT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,13 @@ jobs:
         include:
           # pgo: the amd64 runner can execute x86_64 binaries, so those
           # targets build via scripts/pgo.bash (instrument -> train ->
-          # rebuild with profile). arm targets can't run their
+          # rebuild with profile). bolt: apply post-link optimization to
+          # the glibc x64 binary after PGO. arm targets can't run their
           # instrumented binaries here and stay plain serious builds.
           - name: linux-x64
             target: x86_64-unknown-linux-gnu
             pgo: 1
+            bolt: 1
           - name: linux-x64-musl
             target: x86_64-unknown-linux-musl
             pgo: 1
@@ -65,10 +67,18 @@ jobs:
       - name: Install llvm-tools (PGO)
         if: matrix.pgo
         run: rustup component add llvm-tools
+      - name: Install BOLT
+        if: matrix.bolt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bolt-19
       - name: build-tarball ${{matrix.target}}
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
           MISE_PGO: ${{ matrix.pgo || '' }}
+          MISE_BOLT: ${{ matrix.bolt || '' }}
+          LLVM_BOLT: llvm-bolt-19
+          MERGE_FDATA: merge-fdata-19
         with:
           timeout_minutes: 140
           max_attempts: 3

--- a/scripts/bolt.bash
+++ b/scripts/bolt.bash
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Apply profile-guided LLVM BOLT optimizations to a linked mise ELF binary.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+	echo "usage: $0 <mise-binary>" >&2
+	exit 1
+fi
+
+binary=$1
+if [ ! -x "$binary" ]; then
+	echo "ERROR: BOLT input is not executable: $binary" >&2
+	exit 1
+fi
+binary="$(cd "$(dirname "$binary")" && pwd)/$(basename "$binary")"
+
+llvm_bolt="${LLVM_BOLT:-llvm-bolt}"
+merge_fdata="${MERGE_FDATA:-merge-fdata}"
+for tool in "$llvm_bolt" "$merge_fdata"; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "ERROR: required BOLT tool not found: $tool" >&2
+		exit 1
+	fi
+done
+
+llvm_bolt_path="$(readlink -f "$(command -v "$llvm_bolt")")"
+llvm_bolt_prefix="$(cd "$(dirname "$llvm_bolt_path")/.." && pwd)"
+runtime_instrumentation_lib="${BOLT_RUNTIME_INSTRUMENTATION_LIB:-$llvm_bolt_prefix/lib/libbolt_rt_instr.a}"
+if [ ! -f "$runtime_instrumentation_lib" ]; then
+	echo "ERROR: BOLT instrumentation runtime not found: $runtime_instrumentation_lib" >&2
+	echo "  Set BOLT_RUNTIME_INSTRUMENTATION_LIB to libbolt_rt_instr.a." >&2
+	exit 1
+fi
+runtime_instrumentation_arg="$runtime_instrumentation_lib"
+case "$runtime_instrumentation_arg" in
+/usr/lib/*)
+	# Debian's BOLT resolves this option relative to /usr/lib even when an
+	# absolute path is supplied, which would otherwise produce /usr/lib/usr/lib.
+	runtime_instrumentation_arg="${runtime_instrumentation_arg#/usr/lib/}"
+	;;
+esac
+
+if ! readelf -S "$binary" | grep -q '\.rela\.text'; then
+	echo "ERROR: $binary has no .rela.text section" >&2
+	echo "  Link it with -Wl,--emit-relocs before running BOLT." >&2
+	exit 1
+fi
+
+bolt_dir="$(mktemp -d "${TMPDIR:-/tmp}/mise-bolt.XXXXXX")"
+instrumented="$bolt_dir/mise.instrumented"
+profile_prefix="$bolt_dir/mise.fdata"
+merged_profile="$bolt_dir/merged.fdata"
+optimized="$binary.bolt"
+cleanup() {
+	rm -rf "$bolt_dir"
+	rm -f "$optimized"
+}
+trap cleanup EXIT
+
+echo ">>> [1/3] Instrumenting PGO-optimized binary with BOLT"
+"$llvm_bolt" "$binary" \
+	-instrument \
+	-runtime-instrumentation-lib="$runtime_instrumentation_arg" \
+	-instrumentation-file="$profile_prefix" \
+	-instrumentation-file-append-pid \
+	-o "$instrumented"
+
+echo ">>> [2/3] Training BOLT against hermetic offline workload"
+bash "$(dirname "$0")/train-startup.bash" "$instrumented"
+
+profile_count=$(find "$bolt_dir" -maxdepth 1 -name 'mise.fdata.*' -type f | wc -l | tr -d ' ')
+if [ "$profile_count" -eq 0 ]; then
+	echo "ERROR: BOLT training produced no profiles in $bolt_dir" >&2
+	exit 1
+fi
+echo ">>> $profile_count BOLT profiles collected"
+# BOLT appends only numeric process IDs to this controlled prefix, so the glob
+# cannot contain whitespace and is safe to expand here.
+# shellcheck disable=SC2086
+"$merge_fdata" "$profile_prefix".* >"$merged_profile"
+
+echo ">>> [3/3] Reordering and splitting hot code with BOLT"
+"$llvm_bolt" "$binary" \
+	-o "$optimized" \
+	-data="$merged_profile" \
+	-reorder-blocks=ext-tsp \
+	-reorder-functions=cdsort \
+	-split-functions \
+	-split-all-cold \
+	-split-eh \
+	-dyno-stats
+
+"$optimized" version >/dev/null
+mv "$optimized" "$binary"
+echo ">>> BOLT optimization complete: $binary"
+ls -lh "$binary"

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -83,6 +83,10 @@ if [[ $os == "macos" ]]; then
 	export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12.0}
 fi
 
+if [[ -n "${MISE_BOLT:-}" ]] && [[ -z "${MISE_PGO:-}" ]]; then
+	error "MISE_BOLT requires MISE_PGO so BOLT optimizes the PGO release binary"
+fi
+
 if [[ -n "${MISE_PGO:-}" ]]; then
 	# Profile-guided optimization: instrument, train against the hermetic
 	# offline workload in scripts/pgo.bash, rebuild with the profile.
@@ -102,6 +106,17 @@ fi
 # Use CARGO_TARGET_DIR if set, otherwise default to target
 target_dir="${CARGO_TARGET_DIR:-target}"
 binary_path="$target_dir/$RUST_TRIPLE/serious/mise"
+
+if [[ -n "${MISE_BOLT:-}" ]]; then
+	case "$RUST_TRIPLE" in
+	x86_64-unknown-linux-gnu)
+		bash scripts/bolt.bash "$binary_path"
+		;;
+	*)
+		error "BOLT is only enabled for the x86_64 Linux GNU release target: $RUST_TRIPLE"
+		;;
+	esac
+fi
 
 case "$RUST_TRIPLE" in
 x86_64-unknown-linux-gnu)

--- a/scripts/pgo.bash
+++ b/scripts/pgo.bash
@@ -4,7 +4,8 @@
 # Three-phase rustc PGO flow, adapted from jdx/aube's benchmarks/pgo.bash:
 #
 #   1. Build mise with -Cprofile-generate (instrumented binary).
-#   2. Train against a hermetic, offline workload covering the startup
+#   2. Train via scripts/train-startup.bash against a hermetic, offline
+#      workload covering the startup
 #      hot paths: settings/config load, toolset resolution, hook-env
 #      (both the full run and the per-prompt early-exit fast path),
 #      env rendering, task listing, and exec. No network, no registry —
@@ -112,82 +113,12 @@ fi
 
 # ---------- Phase 2: training ----------
 echo ">>> [2/3] Training against hermetic offline workload"
-
-train_dir="$(mktemp -d "${TMPDIR:-/tmp}/mise-pgo-train.XXXXXX")"
-cleanup() {
-	rm -rf "$train_dir"
-}
-trap cleanup EXIT
-
 # Force the instrumented binary to write profraw to a path we control,
 # regardless of what -Cprofile-generate=<dir> baked in at compile time
 # (with cross, the compile-time path is a container path that doesn't
 # resolve on the host). %m disambiguates per module; %p per process.
 export LLVM_PROFILE_FILE="$PGO_PROFRAW_DIR/mise-%m-%p.profraw"
-
-# Hermetic project fixture: env vars (incl. a template), pinned tools
-# (never resolved against the network), and a trivial task. MISE_OFFLINE
-# is belt-and-braces — nothing in the workload should hit the network.
-mkdir -p "$train_dir/home" "$train_dir/proj/subdir"
-cat >"$train_dir/proj/mise.toml" <<'EOF'
-[env]
-TRAIN_FOO = "bar"
-TRAIN_TEMPLATED = "{{ env.HOME }}/x"
-
-[tools]
-node = "22.17.0"
-
-[tasks.hello]
-run = "true"
-EOF
-echo "node 22.17.0" >"$train_dir/proj/subdir/.tool-versions"
-
-# shellcheck disable=SC2016 # the single-quoted script takes $bin/$proj as args
-train() {
-	# Fresh isolated state per training pass so cold paths (state dirs,
-	# trust, caches) and warm paths both land in the profile.
-	local pass=$1
-	local root="$train_dir/state.$pass"
-	mkdir -p "$root"
-	env -i PATH="$PATH" HOME="$train_dir/home" TMPDIR="${TMPDIR:-/tmp}" \
-		LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
-		MISE_DATA_DIR="$root/data" MISE_CACHE_DIR="$root/cache" \
-		MISE_CONFIG_DIR="$root/config" MISE_STATE_DIR="$root/state" \
-		MISE_GLOBAL_CONFIG_FILE="$root/config/config.toml" \
-		MISE_OFFLINE=1 MISE_HIDE_UPDATE_WARNING=1 \
-		bash -c '
-			set -e
-			bin=$1; proj=$2
-			cd "$proj"
-			"$bin" trust --all >/dev/null 2>&1 || true
-			"$bin" version >/dev/null
-			"$bin" current >/dev/null 2>&1 || true
-			"$bin" ls >/dev/null 2>&1 || true
-			"$bin" env -s zsh >/dev/null 2>&1 || true
-			"$bin" env -s bash >/dev/null 2>&1 || true
-			"$bin" settings >/dev/null 2>&1 || true
-			"$bin" tasks ls >/dev/null 2>&1 || true
-			"$bin" install >/dev/null 2>&1 || true
-			"$bin" exec -- true >/dev/null 2>&1 || true
-			# hook-env: full run, then eval the session so the
-			# remaining runs take the per-prompt early-exit fast
-			# path — the single hottest path in real usage.
-			eval "$("$bin" hook-env -s bash 2>/dev/null)" || true
-			for _ in 1 2 3 4 5; do
-				"$bin" hook-env -s bash >/dev/null 2>&1 || true
-			done
-			# subdir with .tool-versions: idiomatic-file parsing +
-			# config hierarchy walk
-			cd subdir
-			"$bin" current >/dev/null 2>&1 || true
-			"$bin" hook-env -s bash >/dev/null 2>&1 || true
-		' -- "$INSTRUMENTED_BIN" "$train_dir/proj"
-}
-
-for pass in 1 2 3; do
-	echo "  train: pass $pass"
-	train "$pass"
-done
+bash "$SCRIPT_DIR/train-startup.bash" "$INSTRUMENTED_BIN"
 unset LLVM_PROFILE_FILE
 
 # Sanity check: confirm training actually wrote profraw. On cross-built
@@ -226,8 +157,15 @@ echo ">>> Rebuilding with -Cprofile-use"
 # expected (training can't exercise every path) and LLVM otherwise logs
 # a note per uncovered symbol. Uncovered functions compile normally,
 # just without PGO data.
+bolt_rustflags=""
+if [ -n "${MISE_BOLT:-}" ]; then
+	# BOLT needs text relocations to safely reorder whole functions. Only the
+	# final binary needs them; keeping them out of the instrumented link saves
+	# memory and disk during phase 1.
+	bolt_rustflags="-Clink-arg=-Wl,--emit-relocs"
+fi
 # shellcheck disable=SC2086 # intentional word-splitting on $target_arg
-RUSTFLAGS="${RUSTFLAGS:-} -Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function=false" \
+RUSTFLAGS="${RUSTFLAGS:-} -Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function=false $bolt_rustflags" \
 	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg --bin mise "$@"
 
 # Phase 3b wrote to the same path as phase 1, so the file at

--- a/scripts/train-startup.bash
+++ b/scripts/train-startup.bash
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Exercise mise's startup-heavy paths for profile-guided optimizers.
+#
+# The caller is responsible for configuring its profiler. rustc PGO sets
+# LLVM_PROFILE_FILE; BOLT instrumentation bakes its output path into the
+# instrumented binary.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+	echo "usage: $0 <mise-binary>" >&2
+	exit 1
+fi
+
+bin=$1
+if [ ! -x "$bin" ]; then
+	echo "ERROR: training binary is not executable: $bin" >&2
+	exit 1
+fi
+bin="$(cd "$(dirname "$bin")" && pwd)/$(basename "$bin")"
+
+train_dir="$(mktemp -d "${TMPDIR:-/tmp}/mise-profile-train.XXXXXX")"
+cleanup() {
+	rm -rf "$train_dir"
+}
+trap cleanup EXIT
+
+# Hermetic project fixture: env vars (including a template), pinned tools
+# (never resolved against the network), and a trivial task.
+mkdir -p "$train_dir/home" "$train_dir/proj/subdir"
+cat >"$train_dir/proj/mise.toml" <<'EOF'
+[env]
+TRAIN_FOO = "bar"
+TRAIN_TEMPLATED = "{{ env.HOME }}/x"
+
+[tools]
+node = "22.17.0"
+
+[tasks.hello]
+run = "true"
+EOF
+echo "node 22.17.0" >"$train_dir/proj/subdir/.tool-versions"
+
+# Fresh isolated state per pass puts cold paths and warmed-up paths in the
+# profile. LLVM_PROFILE_FILE may be empty for profilers other than rustc PGO.
+# shellcheck disable=SC2016 # the single-quoted script takes $bin/$proj as args
+train() {
+	local pass=$1
+	local root="$train_dir/state.$pass"
+	mkdir -p "$root"
+	env -i PATH="$PATH" HOME="$train_dir/home" TMPDIR="${TMPDIR:-/tmp}" \
+		LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-}" \
+		MISE_DATA_DIR="$root/data" MISE_CACHE_DIR="$root/cache" \
+		MISE_CONFIG_DIR="$root/config" MISE_STATE_DIR="$root/state" \
+		MISE_GLOBAL_CONFIG_FILE="$root/config/config.toml" \
+		MISE_OFFLINE=1 MISE_HIDE_UPDATE_WARNING=1 \
+		bash -c '
+			set -e
+			bin=$1; proj=$2
+			cd "$proj"
+			"$bin" trust --all >/dev/null 2>&1 || true
+			"$bin" version >/dev/null
+			"$bin" current >/dev/null 2>&1 || true
+			"$bin" ls >/dev/null 2>&1 || true
+			"$bin" env -s zsh >/dev/null 2>&1 || true
+			"$bin" env -s bash >/dev/null 2>&1 || true
+			"$bin" settings >/dev/null 2>&1 || true
+			"$bin" tasks ls >/dev/null 2>&1 || true
+			"$bin" install >/dev/null 2>&1 || true
+			"$bin" exec -- true >/dev/null 2>&1 || true
+			# hook-env: full run, then evaluate the session so the
+			# remaining runs take the per-prompt early-exit fast path.
+			eval "$("$bin" hook-env -s bash 2>/dev/null)" || true
+			for _ in 1 2 3 4 5; do
+				"$bin" hook-env -s bash >/dev/null 2>&1 || true
+			done
+			# Subdirectory with .tool-versions: idiomatic-file parsing and
+			# the config hierarchy walk.
+			cd subdir
+			"$bin" current >/dev/null 2>&1 || true
+			"$bin" hook-env -s bash >/dev/null 2>&1 || true
+		' -- "$bin" "$train_dir/proj"
+}
+
+for pass in 1 2 3; do
+	echo "  train: pass $pass"
+	train "$pass"
+done


### PR DESCRIPTION
## Summary

- reuse the existing hermetic startup workload for both rustc PGO and LLVM BOLT training
- apply instrumented BOLT reordering/splitting after PGO + full LTO for the x86_64 Linux GNU release binary
- install Ubuntu's versioned BOLT 19 tools in the release job and handle its versioned instrumentation-runtime layout
- keep musl, ARM, macOS, and Windows release targets unchanged

## One-off benchmark

Successful release-equivalent run: https://github.com/jdx/mise/actions/runs/30594635361

The run used the production xlarge runner, `serious` profile, full LTO, rustc PGO, the release feature set, and the x86_64 GNU cross target. It also preflighted Ubuntu's packaged instrumentation runtime against a tiny ELF before the full build.

| Workload | PGO | PGO + BOLT | Delta |
| --- | ---: | ---: | ---: |
| `mise --help` | 22.1 ms | 21.3 ms | 3.6% faster |
| `mise -C benchmarks/perf-fixture hook-env` | 55.0 ms | 57.3 ms | 4.2% slower |
| `mise registry` | 28.5 ms | 27.4 ms | 3.9% faster |
| binary size | 123,586,216 bytes | 108,528,880 bytes | 12.18% smaller |

The wall-clock timing error bars overlap and the runner reported outliers, so the startup result is inconclusive rather than a claimed uniform speedup. The binary-size reduction was 15,057,336 bytes.

## Validation

- successful one-off PGO + LTO + BOLT build, training, smoke test, and hyperfine run
- `mise run lint-fix`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the primary Linux x64 release artifact is built and linked; misconfiguration or BOLT failures could break that tarball, though scope is limited to one target and other platforms are unchanged.
> 
> **Overview**
> Adds **LLVM BOLT** post-link optimization for the **x86_64 Linux GNU** release binary after rustc PGO, aimed at smaller binaries and better layout of hot startup code.
> 
> The release workflow enables BOLT only on the `linux-x64` matrix row: installs `bolt-19`, sets `MISE_BOLT`, `LLVM_BOLT`, and `MERGE_FDATA`. `build-tarball.sh` requires PGO when BOLT is on and runs `scripts/bolt.bash` after the PGO build. `pgo.bash` adds `-Wl,--emit-relocs` on the final PGO link when `MISE_BOLT` is set so BOLT can reorder functions.
> 
> New **`scripts/bolt.bash`** instruments the linked ELF, trains with the shared workload, merges `.fdata`, then reorders/splits code and replaces the binary in place. PGO training logic moves to **`scripts/train-startup.bash`** so rustc PGO and BOLT share the same hermetic offline startup exercises.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a8761d89121b5ab4d977b86a6a8a095f565461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Linux x64 release tarballs now use LLVM BOLT optimization for improved executable performance.
  * Startup profiling covers representative configuration, tool resolution, environment, task, installation, and execution workflows.
* **Bug Fixes**
  * Added validation to prevent unsupported BOLT targets and invalid profiling/optimization configurations.
  * Enhanced build validation and cleanup for more reliable optimized releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->