### PR TITLE
feat(task): report task cache miss reasons

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -93,7 +93,7 @@ outside this tracker.
 ## Inspection and diagnostics
 
 - [x] Explain the inputs that produced a task's cache key
-- [ ] Report the reason for each cache miss
+- [x] Report the reason for each cache miss
 - [ ] Show resolved cache inputs and outputs
 - [ ] Add machine-readable cache details to dry-run or task-info output
 - [ ] Report hit rate, bytes restored, and time saved

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -744,6 +744,11 @@ Cache entries are stored under `MISE_CACHE_DIR/task-artifacts/v2` by default. Se
 manual and automatic cache pruning. Only successful task runs are cached. Cache read/write failures
 are treated as misses and never turn a successful task run into a failure.
 
+When a cache-enabled task executes instead of restoring a result, mise reports the reason: no
+matching entry, a corrupt entry, forced execution, disabled reads, or a dependency that completed
+without a stable cache key. Raw and dry-run cache bypasses retain their existing warning or preview
+behavior and are not reported as cache misses.
+
 Stdout and stderr are stored as ordered, redacted streams and replayed using the output mode selected
 for the cache hit. Prefix, interleave, keep-order, timed, replacing, quiet, silent, and per-stream
 silence therefore apply to replayed output just as they do to live output. Raw and interactive tasks

--- a/e2e/tasks/test_task_artifact_cache
+++ b/e2e/tasks/test_task_artifact_cache
@@ -20,7 +20,7 @@ EOF
 
 printf 'one\n' >input.txt
 
-PROFILE=debug mise run build
+assert_contains "PROFILE=debug mise run build 2>&1" "cache miss: no matching cache entry"
 assert "wc -l < runs.txt | tr -d ' '" "1"
 assert "cat dist/result.txt" "debug:one"
 

--- a/e2e/tasks/test_task_artifact_cache_dependencies
+++ b/e2e/tasks/test_task_artifact_cache_dependencies
@@ -112,7 +112,7 @@ assert "cat app-dist/result.txt" $'lib-one\napp'
 
 # A dependency that executes without a stable cache identity still forces
 # conservative downstream execution.
-mise run consume
+assert_contains "mise run consume 2>&1" "cache miss: dependency completed without a cache key"
 assert "wc -l < prepare-runs.txt | tr -d ' '" "1"
 assert "wc -l < consume-runs.txt | tr -d ' '" "1"
 printf 'prepare-two\n' >prepare.txt

--- a/e2e/tasks/test_task_artifact_cache_modes
+++ b/e2e/tasks/test_task_artifact_cache_modes
@@ -38,7 +38,9 @@ assert "wc -l < runs.txt | tr -d ' '" "2"
 
 # Read-only misses execute without publishing a new artifact. Naked task
 # invocation must honor MISE_TASK_CACHE as well as `mise run`.
-PROFILE=read-only mise run --task-cache read-only build
+assert_contains \
+  "PROFILE=read-only mise run --task-cache read-only build 2>&1" \
+  "cache miss: no matching cache entry"
 assert "wc -l < runs.txt | tr -d ' '" "3"
 rm -rf dist
 MISE_TASK_CACHE=read-only PROFILE=read-only mise build
@@ -51,22 +53,25 @@ rm -rf dist
 assert_not_contains \
   "PROFILE=write-only mise run --task-cache write-only build 2>&1" \
   "restored outputs from cache"
-assert "wc -l < runs.txt | tr -d ' '" "6"
+assert_contains \
+  "PROFILE=write-only mise run --task-cache write-only build 2>&1" \
+  "cache miss: cache reads are disabled"
+assert "wc -l < runs.txt | tr -d ' '" "7"
 
 # Local-only mode can restore the artifact published by write-only mode.
 rm -rf dist
 assert_contains \
   "PROFILE=write-only mise run --task-cache local-only build 2>&1" \
   "restored outputs from cache"
-assert "wc -l < runs.txt | tr -d ' '" "6"
+assert "wc -l < runs.txt | tr -d ' '" "7"
 
 # Off mode neither reads nor writes task output artifacts.
 rm -rf dist
 PROFILE=off mise run --task-cache off build
-assert "wc -l < runs.txt | tr -d ' '" "7"
+assert "wc -l < runs.txt | tr -d ' '" "8"
 rm -rf dist
 PROFILE=off mise run --task-cache off build
-assert "wc -l < runs.txt | tr -d ' '" "8"
+assert "wc -l < runs.txt | tr -d ' '" "9"
 
 assert_fail_contains \
   "mise run --task-cache invalid build 2>&1" \

--- a/e2e/tasks/test_task_artifact_cache_resilience
+++ b/e2e/tasks/test_task_artifact_cache_resilience
@@ -35,7 +35,7 @@ printf 'stdin\n' >stdin.txt
 mise run build
 manifest="$(find "$MISE_CACHE_DIR/task-artifacts/v2" -type f -name '*.json' -print -quit)"
 printf 'invalid manifest\n' >"$manifest"
