### PR TITLE
perf(task): benchmark artifact cache phases

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -107,7 +107,7 @@ outside this tracker.
 - [x] Add configurable cache size and age limits
 - [x] Test restore behavior on Windows
 - [x] Test executable bits, symlinks, empty directories, and case-sensitive path edge cases
-- [ ] Benchmark hashing, archive creation, and restoration for large task graphs and artifacts
+- [x] Benchmark hashing, archive creation, and restoration for large task graphs and artifacts
 - [x] Avoid rehashing unchanged source files when reliable metadata is available
 - [ ] Add an optional audit mode for undeclared task reads and writes
 

--- a/benchmarks/task-cache/README.md
+++ b/benchmarks/task-cache/README.md
@@ -1,0 +1,24 @@
+# Task artifact cache benchmark
+
+Run `mise run perf:task-cache` to measure the major local-cache phases against
+the release binary. The harness creates an isolated temporary project and
+reports median wall-clock times for:
+
+- hashing a large source set and publishing a result-only entry;
+- executing a task and creating an archive from a large artifact;
+- restoring that artifact from the archive; and
+- traversing a large graph whose tasks all have current cache entries.
+
+The defaults favor a useful local signal over a quick smoke test: 2,000 source
+files, a 32 MiB artifact, 500 graph nodes, and five measured runs per phase.
+Override `TASK_CACHE_BENCH_SOURCES`, `TASK_CACHE_BENCH_ARTIFACT_BYTES`,
+`TASK_CACHE_BENCH_TASKS`, or `TASK_CACHE_BENCH_RUNS` to scale the fixture. Set
+`MISE_BIN` to compare another already-built mise binary without rebuilding it:
+
+```sh
+MISE_BIN=/path/to/mise bash benchmarks/task-cache/benchmark.sh
+```
+
+Preparation such as deleting restored outputs happens outside each timed
+interval. Results are wall-clock measurements, so compare binaries on the same
+machine under similar load.

--- a/benchmarks/task-cache/benchmark.sh
+++ b/benchmarks/task-cache/benchmark.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+mise_bin=${MISE_BIN:-"$repo_root/target/release/mise"}
+source_count=${TASK_CACHE_BENCH_SOURCES:-2000}
+artifact_bytes=${TASK_CACHE_BENCH_ARTIFACT_BYTES:-33554432}
+task_count=${TASK_CACHE_BENCH_TASKS:-500}
+runs=${TASK_CACHE_BENCH_RUNS:-5}
+
+for value in "$source_count" "$artifact_bytes" "$task_count" "$runs"; do
+	if ! [[ $value =~ ^[1-9][0-9]*$ ]]; then
+		echo "benchmark sizes and run count must be positive integers" >&2
+		exit 2
+	fi
+done
+if [[ ! -x $mise_bin ]]; then
+	echo "mise benchmark binary is not executable: $mise_bin" >&2
+	exit 2
+fi
+
+clock="date"
+date_ns=$(date +%s%N)
+if ! [[ $date_ns =~ ^[0-9]+$ ]]; then
+	if command -v gdate >/dev/null && [[ $(gdate +%s%N) =~ ^[0-9]+$ ]]; then
+		clock="gdate"
+	elif command -v perl >/dev/null; then
+		clock="perl"
+	elif command -v python3 >/dev/null; then
+		clock="python3"
+	else
+		echo "benchmark requires GNU date, perl, or python3 for high-resolution timing" >&2
+		exit 2
+	fi
+fi
+
+fixture=$(mktemp -d "${TMPDIR:-/tmp}/mise-task-cache-bench.XXXXXX")
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/sources" "$fixture/cache" "$fixture/state"
+
+for ((i = 1; i <= source_count; i++)); do
+	printf 'source-%08d\n' "$i" >"$fixture/sources/file-$i.txt"
+done
+dd if=/dev/urandom of="$fixture/sources/payload.bin" bs=1024 \
+	count=$(((artifact_bytes + 1023) / 1024)) 2>/dev/null
+
+{
+	cat <<'EOF'
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+
+[tasks.hash]
+run = "true"
+sources = ["sources/**/*"]
+outputs = []
+
+[tasks.archive]
+run = "rm -rf dist && mkdir dist && cp -R sources/. dist/"
+sources = ["sources/**/*"]
+outputs = ["dist"]
+
+[tasks.graph]
+run = "true"
+outputs = []
+depends = [
+EOF
+	for ((i = 1; i <= task_count; i++)); do
+		printf '  "node-%d",\n' "$i"
+	done
+	cat <<'EOF'
+]
+EOF
+	for ((i = 1; i <= task_count; i++)); do
+		printf '\n[tasks."node-%d"]\nrun = "true"\noutputs = []\n' "$i"
+	done
+} >"$fixture/mise.toml"
+
+export MISE_CACHE_DIR="$fixture/cache"
+export MISE_STATE_DIR="$fixture/state"
+export MISE_TRUSTED_CONFIG_PATHS="$fixture"
+export MISE_TASK_CACHE_MAX_AGE=0
+export MISE_TASK_CACHE_MAX_SIZE=0
+
+now_ns() {
+	case $clock in
+	date) date +%s%N ;;
+	gdate) gdate +%s%N ;;
+	perl) perl -MTime::HiRes=time -e 'printf "%.0f\n", time() * 1_000_000_000' ;;
+	python3) python3 -c 'import time; print(time.time_ns())' ;;
+	esac
+}
+
+median() {
+	sort -n | awk '{ samples[NR] = $1 } END {
+    if (NR % 2) print samples[(NR + 1) / 2]
+    else print int((samples[NR / 2] + samples[NR / 2 + 1]) / 2)
+  }'
+}
+
+prepare_phase() {
+	case $1 in
+	archive-publish | restore) rm -rf "$fixture/dist" ;;
+	esac
+}
+
+measure() {
+	local phase=$1
+	shift
+	local samples=()
+	for ((i = 1; i <= runs; i++)); do
+		prepare_phase "$phase"
+		local start end
+		start=$(now_ns)
+		"$@" >/dev/null 2>&1
+		end=$(now_ns)
+		samples+=("$(((end - start) / 1000000))")
+	done
+	printf '| %-15s | %9s | %4d |\n' "$phase" \
+		"$(printf '%s\n' "${samples[@]}" | median) ms" "$runs"
+}
+
+# Populate every entry before timing cache-hit traversal and restoration.
+"$mise_bin" -C "$fixture" run --force hash >/dev/null 2>&1
+"$mise_bin" -C "$fixture" run --force archive >/dev/null 2>&1
+"$mise_bin" -C "$fixture" run --jobs 1 graph >/dev/null 2>&1
+
+printf 'task cache fixture: %d sources, %d artifact bytes, %d graph nodes\n\n' \
+	"$source_count" "$artifact_bytes" "$task_count"
+printf '| Phase           | Median    | Runs |\n'
+printf '|-----------------|-----------|------|\n'
+measure hashing "$mise_bin" -C "$fixture" run --force hash
+measure archive-publish "$mise_bin" -C "$fixture" run --force archive
+measure restore "$mise_bin" -C "$fixture" run archive
+measure cached-graph "$mise_bin" -C "$fixture" run --jobs 1 graph
+
+test -f "$fixture/dist/payload.bin"

