### PR TITLE
feat(config): accept --file on `mise unuse` and --path on `mise unset`

### DIFF
--- a/docs/cli/unset.md
+++ b/docs/cli/unset.md
@@ -22,6 +22,8 @@ e.g.: NODE_ENV
 
 Specify a file to use instead of `mise.toml`
 
+Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
+
 Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 
 ### `-g --global`

--- a/e2e/cli/test_config_target_aliases
+++ b/e2e/cli/test_config_target_aliases
@@ -23,3 +23,34 @@ mise use --path alias.toml dummy@2
 assert_contains "cat alias.toml" 'dummy = "2"'
 mise set --file alias.toml ALIAS_VAR=set-via-file
 assert_contains "cat alias.toml" 'ALIAS_VAR = "set-via-file"'
+
+# the commands that undo those two take the same pair of names
+# `mise unuse --file` is `mise unuse --path`
+mise unuse --no-prune --file alias.toml dummy@2
+assert_not_contains "cat alias.toml" "dummy"
+
+# `mise unset --path` is `mise unset --file`
+mise unset --path alias.toml ALIAS_VAR
+assert_not_contains "cat alias.toml" "ALIAS_VAR"
+
+# and their canonical names are unaffected
+mise use --path alias.toml dummy@3
+mise set --file alias.toml ALIAS_VAR=again
+mise unuse --no-prune --path alias.toml dummy@3
+assert_not_contains "cat alias.toml" "dummy"
+mise unset --file alias.toml ALIAS_VAR
+assert_not_contains "cat alias.toml" "ALIAS_VAR"
+
+# all four accept a directory as well as a file, under either name: the argument resolves to
+# the config file inside that directory
+mkdir -p subdir
+
+mise use --file subdir dummy@1
+assert_contains "cat subdir/mise.toml" 'dummy = "1"'
+mise set --path subdir SUBDIR_VAR=via-dir
+assert_contains "cat subdir/mise.toml" 'SUBDIR_VAR = "via-dir"'
+
+mise unuse --no-prune --file subdir dummy@1
+assert_not_contains "cat subdir/mise.toml" "dummy"
+mise unset --path subdir SUBDIR_VAR
+assert_not_contains "cat subdir/mise.toml" "SUBDIR_VAR"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4285,8 +4285,10 @@ By default, this command modifies `mise.toml` in the current directory.
 \fBOptions:\fR
 .PP
 .TP
-\fB\-f, \-\-file\fR \fI<FILE>\fR
+\fB\-f, \-\-file, \-\-path\fR \fI<FILE>\fR
 Specify a file to use instead of `mise.toml`
+
+Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
 
 Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 .TP
@@ -4339,7 +4341,7 @@ Create/modify an environment\-specific config file like .mise.<env>.toml
 \fB\-g, \-\-global\fR
 Use the global config file (`~/.config/mise/config.toml`) instead of the local one
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Specify a path to a config file or directory
 
 If a directory is specified, it will look for a config file in that directory following the rules above.

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4307,9 +4307,11 @@ Examples:
     $ mise unset NODE_ENV -g
 
 """#
-    flag "-f --file" help="Specify a file to use instead of `mise.toml`" {
+    flag "-f --file --path" help="Specify a file to use instead of `mise.toml`" {
         long_help #"""
 Specify a file to use instead of `mise.toml`
+
+Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
 
 Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 """#
@@ -4366,7 +4368,7 @@ Examples:
         arg <ENV>
     }
     flag "-g --global" help="Use the global config file (`~/.config/mise/config.toml`) instead of the local one"
-    flag "-p --path" help="Specify a path to a config file or directory" {
+    flag "-p --path --file" help="Specify a path to a config file or directory" {
         long_help #"""
 Specify a path to a config file or directory
 

--- a/src/cli/unset.rs
+++ b/src/cli/unset.rs
@@ -19,9 +19,11 @@ pub struct Unset {
 
     /// Specify a file to use instead of `mise.toml`
     ///
+    /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
+    ///
     /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
     /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[clap(short, long, value_hint = clap::ValueHint::FilePath)]
+    #[clap(short, long, visible_alias = "path", value_hint = clap::ValueHint::FilePath)]
     file: Option<PathBuf>,
 
     /// Use the global config file

--- a/src/cli/unuse.rs
+++ b/src/cli/unuse.rs
@@ -47,7 +47,7 @@ pub struct Unuse {
     ///
     /// If a directory is specified, it will look for a config file in that directory following
     /// the rules above.
-    #[clap(short, long, overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
+    #[clap(short, long, visible_alias = "file", overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
     path: Option<PathBuf>,
 
     /// Do not also prune the installed version


### PR DESCRIPTION
Follow-up to #11577, which left the pair half-finished:

| | |
|---|---|
| `mise use --file` | works (#11577) |
| `mise unuse --file` | **does not** |
| `mise set --path` | works (#11577) |
| `mise unset --path` | **does not** |

So the command that adds a tool takes both spellings and the command that removes it does not. This adds `--file` as a visible alias for `mise unuse --path`, and `--path` for `mise unset --file` — the same one-line change #11577 made, applied to the two inverse commands.

The alias is accurate, not just a spelling: both commands accept a directory as well as a file. `unset` resolves through `resolve_target_config_path`, which has a `path.is_dir()` branch, and `unuse` calls `config::config_file_in_dir` when the argument is a directory.

## Background

#4881 asks for `--file`/`--path` as synonyms on the config-target commands. #11116 implemented it across eleven commands and was closed the next day. #11577 narrowed it to the two the discussion actually names, and that merged — so I am walking the rest in small steps rather than re-proposing the wide change.

Remaining after this one: `config get`, `config set`, `dotfiles add`, and the four `bootstrap packages` commands (`use`, `import`, `brew tap`, `brew untap`).

## Generated files

`mise.usage.kdl` and `man/man1/mise.1` carry the four expected lines. They were written by hand from the shape #11577's merged output already has in-tree (`mise set` at man:3295, `mise use` at man:4468), so `mise run render` should be a no-op — the `lint` job will say so either way.

## Tests

`e2e/cli/test_config_target_aliases` — the file #11577 added — gains the inverse half: `unuse --file` and `unset --path` remove what `use --file` and `set --path` wrote, and the canonical spellings still work afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--path` as an alternative to `--file` for `mise unset`.
  * Added `--file` as an alternative to `--path` for `mise unuse`.
  * Existing option names remain supported.
  * File options now accept file or directory paths; directory targets use or create `mise.toml`.

* **Documentation**
  * Clarified file and directory path handling.

* **Tests**
  * Added end-to-end coverage for canonical options, aliases, and directory paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->