### PR TITLE
feat(config): accept --file wherever `--path` names a config to write

### DIFF
--- a/e2e/cli/test_config_target_aliases
+++ b/e2e/cli/test_config_target_aliases
@@ -54,3 +54,19 @@ mise unuse --no-prune --file subdir dummy@1
 assert_not_contains "cat subdir/mise.toml" "dummy"
 mise unset --path subdir SUBDIR_VAR
 assert_not_contains "cat subdir/mise.toml" "SUBDIR_VAR"
+
+# the commands that write to a config under `--path` take --file too. `brew tap`/`untap` only
+# edit `[bootstrap.brew.taps]` — they do not touch a Homebrew installation — so they are the
+# cheap way to exercise this end to end; the rest are covered by the clap assertions in
+# src/cli/mod.rs, since running them installs or applies something.
+mise bootstrap packages brew tap acme/tools --file tap-alias.toml
+assert_contains "cat tap-alias.toml" "acme/tools"
+
+mise bootstrap packages brew untap acme/tools --file tap-alias.toml
+assert_not_contains "cat tap-alias.toml" "acme/tools"
+
+# and the canonical name is unaffected
+mise bootstrap packages brew tap acme/tools --path tap-alias.toml
+assert_contains "cat tap-alias.toml" "acme/tools"
+mise bootstrap packages brew untap acme/tools --path tap-alias.toml
+assert_not_contains "cat tap-alias.toml" "acme/tools"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -947,7 +947,7 @@ Print the config/source updates without writing anything
 \fB\-\-no\-apply\fR
 Add the entry without applying it
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 .TP
 \fB\-s, \-\-source\fR \fI<PATH>\fR
@@ -1189,7 +1189,7 @@ Write to the local config instead of the global config
 \fB\-n, \-\-dry\-run\fR
 Print the config change without writing it
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 \fBArguments:\fR
 .PP
@@ -1213,7 +1213,7 @@ Write to the local config instead of the global config
 \fB\-n, \-\-dry\-run\fR
 Print the config change without writing it
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 \fBArguments:\fR
 .PP
@@ -1250,7 +1250,7 @@ Import every linked formula, including dependencies
 \fB\-n, \-\-dry\-run\fR
 Print the config change without writing config
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 .SH "MISE BOOTSTRAP PACKAGES PRUNE"
 Prune installed system packages no longer declared in `[bootstrap.packages]`
@@ -1346,7 +1346,7 @@ Write to the global config (~/.config/mise/config.toml) instead of the local one
 \fB\-n, \-\-dry\-run\fR
 Print the commands that would run without writing config or installing
 .TP
-\fB\-p, \-\-path\fR \fI<PATH>\fR
+\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
 Write to this config file or directory
 .TP
 \fB\-y, \-\-yes\fR

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -391,7 +391,7 @@ Examples:
             }
             flag "-n --dry-run" help="Print the config/source updates without writing anything"
             flag --no-apply help="Add the entry without applying it"
