### PR TITLE
feat(config): give `mise set` the short -f its neighbours already have

### DIFF
--- a/docs/cli/set.md
+++ b/docs/cli/set.md
@@ -27,6 +27,14 @@ e.g.: NODE_ENV=production
 
 Create/modify an environment-specific config file like .mise.&lt;env>.toml
 
+### `-f --file <FILE>`
+
+The TOML file to update
+
+Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
+Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
+Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+
 ### `-g --global`
 
 Set the environment variable in the global config file
@@ -52,14 +60,6 @@ Can be used multiple times. Requires --age-encrypt.
 [experimental] SSH recipient (public key or path) for age encryption
 
 Can be used multiple times. Requires --age-encrypt.
-
-### `--file <FILE>`
-
-The TOML file to update
-
-Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
-Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 
 ### `--no-redact`
 

--- a/e2e/cli/test_config_target_aliases
+++ b/e2e/cli/test_config_target_aliases
@@ -24,6 +24,10 @@ assert_contains "cat alias.toml" 'dummy = "2"'
 mise set --file alias.toml ALIAS_VAR=set-via-file
 assert_contains "cat alias.toml" 'ALIAS_VAR = "set-via-file"'
 
+# and so does the short form, which `mise set` was the last of these to gain
+mise set -f alias.toml ALIAS_VAR=set-via-short
+assert_contains "cat alias.toml" 'ALIAS_VAR = "set-via-short"'
+
 # the commands that undo those two take the same pair of names
 # `mise unuse --file` is `mise unuse --path`
 mise unuse --no-prune --file alias.toml dummy@2

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3272,6 +3272,13 @@ Use `\-E <env>` to create/modify environment\-specific config files like `mise.<
 \fB\-E, \-\-env\fR \fI<ENV>\fR
 Create/modify an environment\-specific config file like .mise.<env>.toml
 .TP
+\fB\-f, \-\-file, \-\-path\fR \fI<FILE>\fR
+The TOML file to update
+
+Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
+Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
+Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+.TP
 \fB\-g, \-\-global\fR
 Set the environment variable in the global config file
 .TP
@@ -3295,13 +3302,6 @@ Can be used multiple times. Requires \-\-age\-encrypt.
 .TP
 \fB\-\-complete\fR
 Render completions
-.TP
-\fB\-\-file, \-\-path\fR \fI<FILE>\fR
-The TOML file to update
-
-Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
-Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 .TP
 \fB\-\-no\-redact\fR
 Show raw values instead of redacting secrets

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3292,6 +3292,16 @@ Examples:
     flag "-E --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
         arg <ENV>
     }
+    flag "-f --file --path" help="The TOML file to update" {
+        long_help #"""
+The TOML file to update
+
+Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
+Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
+Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+"""#
+        arg <FILE>
+    }
     flag "-g --global" help="Set the environment variable in the global config file"
     flag --age-encrypt help="[experimental] Encrypt the value with age before storing"
     flag --age-key-file help="[experimental] Age identity file for encryption" {
@@ -3319,16 +3329,6 @@ Can be used multiple times. Requires --age-encrypt.
         arg <PATH_OR_PUBKEY>
     }
     flag --complete help="Render completions" hide=#true
-    flag "--file --path" help="The TOML file to update" {
-        long_help #"""
-The TOML file to update
-
-Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
-Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
-Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-"""#
-        arg <FILE>
-    }
     flag --no-redact help="Show raw values instead of redacting secrets"
     flag --prompt help="Prompt for environment variable values"
     flag "--remove --rm --unset" help="Remove the environment variable from config file" var=#true hide=#true {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1041,6 +1041,16 @@ mod tests {
                 "missing visible --{alias} alias for --{arg_name} on {}",
                 path.join(" ")
             );
+
+            // The letter differs by canonical name — `-p` where it is `--path`, `-f` where
+            // it is `--file` — so only require that one exists. `mise set` was the single
+            // command without one, which is what https://github.com/jdx/mise/discussions/5501
+            // ran into: the option was reachable, just not the way every neighbour spells it.
+            assert!(
+                arg.get_short().is_some(),
+                "missing short flag for --{arg_name} on {}",
+                path.join(" ")
+            );
         }
     }
 

--- a/src/cli/set.rs
+++ b/src/cli/set.rs
@@ -35,6 +35,14 @@ pub struct Set {
     #[clap(short = 'E', long, overrides_with_all = &["global", "file"])]
     env: Option<String>,
 
+    /// The TOML file to update
+    ///
+    /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
+    /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
+    /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+    #[clap(long, short, visible_alias = "path", verbatim_doc_comment, required = false, value_hint = clap::ValueHint::AnyPath)]
+    file: Option<PathBuf>,
+
     /// Set the environment variable in the global config file
     #[clap(short, long, verbatim_doc_comment, overrides_with_all = &["file", "env"])]
     global: bool,
@@ -64,14 +72,6 @@ pub struct Set {
     /// Render completions
     #[clap(long, hide = true)]
     complete: bool,
-
-    /// The TOML file to update
-    ///
-    /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
-    /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
-    /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[clap(long, visible_alias = "path", verbatim_doc_comment, required = false, value_hint = clap::ValueHint::AnyPath)]
-    file: Option<PathBuf>,
 
     /// Show raw values instead of redacting secrets
     #[clap(long)]


### PR DESCRIPTION
Follow-up to #5501, whose second observation was:

> `mise use` has an option `-p .` to create the config file when it does not exist, but `mise set` seems to miss such an option

The long-name half of that landed in #11577 — `mise set --path` exists now. This closes the rest.

## `mise set` was the only one without a short flag

Now that every command naming a config file takes both `--file` and `--path` (#11577, #11616, #11631, #11640), the short flags line up like this:

| command | short |
|---|---|
| `use`, `unuse` | `-p` |
| `unset`, `config get`, `config set` | `-f` |
| `dotfiles add`, the four `bootstrap packages` commands | `-p` |
| **`set`** | **none** |

The letter follows the canonical name, so `set` — whose canonical name is `--file` — gets `-f`, matching `unset` and the two `config` commands.

`-f` is free on subcommands: the root `--force` is `#[clap(long, short, hide = true)]` without `global = true`, so it does not propagate, and the globals that do are `-C -E -j -P -q -v -y`. `mise set` itself only uses `-E` and `-g`. The three commands above already prove it.

## Not adding `-p`

#5501 asks for `-p` specifically, and `visible_short_alias = 'p'` would give exact parity with `mise use -p .`. I left it out because no command in this group carries a short alias — adding one to `set` alone makes it the only command with four spellings, which trades the current asymmetry for a different one. `--path` already gives the reporter the same words on both commands; happy to add the short alias if you would rather have full parity.

## Tests

`test_config_target_options_accept_both_names` in `src/cli/mod.rs` already walks all eleven commands asserting the visible alias. It now also asserts a short flag exists — existence only, since the letter legitimately differs by canonical name. That is exactly the invariant `set` was violating.

`e2e/cli/test_config_target_aliases` exercises `mise set -f` alongside the existing `--file` and `--path` cases.

No behavior changes beyond the new spelling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-f` as a short alias for the `mise set --file` option.
  * The alias works alongside the existing `--file` and `--path` options.

* **Documentation**
  * Updated CLI documentation, generated help, and the manual to include the new `-f` alias.

* **Tests**
  * Added coverage confirming `mise set -f` writes variables to the specified configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->