### PR TITLE
feat(task): audit artifact cache declarations

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -109,7 +109,7 @@ outside this tracker.
 - [x] Test executable bits, symlinks, empty directories, and case-sensitive path edge cases
 - [x] Benchmark hashing, archive creation, and restoration for large task graphs and artifacts
 - [x] Avoid rehashing unchanged source files when reliable metadata is available
-- [ ] Add an optional audit mode for undeclared task reads and writes
+- [x] Add an optional audit mode for undeclared task reads and writes
 
 ## Remote cache
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -552,8 +552,8 @@ outputs = { auto = true } # this is the default when sources is defined
 
 ### `cache` <Badge type="warning" text="experimental" />
 
-- **Type**: `{ enabled = bool, env = string[], command_inputs = string[] }`
-- **Default**: `{ enabled = false, env = [], command_inputs = [] }`
+- **Type**: `{ enabled = bool, audit = bool, env = string[], command_inputs = string[] }`
+- **Default**: `{ enabled = false, audit = false, env = [], command_inputs = [] }`
 
 Stores successful task results in a content-addressed local cache and reuses them when the same task
 inputs are seen again. Declared filesystem outputs are restored after deletion. Tasks with
@@ -597,6 +597,25 @@ or retained. Command inputs inherit the task timeout, or have a 30-second timeou
 none, and may emit at most 16 MiB across stdout and stderr. They should be fast, deterministic, and
 free of side effects because they run whenever mise computes the task's cache key. Command inputs
 are not run during dry runs or when caching is disabled for raw or interactive execution.
+
+Set `cache.audit = true` to diagnose incomplete cache declarations on Linux. When a task executes,
+mise uses `strace` to report reads beneath the workspace root that do not match `sources` and writes
+beneath the task directory that do not match `outputs`. The audit is advisory and does not block the
+task or prevent a successful result from being cached. Access outside those roots and directory
+metadata reads are ignored to keep system libraries, executables, and path traversal out of the
+report.
+
+Audit mode requires `strace` on `PATH`. Mise warns and runs the task normally when tracing is not
+available; other platforms are not currently supported. Cached tasks are not executed and therefore
+produce no audit report, so use `mise run --force <task>` when checking an existing cache entry.
+
+```mise-toml
+[tasks.build]
+run = "npm run build"
+sources = ["package.json", "src/**"]
+outputs = ["dist"]
+cache = { enabled = true, audit = true }
+```
 
 #### External dependencies and lockfiles
 

