### PR TITLE
feat(task): verify task cache artifact checksums

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -101,7 +101,7 @@ outside this tracker.
 
 ## Integrity and portability
 
-- [ ] Add an artifact checksum independent of the cache key
+- [x] Add an artifact checksum independent of the cache key
 - [ ] Test and harden concurrent readers and writers for the same key
 - [ ] Clean up interrupted and abandoned partial writes
 - [ ] Add configurable cache size and age limits

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -771,6 +771,11 @@ Cache entries are stored under `MISE_CACHE_DIR/task-artifacts/v2` by default. Se
 manual and automatic cache pruning. Only successful task runs are cached. Cache read/write failures
 are treated as misses and never turn a successful task run into a failure.
 
+New cache entries include a BLAKE3 artifact checksum that is independent of the cache lookup key.
+It covers the archived outputs and captured task result metadata, and mise verifies it before
+extracting files or replaying output. Entries written before checksums were introduced remain
+readable. `mise cache task <task> --json` includes the checksum for cache inspection tooling.
+
 When a cache-enabled task executes instead of restoring a result, mise reports the reason: no
 matching entry, a corrupt entry, forced execution, disabled reads, or a dependency that completed
 without a stable cache key. Raw and dry-run cache bypasses retain their existing warning or preview

--- a/e2e/tasks/test_task_artifact_cache_inspect
+++ b/e2e/tasks/test_task_artifact_cache_inspect
@@ -51,12 +51,13 @@ mise run build
 mise run other
 
 assert_json \
-  "mise cache task build --json | jq '.[0] | {task, entries: (.entries | length), current_entries: ([.entries[] | select(.current)] | length), key_lengths: [.entries[].key | length], outputs: [.entries[].outputs]}'" \
+  "mise cache task build --json | jq '.[0] | {task, entries: (.entries | length), current_entries: ([.entries[] | select(.current)] | length), key_lengths: [.entries[].key | length], checksums: [.entries[].artifact_checksum | startswith(\"blake3:\")], outputs: [.entries[].outputs]}'" \
   '{
     "task": "build",
     "entries": 2,
     "current_entries": 1,
     "key_lengths": [64, 64],
+    "checksums": [true, true],
     "outputs": [["dist"], ["dist"]]
   }'
 cache_key="$(mise cache task build --json | jq -r '.[0].entries[0].key')"

--- a/e2e/tasks/test_task_artifact_cache_resilience
+++ b/e2e/tasks/test_task_artifact_cache_resilience
@@ -38,6 +38,16 @@ printf 'invalid manifest\n' >"$manifest"
 assert_contains "mise run build 2>&1" "cache miss: cache entry was corrupt"
 assert "wc -l < runs.txt | tr -d ' '" "2"
 
+# Archive integrity is verified independently of the cache lookup key. Appended
+# bytes may still be accepted by the compression decoder, but never by the
+# artifact checksum.
+rm -rf dist
+manifest="$(find "$MISE_CACHE_DIR/task-artifacts/v2" -type f -name '*.json' -print -quit)"
+archive="${manifest%.json}.tar.zst"
+printf 'trailing corruption\n' >>"$archive"
+assert_contains "mise run build 2>&1" "task cache artifact checksum mismatch"
+assert "wc -l < runs.txt | tr -d ' '" "3"
+
 # Capturing output for a cacheable interleave task must not disconnect stdin.
 printf 'from-stdin\n' | mise run stdin
 assert "cat stdin-dist/result.txt" "from-stdin"

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -23,6 +23,7 @@ use walkdir::WalkDir;
 
 const CACHE_FORMAT_VERSION: u8 = 2;
 const CACHE_DIR_VERSION: &str = "v2";
