### PR TITLE
fix(config): don't pick a write target that config loading ignores

### DIFF
--- a/e2e/cli/test_config_dir_override
+++ b/e2e/cli/test_config_dir_override
@@ -35,3 +35,20 @@ assert_not_contains "mise config ls" ".config/mise/config.toml"
 # Verify the correct tool version is used (1.0.0 from custom, not 2.0.0 from default)
 mise install
 assert_contains "mise x -- dummy" "1.0.0"
+
+# The write target has to respect the same exclusion. `mise use` used to pick
+# ~/.config/mise/config.toml here -- the very file the assertions above prove is not
+# loaded -- so the tool landed somewhere mise would never read it back.
+mkdir -p "$HOME/writetarget"
+cd "$HOME/writetarget" || exit 1
+
+mise use dummy@1.0.0
+assert "cat mise.toml" '[tools]
+dummy = "1.0.0"'
+assert "cat $HOME/.config/mise/config.toml" '[tools]
+dummy = "2.0.0"'
+
+# `mise set` already resolved this correctly; it shares the resolver now, so pin it.
+mise set WRITE_TARGET=local
+assert_contains "cat mise.toml" "WRITE_TARGET"
+assert_not_contains "cat $HOME/.config/mise/config.toml" "WRITE_TARGET"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1684,17 +1684,47 @@ pub fn config_file_in_dir(dir: &Path) -> PathBuf {
     }
 }
 