-            flag "-p --path" help="Write to this config file or directory" {
+            flag "-p --path --file" help="Write to this config file or directory" {
                 arg <PATH>
             }
             flag "-s --source" help="Source path to use for a single target" {
@@ -598,7 +598,7 @@ Examples:
 """#
                 flag "-l --local" help="Write to the local config instead of the global config"
                 flag "-n --dry-run" help="Print the config change without writing it"
-                flag "-p --path" help="Write to this config file or directory" {
+                flag "-p --path --file" help="Write to this config file or directory" {
                     arg <PATH>
                 }
                 arg <TAP> help="Tap name, e.g. `owner/repo`"
@@ -614,7 +614,7 @@ Examples:
 """#
                 flag "-l --local" help="Write to the local config instead of the global config"
                 flag "-n --dry-run" help="Print the config change without writing it"
-                flag "-p --path" help="Write to this config file or directory" {
+                flag "-p --path --file" help="Write to this config file or directory" {
                     arg <PATH>
                 }
                 arg <TAPS>… help="Tap name(s), e.g. `owner/repo`" var=#true
@@ -648,7 +648,7 @@ Examples:
             }
             flag --all help="Import every linked formula, including dependencies"
             flag "-n --dry-run" help="Print the config change without writing config"
-            flag "-p --path" help="Write to this config file or directory" {
+            flag "-p --path --file" help="Write to this config file or directory" {
                 arg <PATH>
             }
         }
@@ -750,7 +750,7 @@ Examples:
             }
             flag "-g --global" help="Write to the global config (~/.config/mise/config.toml) instead of the local one"
             flag "-n --dry-run" help="Print the commands that would run without writing config or installing"
-            flag "-p --path" help="Write to this config file or directory" {
+            flag "-p --path --file" help="Write to this config file or directory" {
                 arg <PATH>
             }
             flag "-y --yes" help="Skip the confirmation prompt"
@@ -1075,7 +1075,7 @@ Examples:
         }
         flag "-n --dry-run" help="Print the config/source updates without writing anything"
         flag --no-apply help="Add the entry without applying it"
-        flag "-p --path" help="Write to this config file or directory" {
+        flag "-p --path --file" help="Write to this config file or directory" {
             arg <PATH>
         }
         flag "-s --source" help="Source path to use for a single target" {

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -50,7 +50,7 @@ pub struct DotfilesAdd {
     pub(super) no_apply: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with_all = ["global", "local"])]
+    #[clap(long, short, visible_alias = "file", value_name = "PATH", conflicts_with_all = ["global", "local"])]
     pub(super) path: Option<PathBuf>,
 
     /// Source path to use for a single target

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -985,6 +985,63 @@ mod tests {
         }
     }
 
+    /// Commands that name a config file to write to accept both spellings, so it
+    /// does not matter which one you remember. See
+    /// <https://github.com/jdx/mise/discussions/4881>.
+    ///
+    /// Asserted through clap rather than end-to-end because several of these
+    /// commands install or apply something when actually run.
+    #[test]
+    fn test_config_target_options_accept_both_names() {
+        // (command path, argument id, expected alias, available on this platform)
+        let cases: &[(&[&str], &str, &str, bool)] = &[
+            (&["use"], "path", "file", true),
+            (&["unuse"], "path", "file", true),
+            (&["set"], "file", "path", true),
+            (&["unset"], "file", "path", true),
+            (&["dotfiles", "add"], "path", "file", true),
+            (&["bootstrap", "packages", "use"], "path", "file", true),
+            (&["bootstrap", "packages", "import"], "path", "file", true),
+            // the brew manager is not registered on Windows
+            (
+                &["bootstrap", "packages", "brew", "tap"],
+                "path",
+                "file",
+                cfg!(not(windows)),
+            ),
+            (
+                &["bootstrap", "packages", "brew", "untap"],
+                "path",
+                "file",
+                cfg!(not(windows)),
+            ),
+        ];
+        let root = Cli::command();
+
+        for (path, arg_name, alias, available) in cases {
+            if !available {
+                continue;
+            }
+            let command = path.iter().fold(&root, |command, name| {
+                command
+                    .get_subcommands()
+                    .find(|subcommand| subcommand.get_name() == *name)
+                    .unwrap_or_else(|| panic!("missing command path {}", path.join(" ")))
+            });
+            let arg = command
+                .get_arguments()
+                .find(|arg| arg.get_id() == *arg_name)
+                .unwrap_or_else(|| panic!("missing --{arg_name} on {}", path.join(" ")));
+
+            assert!(
+                arg.get_visible_aliases()
+                    .is_some_and(|aliases| aliases.contains(alias)),
+                "missing visible --{alias} alias for --{arg_name} on {}",
+                path.join(" ")
+            );
+        }
+    }
+
     #[test]
     fn test_escape_task_args_preserves_task_separator_tail() {
         let cmd = Cli::command();

--- a/src/cli/system/brew/tap.rs
+++ b/src/cli/system/brew/tap.rs
@@ -28,7 +28,13 @@ pub struct SystemBrewTap {
     dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with = "local")]
+    #[clap(
+        long,
+        short,
+        visible_alias = "file",
+        value_name = "PATH",
+        conflicts_with = "local"
+    )]
     path: Option<PathBuf>,
 }
 