-mise run build
+assert_contains "mise run build 2>&1" "cache miss: cache entry was corrupt"
 assert "wc -l < runs.txt | tr -d ' '" "2"
 
 # Capturing output for a cacheable interleave task must not disconnect stdin.

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -14,6 +14,7 @@ use ignore::overrides::Override;
 use jdx_tar::{Builder, EntryType, Header};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::fs::{self, File};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -118,6 +119,31 @@ struct CacheManifest {
 pub(crate) enum TaskCacheOutput {
     Stdout(String),
     Stderr(String),
+}
+
+pub(crate) enum TaskCacheRestore {
+    Hit(Vec<TaskCacheOutput>),
+    Miss(TaskCacheMissReason),
+}
+
+pub(crate) enum TaskCacheMissReason {
+    CorruptEntry,
+    DependencyWithoutKey,
+    EntryNotFound,
+    Forced,
+    ReadDisabled,
+}
+
+impl fmt::Display for TaskCacheMissReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::CorruptEntry => "cache entry was corrupt",
+            Self::DependencyWithoutKey => "dependency completed without a cache key",
+            Self::EntryNotFound => "no matching cache entry",
+            Self::Forced => "forced execution",
+            Self::ReadDisabled => "cache reads are disabled",
+        })
+    }
 }
 
 pub struct TaskArtifactCache {
@@ -317,10 +343,10 @@ impl TaskArtifactCache {
         file::write(&self.state_path, &self.key)
     }
 
-    pub(crate) fn restore(&self, task: &Task) -> Result<Option<Vec<TaskCacheOutput>>> {
+    pub(crate) fn restore(&self, task: &Task) -> Result<TaskCacheRestore> {
         let (archive_path, manifest_path) = self.paths();
         if !manifest_path.is_file() {
-            return Ok(None);
+            return Ok(TaskCacheRestore::Miss(TaskCacheMissReason::EntryNotFound));
         }
         let restore = || -> Result<Vec<TaskCacheOutput>> {
             let manifest = self.read_manifest()?;
@@ -392,12 +418,12 @@ impl TaskArtifactCache {
         };
 
         match restore() {
-            Ok(output) => Ok(Some(output)),
+            Ok(output) => Ok(TaskCacheRestore::Hit(output)),
             Err(err) => {
                 warn!("ignoring corrupt task cache entry {}: {err}", self.key);
                 let _ = file::remove_file(&archive_path);
                 let _ = file::remove_file(&manifest_path);
-                Ok(None)
+                Ok(TaskCacheRestore::Miss(TaskCacheMissReason::CorruptEntry))
             }
         }
     }
@@ -928,6 +954,27 @@ mod tests {
         assert!(output.contains("tools: 4 resolved versions"));
         assert!(!output.contains("secret"));
         assert!(!output.contains("hunter2"));
+    }
+
+    #[test]
+    fn cache_miss_reasons_are_human_readable() {
+        assert_eq!(
+            TaskCacheMissReason::CorruptEntry.to_string(),
+            "cache entry was corrupt"
+        );
+        assert_eq!(
+            TaskCacheMissReason::DependencyWithoutKey.to_string(),
+            "dependency completed without a cache key"
+        );
+        assert_eq!(
+            TaskCacheMissReason::EntryNotFound.to_string(),
+            "no matching cache entry"
+        );
+        assert_eq!(TaskCacheMissReason::Forced.to_string(), "forced execution");
+        assert_eq!(
+            TaskCacheMissReason::ReadDisabled.to_string(),
+            "cache reads are disabled"
+        );
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -6,7 +6,9 @@ use crate::env_diff::EnvDiff;
 use crate::file::{can_execute_directly, display_path, replace_path};
 use crate::sandbox::SandboxConfig;
 use crate::task::TaskArtifactCache;
-use crate::task::task_cache::{CommandInput, TaskCacheContext};
+use crate::task::task_cache::{
+    CommandInput, TaskCacheContext, TaskCacheMissReason, TaskCacheRestore,
+};
 use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_list::split_task_spec;
 use crate::task::task_output::{TaskOutput, trunc};
@@ -670,48 +672,60 @@ impl TaskExecutor {
                             cache_key: Some(cache.key().to_string()),
                         });
                     }
-                    if !bypass_cache
-                        && self.task_cache.reads()
-                        && !self.force
-                        && !dependency_state.any_unkeyed_did_work
-                    {
-                        Self::check_interruption(allow_during_interruption)?;
-                        if let Some(output) = cache.restore(task)? {
-                            if !self.quiet(Some(task)) {
-                                let kind = if task.outputs.is_no_files() {
-                                    "result"
-                                } else {
-                                    "outputs"
-                                };
-                                self.eprint(
-                                    task,
-                                    &prefix,
-                                    &format!("restored {kind} from cache {}", cache.key()),
-                                );
+                    if bypass_cache {
+                        None
+                    } else {
+                        let miss_reason = if !self.task_cache.reads() {
+                            TaskCacheMissReason::ReadDisabled
+                        } else if self.force {
+                            TaskCacheMissReason::Forced
+                        } else if dependency_state.any_unkeyed_did_work {
+                            TaskCacheMissReason::DependencyWithoutKey
+                        } else {
+                            Self::check_interruption(allow_during_interruption)?;
+                            match cache.restore(task)? {
+                                TaskCacheRestore::Hit(output) => {
+                                    if !self.quiet(Some(task)) {
+                                        let kind = if task.outputs.is_no_files() {
+                                            "result"
+                                        } else {
+                                            "outputs"
+                                        };
+                                        self.eprint(
+                                            task,
+                                            &prefix,
+                                            &format!("restored {kind} from cache {}", cache.key()),
+                                        );
+                                    }
+                                    self.output_handler
+                                        .replay_cached_output(task, &prefix, &output);
+                                    if let Err(err) = save_checksum(task, config).await {
+                                        warn!(
+                                            "task {} artifact cache checksum update failed: {err}",
+                                            task.name
+                                        );
+                                    }
+                                    if self.task_cache.writes()
+                                        && let Err(err) = cache.mark_current()
+                                    {
+                                        warn!(
+                                            "task {} artifact cache state update failed: {err}",
+                                            task.name
+                                        );
+                                    }
+                                    return Ok(TaskRunOutcome {
+                                        did_work: true,
+                                        cache_key: Some(cache.key().to_string()),
+                                    });
+                                }
+                                TaskCacheRestore::Miss(reason) => reason,
                             }
-                            self.output_handler
-                                .replay_cached_output(task, &prefix, &output);
-                            if let Err(err) = save_checksum(task, config).await {
-                                warn!(
-                                    "task {} artifact cache checksum update failed: {err}",
-                                    task.name
-                                );
-                            }
-                            if self.task_cache.writes()
-                                && let Err(err) = cache.mark_current()
-                            {
-                                warn!(
-                                    "task {} artifact cache state update failed: {err}",
-                                    task.name
-                                );
-                            }
-                            return Ok(TaskRunOutcome {
-                                did_work: true,
-                                cache_key: Some(cache.key().to_string()),
-                            });
+                        };
+                        if !self.quiet(Some(task)) {
+                            self.eprint(task, &prefix, &format!("cache miss: {miss_reason}"));
                         }
+                        Some(cache)
                     }
-                    if bypass_cache { None } else { Some(cache) }
                 }
                 None => None,
             }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary

- report why a cache-enabled task executes instead of restoring a result
- distinguish missing and corrupt entries, forced execution, disabled reads, and dependencies without stable cache keys
- preserve existing hit, raw, dry-run, quiet, and silent behavior
- add focused unit and e2e coverage for each miss category
- update cache documentation and the parity tracker

## Why

Cache misses previously fell through to normal task execution without explaining why. That made expected bypasses and actual lookup misses indistinguishable during cache debugging.

## User impact

Cache-enabled task output now includes concise messages such as `cache miss: no matching cache entry`. Cache hits and explicitly bypassed raw or dry-run executions retain their existing output.

## Validation

- `cargo test cache_miss_reasons_are_human_readable -- --nocapture`
- `cargo test cli::tests::test_subcommands_are_sorted -- --nocapture`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache`
- `mise run render`
- `mise run lint`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics and control-flow refactor on the experimental task cache path; hit/restore behavior and bypass modes are explicitly preserved.
> 
> **Overview**
> When a cache-enabled task runs instead of restoring an artifact, mise now prints a **`cache miss: …`** line explaining why.
> 
> **Restore** returns a typed hit or miss (`TaskCacheRestore` / `TaskCacheMissReason`) instead of `Option`, covering missing entries, corrupt artifacts, **`--force`**, read-disabled modes (e.g. write-only), and dependencies that finished without a stable cache key. Raw and dry-run bypasses are unchanged and are not labeled as misses.
> 
> Docs, the parity tracker, unit tests for message text, and e2e assertions cover the main miss paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a1313b09017ef165471ccdb9a12920b5433fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear diagnostics explaining why task artifact caches were missed, including missing, corrupt, disabled, forced, or unstable entries.
  * Added cache-key explanations covering dependencies, environment settings, commands, tools, and platform details.
* **Documentation**
  * Documented cache-miss reasons and behavior for raw and dry-run executions.
* **Tests**
  * Expanded coverage for cache misses, corruption, cache modes, and unstable dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->