### PR TITLE
fix(task): serialize task cache entry access

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -102,7 +102,7 @@ outside this tracker.
 ## Integrity and portability
 
 - [x] Add an artifact checksum independent of the cache key
-- [ ] Test and harden concurrent readers and writers for the same key
+- [x] Test and harden concurrent readers and writers for the same key
 - [ ] Clean up interrupted and abandoned partial writes
 - [ ] Add configurable cache size and age limits
 - [ ] Test restore behavior on Windows

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -776,6 +776,10 @@ It covers the archived outputs and captured task result metadata, and mise verif
 extracting files or replaying output. Entries written before checksums were introduced remain
 readable. `mise cache task <task> --json` includes the checksum for cache inspection tooling.
 
+Readers, writers, inspection, and task-scoped deletion coordinate through a cross-process lock for
+each cache key. Concurrent processes therefore see a complete archive and manifest pair instead of
+mistaking an in-progress replacement for corruption; writers for unrelated keys remain independent.
+
 When a cache-enabled task executes instead of restoring a result, mise reports the reason: no
 matching entry, a corrupt entry, forced execution, disabled reads, or a dependency that completed
 without a stable cache key. Raw and dry-run cache bypasses retain their existing warning or preview

--- a/e2e/tasks/test_task_artifact_cache_concurrency
+++ b/e2e/tasks/test_task_artifact_cache_concurrency
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+run = '''
+mkdir -p dist
+printf '%s\n' "$MISE_CONCURRENT_VALUE" >"dist/$MISE_CONCURRENT_VALUE.txt"
+'''
+sources = ["input.txt"]
+outputs = ["dist"]
+EOF
+
+printf 'input\n' >input.txt
+
+# All writers intentionally share a key while producing different valid
+# artifacts. Their final archive and manifest must always be one matching pair.
+pids=()
+for value in one two three four five six seven eight; do
+  MISE_CONCURRENT_VALUE="$value" mise run build >"writer-$value.log" 2>&1 &
+  pids+=("$!")
+done
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+
+cache_dir="$MISE_CACHE_DIR/task-artifacts/v2"
+assert "find \"$cache_dir\" -maxdepth 1 -name '*.json' | wc -l | tr -d ' '" "1"
+assert "find \"$cache_dir\" -maxdepth 1 -name '*.tar.zst' | wc -l | tr -d ' '" "1"
+assert "find \"$cache_dir\" -maxdepth 1 -name '*.part-*' | wc -l | tr -d ' '" "0"
+
+# Readers share both the cache key and working directory. Entry locks protect
+# the archive/manifest pair, while the existing output lock serializes install.
+rm -rf dist
+pids=()
+for reader in 1 2 3 4 5 6 7 8; do
+  mise run --task-cache read-only build >"reader-$reader.log" 2>&1 &
+  pids+=("$!")
+done
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+
+assert "test \"$(find dist -type f | wc -l | tr -d ' ')\" -ge 1 && echo restored" "restored"
+assert "if grep -q 'cache entry was corrupt' reader-*.log writer-*.log; then echo corrupt; else echo clean; fi" "clean"

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -366,6 +366,7 @@ impl TaskArtifactCache {
     }
 
     pub(crate) fn current_output(&self) -> Option<Vec<TaskCacheOutput>> {
+        let _entry_lock = self.entry_lock().ok()?;
         let (archive_path, manifest_path) = self.paths();
         if !manifest_path.is_file()
             || !file::read_to_string(&self.state_path).is_ok_and(|key| key.trim() == self.key)
@@ -388,6 +389,7 @@ impl TaskArtifactCache {
     }
 
     pub(crate) fn restore(&self, task: &Task) -> Result<TaskCacheRestore> {
+        let _entry_lock = self.entry_lock()?;
         let (archive_path, manifest_path) = self.paths();
         if !manifest_path.is_file() {
             return Ok(TaskCacheRestore::Miss(TaskCacheMissReason::EntryNotFound));
@@ -495,6 +497,7 @@ impl TaskArtifactCache {
         }
 
         file::create_dir_all(&self.cache_dir)?;
+        let _entry_lock = self.entry_lock()?;
         let (archive_path, manifest_path) = self.paths();
         let nonce = crate::rand::random_string(8);
         let archive_partial = self
@@ -546,6 +549,10 @@ impl TaskArtifactCache {
             self.cache_dir.join(format!("{}.tar.zst", self.key)),
             self.cache_dir.join(format!("{}.json", self.key)),
         )
+    }
+
+    fn entry_lock(&self) -> Result<fslock::LockFile> {
+        task_cache_entry_lock(&self.cache_dir, &self.key)
     }
 
     fn read_manifest(&self) -> Result<CacheManifest> {
@@ -625,6 +632,10 @@ pub(crate) fn task_cache_entries(task: &Task, root: &Path) -> Result<Vec<TaskCac
         {
             continue;
         }
+        let Some(key) = manifest_path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        let _entry_lock = task_cache_entry_lock(&cache_dir, key)?;
         let manifest: CacheManifest = match fs::read(&manifest_path)
             .map_err(Report::from)
             .and_then(|contents| serde_json::from_slice(&contents).map_err(Report::from))
@@ -688,6 +699,7 @@ pub(crate) fn clear_task_cache(task: &Task, root: &Path) -> Result<TaskCacheClea
         .clone()
         .fold(0_u64, |total, entry| total.saturating_add(entry.size_bytes));
     for entry in identified_entries.clone() {
+        let _entry_lock = task_cache_entry_lock(&cache_dir, &entry.key)?;
         remove_cache_file(&cache_dir.join(format!("{}.tar.zst", entry.key)))?;
         remove_cache_file(&cache_dir.join(format!("{}.json", entry.key)))?;
     }
@@ -719,6 +731,10 @@ pub(crate) fn clear_task_cache(task: &Task, root: &Path) -> Result<TaskCacheClea
         if manifest_path.extension().and_then(|ext| ext.to_str()) != Some("json") {
             continue;
         }
+        let Some(key) = stem.split_once(".part-").map(|(key, _)| key) else {
+            continue;
+        };
+        let _entry_lock = task_cache_entry_lock(&cache_dir, key)?;
         let Ok(contents) = fs::read(&manifest_path) else {
             continue;
         };
@@ -749,6 +765,12 @@ fn remove_cache_file(path: &Path) -> Result<()> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err.into()),
     }
+}
+
+fn task_cache_entry_lock(cache_dir: &Path, key: &str) -> Result<fslock::LockFile> {
+    crate::lock_file::LockFile::new(&cache_dir.join(format!("{key}.json")))
+        .with_callback(|path| debug!("waiting for task cache entry lock {}", path.display()))
+        .lock()
 }
 
 fn task_cache_identity(task: &Task, root: &Path) -> String {
@@ -1239,6 +1261,9 @@ fn metadata_mode(metadata: &fs::Metadata) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
     use super::*;
 
     #[test]
@@ -1251,6 +1276,28 @@ mod tests {
         assert_eq!(config.env, ["PROFILE"]);
         assert_eq!(config.command_inputs, ["node --version"]);
         assert!(toml::from_str::<TaskCacheConfig>("remote = true").is_err());
+    }
+
+    #[test]
+    fn entry_locks_serialize_same_key_without_blocking_other_keys() {
+        let cache_dir = tempfile::tempdir().unwrap();
+        let held = task_cache_entry_lock(cache_dir.path(), "shared").unwrap();
+        let _other = task_cache_entry_lock(cache_dir.path(), "independent").unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let cache_path = cache_dir.path().to_path_buf();
+
+        let waiter = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let _lock = task_cache_entry_lock(&cache_path, "shared").unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        started_rx.recv().unwrap();
+        assert!(acquired_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(held);
+        acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        waiter.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- coordinate task-cache reads, writes, inspection, and scoped deletion with a cross-process lock per cache key
- hold the entry lock across archive creation and the archive/manifest publish sequence so readers only observe complete pairs
- add unit coverage for same-key serialization and unrelated-key independence, plus concurrent-process writer and reader coverage

## Why
A cache entry is stored as an archive and a manifest. Without coordination, a reader could observe an old manifest with a newly published archive, or concurrent writers could interleave their renames and leave a mismatched pair. The checksum would correctly reject that pair, but the race would be mistaken for persistent corruption and remove an otherwise valid entry.

## User impact
Concurrent mise processes sharing a task cache no longer treat in-progress same-key replacements as corrupt. Operations on different cache keys remain independent.

## Validation
- `cargo test task_cache -- --nocapture`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_concurrency e2e/tasks/test_task_artifact_cache_inspect e2e/tasks/test_task_artifact_cache_resilience`
- `mise run lint-fix`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared cache I/O and locking on restore/store/clear paths; incorrect locking could deadlock or regress cache behavior under concurrency, but scope is localized to task artifact cache.
> 
> **Overview**
> Adds **cross-process per-cache-key locking** so concurrent mise processes no longer treat in-progress archive/manifest updates as corrupt checksum mismatches.
> 
> `task_cache_entry_lock` locks on the manifest path (`{key}.json`) and is held for **restore**, **store** (through partial writes and renames), **current output** inspection, **entry listing**, and **task-scoped cache clear** (including partial files). Unrelated keys can still lock independently.
> 
> Docs and **TASK_CACHE_PARITY** mark concurrent reader/writer hardening done. Coverage includes a unit test for same-key blocking vs other keys, plus an e2e that runs parallel writers and read-only restorers and asserts a single complete pair and no false “corrupt entry” messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aafc722c1a2e2b0fbacd8d159168070af7956160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->