### PR TITLE
fix(pipx): apply extras to git installs

### DIFF
--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -135,6 +135,14 @@ When passing extras inline, use mise's `key=value` tool-option syntax:
 mise use 'pipx:psf/black[extras=jupyter]@latest'
 ```
 
+For Git repositories whose name differs from the Python distribution name, set `package_name` so
+mise can build the requirement used to select extras:
+
+```toml
+[tools]
+"pipx:owner/repository" = { version = "latest", package_name = "distribution", extras = ["feature"] }
+```
+
 ### `pipx_args`
 
 Additional arguments to pass to `pipx` when installing the package.

--- a/docs/dev-tools/backends/pipx.md
+++ b/docs/dev-tools/backends/pipx.md
@@ -125,6 +125,14 @@ Install additional components.
 "pipx:harlequin" = { version = "latest", extras = "postgres,s3" }
 # equivalent array form:
 # "pipx:harlequin" = { version = "latest", extras = ["postgres", "s3"] }
+# extras also work with Git sources:
+# "pipx:psf/black" = { version = "latest", extras = ["jupyter"] }
+```
+
+When passing extras inline, use mise's `key=value` tool-option syntax:
+
+```bash
+mise use 'pipx:psf/black[extras=jupyter]@latest'
 ```
 
 ### `pipx_args`

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -693,16 +693,22 @@ impl PipxRequest {
     fn pipx_request(&self, v: &str, opts: &PipxOptions<'_>) -> String {
         let extras = self.extras_from_opts(opts);
 
-        if v == "latest" {
-            match self {
-                PipxRequest::Git(url) => format!("git+{url}.git"),
-                PipxRequest::Pypi(package) => format!("{package}{extras}"),
+        match self {
+            PipxRequest::Git(url) => {
+                let git_url = if v == "latest" {
+                    format!("git+{url}.git")
+                } else {
+                    format!("git+{url}.git@{v}")
+                };
+                if extras.is_empty() {
+                    git_url
+                } else {
+                    let package = url.rsplit('/').next().unwrap_or(url);
+                    format!("{package}{extras} @ {git_url}")
+                }
             }
-        } else {
-            match self {
-                PipxRequest::Git(url) => format!("git+{url}.git@{v}"),
-                PipxRequest::Pypi(package) => format!("{package}{extras}=={v}"),
-            }
+            PipxRequest::Pypi(package) if v == "latest" => format!("{package}{extras}"),
+            PipxRequest::Pypi(package) => format!("{package}{extras}=={v}"),
         }
     }
 }
@@ -995,6 +1001,15 @@ mod tests {
             PipxRequest::Pypi("harlequin".to_string())
                 .pipx_request("latest", &PipxOptions::new(&array_opts)),
             "harlequin[postgres,s3]"
+        );
+        let git_request = PipxRequest::Git("https://github.com/psf/black".to_string());
+        assert_eq!(
+            git_request.pipx_request("latest", &PipxOptions::new(&array_opts)),
+            "black[postgres,s3] @ git+https://github.com/psf/black.git"
+        );
+        assert_eq!(
+            git_request.pipx_request("24.3.0", &PipxOptions::new(&array_opts)),
+            "black[postgres,s3] @ git+https://github.com/psf/black.git@24.3.0"
         );
         assert_eq!(
             PipxOptions::new(&array_opts)

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -61,6 +61,10 @@ impl<'a> PipxOptions<'a> {
         self.values.comma_joined("extras")
     }
 
+    fn package_name(&self) -> Option<&'a str> {
+        self.values.str("package_name")
+    }
+
     fn pipx_args(&self) -> Option<&'a str> {
         self.values.str("pipx_args")
     }
@@ -351,19 +355,17 @@ impl Backend for PIPXBackend {
             }
         }
 
