### PR TITLE
fix(task): respect group boundaries in wildcards

### DIFF
--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -97,8 +97,8 @@ dependencies.
 Available Wildcard Patterns:
 
 - `?` matches any single character
-- `*` matches 0 or more characters
-- `**` matches 0 or more groups
+- `*` matches 0 or more characters within a single `:`-delimited group
+- `**` matches 0 or more complete `:`-delimited groups
 - `{glob1,glob2,...}` matches any of the comma-separated glob patterns
 - `[ab,...]` matches any of the characters or ranges `[a-z]`
 - `[!ab,...]` matches any character not in the character set
@@ -106,6 +106,20 @@ Available Wildcard Patterns:
 ### Examples
 
 `mise run generate:{completions,docs:*}`
+
+For grouped tasks, use `*` when exactly one group may vary and `**` when the
+match may cross multiple groups:
+
+```bash
+# Matches test:units:local, but not test:e2e:happy:local
+mise run 'test:*:local'
+
+# Matches both test:units:local and test:e2e:happy:local
+mise run 'test:**:local'
+```
+
+If a pattern relied on `*` matching nested task groups in an older mise
+version, replace it with `**` to keep the recursive behavior.
 
 And with dependencies:
 

--- a/e2e/tasks/test_task_group_wildcards_slow
+++ b/e2e/tasks/test_task_group_wildcards_slow
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks."test:local"]
+run = "echo zero groups"
+
+[tasks."test:units:local"]
+run = "echo units local"
+
+[tasks."test:integration:local"]
+run = "echo integration local"
+
+[tasks."test:e2e:happy:local"]
+run = "echo e2e happy local"
+
+[tasks.one-level]
+depends = ["test:*:local"]
+run = "echo one-level aggregate"
+
+[tasks.recursive]
+depends = ["test:**:local"]
+run = "echo recursive aggregate"
+EOF
+
+# A single star stays within one colon-delimited group.
+output="$(mise run 'test:*:local')"
+assert_contains_text "$output" "units local"
+assert_contains_text "$output" "integration local"
+assert_not_contains_text "$output" "zero groups"
+assert_not_contains_text "$output" "e2e happy local"
+
+# A double star spans zero or more groups.
+output="$(mise run 'test:**:local')"
+assert_contains_text "$output" "zero groups"
+assert_contains_text "$output" "units local"
+assert_contains_text "$output" "integration local"
+assert_contains_text "$output" "e2e happy local"
+
+# Dependency patterns use the same matcher as direct execution.
+output="$(mise run one-level)"
+assert_contains_text "$output" "units local"
+assert_not_contains_text "$output" "e2e happy local"
+output="$(mise run recursive)"
+assert_contains_text "$output" "zero groups"
+assert_contains_text "$output" "e2e happy local"
+
+# Monorepo task patterns apply the group rules only to the task-name portion.
+export MISE_EXPERIMENTAL=1
+mkdir -p projects/app
+cat <<'EOF' >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["projects/app"]
+EOF
+cat <<'EOF' >projects/app/mise.toml
+[tasks."test:units:local"]
+run = "echo monorepo units local"
+
+[tasks."test:e2e:happy:local"]
+run = "echo monorepo e2e happy local"
+EOF
+
+output="$(mise run '//projects/app:test:*:local')"
+assert_contains_text "$output" "monorepo units local"
+assert_not_contains_text "$output" "monorepo e2e happy local"
+output="$(mise run '//projects/app:test:**:local')"
+assert_contains_text "$output" "monorepo units local"
+assert_contains_text "$output" "monorepo e2e happy local"
+
+# Inferred workspace tasks keep provider/project matching unchanged while task
+# groups after `#` follow the same wildcard depth rules.
+mkdir -p bin packages/app
+cat <<'EOF' >bin/npm
+#!/bin/sh
+printf '%s\n' "$*"
+EOF
+chmod +x bin/npm
+export PATH="$PWD/bin:$PATH"
+
+cat <<'EOF' >package.json
+{
+  "packageManager": "npm@11.0.0",
+  "workspaces": ["packages/*"]
+}
+EOF
+cat <<'EOF' >packages/app/package.json
+{
+  "name": "@scope/app",
+  "scripts": {
+    "test:units:local": "echo workspace units local",
+    "test:e2e:happy:local": "echo workspace e2e happy local"
+  }
+}
+EOF
+
+output="$(mise -q run 'node:@scope/app#test:*:local')"
+assert_contains_text "$output" "run test:units:local"
+assert_not_contains_text "$output" "run test:e2e:happy:local"
+output="$(mise -q run 'node:@scope/app#test:**:local')"
+assert_contains_text "$output" "run test:units:local"
+assert_contains_text "$output" "run test:e2e:happy:local"

