### PR TITLE
fix(config): make --path <dir> target that directory

### DIFF
--- a/e2e/cli/test_unuse
+++ b/e2e/cli/test_unuse
@@ -90,3 +90,18 @@ EOF
 assert "mise unuse --no-prune --path .tool-versions dummy@1.0.0"
 assert "cat .tool-versions" "dummy 2.0.0 # keep me
 tiny  3.1.0"
+
+# --path <dir> removes from a config inside that directory and leaves the cwd's alone. This used
+# to resolve from the cwd, so `unuse --path <elsewhere>` deleted the tool from the wrong file.
+mkdir -p "$HOME/unusepath/from" "$HOME/unusepath/to"
+printf '[tools]\ndummy = "1.0.0"\n' >"$HOME/unusepath/from/mise.toml"
+printf '[tools]\ndummy = "1.0.0"\n' >"$HOME/unusepath/to/mise.toml"
+cd "$HOME/unusepath/from" || exit 1
+
+assert "mise unuse --no-prune --path ../to dummy@1.0.0"
+assert "cat mise.toml" '[tools]
+dummy = "1.0.0"'
+# removing the only tool empties the file, as it does everywhere else
+assert "cat ../to/mise.toml" ""
+
+cd "$HOME/workdir" || exit 1

--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -163,6 +163,44 @@ assert_contains "mise use --path mise.path.toml dummy@1" "dummy@1."
 assert "cat mise.path.toml" '[tools]
 dummy = "1"'
 
