### PR TITLE
fix(dotfiles): avoid scanning symlink-each targets

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -93,12 +93,12 @@ apply, the same as deleting the source would.
 
 ## Modes
 
-| Mode           | Behavior                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `symlink`      | Symlink the target to the source. Works for files and directories — a directory source gets one link for the whole directory. This is the default.                                                                                                                                                                                    |
-| `symlink-each` | Source must be a directory: recreate its directory structure under the target and symlink each file individually, so the target directory (say, `~/.config`) can also hold files mise doesn't manage. Deleting a source file removes the link it left behind on the next apply; files and links mise didn't create are never touched. |
-| `copy`         | Copy the source file (or directory, recursively). Use when the target must be a real file — e.g. tools that rewrite their config in place. Directory copies are additive: matching files are overwritten, files mise doesn't manage are left in place. Copies are never pruned, so removing a source file leaves the copy behind.     |
-| `template`     | Render the source through the [mise template engine](/templates.html) and write the result. Permissions are taken from the source file (and repaired if they drift).                                                                                                                                                                  |
+| Mode           | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `symlink`      | Symlink the target to the source. Works for files and directories — a directory source gets one link for the whole directory. This is the default.                                                                                                                                                                                                                                                                                                                      |
+| `symlink-each` | Source must be a directory: recreate its directory structure under the target and symlink each file individually, so the target directory (say, `~/.config`) can also hold files mise doesn't manage. Deleting a source file removes the link it left behind on the next apply; files and links mise didn't create are never touched. Managed links are recorded under `$MISE_STATE_DIR/dotfiles`, so shared targets are not recursively scanned after the first apply. |
+| `copy`         | Copy the source file (or directory, recursively). Use when the target must be a real file — e.g. tools that rewrite their config in place. Directory copies are additive: matching files are overwritten, files mise doesn't manage are left in place. Copies are never pruned, so removing a source file leaves the copy behind.                                                                                                                                       |
+| `template`     | Render the source through the [mise template engine](/templates.html) and write the result. Permissions are taken from the source file (and repaired if they drift).                                                                                                                                                                                                                                                                                                    |
 
 Templates get the same context as other mise templates (`env`, `vars`,
 `exec()`, etc.), which is the main reason to use them: one source file,
@@ -195,9 +195,9 @@ edit through a symlink would modify whatever the link points at, often a
 `[dotfiles]` source, so point the edit at the real file instead.
 
 Removing an entry from config leaves its file, block, or line in place
-because mise keeps no state database. Run `mise bootstrap dotfiles unapply`
-before removing the entry when you want mise to clean up its observable
-footprint.
+because the active config still defines which state belongs to an entry. Run
+`mise bootstrap dotfiles unapply` before removing the entry when you want mise
+to clean up its observable footprint.
 
 ## Unapplying
 

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -202,8 +202,8 @@ to clean up its observable footprint.
 ## Unapplying
 
 `mise bootstrap dotfiles unapply` removes configured targets without removing
-their `[dotfiles]` entries or source files. It uses the current config and
-filesystem to determine what the entry owns:
+their `[dotfiles]` entries or source files. It uses the current config,
+filesystem, and recorded `symlink-each` state to determine what the entry owns:
 
 - `symlink` targets are removed only while they still point to the configured
   source.
@@ -216,10 +216,10 @@ filesystem to determine what the entry owns:
 - marker-delimited blocks are removed with their markers. Plain line edits have
   no ownership marker and require `--force`.
 
-Unapply is deliberately conservative because dotfiles do not have an apply
-manifest. In particular, a copied file whose source was deleted can no longer
-be identified inside an additive directory copy. Remove such leftovers by
-hand. Use `--dry-run` to inspect the identifiable removals first; template
+Unapply is deliberately conservative because `copy` and `template` entries have
+no apply manifest. In particular, a copied file whose source was deleted can no
+longer be identified inside an additive directory copy. Remove such leftovers
+by hand. Use `--dry-run` to inspect the identifiable removals first; template
 dry-runs do not render or execute template functions.
 
 ## Commands

--- a/e2e/cli/test_dotfiles_files
+++ b/e2e/cli/test_dotfiles_files
@@ -89,6 +89,18 @@ assert_contains "mise dotfiles status" "applied"
 assert_contains "mise dotfiles apply --yes 2>&1" "all files are applied"
 assert "ls ~/.local/mybin/unmanaged" "$HOME/.local/mybin/unmanaged"
 
