### PR TITLE
feat(task): add provider task suggestions

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -53,7 +53,7 @@ outside this tracker.
       projects first
 - [x] Define deterministic precedence between provider inference, root task defaults, task
       templates, and project-local configuration
-- [ ] Allow providers to suggest inputs, outputs, cacheability, and task dependencies when they can
+- [x] Allow providers to suggest inputs, outputs, cacheability, and task dependencies when they can
       derive them confidently
 - [ ] Explain which provider inferred each project, task, input, output, and dependency
 - [ ] Add Cargo workspace and path-dependency inference

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -451,6 +451,23 @@ defines `run`, while still inheriting cache inputs or environment entries that t
 specify. If a project later defines that task explicitly, the explicit command replaces the package
 script; a named template fills its missing fields before the root default does.
 
+### Provider Task Suggestions
+
+Workspace providers can attach task configuration when ecosystem metadata describes it
+unambiguously. A provider can suggest:
+
+- project-relative input patterns, which become task `sources`
+- project-relative output patterns, including an explicit declaration that a task has no file
+  outputs
+- whether task output caching is enabled or disabled
+- project-relative task dependencies and `^task` dependencies
+
+Suggestions are part of the inferred task definition, so they have the same precedence as the
+provider command. A matching explicit project task replaces them. Otherwise, task templates and
+root task defaults fill only fields the provider did not suggest. Providers leave fields unset when
+their ecosystem metadata is not authoritative; mise does not guess outputs or cacheability from a
+command string.
+
 ### Upstream Task Dependencies
 
 Prefix a task dependency with `^` to run that task in upstream workspace projects first. A root

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -468,6 +468,10 @@ root task defaults fill only fields the provider did not suggest. Providers leav
 their ecosystem metadata is not authoritative; mise does not guess outputs or cacheability from a
 command string.
 
+The Node workspace provider reads `inputs`, `outputs`, `cache`, and `dependsOn` from matching
+`turbo.json` task definitions. Turbo-specific patterns that mise cannot preserve exactly, such as
+`$TURBO_ROOT$`, are left unset so a task template or root task default can supply them instead.
+
 ### Upstream Task Dependencies
 
 Prefix a task dependency with `^` to run that task in upstream workspace projects first. A root

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -63,7 +63,7 @@ cat <<'JSON' >turbo.json
       "inputs": ["src/**", "package.json"],
       "outputs": ["result.txt"],
       "cache": true,
-      "dependsOn": ["^build"]
+      "dependsOn": ["^prepare"]
     }
   }
 }
@@ -96,7 +96,8 @@ cat <<'JSON' >packages/core/package.json
 {
   "name": "@scope/core",
   "scripts": {
-    "build": "printf built > result.txt"
+    "build": "printf built > result.txt",
+    "prepare": "printf prepared > prepare-result.txt"
   }
 }
 JSON
@@ -129,7 +130,7 @@ mise -q run 'node:@scope/app#build' -- forwarded
 assert "cat packages/app/result.txt" "inferred"
 assert "cat packages/app/manager-args.txt" "run build -- forwarded"
 assert "cat packages/app/default.txt" "from-root"
-assert "cat workspace-task.log" $'core:run build --\napp:run build -- forwarded'
+assert "cat workspace-task.log" $'core:run prepare --\napp:run build -- forwarded'
 
 printf stale >packages/app/result.txt
 mise -q run //packages/app:build

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -29,6 +29,9 @@ run = "printf root-default > result.txt"
 [monorepo.task_defaults.template-only]
 run = "printf root-default > template-result.txt"
 
+[monorepo.task_defaults.no-deps]
+depends = ["^prepare"]
+
 [monorepo.task_defaults.lint]
 env = { ROOT_TASK_DEFAULT = "from-executable-default" }
 
@@ -67,6 +70,9 @@ cat <<'JSON' >turbo.json
     },
     "cache-only": {
       "cache": true
+    },
+    "no-deps": {
+      "dependsOn": []
     }
   }
 }
@@ -80,6 +86,7 @@ cat <<'JSON' >packages/app/package.json
   "scripts": {
     "build": "printf inferred > result.txt",
     "cache-only": "printf cached > cache-result.txt",
+    "no-deps": "printf independent > no-deps-result.txt",
     "test:unit": "printf tested > test-result.txt"
   }
 }
@@ -124,6 +131,11 @@ assert_contains "mise task info 'node:@scope/app#build'" "Outputs: result.txt"
 assert_contains "mise task info 'node:@scope/app#build'" "Cache: enabled"
 assert "mise task info 'node:@scope/app#build' --json | jq -r '.cache.env[]'" "NODE_ENV"
 assert_contains "mise task info 'node:@scope/app#cache-only'" "Cache: enabled"