--- a/e2e/tasks/test_task_monorepo_wildcards
+++ b/e2e/tasks/test_task_monorepo_wildcards
@@ -113,11 +113,12 @@ assert_not_contains "mise run '//projects/frontend:test:*'" "frontend build"
 # Test that relative patterns (without //) are not supported
 assert_fail "mise run 'projects/...:build'" "relative path syntax"
 
-# Test combined patterns - ellipsis in path, asterisk in task
-assert_contains "mise run '//projects/...:test*'" "frontend test"
-assert_contains "mise run '//projects/...:test*'" "frontend test:unit"
-assert_contains "mise run '//projects/...:test*'" "frontend test:integration"
-assert_contains "mise run '//projects/...:test*'" "backend test"
+# Test combined patterns - ellipsis in path and recursive task groups. Include
+# the ungrouped `test` name explicitly because `test:**` starts after `test:`.
+assert_contains "mise run '//projects/...:{test,test:**}'" "frontend test"
+assert_contains "mise run '//projects/...:{test,test:**}'" "frontend test:unit"
+assert_contains "mise run '//projects/...:{test,test:**}'" "frontend test:integration"
+assert_contains "mise run '//projects/...:{test,test:**}'" "backend test"
 
 # Test ellipsis wildcard in different positions
 # Create test structure with nested directories

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -10,7 +10,7 @@ use crate::ui::tree::TreeItem;
 use crate::{dirs, env, file};
 use console::{measure_text_width, truncate_str};
 use eyre::{Result, bail, eyre};
-use globset::GlobBuilder;
+use globset::{GlobBuilder, GlobMatcher};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use petgraph::prelude::*;
@@ -2940,6 +2940,23 @@ pub trait GetMatchingExt<T> {
     fn get_matching(&self, pat: &str) -> Result<Vec<&T>>;
 }
 
+/// Compile a task-name glob with `:` treated as a group separator.
+///
+/// globset only assigns recursive semantics to `**` around path separators, so
+/// task groups are normalized to `/` before matching. This makes `*` stay
+/// within one group while `**` can span zero or more groups.
+fn task_name_glob(pattern: &str) -> std::result::Result<GlobMatcher, globset::Error> {
+    GlobBuilder::new(&pattern.replace(':', "/"))
+        .literal_separator(true)
+        .build()
+        .map(|glob| glob.compile_matcher())
+}
+
+fn task_name_matches(matcher: &GlobMatcher, name: &str, allow_ext_strip: bool) -> bool {
+    matcher.is_match(name.replace(':', "/"))
+        || (allow_ext_strip && matcher.is_match(strip_extension(name).replace(':', "/")))
+}
+
 /// Helper function to strip file extension from a task name
 /// e.g., "test.js" -> "test", "build" -> "build"
 /// Special case: hidden files like ".hidden" are preserved to avoid empty strings
@@ -2961,14 +2978,22 @@ where
             return Ok(vec![exact]);
         }
         if is_workspace_project_task(pat) {
-            let matcher = GlobBuilder::new(pat)
+            let (project_pattern, task_pattern) = pat.split_once('#').unwrap();
+            let project_matcher = GlobBuilder::new(project_pattern)
                 .literal_separator(false)
                 .build()
                 .map_err(|err| eyre!("invalid workspace task pattern {pat:?}: {err}"))?
                 .compile_matcher();
+            let task_matcher = task_name_glob(task_pattern)
+                .map_err(|err| eyre!("invalid workspace task pattern {pat:?}: {err}"))?;
             return Ok(self
                 .iter()
-                .filter(|(name, _)| matcher.is_match(name))
+                .filter(|(name, _)| {
+                    name.split_once('#').is_some_and(|(project, task)| {
+                        project_matcher.is_match(project)
+                            && task_name_matches(&task_matcher, task, false)
+                    })
+                })
                 .map(|(_, task)| task)
                 .unique()
                 .collect());
@@ -2986,8 +3011,8 @@ where
                     pat
                 )
             }
