### PR TITLE
feat(task): authenticate remote cache requests

### DIFF
--- a/TASK_CACHE_PARITY.md
+++ b/TASK_CACHE_PARITY.md
@@ -118,7 +118,7 @@ outside this tracker.
 - [x] Add a composite local and remote cache store
 - [x] Stream artifact uploads and downloads
 - [x] Add remote read-only, write-only, and read/write modes
-- [ ] Add authentication and repository or organization namespaces
+- [x] Add authentication and repository or organization namespaces
 - [ ] Add timeouts, retries, request deduplication, and offline fallback
 - [ ] Verify remote artifact integrity and authenticity
 - [ ] Document secret handling for cached logs and artifacts

--- a/docs/tasks/remote-cache-protocol.md
+++ b/docs/tasks/remote-cache-protocol.md
@@ -31,8 +31,11 @@ allows a server to verify all referenced content before publishing a cache hit.
 
 ## Transport and versioning
 
-Version 1 uses HTTPS and HTTP semantics. Plain HTTP is accepted only for loopback development
-servers (`localhost`, `127.0.0.0/8`, and `::1`). Implementations may use HTTP/1.1, HTTP/2, or HTTP/3.
+Version 1 uses HTTPS and HTTP semantics. Requests carrying authorization credentials require HTTPS,
+except for loopback development servers (`localhost`, `127.0.0.0/8`, and `::1`). Clients may connect
+to an unauthenticated non-loopback HTTP service after emitting a visible warning. This mode provides
+neither confidentiality nor server authenticity: an on-path attacker can replace an unsigned action
+result and its internally consistent CAS graph. Implementations may use HTTP/1.1, HTTP/2, or HTTP/3.
 
 Every API request sends:
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1810,6 +1810,10 @@
               "description": "[experimental] Namespace sent to the remote task cache.",
               "type": "string"
             },