--- a/src/cli/system/brew/untap.rs
+++ b/src/cli/system/brew/untap.rs
@@ -24,7 +24,13 @@ pub struct SystemBrewUntap {
     dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with = "local")]
+    #[clap(
+        long,
+        short,
+        visible_alias = "file",
+        value_name = "PATH",
+        conflicts_with = "local"
+    )]
     path: Option<PathBuf>,
 }
 

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -53,7 +53,13 @@ pub struct SystemImport {
     dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with = "global")]
+    #[clap(
+        long,
+        short,
+        visible_alias = "file",
+        value_name = "PATH",
+        conflicts_with = "global"
+    )]
     path: Option<PathBuf>,
 }
 

--- a/src/cli/system/use.rs
+++ b/src/cli/system/use.rs
@@ -43,7 +43,13 @@ pub struct SystemUse {
     dry_run: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, value_name = "PATH", conflicts_with = "global")]
+    #[clap(
+        long,
+        short,
+        visible_alias = "file",
+        value_name = "PATH",
+        conflicts_with = "global"
+    )]
     path: Option<PathBuf>,
 
     /// Skip the confirmation prompt


### PR DESCRIPTION
Third step of #4881, after #11577 (`use`/`set`) and #11616 (`unuse`/`unset`).

Five commands name a config file to write to under `--path`, and they all declare it identically:

```rust
/// Write to this config file or directory
#[clap(long, short, value_name = "PATH", conflicts_with_all = [...])]
path: Option<PathBuf>,
```

- `mise dotfiles add`
- `mise bootstrap packages use`
- `mise bootstrap packages import`
- `mise bootstrap packages brew tap`
- `mise bootstrap packages brew untap`

Each gains `--file` as a visible alias. It reads as five commands but it is one change repeated five times — splitting it further would be noise rather than caution. The alias is accurate rather than cosmetic: the help already says "config file **or directory**", and all five resolve through `resolve_target_config_path`, the same function behind `mise use --path`.

## Generated files

The counts differ on purpose. `mise.usage.kdl` gets **six** lines and `man/man1/mise.1` gets **five**, because `dotfiles add` is mounted twice — as `mise dotfiles add` and `mise bootstrap dotfiles add` — and the kdl carries both mounts while the man page only has a `MISE BOOTSTRAP DOTFILES ADD` section. `docs/cli/*.md` is unchanged; the markdown generator does not render flag aliases.

## Tests

Two layers, because these commands are not equally cheap to run.

`src/cli/mod.rs` gains a clap assertion covering all nine commands done so far. `bootstrap packages use`/`import` install things and `dotfiles add` applies them, so asserting through the parser is the only way to cover them uniformly — and it runs on Windows, where the bash e2e does not. The brew entries are guarded with `cfg!(not(windows))` since that manager is not registered there.

`e2e/cli/test_config_target_aliases` gains `brew tap`/`untap` under both spellings. Those two only edit `[bootstrap.brew.taps]` — they do not touch a Homebrew installation, and `default_tap_url` formats the URL rather than fetching it — so they are the one pair here that can be exercised end to end for free.

## Remaining

Only `mise config get` and `mise config set` after this. They are deliberately left out: both take `-f --file` and, unlike everything above, accept a **file only** — the value goes straight to `read_to_string`/`MiseToml::from_file` with no directory branch. Adding `--path` there needs that difference stated rather than glossed over, so it belongs in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--file` as an alias for `--path` across bootstrap configuration commands, including dotfiles, package imports, package use, and Homebrew tap/untap operations.
  * The alias is also available for the deprecated dotfiles command.
  * Existing `--path` and short-option usage remains supported.

* **Tests**
  * Added coverage confirming both option names target the specified configuration file correctly across supported commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->