### PR TITLE
feat(task): explain affected task selection

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -72,7 +72,7 @@ outside this tracker.
       external dependencies
 - [x] Allow affected selection to feed existing task patterns, dependency expansion, scheduling, and
       caching
-- [ ] Show why each project and task was considered affected
+- [x] Show why each project and task was considered affected
 - [ ] Add machine-readable affected-project and affected-task output
 
 ## Local cache parity

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -46,6 +46,10 @@ Run matching tasks only for projects affected by Git changes
 Git base revision for --affected
 Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
 
+### `--affected-explain`
+
+Explain why projects and tasks were selected by --affected
+
 ### `--affected-head <REV>`
 
 Git head revision for --affected

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -60,6 +60,10 @@ Run matching tasks only for projects affected by Git changes
 Git base revision for --affected
 Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
 
+### `--affected-explain`
+
+Explain why projects and tasks were selected by --affected
+
 ### `--affected-head <REV>`
 
 Git head revision for --affected

--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -359,6 +359,35 @@ The JSON output includes the same information in each project's `provenance`,
 other tooling can distinguish, for example, a `turbo.json` output declaration from a root mise task
 default.
 
+### Affected Tasks
+
+Use `mise run --affected <task-pattern>` to run a task only in projects changed between two Git
+revisions. mise selects projects that own changed paths, then follows reverse project dependencies
+so downstream projects are included. Workspace-global paths and `task_config.global_inputs` select
+the whole workspace. Providers may narrow lockfile changes to the projects whose external
+dependencies changed.
+
+```bash
+# Compare HEAD to its first parent and run affected build tasks
+mise run --affected build
+
+# Inspect the selection while preserving normal dry-run behavior
+mise run --affected --affected-explain --dry-run build
+
+# Compare explicit revisions
+mise run --affected --affected-base origin/main --affected-head HEAD test
+```
+
+`--affected-explain` lists each selected project and its cause: an owned changed path, a
+workspace-global path, a provider-attributed lockfile, or a dependency on another affected project.
+It also lists the task-pattern matches associated with those projects. Normal task dependencies are
+expanded afterward, so a selected task can still run a required prerequisite from an unchanged
+project.
+
+The revision defaults are `HEAD~1` and `HEAD` locally. `MISE_AFFECTED_BASE` and
+`MISE_AFFECTED_HEAD` override them. GitHub Actions and GitLab merge-request metadata provide CI
+defaults when those variables are not set; explicit CLI options take highest precedence.
+
 ### Cargo Workspace Discovery
 
 The Cargo provider discovers packages when the root `Cargo.toml` contains a `[workspace]` table.

--- a/e2e/tasks/test_task_affected
+++ b/e2e/tasks/test_task_affected
@@ -68,7 +68,12 @@ git commit -qm initial
 echo changed >>crates/core/src/lib.rs
 git add .
 git commit -qm core-change
-mise run --affected --jobs 1 build
+output=$(mise run --affected --affected-explain --jobs 1 build)
+assert_contains "echo \"$output\"" "Affected projects (HEAD~1...HEAD):"
+assert_contains "echo \"$output\"" "changed path: crates/core/src/lib.rs"
+assert_contains "echo \"$output\"" "depends on affected project: cargo:core"
+assert_contains "echo \"$output\"" "Affected tasks:"
+assert_contains "echo \"$output\"" "affected project: cargo:app"
 assert "sort affected.log" $'app\ncore\nother-prepare'
 
 : >affected.log
@@ -145,5 +150,7 @@ sed -i 's/1\.0\.0/2.0.0/g' pnpm-lock.yaml
 git add pnpm-lock.yaml
 git commit -qm lockfile-change
 
-mise run --affected --jobs 1 build
+output=$(mise run --affected --affected-explain --jobs 1 build)
+assert_contains "echo \"$output\"" "lockfile change: pnpm-lock.yaml"
+assert_contains "echo \"$output\"" "depends on affected project: node:lib"
 assert "sort affected.log" $'app\nlib'

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3032,6 +3032,9 @@ Run matching tasks only for projects affected by Git changes
 Git base revision for \-\-affected
 Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
 .TP
+\fB\-\-affected\-explain\fR
+Explain why projects and tasks were selected by \-\-affected
+.TP
 \fB\-\-affected\-head\fR \fI<REV>\fR
 Git head revision for \-\-affected
 Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
