### PR TITLE
fix(task): skip dangling task symlinks

### DIFF
--- a/e2e/tasks/test_task_broken_symlinks
+++ b/e2e/tasks/test_task_broken_symlinks
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+mkdir -p .mise/tasks "$HOME/.config/mise/tasks"
+
+cat <<'EOF' >.mise/tasks/healthy
+#!/usr/bin/env bash
+echo "healthy ran"
+EOF
+chmod +x .mise/tasks/healthy
+
+cat <<'EOF' >"$HOME/.config/mise/tasks/global-ok"
+#!/usr/bin/env bash
+echo "global ran"
+EOF
+chmod +x "$HOME/.config/mise/tasks/global-ok"
+
+# Emacs creates .#-prefixed symlinks that may deliberately point at a
+# non-existent lock owner. Following the link must not abort task discovery.
+ln -s missing-target .mise/tasks/.#healthy
+
+# A repository containing linked global tasks may be moved or deleted, leaving
+# the task group dangling while other local and global tasks remain usable.
+ln -s "$MISE_TMP_DIR/missing-global-task-dir" "$HOME/.config/mise/tasks/global"
+
+assert "mise tasks ls --name-only" "global-ok
+healthy"
+assert_contains "mise run healthy" "healthy ran"
+assert_contains "mise run global-ok" "global ran"
+assert_contains "mise tasks --usage" '"healthy"'
+assert_contains "mise tasks --usage" '"global-ok"'

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3693,6 +3693,29 @@ struct LoadTaskIncludesOptions<'a> {
     rendered_file_tasks: Option<&'a mut RenderedTaskCache>,
 }
 
+fn collect_task_files(root: &Path) -> Result<Vec<PathBuf>> {
+    WalkDir::new(root)
+        .follow_links(true)
+        .into_iter()
+        // skip hidden directories (if the root is hidden that's ok)
+        .filter_entry(|e| e.path() == root || !e.file_name().to_string_lossy().starts_with('.'))
+        .filter_map(|entry| match entry {
+            Ok(entry) if entry.file_type().is_file() => Some(Ok(entry.path().to_path_buf())),
+            Ok(_) => None,
+            Err(err)
+                if err
+                    .io_error()
+                    .is_some_and(|err| err.kind() == std::io::ErrorKind::NotFound) =>
+            {
+                debug!("skipping missing task entry: {err}");
+                None
+            }
+            Err(err) => Some(Err(err)),
+        })
+        .try_collect::<_, Vec<PathBuf>, _>()
+        .map_err(Into::into)
+}
+
 async fn load_tasks_includes(
     config: &Arc<Config>,
     root: &Path,
@@ -3719,14 +3742,7 @@ async fn load_tasks_includes(
         )
         .await
     } else if root.is_dir() {
-        let all_files = WalkDir::new(root)
-            .follow_links(true)
-            .into_iter()
-            // skip hidden directories (if the root is hidden that's ok)
-            .filter_entry(|e| e.path() == root || !e.file_name().to_string_lossy().starts_with('.'))
-            .filter_ok(|e| e.file_type().is_file())
-            .map_ok(|e| e.path().to_path_buf())
-            .try_collect::<_, Vec<PathBuf>, _>()?
+        let all_files = collect_task_files(root)?
             .into_iter()
             .filter(|p| {
                 !Settings::get()
@@ -4407,6 +4423,43 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    #[test]
+    fn test_collect_task_files_skips_dangling_symlinks() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let task = tmp.path().join("task");
+        fs::write(&task, "echo ok")?;
+        std::os::unix::fs::symlink("missing", tmp.path().join("dangling"))?;
+
+        assert_eq!(collect_task_files(tmp.path())?, vec![task]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_task_files_follows_valid_directory_symlinks() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let target = tmp.path().join("target");
+        fs::create_dir(&target)?;
+        fs::write(target.join("task"), "echo ok")?;
+        let root = tmp.path().join("root");
+        fs::create_dir(&root)?;
+        std::os::unix::fs::symlink(&target, root.join("linked"))?;
+
+        assert_eq!(collect_task_files(&root)?, vec![root.join("linked/task")]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_task_files_preserves_symlink_loop_errors() -> Result<()> {
+        let tmp = TempDir::new()?;
+        std::os::unix::fs::symlink("loop", tmp.path().join("loop"))?;
+
+        assert!(collect_task_files(tmp.path()).is_err());
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_load() {


### PR DESCRIPTION
## Summary

- skip missing entries while discovering file tasks so dangling symlinks do not abort task loading
- keep following valid task symlinks and continue surfacing permission, loop, and other filesystem errors
- cover project tasks, global task groups, task execution, and dynamic completion metadata

## Problem

File-task discovery uses `WalkDir` with `follow_links(true)` and previously collected every traversal result with `try_collect`. A dangling symlink therefore produced `NotFound` and aborted all task commands, including completion, even when other tasks were healthy.

## Solution

Treat only `NotFound` traversal errors as entries that disappeared or no longer have a target, log them at debug level, and continue collecting the remaining tasks. Other traversal errors remain fatal, and valid directory symlinks are still followed.

## Testing

- `mise exec -- cargo test --all-features config::tests::test_collect_task_files`
- `mise run test:e2e e2e/tasks/test_task_broken_symlinks`
- `mise run test:e2e e2e/tasks/test_task_global_config_dedup`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d e2e/tasks/test_task_broken_symlinks`
- `mise exec -- shellcheck e2e/tasks/test_task_broken_symlinks`

`mise run format` and `mise run lint` were also attempted, but the `hk` wrapper cannot identify this Sapling working copy as a Git repository. The applicable format and lint checks above pass individually.

Addresses https://github.com/jdx/mise/discussions/5975

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*