+# Existing symlink-each installations without ownership state are migrated by
+# the next real apply, even when every target is already converged. Once state
+# exists, status inspects managed paths instead of recursively walking a shared
+# target such as HOME.
+rm -rf "$MISE_STATE_DIR/dotfiles"
+assert_succeed "mise dotfiles apply --yes"
+assert "find '$MISE_STATE_DIR/dotfiles' -type f | wc -l | tr -d ' '" "1"
+mkdir ~/.local/mybin/private
+chmod 000 ~/.local/mybin/private
+assert_not_contains "MISE_DEBUG=1 mise dotfiles status 2>&1" "$HOME/.local/mybin/private"
+chmod 700 ~/.local/mybin/private
+
 # symlink-each cleans up after itself: deleting a source file removes the
 # link it left behind (and any directory that emptied out), while files and
 # links mise didn't create stay put

--- a/e2e/cli/test_dotfiles_unapply
+++ b/e2e/cli/test_dotfiles_unapply
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-mkdir -p dotfiles/links dotfiles/copydir
+mkdir -p dotfiles/links dotfiles/missing-links dotfiles/copydir
 echo "linked" >dotfiles/linked
 echo "copied" >dotfiles/copied
 echo "one" >dotfiles/links/one
 echo "stale" >dotfiles/links/stale
 echo "excluded" >dotfiles/links/excluded
+echo "missing source" >dotfiles/missing-links/file
 echo "managed" >dotfiles/copydir/managed
 cat <<'EOF' >dotfiles/rendered.tmpl
 {{ exec(command="touch $HOME/unapply-rendered") }}rendered
@@ -21,6 +22,7 @@ cat <<EOF >mise.toml
 "~/.managed-rendered" = { source = "dotfiles/rendered.tmpl", mode = "template" }
 "~/.managed-mutating" = { source = "dotfiles/mutating.tmpl", mode = "template" }
 "~/.managed-links" = { source = "dotfiles/links", mode = "symlink-each", exclude = ["excluded"] }
+"~/.managed-missing-links" = { source = "dotfiles/missing-links", mode = "symlink-each" }
 "~/.managed-copydir" = { source = "dotfiles/copydir", mode = "copy" }
 "~/.managed-rc/block" = { block = "managed block" }
 "~/.managed-lines/line" = { line = "possibly preexisting" }
@@ -90,6 +92,11 @@ assert "od -An -tx1 ~/.managed-rc | tr -d ' \n'" "6265666f72650d0a0d0a6166746572
 
 # symlink-each removes path-equivalent and stale exact mappings, but preserves
 # unrelated and excluded user-created links and their containing directory.
+# A manifest remains sufficient ownership evidence when the complete source
+# directory has been deleted.
+rm -r dotfiles/missing-links
+assert_succeed "mise bootstrap dotfiles unapply ~/.managed-missing-links --yes"
+assert_fail "test -L $HOME/.managed-missing-links/file"
 mkdir ~/.managed-links/private
 chmod 000 ~/.managed-links/private
 assert_not_contains "MISE_DEBUG=1 mise bootstrap dotfiles unapply ~/.managed-links --dry-run 2>&1" "$HOME/.managed-links/private"

--- a/e2e/cli/test_dotfiles_unapply
+++ b/e2e/cli/test_dotfiles_unapply
@@ -90,6 +90,10 @@ assert "od -An -tx1 ~/.managed-rc | tr -d ' \n'" "6265666f72650d0a0d0a6166746572
 
 # symlink-each removes path-equivalent and stale exact mappings, but preserves
 # unrelated and excluded user-created links and their containing directory.
+mkdir ~/.managed-links/private
+chmod 000 ~/.managed-links/private
+assert_not_contains "MISE_DEBUG=1 mise bootstrap dotfiles unapply ~/.managed-links --dry-run 2>&1" "$HOME/.managed-links/private"
+chmod 700 ~/.managed-links/private
 ln -s "$PWD/dotfiles/links/one" ~/.managed-links/alias
 ln -s "$PWD/dotfiles/links/excluded" ~/.managed-links/excluded
 rm ~/.managed-links/one
