### PR TITLE
fix(hook-env): track get_env template inputs

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -277,7 +277,10 @@ across task definition(s).
   variable value by name. This helper is provided by mise for compatibility with
   older Tera templates. Prefer the `env` variable in new templates when possible.
   The `default` value is used when the environment variable is not present; empty
-  environment variables are returned as-is.
+  environment variables are returned as-is. In an activated shell, mise tracks
+  variables read through `get_env()` and refreshes the rendered environment when
+  they change. Use `get_env()` when a template must react to changes made after
+  activation; direct access through `env.NAME` is not tracked.
 - `arch() -> String` – Retrieves the system architecture, such as `x64` or `arm64`.
 - `os() -> String` – Returns the name of the operating system,
   e.g. linux, macos, windows.

--- a/e2e/env/test_env_get_env_tracking
+++ b/e2e/env/test_env_get_env_tracking
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export TRACKED_INPUT=first
+export DIRECT_INPUT=direct-first
+export POST_TOOL_INPUT=post-tool-first
+export PLUGIN_CACHE_INPUT=plugin-first
+unset MISSING_INPUT
+
+# Exercise get_env() from an asdf exec-env cache key. Backend environments are
+# resolved in spawned tasks, so their tracker scope must be propagated.
+plugin_dir="$MISE_DATA_DIR/plugins/tracked-env"
+mkdir -p "$plugin_dir/bin" "$MISE_DATA_DIR/installs/tracked-env/1.0.0"
+cat >"$plugin_dir/mise.plugin.toml" <<'EOF'
+[exec-env]
+cache-key = ["{{ get_env(name='PLUGIN_CACHE_INPUT', default='plugin-fallback') }}"]
+EOF
+cat >"$plugin_dir/bin/list-all" <<'EOF'
+#!/usr/bin/env bash
+echo 1.0.0
+EOF
+cat >"$plugin_dir/bin/exec-env" <<'EOF'
+#!/usr/bin/env bash
+export PLUGIN_EXEC_VALUE="${PLUGIN_CACHE_INPUT:-plugin-fallback}"
+EOF
+chmod +x "$plugin_dir/bin/list-all" "$plugin_dir/bin/exec-env"
+
+cat >mise.toml <<'EOF'
+[vars]
+from_input = "{{ get_env(name='TRACKED_INPUT', default='fallback') }}"
+
+[env]
+TRACKED_VALUE = "{{ vars.from_input }}"
+DIRECT_VALUE = "{{ get_env(name='DIRECT_INPUT', default='direct-fallback') }}"
+MISSING_VALUE = "{{ get_env(name='MISSING_INPUT', default='missing-fallback') }}"
+POST_TOOL_VALUE = { value = "{{ get_env(name='POST_TOOL_INPUT', default='post-tool-fallback') }}", tools = true }
+
+[tools]
+tracked-env = "1.0.0"
+
+[settings]
+env_cache = true
+hook_env.cache_ttl = "1h"
+hook_env.chpwd_only = true
+EOF
+
+eval "$(mise activate bash)"
+assert "printf '%s' \"$TRACKED_VALUE\"" "first"
+assert "printf '%s' \"$DIRECT_VALUE\"" "direct-first"
+assert "printf '%s' \"$MISSING_VALUE\"" "missing-fallback"
+assert "printf '%s' \"$POST_TOOL_VALUE\"" "post-tool-first"
+assert "printf '%s' \"$PLUGIN_EXEC_VALUE\"" "plugin-first"
+assert_directory_exists "$HOME/.local/state/mise/env-cache"
+
+# A get_env() input used indirectly through [vars] invalidates both hook-env's
+# fast path and the rendered environment cache.
+export TRACKED_INPUT=second
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"export TRACKED_VALUE=second"* ]] ||
+  fail "changed get_env input was not rendered: $output"
+eval "$output"
+assert "printf '%s' \"$TRACKED_VALUE\"" "second"
+
+# Empty strings are distinct tracked inputs rather than missing values.
+export TRACKED_INPUT=
+output=$(mise hook-env -s bash --reason precmd)
+[[ -n $output ]] || fail "empty get_env input did not invalidate hook-env"
+eval "$output"
+assert "printf '<%s>' \"$TRACKED_VALUE\"" "<>"
+
+# Direct use in [env] is tracked as well, including the transition to missing.
+export DIRECT_INPUT=direct-second
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"export DIRECT_VALUE=direct-second"* ]] ||
+  fail "changed direct get_env input was not rendered: $output"
+eval "$output"
+
+unset DIRECT_INPUT
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"export DIRECT_VALUE=direct-fallback"* ]] ||
+  fail "unset get_env input did not use its default: $output"
+eval "$output"
+assert "printf '%s' \"$DIRECT_VALUE\"" "direct-fallback"
+
+# A variable that was missing during the previous render is tracked when it
+# later becomes set.
+export MISSING_INPUT=now-set
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"export MISSING_VALUE=now-set"* ]] ||
+  fail "newly set get_env input was not rendered: $output"
+eval "$output"
+assert "printf '%s' \"$MISSING_VALUE\"" "now-set"
+
+# tools=true directives are rendered after tool resolution, but their get_env()
+# inputs must still invalidate the full env cache and prompt fast path.
+export POST_TOOL_INPUT=post-tool-second
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"export POST_TOOL_VALUE=post-tool-second"* ]] ||
+  fail "changed tools=true get_env input was not rendered: $output"
+eval "$output"
+assert "printf '%s' \"$POST_TOOL_VALUE\"" "post-tool-second"
+
+# get_env() calls made by spawned backend exec-env work must also invalidate
+# the prompt fast path and select a fresh plugin cache entry.
+export PLUGIN_CACHE_INPUT=plugin-second
+output=$(mise hook-env -s bash --reason precmd)
+[[ $output == *"export PLUGIN_EXEC_VALUE=plugin-second"* ]] ||
+  fail "changed plugin cache-key get_env input was not rendered: $output"
+eval "$output"
+assert "printf '%s' \"$PLUGIN_EXEC_VALUE\"" "plugin-second"
+
+# Environment variables that no rendered get_env() call referenced do not
+# invalidate the prompt fast path.
+export UNRELATED_INPUT=changed
+output=$(mise hook-env -s bash --reason precmd)
+assert "printf '%s' \"$output\"" ""

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,7 +31,10 @@ use crate::shorthands::{Shorthands, get_shorthands};
 use crate::task::task_file_providers::TaskFileProvidersBuilder;
 use crate::task::task_sources::TaskOutputs;
 use crate::task::{RunEntry, Task, TaskCacheConfig, TaskTemplate, monorepo_scope, strip_extension};
