### PR TITLE
feat(task): show resolved cache paths

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -94,7 +94,7 @@ outside this tracker.
 
 - [x] Explain the inputs that produced a task's cache key
 - [x] Report the reason for each cache miss
-- [ ] Show resolved cache inputs and outputs
+- [x] Show resolved cache inputs and outputs
 - [ ] Add machine-readable cache details to dry-run or task-info output
 - [ ] Report hit rate, bytes restored, and time saved
 - [ ] Add per-task cache inspection and deletion

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -701,8 +701,9 @@ produced the cache key without printing the aggregate key itself. Environment va
 identified only by name and whether they are set, while mise variables are identified only by name,
 so the explanation does not publish their contents or per-value digests. Other potentially
 secret-derived inputs—including source contents, dependency keys, command output, task definitions,
-and resolved tool versions—are reported only by category and count. The target platform is listed
-directly.
+and resolved tool versions—are reported only by category and count. Matched source paths, declared
+output patterns, currently resolved output roots, and the target platform are listed directly.
+
 Combine the flag with `--dry-run` to inspect the key inputs without executing, restoring, or storing
 the task. Cache command inputs still run when the explanation is explicitly requested because their
 output hashes are part of the key.

--- a/e2e/tasks/test_task_artifact_cache
+++ b/e2e/tasks/test_task_artifact_cache
@@ -15,7 +15,7 @@ printf '%s:%s\n' "$PROFILE" "$(cat input.txt)" > dist/result.txt
 printf 'ran\n' >> runs.txt
 '''
 sources = ["input.txt"]
-outputs = ["dist"]
+outputs = ["dist", "dist/result.txt"]
 EOF
 
 printf 'one\n' >input.txt
@@ -28,6 +28,12 @@ assert "cat dist/result.txt" "debug:one"
 assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "cache key inputs:"
 assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "task definition:"
 assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "sources:"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "source: input.txt"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "pattern: dist"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "pattern: dist/result.txt"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "resolved outputs: 1"
+assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "output: dist"
+assert_not_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "output: dist/result.txt"
 assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "environment PROFILE: set"
 assert_not_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "environment PROFILE: debug"
 assert_contains "PROFILE=debug mise run --task-cache-explain build 2>&1" "platform:"

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -157,7 +157,9 @@ pub struct TaskArtifactCache {
 #[derive(Debug)]
 pub(crate) struct TaskCacheKeyExplanation {
     format: u8,
-    source_count: usize,
+    source_paths: Vec<PathBuf>,
+    output_patterns: Vec<String>,
+    output_paths: Vec<PathBuf>,
     dependency_count: usize,
     environment: BTreeMap<String, bool>,
     command_input_count: usize,
@@ -170,6 +172,7 @@ pub(crate) struct TaskCacheKeyExplanation {
 pub(crate) struct TaskArtifactCacheBuilder {
     root: PathBuf,
     inputs: TaskCacheInputs,
+    output_roots: Vec<PathBuf>,
 }
 
 pub(crate) struct TaskCacheContext<'a> {
@@ -215,7 +218,11 @@ impl TaskArtifactCache {
                 );
             }
         }
-        Ok(Some(TaskArtifactCacheBuilder { root, inputs }))
+        Ok(Some(TaskArtifactCacheBuilder {
+            root,
+            inputs,
+            output_roots,
+        }))
     }
 }
 
@@ -233,7 +240,11 @@ impl TaskArtifactCacheBuilder {
             command_inputs,
             explain,
         } = ctx;
-        let Self { root, inputs } = self;
+        let Self {
+            root,
+            inputs,
+            output_roots,
+        } = self;
         let mut environment = declared_env
             .iter()
             .map(|(key, _)| (key.clone(), resolved_env.get(key).cloned()))
@@ -255,7 +266,11 @@ impl TaskArtifactCacheBuilder {
             .map(|(_, tv)| tv.to_string())
             .collect::<Vec<_>>();
         tools.sort();
-        let source_count = inputs.source_paths.len();
+        let source_paths = if explain {
+            inputs.source_paths.clone()
+        } else {
+            Vec::new()
+        };
         let material = CacheKeyMaterial {
             format: CACHE_FORMAT_VERSION,
             task: &task.name,
@@ -278,7 +293,9 @@ impl TaskArtifactCacheBuilder {
         let explanation = if explain {
             Some(TaskCacheKeyExplanation {
                 format: material.format,
-                source_count,
+                source_paths,
+                output_patterns: material.outputs.clone(),
+                output_paths: remove_nested_roots(output_roots),
                 dependency_count: material.dependency_keys.len(),
                 environment: material
                     .environment
@@ -495,9 +512,29 @@ impl TaskCacheKeyExplanation {
             "cache key inputs:".to_string(),
             format!("  format: {}", self.format),
             "  task definition: included".to_string(),
-            format!("  sources: {} files", self.source_count),
-            format!("  dependencies: {} artifact keys", self.dependency_count),
+            format!("  sources: {} files", self.source_paths.len()),
         ];
+        lines.extend(
+            self.source_paths
+                .iter()
+                .map(|path| format!("    source: {}", display_cache_path(path))),
+        );
+        lines.push(format!("  output patterns: {}", self.output_patterns.len()));
+        lines.extend(
+            self.output_patterns
+                .iter()
+                .map(|pattern| format!("    pattern: {}", display_cache_text(pattern))),
+        );
+        lines.push(format!("  resolved outputs: {}", self.output_paths.len()));
+        lines.extend(
+            self.output_paths
+                .iter()
+                .map(|path| format!("    output: {}", display_cache_path(path))),
+        );
+        lines.push(format!(
+            "  dependencies: {} artifact keys",
+            self.dependency_count
+        ));
         lines.extend(self.environment.iter().map(|(name, is_set)| {
             let state = if *is_set { "set" } else { "unset" };
             format!("  environment {name}: {state}")
@@ -508,6 +545,14 @@ impl TaskCacheKeyExplanation {
         lines.push(format!("  platform: {}-{}", self.os, self.arch));
         lines
     }
+}
+
+fn display_cache_path(path: &Path) -> String {
+    display_cache_text(&crate::file::display_path(path))
+}
+
+fn display_cache_text(text: &str) -> String {
+    text.escape_debug().to_string()
 }
 
 /// Returns the versioned directory containing task artifact cache entries.
@@ -934,7 +979,12 @@ mod tests {
     fn cache_explanation_omits_environment_and_variable_values() {
         let explanation = TaskCacheKeyExplanation {
             format: 2,
-            source_count: 3,
+            source_paths: vec![
+                PathBuf::from("input.txt"),
+                PathBuf::from("src/\x1b[2J\nfile.rs"),
+            ],
+            output_patterns: vec!["dist".into(), "!dist/private/**".into()],
+            output_paths: vec![PathBuf::from("dist")],
             dependency_count: 1,
             environment: BTreeMap::from([("MISSING".into(), false), ("TOKEN".into(), true)]),
             command_input_count: 2,
@@ -948,7 +998,11 @@ mod tests {
         assert!(output.contains("environment TOKEN: set"));
         assert!(output.contains("environment MISSING: unset"));
         assert!(output.contains("variable: password"));
-        assert!(output.contains("sources: 3 files"));
+        assert!(output.contains("sources: 2 files"));
+        assert!(output.contains("source: input.txt"));
+        assert!(output.contains(r"source: src/\u{1b}[2J\nfile.rs"));
+        assert!(output.contains("pattern: !dist/private/**"));
+        assert!(output.contains("output: dist"));
         assert!(output.contains("dependencies: 1 artifact keys"));
         assert!(output.contains("command inputs: 2"));
         assert!(output.contains("tools: 4 resolved versions"));


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary

- extend `--task-cache-explain` with matched source paths
- show declared output patterns and currently resolved output roots
- escape terminal control characters in paths and patterns
- retain category/count-only reporting for secret-derived values and hashes
- avoid extra path cloning when explanations are disabled
- update cache documentation, tests, and the parity tracker

## Why

Cache explanations identified input categories but did not show which source and output paths those categories represented. This made glob and input-group debugging unnecessarily indirect.

## User impact

Users can now see the concrete files matched as cache sources and how declared outputs resolve, without exposing file contents, environment values, command output, or cache-key material.

## Validation

- `cargo test cache_explanation_omits_environment_and_variable_values -- --nocapture`
- `cargo test cli::tests::test_subcommands_are_sorted -- --nocapture`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache`
- `mise run render`
- `mise run lint`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional diagnostic formatting and documentation; cache keys and restore behavior are unchanged aside from carrying already-resolved output roots for display.
> 
> **Overview**
> **`mise run --task-cache-explain`** now lists **matched source paths**, **declared output patterns**, and **resolved output roots** (nested paths collapsed to top-level roots), not only counts and categories.
> 
> Paths and patterns are printed with **`escape_debug`** so control characters in globs or filenames do not corrupt the terminal. **Environment values, hashes, and other secret-derived key material** stay name-only or count-only; source path lists are only built when explanation mode is on to avoid extra cloning on normal runs.
> 
> Docs, the artifact-cache e2e test, and the parity tracker are updated for the richer explain output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d01f92fdacda8ab38cd3220dd0ff98a8b7fdbb48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->