### PR TITLE
fix(config): let tool versions contain a colon

### DIFF
--- a/e2e/config/test_tool_version_vars
+++ b/e2e/config/test_tool_version_vars
@@ -101,3 +101,35 @@ url = "{{vars.BASE_URL}}/{{ version }}/tool-{{ os() }}-{{ arch() }}.tar.gz"
 EOF
 
 assert_contains "mise tool http:nested-options --tool-options" 'https://example.com/releases/{{ version }}/tool-{{ os() }}-{{ arch() }}.tar.gz'
+
+# A `:` inside a template belongs to the template, not to a version selector. This used to fail
+# during TOML deserialization with `invalid prefix: {{ exec(command='echo VER`, because the
+# selector was parsed before the template was rendered.
+# See: https://github.com/jdx/mise/discussions/5531
+cat <<EOF >mise.toml
+[tools]
+tiny = "{{ exec(command='echo VER: 3.1.0') | split(pat=': ') | last | trim }}"
+EOF
+
+assert_contains "mise ls tiny" "3.1.0"
+
+# Selectors still work when they come out of a template
+cat <<EOF >mise.toml
+[env]
+TINY_PREFIX = "3"
+
+[tools]
+tiny = "prefix:{{ env.TINY_PREFIX }}"
+EOF
+
+assert_contains "mise ls tiny" "3."
+
+# ...and a template rendering to an unknown selector is still an error, naming the file, the
+# template, and what it rendered to.
+cat <<EOF >mise.toml
+[tools]
+tiny = "{{ exec(command='echo bogus:1.0') | trim }}"
+EOF
+
+assert_fail "mise ls tiny" "invalid version for tiny"
+assert_fail "mise ls tiny" 'rendered to "bogus:1.0"'

--- a/e2e/config/test_trust_safe_config
+++ b/e2e/config/test_trust_safe_config
@@ -92,6 +92,16 @@ output=$(MISE_YES=0 mise ls 2>&1 || true)
 [[ ! -f marker ]] || fail "template executed in untrusted config"
 echo "$output" | grep -qi "trust" || fail "expected trust error for template, got: $output"
 
+# the same holds when the template contains a colon. that used to be rejected earlier, by the
+# version parser rather than by the trust check, so pin that trust is still what stops it.
+cat <<'EOF' >mise.toml
+[tools]
+tiny = "{{ exec(command='echo PWNED: 1 > marker') }}"
+EOF
+output=$(MISE_YES=0 mise ls 2>&1 || true)
+[[ ! -f marker ]] || fail "colon template executed in untrusted config"
+echo "$output" | grep -qi "trust" || fail "expected trust error for colon template, got: $output"
+
 # a template in a task renders at load time, so it requires trust
 cat <<'EOF' >mise.toml
 [tasks.hi]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -18,7 +18,7 @@ use toml_edit::{Array, DocumentMut, InlineTable, Item, Key, Value, table, value}
 use versions::Versioning;
 
 use crate::backend::unalias_backend;
-use crate::cli::args::{BackendArg, ToolVersionType};
+use crate::cli::args::BackendArg;
 use crate::config::config_file::{
     ConfigFile, TaskConfig, config_trust_root, is_ignored, trust, trust_check,
 };
@@ -269,7 +269,18 @@ pub struct MiseTomlToolList(Vec<MiseTomlTool>);
 
 #[derive(Debug, Clone)]
 pub struct MiseTomlTool {
-    pub tt: ToolVersionType,
+    /// The version request exactly as written, still un-rendered.
+    ///
+    /// Deliberately not parsed into a [`ToolVersionType`] here: a `:` inside a template belongs to
+    /// the template, not to a version selector, and templates are not rendered until
+    /// [`MiseToml::to_tool_request_set`]. Parsing at deserialize time made
+    /// `{{ exec(command='echo VER: 1.2.3') | split(pat=': ') | last }}` fail as
+    /// `invalid prefix: {{ exec(command='echo VER`. `ToolRequest::new` parses the rendered string,
+    /// so selectors like `prefix:` and `ref:` are still honoured — just later. This matches what
+    /// `[tasks.*.tools]` and `.tool-versions` already do.
+    ///
+    /// See: <https://github.com/jdx/mise/discussions/5531>
+    pub request: String,
     pub options: Option<ToolVersionOptions>,
 }
 