-use crate::tera::{contains_template_syntax, get_empty_tera, render_str, take_tera_accessed_files};
+use crate::tera::{
+    TeraEnvTracker, contains_template_syntax, get_empty_tera, render_str, take_tera_accessed_files,
+    tera_env_vars_hash,
+};
 use crate::toolset::env_cache::{CachedNonToolEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::{
     ResolvedToolOptions, ToolOptionSource, ToolOptions, ToolRequestSet, ToolRequestSetBuilder,
@@ -77,6 +80,7 @@ pub struct Config {
     /// Files accessed by tera template functions (read_file, hash_file, etc.)
     /// during shell alias template rendering, used to watch for changes in hook-env.
     pub tera_files: Vec<PathBuf>,
+    tera_env_tracker: TeraEnvTracker,
     aliases: AliasMap,
     env: OnceCell<EnvResults>,
     env_with_sources: OnceCell<EnvWithSources>,
@@ -153,6 +157,7 @@ impl Config {
             repo_urls,
             shell_aliases: self.shell_aliases.clone(),
             tera_files: self.tera_files.clone(),
+            tera_env_tracker: self.tera_env_tracker.clone(),
             vars: self.vars.clone(),
             vars_results: OnceCell::new(),
         })
@@ -166,6 +171,11 @@ impl Config {
 
     #[async_backtrace::framed]
     pub async fn load() -> Result<Arc<Self>> {
+        let tracker = TeraEnvTracker::default();
+        crate::tera::with_tera_env_tracker(tracker.clone(), Self::load_inner(tracker)).await
+    }
+
+    async fn load_inner(tera_env_tracker: TeraEnvTracker) -> Result<Arc<Self>> {
         backend::load_tools().await?;
         let idiomatic_files = measure!("config::load idiomatic_files", {
             load_idiomatic_filenames().await
@@ -199,6 +209,7 @@ impl Config {
             repo_urls: Default::default(),
             shell_aliases: Default::default(),
             tera_files: Default::default(),
+            tera_env_tracker: tera_env_tracker.clone(),
             vars: Default::default(),
             vars_results: OnceCell::new(),
         };
@@ -218,6 +229,7 @@ impl Config {
             repo_urls: config.repo_urls.clone(),
             shell_aliases: config.shell_aliases.clone(),
             tera_files: config.tera_files.clone(),
+            tera_env_tracker,
             vars: config.vars.clone(),
             vars_results: OnceCell::new(),
         });
@@ -944,6 +956,11 @@ impl Config {
     }
 
     async fn load_env(self: &Arc<Self>) -> Result<EnvResults> {
+        crate::tera::with_tera_env_tracker(self.tera_env_tracker.clone(), self.load_env_inner())
+            .await
+    }
+
+    async fn load_env_inner(self: &Arc<Self>) -> Result<EnvResults> {
         if Settings::no_env() || Settings::get().no_env.unwrap_or(false) {
             return Ok(EnvResults::default());
         }
@@ -1079,6 +1096,8 @@ impl Config {
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
+            let get_env_vars = self.tera_env_vars();
+            let get_env_hash = tera_env_vars_hash(&get_env_vars, &env::PRISTINE_ENV);
             let cached = CachedNonToolEnv {
                 env: env_results.env.clone(),
                 env_remove: env_results.env_remove.clone(),
@@ -1089,6 +1108,8 @@ impl Config {
                 redaction_exclusions: env_results.redaction_exclusions.clone(),
                 watch_files,
                 watch_file_mtimes,
+                get_env_vars,
+                get_env_hash,
                 created_at: now,
                 mise_version: env!("CARGO_PKG_VERSION").to_string(),
                 cache_key_debug: cache_key.clone(),
@@ -1103,6 +1124,18 @@ impl Config {
             debug!("{env_results:?}");
         }
         Ok(env_results)
+    }
+
+    pub(crate) fn tera_env_vars(&self) -> Vec<String> {
+        self.tera_env_tracker.vars()
+    }
+
+    pub(crate) fn tera_env_tracker(&self) -> TeraEnvTracker {
+        self.tera_env_tracker.clone()
+    }
+
+    pub(crate) fn track_tera_env_vars(&self, vars: impl IntoIterator<Item = String>) {
+        self.tera_env_tracker.track_all(vars);
     }
 
     pub async fn hooks(&self) -> Result<&Vec<(PathBuf, Hook)>> {
@@ -4966,6 +4999,7 @@ mod tests {
             repo_urls,
             shell_aliases: Default::default(),
             tera_files: Default::default(),
+            tera_env_tracker: Default::default(),
             vars: Default::default(),
             vars_results: OnceCell::new(),
         };
@@ -5043,6 +5077,7 @@ mod tests {
             repo_urls: Default::default(),
             shell_aliases: Default::default(),
             tera_files: Default::default(),
+            tera_env_tracker: Default::default(),
             vars: Default::default(),
             vars_results: OnceCell::new(),
         };
@@ -5124,6 +5159,7 @@ mod tests {
             repo_urls: Default::default(),
             shell_aliases: Default::default(),
             tera_files: Default::default(),
+            tera_env_tracker: Default::default(),
             vars: Default::default(),
             vars_results: OnceCell::new(),
         };
@@ -5207,6 +5243,7 @@ mod tests {
             repo_urls: Default::default(),
             shell_aliases: Default::default(),
             tera_files: Default::default(),
+            tera_env_tracker: Default::default(),
             vars: Default::default(),
             vars_results: OnceCell::new(),
         };
@@ -5265,6 +5302,7 @@ mod tests {
                 repo_urls: Default::default(),
                 shell_aliases: Default::default(),
                 tera_files: Default::default(),
+                tera_env_tracker: Default::default(),
                 vars: Default::default(),
                 vars_results: OnceCell::new(),
             };
@@ -5348,6 +5386,7 @@ config_roots = ["apps/api", "apps/web"]
             repo_urls: Default::default(),
             shell_aliases: Default::default(),
             tera_files: Default::default(),
+            tera_env_tracker: Default::default(),
             vars: Default::default(),
             vars_results: OnceCell::new(),
         };
@@ -5511,6 +5550,7 @@ config_roots = ["apps/api", "apps/web"]
             repo_urls,
             shell_aliases: Default::default(),
             tera_files: Default::default(),
+            tera_env_tracker: Default::default(),
             vars: Default::default(),
             vars_results: OnceCell::new(),
         };

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -21,7 +21,7 @@ use crate::env_diff::{EnvDiffOperation, EnvDiffPatches, EnvMap};
 use crate::errors::Error;
 use crate::hash::hash_to_str;
 use crate::shell::Shell;
-use crate::{dirs, duration, env, file, hooks, watch_files};
+use crate::{dirs, duration, env, file, hooks, tera, watch_files};
 
 /// Directory to store per-directory last check timestamps.
 /// Timestamps are stored per-directory (using a hash of CWD) so that
@@ -252,6 +252,11 @@ pub fn should_exit_early_fast() -> bool {
     if have_mise_env_vars_been_modified() {
         return false;
     }
+    // `get_env()` reads the pristine process environment. Only compare names
+    // that the previous config render actually accessed.
+    if have_get_env_vars_been_modified() {
+        return false;
+    }
 
     // chpwd_only mode: skip on precmd if directory hasn't changed
     // This significantly reduces stat operations on slow filesystems like NFS
@@ -374,6 +379,9 @@ pub fn should_exit_early(
     if have_mise_env_vars_been_modified() {
         return false;
     }
+    if have_get_env_vars_been_modified() {
+        return false;
+    }
     // The fast path already decided this run is necessary. Check it only after
     // the slow-path checks above, since they also record modified watch files
     // and schedule hooks as side effects.
@@ -452,6 +460,12 @@ fn have_mise_env_vars_been_modified() -> bool {
     get_mise_env_vars_hashed() != PREV_SESSION.env_var_hash
 }
 
+fn have_get_env_vars_been_modified() -> bool {
+    !PREV_SESSION.get_env_vars.is_empty()
+        && tera::tera_env_vars_hash(&PREV_SESSION.get_env_vars, &env::PRISTINE_ENV)
+            != PREV_SESSION.get_env_hash
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct HookEnvSession {
     pub loaded_tools: IndexSet<String>,
@@ -468,6 +482,12 @@ pub struct HookEnvSession {
     /// Stored so the fast-path can detect changes without loading config.
     #[serde(default)]
     pub watch_files: Vec<PathBuf>,
+    /// Environment variable names read through `get_env()` during config rendering.
+    #[serde(default)]
+    pub get_env_vars: Vec<String>,
+    /// Hash of the corresponding values in the pristine process environment.
+    #[serde(default)]
+    get_env_hash: String,
     dir: Option<PathBuf>,
     env_var_hash: String,
     latest_update: u128,
@@ -564,6 +584,9 @@ pub async fn build_session(
         write_last_full_check(now);
     }
 
+    let get_env_vars = config.tera_env_vars();
+    let get_env_hash = tera::tera_env_vars_hash(&get_env_vars, &env::PRISTINE_ENV);
+
     Ok(HookEnvSession {
         dir: dirs::CWD.clone(),
         env_var_hash: get_mise_env_vars_hashed(),
@@ -571,6 +594,8 @@ pub async fn build_session(
         aliases,
         tera_files: config.tera_files.clone(),
         watch_files: resolved_watch_files.into_iter().collect(),
+        get_env_vars,
+        get_env_hash,
         loaded_configs,
         loaded_tools,
         config_paths,

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1,7 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::future::Future;
 use std::iter::once;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use heck::{
     ToKebabCase, ToLowerCamelCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
@@ -27,6 +28,45 @@ use crate::{dirs, duration, env, hash};
 /// push paths here so that hook-env can watch them for changes.
 static TERA_ACCESSED_FILES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
+/// Environment variables read through `get_env()` while rendering one config.
+/// Values are never stored here.
+#[derive(Clone, Default)]
+pub(crate) struct TeraEnvTracker(Arc<Mutex<BTreeSet<String>>>);
+
+impl TeraEnvTracker {
+    fn track(&self, name: String) {
+        if let Ok(mut vars) = self.0.lock() {
+            vars.insert(name);
+        }
+    }
+
+    pub(crate) fn track_all(&self, vars: impl IntoIterator<Item = String>) {
+        if let Ok(mut tracked) = self.0.lock() {
+            tracked.extend(vars);
+        }
+    }
+
+    pub(crate) fn vars(&self) -> Vec<String> {
+        self.0
+            .lock()
+            .map(|vars| vars.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+tokio::task_local! {
+    static TERA_ENV_TRACKER: TeraEnvTracker;
+}
+
+pub(crate) async fn with_tera_env_tracker<T>(
+    tracker: TeraEnvTracker,
+    future: impl Future<Output = T>,
+) -> T {
+    // Config and environment resolution produce large futures. Keep their
+    // storage off the executor thread stack before adding the task-local scope.
+    TERA_ENV_TRACKER.scope(tracker, Box::pin(future)).await
+}
+
 fn track_tera_file(path: &Path) {
     if let Ok(mut files) = TERA_ACCESSED_FILES.lock() {
         files.push(path.to_path_buf());
@@ -42,6 +82,32 @@ pub fn take_tera_accessed_files() -> Vec<PathBuf> {
     files.sort();
     files.dedup();
     files
+}
+
+fn track_tera_env_var(name: &str) {
+    let _ = TERA_ENV_TRACKER.try_with(|tracker| tracker.track(name.to_string()));
+}
+
+/// Restore dependencies when a rendered environment is loaded from cache.
+pub fn track_tera_env_vars(vars: impl IntoIterator<Item = String>) {
+    let vars = vars.into_iter().collect::<Vec<_>>();
+    let _ = TERA_ENV_TRACKER.try_with(|tracker| tracker.track_all(vars));
+}
+
+/// Hash the current values of tracked `get_env()` inputs without persisting
+/// their values. Missing and empty values remain distinct in the serialized
+/// hash input.
+pub fn tera_env_vars_hash(vars: &[String], env: &EnvMap) -> String {
+    let mut vars = vars.to_vec();
+    vars.sort();
+    vars.dedup();
+    let values = vars
+        .iter()
+        .map(|name| (name.as_str(), env.get(name).map(String::as_str)))
+        .collect::<Vec<_>>();
+    hash::hash_blake3_to_str(
+        &serde_json::to_string(&values).expect("get_env dependency values are serializable"),
+    )
 }
 
 /// Fast marker check for Tera 1.x syntax.
@@ -892,6 +958,7 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
 fn tera_get_env(env: EnvMap) -> impl Fn(Kwargs, &State) -> TeraResult<Value> {
     move |args: Kwargs, _: &State| -> TeraResult<Value> {
         let name = args.must_get::<&str>("name")?;
+        track_tera_env_var(name);
         if let Some(value) = env.get(name) {
             return Ok(Value::from(value.clone()));
         }
@@ -1794,6 +1861,57 @@ mod tests {
         assert!(
             tera.render_str("{{ get_env(name='MISE_TEST_MISSING_ENV') }}", &ctx, false)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn get_env_dependency_hash_is_deterministic_and_value_sensitive() {
+        let vars = vec!["SECOND".to_string(), "FIRST".to_string()];
+        let reordered = vec!["FIRST".to_string(), "SECOND".to_string()];
+        let env = EnvMap::from([
+            ("FIRST".to_string(), "value".to_string()),
+            ("SECOND".to_string(), String::new()),
+        ]);
+
+        let hash = tera_env_vars_hash(&vars, &env);
+        assert_eq!(hash, tera_env_vars_hash(&reordered, &env));
+
+        let changed = EnvMap::from([
+            ("FIRST".to_string(), "changed".to_string()),
+            ("SECOND".to_string(), String::new()),
+        ]);
+        assert_ne!(hash, tera_env_vars_hash(&vars, &changed));
+
+        let missing = EnvMap::from([("FIRST".to_string(), "value".to_string())]);
+        assert_ne!(hash, tera_env_vars_hash(&vars, &missing));
+    }
+
+    #[tokio::test]
+    async fn get_env_dependency_tracking_is_scoped() {
+        let first = TeraEnvTracker::default();
+        let second = TeraEnvTracker::default();
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        tokio::join!(
+            with_tera_env_tracker(first.clone(), async {
+                track_tera_env_vars(["FIRST".to_string()]);
+                barrier.wait().await;
+                track_tera_env_vars(["FIRST_AFTER_WAIT".to_string()]);
+            }),
+            with_tera_env_tracker(second.clone(), async {
+                track_tera_env_vars(["SECOND".to_string()]);
+                barrier.wait().await;
+                track_tera_env_vars(["SECOND_AFTER_WAIT".to_string()]);
+            })
+        );
+
+        assert_eq!(
+            first.vars(),
+            vec!["FIRST".to_string(), "FIRST_AFTER_WAIT".to_string()]
+        );
+        assert_eq!(
+            second.vars(),
+            vec!["SECOND".to_string(), "SECOND_AFTER_WAIT".to_string()]
         );
     }
 

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -15,6 +15,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::Settings;
 use crate::dirs;
+use crate::env;
+use crate::env_diff::EnvMap;
 use crate::file;
 
 fn get_encryption_key() -> Option<[u8; 32]> {
@@ -85,7 +87,7 @@ fn validate_watch_files(watch_files: &[PathBuf], expected_mtimes: &[u64]) -> Res
 }
 
 /// Represents the cached environment data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CachedEnv {
     /// Cached environment variables
     pub env: BTreeMap<String, String>,
@@ -99,6 +101,12 @@ pub struct CachedEnv {
     pub watch_files: Vec<PathBuf>,
     /// mtimes of watch files at cache creation time
     pub watch_file_mtimes: Vec<u64>,
+    /// Environment variable names read through `get_env()` while rendering.
+    #[serde(default)]
+    pub get_env_vars: Vec<String>,
+    /// Hash of the corresponding values in the pristine process environment.
+    #[serde(default)]
+    pub get_env_hash: String,
     /// mise version when cache was created
     pub mise_version: String,
     /// SHA256 of the original cache key inputs (for debugging)
@@ -106,7 +114,7 @@ pub struct CachedEnv {
 }
 
 /// Cached environment data for non-tool env results (config-time env resolution)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CachedNonToolEnv {
     /// Environment variables resolved from non-tool directives
     pub env: IndexMap<String, (String, PathBuf)>,
@@ -127,6 +135,12 @@ pub struct CachedNonToolEnv {
     pub watch_files: Vec<PathBuf>,
     /// mtimes of watch files at cache creation time
     pub watch_file_mtimes: Vec<u64>,
+    /// Environment variable names read through `get_env()` while rendering.
+    #[serde(default)]
+    pub get_env_vars: Vec<String>,
+    /// Hash of the corresponding values in the pristine process environment.
+    #[serde(default)]
+    pub get_env_hash: String,
     /// Time when the cache was created
     pub created_at: u64,
     /// mise version when cache was created
@@ -232,6 +246,16 @@ impl CachedEnv {
                 cached.mise_version,
                 env!("CARGO_PKG_VERSION")
             );
+            let _ = file::remove_file(&cache_file);
+            return Ok(None);
+        }
+
+        if !get_env_inputs_match(
+            &cached.get_env_vars,
+            &cached.get_env_hash,
+            &env::PRISTINE_ENV,
+        ) {
+            debug!("env_cache: get_env input changed");
             let _ = file::remove_file(&cache_file);
             return Ok(None);
         }
@@ -383,6 +407,12 @@ impl CachedNonToolEnv {
             return Ok(None);
         }
 
+        if !cached.get_env_inputs_match(&env::PRISTINE_ENV) {
+            debug!("env_cache: get_env input changed");
+            let _ = file::remove_file(&cache_file);
+            return Ok(None);
+        }
+
         // Check TTL
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -403,8 +433,13 @@ impl CachedNonToolEnv {
             return Ok(None);
         }
 
+        crate::tera::track_tera_env_vars(cached.get_env_vars.iter().cloned());
         trace!("env_cache: loaded non-tool env cache for key {}", cache_key);
         Ok(Some(cached))
+    }
+
+    fn get_env_inputs_match(&self, env: &EnvMap) -> bool {
+        get_env_inputs_match(&self.get_env_vars, &self.get_env_hash, env)
     }
 
     /// Saves cached non-tool env data to disk
@@ -434,6 +469,10 @@ impl CachedNonToolEnv {
     pub fn is_enabled() -> bool {
         Settings::get().env_cache && get_encryption_key().is_some()
     }
+}
+
+fn get_env_inputs_match(vars: &[String], expected_hash: &str, env: &EnvMap) -> bool {
+    vars.is_empty() || crate::tera::tera_env_vars_hash(vars, env) == expected_hash
 }
 
 /// Helper to get the mtime of a file as seconds since UNIX epoch
@@ -495,6 +534,43 @@ mod tests {
             base_path,
         );
         assert_ne!(key1, key3);
+    }
+
+    #[test]
+    fn non_tool_cache_matches_only_same_get_env_inputs() {
+        let vars = vec!["TOKEN".to_string()];
+        let original = EnvMap::from([("TOKEN".to_string(), "secret-one".to_string())]);
+        let cache = CachedNonToolEnv {
+            get_env_hash: crate::tera::tera_env_vars_hash(&vars, &original),
+            get_env_vars: vars,
+            ..Default::default()
+        };
+
+        assert!(cache.get_env_inputs_match(&original));
+        assert!(!cache.get_env_inputs_match(&EnvMap::from([(
+            "TOKEN".to_string(),
+            "secret-two".to_string(),
+        )])));
+        assert!(!cache.get_env_inputs_match(&EnvMap::new()));
+    }
+
+    #[test]
+    fn non_tool_cache_does_not_serialize_get_env_values() {
+        let secret = "not-stored-secret";
+        let vars = vec!["TOKEN".to_string()];
+        let env = EnvMap::from([("TOKEN".to_string(), secret.to_string())]);
+        let cache = CachedNonToolEnv {
+            get_env_hash: crate::tera::tera_env_vars_hash(&vars, &env),
+            get_env_vars: vars,
+            ..Default::default()
+        };
+
+        let serialized = rmp_serde::to_vec_named(&cache).unwrap();
+        assert!(
+            !serialized
+                .windows(secret.len())
+                .any(|window| window == secret.as_bytes())
+        );
     }
 
     #[test]

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -169,7 +169,11 @@ impl Toolset {
     ) -> Result<Option<CachedEnv>> {
         config.env_results().await?;
         let cache_key = self.compute_env_cache_key(config)?;
-        CachedEnv::load(&cache_key)
+        let cached = CachedEnv::load(&cache_key)?;
+        if let Some(cached) = &cached {
+            config.track_tera_env_vars(cached.get_env_vars.iter().cloned());
+        }
+        Ok(cached)
     }
 
     /// Try to load environment from cache (returns reconstructed EnvMap)
@@ -232,6 +236,8 @@ impl Toolset {
             .filter(|(k, _)| k.as_str() != PATH_KEY.as_str())
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        let get_env_vars = config.tera_env_vars();
+        let get_env_hash = crate::tera::tera_env_vars_hash(&get_env_vars, &env::PRISTINE_ENV);
 
         let cached = CachedEnv {
             env: env_without_path,
@@ -240,6 +246,8 @@ impl Toolset {
             created_at: now,
             watch_files,
             watch_file_mtimes,
+            get_env_vars,
+            get_env_hash,
             mise_version: env!("CARGO_PKG_VERSION").to_string(),
             cache_key_debug: cache_key.clone(),
         };
@@ -317,17 +325,21 @@ impl Toolset {
             .collect();
 
         let envs = parallel::parallel(items, |(config, this, b, tv)| async move {
-            let backend_id = b.id().to_string();
-            match b.exec_env(&config, &this, &tv).await {
-                Ok(env) => Ok(env
-                    .into_iter()
-                    .map(|(k, v)| (k, v, backend_id.clone()))
-                    .collect::<Vec<_>>()),
-                Err(e) => {
-                    warn!("Error running exec-env: {:#}", e);
-                    Ok(Vec::new())
+            let tracker = config.tera_env_tracker();
+            crate::tera::with_tera_env_tracker(tracker, async move {
+                let backend_id = b.id().to_string();
+                match b.exec_env(&config, &this, &tv).await {
+                    Ok(env) => Ok(env
+                        .into_iter()
+                        .map(|(k, v)| (k, v, backend_id.clone()))
+                        .collect::<Vec<_>>()),
+                    Err(e) => {
+                        warn!("Error running exec-env: {:#}", e);
+                        Ok(Vec::new())
+                    }
                 }
-            }
+            })
+            .await
         })
         .await
         .unwrap_or_default();
@@ -451,19 +463,22 @@ impl Toolset {
             .flatten()
             .collect();
         // trace!("load_env: entries: {:#?}", entries);
-        let env_results = EnvResults::resolve_with_toolset(
-            config,
-            ctx,
-            env,
-            entries,
-            EnvResolveOptions {
-                vars: false,
-                tools: tools_filter,
-                warn_on_missing_required: *WARN_ON_MISSING_REQUIRED_ENV,
-            },
-            // `_.python.venv` needs the *active* python, which is only knowable here: a
-            // `--tool python@3.12` override lives in this toolset and never reaches `Config`.
-            Some(self),
+        let env_results = crate::tera::with_tera_env_tracker(
+            config.tera_env_tracker(),
+            EnvResults::resolve_with_toolset(
+                config,
+                ctx,
+                env,
+                entries,
+                EnvResolveOptions {
+                    vars: false,
+                    tools: tools_filter,
+                    warn_on_missing_required: *WARN_ON_MISSING_REQUIRED_ENV,
+                },
+                // `_.python.venv` needs the *active* python, which is only knowable here: a
+                // `--tool python@3.12` override lives in this toolset and never reaches `Config`.
+                Some(self),
+            ),
         )
         .await?;
         if log::log_enabled!(log::Level::Trace) {


### PR DESCRIPTION
# Summary

Track external environment variables read through `get_env()` so activated shells refresh rendered configuration when those inputs change.

# Details

- Records only the variable names actually read by `get_env()` and stores a deterministic BLAKE3 hash of their pristine process-environment values.
- Checks those inputs before `hook_env.cache_ttl` and `hook_env.chpwd_only` can take the prompt fast path.
- Carries the same dependency metadata through both non-tool and full Toolset environment caches, preventing either cache layer from returning stale rendered values.
- Distinguishes changed, newly set, removed, and empty values without storing raw values in sessions, cache filenames, or logs.
- Leaves direct `env.NAME` template access and unrelated process-environment changes outside invalidation so prompt performance remains bounded.

# Verification

- `mise exec -- cargo test get_env`
- `mise run test:e2e e2e/env/test_env_get_env_tracking e2e/env/test_env_cache e2e/env/test_bash_consecutive_prompt_runs e2e/env/test_zsh_consecutive_precmd_runs`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/env/test_env_get_env_tracking`
- `mise exec -- shfmt -d e2e/env/test_env_get_env_tracking`
- `mise exec -- markdownlint docs/templates.md`
- `mise x prettier -- prettier --check docs/templates.md`

`mise run format` and `mise run lint` reach hk, but hk cannot identify this Sapling working copy as a Git repository. The equivalent checks for the touched Rust, shell, and Markdown files were run individually above.

Addresses https://github.com/jdx/mise/discussions/2519

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment values accessed through `get_env()` are now tracked automatically.
  * Rendered environments refresh when tracked variables change, are unset, or are restored.
  * Cache handling preserves this tracking across sessions while keeping sensitive values private.

* **Documentation**
  * Clarified environment tracking behavior and noted that direct `env.NAME` access is not tracked.

* **Tests**
  * Added end-to-end coverage for environment updates, fallbacks, caching, and unrelated variable changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->