### PR TITLE
docs(install): prefer official release binaries

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,15 +27,6 @@ Verify the installation:
 - `~/.local/bin` does not need to be in `PATH`. mise will automatically add its own directory to `PATH`
   when [activated](#activate-mise).
 
-== Homebrew (alternative)
-
-The official single binary installed by `mise.run` is preferred because it is more optimized than
-the Homebrew build. Use Homebrew when package-manager installation is more important than performance.
-
-```shell
-brew install mise
-```
-
 == Windows
 ::: code-group
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,10 @@ Verify the installation:
 - `~/.local/bin` does not need to be in `PATH`. mise will automatically add its own directory to `PATH`
   when [activated](#activate-mise).
 
-== Brew
+== Homebrew (alternative)
+
+The official single binary installed by `mise.run` is preferred because it is more optimized than
+the Homebrew build. Use Homebrew when package-manager installation is more important than performance.
 
 ```shell
 brew install mise

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -29,7 +29,7 @@ mise connects to many external registries and backends, such as aqua, GitHub rel
 Projects and organizations should generally set a [`min_version`](/configuration.html#minimum-mise-version) when they need a newer mise feature instead of locking every user to a specific mise executable. While there are ways to pin or bootstrap a particular mise version, locking users to one mise version is generally discouraged. Pinning mise back is like preventing `apt update` or `brew update` from refreshing package metadata: it can hide deprecation messages and cause bit rot with upstream integrations like aqua-registry. Breaking changes are avoided unless they go through a long deprecation process, so staying current should usually be low risk.
 :::
 
-### <https://mise.run>
+### <https://mise.run> {#mise-run}
 
 Note that it isn't necessary for `mise` to be on `PATH`. If you run the activate script in your
 shell's rc
@@ -234,7 +234,7 @@ RUN mise trust -a && mise install
 ::: warning
 The Homebrew formula is convenient, but it is not the preferred installation method. Homebrew builds
 mise separately from the official, more optimized release binaries. For the best performance and
-fastest access to new releases, use the [`mise.run`](#https-mise-run) installer instead.
+fastest access to new releases, use the [`mise.run`](#mise-run) installer instead.
 :::
 
 ```sh

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -6,16 +6,18 @@ If you are new to `mise`, follow the [Getting Started](/getting-started) guide f
 
 This page lists various ways to install `mise` on your system.
 
-| Platform              | Recommended    | Alternative     |
-| --------------------- | -------------- | --------------- |
-| macOS                 | Homebrew       | mise.run        |
-| Linux (Debian/Ubuntu) | apt            | mise.run        |
-| Linux (Fedora/RHEL)   | dnf            | mise.run        |
-| Linux (Arch)          | pacman         | mise.run        |
-| Linux (Alpine)        | apk            | mise.run        |
-| Windows               | Scoop          | winget          |
-| Any (Rust users)      | cargo binstall | cargo install   |
-| CI/Docker             | mise.run       | GitHub Releases |
+| Platform              | Recommended | Alternative     |
+| --------------------- | ----------- | --------------- |
+| macOS                 | mise.run    | Homebrew        |
+| Linux                 | mise.run    | System packages |
+| Windows               | Scoop       | winget          |
+| Any (Rust users)      | mise.run    | cargo binstall  |
+| CI/Docker             | mise.run    | GitHub Releases |
+
+The official single-binary release installed by `mise.run` is the preferred method on macOS and
+Linux. These binaries are built with mise's optimized release profile and can be updated immediately
+with `mise self-update`. Package-manager builds, including Homebrew, may be less optimized and may
+not become available as quickly after a mise release.
 
 ::: tip Which methods auto-update?
 Package managers (apt, dnf, brew, pacman, etc.) update mise when you update system packages. Other methods can be updated with `mise self-update`.
@@ -228,6 +230,12 @@ RUN mise trust -a && mise install
 :::
 
 ### Homebrew
+
+::: warning
+The Homebrew formula is convenient, but it is not the preferred installation method. Homebrew builds
+mise separately from the official, more optimized release binaries. For the best performance and
+fastest access to new releases, use the [`mise.run`](#https-mise-run) installer instead.
+:::
 
 ```sh
 brew install mise

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -6,13 +6,13 @@ If you are new to `mise`, follow the [Getting Started](/getting-started) guide f
 
 This page lists various ways to install `mise` on your system.
 
-| Platform              | Recommended | Alternative     |
-| --------------------- | ----------- | --------------- |
-| macOS                 | mise.run    | Homebrew        |
-| Linux                 | mise.run    | System packages |
-| Windows               | Scoop       | winget          |
-| Any (Rust users)      | mise.run    | cargo binstall  |
-| CI/Docker             | mise.run    | GitHub Releases |
+| Platform         | Recommended    | Alternative     |
+| ---------------- | -------------- | --------------- |
+| macOS            | mise.run       | Homebrew        |
+| Linux            | mise.run       | System packages |
+| Windows          | Scoop          | winget          |
+| Any (Rust users) | cargo binstall | cargo install   |
+| CI/Docker        | mise.run       | GitHub Releases |
 
 The official single-binary release installed by `mise.run` is the preferred method on macOS and
 Linux. These binaries are built with mise's optimized release profile and can be updated immediately


### PR DESCRIPTION
## Summary

- recommend the official single binary installed by `mise.run` on macOS and Linux
- position Homebrew and other system package managers as alternatives
- explain that official release binaries use mise's optimized release profile and support immediate `mise self-update` updates

## Validation

- `mise run docs:build`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> Installation docs now steer macOS and Linux users toward the **`mise.run`** single-binary installer instead of Homebrew or per-distro packages.
> 
> On **`installing-mise.md`**, the platform table is simplified so **mise.run** is recommended on macOS/Linux, with a short note on optimized release builds and **`mise self-update`**. Homebrew is demoted to an alternative and gets a **warning** that formula builds may be slower to ship and less optimized. The **`mise.run`** section gains an anchor (`{#mise-run}`) for cross-links.
> 
> On **`getting-started.md`**, the **Homebrew** install tab is removed so the quick-start path matches the curl installer only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b721f715ff09951a7cb1e8e4e04f1b9f2e8b7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to recommend the official `mise.run` binary for macOS, Linux, Rust users, and CI/Docker environments.
  * Relabeled Homebrew as an alternative installation method and noted that its builds may be less optimized or lag behind official releases.
  * Removed the Homebrew installation tab and setup instructions from the getting-started guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->