+const ARTIFACT_CHECKSUM_FORMAT: u8 = 1;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -112,6 +113,8 @@ struct CacheManifest {
     key: String,
     #[serde(default)]
     task_identity: String,
+    #[serde(default)]
+    artifact_checksum: Option<String>,
     roots: Vec<PathBuf>,
     output: Vec<TaskCacheOutput>,
     #[serde(default)]
@@ -143,6 +146,7 @@ pub(crate) struct TaskCacheEntry {
     pub(crate) key: String,
     #[serde(skip)]
     pub(crate) identity_verified: bool,
+    pub(crate) artifact_checksum: Option<String>,
     pub(crate) current: bool,
     pub(crate) size_bytes: u64,
     pub(crate) restored_bytes: u64,
@@ -372,6 +376,7 @@ impl TaskArtifactCache {
         if !manifest.roots.is_empty() && !archive_path.is_file() {
             return None;
         }
+        verify_artifact_checksum(&manifest, &archive_path).ok()?;
         Some(manifest.output)
     }
 
@@ -395,6 +400,7 @@ impl TaskArtifactCache {
             if remove_nested_roots(manifest.roots.clone()) != manifest.roots {
                 bail!("task cache manifest contains duplicate or nested roots");
             }
+            verify_artifact_checksum(&manifest, &archive_path)?;
             if manifest.roots.is_empty() {
                 if let Err(err) = file::touch_file(&manifest_path) {
                     warn!("failed to update task cache manifest access time: {err}");
@@ -510,15 +516,20 @@ impl TaskArtifactCache {
         } else {
             0
         };
-        let manifest = CacheManifest {
+        let mut manifest = CacheManifest {
             format: CACHE_FORMAT_VERSION,
             key: self.key.clone(),
             task_identity: task_cache_identity(task, &self.root),
+            artifact_checksum: None,
             roots,
             output: output.to_vec(),
             restored_bytes: archive_bytes.saturating_add(output_bytes),
             execution_duration_ns: execution_duration.as_nanos().min(u64::MAX as u128) as u64,
         };
+        manifest.artifact_checksum = Some(calculate_artifact_checksum(
+            &manifest,
+            (!manifest.roots.is_empty()).then_some(archive_partial.as_path()),
+        )?);
         fs::write(&manifest_partial, serde_json::to_vec(&manifest)?)?;
         if !manifest.roots.is_empty() {
             file::rename(&archive_partial, &archive_path)?;
@@ -545,6 +556,49 @@ impl TaskArtifactCache {
         }
         Ok(manifest)
     }
+}
+
+fn calculate_artifact_checksum(
+    manifest: &CacheManifest,
+    archive_path: Option<&Path>,
+) -> Result<String> {
+    #[derive(Serialize)]
+    struct ArtifactChecksumMaterial<'a> {
+        format: u8,
+        roots: &'a [PathBuf],
+        output: &'a [TaskCacheOutput],
+        restored_bytes: u64,
+        execution_duration_ns: u64,
+        archive_checksum: Option<String>,
+    }
+
+    let archive_checksum = archive_path
+        .map(|path| hash::file_hash_blake3(path, None))
+        .transpose()?;
+    let material = ArtifactChecksumMaterial {
+        format: ARTIFACT_CHECKSUM_FORMAT,
+        roots: &manifest.roots,
+        output: &manifest.output,
+        restored_bytes: manifest.restored_bytes,
+        execution_duration_ns: manifest.execution_duration_ns,
+        archive_checksum,
+    };
+    let encoded = serde_json::to_string(&material)?;
+    Ok(format!("blake3:{}", hash::hash_blake3_to_str(&encoded)))
+}
+
+fn verify_artifact_checksum(manifest: &CacheManifest, archive_path: &Path) -> Result<()> {
+    let Some(expected) = &manifest.artifact_checksum else {
+        return Ok(());
+    };
+    let actual = calculate_artifact_checksum(
+        manifest,
+        (!manifest.roots.is_empty()).then_some(archive_path),
+    )?;
+    if actual != *expected {
+        bail!("task cache artifact checksum mismatch");
+    }
+    Ok(())
 }
 
 pub(crate) fn task_cache_entries(task: &Task, root: &Path) -> Result<Vec<TaskCacheEntry>> {
@@ -608,6 +662,7 @@ pub(crate) fn task_cache_entries(task: &Task, root: &Path) -> Result<Vec<TaskCac
             current: current_key.as_deref() == Some(manifest.key.as_str()),
             key: manifest.key,
             identity_verified: matches_identity,
+            artifact_checksum: manifest.artifact_checksum,
             size_bytes: manifest_metadata
                 .len()
                 .saturating_add(archive_metadata.map_or(0, |metadata| metadata.len())),
@@ -1211,6 +1266,28 @@ mod tests {
         assert_eq!(manifest.restored_bytes, 0);
         assert_eq!(manifest.execution_duration_ns, 0);
         assert_eq!(manifest.task_identity, "");
+        assert_eq!(manifest.artifact_checksum, None);
+    }
+
+    #[test]
+    fn artifact_checksum_is_independent_of_cache_key_and_task_identity() {
+        let mut manifest = CacheManifest {
+            format: CACHE_FORMAT_VERSION,
+            key: "first-key".into(),
+            task_identity: "first-task".into(),
+            artifact_checksum: None,
+            roots: Vec::new(),
+            output: vec![TaskCacheOutput::Stdout("result\n".into())],
+            restored_bytes: 7,
+            execution_duration_ns: 42,
+        };
+        let first = calculate_artifact_checksum(&manifest, None).unwrap();
+        manifest.key = "second-key".into();
+        manifest.task_identity = "second-task".into();
+        let second = calculate_artifact_checksum(&manifest, None).unwrap();
+
+        assert_eq!(first, second);
+        assert!(first.starts_with("blake3:"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- store a versioned BLAKE3 checksum for each task cache artifact, independent of its lookup key
- verify captured result metadata and archive bytes before replaying output or extracting files
- preserve compatibility with older entries and expose checksums in JSON cache inspection

## Why
The cache key identifies the expected inputs, but it does not prove that the stored result remained intact. A separate artifact checksum detects archive or metadata corruption even when a decoder would otherwise accept the damaged bytes.

## User impact
Corrupt checked entries are removed and treated as cache misses, so the task reruns. Existing entries without checksums remain readable.

## Validation
- `cargo test task_cache -- --nocapture`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_inspect e2e/tasks/test_task_artifact_cache_resilience`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache*`
- `mise run lint`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run render`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the task cache restore hot path for an experimental feature; corrupt or tampered artifacts are rejected safely via cache misses, but any checksum bug could cause unnecessary reruns or missed hits.
> 
> **Overview**
> Adds a **versioned BLAKE3 artifact checksum** to experimental task output cache entries so stored results are checked separately from the cache lookup key. New writes hash captured stdout/stderr metadata plus the archive bytes (when present) and persist `blake3:…` on the manifest; **restore** and **current-output** paths verify before replaying logs or extracting files, treating mismatches like other corrupt entries (warn, delete manifest/archive, cache miss).
> 
> **Backward compatibility:** manifests without `artifact_checksum` still restore without verification. **`mise cache task --json`** now surfaces `artifact_checksum` for inspection; docs and the parity tracker mark this integrity item done. E2E coverage confirms appended archive corruption fails checksum even when the zstd stream might still decode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87624c88dc15a0cce8047f24dd280434fc697e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->