### PR TITLE
fix(task): reject task-list flags on subcommands

### DIFF
--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -14,7 +14,7 @@ Manage tasks
 
 Task name to get info of
 
-## Global Flags
+## Flags
 
 ### `-g --global`
 

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -68,6 +68,9 @@ myglobalfile
 relative-meta
 systemglobalfile
 templated-meta"
+assert "mise tasks ls --local" "mylocal"
+assert_fail "mise tasks deps --local" "unexpected argument '--local'"
+assert_fail "mise tasks --global deps" "task list options cannot be used with subcommands"
 assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run systemglobalfile" "PROJECT_ROOT=$PWD"
 assert "mise run relative-meta" "RELATIVE_OVERLAY=applied"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -69,6 +69,7 @@ relative-meta
 systemglobalfile
 templated-meta"
 assert "mise tasks ls --local" "mylocal"
+assert "mise tasks --local ls" "mylocal"
 assert_fail "mise tasks deps --local" "unexpected argument '--local'"
 assert_fail "mise tasks --global deps" "task list options cannot be used with subcommands"
 assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -70,6 +70,7 @@ systemglobalfile
 templated-meta"
 assert "mise tasks ls --local" "mylocal"
 assert "mise tasks --local ls" "mylocal"
+assert_fail "mise tasks --name-only ls --json" "--name-only cannot be used with --json, --extended, or --usage"
 assert_fail "mise tasks deps --local" "unexpected argument '--local'"
 assert_fail "mise tasks --global deps" "task list options cannot be used with subcommands"
 assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"

--- a/e2e/tasks/test_task_ls_global
+++ b/e2e/tasks/test_task_ls_global
@@ -71,6 +71,8 @@ templated-meta"
 assert "mise tasks ls --local" "mylocal"
 assert "mise tasks --local ls" "mylocal"
 assert_fail "mise tasks --name-only ls --json" "--name-only cannot be used with --json, --extended, or --usage"
+assert_contains "mise tasks mylocal --json" '"name": "mylocal"'
+assert_fail "mise tasks mylocal --local" "task list options cannot be used with task info"
 assert_fail "mise tasks deps --local" "unexpected argument '--local'"
 assert_fail "mise tasks --global deps" "task list options cannot be used with subcommands"
 assert "mise run customglobalfile" "PROJECT_ROOT=$PWD"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3641,29 +3641,29 @@ Examples:
     $ mise tasks ls
 
 """#
-    flag "-g --global" help="Only show global tasks" global=#true
-    flag "-J --json" help="Output in JSON format" global=#true
-    flag "-l --local" help="Only show non-global tasks" global=#true
-    flag "-x --extended" help="Show all columns" global=#true
+    flag "-g --global" help="Only show global tasks"
+    flag "-J --json" help="Output in JSON format"
+    flag "-l --local" help="Only show non-global tasks"
+    flag "-x --extended" help="Show all columns"
     flag --all help=#"""
 Load all tasks from the entire monorepo, including sibling directories.
 By default, only tasks from the current directory hierarchy are loaded.
-"""# global=#true
+"""#
     flag --complete help="Display tasks for usage completion" hide=#true
-    flag --hidden help="Show hidden tasks" global=#true
-    flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools." global=#true
-    flag --no-header help="Do not print table header" global=#true
-    flag --sort help="Sort by column. Default is name." global=#true {
+    flag --hidden help="Show hidden tasks"
+    flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools."
+    flag --no-header help="Do not print table header"
+    flag --sort help="Sort by column. Default is name." {
         arg <COLUMN> {
             choices name alias description source
         }
     }
-    flag --sort-order help="Sort order. Default is asc." global=#true {
+    flag --sort-order help="Sort order. Default is asc." {
         arg <SORT_ORDER> {
             choices asc desc
         }
     }
