### PR TITLE
ci: build perf binaries on bamboo

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -57,8 +57,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false


### PR DESCRIPTION
## Summary

- compile benchmark binaries from scratch inside each disposable Bamboo VM
- prevent a cached `target/` built on Namespace from being measured and labeled as Bamboo
- document the runner-class integrity requirement beside the build setup

## Validation

- `actionlint` on the affected performance workflows
- `git diff --check`

Generated with AI assistance and manually validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to perf CI build caching; no application, auth, or data-path code is modified.
> 
> **Overview**
> **Bamboo perf workflows no longer restore `target/` via `Swatinem/rust-cache`.** `perf.yml` and `perf-pr.yml` now compile benchmark binaries from scratch on each disposable `bamboo-perf` runner, with a short comment that a cached artifact from another runner class could be measured and labeled as Bamboo.
> 
> This keeps **tak** instruction-count baselines and PR comparisons tied to binaries actually built on the pinned Bamboo hardware, instead of reusing a `target/` tree that may have been produced elsewhere (e.g. Namespace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5a89979c1b9d78c886a31a0e4bc9481d4192af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance measurement consistency by ensuring builds are compiled within the temporary measurement environment.
  * Prevented previously cached build artifacts from affecting performance results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->