### PR TITLE
fix(prune): exclude read-only shared installs

### DIFF
--- a/e2e/cli/test_prune_shared_installs
+++ b/e2e/cli/test_prune_shared_installs
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+export MISE_SYSTEM_DATA_DIR="$HOME/.local/share/mise-system"
+system_installs="$MISE_SYSTEM_DATA_DIR/installs"
+shared_installs="$HOME/.local/share/mise-shared"
+export MISE_SHARED_INSTALL_DIRS="$shared_installs"
+local_installs="$MISE_DATA_DIR/installs"
+
+create_python_install() {
+  local installs_dir="$1"
+  local version="$2"
+  local major_minor="${version%.*}"
+  local major="${version%%.*}"
+
+  mkdir -p "$installs_dir/python/$version/bin"
+  cat >"$installs_dir/.mise-installs.toml" <<'EOF'
+[python]
+short = "python"
+full = "core:python"
+explicit_backend = true
+EOF
+  ln -s "./$version" "$installs_dir/python/$major"
+  ln -s "./$version" "$installs_dir/python/$major_minor"
+  ln -s "./$version" "$installs_dir/python/latest"
+}
+
+# System and configured shared installs are read-only fallback locations. They
+# must not be reported as prunable when no primary install exists.
+create_python_install "$system_installs" 3.12.0
+create_python_install "$shared_installs" 3.11.0
+
+cd "$(mktemp -d)" || exit 1
+
+prunable="$(mise ls python --prunable --installed)"
+[[ -z $prunable ]] || fail "shared installs were reported as prunable: $prunable"
+assert_succeed "mise prune --dry-run-code --tools"
+
+# A primary install remains prunable while the system and shared versions stay
+# excluded from the same listing and dry-run plan.
+create_python_install "$local_installs" 3.10.0
+
+prunable="$(mise ls python --prunable --installed)"
+[[ $prunable == *"3.10.0"* ]] || fail "primary install was not reported as prunable: $prunable"
+[[ $prunable != *"3.11.0"* ]] || fail "shared install was reported as prunable: $prunable"
+[[ $prunable != *"3.12.0"* ]] || fail "system install was reported as prunable: $prunable"
+
+output="$(mise prune --dry-run --tools --raw 2>&1)"
+[[ $output == *"3.10.0"* ]] || fail "primary install was not in prune plan: $output"
+[[ $output != *"3.11.0"* ]] || fail "shared install was in prune plan: $output"
+[[ $output != *"3.12.0"* ]] || fail "system install was in prune plan: $output"
+
+# Simulate root-owned fallback directories. Pruning the local version must not
+# attempt to remove or modify either read-only location.
+chmod -R a-w "$system_installs" "$shared_installs"
+trap 'chmod -R u+w "$system_installs" "$shared_installs" 2>/dev/null || true' EXIT
+
+output="$(MISE_YES=1 mise prune --tools --raw 2>&1)" || fail "prune failed: $output"
+[[ $output != *"Permission denied"* ]] || fail "prune touched a read-only install: $output"
+
+assert_fail "test -d '$local_installs/python/3.10.0'"
+assert_directory_exists "$shared_installs/python/3.11.0"
+assert_directory_exists "$system_installs/python/3.12.0"
+assert_succeed "mise prune --dry-run-code --tools"

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -11,7 +11,7 @@ use crate::toolset::{
 };
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::prompt;
-use crate::{backend::Backend, config, exit};
+use crate::{backend::Backend, config, env, exit};
 use console::style;
 use eyre::Result;
 
@@ -120,6 +120,11 @@ pub async fn prunable_tools(
         .list_installed_versions(config)
         .await?
         .into_iter()
+        // System and shared installs are read-only fallback locations. Prune only
+        // manages versions in the user's primary install directory.
+        .filter(|(_, tv)| {
+            env::install_path_category(&tv.install_path()) == env::InstallPathCategory::Local
+        })
         .map(|(p, tv)| ((tv.ba().short.to_string(), tv.tv_pathname()), (p, tv)))
         .collect::<BTreeMap<(String, String), (Arc<dyn Backend>, ToolVersion)>>();
 


### PR DESCRIPTION
## Summary

- exclude system-wide and configured shared tool installs from prune candidates
- keep unused versions in the primary user install directory prunable
- apply the same ownership boundary to prune, dry-run, dry-run-code, and `mise ls --prunable`

## Root cause

The installed-version inventory intentionally merges primary, system, and shared locations so all available tools can be used. `prunable_tools` consumed that merged inventory without checking each version's resolved install path, so unused read-only fallback installs were offered for removal and then failed for unprivileged users.

This change filters candidates through the existing `InstallPathCategory` classification and accepts only `Local` installs. System installs and arbitrary configured shared directories remain visible and usable, but are not managed by prune.

## Validation

- `mise run test:e2e e2e/cli/test_prune_shared_installs`
- `mise run test:e2e e2e/cli/test_shared_install_dirs`
- `mise run test:e2e e2e/cli/test_install_system_readonly`
- existing `e2e/cli/test_prune` passed before its prefix-selected sibling `test_prune_tool_stub` hit an unrelated macOS `touch` timestamp error
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d e2e/cli/test_prune_shared_installs`
- `mise exec -- shellcheck e2e/cli/test_prune_shared_installs`

`mise run format` and `mise run lint` could not run to completion because hk does not recognize the Sapling working copy as a Git repository; the applicable individual checks above passed.

Addresses https://github.com/jdx/mise/discussions/9476

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pruning now excludes tool versions installed in system or shared locations.
  * Pruning targets only local user installations, preventing unintended removal of shared tools.
  * Improved handling of read-only fallback directories without permission errors.
* **Tests**
  * Added end-to-end coverage for pruning across system, shared, and local installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->