### PR TITLE
agent/task usage kdl

### DIFF
--- a/e2e/tasks/test_task_broken_symlinks
+++ b/e2e/tasks/test_task_broken_symlinks
@@ -26,5 +26,5 @@ assert "mise tasks ls --name-only" "global-ok
 healthy"
 assert_contains "mise run healthy" "healthy ran"
 assert_contains "mise run global-ok" "global ran"
-assert_contains "mise tasks --usage" '"healthy"'
-assert_contains "mise tasks --usage" '"global-ok"'
+assert_contains "mise tasks --usage" 'cmd healthy'
+assert_contains "mise tasks --usage" 'cmd global-ok'


### PR DESCRIPTION
## Summary
- update the broken-symlink E2E test for current usage KDL rendering
- assert valid bare command identifiers instead of requiring quoted names
- unblock the task-cache stack's otherwise unrelated E2E job

## Validation
- `mise run test:e2e e2e/tasks/test_task_broken_symlinks`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to usage output expectations; no production logic in this diff.
> 
> **Overview**
> Updates the broken-symlinks task e2e test so **`mise tasks --usage`** checks match the new usage format.
> 
> Assertions change from looking for quoted names (`"healthy"`, `"global-ok"`) to **KDL-style command lines** (`cmd healthy`, `cmd global-ok`), consistent with task usage being emitted as KDL rather than the previous representation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36dca9720191b4b638042a72ae7f025a5ad701f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated task usage checks to reflect the current unquoted command format displayed by `mise tasks --usage`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->