### PR TITLE
docs(task): define workspace task precedence

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -51,7 +51,7 @@ outside this tracker.
 - [x] Add root task defaults that apply by task name across inferred and explicit projects
 - [x] Add dependency-scoped task relationships equivalent to building the same task in upstream
       projects first
-- [ ] Define deterministic precedence between provider inference, root task defaults, task
+- [x] Define deterministic precedence between provider inference, root task defaults, task
       templates, and project-local configuration
 - [ ] Allow providers to suggest inputs, outputs, cacheability, and task dependencies when they can
       derive them confidently

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -428,6 +428,29 @@ task uses `extends`, its template also takes precedence over the root default.
 
 Root task defaults are experimental and are ignored unless experimental features are enabled.
 
+### Task Definition Precedence
+
+Task definitions are resolved in two stages. First, an explicit project task replaces a
+provider-inferred task with the same project and task name. The provider task's project-ID name is
+kept as an alias for the explicit task, so either name runs the explicit definition.
+
+After selecting the task, mise fills unset fields in this order, from highest to lowest precedence:
+
+1. The selected task's own fields, whether they came from project-local configuration or provider
+   inference
+2. A task template named by `extends`, for explicit tasks that use one
+3. A matching `[monorepo.task_defaults.<name>]` definition from the workspace root
+
+Map fields such as `env`, `vars`, and `tools` merge across these layers, with entries from the
+higher-precedence layer winning. Collection fields such as `depends`, `sources`, and `outputs` use
+the complete value from the highest-precedence layer that defines them rather than concatenating
+values from multiple layers. These are the same merge rules used by [task templates](/tasks/templates).
+
+For example, an inferred package script keeps its provider command when the root default also
+defines `run`, while still inheriting cache inputs or environment entries that the provider did not
+specify. If a project later defines that task explicitly, the explicit command replaces the package
+script; a named template fills its missing fields before the root default does.
+
 ### Upstream Task Dependencies
 
 Prefix a task dependency with `^` to run that task in upstream workspace projects first. A root

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -23,6 +23,10 @@ config_roots = ["packages/*"]
 [monorepo.task_defaults.build]
 env = { ROOT_TASK_DEFAULT = "from-root", TASK_PRECEDENCE = "from-root" }
 depends = ["^build"]
+run = "printf root-default > result.txt"
+
+[monorepo.task_defaults.template-only]
+run = "printf root-default > template-result.txt"
 
 [monorepo.task_defaults.lint]
 env = { ROOT_TASK_DEFAULT = "from-executable-default" }
@@ -34,7 +38,11 @@ env = { ROOT_TASK_DEFAULT = "must-not-apply" }
 dir = "{{ invalid"
 
 [task_templates.build-override]
-env = { TASK_PRECEDENCE = "from-template" }
+env = { TASK_PRECEDENCE = "from-template", TEMPLATE_PRECEDENCE = "from-template" }
+run = "printf template > result.txt"
+
+[task_templates.template-only]
+run = "printf template > template-result.txt"
 
 [tasks.local]
 run = "printf local > local-result.txt; printf '%s' \"$ROOT_TASK_DEFAULT\" > local-default.txt"
@@ -84,6 +92,9 @@ mkdir -p packages/tool
 cat <<'TOML' >packages/tool/mise.toml
 [tasks.build]
 run = "printf '%s' \"$ROOT_TASK_DEFAULT\" > config-root-default.txt"
+
+[tasks.template-only]
+extends = "template-only"
 TOML
 
 assert_contains "mise tasks --all" "node:@scope/app#build"
@@ -92,6 +103,9 @@ assert_contains "mise task info 'node:@scope/app#build'" "packages/app/package.j
 
 mise -q run //packages/tool:build
 assert "cat packages/tool/config-root-default.txt" "from-root"
+
+mise -q run //packages/tool:template-only
+assert "cat packages/tool/template-result.txt" "template"
 
 mise -q run 'node:@scope/app#build' -- forwarded
 assert "cat packages/app/result.txt" "inferred"
@@ -106,7 +120,8 @@ assert "cat packages/app/result.txt" "inferred"
 cat <<'TOML' >packages/app/mise.toml
 [tasks.build]
 extends = "build-override"
