### PR TITLE
perf(shim): reuse resolved toolset and config roots

### DIFF
--- a/e2e/cli/test_shims
+++ b/e2e/cli/test_shims
@@ -6,6 +6,9 @@ assert_fail "which dummy"
 
 mise i dummy@latest
 assert_contains "which dummy" "/mise/shims/dummy"
+assert \
+  "MISE_TIMINGS=1 dummy 2>&1 >/dev/null | grep -c 'toolset_builder::build::resolve'" \
+  "1"
 
 mise uninstall -a dummy
 assert_fail "which dummy"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::ffi::OsString;
+use std::sync::Arc;
 
 use clap::ValueHint;
 use duct::IntoExecutablePath;
@@ -17,7 +18,7 @@ use crate::env;
 use crate::env_diff::EnvDiff;
 use crate::sandbox::SandboxConfig;
 use crate::toolset::env_cache::CachedEnv;
-use crate::toolset::{InstallOptions, ResolveOptions, ToolsetBuilder};
+use crate::toolset::{InstallOptions, ResolveOptions, Toolset, ToolsetBuilder};
 
 /// Execute a command with tool(s) set
 ///
@@ -109,7 +110,7 @@ impl Exec {
             env::reset_env_cache_key();
         }
 
-        let mut config = Config::get().await?;
+        let config = Config::get().await?;
 
         // Check if any tool arg explicitly specified @latest
         // If so, resolve to the actual latest version from the registry (not just latest installed)
@@ -128,7 +129,7 @@ impl Exec {
             Default::default()
         };
 
-        let mut ts = measure!("toolset", {
+        let ts = measure!("toolset", {
             ToolsetBuilder::new()
                 .with_args(&self.tool)
                 .with_default_to_latest(true)
@@ -137,6 +138,28 @@ impl Exec {
                 .await?
         });
 
+        self.run_with_context(config, ts, resolve_options, has_explicit_latest)
+            .await
+    }
+
+    /// Execute with a toolset that the shim path has already resolved while
+    /// locating the delegated binary.
+    pub(crate) async fn run_with_toolset(
+        self,
+        config: Arc<Config>,
+        ts: Toolset,
+    ) -> eyre::Result<()> {
+        self.run_with_context(config, ts, ResolveOptions::default(), false)
+            .await
+    }
+
+    async fn run_with_context(
+        self,
+        mut config: Arc<Config>,
+        mut ts: Toolset,
+        resolve_options: ResolveOptions,
+        has_explicit_latest: bool,
+    ) -> eyre::Result<()> {
         let opts = InstallOptions {
             force: false,
             jobs: self.jobs,

--- a/src/config/config_file/config_root.rs
+++ b/src/config/config_file/config_root.rs
@@ -16,15 +16,17 @@ pub fn reset() {
 }
 
 pub fn config_root(path: &Path) -> PathBuf {
-    if is_global_config(path) {
-        return env::MISE_GLOBAL_CONFIG_ROOT.to_path_buf();
-    }
     let path = path
         .absolutize()
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|_| path.to_path_buf());
     if let Some(cached) = CONFIG_ROOT_CACHE.lock().unwrap().get(&path).cloned() {
         return cached;
+    }
+    if is_global_config(&path) {
+        let root = env::MISE_GLOBAL_CONFIG_ROOT.to_path_buf();
+        CONFIG_ROOT_CACHE.lock().unwrap().insert(path, root.clone());
+        return root;
     }
     let parts = path
         .components()

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -52,10 +52,8 @@ pub async fn handle_shim() -> Result<()> {
     let mut args = env::ARGS.read().unwrap().clone();
     env::PREFER_OFFLINE.store(true, Ordering::Relaxed);
     trace!("shim[{bin_name}] args: {}", args.join(" "));
-    args[0] = which_shim(&mut config, &env::MISE_BIN_NAME, &args)
-        .await?
-        .to_string_lossy()
-        .to_string();
+    let (bin, ts) = which_shim(&mut config, &env::MISE_BIN_NAME, &args).await?;
+    args[0] = bin.to_string_lossy().to_string();
     env::set_var("__MISE_SHIM", "1");
     let exec = Exec {
         tool: vec![],
@@ -76,7 +74,7 @@ pub async fn handle_shim() -> Result<()> {
         allow_env: vec![],
     };
     time!("shim exec");
-    exec.run().await?;
+    exec.run_with_toolset(config, ts).await?;
     Err(request_exit(0))
 }
 
@@ -98,7 +96,11 @@ fn invoked_shim_path() -> PathBuf {
         .unwrap_or(argv0)
 }
 
-async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -> Result<PathBuf> {
+async fn which_shim(
+    config: &mut Arc<Config>,
+    bin_name: &str,
+    args: &[String],
+) -> Result<(PathBuf, Toolset)> {
     // Shell completion invokes `usage complete-word` through the `usage` shim.
     // It should use the installed CLI or fail locally, never resolve a floating
     // tool version or auto-install over the network while the user is pressing
@@ -128,7 +130,7 @@ async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -
             "shim[{bin_name}] ToolVersion: {tv} bin: {bin}",
             bin = display_path(&bin)
         );
-        return Ok(bin);
+        return Ok((bin, ts));
     }
     // Auto-installing here would download a tool over the network; skip it for
     // offline completion so `usage complete-word` fails locally instead.
@@ -144,7 +146,7 @@ async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -
                     "shim[{bin_name}] NOT_FOUND ToolVersion: {tv} bin: {bin}",
                     bin = display_path(&bin)
                 );
-                return Ok(bin);
+                return Ok((bin, ts));
             }
         }
     }
@@ -164,11 +166,14 @@ async fn which_shim(config: &mut Arc<Config>, bin_name: &str, args: &[String]) -
                 continue;
             }
             trace!("shim[{bin_name}] SYSTEM {bin}", bin = display_path(&bin));
