### PR TITLE
fix(hook-env): restore modified managed environment

### DIFF
--- a/e2e/env/test_hook_env_managed_drift
+++ b/e2e/env/test_hook_env_managed_drift
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p managed-bin user-bin
+managed_bin="$PWD/managed-bin"
+user_bin="$PWD/user-bin"
+
+cat >mise.toml <<EOF
+[env]
+MANAGED_VALUE = "expected"
+_.path = ["$managed_bin"]
+
+[settings]
+hook_env.cache_ttl = "1h"
+hook_env.chpwd_only = true
+EOF
+
+eval "$(mise activate bash)"
+
+# Managed values are repaired even when the filesystem fast path is cached.
+export MANAGED_VALUE=changed
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"export MANAGED_VALUE=expected"* ]] ||
+  fail "changed managed value was not repaired: $output"
+eval "$output"
+assert "printf '%s' \"$MANAGED_VALUE\"" "expected"
+
+unset MANAGED_VALUE
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"export MANAGED_VALUE=expected"* ]] ||
+  fail "unset managed value was not repaired: $output"
+eval "$output"
+assert "printf '%s' \"$MANAGED_VALUE\"" "expected"
+
+# Removing a mise-owned PATH entry restores it while preserving user additions.
+PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -Fvx "$managed_bin" | paste -sd ':' -)
+export PATH="$user_bin:$PATH"
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"$managed_bin"* ]] || fail "managed PATH was not repaired: $output"
+eval "$output"
+assert_succeed "printf '%s' \"$PATH\" | tr ':' '\n' | grep -Fx '$managed_bin'"
+assert_succeed "printf '%s' \"$PATH\" | tr ':' '\n' | grep -Fx '$user_bin'"
+
+# Unmanaged changes alone do not invalidate the fast path.
+export UNMANAGED_VALUE=changed
+PATH="$PATH:$PWD/another-user-bin"
+export PATH
+output=$(mise hook-env -s bash --reason precmd)
+assert "printf '%s' \"$output\"" ""

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -17,7 +17,7 @@ use std::sync::LazyLock as Lazy;
 use crate::cli::HookReason;
 use crate::config::{Config, DEFAULT_CONFIG_FILENAMES, Settings, config_file};
 use crate::env::PATH_KEY;
-use crate::env_diff::{EnvDiffOperation, EnvDiffPatches, EnvMap};
+use crate::env_diff::{EnvDiff, EnvDiffOperation, EnvDiffPatches, EnvMap};
 use crate::errors::Error;
 use crate::hash::hash_to_str;
 use crate::shell::Shell;
