### PR TITLE
fix(config): don't write the global config into a conf.d drop-in

### DIFF
--- a/e2e/cli/test_global_config_confd
+++ b/e2e/cli/test_global_config_confd
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Writing to the global config must never land in a `conf.d` drop-in.
+#
+# `first_config_file` skips conf.d entries while choosing, but falls back to the
+# first candidate when nothing else qualifies — and `config_files_from_dir`
+# inserts conf.d entries first. A config dir holding only drop-ins therefore
+# handed one back as the write target.
+#
+# See: https://github.com/jdx/mise/discussions/5842
+
+mkdir -p "$HOME/.config/mise/conf.d"
+cat >"$HOME/.config/mise/conf.d/10-drop-in.toml" <<'TOML'
+[env]
+FROM_CONFD = "yes"
+TOML
+
+# the reported state: drop-ins exist, the global config itself does not
+assert_fail "test -f $HOME/.config/mise/config.toml"
+
+# the drop-in is loaded — the filter is about writing, not reading
+assert_contains "mise env -s bash" "FROM_CONFD"
+
+# A `.tool-versions` global config still wins over a drop-in, and skipping
+# drop-ins must not divert those writes. This holds because
+# `global_config_files()` inserts ~/.tool-versions ahead of the conf.d entries,
+# so it — not a drop-in — is what the fallback returns; pin that ordering here.
+printf 'dummy 1.0.0\n' >"$HOME/.tool-versions"
+MISE_USE_TOML=false mise use -g dummy@system
+assert_contains "cat $HOME/.tool-versions" "dummy"
+assert_not_contains "cat $HOME/.config/mise/conf.d/10-drop-in.toml" "dummy"
+assert_fail "test -f $HOME/.config/mise/config.toml"
+rm "$HOME/.tool-versions"
+
+# `mise use --global` creates the global config rather than editing the drop-in
+mise use -g dummy@system
+assert_contains "cat $HOME/.config/mise/config.toml" 'dummy = "system"'
+assert_not_contains "cat $HOME/.config/mise/conf.d/10-drop-in.toml" "dummy"
+
+# `mise set --global` and `mise settings set` resolve through the same function
+mise set -g CONFD_GUARD=set
+assert_contains "cat $HOME/.config/mise/config.toml" "CONFD_GUARD"
+assert_not_contains "cat $HOME/.config/mise/conf.d/10-drop-in.toml" "CONFD_GUARD"
+
+mise settings set jobs 3
+assert_contains "cat $HOME/.config/mise/config.toml" "jobs"
+assert_not_contains "cat $HOME/.config/mise/conf.d/10-drop-in.toml" "jobs"
+
+# removal goes to the same place, and the drop-in is still intact and loaded
+mise unuse -y dummy@system
+assert_not_contains "cat $HOME/.config/mise/config.toml" "dummy"
+assert_contains "cat $HOME/.config/mise/conf.d/10-drop-in.toml" "FROM_CONFD"
+assert_contains "mise env -s bash" "FROM_CONFD"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2225,6 +2225,11 @@ fn config_files_from_dir(dir: &Path) -> IndexSet<PathBuf> {
 pub fn global_config_path() -> PathBuf {
     let files = global_config_files();
     first_config_file(&files)
+        // Never write into a `conf.d` drop-in. `first_config_file` skips them
+        // while choosing, but falls back to `files.first()` when nothing else
+        // qualifies — and `config_files_from_dir` inserts conf.d entries first,
+        // so a config dir holding only drop-ins would hand one back here.
+        .filter(|p| !is_conf_d_file(p.as_path()))
         .cloned()
         .or_else(|| env::MISE_GLOBAL_CONFIG_FILE.clone())
         .unwrap_or_else(|| dirs::CONFIG.join("config.toml"))


### PR DESCRIPTION
Reported in #5842: with `~/.config/mise/config.toml` not yet created and `conf.d/*.toml` present, `mise use --global` edits a **drop-in** instead.

Measured on v2026.7.15, config dir holding only `conf.d/10-a.toml`:

```console
$ mise use -g --dry-run jq@1.7.1
mise would update .../cfg/conf.d/10-a.toml (add: jq@1.7.1)
```

## Cause

`first_config_file` deliberately skips conf.d entries while choosing, but falls back to `files.first()` when nothing else qualifies — and `config_files_from_dir` inserts conf.d entries **before** `CONFIG_FILENAMES`. So a config dir holding only drop-ins hands one straight back to `global_config_path`, whose own doc comment reads *"the preferred global config file to write to, or the path where it should be created"*.

That also explains the reporter's observation that it works correctly once conf.d is empty.

## Change

One `.filter` in `global_config_path`, so an unqualified candidate falls through to `MISE_GLOBAL_CONFIG_FILE` and then to `<config dir>/config.toml` — the name `mise use --help` already documents for `--global`.

`first_config_file` itself is left alone: its `files.first()` fallback is what makes a `.tool-versions`-only global config work, and other callers rely on it. Only the global write-target resolution needed narrowing.

## What else this touches

All nine callers of `global_config_path()` are write-target resolution, so they are all fixed by the same change and none of them wanted a drop-in:

- `Config::global_config()` — the base for settings writes
- `resolve_target_config_path` — the `--global` branch and the in-`$HOME` branch
- `cli/unuse.rs`, `cli/edit.rs`, `cli/settings/set.rs`, `cli/settings/unset.rs`

Unchanged: reading. Drop-ins are still discovered and loaded exactly as before — the filter only decides where writes go. Also unchanged: a `.tool-versions` global config (reachable with `MISE_USE_TOML=false`), which is not a conf.d file and passes the filter.

If `<config dir>/mise.toml` already exists it is still preferred over creating `config.toml`, since `first_config_file` finds it before the fallback is reached.

## Tests

`e2e/cli/test_global_config_confd`, modelled on the existing `test_global_config_file_home`: with only a drop-in present, `mise use -g` / `mise set -g` / `mise settings set` all write to `config.toml`, the drop-in is byte-for-byte untouched, and it is still loaded before and after — the reading path is the thing most worth guarding here.

No unit test: `config/mod.rs`'s `mod tests` is `#[cfg(unix)]` and snapshot-based, and `global_config_files()` reads `dirs::CONFIG` through a `Mutex`-cached static that a test cannot vary.

## Note

@jdx said in the thread that this was "probably easier said than done" — it turned out to be one predicate, because the intent was already encoded in `first_config_file`; only the fallback leaked past it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global configuration updates now consistently write to the primary `config.toml` file instead of `conf.d` drop-in files.
  * Existing drop-in configuration files remain preserved when global settings, tools, or environment values are added or removed.
* **Tests**
  * Added end-to-end coverage confirming correct configuration file selection and preservation of drop-in settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->