### PR TITLE
fix(task): clean abandoned cache writes

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -103,7 +103,7 @@ outside this tracker.
 
 - [x] Add an artifact checksum independent of the cache key
 - [x] Test and harden concurrent readers and writers for the same key
-- [ ] Clean up interrupted and abandoned partial writes
+- [x] Clean up interrupted and abandoned partial writes
 - [ ] Add configurable cache size and age limits
 - [ ] Test restore behavior on Windows
 - [ ] Test executable bits, symlinks, empty directories, and case-sensitive path edge cases

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -784,6 +784,9 @@ readable. `mise cache task <task> --json` includes the checksum for cache inspec
 Readers, writers, inspection, and task-scoped deletion coordinate through a cross-process lock for
 each cache key. Concurrent processes therefore see a complete archive and manifest pair instead of
 mistaking an in-progress replacement for corruption; writers for unrelated keys remain independent.
+Temporary archive and manifest files are removed when a write fails normally. On a later cache use,
+mise also removes partial files abandoned by an interrupted process after acquiring the associated
+cache-key lock, so it never deletes files that an active writer is still publishing.
 
 When a cache-enabled task executes instead of restoring a result, mise reports the reason: no
 matching entry, a corrupt entry, forced execution, disabled reads, or a dependency that completed

--- a/e2e/tasks/test_task_artifact_cache_concurrency
+++ b/e2e/tasks/test_task_artifact_cache_concurrency
@@ -34,6 +34,13 @@ assert "find \"$cache_dir\" -maxdepth 1 -name '*.json' | wc -l | tr -d ' '" "1"
 assert "find \"$cache_dir\" -maxdepth 1 -name '*.tar.zst' | wc -l | tr -d ' '" "1"
 assert "find \"$cache_dir\" -maxdepth 1 -name '*.part-*' | wc -l | tr -d ' '" "0"
 
+# A later cache-enabled process cleans partial files left by an interrupted
+# writer, including entries unrelated to the task it is about to restore.
+printf 'abandoned archive\n' >"$cache_dir/abandoned.part-deadbeef.tar.zst"
+printf 'abandoned manifest\n' >"$cache_dir/abandoned.part-deadbeef.json"
+mise run --task-cache read-only build >/dev/null
+assert "find \"$cache_dir\" -maxdepth 1 -name '*.part-*' | wc -l | tr -d ' '" "0"
+
 # Readers share both the cache key and working directory. Entry locks protect
 # the archive/manifest pair, while the existing output lock serializes install.
 rm -rf dist

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -584,6 +584,9 @@ impl Drop for PartialCacheFiles {
 }
 
 fn cleanup_abandoned_partial_writes_once(cache_dir: &Path) {
+    if !cache_dir.is_dir() {
+        return;
+    }
     let should_clean = CLEANED_PARTIAL_CACHE_DIRS
         .lock()
         .unwrap_or_else(|err| err.into_inner())
@@ -1388,6 +1391,20 @@ mod tests {
         assert!(!abandoned_archive.exists());
         assert!(complete_manifest.exists());
         assert!(unrelated.exists());
+    }
+
+    #[test]
+    fn missing_cache_directory_remains_eligible_for_partial_cleanup() {
+        let root = tempfile::tempdir().unwrap();
+        let cache_dir = root.path().join("later-cache");
+        cleanup_abandoned_partial_writes_once(&cache_dir);
+
+        fs::create_dir(&cache_dir).unwrap();
+        let abandoned = cache_dir.join("abandoned.part-deadbeef.json");
+        fs::write(&abandoned, "partial manifest").unwrap();
+        cleanup_abandoned_partial_writes_once(&cache_dir);
+
+        assert!(!abandoned.exists());
     }
 
     #[test]

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -542,12 +542,12 @@ impl TaskArtifactCache {
             (!manifest.roots.is_empty()).then_some(archive_partial.as_path()),
         )?);
         fs::write(&manifest_partial, serde_json::to_vec(&manifest)?)?;
+        file::rename(&manifest_partial, &manifest_path)?;
         if !manifest.roots.is_empty() {
             file::rename(&archive_partial, &archive_path)?;
         } else {
             let _ = file::remove_file(&archive_path);
         }
