### PR TITLE
feat(config): accept --path on `mise config get` and `mise config set`

### DIFF
--- a/docs/cli/config/get.md
+++ b/docs/cli/config/get.md
@@ -17,7 +17,9 @@ The path of the config to display
 
 ### `-f --file <FILE>`
 
-The path to the mise.toml file to edit
+The path to the mise.toml file to read
+
+Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
 If not provided, the nearest mise.toml file will be used
 

--- a/docs/cli/config/set.md
+++ b/docs/cli/config/set.md
@@ -23,6 +23,8 @@ The value to set the key to (optional if provided as KEY=VALUE)
 
 The path to the mise.toml file to edit
 
+Can be a file path or directory. If a directory is provided, the config file in that directory is used.
+
 If not provided, the nearest mise.toml file will be used
 
 ### `-t --type <TYPE>`

--- a/e2e/cli/test_config_target_aliases
+++ b/e2e/cli/test_config_target_aliases
@@ -70,3 +70,26 @@ mise bootstrap packages brew tap acme/tools --path tap-alias.toml
 assert_contains "cat tap-alias.toml" "acme/tools"
 mise bootstrap packages brew untap acme/tools --path tap-alias.toml
 assert_not_contains "cat tap-alias.toml" "acme/tools"
+
+# `mise config get` and `mise config set` name the option --file; both take --path too
+printf '[tools]\ndummy = "1"\n' >cfg.toml
+mise config set --path cfg.toml tools.dummy 2
+assert "mise config get --file cfg.toml tools.dummy" "2"
+mise config set --file cfg.toml tools.dummy 3
+assert "mise config get --path cfg.toml tools.dummy" "3"
+
+# and a directory resolves to the config file inside it, as it does for the commands above
+mkdir -p cfgdir
+printf '[tools]\ndummy = "1"\n' >cfgdir/mise.toml
+mise config set --path cfgdir tools.dummy 2
+assert "mise config get -f cfgdir tools.dummy" "2"
+assert_contains "cat cfgdir/mise.toml" 'dummy = "2"'
+
+# unlike the write commands above, these two do not create the file — a target that resolves to
+# nothing names itself instead of surfacing a bare io error. The resolved path is asserted and not
+# just the message, since for a directory that is what shows the argument reached the config file
+# inside it rather than being used as-is.
+mkdir -p emptydir
+assert_fail "mise config get --path ./nope.toml tools.dummy" "config file not found: ~/workdir/aliases/nope.toml"
+assert_fail "mise config get --path ./emptydir tools.dummy" "config file not found: ~/workdir/aliases/emptydir/mise.toml"
+assert_fail "mise config set --path ./emptydir tools.dummy 1" "config file not found: ~/workdir/aliases/emptydir/mise.toml"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1571,8 +1571,10 @@ Display the value of a setting in a mise.toml file
 \fBOptions:\fR
 .PP
 .TP
-\fB\-f, \-\-file\fR \fI<FILE>\fR
-The path to the mise.toml file to edit
+\fB\-f, \-\-file, \-\-path\fR \fI<FILE>\fR
+The path to the mise.toml file to read
+
+Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
 If not provided, the nearest mise.toml file will be used
 \fBArguments:\fR
@@ -1604,8 +1606,10 @@ Set the value of a setting in a mise.toml file
 \fBOptions:\fR
 .PP
 .TP
-\fB\-f, \-\-file\fR \fI<FILE>\fR
+\fB\-f, \-\-file, \-\-path\fR \fI<FILE>\fR
 The path to the mise.toml file to edit
+
+Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
 If not provided, the nearest mise.toml file will be used
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -912,9 +912,11 @@ Examples:
     3.12
 
 """#
-        flag "-f --file" help="The path to the mise.toml file to edit" {
+        flag "-f --file --path" help="The path to the mise.toml file to read" {
             long_help #"""
-The path to the mise.toml file to edit
+The path to the mise.toml file to read
+
+Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
 If not provided, the nearest mise.toml file will be used
 """#
@@ -950,9 +952,11 @@ Examples:
     $ mise config set settings.jobs 4
 
 """#
