### PR TITLE
feat(task): add remote cache access modes

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -117,7 +117,7 @@ outside this tracker.
 - [x] Define and document a versioned remote cache protocol
 - [x] Add a composite local and remote cache store
 - [x] Stream artifact uploads and downloads
-- [ ] Add remote read-only, write-only, and read/write modes
+- [x] Add remote read-only, write-only, and read/write modes
 - [ ] Add authentication and repository or organization namespaces
 - [ ] Add timeouts, retries, request deduplication, and offline fallback
 - [ ] Verify remote artifact integrity and authenticity

--- a/e2e/tasks/test_task_artifact_cache_remote_modes
+++ b/e2e/tasks/test_task_artifact_cache_remote_modes
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+task.cache_remote_url = "http://127.0.0.1:9/cache"
+
+[task_config.cache]
+enabled = true
+
+[tasks.build]
+run = "printf 'ran\\n' >> runs.txt"
+sources = ["input.txt"]
+outputs = []
+EOF
+
+printf 'input\n' >input.txt
+
+assert_fail_contains "mise run build" "task.cache_remote_namespace is required"
+
+# local-only must bypass remote configuration completely.
+MISE_TASK_CACHE=local-only mise run build
+assert "wc -l < runs.txt | tr -d ' '" "1"
+
+assert_fail_contains "MISE_TASK_CACHE_REMOTE_MODE=invalid mise run build" "unknown variant"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1800,6 +1800,20 @@
               "description": "[experimental] Maximum total size of task output cache entries.",
               "type": "string"
             },
