### PR TITLE
fix(python): honour --tool when creating a venv

### DIFF
--- a/e2e/core/test_python_venv_tool_override
+++ b/e2e/core/test_python_venv_tool_override
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Regression test: a `--tool python@X` override must reach venv creation.
+#
+# `_.python.venv` rebuilds a python/uv-only toolset from the config files to avoid a circular wait
+# during env resolution, so on its own it cannot see a CLI override — it would build the venv from
+# the first `[tools] python` entry and then silently run every task under that interpreter.
+# https://github.com/jdx/mise/discussions/5281
+
+export MISE_PYTHON_GITHUB_ATTESTATIONS=0
+
+cat >.mise.toml <<EOF
+[tools]
+python = ["3.13.14", "3.12.13"]
+[env._.python]
+venv = {path = "{{env.HOME}}/my_venv", create=true}
+[tasks]
+version = "python --version"
+EOF
+
+mise i
+
+# no override: the first [tools] entry, unchanged
+assert_contains "mise run version" "Python 3.13.14"
+
+# the override decides which interpreter the venv is built from. A venv cannot be retargeted after
+# creation, so remove it first — that is the same thing a per-version venv path would achieve.
+rm -rf "$HOME/my_venv"
+assert_contains "mise run --tool python@3.12.13 version" "Python 3.12.13"

--- a/src/config/env_directive/mod.rs
+++ b/src/config/env_directive/mod.rs
@@ -7,6 +7,7 @@ use crate::path_env::PathEnv;
 use crate::tera::{
     TeraEngine, contains_template_syntax, get_tera, render_str, tera_exec, tera1_exec,
 };
+use crate::toolset::Toolset;
 use eyre::{Context, eyre};
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -337,6 +338,12 @@ pub(super) struct EnvDirectiveContext<'a> {
     source: &'a Path,
     exec_env: &'a EnvMap,
     config_root: &'a Path,
+    /// The caller's resolved toolset, when the caller has one. `Toolset::env` does; plain
+    /// `Config::env` does not, because it runs before any toolset exists. Directives that need to
+    /// know *which* version of a tool is active — rather than just rendering `tools.*` templates —
+    /// read it from here, since CLI overrides such as `--tool python@3.12` only ever reach a
+    /// toolset and are never written back to `Config`.
+    toolset: Option<&'a Toolset>,
 }
 
 impl EnvDirectiveContext<'_> {
