### PR TITLE
perf(task): cache workspace discovery filesystem access

### DIFF
--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug, Display};
+use std::fs;
+use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 
 use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
@@ -226,6 +229,15 @@ pub trait WorkspaceProvider: Debug + Send + Sync {
     /// sets determine the canonical graph order instead.
     fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>>;
 
+    /// Returns every project using filesystem results shared across providers.
+    fn discover_with_context(
+        &self,
+        workspace_root: &Path,
+        _context: &WorkspaceDiscoveryContext,
+    ) -> Result<Vec<WorkspaceProject>> {
+        self.discover(workspace_root)
+    }
+
     /// Re-discovers location-derived tasks after an explicit root override.
     fn discover_project_tasks(
         &self,
@@ -234,6 +246,162 @@ pub trait WorkspaceProvider: Debug + Send + Sync {
     ) -> Result<BTreeMap<String, WorkspaceTask>> {
         Ok(BTreeMap::new())
     }
+
+    /// Re-discovers tasks using filesystem results shared across providers.
+    fn discover_project_tasks_with_context(
+        &self,
+        workspace_root: &Path,
+        project_root: &Path,
+        _context: &WorkspaceDiscoveryContext,
+    ) -> Result<BTreeMap<String, WorkspaceTask>> {
+        self.discover_project_tasks(workspace_root, project_root)
+    }
+}
+
+/// Filesystem results shared by every provider during one graph discovery.
+#[derive(Debug, Default)]
+pub struct WorkspaceDiscoveryContext {
+    cache: Mutex<WorkspaceDiscoveryCache>,
+    #[cfg(test)]
+    physical_accesses: WorkspaceDiscoveryAccessCounts,
+}
+
+#[derive(Debug, Default)]
+struct WorkspaceDiscoveryCache {
+    canonical_paths: BTreeMap<PathBuf, CachedIo<PathBuf>>,
+    file_kinds: BTreeMap<PathBuf, Option<CachedFileKind>>,
+    file_contents: BTreeMap<PathBuf, CachedIo<Arc<str>>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CachedFileKind {
+    File,
+    Directory,
+    Other,
+}
+
+#[derive(Clone, Debug)]
+enum CachedIo<T> {
+    Ok(T),
+    Err(io::ErrorKind, String),
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct WorkspaceDiscoveryAccessCounts {
+    canonicalize: std::sync::atomic::AtomicUsize,
+    metadata: std::sync::atomic::AtomicUsize,
+    read: std::sync::atomic::AtomicUsize,
+}
+
+impl WorkspaceDiscoveryContext {
+    /// Creates an empty cache scoped to one workspace graph discovery.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a canonical path without repeating the filesystem operation.
+    pub fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        let key = self.cache_key(path);
+        let mut cache = self.cache.lock().expect("workspace discovery cache lock");
+        cache
+            .canonical_paths
+            .entry(key.clone())
+            .or_insert_with(|| {
+                #[cfg(test)]
+                self.physical_accesses
+                    .canonicalize
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                CachedIo::from_result(fs::canonicalize(key))
+            })
+            .to_result()
+    }
+
+    /// Returns whether a path is a regular file using a shared metadata probe.
+    pub fn is_file(&self, path: &Path) -> bool {
+        self.file_kind(path) == Some(CachedFileKind::File)
+    }
+
+    /// Returns whether a path is a directory using a shared metadata probe.
+    pub fn is_dir(&self, path: &Path) -> bool {
+        self.file_kind(path) == Some(CachedFileKind::Directory)
+    }
+
+    /// Returns whether a path exists using a shared metadata probe.
+    pub fn exists(&self, path: &Path) -> bool {
+        self.file_kind(path).is_some()
+    }
+
+    /// Reads UTF-8 file contents without repeating the filesystem operation.
+    pub fn read_to_string(&self, path: &Path) -> io::Result<Arc<str>> {
+        let key = self.cache_key(path);
+        let mut cache = self.cache.lock().expect("workspace discovery cache lock");
+        cache
+            .file_contents
+            .entry(key.clone())
+            .or_insert_with(|| {
+                #[cfg(test)]
+                self.physical_accesses
+                    .read
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                CachedIo::from_result(fs::read_to_string(key).map(Arc::<str>::from))
+            })
+            .to_result()
+    }
+
+    fn file_kind(&self, path: &Path) -> Option<CachedFileKind> {
+        let key = self.cache_key(path);
+        let mut cache = self.cache.lock().expect("workspace discovery cache lock");
+        *cache.file_kinds.entry(key.clone()).or_insert_with(|| {
+            #[cfg(test)]
+            self.physical_accesses
+                .metadata
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            fs::metadata(key).ok().map(|metadata| {
+                if metadata.is_file() {
+                    CachedFileKind::File
+                } else if metadata.is_dir() {
+                    CachedFileKind::Directory
+                } else {
+                    CachedFileKind::Other
+                }
+            })
+        })
+    }
+
+    fn cache_key(&self, path: &Path) -> PathBuf {
+        normalize_filesystem_path(path)
+    }
+}
+
+impl<T: Clone> CachedIo<T> {
+    fn from_result(result: io::Result<T>) -> Self {
+        match result {
+            Ok(value) => Self::Ok(value),
+            Err(error) => Self::Err(error.kind(), error.to_string()),
+        }
+    }
+
+    fn to_result(&self) -> io::Result<T> {
+        match self {
+            Self::Ok(value) => Ok(value.clone()),
+            Self::Err(kind, message) => Err(io::Error::new(*kind, message.clone())),
+        }
+    }
+}
+
+fn normalize_filesystem_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    if normalized.as_os_str().is_empty() && !path.as_os_str().is_empty() {
+        normalized.push(".");
+    }
+    normalized
 }
 
 /// A validated, deterministically ordered project graph from workspace providers.
@@ -295,7 +463,8 @@ impl WorkspaceProjectGraph {
         providers: &[&dyn WorkspaceProvider],
         workspace_root: &Path,
     ) -> Result<WorkspaceProjectGraph> {
-        let graph = Self::collect_provider_projects(providers, workspace_root, false)?;
+        let context = WorkspaceDiscoveryContext::new();
+        let graph = Self::collect_provider_projects(providers, workspace_root, &context, false)?;
         graph.validate()?;
         Ok(graph)
     }
@@ -331,9 +500,14 @@ impl WorkspaceProjectGraph {
         overrides: &BTreeMap<String, WorkspaceProjectOverride>,
         skip_provider_errors: bool,
     ) -> Result<WorkspaceProjectGraph> {
-        let mut graph =
-            Self::collect_provider_projects(providers, workspace_root, skip_provider_errors)?
-                .with_overrides(overrides)?;
+        let context = WorkspaceDiscoveryContext::new();
+        let mut graph = Self::collect_provider_projects(
+            providers,
+            workspace_root,
+            &context,
+            skip_provider_errors,
+        )?
+        .with_overrides(overrides)?;
         for (raw_id, config) in overrides {
             if config.remove || config.root.is_none() {
                 continue;
@@ -352,7 +526,11 @@ impl WorkspaceProjectGraph {
                 .projects
                 .get_mut(&id)
                 .expect("non-removed override project exists");
-            match provider.discover_project_tasks(workspace_root, project.root.as_path()) {
+            match provider.discover_project_tasks_with_context(
+                workspace_root,
+                project.root.as_path(),
+                &context,
+            ) {
                 Ok(mut tasks) => {
                     for task in tasks.values_mut() {
                         attach_task_provenance(task, provider_id);
@@ -374,6 +552,7 @@ impl WorkspaceProjectGraph {
     fn collect_provider_projects(
         providers: &[&dyn WorkspaceProvider],
         workspace_root: &Path,
+        context: &WorkspaceDiscoveryContext,
         skip_provider_errors: bool,
     ) -> Result<WorkspaceProjectGraph> {
         let mut providers = providers
@@ -392,7 +571,7 @@ impl WorkspaceProjectGraph {
         let mut projects = BTreeMap::new();
         let mut provider_errors = BTreeMap::new();
         for (provider_id, provider) in providers {
-            let discovered = match provider.discover(workspace_root) {
+            let discovered = match provider.discover_with_context(workspace_root, context) {
                 Ok(projects) => projects,
                 Err(error) if skip_provider_errors => {
                     let error = format!("{error:#}");
@@ -820,6 +999,34 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct ContextObservingProvider {
+        id: &'static str,
+        contents: Arc<Mutex<Vec<Arc<str>>>>,
+    }
+
+    impl WorkspaceProvider for ContextObservingProvider {
+        fn id(&self) -> &str {
+            self.id
+        }
+
+        fn discover(&self, _workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+            bail!("graph discovery did not provide a shared context")
+        }
+
+        fn discover_with_context(
+            &self,
+            workspace_root: &Path,
+            context: &WorkspaceDiscoveryContext,
+        ) -> Result<Vec<WorkspaceProject>> {
+            self.contents
+                .lock()
+                .unwrap()
+                .push(context.read_to_string(&workspace_root.join("shared.txt"))?);
+            Ok(Vec::new())
+        }
+    }
+
     fn project(provider: &str, name: &str, root: &str) -> WorkspaceProject {
         WorkspaceProject::new(ProjectId::new(provider, name).unwrap(), root)
     }
@@ -829,6 +1036,94 @@ mod tests {
             id: "test",
             projects,
         }
+    }
+
+    #[test]
+    fn discovery_context_deduplicates_filesystem_accesses() {
+        use std::sync::atomic::Ordering;
+
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = temp.path().join("manifest.txt");
+        std::fs::write(&manifest, "workspace").unwrap();
+        let context = WorkspaceDiscoveryContext::new();
+
+        assert!(context.is_file(&manifest));
+        assert!(context.exists(&temp.path().join("./manifest.txt")));
+        let first = context.read_to_string(&manifest).unwrap();
+        let second = context
+            .read_to_string(&temp.path().join("./manifest.txt"))
+            .unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            context.canonicalize(temp.path()).unwrap(),
+            context.canonicalize(temp.path()).unwrap()
+        );
+
+        assert_eq!(
+            context.physical_accesses.metadata.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(context.physical_accesses.read.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            context
+                .physical_accesses
+                .canonicalize
+                .load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn discovery_context_preserves_current_and_parent_components() {
+        let context = WorkspaceDiscoveryContext::new();
+
+        assert_eq!(
+            context.canonicalize(Path::new(".")).unwrap(),
+            std::fs::canonicalize(".").unwrap()
+        );
+        assert_eq!(
+            normalize_filesystem_path(Path::new("package/../manifest.txt")),
+            Path::new("package/../manifest.txt")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovery_context_preserves_symlink_parent_traversal() {
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp.path().join("real");
+        std::fs::create_dir_all(real.join("nested")).unwrap();
+        std::fs::write(real.join("manifest.txt"), "workspace").unwrap();
+        std::os::unix::fs::symlink(real.join("nested"), temp.path().join("link")).unwrap();
+        let path = temp.path().join("link/../manifest.txt");
+        let context = WorkspaceDiscoveryContext::new();
+
+        assert!(context.is_file(&path));
+        assert_eq!(
+            context.canonicalize(&path).unwrap(),
+            std::fs::canonicalize(real.join("manifest.txt")).unwrap()
+        );
+    }
+
+    #[test]
+    fn graph_discovery_shares_context_between_providers() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("shared.txt"), "workspace").unwrap();
+        let contents = Arc::new(Mutex::new(Vec::new()));
+        let first = ContextObservingProvider {
+            id: "first",
+            contents: contents.clone(),
+        };
+        let second = ContextObservingProvider {
+            id: "second",
+            contents: contents.clone(),
+        };
+
+        WorkspaceProjectGraph::discover_all(&[&first, &second], temp.path()).unwrap();
+
+        let contents = contents.lock().unwrap();
+        assert_eq!(contents.len(), 2);
+        assert!(Arc::ptr_eq(&contents[0], &contents[1]));
     }
 
     #[test]

--- a/src/task/workspace/cargo.rs
+++ b/src/task/workspace/cargo.rs
@@ -1,12 +1,13 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use eyre::{Context, Result, bail};
 use glob::{MatchOptions, Pattern};
 use serde::Deserialize;
 
-use super::{ProjectId, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider};
+use super::{
+    ProjectId, WorkspaceDiscoveryContext, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider,
+};
 
 const CARGO_TOML: &str = "Cargo.toml";
 
@@ -14,7 +15,7 @@ const CARGO_TOML: &str = "Cargo.toml";
 #[derive(Debug, Default)]
 pub struct CargoWorkspaceProvider;
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct CargoManifest {
     package: Option<CargoPackage>,
@@ -27,12 +28,12 @@ struct CargoManifest {
     target: BTreeMap<String, TargetDependencies>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct CargoPackage {
     name: String,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct CargoWorkspace {
     members: Vec<String>,
@@ -40,7 +41,7 @@ struct CargoWorkspace {
     dependencies: DependencyMap,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct TargetDependencies {
     dependencies: DependencyMap,
@@ -65,15 +66,24 @@ impl WorkspaceProvider for CargoWorkspaceProvider {
     }
 
     fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+        let context = WorkspaceDiscoveryContext::new();
+        self.discover_with_context(workspace_root, &context)
+    }
+
+    fn discover_with_context(
+        &self,
+        workspace_root: &Path,
+        context: &WorkspaceDiscoveryContext,
+    ) -> Result<Vec<WorkspaceProject>> {
         let root_manifest_path = workspace_root.join(CARGO_TOML);
-        if !root_manifest_path.is_file() {
+        if !context.is_file(&root_manifest_path) {
             return Ok(Vec::new());
         }
-        let root_manifest = read_manifest(&root_manifest_path)?;
+        let root_manifest = read_manifest(context, &root_manifest_path)?;
         let Some(workspace) = root_manifest.workspace.as_ref() else {
             return Ok(Vec::new());
         };
-        let canonical_root = workspace_root.canonicalize().wrap_err_with(|| {
+        let canonical_root = context.canonicalize(workspace_root).wrap_err_with(|| {
             format!(
                 "failed to resolve Cargo workspace root {}",
                 workspace_root.display()
@@ -94,6 +104,7 @@ impl WorkspaceProvider for CargoWorkspaceProvider {
             &canonical_root,
             &workspace.members,
             &excludes,
+            context,
         )?;
         if root_manifest.package.is_some() && !is_excluded(Path::new("."), &excludes) {
             roots.insert(canonical_root.clone());
@@ -109,9 +120,9 @@ impl WorkspaceProvider for CargoWorkspaceProvider {
             let relative = relative_root(&canonical_root, &package_root)?;
             let manifest_path = package_root.join(CARGO_TOML);
             let manifest = if package_root == canonical_root {
-                read_manifest(&root_manifest_path)?
+                root_manifest.clone()
             } else {
-                read_manifest(&manifest_path)?
+                read_manifest(context, &manifest_path)?
             };
             let package = manifest.package.as_ref().ok_or_else(|| {
                 eyre::eyre!(
@@ -128,10 +139,10 @@ impl WorkspaceProvider for CargoWorkspaceProvider {
                     continue;
                 };
                 let candidate = base.join(path);
-                if !candidate.join(CARGO_TOML).is_file() {
+                if !context.is_file(&candidate.join(CARGO_TOML)) {
                     continue;
                 }
-                let candidate = candidate.canonicalize().wrap_err_with(|| {
+                let candidate = context.canonicalize(&candidate).wrap_err_with(|| {
                     format!(
                         "failed to resolve Cargo path dependency {}",
                         candidate.display()
@@ -177,10 +188,10 @@ impl WorkspaceProvider for CargoWorkspaceProvider {
                         continue;
                     };
                     let candidate = base.join(path);
-                    if !candidate.join(CARGO_TOML).is_file() {
+                    if !context.is_file(&candidate.join(CARGO_TOML)) {
                         continue;
                     }
-                    let candidate = candidate.canonicalize().wrap_err_with(|| {
+                    let candidate = context.canonicalize(&candidate).wrap_err_with(|| {
                         format!(
                             "failed to resolve Cargo path dependency {}",
                             candidate.display()
@@ -214,8 +225,9 @@ impl WorkspaceProvider for CargoWorkspaceProvider {
     }
 }
 
-fn read_manifest(path: &Path) -> Result<CargoManifest> {
-    let contents = fs::read_to_string(path)
+fn read_manifest(context: &WorkspaceDiscoveryContext, path: &Path) -> Result<CargoManifest> {
+    let contents = context
+        .read_to_string(path)
         .wrap_err_with(|| format!("failed to read Cargo manifest {}", path.display()))?;
     toml::from_str(&contents)
         .wrap_err_with(|| format!("failed to parse Cargo manifest {}", path.display()))
@@ -226,6 +238,7 @@ fn discover_members(
     canonical_root: &Path,
     members: &[String],
     excludes: &[Pattern],
+    context: &WorkspaceDiscoveryContext,
 ) -> Result<BTreeSet<PathBuf>> {
     let options = MatchOptions {
         case_sensitive: true,
@@ -247,10 +260,10 @@ fn discover_members(
             let candidate = candidate.wrap_err_with(|| {
                 format!("failed to evaluate Cargo workspace member pattern {member:?}")
             })?;
-            if !candidate.join(CARGO_TOML).is_file() {
+            if !context.is_file(&candidate.join(CARGO_TOML)) {
                 continue;
             }
-            let candidate = candidate.canonicalize().wrap_err_with(|| {
+            let candidate = context.canonicalize(&candidate).wrap_err_with(|| {
                 format!(
                     "failed to resolve Cargo workspace member {}",
                     candidate.display()

--- a/src/task/workspace/go.rs
+++ b/src/task/workspace/go.rs
@@ -1,10 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
 use std::path::{Component, Path, PathBuf};
 
 use eyre::{Context, Result, bail};
 
-use super::{ProjectId, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider};
+use super::{
+    ProjectId, WorkspaceDiscoveryContext, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider,
+};
 
 const GO_MOD: &str = "go.mod";
 const GO_WORK: &str = "go.work";
@@ -19,18 +20,27 @@ impl WorkspaceProvider for GoWorkspaceProvider {
     }
 
     fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+        let context = WorkspaceDiscoveryContext::new();
+        self.discover_with_context(workspace_root, &context)
+    }
+
+    fn discover_with_context(
+        &self,
+        workspace_root: &Path,
+        context: &WorkspaceDiscoveryContext,
+    ) -> Result<Vec<WorkspaceProject>> {
         let workfile_path = workspace_root.join(GO_WORK);
-        if !workfile_path.is_file() {
+        if !context.is_file(&workfile_path) {
             return Ok(Vec::new());
         }
-        let canonical_root = workspace_root.canonicalize().wrap_err_with(|| {
+        let canonical_root = context.canonicalize(workspace_root).wrap_err_with(|| {
             format!(
                 "failed to resolve Go workspace root {}",
                 workspace_root.display()
             )
         })?;
         let lexical_root = lexical_absolute(workspace_root)?;
-        let module_directories = read_workfile(&workfile_path)?;
+        let module_directories = read_workfile(context, &workfile_path)?;
         let mut modules = BTreeMap::new();
 
         for directory in module_directories {
@@ -46,7 +56,7 @@ impl WorkspaceProvider for GoWorkspaceProvider {
                 continue;
             }
             let candidate = lexical_candidate;
-            if !candidate.exists() {
+            if !context.exists(&candidate) {
                 if missing_path_resolves_outside(&candidate, &lexical_root, &canonical_root)? {
                     continue;
                 }
@@ -55,7 +65,7 @@ impl WorkspaceProvider for GoWorkspaceProvider {
                     candidate.display()
                 );
             }
-            let canonical_module = candidate.canonicalize().wrap_err_with(|| {
+            let canonical_module = context.canonicalize(&candidate).wrap_err_with(|| {
                 format!(
                     "failed to resolve Go workspace module {}",
                     candidate.display()
@@ -64,14 +74,14 @@ impl WorkspaceProvider for GoWorkspaceProvider {
             let Ok(relative) = canonical_module.strip_prefix(&canonical_root) else {
                 continue;
             };
-            if !canonical_module.join(GO_MOD).is_file() {
+            if !context.is_file(&canonical_module.join(GO_MOD)) {
                 bail!(
                     "Go workspace module {} is missing {GO_MOD}",
                     candidate.display()
                 );
             }
             let relative = normalize_relative(relative);
-            let module_path = read_module_path(&canonical_module.join(GO_MOD))?;
+            let module_path = read_module_path(context, &canonical_module.join(GO_MOD))?;
             let id = ProjectId::new(self.id(), &module_path)?;
             let source = relative.join(GO_MOD);
             let provenance = WorkspaceProvenance {
@@ -90,8 +100,9 @@ impl WorkspaceProvider for GoWorkspaceProvider {
     }
 }
 
-fn read_workfile(path: &Path) -> Result<Vec<PathBuf>> {
-    let contents = fs::read_to_string(path)
+fn read_workfile(context: &WorkspaceDiscoveryContext, path: &Path) -> Result<Vec<PathBuf>> {
+    let contents = context
+        .read_to_string(path)
         .wrap_err_with(|| format!("failed to read Go workspace metadata {}", path.display()))?;
     parse_workfile(&contents)
         .wrap_err_with(|| format!("failed to parse Go workspace metadata {}", path.display()))
@@ -136,8 +147,9 @@ fn parse_workfile(contents: &str) -> Result<Vec<PathBuf>> {
     Ok(directories)
 }
 
-fn read_module_path(path: &Path) -> Result<String> {
-    let contents = fs::read_to_string(path)
+fn read_module_path(context: &WorkspaceDiscoveryContext, path: &Path) -> Result<String> {
+    let contents = context
+        .read_to_string(path)
         .wrap_err_with(|| format!("failed to read Go module metadata {}", path.display()))?;
     let mut module_path = None;
 

--- a/src/task/workspace/node.rs
+++ b/src/task/workspace/node.rs
@@ -6,8 +6,8 @@ use eyre::{Context, Result};
 use serde::Deserialize;
 
 use super::{
-    ProjectId, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider, WorkspaceTask,
-    WorkspaceTaskSuggestions,
+    ProjectId, WorkspaceDiscoveryContext, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider,
+    WorkspaceTask, WorkspaceTaskSuggestions,
 };
 
 const PACKAGE_JSON: &str = "package.json";
@@ -22,6 +22,7 @@ struct WorkspaceDefinition {
     source: &'static str,
     package_manager: Option<String>,
     include_named_root: bool,
+    root_manifest: Option<PackageJson>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -46,16 +47,25 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
     }
 
     fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
-        let Some(definition) = workspace_definition(workspace_root)? else {
+        let context = WorkspaceDiscoveryContext::new();
+        self.discover_with_context(workspace_root, &context)
+    }
+
+    fn discover_with_context(
+        &self,
+        workspace_root: &Path,
+        context: &WorkspaceDiscoveryContext,
+    ) -> Result<Vec<WorkspaceProject>> {
+        let Some(definition) = workspace_definition(workspace_root, context)? else {
             return Ok(Vec::new());
         };
-        let canonical_root = workspace_root.canonicalize().wrap_err_with(|| {
+        let canonical_root = context.canonicalize(workspace_root).wrap_err_with(|| {
             format!(
                 "failed to resolve Node workspace root {}",
                 workspace_root.display()
             )
         })?;
-        let turbo = read_turbo_json(workspace_root)?;
+        let turbo = read_turbo_json(workspace_root, context)?;
         let mut roots = aube::embed::discover_workspace_packages(
             &canonical_root,
             WorkspaceDiscoveryOptions::confined_to_root(),
@@ -89,22 +99,36 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
             }
         })
         .collect::<Result<BTreeSet<_>>>()?;
-        if definition.include_named_root {
+        let mut root_manifest = definition.root_manifest.clone();
+        if definition.include_named_root && root_manifest.is_none() {
             let root_manifest_path = workspace_root.join(PACKAGE_JSON);
-            if root_manifest_path.is_file()
-                && read_package_json_if_valid(&root_manifest_path)?
-                    .and_then(|manifest| manifest.name)
-                    .is_some()
-            {
-                roots.insert(PathBuf::from("."));
-            }
+            root_manifest = context
+                .is_file(&root_manifest_path)
+                .then(|| read_package_json_if_valid(context, &root_manifest_path))
+                .transpose()?
+                .flatten();
+        }
+        if definition.include_named_root
+            && root_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.name.as_ref())
+                .is_some()
+        {
+            roots.insert(PathBuf::from("."));
         }
 
         let manifests = roots
             .into_iter()
             .map(|root| {
                 let manifest_path = workspace_root.join(&root).join(PACKAGE_JSON);
-                let manifest = read_package_json(&manifest_path)?;
+                let manifest = if root == Path::new(".") {
+                    match root_manifest.clone() {
+                        Some(manifest) => manifest,
+                        None => read_package_json(context, &manifest_path)?,
+                    }
+                } else {
+                    read_package_json(context, &manifest_path)?
+                };
                 let name = manifest.name.clone().ok_or_else(|| {
                     eyre::eyre!(
                         "Node workspace package at {} is missing the package.json \"name\" field",
@@ -179,19 +203,29 @@ impl WorkspaceProvider for NodeWorkspaceProvider {
         workspace_root: &Path,
         project_root: &Path,
     ) -> Result<BTreeMap<String, WorkspaceTask>> {
-        let Some(definition) = workspace_definition(workspace_root)? else {
+        let context = WorkspaceDiscoveryContext::new();
+        self.discover_project_tasks_with_context(workspace_root, project_root, &context)
+    }
+
+    fn discover_project_tasks_with_context(
+        &self,
+        workspace_root: &Path,
+        project_root: &Path,
+        context: &WorkspaceDiscoveryContext,
+    ) -> Result<BTreeMap<String, WorkspaceTask>> {
+        let Some(definition) = workspace_definition(workspace_root, context)? else {
             return Ok(BTreeMap::new());
         };
         let source = project_root.join(PACKAGE_JSON);
         let manifest_path = workspace_root.join(&source);
-        if !manifest_path.is_file() {
+        if !context.is_file(&manifest_path) {
             return Ok(BTreeMap::new());
         }
-        let Some(manifest) = read_package_json_if_valid(&manifest_path)? else {
+        let Some(manifest) = read_package_json_if_valid(context, &manifest_path)? else {
             return Ok(BTreeMap::new());
         };
         let package_manager = definition.package_manager.as_deref().unwrap_or("npm");
-        let turbo = read_turbo_json(workspace_root)?;
+        let turbo = read_turbo_json(workspace_root, context)?;
         Ok(workspace_tasks(
             &manifest,
             package_manager,
@@ -285,12 +319,15 @@ impl TurboTask {
     }
 }
 
-fn read_turbo_json(workspace_root: &Path) -> Result<Option<TurboJson>> {
+fn read_turbo_json(
+    workspace_root: &Path,
+    context: &WorkspaceDiscoveryContext,
+) -> Result<Option<TurboJson>> {
     let path = workspace_root.join(TURBO_JSON);
-    if !path.is_file() {
+    if !context.is_file(&path) {
         return Ok(None);
     }
-    let contents = match std::fs::read_to_string(&path) {
+    let contents = match context.read_to_string(&path) {
         Ok(contents) => contents,
         Err(error) => {
             warn!("failed to read optional {}: {error}", path.display());
@@ -306,20 +343,24 @@ fn read_turbo_json(workspace_root: &Path) -> Result<Option<TurboJson>> {
     }
 }
 
-fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinition>> {
+fn workspace_definition(
+    workspace_root: &Path,
+    context: &WorkspaceDiscoveryContext,
+) -> Result<Option<WorkspaceDefinition>> {
     let pnpm_workspace_path = workspace_root.join(PNPM_WORKSPACE);
-    if pnpm_workspace_path.is_file() {
+    if context.is_file(&pnpm_workspace_path) {
         return Ok(Some(WorkspaceDefinition {
             source: PNPM_WORKSPACE,
             package_manager: Some("pnpm".to_string()),
             include_named_root: true,
+            root_manifest: None,
         }));
     }
 
     let root_manifest_path = workspace_root.join(PACKAGE_JSON);
-    let root_manifest = root_manifest_path
-        .is_file()
-        .then(|| read_package_json_if_valid(&root_manifest_path))
+    let root_manifest = context
+        .is_file(&root_manifest_path)
+        .then(|| read_package_json_if_valid(context, &root_manifest_path))
         .transpose()?
         .flatten();
     let Some(root_manifest) = root_manifest else {
@@ -338,17 +379,25 @@ fn workspace_definition(workspace_root: &Path) -> Result<Option<WorkspaceDefinit
             .get("packageManager")
             .and_then(serde_json::Value::as_str)
             .map(str::to_string),
+        context,
     );
     let include_named_root = package_manager.as_deref() == Some("yarn");
     Ok(Some(WorkspaceDefinition {
         source: PACKAGE_JSON,
         package_manager,
         include_named_root,
+        root_manifest: Some(root_manifest),
     }))
 }
 
-fn read_package_json(path: &Path) -> Result<PackageJson> {
-    PackageJson::from_path(path).map_err(|error| {
+fn read_package_json(context: &WorkspaceDiscoveryContext, path: &Path) -> Result<PackageJson> {
+    let contents = context.read_to_string(path).map_err(|error| {
+        eyre::eyre!(
+            "failed to read Node package manifest {}: {error}",
+            path.display()
+        )
+    })?;
+    PackageJson::parse(path, contents.to_string()).map_err(|error| {
         eyre::eyre!(
             "failed to parse Node package manifest {}: {error}",
             path.display()
@@ -356,8 +405,17 @@ fn read_package_json(path: &Path) -> Result<PackageJson> {
     })
 }
 
-fn read_package_json_if_valid(path: &Path) -> Result<Option<PackageJson>> {
-    match PackageJson::from_path(path) {
+fn read_package_json_if_valid(
+    context: &WorkspaceDiscoveryContext,
+    path: &Path,
+) -> Result<Option<PackageJson>> {
+    let contents = context.read_to_string(path).map_err(|error| {
+        eyre::eyre!(
+            "failed to read Node package manifest {}: {error}",
+            path.display()
+        )
+    })?;
+    match PackageJson::parse(path, contents.to_string()) {
         Ok(manifest) => Ok(Some(manifest)),
         Err(ManifestError::Parse(_)) => Ok(None),
         Err(error) => Err(eyre::eyre!(
@@ -367,7 +425,11 @@ fn read_package_json_if_valid(path: &Path) -> Result<Option<PackageJson>> {
     }
 }
 
-fn detect_package_manager(workspace_root: &Path, configured: Option<String>) -> Option<String> {
+fn detect_package_manager(
+    workspace_root: &Path,
+    configured: Option<String>,
+    context: &WorkspaceDiscoveryContext,
+) -> Option<String> {
     configured
         .as_deref()
         .map(|value| value.split_once('@').map_or(value, |(name, _)| name))
@@ -387,7 +449,7 @@ fn detect_package_manager(workspace_root: &Path, configured: Option<String>) -> 
             .find_map(|(manager, lockfiles)| {
                 lockfiles
                     .iter()
-                    .any(|lockfile| workspace_root.join(lockfile).is_file())
+                    .any(|lockfile| context.is_file(&workspace_root.join(lockfile)))
                     .then(|| manager.to_string())
             })
         })
@@ -903,6 +965,21 @@ mod tests {
         assert_eq!(
             project_summary(&projects),
             vec![("node:app", Path::new("packages/app"), Some("pnpm"))]
+        );
+    }
+
+    #[test]
+    fn pnpm_root_package_parse_errors_do_not_panic() {
+        let temp = tempdir().unwrap();
+        write(&temp.path().join(PACKAGE_JSON), "{");
+        write(&temp.path().join(PNPM_WORKSPACE), "packages:\n  - .\n");
+
+        let error = NodeWorkspaceProvider.discover(temp.path()).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to parse Node package manifest")
         );
     }
 

--- a/src/task/workspace/uv.rs
+++ b/src/task/workspace/uv.rs
@@ -1,12 +1,13 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use eyre::{Context, Result, bail};
 use glob::{MatchOptions, Pattern};
 use serde::Deserialize;
 
-use super::{ProjectId, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider};
+use super::{
+    ProjectId, WorkspaceDiscoveryContext, WorkspaceProject, WorkspaceProvenance, WorkspaceProvider,
+};
 
 const PYPROJECT_TOML: &str = "pyproject.toml";
 
@@ -14,7 +15,7 @@ const PYPROJECT_TOML: &str = "pyproject.toml";
 #[derive(Debug, Default)]
 pub struct UvWorkspaceProvider;
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct PyProject {
     project: Option<PythonProject>,
@@ -23,7 +24,7 @@ struct PyProject {
     tool: ToolTable,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct PythonProject {
     name: String,
@@ -32,13 +33,13 @@ struct PythonProject {
     optional_dependencies: BTreeMap<String, Vec<String>>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct ToolTable {
     uv: UvTable,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct UvTable {
     workspace: Option<UvWorkspace>,
@@ -47,7 +48,7 @@ struct UvTable {
     dev_dependencies: Vec<String>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 struct UvWorkspace {
     members: Vec<String>,
@@ -68,15 +69,24 @@ impl WorkspaceProvider for UvWorkspaceProvider {
     }
 
     fn discover(&self, workspace_root: &Path) -> Result<Vec<WorkspaceProject>> {
+        let context = WorkspaceDiscoveryContext::new();
+        self.discover_with_context(workspace_root, &context)
+    }
+
+    fn discover_with_context(
+        &self,
+        workspace_root: &Path,
+        context: &WorkspaceDiscoveryContext,
+    ) -> Result<Vec<WorkspaceProject>> {
         let root_pyproject_path = workspace_root.join(PYPROJECT_TOML);
-        if !root_pyproject_path.is_file() {
+        if !context.is_file(&root_pyproject_path) {
             return Ok(Vec::new());
         }
-        let root_pyproject = read_pyproject(&root_pyproject_path)?;
+        let root_pyproject = read_pyproject(context, &root_pyproject_path)?;
         let Some(workspace) = root_pyproject.tool.uv.workspace.as_ref() else {
             return Ok(Vec::new());
         };
-        let canonical_root = workspace_root.canonicalize().wrap_err_with(|| {
+        let canonical_root = context.canonicalize(workspace_root).wrap_err_with(|| {
             format!(
                 "failed to resolve uv workspace root {}",
                 workspace_root.display()
@@ -88,6 +98,7 @@ impl WorkspaceProvider for UvWorkspaceProvider {
             &canonical_root,
             &workspace.members,
             &excludes,
+            context,
         )?;
         if root_pyproject.project.is_some() {
             workspace_roots.insert(canonical_root.clone());
@@ -102,7 +113,11 @@ impl WorkspaceProvider for UvWorkspaceProvider {
             }
             let relative = relative_root(&canonical_root, &project_root)?;
             let pyproject_path = project_root.join(PYPROJECT_TOML);
-            let pyproject = read_pyproject(&pyproject_path)?;
+            let pyproject = if project_root == canonical_root {
+                root_pyproject.clone()
+            } else {
+                read_pyproject(context, &pyproject_path)?
+            };
             let project = pyproject.project.as_ref().ok_or_else(|| {
                 eyre::eyre!("uv project at {} is missing [project]", relative.display())
             })?;
@@ -131,10 +146,10 @@ impl WorkspaceProvider for UvWorkspaceProvider {
                         continue;
                     };
                     let candidate = source_base.join(path);
-                    if !candidate.join(PYPROJECT_TOML).is_file() {
+                    if !context.is_file(&candidate.join(PYPROJECT_TOML)) {
                         continue;
                     }
-                    let candidate = candidate.canonicalize().wrap_err_with(|| {
+                    let candidate = context.canonicalize(&candidate).wrap_err_with(|| {
                         format!(
                             "failed to resolve uv path dependency {}",
                             candidate.display()
@@ -206,10 +221,10 @@ impl WorkspaceProvider for UvWorkspaceProvider {
                             continue;
                         };
                         let candidate = source_base.join(path);
-                        if !candidate.join(PYPROJECT_TOML).is_file() {
+                        if !context.is_file(&candidate.join(PYPROJECT_TOML)) {
                             continue;
                         }
-                        let candidate = candidate.canonicalize().wrap_err_with(|| {
+                        let candidate = context.canonicalize(&candidate).wrap_err_with(|| {
                             format!(
                                 "failed to resolve uv path dependency {}",
                                 candidate.display()
@@ -244,8 +259,9 @@ impl WorkspaceProvider for UvWorkspaceProvider {
     }
 }
 
-fn read_pyproject(path: &Path) -> Result<PyProject> {
-    let contents = fs::read_to_string(path)
+fn read_pyproject(context: &WorkspaceDiscoveryContext, path: &Path) -> Result<PyProject> {
+    let contents = context
+        .read_to_string(path)
         .wrap_err_with(|| format!("failed to read uv project metadata {}", path.display()))?;
     toml::from_str(&contents)
         .wrap_err_with(|| format!("failed to parse uv project metadata {}", path.display()))
@@ -266,6 +282,7 @@ fn discover_members(
     canonical_root: &Path,
     members: &[String],
     excludes: &[Pattern],
+    context: &WorkspaceDiscoveryContext,
 ) -> Result<BTreeSet<PathBuf>> {
     let options = match_options();
     // Avoid canonical Windows roots here because their verbatim `\\?\` prefix
@@ -283,10 +300,10 @@ fn discover_members(
             let candidate = candidate.wrap_err_with(|| {
                 format!("failed to evaluate uv workspace member pattern {member:?}")
             })?;
-            if !candidate.is_dir() {
+            if !context.is_dir(&candidate) {
                 continue;
             }
-            let candidate = candidate.canonicalize().wrap_err_with(|| {
+            let candidate = context.canonicalize(&candidate).wrap_err_with(|| {
                 format!(
                     "failed to resolve uv workspace member {}",
                     candidate.display()
@@ -296,7 +313,7 @@ fn discover_members(
             if is_excluded(&relative, excludes) {
                 continue;
             }
-            if !candidate.join(PYPROJECT_TOML).is_file() {
+            if !context.is_file(&candidate.join(PYPROJECT_TOML)) {
                 bail!(
                     "uv workspace member at {} is missing {PYPROJECT_TOML}",
                     relative.display()


### PR DESCRIPTION
## Summary
- share filesystem metadata, file contents, and canonical paths across workspace providers during one graph discovery
- reuse parsed Cargo, uv, and Node root manifests instead of reading and parsing them again
- share the same cache with override-driven task rediscovery while preserving each package manager's existing workspace-glob semantics

## Why
Polyglot workspaces can ask several providers about the same root files and paths. This avoids duplicate filesystem work without introducing a repository-wide crawl or changing ecosystem-specific matching behavior.

## Validation
- `cargo check --all-features`
- `cargo test task::workspace`
- `mise run test:e2e test_task_cargo_workspace_graph test_task_uv_workspace_graph test_task_go_workspace_graph test_task_node_workspace_graph`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core monorepo discovery paths for all ecosystems; behavior should be equivalent but caching and path-key normalization could surface subtle filesystem edge-case differences.
> 
> **Overview**
> Introduces **`WorkspaceDiscoveryContext`**, a per–graph-discovery cache for canonical paths, metadata probes, and file reads so Cargo, Go, Node, and uv providers no longer repeat the same filesystem work when a monorepo is scanned together.
> 
> **`WorkspaceProvider`** gains default **`discover_with_context`** / **`discover_project_tasks_with_context`** hooks; **`WorkspaceProjectGraph`** creates one context per **`discover_all`** / override pass and passes it through provider collection and override-driven task rediscovery. Ecosystem providers route **`is_file`**, **`read_to_string`**, and **`canonicalize`** through the context and reuse cloned root manifests (Cargo/uv) or cached root **`package.json`** parses (Node) instead of re-reading the same files.
> 
> Node also fixes pnpm workspaces that include **`.`** when the root **`package.json`** is invalid—discovery now returns a parse error instead of silently misbehaving.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc4f4e6652fb041c27d04d7b23afca79e246bba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->