### PR TITLE
fix(forgejo): support new fj macos key path

### DIFF
--- a/docs/dev-tools/backends/forgejo.md
+++ b/docs/dev-tools/backends/forgejo.md
@@ -87,7 +87,8 @@ The legacy `$1`/`${1}` hostname argument is deprecated. Use `MISE_CREDENTIAL_HOS
 mise can read tokens from the [`fj` CLI](https://codeberg.org/forgejo-contrib/forgejo-cli) (`keys.json`) as a fallback. It checks:
 
 1. `$XDG_DATA_HOME/forgejo-cli/keys.json` (defaults to `~/.local/share/forgejo-cli/keys.json`)
-2. `~/Library/Application Support/Cyborus.forgejo-cli/keys.json` (macOS)
+2. `~/Library/Application Support/forgejo-cli.forgejo-cli/keys.json` (macOS)
+3. `~/Library/Application Support/Cyborus.forgejo-cli/keys.json` (legacy macOS location)
 
 Disable this fallback with:
 

--- a/settings.toml
+++ b/settings.toml
@@ -780,7 +780,8 @@ description = "Read Forgejo tokens from the fj CLI config."
 docs = """
 When enabled, mise will read tokens from the fj CLI keys file
 (`~/.local/share/forgejo-cli/keys.json` on Linux,
-`~/Library/Application Support/Cyborus.forgejo-cli/keys.json` on macOS).
+`~/Library/Application Support/forgejo-cli.forgejo-cli/keys.json` on macOS,
+with the legacy `Cyborus.forgejo-cli` location as a fallback).
 This is used as a fallback when no `FORGEJO_TOKEN` or `MISE_FORGEJO_TOKEN`
 environment variable is set.
 

--- a/src/forgejo.rs
+++ b/src/forgejo.rs
@@ -308,20 +308,29 @@ static FJ_HOSTS: Lazy<HashMap<String, String>> = Lazy::new(|| read_fj_hosts().un
 fn fj_keys_path() -> Option<PathBuf> {
     // Linux/XDG: $XDG_DATA_HOME/forgejo-cli/keys.json
     let xdg_path = env::XDG_DATA_HOME.join("forgejo-cli/keys.json");
-    if xdg_path.exists() {
-        return Some(xdg_path);
-    }
+    let candidates = [xdg_path.clone()]
+        .into_iter()
+        .chain(fj_native_keys_paths())
+        .collect();
+    Some(tokens::first_existing_file(candidates, xdg_path))
+}
 
-    #[cfg(target_os = "macos")]
-    {
-        let macos_path =
-            dirs::HOME.join("Library/Application Support/Cyborus.forgejo-cli/keys.json");
-        if macos_path.exists() {
-            return Some(macos_path);
-        }
-    }
+#[cfg(target_os = "macos")]
+fn fj_native_keys_paths() -> Vec<PathBuf> {
+    fj_macos_keys_paths(&dirs::HOME).into()
+}
 
-    Some(xdg_path)
+#[cfg(not(target_os = "macos"))]
+fn fj_native_keys_paths() -> Vec<PathBuf> {
+    Vec::new()
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn fj_macos_keys_paths(home: &std::path::Path) -> [PathBuf; 2] {
+    [
+        home.join("Library/Application Support/forgejo-cli.forgejo-cli/keys.json"),
+        home.join("Library/Application Support/Cyborus.forgejo-cli/keys.json"),
+    ]
 }
 
 fn read_fj_hosts() -> Option<HashMap<String, String>> {
@@ -428,6 +437,22 @@ something_else = "value"
 "#;
         let result = tokens::parse_tokens_toml(toml).unwrap();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_fj_macos_keys_paths_prefers_current_path() {
+        let paths = fj_macos_keys_paths(std::path::Path::new("/Users/test"));
+        assert_eq!(
+            paths,
+            [
+                PathBuf::from(
+                    "/Users/test/Library/Application Support/forgejo-cli.forgejo-cli/keys.json"
+                ),
+                PathBuf::from(
+                    "/Users/test/Library/Application Support/Cyborus.forgejo-cli/keys.json"
+                ),
+            ]
+        );
     }
 
     // #10343: a first page made up entirely of prereleases must not yield "no


### PR DESCRIPTION
## Summary

- recognize the new `fj` macOS key location
- retain the legacy `Cyborus.forgejo-cli` path as a fallback
- document the path order and cover it with a focused unit test

## Root cause

forgejo-cli changed its macOS project directory from `Cyborus.forgejo-cli` to `forgejo-cli.forgejo-cli`. mise only checked the old location, so current `fj` credentials were not discovered.

This addresses [discussion #11540](https://github.com/jdx/mise/discussions/11540).

## Validation

- `cargo test forgejo::tests::test_fj_macos_keys_paths_prefers_current_path`
- `mise run test:e2e e2e/cli/test_token_forgejo`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to optional `fj` CLI token fallback on macOS; Linux behavior unchanged and the old path remains as fallback.
> 
> **Overview**
> **Forgejo `fj` CLI token discovery on macOS** now looks for `keys.json` at the current forgejo-cli location (`~/Library/Application Support/forgejo-cli.forgejo-cli/keys.json`) before the legacy `Cyborus.forgejo-cli` path, so mise picks up tokens from recent `fj` installs again.
> 
> Path resolution is refactored to walk XDG plus macOS candidates through `tokens::first_existing_file`, matching the pattern used for other forge CLIs. **Docs** (`forgejo.md`, `forgejo.fj_cli_tokens` in `settings.toml`) describe the ordered lookup. A unit test locks in macOS path priority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcf2bd77240b9d42e625bba9162a6b308895c03e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Forgejo CLI token discovery across XDG, native, and legacy macOS configuration paths.
  * The application now prioritizes the correct available configuration path.

* **Documentation**
  * Updated Forgejo CLI token setup guidance with the current macOS path and legacy fallback path.

* **Tests**
  * Added coverage for macOS configuration path precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->