### PR TITLE
fix(config): apply ignore filters to --path <dir> write targets

### DIFF
--- a/e2e/config/test_config_ignore_write_target
+++ b/e2e/config/test_config_ignore_write_target
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# The write target has to respect the same exclusions as config loading.
+#
+# `--path`/`--file` resolve to a file inside the named directory, but the lookup did not apply
+# the ignore filters, so `mise use --path <dir>` could pick a config that loading skips --
+# writing a tool somewhere mise never reads back.
+#
+# `ignored_config_paths` is the lever that produces this state. The persisted ignore list
+# (`mise trust --ignore`) cannot: `trusted_config_paths` overrides it, and without that override
+# the write fails the trust check instead of landing silently.
+
+mkdir -p mixed excluded plain
+
+cat <<EOF >mixed/mise.toml
+[env]
+FROM = "mise.toml"
+EOF
+cat <<EOF >mixed/mise.local.toml
+[env]
+FROM = "mise.local.toml"
+EOF
+
+#################################################################################
+# One file in the directory is excluded, a sibling is not
+#################################################################################
+
+# mise.toml sorts before mise.local.toml, so it is what the unfiltered lookup returned.
+MISE_IGNORED_CONFIG_PATHS="$PWD/mixed/mise.toml" mise use --path mixed dummy@1.0.0
+assert_not_contains "cat mixed/mise.toml" "dummy"
+assert_contains "cat mixed/mise.local.toml" "dummy"
+
+#################################################################################
+# The whole directory is excluded
+#################################################################################
+
+# It was named explicitly, so mise still creates what was asked for -- but says that it will
+# not be read back, instead of writing silently.
+assert_contains "MISE_IGNORED_CONFIG_PATHS=$PWD/excluded mise use --path excluded dummy@1.0.0 2>&1" \
+  "will not read back what it writes there"
+assert_contains "cat excluded/mise.toml" "dummy"
+
+#################################################################################
+# Nothing excluded: unchanged
+#################################################################################
+
+cat <<EOF >plain/mise.toml
+[env]
+FROM = "plain"
+EOF
+
+mise use --path plain dummy@1.0.0
+assert_contains "cat plain/mise.toml" "dummy"
+assert_not_contains "mise use --path plain dummy@2.0.0 2>&1" "will not read back what it writes there"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1665,23 +1665,53 @@ fn is_conf_d_file(p: &Path) -> bool {
         .is_some_and(|d| d.file_name().is_some_and(|n| n == "conf.d"))
 }
 
+/// The config files in `dir` that config loading would actually read, with the same
+/// exclusions `load_config_paths` applies.
+///
+/// [`config_files_in_dir`] deliberately does **not** filter — `mise trust` has to see a
+/// file in order to un-ignore it, and `mise fmt` and task discovery want everything on
+/// disk. Choosing a file to *write* to is the one case that must not.
+fn loadable_config_files_in_dir(dir: &Path, filenames: &[String]) -> IndexSet<PathBuf> {
+    if config_dir_is_ignored(dir, false) {
+        return IndexSet::new();
+    }
+    filenames
+        .iter()
+        .flat_map(|f| glob(dir, f).unwrap_or_default())
+        .unique_by(|p| file::desymlink_path(p))
+        .filter(|p| !config_path_is_ignored(p, false))
+        .collect()
+}
+
 /// The config file to write to **inside `dir` itself**, or where one should be created.
 ///
 /// `--path`/`--file` name a specific directory, so the answer has to be inside it: "if a directory
 /// is specified, it will look for a config file in that directory" (`mise use --help`). This
 /// deliberately does not walk up. [`config_file_from_dir`] is the walking one, and it is only ever
 /// asked about the cwd.
