### PR TITLE
feat(task): include global inputs in affected projects

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -66,7 +66,7 @@ outside this tracker.
 - [x] Map changed files to their owning projects
 - [x] Compute affected projects from changed projects and reverse project dependency edges
 - [x] Add configurable Git base and head revisions with sensible local and CI defaults
-- [ ] Treat workspace-global files and explicitly declared global inputs as affecting the
+- [x] Treat workspace-global files and explicitly declared global inputs as affecting the
       appropriate project set
 - [ ] Account for lockfile changes at project granularity when a provider can determine the affected
       external dependencies

--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -66,7 +66,7 @@ outside this tracker.
 - [x] Map changed files to their owning projects
 - [x] Compute affected projects from changed projects and reverse project dependency edges
 - [x] Add configurable Git base and head revisions with sensible local and CI defaults
-- [x] Treat workspace-global files and explicitly declared global inputs as affecting the
+- [ ] Treat workspace-global files and explicitly declared global inputs as affecting the
       appropriate project set
 - [ ] Account for lockfile changes at project granularity when a provider can determine the affected
       external dependencies

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -9,7 +9,11 @@ use std::sync::{Arc, Mutex};
 use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
 
-use super::{Task, TaskCacheConfig, task_sources::TaskOutputs};
+use super::{
+    Task, TaskCacheConfig,
+    task_source_checker::{build_source_matcher, is_source},
+    task_sources::TaskOutputs,
+};
 
 pub mod cargo;
 pub mod git;
@@ -778,6 +782,37 @@ impl WorkspaceProjectGraph {
             }
         }
         Ok(affected)
+    }
+
+    /// Maps changed paths to affected projects, including workspace-global inputs.
+    ///
+    /// Paths outside every project root are workspace-global and affect every
+    /// project. A changed path selected by the resolved `task_config.global_inputs`
+    /// patterns does the same, even when that path is owned by a project.
+    pub fn affected_projects_for_paths(
+        &self,
+        workspace_root: &Path,
+        paths: impl IntoIterator<Item = impl AsRef<Path>>,
+        resolved_global_inputs: &[String],
+    ) -> Result<BTreeSet<ProjectId>> {
+        let mapped = self.map_paths_to_projects(paths)?;
+        let global_matcher =
+            build_source_matcher(workspace_root, workspace_root, resolved_global_inputs);
+        let global_input_changed = mapped
+            .projects_by_path
+            .keys()
+            .chain(&mapped.unowned_paths)
+            .any(|path| is_source(&global_matcher, &workspace_root.join(path)));
+        if !mapped.unowned_paths.is_empty() || global_input_changed {
+            return Ok(self.projects.keys().cloned().collect());
+        }
+
+        let changed = mapped
+            .projects_by_path
+            .values()
+            .flat_map(BTreeSet::iter)
+            .collect::<BTreeSet<_>>();
+        self.affected_projects(changed)
     }
 
     /// Summarizes provider failures retained during lenient task discovery.
@@ -2210,6 +2245,98 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "unknown workspace project ProjectId(\"node:missing\")"
+        );
+    }
+
+    #[test]
+    fn unowned_workspace_paths_affect_every_project() {
+        let provider = test_provider(vec![
+            project("test", "app", "apps/app"),
+            project("test", "lib", "packages/lib"),
+            project("test", "docs", "docs"),
+        ]);
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap();
+
+        let affected = graph
+            .affected_projects_for_paths(Path::new("/workspace"), ["workspace.toml"], &[])
+            .unwrap();
+
+        assert_eq!(
+            affected,
+            BTreeSet::from([
+                ProjectId::new("test", "app").unwrap(),
+                ProjectId::new("test", "docs").unwrap(),
+                ProjectId::new("test", "lib").unwrap(),
+            ])
+        );
+    }
+
+    #[test]
+    fn declared_global_inputs_affect_every_project() {
+        let provider = test_provider(vec![
+            project("test", "app", "apps/app"),
+            project("test", "lib", "packages/lib"),
+            project("test", "docs", "docs"),
+        ]);
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap();
+
+        let affected = graph
+            .affected_projects_for_paths(
+                Path::new("/workspace"),
+                ["apps/app/toolchain.toml"],
+                &["**/toolchain.toml".to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(
+            affected,
+            graph.projects().map(|project| project.id.clone()).collect()
+        );
+    }
+
+    #[test]
+    fn ordinary_owned_paths_affect_only_their_reverse_dependency_closure() {
+        let lib_id = ProjectId::new("test", "lib").unwrap();
+        let app_id = ProjectId::new("test", "app").unwrap();
+        let mut app = project("test", "app", "apps/app");
+        app.dependencies.insert(lib_id.clone());
+        let provider = test_provider(vec![
+            app,
+            project("test", "lib", "packages/lib"),
+            project("test", "docs", "docs"),
+        ]);
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap();
+
+        let affected = graph
+            .affected_projects_for_paths(
+                Path::new("/workspace"),
+                ["packages/lib/src/lib.rs"],
+                &["**/toolchain.toml".to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(affected, BTreeSet::from([lib_id, app_id]));
+    }
+
+    #[test]
+    fn global_input_exclusions_preserve_project_scoping() {
+        let provider = test_provider(vec![
+            project("test", "app", "apps/app"),
+            project("test", "docs", "docs"),
+        ]);
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap();
+
+        let affected = graph
+            .affected_projects_for_paths(
+                Path::new("/workspace"),
+                ["docs/config.json"],
+                &["**/*.json".to_string(), "!docs/**".to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(
+            affected,
+            BTreeSet::from([ProjectId::new("test", "docs").unwrap()])
         );
     }
 


### PR DESCRIPTION
## Summary
- treat changed paths outside every workspace project as workspace-global
- treat changed paths matching resolved task_config.global_inputs patterns as workspace-global
- affect every project for global changes while preserving reverse-dependency scoping for ordinary owned paths
- reuse task source include, exclude, brace, and absolute-path matching semantics

## Why
Changed-file ownership alone cannot safely narrow repository-wide configuration and shared inputs. This layer connects changed paths to affected project expansion while reusing the existing global-input contract instead of introducing parallel configuration.

## Validation
- cargo fmt --check
- cargo test task::workspace::
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- git diff --check

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Affects which monorepo projects run on file changes; incorrect global-input matching could over- or under-run tasks, but logic reuses existing task source matchers and is covered by new tests.
> 
> **Overview**
> Adds **`affected_projects_for_paths`** on `WorkspaceProjectGraph` so changed-file → affected-project expansion respects **workspace-global** inputs, not only per-project ownership.
> 
> Changes under paths that match resolved **`task_config.global_inputs`** (via existing `build_source_matcher` / `is_source` semantics, including excludes) mark the whole workspace affected, even when the file lives inside a project root. Paths with no owning project do the same. Otherwise behavior stays the same: map paths to projects and expand through **`affected_projects`** (reverse-dependency closure).
> 
> Unit tests cover unowned paths, global patterns, ordinary scoped changes, and exclusion patterns that keep changes local to one project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b4052a7acb78458fadb5cec6f62fd01d30d4fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workspace change detection to identify all projects affected by modified files.
  * Changes to project dependencies now correctly include dependent projects.
  * Updates outside known project directories or matching global inputs now trigger processing for the full workspace.
  * Excluded paths are handled correctly to prevent unnecessary project processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->