### PR TITLE
fix(task): support brace globs in sources and outputs

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -385,7 +385,9 @@ cause the task to be run.
 
 This is also used in `mise watch` to know which files/directories to watch.
 
-This can be specified with relative paths to the config file and/or with glob patterns, e.g.: `src/**/*.rs`.
+This can be specified with relative paths to the config file and/or with glob patterns, e.g.:
+`src/**/*.rs`. Brace alternatives such as `src/**/*.{js,ts}` are supported by freshness checks,
+`mise watch`, and `task_source_files()`.
 Ensure you don't go crazy with adding a ton of files in a glob though—mise has to scan each and every one to check
 the timestamp.
 
@@ -517,7 +519,8 @@ it executes.
 
 Entries prefixed with `!` exclude matching outputs. As with `sources`, entries
 are evaluated in order, a later entry can re-include a path, and `\!` escapes a
-literal leading bang.
+literal leading bang. Output globs also support brace alternatives such as
+`dist/{client,server}/**`.
 
 ```mise-toml
 [tasks.build]

--- a/e2e/tasks/test_task_run_sources
+++ b/e2e/tasks/test_task_run_sources
@@ -88,3 +88,46 @@ EOF
 touch pen apple
 mkdir child && cd child || exit 1
 assert "mise run -q source-files test" "pen apple test"
+
+cd ../.. || exit 1
+mkdir brace-globs && cd brace-globs || exit 1
+cat <<'EOF' >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+sources = ["{a,b}.txt"]
+outputs = ["{a,b}.out"]
+run = "cp a.txt a.out; cp b.txt b.out; echo run"
+
+[tasks.list-sources]
+sources = ["{a,b}.txt"]
+run = "echo {{ task_source_files() | join(sep=' ') }}"
+EOF
+touch a.txt b.txt
+assert "mise run -q build" "run"
+assert_empty "mise run -q build"
+touch -r b.txt b.txt.mtime
+echo changed >b.txt
+touch -r b.txt.mtime b.txt
+rm b.txt.mtime
+assert "mise run -q build" "run"
+assert_empty "mise run -q build"
+rm b.out
+assert "mise run -q build" "run"
+assert "mise run -q list-sources" "a.txt b.txt"
+
+cd .. || exit 1
+mkdir brace-globs-mtime && cd brace-globs-mtime || exit 1
+cat <<'EOF' >mise.toml
+[tasks.build]
+sources = ["{a,b}.txt"]
+outputs = ["{a,b}.out"]
+run = "cp a.txt a.out; cp b.txt b.out; echo run"
+EOF
+touch a.txt b.txt
+assert "mise run -q build" "run"
+assert_empty "mise run -q build"
+sleep 1
+touch b.txt
+assert "mise run -q build" "run"

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -3,8 +3,8 @@ use crate::dirs;
 use crate::file::{self, ExtractOptions, ExtractionFormat};
 use crate::hash;
 use crate::task::task_source_checker::{
-    TaskCacheInputs, build_output_matcher, is_output, output_glob_patterns, task_cache_inputs,
-    task_cwd,
+    TaskCacheInputs, build_output_matcher, expand_glob_braces, is_output, output_glob_patterns,
+    task_cache_inputs, task_cwd,
 };
 use crate::task::{RunEntry, Task};
 use crate::toolset::Toolset;
@@ -507,14 +507,17 @@ fn resolve_output_roots(task: &Task, root: &Path, require_matches: bool) -> Resu
         ensure_safe_relative(Path::new(&output))?;
         if crate::task::task_source_checker::is_glob_pattern(&output) {
             let mut glob_matched = false;
-            for entry in glob(root.join(&output).to_str().unwrap_or_default())? {
-                let path = entry?;
-                glob_matched = true;
-                let rel = path.strip_prefix(root)?.to_path_buf();
-                ensure_safe_relative(&rel)?;
-                let is_dir = fs::symlink_metadata(&path)?.is_dir();
-                if is_output(&matcher, &path, is_dir) {
-                    resolved.insert(rel);
+            for expanded in expand_glob_braces(&output)? {
+                ensure_safe_relative(Path::new(&expanded))?;
+                for entry in glob(root.join(expanded).to_str().unwrap_or_default())? {
+                    let path = entry?;
+                    glob_matched = true;
+                    let rel = path.strip_prefix(root)?.to_path_buf();
+                    ensure_safe_relative(&rel)?;
+                    let is_dir = fs::symlink_metadata(&path)?.is_dir();
+                    if is_output(&matcher, &path, is_dir) {
+                        resolved.insert(rel);
+                    }
                 }
             }
             if require_matches && !glob_matched {
@@ -877,6 +880,42 @@ mod tests {
             resolve_output_roots(&task, root.path(), true).unwrap(),
             Vec::<PathBuf>::new()
         );
+    }
+
+    #[test]
+    fn output_roots_support_brace_globs() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("dist/client")).unwrap();
+        fs::create_dir_all(root.path().join("dist/server")).unwrap();
+        fs::write(root.path().join("dist/client/app.js"), "client").unwrap();
+        fs::write(root.path().join("dist/server/app.js"), "server").unwrap();
+        let task = Task {
+            outputs: crate::task::task_sources::TaskOutputs::Files(vec![
+                "dist/{client,server}/**/*.js".to_string(),
+            ]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            resolve_output_roots(&task, root.path(), true).unwrap(),
+            [
+                PathBuf::from("dist/client/app.js"),
+                PathBuf::from("dist/server/app.js"),
+            ]
+        );
+    }
+
+    #[test]
+    fn output_roots_reject_unsafe_brace_expansions() {
+        let root = tempfile::tempdir().unwrap();
+        let task = Task {
+            outputs: crate::task::task_sources::TaskOutputs::Files(vec![
+                "{..,ok}/secret.txt".to_string(),
+            ]),
+            ..Default::default()
+        };
+
+        assert!(resolve_output_roots(&task, root.path(), false).is_err());
     }
 
     #[test]

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -196,65 +196,81 @@ impl TaskScriptParser {
                         continue;
                     }
 
-                    let pattern_path = Path::new(pattern);
-                    let is_relative = pattern_path.is_relative();
-                    let rooted_pattern = if is_relative {
-                        Path::new(&escaped_root)
-                            .join(pattern_path)
-                            .to_string_lossy()
-                            .to_string()
-                    } else {
-                        pattern.clone()
-                    };
-
-                    match glob::glob_with(
-                        &rooted_pattern,
-                        glob::MatchOptions {
-                            case_sensitive: false,
-                            require_literal_separator: false,
-                            require_literal_leading_dot: false,
-                        },
-                    ) {
+                    let expanded_patterns =
+                        crate::task::task_source_checker::expand_glob_braces(pattern);
+                    match expanded_patterns {
                         Err(error) => {
                             warn!(
                                 "tera::render::resolve_task_sources including '{pattern}' in resolved task sources, ignoring glob parsing error: {error:#?}"
                             );
                             resolved.push(pattern.clone());
                         }
-                        Ok(expanded) => {
+                        Ok(expanded_patterns) => {
                             let mut source_found = false;
-
-                            for path in expanded {
-                                source_found = true;
-
-                                match path {
-                                    Ok(path) => {
-                                        if !crate::task::task_source_checker::is_source(
-                                            &matcher, &path,
-                                        ) {
-                                            trace!(
-                                                "tera::render::resolve_task_sources excluded '{}' due to !-pattern",
-                                                path.display()
-                                            );
-                                            continue;
-                                        }
-                                        let source = if is_relative {
-                                            path.strip_prefix(&root).unwrap_or(&path)
-                                        } else {
-                                            &path
-                                        };
-                                        let source = source.display();
-                                        trace!(
-                                            "tera::render::resolve_task_sources resolved source from pattern '{pattern}': {source}"
-                                        );
-                                        resolved.push(source.to_string());
-                                    }
+                            let mut pattern_preserved = false;
+                            for expanded_pattern in expanded_patterns {
+                                let pattern_path = Path::new(&expanded_pattern);
+                                let is_relative = pattern_path.is_relative();
+                                let rooted_pattern = if is_relative {
+                                    Path::new(&escaped_root)
+                                        .join(pattern_path)
+                                        .to_string_lossy()
+                                        .to_string()
+                                } else {
+                                    expanded_pattern
+                                };
+                                let expanded = match glob::glob_with(
+                                    &rooted_pattern,
+                                    glob::MatchOptions {
+                                        case_sensitive: false,
+                                        require_literal_separator: false,
+                                        require_literal_leading_dot: false,
+                                    },
+                                ) {
+                                    Ok(expanded) => expanded,
                                     Err(error) => {
-                                        let source = error.path().display();
                                         warn!(
-                                            "tera::render::resolve_task_sources omitting '{source}' from resolved task sources due to: {:#?}",
-                                            error.error()
+                                            "tera::render::resolve_task_sources including '{pattern}' in resolved task sources, ignoring glob parsing error: {error:#?}"
                                         );
+                                        if !pattern_preserved {
+                                            resolved.push(pattern.clone());
+                                            pattern_preserved = true;
+                                        }
+                                        source_found = true;
+                                        continue;
+                                    }
+                                };
+                                for path in expanded {
+                                    source_found = true;
+                                    match path {
+                                        Ok(path) => {
+                                            if !crate::task::task_source_checker::is_source(
+                                                &matcher, &path,
+                                            ) {
+                                                trace!(
+                                                    "tera::render::resolve_task_sources excluded '{}' due to !-pattern",
+                                                    path.display()
+                                                );
+                                                continue;
+                                            }
+                                            let source = if is_relative {
+                                                path.strip_prefix(&root).unwrap_or(&path)
+                                            } else {
+                                                &path
+                                            };
+                                            let source = source.display();
+                                            trace!(
+                                                "tera::render::resolve_task_sources resolved source from pattern '{pattern}': {source}"
+                                            );
+                                            resolved.push(source.to_string());
+                                        }
+                                        Err(error) => {
+                                            let source = error.path().display();
+                                            warn!(
+                                                "tera::render::resolve_task_sources omitting '{source}' from resolved task sources due to: {:#?}",
+                                                error.error()
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -1341,12 +1357,13 @@ mod tests {
         let root = temp.path().join("project[1]");
         std::fs::create_dir(&root).unwrap();
         std::fs::write(root.join("input.txt"), "test").unwrap();
+        std::fs::write(root.join("config.txt"), "test").unwrap();
         let task = Task {
-            sources: vec!["*.txt".to_string()],
+            sources: vec!["{input,config}.txt".to_string(), "!config.txt".to_string()],
             ..Default::default()
         };
         let parser = TaskScriptParser::new(Some(root));
-        let scripts = vec!["echo {{ task_source_files() | first }}".to_string()];
+        let scripts = vec!["echo {{ task_source_files() | join(sep=' ') }}".to_string()];
 
         let (parsed, _) = parser
             .parse_run_scripts(&config, &task, &scripts, &Default::default())
@@ -1354,6 +1371,25 @@ mod tests {
             .unwrap();
 
         assert_eq!(parsed, vec!["echo input.txt"]);
+    }
+
+    #[tokio::test]
+    async fn test_task_source_files_preserves_invalid_brace_glob_once() {
+        let config = Config::get().await.unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let task = Task {
+            sources: vec!["{a,b}/[invalid".to_string()],
+            ..Default::default()
+        };
+        let parser = TaskScriptParser::new(Some(temp.path().to_path_buf()));
+        let scripts = vec!["echo {{ task_source_files() | join(sep=' ') }}".to_string()];
+
+        let (parsed, _) = parser
+            .parse_run_scripts(&config, &task, &scripts, &Default::default())
+            .await
+            .unwrap();
+
+        assert_eq!(parsed, vec!["echo {a,b}/[invalid"]);
     }
 
     #[tokio::test]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -4,7 +4,7 @@ use crate::file::{self, display_path};
 use crate::hash;
 use crate::rand::random_string;
 use crate::task::Task;
-use eyre::Result;
+use eyre::{Result, bail};
 use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
@@ -45,6 +45,107 @@ pub fn is_glob_pattern(path: &str) -> bool {
     path.chars().any(|c| glob_chars.contains(&c))
 }
 
+const MAX_BRACE_EXPANSIONS: usize = 1024;
+
+/// Expand globset-style brace alternates before passing a pattern to `glob`.
+///
+/// `Override`/globset understands patterns such as `{a,b}.txt`, but the `glob`
+/// crate used to enumerate task sources and outputs treats braces literally.
+/// Expanding only the alternates lets both stages share the same syntax without
+/// returning to a recursive filesystem walker.
+pub(crate) fn expand_glob_braces(pattern: &str) -> Result<Vec<String>> {
+    struct BraceGroup {
+        start: usize,
+        end: usize,
+        branches: Vec<(usize, usize)>,
+    }
+
+    fn find_group(pattern: &str) -> Result<Option<BraceGroup>> {
+        let mut escaped = false;
+        let mut class_depth = 0;
+        let mut group_start = None;
+        let mut group_depth = 0;
+        let mut branch_start = 0;
+        let mut branches = Vec::new();
+
+        for (idx, ch) in pattern.char_indices() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            // On Windows, backslashes are path separators rather than glob
+            // escapes. Literal braces can still be expressed with a character
+            // class, e.g. `[{]` and `[}]`.
+            if ch == '\\' && !cfg!(windows) {
+                escaped = true;
+                continue;
+            }
+            match ch {
+                '[' if class_depth == 0 => class_depth = 1,
+                ']' if class_depth == 1 => class_depth = 0,
+                '{' if class_depth == 0 => {
+                    if group_depth == 0 {
+                        group_start = Some(idx);
+                        branch_start = idx + ch.len_utf8();
+                    }
+                    group_depth += 1;
+                }
+                ',' if class_depth == 0 && group_depth == 1 => {
+                    branches.push((branch_start, idx));
+                    branch_start = idx + ch.len_utf8();
+                }
+                '}' if class_depth == 0 => {
+                    if group_depth == 0 {
+                        bail!("unopened brace alternate in glob pattern {pattern:?}");
+                    }
+                    group_depth -= 1;
+                    if group_depth == 0 {
+                        branches.push((branch_start, idx));
+                        return Ok(Some(BraceGroup {
+                            start: group_start.unwrap(),
+                            end: idx,
+                            branches,
+                        }));
+                    }
+                }
+                _ => {}
+            }
+        }
+        if group_depth != 0 {
+            bail!("unclosed brace alternate in glob pattern {pattern:?}");
+        }
+        Ok(None)
+    }
+
+    fn expand(pattern: &str, expanded: &mut Vec<String>) -> Result<()> {
+        let Some(group) = find_group(pattern)? else {
+            if expanded.len() >= MAX_BRACE_EXPANSIONS {
+                bail!(
+                    "glob pattern expands to more than {MAX_BRACE_EXPANSIONS} alternatives: {pattern:?}"
+                );
+            }
+            expanded.push(pattern.to_string());
+            return Ok(());
+        };
+
+        let prefix = &pattern[..group.start];
+        let suffix = &pattern[group.end + 1..];
+        for (branch_start, branch_end) in group.branches {
+            let branch = &pattern[branch_start..branch_end];
+            // Match globset's default: empty alternatives are discarded.
+            if branch.is_empty() {
+                continue;
+            }
+            expand(&format!("{prefix}{branch}{suffix}"), expanded)?;
+        }
+        Ok(())
+    }
+
+    let mut expanded = Vec::new();
+    expand(pattern, &mut expanded)?;
+    Ok(expanded)
+}
+
 /// Build an [`Override`] matcher for a task's `sources` patterns.
 ///
 /// `match_root` is the directory the [`Override`] is anchored at (the workspace
@@ -65,8 +166,20 @@ pub(crate) fn build_source_matcher(
     let mut builder = OverrideBuilder::new(match_root);
     for s in sources {
         let normalized = normalize_pattern(match_root, task_cwd, s);
-        if let Err(e) = builder.add(&normalized) {
-            warn!("invalid source pattern {s:?}: {e}");
+        let expanded = match expand_glob_braces(&normalized) {
+            Ok(expanded) => expanded,
+            Err(e) => {
+                // Source matcher construction is infallible to callers. An
+                // invalid pattern is skipped so freshness falls back to stale
+                // when no sources can be enumerated.
+                warn!("invalid source pattern {s:?}: {e}");
+                continue;
+            }
+        };
+        for normalized in expanded {
+            if let Err(e) = builder.add(&normalized) {
+                warn!("invalid source pattern {s:?}: {e}");
+            }
         }
     }
     builder.build().unwrap_or_else(|e| {
@@ -161,16 +274,20 @@ pub(crate) fn build_output_matcher(root: &Path, outputs: &[String]) -> Result<Ov
     let mut builder = OverrideBuilder::new(root);
     for output in outputs {
         let output = normalize_pattern(root, root, output);
-        builder.add(&output)?;
-        let descendant = if let Some(body) = output.strip_prefix('!') {
-            format!("!{body}/**")
-        } else if let Some(body) = output.strip_prefix("\\!") {
-            format!("\\!{body}/**")
-        } else {
-            format!("{output}/**")
-        };
-        if !output.ends_with("/**") {
-            builder.add(&descendant)?;
+        // Output callers already propagate matcher errors and conservatively
+        // treat the task as stale, so keep malformed patterns visible here.
+        for output in expand_glob_braces(&output)? {
+            builder.add(&output)?;
+            let descendant = if let Some(body) = output.strip_prefix('!') {
+                format!("!{body}/**")
+            } else if let Some(body) = output.strip_prefix("\\!") {
+                format!("\\!{body}/**")
+            } else {
+                format!("{output}/**")
+            };
+            if !output.ends_with("/**") {
+                builder.add(&descendant)?;
+            }
         }
     }
     Ok(builder.build()?)
@@ -474,9 +591,15 @@ pub async fn save_checksum(task: &Task, config: &Arc<Config>) -> Result<()> {
         // Warn if any explicitly declared output was not generated.
         for output in output_glob_patterns(&task.outputs.paths(task, &root)) {
             let output_exists = if is_glob_pattern(&output) {
-                let pattern = root.join(&output);
-                glob(pattern.to_str().unwrap_or_default())
-                    .map(|paths| paths.flatten().next().is_some())
+                expand_glob_braces(&output)
+                    .map(|patterns| {
+                        patterns.into_iter().any(|pattern| {
+                            let pattern = resolve_task_path(&root, pattern);
+                            glob(pattern.to_str().unwrap_or_default())
+                                .map(|paths| paths.flatten().next().is_some())
+                                .unwrap_or(false)
+                        })
+                    })
                     .unwrap_or(false)
             } else {
                 let path = Path::new(&output);
@@ -684,38 +807,40 @@ fn compute_output_hash(task: &Task, root: &Path) -> Result<Option<String>> {
     }
 
     for pattern_str in glob_pats {
-        let full = root.join(pattern_str.as_str());
         let mut glob_matched = false;
-        for entry in glob(full.to_str().unwrap_or_default())? {
-            // Propagate glob resolution errors (OS errors during directory
-            // reads) rather than silently skipping them — a partial result
-            // could produce the same hash as a complete one.
-            let path = entry?;
-            glob_matched = true;
-            let metadata = match path.metadata() {
-                Ok(metadata) => metadata,
-                Err(_) => {
-                    if !is_output(&matcher, &path, false) && !is_output(&matcher, &path, true) {
-                        continue;
+        for expanded in expand_glob_braces(pattern_str)? {
+            let full = resolve_task_path(root, expanded);
+            for entry in glob(full.to_str().unwrap_or_default())? {
+                // Propagate glob resolution errors (OS errors during directory
+                // reads) rather than silently skipping them — a partial result
+                // could produce the same hash as a complete one.
+                let path = entry?;
+                glob_matched = true;
+                let metadata = match path.metadata() {
+                    Ok(metadata) => metadata,
+                    Err(_) => {
+                        if !is_output(&matcher, &path, false) && !is_output(&matcher, &path, true) {
+                            continue;
+                        }
+                        return Ok(None); // selected and unreadable → outputs incomplete
                     }
-                    return Ok(None); // selected and unreadable → outputs incomplete
+                };
+                if !is_output(&matcher, &path, metadata.is_dir()) {
+                    continue;
                 }
-            };
-            if !is_output(&matcher, &path, metadata.is_dir()) {
-                continue;
-            }
-            match metadata {
-                m if m.is_file() => {
-                    entries.push(hash_file(&path)?);
-                }
-                m if m.is_dir() => {
-                    let found = push_dir_entries(&path, &mut entries, &matcher)?;
-                    if !found {
-                        entries.push((path, "empty-dir".to_string()));
+                match metadata {
+                    m if m.is_file() => {
+                        entries.push(hash_file(&path)?);
                     }
-                }
-                _ => {
-                    entries.push((path, "other".to_string()));
+                    m if m.is_dir() => {
+                        let found = push_dir_entries(&path, &mut entries, &matcher)?;
+                        if !found {
+                            entries.push((path, "empty-dir".to_string()));
+                        }
+                    }
+                    _ => {
+                        entries.push((path, "other".to_string()));
+                    }
                 }
             }
         }
@@ -744,11 +869,13 @@ fn get_file_metadatas(
 
     let mut metadatas = BTreeMap::new();
     for pattern in patterns {
-        let pattern = resolve_task_path(root, pattern);
-        let files = glob(pattern.to_str().unwrap())?;
-        for file in files.flatten() {
-            if let Ok(metadata) = file.metadata() {
-                metadatas.insert(file, metadata);
+        for expanded in expand_glob_braces(pattern)? {
+            let pattern = resolve_task_path(root, expanded);
+            let files = glob(pattern.to_str().unwrap())?;
+            for file in files.flatten() {
+                if let Ok(metadata) = file.metadata() {
+                    metadatas.insert(file, metadata);
+                }
             }
         }
     }
@@ -904,12 +1031,14 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
     let mut directory_modified = Vec::new();
     for pattern in output_glob_patterns(patterns_or_paths) {
         let candidates = if is_glob_pattern(&pattern) {
-            glob(
-                resolve_task_path(root, &pattern)
-                    .to_str()
-                    .unwrap_or_default(),
-            )?
-            .collect::<Result<Vec<_>, _>>()?
+            let mut candidates = Vec::new();
+            for expanded in expand_glob_braces(&pattern)? {
+                let expanded = resolve_task_path(root, expanded);
+                candidates.extend(
+                    glob(expanded.to_str().unwrap_or_default())?.collect::<Result<Vec<_>, _>>()?,
+                );
+            }
+            candidates
         } else {
             vec![resolve_task_path(root, &pattern)]
         };
@@ -1041,6 +1170,82 @@ mod tests {
             ]),
             ["dist", "!important"]
         );
+    }
+
+    #[test]
+    fn glob_braces_expand_nested_and_multiple_alternates() {
+        assert_eq!(
+            expand_glob_braces("src/{a,{b,c}}/{one,two}.txt").unwrap(),
+            [
+                "src/a/one.txt",
+                "src/a/two.txt",
+                "src/b/one.txt",
+                "src/b/two.txt",
+                "src/c/one.txt",
+                "src/c/two.txt",
+            ]
+        );
+        assert_eq!(expand_glob_braces("{,a}.txt").unwrap(), ["a.txt"]);
+        assert!(expand_glob_braces("src/{a,b.txt").is_err());
+        assert!(expand_glob_braces(&"{a,b}".repeat(11)).is_err());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn glob_braces_preserve_escaped_unix_braces() {
+        assert_eq!(
+            expand_glob_braces(r"src/\{literal\}/[{}].txt").unwrap(),
+            [r"src/\{literal\}/[{}].txt"]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn glob_braces_treat_windows_backslashes_as_separators() {
+        assert_eq!(
+            expand_glob_braces(r"C:\build\{debug,release}\*.exe").unwrap(),
+            [r"C:\build\debug\*.exe", r"C:\build\release\*.exe"]
+        );
+    }
+
+    #[test]
+    fn source_and_output_matchers_support_ordered_brace_globs() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let source_matcher = build_source_matcher(
+            root,
+            root,
+            &[
+                "{Cargo.toml,README.md}".to_string(),
+                "!README.md".to_string(),
+                "README.md".to_string(),
+            ],
+        );
+        let output_matcher = build_output_matcher(
+            root,
+            &[
+                "{Cargo.toml,README.md}".to_string(),
+                "!README.md".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert!(is_source(&source_matcher, &root.join("Cargo.toml")));
+        assert!(is_source(&source_matcher, &root.join("README.md")));
+        assert!(is_output(&output_matcher, &root.join("Cargo.toml"), false));
+        assert!(!is_output(&output_matcher, &root.join("README.md"), false));
+    }
+
+    #[test]
+    fn output_hash_supports_brace_globs() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("a.out"), "a").unwrap();
+        fs::write(root.path().join("b.out"), "b").unwrap();
+        let task = Task {
+            outputs: crate::task::task_sources::TaskOutputs::Files(vec!["{a,b}.out".to_string()]),
+            ..Default::default()
+        };
+
+        assert!(compute_output_hash(&task, root.path()).unwrap().is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- expand globset-style brace alternatives before task file enumeration
- apply the same expansion to source freshness, output validation and hashing, ordered include/exclude matchers, and `task_source_files()`
- document brace alternatives for task sources and outputs

## Root cause

Task matching uses globset semantics, which recognize patterns such as `{a,b}.txt`, while filesystem enumeration uses the `glob` crate, which treats braces literally. As a result, `mise watch` could observe these patterns but freshness checks and template expansion enumerated no files.

This keeps the current `glob` traversal instead of restoring `globwalk`, which was removed to fix a filesystem traversal stall. A bounded expansion step preserves that fix while making enumeration agree with matching. Expansion supports nested and repeated alternatives, ignores escaped braces and character classes, and rejects more than 1,024 expanded patterns.

## Test Plan

- `cargo test` for brace expansion, ordered source/output matchers, output hashing, and `task_source_files()`
- `mise run test:e2e e2e/tasks/test_task_run_sources`
- `mise run test:e2e e2e/cli/test_watch`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- Rustfmt, shfmt, ShellCheck, and Markdown lint

`mise run format` and `mise run lint` reach `hk` but cannot complete because `hk` does not recognize this Sapling working copy as a Git repository; the corresponding checks above pass individually.

Addresses https://github.com/jdx/mise/discussions/4469

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for brace-alternative glob patterns in task sources and outputs.
  - Brace patterns now work with source discovery, output tracking, content-hash freshness, modification-time checks, caching, and `task_source_files()`.
  - Supports nested alternatives, exclusions, escaped characters, and character classes.
  - Invalid patterns are handled safely, with limits on excessive expansions.

- **Documentation**
  - Expanded task configuration guidance with examples and details for brace-pattern support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->