+
+: >workspace-task.log
+mise -q run 'node:@scope/app#no-deps'
+assert "cat workspace-task.log" "app:run no-deps --"
+: >workspace-task.log
 
 mise -q run //packages/tool:build
 assert "cat packages/tool/config-root-default.txt" "from-root"

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -23,6 +23,7 @@ config_roots = ["packages/*"]
 [monorepo.task_defaults.build]
 env = { ROOT_TASK_DEFAULT = "from-root", TASK_PRECEDENCE = "from-root" }
 depends = ["^build"]
+cache = { env = ["NODE_ENV"] }
 run = "printf root-default > result.txt"
 
 [monorepo.task_defaults.template-only]
@@ -53,6 +54,18 @@ cat <<'JSON' >package.json
 {
   "packageManager": "npm@11.0.0",
   "workspaces": ["packages/*"]
+}
+JSON
+cat <<'JSON' >turbo.json
+{
+  "tasks": {
+    "build": {
+      "inputs": ["src/**", "package.json"],
+      "outputs": ["result.txt"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    }
+  }
 }
 JSON
 cat <<'JSON' >packages/app/package.json
@@ -100,6 +113,11 @@ TOML
 assert_contains "mise tasks --all" "node:@scope/app#build"
 assert_not_contains "mise tasks --all" "node:@scope/app#test:unit"
 assert_contains "mise task info 'node:@scope/app#build'" "packages/app/package.json"
+assert_contains "mise task info 'node:@scope/app#build'" "turbo.json"
+assert_contains "mise task info 'node:@scope/app#build'" "Sources: src/**, package.json"
+assert_contains "mise task info 'node:@scope/app#build'" "Outputs: result.txt"
+assert_contains "mise task info 'node:@scope/app#build'" "Cache: enabled"
+assert "mise task info 'node:@scope/app#build' --json | jq -r '.cache.env[]'" "NODE_ENV"
 
 mise -q run //packages/tool:build
 assert "cat packages/tool/config-root-default.txt" "from-root"

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -64,6 +64,9 @@ cat <<'JSON' >turbo.json
       "outputs": ["result.txt"],
       "cache": true,
       "dependsOn": ["^prepare"]
+    },
+    "cache-only": {
+      "cache": true
     }
   }
 }
@@ -76,6 +79,7 @@ cat <<'JSON' >packages/app/package.json
   },
   "scripts": {
     "build": "printf inferred > result.txt",
+    "cache-only": "printf cached > cache-result.txt",
     "test:unit": "printf tested > test-result.txt"
   }
 }
@@ -119,6 +123,7 @@ assert_contains "mise task info 'node:@scope/app#build'" "Sources: src/**, packa
 assert_contains "mise task info 'node:@scope/app#build'" "Outputs: result.txt"
 assert_contains "mise task info 'node:@scope/app#build'" "Cache: enabled"
 assert "mise task info 'node:@scope/app#build' --json | jq -r '.cache.env[]'" "NODE_ENV"
+assert_contains "mise task info 'node:@scope/app#cache-only'" "Cache: enabled"
 
 mise -q run //packages/tool:build
 assert "cat packages/tool/config-root-default.txt" "from-root"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2901,7 +2901,7 @@ async fn inferred_workspace_tasks(
                 run: vec![RunEntry::Script(inferred.command.clone())],
                 ..Default::default()
             };