-            // If it doesn't contain wildcards or ':', it's a simple task name
-            if !pat.contains('*') && !pat.contains("...") && !pat.contains(':') {
+            // If it doesn't contain glob syntax or ':', it's a simple task name
+            if !pat.contains(['*', '?', '[', '{']) && !pat.contains("...") && !pat.contains(':') {
                 // Prefer exact name matches; only fall back to extension-stripped
                 // matches when there is no exact match. Otherwise a TOML task
                 // "hello" and an auto-discovered file task "hello.sh" would both
@@ -3006,8 +3031,27 @@ where
                     .map(|(_, v)| v)
                     .collect());
             }
-            // Has wildcards or colon but no /, so it's a regular task pattern like "render:*" or "build:linux"
-            // Process with glob matching below
+            // Regular task patterns use `:` as their group separator. Match the
+            // entire task identity here rather than treating the first group as
+            // a monorepo path.
+            let Some(matcher) = task_name_glob(pat).ok() else {
+                return Ok(vec![]);
+            };
+            let exact: Vec<&T> = self
+                .iter()
+                .filter(|(name, _)| task_name_matches(&matcher, name, false))
+                .map(|(_, task)| task)
+                .unique()
+                .collect();
+            if !exact.is_empty() {
+                return Ok(exact);
+            }
+            return Ok(self
+                .iter()
+                .filter(|(name, _)| task_name_matches(&matcher, name, true))
+                .map(|(_, task)| task)
+                .unique()
+                .collect());
         }
 
         // === Parse monorepo pattern ===
@@ -3032,7 +3076,6 @@ where
                 pat
             );
         }
-        let has_explicit_task_glob = parts.len() > 1;
         let (path_pattern, task_pattern) = match parts.as_slice() {
             [path, task] => (*path, *task),
             [path] => (*path, "*"),
@@ -3047,8 +3090,8 @@ where
             .strip_suffix("/...")
             .map(|base| if base == "/" { "//" } else { base });
 
-        // For task patterns, * only matches within the task name portion (after final :)
-        // e.g., test:* matches test:unit, test:integration, etc.
+        // Task groups use `:` as their separator. The task matcher normalizes
+        // that separator so `*` matches one group and `**` matches recursively.
         let task_glob = task_pattern;
 
         // === Build glob matchers once (performance optimization) ===
@@ -3062,42 +3105,7 @@ where
             .and_then(|base| GlobBuilder::new(base).literal_separator(true).build().ok())
             .map(|glob| glob.compile_matcher());
 
-        // Build task matcher if not wildcard
-        let task_matcher = if task_glob != "*" {
-            GlobBuilder::new(task_glob)
-                .literal_separator(false) // Allow * to match : in task names
-                .build()
-                .ok()
-                .map(|b| b.compile_matcher())
-        } else {
-            None
-        };
-
-        // Build relative pattern matchers if needed
-        let (rel_path_matcher, rel_task_matcher) = if !pat.starts_with("//") {
-            let rel_path_pattern = path_pattern.strip_prefix("//").unwrap_or(path_pattern);
-            let rel_path_glob = rel_path_pattern.replace("...", "**");
-
-            let rel_path = GlobBuilder::new(&rel_path_glob)
-                .literal_separator(true)
-                .build()
-                .ok()
-                .map(|b| b.compile_matcher());
-
-            let rel_task = if task_glob != "*" {
-                GlobBuilder::new(task_glob)
-                    .literal_separator(false)
-                    .build()
-                    .ok()
-                    .map(|b| b.compile_matcher())
-            } else {
-                None
-            };
-
-            (rel_path, rel_task)
-        } else {
-            (None, None)
-        };
+        let task_matcher = task_name_glob(task_glob).ok();
 
         // === Match tasks ===
         // Whether a key matches the pattern. `allow_ext_strip` enables the
@@ -3125,52 +3133,11 @@ where
                 false
             };
 
