### PR TITLE
feat(task): infer Cargo workspace dependencies

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -56,7 +56,7 @@ outside this tracker.
 - [x] Allow providers to suggest inputs, outputs, cacheability, and task dependencies when they can
       derive them confidently
 - [x] Explain which provider inferred each project, task, input, output, and dependency
-- [ ] Add Cargo workspace and path-dependency inference
+- [x] Add Cargo workspace and path-dependency inference
 - [ ] Add uv workspace and local/path-dependency inference
 - [ ] Add Go workspace discovery, with explicit dependency overrides where module metadata is
       insufficient

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -359,6 +359,31 @@ The JSON output includes the same information in each project's `provenance`,
 other tooling can distinguish, for example, a `turbo.json` output declaration from a root mise task
 default.
 
+### Cargo Workspace Discovery
+
+The Cargo provider discovers packages when the root `Cargo.toml` contains a `[workspace]` table.
+It expands the workspace's `members` patterns, honors `exclude`, and includes the root package when
+the workspace manifest also contains `[package]`. Path dependencies inside the workspace root are
+included as implicit members, matching Cargo's workspace membership behavior. A path outside the
+workspace remains an external dependency and is not added to the graph.
+
+Each discovered package must have a `[package].name`. mise uses that stable ecosystem identity to
+create an ID such as `cargo:my-crate`; moving the crate to another directory does not change its ID.
+`mise tasks graph` also reports the package root and `Cargo.toml` as the workspace-definition source.
+Discovery parses manifests directly and does not require the `cargo` executable to be installed.
+
+### Cargo Dependency Inference
+
+For every discovered Cargo package, mise infers internal edges from dependencies with a local
+`path`. Normal, development, build, and target-specific dependency tables all participate. Renamed
+dependencies are resolved by their path, and declarations with `workspace = true` inherit paths
+from the root `[workspace.dependencies]` table.
+
+Version-only and registry dependencies are ignored, as are path dependencies outside the workspace
+or beneath an excluded path. Declarations that resolve back to the same package do not create a
+self-edge. If the inferred internal edges produce a cycle, `mise tasks graph` reports the cycle;
+project overrides can replace or adjust the inferred dependencies when needed.
+
 ### Node Workspace Discovery
 
 The Node provider discovers npm, pnpm, Yarn, and Bun workspace packages from:

--- a/e2e/tasks/test_task_cargo_workspace_graph
+++ b/e2e/tasks/test_task_cargo_workspace_graph
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+cat <<'EOF' >mise.toml
+monorepo_root = true
+EOF
+
+cat <<'EOF' >Cargo.toml
+[workspace]
+members = ["crates/app", "crates/core", "crates/shared"]
+
+[workspace.dependencies]
+shared = { path = "crates/shared" }
+EOF
+
+mkdir -p crates/app crates/core crates/shared crates/build-helper
+
+cat <<'EOF' >crates/app/Cargo.toml
+[package]
+name = "app"
+version = "0.1.0"
+
+[dependencies]
+renamed-core = { package = "core", path = "../core" }
+
+[dev-dependencies]
+shared = { workspace = true }
+
+[target.'cfg(unix)'.build-dependencies]
+build-helper = { path = "../build-helper" }
+EOF
+
+for crate in core shared build-helper; do
+  cat <<EOF >"crates/$crate/Cargo.toml"
+[package]
+name = "$crate"
+version = "0.1.0"
+EOF
+done
+
+assert_contains "mise tasks graph" "cargo:app"
+assert_contains "mise tasks graph" "crates/app"
+assert_contains "mise tasks graph" '"workspace_source":"Cargo.toml"'
+assert_contains "mise tasks graph --explain" "Project: cargo:app"
+assert_contains "mise tasks graph --explain" "cargo:core — cargo (crates/app/Cargo.toml)"
+
+assert_json "mise tasks graph --json | jq '.projects | map({id, root, dependencies})'" '[
+  {
+    "id": "cargo:app",
+    "root": "crates/app",
+    "dependencies": [
+      "cargo:build-helper",
+      "cargo:core",
+      "cargo:shared"
+    ]
+  },
+  {
+    "id": "cargo:build-helper",
+    "root": "crates/build-helper",
+    "dependencies": []
+  },
+  {
+    "id": "cargo:core",
+    "root": "crates/core",
+    "dependencies": []
+  },
+  {
+    "id": "cargo:shared",
+    "root": "crates/shared",
+    "dependencies": []
+  }
+]'
+
+assert_json "mise tasks graph --json | jq '.projects[] | select(.id == \"cargo:app\") | {
+  project: .provenance,
+  dependency: .dependency_provenance[\"cargo:core\"]
+}'" '{
+  "project": {
+    "provider": "cargo",
+    "source": "crates/app/Cargo.toml"
+  },
+  "dependency": {
+    "provider": "cargo",
+    "source": "crates/app/Cargo.toml"
+  }
+}'

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -205,4 +205,5 @@ assert "cat local-default.txt" ""
 printf stale >packages/app/executable-default.txt
 mise -q run //packages/app:lint
 assert "cat packages/app/executable-default.txt" "from-executable-default"