-        flag "-f --file" help="The path to the mise.toml file to edit" {
+        flag "-f --file --path" help="The path to the mise.toml file to edit" {
             long_help #"""
 The path to the mise.toml file to edit
+
+Can be a file path or directory. If a directory is provided, the config file in that directory is used.
 
 If not provided, the nearest mise.toml file will be used
 """#

--- a/src/cli/config/get.rs
+++ b/src/cli/config/get.rs
@@ -1,4 +1,4 @@
-use crate::config::top_toml_config;
+use crate::config::{ConfigPathOptions, resolve_target_config_path, top_toml_config};
 use crate::file::display_path;
 use eyre::bail;
 use std::path::PathBuf;
@@ -10,20 +10,31 @@ pub struct ConfigGet {
     /// The path of the config to display
     pub key: Option<String>,
 
-    /// The path to the mise.toml file to edit
+    /// The path to the mise.toml file to read
+    ///
+    /// Can be a file path or directory. If a directory is provided, the config file in that directory is used.
     ///
     /// If not provided, the nearest mise.toml file will be used
-    #[clap(short, long)]
+    #[clap(short, long, visible_alias = "path", value_hint = clap::ValueHint::AnyPath)]
     pub file: Option<PathBuf>,
 }
 
 impl ConfigGet {
     pub fn run(self) -> eyre::Result<()> {
-        let mut file = self.file;
-        if file.is_none() {
-            file = top_toml_config();
-        }
+        // Only an explicitly named target goes through the shared resolver — the default is a
+        // different rule (the top TOML config of the loaded set, not the nearest writable one).
+        let file = match self.file {
+            Some(path) => Some(resolve_target_config_path(ConfigPathOptions {
+                path: Some(path),
+                prefer_toml: true,
+                ..Default::default()
+            })?),
+            None => top_toml_config(),
+        };
         if let Some(file) = file {
+            if !file.exists() {
+                bail!("config file not found: {}", display_path(&file));
+            }
             let content = std::fs::read_to_string(&file)?;
             let config: toml::Value = toml::de::from_str(&content)?;
             let mut value = &config;

--- a/src/cli/config/set.rs
+++ b/src/cli/config/set.rs
@@ -1,6 +1,7 @@
 use crate::config::config_file::mise_toml::MiseToml;
 use crate::config::settings::{SETTINGS_META, SettingsType};
-use crate::config::top_toml_config;
+use crate::config::{ConfigPathOptions, resolve_target_config_path, top_toml_config};
+use crate::file::display_path;
 use crate::toml::dedup_toml_array;
 use clap::ValueEnum;
 use eyre::bail;
@@ -18,8 +19,10 @@ pub struct ConfigSet {
 
     /// The path to the mise.toml file to edit
     ///
+    /// Can be a file path or directory. If a directory is provided, the config file in that directory is used.
+    ///
     /// If not provided, the nearest mise.toml file will be used
-    #[clap(short, long)]
+    #[clap(short, long, visible_alias = "path", value_hint = clap::ValueHint::AnyPath)]
     pub file: Option<PathBuf>,
 
     #[clap(value_enum, short, long, default_value_t)]
@@ -57,13 +60,22 @@ impl ConfigSet {
                 (k.to_string(), v.to_string())
             }
         };
-        let mut file = self.file;
-        if file.is_none() {
-            file = top_toml_config();
-        }
+        // Only an explicitly named target goes through the shared resolver — the default is a
+        // different rule (the top TOML config of the loaded set, not the nearest writable one).
+        let file = match self.file {
+            Some(path) => Some(resolve_target_config_path(ConfigPathOptions {
+                path: Some(path),
+                prefer_toml: true,
+                ..Default::default()
+            })?),
+            None => top_toml_config(),
+        };
         let Some(file) = file else {
             bail!("No mise.toml file found");
         };
+        if !file.exists() {
+            bail!("config file not found: {}", display_path(&file));
+        }
         let mut config: toml_edit::DocumentMut = std::fs::read_to_string(&file)?.parse()?;
         let mut container = config.as_item_mut();
         let parts = full_key.split('.').collect::<Vec<&str>>();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -999,6 +999,8 @@ mod tests {
             (&["unuse"], "path", "file", true),
             (&["set"], "file", "path", true),
             (&["unset"], "file", "path", true),
+            (&["config", "get"], "file", "path", true),
+            (&["config", "set"], "file", "path", true),
             (&["dotfiles", "add"], "path", "file", true),
             (&["bootstrap", "packages", "use"], "path", "file", true),
             (&["bootstrap", "packages", "import"], "path", "file", true),


### PR DESCRIPTION
Last step of the option-name ladder from #4881. `mise use` names its config-file option `--path` and `mise set` names it `--file`; #11577, #11616 and #11631 made the two names interchangeable across nine commands. `config get` and `config set` were the last two still taking it under one name.

Measured on v2026.8.0:

| | |
|---|---|
| `mise config get --path mise.toml tools.jq` | `error: unexpected argument '--path' found` |
| `mise config get -f mise.toml tools.jq` | `1.7` |
| `mise config get -f .` | `mise ERROR Is a directory (os error 21)` |
| `mise config get -f ./nope.toml` | `mise ERROR No such file or directory (os error 2)` |
| `mise use --path ./sub` | resolves to `./sub/mise.toml` |

So these two were also the only ones left that reject a directory. `e2e/cli/test_config_target_aliases` already pins "all four accept a directory as well as a file, under either name" for the commands covered so far, and adding `--path` to two commands that don't honor that would have created a new inconsistency rather than removing one.

## Change

`visible_alias = "path"` on both, and an explicitly named target now goes through `resolve_target_config_path` with `prefer_toml: true` — the same resolver `set`, `unset`, `dotfiles add` and the `bootstrap packages` commands use. A directory resolves to the config file inside it; `prefer_toml` matters here because `config_file_in_dir` can hand back `.tool-versions` under `asdf_compat`, which these two would then feed to a TOML parser.

The **default** — no option given — deliberately stays on `top_toml_config()`. The resolver's own default is `local_toml_config_path_from_dir`, a different rule, so routing that through it would have changed behavior for everyone not passing the option.

With directories resolved, the only remaining failure is a path that resolves to nothing, so both raw io errors collapse into a single `config file not found: <path>` naming the resolved target.

**These two do not create the file.** `mise use --path <dir>` does; `config get`/`config set` have always required an existing file (they read it, then edit the parsed document), and creating one is a separate behavior change. A directory with no config therefore resolves to `<dir>/mise.toml` and reports it as not found.

Also corrected while regenerating the docs: `config get`'s option said "the mise.toml file **to edit**" on a read-only command.

## Tests

- `src/cli/mod.rs` — two rows added to `test_config_target_options_accept_both_names`, the clap-introspection test that asserts the visible alias exists on every command in the ladder
- `e2e/cli/test_config_target_aliases` — both names against a file, both names against a directory, and the three not-found paths (missing file via `get`, empty directory via `get` and via `set`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--path` as an alias for `--file` in `config get` and `config set`.
  * Both commands now accept file paths or directories, automatically locating the applicable `mise.toml` file.

* **Bug Fixes**
  * Missing configuration targets now display a clear “config file not found” error with the requested path.

* **Documentation**
  * Updated command help, manuals, and usage documentation to reflect the new options and directory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->