+            "cache_remote_token": {
+              "description": "[experimental] Bearer token for remote task cache authentication.",
+              "type": "string"
+            },
             "cache_remote_url": {
               "description": "[experimental] Base URL for the remote task cache service.",
               "type": "string"

--- a/settings.toml
+++ b/settings.toml
@@ -2682,6 +2682,18 @@ env = "MISE_TASK_CACHE_REMOTE_NAMESPACE"
 optional = true
 type = "String"
 
+[task.cache_remote_token]
+description = "[experimental] Bearer token for remote task cache authentication."
+docs = """
+Authenticate remote task cache requests with an HTTP `Authorization: Bearer` header. Prefer the
+`MISE_TASK_CACHE_REMOTE_TOKEN` environment variable or a protected global configuration file; this
+setting is global-only so shared project configuration cannot supply credentials.
+"""
+env = "MISE_TASK_CACHE_REMOTE_TOKEN"
+global_only = true
+optional = true
+type = "String"
+
 [task.cache_remote_url]
 description = "[experimental] Base URL for the remote task cache service."
 docs = """

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -588,11 +588,11 @@ impl Settings {
         if cfg!(test) {
             settings.experimental = true;
         }
+        trace!("Settings: {:#?}", redacted_settings_for_debug(&settings));
         let settings = Arc::new(settings);
         LAST_SAFE.store(u8::from(settings.safe), Ordering::Relaxed);
         *BASE_SETTINGS.write().unwrap() = Some(settings.clone());
         time!("try_get done");
-        trace!("Settings: {:#?}", settings);
         Ok(settings)
     }
 
@@ -1167,6 +1167,14 @@ impl Settings {
     }
 }
 
+fn redacted_settings_for_debug(settings: &Settings) -> Settings {
+    let mut debug_settings = settings.clone();
+    if debug_settings.task.cache_remote_token.is_some() {
+        debug_settings.task.cache_remote_token = Some("[redacted]".to_string());
+    }
+    debug_settings
+}
+
 impl Display for Settings {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match toml::to_string_pretty(self) {
@@ -1358,6 +1366,17 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn debug_settings_redact_remote_cache_token() {
+        let mut settings = Settings::default();
+        settings.task.cache_remote_token = Some("super-secret-token".to_string());
+
+        let debug = format!("{:?}", redacted_settings_for_debug(&settings));
+
+        assert!(!debug.contains("super-secret-token"));
+        assert!(debug.contains("[redacted]"));
+    }
 
     fn credential_command_settings_table() -> toml::Table {
         toml::from_str::<toml::Value>(

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -903,7 +903,8 @@ impl Settings {
 
     pub fn as_dict(&self) -> eyre::Result<toml::Table> {
         let s = toml::to_string(self)?;
-        let table = toml::from_str(&s)?;
+        let mut table = toml::from_str(&s)?;
+        redact_settings_table(&mut table);
         Ok(table)
     }
 
@@ -1026,7 +1027,8 @@ impl Settings {
 
     pub fn partial_as_dict(partial: &SettingsPartial) -> eyre::Result<toml::Table> {
         let s = toml::to_string(partial)?;
-        let table = toml::from_str(&s)?;
+        let mut table = toml::from_str(&s)?;
+        redact_settings_table(&mut table);
         Ok(table)
     }
 
@@ -1173,6 +1175,18 @@ fn redacted_settings_for_debug(settings: &Settings) -> Settings {
         debug_settings.task.cache_remote_token = Some("[redacted]".to_string());
     }
     debug_settings
+}
+
+fn redact_settings_table(table: &mut toml::Table) {
+    let Some(task) = table.get_mut("task").and_then(toml::Value::as_table_mut) else {
+        return;
+    };
+    if task.contains_key("cache_remote_token") {
+        task.insert(
+            "cache_remote_token".to_string(),
+            toml::Value::String("[redacted]".to_string()),
+        );
+    }
 }
 
 impl Display for Settings {
@@ -1376,6 +1390,18 @@ mod tests {
 
         assert!(!debug.contains("super-secret-token"));
         assert!(debug.contains("[redacted]"));
+    }
+
+    #[test]
+    fn settings_dictionary_redacts_remote_cache_token() {
+        let mut settings = Settings::default();
+        settings.task.cache_remote_token = Some("super-secret-token".to_string());
+
+        let table = settings.as_dict().unwrap();
+        let encoded = toml::to_string(&table).unwrap();
+
+        assert!(!encoded.contains("super-secret-token"));
+        assert!(encoded.contains("[redacted]"));
     }
 
     fn credential_command_settings_table() -> toml::Table {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -404,6 +404,7 @@ impl TaskArtifactCacheBuilder {
                 namespace,
                 staging_dir: cache_dir.join("remote"),
                 mode: settings.task.cache_remote_mode,
+                token: settings.task.cache_remote_token.clone(),
             })
         } else {
             None

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 use eyre::{Result, bail, eyre};
 use jdx_tar::{Archive, Builder, EntryType, Header};
 use reqwest::StatusCode;
-use reqwest::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, IF_NONE_MATCH};
+use reqwest::header::{
+    ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, IF_NONE_MATCH,
+};
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
 use std::collections::{BTreeMap, BTreeSet};
@@ -16,7 +18,7 @@ use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
-use url::Url;
+use url::{Host, Url};
 
 const REMOTE_CACHE_PROTOCOL_VERSION: u8 = 1;
 const REMOTE_CACHE_PROTOCOL_HEADER: &str = "Mise-Cache-Protocol";
@@ -68,6 +70,7 @@ pub(crate) struct RemoteTaskCacheConfig {
     pub(crate) namespace: String,
     pub(crate) staging_dir: PathBuf,
     pub(crate) mode: TaskCacheRemoteMode,
+    pub(crate) token: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -502,11 +505,14 @@ pub(crate) fn compose_task_cache_stores(
 ) -> Result<Arc<dyn TaskCacheStore>> {
     match remote {
         Some(remote_config) => {
+            let authorization = authorization_header(remote_config.token.as_deref())?;
+            validate_remote_url(&remote_config.base_url)?;
             let remote = Arc::new(HttpTaskCacheStore {
                 base_url: normalized_base_url(remote_config.base_url),
                 namespace: remote_config.namespace,
                 staging_dir: remote_config.staging_dir,
                 client: reqwest::Client::new(),
+                authorization,
             });
             Ok(Arc::new(CompositeTaskCacheStore::new(
                 local,
@@ -518,11 +524,39 @@ pub(crate) fn compose_task_cache_stores(
     }
 }
 
+fn authorization_header(token: Option<&str>) -> Result<Option<HeaderValue>> {
+    let Some(token) = token.map(str::trim).filter(|token| !token.is_empty()) else {
+        return Ok(None);
+    };
+    let mut value = HeaderValue::from_str(&format!("Bearer {token}"))?;
+    value.set_sensitive(true);
+    Ok(Some(value))
+}
+
+fn validate_remote_url(base_url: &Url) -> Result<()> {
+    if base_url.scheme() == "https" {
+        return Ok(());
+    }
+    if base_url.scheme() != "http" {
+        bail!("task.cache_remote_url must use HTTPS");
+    }
+    let is_loopback = base_url.host().is_some_and(|host| match host {
+        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+        Host::Ipv4(address) => address.is_loopback(),
+        Host::Ipv6(address) => address.is_loopback(),
+    });
+    if !is_loopback {
+        bail!("task.cache_remote_url must use HTTPS except for loopback development servers");
+    }
+    Ok(())
+}
+
 struct HttpTaskCacheStore {
     base_url: Url,
     namespace: String,
     staging_dir: PathBuf,
     client: reqwest::Client,
+    authorization: Option<HeaderValue>,
 }
 
 impl HttpTaskCacheStore {
@@ -547,11 +581,17 @@ impl HttpTaskCacheStore {
         url: Url,
         media_type: &'static str,
     ) -> reqwest::RequestBuilder {
-        self.client
+        let request = self
+            .client
             .request(method, url)
             .header(REMOTE_CACHE_PROTOCOL_HEADER, "1")
             .header(REMOTE_CACHE_NAMESPACE_HEADER, &self.namespace)
-            .header(ACCEPT, media_type)
+            .header(ACCEPT, media_type);
+        if let Some(authorization) = &self.authorization {
+            request.header(AUTHORIZATION, authorization)
+        } else {
+            request
+        }
     }
 
     async fn get_blob(&self, digest: &CacheDigest, media_type: &'static str) -> Result<Vec<u8>> {
@@ -1247,6 +1287,27 @@ mod tests {
         assert!(sha256.matches_file(file.path()).unwrap());
     }
 
+    #[test]
+    fn bearer_authorization_headers_are_sensitive() {
+        let header = authorization_header(Some(" test-token ")).unwrap().unwrap();
+        assert_eq!(header, "Bearer test-token");
+        assert!(header.is_sensitive());
+        assert!(authorization_header(Some(" ")).unwrap().is_none());
+    }
+
+    #[test]
+    fn remote_urls_require_https_except_for_loopback() {
+        for url in [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://[::1]:3000",
+            "https://cache.example.com",
+        ] {
+            validate_remote_url(&url.parse().unwrap()).unwrap();
+        }
+        assert!(validate_remote_url(&"http://cache.example.com".parse().unwrap()).is_err());
+    }
+
     struct FailingTaskCacheStore {
         inner: LocalTaskCacheStore,
     }
@@ -1589,6 +1650,7 @@ mod tests {
             namespace: "test-namespace".into(),
             staging_dir: staging.path().to_path_buf(),
             client: reqwest::Client::new(),
+            authorization: Some(HeaderValue::from_static("Bearer test-token")),
         };
         let write = store.begin_write(key).unwrap();
 

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -506,7 +506,7 @@ pub(crate) fn compose_task_cache_stores(
     match remote {
         Some(remote_config) => {
             let authorization = authorization_header(remote_config.token.as_deref())?;
-            validate_remote_url(&remote_config.base_url)?;
+            validate_remote_url(&remote_config.base_url, authorization.is_some())?;
             let remote = Arc::new(HttpTaskCacheStore {
                 base_url: normalized_base_url(remote_config.base_url),
                 namespace: remote_config.namespace,
@@ -533,7 +533,7 @@ fn authorization_header(token: Option<&str>) -> Result<Option<HeaderValue>> {
     Ok(Some(value))
 }
 
-fn validate_remote_url(base_url: &Url) -> Result<()> {
+fn validate_remote_url(base_url: &Url, authenticated: bool) -> Result<()> {
     if base_url.scheme() == "https" {
         return Ok(());
     }
@@ -545,8 +545,14 @@ fn validate_remote_url(base_url: &Url) -> Result<()> {
         Host::Ipv4(address) => address.is_loopback(),
         Host::Ipv6(address) => address.is_loopback(),
     });
-    if !is_loopback {
+    if !is_loopback && authenticated {
         bail!("task.cache_remote_url must use HTTPS except for loopback development servers");
+    }
+    if !is_loopback {
+        warn!(
+            "using an unauthenticated remote task cache over plain HTTP; cache traffic can be read \
+             or modified in transit"
+        );
     }
     Ok(())
 }
@@ -1296,16 +1302,18 @@ mod tests {
     }
 
     #[test]
-    fn remote_urls_require_https_except_for_loopback() {
+    fn remote_urls_require_https_for_authenticated_requests() {
         for url in [
             "http://localhost:3000",
             "http://127.0.0.1:3000",
             "http://[::1]:3000",
             "https://cache.example.com",
         ] {
-            validate_remote_url(&url.parse().unwrap()).unwrap();
+            validate_remote_url(&url.parse().unwrap(), true).unwrap();
         }
-        assert!(validate_remote_url(&"http://cache.example.com".parse().unwrap()).is_err());
+        let insecure: Url = "http://cache.example.com".parse().unwrap();
+        assert!(validate_remote_url(&insecure, true).is_err());
+        validate_remote_url(&insecure, false).unwrap();
     }
 
     struct FailingTaskCacheStore {


### PR DESCRIPTION
## Summary
- add a global-only experimental Bearer token setting for remote task cache authentication
- attach the token to every remote request with a sensitive `Authorization` header
- retain explicit repository or organization namespace isolation from the preceding stack layer

## Tests
- `cargo test task_cache_store::tests`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces credential handling and transport policy for remote cache traffic; mitigations include global-only config, HTTPS enforcement when a token is set, sensitive header marking, and redaction in diagnostics.
> 
> **Overview**
> Adds **Bearer token authentication** for the experimental remote task cache via a new global-only `task.cache_remote_token` setting (`MISE_TASK_CACHE_REMOTE_TOKEN`), wired from settings into `RemoteTaskCacheConfig` and sent on every HTTP cache request as a sensitive `Authorization` header.
> 
> **Transport rules** are tightened: credentialed requests require **HTTPS** except on loopback; unauthenticated non-loopback HTTP is allowed only with an explicit transit-risk warning. The remote cache protocol doc and JSON schema/settings docs are updated accordingly, and the parity tracker marks authentication/namespaces as done.
> 
> **Credential hygiene**: remote cache tokens are **redacted** in debug settings dumps and in `as_dict` / partial settings tables so they do not leak in logs or exported config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de646abf94a1a2d1ac55066bf3dcc73561fd6110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->