-    flag --usage hide=#true global=#true
+    flag --usage hide=#true
     arg "[TASK]" help="Task name to get info of" required=#false
     cmd add help="Create a new task" effect=write {
         long_help #"""
@@ -3831,29 +3831,29 @@ Examples:
     $ mise tasks ls
 
 """#
-        flag "-g --global" help="Only show global tasks" global=#true
-        flag "-J --json" help="Output in JSON format" global=#true
-        flag "-l --local" help="Only show non-global tasks" global=#true
-        flag "-x --extended" help="Show all columns" global=#true
+        flag "-g --global" help="Only show global tasks"
+        flag "-J --json" help="Output in JSON format"
+        flag "-l --local" help="Only show non-global tasks"
+        flag "-x --extended" help="Show all columns"
         flag --all help=#"""
 Load all tasks from the entire monorepo, including sibling directories.
 By default, only tasks from the current directory hierarchy are loaded.
-"""# global=#true
+"""#
         flag --complete help="Display tasks for usage completion" hide=#true
-        flag --hidden help="Show hidden tasks" global=#true
-        flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools." global=#true
-        flag --no-header help="Do not print table header" global=#true
-        flag --sort help="Sort by column. Default is name." global=#true {
+        flag --hidden help="Show hidden tasks"
+        flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools."
+        flag --no-header help="Do not print table header"
+        flag --sort help="Sort by column. Default is name." {
             arg <COLUMN> {
                 choices name alias description source
             }
         }
-        flag --sort-order help="Sort order. Default is asc." global=#true {
+        flag --sort-order help="Sort order. Default is asc." {
             arg <SORT_ORDER> {
                 choices asc desc
             }
         }
-        flag --usage hide=#true global=#true
+        flag --usage hide=#true
     }
     cmd run restart_token=::: help="Run task(s)" {
         alias r

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -90,6 +90,24 @@ pub enum SortOrder {
 }
 
 impl TasksLs {
+    pub fn merge(mut self, later: Self) -> Self {
+        if later.global || later.local {
+            self.global = later.global;
+            self.local = later.local;
+        }
+        self.json |= later.json;
+        self.extended |= later.extended;
+        self.all |= later.all;
+        self.complete |= later.complete;
+        self.hidden |= later.hidden;
+        self.name_only |= later.name_only;
+        self.no_header |= later.no_header;
+        self.sort = later.sort.or(self.sort);
+        self.sort_order = later.sort_order.or(self.sort_order);
+        self.usage |= later.usage;
+        self
+    }
+
     pub fn has_options(&self) -> bool {
         self.global
             || self.json

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -112,8 +112,11 @@ impl TasksLs {
     }
 
     pub fn has_options(&self) -> bool {
+        self.json || self.has_non_json_options()
+    }
+
+    pub fn has_non_json_options(&self) -> bool {
         self.global
-            || self.json
             || self.local
             || self.extended
             || self.all

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -23,36 +23,24 @@ use serde_json::json;
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct TasksLs {
     /// Only show global tasks
-    #[clap(
-        short,
-        long,
-        global = true,
-        overrides_with = "local",
-        verbatim_doc_comment
-    )]
+    #[clap(short, long, overrides_with = "local", verbatim_doc_comment)]
     pub global: bool,
 
     /// Output in JSON format
-    #[clap(short = 'J', global = true, long, verbatim_doc_comment)]
+    #[clap(short = 'J', long, verbatim_doc_comment)]
     pub json: bool,
 
     /// Only show non-global tasks
-    #[clap(
-        short,
-        long,
-        global = true,
-        overrides_with = "global",
-        verbatim_doc_comment
-    )]
+    #[clap(short, long, overrides_with = "global", verbatim_doc_comment)]
     pub local: bool,
 
     /// Show all columns
-    #[clap(short = 'x', long, global = true, verbatim_doc_comment)]
+    #[clap(short = 'x', long, verbatim_doc_comment)]
     pub extended: bool,
 
     /// Load all tasks from the entire monorepo, including sibling directories.
     /// By default, only tasks from the current directory hierarchy are loaded.
-    #[clap(long, global = true, verbatim_doc_comment)]
+    #[clap(long, verbatim_doc_comment)]
     pub all: bool,
 
     /// Display tasks for usage completion
@@ -60,31 +48,30 @@ pub struct TasksLs {
     pub complete: bool,
 
     /// Show hidden tasks
-    #[clap(long, global = true, verbatim_doc_comment)]
+    #[clap(long, verbatim_doc_comment)]
     pub hidden: bool,
 
     /// Only show task names, one per line. Useful for piping to fzf and similar tools.
     #[clap(
         long,
-        global = true,
         verbatim_doc_comment,
         conflicts_with_all = ["json", "extended", "usage"]
     )]
     pub name_only: bool,
 
     /// Do not print table header
