### PR TITLE
ci: run perf jobs on bamboo

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
+    - bamboo-perf
     - macos-14
     - namespace-profile-endev-macos-arm64
     - namespace-profile-endev-macos-arm64-large

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
 
 jobs:
   measure:
@@ -35,7 +36,7 @@ jobs:
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
     # the report would say "nothing was compared" instead of anything useful.
-    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=mise-pr-rust-linux
+    runs-on: bamboo-perf
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it
@@ -55,9 +56,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   measure:
     name: Compare instruction counts
+    if: github.event.pull_request.user.login == 'jdx'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
@@ -138,7 +139,7 @@ jobs:
   report:
     name: Report and gate
     needs: measure
-    if: always()
+    if: always() && github.event.pull_request.user.login == 'jdx'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
 
 jobs:
   measure:
@@ -34,11 +35,9 @@ jobs:
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
-    # A cache tag of its own. Namespace shares a volume across jobs in a
-    # repository by default, so this job — which holds a write token and pushes
-    # notes — must not read a cache that perf-pr.yml, running pull-request
-    # code, can write to.
-    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=mise-perf-main
+    # The disposable runner and cache key isolate this main-only job from
+    # perf-pr.yml, which executes pull-request code with read-only permissions.
+    runs-on: bamboo-perf
     timeout-minutes: 30
     permissions:
       contents: write # pushing refs/notes/tak is a write to this repository
@@ -47,9 +46,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:


### PR DESCRIPTION
## Summary

- run Tak measurement jobs on the isolated `bamboo-perf` runner
- identify the Bamboo image/toolchain as a distinct Tak runner class
- leave report and publish jobs on hosted runners

## Validation

- `actionlint` (with `bamboo-perf` registered as the expected custom label)
- `git diff --check`
- trusted `main` baseline queued on the disposable runner

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI infrastructure and Tak baseline comparability (new runner class); perf-pr gating means most PRs skip perf until removed.
> 
> **Overview**
> Tak **measure** jobs in `perf.yml` and `perf-pr.yml` now run on the isolated **`bamboo-perf`** runner instead of Namespace `endev-linux-amd64-large` profiles (and the main perf job drops the separate `mise-perf-main` cache-tag label). Both workflows set **`TAK_RUNNER`** to the Bamboo image/toolchain id so Tak treats measurements as one runner class.
> 
> Rust caching switches from **`namespacelabs/nscloud-cache-action`** to **`Swatinem/rust-cache`**. **`perf-pr`** temporarily limits **`measure`** and **`report`** to PRs opened by **`jdx`**; report/publish-style jobs still use hosted **`ubuntu-latest`**. **`actionlint.yaml`** registers the **`bamboo-perf`** label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6dfaf8734586b2376511dbb7ec296c04919fb6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated performance testing workflows to run on a dedicated performance environment.
  * Improved Rust dependency caching for more consistent and efficient performance runs.
  * Applied the updated configuration to both pull request and scheduled performance tests.
  * Standardized runner configuration across performance workflows to improve the reliability and comparability of results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->