-            // Match task part with asterisk support and (optional) extension stripping.
-            // When the pattern explicitly uses a wildcard after `:` (e.g., "test:*"),
-            // require the key to actually have a task part (i.e., contain a `:`
-            // separator). This prevents "test" from matching "test:*", which would
-            // cause circular dependencies. Implicit wildcards (bare names like "test")
-            // should still match the exact task.
-            let task_matches = if task_glob == "*" {
-                !has_explicit_task_glob || !key_task.is_empty()
-            } else if let Some(ref matcher) = task_matcher {
-                matcher.is_match(key_task)
-                    || (allow_ext_strip && matcher.is_match(strip_extension(key_task)))
-            } else {
-                false
-            };
+            let task_matches = task_matcher
+                .as_ref()
+                .is_some_and(|matcher| task_name_matches(matcher, key_task, allow_ext_strip));
 
-            // Try matching without // prefix for relative patterns
-            let relative_match = if !pat.starts_with("//") {
-                let stripped_key = k.strip_prefix("//").unwrap_or(k);
-                let stripped_parts: Vec<&str> = stripped_key.splitn(2, ':').collect();
-                let (stripped_path, stripped_task) = match stripped_parts.as_slice() {
-                    [path, task] => (*path, *task),
-                    [path] => (*path, ""),
-                    _ => (stripped_key, ""),
-                };
-
-                let rel_path_matches = if let Some(ref matcher) = rel_path_matcher {
-                    matcher.is_match(stripped_path)
-                } else {
-                    false
-                };
-
-                let rel_task_matches = if task_glob == "*" {
-                    !has_explicit_task_glob || !stripped_task.is_empty()
-                } else if let Some(ref matcher) = rel_task_matcher {
-                    matcher.is_match(stripped_task)
-                        || (allow_ext_strip && matcher.is_match(strip_extension(stripped_task)))
-                } else {
-                    false
-                };
-
-                rel_path_matches && rel_task_matches
-            } else {
-                false
-            };
-
-            (path_matches && task_matches) || relative_match
+            path_matches && task_matches
         };
 
         // Prefer exact task-name matches; fall back to extension-stripped matches
@@ -5408,6 +5375,149 @@ echo "test"
         // Bare name "test" should still match the "test" task (implicit wildcard)
         let matches = tasks.get_matching("test").unwrap();
         assert!(matches.contains(&&"test".to_string()));
