### PR TITLE
fix(env): allow redact false to override patterns

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -151,6 +151,14 @@ API_TOKEN = "token_123"
 PASSWORD = "my_password"
 ```
 
+Set `redact = false` on an individual variable to exclude it from matching `redactions` patterns,
+including patterns inherited from a global config:
+
+```toml
+[env]
+TEST_TOKEN = { value = "not-sensitive", redact = false }
+```
+
 ### Viewing Redacted Environment Variables
 
 The `mise env` command provides flags to work with redacted variables:

--- a/e2e/cli/test_set
+++ b/e2e/cli/test_set
@@ -96,6 +96,21 @@ assert_not_contains "mise set" "super_secret"
 assert_contains "mise set" "john"
 assert_contains "mise set --no-redact" "super_secret"
 
+# Test that redact=false overrides inherited redaction patterns
+rm -f mise.toml
+cat <<EOF >global.mise.toml
+redactions = ["*TOKEN*"]
+[env]
+SECRET_TOKEN = "secret value"
+EOF
+cat <<EOF >mise.toml
+[env]
+TEST_TOKEN = { value = "e", redact = false }
+EOF
+assert_contains "MISE_GLOBAL_CONFIG_FILE=$PWD/global.mise.toml mise set" "SECRET_TOKEN  [redacted]"
+assert_contains "MISE_GLOBAL_CONFIG_FILE=$PWD/global.mise.toml mise set" "TEST_TOKEN    e"
+assert_not_contains "MISE_GLOBAL_CONFIG_FILE=$PWD/global.mise.toml mise set" "s[redacted]cr[redacted]t"
+
 # Test redaction with --file flag
 rm -f mise.toml
 cat <<EOF >mise.toml

--- a/e2e/tasks/test_task_redactions
+++ b/e2e/tasks/test_task_redactions
@@ -22,6 +22,18 @@ run = 'echo "secret value:$TEST_TOKEN"'
 TOML
 assert "mise run a" "secret value:e"
 
+# Test a task-level redact=true assignment overrides a config-level exclusion
+cat <<'TOML' >mise.toml
+redactions = ["*TOKEN*"]
+[env]
+TEST_TOKEN = { value = "e", redact = false }
+
+[tasks.a]
+run = 'echo "secret:$TEST_TOKEN"'
+env.TEST_TOKEN = { value = "task_secret", redact = true }
+TOML
+assert "mise run a" "secret:[redacted]"
+
 cat <<EOF >mise.toml
 redactions = ["secret"]
 [tasks.a]

--- a/e2e/tasks/test_task_redactions
+++ b/e2e/tasks/test_task_redactions
@@ -11,6 +11,17 @@ EOF
 
 assert "mise run a" "secret: [redacted]"
 
+# Test config-level redact=false exclusions survive task context construction
+cat <<'TOML' >mise.toml
+redactions = ["*TOKEN*"]
+[env]
+TEST_TOKEN = { value = "e", redact = false }
+
+[tasks.a]
+run = 'echo "secret value:$TEST_TOKEN"'
+TOML
+assert "mise run a" "secret value:e"
+
 cat <<EOF >mise.toml
 redactions = ["secret"]
 [tasks.a]

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -509,7 +509,6 @@ impl EnvResults {
                     }
                 }
                 EnvDirective::Default(k, v, _opts) => {
-                    r.track_redaction_override(&k, redact);
                     if resolve_opts.vars {
                         if let Some((v, _)) = r.vars.get(&k).filter(|(v, _)| !v.is_empty()) {
                             if redact.unwrap_or(false) {
@@ -532,6 +531,7 @@ impl EnvResults {
                         continue;
                     }
 
+                    r.track_redaction_override(&k, redact);
                     let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &v)?;
 
                     if resolve_opts.vars {
@@ -1219,5 +1219,33 @@ mod tests {
         let keys: Vec<String> = results.env.keys().cloned().collect();
         assert_eq!(keys, vec!["TOOLS_VAL".to_string()]);
         assert!(results.env_paths.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_skipped_default_does_not_override_redaction() {
+        let env = EnvMap::from_iter([("SECRET_TOKEN".to_string(), "secret".to_string())]);
+        let config = Config::get().await.unwrap();
+        let options = EnvDirectiveOptions {
+            redact: Some(false),
+            ..Default::default()
+        };
+        let results = EnvResults::resolve(
+            &config,
+            BASE_CONTEXT.clone(),
+            &env,
+            vec![(
+                EnvDirective::Default("SECRET_TOKEN".into(), "fallback".into(), options),
+                PathBuf::from("/config"),
+            )],
+            EnvResolveOptions {
+                vars: false,
+                tools: ToolsFilter::Both,
+                warn_on_missing_required: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!results.redaction_exclusions.contains("SECRET_TOKEN"));
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -376,10 +376,9 @@ impl EnvResults {
             Some(false) => {
                 self.redaction_exclusions.insert(key.to_string());
             }
-            Some(true) => {
+            Some(true) | None => {
                 self.redaction_exclusions.remove(key);
             }
-            None => {}
         }
     }
 
@@ -549,10 +548,10 @@ impl EnvResults {
                 }
                 EnvDirective::Rm(k, _opts) => {
                     env.shift_remove(&k);
+                    r.redaction_exclusions.remove(&k);
                     r.env_remove.insert(k);
                 }
                 EnvDirective::Required(k, _opts) => {
-                    r.track_redaction_override(&k, redact);
                     // Env required directives only validate. Var required directives also surface
                     // process environment values so `{{vars.KEY}}` can render.
                     if resolve_opts.vars {
@@ -562,6 +561,7 @@ impl EnvResults {
                         if !vars.contains_key(&k)
                             && let Some(v) = required_env.get(&k)
                         {
+                            r.track_redaction_override(&k, redact);
                             r.vars.insert(k, (v.clone(), source.clone()));
                         }
                     }
@@ -1247,5 +1247,56 @@ mod tests {
         .unwrap();
 
         assert!(!results.redaction_exclusions.contains("SECRET_TOKEN"));
+    }
+
+    #[tokio::test]
+    async fn test_reassignment_and_remove_clear_redaction_exclusion() {
+        let config = Config::get().await.unwrap();
+        let excluded = EnvDirectiveOptions {
+            redact: Some(false),
+            ..Default::default()
+        };
+        let initial = EnvMap::new();
+        let resolve = |directives| {
+            EnvResults::resolve(
+                &config,
+                BASE_CONTEXT.clone(),
+                &initial,
+                directives,
+                EnvResolveOptions {
+                    vars: false,
+                    tools: ToolsFilter::Both,
+                    warn_on_missing_required: false,
+                },
+            )
+        };
+
+        let reassigned = resolve(vec![
+            (
+                EnvDirective::Val("TOKEN".into(), "first".into(), excluded.clone()),
+                PathBuf::from("/global"),
+            ),
+            (
+                EnvDirective::Val("TOKEN".into(), "second".into(), Default::default()),
+                PathBuf::from("/local"),
+            ),
+        ])
+        .await
+        .unwrap();
+        assert!(!reassigned.redaction_exclusions.contains("TOKEN"));
+
+        let removed = resolve(vec![
+            (
+                EnvDirective::Val("TOKEN".into(), "first".into(), excluded),
+                PathBuf::from("/global"),
+            ),
+            (
+                EnvDirective::Rm("TOKEN".into(), Default::default()),
+                PathBuf::from("/local"),
+            ),
+        ])
+        .await
+        .unwrap();
+        assert!(!removed.redaction_exclusions.contains("TOKEN"));
     }
 }

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -320,6 +320,7 @@ pub struct EnvResults {
     pub env_paths: Vec<PathBuf>,
     pub env_scripts: Vec<PathBuf>,
     pub redactions: Vec<String>,
+    pub redaction_exclusions: BTreeSet<String>,
     pub tool_add_paths: Vec<PathBuf>,
     /// Files to watch for cache invalidation (from modules and _.source directives)
     pub watch_files: Vec<PathBuf>,
@@ -370,6 +371,18 @@ pub struct EnvResolveOptions {
 }
 
 impl EnvResults {
+    fn track_redaction_override(&mut self, key: &str, redact: Option<bool>) {
+        match redact {
+            Some(false) => {
+                self.redaction_exclusions.insert(key.to_string());
+            }
+            Some(true) => {
+                self.redaction_exclusions.remove(key);
+            }
+            None => {}
+        }
+    }
+
     pub async fn resolve(
         config: &Arc<Config>,
         mut ctx: tera::Context,
@@ -478,6 +491,7 @@ impl EnvResults {
             // trace!("resolve: ctx.get('env'): {:#?}", &ctx.get("env"));
             match directive {
                 EnvDirective::Val(k, v, _opts) => {
+                    r.track_redaction_override(&k, redact);
                     let v = r.parse_template(&ctx, &mut tera, &source, &env_vars, &v)?;
 
                     if resolve_opts.vars {
@@ -495,6 +509,7 @@ impl EnvResults {
                     }
                 }
                 EnvDirective::Default(k, v, _opts) => {
+                    r.track_redaction_override(&k, redact);
                     if resolve_opts.vars {
                         if let Some((v, _)) = r.vars.get(&k).filter(|(v, _)| !v.is_empty()) {
                             if redact.unwrap_or(false) {
@@ -537,6 +552,7 @@ impl EnvResults {
                     r.env_remove.insert(k);
                 }
                 EnvDirective::Required(k, _opts) => {
+                    r.track_redaction_override(&k, redact);
                     // Env required directives only validate. Var required directives also surface
                     // process environment values so `{{vars.KEY}}` can render.
                     if resolve_opts.vars {
@@ -555,6 +571,7 @@ impl EnvResults {
                     ref options,
                     ..
                 } => {
+                    r.track_redaction_override(k, options.redact);
                     // Decrypt age-encrypted value
                     let res = crate::agecrypt::decrypt_age_directive(&directive).await;
                     let decrypted_v = match res {
@@ -644,6 +661,7 @@ impl EnvResults {
                     for (f, new_env) in files {
                         r.env_files.push(f.clone());
                         for (k, v) in new_env {
+                            r.track_redaction_override(&k, redact);
                             if resolve_opts.vars {
                                 if redact.unwrap_or(false) {
                                     r.redactions.push(k.clone());
@@ -673,6 +691,7 @@ impl EnvResults {
                     for (f, new_env) in files {
                         r.env_scripts.push(f.clone());
                         for (k, v) in new_env {
+                            r.track_redaction_override(&k, redact);
                             if resolve_opts.vars {
                                 if redact.unwrap_or(false) {
                                     r.redactions.push(k.clone());

--- a/src/config/env_directive/module.rs
+++ b/src/config/env_directive/module.rs
@@ -51,6 +51,7 @@ impl EnvResults {
             // User's explicit redact setting takes priority, otherwise use plugin's preference
             let should_redact = redact.unwrap_or(response.redact);
             for (k, v) in response.env {
+                r.track_redaction_override(&k, redact);
                 if should_redact {
                     r.redactions.push(k.clone());
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1205,6 +1205,9 @@ impl Config {
         exclusions: &BTreeSet<String>,
     ) {
         let mut r = _REDACTOR.lock().unwrap();
+        // Redactions are intentionally append-only. An exclusion prevents this key from
+        // contributing its value, but removing an already registered value could expose a
+        // different secret key (or concurrent task) that uses the same value.
         let new_redactions = redactions.into_iter().flat_map(|pattern| {
             let matcher = Wildcard::new(vec![pattern]);
             env.iter()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -248,12 +248,13 @@ impl Config {
         config.all_aliases = measure!("config::load all_aliases", { config.load_all_aliases() });
 
         measure!("config::load redactions", {
-            config.add_redactions(
+            config.add_redactions_excluding(
                 config
                     .redaction_keys()
                     .into_iter()
                     .chain(vars_results.redactions.iter().cloned()),
                 &config.vars.clone().into_iter().collect(),
+                &vars_results.redaction_exclusions,
             );
         });
 
@@ -977,6 +978,7 @@ impl Config {
                 env_paths: cached.env_paths.clone(),
                 env_scripts: cached.env_scripts.clone(),
                 redactions: cached.redactions.clone(),
+                redaction_exclusions: cached.redaction_exclusions.clone(),
                 tool_add_paths: Vec::new(),
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
@@ -986,13 +988,14 @@ impl Config {
                 .into_iter()
                 .chain(env_results.redactions.clone())
                 .collect_vec();
-            self.add_redactions(
+            self.add_redactions_excluding(
                 redact_keys,
                 &env_results
                     .env
                     .iter()
                     .map(|(k, v)| (k.clone(), v.0.clone()))
                     .collect(),
+                &env_results.redaction_exclusions,
             );
             if log::log_enabled!(log::Level::Trace) {
                 trace!("{env_results:#?}");
@@ -1052,13 +1055,14 @@ impl Config {
             .into_iter()
             .chain(env_results.redactions.clone())
             .collect_vec();
-        self.add_redactions(
+        self.add_redactions_excluding(
             redact_keys,
             &env_results
                 .env
                 .iter()
                 .map(|(k, v)| (k.clone(), v.0.clone()))
                 .collect(),
+            &env_results.redaction_exclusions,
         );
         if cache_enabled
             && !env_results.has_uncacheable
@@ -1082,6 +1086,7 @@ impl Config {
                 env_paths: env_results.env_paths.clone(),
                 env_scripts: env_results.env_scripts.clone(),
                 redactions: env_results.redactions.clone(),
+                redaction_exclusions: env_results.redaction_exclusions.clone(),
                 watch_files,
                 watch_file_mtimes,
                 created_at: now,
@@ -1193,12 +1198,17 @@ impl Config {
             .cloned()
             .collect()
     }
-    pub fn add_redactions(&self, redactions: impl IntoIterator<Item = String>, env: &EnvMap) {
+    pub fn add_redactions_excluding(
+        &self,
+        redactions: impl IntoIterator<Item = String>,
+        env: &EnvMap,
+        exclusions: &BTreeSet<String>,
+    ) {
         let mut r = _REDACTOR.lock().unwrap();
         let new_redactions = redactions.into_iter().flat_map(|pattern| {
             let matcher = Wildcard::new(vec![pattern]);
             env.iter()
-                .filter(|(k, _)| matcher.match_any(k))
+                .filter(|(k, _)| !exclusions.contains(*k) && matcher.match_any(k))
                 .map(|(_, v)| v.clone())
                 .collect::<Vec<_>>()
         });

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1936,9 +1936,10 @@ impl Task {
             .iter()
             .map(|(k, (v, _))| (k.clone(), v.clone()))
             .collect();
-        config.add_redactions(
+        config.add_redactions_excluding(
             vars_results.redactions.iter().cloned(),
             &vars.clone().into_iter().collect(),
+            &vars_results.redaction_exclusions,
         );
         TASK_VARS_CACHE
             .lock()
@@ -2031,7 +2032,11 @@ impl Task {
             env.insert(env::PATH_KEY.to_string(), path_env.to_string());
         }
         if !results.redactions.is_empty() {
-            config.add_redactions(results.redactions, &env);
+            config.add_redactions_excluding(
+                results.redactions.iter().cloned(),
+                &env,
+                &results.redaction_exclusions,
+            );
         }
         TASK_ENV_CACHE
             .lock()
@@ -2085,7 +2090,11 @@ impl Task {
             .and_then(|v| serde::Deserialize::deserialize(v.clone()).ok())
             .unwrap_or_default();
         redaction_vars.extend(vars.clone());
-        config.add_redactions(results.redactions.iter().cloned(), &redaction_vars);
+        config.add_redactions_excluding(
+            results.redactions.iter().cloned(),
+            &redaction_vars,
+            &results.redaction_exclusions,
+        );
         Ok(vars)
     }
 
@@ -2515,7 +2524,11 @@ impl Task {
             .iter()
             .map(|(k, (v, _))| (k.clone(), v.clone()))
             .collect();
-        config.add_redactions(redact_keys, &task_env_map);
+        config.add_redactions_excluding(
+            redact_keys,
+            &task_env_map,
+            &env_results.redaction_exclusions,
+        );
 
         let task_env = env_results.env.into_iter().map(|(k, (v, _))| (k, v));
         // Apply the resolved environment variables

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -258,7 +258,11 @@ impl TaskContextBuilder {
 
         // Register config-level redactions resolved through the task context
         if !config_env_results.redactions.is_empty() {
-            config.add_redactions(config_env_results.redactions.iter().cloned(), &env);
+            config.add_redactions_excluding(
+                config_env_results.redactions.iter().cloned(),
+                &env,
+                &config_env_results.redaction_exclusions,
+            );
         }
 
         let task_env_directives = self.build_task_env_directives(task);
@@ -276,7 +280,11 @@ impl TaskContextBuilder {
             .redaction_keys()
             .into_iter()
             .chain(task_env_results.redactions.iter().cloned());
-        config.add_redactions(task_redact_keys, &env);
+        config.add_redactions_excluding(
+            task_redact_keys,
+            &env,
+            &task_env_results.redaction_exclusions,
+        );
 
         // Cache the result if no task-specific env directives or tools
         if task.env.0.is_empty()
@@ -373,9 +381,10 @@ impl TaskContextBuilder {
                 for (k, (v, _)) in &vars_results.vars {
                     vars.insert(k.clone(), v.clone());
                 }
-                config.add_redactions(
+                config.add_redactions_excluding(
                     vars_results.redactions.iter().cloned(),
                     &vars.clone().into_iter().collect(),
+                    &vars_results.redaction_exclusions,
                 );
                 tera_ctx.insert("vars", &vars);
                 resolved_vars = Some(vars);

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -8,7 +8,7 @@ use crate::task::task_helpers::canonicalize_path;
 use crate::toolset::{Toolset, ToolsetBuilder};
 use eyre::Result;
 use indexmap::IndexMap;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
@@ -280,11 +280,11 @@ impl TaskContextBuilder {
             .redaction_keys()
             .into_iter()
             .chain(task_env_results.redactions.iter().cloned());
-        let redaction_exclusions: BTreeSet<_> = config_env_results
-            .redaction_exclusions
-            .union(&task_env_results.redaction_exclusions)
-            .cloned()
-            .collect();
+        let mut redaction_exclusions = config_env_results.redaction_exclusions.clone();
+        for key in task_env_results.env.keys() {
+            redaction_exclusions.remove(key);
+        }
+        redaction_exclusions.extend(task_env_results.redaction_exclusions.iter().cloned());
         config.add_redactions_excluding(task_redact_keys, &env, &redaction_exclusions);
 
         // Cache the result if no task-specific env directives or tools

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -8,7 +8,7 @@ use crate::task::task_helpers::canonicalize_path;
 use crate::toolset::{Toolset, ToolsetBuilder};
 use eyre::Result;
 use indexmap::IndexMap;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
@@ -280,11 +280,12 @@ impl TaskContextBuilder {
             .redaction_keys()
             .into_iter()
             .chain(task_env_results.redactions.iter().cloned());
-        config.add_redactions_excluding(
-            task_redact_keys,
-            &env,
-            &task_env_results.redaction_exclusions,
-        );
+        let redaction_exclusions: BTreeSet<_> = config_env_results
+            .redaction_exclusions
+            .union(&task_env_results.redaction_exclusions)
+            .cloned()
+            .collect();
+        config.add_redactions_excluding(task_redact_keys, &env, &redaction_exclusions);
 
         // Cache the result if no task-specific env directives or tools
         if task.env.0.is_empty()

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -120,6 +120,9 @@ pub struct CachedNonToolEnv {
     pub env_scripts: Vec<PathBuf>,
     /// redaction patterns contributed by env directives
     pub redactions: Vec<String>,
+    /// environment keys explicitly excluded from redaction
+    #[serde(default)]
+    pub redaction_exclusions: BTreeSet<String>,
     /// Files to watch for changes (from modules and _.source directives)
     pub watch_files: Vec<PathBuf>,
     /// mtimes of watch files at cache creation time

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -418,7 +418,11 @@ impl Toolset {
 
         // Apply redactions from tools-only env vars (e.g. redact=true + tools=true)
         if !env_results.redactions.is_empty() {
-            config.add_redactions(env_results.redactions.iter().cloned(), &env);
+            config.add_redactions_excluding(
+                env_results.redactions.iter().cloned(),
+                &env,
+                &env_results.redaction_exclusions,
+            );
         }
 
         Ok((env, env_results))


### PR DESCRIPTION
## Summary

- treat explicit `redact = false` as an exclusion from matching `redactions` patterns
- propagate exclusions through config, task, tool, and cached environment resolution
- document the override behavior and add a layered `mise set` regression test

## Root cause

`redactions` patterns were matched against every resolved environment key without considering an explicit per-variable `redact = false`. A short opted-out value could therefore enter the global value scrubber and partially redact unrelated secrets.

Fixes the behavior reported in https://github.com/jdx/mise/discussions/11560.

## Validation

- `mise run test:e2e e2e/cli/test_set`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret scrubbing across config, task, and cached env resolution; incorrect exclusion merging could leak values or break redaction of related output.
> 
> **Overview**
> Fixes env redaction so **`redact = false` on a variable opts that key out of `redactions` wildcards**, including patterns from global config, instead of still registering its value for line-by-line scrubbing (which could partially redact unrelated secrets).
> 
> **`EnvResults`** now tracks **`redaction_exclusions`** via `track_redaction_override` across val/default/file/source/module/age paths; exclusions clear on reassignment without `redact = false` or on `unset`. **`Config::add_redactions_excluding`** skips excluded keys when mapping patterns to values (redactor stays append-only). Exclusions flow through **vars/env resolution, non-tool env cache, toolset env, and task context**—task env can **re-apply redaction** for a key that was excluded at config level when the task sets `redact = true`.
> 
> Docs add a TOML example; e2e covers **`mise set`** with global patterns and **task output** for exclusion vs task override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104d91b0b4b2485f4da20d3db880a581fd2f3c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for setting individual environment variables to `redact = false`, even when inherited or local redaction patterns match.
  * Redaction exclusions are preserved across environment loading, task execution, and caching.
  * Task-specific `redact = true` settings continue to enforce redaction when needed.

* **Documentation**
  * Added configuration guidance and a TOML example for overriding redaction behavior.

* **Tests**
  * Added end-to-end coverage confirming exempt variables remain visible while matching variables are redacted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->