### PR TITLE
fix(aqua): fetch the checksum manifest with get_text again

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2161,8 +2161,8 @@ impl AquaBackend {
         let url = match checksum_config._type() {
             AquaChecksumType::GithubRelease => {
                 let asset_strs = checksum_config.asset_strs(pkg, v, target_os, target_arch)?;
-                // Only the bytes are read here (no filename derivation), so the transport
-                // URL is all that is needed.
+                // No filename derivation is needed here, so the transport URL is all that
+                // is needed.
                 match self.github_release_asset_urls(pkg, v, asset_strs).await {
                     Ok((_, download_url)) => download_url,
                     Err(e) => {
@@ -2174,21 +2174,14 @@ impl AquaBackend {
             AquaChecksumType::Http => checksum_config.url(pkg, v, target_os, target_arch)?,
         };
 
-        // Download checksum file content. Read the bytes rather than `get_text`, which decodes with
-        // the response charset and silently replaces anything it cannot map — a UTF-16 checksum
-        // file would be recorded as mojibake instead of failing. `decode_text` honours a BOM, the
-        // same as the install path above.
-        let checksum_bytes = match HTTP.get_bytes(&url).await {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                debug!("Failed to download checksum file {}: {}", url, e);
-                return Ok(None);
-            }
-        };
-        let checksum_content = match file::decode_text(checksum_bytes.as_ref()) {
+        // Download checksum file content. `get_text` decodes with BOM sniffing (reqwest's
+        // `text_with_charset` -> `encoding_rs::Encoding::decode`), so a UTF-16 checksum file is
+        // handled here without help — unlike the install path above, which reads from disk. It
+        // also detects an HTML body and retries over https, which reading bytes would skip.
+        let checksum_content = match HTTP.get_text(&url).await {
             Ok(content) => content,
             Err(e) => {
-                debug!("Failed to decode checksum file {}: {}", url, e);
+                debug!("Failed to download checksum file {}: {}", url, e);
                 return Ok(None);
             }
         };
@@ -4783,6 +4776,53 @@ mod lock_candidate_tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("does not match expected checksum"), "{err}");
+    }
+
+    /// The counterpart over HTTP, which needs no decoding of its own: reqwest's `text()` goes
+    /// through `text_with_charset` -> `encoding_rs::Encoding::decode`, which sniffs the BOM and
+    /// strips it. Pinned here because that is a property of the *transport*, easy to lose by
+    /// swapping `get_text` for a byte-level read on the assumption it needs the same help the
+    /// file path does.
+    #[tokio::test]
+    async fn test_fetch_checksum_from_file_decodes_a_utf16_body() {
+        const ARTIFACT: &str = "tool-1.0.0-linux-amd64.tar.gz";
+        const DIGEST: &str = "d91b9172668f4b6aef4abce8c780cd298872c7a0f4487cc47444d26877ba49f6";
+
+        let mut body = vec![0xff, 0xfe];
+        body.extend(
+            format!("{DIGEST} *{ARTIFACT}\n")
+                .encode_utf16()
+                .flat_map(u16::to_le_bytes),
+        );
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/hashes.sha256")
+            .with_status(200)
+            .with_body(body)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut pkg = AquaPackage::default();
+        pkg.checksum = Some(
+            serde_json::from_str(&format!(
+                r#"{{"type":"http","algorithm":"sha256","url":"{}/hashes.sha256"}}"#,
+                server.url()
+            ))
+            .unwrap(),
+        );
+        let backend = AquaBackend::from_arg(BackendArg::new(
+            "tool".to_string(),
+            Some("aqua:owner/repo".to_string()),
+        ));
+
+        let checksum = backend
+            .fetch_checksum_from_file(&pkg, "1.0.0", "linux", "amd64", Some(ARTIFACT))
+            .await
+            .unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(checksum, Some(format!("sha256:{DIGEST}")));
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -374,6 +374,12 @@ pub fn decode_text(bytes: &[u8]) -> Result<String> {
 }
 
 /// [`read_to_string`], but tolerant of a byte-order mark. See [`decode_text`].
+///
+/// Only reads *from disk* need this. Bodies fetched over HTTP already arrive decoded: reqwest's
+/// `text()` goes through `text_with_charset` -> `encoding_rs::Encoding::decode`, which sniffs a BOM
+/// and lets it override the declared charset. `std::fs::read_to_string` has no such step, and that
+/// asymmetry is the only reason this function exists — reaching for it on an `HTTP.get_text` result
+/// would be redundant.
 pub fn read_to_string_bom<P: AsRef<Path>>(path: P) -> Result<String> {
     let path = path.as_ref();
     trace!("cat {}", path.display_user());


### PR DESCRIPTION
Corrects one third of my own #11552. **The reasoning I gave for the HTTP-side change there was wrong**, and the comment stating it is now in `main`.

## The claim, and why it's false

#11552 converted `fetch_checksum_from_file` from `get_text` to `get_bytes` + `file::decode_text`, with this comment:

> Read the bytes rather than `get_text`, which decodes with the response charset and silently replaces anything it cannot map — a UTF-16 checksum file would be recorded as mojibake instead of failing.

reqwest's `text()` (`reqwest-0.13.4/src/async_impl/response.rs:163`) delegates to `text_with_charset("utf-8")` when the `charset` feature is on — which mise enables in `Cargo.toml`. Its own docs say it *"decodes the response body with BOM sniffing"* and that *"the BOM is stripped from the returned String"*. The body is `encoding.decode(&full)`, which is `encoding_rs-0.8.35/src/lib.rs:3009`:

```rust
pub fn decode<'a>(&'static self, bytes: &'a [u8]) -> (Cow<'a, str>, &'static Encoding, bool) {
    let (encoding, without_bom) = match Encoding::for_bom(bytes) {
        Some((encoding, bom_length)) => (encoding, &bytes[bom_length..]),
        None => (self, bytes),
    };
    ...
```

A BOM overrides the declared encoding and is stripped. **The HTTP path already handled UTF-16 correctly**, so that conversion fixed nothing.

## What it cost

`get_text` goes through `TextRequest::send` (`http.rs:845`), which detects a `<!DOCTYPE html>` body and re-sends over https when the URL was plain `http`. `get_bytes` → `get_async` → `send_with_https_fallback` has no such branch. So an `http://` checksum URL answered with an HTML error page would decode cleanly and get parsed as a checksum, where it used to be retried over https.

Registry checksum URLs are https, so the exposure is small — but it was behaviour given up for no gain.

To be precise about what was *not* lost: **retries were fine either way.** `send_with_https_fallback` (`http.rs:484`) delegates to `send_with_https_fallback_with_retries` with `Settings::get().http_retries()`, the same default `TextRequest` uses. I checked before writing this.

## What stays

The two file-reading sites from #11552 are correct and untouched: `aqua.rs:1785` and `:2515` go through `std::fs::read_to_string`, which really does reject non-UTF-8 — that is the exact frame in #5399's stack trace, and `file::read_to_string_bom` is the right fix for it.

`read_to_string_bom` now documents the asymmetry, so the HTTP path doesn't get "fixed" again:

```rust
/// Only reads *from disk* need this. Bodies fetched over HTTP already arrive decoded: reqwest's
/// `text()` goes through `text_with_charset` -> `encoding_rs::Encoding::decode`, which sniffs a BOM
/// and lets it override the declared charset. `std::fs::read_to_string` has no such step, and that
/// asymmetry is the only reason this function exists — reaching for it on an `HTTP.get_text` result
/// would be redundant.
```

The same finding also applies to `static_helpers.rs`, `backend/http.rs`, `node.rs` and `pkgx.rs`, which all read checksums via `get_text`/`get_text_cached`. I had listed those in #11552 as adjacent work left for later; **they need nothing**, and this PR is the record of why.

## Verification

Read from reqwest's and encoding_rs's source, cited above — I have not exercised the HTTP path locally. No local `cargo` run; `rustfmt --edition 2024` only. The `src/file.rs` decoder tests and #11552's aqua UTF-16 fixture test both cover file paths and are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum retrieval from HTTP and HTTPS sources.
  * Added more reliable support for text encodings and byte-order marks, including UTF-16 checksum files.
  * Improved handling of checksum download responses.

* **Documentation**
  * Clarified that BOM-aware text reading applies to local files, while HTTP responses are decoded automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->