@@ -3837,6 +3840,9 @@ Run matching tasks only for projects affected by Git changes
 \fB\-\-affected\-base\fR \fI<REV>\fR
 Git base revision for \-\-affected
 Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
+.TP
+\fB\-\-affected\-explain\fR
+Explain why projects and tasks were selected by \-\-affected
 .TP
 \fB\-\-affected\-head\fR \fI<REV>\fR
 Git head revision for \-\-affected

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3052,6 +3052,7 @@ Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
 """# {
         arg <REV>
     }
+    flag --affected-explain help="Explain why projects and tasks were selected by --affected"
     flag --affected-head help=#"""
 Git head revision for --affected
 Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
@@ -3900,6 +3901,7 @@ Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
 """# {
             arg <REV>
         }
+        flag --affected-explain help="Explain why projects and tasks were selected by --affected"
         flag --affected-head help=#"""
 Git head revision for --affected
 Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -902,6 +902,7 @@ impl Bootstrap {
             affected: false,
             affected_base: None,
             affected_head: None,
+            affected_explain: false,
             cd: None,
             continue_on_error: false,
             dry_run: self.dry_run,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -778,6 +778,7 @@ impl Cli {
                         affected: false,
                         affected_base: None,
                         affected_head: None,
+                        affected_explain: false,
                         cd: self.cd,
                         continue_on_error: self.continue_on_error,
                         dry_run: self.dry_run,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,5 +1,5 @@
 use crate::errors::Error;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::iter::once;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -82,6 +82,10 @@ pub struct Run {
     /// Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
     #[clap(long, requires = "affected", value_name = "REV", verbatim_doc_comment)]
     pub affected_base: Option<String>,
+
+    /// Explain why projects and tasks were selected by --affected
+    #[clap(long, requires = "affected", verbatim_doc_comment)]
+    pub affected_explain: bool,
 
     /// Git head revision for --affected
     /// Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
@@ -288,6 +292,7 @@ async fn get_affected_task_list(
     only: bool,
     base: Option<&str>,
     head: Option<&str>,
+    explain: bool,
 ) -> Result<Vec<Task>> {
     Settings::get().ensure_experimental("affected tasks")?;
     let workspace_root = config
@@ -304,7 +309,7 @@ async fn get_affected_task_list(
     let uv = crate::task::workspace::uv::UvWorkspaceProvider;
     let providers: [&dyn crate::task::workspace::WorkspaceProvider; 4] = [&cargo, &go, &node, &uv];
     let mut regular_paths = BTreeSet::new();
-    let mut lockfile_projects = BTreeSet::new();
+    let mut lockfile_projects = BTreeMap::<PathBuf, BTreeSet<_>>::new();
     let mut comparison_base: Option<String> = None;
 
     for path in changed_paths {
@@ -331,15 +336,19 @@ async fn get_affected_task_list(
             before.as_deref(),
             after.as_deref(),
         )? {
-            lockfile_projects.extend(projects);
+            lockfile_projects.entry(path).or_default().extend(projects);
         }
     }
 
-    let mut affected =
-        graph.affected_projects_for_paths(&workspace_root, regular_paths, &global_inputs)?;
-    affected.extend(graph.affected_projects(&lockfile_projects)?);
+    let affected = graph.affected_projects_for_changes(
+        &workspace_root,
+        regular_paths,
+        &global_inputs,
+        &lockfile_projects,
+    )?;
     let affected_roots = affected
-        .iter()
+        .projects()
+        .map(|(id, _)| id)
         .filter_map(|id| graph.get(id))
         .map(|project| crate::file::desymlink_path(&workspace_root.join(&project.root)))
         .collect::<BTreeSet<_>>();
@@ -356,7 +365,81 @@ async fn get_affected_task_list(
                 .map(crate::file::desymlink_path)
                 .is_some_and(|root| affected_roots.contains(&root))
     });
+    if explain {
+        display_affected_explanation(&revisions, &workspace_root, &graph, &affected, &tasks)?;
+    }
     Ok(tasks)
+}
+
+fn display_affected_explanation(
+    revisions: &crate::task::workspace::git::WorkspaceGitRevisions,
+    workspace_root: &std::path::Path,
+    graph: &crate::task::workspace::WorkspaceProjectGraph,
+    affected: &crate::task::workspace::AffectedProjects,
+    tasks: &[Task],
+) -> Result<()> {
+    use crate::task::workspace::AffectedProjectReason;
+
+    miseprintln!(
+        "Affected projects ({}...{}):{}",
+        revisions.base,
+        revisions.head,
+        if affected.is_empty() { " none" } else { "" }
+    );
+    let mut projects_by_root = BTreeMap::<PathBuf, Vec<_>>::new();
+    for (id, reasons) in affected.projects() {
+        let project = graph.get(id).expect("affected project exists in graph");
+        miseprintln!("  {} ({})", id, display_affected_path(&project.root));
+        for reason in reasons {
+            match reason {
+                AffectedProjectReason::ChangedPath { path } => {
+                    miseprintln!("    changed path: {}", display_affected_path(path));
+                }
+                AffectedProjectReason::GlobalPath { path } => {
+                    miseprintln!("    workspace-global path: {}", display_affected_path(path));
+                }
+                AffectedProjectReason::Lockfile { path } => {
+                    miseprintln!("    lockfile change: {}", display_affected_path(path));
+                }
+                AffectedProjectReason::Dependent { dependency } => {
+                    miseprintln!("    depends on affected project: {dependency}");
+                }
+            }
+        }
+        projects_by_root
+            .entry(crate::file::desymlink_path(
+                &workspace_root.join(&project.root),
+            ))
+            .or_default()
+            .push(id);
+    }
+
+    miseprintln!(
+        "Affected tasks:{}",
+        if tasks.is_empty() { " none" } else { "" }
+    );
+    for task in tasks {
+        miseprintln!("  {}", display_affected_text(&task.display_name));
+        if let Some(ids) = task
+            .config_root
+            .as_deref()
+            .map(crate::file::desymlink_path)
+            .and_then(|root| projects_by_root.get(&root))
+        {
+            for id in ids {
+                miseprintln!("    affected project: {id}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn display_affected_path(path: &std::path::Path) -> String {
+    display_affected_text(&path.to_string_lossy())
+}
+
+fn display_affected_text(text: &str) -> String {
+    text.escape_debug().to_string()
 }
 
 impl Run {
@@ -448,6 +531,7 @@ impl Run {
                 self.skip_deps,
                 self.affected_base.as_deref(),
                 self.affected_head.as_deref(),
+                self.affected_explain,
             )
             .await?
         } else {
@@ -1296,6 +1380,18 @@ mod tests {
                 ":::",
                 "node:@scope/app#lint",
             ]
+        );
+    }
+
+    #[test]
+    fn affected_paths_escape_terminal_control_characters() {
+        assert_eq!(
+            display_affected_path(std::path::Path::new("src/\x1b[2J\nfile.rs")),
+            r"src/\u{1b}[2J\nfile.rs"
+        );
+        assert_eq!(
+            display_affected_text("//app:\x1b]8;;https://example.com\x1b\\build"),
+            r"//app:\u{1b}]8;;https://example.com\u{1b}\\build"
         );
     }
 }

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -440,6 +440,40 @@ pub struct WorkspaceProjectPathMap {
     pub unowned_paths: BTreeSet<PathBuf>,
 }
 
+/// A direct or dependency-derived reason that a workspace project is affected.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum AffectedProjectReason {
+    /// A changed file is owned by this project.
+    ChangedPath { path: PathBuf },
+    /// A changed file affects every project in the workspace.
+    GlobalPath { path: PathBuf },
+    /// A provider attributed a changed lockfile to this project.
+    Lockfile { path: PathBuf },
+    /// This project depends on another affected project.
+    Dependent { dependency: ProjectId },
+}
+
+/// Affected workspace projects and the reasons each was selected.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct AffectedProjects {
+    projects: BTreeMap<ProjectId, BTreeSet<AffectedProjectReason>>,
+}
+
+impl AffectedProjects {
+    /// Returns affected projects and their reasons in stable project-ID order.
+    pub fn projects(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (&ProjectId, &BTreeSet<AffectedProjectReason>)> {
+        self.projects.iter()
+    }
+
+    /// Returns whether no projects are affected.
+    pub fn is_empty(&self) -> bool {
+        self.projects.is_empty()
+    }
+}
+
 /// A deterministic dependency cycle found in the workspace project graph.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WorkspaceProjectCycleError {
@@ -810,24 +844,99 @@ impl WorkspaceProjectGraph {
         paths: impl IntoIterator<Item = impl AsRef<Path>>,
         resolved_global_inputs: &[String],
     ) -> Result<BTreeSet<ProjectId>> {
+        Ok(self
+            .affected_projects_for_changes(
+                workspace_root,
+                paths,
+                resolved_global_inputs,
+                &BTreeMap::new(),
+            )?
+            .projects
+            .into_keys()
+            .collect())
+    }
+
+    /// Explains affected projects from ordinary paths and provider-attributed lockfiles.
+    pub fn affected_projects_for_changes(
+        &self,
+        workspace_root: &Path,
+        paths: impl IntoIterator<Item = impl AsRef<Path>>,
+        resolved_global_inputs: &[String],
+        lockfile_projects: &BTreeMap<PathBuf, BTreeSet<ProjectId>>,
+    ) -> Result<AffectedProjects> {
         let mapped = self.map_paths_to_projects(paths)?;
         let global_matcher =
             build_source_matcher(workspace_root, workspace_root, resolved_global_inputs);
-        let global_input_changed = mapped
+        let global_paths = mapped
             .projects_by_path
             .keys()
             .chain(&mapped.unowned_paths)
-            .any(|path| is_source(&global_matcher, &workspace_root.join(path)));
-        if !mapped.unowned_paths.is_empty() || global_input_changed {
-            return Ok(self.projects.keys().cloned().collect());
+            .filter(|path| {
+                mapped.unowned_paths.contains(*path)
+                    || is_source(&global_matcher, &workspace_root.join(path))
+            })
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let mut projects = BTreeMap::<ProjectId, BTreeSet<AffectedProjectReason>>::new();
+        if global_paths.is_empty() {
+            for (path, owners) in mapped.projects_by_path {
+                for id in owners {
+                    projects
+                        .entry(id)
+                        .or_default()
+                        .insert(AffectedProjectReason::ChangedPath { path: path.clone() });
+                }
+            }
+        } else {
+            for id in self.projects.keys() {
+                projects.entry(id.clone()).or_default().extend(
+                    global_paths
+                        .iter()
+                        .cloned()
+                        .map(|path| AffectedProjectReason::GlobalPath { path }),
+                );
+            }
         }
 
-        let changed = mapped
-            .projects_by_path
-            .values()
-            .flat_map(BTreeSet::iter)
-            .collect::<BTreeSet<_>>();
-        self.affected_projects(changed)
+        for (path, ids) in lockfile_projects {
+            for id in ids {
+                if !self.projects.contains_key(id) {
+                    bail!(
+                        "lockfile {:?} attributed to unknown workspace project {id:?}",
+                        path
+                    );
+                }
+                projects
+                    .entry(id.clone())
+                    .or_default()
+                    .insert(AffectedProjectReason::Lockfile { path: path.clone() });
+            }
+        }
+
+        let mut dependents = BTreeMap::<ProjectId, BTreeSet<ProjectId>>::new();
+        for project in self.projects() {
+            for dependency in &project.dependencies {
+                dependents
+                    .entry(dependency.clone())
+                    .or_default()
+                    .insert(project.id.clone());
+            }
+        }
+        let mut pending = projects.keys().rev().cloned().collect::<Vec<_>>();
+        while let Some(dependency) = pending.pop() {
+            for dependent in dependents.get(&dependency).into_iter().flatten() {
+                let is_new = !projects.contains_key(dependent);
+                projects.entry(dependent.clone()).or_default().insert(
+                    AffectedProjectReason::Dependent {
+                        dependency: dependency.clone(),
+                    },
+                );
+                if is_new {
+                    pending.push(dependent.clone());
+                }
+            }
+        }
+        Ok(AffectedProjects { projects })
     }
 
     /// Asks workspace providers to attribute a changed lockfile to projects.
@@ -2338,6 +2447,89 @@ mod tests {
         assert_eq!(
             graph.affected_projects([&app_id]).unwrap(),
             BTreeSet::from([app_id])
+        );
+    }
+
+    #[test]
+    fn affected_project_reasons_distinguish_changes_and_dependents() {
+        let lib_id = ProjectId::new("node", "lib").unwrap();
+        let app_id = ProjectId::new("node", "app").unwrap();
+        let lib = project("node", "lib", "packages/lib");
+        let mut app = project("node", "app", "packages/app");
+        app.dependencies.insert(lib_id.clone());
+        let provider = TestProvider {
+            id: "node",
+            projects: vec![app, lib],
+        };
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap();
+
+        let affected = graph
+            .affected_projects_for_changes(
+                Path::new("/workspace"),
+                ["packages/lib/src/lib.rs"],
+                &[],
+                &BTreeMap::new(),
+            )
+            .unwrap();
+        let reasons = affected
+            .projects()
+            .map(|(id, reasons)| (id.clone(), reasons.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(
+            reasons[&lib_id],
+            BTreeSet::from([AffectedProjectReason::ChangedPath {
+                path: PathBuf::from("packages/lib/src/lib.rs"),
+            }])
+        );
+        assert_eq!(
+            reasons[&app_id],
+            BTreeSet::from([AffectedProjectReason::Dependent { dependency: lib_id }])
+        );
+    }
+
+    #[test]
+    fn affected_project_reasons_retain_every_dependency_cause() {
+        let core_id = ProjectId::new("node", "core").unwrap();
+        let left_id = ProjectId::new("node", "left").unwrap();
+        let right_id = ProjectId::new("node", "right").unwrap();
+        let app_id = ProjectId::new("node", "app").unwrap();
+        let core = project("node", "core", "packages/core");
+        let mut left = project("node", "left", "packages/left");
+        left.dependencies.insert(core_id.clone());
+        let mut right = project("node", "right", "packages/right");
+        right.dependencies.insert(core_id.clone());
+        let mut app = project("node", "app", "apps/app");
+        app.dependencies = BTreeSet::from([left_id.clone(), right_id.clone()]);
+        let provider = TestProvider {
+            id: "node",
+            projects: vec![app, core, left, right],
+        };
+        let graph = WorkspaceProjectGraph::discover(&provider, Path::new("/workspace")).unwrap();
+
+        let affected = graph
+            .affected_projects_for_changes(
+                Path::new("/workspace"),
+                ["packages/core/src/lib.rs"],
+                &[],
+                &BTreeMap::new(),
+            )
+            .unwrap();
+        let app_reasons = affected
+            .projects()
+            .find_map(|(id, reasons)| (id == &app_id).then_some(reasons))
+            .unwrap();
+
+        assert_eq!(
+            app_reasons,
+            &BTreeSet::from([
+                AffectedProjectReason::Dependent {
+                    dependency: left_id,
+                },
+                AffectedProjectReason::Dependent {
+                    dependency: right_id,
+                },
+            ])
         );
     }
 


### PR DESCRIPTION
## Summary
- add `--affected-explain` to show why workspace projects and task-pattern matches were selected
- retain structured, deterministic causes for changed paths, workspace-global paths, provider-attributed lockfiles, and reverse dependents
- document affected task execution and revision precedence
- complete the affected-explanation milestone in the task parity tracker

## Testing
- `target/debug/mise run lint-fix`
- `cargo clippy --quiet --workspace --all-features --all-targets -- -D warnings`
- `target/debug/mise run test:e2e e2e/tasks/test_task_affected`
- `cargo test --quiet task::workspace::tests::affected_project_reasons_distinguish_changes_and_dependents`
- `shellcheck -x e2e/tasks/test_task_affected`
- `shfmt -d e2e/tasks/test_task_affected`
- `target/debug/mise run render:usage`

Stacked on #11590.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only CLI and graph API extension; affected selection behavior is unchanged aside from richer internal reasoning and explain output.
> 
> **Overview**
> Adds **`--affected-explain`** to `mise run` (requires `--affected`) so runs print why workspace projects and matching task patterns were selected, without changing which tasks execute.
> 
> Affected analysis now keeps **structured reasons** per project via `AffectedProjectReason` and `AffectedProjects`, with `affected_projects_for_changes` recording changed paths, workspace-global paths, provider-attributed lockfiles, and reverse dependents (including multiple dependency causes). Human-readable output lists revisions, each project’s causes, and affected tasks; paths and labels use **`escape_debug`** for safer terminal output.
> 
> Docs, usage/man pages, the parity tracker milestone, unit tests, and e2e coverage for path/lockfile explanations are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6bb87214872abb14206728f15e83dc7f5a2254a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->