### PR TITLE
feat(upgrade): add --no-prune to keep the version being replaced

### DIFF
--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -83,6 +83,14 @@ Explicitly pinned versions like "22.5.0" are not filtered.
 
 Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.
 
+### `--no-prune`
+
+Do not uninstall the versions that were upgraded away from
+
+By default the old version is removed once the new one installs, unless another
+tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
+something outside of mise points at the old install directory.
+
 ### `--raw`
 
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# `mise upgrade --no-prune` keeps the version it upgraded away from.
+#
+# By default that version is uninstalled outright — its install directory is
+# deleted — which breaks anything outside of mise that points at that path, such
+# as a virtualenv built from a mise-managed interpreter. The existing protection
+# only covers versions another tracked config or tool stub still asks for.
+#
+# See: https://github.com/jdx/mise/discussions/5840
+
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "1"
+EOF
+
+mise uninstall dummy --all
+mise install dummy@1.0.0
+
+# --dry-run announces the removal, and --no-prune withdraws it while still
+# reporting the install
+assert_contains "mise up dummy -n" "Would uninstall dummy@1.0.0"
+assert_not_contains "mise up dummy -n --no-prune" "Would uninstall"
+assert_contains "mise up dummy -n --no-prune" "Would install dummy@1.1.0"
+
+mise upgrade dummy --no-prune
+assert_contains "mise ls --installed dummy" "1.1.0"
+assert_contains "mise ls --installed dummy" "1.0.0"
+# the install directory itself has to survive — that is what an outside
+# reference resolves through
+assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
+
+# the default is unchanged
+mise uninstall dummy --all
+mise install dummy@1.0.0
+mise upgrade dummy
+assert_contains "mise ls --installed dummy" "1.1.0"
+assert_not_contains "mise ls --installed dummy" "1.0.0"
+
+# --bump rewrites the config and still honors the flag
+mise uninstall dummy --all
+mise install dummy@1.0.0
+mise upgrade dummy --bump --no-prune
+assert_contains "mise ls --installed dummy" "2.0.0"
+assert_contains "mise ls --installed dummy" "1.0.0"
+assert_contains "cat mise.toml" 'dummy = "2"'
+
+rm -f mise.toml

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4416,6 +4416,13 @@ Explicitly pinned versions like "22.5.0" are not filtered.
 \fB\-\-monorepo\fR
 Placeholder for future monorepo upgrades; `mise upgrade \-\-monorepo` is not implemented yet.
 .TP
+\fB\-\-no\-prune\fR
+Do not uninstall the versions that were upgraded away from
+
+By default the old version is removed once the new one installs, unless another
+tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
+something outside of mise points at the old install directory.
+.TP
 \fB\-\-raw\fR
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1
 \fBArguments:\fR

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4475,6 +4475,15 @@ Explicitly pinned versions like "22.5.0" are not filtered.
         arg <MINIMUM_RELEASE_AGE>
     }
     flag --monorepo help="Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet."
