### PR TITLE
fix(task): preserve literal singleton braces in globs

### DIFF
--- a/e2e/tasks/test_task_run_sources
+++ b/e2e/tasks/test_task_run_sources
@@ -118,6 +118,36 @@ assert "mise run -q build" "run"
 assert "mise run -q list-sources" "a.txt b.txt"
 
 cd .. || exit 1
+mkdir literal-braces && cd literal-braces || exit 1
+cat <<'EOF' >mise.toml
+[settings.task]
+source_freshness_hash_contents = true
+
+[tasks.build]
+sources = ["{generated}.txt"]
+outputs = ["{generated}.out"]
+run = "cp '{generated}.txt' '{generated}.out'; echo run"
+
+[tasks.list-sources]
+sources = ["{generated}.txt"]
+run = "echo {{ task_source_files() | join(sep=' ') }}"
+
+[tasks.list-later-alternates]
+sources = ["{generated}.{txt,out}"]
+run = "echo {{ task_source_files() | join(sep=' ') }}"
+EOF
+touch '{generated}.txt'
+assert "mise run -q build" "run"
+assert_empty "mise run -q build"
+echo changed >'{generated}.txt'
+assert "mise run -q build" "run"
+assert_empty "mise run -q build"
+rm '{generated}.out'
+assert "mise run -q build" "run"
+assert "mise run -q list-sources" "{generated}.txt"
+assert "mise run -q list-later-alternates" "{generated}.txt {generated}.out"
+
+cd .. || exit 1
 mkdir brace-globs-mtime && cd brace-globs-mtime || exit 1
 cat <<'EOF' >mise.toml
 [tasks.build]

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -51,8 +51,10 @@ const MAX_BRACE_EXPANSIONS: usize = 1024;
 ///
 /// `Override`/globset understands patterns such as `{a,b}.txt`, but the `glob`
 /// crate used to enumerate task sources and outputs treats braces literally.
-/// Expanding only the alternates lets both stages share the same syntax without
-/// returning to a recursive filesystem walker.
+/// Expanding only groups with comma-separated choices lets both stages share
+/// the same syntax without returning to a recursive filesystem walker. Balanced
+/// braces without a comma are encoded as character classes so they keep their
+/// literal meaning in both `glob` and globset.
 pub(crate) fn expand_glob_braces(pattern: &str) -> Result<Vec<String>> {
     struct BraceGroup {
         start: usize,
@@ -100,12 +102,32 @@ pub(crate) fn expand_glob_braces(pattern: &str) -> Result<Vec<String>> {
                     }
                     group_depth -= 1;
                     if group_depth == 0 {
-                        branches.push((branch_start, idx));
-                        return Ok(Some(BraceGroup {
-                            start: group_start.unwrap(),
-                            end: idx,
-                            branches,
-                        }));
+                        let start = group_start.unwrap();
+                        if !branches.is_empty() {
+                            branches.push((branch_start, idx));
+                            return Ok(Some(BraceGroup {
+                                start,
+                                end: idx,
+                                branches,
+                            }));
+                        }
+
+                        // A balanced group without a top-level comma is a
+                        // literal brace pair. It may still contain a nested
+                        // alternate, so look inside it before continuing with
+                        // the remainder of the pattern.
+                        if let Some(mut nested) = find_group(&pattern[start + 1..idx])? {
+                            let offset = start + 1;
+                            nested.start += offset;
+                            nested.end += offset;
+                            for (branch_start, branch_end) in &mut nested.branches {
+                                *branch_start += offset;
+                                *branch_end += offset;
+                            }
+                            return Ok(Some(nested));
+                        }
+                        group_start = None;
+                        branches.clear();
                     }
                 }
                 _ => {}
@@ -124,7 +146,35 @@ pub(crate) fn expand_glob_braces(pattern: &str) -> Result<Vec<String>> {
                     "glob pattern expands to more than {MAX_BRACE_EXPANSIONS} alternatives: {pattern:?}"
                 );
             }
-            expanded.push(pattern.to_string());
+            let mut literal = String::with_capacity(pattern.len());
+            let mut escaped = false;
+            let mut class_depth = 0;
+            for ch in pattern.chars() {
+                if escaped {
+                    escaped = false;
+                    literal.push(ch);
+                    continue;
+                }
+                if ch == '\\' && !cfg!(windows) {
+                    escaped = true;
+                    literal.push(ch);
+                    continue;
+                }
+                match ch {
+                    '[' if class_depth == 0 => {
+                        class_depth = 1;
+                        literal.push(ch);
+                    }
+                    ']' if class_depth == 1 => {
+                        class_depth = 0;
+                        literal.push(ch);
+                    }
+                    '{' if class_depth == 0 => literal.push_str("[{]"),
+                    '}' if class_depth == 0 => literal.push_str("[}]"),
+                    _ => literal.push(ch),
+                }
+            }
+            expanded.push(literal);
             return Ok(());
         };
 
@@ -1188,6 +1238,26 @@ mod tests {
         assert_eq!(expand_glob_braces("{,a}.txt").unwrap(), ["a.txt"]);
         assert!(expand_glob_braces("src/{a,b.txt").is_err());
         assert!(expand_glob_braces(&"{a,b}".repeat(11)).is_err());
+    }
+
+    #[test]
+    fn glob_braces_preserve_literal_singleton_groups() {
+        assert_eq!(
+            expand_glob_braces("{generated}.txt").unwrap(),
+            ["[{]generated[}].txt"]
+        );
+        assert_eq!(
+            expand_glob_braces("{generated}/{a,b}.txt").unwrap(),
+            ["[{]generated[}]/a.txt", "[{]generated[}]/b.txt"]
+        );
+        assert_eq!(
+            expand_glob_braces("{generated}.{txt,out}").unwrap(),
+            ["[{]generated[}].txt", "[{]generated[}].out"]
+        );
+        assert_eq!(
+            expand_glob_braces("{prefix-{a,b}}.txt").unwrap(),
+            ["[{]prefix-a[}].txt", "[{]prefix-b[}].txt"]
+        );
     }
 
     #[cfg(not(windows))]


### PR DESCRIPTION
## Summary

- preserve balanced brace-containing task paths such as `{generated}.txt` instead of rewriting them to `generated.txt`
- expand only brace groups that contain comma-separated alternatives
- keep nested and later alternates working by encoding literal brace pairs as portable character classes for both `glob` and globset

## Context

This is a follow-up to #11555 and the [Greptile review](https://github.com/jdx/mise/pull/11555#discussion_r3692967026). The brace expansion helper treated every balanced pair as an alternate, including singleton groups with no comma. That caused freshness checks, output hashes, and `task_source_files()` to inspect a different filename from the one configured.

## Verification

- `mise exec -- cargo test task_source_checker::tests` (31 passed)
- `mise run test:e2e e2e/tasks/test_task_run_sources`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/tasks/test_task_run_sources`
- `mise exec -- shfmt -d e2e/tasks/test_task_run_sources`

`mise run format` and `mise run lint` could not enter hk because hk does not recognize this Sapling working copy as a Git repository; the relevant format and lint checks above passed individually.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of filenames containing braces so they are treated literally rather than as unintended wildcard patterns.
  * Improved support for paths that combine literal braces with valid alternate patterns.
  * Improved task freshness and rebuild behavior when brace-containing source files change or outputs are removed.
  * Corrected reporting of literal brace-containing source paths.
  * Added coverage for singleton, nested, and mixed brace patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->