-        file::rename(&manifest_partial, &manifest_path)?;
         Ok(())
     }
 
@@ -609,18 +609,17 @@ fn cleanup_abandoned_partial_writes(cache_dir: &Path) -> Result<()> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(err) => return Err(err.into()),
     };
-    let mut keys = BTreeSet::new();
+    let mut candidates = BTreeMap::<String, Vec<PathBuf>>::new();
     for entry in entries {
         let path = entry?.path();
         if let Some(key) = partial_cache_key(&path) {
-            keys.insert(key.to_string());
+            candidates.entry(key.to_string()).or_default().push(path);
         }
     }
-    for key in keys {
+    for (key, paths) in candidates {
         let _entry_lock = task_cache_entry_lock(cache_dir, &key)?;
-        for entry in fs::read_dir(cache_dir)? {
-            let path = entry?.path();
-            if partial_cache_key(&path) == Some(key.as_str()) {
+        for path in paths {
+            if path.exists() {
                 remove_cache_file(&path)?;
             }
         }
@@ -1391,6 +1390,35 @@ mod tests {
         assert!(!abandoned_archive.exists());
         assert!(complete_manifest.exists());
         assert!(unrelated.exists());
+    }
+
+    #[test]
+    fn active_partial_writes_are_not_removed_while_locked() {
+        let cache_dir = tempfile::tempdir().unwrap();
+        let partial_manifest = cache_dir.path().join("active.part-deadbeef.json");
+        let partial_archive = cache_dir.path().join("active.part-deadbeef.tar.zst");
+        fs::write(&partial_manifest, "partial manifest").unwrap();
+        fs::write(&partial_archive, "partial archive").unwrap();
+        let held = task_cache_entry_lock(cache_dir.path(), "active").unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (finished_tx, finished_rx) = mpsc::channel();
+        let cache_path = cache_dir.path().to_path_buf();
+
+        let cleanup = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            cleanup_abandoned_partial_writes(&cache_path).unwrap();
+            finished_tx.send(()).unwrap();
+        });
+
+        started_rx.recv().unwrap();
+        assert!(finished_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        assert!(partial_manifest.exists());
+        assert!(partial_archive.exists());
+        drop(held);
+        finished_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        cleanup.join().unwrap();
+        assert!(!partial_manifest.exists());
+        assert!(!partial_archive.exists());
     }
 
     #[test]

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -17,13 +17,16 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs::{self, File};
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::UNIX_EPOCH;
 use walkdir::WalkDir;
 
 const CACHE_FORMAT_VERSION: u8 = 2;
 const CACHE_DIR_VERSION: &str = "v2";
 const ARTIFACT_CHECKSUM_FORMAT: u8 = 1;
+
+static CLEANED_PARTIAL_CACHE_DIRS: LazyLock<Mutex<BTreeSet<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(BTreeSet::new()));
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -348,9 +351,11 @@ impl TaskArtifactCacheBuilder {
             None
         };
         let state_path = task_cache_state_path(task, &root);
+        let cache_dir = task_cache_dir();
+        cleanup_abandoned_partial_writes_once(&cache_dir);
         Ok(TaskArtifactCache {
             root,
-            cache_dir: task_cache_dir(),
+            cache_dir,
             key,
             explanation,
             state_path,
@@ -508,6 +513,7 @@ impl TaskArtifactCache {
         let manifest_partial = self
             .cache_dir
             .join(format!("{}.part-{nonce}.json", self.key));
+        let _partial_files = PartialCacheFiles([archive_partial.clone(), manifest_partial.clone()]);
 
         let output_bytes = output.iter().fold(0_u64, |total, line| {
             let bytes = match line {
@@ -565,6 +571,67 @@ impl TaskArtifactCache {
         }
         Ok(manifest)
     }
+}
+
+struct PartialCacheFiles([PathBuf; 2]);
+
+impl Drop for PartialCacheFiles {
+    fn drop(&mut self) {
+        for path in &self.0 {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn cleanup_abandoned_partial_writes_once(cache_dir: &Path) {
+    let should_clean = CLEANED_PARTIAL_CACHE_DIRS
+        .lock()
+        .unwrap_or_else(|err| err.into_inner())
+        .insert(cache_dir.to_path_buf());
+    if should_clean && let Err(err) = cleanup_abandoned_partial_writes(cache_dir) {
+        CLEANED_PARTIAL_CACHE_DIRS
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .remove(cache_dir);
+        warn!(
+            "failed to clean abandoned task cache writes in {}: {err}",
+            cache_dir.display()
+        );
+    }
+}
+
+fn cleanup_abandoned_partial_writes(cache_dir: &Path) -> Result<()> {
+    let entries = match fs::read_dir(cache_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+    let mut keys = BTreeSet::new();
+    for entry in entries {
+        let path = entry?.path();
+        if let Some(key) = partial_cache_key(&path) {
+            keys.insert(key.to_string());
+        }
+    }
+    for key in keys {
+        let _entry_lock = task_cache_entry_lock(cache_dir, &key)?;
+        for entry in fs::read_dir(cache_dir)? {
+            let path = entry?.path();
+            if partial_cache_key(&path) == Some(key.as_str()) {
+                remove_cache_file(&path)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn partial_cache_key(path: &Path) -> Option<&str> {
+    let filename = path.file_name()?.to_str()?;
+    let stem = filename
+        .strip_suffix(".tar.zst")
+        .or_else(|| filename.strip_suffix(".json"))?;
+    let (key, nonce) = stem.split_once(".part-")?;
+    (!key.is_empty() && !nonce.is_empty()).then_some(key)
 }
 
 fn calculate_artifact_checksum(
@@ -1301,6 +1368,26 @@ mod tests {
         drop(held);
         acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap();
         waiter.join().unwrap();
+    }
+
+    #[test]
+    fn abandoned_partial_writes_are_removed_without_touching_complete_entries() {
+        let cache_dir = tempfile::tempdir().unwrap();
+        let abandoned_manifest = cache_dir.path().join("abandoned.part-deadbeef.json");
+        let abandoned_archive = cache_dir.path().join("abandoned.part-deadbeef.tar.zst");
+        let complete_manifest = cache_dir.path().join("complete.json");
+        let unrelated = cache_dir.path().join("abandoned.part-deadbeef.txt");
+        fs::write(&abandoned_manifest, "partial manifest").unwrap();
+        fs::write(&abandoned_archive, "partial archive").unwrap();
+        fs::write(&complete_manifest, "complete manifest").unwrap();
+        fs::write(&unrelated, "unrelated").unwrap();
+
+        cleanup_abandoned_partial_writes(cache_dir.path()).unwrap();
+
+        assert!(!abandoned_manifest.exists());
+        assert!(!abandoned_archive.exists());
+        assert!(complete_manifest.exists());
+        assert!(unrelated.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove temporary task-cache files when a write returns an error
- sweep partial files left by interrupted processes once per cache directory and process
- coordinate cleanup with per-key locks so active writers are preserved
- document the behavior and complete the parity-tracker item

## Validation
- `cargo test task_cache -- --nocapture`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_concurrency`
- `mise run lint-fix`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task cache write/publish paths and shared cache directory cleanup; incorrect locking or deletion could affect cache integrity, though behavior is guarded by per-key locks and tests.
> 
> **Overview**
> **Task artifact cache** now drops leftover `*.part-*` archive and manifest files from crashed or interrupted writes, without touching complete entries.
> 
> On **failed writes**, a `PartialCacheFiles` guard deletes the in-flight partial paths when `store` unwinds. On **later cache use**, mise runs a **once-per-process-per-cache-directory** sweep that finds `key.part-<nonce>` files, takes the **per-cache-key lock** for each key, then removes only those partials—so an active writer holding the lock is not cleared. Cache key construction triggers that sweep when a cache directory is first used in a process.
> 
> Docs and the parity tracker note this behavior; e2e and unit tests cover abandoned cleanup, lock coordination, and missing cache dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1afc1ba6d179c8fc840fddd0e3599cd7210e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes abandoned partial task-cache archive and manifest files left behind by interrupted writes.
  * Performs cleanup safely after acquiring the relevant cache lock, preserving files still being written.
  * Keeps complete cache entries and unrelated files intact.

* **Documentation**
  * Updated task-cache configuration documentation to describe partial-file cleanup behavior.

* **Tests**
  * Added coverage for cleanup during read-only cache operations and for initially missing cache directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->