-            inferred.suggestions.apply_to(&mut task);
+            inferred.suggestions.apply_before_defaults(&mut task);
             if let Err(err) = resolve_task_template(&mut task, task_definitions) {
                 warn!(
                     "Failed to resolve inferred task {} in {}: {err:#}. Task will not be available.",
@@ -2910,6 +2910,7 @@ async fn inferred_workspace_tasks(
                 );
                 continue;
             }
+            inferred.suggestions.apply_after_defaults(&mut task);
             if let Err(err) = task.render(config, &project_root).await {
                 warn!(
                     "Failed to render inferred task {} in {}: {err:#}. Task will not be available.",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2901,6 +2901,7 @@ async fn inferred_workspace_tasks(
                 run: vec![RunEntry::Script(inferred.command.clone())],
                 ..Default::default()
             };
+            inferred.suggestions.apply_to(&mut task);
             if let Err(err) = resolve_task_template(&mut task, task_definitions) {
                 warn!(
                     "Failed to resolve inferred task {} in {}: {err:#}. Task will not be available.",

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -115,8 +115,9 @@ pub struct WorkspaceTaskSuggestions {
     pub outputs: Option<Vec<String>>,
     /// Whether task output caching should be enabled or disabled.
     pub cache: Option<bool>,
-    /// Task dependencies, including project-relative and `^task` dependencies.
-    pub depends: Vec<String>,
+    /// Task dependencies, including project-relative and `^task` dependencies. An empty vector
+    /// means the task has no dependencies.
+    pub depends: Option<Vec<String>>,
     /// Additional metadata files that contributed these suggestions.
     pub config_sources: Vec<PathBuf>,
 }
@@ -133,14 +134,19 @@ impl WorkspaceTaskSuggestions {
                 TaskOutputs::Files(outputs.clone())
             };
         }
-        if !self.depends.is_empty() {
-            task.depends = self.depends.iter().cloned().map(Into::into).collect();
+        if let Some(depends) = &self.depends
+            && !depends.is_empty()
+        {
+            task.depends = depends.iter().cloned().map(Into::into).collect();
         }
         task.additional_config_sources
             .extend(self.config_sources.iter().cloned());
     }
 
     pub(crate) fn apply_after_defaults(&self, task: &mut Task) {
+        if self.depends.as_ref().is_some_and(Vec::is_empty) {
+            task.depends.clear();
+        }
         if let Some(enabled) = self.cache {
             task.cache
                 .get_or_insert_with(TaskCacheConfig::default)
@@ -663,7 +669,7 @@ mod tests {
             inputs: vec!["src/**".to_string(), "package.json".to_string()],
             outputs: Some(vec!["dist/**".to_string()]),
             cache: Some(true),
-            depends: vec!["prepare".to_string(), "^build".to_string()],
+            depends: Some(vec!["prepare".to_string(), "^build".to_string()]),
             config_sources: vec![PathBuf::from("turbo.json")],
         };
         let mut task = Task::default();
@@ -691,7 +697,7 @@ mod tests {
     }
 
     #[test]
-    fn task_suggestions_distinguish_no_outputs_from_no_suggestion() {
+    fn task_suggestions_distinguish_empty_values_from_no_suggestion() {
         let mut no_outputs = Task::default();
         let no_output_suggestions = WorkspaceTaskSuggestions {
             outputs: Some(Vec::new()),
@@ -732,6 +738,19 @@ mod tests {
                 .as_ref()
                 .is_some_and(|cache| cache.enabled)
         );
+
+        let suggestions = WorkspaceTaskSuggestions {
+            depends: Some(Vec::new()),
+            ..Default::default()
+        };
+        let mut no_dependencies = Task::default();
+        suggestions.apply_before_defaults(&mut no_dependencies);
+        no_dependencies.merge_template(&super::super::TaskTemplate {
+            depends: vec!["default".to_string().into()],
+            ..Default::default()
+        });
+        suggestions.apply_after_defaults(&mut no_dependencies);
+        assert!(no_dependencies.depends.is_empty());
     }
 
     #[test]

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
 
+use super::{Task, TaskCacheConfig, task_sources::TaskOutputs};
+
 pub mod node;
 
 /// A stable, provider-namespaced identifier for a workspace project.
@@ -100,6 +102,45 @@ pub struct WorkspaceTask {
     pub description: String,
     /// File relative to the workspace root that supplied the task.
     pub source: PathBuf,
+    /// Provider-derived task configuration applied before user defaults.
+    pub suggestions: WorkspaceTaskSuggestions,
+}
+
+/// Optional task configuration a workspace provider can derive confidently.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct WorkspaceTaskSuggestions {
+    /// Project-relative input patterns, mapped to mise task sources.
+    pub inputs: Vec<String>,
+    /// Project-relative output patterns. An empty vector means the task has no file outputs.
+    pub outputs: Option<Vec<String>>,
+    /// Whether task output caching should be enabled or disabled.
+    pub cache: Option<bool>,
+    /// Task dependencies, including project-relative and `^task` dependencies.
+    pub depends: Vec<String>,
+}
+
+impl WorkspaceTaskSuggestions {
+    pub(crate) fn apply_to(&self, task: &mut Task) {
+        if !self.inputs.is_empty() {
+            task.sources.clone_from(&self.inputs);
+        }
+        if let Some(outputs) = &self.outputs {
+            task.outputs = if outputs.is_empty() {
+                TaskOutputs::NoFiles
+            } else {
+                TaskOutputs::Files(outputs.clone())
+            };
+        }
+        if let Some(enabled) = self.cache {
+            task.cache = Some(TaskCacheConfig {
+                enabled,
+                ..Default::default()
+            });
+        }
+        if !self.depends.is_empty() {
+            task.depends = self.depends.iter().cloned().map(Into::into).collect();
+        }
+    }
 }
 
 /// Explicit changes applied after workspace providers discover their projects.
@@ -574,6 +615,7 @@ mod tests {
                     command: "old build".to_string(),
                     description: "old build".to_string(),
                     source: "old/manifest".into(),
+                    suggestions: WorkspaceTaskSuggestions::default(),
                 },
             );
             Ok(vec![project])
@@ -607,6 +649,75 @@ mod tests {
         );
         assert!(ProjectId::new("", "app").is_err());
         assert!(ProjectId::new("node", " app").is_err());
+    }
+
+    #[test]
+    fn task_suggestions_map_to_inferred_task_configuration() {
+        let suggestions = WorkspaceTaskSuggestions {
+            inputs: vec!["src/**".to_string(), "package.json".to_string()],
+            outputs: Some(vec!["dist/**".to_string()]),
+            cache: Some(true),
+            depends: vec!["prepare".to_string(), "^build".to_string()],
+        };
+        let mut task = Task::default();
+
+        suggestions.apply_to(&mut task);
+
+        assert_eq!(task.sources, vec!["src/**", "package.json"]);
+        assert_eq!(
+            task.outputs,
+            TaskOutputs::Files(vec!["dist/**".to_string()])
+        );
+        assert!(task.cache.as_ref().is_some_and(|cache| cache.enabled));
+        assert_eq!(
+            task.depends
+                .iter()
+                .map(|dependency| dependency.task.as_str())
+                .collect::<Vec<_>>(),
+            vec!["prepare", "^build"]
+        );
+    }
+
+    #[test]
+    fn task_suggestions_distinguish_no_outputs_from_no_suggestion() {
+        let mut no_outputs = Task::default();
+        WorkspaceTaskSuggestions {
+            outputs: Some(Vec::new()),
+            cache: Some(false),
+            ..Default::default()
+        }
+        .apply_to(&mut no_outputs);
+        assert_eq!(no_outputs.outputs, TaskOutputs::NoFiles);
+        assert!(
+            no_outputs
+                .cache
+                .as_ref()
+                .is_some_and(|cache| !cache.enabled)
+        );
+
+        let mut unspecified = Task {
+            sources: vec!["existing".to_string()],
+            outputs: TaskOutputs::Files(vec!["existing".to_string()]),
+            cache: Some(TaskCacheConfig {
+                enabled: true,
+                ..Default::default()
+            }),
+            depends: vec!["existing".to_string().into()],
+            ..Default::default()
+        };
+        WorkspaceTaskSuggestions::default().apply_to(&mut unspecified);
+        assert_eq!(unspecified.sources, vec!["existing"]);
+        assert_eq!(
+            unspecified.outputs,
+            TaskOutputs::Files(vec!["existing".to_string()])
+        );
+        assert_eq!(unspecified.depends[0].task, "existing");
+        assert!(
+            unspecified
+                .cache
+                .as_ref()
+                .is_some_and(|cache| cache.enabled)
+        );
     }
 
     #[test]
@@ -765,6 +876,7 @@ mod tests {
                 command: "npm run build --".to_string(),
                 description: "vite build".to_string(),
                 source: "apps/app/package.json".into(),
+                suggestions: WorkspaceTaskSuggestions::default(),
             },
         );
         let node = TestProvider {

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -117,10 +117,12 @@ pub struct WorkspaceTaskSuggestions {
     pub cache: Option<bool>,
     /// Task dependencies, including project-relative and `^task` dependencies.
     pub depends: Vec<String>,
+    /// Additional metadata files that contributed these suggestions.
+    pub config_sources: Vec<PathBuf>,
 }
 
 impl WorkspaceTaskSuggestions {
-    pub(crate) fn apply_to(&self, task: &mut Task) {
+    pub(crate) fn apply_before_defaults(&self, task: &mut Task) {
         if !self.inputs.is_empty() {
             task.sources.clone_from(&self.inputs);
         }
@@ -131,14 +133,18 @@ impl WorkspaceTaskSuggestions {
                 TaskOutputs::Files(outputs.clone())
             };
         }
-        if let Some(enabled) = self.cache {
-            task.cache = Some(TaskCacheConfig {
-                enabled,
-                ..Default::default()
-            });
-        }
         if !self.depends.is_empty() {
             task.depends = self.depends.iter().cloned().map(Into::into).collect();
+        }
+        task.additional_config_sources
+            .extend(self.config_sources.iter().cloned());
+    }
+
+    pub(crate) fn apply_after_defaults(&self, task: &mut Task) {
+        if let Some(enabled) = self.cache {
+            task.cache
+                .get_or_insert_with(TaskCacheConfig::default)
+                .enabled = enabled;
         }
     }
 }
@@ -658,10 +664,12 @@ mod tests {
             outputs: Some(vec!["dist/**".to_string()]),
             cache: Some(true),
             depends: vec!["prepare".to_string(), "^build".to_string()],
+            config_sources: vec![PathBuf::from("turbo.json")],
         };
         let mut task = Task::default();
 
-        suggestions.apply_to(&mut task);
+        suggestions.apply_before_defaults(&mut task);
+        suggestions.apply_after_defaults(&mut task);
 
         assert_eq!(task.sources, vec!["src/**", "package.json"]);
         assert_eq!(
@@ -676,17 +684,22 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["prepare", "^build"]
         );
+        assert_eq!(
+            task.additional_config_sources,
+            [PathBuf::from("turbo.json")]
+        );
     }
 
     #[test]
     fn task_suggestions_distinguish_no_outputs_from_no_suggestion() {
         let mut no_outputs = Task::default();
-        WorkspaceTaskSuggestions {
+        let no_output_suggestions = WorkspaceTaskSuggestions {
             outputs: Some(Vec::new()),
             cache: Some(false),
             ..Default::default()
-        }
-        .apply_to(&mut no_outputs);
+        };
+        no_output_suggestions.apply_before_defaults(&mut no_outputs);
+        no_output_suggestions.apply_after_defaults(&mut no_outputs);
         assert_eq!(no_outputs.outputs, TaskOutputs::NoFiles);
         assert!(
             no_outputs
@@ -705,7 +718,8 @@ mod tests {
             depends: vec!["existing".to_string().into()],
             ..Default::default()
         };
-        WorkspaceTaskSuggestions::default().apply_to(&mut unspecified);
+        WorkspaceTaskSuggestions::default().apply_before_defaults(&mut unspecified);
+        WorkspaceTaskSuggestions::default().apply_after_defaults(&mut unspecified);
         assert_eq!(unspecified.sources, vec!["existing"]);
         assert_eq!(
             unspecified.outputs,
@@ -717,6 +731,35 @@ mod tests {
                 .cache
                 .as_ref()
                 .is_some_and(|cache| cache.enabled)
+        );
+    }
+
+    #[test]
+    fn cache_suggestion_preserves_default_cache_inputs() {
+        let suggestions = WorkspaceTaskSuggestions {
+            cache: Some(true),
+            ..Default::default()
+        };
+        let mut task = Task::default();
+
+        suggestions.apply_before_defaults(&mut task);
+        task.merge_template(&super::super::TaskTemplate {
+            cache: Some(TaskCacheConfig {
+                env: vec!["NODE_ENV".to_string()],
+                command_inputs: vec!["node --version".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        suggestions.apply_after_defaults(&mut task);
+
+        assert_eq!(
+            task.cache,
+            Some(TaskCacheConfig {
+                enabled: true,
+                env: vec!["NODE_ENV".to_string()],
+                command_inputs: vec!["node --version".to_string()],
+            })
         );
     }
 

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -144,6 +144,9 @@ impl WorkspaceTaskSuggestions {
     }
 
     pub(crate) fn apply_after_defaults(&self, task: &mut Task) {
+        if self.outputs.as_ref().is_some_and(Vec::is_empty) {
+            task.outputs = TaskOutputs::NoFiles;
+        }
         if self.depends.as_ref().is_some_and(Vec::is_empty) {
             task.depends.clear();
         }
@@ -705,6 +708,10 @@ mod tests {
             ..Default::default()
         };
         no_output_suggestions.apply_before_defaults(&mut no_outputs);
+        no_outputs.merge_template(&super::super::TaskTemplate {
+            outputs: TaskOutputs::Files(vec!["default".to_string()]),
+            ..Default::default()
+        });
         no_output_suggestions.apply_after_defaults(&mut no_outputs);
         assert_eq!(no_outputs.outputs, TaskOutputs::NoFiles);
         assert!(

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -258,11 +258,20 @@ fn read_turbo_json(workspace_root: &Path) -> Result<Option<TurboJson>> {
     if !path.is_file() {
         return Ok(None);
     }
-    let contents = std::fs::read_to_string(&path)
-        .wrap_err_with(|| format!("failed to read {}", path.display()))?;
-    serde_json::from_str(&contents)
-        .map(Some)
-        .wrap_err_with(|| format!("failed to parse {}", path.display()))
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            warn!("failed to read optional {}: {error}", path.display());
+            return Ok(None);
+        }
+    };
+    match serde_json::from_str(&contents) {
+        Ok(turbo) => Ok(Some(turbo)),
+        Err(error) => {
+            warn!("failed to parse optional {}: {error}", path.display());
+            Ok(None)
+        }
+    }
 }
 
 fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinition>> {
@@ -452,6 +461,28 @@ mod tests {
         assert_eq!(suggestions.cache, Some(true));
         assert_eq!(suggestions.depends, ["^build", "prepare"]);
         assert_eq!(suggestions.config_sources, [temp.path().join(TURBO_JSON)]);
+    }
+
+    #[test]
+    fn invalid_turbo_json_does_not_remove_package_scripts() {
+        for contents in ["{", r#"{"tasks":{"build":{"cache":"yes"}}}"#] {
+            let temp = tempdir().unwrap();
+            write(
+                &temp.path().join(PACKAGE_JSON),
+                r#"{"packageManager":"pnpm@10.0.0","workspaces":["packages/*"]}"#,
+            );
+            write(
+                &temp.path().join("packages/app/package.json"),
+                r#"{"name":"app","scripts":{"build":"vite build"}}"#,
+            );
+            write(&temp.path().join(TURBO_JSON), contents);
+
+            let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+            let task = &projects[0].tasks["build"];
+
+            assert_eq!(task.command, "pnpm run build --");
+            assert_eq!(task.suggestions, WorkspaceTaskSuggestions::default());
+        }
     }
 
     #[test]

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -240,8 +240,7 @@ impl TurboTask {
                     !task.is_empty() && !task.contains('#') && !task.contains('$')
                 })
             })
-            .cloned()
-            .unwrap_or_default();
+            .cloned();
 
         WorkspaceTaskSuggestions {
             inputs,
@@ -459,7 +458,13 @@ mod tests {
             Some(vec!["dist/**"])
         );
         assert_eq!(suggestions.cache, Some(true));
-        assert_eq!(suggestions.depends, ["^build", "prepare"]);
+        assert_eq!(
+            suggestions
+                .depends
+                .as_ref()
+                .map(|depends| { depends.iter().map(String::as_str).collect::<Vec<_>>() }),
+            Some(vec!["^build", "prepare"])
+        );
         assert_eq!(suggestions.config_sources, [temp.path().join(TURBO_JSON)]);
     }
 
@@ -501,7 +506,7 @@ mod tests {
 
         assert!(suggestions.inputs.is_empty());
         assert!(suggestions.outputs.is_none());
-        assert!(suggestions.depends.is_empty());
+        assert!(suggestions.depends.is_none());
         assert_eq!(suggestions.cache, Some(false));
     }
 

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use aube::embed::{ManifestError, PackageJson, WorkspaceDiscoveryOptions};
 use eyre::{Context, Result};
+use serde::Deserialize;
 
 use super::{
     ProjectId, WorkspaceProject, WorkspaceProvider, WorkspaceTask, WorkspaceTaskSuggestions,
@@ -10,6 +11,7 @@ use super::{
 
 const PACKAGE_JSON: &str = "package.json";
 const PNPM_WORKSPACE: &str = "pnpm-workspace.yaml";
+const TURBO_JSON: &str = "turbo.json";
 
 /// Discovers Node projects from npm, pnpm, Yarn, and Bun workspace definitions.
 #[derive(Debug, Default)]
@@ -19,6 +21,22 @@ struct WorkspaceDefinition {
     source: &'static str,
     package_manager: Option<String>,
     include_named_root: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct TurboJson {
+    tasks: BTreeMap<String, TurboTask>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct TurboTask {
+    inputs: Option<Vec<String>>,
+    outputs: Option<Vec<String>>,
+    cache: Option<bool>,
+    #[serde(rename = "dependsOn")]
+    depends_on: Option<Vec<String>>,
 }
 
 impl WorkspaceProvider for NodeWorkspaceProvider {
@@ -36,6 +54,7 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
                 workspace_root.display()
             )
         })?;
+        let turbo = read_turbo_json(workspace_root)?;
         let mut roots = aube::embed::discover_workspace_packages(
             &canonical_root,
             WorkspaceDiscoveryOptions::confined_to_root(),
@@ -124,7 +143,13 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
                         .insert("package_manager".to_string(), package_manager.clone());
                 }
                 let package_manager = definition.package_manager.as_deref().unwrap_or("npm");
-                project.tasks = workspace_tasks(&manifest, package_manager, &source);
+                project.tasks = workspace_tasks(
+                    &manifest,
+                    package_manager,
+                    &source,
+                    turbo.as_ref(),
+                    workspace_root,
+                );
                 Ok(project)
             })
             .collect()
@@ -147,7 +172,14 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
             return Ok(BTreeMap::new());
         };
         let package_manager = definition.package_manager.as_deref().unwrap_or("npm");
-        Ok(workspace_tasks(&manifest, package_manager, &source))
+        let turbo = read_turbo_json(workspace_root)?;
+        Ok(workspace_tasks(
+            &manifest,
+            package_manager,
+            &source,
+            turbo.as_ref(),
+            workspace_root,
+        ))
     }
 }
 
@@ -155,6 +187,8 @@ fn workspace_tasks(
     manifest: &PackageJson,
     package_manager: &str,
     source: &Path,
+    turbo: Option<&TurboJson>,
+    workspace_root: &Path,
 ) -> BTreeMap<String, WorkspaceTask> {
     manifest
         .scripts
@@ -167,11 +201,68 @@ fn workspace_tasks(
                     command,
                     description: script.clone(),
                     source: source.to_path_buf(),
-                    suggestions: WorkspaceTaskSuggestions::default(),
+                    suggestions: turbo
+                        .and_then(|turbo| turbo.task(manifest.name.as_deref(), name))
+                        .map(|task| task.suggestions(workspace_root))
+                        .unwrap_or_default(),
                 },
             )
         })
         .collect()
+}
+
+impl TurboJson {
+    fn task(&self, package: Option<&str>, task: &str) -> Option<&TurboTask> {
+        package
+            .and_then(|package| self.tasks.get(&format!("{package}#{task}")))
+            .or_else(|| self.tasks.get(task))
+    }
+}
+
+impl TurboTask {
+    fn suggestions(&self, workspace_root: &Path) -> WorkspaceTaskSuggestions {
+        let supported_patterns = |patterns: &Option<Vec<String>>| {
+            patterns
+                .as_ref()
+                .filter(|patterns| patterns.iter().all(|pattern| !pattern.contains('$')))
+                .cloned()
+        };
+        let inputs = supported_patterns(&self.inputs)
+            .filter(|patterns| !patterns.is_empty())
+            .unwrap_or_default();
+        let outputs = supported_patterns(&self.outputs);
+        let depends = self
+            .depends_on
+            .as_ref()
+            .filter(|dependencies| {
+                dependencies.iter().all(|dependency| {
+                    let task = dependency.strip_prefix('^').unwrap_or(dependency);
+                    !task.is_empty() && !task.contains('#') && !task.contains('$')
+                })
+            })
+            .cloned()
+            .unwrap_or_default();
+
+        WorkspaceTaskSuggestions {
+            inputs,
+            outputs,
+            cache: self.cache,
+            depends,
+            config_sources: vec![workspace_root.join(TURBO_JSON)],
+        }
+    }
+}
+
+fn read_turbo_json(workspace_root: &Path) -> Result<Option<TurboJson>> {
+    let path = workspace_root.join(TURBO_JSON);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let contents = std::fs::read_to_string(&path)
+        .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&contents)
+        .map(Some)
+        .wrap_err_with(|| format!("failed to parse {}", path.display()))
 }
 
 fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinition>> {
@@ -320,6 +411,67 @@ mod tests {
                 .map(|task| task.command.as_str()),
             Some("pnpm run test:unit --")
         );
+    }
+
+    #[test]
+    fn imports_authoritative_turbo_task_suggestions() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(PACKAGE_JSON),
+            r#"{"packageManager":"pnpm@10.0.0","workspaces":["packages/*"]}"#,
+        );
+        write(
+            &temp.path().join("packages/app/package.json"),
+            r#"{"name":"@scope/app","scripts":{"build":"vite build"}}"#,
+        );
+        write(
+            &temp.path().join(TURBO_JSON),
+            r#"{
+                "tasks": {
+                    "build": {
+                        "inputs": ["src/**", "package.json"],
+                        "outputs": ["dist/**"],
+                        "cache": true,
+                        "dependsOn": ["^build", "prepare"]
+                    }
+                }
+            }"#,
+        );
+
+        let projects = NodeWorkspaceProvider.discover(temp.path()).unwrap();
+        let suggestions = &projects[0].tasks["build"].suggestions;
+
+        assert_eq!(suggestions.inputs, ["src/**", "package.json"]);
+        assert_eq!(
+            suggestions
+                .outputs
+                .as_ref()
+                .map(|outputs| outputs.iter().map(String::as_str).collect::<Vec<_>>()),
+            Some(vec!["dist/**"])
+        );
+        assert_eq!(suggestions.cache, Some(true));
+        assert_eq!(suggestions.depends, ["^build", "prepare"]);
+        assert_eq!(suggestions.config_sources, [temp.path().join(TURBO_JSON)]);
+    }
+
+    #[test]
+    fn leaves_unsupported_turbo_suggestion_fields_unset() {
+        let task: TurboTask = serde_json::from_str(
+            r#"{
+                "inputs": ["$TURBO_DEFAULT$", "src/**"],
+                "outputs": ["$TURBO_ROOT$/dist/**"],
+                "dependsOn": ["other-package#build"],
+                "cache": false
+            }"#,
+        )
+        .unwrap();
+
+        let suggestions = task.suggestions(Path::new("/workspace"));
+
+        assert!(suggestions.inputs.is_empty());
+        assert!(suggestions.outputs.is_none());
+        assert!(suggestions.depends.is_empty());
+        assert_eq!(suggestions.cache, Some(false));
     }
 
     #[test]

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use aube::embed::{ManifestError, PackageJson, WorkspaceDiscoveryOptions};
 use eyre::{Context, Result};
 
