### PR TITLE
feat(task): compose local and remote cache stores

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -115,7 +115,7 @@ outside this tracker.
 
 - [x] Extract a versioned cache-store interface from the local filesystem implementation
 - [x] Define and document a versioned remote cache protocol
-- [ ] Add a composite local and remote cache store
+- [x] Add a composite local and remote cache store
 - [ ] Stream artifact uploads and downloads
 - [ ] Add remote read-only, write-only, and read/write modes
 - [ ] Add authentication and repository or organization namespaces

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -4,7 +4,7 @@ use crate::duration;
 use crate::file::{self, ExtractOptions, ExtractionFormat};
 use crate::hash;
 use crate::task::task_cache_store::{
-    LocalTaskCacheStore, TASK_CACHE_STORE_VERSION, TaskCacheStore,
+    LocalTaskCacheStore, TASK_CACHE_STORE_VERSION, TaskCacheStore, compose_task_cache_stores,
 };
 use crate::task::task_source_checker::{
     TaskCacheInputs, build_output_matcher, expand_glob_braces, is_output, output_glob_patterns,
@@ -377,7 +377,8 @@ impl TaskArtifactCacheBuilder {
         let cache_dir = task_cache_dir();
         let limits = task_cache_limits()?;
         cleanup_abandoned_partial_writes_once(&cache_dir);
-        let store: Arc<dyn TaskCacheStore> = Arc::new(LocalTaskCacheStore::new(cache_dir.clone()));
+        let local: Arc<dyn TaskCacheStore> = Arc::new(LocalTaskCacheStore::new(cache_dir.clone()));
+        let store = compose_task_cache_stores(local, None)?;
         if store.version() != TASK_CACHE_STORE_VERSION {
             bail!(
                 "unsupported task cache store version {}; expected {}",
@@ -444,7 +445,12 @@ impl TaskArtifactCache {
             }
         };
         if self.exceeded_max_age()? {
-            self.store.remove(&self.key)?;
+            if let Err(err) = self.store.remove(&self.key) {
+                warn!(
+                    "failed to remove expired task cache entry {}: {err}",
+                    self.key
+                );
+            }
             return Ok(TaskCacheRestore::Miss(TaskCacheMissReason::Expired));
         }
         let restore = || -> Result<TaskCacheHit> {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -445,9 +445,9 @@ impl TaskArtifactCache {
             }
         };
         if self.exceeded_max_age()? {
-            if let Err(err) = self.store.remove(&self.key) {
+            if let Err(err) = self.store.remove_local(&self.key) {
                 warn!(
-                    "failed to remove expired task cache entry {}: {err}",
+                    "failed to remove expired local task cache entry {}: {err}",
                     self.key
                 );
             }

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -48,6 +48,9 @@ pub(crate) trait TaskCacheStore: Send + Sync {
         has_artifact: bool,
     ) -> Result<()>;
     fn remove(&self, key: &str) -> Result<()>;
+    fn remove_local(&self, key: &str) -> Result<()> {
+        self.remove(key)
+    }
     fn touch(&self, key: &str);
 }
 
@@ -147,6 +150,10 @@ impl TaskCacheStore for CompositeTaskCacheStore {
         // entry to be promoted back after its local copy was removed.
         self.remote.remove(key)?;
         self.local.remove(key)
+    }
+
+    fn remove_local(&self, key: &str) -> Result<()> {
+        self.local.remove_local(key)
     }
 
     fn touch(&self, key: &str) {
@@ -386,5 +393,28 @@ mod tests {
         seed(local.as_ref(), "remove", b"local", None);
         assert!(composite.remove("remove").is_err());
         assert!(local.get("remove").unwrap().is_some());
+    }
+
+    #[test]
+    fn composite_store_local_removal_preserves_and_repromotes_remote_entry() {
+        let local_root = tempfile::tempdir().unwrap();
+        let remote_root = tempfile::tempdir().unwrap();
+        let local: Arc<dyn TaskCacheStore> =
+            Arc::new(LocalTaskCacheStore::new(local_root.path().to_path_buf()));
+        let remote: Arc<dyn TaskCacheStore> =
+            Arc::new(LocalTaskCacheStore::new(remote_root.path().to_path_buf()));
+        seed(local.as_ref(), "expired", b"local", None);
+        seed(remote.as_ref(), "expired", b"remote", None);
+        let composite = CompositeTaskCacheStore::new(local.clone(), remote.clone()).unwrap();
+
+        composite.remove_local("expired").unwrap();
+
+        assert!(local.get("expired").unwrap().is_none());
+        assert!(remote.get("expired").unwrap().is_some());
+        assert_eq!(
+            composite.get("expired").unwrap().unwrap().manifest,
+            b"remote"
+        );
+        assert!(local.get("expired").unwrap().is_some());
     }
 }

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -153,7 +153,20 @@ impl TaskCacheStore for CompositeTaskCacheStore {
     }
 
     fn remove_local(&self, key: &str) -> Result<()> {
-        self.local.remove_local(key)
+        let Err(remove_err) = self.local.remove_local(key) else {
+            return Ok(());
+        };
+        let Some(entry) = self.remote.get(key)? else {
+            return Err(remove_err);
+        };
+        self.promote(key, &entry)
+            .map(|_| ())
+            .map_err(|promote_err| {
+                eyre::eyre!(
+                    "failed to remove expired local cache entry: {remove_err}; \
+                 failed to refresh it from remote: {promote_err}"
+                )
+            })
     }
 
     fn touch(&self, key: &str) {
@@ -266,6 +279,42 @@ mod tests {
 
     struct FailingTaskCacheStore {
         inner: LocalTaskCacheStore,
+    }
+
+    struct RemoveFailingTaskCacheStore {
+        inner: LocalTaskCacheStore,
+    }
+
+    impl TaskCacheStore for RemoveFailingTaskCacheStore {
+        fn version(&self) -> u8 {
+            self.inner.version()
+        }
+
+        fn get(&self, key: &str) -> Result<Option<TaskCacheStoreEntry>> {
+            self.inner.get(key)
+        }
+
+        fn begin_write(&self, key: &str) -> Result<TaskCacheStoreWrite> {
+            self.inner.begin_write(key)
+        }
+
+        fn commit(
+            &self,
+            key: &str,
+            write: &TaskCacheStoreWrite,
+            manifest: &[u8],
+            has_artifact: bool,
+        ) -> Result<()> {
+            self.inner.commit(key, write, manifest, has_artifact)
+        }
+
+        fn remove(&self, _key: &str) -> Result<()> {
+            bail!("local remove failed")
+        }
+
+        fn touch(&self, key: &str) {
+            self.inner.touch(key);
+        }
     }
 
     impl TaskCacheStore for FailingTaskCacheStore {
@@ -416,5 +465,26 @@ mod tests {
             b"remote"
         );
         assert!(local.get("expired").unwrap().is_some());
+    }
+
+    #[test]
+    fn composite_store_repairs_failed_local_removal_from_remote() {
+        let local_root = tempfile::tempdir().unwrap();
+        let remote_root = tempfile::tempdir().unwrap();
+        let local_inner = LocalTaskCacheStore::new(local_root.path().to_path_buf());
+        seed(&local_inner, "expired", b"stale-local", None);
+        let local: Arc<dyn TaskCacheStore> =
+            Arc::new(RemoveFailingTaskCacheStore { inner: local_inner });
+        let remote: Arc<dyn TaskCacheStore> =
+            Arc::new(LocalTaskCacheStore::new(remote_root.path().to_path_buf()));
+        seed(remote.as_ref(), "expired", b"fresh-remote", None);
+        let composite = CompositeTaskCacheStore::new(local.clone(), remote).unwrap();
+
+        composite.remove_local("expired").unwrap();
+
+        assert_eq!(
+            local.get("expired").unwrap().unwrap().manifest,
+            b"fresh-remote"
+        );
     }
 }

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -1,7 +1,8 @@
 use crate::file;
-use eyre::Result;
+use eyre::{Result, bail};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Version of the cache-store contract. This is independent of the artifact
 /// manifest format so stores and transports can evolve without changing keys.
@@ -48,6 +49,120 @@ pub(crate) trait TaskCacheStore: Send + Sync {
     ) -> Result<()>;
     fn remove(&self, key: &str) -> Result<()>;
     fn touch(&self, key: &str);
+}
+
+pub(crate) struct CompositeTaskCacheStore {
+    local: Arc<dyn TaskCacheStore>,
+    remote: Arc<dyn TaskCacheStore>,
+}
+
+impl CompositeTaskCacheStore {
+    pub(crate) fn new(
+        local: Arc<dyn TaskCacheStore>,
+        remote: Arc<dyn TaskCacheStore>,
+    ) -> Result<Self> {
+        if local.version() != remote.version() {
+            bail!(
+                "task cache store version mismatch: local version {}, remote version {}",
+                local.version(),
+                remote.version()
+            );
+        }
+        Ok(Self { local, remote })
+    }
+
+    fn copy_artifact(source: Option<&Path>, write: &TaskCacheStoreWrite) -> Result<bool> {
+        let Some(source) = source else {
+            return Ok(false);
+        };
+        fs::copy(source, write.artifact_path())?;
+        Ok(true)
+    }
+
+    fn promote(&self, key: &str, entry: &TaskCacheStoreEntry) -> Result<TaskCacheStoreEntry> {
+        // A remote lookup is an access, so promotion intentionally starts a
+        // fresh local inactivity window for task.cache_max_age.
+        let write = self.local.begin_write(key)?;
+        let has_artifact = Self::copy_artifact(entry.artifact_path.as_deref(), &write)?;
+        self.local
+            .commit(key, &write, &entry.manifest, has_artifact)?;
+        self.local
+            .get(key)?
+            .ok_or_else(|| eyre::eyre!("promoted task cache entry disappeared"))
+    }
+}
+
+impl TaskCacheStore for CompositeTaskCacheStore {
+    fn version(&self) -> u8 {
+        self.local.version()
+    }
+
+    fn get(&self, key: &str) -> Result<Option<TaskCacheStoreEntry>> {
+        if let Some(entry) = self.local.get(key)? {
+            return Ok(Some(entry));
+        }
+        let Some(entry) = self.remote.get(key)? else {
+            return Ok(None);
+        };
+        match self.promote(key, &entry) {
+            Ok(entry) => Ok(Some(entry)),
+            Err(err) => {
+                warn!("failed to promote remote task cache entry {key} locally: {err}");
+                Ok(Some(entry))
+            }
+        }
+    }
+
+    fn begin_write(&self, key: &str) -> Result<TaskCacheStoreWrite> {
+        self.local.begin_write(key)
+    }
+
+    fn commit(
+        &self,
+        key: &str,
+        write: &TaskCacheStoreWrite,
+        manifest: &[u8],
+        has_artifact: bool,
+    ) -> Result<()> {
+        self.local.commit(key, write, manifest, has_artifact)?;
+        let mirror = || -> Result<()> {
+            let entry = self
+                .local
+                .get(key)?
+                .ok_or_else(|| eyre::eyre!("published local task cache entry disappeared"))?;
+            let remote_write = self.remote.begin_write(key)?;
+            let remote_has_artifact =
+                Self::copy_artifact(entry.artifact_path.as_deref(), &remote_write)?;
+            self.remote
+                .commit(key, &remote_write, &entry.manifest, remote_has_artifact)
+        };
+        if let Err(err) = mirror() {
+            warn!("failed to mirror task cache entry {key} remotely: {err}");
+        }
+        Ok(())
+    }
+
+    fn remove(&self, key: &str) -> Result<()> {
+        // Delete remotely first so a failed remote delete cannot allow the
+        // entry to be promoted back after its local copy was removed.
+        self.remote.remove(key)?;
+        self.local.remove(key)
+    }
+
+    fn touch(&self, key: &str) {
+        self.local.touch(key);
+        self.remote.touch(key);
+    }
+}
+
+pub(crate) fn compose_task_cache_stores(
+    local: Arc<dyn TaskCacheStore>,
+    remote: Option<Arc<dyn TaskCacheStore>>,
+) -> Result<Arc<dyn TaskCacheStore>> {
+    match remote {
+        Some(remote) => Ok(Arc::new(CompositeTaskCacheStore::new(local, remote)?)),
+        None => Ok(local),
+    }
 }
 
 pub(crate) struct LocalTaskCacheStore {
@@ -142,6 +257,42 @@ fn remove_file(path: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
+    struct FailingTaskCacheStore {
+        inner: LocalTaskCacheStore,
+    }
+
+    impl TaskCacheStore for FailingTaskCacheStore {
+        fn version(&self) -> u8 {
+            self.inner.version()
+        }
+
+        fn get(&self, key: &str) -> Result<Option<TaskCacheStoreEntry>> {
+            self.inner.get(key)
+        }
+
+        fn begin_write(&self, key: &str) -> Result<TaskCacheStoreWrite> {
+            self.inner.begin_write(key)
+        }
+
+        fn commit(
+            &self,
+            _key: &str,
+            _write: &TaskCacheStoreWrite,
+            _manifest: &[u8],
+            _has_artifact: bool,
+        ) -> Result<()> {
+            bail!("remote commit failed")
+        }
+
+        fn remove(&self, _key: &str) -> Result<()> {
+            bail!("remote remove failed")
+        }
+
+        fn touch(&self, key: &str) {
+            self.inner.touch(key);
+        }
+    }
+
     #[test]
     fn local_store_round_trips_result_and_artifact_entries() {
         let root = tempfile::tempdir().unwrap();
@@ -165,5 +316,75 @@ mod tests {
 
         store.remove("artifact").unwrap();
         assert!(store.get("artifact").unwrap().is_none());
+    }
+
+    fn seed(store: &dyn TaskCacheStore, key: &str, manifest: &[u8], artifact: Option<&[u8]>) {
+        let write = store.begin_write(key).unwrap();
+        if let Some(artifact) = artifact {
+            fs::write(write.artifact_path(), artifact).unwrap();
+        }
+        store
+            .commit(key, &write, manifest, artifact.is_some())
+            .unwrap();
+    }
+
+    #[test]
+    fn composite_store_promotes_remote_hits_and_mirrors_writes() {
+        let local_root = tempfile::tempdir().unwrap();
+        let remote_root = tempfile::tempdir().unwrap();
+        let local: Arc<dyn TaskCacheStore> =
+            Arc::new(LocalTaskCacheStore::new(local_root.path().to_path_buf()));
+        let remote: Arc<dyn TaskCacheStore> =
+            Arc::new(LocalTaskCacheStore::new(remote_root.path().to_path_buf()));
+        seed(remote.as_ref(), "remote-hit", b"remote", Some(b"artifact"));
+        let composite = CompositeTaskCacheStore::new(local.clone(), remote.clone()).unwrap();
+
+        let hit = composite.get("remote-hit").unwrap().unwrap();
+        assert_eq!(hit.manifest, b"remote");
+        assert_eq!(fs::read(hit.artifact_path.unwrap()).unwrap(), b"artifact");
+        assert!(local.get("remote-hit").unwrap().is_some());
+
+        seed(&composite, "mirrored", b"manifest", Some(b"output"));
+        assert_eq!(
+            local.get("mirrored").unwrap().unwrap().manifest,
+            b"manifest"
+        );
+        let mirrored = remote.get("mirrored").unwrap().unwrap();
+        assert_eq!(mirrored.manifest, b"manifest");
+        assert_eq!(
+            fs::read(mirrored.artifact_path.unwrap()).unwrap(),
+            b"output"
+        );
+
+        seed(&composite, "result-only", b"result", None);
+        assert!(
+            remote
+                .get("result-only")
+                .unwrap()
+                .unwrap()
+                .artifact_path
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn composite_store_keeps_local_entries_when_remote_operations_fail() {
+        let local_root = tempfile::tempdir().unwrap();
+        let remote_root = tempfile::tempdir().unwrap();
+        let local: Arc<dyn TaskCacheStore> =
+            Arc::new(LocalTaskCacheStore::new(local_root.path().to_path_buf()));
+        let remote_inner = LocalTaskCacheStore::new(remote_root.path().to_path_buf());
+        seed(&remote_inner, "remove", b"remote", None);
+        let remote: Arc<dyn TaskCacheStore> = Arc::new(FailingTaskCacheStore {
+            inner: remote_inner,
+        });
+        let composite = CompositeTaskCacheStore::new(local.clone(), remote).unwrap();
+
+        seed(&composite, "commit", b"local", None);
+        assert_eq!(local.get("commit").unwrap().unwrap().manifest, b"local");
+
+        seed(local.as_ref(), "remove", b"local", None);
+        assert!(composite.remove("remove").is_err());
+        assert!(local.get("remove").unwrap().is_some());
     }
 }


### PR DESCRIPTION
## Summary
- add a version-compatible composite task-cache store
- read local entries first and promote remote hits into the local store
- publish locally before mirroring entries remotely so local results survive remote write errors
- cover artifact-bearing and result-only promotion and mirroring
- mark the composite-store tracker item complete

## Validation
- `cargo test --all-features composite_store_promotes_remote_hits_and_mirrors_writes -- --nocapture`
- `cargo check --all-features`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache hit/miss, expiry, and delete ordering on correctness-sensitive paths; remote is not enabled yet but composite semantics are exercised in tests.
> 
> **Overview**
> Adds a **composite task cache store** that layers local and remote backends behind the existing `TaskCacheStore` trait, with `compose_task_cache_stores` wiring the artifact cache through local-only today (`remote: None`) until a remote implementation is plugged in.
> 
> **Reads** prefer the local store; on a remote hit, entries are **promoted** into local storage (resetting the local `cache_max_age` window). Failed promotion still returns the remote entry with a warning.
> 
> **Writes** commit locally first, then **mirror** manifest and artifact files to remote; remote mirror failures are warnings so local cache hits keep working.
> 
> **Deletes** run remote before local so a failed remote delete cannot resurrect an entry via promotion. **`remove_local`** (used when entries expire) drops only the local copy and can **re-promote** from remote if local removal fails or the remote copy is still valid.
> 
> Unit tests cover promotion, mirroring, result-only entries, and behavior when remote commit/remove fails. The parity tracker marks the composite-store item complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53dd2713038edbdc8063277acb2f0f7da132fbae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->