+assert_fail_contains "mise run //packages/app:build" "inferred tasks and upstream task dependencies from this provider are unavailable"
 assert_fail_contains "mise run //packages/app:build" "failed to resolve upstream task dependencies"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -482,6 +482,19 @@ impl Config {
     /// Discovers the provider-neutral workspace project graph and applies the
     /// explicit overrides from the active monorepo root.
     pub fn workspace_project_graph(&self) -> Result<crate::task::workspace::WorkspaceProjectGraph> {
+        self.workspace_project_graph_with_provider_errors(false)
+    }
+
+    fn workspace_project_graph_for_task_loading(
+        &self,
+    ) -> Result<crate::task::workspace::WorkspaceProjectGraph> {
+        self.workspace_project_graph_with_provider_errors(true)
+    }
+
+    fn workspace_project_graph_with_provider_errors(
+        &self,
+        skip_provider_errors: bool,
+    ) -> Result<crate::task::workspace::WorkspaceProjectGraph> {
         let monorepo_config = find_monorepo_config(&self.config_files)
             .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
         let monorepo_root = monorepo_config
@@ -492,13 +505,22 @@ impl Config {
             .map(|config| &config.projects)
             .cloned()
             .unwrap_or_default();
+        let cargo = crate::task::workspace::cargo::CargoWorkspaceProvider;
         let node = crate::task::workspace::node::NodeWorkspaceProvider;
 
-        crate::task::workspace::WorkspaceProjectGraph::discover_all_with_overrides(
-            &[&node],
-            &monorepo_root,
-            &overrides,
-        )
+        if skip_provider_errors {
+            crate::task::workspace::WorkspaceProjectGraph::discover_all_with_overrides_lenient(
+                &[&cargo, &node],
+                &monorepo_root,
+                &overrides,
+            )
+        } else {
+            crate::task::workspace::WorkspaceProjectGraph::discover_all_with_overrides(
+                &[&cargo, &node],
+                &monorepo_root,
+                &overrides,
+            )
+        }
     }
 
     /// Returns the root lockfile directory when unified monorepo lockfiles are active.
@@ -743,7 +765,7 @@ impl Config {
         time!("load_all_tasks");
 
         let workspace_graph = (Settings::get().experimental && config.monorepo_root().is_some())
-            .then(|| config.workspace_project_graph());
+            .then(|| config.workspace_project_graph_for_task_loading());
         let task_definitions = collect_task_definitions(
             &config.config_files,
             workspace_graph
@@ -3991,7 +4013,7 @@ pub async fn load_tasks_in_dir(
     templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let workspace_graph = (Settings::get().experimental && config.monorepo_root().is_some())
-        .then(|| config.workspace_project_graph());
+        .then(|| config.workspace_project_graph_for_task_loading());
     let mut definitions = collect_task_definitions(
         config_files,
         workspace_graph

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1554,6 +1554,13 @@ impl Task {
         }
 
         if project_ids.is_empty() {
+            if let Some(error) = graph.provider_discovery_error() {
+                self.workspace_dependency_error = Some(format!(
+                    "failed to resolve upstream task dependencies because workspace provider \
+                     discovery failed: {error}"
+                ));
+                return Ok(());
+            }
             self.depends
                 .retain(|dependency| !dependency.task.starts_with('^'));
             if let Some(raw) = &mut self.depends_raw {
@@ -3305,6 +3312,41 @@ mod tests {
         tera_template_has_usage_ref,
     };
 
+    #[derive(Debug)]
+    struct BrokenWorkspaceProvider;
+
+    impl workspace::WorkspaceProvider for BrokenWorkspaceProvider {
+        fn id(&self) -> &str {
+            "broken"
+        }
+
+        fn discover(
+            &self,
+            _workspace_root: &Path,
+        ) -> eyre::Result<Vec<workspace::WorkspaceProject>> {
+            eyre::bail!("broken workspace metadata")
+        }
+    }
+
+    #[derive(Debug)]
+    struct WorkingWorkspaceProvider;
+
+    impl workspace::WorkspaceProvider for WorkingWorkspaceProvider {
+        fn id(&self) -> &str {
+            "node"
+        }
+
+        fn discover(
+            &self,
+            _workspace_root: &Path,
+        ) -> eyre::Result<Vec<workspace::WorkspaceProject>> {
+            Ok(vec![workspace::WorkspaceProject::new(
+                workspace::ProjectId::new("node", "app")?,
+                "packages/app",
+            )])
+        }
+    }
+
     #[test]
     fn test_merge_toml_overlay_tracks_definition_sources() {
         let mut file_task = Task {
@@ -3625,6 +3667,45 @@ exec proxy "$@"
         assert_eq!(
             err.to_string(),
             "^task dependencies are supported only in depends"
+        );
+    }
+
+    #[test]
+    fn workspace_task_dependencies_preserve_lenient_discovery_errors() {
+        let graph = workspace::WorkspaceProjectGraph::discover_all_with_overrides_lenient(
+            &[&BrokenWorkspaceProvider, &WorkingWorkspaceProvider],
+            Path::new("/workspace"),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        let project_ids_by_root = BTreeMap::new();
+
+        let mut discovered_task = Task {
+            name: "node:app#build".to_string(),
+            depends: vec!["^build".to_string().into()],
+            ..Default::default()
+        };
+        discovered_task
+            .resolve_workspace_task_dependencies(&graph, &project_ids_by_root)
+            .unwrap();
+        assert!(discovered_task.workspace_dependency_error.is_none());
+        assert!(discovered_task.depends.is_empty());
+
+        let mut unresolved_task = Task {
+            name: "//packages/missing:build".to_string(),
+            depends: vec!["^build".to_string().into()],
+            ..Default::default()
+        };
+        unresolved_task
+            .resolve_workspace_task_dependencies(&graph, &project_ids_by_root)
+            .unwrap();
+        assert_eq!(unresolved_task.depends[0].task, "^build");
+        assert_eq!(
+            unresolved_task.workspace_dependency_error.as_deref(),
+            Some(
+                "failed to resolve upstream task dependencies because workspace provider \
+                 discovery failed: broken: broken workspace metadata"
+            )
         );
     }
 

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{Task, TaskCacheConfig, task_sources::TaskOutputs};
 
+pub mod cargo;
 pub mod node;
 
 /// A stable, provider-namespaced identifier for a workspace project.
@@ -237,6 +238,7 @@ pub trait WorkspaceProvider: Debug + Send + Sync {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct WorkspaceProjectGraph {
     projects: BTreeMap<ProjectId, WorkspaceProject>,
+    provider_errors: BTreeMap<String, String>,
 }
 
 /// A deterministic dependency cycle found in the workspace project graph.
@@ -291,7 +293,7 @@ impl WorkspaceProjectGraph {
         providers: &[&dyn WorkspaceProvider],
         workspace_root: &Path,
     ) -> Result<WorkspaceProjectGraph> {
-        let graph = Self::collect_provider_projects(providers, workspace_root)?;
+        let graph = Self::collect_provider_projects(providers, workspace_root, false)?;
         graph.validate()?;
         Ok(graph)
     }
@@ -305,8 +307,31 @@ impl WorkspaceProjectGraph {
         workspace_root: &Path,
         overrides: &BTreeMap<String, WorkspaceProjectOverride>,
     ) -> Result<WorkspaceProjectGraph> {
-        let mut graph = Self::collect_provider_projects(providers, workspace_root)?
-            .with_overrides(overrides)?;
+        Self::discover_all_with_overrides_inner(providers, workspace_root, overrides, false)
+    }
+
+    /// Discovers projects for task loading while isolating provider failures.
+    ///
+    /// A malformed manifest in one ecosystem must not disable inferred tasks
+    /// from another ecosystem. Explicit overrides and successfully discovered
+    /// provider results remain fully validated.
+    pub fn discover_all_with_overrides_lenient(
+        providers: &[&dyn WorkspaceProvider],
+        workspace_root: &Path,
+        overrides: &BTreeMap<String, WorkspaceProjectOverride>,
+    ) -> Result<WorkspaceProjectGraph> {
+        Self::discover_all_with_overrides_inner(providers, workspace_root, overrides, true)
+    }
+
+    fn discover_all_with_overrides_inner(
+        providers: &[&dyn WorkspaceProvider],
+        workspace_root: &Path,
+        overrides: &BTreeMap<String, WorkspaceProjectOverride>,
+        skip_provider_errors: bool,
+    ) -> Result<WorkspaceProjectGraph> {
+        let mut graph =
+            Self::collect_provider_projects(providers, workspace_root, skip_provider_errors)?
+                .with_overrides(overrides)?;
         for (raw_id, config) in overrides {
             if config.remove || config.root.is_none() {
                 continue;
@@ -347,6 +372,7 @@ impl WorkspaceProjectGraph {
     fn collect_provider_projects(
         providers: &[&dyn WorkspaceProvider],
         workspace_root: &Path,
+        skip_provider_errors: bool,
     ) -> Result<WorkspaceProjectGraph> {
         let mut providers = providers
             .iter()
@@ -362,8 +388,23 @@ impl WorkspaceProjectGraph {
         }
 
         let mut projects = BTreeMap::new();
+        let mut provider_errors = BTreeMap::new();
         for (provider_id, provider) in providers {
-            for mut project in provider.discover(workspace_root)? {
+            let discovered = match provider.discover(workspace_root) {
+                Ok(projects) => projects,
+                Err(error) if skip_provider_errors => {
+                    let error = format!("{error:#}");
+                    warn!(
+                        "failed to discover {provider_id} workspace projects at {}; inferred tasks \
+                         and upstream task dependencies from this provider are unavailable: {error}",
+                        workspace_root.display(),
+                    );
+                    provider_errors.insert(provider_id, error);
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            for mut project in discovered {
                 let expected_prefix = format!("{provider_id}:");
                 let Some(local_id) = project.id.as_str().strip_prefix(&expected_prefix) else {
                     bail!(
@@ -383,7 +424,10 @@ impl WorkspaceProjectGraph {
             }
         }
 
-        Ok(Self { projects })
+        Ok(Self {
+            projects,
+            provider_errors,
+        })
     }
 
     /// Applies explicit project and dependency changes after provider discovery.
@@ -470,6 +514,17 @@ impl WorkspaceProjectGraph {
     /// Finds a project by its stable ID.
     pub fn get(&self, id: &ProjectId) -> Option<&WorkspaceProject> {
         self.projects.get(id)
+    }
+
+    /// Summarizes provider failures retained during lenient task discovery.
+    pub(crate) fn provider_discovery_error(&self) -> Option<String> {
+        (!self.provider_errors.is_empty()).then(|| {
+            self.provider_errors
+                .iter()
+                .map(|(provider, error)| format!("{provider}: {error}"))
+                .collect::<Vec<_>>()
+                .join("; ")
+        })
     }
 
     /// Returns matching projects in the transitive dependency closure.
@@ -750,6 +805,19 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct FailingDiscoveryProvider;
+
+    impl WorkspaceProvider for FailingDiscoveryProvider {
+        fn id(&self) -> &str {
+            "broken"
+        }
+
+        fn discover(&self, _workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+            bail!("broken workspace metadata")
+        }
+    }
+
     fn project(provider: &str, name: &str, root: &str) -> WorkspaceProject {
         WorkspaceProject::new(ProjectId::new(provider, name).unwrap(), root)
     }
@@ -1027,6 +1095,38 @@ mod tests {
             WorkspaceProjectGraph::discover_all(&[&node, &cargo], Path::new("/workspace")).unwrap();
 
         assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn lenient_discovery_isolates_provider_errors() {
+        let working = TestProvider {
+            id: "node",
+            projects: vec![project("node", "app", "apps/app")],
+        };
+
+        assert!(
+            WorkspaceProjectGraph::discover_all_with_overrides(
+                &[&FailingDiscoveryProvider, &working],
+                Path::new("/workspace"),
+                &BTreeMap::new(),
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("broken workspace metadata")
+        );
+
+        let graph = WorkspaceProjectGraph::discover_all_with_overrides_lenient(
+            &[&FailingDiscoveryProvider, &working],
+            Path::new("/workspace"),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(graph.get(&ProjectId::new("node", "app").unwrap()).is_some());
+        assert_eq!(
+            graph.provider_discovery_error().as_deref(),
+            Some("broken: broken workspace metadata")
+        );
     }
 
     #[test]

--- a/src/task/workspace/cargo.rs
+++ b/src/task/workspace/cargo.rs
@@ -1,0 +1,460 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use eyre::{Context, Result, bail};
+use glob::{MatchOptions, Pattern};
+use serde::Deserialize;
+
+use super::{ProjectId, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider};
+
+const CARGO_TOML: &str = "Cargo.toml";
+
+/// Discovers Cargo packages from a workspace manifest.
+#[derive(Debug, Default)]
+pub struct CargoWorkspaceProvider;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct CargoManifest {
+    package: Option<CargoPackage>,
+    workspace: Option<CargoWorkspace>,
+    dependencies: DependencyMap,
+    #[serde(rename = "dev-dependencies")]
+    dev_dependencies: DependencyMap,
+    #[serde(rename = "build-dependencies")]
+    build_dependencies: DependencyMap,
+    target: BTreeMap<String, TargetDependencies>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoPackage {
+    name: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct CargoWorkspace {
+    members: Vec<String>,
+    exclude: Vec<String>,
+    dependencies: DependencyMap,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct TargetDependencies {
+    dependencies: DependencyMap,
+    #[serde(rename = "dev-dependencies")]
+    dev_dependencies: DependencyMap,
+    #[serde(rename = "build-dependencies")]
+    build_dependencies: DependencyMap,
+}
+
+type DependencyMap = BTreeMap<String, toml::Value>;
+
+struct PackageManifest {
+    root: PathBuf,
+    canonical_root: PathBuf,
+    manifest: CargoManifest,
+    id: ProjectId,
+}
+
+impl WorkspaceProvider for CargoWorkspaceProvider {
+    fn id(&self) -> &str {
+        "cargo"
+    }
+
+    fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+        let root_manifest_path = workspace_root.join(CARGO_TOML);
+        if !root_manifest_path.is_file() {
+            return Ok(Vec::new());
+        }
+        let root_manifest = read_manifest(&root_manifest_path)?;
+        let Some(workspace) = root_manifest.workspace.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let canonical_root = workspace_root.canonicalize().wrap_err_with(|| {
+            format!(
+                "failed to resolve Cargo workspace root {}",
+                workspace_root.display()
+            )
+        })?;
+        let excludes = workspace
+            .exclude
+            .iter()
+            .map(|exclude| {
+                Pattern::new(exclude).wrap_err_with(|| {
+                    format!("invalid Cargo workspace exclude pattern {exclude:?}")
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut roots = discover_members(
+            workspace_root,
+            &canonical_root,
+            &workspace.members,
+            &excludes,
+        )?;
+        if root_manifest.package.is_some() && !is_excluded(Path::new("."), &excludes) {
+            roots.insert(canonical_root.clone());
+        }
+
+        // Cargo implicitly treats path dependencies below the workspace root as members.
+        let mut queue = roots.iter().cloned().collect::<VecDeque<_>>();
+        let mut manifests = BTreeMap::new();
+        while let Some(package_root) = queue.pop_front() {
+            if manifests.contains_key(&package_root) {
+                continue;
+            }
+            let relative = relative_root(&canonical_root, &package_root)?;
+            let manifest_path = package_root.join(CARGO_TOML);
+            let manifest = if package_root == canonical_root {
+                read_manifest(&root_manifest_path)?
+            } else {
+                read_manifest(&manifest_path)?
+            };
+            let package = manifest.package.as_ref().ok_or_else(|| {
+                eyre::eyre!(
+                    "Cargo workspace member at {} is missing [package]",
+                    relative.display()
+                )
+            })?;
+            let id = ProjectId::new(self.id(), &package.name)?;
+
+            for (dependency, base) in
+                dependency_values(&manifest, workspace, &package_root, &canonical_root)
+            {
+                let Some(path) = dependency_path(dependency) else {
+                    continue;
+                };
+                let candidate = base.join(path);
+                if !candidate.join(CARGO_TOML).is_file() {
+                    continue;
+                }
+                let candidate = candidate.canonicalize().wrap_err_with(|| {
+                    format!(
+                        "failed to resolve Cargo path dependency {}",
+                        candidate.display()
+                    )
+                })?;
+                let Ok(relative) = candidate.strip_prefix(&canonical_root) else {
+                    continue;
+                };
+                let relative = normalize_relative(relative);
+                if !is_excluded(&relative, &excludes) && roots.insert(candidate.clone()) {
+                    queue.push_back(candidate);
+                }
+            }
+
+            manifests.insert(
+                package_root.clone(),
+                PackageManifest {
+                    root: relative,
+                    canonical_root: package_root,
+                    manifest,
+                    id,
+                },
+            );
+        }
+
+        let ids_by_root = manifests
+            .values()
+            .map(|package| (package.canonical_root.clone(), package.id.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        manifests
+            .into_values()
+            .map(|package| {
+                let source = package.root.join(CARGO_TOML);
+                let mut dependencies = BTreeSet::new();
+                for (dependency, base) in dependency_values(
+                    &package.manifest,
+                    workspace,
+                    &package.canonical_root,
+                    &canonical_root,
+                ) {
+                    let Some(path) = dependency_path(dependency) else {
+                        continue;
+                    };
+                    let candidate = base.join(path);
+                    if !candidate.join(CARGO_TOML).is_file() {
+                        continue;
+                    }
+                    let candidate = candidate.canonicalize().wrap_err_with(|| {
+                        format!(
+                            "failed to resolve Cargo path dependency {}",
+                            candidate.display()
+                        )
+                    })?;
+                    if let Some(dependency_id) = ids_by_root.get(&candidate)
+                        && dependency_id != &package.id
+                    {
+                        dependencies.insert(dependency_id.clone());
+                    }
+                }
+
+                let provenance = WorkspaceProvenance {
+                    provider: Some(self.id().to_string()),
+                    source: Some(source.clone()),
+                };
+                let mut project = WorkspaceProject::new(package.id, package.root);
+                project.dependency_provenance = dependencies
+                    .iter()
+                    .cloned()
+                    .map(|dependency| (dependency, provenance.clone()))
+                    .collect();
+                project.dependencies = dependencies;
+                project.provenance = provenance;
+                project
+                    .metadata
+                    .insert("workspace_source".to_string(), CARGO_TOML.to_string());
+                Ok(project)
+            })
+            .collect()
+    }
+}
+
+fn read_manifest(path: &Path) -> Result<CargoManifest> {
+    let contents = fs::read_to_string(path)
+        .wrap_err_with(|| format!("failed to read Cargo manifest {}", path.display()))?;
+    toml::from_str(&contents)
+        .wrap_err_with(|| format!("failed to parse Cargo manifest {}", path.display()))
+}
+
+fn discover_members(
+    pattern_root: &Path,
+    canonical_root: &Path,
+    members: &[String],
+    excludes: &[Pattern],
+) -> Result<BTreeSet<PathBuf>> {
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: true,
+    };
+    // Use the caller's non-canonical path for globbing. Windows canonical paths
+    // use a verbatim `\\?\` prefix whose `?` is interpreted as a glob token.
+    let escaped_root = Pattern::escape(&pattern_root.to_string_lossy());
+    let mut roots = BTreeSet::new();
+    for member in members {
+        if Path::new(member).is_absolute() {
+            bail!("Cargo workspace member pattern {member:?} must be relative");
+        }
+        let pattern = format!("{escaped_root}/{member}");
+        for candidate in glob::glob_with(&pattern, options)
+            .wrap_err_with(|| format!("invalid Cargo workspace member pattern {member:?}"))?
+        {
+            let candidate = candidate.wrap_err_with(|| {
+                format!("failed to evaluate Cargo workspace member pattern {member:?}")
+            })?;
+            if !candidate.join(CARGO_TOML).is_file() {
+                continue;
+            }
+            let candidate = candidate.canonicalize().wrap_err_with(|| {
+                format!(
+                    "failed to resolve Cargo workspace member {}",
+                    candidate.display()
+                )
+            })?;
+            let relative = relative_root(canonical_root, &candidate)?;
+            if !is_excluded(&relative, excludes) {
+                roots.insert(candidate);
+            }
+        }
+    }
+    Ok(roots)
+}
+
+fn relative_root(workspace_root: &Path, package_root: &Path) -> Result<PathBuf> {
+    let relative = package_root.strip_prefix(workspace_root).map_err(|_| {
+        eyre::eyre!(
+            "Cargo workspace member {} is outside workspace root {}",
+            package_root.display(),
+            workspace_root.display()
+        )
+    })?;
+    Ok(normalize_relative(relative))
+}
+
+fn normalize_relative(path: &Path) -> PathBuf {
+    if path.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        path.to_path_buf()
+    }
+}
+
+fn is_excluded(relative: &Path, excludes: &[Pattern]) -> bool {
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: true,
+    };
+    relative.ancestors().any(|candidate| {
+        excludes
+            .iter()
+            .any(|exclude| exclude.matches_path_with(candidate, options))
+    })
+}
+
+fn dependency_values<'a>(
+    manifest: &'a CargoManifest,
+    workspace: &'a CargoWorkspace,
+    package_root: &'a Path,
+    workspace_root: &'a Path,
+) -> Vec<(&'a toml::Value, &'a Path)> {
+    manifest
+        .dependencies
+        .iter()
+        .chain(&manifest.dev_dependencies)
+        .chain(&manifest.build_dependencies)
+        .chain(manifest.target.values().flat_map(|target| {
+            target
+                .dependencies
+                .iter()
+                .chain(&target.dev_dependencies)
+                .chain(&target.build_dependencies)
+        }))
+        .filter_map(|(name, dependency)| {
+            if dependency
+                .as_table()
+                .and_then(|table| table.get("workspace"))
+                .and_then(toml::Value::as_bool)
+                == Some(true)
+            {
+                workspace
+                    .dependencies
+                    .get(name)
+                    .map(|dependency| (dependency, workspace_root))
+            } else {
+                Some((dependency, package_root))
+            }
+        })
+        .collect()
+}
+
+fn dependency_path(dependency: &toml::Value) -> Option<&Path> {
+    dependency.as_table()?.get("path")?.as_str().map(Path::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    fn package(path: &Path, name: &str, extra: &str) {
+        write(
+            &path.join(CARGO_TOML),
+            &format!("[package]\nname = {name:?}\nversion = \"0.1.0\"\n{extra}"),
+        );
+    }
+
+    #[test]
+    fn discovers_members_root_package_and_excludes() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(CARGO_TOML),
+            "[package]\nname = \"root\"\nversion = \"0.1.0\"\n\
+             [workspace]\nmembers = [\"crates/*\", \"crates/*/*\"]\nexclude = [\"crates/skip\"]\n",
+        );
+        package(&temp.path().join("crates/app"), "app", "");
+        package(&temp.path().join("crates/skip"), "skip", "");
+        package(&temp.path().join("crates/skip/nested"), "nested", "");
+
+        let projects = CargoWorkspaceProvider.discover(temp.path()).unwrap();
+        let summary = projects
+            .iter()
+            .map(|project| (project.id.as_str(), project.root.as_path()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            summary,
+            vec![
+                ("cargo:root", Path::new(".")),
+                ("cargo:app", Path::new("crates/app"))
+            ]
+        );
+        assert!(projects.iter().all(|project| {
+            project.metadata.get("workspace_source").map(String::as_str) == Some(CARGO_TOML)
+        }));
+    }
+
+    #[test]
+    fn infers_all_path_dependency_kinds_and_implicit_members() {
+        let temp = tempdir().unwrap();
+        write(
+            &temp.path().join(CARGO_TOML),
+            "[workspace]\nmembers = [\"crates/app\", \"crates/core\"]\n\
+             [workspace.dependencies]\nshared = { path = \"crates/shared\" }\n",
+        );
+        package(
+            &temp.path().join("crates/app"),
+            "app",
+            "[dependencies]\nrenamed = { package = \"core\", path = \"../core\" }\n\
+             [dev-dependencies]\nshared = { workspace = true }\n\
+             [build-dependencies]\nbuild-helper = { path = \"../build-helper\" }\n\
+             [target.'cfg(unix)'.dependencies]\ntarget-helper = { path = \"../target-helper\" }\n\
+             [target.'cfg(windows)'.dev-dependencies]\nexternal = \"1\"\n",
+        );
+        for name in ["core", "shared", "build-helper", "target-helper"] {
+            package(&temp.path().join(format!("crates/{name}")), name, "");
+        }
+
+        let projects = CargoWorkspaceProvider.discover(temp.path()).unwrap();
+        let app = projects
+            .iter()
+            .find(|project| project.id.as_str() == "cargo:app")
+            .unwrap();
+
+        assert_eq!(
+            app.dependencies,
+            ["build-helper", "core", "shared", "target-helper"]
+                .into_iter()
+                .map(|name| ProjectId::new("cargo", name).unwrap())
+                .collect()
+        );
+        assert_eq!(projects.len(), 5);
+        assert!(app.dependencies.iter().all(|dependency| {
+            app.dependency_provenance[dependency].source
+                == Some(PathBuf::from("crates/app/Cargo.toml"))
+        }));
+    }
+
+    #[test]
+    fn ignores_manifests_without_a_workspace() {
+        let temp = tempdir().unwrap();
+        package(temp.path(), "standalone", "");
+
+        assert!(
+            CargoWorkspaceProvider
+                .discover(temp.path())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn rejects_members_outside_the_workspace() {
+        let temp = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        package(outside.path(), "outside", "");
+        write(
+            &temp.path().join(CARGO_TOML),
+            &format!(
+                "[workspace]\nmembers = [{:?}]\n",
+                outside.path().display().to_string()
+            ),
+        );
+
+        let error = CargoWorkspaceProvider.discover(temp.path()).unwrap_err();
+        assert!(error.to_string().contains("must be relative"));
+    }
+}


### PR DESCRIPTION
## Summary

- discover Cargo workspace packages from root members, excludes, root packages, and implicit in-root path members
- infer internal edges from normal, development, build, target-specific, renamed, and inherited workspace path dependencies
- expose Cargo provenance in task graph output and document the experimental behavior

## Why

This completes the next workspace-provider milestone in `TASK_CACHE_PARITY.md` without requiring the `cargo` executable to be installed.

## Validation

- `cargo test task::workspace`
- `mise run test:e2e e2e/tasks/test_task_cargo_workspace_graph e2e/tasks/test_task_node_workspace_graph e2e/tasks/test_task_workspace_graph`
- `mise run lint`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes experimental monorepo task graph and `^` dependency resolution when a provider fails; incorrect Cargo parsing could mis-order builds, but scope is gated behind experimental monorepo features.
> 
> **Overview**
> Introduces a **Cargo workspace provider** that builds `cargo:<package-name>` projects and internal dependency edges by parsing root and member `Cargo.toml` files—no `cargo` binary required. Discovery follows Cargo semantics: `members`/`exclude`, optional root `[package]`, implicit members from in-workspace path deps, and edges from normal/dev/build/target-specific deps (including renames and `workspace = true` inherited paths).
> 
> **Workspace graph assembly** now runs the Cargo provider alongside Node. `mise tasks graph` still fails fast on provider errors; **task loading** uses lenient discovery that records per-provider failures, keeps successful providers’ projects, and surfaces errors when `^` upstream dependencies cannot be resolved (e.g. broken Node `package.json` no longer silently strips `^build` for scoped inferred tasks).
> 
> Documentation and parity tracker mark Cargo inference complete; e2e covers graph JSON, explain output, and provenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51975417ae1059688f0bc052288b8c5bea7958d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cargo workspace project discovery for task graphs.
  * Detects workspace packages, path dependencies, exclusions, and relationships across supported Cargo dependency types.
  * Reports dependency ordering and provenance in text, explanation, and JSON graph output.
  * Supports Node workspace discovery alongside Cargo.
  * Continues task loading when an individual provider cannot be discovered, while preserving strict graph requests and reporting unavailable dependencies.

* **Documentation**
  * Documented Cargo workspace discovery, dependency inference, exclusions, and cycle reporting.

* **Tests**
  * Added end-to-end coverage for Cargo workspace graphs and provider failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->