### PR TITLE
feat(task): resolve affected Git revisions

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -65,7 +65,7 @@ outside this tracker.
 
 - [x] Map changed files to their owning projects
 - [x] Compute affected projects from changed projects and reverse project dependency edges
-- [ ] Add configurable Git base and head revisions with sensible local and CI defaults
+- [x] Add configurable Git base and head revisions with sensible local and CI defaults
 - [ ] Treat workspace-global files and explicitly declared global inputs as affecting the
       appropriate project set
 - [ ] Account for lockfile changes at project granularity when a provider can determine the affected

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
@@ -14,6 +14,9 @@ use crate::cmd::CmdLineRunner;
 use crate::config::Settings;
 use crate::file::touch_dir;
 use crate::ui::progress_report::SingleReport;
+
+#[cfg(unix)]
+use std::ffi::OsString;
 
 pub struct Git {
     pub dir: PathBuf,
@@ -394,6 +397,39 @@ impl Git {
             .into())
     }
 
+    /// Returns paths changed between the merge base of two revisions.
+    ///
+    /// Rename detection is disabled so moves report both the old and new path.
+    /// Paths are relative to `self.dir`, and changes outside it are excluded.
+    pub fn changed_paths(&self, base: &str, head: &str) -> Result<BTreeSet<PathBuf>> {
+        for (name, revision) in [("base", base), ("head", head)] {
+            if revision.is_empty() || revision.starts_with('-') || revision.contains('\0') {
+                return Err(eyre!("invalid Git {name} revision {revision:?}"));
+            }
+        }
+        let range = format!("{base}...{head}");
+        let output = git_cmd!(
+            &self.dir,
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            "--relative",
+            &range,
+            "--",
+            "."
+        )
+        .stdout_capture()
+        .run()
+        .wrap_err_with(|| format!("git diff for {range} failed"))?;
+        output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+            .map(path_from_git_bytes)
+            .collect()
+    }
+
     pub fn get_path<P: AsRef<Path>>(path: P) -> eyre::Result<PathBuf> {
         let root = Self::get_root()?;
         let path = cmd!("git", "-C", &root, "rev-parse", "--git-path", path.as_ref()).read()?;
@@ -403,6 +439,20 @@ impl Git {
         } else {
             root.join(path)
         })
+    }
+}
+
+fn path_from_git_bytes(path: &[u8]) -> Result<PathBuf> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        Ok(OsString::from_vec(path.to_vec()).into())
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(String::from_utf8(path.to_vec())
+            .wrap_err("Git returned a non-UTF-8 path")?
+            .into())
     }
 }
 

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::{Task, TaskCacheConfig, task_sources::TaskOutputs};
 
 pub mod cargo;
+pub mod git;
 pub mod go;
 pub mod node;
 pub mod uv;