+/// The nearest local config file walking up from `start`: the highest-precedence directory
+/// that has one, then the lowest-precedence file inside it.
+///
+/// Both write-target resolvers share this. They were separate implementations of the same
+/// rule, and only one of them was kept current — the ignore filter added for
+/// <https://github.com/jdx/mise/discussions/7015> reached `local_toml_config_path_from_dir`
+/// and not `config_file_from_dir`, so `mise use` picked a file that config loading
+/// deliberately skips and wrote a tool into it that mise would never read back.
+fn nearest_local_config_file(start: &Path, filenames: &[String]) -> Option<PathBuf> {
+    if Settings::no_config() {
+        return None;
+    }
+    for dir in all_dirs_from(start).unwrap_or_default() {
+        if config_dir_is_ignored(&dir, false) {
+            continue;
+        }
+        let files: IndexSet<PathBuf> = filenames
+            .iter()
+            .flat_map(|f| glob(&dir, f).unwrap_or_default())
+            .unique_by(|p| file::desymlink_path(p))
+            .filter(|p| !config_path_is_ignored(p, false))
+            .collect();
+        if let Some(cf) = first_config_file(&files)
+            && !is_global_config(cf)
+        {
+            return Some(cf.clone());
+        }
+    }
+    None
+}
+
 pub fn config_file_from_dir(p: &Path) -> PathBuf {
     if !p.is_dir() {
         return p.to_path_buf();
     }
-    for dir in all_dirs().unwrap_or_default() {
-        let files = self::config_files_in_dir(&dir);
-        if let Some(cf) = first_config_file(&files)
-            && !is_global_config(cf)
-        {
-            return cf.clone();
-        }
+    // Walk from the cwd rather than from `p`, which is what this has always done.
+    if let Some(cf) = env::current_dir()
+        .ok()
+        .and_then(|cwd| nearest_local_config_file(&cwd, &DEFAULT_CONFIG_FILENAMES))
+    {
+        return cf;
     }
     match Settings::get().asdf_compat {
         true => p.join(&*MISE_DEFAULT_TOOL_VERSIONS_FILENAME),
@@ -2196,25 +2226,8 @@ pub fn local_toml_config_path() -> PathBuf {
 /// This matches the write-target rule from the docs: choose the highest-precedence
 /// directory first, then the lowest-precedence file inside that directory.
 pub fn local_toml_config_path_from_dir(cwd: &Path) -> PathBuf {
-    if !Settings::no_config() {
-        for dir in all_dirs_from(cwd).unwrap_or_default() {
-            if config_dir_is_ignored(&dir, false) {
-                continue;
-            }
-            let files = TOML_CONFIG_FILENAMES
-                .iter()
-                .flat_map(|f| glob(&dir, f).unwrap_or_default())
-                .unique_by(|p| file::desymlink_path(p))
-                .filter(|p| !config_path_is_ignored(p, false))
-                .collect();
-            if let Some(cf) = first_config_file(&files)
-                && !is_global_config(cf)
-            {
-                return cf.clone();
-            }
-        }
-    }
-    cwd.join(&*env::MISE_DEFAULT_CONFIG_FILENAME)
+    nearest_local_config_file(cwd, &TOML_CONFIG_FILENAMES)
+        .unwrap_or_else(|| cwd.join(&*env::MISE_DEFAULT_CONFIG_FILENAME))
 }
 
 /// Options for resolving target config file path


### PR DESCRIPTION
## Summary

`mise use` can pick a write target that config loading deliberately skips, so the tool it writes is never read back.

The two write-target resolvers are separate implementations of the same rule, and only one was kept current. The exclusion added for #7015 — which drops configs under the default `~/.config/mise` once `MISE_CONFIG_DIR` points elsewhere — is reached through `config_path_is_ignored`, and only `local_toml_config_path_from_dir` calls it. `config_file_from_dir` applies just `!is_global_config(cf)`.

With a relocated config dir, `config_file_from_dir` walks up to `$HOME`, finds `~/.config/mise/config.toml` (a recognised *local* config filename), no longer recognises it as the global config, and returns it.

```console
$ export MISE_CONFIG_DIR=/root/alt/mise

$ mise config ls
~/alt/mise/config.toml                          # the default location is excluded, as #7015 intends

$ mise use --dry-run uv@0.12.0
mise would update ~/.config/mise/config.toml    # ...but that is where the tool goes
```

Measured on v2026.7.15 and v2026.7.18, Linux and Windows alike. `mise set` is unaffected — it goes through the resolver that has the filter.

## What changed

The shared walk is extracted into `nearest_local_config_file(start, filenames)`, and both resolvers use it. That is `local_toml_config_path_from_dir`'s existing body with the filename list and the walk root as parameters, so each caller keeps its own filenames and its own fallback (`config_file_from_dir` keeps the `asdf_compat` one).

- **`mise set` and friends: no behaviour change.** Same filenames, same walk root, same fallback.
- **`mise use`: gains the four filters it was missing** — the `MISE_NO_CONFIG` short-circuit, `config_dir_is_ignored`, the desymlink dedupe, and `config_path_is_ignored`.

That last point is worth calling out because it is broader than the bug above: `mise use` now also honours `MISE_IGNORED_CONFIG_PATHS` and `MISE_NO_CONFIG` when choosing where to write, which it arguably should have all along and which `mise set` already did. Happy to narrow this to only the `#7015` filter if you would rather keep the change minimal.

`config_file_from_dir` still walks from `env::current_dir()` rather than from its `p` argument. That is pre-existing and affects `use --path` / `unuse --path`, so I left it alone here.

## Tests

`e2e/cli/test_config_dir_override` is the test written for #7015 and only covered reads. It now also asserts the write target, plus a pin on `mise set` since it shares the resolver now.

Verified locally on Windows against the released v2026.7.18 binary; every case below matches except the first, which is the bug:

| | v2026.7.18 | this PR |
|---|---|---|
| `use`, `MISE_CONFIG_DIR` relocated, no local config | `~/.config/mise/config.toml` | `./mise.toml` |
| `use`, config-less deep dir | `plain/deep/mise.toml` | same |
| `use`, ancestor has `mise.toml` | `anc/mise.toml` | same |
| `use`, `mise.toml` + `mise.local.toml` | `both/mise.toml` | same |
| `use -g` | `<config dir>/config.toml` | same |
| `set`, nested dirs | `anc/mise.toml` | same |
| `set`, lowest-precedence file | `both/mise.toml` | same |
| `set`, `MISE_IGNORED_CONFIG_PATHS` | `anc/x/y/mise.toml` | same |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration changes made with `mise use` and `mise set` are now written to the nearest valid local configuration file.
  * Prevented updates from being written to excluded default configuration files.
  * Improved consistency when resolving local configuration files across directories, symlinks, and ignored paths.
* **Tests**
  * Expanded end-to-end coverage to verify configuration write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->