### PR TITLE
docs(npm): clarify node dependency behavior

### DIFF
--- a/docs/dev-tools/backends/npm.md
+++ b/docs/dev-tools/backends/npm.md
@@ -13,8 +13,10 @@ the npm registry directly over HTTP, and packages are installed with mise's
 embedded [aube](https://github.com/jdx/aube) package manager. The registry,
 scoped registries (`@scope:registry`), and auth tokens configured in `~/.npmrc`
 (or `NPM_CONFIG_USERCONFIG`) and `NPM_CONFIG_*` environment variables are honored
-by both. `node` is only needed to _run_ the installed tools (and any package
-lifecycle scripts), not to install them.
+by both. An installed package may still require `node` at runtime, and enabled
+package lifecycle scripts may require it during installation. When `node` is
+already configured, mise orders its installation before `npm:` tools, but the
+npm backend does not add or install `node` automatically.
 
 To shell out to the npm CLI instead — `npm view` for metadata and
 `npm install -g` for installs — set
@@ -43,15 +45,6 @@ supporting its release-age flag:
 If you want transitive protection when shelling out, install and use a package
 manager version that meets the corresponding requirement above. Older versions
 may fail while processing the forwarded argument.
-
-`node` is installed automatically as a dependency. To use a specific package
-manager CLI instead of the embedded installer:
-
-```sh
-mise use -g pnpm
-# or
-mise use -g bun
-```
 
 ## Socket security
 

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -277,9 +277,11 @@ impl Backend for NPMBackend {
     fn get_dependencies(&self) -> eyre::Result<Vec<&str>> {
         // Version queries hit the npm registry over HTTP and installs use the
         // embedded aube package manager, so by default neither needs a
-        // package-manager binary. `node` is still listed because installed JS
-        // tools (and any lifecycle scripts) need a runtime. Explicit non-aube
-        // package managers — or `npm.shell_out` — need their CLI on PATH.
+        // package-manager binary. `node` is listed so an already-configured node
+        // installs first when a package or lifecycle script needs it; backend
+        // dependencies do not add missing tools, and not every package needs node.
+        // Explicit non-aube package managers — or `npm.shell_out` — need their CLI
+        // on PATH.
         let settings = Settings::get();
         let shell_out = settings.npm.shell_out;
         let tool_name = self.tool_name();
@@ -1052,9 +1054,9 @@ impl NPMBackend {
         eyre::eyre!(build_aube_install_error_message(&err, &self.ba().full()))
     }
 
-    /// The `node` mise resolved as a dependency, handed to the embedded aube
-    /// installer so lifecycle scripts spawn on it. `None` (no node dependency
-    /// resolved) lets aube fall back to an ambient `node`.
+    /// A configured `node`, when available, is handed to the embedded aube
+    /// installer so lifecycle scripts spawn on it. `None` lets aube fall back
+    /// to an ambient `node`.
     ///
     /// `selector` is the version-manager shape: mise hands over a real bin dir
     /// holding `node`/`npm`/`npx`, aube prepends it to PATH and uses that node
@@ -1601,8 +1603,8 @@ mod tests {
 
     #[test]
     fn test_get_dependencies_for_npm_itself() {
-        // When the tool is npm itself (npm:npm) with default settings (npm as package manager),
-        // it should only depend on node. With bun/pnpm configured, it would include those too.
+        // The node dependency only orders a node that is already in the install
+        // set; it does not cause node to be installed automatically.
         let backend = create_npm_backend("npm");
         let deps = backend.get_dependencies().unwrap();
         assert_eq!(deps, vec!["node"]);
@@ -1610,8 +1612,8 @@ mod tests {
 
     #[test]
     fn test_get_dependencies_default_package_manager() {
-        // Default (auto) installs via the embedded aube package manager, so a
-        // package only needs node at runtime — no npm/aube/bun/pnpm binary.
+        // Default (auto) needs no external installer. Node remains an ordering
+        // dependency for configured packages that need it at runtime.
         let backend = create_npm_backend("prettier");
         let deps = backend.get_dependencies().unwrap();
         assert_eq!(deps, vec!["node"]);


### PR DESCRIPTION
## Summary

- clarify that the embedded npm installer does not add or install Node automatically
- explain that Node requirements are package-specific and that an already-configured Node is only ordered ahead of `npm:` tools
- remove examples that installed pnpm or Bun without selecting them via `npm.package_manager`
- align backend comments and test descriptions with the scheduler's actual dependency semantics

## Testing

- `cargo test test_get_dependencies`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only alignment; no install logic changes in the diff.
> 
> **Overview**
> Corrects npm backend docs and inline comments so they match how mise actually treats **`node`**: listing it in `get_dependencies` only **orders** an already-configured Node ahead of `npm:` tools; the backend does **not** pull Node into the install set by itself. Runtime and lifecycle-script needs are described as **package-specific**.
> 
> The **Dependencies** section now spells out when Node may still be required and drops the misleading `mise use -g pnpm` / `bun` examples that implied automatic Node or installer setup without `npm.package_manager`. Comments on `get_dependencies`, `aube_embed_runtime`, and the dependency unit tests are updated to the same semantics (ordering vs auto-install).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fe17290456119d9056fb1e4730fbede7ad8329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when Node.js is required during npm package installation and tool execution.
  * Documented that configured Node.js is installed before npm tools, without automatic Node.js installation.
  * Removed obsolete guidance about automatic dependencies and package-manager CLI installation.
* **Refactor**
  * Clarified runtime dependency behavior for npm tools and embedded execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->