### PR TITLE
feat(task): configure vcs ignores for watch

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -402,6 +402,24 @@ has changed since the last build.
 The [`task_source_files`](../templates.md#task-source-files) function can be used to iterate over a task's
 `sources` within its template context.
 
+#### Watching VCS-ignored sources
+
+By default, `mise watch` respects VCS ignore files such as `.gitignore`, even when an ignored path is
+listed in `sources`. Set `watch.no_vcs_ignore` for tasks that need to watch generated or intermediary
+files which are intentionally excluded from version control:
+
+```mise-toml
+[tasks.generate]
+run = "process generated/output.json"
+sources = ["generated/output.json"]
+watch = { no_vcs_ignore = true }
+```
+
+This is equivalent to passing `--no-vcs-ignore` to watchexec. Because watchexec applies ignore options
+to the entire watch process, watching multiple tasks together disables VCS ignores for all of them if
+any selected task enables this option. Keep `sources` narrowly scoped: disabling VCS ignores for broad
+build, distribution, or dependency directories may substantially increase filesystem scanning.
+
 #### Excluding sources
 
 Entries in `sources` prefixed with `!` are excluded, matching the convention

--- a/e2e/cli/test_watch_task_no_vcs_ignore
+++ b/e2e/cli/test_watch_task_no_vcs_ignore
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+mise use -g watchexec@latest
+
+git init -q
+
+cat <<'EOF' >mise.toml
+[tasks.default]
+run = "touch default-ran"
+sources = ["generated/ignored.txt"]
+
+[tasks.opted-in]
+run = "touch opted-in-ran"
+sources = ["generated/ignored.txt"]
+watch = { no_vcs_ignore = true }
+
+[tasks.dependency]
+run = "echo dependency"
+sources = ["generated/ignored.txt"]
+watch = { no_vcs_ignore = true }
+
+[tasks.root]
+run = "echo root"
+sources = ["root.txt"]
+depends = ["dependency"]
+EOF
+
+mkdir generated
+touch generated/ignored.txt root.txt
+echo generated/ >.gitignore
+
+watch_pid=""
+trap '[[ -z "$watch_pid" ]] || stop_watch' EXIT
+
+wait_for_watchexec() {
+  local log_file=$1
+  for _ in $(seq 1 40); do
+    grep -Fq '$ watchexec ' "$log_file" && return 0
+    sleep 0.25
+  done
+  fail "timed out waiting for watchexec command in $log_file"
+}
+
+stop_watch() {
+  local pid=$watch_pid
+  local child_pid
+  local child_pids=()
+
+  while IFS= read -r child_pid; do
+    child_pids+=("$child_pid")
+  done < <(pgrep -P "$pid" 2>/dev/null || true)
+  for child_pid in "${child_pids[@]}"; do
+    kill -TERM "$child_pid" 2>/dev/null || true
+  done
+  kill -TERM "$pid" 2>/dev/null || true
+  sleep 0.2
+
+  for child_pid in "${child_pids[@]}"; do
+    kill -KILL "$child_pid" 2>/dev/null || true
+  done
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  watch_pid=""
+}
+
+# VCS ignores remain enabled by default, even for explicit task sources.
+MISE_DEBUG=1 mise watch default --postpone --poll=100ms >default.log 2>&1 &
+watch_pid=$!
+wait_for_watchexec default.log
+sleep 0.5
+touch generated/ignored.txt
+sleep 1
+stop_watch
+
+if [[ -e default-ran ]]; then
+  fail "expected gitignored source not to trigger without watch.no_vcs_ignore"
+fi
+
+# Opting in forwards the watchexec flag and makes the ignored source observable.
+MISE_DEBUG=1 mise watch opted-in --postpone --poll=100ms >opted-in.log 2>&1 &
+watch_pid=$!
+wait_for_watchexec opted-in.log
+sleep 0.5
+touch generated/ignored.txt
+for _ in $(seq 1 40); do
+  [[ -e opted-in-ran ]] && break
+  sleep 0.25
+done
+stop_watch
+
+if [[ ! -e opted-in-ran ]]; then
+  fail "expected gitignored source to trigger with watch.no_vcs_ignore"
+fi
+
+debug_line=$(grep -F '$ watchexec ' opted-in.log | tail -1)
+flag_count=$(grep -o -- '--no-vcs-ignore' <<<"$debug_line" | wc -l | tr -d ' ')
+assert "echo $flag_count" "1"
+
+# --skip-deps excludes dependency task watch settings from the combined process.
+MISE_DEBUG=1 mise watch root --skip-deps --postpone >skip-deps.log 2>&1 &
+watch_pid=$!
+wait_for_watchexec skip-deps.log
+stop_watch
+assert_not_contains "grep -F '\$ watchexec ' skip-deps.log" "--no-vcs-ignore"
+
+# Without --skip-deps, an opted-in dependency enables the process-wide flag.
+MISE_DEBUG=1 mise watch root --postpone >with-deps.log 2>&1 &
+watch_pid=$!
+wait_for_watchexec with-deps.log
+stop_watch
+assert_contains "grep -F '\$ watchexec ' with-deps.log" "--no-vcs-ignore"

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -303,6 +303,9 @@
             }
           ]
         },