@@ -384,10 +391,23 @@ impl EnvResults {
 
     pub async fn resolve(
         config: &Arc<Config>,
+        ctx: tera::Context,
+        initial: &EnvMap,
+        input: Vec<(EnvDirective, PathBuf)>,
+        resolve_opts: EnvResolveOptions,
+    ) -> eyre::Result<Self> {
+        Self::resolve_with_toolset(config, ctx, initial, input, resolve_opts, None).await
+    }
+
+    /// [`Self::resolve`] for callers that already have a resolved toolset. See
+    /// [`EnvDirectiveContext::toolset`] for why a directive would want it.
+    pub async fn resolve_with_toolset(
+        config: &Arc<Config>,
         mut ctx: tera::Context,
         initial: &EnvMap,
         input: Vec<(EnvDirective, PathBuf)>,
         resolve_opts: EnvResolveOptions,
+        toolset: Option<&Toolset>,
     ) -> eyre::Result<Self> {
         // trace!("resolve: input: {:#?}", &input);
         let mut env = initial
@@ -640,6 +660,7 @@ impl EnvResults {
                         source: &source,
                         exec_env: &env_vars,
                         config_root: &config_root,
+                        toolset,
                     };
                     let path = Self::path(&mut directive_ctx, input_str).await?;
                     paths.push((path.clone(), source.clone()));
@@ -656,6 +677,7 @@ impl EnvResults {
                         source: &source,
                         exec_env: &env_vars,
                         config_root: &config_root,
+                        toolset,
                     };
                     let files = Self::file(&mut directive_ctx, input, opts.expand).await?;
                     for (f, new_env) in files {
@@ -686,6 +708,7 @@ impl EnvResults {
                         source: &source,
                         exec_env: &env_vars,
                         config_root: &config_root,
+                        toolset,
                     };
                     let files = Self::source(&mut directive_ctx, &mut paths, input)?;
                     for (f, new_env) in files {
@@ -723,6 +746,7 @@ impl EnvResults {
                         source: &source,
                         exec_env: &env_vars,
                         config_root: &config_root,
+                        toolset,
                     };
                     Self::venv(
                         &mut directive_ctx,
@@ -731,6 +755,8 @@ impl EnvResults {
                         create,
                         venv::PythonVenvOptions {
                             python,
+                            // filled in by `venv()` from the caller's toolset
+                            active_python: None,
                             uv_create_args,
                             python_create_args,
                             require_uv: false,

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -24,7 +24,13 @@ pub struct Venv {
 
 #[derive(Default)]
 pub(crate) struct PythonVenvOptions {
+    /// `_.python.venv.python` — the user asked for this version by name, so a miss is an error
+    /// they should see rather than something to paper over.
     pub(crate) python: Option<String>,
+    /// The python the caller's toolset has active, filled in by [`EnvResults::venv`]. A
+    /// *preference*, not a request: if the config-derived toolset cannot offer it we fall back to
+    /// the previous behaviour instead of failing, because the user never named this version.
+    pub(crate) active_python: Option<String>,
     pub(crate) uv_create_args: Option<Vec<String>>,
     pub(crate) python_create_args: Option<Vec<String>>,
     pub(crate) require_uv: bool,
@@ -109,6 +115,7 @@ pub(crate) async fn create_python_venv(
 ) -> Result<bool> {
     let PythonVenvOptions {
         python,
+        active_python,
         uv_create_args,
         python_create_args,
         require_uv,
@@ -120,6 +127,18 @@ pub(crate) async fn create_python_venv(
         // otherwise use the first since that's what `python3` will refer to
         if let Some(v) = python {
             tv.versions.iter().find(|t| t.version.starts_with(v))
+        } else if let Some(v) = &active_python {
+            // the caller's active python, which this toolset may not list at all — it was rebuilt
+            // from the config files. Falling back keeps a `--tool` version that is absent from
+            // `[tools]` working exactly as it did before (#5281).
+            //
+            // Matched exactly, unlike the branch above: that one compares against whatever partial
+            // version the user wrote in `_.python.venv.python`, while this is already resolved on
+            // both sides. A prefix match here would let `3.12.0` select a configured `3.12.0a1`.
+            tv.versions
+                .iter()
+                .find(|t| t.version == *v)
+                .or_else(|| tv.versions.first())
         } else {
             tv.versions.first()
         }
@@ -179,19 +198,35 @@ pub(crate) async fn create_python_venv(
     Ok(true)
 }
 
+/// The version of the python the caller's toolset has active, if any.
+///
+/// `create_python_venv` resolves its own python/uv-only toolset to avoid a circular wait (see
+/// below), and that toolset is built from the config files — so it lists every `[tools] python`
+/// entry in config order and knows nothing about `--tool`. Feeding this back in as the `python`
+/// option makes it select the same interpreter the rest of the run is using, and costs nothing
+/// when there is no override: the caller's toolset then holds the same first entry.
+fn active_python_version(toolset: Option<&Toolset>) -> Option<String> {
+    let tvl = toolset?.versions.get(&BackendArg::from("python"))?;
+    Some(tvl.versions.first()?.version.clone())
+}
+
 impl EnvResults {
     pub(super) async fn venv(
         ctx: &mut EnvDirectiveContext<'_>,
         env: &mut IndexMap<String, (String, Option<PathBuf>)>,
         path: String,
         create: bool,
-        options: PythonVenvOptions,
+        mut options: PythonVenvOptions,
     ) -> Result<()> {
         trace!("python venv: {} create={create}", display_path(&path));
         trust_check(ctx.source)?;
         let venv = ctx.parse_template(&path)?;
         let venv = ctx.normalize_path(venv.into());
         let venv_lock = LockFile::new(&venv).lock()?;
+        // Record whichever python the caller actually has active. The toolset rebuilt below comes
+        // from the config files, so on its own it cannot see a CLI override — `mise run --tool
+        // python@3.12` would silently build the venv from the first `[tools] python` entry (#5281).
+        options.active_python = active_python_version(ctx.toolset);
         if !venv.exists() && create {
             // TODO: the toolset stuff doesn't feel like it's in the right place here
             // TODO: in fact this should probably be moved to execute at the same time as src/uv.rs runs in ts.env() instead of config.env()

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -451,7 +451,7 @@ impl Toolset {
             .flatten()
             .collect();
         // trace!("load_env: entries: {:#?}", entries);
-        let env_results = EnvResults::resolve(
+        let env_results = EnvResults::resolve_with_toolset(
             config,
             ctx,
             env,
@@ -461,6 +461,9 @@ impl Toolset {
                 tools: tools_filter,
                 warn_on_missing_required: *WARN_ON_MISSING_REQUIRED_ENV,
             },
+            // `_.python.venv` needs the *active* python, which is only knowable here: a
+            // `--tool python@3.12` override lives in this toolset and never reaches `Config`.
+            Some(self),
         )
         .await?;
         if log::log_enabled!(log::Level::Trace) {


### PR DESCRIPTION
Fixes #5281.

`_.python.venv` builds the venv from the first `[tools] python` entry even when the run selected a different one, so

```bash
mise run --tool python@3.12 test
```

silently executes under 3.13. @risu729 reduced it to this a year ago and it still reproduces on v2026.7.15:

```toml
[tools]
python = ["3.13", "3.12"]
[env._.python]
venv = { path = ".venv", create = true }
[tasks]
version = "python --version"
```

| config | `mise run version` | `mise run --tool python@3.12 version` |
|---|---|---|
| with `_.python.venv` | Python 3.13.14 | **Python 3.13.14** |
| without it | Python 3.13.14 | Python 3.12.13 |

## Cause

Not the version selection itself. `EnvResults::venv` resolves its **own** python/uv-only toolset — deliberately, to avoid the circular wait when unrelated backends re-enter `config.env()` during env resolution (the `go:` deadlock from #7059) — and that toolset is rebuilt from the config files. A `--tool` override only ever reaches a `Toolset` built by `ToolsetBuilder::with_args`; it is never written back to `Config`, so it cannot be seen from there.

Giving the venv a version-templated path makes the split visible. Under `--tool python@3.12` the directory is named for the override while its `pyvenv.cfg` records the other interpreter:

```
$ cat .venv-3.12.13/pyvenv.cfg
home = .../installs/python/3.13.14
version = 3.13.14
command = .../installs/python/3.13.14/python.exe -m venv .../.venv-3.12.13
```

Template rendering saw the override; interpreter selection did not.

## Fix

`Toolset::env` *does* have the right toolset, so it now passes it down via `EnvResults::resolve_with_toolset`, and the venv directive records the active python version.

**The rebuild and its filter are unchanged** — this only changes which entry is selected *within* the rebuilt toolset, so the deadlock it guards against is untouched. Passing the full toolset through to `create_python_venv` would not be safe: `which_bin` walks every backend's `which`, which is the re-entrancy path the filter exists to avoid.

The active version is kept in a **separate field** from the user-facing `_.python.venv.python` option, and is a preference rather than a request: if the config-derived toolset cannot offer it we fall back to the previous behaviour instead of failing. Without that, a `--tool` version absent from `[tools]` would start erroring where it used to work.

`uv.rs` already passed the real toolset to `create_python_venv`, so `uv_venv_auto` was never affected and is untouched — that path is the precedent this follows.

## Out of scope

An existing venv is not rebuilt (`if !venv.exists() && create`). A venv cannot be retargeted after creation, so a matrix over interpreters still needs one venv per version — a templated path, or `venv = { path = "...", python = "3.12" }`, which I verified works today.

## Verification

Built and tested on a fork before opening this, since the change touches the deadlock-sensitive path:

- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅
- e2e, with `TEST_ALL=1` so the `_slow` guard actually runs:
  - `test_python_venv_tool_override` (new — the regression above) ✅
  - **`test_python_venv_with_go_backend_deadlock_slow`** (#7059, the deadlock this filter exists for) ✅
  - `test_exec_venv_path_order` (#8340) ✅
  - `test_python_venv` ✅

The two risks worth naming — reintroducing the deadlock, and changing venv PATH ordering — are both covered by existing tests that pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Python virtual environment creation to honor the interpreter selected with the `--tool python@...` option.
  * Ensured environment configuration consistently uses the active Python version when resolving virtual environments.

* **Tests**
  * Added regression coverage confirming both default and command-line-selected Python interpreters are used correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->