-use super::{ProjectId, WorkspaceProject, WorkspaceProvider, WorkspaceTask};
+use super::{
+    ProjectId, WorkspaceProject, WorkspaceProvider, WorkspaceTask, WorkspaceTaskSuggestions,
+};
 
 const PACKAGE_JSON: &str = "package.json";
 const PNPM_WORKSPACE: &str = "pnpm-workspace.yaml";
@@ -165,6 +167,7 @@ fn workspace_tasks(
                     command,
                     description: script.clone(),
                     source: source.to_path_buf(),
+                    suggestions: WorkspaceTaskSuggestions::default(),
                 },
             )
         })
@@ -307,6 +310,7 @@ mod tests {
                 command: "pnpm run build --".to_string(),
                 description: "vite build".to_string(),
                 source: PathBuf::from("packages/app/package.json"),
+                suggestions: WorkspaceTaskSuggestions::default(),
             })
         );
         assert_eq!(
@@ -357,6 +361,7 @@ mod tests {
                 command: "pnpm run new --".to_string(),
                 description: "new command".to_string(),
                 source: PathBuf::from("overrides/app/package.json"),
+                suggestions: WorkspaceTaskSuggestions::default(),
             })
         );
     }


### PR DESCRIPTION
## Summary

- add provider-neutral task suggestions for project-relative inputs and outputs, cacheability, and task dependencies
- import supported `inputs`, `outputs`, `cache`, and `dependsOn` metadata from matching Node workspace `turbo.json` task definitions
- preserve root-default cache key inputs when a provider suggests only cache enablement, and leave unsupported Turbo expressions unset
- track provider metadata files as task definition sources and document the production integration