@@ -101,6 +105,7 @@ assert_fail "test -e $HOME/.managed-links/one"
 assert_fail "test -e $HOME/.managed-links/stale"
 assert "readlink ~/.managed-links/alias" "$PWD/dotfiles/links/one"
 assert "readlink ~/.managed-links/excluded" "$PWD/dotfiles/links/excluded"
+assert "find '$MISE_STATE_DIR/dotfiles' -type f | wc -l | tr -d ' '" "0"
 
 # Modified copies are refused unless forced.
 assert_fail "mise bootstrap dotfiles unapply ~/.managed-copy --yes" "use --force"

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -1541,13 +1541,6 @@ fn owned_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
             out.insert(link.target, ());
         }
     }
-    // Include current mappings as a safe repair path for an incomplete older
-    // state file. Unlike the legacy fallback, this only walks the source.
-    for (source, target) in walk_source_files(req)? {
-        if link_points_to(&source, &target) {
-            out.insert(target, ());
-        }
-    }
     Ok(out.into_keys().collect())
 }
 

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -25,11 +25,12 @@ use eyre::{Result, bail};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{Config, ConfigMap, Settings};
 use crate::dirs;
 use crate::file;
+use crate::hash::hash_to_str;
 use crate::path::PathExt;
 use crate::ui::prompt;
 
