### PR TITLE
feat(task): explain task cache keys

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -92,7 +92,7 @@ outside this tracker.
 
 ## Inspection and diagnostics
 
-- [ ] Explain the inputs that produced a task's cache key
+- [x] Explain the inputs that produced a task's cache key
 - [ ] Report the reason for each cache miss
 - [ ] Show resolved cache inputs and outputs
 - [ ] Add machine-readable cache details to dry-run or task-info output

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -205,6 +205,10 @@ Set task output cache access for this run
 
 **Default:** `read-write`
 
+### `--task-cache-explain`
+
+Explain the inputs that produced each task's output cache key
+
 ### `--timeout <TIMEOUT>`
 
 Timeout for the task to complete

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -219,6 +219,10 @@ Set task output cache access for this run
 
 **Default:** `read-write`
 
+### `--task-cache-explain`
+
+Explain the inputs that produced each task's output cache key
+
 ### `--timeout <TIMEOUT>`
 
 Timeout for the task to complete

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -696,6 +696,17 @@ the values (or absence) of variables named in `cache.env`, command-input output,
 versions, dependency artifact keys, and the operating system and architecture. Variables inherited
 from the ambient process are ignored unless listed in `cache.env`.
 
+Use `mise run --task-cache-explain <task>` to print a deterministic breakdown of the inputs that
+produced the cache key without printing the aggregate key itself. Environment variables are
+identified only by name and whether they are set, while mise variables are identified only by name,
+so the explanation does not publish their contents or per-value digests. Other potentially
+secret-derived inputs—including source contents, dependency keys, command output, task definitions,
+and resolved tool versions—are reported only by category and count. The target platform is listed
+directly.
+Combine the flag with `--dry-run` to inspect the key inputs without executing, restoring, or storing
+the task. Cache command inputs still run when the explanation is explicitly requested because their
+output hashes are part of the key.
+
 `task_config.global_env` adds ambient variable names to every enabled task cache in the config
 scope, including tasks with a task-local `cache` value. Unlike the default values under
 `task_config.cache`, these names always compose with task-local `cache.env`.

--- a/e2e/tasks/test_task_affected
+++ b/e2e/tasks/test_task_affected
@@ -131,6 +131,23 @@ assert "sort affected.log" $'app\ncore\nother\nother-prepare'
 mise run --affected --affected-base HEAD --affected-head HEAD --jobs 1 build
 assert "cat affected.log" ""
 
+# A pnpm lockfile in a workspace without Node projects falls back to ordinary
+# changed-path mapping instead of being swallowed as an empty provider result.
+cat <<'EOF' >pnpm-lock.yaml
+lockfileVersion: '9.0'
+EOF
+git add pnpm-lock.yaml
+git commit -qm add-unrelated-pnpm-lockfile
+cat <<'EOF' >pnpm-lock.yaml
+lockfileVersion: '9.1'
+EOF
+git add pnpm-lock.yaml
+git commit -qm change-unrelated-pnpm-lockfile
+: >affected.log
+output=$(mise run --affected --affected-explain --jobs 1 build)
+assert_contains "echo \"$output\"" "workspace-global path: pnpm-lock.yaml"
+assert "sort affected.log" $'app\ncore\nother\nother-prepare'
+
 mkdir node-case
 cd node-case
 export AFFECTED_LOG="$PWD/affected.log"

--- a/e2e/tasks/test_task_artifact_cache
+++ b/e2e/tasks/test_task_artifact_cache
@@ -24,6 +24,17 @@ PROFILE=debug mise run build
 assert "wc -l < runs.txt | tr -d ' '" "1"
 assert "cat dist/result.txt" "debug:one"
 
+# Cache explanations show the contributing input groups without exposing values.
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "cache key inputs:"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "task definition:"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "sources:"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "environment PROFILE: set"
+assert_not_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "environment PROFILE: debug"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "platform:"
+assert_not_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "cache key:"
+assert_contains "PROFILE=debug mise run --dry-run --task-cache-explain build 2>&1" "cache key inputs:"
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
 # Existing fresh outputs use the normal fast freshness path.
 assert_contains "PROFILE=debug mise run build 2>&1" "sources up-to-date, skipping"
 assert "wc -l < runs.txt | tr -d ' '" "1"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3154,6 +3154,9 @@ Set task output cache access for this run
 \fIDefault: \fRread\-write
 .RE
 .TP
+\fB\-\-task\-cache\-explain\fR
+Explain the inputs that produced each task's output cache key
+.TP
 \fB\-\-timeout\fR \fI<TIMEOUT>\fR
 Timeout for the task to complete
 e.g.: 30s, 5m
@@ -3965,6 +3968,9 @@ Set task output cache access for this run
 .RS
 \fIDefault: \fRread\-write
 .RE
