### PR TITLE
fix(registry): gate baked registry accessor in release builds

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -25,6 +25,7 @@ use url::Url;
 // the registry is generated from registry/ in the project root
 static BAKED_REGISTRY: Registry = include!(concat!(env!("OUT_DIR"), "/registry.rs"));
 
+#[cfg(debug_assertions)]
 pub(crate) fn baked_registry() -> &'static Registry {
     &BAKED_REGISTRY
 }


### PR DESCRIPTION
## Summary
- compile `baked_registry()` only when debug assertions are enabled
- align the helper with its sole consumer, the debug-only `render-help` command

## Root cause
Release builds exclude `render-help` but still compiled its dedicated registry accessor, causing a `dead_code` warning.

## Impact
Release builds no longer emit the unused `baked_registry` warning. Runtime registry behavior is unchanged.

## Validation
- `mise run lint-fix`
- `cargo check --release --all-features`
- `cargo check --all-features`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time cfg only; no change to release runtime registry behavior.
> 
> **Overview**
> Adds **`#[cfg(debug_assertions)]`** around **`baked_registry()`** so release builds no longer compile that helper.
> 
> The function is only used by the debug-only **`render-help`** flow (idiomatic version files table). **`REGISTRY`** and **`BAKED_REGISTRY`** are unchanged; this is a compile-time cleanup to silence **`dead_code`** in **`cargo check --release`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02302df959cbd0168604ee8cadc2c29065dd2f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced release-build overhead by excluding development-only registry data from production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->