### PR TITLE
fix(shim): recognize legacy rtx executable name

### DIFF
--- a/e2e/cli/test_rtx_compat_symlink
+++ b/e2e/cli/test_rtx_compat_symlink
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# `rtx` is mise's former executable name. The migration documentation supports
+# keeping old scripts working by symlinking that name to the mise binary.
+mise_bin="$(command -v mise)"
+rtx="$PWD/rtx"
+ln -s "$mise_bin" "$rtx"
+
+assert "$rtx --version" "$(mise --version)"
+assert_contains "$rtx activate bash" "export __MISE_EXE=$rtx"
+assert_succeed "$rtx reshim"

--- a/src/env.rs
+++ b/src/env.rs
@@ -470,9 +470,14 @@ pub static IS_RUNNING_AS_SHIM: Lazy<bool> = Lazy::new(|| {
 });
 
 /// Returns true if the given binary name refers to mise itself (not a shim).
-/// Handles "mise", "mise.exe", "mise.bat", "mise.cmd", "mise-doctor", etc.
+/// Handles "mise", "mise.exe", "mise.bat", "mise.cmd", "mise-doctor", and
+/// the legacy "rtx" executable name.
 pub fn is_mise_binary(bin_name: &str) -> bool {
-    bin_name == "mise" || bin_name.starts_with("mise.") || bin_name.starts_with("mise-")
+    bin_name == "mise"
+        || bin_name.starts_with("mise.")
+        || bin_name.starts_with("mise-")
+        || bin_name == "rtx"
+        || bin_name.starts_with("rtx.")
 }
 
 /// Explicit terminal-width override: `MISE_TERM_WIDTH` takes precedence, then the
@@ -993,6 +998,27 @@ mod tests {
     use crate::config::Config;
 
     use super::*;
+
+    #[test]
+    fn test_is_mise_binary_includes_legacy_rtx_name() {
+        for bin_name in [
+            "mise",
+            "mise.exe",
+            "mise-doctor",
+            "rtx",
+            "rtx.exe",
+            "rtx.cmd",
+        ] {
+            assert!(is_mise_binary(bin_name), "expected {bin_name} to be mise");
+        }
+
+        for bin_name in ["rtx-tiny", "rtx_tiny", "node"] {
+            assert!(
+                !is_mise_binary(bin_name),
+                "expected {bin_name} to remain a shim"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn test_apply_patches() {


### PR DESCRIPTION
## Summary

Restore the documented legacy `rtx` executable symlink compatibility by recognizing `rtx` and platform-suffixed names such as `rtx.exe` as mise itself.

The recursive hang described in the original report has since become a bounded invalid-shim error, but the underlying misclassification remained: invoking a symlink named `rtx` still entered tool-shim dispatch instead of running the mise CLI.

## Changes

- Treat `rtx` and `rtx.*` as mise executable names in the shared shim-detection predicate.
- Keep names such as `rtx-tiny` available for normal tool shim dispatch.
- Add an end-to-end test using a real `rtx` symlink that covers `--version`, `activate bash`, and `reshim`.
- Add unit coverage for Unix and platform-suffixed legacy names.

This aligns runtime behavior with the existing migration documentation, which recommends symlinking `rtx` to `mise` while transitioning existing shell setup.

## Validation

- `mise exec -- cargo test --all-features env::tests::test_is_mise_binary_includes_legacy_rtx_name`
- `mise run test:e2e e2e/cli/test_rtx_compat_symlink`
- `mise run test:e2e e2e/plugins/test_tiny_shim e2e/cli/test_system_shims_no_recursion e2e/cli/test_reshim_with_shims_on_path`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all`
- `mise exec -- shfmt -w e2e/cli/test_rtx_compat_symlink`
- `mise exec -- shellcheck e2e/cli/test_rtx_compat_symlink`

`mise run format` and `mise run lint` could not start because hk does not recognize this Sapling working copy as a Git repository; the applicable formatting, shell, compilation, Clippy, unit, and E2E checks above passed individually.

Addresses https://github.com/jdx/mise/discussions/3223

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility for the legacy `rtx` executable name, including version reporting, shell activation, and `reshim` support.
  * Recognizes `rtx` and related executable variants while continuing to support existing `mise` names.

* **Tests**
  * Added end-to-end and validation coverage for legacy executable compatibility and shim-name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->