### PR TITLE
chore: release 2026.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,111 @@
 # Changelog
 
+## [2026.8.1](https://github.com/jdx/mise/compare/v2026.8.0..v2026.8.1) - 2026-08-03
+
+### 🚀 Features
+
+- **(config)** accept --file on `mise use` and --path on `mise set` by @JamBalaya56562 in [#11577](https://github.com/jdx/mise/pull/11577)
+- **(config)** accept --file on `mise unuse` and --path on `mise unset` by @JamBalaya56562 in [#11616](https://github.com/jdx/mise/pull/11616)
+- **(config)** accept --file wherever `--path` names a config to write by @JamBalaya56562 in [#11631](https://github.com/jdx/mise/pull/11631)
+- **(config)** accept --path on `mise config get` and `mise config set` by @JamBalaya56562 in [#11640](https://github.com/jdx/mise/pull/11640)
+- **(env)** warn when PATH is long enough for cmd.exe to ignore by @JamBalaya56562 in [#11643](https://github.com/jdx/mise/pull/11643)
+- **(task)** include global inputs in affected projects by @jdx in [#11587](https://github.com/jdx/mise/pull/11587)
+- **(task)** attribute pnpm lockfile changes by @jdx in [#11589](https://github.com/jdx/mise/pull/11589)
+- **(task)** run affected workspace tasks by @jdx in [#11590](https://github.com/jdx/mise/pull/11590)
+- **(task)** explain affected task selection by @jdx in [#11591](https://github.com/jdx/mise/pull/11591)
+- **(task)** add affected JSON output by @jdx in [#11593](https://github.com/jdx/mise/pull/11593)
+- **(task)** explain task cache keys by @jdx in [#11595](https://github.com/jdx/mise/pull/11595)
+- **(task)** report task cache miss reasons by @jdx in [#11597](https://github.com/jdx/mise/pull/11597)
+- **(task)** show resolved cache paths by @jdx in [#11599](https://github.com/jdx/mise/pull/11599)
+- **(task)** add cache explanation JSON output by @jdx in [#11600](https://github.com/jdx/mise/pull/11600)
+- **(task)** report task cache statistics by @jdx in [#11601](https://github.com/jdx/mise/pull/11601)
+- **(task)** inspect and clear task cache entries by @jdx in [#11604](https://github.com/jdx/mise/pull/11604)
+- **(task)** verify task cache artifact checksums by @jdx in [#11605](https://github.com/jdx/mise/pull/11605)
+- **(task)** add task cache size and age limits by @jdx in [#11610](https://github.com/jdx/mise/pull/11610)
+- **(task)** audit artifact cache declarations by @jdx in [#11617](https://github.com/jdx/mise/pull/11617)
+- **(task)** compose local and remote cache stores by @jdx in [#11622](https://github.com/jdx/mise/pull/11622)
+- **(task)** stream remote cache artifacts by @jdx in [#11623](https://github.com/jdx/mise/pull/11623)
+- **(task)** add remote cache access modes by @jdx in [#11624](https://github.com/jdx/mise/pull/11624)
+- **(task)** authenticate remote cache requests by @jdx in [#11625](https://github.com/jdx/mise/pull/11625)
+- **(task)** harden remote cache requests by @jdx in [#11626](https://github.com/jdx/mise/pull/11626)
+- **(task)** verify remote cache artifacts by @jdx in [#11627](https://github.com/jdx/mise/pull/11627)
+- **(task)** acquire remote cache OIDC credentials by @jdx in [#11653](https://github.com/jdx/mise/pull/11653)
+- **(upgrade)** add --no-prune to keep the version being replaced by @JamBalaya56562 in [#11639](https://github.com/jdx/mise/pull/11639)
+- **(vfox)** add lua archive and file operations by @jdx in [#11652](https://github.com/jdx/mise/pull/11652)
+
+### 🐛 Bug Fixes
+
+- **(brew)** relocate shebang executables with long prefixes by @Marukome0743 in [#11632](https://github.com/jdx/mise/pull/11632)
+- **(config)** don't pick a write target that config loading ignores by @JamBalaya56562 in [#11571](https://github.com/jdx/mise/pull/11571)
+- **(config)** let tool versions contain a colon by @JamBalaya56562 in [#11580](https://github.com/jdx/mise/pull/11580)
+- **(config)** apply ignore filters to --path <dir> write targets by @JamBalaya56562 in [#11609](https://github.com/jdx/mise/pull/11609)
+- **(config)** don't write the global config into a conf.d drop-in by @JamBalaya56562 in [#11633](https://github.com/jdx/mise/pull/11633)
+- **(install)** restore runtime symlinks after failures by @Marukome0743 in [#11579](https://github.com/jdx/mise/pull/11579)
+- **(pipx)** apply extras to git installs by @jdx in [#11586](https://github.com/jdx/mise/pull/11586)
+- **(prune)** exclude read-only shared installs by @Marukome0743 in [#11644](https://github.com/jdx/mise/pull/11644)
+- **(registry)** gate baked registry accessor in release builds by @jdx in [#11594](https://github.com/jdx/mise/pull/11594)
+- **(schema)** publish schemas with documentation by @jdx in [#11596](https://github.com/jdx/mise/pull/11596)
+- **(task)** skip dangling task symlinks by @Marukome0743 in [#11574](https://github.com/jdx/mise/pull/11574)
+- **(task)** serialize task cache entry access by @jdx in [#11606](https://github.com/jdx/mise/pull/11606)
+- **(task)** respect group boundaries in wildcards by @Marukome0743 in [#11581](https://github.com/jdx/mise/pull/11581)
+- **(task)** support shared pre and post dependencies by @Marukome0743 in [#11578](https://github.com/jdx/mise/pull/11578)
+- **(task)** reject task-list flags on subcommands by @jdx in [#11638](https://github.com/jdx/mise/pull/11638)
+- **(task)** clean abandoned cache writes by @jdx in [#11608](https://github.com/jdx/mise/pull/11608)
+- **(upgrade)** apply all config bumps by @Marukome0743 in [#11572](https://github.com/jdx/mise/pull/11572)
+
+### 🚜 Refactor
+
+- **(task)** extract versioned cache store by @jdx in [#11620](https://github.com/jdx/mise/pull/11620)
+
+### 📚 Documentation
+
+- **(install)** prefer official release binaries by @jdx in [#11615](https://github.com/jdx/mise/pull/11615)
+- **(npm)** clarify node dependency behavior by @jdx in [#11637](https://github.com/jdx/mise/pull/11637)
+- **(task)** define remote cache protocol by @jdx in [#11621](https://github.com/jdx/mise/pull/11621)
+- **(task)** define cache trust requirements by @jdx in [#11628](https://github.com/jdx/mise/pull/11628)
+- **(task)** remove completed cache parity tracker by @jdx in [#11650](https://github.com/jdx/mise/pull/11650)
+- **(troubleshooting)** offer shims for the Windows Path limit, and fix the test for it by @JamBalaya56562 in [#11642](https://github.com/jdx/mise/pull/11642)
+- fix dead gh CLI tool-stub example URL by @Bartok9 in [#11377](https://github.com/jdx/mise/pull/11377)
+- add trailing slash to node.mirror_url npmmirror example by @Bartok9 in [#11460](https://github.com/jdx/mise/pull/11460)
+
+### ⚡ Performance
+
+- **(task)** benchmark artifact cache phases by @jdx in [#11614](https://github.com/jdx/mise/pull/11614)
+
+### 🧪 Testing
+
+- **(task)** cover task cache restore on windows by @jdx in [#11612](https://github.com/jdx/mise/pull/11612)
+- **(task)** cover task cache portability edge cases by @jdx in [#11613](https://github.com/jdx/mise/pull/11613)
+- **(task)** add remote cache compatibility suite by @jdx in [#11629](https://github.com/jdx/mise/pull/11629)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by @renovate[bot] in [#11655](https://github.com/jdx/mise/pull/11655)
+
+### Chore
+
+- **(docs)** switch canonical domain to mise.jdx.dev by @jdx in [#11598](https://github.com/jdx/mise/pull/11598)
+
+### Ci
+
+- run perf jobs on bamboo by @jdx in [#11603](https://github.com/jdx/mise/pull/11603)
+- build perf binaries on bamboo by @jdx in [#11607](https://github.com/jdx/mise/pull/11607)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`d2lang/d2`](https://github.com/d2lang/d2)
+- [`linnea-bakshi/gha-doctor`](https://github.com/linnea-bakshi/gha-doctor)
+- [`protonpass/pass-cli`](https://github.com/protonpass/pass-cli)
+
+#### Updated Packages (4)
+
+- [`grafana/flint`](https://github.com/grafana/flint)
+- [`nodejs/node`](https://github.com/nodejs/node)
+- [`pnpm/pnpm`](https://github.com/pnpm/pnpm)
+- [`snyk/cli`](https://github.com/snyk/cli)
+
 ## [2026.8.0](https://github.com/jdx/mise/compare/v2026.7.18..v2026.8.0) - 2026-08-01
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.0"
+version = "2026.8.1"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.0"
+version = "2026.8.1"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.0 macos-arm64 (2026-08-01)
+2026.8.1 macos-arm64 (2026-08-03)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_0.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_1.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_0.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_1.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -p usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_0.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_1.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_0.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_1.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.0";
+  version = "2026.8.1";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "31.4k",
+      stars: "31.5k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.0
+Version: 2026.8.1
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.0"
+version: "2026.8.1"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "c294d12eaa19030a91d9e84801d1f4575a9e5f3b"
+  "tag": "3ffe9062426d630471a3c06912a5ddbcd854a9ee"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -31006,6 +31006,18 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: d2lang
+    repo_name: d2
+    aliases:
+      - name: terrastruct/d2
+    asset: d2-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: D2 is a modern diagram scripting language that turns text to diagrams
+    replacements:
+      darwin: macos
+    files:
+      - name: d2
+        src: d2-{{.Version}}/bin/d2
+  - type: github_release
     repo_owner: dadav
     repo_name: helm-schema
     description: Generate jsonschemas from helm charts
@@ -46329,6 +46341,16 @@ packages:
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:
@@ -62178,6 +62200,22 @@ packages:
           - goos: windows
             asset: linkerd2-cli-{{.Version}}-{{.OS}}
   - type: github_release
+    repo_owner: linnea-bakshi
+    repo_name: gha-doctor
+    description: "Diagnose GitHub Actions: flaky jobs, wasted minutes, slow steps, and anti-patterns"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gha-doctor_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: lintnet
     repo_name: lintnet
     aliases:
@@ -69947,25 +69985,35 @@ packages:
           windows: win
         files:
           - name: corepack
-            src: node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/corepack
+            src: "{{.AssetWithoutExt}}/bin/corepack"
           - name: node
-            src: node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/node
+            src: "{{.AssetWithoutExt}}/bin/node"
           - name: npm
-            src: node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/npm
+            src: "{{.AssetWithoutExt}}/bin/npm"
           - name: npx
-            src: node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/npx
+            src: "{{.AssetWithoutExt}}/bin/npx"
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            variants:
+              - key: libc
+                value: musl
+            type: http
+            url: https://unofficial-builds.nodejs.org/download/release/{{.Version}}/node-{{.Version}}-linux-{{.Arch}}-musl.tar.gz
           - goos: windows
             format: zip
             files:
               - name: corepack
-                src: node-{{.Version}}-{{.OS}}-{{.Arch}}/corepack.cmd
+                src: "{{.AssetWithoutExt}}/corepack.cmd"
               - name: node
-                src: node-{{.Version}}-{{.OS}}-{{.Arch}}/node
+                src: "{{.AssetWithoutExt}}/node"
               - name: npm
-                src: node-{{.Version}}-{{.OS}}-{{.Arch}}/npm.cmd
+                src: "{{.AssetWithoutExt}}/npm.cmd"
               - name: npx
-                src: node-{{.Version}}-{{.OS}}-{{.Arch}}/npx.cmd
+                src: "{{.AssetWithoutExt}}/npx.cmd"
       - version_constraint: "true"
         url: https://nodejs.org/dist/{{.Version}}/node-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -69975,21 +70023,31 @@ packages:
           windows: win
         files:
           - name: node
-            src: node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/node
+            src: "{{.AssetWithoutExt}}/bin/node"
           - name: npm
-            src: node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/npm
+            src: "{{.AssetWithoutExt}}/bin/npm"
           - name: npx
-            src: node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/npx
+            src: "{{.AssetWithoutExt}}/bin/npx"
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            variants:
+              - key: libc
+                value: musl
+            type: http
+            url: https://unofficial-builds.nodejs.org/download/release/{{.Version}}/node-{{.Version}}-linux-{{.Arch}}-musl.tar.gz
           - goos: windows
             format: zip
             files:
               - name: node
-                src: node-{{.Version}}-{{.OS}}-{{.Arch}}/node
+                src: "{{.AssetWithoutExt}}/node"
               - name: npm
-                src: node-{{.Version}}-{{.OS}}-{{.Arch}}/npm.cmd
+                src: "{{.AssetWithoutExt}}/npm.cmd"
               - name: npx
-                src: node-{{.Version}}-{{.OS}}-{{.Arch}}/npx.cmd
+                src: "{{.AssetWithoutExt}}/npx.cmd"
   - type: github_release
     repo_owner: nojima
     repo_name: httpie-go
@@ -75690,6 +75748,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
       - version_constraint: semver("<= 11.0.6")
@@ -75704,6 +75771,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:
@@ -75732,6 +75808,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:
@@ -76601,6 +76686,28 @@ packages:
     overrides:
       - goos: windows
         asset: protoc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+  - type: github_release
+    repo_owner: protonpass
+    repo_name: pass-cli
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: pass-cli-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            asset: pass-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements: {}
   - name: psastras/sarif-rs/clang-tidy-sarif
     type: github_release
     repo_owner: psastras
@@ -85465,6 +85572,25 @@ packages:
           - goos: linux
             goarch: arm64
             asset: snyk-{{.OS}}-{{.Arch}}
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            goarch: arm64
+            asset: snyk-alpine-{{.Arch}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            variants:
+              - key: libc
+                value: musl
+            replacements:
+              linux: alpine
           - goos: darwin
             goarch: arm64
             asset: snyk-{{.OS}}-{{.Arch}}
@@ -93240,16 +93366,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-  - type: github_release
-    repo_owner: terrastruct
-    repo_name: d2
-    asset: d2-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-    description: D2 is a modern diagram scripting language that turns text to diagrams
-    replacements:
-      darwin: macos
-    files:
-      - name: d2
-        src: d2-{{.Version}}/bin/d2
   - type: github_release
     repo_owner: terrastruct
     repo_name: tala


### PR DESCRIPTION
### 🚀 Features

- **(config)** accept --file on `mise use` and --path on `mise set` by @JamBalaya56562 in [#11577](https://github.com/jdx/mise/pull/11577)
- **(config)** accept --file on `mise unuse` and --path on `mise unset` by @JamBalaya56562 in [#11616](https://github.com/jdx/mise/pull/11616)
- **(config)** accept --file wherever `--path` names a config to write by @JamBalaya56562 in [#11631](https://github.com/jdx/mise/pull/11631)
- **(config)** accept --path on `mise config get` and `mise config set` by @JamBalaya56562 in [#11640](https://github.com/jdx/mise/pull/11640)
- **(env)** warn when PATH is long enough for cmd.exe to ignore by @JamBalaya56562 in [#11643](https://github.com/jdx/mise/pull/11643)
- **(task)** include global inputs in affected projects by @jdx in [#11587](https://github.com/jdx/mise/pull/11587)
- **(task)** attribute pnpm lockfile changes by @jdx in [#11589](https://github.com/jdx/mise/pull/11589)
- **(task)** run affected workspace tasks by @jdx in [#11590](https://github.com/jdx/mise/pull/11590)
- **(task)** explain affected task selection by @jdx in [#11591](https://github.com/jdx/mise/pull/11591)
- **(task)** add affected JSON output by @jdx in [#11593](https://github.com/jdx/mise/pull/11593)
- **(task)** explain task cache keys by @jdx in [#11595](https://github.com/jdx/mise/pull/11595)
- **(task)** report task cache miss reasons by @jdx in [#11597](https://github.com/jdx/mise/pull/11597)
- **(task)** show resolved cache paths by @jdx in [#11599](https://github.com/jdx/mise/pull/11599)
- **(task)** add cache explanation JSON output by @jdx in [#11600](https://github.com/jdx/mise/pull/11600)
- **(task)** report task cache statistics by @jdx in [#11601](https://github.com/jdx/mise/pull/11601)
- **(task)** inspect and clear task cache entries by @jdx in [#11604](https://github.com/jdx/mise/pull/11604)
- **(task)** verify task cache artifact checksums by @jdx in [#11605](https://github.com/jdx/mise/pull/11605)
- **(task)** add task cache size and age limits by @jdx in [#11610](https://github.com/jdx/mise/pull/11610)
- **(task)** audit artifact cache declarations by @jdx in [#11617](https://github.com/jdx/mise/pull/11617)
- **(task)** compose local and remote cache stores by @jdx in [#11622](https://github.com/jdx/mise/pull/11622)
- **(task)** stream remote cache artifacts by @jdx in [#11623](https://github.com/jdx/mise/pull/11623)
- **(task)** add remote cache access modes by @jdx in [#11624](https://github.com/jdx/mise/pull/11624)
- **(task)** authenticate remote cache requests by @jdx in [#11625](https://github.com/jdx/mise/pull/11625)
- **(task)** harden remote cache requests by @jdx in [#11626](https://github.com/jdx/mise/pull/11626)
- **(task)** verify remote cache artifacts by @jdx in [#11627](https://github.com/jdx/mise/pull/11627)
- **(task)** acquire remote cache OIDC credentials by @jdx in [#11653](https://github.com/jdx/mise/pull/11653)
- **(upgrade)** add --no-prune to keep the version being replaced by @JamBalaya56562 in [#11639](https://github.com/jdx/mise/pull/11639)
- **(vfox)** add lua archive and file operations by @jdx in [#11652](https://github.com/jdx/mise/pull/11652)

### 🐛 Bug Fixes

- **(brew)** relocate shebang executables with long prefixes by @Marukome0743 in [#11632](https://github.com/jdx/mise/pull/11632)
- **(config)** don't pick a write target that config loading ignores by @JamBalaya56562 in [#11571](https://github.com/jdx/mise/pull/11571)
- **(config)** let tool versions contain a colon by @JamBalaya56562 in [#11580](https://github.com/jdx/mise/pull/11580)
- **(config)** apply ignore filters to --path <dir> write targets by @JamBalaya56562 in [#11609](https://github.com/jdx/mise/pull/11609)
- **(config)** don't write the global config into a conf.d drop-in by @JamBalaya56562 in [#11633](https://github.com/jdx/mise/pull/11633)
- **(install)** restore runtime symlinks after failures by @Marukome0743 in [#11579](https://github.com/jdx/mise/pull/11579)
- **(pipx)** apply extras to git installs by @jdx in [#11586](https://github.com/jdx/mise/pull/11586)
- **(prune)** exclude read-only shared installs by @Marukome0743 in [#11644](https://github.com/jdx/mise/pull/11644)
- **(registry)** gate baked registry accessor in release builds by @jdx in [#11594](https://github.com/jdx/mise/pull/11594)
- **(schema)** publish schemas with documentation by @jdx in [#11596](https://github.com/jdx/mise/pull/11596)
- **(task)** skip dangling task symlinks by @Marukome0743 in [#11574](https://github.com/jdx/mise/pull/11574)
- **(task)** serialize task cache entry access by @jdx in [#11606](https://github.com/jdx/mise/pull/11606)
- **(task)** respect group boundaries in wildcards by @Marukome0743 in [#11581](https://github.com/jdx/mise/pull/11581)
- **(task)** support shared pre and post dependencies by @Marukome0743 in [#11578](https://github.com/jdx/mise/pull/11578)
- **(task)** reject task-list flags on subcommands by @jdx in [#11638](https://github.com/jdx/mise/pull/11638)
- **(task)** clean abandoned cache writes by @jdx in [#11608](https://github.com/jdx/mise/pull/11608)
- **(upgrade)** apply all config bumps by @Marukome0743 in [#11572](https://github.com/jdx/mise/pull/11572)

### 🚜 Refactor

- **(task)** extract versioned cache store by @jdx in [#11620](https://github.com/jdx/mise/pull/11620)

### 📚 Documentation

- **(install)** prefer official release binaries by @jdx in [#11615](https://github.com/jdx/mise/pull/11615)
- **(npm)** clarify node dependency behavior by @jdx in [#11637](https://github.com/jdx/mise/pull/11637)
- **(task)** define remote cache protocol by @jdx in [#11621](https://github.com/jdx/mise/pull/11621)
- **(task)** define cache trust requirements by @jdx in [#11628](https://github.com/jdx/mise/pull/11628)
- **(task)** remove completed cache parity tracker by @jdx in [#11650](https://github.com/jdx/mise/pull/11650)
- **(troubleshooting)** offer shims for the Windows Path limit, and fix the test for it by @JamBalaya56562 in [#11642](https://github.com/jdx/mise/pull/11642)
- fix dead gh CLI tool-stub example URL by @Bartok9 in [#11377](https://github.com/jdx/mise/pull/11377)
- add trailing slash to node.mirror_url npmmirror example by @Bartok9 in [#11460](https://github.com/jdx/mise/pull/11460)

### ⚡ Performance

- **(task)** benchmark artifact cache phases by @jdx in [#11614](https://github.com/jdx/mise/pull/11614)

### 🧪 Testing

- **(task)** cover task cache restore on windows by @jdx in [#11612](https://github.com/jdx/mise/pull/11612)
- **(task)** cover task cache portability edge cases by @jdx in [#11613](https://github.com/jdx/mise/pull/11613)
- **(task)** add remote cache compatibility suite by @jdx in [#11629](https://github.com/jdx/mise/pull/11629)

### 📦️ Dependency Updates

- lock file maintenance by @renovate[bot] in [#11655](https://github.com/jdx/mise/pull/11655)

### Chore

- **(docs)** switch canonical domain to mise.jdx.dev by @jdx in [#11598](https://github.com/jdx/mise/pull/11598)

### Ci

- run perf jobs on bamboo by @jdx in [#11603](https://github.com/jdx/mise/pull/11603)
- build perf binaries on bamboo by @jdx in [#11607](https://github.com/jdx/mise/pull/11607)

## 📦 Aqua Registry Updates

### New Packages (3)

- [`d2lang/d2`](https://github.com/d2lang/d2)
- [`linnea-bakshi/gha-doctor`](https://github.com/linnea-bakshi/gha-doctor)
- [`protonpass/pass-cli`](https://github.com/protonpass/pass-cli)

### Updated Packages (4)

- [`grafana/flint`](https://github.com/grafana/flint)
- [`nodejs/node`](https://github.com/nodejs/node)
- [`pnpm/pnpm`](https://github.com/pnpm/pnpm)
- [`snyk/cli`](https://github.com/snyk/cli)