-            return Ok(bin);
+            return Ok((bin, ts));
         }
     }
     let tvs = ts.list_rtvs_with_bin(config, bin_name).await?;
-    err_no_version_set(config, ts, bin_name, tvs).await
+    match err_no_version_set(config, ts, bin_name, tvs).await {
+        Ok(_) => unreachable!("err_no_version_set always returns an error"),
+        Err(err) => Err(err),
+    }
 }
 
 /// Build the actionable, `which_shim`-style resolution error for a bin that a


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/jdx/mise/trails/1
<!-- entire-trail-link-end -->

## Summary

- reuse the toolset already resolved while locating a shim target instead of rebuilding and resolving it in `Exec`
- consult the config-root cache before global-config detection and cache global roots too
- add an E2E regression assertion that shim dispatch performs one toolset resolution

## Root cause

Shim dispatch resolved the active toolset once to locate the delegated binary, then passed through `Exec`, which rebuilt and resolved the same toolset again before constructing the environment.

Separately, `config_root()` called `is_global_config()` before checking `CONFIG_ROOT_CACHE`. Local config paths therefore repeatedly fell through symlink-tolerant membership checks that canonicalized the local config and global config paths even when their config root had already been cached. This matches the redundant `statx`/`readlink` pattern reported in https://github.com/jdx/mise/discussions/11456#discussioncomment-17848966.

## Impact

Shim execution now performs one toolset resolution and avoids repeated config-path canonicalization after the root is cached. In a local 20-run debug benchmark, moving the config-root cache lookup ahead of global detection reduced mean shim time from 56.8 ms to 52.3 ms (about 9%); filesystems where canonicalization dominates should benefit more.

## Validation

- `cargo test --all-features config_root::tests -- --nocapture`
- `mise run test:e2e e2e/cli/test_shims`
- `mise run test:e2e e2e/cli/test_usage_completion_shim_offline`
- `cargo check --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hot-path performance refactor with intended behavior parity; risk is mainly regression in shim/env resolution or config-root caching edge cases.
> 
> **Overview**
> Shim dispatch no longer resolves the active toolset twice: **`which_shim`** now returns the resolved **`Toolset`** along with the binary path, and **`Exec::run_with_toolset`** reuses it instead of **`ToolsetBuilder::build`** running again inside **`run`**. Normal **`mise exec`** still builds once via a shared **`run_with_context`** path.
> 
> **`config_root`** checks **`CONFIG_ROOT_CACHE`** before **`is_global_config`**, and stores global config roots in the cache so repeated lookups skip extra canonicalization.
> 
> E2E **`test_shims`** asserts **`MISE_TIMINGS`** shows a single **`toolset_builder::build::resolve`** per shim invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58328dc58cbdc88fb9285d345407a4b1afd76fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command execution through shims by reusing resolved tool information, helping commands run more efficiently and reliably.
  - Improved global configuration handling by consistently normalizing configuration paths before evaluation.

- **Tests**
  - Added coverage to verify timing reports include toolset resolution details when timing output is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->