+            "cache_remote_mode": {
+              "default": "read-write",
+              "description": "[experimental] Remote task cache access mode.",
+              "type": "string",
+              "enum": ["read-write", "read-only", "write-only"]
+            },
+            "cache_remote_namespace": {
+              "description": "[experimental] Namespace sent to the remote task cache.",
+              "type": "string"
+            },
+            "cache_remote_url": {
+              "description": "[experimental] Base URL for the remote task cache service.",
+              "type": "string"
+            },
             "disable_paths": {
               "default": [],
               "description": "Paths that mise will not look for tasks in.",

--- a/settings.toml
+++ b/settings.toml
@@ -2654,6 +2654,45 @@ env = "MISE_TASK_CACHE_MAX_SIZE"
 optional = true
 type = "String"
 
+[task.cache_remote_mode]
+default = "read-write"
+description = "[experimental] Remote task cache access mode."
+docs = """
+Control remote cache access while keeping the local task cache enabled:
+
+- `read-write` reads remote misses and uploads successful local results.
+- `read-only` reads remote misses without uploading results.
+- `write-only` uploads results without reading remote entries.
+
+The per-run `--task-cache` mode remains authoritative. In particular, `--task-cache=local-only`
+disables all remote access.
+"""
+enum = ["read-write", "read-only", "write-only"]
+env = "MISE_TASK_CACHE_REMOTE_MODE"
+rust_type = "crate::task::TaskCacheRemoteMode"
+type = "String"
+
+[task.cache_remote_namespace]
+description = "[experimental] Namespace sent to the remote task cache."
+docs = """
+Opaque repository or organization namespace used to isolate remote cache entries. This setting is
+required when [`task.cache_remote_url`](#task-cache-remote-url) is configured.
+"""
+env = "MISE_TASK_CACHE_REMOTE_NAMESPACE"
+optional = true
+type = "String"
+
+[task.cache_remote_url]
+description = "[experimental] Base URL for the remote task cache service."
+docs = """
+Enable the versioned HTTP remote task cache protocol at this base URL. Remote access also requires
+[`task.cache_remote_namespace`](#task-cache-remote-namespace). Leave unset to use only the local
+task cache.
+"""
+env = "MISE_TASK_CACHE_REMOTE_URL"
+optional = true
+type = "Url"
+
 [task.disable_paths]
 default = []
 description = "Paths that mise will not look for tasks in."

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -71,6 +71,7 @@ pub mod workspace;
 pub(crate) use task_cache::TaskCacheOutput;
 pub use task_cache::{TaskArtifactCache, TaskCacheConfig, TaskCacheMode};
 pub(crate) use task_cache_audit::TaskCacheAudit;
+pub use task_cache_store::TaskCacheRemoteMode;
 pub use task_confirm::TaskConfirm;
 pub(crate) use task_load_context::monorepo_scope;
 pub use task_load_context::{TaskLoadContext, expand_colon_task_syntax, is_workspace_project_task};

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -4,7 +4,8 @@ use crate::duration;
 use crate::file::{self, ExtractOptions, ExtractionFormat};
 use crate::hash;
 use crate::task::task_cache_store::{
-    LocalTaskCacheStore, TASK_CACHE_STORE_VERSION, TaskCacheStore, compose_task_cache_stores,
+    LocalTaskCacheStore, RemoteTaskCacheConfig, TASK_CACHE_STORE_VERSION, TaskCacheStore,
+    compose_task_cache_stores,
 };
 use crate::task::task_source_checker::{
     TaskCacheInputs, build_output_matcher, expand_glob_braces, is_output, output_glob_patterns,
@@ -247,6 +248,7 @@ pub(crate) struct TaskCacheContext<'a> {
     pub(crate) dependency_keys: &'a [String],
     pub(crate) command_inputs: Vec<CommandInput>,
     pub(crate) explain: bool,
+    pub(crate) mode: TaskCacheMode,
 }
 
 impl TaskArtifactCache {
@@ -302,6 +304,7 @@ impl TaskArtifactCacheBuilder {
             dependency_keys,
             command_inputs,
             explain,
+            mode,
         } = ctx;
         let Self {
             root,
@@ -380,7 +383,32 @@ impl TaskArtifactCacheBuilder {
         let limits = task_cache_limits()?;
         cleanup_abandoned_partial_writes_once(&cache_dir);
         let local: Arc<dyn TaskCacheStore> = Arc::new(LocalTaskCacheStore::new(cache_dir.clone()));
-        let store = compose_task_cache_stores(local, None)?;
+        let settings = Settings::get();
+        let remote = if mode == TaskCacheMode::LocalOnly {
+            None
+        } else if let Some(base_url) = settings.task.cache_remote_url.clone() {
+            let namespace = settings
+                .task
+                .cache_remote_namespace
+                .as_deref()
+                .map(str::trim)
+                .filter(|namespace| !namespace.is_empty())
+                .ok_or_else(|| {
+                    eyre!(
+                        "task.cache_remote_namespace is required when task.cache_remote_url is set"
+                    )
+                })?
+                .to_string();
+            Some(RemoteTaskCacheConfig {
+                base_url: base_url.parse().wrap_err("invalid task.cache_remote_url")?,
+                namespace,
+                staging_dir: cache_dir.join("remote"),
+                mode: settings.task.cache_remote_mode,
+            })
+        } else {
+            None
+        };
+        let store = compose_task_cache_stores(local, remote)?;
         if store.version() != TASK_CACHE_STORE_VERSION {
             bail!(
                 "unsupported task cache store version {}; expected {}",

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -32,6 +32,44 @@ const REMOTE_CACHE_BLOB_MEDIA_TYPE: &str = "application/octet-stream";
 /// manifest format so stores and transports can evolve without changing keys.
 pub(crate) const TASK_CACHE_STORE_VERSION: u8 = 1;
 
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Default,
+    strum::EnumString,
+    strum::Display,
+    PartialEq,
+    Eq,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum TaskCacheRemoteMode {
+    #[default]
+    ReadWrite,
+    ReadOnly,
+    WriteOnly,
+}
+
+impl TaskCacheRemoteMode {
+    fn reads(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::ReadOnly)
+    }
+
+    fn writes(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::WriteOnly)
+    }
+}
+
+pub(crate) struct RemoteTaskCacheConfig {
+    pub(crate) base_url: Url,
+    pub(crate) namespace: String,
+    pub(crate) staging_dir: PathBuf,
+    pub(crate) mode: TaskCacheRemoteMode,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 struct CacheDigest {
     algorithm: String,
@@ -291,12 +329,14 @@ pub(crate) trait TaskCacheStore: Send + Sync {
 pub(crate) struct CompositeTaskCacheStore {
     local: Arc<dyn TaskCacheStore>,
     remote: Arc<dyn TaskCacheStore>,
+    remote_mode: TaskCacheRemoteMode,
 }
 
 impl CompositeTaskCacheStore {
     pub(crate) fn new(
         local: Arc<dyn TaskCacheStore>,
         remote: Arc<dyn TaskCacheStore>,
+        remote_mode: TaskCacheRemoteMode,
     ) -> Result<Self> {
         if local.version() != remote.version() {
             bail!(
@@ -305,7 +345,11 @@ impl CompositeTaskCacheStore {
                 remote.version()
             );
         }
-        Ok(Self { local, remote })
+        Ok(Self {
+            local,
+            remote,
+            remote_mode,
+        })
     }
 
     fn copy_artifact(source: Option<&Path>, write: &TaskCacheStoreWrite) -> Result<bool> {
@@ -349,6 +393,9 @@ impl TaskCacheStore for CompositeTaskCacheStore {
         if let Some(entry) = self.local.get(key, action_size).await? {
             return Ok(Some(entry));
         }
+        if !self.remote_mode.reads() {
+            return Ok(None);
+        }
         let entry = match self.remote.get(key, action_size).await {
             Ok(Some(entry)) => entry,
             Ok(None) => return Ok(None),
@@ -381,6 +428,9 @@ impl TaskCacheStore for CompositeTaskCacheStore {
         self.local
             .commit(key, action, write, manifest, has_artifact)
             .await?;
+        if !self.remote_mode.writes() {
+            return Ok(());
+        }
         let mirror: Result<()> = async {
             let entry = self
                 .local
@@ -410,6 +460,9 @@ impl TaskCacheStore for CompositeTaskCacheStore {
     }
 
     async fn remove(&self, key: &str) -> Result<()> {
+        if !self.remote_mode.writes() {
+            return self.local.remove(key).await;
+        }
         // Delete remotely first so a failed remote delete cannot allow the
         // entry to be promoted back after its local copy was removed.
         self.remote.remove(key).await?;
@@ -442,17 +495,21 @@ impl TaskCacheStore for CompositeTaskCacheStore {
 
 pub(crate) fn compose_task_cache_stores(
     local: Arc<dyn TaskCacheStore>,
-    remote: Option<(Url, String, PathBuf)>,
+    remote: Option<RemoteTaskCacheConfig>,
 ) -> Result<Arc<dyn TaskCacheStore>> {
     match remote {
-        Some((base_url, namespace, staging_dir)) => {
+        Some(remote_config) => {
             let remote = Arc::new(HttpTaskCacheStore {
-                base_url: normalized_base_url(base_url),
-                namespace,
-                staging_dir,
+                base_url: normalized_base_url(remote_config.base_url),
+                namespace: remote_config.namespace,
+                staging_dir: remote_config.staging_dir,
                 client: reqwest::Client::new(),
             });
-            Ok(Arc::new(CompositeTaskCacheStore::new(local, remote)?))
+            Ok(Arc::new(CompositeTaskCacheStore::new(
+                local,
+                remote,
+                remote_config.mode,
+            )?))
         }
         None => Ok(local),
     }

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -1374,7 +1374,12 @@ mod tests {
         let remote: Arc<dyn TaskCacheStore> =
             Arc::new(LocalTaskCacheStore::new(remote_root.path().to_path_buf()));
         seed(remote.as_ref(), "remote-hit", b"remote", Some(b"artifact")).await;
-        let composite = CompositeTaskCacheStore::new(local.clone(), remote.clone()).unwrap();
+        let composite = CompositeTaskCacheStore::new(
+            local.clone(),
+            remote.clone(),
+            TaskCacheRemoteMode::ReadWrite,
+        )
+        .unwrap();
 
         let hit = composite.get("remote-hit", 6).await.unwrap().unwrap();
         assert_eq!(hit.manifest, b"remote");
@@ -1416,7 +1421,9 @@ mod tests {
         let remote: Arc<dyn TaskCacheStore> = Arc::new(FailingTaskCacheStore {
             inner: remote_inner,
         });
-        let composite = CompositeTaskCacheStore::new(local.clone(), remote).unwrap();
+        let composite =
+            CompositeTaskCacheStore::new(local.clone(), remote, TaskCacheRemoteMode::ReadWrite)
+                .unwrap();
 
         assert!(composite.get("unavailable", 6).await.unwrap().is_none());
 

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -1638,7 +1638,9 @@ mod tests {
         let remote: Arc<dyn TaskCacheStore> =
             Arc::new(LocalTaskCacheStore::new(remote_root.path().to_path_buf()));
         seed(remote.as_ref(), "expired", b"fresh-remote", None).await;
-        let composite = CompositeTaskCacheStore::new(local.clone(), remote).unwrap();
+        let composite =
+            CompositeTaskCacheStore::new(local.clone(), remote, TaskCacheRemoteMode::ReadWrite)
+                .unwrap();
 
         composite.remove_local("expired", 6).await.unwrap();
 

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -1609,7 +1609,12 @@ mod tests {
             Arc::new(LocalTaskCacheStore::new(remote_root.path().to_path_buf()));
         seed(local.as_ref(), "expired", b"local", None).await;
         seed(remote.as_ref(), "expired", b"remote", None).await;
-        let composite = CompositeTaskCacheStore::new(local.clone(), remote.clone()).unwrap();
+        let composite = CompositeTaskCacheStore::new(
+            local.clone(),
+            remote.clone(),
+            TaskCacheRemoteMode::ReadWrite,
+        )
+        .unwrap();
 
         composite.remove_local("expired", 6).await.unwrap();
 

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -473,6 +473,9 @@ impl TaskCacheStore for CompositeTaskCacheStore {
         let Err(remove_err) = self.local.remove_local(key, action_size).await else {
             return Ok(());
         };
+        if !self.remote_mode.reads() {
+            return Err(remove_err);
+        }
         let Some(entry) = self.remote.get(key, action_size).await? else {
             return Err(remove_err);
         };
@@ -1654,6 +1657,28 @@ mod tests {
         assert_eq!(
             local.get("expired", 6).await.unwrap().unwrap().manifest,
             b"fresh-remote"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_only_store_does_not_repair_local_removal_from_remote() {
+        let local_root = tempfile::tempdir().unwrap();
+        let remote_root = tempfile::tempdir().unwrap();
+        let local_inner = LocalTaskCacheStore::new(local_root.path().to_path_buf());
+        seed(&local_inner, "expired", b"stale-local", None).await;
+        let local: Arc<dyn TaskCacheStore> =
+            Arc::new(RemoveFailingTaskCacheStore { inner: local_inner });
+        let remote: Arc<dyn TaskCacheStore> =
+            Arc::new(LocalTaskCacheStore::new(remote_root.path().to_path_buf()));
+        seed(remote.as_ref(), "expired", b"fresh-remote", None).await;
+        let composite =
+            CompositeTaskCacheStore::new(local.clone(), remote, TaskCacheRemoteMode::WriteOnly)
+                .unwrap();
+
+        assert!(composite.remove_local("expired", 6).await.is_err());
+        assert_eq!(
+            local.get("expired", 6).await.unwrap().unwrap().manifest,
+            b"stale-local"
         );
     }
 }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -671,6 +671,7 @@ impl TaskExecutor {
                             dependency_keys: &dependency_state.cache_keys,
                             command_inputs,
                             explain: self.task_cache_explain || self.task_cache_explain_json,
+                            mode: self.task_cache,
                         })
                         .await?;
                     if let Some(explanation) = cache.explanation() {


### PR DESCRIPTION
## Summary
- add experimental remote cache URL, namespace, and access-mode settings
- support remote `read-write`, `read-only`, and `write-only` policies while retaining local caching
- make the existing per-run `local-only` mode bypass remote configuration and network access

## Tests
- `cargo test task_cache_store::tests`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run test:e2e e2e/tasks/test_task_artifact_cache_remote_modes`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task cache I/O and remote networking behavior; mistakes could cause stale hits, missed remote uploads, or unexpected remote access when URL is configured.
> 
> **Overview**
> Adds **experimental remote task cache** configuration (`task.cache_remote_url`, `task.cache_remote_namespace`, `task.cache_remote_mode`) with documented schema and `MISE_TASK_CACHE_REMOTE_*` env vars. A remote URL without a namespace now fails fast with a clear error.
> 
> The composite local/remote store honors **`read-write`**, **`read-only`**, and **`write-only`**: reads, uploads, deletes, and local-expiry repromotion from remote are gated accordingly (e.g. write-only skips remote lookups and remote-assisted local repair). **`TaskCacheMode::LocalOnly`** (per-run `--task-cache` / `MISE_TASK_CACHE`) still disables remote setup entirely.
> 
> E2E coverage checks namespace validation, local-only bypass, and invalid remote mode values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c23b39c8d55816f8caf5851763ebc0bca6f121f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->