### PR TITLE
docs(troubleshooting): offer shims for the Windows Path limit, and fix the test for it

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -134,25 +134,32 @@ Windows.
 
 If you have many tools defined in your `mise.toml` hierarchy, then it is possible that `mise x` will produce a `Path` environment variable that is too long for certain tools to handle, most notably, `cmd.exe`. This will affect `mise` tools that invoke `cmd.exe` (like `npm install`).
 
+The limit is **8191 characters**, and `cmd.exe` does not truncate a longer `Path` — it [ignores the variable entirely](https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation). So the symptom is not that one tool goes missing: everything that was found through `Path` stops resolving at once and reports `is not recognized`. Programs in `C:\Windows\System32` keep working, because `cmd.exe` finds those without consulting `Path` — which is what makes the failure look arbitrary, and why the test below matters.
+
 You have a few options:
 
 1. Set the `MISE_INSTALLS_DIR` environment variable to a shorter location, e.g. `C:\.mise-installs`.
 1. Use `powershell.exe` or `pwsh.exe` instead of `cmd.exe`, since they can handle a longer `Path`.
 1. Re-organise the `mise.toml` files in your monorepo, to specify only the tools they need.
+1. [Shims](/dev-tools/shims.html) keep your **shell's** `Path` from growing with your toolset — `mise activate --shims` adds one directory rather than one per tool. Be aware of what this does not cover: running a tool through a shim still builds an environment containing every active tool's directory, so a mise-managed tool that itself invokes `cmd.exe` (like `npm`) sees the same long `Path` either way. Shims also [do not support all the features](/dev-tools/shims.html#shims-vs-path) of `mise activate`.
 
 You can run the following command to test whether you have hit the `cmd.exe` `Path` limitation:
 
 ```powershell
 # Path is within limits
-❯ mise x -- cmd.exe /d /s /c "where.exe where"
-C:\Windows\System32\where.exe
+❯ mise x -- cmd.exe /d /s /c "git --version"
+git version 2.55.0.windows.3
 # Path exceeds cmd.exe limits
-❯ mise x -- cmd.exe /d /s /c "where.exe where"
-'where.exe' is not recognized as an internal or external command,
+❯ mise x -- cmd.exe /d /s /c "git --version"
+'git' is not recognized as an internal or external command,
 operable program or batch file.
 mise ERROR command failed: exit code 1
 mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
 ```
+
+Two things to get right about that test. Pick a program that is **not** in `C:\Windows\System32` and not in the directory you run the test from: `cmd.exe` searches the current directory before `Path`, and finds system-directory programs without consulting `Path` at all, so a probe in either place succeeds however long `Path` is. That is exactly why `where.exe` tells you nothing. Then check that your chosen program runs normally first (`git --version` in your shell), since a program you simply do not have produces the same `is not recognized` that the limit does.
+
+Duplicate `Path` entries are less of a factor than they used to be: on reactivation mise now drops the stale install directories it finds on the inherited `Path` before adding the current toolset's (v2026.5.18), and it collapses exact duplicates in the environments it computes (`mise x`, `mise run`, `mise env`, `mise doctor`) as of v2026.7.18. That lowers what mise contributes, but it does not raise the ceiling — enough distinct tools will still reach 8191.
 
 ### Shims leaking into WSL
 


### PR DESCRIPTION
From #5830, where the reporter's Windows `Path` exceeds what `cmd.exe` accepts and `npm`/`npx` break. Three things in the "Path limits" section were worth fixing before anything structural is decided.

## The documented test does not work

`docs/troubleshooting.md` tells you to run `mise x -- cmd.exe /d /s /c "where.exe where"` and shows it failing when `Path` is too long. It does not fail. `where.exe` is in `C:\Windows\System32`, which `cmd.exe` can still resolve while it is ignoring `Path` entirely.

Measured on Windows 11 26200 / cmd 10.0.26100.8875 — same `Path` for both columns, `Git\cmd` appended last:

| Path length | `where.exe where` | `git --version` |
|---|---|---|
| 2024 | OK | OK |
| 8129 | OK | OK |
| 8184 | OK | OK |
| 8349 | **OK** | not recognized |
| 12034 | **OK** | not recognized |
| 30019 | **OK** | not recognized |

The recommended probe reports success at every length, including where `Path` is being ignored outright. Anyone following the docs would conclude they were fine.

## The limit is 8191, and it is not a truncation

The same measurement puts the cliff between 8184 and 8239 — the 8191 documented in [KB 830473](https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation):

> Even though the Win32 limitation for environment variables is 32,767 characters, Command Prompt ignores any environment variables that are inherited from the parent process and are longer than its own limitations of 8191 characters (as appropriate to the operating system).

That KB's "Applies to" only lists Windows 7 / Server 2008 R2 / 2012 R2, so it is worth stating that it still holds on current Windows 11 — the table above is that check.

**Ignores**, not truncates: past the limit nothing on `Path` resolves, so the symptom is every command reporting `is not recognized`, not one tool going missing. The old wording ("too long for certain tools to handle") suggests partial degradation.

## Shims are now listed, along with what they do not cover

`mise activate --shims` keeps the *shell's* `Path` short — one directory instead of one per tool — and was missing from the list. It is listed now, but deliberately not as the fix, because it does not cover the failure this section is about.

Measured on v2026.8.0 with three tools active, this is the environment mise builds to run **one** of them:

```console
$ mise x -- printenv PATH | tr ':' '\n' | grep installs
~/.local/share/mise/installs/jq/1.7
~/.local/share/mise/installs/shellcheck/0.10.0/shellcheck-v0.10.0
~/.local/share/mise/installs/shfmt/3.10.0
```

Every active tool, not just the one being run. So a shim hands `npm` the same long `Path` that activation would, and `npm` shelling out to `cmd.exe` fails identically. The entry states that scope rather than leaving readers to switch and find out.

## Also noted

Duplicate entries are no longer part of this problem — #10162 (v2026.5.18) stopped install dirs re-accumulating on reactivation, and #11491 (v2026.7.18) collapses exact duplicates in computed environments. On the `Path` pasted in #5830 that is 208 entries / 8261 chars down to 125 / 4738. The section says so, and is explicit that it lowers mise's contribution without raising the ceiling.

Docs only — no code, no generated files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Windows PATH troubleshooting guidance to explain the `cmd.exe` 8,191-character limit and that oversized PATH values may be ignored entirely.
  - Improved diagnostic steps by recommending `git`, verifying the selected program exists, and avoiding system-directory or current-directory probes.
  - Documented PATH deduplication behavior, relevant version milestones, and shims as the first recommended mitigation, including their limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->