--- a/src/task/workspace/git.rs
+++ b/src/task/workspace/git.rs
@@ -1,0 +1,237 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::path::{Path, PathBuf};
+
+use eyre::Result;
+
+use crate::git::Git;
+
+const DEFAULT_BASE: &str = "HEAD~1";
+const DEFAULT_HEAD: &str = "HEAD";
+
+/// Git revisions used to discover changed workspace paths.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceGitRevisions {
+    pub base: String,
+    pub head: String,
+}
+
+impl WorkspaceGitRevisions {
+    /// Resolves explicit revisions, mise environment overrides, CI metadata,
+    /// and finally the local `HEAD~1...HEAD` default, in that order.
+    pub fn resolve(base: Option<&str>, head: Option<&str>) -> Self {
+        Self::resolve_with(base, head, |name| env::var(name).ok())
+    }
+
+    fn resolve_with(
+        base: Option<&str>,
+        head: Option<&str>,
+        get_env: impl Fn(&str) -> Option<String>,
+    ) -> Self {
+        let base = nonempty(base)
+            .map(str::to_string)
+            .or_else(|| env_value(&get_env, "MISE_AFFECTED_BASE"))
+            .or_else(|| ci_base(&get_env))
+            .unwrap_or_else(|| DEFAULT_BASE.to_string());
+        let head = nonempty(head)
+            .map(str::to_string)
+            .or_else(|| env_value(&get_env, "MISE_AFFECTED_HEAD"))
+            .or_else(|| ci_head(&get_env))
+            .unwrap_or_else(|| DEFAULT_HEAD.to_string());
+        Self { base, head }
+    }
+
+    /// Collects workspace-relative paths changed between the configured revisions.
+    pub fn changed_paths(&self, workspace_root: &Path) -> Result<BTreeSet<PathBuf>> {
+        Git::new(workspace_root).changed_paths(&self.base, &self.head)
+    }
+}
+
+fn nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn env_value(get_env: &impl Fn(&str) -> Option<String>, name: &str) -> Option<String> {
+    get_env(name)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn env_enabled(get_env: &impl Fn(&str) -> Option<String>, name: &str) -> bool {
+    env_value(get_env, name)
+        .is_some_and(|value| value != "0" && !value.eq_ignore_ascii_case("false"))
+}
+
+fn ci_base(get_env: &impl Fn(&str) -> Option<String>) -> Option<String> {
+    if env_enabled(get_env, "GITHUB_ACTIONS") {
+        return env_value(get_env, "GITHUB_BASE_REF").map(remote_branch);
+    }
+    if env_enabled(get_env, "GITLAB_CI") {
+        return env_value(get_env, "CI_MERGE_REQUEST_DIFF_BASE_SHA").or_else(|| {
+            env_value(get_env, "CI_MERGE_REQUEST_TARGET_BRANCH_NAME").map(remote_branch)
+        });
+    }
+    None
+}
+
+fn ci_head(get_env: &impl Fn(&str) -> Option<String>) -> Option<String> {
+    if env_enabled(get_env, "GITHUB_ACTIONS") {
+        return env_value(get_env, "GITHUB_SHA");
+    }
+    if env_enabled(get_env, "GITLAB_CI") {
+        return env_value(get_env, "CI_COMMIT_SHA");
+    }
+    None
+}
+
+fn remote_branch(branch: String) -> String {
+    let branch = branch.strip_prefix("refs/heads/").unwrap_or(&branch);
+    if branch.starts_with("refs/remotes/") || branch.starts_with("origin/") {
+        branch.to_string()
+    } else {
+        format!("origin/{branch}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::process::Command;
+
+    use super::*;
+
+    fn resolve_with_env(
+        base: Option<&str>,
+        head: Option<&str>,
+        values: &[(&str, &str)],
+    ) -> WorkspaceGitRevisions {
+        let values = values
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect::<BTreeMap<_, _>>();
+        WorkspaceGitRevisions::resolve_with(base, head, |name| values.get(name).cloned())
+    }
+
+    #[test]
+    fn explicit_revisions_override_environment_and_ci_defaults() {
+        let revisions = resolve_with_env(
+            Some("release-base"),
+            Some("release-head"),
+            &[
+                ("MISE_AFFECTED_BASE", "env-base"),
+                ("MISE_AFFECTED_HEAD", "env-head"),
+                ("GITHUB_ACTIONS", "true"),
+                ("GITHUB_BASE_REF", "main"),
+                ("GITHUB_SHA", "github-head"),
+            ],
+        );
+
+        assert_eq!(
+            revisions,
+            WorkspaceGitRevisions {
+                base: "release-base".to_string(),
+                head: "release-head".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn mise_environment_overrides_ci_defaults() {
+        let revisions = resolve_with_env(
+            None,
+            None,
+            &[
+                ("MISE_AFFECTED_BASE", "env-base"),
+                ("MISE_AFFECTED_HEAD", "env-head"),
+                ("GITLAB_CI", "true"),
+                ("CI_MERGE_REQUEST_DIFF_BASE_SHA", "gitlab-base"),
+                ("CI_COMMIT_SHA", "gitlab-head"),
+            ],
+        );
+
+        assert_eq!(revisions.base, "env-base");
+        assert_eq!(revisions.head, "env-head");
+    }
+
+    #[test]
+    fn github_and_gitlab_metadata_supply_ci_defaults() {
+        let github = resolve_with_env(
+            None,
+            None,
+            &[
+                ("GITHUB_ACTIONS", "true"),
+                ("GITHUB_BASE_REF", "refs/heads/main"),
+                ("GITHUB_SHA", "github-head"),
+            ],
+        );
+        let gitlab = resolve_with_env(
+            None,
+            None,
+            &[
+                ("GITLAB_CI", "true"),
+                ("CI_MERGE_REQUEST_DIFF_BASE_SHA", "gitlab-base"),
+                ("CI_COMMIT_SHA", "gitlab-head"),
+            ],
+        );
+
+        assert_eq!(github.base, "origin/main");
+        assert_eq!(github.head, "github-head");
+        assert_eq!(gitlab.base, "gitlab-base");
+        assert_eq!(gitlab.head, "gitlab-head");
+    }
+
+    #[test]
+    fn local_defaults_compare_head_to_its_first_parent() {
+        let revisions = resolve_with_env(None, None, &[]);
+
+        assert_eq!(revisions.base, DEFAULT_BASE);
+        assert_eq!(revisions.head, DEFAULT_HEAD);
+    }
+
+    #[test]
+    fn changed_paths_are_relative_and_include_both_sides_of_renames() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["-c", "init.defaultBranch=main", "init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        std::fs::create_dir(root.join("nested")).unwrap();
+        std::fs::write(root.join("old.txt"), "old\n").unwrap();
+        std::fs::write(root.join("nested/keep.txt"), "before\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "initial"]);
+        std::fs::rename(root.join("old.txt"), root.join("new.txt")).unwrap();
+        std::fs::write(root.join("nested/keep.txt"), "after\n").unwrap();
+        std::fs::write(root.join("nested/space name.txt"), "new\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "change"]);
+
+        let revisions = WorkspaceGitRevisions::resolve(Some("HEAD~1"), Some("HEAD"));
+
+        assert_eq!(
+            revisions.changed_paths(root).unwrap(),
+            BTreeSet::from([
+                PathBuf::from("nested/keep.txt"),
+                PathBuf::from("nested/space name.txt"),
+                PathBuf::from("new.txt"),
+                PathBuf::from("old.txt"),
+            ])
+        );
+        assert_eq!(
+            revisions.changed_paths(&root.join("nested")).unwrap(),
+            BTreeSet::from([PathBuf::from("keep.txt"), PathBuf::from("space name.txt"),])
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- resolve explicit affected base and head revisions with mise environment overrides
- use GitHub Actions and GitLab merge-request metadata as CI defaults, with HEAD~1 and HEAD locally
- collect workspace-relative changed paths from the merge base while retaining both sides of renames
- mark the affected Git revision milestone complete

## Why
Affected project selection needs a deterministic changed-path source before it can apply global-input policy or feed task patterns. This isolates Git and CI concerns from project graph traversal and allows later CLI options to pass explicit revisions directly.

## Validation
- cargo fmt --check
- cargo test task::workspace::git::tests
- cargo test git::tests
- cargo test task::workspace::
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- git diff --check

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Git helper and workspace module with tests; no changes to task execution, caching, or CLI behavior yet.
> 
> **Overview**
> Adds **configurable Git base and head revisions** for discovering which workspace files changed, as groundwork for affected monorepo execution.
> 
> `Git::changed_paths` runs a merge-base `git diff` (`base...head`), returns workspace-relative paths (with `--no-renames` so renames surface as both old and new paths), validates revision strings, and decodes NUL-separated paths (including non-UTF-8 on Unix).
> 
> New `task::workspace::git::WorkspaceGitRevisions` resolves **base/head** in order: explicit args → `MISE_AFFECTED_BASE` / `MISE_AFFECTED_HEAD` → GitHub Actions / GitLab CI env → local default **`HEAD~1`…`HEAD`**. It delegates to `changed_paths` at the workspace root (or a subdirectory). Unit tests cover precedence and real-repo diff behavior. The task-cache parity tracker marks this affected-project item complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831524ae32ac1b9bd6d6792a82da031c299fde1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for determining affected workspace files from Git changes.
  * Git base and head revisions can now be configured explicitly or detected automatically from supported CI environments and local history.
  * Handles renamed files, paths containing spaces, nested workspaces, and non-standard file names.

* **Documentation**
  * Updated the task cache parity tracker to mark configurable Git revisions as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->