-    #[clap(long, alias = "no-headers", global = true, verbatim_doc_comment)]
+    #[clap(long, alias = "no-headers", verbatim_doc_comment)]
     pub no_header: bool,
 
     /// Sort by column. Default is name.
-    #[clap(long, global = true, value_name = "COLUMN", verbatim_doc_comment)]
+    #[clap(long, value_name = "COLUMN", verbatim_doc_comment)]
     pub sort: Option<SortColumn>,
 
     /// Sort order. Default is asc.
-    #[clap(long, global = true, verbatim_doc_comment)]
+    #[clap(long, verbatim_doc_comment)]
     pub sort_order: Option<SortOrder>,
 
-    #[clap(long, global = true, hide = true)]
+    #[clap(long, hide = true)]
     pub usage: bool,
 }
 
@@ -103,6 +90,21 @@ pub enum SortOrder {
 }
 
 impl TasksLs {
+    pub fn has_options(&self) -> bool {
+        self.global
+            || self.json
+            || self.local
+            || self.extended
+            || self.all
+            || self.complete
+            || self.hidden
+            || self.name_only
+            || self.no_header
+            || self.sort.is_some()
+            || self.sort_order.is_some()
+            || self.usage
+    }
+
     pub async fn run(self) -> Result<()> {
         use crate::task::TaskLoadContext;
 

--- a/src/cli/tasks/ls.rs
+++ b/src/cli/tasks/ls.rs
@@ -8,7 +8,7 @@ use crate::task::task_fetcher::TaskFetcher;
 use crate::task::task_list::find_non_executable_task_files;
 use crate::ui::table::MiseTable;
 use comfy_table::{Attribute, Cell, Row};
-use eyre::Result;
+use eyre::{Result, bail};
 use itertools::Itertools;
 use serde_json::json;
 
@@ -90,7 +90,7 @@ pub enum SortOrder {
 }
 
 impl TasksLs {
-    pub fn merge(mut self, later: Self) -> Self {
+    pub fn merge(mut self, later: Self) -> Result<Self> {
         if later.global || later.local {
             self.global = later.global;
             self.local = later.local;
@@ -105,7 +105,10 @@ impl TasksLs {
         self.sort = later.sort.or(self.sort);
         self.sort_order = later.sort_order.or(self.sort_order);
         self.usage |= later.usage;
-        self
+        if self.name_only && (self.json || self.extended || self.usage) {
+            bail!("--name-only cannot be used with --json, --extended, or --usage");
+        }
+        Ok(self)
     }
 
     pub fn has_options(&self) -> bool {

--- a/src/cli/tasks/mod.rs
+++ b/src/cli/tasks/mod.rs
@@ -63,14 +63,18 @@ impl Tasks {
                 }
                 cmd
             }
-            None => task
-                .map(|task| {
+            None => match task {
+                Some(task) => {
+                    if ls.has_non_json_options() {
+                        bail!("task list options cannot be used with task info");
+                    }
                     Commands::Info(info::TasksInfo {
                         task,
                         json: ls.json,
                     })
-                })
-                .unwrap_or(Commands::Ls(ls)),
+                }
+                None => Commands::Ls(ls),
+            },
         };
 
         cmd.run().await

--- a/src/cli/tasks/mod.rs
+++ b/src/cli/tasks/mod.rs
@@ -56,7 +56,7 @@ impl Tasks {
     pub async fn run(self) -> Result<()> {
         let Self { command, task, ls } = self;
         let cmd = match command {
-            Some(Commands::Ls(cmd)) => Commands::Ls(ls.merge(cmd)),
+            Some(Commands::Ls(cmd)) => Commands::Ls(ls.merge(cmd)?),
             Some(cmd) => {
                 if ls.has_options() {
                     bail!("task list options cannot be used with subcommands");

--- a/src/cli/tasks/mod.rs
+++ b/src/cli/tasks/mod.rs
@@ -1,5 +1,5 @@
 use clap::Subcommand;
-use eyre::Result;
+use eyre::{Result, bail};
 
 use crate::cli::run;
 
@@ -54,6 +54,10 @@ impl Commands {
 
 impl Tasks {
     pub async fn run(self) -> Result<()> {
+        if self.command.is_some() && self.ls.has_options() {
+            bail!("task list options cannot be used with subcommands");
+        }
+
         let cmd = self
             .command
             .or(self.task.map(|t| {

--- a/src/cli/tasks/mod.rs
+++ b/src/cli/tasks/mod.rs
@@ -54,19 +54,24 @@ impl Commands {
 
 impl Tasks {
     pub async fn run(self) -> Result<()> {
-        if self.command.is_some() && self.ls.has_options() {
-            bail!("task list options cannot be used with subcommands");
-        }
-
-        let cmd = self
-            .command
-            .or(self.task.map(|t| {
-                Commands::Info(info::TasksInfo {
-                    task: t,
-                    json: self.ls.json,
+        let Self { command, task, ls } = self;
+        let cmd = match command {
+            Some(Commands::Ls(cmd)) => Commands::Ls(ls.merge(cmd)),
+            Some(cmd) => {
+                if ls.has_options() {
+                    bail!("task list options cannot be used with subcommands");
+                }
+                cmd
+            }
+            None => task
+                .map(|task| {
+                    Commands::Info(info::TasksInfo {
+                        task,
+                        json: ls.json,
+                    })
                 })
-            }))
-            .unwrap_or(Commands::Ls(self.ls));
+                .unwrap_or(Commands::Ls(ls)),
+        };
 
         cmd.run().await
     }


### PR DESCRIPTION
## Summary

- scope task-list flags to `mise tasks` and `mise tasks ls`
- reject task-list flags placed before an explicit task subcommand instead of silently ignoring them
- regenerate CLI usage documentation and add regression coverage

## Root cause

`TasksLs` is flattened into the parent `tasks` command so `mise tasks` can default to listing tasks. Its options were also marked as clap-global, which propagated them to every descendant subcommand even though those subcommands discarded the parsed values. As a result, commands such as `mise tasks deps --local` succeeded without applying the requested filter.

## User impact

Task subcommands now advertise and accept only the options they implement. Existing list forms such as `mise tasks --local` and `mise tasks ls --local` continue to work.

## Validation

- `mise run format`
- `mise run test:e2e tasks/test_task_ls_global`
- `mise run test:e2e tasks/test_task_deps`
- `mise run render`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI parsing and validation only; existing list invocations are preserved and behavior for unsupported flag combos changes from silent ignore to explicit errors.
> 
> **Overview**
> **Task-list flags** (`--local`, `--global`, `--json`, etc.) no longer propagate as clap-global options to every `mise tasks` subcommand. They apply only to default listing (`mise tasks`) and `mise tasks ls`, with parent and `ls` options merged when both are used.
> 
> **Invalid combinations now error** instead of being ignored: list flags before another subcommand (e.g. `mise tasks --global deps`), list flags with task info (e.g. `mise tasks mylocal --local`), and `--name-only` with `--json` / `--extended` / `--usage`. Subcommands like `deps` no longer accept stray list flags (e.g. `mise tasks deps --local`).
> 
> CLI usage spec and docs were regenerated; e2e tests cover merged `ls` forms and the new errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5aa83b1cc41ecb480f19cdb46a9cd77ade68a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task-listing option handling across command aliases and explicit task-list commands.
  - Local task listings now work consistently whether options appear before or after the list command.
  - Added clear errors for incompatible options, including task dependencies and task-information lookups.
  - Improved validation for JSON and name-only listing combinations.
  - Preserved task-name information and default listing behavior.

- **Documentation**
  - Updated the CLI documentation to refer to task-listing options simply as “Flags.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->