+    }
+
+    #[test]
+    fn test_get_matching_respects_task_group_boundaries() {
+        use std::collections::BTreeMap;
+
+        use super::GetMatchingExt;
+
+        let tasks = BTreeMap::from([
+            ("test".to_string(), "test".to_string()),
+            ("test:local".to_string(), "test:local".to_string()),
+            (
+                "test:units:local".to_string(),
+                "test:units:local".to_string(),
+            ),
+            (
+                "test:integration:local".to_string(),
+                "test:integration:local".to_string(),
+            ),
+            (
+                "test:e2e:happy:local".to_string(),
+                "test:e2e:happy:local".to_string(),
+            ),
+        ]);
+
+        assert_eq!(
+            tasks.get_matching("test:*:local").unwrap(),
+            vec![
+                &"test:integration:local".to_string(),
+                &"test:units:local".to_string(),
+            ]
+        );
+        assert_eq!(
+            tasks.get_matching("test:**:local").unwrap(),
+            vec![
+                &"test:e2e:happy:local".to_string(),
+                &"test:integration:local".to_string(),
+                &"test:local".to_string(),
+                &"test:units:local".to_string(),
+            ]
+        );
+        assert!(
+            tasks
+                .get_matching("test:*")
+                .unwrap()
+                .contains(&&"test:local".to_string())
+        );
+        assert!(
+            !tasks
+                .get_matching("test:*")
+                .unwrap()
+                .contains(&&"test".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_matching_group_globs_support_other_glob_syntax() {
+        use std::collections::BTreeMap;
+
+        use super::GetMatchingExt;
+
+        let tasks = BTreeMap::from([
+            (
+                "generate:completions".to_string(),
+                "generate:completions".to_string(),
+            ),
+            (
+                "generate:docs:api".to_string(),
+                "generate:docs:api".to_string(),
+            ),
+            (
+                "generate:docs:api:deep".to_string(),
+                "generate:docs:api:deep".to_string(),
+            ),
+            ("check:a".to_string(), "check:a".to_string()),
+            ("check:b".to_string(), "check:b".to_string()),
+            ("check:ab".to_string(), "check:ab".to_string()),
+        ]);
+
+        assert_eq!(
+            tasks.get_matching("generate:{completions,docs:*}").unwrap(),
+            vec![
+                &"generate:completions".to_string(),
+                &"generate:docs:api".to_string(),
+            ]
+        );
+        assert_eq!(
+            tasks.get_matching("check:?").unwrap(),
+            vec![&"check:a".to_string(), &"check:b".to_string()]
+        );
+        assert_eq!(
+            tasks.get_matching("check:[ab]").unwrap(),
+            vec![&"check:a".to_string(), &"check:b".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_get_matching_group_boundaries_in_monorepo_and_workspace_tasks() {
+        use std::collections::BTreeMap;
+
+        use super::GetMatchingExt;
+
+        let tasks = BTreeMap::from([
+            (
+                "//pkg:test:units:local".to_string(),
+                "//pkg:test:units:local".to_string(),
+            ),
+            (
+                "//pkg:test:e2e:happy:local".to_string(),
+                "//pkg:test:e2e:happy:local".to_string(),
+            ),
+            (
+                "node:@scope/app#test:units:local".to_string(),
+                "node:@scope/app#test:units:local".to_string(),
+            ),
+            (
+                "node:@scope/app#test:e2e:happy:local".to_string(),
+                "node:@scope/app#test:e2e:happy:local".to_string(),
+            ),
+        ]);
+
+        assert_eq!(
+            tasks.get_matching("//pkg:test:*:local").unwrap(),
+            vec![&"//pkg:test:units:local".to_string()]
+        );
+        assert_eq!(
+            tasks.get_matching("//pkg:test:**:local").unwrap(),
+            vec![
+                &"//pkg:test:e2e:happy:local".to_string(),
+                &"//pkg:test:units:local".to_string(),
+            ]
+        );
+        assert_eq!(
+            tasks.get_matching("node:@scope/app#test:*:local").unwrap(),
+            vec![&"node:@scope/app#test:units:local".to_string()]
+        );
+        assert_eq!(
+            tasks.get_matching("node:@scope/app#test:**:local").unwrap(),
+            vec![
+                &"node:@scope/app#test:e2e:happy:local".to_string(),
+                &"node:@scope/app#test:units:local".to_string(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Treat `:` as a task-group separator when matching task wildcards.
- Keep `*`, `?`, character classes, and brace alternatives within one group, while allowing `**` to span zero or more groups.
- Apply the same matcher to regular, monorepo, workspace, and dependency task references.

## Problem

Task wildcards were compiled without a literal separator, so `*` crossed `:` boundaries and behaved recursively. For example, `test:*:local` matched both `test:unit:local` and `test:e2e:happy:local`, contrary to the documented distinction between `*` and `**`.

## Solution

Task names are normalized from colon-delimited groups to path-like components and compiled with globset literal separators enabled. Exact task identities and aliases still take precedence, monorepo filesystem path matching remains unchanged, and workspace provider/project matching is kept separate from the task-name matcher.

Existing patterns that intentionally relied on recursive `*` matching should use `**`. The documentation now includes concrete one-level and recursive examples.

## Testing

- `mise exec -- cargo test test_get_matching`
- `mise run test:e2e e2e/tasks/test_task_group_wildcards_slow`
- `mise run test:e2e e2e/tasks/test_task_monorepo_wildcards e2e/tasks/test_task_monorepo_wildcard_with_deps e2e/tasks/test_task_node_workspace_scripts`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- shellcheck e2e/tasks/test_task_group_wildcards_slow e2e/tasks/test_task_monorepo_wildcards`
- `mise exec -- shfmt -d e2e/tasks/test_task_group_wildcards_slow e2e/tasks/test_task_monorepo_wildcards`

`mise run lint` could not invoke hk because hk does not recognize this Sapling working copy as a Git repository (`failed to find git repository`). Rustfmt, shfmt, ShellCheck, Cargo check, and Clippy were run individually and passed.

Addresses https://github.com/jdx/mise/discussions/2907

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*