--- a/e2e/tasks/test_task_artifact_cache_audit
+++ b/e2e/tasks/test_task_artifact_cache_audit
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+mkdir -p bin
+cat <<'EOF' >bin/strace
+#!/usr/bin/env bash
+set -euo pipefail
+
+trace=
+while (($#)); do
+  case $1 in
+  -o)
+    trace=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *) shift ;;
+  esac
+done
+if [[ -z $trace ]]; then
+  exec "$@"
+fi
+cat <<TRACE >"$trace"
+123 openat(AT_FDCWD<$PWD>, "input.txt", O_RDONLY) = 3
+123 openat(AT_FDCWD<$PWD>, "../shared.txt", O_RDONLY) = 3
+123 openat(AT_FDCWD<$PWD>, "secret.txt", O_RDONLY) = 3
+123 openat(AT_FDCWD<$PWD>, "dist/result.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3
+123 openat(AT_FDCWD<$PWD>, "leak.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3
+TRACE
+exec "$@"
+EOF
+chmod +x bin/strace
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+dir = "pkg"
+run = "mkdir -p dist && cat input.txt secret.txt ../shared.txt >dist/result.txt && touch leak.txt"
+sources = ["input.txt", "{{ config_root }}/shared.txt"]
+outputs = ["dist"]
+cache = { enabled = true, audit = true }
+EOF
+
+mkdir -p pkg
+printf 'declared\n' >pkg/input.txt
+printf 'workspace source\n' >shared.txt
+printf 'undeclared\n' >pkg/secret.txt
+
+output=$(PATH="$PWD/bin:$PATH" mise run --force build 2>&1)
+assert_contains "echo \"$output\"" "cache audit detected undeclared read: secret.txt"
+assert_contains "echo \"$output\"" "cache audit detected undeclared write: leak.txt"
+assert_not_contains "echo \"$output\"" "undeclared read: input.txt"
+assert_not_contains "echo \"$output\"" "undeclared read: shared.txt"
+assert_not_contains "echo \"$output\"" "undeclared write: dist/result.txt"
+
+# Audit mode is advisory: successful tasks still publish cache entries.
+rm -rf pkg/dist pkg/leak.txt
+assert_contains "PATH=\"$PWD/bin:$PATH\" mise run build 2>&1" "restored outputs from cache"

--- a/e2e/tasks/test_task_info
+++ b/e2e/tasks/test_task_info
@@ -46,6 +46,7 @@ assert_json "mise tasks info lint --json" "$(
   "outputs": [],
   "cache": {
     "enabled": false,
+    "audit": false,
     "env": [],
     "command_inputs": []
   },

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -195,6 +195,11 @@
               "description": "store and restore task outputs from the local mise cache",
               "type": "boolean"
             },
+            "audit": {
+              "default": false,
+              "description": "report project files read or written outside declared cache sources and outputs",
+              "type": "boolean"
+            },
             "env": {
               "description": "ambient environment variable names whose values affect the cache key",
               "items": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2308,6 +2308,11 @@
               "description": "store and restore eligible task outputs from the local mise cache",
               "type": "boolean"
             },
+            "audit": {
+              "default": false,
+              "description": "report project files read or written outside declared cache sources and outputs",
+              "type": "boolean"
+            },
             "env": {
               "description": "ambient environment variable names whose values affect eligible task cache keys",
               "items": {
@@ -3059,6 +3064,11 @@
             "enabled": {
               "default": false,
               "description": "store and restore task outputs from the local mise cache",
+              "type": "boolean"
+            },
+            "audit": {
+              "default": false,
+              "description": "report project files read or written outside declared cache sources and outputs",
               "type": "boolean"
             },
             "env": {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -43,6 +43,7 @@ pub type FailedTasks = Arc<std::sync::Mutex<Vec<(Task, Option<i32>)>>>;
 
 mod deps;
 pub mod task_cache;
+mod task_cache_audit;
 pub mod task_confirm;
 pub mod task_context_builder;
 mod task_dep;
@@ -68,6 +69,7 @@ pub mod workspace;
 
 pub(crate) use task_cache::TaskCacheOutput;
 pub use task_cache::{TaskArtifactCache, TaskCacheConfig, TaskCacheMode};
+pub(crate) use task_cache_audit::TaskCacheAudit;
 pub use task_confirm::TaskConfirm;
 pub(crate) use task_load_context::monorepo_scope;
 pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax, is_workspace_project_task};
@@ -4674,6 +4676,7 @@ echo "test"
             task.cache,
             Some(TaskCacheConfig {
                 enabled: true,
+                audit: false,
                 env: vec!["PROFILE".to_string()],
                 command_inputs: vec![],
             })

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -34,6 +34,8 @@ static CLEANED_PARTIAL_CACHE_DIRS: LazyLock<Mutex<BTreeSet<PathBuf>>> =
 #[serde(default, deny_unknown_fields)]
 pub struct TaskCacheConfig {
     pub enabled: bool,
+    /// Report project files read or written outside the declared cache contract.
+    pub audit: bool,
     /// Ambient environment variables whose resolved values affect the cache key.
     pub env: Vec<String>,
     /// Commands whose stdout and stderr affect the cache key.
@@ -1504,10 +1506,11 @@ mod tests {
     #[test]
     fn config_deserializes_and_rejects_unknown_fields() {
         let config: TaskCacheConfig = toml::from_str(
-            "enabled = true\nenv = ['PROFILE']\ncommand_inputs = ['node --version']",
+            "enabled = true\naudit = true\nenv = ['PROFILE']\ncommand_inputs = ['node --version']",
         )
         .unwrap();
         assert!(config.enabled);
+        assert!(config.audit);
         assert_eq!(config.env, ["PROFILE"]);
         assert_eq!(config.command_inputs, ["node --version"]);
         assert!(toml::from_str::<TaskCacheConfig>("remote = true").is_err());

--- a/src/task/task_cache_audit.rs
+++ b/src/task/task_cache_audit.rs
@@ -1,0 +1,464 @@
+use crate::config::Config;
+#[cfg(target_os = "linux")]
+use crate::file;
+use crate::task::Task;
+#[cfg(target_os = "linux")]
+use crate::task::task_source_checker::{
+    build_output_matcher, build_source_matcher, task_cwd, task_source_match_root,
+};
+use eyre::Result;
+use ignore::overrides::Override;
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::process::Stdio;
+use std::sync::Arc;
+use tempfile::NamedTempFile;
+#[cfg(target_os = "linux")]
+use tokio::sync::OnceCell;
+
+const MAX_REPORTED_PATHS: usize = 20;
+
+#[cfg(target_os = "linux")]
+static STRACE: OnceCell<Option<PathBuf>> = OnceCell::const_new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum AccessKind {
+    Read,
+    Write,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TraceAccess {
+    kind: AccessKind,
+    path: PathBuf,
+    base: Option<PathBuf>,
+}
+
+pub(crate) struct TaskCacheAudit {
+    #[cfg(target_os = "linux")]
+    strace: PathBuf,
+    trace: NamedTempFile,
+    root: PathBuf,
+    source_root: PathBuf,
+    sources: Override,
+    outputs: Override,
+    config_sources: BTreeSet<PathBuf>,
+}
+
+impl TaskCacheAudit {
+    pub(crate) async fn prepare(task: &Task, config: &Arc<Config>) -> Result<Option<Self>> {
+        if !task
+            .cache
+            .as_ref()
+            .is_some_and(|cache| cache.enabled && cache.audit)
+        {
+            return Ok(None);
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (task, config);
+            warn_once!("task cache audit is currently supported only on Linux with strace");
+            Ok(None)
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let Some(strace) = usable_strace().await else {
+                return Ok(None);
+            };
+            let root = task_cwd(task, config).await?;
+            let source_root = task_source_match_root(&root, config);
+            let sources = build_source_matcher(&source_root, &root, &task.sources);
+            let outputs = build_output_matcher(&root, &task.outputs.patterns())?;
+            let config_sources = task
+                .config_sources()
+                .into_iter()
+                .map(|path| {
+                    lexical_normalize(&if path.is_absolute() {
+                        path.to_path_buf()
+                    } else {
+                        root.join(path)
+                    })
+                })
+                .collect();
+            Ok(Some(Self {
+                strace,
+                trace: NamedTempFile::new()?,
+                root,
+                source_root,
+                sources,
+                outputs,
+                config_sources,
+            }))
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn wrap(&self, program: OsString, args: &[String]) -> (OsString, Vec<String>) {
+        let mut wrapped = vec![
+            "-f".to_string(),
+            "-qq".to_string(),
+            "-yy".to_string(),
+            "-e".to_string(),
+            "trace=%file".to_string(),
+            "-s".to_string(),
+            "4096".to_string(),
+            "-o".to_string(),
+            self.trace.path().to_string_lossy().into_owned(),
+            "--".to_string(),
+            program.to_string_lossy().into_owned(),
+        ];
+        wrapped.extend(args.iter().cloned());
+        (self.strace.clone().into_os_string(), wrapped)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub(crate) fn wrap(&self, program: OsString, args: &[String]) -> (OsString, Vec<String>) {
+        (program, args.to_vec())
+    }
+
+    pub(crate) fn report(&self, task: &Task) {
+        let trace = match fs::read_to_string(self.trace.path()) {
+            Ok(trace) => trace,
+            Err(err) => {
+                warn!(
+                    "task {} cache audit could not read its trace: {err}",
+                    task.name
+                );
+                return;
+            }
+        };
+        let mut undeclared = BTreeSet::new();
+        for line in trace.lines() {
+            for access in parse_trace_line(line) {
+                let path = lexical_normalize(&if access.path.is_absolute() {
+                    access.path
+                } else {
+                    access
+                        .base
+                        .unwrap_or_else(|| self.root.clone())
+                        .join(access.path)
+                });
+                let scope_root = if access.kind == AccessKind::Read {
+                    &self.source_root
+                } else {
+                    &self.root
+                };
+                let Ok(relative) = path.strip_prefix(scope_root) else {
+                    continue;
+                };
+                if relative.as_os_str().is_empty()
+                    || (access.kind == AccessKind::Read && path.is_dir())
+                    || self.is_declared(access.kind, &path)
+                {
+                    continue;
+                }
+                let display_path = path.strip_prefix(&self.root).unwrap_or(relative);
+                undeclared.insert((access.kind, display_path.to_path_buf()));
+            }
+        }
+        let total = undeclared.len();
+        for (kind, path) in undeclared.into_iter().take(MAX_REPORTED_PATHS) {
+            let kind = match kind {
+                AccessKind::Read => "read",
+                AccessKind::Write => "write",
+            };
+            warn!(
+                "task {} cache audit detected undeclared {kind}: {}",
+                task.name,
+                path.display()
+            );
+        }
+        if total > MAX_REPORTED_PATHS {
+            warn!(
+                "task {} cache audit omitted {} additional paths",
+                task.name,
+                total - MAX_REPORTED_PATHS
+            );
+        }
+    }
+
+    fn is_declared(&self, kind: AccessKind, path: &Path) -> bool {
+        if self.config_sources.contains(path) {
+            return true;
+        }
+        if let Ok(relative) = path.strip_prefix(&self.root)
+            && matches_override(&self.outputs, relative)
+        {
+            return true;
+        }
+        kind == AccessKind::Read
+            && path
+                .strip_prefix(&self.source_root)
+                .is_ok_and(|relative| matches_override(&self.sources, relative))
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn usable_strace() -> Option<PathBuf> {
+    STRACE
+        .get_or_init(|| async {
+            let Some(strace) = file::which("strace") else {
+                warn_once!("task cache audit requires strace; running without filesystem auditing");
+                return None;
+            };
+            let status = tokio::process::Command::new(&strace)
+                .args(["-qq", "-yy", "-e", "trace=none", "--", "true"])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .await;
+            if !status.is_ok_and(|status| status.success()) {
+                warn_once!(
+                    "task cache audit could not start strace; running without filesystem auditing"
+                );
+                return None;
+            }
+            Some(strace)
+        })
+        .await
+        .clone()
+}
+
+fn matches_override(matcher: &Override, path: &Path) -> bool {
+    matcher.matched(path, false).is_whitelist() || matcher.matched(path, true).is_whitelist()
+}
+
+fn parse_trace_line(line: &str) -> Vec<TraceAccess> {
+    if line.contains(" = -1 ") || line.ends_with(" = -1") {
+        return Vec::new();
+    }
+    let Some(open) = line.find('(') else {
+        return Vec::new();
+    };
+    let syscall = line[..open].split_whitespace().last().unwrap_or_default();
+    let arguments = &line[open + 1..];
+    let mut paths = quoted_paths(arguments).into_iter();
+    let write = matches!(
+        syscall,
+        "creat"
+            | "mkdir"
+            | "mkdirat"
+            | "mknod"
+            | "mknodat"
+            | "rename"
+            | "renameat"
+            | "renameat2"
+            | "rmdir"
+            | "truncate"
+            | "unlink"
+            | "unlinkat"
+            | "utime"
+            | "utimes"
+            | "utimensat"
+            | "chmod"
+            | "fchmodat"
+            | "chown"
+            | "lchown"
+            | "fchownat"
+            | "link"
+            | "linkat"
+            | "symlink"
+            | "symlinkat"
+    ) || matches!(syscall, "open" | "openat" | "openat2")
+        && ["O_WRONLY", "O_RDWR", "O_CREAT", "O_TRUNC"]
+            .iter()
+            .any(|flag| contains_unquoted_token(arguments, flag));
+    if write {
+        paths
+            .map(|(path, base)| TraceAccess {
+                kind: AccessKind::Write,
+                path,
+                base,
+            })
+            .collect()
+    } else {
+        paths
+            .next()
+            .map(|(path, base)| {
+                vec![TraceAccess {
+                    kind: AccessKind::Read,
+                    path,
+                    base,
+                }]
+            })
+            .unwrap_or_default()
+    }
+}
+
+fn contains_unquoted_token(input: &str, expected: &str) -> bool {
+    let mut quoted = false;
+    let mut escaped = false;
+    let mut token = Vec::new();
+    for byte in input.bytes() {
+        if quoted {
+            match (escaped, byte) {
+                (true, _) => escaped = false,
+                (false, b'\\') => escaped = true,
+                (false, b'"') => quoted = false,
+                _ => {}
+            }
+        } else if byte == b'"' {
+            if token == expected.as_bytes() {
+                return true;
+            }
+            token.clear();
+            quoted = true;
+        } else if byte.is_ascii_alphanumeric() || byte == b'_' {
+            token.push(byte);
+        } else {
+            if token == expected.as_bytes() {
+                return true;
+            }
+            token.clear();
+        }
+    }
+    token == expected.as_bytes()
+}
+
+#[cfg(test)]
+fn quoted_strings(input: &str) -> Vec<String> {
+    quoted_paths(input)
+        .into_iter()
+        .map(|(path, _)| path.to_string_lossy().into_owned())
+        .collect()
+}
+
+fn quoted_paths(input: &str) -> Vec<(PathBuf, Option<PathBuf>)> {
+    let bytes = input.as_bytes();
+    let mut values = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'"' {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        index += 1;
+        let mut escaped = false;
+        while index < bytes.len() {
+            match (escaped, bytes[index]) {
+                (true, _) => escaped = false,
+                (false, b'\\') => escaped = true,
+                (false, b'"') => {
+                    let encoded = &input[start..=index];
+                    if let Ok(value) = serde_json::from_str::<String>(encoded) {
+                        let base = dirfd_base(&input[..start]);
+                        values.push((PathBuf::from(value), base));
+                    }
+                    index += 1;
+                    break;
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+    }
+    values
+}
+
+fn dirfd_base(input: &str) -> Option<PathBuf> {
+    let end = input.rfind('>')?;
+    let start = input[..end].rfind('<')?;
+    let path = Path::new(&input[start + 1..end]);
+    path.is_absolute().then(|| path.to_path_buf())
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AccessKind, TraceAccess, parse_trace_line, quoted_strings};
+    use std::path::PathBuf;
+
+    #[test]
+    fn parses_strace_file_accesses() {
+        assert_eq!(
+            parse_trace_line(r#"123 openat(AT_FDCWD, "src/input.txt", O_RDONLY) = 3"#),
+            vec![TraceAccess {
+                kind: AccessKind::Read,
+                path: PathBuf::from("src/input.txt"),
+                base: None,
+            }]
+        );
+        assert_eq!(
+            parse_trace_line(
+                r#"123 openat(AT_FDCWD, "dist/output.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3"#
+            ),
+            vec![TraceAccess {
+                kind: AccessKind::Write,
+                path: PathBuf::from("dist/output.txt"),
+                base: None,
+            }]
+        );
+        assert_eq!(
+            parse_trace_line(r#"rename("tmp", "dist/output.txt") = 0"#),
+            vec![
+                TraceAccess {
+                    kind: AccessKind::Write,
+                    path: PathBuf::from("tmp"),
+                    base: None,
+                },
+                TraceAccess {
+                    kind: AccessKind::Write,
+                    path: PathBuf::from("dist/output.txt"),
+                    base: None,
+                }
+            ]
+        );
+        assert!(parse_trace_line(r#"access("missing", F_OK) = -1 ENOENT"#).is_empty());
+        assert_eq!(
+            parse_trace_line(r#"openat(AT_FDCWD, "O_CREAT-report", O_RDONLY) = 3"#),
+            vec![TraceAccess {
+                kind: AccessKind::Read,
+                path: PathBuf::from("O_CREAT-report"),
+                base: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_escaped_quoted_paths() {
+        assert_eq!(quoted_strings(r#"AT_FDCWD, "a\"b", O_RDONLY"#), ["a\"b"]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolves_strace_dirfd_annotations() {
+        assert_eq!(
+            parse_trace_line(
+                r#"123 openat(AT_FDCWD</workspace/pkg>, "src/input.txt", O_RDONLY) = 3</workspace/pkg/src/input.txt>"#
+            ),
+            vec![TraceAccess {
+                kind: AccessKind::Read,
+                path: PathBuf::from("src/input.txt"),
+                base: Some(PathBuf::from("/workspace/pkg")),
+            }]
+        );
+        assert_eq!(
+            parse_trace_line(
+                r#"123 openat(3</workspace/shared>, "input.txt", O_RDONLY) = 4</workspace/shared/input.txt>"#
+            ),
+            vec![TraceAccess {
+                kind: AccessKind::Read,
+                path: PathBuf::from("input.txt"),
+                base: Some(PathBuf::from("/workspace/shared")),
+            }]
+        );
+    }
+}

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -18,7 +18,9 @@ use crate::task::task_script_parser::subcommand_name_from_parse;
 use crate::task::task_source_checker::{
     remove_auto_output, save_checksum, sources_are_fresh, task_cwd,
 };
-use crate::task::{Deps, FailedTasks, GetMatchingExt, Task, TaskCacheMode, TaskCacheOutput};
+use crate::task::{
+    Deps, FailedTasks, GetMatchingExt, Task, TaskCacheAudit, TaskCacheMode, TaskCacheOutput,
+};
 use crate::task::{TaskCompletionState, TaskDependencyState};
 use crate::tera::{contains_template_syntax, render_str};
 use crate::toolset::env_cache::CachedEnv;
@@ -1563,6 +1565,16 @@ impl TaskExecutor {
         let program =
             crate::path::resolve_posix_shell_program_path(&program, env).unwrap_or(program);
         let env = maybe_convert_env_for_msys_shell(Path::new(&program), env);
+        let audit = if raw || self.dry_run {
+            None
+        } else {
+            TaskCacheAudit::prepare(task, &config).await?
+        };
+        let (program, args) = if let Some(audit) = &audit {
+            audit.wrap(program, args)
+        } else {
+            (program, args.to_vec())
+        };
         let runner = CmdLineRunner::new(program.clone());
         // On Windows, `cmd_verbatim` means `args` are already wrapped for cmd.exe
         // and must be appended to the command line without std's MSVCRT-style
@@ -1572,10 +1584,10 @@ impl TaskExecutor {
         let runner = if cmd_verbatim {
             args.iter().fold(runner, |r, a| r.raw_arg(a))
         } else {
-            runner.args(args)
+            runner.args(&args)
         };
         #[cfg(not(windows))]
-        let runner = runner.args(args);
+        let runner = runner.args(&args);
         // Command inherits the current process environment in addition to the
         // explicit task env, so remove usage_* keys that argument parsing
         // intentionally cleared from the task env.
@@ -1803,10 +1815,15 @@ impl TaskExecutor {
         }
         // Apply sandbox async (DNS resolution for macOS) before spawning.
         cmd.apply_sandbox().await?;
-        cmd.execute_async_with_cancel_check(|| {
-            !allow_during_interruption && crate::ui::ctrlc::is_cancelled()
-        })
-        .await?;
+        let result = cmd
+            .execute_async_with_cancel_check(|| {
+                !allow_during_interruption && crate::ui::ctrlc::is_cancelled()
+            })
+            .await;
+        if let Some(audit) = audit {
+            audit.report(task);
+        }
+        result?;
         trace!("{prefix} exited successfully");
         Ok(())
     }

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -378,6 +378,20 @@ pub async fn task_cwd(task: &Task, config: &Arc<Config>) -> Result<PathBuf> {
     }
 }
 
+/// Return the outermost config root that contains the task working directory.
+///
+/// Source patterns are anchored here so workspace-rooted patterns and task-CWD
+/// relative patterns use the same namespace.
+pub(crate) fn task_source_match_root(root: &Path, config: &Config) -> PathBuf {
+    config
+        .config_files
+        .values()
+        .filter_map(|cf| cf.project_root())
+        .filter(|pr| root.starts_with(pr) || *pr == root)
+        .min_by_key(|p| p.components().count())
+        .unwrap_or_else(|| root.to_path_buf())
+}
+
 /// Collect source file metadatas for a task, anchored at the correct workspace root.
 async fn collect_source_metadatas(
     task: &Task,
@@ -394,13 +408,7 @@ async fn collect_source_metadatas(
     // lexicographic path order, so a subproject config may be returned
     // before the workspace root config (mise.toml) even though
     // the workspace root has a shorter path.
-    let match_root_owned = config
-        .config_files
-        .values()
-        .filter_map(|cf| cf.project_root())
-        .filter(|pr| root.starts_with(pr) || *pr == root)
-        .min_by_key(|p| p.components().count())
-        .unwrap_or_else(|| root.clone());
+    let match_root_owned = task_source_match_root(&root, config);
     let match_root = match_root_owned.as_path();
     let matcher = build_source_matcher(match_root, &root, &task.sources);
     let glob_patterns = source_glob_patterns(&task.sources);

--- a/src/task/task_template.rs
+++ b/src/task/task_template.rs
@@ -381,6 +381,7 @@ mod tests {
         let template = TaskTemplate {
             cache: Some(TaskCacheConfig {
                 enabled: true,
+                audit: false,
                 env: vec!["PROFILE".to_string()],
                 command_inputs: vec![],
             }),

--- a/src/task/workspace.rs
+++ b/src/task/workspace.rs
@@ -1613,6 +1613,7 @@ mod tests {
             task.cache,
             Some(TaskCacheConfig {
                 enabled: true,
+                audit: false,
                 env: vec!["NODE_ENV".to_string()],
                 command_inputs: vec!["node --version".to_string()],
             })


### PR DESCRIPTION
## Summary
- add an opt-in `cache.audit` mode for task artifact cache declarations
- trace Linux task execution with `strace` and warn about undeclared project reads and writes
- keep auditing advisory, bounded, and disabled when tracing is unavailable
- expose the option in task schemas and documentation
- cover classification, cache publication, and task-info serialization

## Validation
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_audit e2e/tasks/test_task_info`
- `cargo test --all-features task_cache_audit::tests -- --nocapture`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run lint-fix`
- `mise run render:schema`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are opt-in and Linux-only for tracing; execution path only wraps commands when audit is enabled, with graceful fallback when strace is unavailable.
> 
> **Overview**
> Adds opt-in **`cache.audit`** on experimental task artifact caching so teams can spot incomplete `sources` / `outputs` declarations.
> 
> On **Linux**, when audit is enabled and caching is on, mise wraps the real task command with **`strace`**, parses file syscalls after the run, and **warns** about undeclared reads under the workspace source root and undeclared writes under the task directory. Auditing is **advisory** (tasks still succeed and can still be cached); it is skipped for raw/dry-run runs, when `strace` is missing, or on non-Linux (warn once). Cache hits do not run the task, so **`mise run --force`** is needed to audit an existing entry.
> 
> Configuration is wired through **`TaskCacheConfig`**, JSON schemas, docs, and **`mise tasks info`**. Source matching for audits reuses a shared **`task_source_match_root`** helper extracted from the source checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db83e203de06d08474687d7e9311d8f86918ddc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->