### PR TITLE
fix(unuse): preserve unselected tool versions

### DIFF
--- a/e2e/cli/test_unuse
+++ b/e2e/cli/test_unuse
@@ -52,3 +52,41 @@ assert "mise use dummy@2"
 assert "mise ls dummy" "dummy  2.0.0  ~/workdir/mise.toml  2"
 assert "mise unuse dummy"
 assert_empty "mise ls dummy"
+
+# removing a specific version preserves the other configured versions
+cat >mise.toml <<'EOF'
+[tools]
+dummy = ["1.0.0", "2.0.0", "3.0.0"]
+EOF
+assert "mise unuse --no-prune dummy@1.0.0 dummy@1.0.0 2>&1" \
+  "mise removed: dummy@1.0.0 from ~/workdir/mise.toml"
+assert_not_contains "cat mise.toml" '"1.0.0"'
+assert_contains "cat mise.toml" '"2.0.0"'
+assert_contains "cat mise.toml" '"3.0.0"'
+
+# multiple versions of the same tool are removed together without restoring an earlier one
+assert_contains "mise unuse --no-prune dummy@2.0.0 dummy@3.0.0 2>&1" \
+  "removed: dummy@2.0.0, dummy@3.0.0"
+assert_not_contains "cat mise.toml" "dummy"
+
+# options on an unselected structured entry are preserved
+cat >mise.toml <<'EOF'
+[tools]
+dummy = [
+  { version = "1.0.0", install_env = { REMOVE = "yes" } },
+  { version = "2.0.0", install_env = { KEEP = "yes" } },
+]
+EOF
+assert "mise unuse --no-prune dummy@1.0.0"
+assert_not_contains "cat mise.toml" "REMOVE"
+assert_contains "cat mise.toml" 'version = "2.0.0"'
+assert_contains "cat mise.toml" 'install_env = { KEEP = "yes" }'
+
+# .tool-versions keeps the other versions, tools, and trailing comment
+cat >.tool-versions <<'EOF'
+dummy 1.0.0 2.0.0 # keep me
+tiny 3.1.0
+EOF
+assert "mise unuse --no-prune --path .tool-versions dummy@1.0.0"
+assert "cat .tool-versions" "dummy 2.0.0 # keep me
+tiny  3.1.0"

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -62,17 +62,56 @@ impl Unuse {
         let tools = cf.to_tool_request_set()?.tools;
         let mut removed: Vec<&ToolArg> = vec![];
         for ta in &self.installed_tool {
-            if let Some(tool_requests) = tools.get(ta.ba.as_ref()) {
-                let should_remove = if let Some(v) = &ta.version {
-                    tool_requests.iter().any(|tv| &tv.version() == v)
-                } else {
-                    true
-                };
-                // TODO: this won't work properly for unusing a specific version in of multiple in a config
-                if should_remove {
-                    removed.push(ta);
-                    cf.remove_tool(&ta.ba)?;
-                }
+            let already_removed = removed.iter().any(|existing| {
+                existing.ba.as_ref() == ta.ba.as_ref() && existing.version == ta.version
+            });
+            if already_removed {
+                continue;
+            }
+            let Some(tool_requests) = tools.get(ta.ba.as_ref()) else {
+                continue;
+            };
+            let matches = match &ta.version {
+                Some(version) => tool_requests.iter().any(|tr| tr.version() == *version),
+                None => true,
+            };
+            if matches {
+                removed.push(ta);
+            }
+        }
+
+        for (ba, tool_requests) in &tools {
+            let matching_args = removed
+                .iter()
+                .copied()
+                .filter(|ta| ta.ba.as_ref() == ba.as_ref())
+                .collect_vec();
+            if matching_args.is_empty() {
+                continue;
+            }
+
+            if matching_args.iter().any(|ta| ta.version.is_none()) {
+                cf.remove_tool(ba)?;
+                continue;
+            }
+
+            let remaining = tool_requests
+                .iter()
+                .filter(|tr| {
+                    let version = tr.version();
+                    !matching_args
+                        .iter()
+                        .any(|ta| ta.version.as_deref() == Some(version.as_str()))
+                })
+                .cloned()
+                .collect_vec();
+            if remaining.len() == tool_requests.len() {
+                continue;
+            }
+            if remaining.is_empty() {
+                cf.remove_tool(ba)?;
+            } else {
+                cf.replace_versions(ba, remaining)?;
             }
         }
         if removed.is_empty() {


### PR DESCRIPTION
## Summary

Fix `mise unuse TOOL@VERSION` so it removes only matching configured requests when a tool has multiple versions.

The original report described an unrelated installed version causing the configured `latest` request to be removed. Exact matching already prevents that case, but the same code still removed the entire tool entry after any configured version matched. For example, unusing `node@20` from `node = ["20", "22"]` also deleted `node@22`.

## Changes

- determine matches from the original config request set
- process all requested versions for a tool together so one update cannot overwrite another
- replace the configured version list when unselected versions remain
- remove the complete tool key only for an unversioned request or after the final configured version is selected
- preserve structured options and `.tool-versions` entries for unselected versions
- report only CLI selectors that actually matched the config

## Testing

- `mise run test:e2e e2e/cli/test_unuse`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/cli/test_unuse`
- `mise exec -- shfmt -w e2e/cli/test_unuse`

`mise run format` and `mise run lint` reach `hk` but cannot complete because `hk` does not recognize the Sapling working copy as a Git repository. The equivalent checks for the changed Rust and shell files passed individually.

Addresses https://github.com/jdx/mise/discussions/4080

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mise unuse` to remove only the specified tool versions from TOML and `.tool-versions` files.
  * Preserved other configured versions, tool options, unrelated tools, and trailing comments.
  * Removed entire tool entries only when no versions remain or when no version is specified.
  * Avoided unnecessary configuration changes when no requested versions match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->