### PR TITLE
test(task): cover task cache restore on windows

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -105,7 +105,7 @@ outside this tracker.
 - [x] Test and harden concurrent readers and writers for the same key
 - [x] Clean up interrupted and abandoned partial writes
 - [x] Add configurable cache size and age limits
-- [ ] Test restore behavior on Windows
+- [x] Test restore behavior on Windows
 - [ ] Test executable bits, symlinks, empty directories, and case-sensitive path edge cases
 - [ ] Benchmark hashing, archive creation, and restoration for large task graphs and artifacts
 - [x] Avoid rehashing unchanged source files when reliable metadata is available

--- a/e2e-win/task_artifact_cache.Tests.ps1
+++ b/e2e-win/task_artifact_cache.Tests.ps1
@@ -1,0 +1,70 @@
+Describe 'task artifact cache' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+        Set-Location $script:TestRoot
+
+        $script:OriginalEnv = @{
+            MISE_CACHE_DIR = $env:MISE_CACHE_DIR
+            MISE_STATE_DIR = $env:MISE_STATE_DIR
+            MISE_TRUSTED_CONFIG_PATHS = $env:MISE_TRUSTED_CONFIG_PATHS
+        }
+        $env:MISE_CACHE_DIR = Join-Path $script:TestRoot 'cache'
+        $env:MISE_STATE_DIR = Join-Path $script:TestRoot 'state'
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+
+        @'
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+shell = "pwsh -NoProfile -Command"
+run = '''
+New-Item -ItemType Directory -Force -Path dist | Out-Null
+Get-Content input.txt | Set-Content dist/result.txt
+Add-Content runs.txt ran
+Write-Output cache-stdout
+[Console]::Error.WriteLine('cache-stderr')
+'''
+sources = ["input.txt"]
+outputs = ["dist"]
+'@ | Out-File -FilePath 'mise.toml' -Encoding utf8NoBOM
+        Set-Content -Path 'input.txt' -Value 'windows-cache-input'
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        foreach ($name in $script:OriginalEnv.Keys) {
+            if ($null -eq $script:OriginalEnv[$name]) {
+                Remove-Item -Path "Env:$name" -ErrorAction Ignore
+            } else {
+                Set-Item -Path "Env:$name" -Value $script:OriginalEnv[$name]
+            }
+        }
+    }
+
+    It 'restores files and captured output from an archive' {
+        $first = mise run build 2>&1 | Out-String
+        $first | Should -Match 'cache-stdout'
+        $first | Should -Match 'cache-stderr'
+        (Get-Content 'dist/result.txt').Trim() | Should -Be 'windows-cache-input'
+        @(Get-Content 'runs.txt').Count | Should -Be 1
+
+        $cacheDir = Join-Path $env:MISE_CACHE_DIR 'task-artifacts/v2'
+        @(Get-ChildItem $cacheDir -Filter '*.json').Count | Should -Be 1
+        @(Get-ChildItem $cacheDir -Filter '*.tar.zst').Count | Should -Be 1
+
+        Remove-Item 'dist' -Recurse -Force
+        $second = mise run build 2>&1 | Out-String
+
+        $second | Should -Match 'restored outputs from cache'
+        $second | Should -Match 'cache-stdout'
+        $second | Should -Match 'cache-stderr'
+        (Get-Content 'dist/result.txt').Trim() | Should -Be 'windows-cache-input'
+        @(Get-Content 'runs.txt').Count | Should -Be 1
+    }
+}


### PR DESCRIPTION
## Summary
- add a Windows Pester test for task artifact cache restoration
- verify the first run publishes one manifest/archive pair
- remove declared outputs and prove the second run restores files, stdout, and stderr without executing again
- complete the Windows restore coverage tracker item

## Validation
- `mise run lint-fix`
- Windows execution is covered by the `windows-e2e` GitHub Actions job; PowerShell is not available on the local Linux host

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and tracker doc update; no changes to cache or task runtime behavior.
> 
> **Overview**
> Adds **Windows end-to-end coverage** for experimental task artifact cache restore via a new Pester suite in `e2e-win/task_artifact_cache.Tests.ps1`.
> 
> The test spins up an isolated `mise.toml` with cache enabled, runs a `pwsh` `build` task that writes `dist/` and appends to `runs.txt`, then asserts the first run emits stdout/stderr and creates exactly one manifest (`.json`) and archive (`.tar.zst`) under `task-artifacts/v2`. After deleting `dist`, a second `mise run build` must report a cache restore, replay captured output, restore `dist/result.txt`, and **not** run the task again (`runs.txt` still has one line).
> 
> Marks **“Test restore behavior on Windows”** complete in `TASK_CACHE_PARITY.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f0805b47cb6b1671b88026cc7d112ed03236a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->