@@ -106,6 +107,27 @@ pub struct FileRequest {
     /// directory of the declaring config file — base dir for template
     /// functions like `exec` and `read_file`
     pub base: PathBuf,
+}
+
+const SYMLINK_EACH_STATE_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ManagedLink {
+    source: PathBuf,
+    target: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SymlinkEachState {
+    version: u8,
+    target: PathBuf,
+    links: Vec<ManagedLink>,
+}
+
+enum LoadedSymlinkEachState {
+    Missing,
+    Invalid,
+    Present(SymlinkEachState),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -753,26 +775,108 @@ fn needed_dirs(req: &FileRequest) -> Result<Vec<PathBuf>> {
     Ok(out.into_iter().collect())
 }
 
-/// symlinks under a symlink-each target that mise created for this entry but
-/// no longer manages, because the source file was deleted or is now covered
-/// by `exclude`. These are the entry's own leftovers — un-managing a source
-/// file has to un-manage its target, or the target keeps a link mise would
-/// never write again.
-///
-/// Ownership is the exact link this entry would have written: `<target>/rel`
-/// pointing at `<source>/rel`. There is no record of who created a link, so
-/// mirroring [`walk_source_files`] is what makes the claim checkable — a
-/// user's own link is only ever pruned if it sits at the same path *and*
-/// points at the same place mise would have, which is indistinguishable from
-/// a leftover. A link to any other path, and anything that isn't a symlink,
-/// is left alone.
-///
-/// On Windows file symlinks are applied as copies (see `link_path`), so a
-/// leftover there is a regular file, indistinguishable from one the user
-/// wrote. `check_symlink` already treats those targets as copies on that
-/// platform; pruning nothing keeps this consistent with it rather than
-/// reporting links stale that the per-file check considers copies.
-fn stale_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
+fn symlink_each_state_path(target: &Path) -> PathBuf {
+    dirs::STATE
+        .join("dotfiles")
+        .join(format!("{}.toml", hash_to_str(&target)))
+}
+
+fn desired_symlink_each_state(req: &FileRequest) -> Result<SymlinkEachState> {
+    Ok(SymlinkEachState {
+        version: SYMLINK_EACH_STATE_VERSION,
+        target: req.target.clone(),
+        links: walk_source_files(req)?
+            .into_iter()
+            .map(|(source, target)| ManagedLink { source, target })
+            .collect(),
+    })
+}
+
+fn load_symlink_each_state(req: &FileRequest) -> LoadedSymlinkEachState {
+    let path = symlink_each_state_path(&req.target);
+    if !path.exists() {
+        return LoadedSymlinkEachState::Missing;
+    }
+    let state = match file::read_to_string(&path)
+        .and_then(|contents| toml::from_str::<SymlinkEachState>(&contents).map_err(Into::into))
+    {
+        Ok(state) => state,
+        Err(err) => {
+            warn!(
+                "files: failed to read dotfiles state {}: {err}",
+                path.display_user()
+            );
+            return LoadedSymlinkEachState::Invalid;
+        }
+    };
+    let valid = state.version == SYMLINK_EACH_STATE_VERSION
+        && state.target == req.target
+        && state
+            .links
+            .iter()
+            .all(|link| link.target != req.target && link.target.starts_with(&req.target));
+    if valid {
+        LoadedSymlinkEachState::Present(state)
+    } else {
+        warn!(
+            "files: ignoring invalid dotfiles state {}",
+            path.display_user()
+        );
+        LoadedSymlinkEachState::Invalid
+    }
+}
+
+fn save_symlink_each_state(req: &FileRequest) -> Result<()> {
+    if cfg!(windows) {
+        return Ok(());
+    }
+    let path = symlink_each_state_path(&req.target);
+    file::create_dir_all(path.parent().expect("dotfiles state parent"))?;
+    file::write(
+        &path,
+        toml::to_string_pretty(&desired_symlink_each_state(req)?)?,
+    )
+}
+
+fn remove_symlink_each_state(req: &FileRequest) -> Result<()> {
+    let path = symlink_each_state_path(&req.target);
+    if path.exists() {
+        file::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn link_points_to(source: &Path, target: &Path) -> bool {
+    if !target.is_symlink() {
+        return false;
+    }
+    std::fs::read_link(target)
+        .is_ok_and(|dest| dest == source || points_at_same_file(target, source))
+}
+
+fn tracked_stale_links(state: &SymlinkEachState, desired: &SymlinkEachState) -> Vec<PathBuf> {
+    let desired = desired
+        .links
+        .iter()
+        .map(|link| (&link.target, &link.source))
+        .collect::<std::collections::HashMap<_, _>>();
+    state
+        .links
+        .iter()
+        .filter(|link| {
+            desired
+                .get(&link.target)
+                .is_none_or(|source| **source != link.source)
+                && link_points_to(&link.source, &link.target)
+        })
+        .map(|link| link.target.clone())
+        .collect()
+}
+
+/// Legacy ownership discovery for installations that predate persistent
+/// symlink-each state. A successful apply records the exact links it owns, so
+/// this unbounded target walk happens at most once per target.
+fn legacy_stale_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
     if cfg!(windows) || !req.target.is_dir() || req.target.is_symlink() {
         return Ok(vec![]);
     }
@@ -808,6 +912,32 @@ fn stale_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
         }
     }
     Ok(out)
+}
+
+/// Links recorded for this target that are no longer desired. Persistent
+/// ownership state keeps this proportional to the managed source tree instead
+/// of recursively walking a shared target such as the user's home directory.
+fn stale_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
+    match load_symlink_each_state(req) {
+        LoadedSymlinkEachState::Present(state) => Ok(tracked_stale_links(
+            &state,
+            &desired_symlink_each_state(req)?,
+        )),
+        LoadedSymlinkEachState::Missing | LoadedSymlinkEachState::Invalid => {
+            legacy_stale_links(req)
+        }
+    }
+}
+
+fn symlink_each_state_needs_update(req: &FileRequest) -> Result<bool> {
+    if cfg!(windows) {
+        return Ok(false);
+    }
+    let desired = desired_symlink_each_state(req)?;
+    Ok(!matches!(
+        load_symlink_each_state(req),
+        LoadedSymlinkEachState::Present(state) if state == desired
+    ))
 }
 
 /// Whether a source-relative path is dropped by the entry's `exclude`
