### PR TITLE
feat(config): accept --file on `mise use` and --path on `mise set`

### DIFF
--- a/e2e/cli/test_config_target_aliases
+++ b/e2e/cli/test_config_target_aliases
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# `mise use` names its config-file option --path while `mise set` names it --file, so which one
+# works depends on the command. Each now accepts the other's name.
+# See: https://github.com/jdx/mise/discussions/4881
+
+mkdir -p "$HOME/workdir/aliases"
+cd "$HOME/workdir/aliases" || exit 1
+
+# `mise use --file` is `mise use --path`
+mise use --file alias.toml dummy@1
+assert "cat alias.toml" '[tools]
+dummy = "1"'
+
+# `mise set --path` is `mise set --file`
+mise set --path alias.toml ALIAS_VAR=set-via-path
+assert_contains "cat alias.toml" 'ALIAS_VAR = "set-via-path"'
+
+# both names reach the same argument, so the cwd's own config is untouched either way
+assert_fail "test -f mise.toml"
+
+# the canonical names still work
+mise use --path alias.toml dummy@2
+assert_contains "cat alias.toml" 'dummy = "2"'
+mise set --file alias.toml ALIAS_VAR=set-via-file
+assert_contains "cat alias.toml" 'ALIAS_VAR = "set-via-file"'

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3271,7 +3271,7 @@ Can be used multiple times. Requires \-\-age\-encrypt.
 \fB\-\-complete\fR
 Render completions
 .TP
-\fB\-\-file\fR \fI<FILE>\fR
+\fB\-\-file, \-\-path\fR \fI<FILE>\fR
 The TOML file to update
 
 Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
@@ -4444,7 +4444,7 @@ Number of jobs to run in parallel
 \fB\-n, \-\-dry\-run\fR
 Perform a dry run, showing what would be installed and modified without making changes
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Specify a path to a config file or directory
 
 If a directory is specified, it will look for a config file in that directory following the rules above.

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3308,7 +3308,7 @@ Can be used multiple times. Requires --age-encrypt.
         arg <PATH_OR_PUBKEY>
     }
     flag --complete help="Render completions" hide=#true
-    flag --file help="The TOML file to update" {
+    flag "--file --path" help="The TOML file to update" {
         long_help #"""
 The TOML file to update
 
@@ -4536,7 +4536,7 @@ Number of jobs to run in parallel
         arg <JOBS>
     }
     flag "-n --dry-run" help="Perform a dry run, showing what would be installed and modified without making changes"
-    flag "-p --path" help="Specify a path to a config file or directory" {
+    flag "-p --path --file" help="Specify a path to a config file or directory" {
         long_help #"""
 Specify a path to a config file or directory
 

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -70,7 +70,7 @@ pub struct Set {
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
     /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[clap(long, verbatim_doc_comment, required = false, value_hint = clap::ValueHint::AnyPath)]
+    #[clap(long, visible_alias = "path", verbatim_doc_comment, required = false, value_hint = clap::ValueHint::AnyPath)]
     file: Option<PathBuf>,
 
     /// Show raw values instead of redacting secrets

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -79,7 +79,7 @@ pub struct Use {
     ///
     /// If a directory is specified, it will look for a config file in that directory following
     /// the rules above.
-    #[clap(short, long, overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
+    #[clap(short, long, visible_alias = "file", overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
     path: Option<PathBuf>,
 
     /// Like --dry-run but exits with code 1 if there are changes to make


### PR DESCRIPTION
## Summary

Which flag names the config file depends on the command: `mise use` calls it `--path`, `mise set` calls it `--file`, and each rejects the other. This makes them synonyms on those two commands.

```console
$ mise use --file mise.local.toml node@22     # used to be: unexpected argument
$ mise set --path mise.local.toml FOO=bar     # used to be: unexpected argument
```

Two `visible_alias` attributes; `mise.usage.kdl` and the man page are the regenerated output.

Fixes #4881.

## About #11116

@Marukome0743 sent essentially this in #11116 and it was closed without a comment, so I don't know what the objection was. The two things I can see that differ:

- #4881 asks for `use` and `set`. #11116 aliased **nine** commands — `use`, `unuse`, `bootstrap packages use/import`, `bootstrap packages brew tap/untap`, `dotfiles add`, `config get/set` — plus a table-driven clap-introspection test over all of them.
- This one is the two commands the discussion names, and nothing else. `unuse` is deliberately left out even though it is `use`'s sibling.

So: if the scope was the problem, this should be uncontroversial. **If the aliasing idea itself is unwanted, close this and I'll drop it** — that is genuinely useful to know, and #4881 has sat unanswered for over a year.

## Generated files

`mise.usage.kdl` and `man/man1/mise.1` are the output of `mise run render`, and the diff is four lines:

```diff
-    flag --file help="The TOML file to update" {
+    flag "--file --path" help="The TOML file to update" {
-    flag "-p --path" help="Specify a path to a config file or directory" {
+    flag "-p --path --file" help="Specify a path to a config file or directory" {
```

`docs/cli/*.md` is unchanged — `usage generate markdown` does not render flag aliases, which is why #11116 didn't touch it either.

I develop on Windows, where `mise usage` omits the Homebrew subcommands (they aren't registered there) and would have produced a large spurious diff, so these two files come from an actual `mise run render` on Linux rather than from hand-editing.

## Tests

`e2e/cli/test_config_target_aliases` checks both aliases write to the named file, that the canonical names still work, and that the cwd's own config is untouched either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interchangeable `--file` and `--path` aliases to the `mise use` and `mise set` commands.
  * Preserved existing option precedence and configuration behavior.

* **Documentation**
  * Updated the CLI reference and manual to document both aliases.

* **Tests**
  * Added end-to-end coverage confirming both aliases work correctly without modifying the default working-directory configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->