--- a/mise.toml
+++ b/mise.toml
@@ -61,3 +61,9 @@ run = ["cargo build --release", "tak run"]
 dir = "{{config_root}}"
 env = { MISE_OFFLINE = "1" }
 run = ["cargo build --release", "tak run --record"]
+
+# End-to-end task artifact cache phases. The harness generates an isolated
+# large fixture so benchmark inputs never need to be checked into the repo.
+[tasks."perf:task-cache"]
+dir = "{{config_root}}"
+run = ["cargo build --release", "bash benchmarks/task-cache/benchmark.sh"]

--- a/tasks.md
+++ b/tasks.md
@@ -110,6 +110,10 @@ Lint HK files
 
 - **Usage**: `perf:record`
 
+## `perf:task-cache`
+
+- **Usage**: `perf:task-cache`
+
 ## `pre-commit`
 
 - **Usage**: `pre-commit`


### PR DESCRIPTION
## Summary
- add an isolated task artifact cache benchmark harness
- measure source hashing, archive publication, restoration, and cached graph traversal separately
- generate configurable large source, artifact, and dependency-graph fixtures
- document usage and complete the benchmark tracker item

## Validation
- `TASK_CACHE_BENCH_SOURCES=10 TASK_CACHE_BENCH_ARTIFACT_BYTES=65536 TASK_CACHE_BENCH_TASKS=5 TASK_CACHE_BENCH_RUNS=2 MISE_BIN="$PWD/target/debug/mise" bash benchmarks/task-cache/benchmark.sh`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and documentation only; no changes to cache runtime behavior or production code paths.
> 
> **Overview**
> Adds an **end-to-end benchmark harness** for the experimental local task artifact cache, wired as `mise run perf:task-cache` (release build + `benchmarks/task-cache/benchmark.sh`).
> 
> The script spins up a **temporary mise project** with configurable scale (defaults: 2k sources, 32 MiB artifact, 500-node graph) and reports **median wall-clock** times for four phases: source hashing / result-only publish, task run + archive creation, cache restore, and fully cached graph traversal. Fixture prep and cache warm-up sit outside the timed windows; `MISE_BIN` and `TASK_CACHE_BENCH_*` env vars tune binary and size.
> 
> **Docs and tracking:** README describes usage and env overrides; `TASK_CACHE_PARITY.md` marks the hashing/archive/restore benchmark tracker item done; `tasks.md` documents the new task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03aa16066835105235099c8f972977f470d572e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->