### PR TITLE
test(task): cover task cache portability edge cases

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -106,7 +106,7 @@ outside this tracker.
 - [x] Clean up interrupted and abandoned partial writes
 - [x] Add configurable cache size and age limits
 - [x] Test restore behavior on Windows
-- [ ] Test executable bits, symlinks, empty directories, and case-sensitive path edge cases
+- [x] Test executable bits, symlinks, empty directories, and case-sensitive path edge cases
 - [ ] Benchmark hashing, archive creation, and restoration for large task graphs and artifacts
 - [x] Avoid rehashing unchanged source files when reliable metadata is available
 - [ ] Add an optional audit mode for undeclared task reads and writes

--- a/e2e/tasks/test_task_artifact_cache_portability
+++ b/e2e/tasks/test_task_artifact_cache_portability
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+run = '''
+mkdir -p dist/empty
+printf 'upper\n' >dist/Case.txt
+printf 'lower\n' >dist/case.txt
+printf '#!/usr/bin/env sh\necho executable\n' >dist/tool
+chmod 751 dist/tool
+ln -s Case.txt dist/link
+printf 'ran\n' >>runs.txt
+'''
+sources = ["input.txt"]
+outputs = ["dist"]
+EOF
+
+printf 'input\n' >input.txt
+
+mkdir case-probe
+printf 'upper\n' >case-probe/Case.txt
+printf 'lower\n' >case-probe/case.txt
+case_sensitive_fs=false
+if [[ $(find case-probe -maxdepth 1 -type f -iname '*ase.txt' | wc -l | tr -d ' ') == 2 ]]; then
+  case_sensitive_fs=true
+fi
+rm -rf case-probe
+
+assert_portable_outputs() {
+  assert "test -x dist/tool && echo executable" "executable"
+  assert "test -L dist/link && readlink dist/link" "Case.txt"
+  assert "test -d dist/empty && echo empty-directory" "empty-directory"
+  if $case_sensitive_fs; then
+    assert "cat dist/link" "upper"
+    assert "cat dist/Case.txt" "upper"
+    assert "cat dist/case.txt" "lower"
+    assert "find dist -maxdepth 1 -type f -iname '*ase.txt' | wc -l | tr -d ' '" "2"
+  else
+    assert "cat dist/link" "lower"
+  fi
+}
+
+mise run build
+assert_portable_outputs
+assert "wc -l <runs.txt | tr -d ' '" "1"
+
+rm -rf dist
+assert_contains "mise run build 2>&1" "restored outputs from cache"
+assert_portable_outputs
+assert "wc -l <runs.txt | tr -d ' '" "1"


### PR DESCRIPTION
## Summary
- add task-cache restore coverage for executable permissions
- verify symlink targets and empty directories survive archive round trips
- preserve distinct case-sensitive output names and contents
- complete the portability edge-case tracker item

## Validation
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_portability`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation tracker update; no runtime or cache implementation changes.
> 
> **Overview**
> Adds an end-to-end test that builds a `dist` output tree with **executable permissions**, a **symlink**, an **empty directory**, and **distinct `Case.txt` / `case.txt` names**, then verifies those properties after a normal run and again after deleting `dist` and **restoring from the task artifact cache** (task must not re-run).
> 
> The test **probes the filesystem** for case sensitivity and only asserts separate case-distinct files when the host FS is case-sensitive.
> 
> Marks the matching **integrity/portability** checklist item complete in `TASK_CACHE_PARITY.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d08fb5aa738d13be892c91f0a073acc1a73822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->