+///
+/// Candidates that config loading skips are skipped here too: writing into one produces a
+/// file mise will never read back. When nothing in `dir` is loadable the default name is
+/// still returned — the directory was named explicitly, so mise creates what was asked for
+/// — but the caller is warned that it will not be read.
 pub fn config_file_in_dir(dir: &Path) -> PathBuf {
-    let files = config_files_in_dir(dir);
+    let files = loadable_config_files_in_dir(dir, &DEFAULT_CONFIG_FILENAMES);
     if let Some(cf) = first_config_file(&files)
         && !is_global_config(cf)
     {
         return cf.clone();
     }
-    match Settings::get().asdf_compat {
+    let fallback = match Settings::get().asdf_compat {
         true => dir.join(&*MISE_DEFAULT_TOOL_VERSIONS_FILENAME),
         false => dir.join(&*MISE_DEFAULT_CONFIG_FILENAME),
+    };
+    if config_dir_is_ignored(dir, false) || config_path_is_ignored(&fallback, false) {
+        warn_once!(
+            "{p} is excluded from config loading, so mise will not read back what it writes there",
+            p = display_path(&fallback)
+        );
     }
+    fallback
 }
 
 /// The nearest local config file walking up from `start`: the highest-precedence directory


### PR DESCRIPTION
## Problem

Pointing `--path`/`--file` at a directory can write into a config file that mise itself has excluded from loading. The write succeeds, exits 0, and the value is never read back.

Measured on **v2026.7.15**:

```console
$ mise config ls
~/scratch/global.toml   (none)          # proj/mise.toml is not listed -- it is excluded

$ mise set --file ~/scratch/proj FOO=bar
$ cat ~/scratch/proj/mise.toml
[env]
EXISTING = "yes"
FOO = "bar"

$ mise env
export EXISTING=...                     # nothing; FOO never appears
```

With the exclusion removed, the same sequence round-trips fine — so this is specifically about writing somewhere loading skips.

`ignored_config_paths` is the lever that produces this state. The persisted ignore list (`mise trust --ignore`) cannot: `trusted_config_paths` overrides it, and without that override the write fails the trust check instead of landing silently.

## Cause

`resolve_target_config_path` sends a directory to `config_file_in_dir`, which picks a candidate with `config_files_in_dir` + `first_config_file`. Neither applies `config_dir_is_ignored` or `config_path_is_ignored`, which is what `load_config_paths` uses to decide what actually gets read.

## Change

Adds `loadable_config_files_in_dir(dir, filenames)` — the same directory scan with the ignore filters applied — and uses it in `config_file_in_dir`. Behaviour splits three ways:

| directory | result |
|---|---|
| has a loadable candidate | that one is chosen (`mise.toml` excluded + `mise.local.toml` live → the latter) |
| no loadable candidate, and the dir or default file is excluded | default name is still returned, with a warning |
| no candidate, nothing excluded | unchanged |

The fallback still returns the default name rather than erroring: the directory was named explicitly, so mise creates what was asked for. It just says that it will not be read back instead of writing silently.

**`config_files_in_dir` itself is deliberately left unfiltered.** Three callers depend on seeing files that loading skips: `cli/trust.rs` (you have to see a file to un-ignore it), `cli/fmt.rs`, and `task/task_list.rs`.

`mise unuse --path` (`cli/unuse.rs`) resolves through the same function and is fixed by the same change.

## Relation to #11571

#11571 (now merged) fixed the two *walking* resolvers by giving them a shared `nearest_local_config_file`. It did not touch `config_file_in_dir`, which came in with #11575 and must not walk up — `--path <dir>` means that directory, so the walking helper cannot be reused as-is.

`nearest_local_config_file`'s loop body is the same per-directory scan this PR extracts, so it can now be collapsed onto `loadable_config_files_in_dir`. Happy to fold that in here or leave it as a separate tidy-up — say which you prefer.

## Tests

`e2e/config/test_config_ignore_write_target`:

- one file excluded via `ignored_config_paths`, a sibling live → the write lands on `mise.local.toml`. `mise.toml` sorts first in `LOCAL_CONFIG_FILENAMES`, so it is exactly what the unfiltered lookup returned before
- whole directory excluded → the file is still created and the warning is emitted
- nothing excluded → unchanged, no warning

No unit test: `src/config/mod.rs`'s `mod tests` is `#[cfg(unix)]` and snapshot-based, and `config_dir_is_ignored` reads a `Lazy` static that a test cannot vary.

## Question for review

Is a warning the right call, or should an explicitly-named excluded directory be a hard error? `resolve_target_config_path` returns `Result`, so erroring is available. I picked the warning because it does not break anyone who is deliberately staging a config they intend to un-ignore later, but I don't have a strong view.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration writes now avoid ignored directories, excluded paths, and duplicate symlink targets.
  * Explicit writes to excluded directories continue to work, with a warning.
  * Configuration files written in unrestricted directories retain their normal behavior.
  * Warnings now clarify when a fallback configuration file will not be loaded.
  * Improved consistency between configuration discovery and configuration file writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->