### PR TITLE
registry: add uxlint

### DIFF
--- a/registry/uxlint.toml
+++ b/registry/uxlint.toml
@@ -1,0 +1,4 @@
+backends = ["github:uxlint-net/uxlint-cli"]
+description = "UX linter that audits a website in a real browser and reports issues with fixes"
+os = ["linux", "macos"]
+test = { cmd = "uxlint --version", expected = "uxlint {{version}}" }


### PR DESCRIPTION
Adds a registry shorthand for **uxlint**, so `mise use uxlint` works.

uxlint is a UX linter: it opens a website in a real browser, uses it like a first-time visitor, and reports UX/accessibility problems with a concrete fix for each.

### Backend

Uses the **`github`** backend (`github:uxlint-net/uxlint-cli`):
- Not in the aqua registry, so `aqua` isn't available.
- `ubi` is deprecated for new entries per the [registry docs](https://github.com/jdx/mise/blob/main/docs/registry.md#backends).
- The CLI ships prebuilt release binaries, so `cargo` (compile-from-source) would be strictly worse.

The repo is `uxlint-cli` but the binary/tool is `uxlint`; the github backend's asset autodetection resolves this without extra options.

### Platforms

Release assets cover linux and macos (x64 + arm64) only — no Windows build — so the entry sets `os = ["linux", "macos"]`.

### Tested locally

```
$ mise x github:uxlint-net/uxlint-cli@0.1.5 -- uxlint --version
mise  github:uxlint-net/uxlint-cli@0.1.5 download uxlint-linux-x64.tar.gz
mise  github:uxlint-net/uxlint-cli@0.1.5 extract uxlint-linux-x64.tar.gz
mise  github:uxlint-net/uxlint-cli@0.1.5 checksum uxlint-linux-x64.tar.gz
mise  github:uxlint-net/uxlint-cli@0.1.5 ✓ installed
uxlint 0.1.5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added uxlint to the available tool registry with platform support, a description, and version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->