### PR TITLE
fix(asdf): fail when bin/install installs nothing

### DIFF
--- a/src/backend/asdf.rs
+++ b/src/backend/asdf.rs
@@ -26,7 +26,7 @@ use crate::ui::progress_report::SingleReport;
 use crate::{backend::Backend, plugins::PluginEnum, timeout};
 use crate::{dirs, env, file};
 use async_trait::async_trait;
-use color_eyre::eyre::{Result, WrapErr, eyre};
+use color_eyre::eyre::{Result, WrapErr, bail, eyre};
 use console::style;
 use heck::ToKebabCase;
 
@@ -464,6 +464,7 @@ impl Backend for AsdfBackend {
         }
         ctx.pr.set_message("bin/install".into());
         run_script(&Install)?;
+        verify_install_script_output(&self.ba.short, &tv.install_path())?;
         file::remove_dir(&self.ba.downloads_path)?;
 
         Ok(tv)
@@ -526,6 +527,31 @@ impl Backend for AsdfBackend {
     }
 }
 
+/// Verifies that `bin/install` actually put something in `$ASDF_INSTALL_PATH`.
+///
+/// `bin/install` is a plugin-supplied shell script, and one that installs nothing can still exit 0
+/// — a missing `set -e`, a build that fails inside a pipeline, a download that 404s. mise would
+/// otherwise report `✓ installed`, record the version in install state, and keep resolving to an
+/// empty directory afterwards (#5288).
+///
+/// Emptiness is exact rather than a guess: `Backend::create_install_dirs` recreates the install
+/// path immediately before the script runs, and the `incomplete` marker lives under the cache dir,
+/// so anything present afterwards came from the plugin. It is also all that can be checked — asdf
+/// plugins install into `bin/`, `libexec/`, an unpacked tarball root, or wherever the tool puts
+/// things, so a stricter test (spm requires an executable in `bin/`) would reject working plugins.
+///
+/// There is no `system` case to exclude: anything reaching here has already been through
+/// `script_man_for_tv`, which panics for `ToolRequest::System`.
+fn verify_install_script_output(tool: &str, install_path: &Path) -> Result<()> {
+    if file::ls(install_path)?.is_empty() {
+        bail!(
+            "{tool}'s bin/install exited successfully but installed nothing into {}; check that the plugin installs into $ASDF_INSTALL_PATH and that it fails when the build fails",
+            file::display_path(install_path)
+        );
+    }
+    Ok(())
+}
+
 impl Debug for AsdfBackend {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AsdfPlugin")
@@ -544,6 +570,25 @@ mod tests {
 
     use super::*;
     use std::ffi::OsString;
+
+    #[test]
+    fn test_verify_install_script_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let install_path = temp.path().join("1.0.0");
+
+        // a missing install path is the same failure as an empty one: nothing was installed
+        let err = verify_install_script_output("tiny", &install_path)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("installed nothing into"), "{err}");
+        std::fs::create_dir_all(&install_path).unwrap();
+        assert!(verify_install_script_output("tiny", &install_path).is_err());
+
+        // anything at all is enough — deliberately not an executable and not `bin/`, because asdf
+        // plugins choose their own layout and this must not become spm's stricter check
+        std::fs::create_dir(install_path.join("libexec")).unwrap();
+        verify_install_script_output("tiny", &install_path).unwrap();
+    }
 
     fn env_results(entries: &[(&str, &str)], removals: &[&str], paths: &[&str]) -> EnvResults {
         let mut results = EnvResults::default();


### PR DESCRIPTION
From #5288 — "mise install gitleaks falsely reports success while not installing anything… no error is displayed".

`AsdfBackend::install_version_` ran the plugin's `bin/install` and returned `Ok(tv)` without looking at the result:

```rust
ctx.pr.set_message("bin/install".into());
run_script(&Install)?;
file::remove_dir(&self.ba.downloads_path)?;

Ok(tv)
```

`bin/install` is a plugin-supplied shell script, and one that installs nothing can still exit 0 — a missing `set -e`, a build that fails inside a pipeline, a download that 404s. mise then prints `✓ installed`, records the version in install state, and keeps resolving to the empty directory afterwards.

## Why "the install path is empty" is exact, not a guess

`Backend::create_install_dirs` does `remove_all` + `create_dir_all` on `tv.install_path()` immediately before the backend runs, and the `incomplete` marker lives under the cache dir, not the install path. So the directory is provably empty when the script starts, and anything in it afterwards came from the plugin. `script_man_for_tv` hands that same path to the script as `ASDF_INSTALL_PATH`, so it is the directory the plugin was told to fill.

## Why not spm's check

`spm.rs`'s `verify_install_command_output` requires an executable in `bin/`. That would be wrong here: asdf plugins install into `bin/`, `libexec/`, an unpacked tarball root, or wherever the tool puts things. Emptiness is the narrowest signal that still catches the reported failure, and the test pins that intent by accepting a bare subdirectory — so a later "tighten it up to match spm" change fails loudly instead of quietly rejecting working plugins.

## Error, not warning

Erroring is what makes the caller run `cleanup_install_dirs_on_error`, so the empty directory is removed and nothing reaches install state. A warning would leave behind exactly the stale asdf-backed install that keeps winning resolution afterwards — which is the shape most of these "it says installed but it isn't" reports end up having.

## Adjacent, deliberately not fixed here

While reviewing this, CodeRabbit surfaced a **pre-existing panic** on `main`, unrelated to this diff. `script_man_for_tv` has:

```rust
ToolRequest::System { .. } => panic!("should not be called for system tool")
```

and `install_version_` calls it on its first line. Normally a `system` version returns early from `install_version` as already satisfied — but `will_uninstall = (ctx.force || rolling_reinstall) && is_version_installed(...)` is `true` for `System` under `--force`, which takes the uninstall arm instead of the early return and falls through into a real install, and therefore into the panic.

I've left it alone: it needs its own decision about what `mise install --force <tool>@system` should mean for an asdf plugin, and it should be visible on its own rather than buried in an install-verification change. Happy to open it separately.

## Scope and what I can't claim

The reporter never posted `mise doctor`, and @risu729 correctly pointed out the default is `aqua:gitleaks/gitleaks`, which cannot silently no-op — so **I can't claim this reproduces their exact session**. What I can say is that the defect in the title is real, is in the asdf backend, and is what their linked `jmcvetta/asdf-gitleaks` issue would produce.

The one way this could bite: a plugin that installs outside `$ASDF_INSTALL_PATH` and returns absolute paths from `bin/list-bin-paths` would now fail where it previously "worked". I haven't found one, and the existing e2e tests (`test_asdf`, `test_asdf_fake_list`, `test_asdf_install_dependency_path`, `test_asdf_version_env`) all use plugins that do install into the install path — they're the regression check. If you'd rather not take that risk at all, this is one line away from being a `warn!`.

## Verification

No local `cargo` run — `rustfmt --edition 2024` only. `lint`, linux `cargo test`, `unit-macos` and `windows-unit` cover it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for ASDF plugin installations to detect missing or empty installation output.
  * Improved error reporting when an installation does not produce the expected files.
  * Preserved support for system-wide installations with nonstandard layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->