### PR TITLE
fix(aqua): read checksum files that carry a byte-order mark

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1782,7 +1782,7 @@ impl AquaBackend {
         artifact_filename: &str,
         expected_checksum: Option<&str>,
     ) -> Result<()> {
-        let checksum_content = file::read_to_string(checksum_path)?;
+        let checksum_content = file::read_to_string_bom(checksum_path)?;
         let checksum_str = self.parse_checksum_from_content(
             &checksum_content,
             checksum_config,
@@ -2174,11 +2174,21 @@ impl AquaBackend {
             AquaChecksumType::Http => checksum_config.url(pkg, v, target_os, target_arch)?,
         };
 
-        // Download checksum file content
-        let checksum_content = match HTTP.get_text(&url).await {
-            Ok(content) => content,
+        // Download checksum file content. Read the bytes rather than `get_text`, which decodes with
+        // the response charset and silently replaces anything it cannot map — a UTF-16 checksum
+        // file would be recorded as mojibake instead of failing. `decode_text` honours a BOM, the
+        // same as the install path above.
+        let checksum_bytes = match HTTP.get_bytes(&url).await {
+            Ok(bytes) => bytes,
             Err(e) => {
                 debug!("Failed to download checksum file {}: {}", url, e);
+                return Ok(None);
+            }
+        };
+        let checksum_content = match file::decode_text(checksum_bytes.as_ref()) {
+            Ok(content) => content,
+            Err(e) => {
+                debug!("Failed to decode checksum file {}: {}", url, e);
                 return Ok(None);
             }
         };
@@ -2502,7 +2512,7 @@ impl AquaBackend {
             }
 
             if needs_verified_checksum_binding && checksum_path.exists() {
-                let checksum_content = file::read_to_string(&checksum_path)?;
+                let checksum_content = file::read_to_string_bom(&checksum_path)?;
                 let checksum_str =
                     self.parse_checksum_from_content(&checksum_content, checksum, filename)?;
                 let checksum_val = format!("{}:{}", checksum.algorithm(), checksum_str);
@@ -4724,6 +4734,55 @@ mod lock_candidate_tests {
         assert!(same_checksum_algorithm("sha256:abc", "SHA256:def"));
         assert!(!same_checksum_algorithm("sha256:abc", "sha512:def"));
         assert!(same_checksum_algorithm("abc", "sha256:def"));
+    }
+
+    /// A UTF-16LE checksum file is read, not rejected.
+    ///
+    /// The fixture is the real line for the artifact in #5399, taken from PowerShell v7.4.10's
+    /// `hashes.sha256` — which that release published as UTF-16LE. Before this, the install died
+    /// at `read_to_string` with "stream did not contain valid UTF-8".
+    #[test]
+    fn test_verify_checksum_file_reads_utf16() {
+        const ARTIFACT: &str = "powershell-7.4.10-linux-x64.tar.gz";
+        const DIGEST: &str = "d91b9172668f4b6aef4abce8c780cd298872c7a0f4487cc47444d26877ba49f6";
+
+        let mut bytes = vec![0xff, 0xfe];
+        bytes.extend(
+            format!("{DIGEST} *{ARTIFACT}\n")
+                .encode_utf16()
+                .flat_map(u16::to_le_bytes),
+        );
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hashes.sha256");
+        std::fs::write(&path, bytes).unwrap();
+
+        let backend = AquaBackend::from_arg(BackendArg::new(
+            "powershell-core".to_string(),
+            Some("aqua:PowerShell/PowerShell".to_string()),
+        ));
+        let checksum: AquaChecksum = serde_json::from_str(r#"{"algorithm":"sha256"}"#).unwrap();
+
+        backend
+            .verify_checksum_file_matches_expected(
+                &checksum,
+                &path,
+                ARTIFACT,
+                Some(&format!("sha256:{DIGEST}")),
+            )
+            .unwrap();
+
+        // a wrong expectation must be caught — otherwise the assertion above would also pass on a
+        // file that was never actually parsed
+        let err = backend
+            .verify_checksum_file_matches_expected(
+                &checksum,
+                &path,
+                ARTIFACT,
+                Some(&format!("sha256:{}", "0".repeat(64))),
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not match expected checksum"), "{err}");
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -337,6 +337,50 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
         .wrap_err_with(|| format!("failed read_to_string: {}", path.display_user()))
 }
 
+/// Decode text that may begin with a byte-order mark.
+///
+/// `std`'s UTF-8-only readers reject UTF-16 outright, which is how a checksum file sank an install
+/// in #5399: PowerShell shipped `hashes.sha256` as UTF-16LE and mise stopped at "stream did not
+/// contain valid UTF-8". Windows PowerShell 5.1's `Out-File` writes UTF-16LE by default, so any
+/// project generating checksums that way produces the same thing.
+///
+/// Only a BOM switches the encoding. Detecting UTF-16 without one means guessing from the density
+/// of NUL bytes, which can misfire on binary input; `Out-File` always writes a BOM, so the guess
+/// buys nothing here. Input with no BOM is decoded as UTF-8, exactly as before.
+pub fn decode_text(bytes: &[u8]) -> Result<String> {
+    fn from_utf16(bytes: &[u8], to_u16: fn([u8; 2]) -> u16, label: &str) -> Result<String> {
+        if !bytes.len().is_multiple_of(2) {
+            bail!(
+                "truncated {label} text: {} bytes is not a whole number of code units",
+                bytes.len()
+            );
+        }
+        let units = bytes
+            .chunks_exact(2)
+            .map(|c| to_u16([c[0], c[1]]))
+            .collect_vec();
+        String::from_utf16(&units).wrap_err_with(|| format!("invalid {label} text"))
+    }
+
+    match bytes {
+        [0xef, 0xbb, 0xbf, rest @ ..] => {
+            String::from_utf8(rest.to_vec()).wrap_err("invalid UTF-8 text after a UTF-8 BOM")
+        }
+        [0xff, 0xfe, rest @ ..] => from_utf16(rest, u16::from_le_bytes, "UTF-16LE"),
+        [0xfe, 0xff, rest @ ..] => from_utf16(rest, u16::from_be_bytes, "UTF-16BE"),
+        _ => String::from_utf8(bytes.to_vec())
+            .wrap_err("invalid UTF-8 text, and no byte-order mark identifying another encoding"),
+    }
+}
+
+/// [`read_to_string`], but tolerant of a byte-order mark. See [`decode_text`].
+pub fn read_to_string_bom<P: AsRef<Path>>(path: P) -> Result<String> {
+    let path = path.as_ref();
+    trace!("cat {}", path.display_user());
+    let bytes = fs::read(path).wrap_err_with(|| format!("failed read: {}", path.display_user()))?;
+    decode_text(&bytes).wrap_err_with(|| format!("failed to decode {}", path.display_user()))
+}
+
 pub async fn read_to_string_async<P: AsRef<Path>>(path: P) -> Result<String> {
     let path = path.as_ref();
     trace!("cat {}", path.display_user());
@@ -2022,6 +2066,63 @@ mod tests {
     fn test_run_blocking_outside_runtime() {
         // no tokio runtime at all — must run the closure inline, not panic
         assert_eq!(run_blocking(|| 42), 42);
+    }
+
+    fn utf16le(s: &str) -> Vec<u8> {
+        let mut bytes = vec![0xff, 0xfe];
+        bytes.extend(s.encode_utf16().flat_map(u16::to_le_bytes));
+        bytes
+    }
+
+    #[test]
+    fn test_decode_text_honours_a_byte_order_mark() {
+        // the encoding that broke #5399 — PowerShell shipped hashes.sha256 as UTF-16LE
+        assert_eq!(decode_text(&utf16le("abc\n")).unwrap(), "abc\n");
+
+        let mut be = vec![0xfe, 0xff];
+        be.extend("abc\n".encode_utf16().flat_map(u16::to_be_bytes));
+        assert_eq!(decode_text(&be).unwrap(), "abc\n");
+
+        // a UTF-8 BOM is stripped rather than left to poison the first token
+        assert_eq!(decode_text(b"\xef\xbb\xbfabc\n").unwrap(), "abc\n");
+
+        // no BOM: unchanged from plain `read_to_string`
+        assert_eq!(decode_text(b"abc\n").unwrap(), "abc\n");
+        assert_eq!(decode_text(b"").unwrap(), "");
+    }
+
+    #[test]
+    fn test_decode_text_rejects_what_it_cannot_decode() {
+        // invalid UTF-8 with no BOM still fails, but says why rather than "stream did not
+        // contain valid UTF-8"
+        let err = decode_text(b"\xff\x00abc").unwrap_err().to_string();
+        assert!(err.contains("byte-order mark"), "{err}");
+
+        // an odd trailing byte cannot be a whole UTF-16 code unit
+        let mut truncated = utf16le("abc");
+        truncated.pop();
+        let err = decode_text(&truncated).unwrap_err().to_string();
+        assert!(err.contains("truncated UTF-16LE"), "{err}");
+
+        // an unpaired surrogate is well-formed UTF-16 bytes but not a valid string
+        let err = decode_text(&[0xff, 0xfe, 0x00, 0xd8])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid UTF-16LE"), "{err}");
+    }
+
+    #[test]
+    fn test_read_to_string_bom_decodes_a_utf16_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hashes.sha256");
+        fs::write(&path, utf16le("deadbeef *tool.tar.gz\n")).unwrap();
+
+        assert_eq!(
+            read_to_string_bom(&path).unwrap(),
+            "deadbeef *tool.tar.gz\n"
+        );
+        // the plain reader is what #5399 hit, and is deliberately left alone
+        assert!(read_to_string(&path).is_err());
     }
 
     #[test]


### PR DESCRIPTION
From #5399. `std::fs::read_to_string` rejects any file that is not UTF-8, so a UTF-16 checksum file aborts the install:

```
1: failed read_to_string: .../powershell-7.4.10-linux-x64.tar.gz.checksum
2: stream did not contain valid UTF-8
```

## What this actually costs today

I want to be precise rather than oversell it: **nobody is hitting that crash right now**, and the reason is the point.

PowerShell's release tooling regressed and published `hashes.sha256` as UTF-16LE (PowerShell/PowerShell#25693). The fix was aquaproj/aqua-registry#38202, which **disabled checksum verification for the affected range**. So the standing cost of mise not reading UTF-16 is that verification stays switched off for a whole band of releases.

Fetching the raw bytes from GitHub shows the registry's version boundary is exactly an encoding boundary:

| release | first bytes | |
|---|---|---|
| v7.4.7 | `61 32 39 37 33 65 …` | UTF-8 |
| **v7.4.10** | **`FF FE 36 00 64 00 …`** | **UTF-16LE BOM, not valid UTF-8** |
| v7.5.0 | `35 38 31 33 34 31 …` | UTF-8 |

which lines up with the vendored registry: `semver("<= 7.4.7")` keeps `asset: hashes.sha256`, and everything above it has no `checksum` block at all.

It is not PowerShell-specific either — Windows PowerShell 5.1's `Out-File` writes UTF-16LE by default, so this recurs for anything generating checksums that way.

## The change

`file::decode_text` + `file::read_to_string_bom`, used at the three aqua sites that feed `parse_checksum_from_content`:

- `verify_checksum_file_matches_expected` — the install path, and the frame in #5399's stack
- the lockfile checksum binding after download
- `fetch_checksum_from_file` — switches `get_text` → `get_bytes` + `decode_text`. `get_text` decodes with the response charset and replaces what it cannot map instead of failing, so that path could not fail the way the file path does; it would record whatever the lossy decode produced. I have not reproduced that — converting it just makes all three agree.

**Only a BOM selects the encoding.** Detecting UTF-16 without one means guessing from the density of NUL bytes, which can misfire on binary input, and `Out-File` always writes a BOM, so the guess buys nothing. Input with no BOM is decoded as UTF-8 exactly as before — it just gets an error message naming the problem instead of std's bare "stream did not contain valid UTF-8".

`encoding_rs` is only a transitive dep (via reqwest's `charset`), and BOM'd UTF-16 is ~25 lines of `std`, so no new direct dependency.

## Deliberately not done

- **`file::read_to_string` itself is untouched.** Over a hundred call sites, config files and plugin scripts among them; that is a much bigger behaviour change than this bug warrants. Happy to widen it if you'd rather have it everywhere.
- Other backends read checksums too (`http.rs`, `pkgx.rs`, `static_helpers.rs`, all via `get_text`). Same defect class, left out to keep this reviewable — `decode_text` is public so they can adopt it.

## Tests

Decoder: UTF-16LE, UTF-16BE, a UTF-8 BOM, plain UTF-8 and empty input unchanged, an odd trailing byte, and an unpaired surrogate.

End to end: the **real line for the artifact in #5399**, taken from the v7.4.10 `hashes.sha256` that broke it —

```
d91b9172668f4b6aef4abce8c780cd298872c7a0f4487cc47444d26877ba49f6 *powershell-7.4.10-linux-x64.tar.gz
```

— written as UTF-16LE with BOM, verified against the correct expectation and then against a wrong one, so the passing case cannot be a file that was silently never parsed.

## Verification

No local `cargo` run; `rustfmt --edition 2024` only. `lint` (clippy `-D warnings`), linux `cargo test`, `unit-macos` and `windows-unit` all cover these files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum verification for files encoded as UTF-8 or UTF-16.
  * Added support for detecting byte-order marks when reading text files.
  * Improved handling of invalid or truncated text data while preserving clear failure behavior.
  * Prevented valid UTF-16 checksum files from being rejected during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->