## Stacked on

- #11542

This PR intentionally targets `agent/define-task-precedence` so the documented precedence contract lands before providers begin contributing task configuration.

## Testing

- `cargo test --all-features task_suggestions`
- `cargo test --all-features task::workspace::node::tests`
- `cargo test --all-features cache_suggestion_preserves_default_cache_inputs`
- `mise run test:e2e tasks/test_task_node_workspace_scripts`
- `mise run lint-fix`
- `mise run lint`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes monorepo task resolution order for inferred Node tasks (dependencies, cache, and I/O), which can alter execution graphs and caching behavior in workspaces that use `turbo.json`.
> 
> **Overview**
> Workspace providers can now attach **task suggestions** (sources, outputs, cache on/off, and `depends`) when ecosystem metadata is authoritative. Suggestions apply in two phases around templates and root task defaults so provider values win on collection fields, while **empty** Turbo `dependsOn` / outputs still override inherited defaults.
> 
> The **Node workspace provider** reads matching `turbo.json` task entries (`inputs`, `outputs`, `cache`, `dependsOn`) for inferred package scripts; unsupported Turbo patterns (e.g. `$TURBO_ROOT$`, cross-package `#` deps) are left unset. `turbo.json` is tracked as an additional task definition source, and enabling cache from Turbo can merge with root-default cache env keys.
> 
> Docs and the parity tracker describe precedence; e2e coverage asserts `mise task info` and upstream `^prepare` ordering from Turbo `dependsOn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a4fb4cf45b43fd6948ef0e79c6018d40e3d12b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node workspace tasks now recognize optional Turbo configuration for inputs, outputs, caching, and dependencies.
  * Task settings combine explicit definitions, provider suggestions, defaults, and templates with predictable precedence.
  * Task details include contributing configuration sources and cache-related environment information.

* **Documentation**
  * Added guidance on provider task suggestions, configuration precedence, and unsupported Turbo patterns.

* **Tests**
  * Expanded coverage for Turbo task discovery, metadata, caching, outputs, dependencies, configuration handling, and upstream task execution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->