@@ -865,6 +995,7 @@ pub struct ApplyOpts {
 
 pub struct ApplyPlan<'a> {
     todo: Vec<(&'a FileRequest, Option<String>)>,
+    record_symlink_each: Vec<&'a FileRequest>,
 }
 
 /// Apply all entries that aren't already in the desired state. Conflicting
@@ -878,6 +1009,11 @@ pub fn apply(config: &Config, requests: &[FileRequest], opts: &ApplyOpts) -> Res
 
 pub fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<bool> {
     if plan.todo.is_empty() {
+        if !opts.dry_run {
+            for req in plan.record_symlink_each {
+                save_symlink_each_state(req)?;
+            }
+        }
         info!("files: all files are applied");
         return Ok(true);
     }
@@ -908,7 +1044,15 @@ pub fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<bool> {
     }
     for (req, rendered) in &plan.todo {
         apply_one(req, rendered.as_deref())?;
+        if req.mode == FileMode::SymlinkEach {
+            save_symlink_each_state(req)?;
+        }
         info!("files: {}", describe_applied(req)?);
+    }
+    for req in plan.record_symlink_each {
+        if !plan.todo.iter().any(|(todo, _)| todo.target == req.target) {
+            save_symlink_each_state(req)?;
+        }
     }
     info!(
         "files: applied {}",
@@ -934,6 +1078,7 @@ pub fn plan_apply<'a>(
     let mut missing_sources = vec![];
     let mut broken = vec![];
     let mut conflicts = vec![];
+    let mut record_symlink_each = vec![];
     for req in requests {
         // report every problem in one pass instead of fix-and-retry — a
         // render or check failure on one entry must not hide the rest
@@ -964,7 +1109,12 @@ pub fn plan_apply<'a>(
             _ => None,
         };
         match check_rendered(req, rendered.as_deref()) {
-            Ok(FileState::Applied) => continue,
+            Ok(FileState::Applied) => {
+                if req.mode == FileMode::SymlinkEach && symlink_each_state_needs_update(req)? {
+                    record_symlink_each.push(req);
+                }
+                continue;
+            }
             Ok(_) => {}
             Err(err) => {
                 broken.push(format!("  [dotfiles].\"{}\": {err}", req.target_raw));
@@ -998,7 +1148,10 @@ pub fn plan_apply<'a>(
     if !problems.is_empty() {
         bail!("files: {}", problems.join("\nfiles: "));
     }
-    Ok(ApplyPlan { todo })
+    Ok(ApplyPlan {
+        todo,
+        record_symlink_each,
+    })
 }
 
 pub struct UnapplyOpts {
@@ -1020,6 +1173,8 @@ pub struct UnapplyPlan<'a> {
     cleanup_empty_dirs: bool,
     /// template dry-runs do not render, so the removal is conditional
     conditional: bool,
+    /// remove persistent symlink-each ownership after successful cleanup
+    clear_symlink_each_state: bool,
 }
 
 /// Remove configured whole-file entries without recursively deleting
@@ -1095,6 +1250,7 @@ pub fn resolve_unapply(
                         paths: paths.into_keys().collect(),
                         cleanup_empty_dirs: false,
                         conditional: false,
+                        clear_symlink_each_state: false,
                     })
                 },
             )
@@ -1157,6 +1313,9 @@ pub fn execute_unapply(plans: &[UnapplyPlan<'_>], opts: &UnapplyOpts) -> Result<
     }
     for plan in todo {
         unapply_one(plan)?;
+        if plan.clear_symlink_each_state {
+            remove_symlink_each_state(plan.req)?;
+        }
     }
     info!(
         "files: unapplied {}",
@@ -1174,6 +1333,7 @@ fn plan_unapply_one<'a>(
     let mut paths = IndexMap::<PathBuf, ()>::new();
     let mut cleanup_empty_dirs = false;
     let mut conditional = false;
+    let mut clear_symlink_each_state = false;
     match req.mode {
         FileMode::Symlink if !(cfg!(windows) && req.source.is_file()) => {
             if req.target.is_symlink() {
@@ -1196,6 +1356,7 @@ fn plan_unapply_one<'a>(
             }
         }
         FileMode::SymlinkEach if !cfg!(windows) => {
+            clear_symlink_each_state = symlink_each_state_path(&req.target).exists();
             if req.target.is_symlink() || (req.target.exists() && !req.target.is_dir()) {
                 if opts.force {
                     paths.insert(req.target.clone(), ());
@@ -1256,7 +1417,7 @@ fn plan_unapply_one<'a>(
             }
         }
     }
-    if paths.is_empty() && !cleanup_empty_dirs && !conditional {
+    if paths.is_empty() && !cleanup_empty_dirs && !conditional && !clear_symlink_each_state {
         Ok(None)
     } else {
         Ok(Some(UnapplyPlan {
@@ -1264,6 +1425,7 @@ fn plan_unapply_one<'a>(
             paths: paths.into_keys().collect(),
             cleanup_empty_dirs,
             conditional,
+            clear_symlink_each_state,
         }))
     }
 }
@@ -1327,7 +1489,7 @@ fn plan_expected_content(
 /// entry maps that relative path. Unlike stale-link pruning this includes
 /// both current and deleted source files because unapply removes the entry's
 /// complete observable footprint.
-fn owned_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
+fn legacy_owned_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
     if !req.target.is_dir() || req.target.is_symlink() {
         return Ok(vec![]);
     }
@@ -1364,6 +1526,29 @@ fn owned_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
         }
     }
     Ok(out)
+}
+
+fn owned_links(req: &FileRequest) -> Result<Vec<PathBuf>> {
+    let state = match load_symlink_each_state(req) {
+        LoadedSymlinkEachState::Present(state) => state,
+        LoadedSymlinkEachState::Missing | LoadedSymlinkEachState::Invalid => {
+            return legacy_owned_links(req);
+        }
+    };
+    let mut out = IndexMap::<PathBuf, ()>::new();
+    for link in state.links {
+        if link_points_to(&link.source, &link.target) {
+            out.insert(link.target, ());
+        }
+    }
+    // Include current mappings as a safe repair path for an incomplete older
+    // state file. Unlike the legacy fallback, this only walks the source.
+    for (source, target) in walk_source_files(req)? {
+        if link_points_to(&source, &target) {
+            out.insert(target, ());
+        }
+    }
+    Ok(out.into_keys().collect())
 }
 
 fn unapply_one(plan: &UnapplyPlan<'_>) -> Result<()> {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -120,6 +120,7 @@ struct ManagedLink {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct SymlinkEachState {
     version: u8,
+    source: PathBuf,
     target: PathBuf,
     links: Vec<ManagedLink>,
 }
@@ -775,15 +776,17 @@ fn needed_dirs(req: &FileRequest) -> Result<Vec<PathBuf>> {
     Ok(out.into_iter().collect())
 }
 
-fn symlink_each_state_path(target: &Path) -> PathBuf {
-    dirs::STATE
-        .join("dotfiles")
-        .join(format!("{}.toml", hash_to_str(&target)))
+fn symlink_each_state_path(req: &FileRequest) -> PathBuf {
+    dirs::STATE.join("dotfiles").join(format!(
+        "{}.toml",
+        hash_to_str(&(req.source.as_path(), req.target.as_path()))
+    ))
 }
 
 fn desired_symlink_each_state(req: &FileRequest) -> Result<SymlinkEachState> {
     Ok(SymlinkEachState {
         version: SYMLINK_EACH_STATE_VERSION,
+        source: req.source.clone(),
         target: req.target.clone(),
         links: walk_source_files(req)?
             .into_iter()
@@ -793,7 +796,7 @@ fn desired_symlink_each_state(req: &FileRequest) -> Result<SymlinkEachState> {
 }
 
 fn load_symlink_each_state(req: &FileRequest) -> LoadedSymlinkEachState {
-    let path = symlink_each_state_path(&req.target);
+    let path = symlink_each_state_path(req);
     if !path.exists() {
         return LoadedSymlinkEachState::Missing;
     }
@@ -810,6 +813,7 @@ fn load_symlink_each_state(req: &FileRequest) -> LoadedSymlinkEachState {
         }
     };
     let valid = state.version == SYMLINK_EACH_STATE_VERSION
+        && state.source == req.source
         && state.target == req.target
         && state
             .links
@@ -826,20 +830,28 @@ fn load_symlink_each_state(req: &FileRequest) -> LoadedSymlinkEachState {
     }
 }
 
-fn save_symlink_each_state(req: &FileRequest) -> Result<()> {
+fn save_symlink_each_state(req: &FileRequest) {
     if cfg!(windows) {
-        return Ok(());
+        return;
     }
-    let path = symlink_each_state_path(&req.target);
-    file::create_dir_all(path.parent().expect("dotfiles state parent"))?;
-    file::write(
-        &path,
-        toml::to_string_pretty(&desired_symlink_each_state(req)?)?,
-    )
+    let path = symlink_each_state_path(req);
+    let result = (|| -> Result<()> {
+        file::create_dir_all(path.parent().expect("dotfiles state parent"))?;
+        file::write(
+            &path,
+            toml::to_string_pretty(&desired_symlink_each_state(req)?)?,
+        )
+    })();
+    if let Err(err) = result {
+        warn!(
+            "files: failed to write dotfiles state {}: {err}",
+            path.display_user()
+        );
+    }
 }
 
 fn remove_symlink_each_state(req: &FileRequest) -> Result<()> {
-    let path = symlink_each_state_path(&req.target);
+    let path = symlink_each_state_path(req);
     if path.exists() {
         file::remove_file(path)?;
     }
@@ -1011,7 +1023,7 @@ pub fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<bool> {
     if plan.todo.is_empty() {
         if !opts.dry_run {
             for req in plan.record_symlink_each {
-                save_symlink_each_state(req)?;
+                save_symlink_each_state(req);
             }
         }
         info!("files: all files are applied");
@@ -1045,13 +1057,13 @@ pub fn execute_apply(plan: ApplyPlan<'_>, opts: &ApplyOpts) -> Result<bool> {
     for (req, rendered) in &plan.todo {
         apply_one(req, rendered.as_deref())?;
         if req.mode == FileMode::SymlinkEach {
-            save_symlink_each_state(req)?;
+            save_symlink_each_state(req);
         }
         info!("files: {}", describe_applied(req)?);
     }
     for req in plan.record_symlink_each {
         if !plan.todo.iter().any(|(todo, _)| todo.target == req.target) {
-            save_symlink_each_state(req)?;
+            save_symlink_each_state(req);
         }
     }
     info!(
@@ -1356,7 +1368,7 @@ fn plan_unapply_one<'a>(
             }
         }
         FileMode::SymlinkEach if !cfg!(windows) => {
-            clear_symlink_each_state = symlink_each_state_path(&req.target).exists();
+            clear_symlink_each_state = symlink_each_state_path(req).exists();
             if req.target.is_symlink() || (req.target.exists() && !req.target.is_dir()) {
                 if opts.force {
                     paths.insert(req.target.clone(), ());


### PR DESCRIPTION
## Summary

- persist exact `symlink-each` source/target ownership under `$MISE_STATE_DIR/dotfiles`
- use the ownership manifest for stale-link detection and unapply instead of recursively walking shared targets such as `~`
- migrate existing installations with one legacy scan on their next real apply, including already-converged entries
- remove ownership state after a successful unapply and keep Windows copy behavior unchanged

## Root cause

Stale-link cleanup added in #11388 had no persistent ownership information. Finding links whose source was deleted therefore required recursively walking the entire target directory. With `"~"` as the target, apply, status, and unapply traversed the user's complete home directory, including unrelated and unreadable trees. Verbose apply could repeat that traversal three times.

This addresses the behavior reported in https://github.com/jdx/mise/discussions/11548.

## Safety

The manifest records only exact link pairs successfully applied by mise. Cleanup still verifies that each target is a symlink pointing to its recorded source before removing it. Missing or invalid state falls back to the existing filesystem discovery behavior, so upgrades retain stale-link cleanup semantics. A real apply then repairs the state.

## Verification

- `mise run test:e2e e2e/cli/test_dotfiles_files e2e/cli/test_dotfiles_unapply`
- `mise run test:unit` (2208 passed)
- `mise run lint`

The e2e coverage verifies one-time migration, stale-link pruning, state removal on unapply, and that unreadable unmanaged subdirectories are not traversed once state exists.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes symlink-each status/apply/unapply behavior for shared targets like `$HOME`, but removals still verify symlinks against recorded pairs and missing state keeps the old discovery path.
> 
> **Overview**
> **`symlink-each`** no longer discovers managed links by recursively walking the whole target (e.g. `~`). After the first real apply, mise writes a TOML manifest under **`$MISE_STATE_DIR/dotfiles`** listing exact source→target pairs; **status**, stale-link cleanup, and **unapply** use that list instead of scanning the filesystem.
> 
> Installations without state still get **one legacy full walk** on the next apply (including when everything is already converged), which backfills the manifest. **Unapply** drops the manifest when symlink-each cleanup finishes; **`copy`** / **`template`** entries still have no apply manifest (docs updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed8df6bf3e19f4c83a4bb3dc0fe5602e4618bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent tracking for managed `symlink-each` links across runs.
  - Existing installations can now be recognized and tracked without modifying already-correct links.
  - Unapplying dotfiles now removes associated tracking information.

- **Bug Fixes**
  - Prevented repeated recursive scanning of shared targets, including inaccessible directories.
  - Improved cleanup after removing or unapplying configured dotfiles.

- **Documentation**
  - Clarified ownership tracking, migration behavior, and recommended cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->