+        "watch": {
+          "$ref": "#/$defs/task_watch"
+        },
         "shell": {
           "description": "specify a shell command to run the script with",
           "type": "string"
@@ -818,6 +821,18 @@
             "unevaluatedProperties": false
           }
         ]
+      }
+    },
+    "task_watch": {
+      "description": "options used by `mise watch` for this task",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "no_vcs_ignore": {
+          "default": false,
+          "description": "do not load VCS ignore files such as `.gitignore` when watching this task",
+          "type": "boolean"
+        }
       }
     },
     "tool": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2887,6 +2887,18 @@
       "unevaluatedProperties": false,
       "description": "Prepare provider configuration"
     },
+    "task_watch": {
+      "description": "options used by `mise watch` for this task",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "no_vcs_ignore": {
+          "default": false,
+          "description": "do not load VCS ignore files such as `.gitignore` when watching this task",
+          "type": "boolean"
+        }
+      }
+    },
     "task_props": {
       "description": "common task properties",
       "properties": {
@@ -3148,6 +3160,9 @@
               "type": "string"
             }
           ]
+        },
+        "watch": {
+          "$ref": "#/$defs/task_watch"
         },
         "shell": {
           "description": "specify a shell command to run the script with",

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -6,8 +6,8 @@ use crate::config::Config;
 use crate::dirs;
 use crate::env;
 use crate::request_exit;
-use crate::task::Deps;
 use crate::task::task_source_checker::task_cwd;
+use crate::task::{Deps, Task};
 use crate::toolset::ToolsetBuilder;
 use clap::{CommandFactory, ValueEnum, ValueHint};
 use console::style;
@@ -86,6 +86,12 @@ impl Watch {
             bail!("No tasks specified");
         }
         let tasks = crate::task::task_list::get_task_lists(&config, &args, false, false).await?;
+        let watched_tasks = if self.skip_deps {
+            tasks.to_vec()
+        } else {
+            let deps = Deps::new(&config, tasks.clone()).await?;
+            deps.all().cloned().collect()
+        };
         let mut args = vec![];
         if let Some(delay_run) = self.watchexec.delay_run {
             args.push("--delay-run".to_string());
@@ -114,7 +120,7 @@ impl Watch {
         if self.watchexec.stdin_quit {
             args.push("--stdin-quit".to_string());
         }
-        if self.watchexec.no_vcs_ignore {
+        if self.watchexec.no_vcs_ignore || tasks_disable_vcs_ignores(&watched_tasks) {
             args.push("--no-vcs-ignore".to_string());
         }
         if self.watchexec.no_project_ignore {
@@ -210,14 +216,8 @@ impl Watch {
         let (globs, ignores, extra_watch_dirs, filter_anchor) = if !self.glob.is_empty() {
             (self.glob.clone(), Vec::new(), Vec::new(), None)
         } else {
-            let collected: Vec<_> = if self.skip_deps {
-                tasks.to_vec()
-            } else {
-                let deps = Deps::new(&config, tasks.clone()).await?;
-                deps.all().cloned().collect()
-            };
-            let mut task_cwds: Vec<(&_, PathBuf)> = Vec::with_capacity(collected.len());
-            for t in &collected {
+            let mut task_cwds: Vec<(&_, PathBuf)> = Vec::with_capacity(watched_tasks.len());
+            for t in &watched_tasks {
                 let cwd = task_cwd(t, &config).await?;
                 task_cwds.push((t, cwd));
             }
@@ -490,6 +490,12 @@ fn relativize_source(kind: SourceKind, absolute: &Path, anchor: &Path) -> String
         }
         SourceKind::LiteralBang | SourceKind::Plain => relative,
     }
+}
+
+fn tasks_disable_vcs_ignores(tasks: &[Task]) -> bool {
+    tasks
+        .iter()
+        .any(|task| task.watch.as_ref().is_some_and(|watch| watch.no_vcs_ignore))
 }
 
 /// Merge each task's `sources` into the (filter, ignore) pair watchexec
@@ -1510,8 +1516,9 @@ pub enum ColourMode {
 mod tests {
     use super::{
         WrapMode, common_ancestor, merge_watch_patterns, normalize_path, parse_source,
-        relativize_source, source_watch_dir, wrap_process_args,
+        relativize_source, source_watch_dir, tasks_disable_vcs_ignores, wrap_process_args,
     };
+    use crate::task::{Task, TaskWatchOptions};
     use std::path::{Path, PathBuf};
 
     fn s(v: &[&str]) -> Vec<String> {
@@ -1556,6 +1563,22 @@ mod tests {
         // Nothing is forwarded, so watchexec applies its own platform-dependent default
         // (`session` on macOS, `group` elsewhere) rather than one mise guessed.
         assert!(wrap_process_args(None).is_empty());
+    }
+
+    #[test]
+    fn task_watch_options_disable_vcs_ignores_for_combined_watch() {
+        let default_task = Task::default();
+        let opted_in_task = Task {
+            watch: Some(TaskWatchOptions {
+                no_vcs_ignore: true,
+            }),
+            ..Default::default()
+        };
+
+        assert!(!tasks_disable_vcs_ignores(std::slice::from_ref(
+            &default_task,
+        )));
+        assert!(tasks_disable_vcs_ignores(&[default_task, opted_in_task]));
     }
 
     #[test]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -527,6 +527,13 @@ impl Display for RunEntry {
     }
 }
 
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct TaskWatchOptions {
+    /// Ignore VCS ignore files such as `.gitignore` when running `mise watch`.
+    pub no_vcs_ignore: bool,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Task {
@@ -598,6 +605,8 @@ pub struct Task {
     pub interactive: bool,
     #[serde(default)]
     pub sources: Vec<String>,
+    #[serde(default)]
+    pub watch: Option<TaskWatchOptions>,
     #[serde(default)]
     pub outputs: TaskOutputs,
     /// Experimental local artifact cache configuration.
@@ -1186,6 +1195,13 @@ impl Task {
         task.raw_args = p.parse_bool("raw_args").unwrap_or_default();
         task.interactive = p.parse_bool("interactive").unwrap_or_default();
         task.sources = p.parse_array("sources").unwrap_or_default();
+        task.watch = p
+            .get_raw("watch")
+            .map(|v| {
+                TaskWatchOptions::deserialize(v.clone())
+                    .map_err(|e| eyre!("failed to parse watch field in task header: {e}"))
+            })
+            .transpose()?;
         task.outputs = p.get_raw("outputs").map(|to| to.into()).unwrap_or_default();
         task.cache = p
             .get_raw("cache")
@@ -2215,6 +2231,9 @@ impl Task {
             self.output = other.output;
         }
         self.sources.extend(other.sources);
+        if other.watch.is_some() {
+            self.watch = other.watch;
+        }
         if !other.outputs.is_empty() {
             self.outputs = other.outputs;
         }
@@ -2777,6 +2796,7 @@ impl Default for Task {
             trailing_args: vec![],
             interactive: false,
             sources: vec![],
+            watch: None,
             outputs: Default::default(),
             cache: Default::default(),
             raw_outputs: Default::default(),
@@ -3258,7 +3278,7 @@ mod tests {
     use std::sync::Mutex;
 
     use crate::task::workspace;
-    use crate::task::{RunEntry, Task};
+    use crate::task::{RunEntry, Task, TaskWatchOptions};
     use crate::{config::Config, dirs};
     use indexmap::IndexMap;
     use pretty_assertions::assert_eq;
@@ -3290,6 +3310,49 @@ mod tests {
         assert_eq!(
             file_task.config_sources(),
             vec![Path::new(".mise/tasks/build"), Path::new("mise.toml")]
+        );
+    }
+
+    #[test]
+    fn test_task_watch_options_deserialize() {
+        let task: Task = toml::from_str(
+            r#"
+run = "echo build"
+watch = { no_vcs_ignore = true }
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            task.watch,
+            Some(TaskWatchOptions {
+                no_vcs_ignore: true
+            })
+        );
+    }
+
+    #[test]
+    fn test_merge_toml_overlay_replaces_watch_options() {
+        let mut file_task = Task {
+            watch: Some(TaskWatchOptions {
+                no_vcs_ignore: true,
+            }),
+            ..Default::default()
+        };
+        let overlay = Task {
+            watch: Some(TaskWatchOptions {
+                no_vcs_ignore: false,
+            }),
+            ..Default::default()
+        };
+
+        file_task.merge_toml_overlay(overlay);
+
+        assert_eq!(
+            file_task.watch,
+            Some(TaskWatchOptions {
+                no_vcs_ignore: false
+            })
         );
     }
 
@@ -4461,6 +4524,7 @@ echo "hello world"
 #MISE raw_args=true
 #MISE interactive=true
 #MISE sources=["src1.txt", "src2.txt"]
+#MISE watch={no_vcs_ignore=true}
 #MISE outputs=["out1.txt"]
 #MISE cache={enabled=true,env=["PROFILE"]}
 #MISE pass_through_env=["DEPLOY_TOKEN"]
@@ -4491,6 +4555,12 @@ echo "test"
         assert_eq!(task.raw_args, true);
         assert_eq!(task.interactive, true);
         assert_eq!(task.sources, vec!["src1.txt", "src2.txt"]);
+        assert_eq!(
+            task.watch,
+            Some(TaskWatchOptions {
+                no_vcs_ignore: true
+            })
+        );
         assert_eq!(
             task.cache,
             Some(TaskCacheConfig {

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -3,6 +3,7 @@ use crate::config::config_file::toml::deserialize_arr;
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{
     RunEntry, Silent, Task, TaskCacheConfig, TaskConfirm, TaskDep, TaskOutput, TaskToolValue,
+    TaskWatchOptions,
 };
 use indexmap::IndexMap;
 use serde::Deserialize;
@@ -31,6 +32,8 @@ pub struct TaskTemplate {
     pub dir: Option<String>,
     #[serde(default)]
     pub sources: Vec<String>,
+    #[serde(default)]
+    pub watch: Option<TaskWatchOptions>,
     #[serde(default)]
     pub outputs: TaskOutputs,
     #[serde(default)]
@@ -164,6 +167,10 @@ impl Task {
         // sources: local overrides completely if non-empty
         if self.sources.is_empty() && !template.sources.is_empty() {
             self.sources = template.sources.clone();
+        }
+
+        if self.watch.is_none() {
+            self.watch = template.watch.clone();
         }
 
         // outputs: local overrides completely if default
@@ -339,6 +346,34 @@ mod tests {
         };
         overridden.merge_template(&template);
         assert_eq!(overridden.output, Some(TaskOutput::Interleave));
+    }
+
+    #[test]
+    fn test_merge_template_watch_options() {
+        let template = TaskTemplate {
+            watch: Some(TaskWatchOptions {
+                no_vcs_ignore: true,
+            }),
+            ..Default::default()
+        };
+
+        let mut inherited = Task::default();
+        inherited.merge_template(&template);
+        assert_eq!(inherited.watch, template.watch);
+
+        let mut overridden = Task {
+            watch: Some(TaskWatchOptions {
+                no_vcs_ignore: false,
+            }),
+            ..Default::default()
+        };
+        overridden.merge_template(&template);
+        assert_eq!(
+            overridden.watch,
+            Some(TaskWatchOptions {
+                no_vcs_ignore: false
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add task-level `watch.no_vcs_ignore` configuration for `mise watch`
- forward `--no-vcs-ignore` to watchexec when any watched task opts in
- keep dependency handling consistent with `--skip-deps` and document the process-wide behavior

## Motivation

Task sources may intentionally point at generated or intermediary files that are excluded by `.gitignore`. Watchexec filters those files before the explicit source filters can trigger a rerun, so listing the path in `sources` alone is not enough.

VCS ignores remain enabled by default to avoid recursively scanning broad build, distribution, or dependency directories. Tasks that need ignored sources can opt in explicitly:

```toml
[tasks.generate]
run = "process generated/output.json"
sources = ["generated/output.json"]
watch = { no_vcs_ignore = true }
```

Watchexec applies this option to the whole watch process. When multiple tasks are watched together, one opted-in task enables it for the combined process. Dependencies excluded by `--skip-deps` do not affect the decision.

## Testing

- `mise exec -- cargo test cli::watch::tests::task_watch_options_disable_vcs_ignores_for_combined_watch`
- task parsing, overlay, and template unit tests
- `mise run test:e2e e2e/cli/test_watch_task_no_vcs_ignore e2e/cli/test_watch_ignore e2e/tasks/test_task_watch_skip_deps`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- Rustfmt, ShellCheck, shfmt, Markdownlint, Prettier, and AJV checks passed individually

`mise run lint` cannot run as a single command in this Sapling working copy because hk reports `failed to find git repository`; all checks relevant to the changed files were run individually.

Addresses https://github.com/jdx/mise/discussions/4671

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `watch.no_vcs_ignore` to monitor files ignored by version-control rules.
  * Added support for configuring this option in task definitions and templates.
  * Added the `--no-vcs-ignore` command-line option for watch commands.
  * Dependency watch behavior now respects task-specific settings and `--skip-deps`.

* **Documentation**
  * Documented configuration, command-line behavior, multi-task effects, and filesystem-scanning considerations.

* **Tests**
  * Added coverage for ignored files, dependency handling, option forwarding, and configuration precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->