+# --path <dir> writes inside that directory, never the cwd's config. This used to resolve from
+# the cwd and silently discard --path entirely.
+mkdir -p "$HOME/workdir/pathtarget/from" "$HOME/workdir/pathtarget/to"
+printf '[tools]\ndummy = "1"\n' >"$HOME/workdir/pathtarget/from/mise.toml"
+cd "$HOME/workdir/pathtarget/from" || exit 1
+
+mise use --path ../to dummy@2
+assert "cat ../to/mise.toml" '[tools]
+dummy = "2"'
+assert "cat mise.toml" '[tools]
+dummy = "1"'
+
+# and with an absolute path
+mise use --path "$HOME/workdir/pathtarget/to" dummy@3
+assert "cat ../to/mise.toml" '[tools]
+dummy = "3"'
+assert "cat mise.toml" '[tools]
+dummy = "1"'
+
+# a directory whose only config is .tool-versions keeps using it rather than growing a mise.toml
+mkdir -p "$HOME/workdir/pathtarget/tv"
+printf 'dummy 1.0.0\n' >"$HOME/workdir/pathtarget/tv/.tool-versions"
+mise use --path ../tv dummy@2.0.0
+assert "cat ../tv/.tool-versions" "dummy 2.0.0"
+assert_fail "cat ../tv/mise.toml"
+
+# --path . still means "here"
+mise use --path . dummy@4
+assert "cat mise.toml" '[tools]
+dummy = "4"'
+
+# the same rule applies to `mise set --file <dir>`
+mise set --file ../to PATHTARGET=yes
+assert_contains "cat ../to/mise.toml" "PATHTARGET"
+assert_not_contains "cat mise.toml" "PATHTARGET"
+
+cd "$HOME/workdir" || exit 1
+
 # comments around a tool survive the version being replaced
 # See: https://github.com/jdx/mise/discussions/4797
 mkdir -p "$HOME/workdir/comments"

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -151,11 +151,11 @@ impl Unuse {
         let path = if self.global {
             config::global_config_path()
         } else if let Some(p) = &self.path {
-            let from_dir = config::config_file_from_dir(p).absolutize()?.to_path_buf();
-            if from_dir.starts_with(&cwd) {
-                from_dir
+            let p = p.absolutize()?.to_path_buf();
+            if p.is_dir() {
+                config::config_file_in_dir(&p)
             } else {
-                p.clone()
+                p
             }
         } else if let Some(env) = &self.env {
             let p = cwd.join(format!(".mise.{env}.toml"));

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -7,7 +7,6 @@ use console::{Term, style};
 use eyre::{Result, bail, eyre};
 use itertools::Itertools;
 use jiff::Timestamp;
-use path_absolutize::Absolutize;
 
 use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::config_file::ConfigFile;
@@ -248,26 +247,15 @@ impl Use {
 
     async fn get_config_file(&self) -> Result<Arc<dyn ConfigFile>> {
         let cwd = env::current_dir()?;
-
-        // Handle special case for --path that needs absolutize logic for compatibility
-        let path = if let Some(p) = &self.path {
-            let from_dir = config::config_file_from_dir(p).absolutize()?.to_path_buf();
-            if from_dir.starts_with(&cwd) {
-                from_dir
-            } else {
-                p.clone()
-            }
-        } else {
-            let opts = ConfigPathOptions {
-                global: self.global,
-                path: None, // handled above
-                env: self.env.clone(),
-                cwd: Some(cwd),
-                prefer_toml: false, // mise use supports .tool-versions and other formats
-                prevent_home_local: true, // When in HOME, use global config
-            };
-            resolve_target_config_path(opts)?
+        let opts = ConfigPathOptions {
+            global: self.global,
+            path: self.path.clone(),
+            env: self.env.clone(),
+            cwd: Some(cwd),
+            prefer_toml: false, // mise use supports .tool-versions and other formats
+            prevent_home_local: true, // When in HOME, use global config
         };
+        let path = resolve_target_config_path(opts)?;
 
         config_file::parse_or_init(&path).await
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@ use dashmap::DashMap;
 use eyre::{Context, Result, bail, eyre};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
+use path_absolutize::Absolutize;
 pub use settings::Settings;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env::join_paths;
@@ -1606,6 +1607,25 @@ fn is_conf_d_file(p: &Path) -> bool {
         .is_some_and(|d| d.file_name().is_some_and(|n| n == "conf.d"))
 }
 
+/// The config file to write to **inside `dir` itself**, or where one should be created.
+///
+/// `--path`/`--file` name a specific directory, so the answer has to be inside it: "if a directory
+/// is specified, it will look for a config file in that directory" (`mise use --help`). This
+/// deliberately does not walk up. [`config_file_from_dir`] is the walking one, and it is only ever
+/// asked about the cwd.
+pub fn config_file_in_dir(dir: &Path) -> PathBuf {
+    let files = config_files_in_dir(dir);
+    if let Some(cf) = first_config_file(&files)
+        && !is_global_config(cf)
+    {
+        return cf.clone();
+    }
+    match Settings::get().asdf_compat {
+        true => dir.join(&*MISE_DEFAULT_TOOL_VERSIONS_FILENAME),
+        false => dir.join(&*MISE_DEFAULT_CONFIG_FILENAME),
+    }
+}
+
 pub fn config_file_from_dir(p: &Path) -> PathBuf {
     if !p.is_dir() {
         return p.to_path_buf();
@@ -2160,12 +2180,16 @@ pub fn resolve_target_config_path(opts: ConfigPathOptions) -> Result<PathBuf> {
         None => env::current_dir()?,
     };
 
-    // If path is provided, handle it (file or directory) - explicit paths take precedence
+    // If path is provided, handle it (file or directory) - explicit paths take precedence.
+    // Absolutized once here so every arm returns an absolute path: a relative one would still
+    // resolve correctly against the cwd for reads, but it silently disables the monorepo lockfile
+    // redirection in `lockfile::lockfile_path_for_config`, which compares against an absolute root.
     if let Some(ref path) = opts.path {
+        let path = path.absolutize()?.to_path_buf();
         if path.is_file() {
-            return Ok(path.clone());
+            return Ok(path);
         } else if path.is_dir() {
-            let resolved = config_file_from_dir(path);
+            let resolved = config_file_in_dir(&path);
             if opts.prefer_toml && !resolved.to_string_lossy().ends_with(".toml") {
                 // For TOML-only commands, ensure we get a TOML file in the specified directory
                 return Ok(path.join(&*env::MISE_DEFAULT_CONFIG_FILENAME));
@@ -2173,7 +2197,7 @@ pub fn resolve_target_config_path(opts: ConfigPathOptions) -> Result<PathBuf> {
             return Ok(resolved);
         } else {
             // Path doesn't exist yet, return it as-is
-            return Ok(path.clone());
+            return Ok(path);
         }
     }
 


### PR DESCRIPTION
## Summary

`mise use --path <dir>` and `mise unuse --path <dir>` write to the **cwd's** config, not to one under `<dir>`. When the cwd has a config in scope, `--path` is discarded entirely. `unuse` is the destructive case — it removes the tool from the wrong file.

Measured on v2026.7.18 (Linux and Windows alike), with `here/mise.toml` and `other/mise.toml`, run from `here`:

| command | wrote to |
|---|---|
| `mise use --path ../other` | `here/mise.toml` |
| `mise use --path ./sub` | `here/mise.toml` |
| `mise unuse --path ../other uv` | **removed `uv` from `here/mise.toml`** |
| `mise use --path ../other` from a dir whose walk finds nothing | `other/mise.toml` (correct) |
| `mise use --path ../other/mise.toml` (a *file*) | `other/mise.toml` (correct) |

So `--path <dir>` only works when the cwd has no config in scope, which is why this has gone unnoticed.

## Why

`config_file_from_dir(p)` never searches `p`. It walks `all_dirs()` — the ancestors of `env::current_dir()`. `p` is used only by the `!p.is_dir()` early return and the trailing `p.join(...)` fallback.

That is a regression from #3273 ("feat: fragmented configs", 2024-11-29), which replaced

```rust
for p in FindUp::new(p, &filenames) { ... }     // walks up from `p`
```

with `file::all_dirs()` (walks up from the cwd) as collateral to the `conf.d` work; the PR body does not mention the function.

The `if from_dir.starts_with(&cwd) { from_dir } else { p.clone() }` guard in `use.rs`/`unuse.rs` came from #2818, where it kept that argument-based walk from escaping the tree. Once the walk started at the cwd instead, the guard became dead — and worse than dead: `from_dir` *is* the cwd's own config, so `starts_with` is true and the guard is what admits it. `.absolutize()` (#3038, fixing #3033) exists only to make that comparison well-defined.

## What changed

`config_file_in_dir(dir)` looks only inside the given directory — lowest-precedence non-global config, else `<dir>/mise.toml` (or `.tool-versions` under `asdf_compat`). That is the documented contract:

> If a directory is specified, it will look for a config file **in that directory** following the rules above.

("the rules above" being the file-precedence rules — `mise.toml` over `mise.local.toml`.) It also matches what #3033's reporter asked for: *"I'd expect mise to find or create a new config file in the PWD."*

- `use.rs` drops its bespoke `--path` branch and goes through `resolve_target_config_path` like everything else.
- `unuse.rs` drops the same copy of the guard.
- `resolve_target_config_path` absolutizes `opts.path` once, so every arm returns an absolute path. A relative one still resolved fine for reads, but it silently disabled the monorepo lockfile redirection in `lockfile_path_for_config`, which compares against an absolute root.
- **`config_file_from_dir` is left alone.** It is now only ever asked about the cwd, so nothing that omits `--path` changes behaviour.

This also fixes the six other commands that document `--path`/`--file` as accepting a directory and route through the same `path.is_dir()` arm: `set`, `unset`, `dotfiles add`, `system use`, `system import`, `system brew tap`, `system brew untap`.

## Behaviour change worth flagging

`mise use -p .` in a directory with **no** config no longer walks up to the project root — it creates `./mise.toml`. That is the documented behaviour and what #3033 asked for, but it differs from today, so it is worth a maintainer's eye.

## Tests

No existing test pointed `--path` at a directory outside the cwd. `e2e/cli/test_use:66` uses `--path .`, `test_unuse:20` uses a file, and `test_set_use_consistency` passes only because its cwd walk finds nothing. Added to `e2e/cli/test_use` and `e2e/cli/test_unuse`:

- `--path ../to` (relative) and the absolute form — target gets the tool, cwd's config is byte-identical
- a directory whose only config is `.tool-versions` keeps using it instead of growing a `mise.toml`
- `--path .` still means "here"
- `mise set --file ../to` — the `resolve_target_config_path` half
- `unuse --no-prune --path ../to` — the destructive case, asserting the cwd's config survives

Verified on Windows against the released v2026.7.18 binary. Everything below is byte-identical before and after: `--path <file>`, `--path .`, `use` with no `--path` (config-less deep dir / ancestor `mise.toml` / `mise.toml` + `mise.local.toml`), `use -g`, and `mise set` (nested dirs, lowest-precedence file, `MISE_IGNORED_CONFIG_PATHS`).

## Not in this PR

`mise use --path <directory that does not exist>` panics in `config_file::init` (`Unknown config file type`). I measured it on v2026.7.18 and on this branch — unchanged either way, so it is a separate pre-existing issue rather than something this change introduces or should quietly absorb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path handling for `mise use` and `mise unuse`, including relative and absolute paths.
  - Configuration changes now apply strictly within the specified directory and no longer modify parent or current-directory configuration files unexpectedly.
  - `mise set --file` reliably writes only to the requested location.
  - `.tool-versions` updates no longer create an unintended `mise.toml` file.
  - Added safeguards for emptying target configuration files when their only tool is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->