@@ -277,13 +288,12 @@ fn parse_mise_toml_tool_map<E>(parsed: ParsedToolMap) -> std::result::Result<Mis
 where
     E: de::Error,
 {
-    let tt = parsed.request.parse().map_err(de::Error::custom)?;
     let mut options = ToolVersionOptions::default();
     for (key, value) in parsed.options {
         insert_tool_option(&mut options, key, value)?;
     }
     Ok(MiseTomlTool {
-        tt,
+        request: parsed.request,
         options: Some(options),
     })
 }
@@ -805,6 +815,28 @@ impl MiseToml {
         self.parse_template_with_context(&self.template_context(), input)
     }
 
+    /// Context for a version request that only became invalid after its template was rendered.
+    ///
+    /// Deserialization no longer validates the version, so this is the first place such a failure
+    /// can surface — and it is far from the file that caused it. Name the file, and show the
+    /// template alongside what it produced, since neither alone explains the error.
+    fn tool_request_error_context(
+        &self,
+        short: &str,
+        tool: &MiseTomlTool,
+        rendered: &str,
+    ) -> String {
+        let where_ = format!("{short} in {}", display_path(&self.path));
+        if tool.request == rendered {
+            format!("invalid version for {where_}")
+        } else {
+            format!(
+                "invalid version for {where_}: {} rendered to {rendered:?}",
+                tool.request
+            )
+        }
+    }
+
     fn parse_template_with_context(
         &self,
         context: &TeraContext,
@@ -1161,7 +1193,9 @@ impl ConfigFile for MiseToml {
         Self::insert_resolved_vars(&mut context);
         for (ba, tvp) in tools.iter() {
             for tool in &tvp.0 {
-                let version = self.parse_template_with_context(&context, &tool.tt.to_string())?;
+                let version = self.parse_template_with_context(&context, &tool.request)?;
+                // taken before `ba` is consumed below
+                let short = ba.short.clone();
                 let tvr = if let Some(mut options) = tool.options.clone() {
                     // Add placeholder for version since it's not available at config load time
                     // This preserves {{ version }} in the output for install-time rendering
@@ -1228,9 +1262,11 @@ impl ConfigFile for MiseToml {
                     ba_opts.depends = options.depends.clone();
                     ba_opts.install_env = options.install_env.clone();
                     ba.set_opts(Some(ba_opts.clone()));
-                    ToolRequest::new_opts(ba.into(), &version, ba_opts, source.clone())?
+                    ToolRequest::new_opts(ba.into(), &version, ba_opts, source.clone())
+                        .wrap_err_with(|| self.tool_request_error_context(&short, tool, &version))?
                 } else {
-                    ToolRequest::new(ba.clone().into(), &version, source.clone())?
+                    ToolRequest::new(ba.clone().into(), &version, source.clone())
+                        .wrap_err_with(|| self.tool_request_error_context(&short, tool, &version))?
                 };
                 trs.add_version(tvr, &source);
             }
@@ -1558,85 +1594,16 @@ impl Clone for MiseToml {
 
 impl From<ToolRequest> for MiseTomlTool {
     fn from(tr: ToolRequest) -> Self {
-        match tr {
-            ToolRequest::Version {
-                version,
-                options,
-                backend: _backend,
-                source: _source,
-            } => Self {
-                tt: ToolVersionType::Version(version),
-                options: if options.is_empty() {
-                    None
-                } else {
-                    Some(options)
-                },
-            },
-            ToolRequest::Path {
-                path,
-                options,
-                backend: _backend,
-                source: _source,
-            } => Self {
-                tt: ToolVersionType::Path(path),
-                options: if options.is_empty() {
-                    None
-                } else {
-                    Some(options)
-                },
-            },
-            ToolRequest::Prefix {
-                prefix,
-                options,
-                backend: _backend,
-                source: _source,
-            } => Self {
-                tt: ToolVersionType::Prefix(prefix),
-                options: if options.is_empty() {
-                    None
-                } else {
-                    Some(options)
-                },
-            },
-            ToolRequest::Ref {
-                ref_,
-                ref_type,
-                options,
-                backend: _backend,
-                source: _source,
-            } => Self {
-                tt: ToolVersionType::Ref(ref_, ref_type),
-                options: if options.is_empty() {
-                    None
-                } else {
-                    Some(options)
-                },
-            },
-            ToolRequest::Sub {
-                sub,
-                options,
-                orig_version,
-                backend: _backend,
-                source: _source,
-            } => Self {
-                tt: ToolVersionType::Sub { sub, orig_version },
-                options: if options.is_empty() {
-                    None
-                } else {
-                    Some(options)
-                },
-            },
-            ToolRequest::System {
-                options,
-                backend: _backend,
-                source: _source,
-            } => Self {
-                tt: ToolVersionType::System,
-                options: if options.is_empty() {
-                    None
-                } else {
-                    Some(options)
-                },
+        // `ToolRequest::version()` re-emits the selector prefix (`prefix:`, `ref:`, `path:`,
+        // `sub-N:`, `system`), which is the same string this would have been written from, so the
+        // per-variant reconstruction that used to live here is redundant.
+        let options = tr.options();
+        Self {
+            request: tr.version(),
+            options: if options.is_empty() {
+                None
+            } else {
+                Some(options)
             },
         }
     }
@@ -2283,10 +2250,10 @@ impl<'de> de::Deserialize<'de> for MiseTomlToolList {
             where
                 E: de::Error,
             {
-                let tt: ToolVersionType = v
-                    .parse()
-                    .map_err(|e| de::Error::custom(format!("invalid tool: {e}")))?;
-                Ok(MiseTomlToolList(vec![MiseTomlTool { tt, options: None }]))
+                Ok(MiseTomlToolList(vec![MiseTomlTool {
+                    request: v.to_string(),
+                    options: None,
+                }]))
             }
 
             fn visit_seq<S>(self, mut seq: S) -> std::result::Result<Self::Value, S::Error>
@@ -2333,10 +2300,10 @@ impl<'de> de::Deserialize<'de> for MiseTomlTool {
             where
                 E: de::Error,
             {
-                let tt: ToolVersionType = v
-                    .parse()
-                    .map_err(|e| de::Error::custom(format!("invalid tool: {e}")))?;
-                Ok(MiseTomlTool { tt, options: None })
+                Ok(MiseTomlTool {
+                    request: v.to_string(),
+                    options: None,
+                })
             }
 
             fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
@@ -2894,6 +2861,64 @@ mod tests {
             "{:#?}",
             cf.to_tool_request_set().unwrap().tools
         )));
+    }
+
+    /// A `:` inside a template belongs to the template, not to a version selector, and the
+    /// template has not been rendered yet when the config is deserialized. Selectors must still
+    /// come out the other side, so this pins the rendered `ToolRequest`, not the raw string.
+    ///
+    /// See: <https://github.com/jdx/mise/discussions/5531>
+    #[tokio::test]
+    async fn test_colon_in_templated_tool_version() {
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".test.mise.toml");
+        file::write(
+            &p,
+            r#"
+        [env]
+        BRANCH = 'main'
+
+        [tools]
+        terraform = "{{ exec(command='echo VER: 1.0.0') | split(pat=': ') | last | trim }}"
+        jq = { ref = "{{ env.BRANCH }}" }
+        node = "{% if true %}20.0.0{% else %}18.0.0{% endif %}"
+        "#,
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let trs = cf.to_tool_request_set().unwrap();
+        let version_of = |short: &str| {
+            trs.tools
+                .iter()
+                .find(|(ba, _)| ba.short == short)
+                .unwrap_or_else(|| panic!("{short} missing"))
+                .1[0]
+                .version()
+        };
+        // the colon belonged to the template, not to a selector
+        assert_eq!(version_of("terraform"), "1.0.0");
+        // ...and a real selector still survives being rendered late
+        assert_eq!(version_of("jq"), "ref:main");
+        assert_eq!(version_of("node"), "20.0.0");
+    }
+
+    /// The version is no longer validated at deserialize time, so a template that renders to an
+    /// unknown selector fails later and further from the config. Pin that the error still names
+    /// the file, the template, and what it became.
+    #[tokio::test]
+    async fn test_templated_tool_version_rendering_to_bad_selector() {
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".test.mise.toml");
+        file::write(
+            &p,
+            "[tools]\nterraform = \"{{ exec(command='echo bogus:1.0') | trim }}\"\n",
+        )
+        .unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+        let err = cf.to_tool_request_set().unwrap_err().to_string();
+        assert!(err.contains("invalid version for terraform"), "{err}");
+        assert!(err.contains(".test.mise.toml"), "{err}");
+        assert!(err.contains("rendered to \"bogus:1.0\""), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A `:` anywhere in a `[tools]` version makes config loading fail. The version's *selector* is parsed at TOML-deserialize time, before templates are rendered, so a template containing a colon gets split mid-expression:

```toml
[tools."npm:cowsay"]
version = '''{{ exec(command='echo VER: 1.2.3') | split(pat=': ') | last | trim }}'''
```

```
  × Invalid TOML in config file
   ╭─[mise.toml:1:1]
 1 │ [tools."npm:cowsay"]
   · ──────────┬─────────
   ·           ╰── invalid prefix: {{ exec(command='echo VER
```

Not template-specific — `"npm:cowsay" = "1.2.3:x"` fails the same way with `invalid tool: invalid prefix: 1.2.3`. Not a regression either: colon-free templates work on every release back to v2025.7.0, so it has always been the colon.

Reported in #5531, where the reporter's template contained `'ANSIBLE_VERSION: '`. Their diagnosis was right.

## Fix

Keep the version request as the raw string until it is rendered.

`mise.toml`'s `[tools]` was the one place that parsed first and rendered second:

| | order |
|---|---|
| `[tasks.*.tools]` | store string → `Task::render` → parse |
| `.tool-versions` | render whole body → parse |
| **`mise.toml` `[tools]`** | **parse → `Display` → render → re-parse** |

`MiseTomlTool` now holds `request: String`, and `ToolRequest::new` — which already re-parses the rendered string — is where selectors are resolved. `prefix:`, `ref:`, `path:`, `sub-N:` and `system` all still work, including when they come out of a template (`prefix:{{ env.X }}`).

**`ToolVersionType` is deliberately untouched.** Guarding it on `contains_template_syntax` would have been a smaller diff, but it is also the version filter for remote listings in `backend/mod.rs` and `backend/github.rs` (`Ok(ToolVersionType::Version(_)) => true`), and relaxing it there would let an upstream tag containing template syntax through. Removing the caller is the narrower change even though the diff is larger.

Collapsing `From<ToolRequest> for MiseTomlTool` onto `ToolRequest::version()` also drops a latent bug: the `Ref` arm passed `(ref_, ref_type)` where both `FromStr` and `Display` take the type first, so `branch:main` round-tripped to `main:branch`.

## Diagnostics

Deserialization no longer rejects a bad version, so the failure now surfaces in `to_tool_request_set()` — further from the config, and behind five call sites that `.ok()` the result (`install.rs`, `upgrade.rs` ×2, `lock.rs` ×2, `task_tool_installer.rs`). To keep it actionable the error names the file, the template, and what it became:

```
0: invalid version for terraform in ~/mise.toml: {{ exec(command='echo bogus:1.0') | trim }} rendered to "bogus:1.0"
1: invalid tool version request: bogus:1.0
```

Making those callers stop swallowing the error is a separate change; I left it alone here.

## Tests

- `test_colon_in_templated_tool_version` — the reported case, plus `ref = "{{ env.BRANCH }}"` and a `{% if %}` block. Asserts the resulting `ToolRequest`, so it pins that the *selector survives being resolved late* rather than pinning the intermediate representation.
- `test_templated_tool_version_rendering_to_bad_selector` — the deferred error still names file, template and rendered value.
- `e2e/config/test_tool_version_vars` — the repro, `prefix:{{ env.X }}`, and a negative case. Every template in that file was colon-free before this.
- `e2e/config/test_trust_safe_config` — a colon-bearing template in `[tools]` must still require trust and must not execute. Previously the version parser rejected it first, so this pins that trust is what stops it now.

Verified on Windows against the released v2026.7.18 binary: the repro flips, and `prefix:` / `path:` / `ref:` / `sub-1:` / `system` / plain / colon-free templates / both table forms are byte-identical, as is `mise use` write-back (an unrelated tool's `prefix:` selector survives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool version templates containing colons are now supported in configuration files.
  * Selectors are preserved and applied correctly after template rendering.

* **Bug Fixes**
  * Invalid rendered tool versions now produce clearer errors with relevant configuration context.
  * Unsafe templated version values are blocked before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->