### PR TITLE
feat(ruby): make precompiled binaries the default

### DIFF
--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -26,7 +26,7 @@ settings and troubleshooting.
 
 ## Precompiled Binaries
 
-Mise downloads precompiled Ruby binaries by default. This significantly reduces installation time.
+mise downloads precompiled Ruby binaries by default. This significantly reduces installation time.
 
 Precompiled binaries are sourced from [jdx/ruby](https://github.com/jdx/ruby) and are available
 for the following platforms:

--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -18,23 +18,15 @@ installed) and makes it the global default:
 mise use -g ruby@3.2
 ```
 
-Behind the scenes, mise uses [`ruby-build`](https://github.com/rbenv/ruby-build) to compile ruby
-from source. Ensure that you have the necessary
-[dependencies](https://github.com/rbenv/ruby-build/wiki#suggested-build-environment) installed.
-You can check its [README](https://github.com/rbenv/ruby-build/blob/master/README.md) for additional settings and some
-troubleshooting.
+By default, mise installs a precompiled Ruby binary when one is available and falls back to
+compiling from source with [`ruby-build`](https://github.com/rbenv/ruby-build). Source builds require
+the necessary [dependencies](https://github.com/rbenv/ruby-build/wiki#suggested-build-environment).
+See the ruby-build [README](https://github.com/rbenv/ruby-build/blob/master/README.md) for additional
+settings and troubleshooting.
 
 ## Precompiled Binaries
 
-Mise can download precompiled Ruby binaries instead of
-compiling from source. This significantly reduces installation time.
-
-Precompiled binaries will become the default in 2026.8.0. To opt in now:
-
-```sh
-mise settings ruby.compile=false
-mise use ruby@3.4.1
-```
+Mise downloads precompiled Ruby binaries by default. This significantly reduces installation time.
 
 Precompiled binaries are sourced from [jdx/ruby](https://github.com/jdx/ruby) and are available
 for the following platforms:

--- a/e2e/core/test_ruby_precompiled
+++ b/e2e/core/test_ruby_precompiled
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-# Test precompiled Ruby binaries from jdx/ruby
-export MISE_RUBY_COMPILE=false
-
-# Install precompiled Ruby 3.4.1
+# Test that precompiled Ruby binaries from jdx/ruby are the default
 assert_contains "mise use ruby@3.4.1 2>&1" "ruby@3.4.1"
 assert_contains "mise x -- ruby --version" "ruby 3.4.1"
 

--- a/settings.toml
+++ b/settings.toml
@@ -2210,7 +2210,7 @@ Controls whether Ruby is compiled from source or downloaded as precompiled binar
 
 - If `false`: Try precompiled binaries first, fall back to compiling if unavailable
 - If `true`: Always compile from source using ruby-build
-- If unset: Defaults to compiling from source (will change to precompiled in 2026.8.0). Note: if `experimental = true`, precompiled binaries are used when unset.
+- If unset: Try precompiled binaries first, fall back to compiling if unavailable
 """
 env = "MISE_RUBY_COMPILE"
 optional = true

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -445,17 +445,10 @@ impl RubyPlugin {
         Self::is_default_ruby_source(source)
     }
 
-    /// Check if precompiled binaries should be tried
-    /// Precompiled if: explicit opt-in (compile=false), or experimental + not opted out
-    /// TODO(2026.8.0): make precompiled the default when compile is unset, remove this debug_assert
+    /// Check if precompiled binaries should be tried.
+    /// Precompiled binaries are the default unless source compilation is explicitly requested.
     fn should_try_precompiled(&self) -> bool {
-        debug_assert!(
-            *crate::cli::version::V < versions::Versioning::new("2026.8.0").unwrap(),
-            "precompiled ruby should be the default now, update should_try_precompiled()"
-        );
-        let settings = Settings::get();
-        settings.ruby.compile == Some(false)
-            || (settings.experimental && settings.ruby.compile.is_none())
+        Settings::get().ruby.compile != Some(true)
     }
 
     /// Get platform identifier for precompiled binaries
@@ -966,16 +959,7 @@ impl Backend for RubyPlugin {
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         let mut tv = tv;
-        let settings = Settings::get();
-        if settings.ruby.compile.is_none() && !settings.experimental {
-            warn_once!(
-                "precompiled ruby will be the default in 2026.8.0.\n\
-                 To use precompiled binaries now: mise settings ruby.compile=false\n\
-                 To keep compiling from source: mise settings ruby.compile=true"
-            );
-        }
-
-        // Try precompiled if compile=false or experimental + not opted out
+        // Try precompiled unless source compilation was explicitly requested.
         if self.should_try_precompiled()
             && let Some(installed_tv) = self.install_precompiled(ctx, &mut tv).await?
         {
@@ -1420,9 +1404,8 @@ mod tests {
     }
 
     #[test]
-    fn test_ruby_lockfile_options_include_experimental_precompiled_default() {
+    fn test_ruby_lockfile_options_include_precompiled_default() {
         let opts = resolve_ruby_lockfile_options(|settings| {
-            settings.experimental = Some(true);
             settings.ruby.precompiled_url = Some("acme/ruby".to_string());
             settings.ruby.precompiled_arch = Some("arm64".to_string());
             settings.ruby.precompiled_os = Some("linux".to_string());


### PR DESCRIPTION
## Summary

- make precompiled Ruby binaries the default when `ruby.compile` is unset
- preserve `ruby.compile=true` as the explicit source-build setting and retain source fallback when a binary is unavailable
- remove the 2026.8.0 migration assertion and warning
- update Ruby documentation, settings text, unit coverage, and the precompiled Ruby e2e test

## Root cause

The 2026.8.0 release bump activated a deliberate debug assertion that was added as a reminder to complete this default transition. Debug test binaries consequently panicked in every Ruby-related code path.

## Testing

- `cargo test --all-features plugins::core::ruby::tests::`
- `mise run test:e2e e2e/core/test_ruby_precompiled`
- `mise run render:schema`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Ruby install artifacts for users who relied on implicit source builds; behavior is still overridable with `ruby.compile=true`, and source fallback remains when binaries are missing.
> 
> **Overview**
> **Precompiled Ruby is now the default** when `ruby.compile` is unset: installs try `jdx/ruby` binaries first and still fall back to ruby-build when none exist. Only **`ruby.compile=true`** forces a source build.
> 
> The delayed **2026.8.0 migration** is completed in code: the version-gated `debug_assert`, the one-time install warning, and the **`experimental`** gate for precompiled are removed. **`should_try_precompiled`** is now `ruby.compile != Some(true)`.
> 
> Docs (`docs/lang/ruby.md`), **`ruby.compile`** setting text in `settings.toml`, the precompiled Ruby e2e test (no `MISE_RUBY_COMPILE=false`), and lockfile unit coverage are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 688139dd49457aada7bda8f9e71b707ae1a6cf85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ruby installations now use precompiled binaries by default when available.
  * If unavailable, installation automatically falls back to compiling Ruby from source.
  * Source compilation can still be selected explicitly through the Ruby compilation setting.

* **Documentation**
  * Updated Ruby installation guidance and configuration details to reflect the new default behavior.
  * Added links to dependency and troubleshooting information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->