+    flag --no-prune help="Do not uninstall the versions that were upgraded away from" {
+        long_help #"""
+Do not uninstall the versions that were upgraded away from
+
+By default the old version is removed once the new one installs, unless another
+tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
+something outside of mise points at the old install directory.
+"""#
+    }
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
     arg "[INSTALLED_TOOL@VERSION]…" help=#"""
 Tool(s) to upgrade

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -102,6 +102,14 @@ pub struct Upgrade {
     #[clap(long, verbatim_doc_comment)]
     monorepo: bool,
 
+    /// Do not uninstall the versions that were upgraded away from
+    ///
+    /// By default the old version is removed once the new one installs, unless another
+    /// tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
+    /// something outside of mise points at the old install directory.
+    #[clap(long, verbatim_doc_comment)]
+    no_prune: bool,
+
     /// Connect backend install command stdin/stdout/stderr directly to the terminal
     /// Implies --jobs=1
     #[clap(long, overrides_with = "jobs")]
@@ -244,19 +252,23 @@ impl Upgrade {
 
         // Determine which old versions should be uninstalled after upgrade
         // Skip uninstall when current == latest (channel-based versions that update in-place)
-        let to_remove: Vec<_> = outdated
-            .iter()
-            .filter_map(|o| {
-                o.current.as_ref().and_then(|current| {
-                    // Skip if current and latest version strings are identical
-                    // This handles channels like "nightly", "stable", "beta" that update in-place
-                    if &o.latest == current {
-                        return None;
-                    }
-                    Some((o, current.clone()))
+        let to_remove: Vec<_> = if self.no_prune {
+            vec![]
+        } else {
+            outdated
+                .iter()
+                .filter_map(|o| {
+                    o.current.as_ref().and_then(|current| {
+                        // Skip if current and latest version strings are identical
+                        // This handles channels like "nightly", "stable", "beta" that update in-place
+                        if &o.latest == current {
+                            return None;
+                        }
+                        Some((o, current.clone()))
+                    })
                 })
-            })
-            .collect();
+                .collect()
+        };
 
         if self.is_dry_run() {
             for (o, current) in &to_remove {
@@ -456,15 +468,22 @@ impl Upgrade {
                 upgraded_config_paths.insert(path.clone());
             }
         }
-        let mut versions_needed_by_tracked =
-            get_versions_needed_by_tracked_configs_excluding_locks(
+        // Resolving every tracked config and stub is only worth doing when something is
+        // actually up for removal — with --no-prune, or when every upgrade was in-place,
+        // the answer would be discarded.
+        let versions_needed_by_tracked = if to_remove.is_empty() {
+            HashSet::new()
+        } else {
+            let mut needed = get_versions_needed_by_tracked_configs_excluding_locks(
                 config,
                 true,
                 false,
                 &upgraded_config_paths,
             )
             .await?;
-        versions_needed_by_tracked.extend(get_versions_needed_by_tracked_stubs(config).await?);
+            needed.extend(get_versions_needed_by_tracked_stubs(config).await?);
+            needed
+        };
 
         // Only uninstall old versions of tools that were successfully upgraded
         // and are not needed by any tracked config


### PR DESCRIPTION
Requested in #5840: `mise upgrade` uninstalls the version it upgraded away from, and there is no way to keep it. The reporter builds virtualenvs from mise-managed Pythons, so every upgrade breaks them.

Measured on v2026.8.0, config `jq = "1"` with only 1.7 installed:

```console
$ mise upgrade jq
mise jq@1.8.2      ✓ installed
mise uninstall jq@1.7 uninstall
mise uninstall jq@1.7 remove ~/.local/share/mise/installs/jq/1.7
mise uninstall jq@1.7 remove ~/.cache/mise/jq/1.7
mise uninstall jq@1.7 ✓ done
```

The install directory goes away, so anything resolving through that path — a virtualenv's `bin/python`, a hardcoded shebang, a symlink someone made — stops working. Same with `--bump`; the removal is driven by `outdated`, not by whether the config gets rewritten.

## Why the existing guard doesn't help here

`upgrade.rs` already spares versions that are still wanted:

```rust
if versions_needed_by_tracked.contains(&version_key) {
    debug!("Keeping {}@{} because it's still needed by a tracked config or tool stub", ...);
    continue;
}
```

That covers tracked configs and tool stubs (#10790, #11501). A reference held outside of mise is invisible to it, which is exactly the reported case.

## Change

`--no-prune`, the same flag `mise unuse` already carries and with the same meaning.

It empties `to_remove` rather than guarding the uninstall loop, so the dry-run listing follows along — today `mise upgrade jq --dry-run` prints

```console
Would uninstall jq@1.7
Would install jq@1.8.2
```

and with the flag only the install line remains.

Second, small: resolving every tracked config and stub is now skipped when `to_remove` is empty. Two `await`s whose result was already being discarded in that case — reachable before this PR whenever every upgrade was in-place, and reachable on every `--no-prune` run after it.

No default behavior changes.

## Tests

`e2e/cli/test_upgrade_no_prune`:

- the dry-run listing with and without the flag
- `--no-prune` keeps the old version, and `$MISE_DATA_DIR/installs/dummy/1.0.0` still exists — the directory is what an outside reference actually resolves through, so it is asserted directly rather than only through `mise ls`
- without the flag the old version is still removed, i.e. the default is untouched
- `--bump --no-prune` bumps the config and still keeps the old version

## Note

#5840 also asks for a setting (`auto_prune_old_versions = false`) so unattended upgrades keep old versions without repeating the flag. I left that out to keep this reviewable — happy to add it if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-prune` option to `mise upgrade` to retain older tool versions after upgrading.
  * Works with regular upgrades, dry runs, and `--bump` upgrades.

* **Documentation**
  * Updated command-line help, user documentation, and the manual with the new option.

* **Tests**
  * Added coverage verifying version retention and preserving the default pruning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->