@@ -252,6 +252,11 @@ pub fn should_exit_early_fast() -> bool {
     if have_mise_env_vars_been_modified() {
         return false;
     }
+    // Restore only environment state previously owned by mise. User-added
+    // variables and PATH entries do not affect this check.
+    if has_managed_env_drift(&env::__MISE_DIFF, &current_managed_env(&env::__MISE_DIFF)) {
+        return false;
+    }
 
     // chpwd_only mode: skip on precmd if directory hasn't changed
     // This significantly reduces stat operations on slow filesystems like NFS
@@ -374,6 +379,9 @@ pub fn should_exit_early(
     if have_mise_env_vars_been_modified() {
         return false;
     }
+    if has_managed_env_drift(&env::__MISE_DIFF, &current_managed_env(&env::__MISE_DIFF)) {
+        return false;
+    }
     // The fast path already decided this run is necessary. Check it only after
     // the slow-path checks above, since they also record modified watch files
     // and schedule hooks as side effects.
@@ -450,6 +458,49 @@ fn has_preclap_logging_flag(args: &[String]) -> bool {
 
 fn have_mise_env_vars_been_modified() -> bool {
     get_mise_env_vars_hashed() != PREV_SESSION.env_var_hash
+}
+
+fn current_managed_env(diff: &EnvDiff) -> EnvMap {
+    let mut current: EnvMap = diff
+        .new
+        .keys()
+        .filter_map(|key| env::var(key).ok().map(|value| (key.clone(), value)))
+        .collect();
+    if !diff.path.is_empty()
+        && let Ok(path) = env::var(&*PATH_KEY)
+    {
+        current.insert(PATH_KEY.to_string(), path);
+    }
+    current
+}
+
+fn has_managed_env_drift(diff: &EnvDiff, current: &EnvMap) -> bool {
+    for (key, expected) in &diff.new {
+        if current.get(key) != Some(expected) {
+            trace!("mise-managed environment variable changed: {key}");
+            return true;
+        }
+    }
+
+    if diff.path.is_empty() {
+        return false;
+    }
+
+    // PATH ownership is set-based: shells such as fish deduplicate entries when
+    // applying the environment, so requiring the serialized occurrence count
+    // would report permanent drift even though the managed path is present.
+    let current_paths = current
+        .get(&*PATH_KEY)
+        .map(|path| env::split_paths(path).collect::<std::collections::HashSet<PathBuf>>())
+        .unwrap_or_default();
+    diff.path.iter().any(|path| {
+        if !current_paths.contains(path) {
+            trace!("mise-managed PATH entry changed: {}", path.display());
+            true
+        } else {
+            false
+        }
+    })
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -792,7 +843,13 @@ pub fn build_alias_commands(
 
 #[cfg(test)]
 mod tests {
-    use super::{FAST_PATH_FORCED_FULL_RUN, force_full_run, has_preclap_logging_flag};
+    use super::{
+        FAST_PATH_FORCED_FULL_RUN, force_full_run, has_managed_env_drift, has_preclap_logging_flag,
+    };
+    use crate::env::PATH_KEY;
+    use crate::env_diff::{EnvDiff, EnvMap};
+    use indexmap::indexmap;
+    use std::path::PathBuf;
     use std::sync::atomic::Ordering;
 
     fn args(values: &[&str]) -> Vec<String> {
@@ -849,5 +906,65 @@ mod tests {
             "hook-env",
             "--verbose"
         ])));
+    }
+
+    fn managed_diff() -> EnvDiff {
+        EnvDiff {
+            new: indexmap! {
+                "MANAGED".into() => "expected".into(),
+            },
+            path: vec![PathBuf::from("/managed/bin"), PathBuf::from("/managed/bin")],
+            ..Default::default()
+        }
+    }
+
+    fn current_env(entries: &[(&str, &str)]) -> EnvMap {
+        entries
+            .iter()
+            .map(|(key, value)| ((*key).into(), (*value).into()))
+            .collect()
+    }
+
+    #[test]
+    fn detects_changed_or_missing_managed_variables() {
+        let diff = managed_diff();
+        let path = std::env::join_paths(["/managed/bin", "/managed/bin"])
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+
+        let changed = current_env(&[("MANAGED", "changed"), (PATH_KEY.as_str(), &path)]);
+        assert!(has_managed_env_drift(&diff, &changed));
+
+        let missing = current_env(&[(PATH_KEY.as_str(), &path)]);
+        assert!(has_managed_env_drift(&diff, &missing));
+    }
+
+    #[test]
+    fn ignores_unmanaged_variables_path_order_and_duplicate_managed_entries() {
+        let diff = managed_diff();
+        let path = std::env::join_paths(["/user/after", "/managed/bin", "/user/before"])
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let current = current_env(&[
+            ("MANAGED", "expected"),
+            ("UNMANAGED", "changed"),
+            (PATH_KEY.as_str(), &path),
+        ]);
+
+        assert!(!has_managed_env_drift(&diff, &current));
+    }
+
+    #[test]
+    fn detects_missing_managed_path() {
+        let diff = managed_diff();
+        let path = std::env::join_paths(["/user/bin"])
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let current = current_env(&[("MANAGED", "expected"), (PATH_KEY.as_str(), &path)]);
+
+        assert!(has_managed_env_drift(&diff, &current));
     }
 }


### PR DESCRIPTION
## Summary

- detect drift in environment variables previously written by mise through `__MISE_DIFF`
- restore missing mise-managed PATH entries without treating user-owned variables or PATH additions as drift
- keep the check active before `hook_env.cache_ttl` and `hook_env.chpwd_only` fast exits

## Root cause

`mise hook-env` only compared `MISE_*` variables and watched filesystem state before taking its fast exit. If a shell command overwrote or unset a configured environment variable, or removed a PATH entry added by mise, the unchanged fast-path inputs caused `hook-env` to emit nothing.

The fix uses the existing `__MISE_DIFF` as the ownership boundary. Values in `diff.new` must still match the live process environment, and each unique path recorded in `diff.path` must still be present. PATH ownership is intentionally set-based because shells such as fish deduplicate entries when applying environment changes; requiring the serialized occurrence count would otherwise cause permanent false drift. Unmanaged variables, added PATH entries, and PATH reordering remain user-owned and do not force a refresh. No session format or public setting changes are required.

## Verification

- `mise exec -- cargo test hook_env::tests`
- `mise run test:e2e e2e/env/test_hook_env_managed_drift`
- `mise run test:e2e e2e/env/test_zsh_consecutive_precmd_runs e2e/env/test_path_reorder_after_activate e2e/env/test_bash_consecutive_prompt_runs`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/env/test_hook_env_managed_drift`
- `mise exec -- shfmt -d e2e/env/test_hook_env_managed_drift`

`mise run format` and `mise run lint` were also attempted, but their `hk` step cannot recognize this Sapling working copy as a Git repository. The corresponding Rustfmt, ShellCheck, shfmt, and Clippy checks above pass individually.

Addresses https://github.com/jdx/mise/discussions/4987

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment refresh behavior when managed variables or PATH entries are changed or removed.
  * Preserves user-added environment values while restoring managed settings.
  * Correctly handles PATH reordering, duplicate entries, and changes to unmanaged values without unnecessary refreshes.
* **Tests**
  * Added end-to-end coverage for managed environment drift and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->