+.TP
+\fB\-\-task\-cache\-explain\fR
+Explain the inputs that produced each task's output cache key
 .TP
 \fB\-\-timeout\fR \fI<TIMEOUT>\fR
 Timeout for the task to complete

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3160,6 +3160,7 @@ Set task output cache access for this run
             choices read-write read-only write-only off local-only
         }
     }
+    flag --task-cache-explain help="Explain the inputs that produced each task's output cache key"
     flag --timeout help=#"""
 Timeout for the task to complete
 e.g.: 30s, 5m
@@ -4010,6 +4011,7 @@ Set task output cache access for this run
                 choices read-write read-only write-only off local-only
             }
         }
+        flag --task-cache-explain help="Explain the inputs that produced each task's output cache key"
         flag --timeout help=#"""
 Timeout for the task to complete
 e.g.: 30s, 5m

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -924,6 +924,7 @@ impl Bootstrap {
             executor: None,
             no_cache: Default::default(),
             task_cache: crate::task::TaskCacheMode::from_env()?,
+            task_cache_explain: false,
             timeout: None,
             skip_deps: false,
             // a dry run must not auto-install tools before the (not actually

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -800,6 +800,7 @@ impl Cli {
                         executor: None,
                         no_cache: Default::default(),
                         task_cache: crate::task::TaskCacheMode::from_env()?,
+                        task_cache_explain: false,
                         timeout: None,
                         skip_deps: false,
                         skip_tools: false,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -253,6 +253,10 @@ pub struct Run {
     )]
     pub task_cache: TaskCacheMode,
 
+    /// Explain the inputs that produced each task's output cache key
+    #[clap(long, verbatim_doc_comment)]
+    pub task_cache_explain: bool,
+
     /// Timeout for the task to complete
     /// e.g.: 30s, 5m
     #[clap(long, verbatim_doc_comment)]
@@ -329,10 +333,13 @@ async fn get_affected_task_list(
     let mut comparison_base: Option<String> = None;
 
     for path in changed_paths {
-        if graph
-            .affected_projects_for_lockfile(&providers, &path, None, None)?
-            .is_none()
-        {
+        let Some(lockfile_candidates) =
+            graph.affected_projects_for_lockfile(&providers, &path, None, None)?
+        else {
+            regular_paths.insert(path);
+            continue;
+        };
+        if lockfile_candidates.is_empty() {
             regular_paths.insert(path);
             continue;
         }
@@ -1168,6 +1175,7 @@ impl Run {
             dry_run: self.dry_run,
             skip_deps: self.skip_deps,
             task_cache: self.task_cache,
+            task_cache_explain: self.task_cache_explain,
             sandbox: crate::sandbox::SandboxConfig::from_settings_and_cli(
                 &Settings::get().sandbox,
                 self.deny_all,

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -124,7 +124,21 @@ pub struct TaskArtifactCache {
     root: PathBuf,
     cache_dir: PathBuf,
     key: String,
+    explanation: Option<TaskCacheKeyExplanation>,
     state_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) struct TaskCacheKeyExplanation {
+    format: u8,
+    source_count: usize,
+    dependency_count: usize,
+    environment: BTreeMap<String, bool>,
+    command_input_count: usize,
+    vars: Vec<String>,
+    tool_count: usize,
+    os: &'static str,
+    arch: &'static str,
 }
 
 pub(crate) struct TaskArtifactCacheBuilder {
@@ -140,6 +154,7 @@ pub(crate) struct TaskCacheContext<'a> {
     pub(crate) declared_env: &'a [(String, String)],
     pub(crate) dependency_keys: &'a [String],
     pub(crate) command_inputs: Vec<CommandInput>,
+    pub(crate) explain: bool,
 }
 
 impl TaskArtifactCache {
@@ -190,6 +205,7 @@ impl TaskArtifactCacheBuilder {
             declared_env,
             dependency_keys,
             command_inputs,
+            explain,
         } = ctx;
         let Self { root, inputs } = self;
         let mut environment = declared_env
@@ -213,6 +229,7 @@ impl TaskArtifactCacheBuilder {
             .map(|(_, tv)| tv.to_string())
             .collect::<Vec<_>>();
         tools.sort();
+        let source_count = inputs.source_paths.len();
         let material = CacheKeyMaterial {
             format: CACHE_FORMAT_VERSION,
             task: &task.name,
@@ -232,6 +249,25 @@ impl TaskArtifactCacheBuilder {
         };
         let encoded = serde_json::to_vec(&material)?;
         let key = hash::hash_blake3_to_str(std::str::from_utf8(&encoded)?);
+        let explanation = if explain {
+            Some(TaskCacheKeyExplanation {
+                format: material.format,
+                source_count,
+                dependency_count: material.dependency_keys.len(),
+                environment: material
+                    .environment
+                    .iter()
+                    .map(|(name, value)| (name.clone(), value.is_some()))
+                    .collect(),
+                command_input_count: material.command_inputs.len(),
+                vars: material.vars.keys().cloned().collect(),
+                tool_count: material.tools.len(),
+                os: material.os,
+                arch: material.arch,
+            })
+        } else {
+            None
+        };
         let state_identity = hash::hash_blake3_to_str(&format!(
             "{}\0{}\0{}",
             root.display(),
@@ -245,6 +281,7 @@ impl TaskArtifactCacheBuilder {
             root,
             cache_dir: task_cache_dir(),
             key,
+            explanation,
             state_path,
         })
     }
@@ -253,6 +290,10 @@ impl TaskArtifactCacheBuilder {
 impl TaskArtifactCache {
     pub fn key(&self) -> &str {
         &self.key
+    }
+
+    pub(crate) fn explanation(&self) -> Option<&TaskCacheKeyExplanation> {
+        self.explanation.as_ref()
     }
 
     pub(crate) fn current_output(&self) -> Option<Vec<TaskCacheOutput>> {
@@ -419,6 +460,27 @@ impl TaskArtifactCache {
             bail!("task cache manifest does not match cache key");
         }
         Ok(manifest)
+    }
+}
+
+impl TaskCacheKeyExplanation {
+    pub(crate) fn lines(&self) -> Vec<String> {
+        let mut lines = vec![
+            "cache key inputs:".to_string(),
+            format!("  format: {}", self.format),
+            "  task definition: included".to_string(),
+            format!("  sources: {} files", self.source_count),
+            format!("  dependencies: {} artifact keys", self.dependency_count),
+        ];
+        lines.extend(self.environment.iter().map(|(name, is_set)| {
+            let state = if *is_set { "set" } else { "unset" };
+            format!("  environment {name}: {state}")
+        }));
+        lines.push(format!("  command inputs: {}", self.command_input_count));
+        lines.extend(self.vars.iter().map(|name| format!("  variable: {name}")));
+        lines.push(format!("  tools: {} resolved versions", self.tool_count));
+        lines.push(format!("  platform: {}-{}", self.os, self.arch));
+        lines
     }
 }
 
@@ -840,6 +902,32 @@ mod tests {
         assert_eq!(config.env, ["PROFILE"]);
         assert_eq!(config.command_inputs, ["node --version"]);
         assert!(toml::from_str::<TaskCacheConfig>("remote = true").is_err());
+    }
+
+    #[test]
+    fn cache_explanation_omits_environment_and_variable_values() {
+        let explanation = TaskCacheKeyExplanation {
+            format: 2,
+            source_count: 3,
+            dependency_count: 1,
+            environment: BTreeMap::from([("MISSING".into(), false), ("TOKEN".into(), true)]),
+            command_input_count: 2,
+            vars: vec!["password".into()],
+            tool_count: 4,
+            os: "linux",
+            arch: "x86_64",
+        };
+
+        let output = explanation.lines().join("\n");
+        assert!(output.contains("environment TOKEN: set"));
+        assert!(output.contains("environment MISSING: unset"));
+        assert!(output.contains("variable: password"));
+        assert!(output.contains("sources: 3 files"));
+        assert!(output.contains("dependencies: 1 artifact keys"));
+        assert!(output.contains("command inputs: 2"));
+        assert!(output.contains("tools: 4 resolved versions"));
+        assert!(!output.contains("secret"));
+        assert!(!output.contains("hunter2"));
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -209,6 +209,7 @@ pub struct TaskExecutorConfig {
     pub dry_run: bool,
     pub skip_deps: bool,
     pub task_cache: TaskCacheMode,
+    pub task_cache_explain: bool,
     /// CLI-level sandbox overrides (merged with task-level sandbox config)
     pub sandbox: crate::sandbox::SandboxConfig,
 }
@@ -230,6 +231,7 @@ pub struct TaskExecutor {
     pub dry_run: bool,
     pub skip_deps: bool,
     pub task_cache: TaskCacheMode,
+    pub task_cache_explain: bool,
     pub sandbox: crate::sandbox::SandboxConfig,
 }
 
@@ -259,6 +261,7 @@ impl TaskExecutor {
             dry_run: config.dry_run,
             skip_deps: config.skip_deps,
             task_cache: config.task_cache,
+            task_cache_explain: config.task_cache_explain,
             sandbox: config.sandbox,
         }
     }
@@ -607,8 +610,8 @@ impl TaskExecutor {
             && task.cache.as_ref().is_some_and(|cache| cache.enabled)
         {
             match TaskArtifactCache::prepare(task, config, self.dry_run).await? {
-                Some(_) if self.dry_run => None,
-                Some(_) if self.raw(Some(task)) => {
+                Some(_) if self.dry_run && !self.task_cache_explain => None,
+                Some(_) if self.raw(Some(task)) && !self.task_cache_explain => {
                     warn!(
                         "task {} artifact caching disabled for raw or interactive execution",
                         task.name
@@ -628,9 +631,26 @@ impl TaskExecutor {
                             declared_env: &task_env,
                             dependency_keys: &dependency_state.cache_keys,
                             command_inputs,
+                            explain: self.task_cache_explain,
                         })
                         .await?;
-                    let current_output = if self.task_cache.reads()
+                    if !self.quiet(Some(task))
+                        && let Some(explanation) = cache.explanation()
+                    {
+                        for line in explanation.lines() {
+                            self.eprint(task, &prefix, &line);
+                        }
+                    }
+                    let raw = self.raw(Some(task));
+                    if raw {
+                        warn!(
+                            "task {} artifact caching disabled for raw or interactive execution",
+                            task.name
+                        );
+                    }
+                    let bypass_cache = self.dry_run || raw;
+                    let current_output = if !bypass_cache
+                        && self.task_cache.reads()
                         && !self.force
                         && !dependency_state.any_unkeyed_did_work
                         && (task.outputs.is_no_files() || sources_are_fresh(task, config).await?)
@@ -650,7 +670,8 @@ impl TaskExecutor {
                             cache_key: Some(cache.key().to_string()),
                         });
                     }
-                    if self.task_cache.reads()
+                    if !bypass_cache
+                        && self.task_cache.reads()
                         && !self.force
                         && !dependency_state.any_unkeyed_did_work
                     {
@@ -690,7 +711,7 @@ impl TaskExecutor {
                             });
                         }
                     }
-                    Some(cache)
+                    if bypass_cache { None } else { Some(cache) }
                 }
                 None => None,
             }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary

- add `mise run --task-cache-explain <task>`
- report cache-key input categories, counts, environment names/presence, variable names, and platform without emitting secret-derived hashes
- support explicit cache explanations during dry-run and raw execution while still bypassing cache restore/write behavior
- make pnpm lockfile handling fall back to ordinary affected-path mapping when the graph has no Node projects
- compute explanation details only when requested
- update generated CLI docs, the cache guide, tests, and the parity tracker

## Why

Task output cache keys were opaque, which made it difficult to understand what contributes to them. The explanation is deliberately structural: potentially secret-bearing values and hashes are unavailable to the renderer. Review also identified that dry-run skipped explanations and that an empty pnpm provider result could swallow a changed path; both are corrected here because the affected-task prerequisite PRs have merged.

## User impact

Cache-enabled tasks can inspect key inputs without executing, restoring, or storing task output. Ordinary runs do not pay diagnostic construction costs. A pnpm lockfile in a non-Node workspace now affects projects through the normal workspace-global path rules.

## Validation

- `cargo test cache_explanation_omits_environment_and_variable_values -- --nocapture`
- `cargo test cli::tests::test_subcommands_are_sorted -- --nocapture`
- `mise run test:e2e e2e/tasks/test_task_affected e2e/tasks/test_task_artifact_cache`
- `mise run render`
- `mise run lint`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task cache key construction and affected-project lockfile routing; behavior is guarded by an opt-in flag and e2e tests, but cache and monorepo selection paths are user-visible when enabled.
> 
> **Overview**
> Adds **`mise run --task-cache-explain`** so cache-enabled tasks can print a structural breakdown of what feeds the output cache key—categories, counts, env/var **names** and set/unset state, and platform—without emitting the aggregate key or secret-bearing hashes.
> 
> The executor builds that explanation only when the flag is set, prints it before cache logic, and still **skips restore/write** under `--dry-run` or raw/interactive runs while allowing explain (including running cache **command inputs** when needed for the key). CLI wiring, generated docs, task-configuration guide, e2e coverage, and the parity tracker are updated accordingly.
> 
> **`--affected`** lockfile handling now treats an **empty** provider attribution as “not handled” and falls back to ordinary changed-path / workspace-global mapping, so an unrelated `pnpm-lock.yaml` in a non-Node workspace is no longer swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 864c2703ecfd82269bac21d6cea1dedd5808aeaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--task-cache-explain` to `mise run` and `mise tasks run`.
  - Displays task cache keys and a deterministic breakdown of their inputs, including sources, dependencies, tools, platform, and command outputs.
  - Redacts environment and variable values while preserving useful cache details.
  - Supports explanations during dry runs without executing tasks.

- **Bug Fixes**
  - Improved affected-project detection for pnpm lockfile changes in Cargo workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->