-run = "printf explicit > result.txt; printf '%s' \"$ROOT_TASK_DEFAULT\" > explicit-default.txt; printf '%s' \"$TASK_PRECEDENCE\" > precedence.txt"
+env = { TASK_PRECEDENCE = "from-local" }
+run = "printf explicit > result.txt; printf '%s' \"$ROOT_TASK_DEFAULT\" > explicit-default.txt; printf '%s' \"$TASK_PRECEDENCE\" > precedence.txt; printf '%s' \"$TEMPLATE_PRECEDENCE\" > template-precedence.txt"
 
 [tasks.deploy]
 usage = 'arg "<task>"'
@@ -130,7 +145,8 @@ printf stale >packages/app/result.txt
 mise -q run 'node:@scope/app#build'
 assert "cat packages/app/result.txt" "explicit"
 assert "cat packages/app/explicit-default.txt" "from-root"
-assert "cat packages/app/precedence.txt" "from-template"
+assert "cat packages/app/precedence.txt" "from-local"
+assert "cat packages/app/template-precedence.txt" "from-template"
 assert "cat packages/core/explicit-result.txt" "explicit-upstream"
 
 printf stale >packages/core/explicit-result.txt

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -786,6 +786,8 @@ impl Config {
                 None => Vec::new(),
             };
             for task in inferred_tasks {
+                // Explicit project tasks replace provider inference. Preserve the provider-scoped
+                // name as an alias, but never merge provider fields into the explicit definition.
                 if tasks.contains_key(&task.name) {
                     let available_aliases = task
                         .aliases
@@ -2495,8 +2497,12 @@ fn collect_task_definitions(
     }
 }
 
-/// Resolve a task template and merge it into the task, then fill remaining fields from any
-/// workspace-root default matching the task's unscoped name.
+/// Resolve task definition layers from highest to lowest precedence.
+///
+/// The task already contains either project-local or provider-inferred fields. An explicitly named
+/// template fills gaps first, then the workspace-root task default fills anything still unset.
+/// Explicit tasks replace matching provider-inferred tasks separately when the final task map is
+/// assembled.
 /// Returns an error if the template is not found.
 fn resolve_task_template(task: &mut Task, definitions: &TaskDefinitions) -> Result<()> {
     if let Some(template_name) = &task.extends {


### PR DESCRIPTION
## Summary

- document deterministic precedence between provider inference, project-local tasks, task templates, and root task defaults
- expand Node workspace end-to-end coverage across inferred commands, explicit tasks, templates, and defaults
- mark the precedence item complete in the task runner parity tracker

## Precedence

Task selection prefers an explicit project task over a matching provider-inferred task while preserving the provider-scoped name as an alias. Once selected, unset fields are filled from an explicitly named task template and then from matching root task defaults. Existing map and collection merge semantics remain unchanged.

## Testing

- `mise run test:e2e tasks/test_task_node_workspace_scripts`
- `mise run lint-fix`
- `mise run lint`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, tests, and comments only; no new runtime logic in the diff.
> 
> **Overview**
> **Documents** how monorepo tasks are resolved: an explicit project task **replaces** a matching Node-inferred task while keeping the provider-scoped name as an alias; unset fields are filled **task → `extends` template → `[monorepo.task_defaults]`**, with the same map/collection merge rules as task templates.
> 
> **Expands** the Node workspace e2e script to assert that inferred `run` is not overridden by root defaults, templates win over defaults for missing fields, and local `env` beats template `env` when both set the same key.
> 
> **Updates** `TASK_CACHE_PARITY.md` to check off precedence work and adds clarifying comments on `resolve_task_template` / inferred-task assembly in `src/config/mod.rs` (no behavioral logic change in the diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4ed2a11cfa0302b5b7ff7c4805a7506b951e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented task configuration precedence across project tasks, provider defaults, templates, and workspace defaults.
  - Clarified how task settings are inherited, overridden, and merged, including provider names retained as aliases.

- **Tests**
  - Expanded workspace task coverage for template inheritance, environment variables, run commands, and local configuration overrides.
  - Added validation that generated task output reflects the expected precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->