### PR TITLE
fix(http): handle client initialization failures

### DIFF
--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -199,9 +199,13 @@ async fn get_latest_version_call() -> Option<String> {
 
 #[cfg(not(test))]
 async fn get_latest_version_call() -> Option<String> {
+    fetch_latest_version(&crate::http::HTTP).await
+}
+
+async fn fetch_latest_version(client: &crate::http::Client) -> Option<String> {
     let url = "https://mise.jdx.dev/VERSION";
     debug!("checking mise version from {}", url);
-    match crate::http::HTTP.get_text(url).await {
+    match client.get_text(url).await {
         Ok(text) => {
             debug!("got version {text}");
             Some(text.trim().to_string())
@@ -286,6 +290,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = write(dir.path(), "2030.1.2\n");
         assert_eq!(cached_latest_version(&p, Duration::ZERO), Cached::Stale);
+    }
+
+    #[tokio::test]
+    async fn latest_version_ignores_http_client_initialization_errors() {
+        let client = crate::http::Client::with_init_error("builder error: OpenSSL error");
+
+        assert_eq!(fetch_latest_version(&client).await, None);
     }
 
     /// Regression: freshness must not depend on the cached version being newer

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -290,7 +290,7 @@ async fn create_device_code() -> Result<DeviceCodeResponse> {
         form.push(("scope", scopes));
     }
     Ok(crate::http::HTTP
-        .reqwest()
+        .reqwest()?
         .post(url)
         .header("Accept", "application/json")
         .form(&form)
@@ -310,7 +310,7 @@ async fn poll_access_token(device: &DeviceCodeResponse) -> Result<TokenResponse>
         settings.github.oauth_auth_url.trim_end_matches('/')
     );
     let client_id = settings.github.oauth_client_id.trim();
-    let client = crate::http::HTTP.reqwest();
+    let client = crate::http::HTTP.reqwest()?;
 
     loop {
         if chrono::Utc::now() >= deadline {
@@ -379,7 +379,7 @@ async fn refresh_token(cached: &CachedToken) -> Result<Option<CachedToken>> {
         settings.github.oauth_auth_url.trim_end_matches('/')
     );
     let response = crate::http::HTTP
-        .reqwest()
+        .reqwest()?
         .post(url)
         .header("Accept", "application/json")
         .form(&[

--- a/src/http.rs
+++ b/src/http.rs
@@ -25,14 +25,13 @@ use crate::ui::time::format_duration;
 use crate::{env, file};
 
 pub static HTTP: Lazy<Client> =
-    Lazy::new(|| Client::new(Settings::get().http_timeout(), ClientKind::Http).unwrap());
+    Lazy::new(|| Client::new_shared(Settings::get().http_timeout(), ClientKind::Http));
 
 pub static HTTP_FETCH: Lazy<Client> = Lazy::new(|| {
-    Client::new(
+    Client::new_shared(
         Settings::get().configured_fetch_remote_versions_timeout(),
         ClientKind::Fetch,
     )
-    .unwrap()
 });
 
 /// In-memory cache for HTTP text responses, useful for requests that are repeated
@@ -107,7 +106,7 @@ impl SendOnceOptions {
 
 #[derive(Debug)]
 pub struct Client {
-    reqwest: reqwest::Client,
+    reqwest: Result<reqwest::Client, String>,
     timeout: Duration,
     kind: ClientKind,
 }
@@ -119,15 +118,37 @@ enum ClientKind {
 }
 
 impl Client {
+    #[cfg(test)]
     fn new(timeout: Duration, kind: ClientKind) -> Result<Self> {
         Ok(Self {
-            reqwest: Self::_new()
-                .read_timeout(timeout)
-                .connect_timeout(timeout)
-                .build()?,
+            reqwest: Ok(Self::build(timeout)?),
             timeout,
             kind,
         })
+    }
+
+    fn new_shared(timeout: Duration, kind: ClientKind) -> Self {
+        Self {
+            reqwest: Self::build(timeout).map_err(|err| format!("{err:#}")),
+            timeout,
+            kind,
+        }
+    }
+
+    fn build(timeout: Duration) -> Result<reqwest::Client> {
+        Ok(Self::_new()
+            .read_timeout(timeout)
+            .connect_timeout(timeout)
+            .build()?)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_init_error(error: impl Into<String>) -> Self {
+        Self {
+            reqwest: Err(error.into()),
+            timeout: Duration::from_secs(1),
+            kind: ClientKind::Http,
+        }
     }
 
     /// Underlying reqwest client. Use sparingly — most callers should reach for
@@ -135,8 +156,10 @@ impl Client {
     /// exists for callers that need request shapes those helpers don't cover
     /// (e.g. form-encoded POST in the GitHub OAuth flow) but still want the
     /// shared timeouts, gzip, and user-agent.
-    pub fn reqwest(&self) -> &reqwest::Client {
-        &self.reqwest
+    pub fn reqwest(&self) -> Result<&reqwest::Client> {
+        self.reqwest
+            .as_ref()
+            .map_err(|err| eyre!("Could not initialize the HTTP client: {err}"))
     }
 
     fn _new() -> ClientBuilder {
@@ -360,7 +383,7 @@ impl Client {
         let url = url.into_url()?;
         debug!("POST {}", &url);
         let resp = self
-            .reqwest
+            .reqwest()?
             .post(url)
             .header("Content-Type", "application/json")
             .headers(headers.clone())
@@ -663,7 +686,7 @@ impl Client {
         }
 
         let request_timeout = self.request_timeout();
-        let mut req = self.reqwest.request(method.clone(), url.clone());
+        let mut req = self.reqwest()?.request(method.clone(), url.clone());
         if matches!(self.kind, ClientKind::Fetch) {
             req = req.timeout(request_timeout);
         }
@@ -1425,6 +1448,16 @@ mod tests {
         assert!(client.head("").await.is_err());
         assert!(client.get_text("").await.is_err());
         assert!(client.get_text_request("").send().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_client_initialization_error_is_returned_not_panicked() {
+        let client = Client::with_init_error("builder error: OpenSSL error");
+
+        let err = client.get_text("https://example.com").await.unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("Could not initialize the HTTP client"));
+        assert!(message.contains("builder error: OpenSSL error"));
     }
 
     #[tokio::test]
@@ -2201,12 +2234,12 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let _settings_guard = set_test_prefer_offline(3);
         let timeout = Duration::from_secs(3);
         let client = Client {
-            reqwest: Client::_new()
+            reqwest: Ok(Client::_new()
                 .no_proxy()
                 .read_timeout(timeout)
                 .connect_timeout(timeout)
                 .build()
-                .unwrap(),
+                .unwrap()),
             timeout,
             kind: ClientKind::Fetch,
         };

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -340,15 +340,15 @@ impl AuthSession {
     /// any streamed body itself.
     async fn send<F>(&mut self, build: F) -> Result<reqwest::Response>
     where
-        F: Fn(Option<&str>) -> reqwest::RequestBuilder,
+        F: Fn(Option<&str>) -> Result<reqwest::RequestBuilder>,
     {
-        let resp = build(self.header()).send().await?;
+        let resp = build(self.header())?.send().await?;
         if resp.status() != StatusCode::UNAUTHORIZED {
             return Ok(resp);
         }
         let www_auth = header_str(&resp, "www-authenticate");
         if self.answer_challenge(&www_auth).await? {
-            return Ok(build(self.header()).send().await?);
+            return Ok(build(self.header())?.send().await?);
         }
         Ok(resp)
     }
@@ -380,7 +380,7 @@ async fn fetch_bearer_token(
             form.push(("service", s));
         }
         let resp = HTTP
-            .reqwest()
+            .reqwest()?
             .post(realm)
             .form(&form)
             .send()
@@ -433,11 +433,11 @@ async fn fetch_manifest_json(
     let accept_hdr = accept.join(", ");
     let resp = session
         .send(|auth| {
-            let mut rb = HTTP.reqwest().get(url).header("Accept", &accept_hdr);
+            let mut rb = HTTP.reqwest()?.get(url).header("Accept", &accept_hdr);
             if let Some(a) = auth {
                 rb = rb.header("Authorization", a);
             }
-            rb
+            Ok(rb)
         })
         .await
         .wrap_err_with(|| format!("fetching {url}"))?;
@@ -519,11 +519,11 @@ async fn download_blob_once(
 ) -> Result<Vec<u8>> {
     let resp = session
         .send(|auth| {
-            let mut rb = HTTP.reqwest().get(url);
+            let mut rb = HTTP.reqwest()?.get(url);
             if let Some(a) = auth {
                 rb = rb.header("Authorization", a);
             }
-            rb
+            Ok(rb)
         })
         .await
         .wrap_err_with(|| format!("GET {url}"))?;
@@ -768,13 +768,13 @@ pub async fn fetch_remote_image(reference: &str) -> Result<Option<RemoteImage>> 
     let resp = session
         .send(|auth| {
             let mut rb = HTTP
-                .reqwest()
+                .reqwest()?
                 .get(&manifest_url)
                 .header("Accept", index_accept.join(", "));
             if let Some(a) = auth {
                 rb = rb.header("Authorization", a);
             }
-            rb
+            Ok(rb)
         })
         .await
         .wrap_err_with(|| format!("fetching {manifest_url}"))?;
@@ -1226,11 +1226,11 @@ impl Pusher {
         let resp = self
             .session
             .send(|auth| {
-                let mut rb = HTTP.reqwest().head(&url);
+                let mut rb = HTTP.reqwest()?.head(&url);
                 if let Some(a) = auth {
                     rb = rb.header("Authorization", a);
                 }
-                rb
+                Ok(rb)
             })
             .await
             .wrap_err_with(|| format!("HEAD {url}"))?;
@@ -1292,13 +1292,13 @@ impl Pusher {
             .session
             .send(|auth| {
                 let mut rb = HTTP
-                    .reqwest()
+                    .reqwest()?
                     .post(start_url.as_str())
                     .header("Content-Length", "0");
                 if let Some(a) = auth {
                     rb = rb.header("Authorization", a);
                 }
-                rb
+                Ok(rb)
             })
             .await
             .wrap_err_with(|| format!("POST {start_url}"))?;
@@ -1330,8 +1330,8 @@ impl Pusher {
                 let resp = self
                     .session
                     .send(|auth| {
-                        build_upload_request(
-                            HTTP.reqwest().patch(location.as_str()),
+                        Ok(build_upload_request(
+                            HTTP.reqwest()?.patch(location.as_str()),
                             auth,
                             path,
                             offset,
@@ -1340,7 +1340,7 @@ impl Pusher {
                             &err_slot,
                         )
                         // Content-Range is inclusive on both ends.
-                        .header("Content-Range", format!("{}-{}", offset, offset + len - 1))
+                        .header("Content-Range", format!("{}-{}", offset, offset + len - 1)))
                     })
                     .await
                     .wrap_err("PATCH blob chunk")?;
@@ -1369,13 +1369,13 @@ impl Pusher {
                 .session
                 .send(|auth| {
                     let mut rb = HTTP
-                        .reqwest()
+                        .reqwest()?
                         .put(put_url.as_str())
                         .header("Content-Length", "0");
                     if let Some(a) = auth {
                         rb = rb.header("Authorization", a);
                     }
-                    rb
+                    Ok(rb)
                 })
                 .await
                 .wrap_err("PUT blob upload (finalize)")?;
@@ -1398,15 +1398,15 @@ impl Pusher {
             let resp = self
                 .session
                 .send(|auth| {
-                    build_upload_request(
-                        HTTP.reqwest().put(put_url.as_str()),
+                    Ok(build_upload_request(
+                        HTTP.reqwest()?.put(put_url.as_str()),
                         auth,
                         path,
                         0,
                         size,
                         pr,
                         &err_slot,
-                    )
+                    ))
                 })
                 .await
                 .wrap_err("PUT blob upload")?;
@@ -1449,14 +1449,14 @@ impl Pusher {
             .session
             .send(|auth| {
                 let mut rb = HTTP
-                    .reqwest()
+                    .reqwest()?
                     .put(&url)
                     .header("Content-Type", media_type)
                     .body(body.clone());
                 if let Some(a) = auth {
                     rb = rb.header("Authorization", a);
                 }
-                rb
+                Ok(rb)
             })
             .await
             .wrap_err_with(|| format!("PUT {url}"))?;
@@ -1516,11 +1516,11 @@ impl Pusher {
         let resp = self
             .session
             .send(|auth| {
-                let mut rb = HTTP.reqwest().get(&url).header("Accept", &accept);
+                let mut rb = HTTP.reqwest()?.get(&url).header("Accept", &accept);
                 if let Some(a) = auth {
                     rb = rb.header("Authorization", a);
                 }
-                rb
+                Ok(rb)
             })
             .await
             .wrap_err_with(|| format!("GET {url}"))?;


### PR DESCRIPTION
## Summary
- preserve HTTP client initialization failures instead of panicking from the shared lazy clients
- propagate initialization errors through high-level requests, GitHub OAuth, and OCI registry operations
- keep version reporting best-effort so a failed client yields no latest version while network-dependent commands retain the full cause

## Root cause
The shared HTTP clients were constructed with `Client::new(...).unwrap()`. A reqwest builder failure, including native-tls/OpenSSL initialization failures, therefore panicked as soon as an HTTP path first accessed the lazy client.

The shared client now stores either the initialized reqwest client or its initialization error. Accessors return `Could not initialize the HTTP client` with the original builder error, and all raw reqwest consumers propagate that result. Initialization remains once per shared client per process, so a failed initialization is not retried unpredictably.

Version update checks continue to be best-effort: an initialization error is debug-logged and treated as no remote version. Normal version output still succeeds, and JSON output uses `latest: null`. Commands that require network access instead fail normally with the initialization context.

## Test Plan
- `mise exec -- cargo test --bin mise` (2,235 tests passed)
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- Linux native-tls container with an empty version cache, no network, and unavailable certificate paths: version output completed successfully and the failed update check remained debug-only

`mise run format` and `mise run lint` reach `hk`, which cannot identify this Sapling working copy as a Git repository (`failed to find git repository`); the applicable Rustfmt and Clippy checks were run directly above.

Addresses https://github.com/jdx/mise/discussions/4447

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*