-        let pipx_request = self
-            .tool_name()
-            .parse::<PipxRequest>()?
-            .pipx_request(&tv.version, &options);
+        let request = self.tool_name().parse::<PipxRequest>()?;
 
         if let Some(uv_program) = uv_program {
+            let package_request = request.uvx_request(&tv.version, &options);
             self.warn_if_uv_may_not_support_exclude_newer(ctx).await;
             ctx.pr
-                .set_message(format!("uv tool install {pipx_request}"));
+                .set_message(format!("uv tool install {package_request}"));
             let mut cmd = Self::uvx_cmd(
                 &uv_program,
                 &ctx.config,
-                &["tool", "install", &pipx_request],
+                &["tool", "install", &package_request],
                 self,
                 &tv,
                 &ctx.ts,
@@ -402,10 +404,12 @@ impl Backend for PIPXBackend {
                 }
             }
 
-            ctx.pr.set_message(format!("pipx install {pipx_request}"));
+            let package_request = request.pipx_request(&tv.version, &options);
+            ctx.pr
+                .set_message(format!("pipx install {package_request}"));
             let mut cmd = Self::pipx_cmd(
                 &ctx.config,
-                &["install", &pipx_request],
+                &["install", &package_request],
                 self,
                 &tv,
                 &ctx.ts,
@@ -441,6 +445,7 @@ impl Backend for PIPXBackend {
 pub fn install_time_option_keys() -> Vec<String> {
     vec![
         "extras".into(),
+        "package_name".into(),
         "pipx_args".into(),
         "uvx_args".into(),
         "uvx".into(),
@@ -690,21 +695,50 @@ impl PipxRequest {
         }
     }
 
+    fn git_url(url: &str, v: &str) -> String {
+        if v == "latest" {
+            format!("git+{url}.git")
+        } else {
+            format!("git+{url}.git@{v}")
+        }
+    }
+
+    fn git_package_name<'a>(url: &'a str, opts: &PipxOptions<'a>) -> &'a str {
+        opts.package_name()
+            .unwrap_or_else(|| url.rsplit('/').next().unwrap_or(url))
+    }
+
+    fn uvx_request(&self, v: &str, opts: &PipxOptions<'_>) -> String {
+        let extras = self.extras_from_opts(opts);
+
+        match self {
+            PipxRequest::Git(url) => {
+                let git_url = Self::git_url(url, v);
+                if extras.is_empty() {
+                    git_url
+                } else {
+                    let package = Self::git_package_name(url, opts);
+                    format!("{package}{extras} @ {git_url}")
+                }
+            }
+            PipxRequest::Pypi(package) if v == "latest" => format!("{package}{extras}"),
+            PipxRequest::Pypi(package) => format!("{package}{extras}=={v}"),
+        }
+    }
+
     fn pipx_request(&self, v: &str, opts: &PipxOptions<'_>) -> String {
         let extras = self.extras_from_opts(opts);
 
         match self {
             PipxRequest::Git(url) => {
-                let git_url = if v == "latest" {
-                    format!("git+{url}.git")
-                } else {
-                    format!("git+{url}.git@{v}")
-                };
+                let git_url = Self::git_url(url, v);
                 if extras.is_empty() {
                     git_url
                 } else {
-                    let package = url.rsplit('/').next().unwrap_or(url);
-                    format!("{package}{extras} @ {git_url}")
+                    // pipx ignored extras on PEP 508 URL requirements before 0.15.6.0.
+                    // Its VCS `egg` form works across the supported pipx version range.
+                    let package = Self::git_package_name(url, opts);
+                    format!("{git_url}#egg={package}{extras}")
                 }
             }
             PipxRequest::Pypi(package) if v == "latest" => format!("{package}{extras}"),
@@ -1002,20 +1036,63 @@ mod tests {
                 .pipx_request("latest", &PipxOptions::new(&array_opts)),
             "harlequin[postgres,s3]"
         );
-        let git_request = PipxRequest::Git("https://github.com/psf/black".to_string());
-        assert_eq!(
-            git_request.pipx_request("latest", &PipxOptions::new(&array_opts)),
-            "black[postgres,s3] @ git+https://github.com/psf/black.git"
-        );
-        assert_eq!(
-            git_request.pipx_request("24.3.0", &PipxOptions::new(&array_opts)),
-            "black[postgres,s3] @ git+https://github.com/psf/black.git@24.3.0"
-        );
         assert_eq!(
             PipxOptions::new(&array_opts)
                 .lockfile_options()
                 .get("extras"),
             Some(&"postgres,s3".to_string())
+        );
+    }
+
+    #[test]
+    fn test_git_extras_use_frontend_compatible_requests() {
+        let mut inferred_opts = ToolVersionOptions::default();
+        inferred_opts.opts.insert(
+            "extras".to_string(),
+            toml::Value::Array(vec![toml::Value::String("jupyter".to_string())]),
+        );
+        let inferred_opts = PipxOptions::new(&inferred_opts);
+        let inferred_request = PipxRequest::Git("https://github.com/psf/black".to_string());
+        assert_eq!(
+            inferred_request.uvx_request("latest", &inferred_opts),
+            "black[jupyter] @ git+https://github.com/psf/black.git"
+        );
+        assert_eq!(
+            inferred_request.pipx_request("latest", &inferred_opts),
+            "git+https://github.com/psf/black.git#egg=black[jupyter]"
+        );
+
+        let mut named_opts = ToolVersionOptions::default();
+        named_opts.opts.insert(
+            "extras".to_string(),
+            toml::Value::Array(vec![toml::Value::String("jupyter".to_string())]),
+        );
+        named_opts.opts.insert(
+            "package_name".to_string(),
+            toml::Value::String("black".to_string()),
+        );
+        let named_opts = PipxOptions::new(&named_opts);
+        let request = PipxRequest::Git("https://github.com/psf/black-repository".to_string());
+
+        assert_eq!(
+            request.uvx_request("latest", &named_opts),
+            "black[jupyter] @ git+https://github.com/psf/black-repository.git"
+        );
+        assert_eq!(
+            request.uvx_request("24.3.0", &named_opts),
+            "black[jupyter] @ git+https://github.com/psf/black-repository.git@24.3.0"
+        );
+        assert_eq!(
+            request.pipx_request("latest", &named_opts),
+            "git+https://github.com/psf/black-repository.git#egg=black[jupyter]"
+        );
+        assert_eq!(
+            request.pipx_request("24.3.0", &named_opts),
+            "git+https://github.com/psf/black-repository.git@24.3.0#egg=black[jupyter]"
+        );
+        assert_eq!(
+            named_opts.lockfile_options().get("package_name"),
+            Some(&"black".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- apply configured `extras` to Git-based `pipx:` installs
- emit installer-specific Git requirements: named PEP 508 references for uv and VCS `#egg` references for compatibility with older pipx releases
- support an explicit `package_name` when the repository and Python distribution names differ
- document Git and inline `extras` configuration

## Root cause
`PipxRequest` appended extras only for PyPI requests. Both Git request branches built a bare VCS URL and discarded the parsed extras.

Fixes the bug reported in https://github.com/jdx/mise/discussions/11582.

## Validation
- `cargo test backend::pipx::tests`
- `cargo fmt --all -- --check`
- `mise run lint-fix`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*