### PR TITLE
feat(vfox): add lua archive and file operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11147,6 +11147,7 @@ version = "2026.7.2"
 dependencies = [
  "clap",
  "env_logger",
+ "glob",
  "homedir",
  "indexmap 2.14.0",
  "insta",

--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -28,6 +28,7 @@ name = "vfox-cli"
 path = "src/bin.rs"
 
 [dependencies]
+glob = "0.3"
 homedir = "0.3"
 indexmap = { version = "2", features = ["serde"] }
 itertools = "0.15"

--- a/crates/vfox/src/lua_mod/archiver.rs
+++ b/crates/vfox/src/lua_mod/archiver.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use mlua::{ExternalResult, Lua, MultiValue, Table, Value};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 pub fn mod_archiver(lua: &Lua) -> Result<()> {
@@ -64,6 +65,8 @@ fn decompress(_lua: &Lua, input: MultiValue) -> mlua::Result<()> {
 /// Match mise's built-in archive extraction behavior: promote the contents of
 /// top-level directories while retaining files that are already at the root.
 fn strip_archive_path_components(extracted: &Path, destination: &Path) -> mlua::Result<()> {
+    let mut moves = vec![];
+    let mut targets = BTreeSet::new();
     for entry in xx::file::ls(extracted).into_lua_err()? {
         if entry
             .symlink_metadata()
@@ -75,15 +78,49 @@ fn strip_archive_path_components(extracted: &Path, destination: &Path) -> mlua::
                 let file_name = child.file_name().ok_or_else(|| {
                     mlua::Error::runtime(format!("invalid archive entry: {}", child.display()))
                 })?;
-                xx::file::mv(&child, destination.join(file_name)).into_lua_err()?;
+                plan_move(
+                    child.clone(),
+                    destination.join(file_name),
+                    &mut moves,
+                    &mut targets,
+                )?;
             }
         } else {
             let file_name = entry.file_name().ok_or_else(|| {
                 mlua::Error::runtime(format!("invalid archive entry: {}", entry.display()))
             })?;
-            xx::file::mv(&entry, destination.join(file_name)).into_lua_err()?;
+            plan_move(
+                entry.clone(),
+                destination.join(file_name),
+                &mut moves,
+                &mut targets,
+            )?;
         }
     }
+    for (source, target) in moves {
+        xx::file::mv(source, target).into_lua_err()?;
+    }
+    Ok(())
+}
+
+fn plan_move(
+    source: PathBuf,
+    target: PathBuf,
+    moves: &mut Vec<(PathBuf, PathBuf)>,
+    targets: &mut BTreeSet<PathBuf>,
+) -> mlua::Result<()> {
+    let target_exists = match target.symlink_metadata() {
+        Ok(_) => true,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+        Err(err) => return Err(mlua::Error::external(err)),
+    };
+    if target_exists || !targets.insert(target.clone()) {
+        return Err(mlua::Error::runtime(format!(
+            "archive strip destination already exists: {}",
+            target.display()
+        )));
+    }
+    moves.push((source, target));
     Ok(())
 }
 
@@ -176,6 +213,38 @@ mod tests {
             "tool"
         );
         assert!(!destination.join("pkg").exists());
+    }
+
+    #[test]
+    fn test_strip_components_rejects_collisions_before_moving() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let extracted = temp_dir.path().join("extracted");
+        let destination = temp_dir.path().join("destination");
+        std::fs::create_dir_all(extracted.join("pkg")).unwrap();
+        std::fs::create_dir_all(&destination).unwrap();
+        std::fs::write(extracted.join("tool"), "root").unwrap();
+        std::fs::write(extracted.join("pkg/tool"), "nested").unwrap();
+
+        let err = strip_archive_path_components(&extracted, &destination).unwrap_err();
+
+        assert!(err.to_string().contains("destination already exists"));
+        assert!(!destination.join("tool").exists());
+        assert!(extracted.join("tool").exists());
+        assert!(extracted.join("pkg/tool").exists());
+    }
+
+    #[test]
+    fn test_decompress_error_can_be_caught_with_pcall() {
+        let lua = Lua::new();
+        mod_archiver(&lua).unwrap();
+        lua.load(mlua::chunk! {
+            local archiver = require("archiver")
+            local ok, err = pcall(archiver.decompress, "archive.rar", "destination")
+            assert(not ok, "pcall should catch decompression errors")
+            assert(tostring(err):match("unsupported archive format"))
+        })
+        .exec()
+        .unwrap();
     }
 
     #[test]

--- a/crates/vfox/src/lua_mod/archiver.rs
+++ b/crates/vfox/src/lua_mod/archiver.rs
@@ -58,8 +58,13 @@ fn decompress(_lua: &Lua, input: MultiValue) -> mlua::Result<()> {
         .into_lua_err()?;
     decompress_archive(&archive, temp_dir.path())?;
     xx::file::mkdirp(&destination).into_lua_err()?;
+    strip_archive_path_components(temp_dir.path(), &destination)
+}
 
-    for entry in xx::file::ls(temp_dir.path()).into_lua_err()? {
+/// Match mise's built-in archive extraction behavior: promote the contents of
+/// top-level directories while retaining files that are already at the root.
+fn strip_archive_path_components(extracted: &Path, destination: &Path) -> mlua::Result<()> {
+    for entry in xx::file::ls(extracted).into_lua_err()? {
         if entry
             .symlink_metadata()
             .into_lua_err()?
@@ -148,6 +153,29 @@ mod tests {
             "yep\n"
         );
         assert!(!dst_path.join("foo").exists());
+    }
+
+    #[test]
+    fn test_strip_components_preserves_root_files() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let extracted = temp_dir.path().join("extracted");
+        let destination = temp_dir.path().join("destination");
+        std::fs::create_dir_all(extracted.join("pkg")).unwrap();
+        std::fs::create_dir_all(&destination).unwrap();
+        std::fs::write(extracted.join("README"), "readme").unwrap();
+        std::fs::write(extracted.join("pkg/tool"), "tool").unwrap();
+
+        strip_archive_path_components(&extracted, &destination).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(destination.join("README")).unwrap(),
+            "readme"
+        );
+        assert_eq!(
+            std::fs::read_to_string(destination.join("tool")).unwrap(),
+            "tool"
+        );
+        assert!(!destination.join("pkg").exists());
     }
 
     #[test]

--- a/crates/vfox/src/lua_mod/archiver.rs
+++ b/crates/vfox/src/lua_mod/archiver.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
-use mlua::{ExternalResult, Lua, MultiValue, Table};
-use std::path::PathBuf;
+use mlua::{ExternalResult, Lua, MultiValue, Table, Value};
+use std::path::{Path, PathBuf};
 
 pub fn mod_archiver(lua: &Lua) -> Result<()> {
     let package: Table = lua.globals().get("package")?;
@@ -18,19 +18,90 @@ pub fn mod_archiver(lua: &Lua) -> Result<()> {
 
 fn decompress(_lua: &Lua, input: MultiValue) -> mlua::Result<()> {
     let paths: Vec<mlua::Value> = input.into_iter().collect();
+    if paths.len() < 2 {
+        return Err(mlua::Error::runtime(
+            "archiver.decompress requires an archive and destination",
+        ));
+    }
     let archive: PathBuf = PathBuf::from(paths[0].to_string()?);
     let destination: PathBuf = PathBuf::from(paths[1].to_string()?);
-    let filename = archive.file_name().unwrap().to_str().unwrap();
+    let strip_components = match paths.get(2) {
+        None | Some(Value::Nil) => 0,
+        Some(Value::Table(options)) => options
+            .get::<Option<usize>>("strip_components")?
+            .unwrap_or(0),
+        Some(value) => {
+            return Err(mlua::Error::runtime(format!(
+                "archiver.decompress options must be a table, got {}",
+                value.type_name()
+            )));
+        }
+    };
+    if strip_components > 1 {
+        return Err(mlua::Error::runtime(
+            "archiver.decompress only supports strip_components values of 0 or 1",
+        ));
+    }
+
+    if strip_components == 0 {
+        return decompress_archive(&archive, &destination);
+    }
+
+    let parent = destination
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    xx::file::mkdirp(parent).into_lua_err()?;
+    let temp_dir = tempfile::Builder::new()
+        .prefix(".mise-extract-")
+        .tempdir_in(parent)
+        .into_lua_err()?;
+    decompress_archive(&archive, temp_dir.path())?;
+    xx::file::mkdirp(&destination).into_lua_err()?;
+
+    for entry in xx::file::ls(temp_dir.path()).into_lua_err()? {
+        if entry
+            .symlink_metadata()
+            .into_lua_err()?
+            .file_type()
+            .is_dir()
+        {
+            for child in xx::file::ls(&entry).into_lua_err()? {
+                let file_name = child.file_name().ok_or_else(|| {
+                    mlua::Error::runtime(format!("invalid archive entry: {}", child.display()))
+                })?;
+                xx::file::mv(&child, destination.join(file_name)).into_lua_err()?;
+            }
+        } else {
+            let file_name = entry.file_name().ok_or_else(|| {
+                mlua::Error::runtime(format!("invalid archive entry: {}", entry.display()))
+            })?;
+            xx::file::mv(&entry, destination.join(file_name)).into_lua_err()?;
+        }
+    }
+    Ok(())
+}
+
+fn decompress_archive(archive: &Path, destination: &Path) -> mlua::Result<()> {
+    let filename = archive
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            mlua::Error::runtime(format!("invalid archive path: {}", archive.display()))
+        })?;
     if filename.ends_with(".zip") {
-        xx::archive::unzip(&archive, &destination).into_lua_err()?;
+        xx::archive::unzip(archive, destination).into_lua_err()?;
     } else if filename.ends_with(".tar.gz") {
-        xx::archive::untar_gz(&archive, &destination).into_lua_err()?;
+        xx::archive::untar_gz(archive, destination).into_lua_err()?;
     } else if filename.ends_with(".tar.xz") {
-        xx::archive::untar_xz(&archive, &destination).into_lua_err()?;
+        xx::archive::untar_xz(archive, destination).into_lua_err()?;
     } else if filename.ends_with(".tar.bz2") {
-        xx::archive::untar_bz2(&archive, &destination).into_lua_err()?;
+        xx::archive::untar_bz2(archive, destination).into_lua_err()?;
     } else {
-        unimplemented!("Unsupported archive format {:?}", archive);
+        return Err(mlua::Error::runtime(format!(
+            "unsupported archive format: {}",
+            archive.display()
+        )));
     }
     Ok(())
 }
@@ -57,5 +128,39 @@ mod tests {
             "yep\n"
         );
         // TempDir automatically cleans up when dropped
+    }
+
+    #[test]
+    fn test_zip_strip_components() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let dst_path = temp_dir.path().join("unzip");
+        let dst_path_str = dst_path.to_string_lossy().to_string();
+        let lua = Lua::new();
+        mod_archiver(&lua).unwrap();
+        lua.load(mlua::chunk! {
+            local archiver = require("archiver")
+            archiver.decompress("test/data/foo.zip", $dst_path_str, {strip_components = 1})
+        })
+        .exec()
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dst_path.join("test.txt")).unwrap(),
+            "yep\n"
+        );
+        assert!(!dst_path.join("foo").exists());
+    }
+
+    #[test]
+    fn test_unsupported_archive_returns_lua_error() {
+        let lua = Lua::new();
+        mod_archiver(&lua).unwrap();
+        let err = lua
+            .load(mlua::chunk! {
+                local archiver = require("archiver")
+                archiver.decompress("archive.rar", "destination")
+            })
+            .exec()
+            .unwrap_err();
+        assert!(err.to_string().contains("unsupported archive format"));
     }
 }

--- a/crates/vfox/src/lua_mod/file.rs
+++ b/crates/vfox/src/lua_mod/file.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::{PermissionsExt, symlink as _symlink};
 use std::os::windows::fs::symlink_dir;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_file;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn join_path(_lua: &Lua, args: MultiValue) -> mlua::Result<String> {
     let sep = std::path::MAIN_SEPARATOR;
@@ -51,8 +51,36 @@ pub fn mod_file(lua: &Lua) -> Result<()> {
                     stat(&_lua, path).await
                 })?,
             ),
+            ("list", lua.create_function(list)?),
+            ("glob", lua.create_function(glob)?),
+            ("move", lua.create_function(move_path)?),
         ])?,
     )?)
+}
+
+fn paths_to_strings(paths: Vec<PathBuf>) -> Vec<String> {
+    let mut paths = paths
+        .into_iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
+fn list(_lua: &Lua, path: String) -> mlua::Result<Vec<String>> {
+    xx::file::ls(path).map(paths_to_strings).into_lua_err()
+}
+
+fn glob(_lua: &Lua, pattern: String) -> mlua::Result<Vec<String>> {
+    let paths = glob::glob(&pattern)
+        .map_err(mlua::Error::external)?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(mlua::Error::external)?;
+    Ok(paths_to_strings(paths))
+}
+
+fn move_path(_lua: &Lua, (source, destination): (String, String)) -> mlua::Result<()> {
+    xx::file::mv(source, destination).into_lua_err()
 }
 
 async fn read(_lua: &Lua, input: MultiValue) -> mlua::Result<String> {
@@ -272,5 +300,45 @@ mod tests {
             .exec()
             .unwrap();
         }
+    }
+
+    #[test]
+    fn test_list_glob_and_move() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let source_dir = temp_dir.path().join("source");
+        let nested_dir = source_dir.join("nested");
+        let destination_dir = temp_dir.path().join("destination");
+        fs::create_dir_all(&nested_dir).unwrap();
+        fs::write(source_dir.join("a.txt"), "a").unwrap();
+        fs::write(source_dir.join("b.log"), "b").unwrap();
+        fs::write(nested_dir.join("c.txt"), "c").unwrap();
+
+        let source_dir_str = source_dir.to_string_lossy().to_string();
+        let glob_pattern = source_dir.join("*.txt").to_string_lossy().to_string();
+        let nested_dir_str = nested_dir.to_string_lossy().to_string();
+        let destination_dir_str = destination_dir.to_string_lossy().to_string();
+        let lua = Lua::new();
+        mod_file(&lua).unwrap();
+
+        lua.load(mlua::chunk! {
+            local file = require("file")
+            local entries = file.list($source_dir_str)
+            assert(#entries == 3, "list should return immediate directory entries")
+            assert(entries[1] < entries[2] and entries[2] < entries[3], "list should be sorted")
+
+            local matches = file.glob($glob_pattern)
+            assert(#matches == 1, "glob should return matching files")
+            assert(matches[1]:match("a%.txt$"), "glob should return the matching path")
+
+            file.move($nested_dir_str, $destination_dir_str)
+        })
+        .exec()
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination_dir.join("c.txt")).unwrap(),
+            "c"
+        );
+        assert!(!nested_dir.exists());
     }
 }

--- a/crates/vfox/types/mise-plugin.lua
+++ b/crates/vfox/types/mise-plugin.lua
@@ -182,6 +182,9 @@ local json = {}
 ---@field symlink fun(src: string, dst: string) Create a symbolic link
 ---@field join_path fun(...: string): string Join path components
 ---@field stat fun(path: string): FileStat|nil Get file metadata or nil if not found
+---@field list fun(path: string): string[] List immediate directory entries in sorted order
+---@field glob fun(pattern: string): string[] List paths matching a glob pattern in sorted order
+---@field move fun(src: string, dst: string) Move a file or directory
 local file = {}
 
 -- cmd module ---------------------------------------------------------
@@ -204,8 +207,11 @@ local env = {}
 
 -- archiver module ----------------------------------------------------
 
+---@class ArchiverDecompressOpts
+---@field strip_components? integer Number of leading archive path components to remove (0 or 1)
+
 ---@class archiver
----@field decompress fun(archive: string, dest: string) Decompress an archive (.zip, .tar.gz, .tar.xz, .tar.bz2)
+---@field decompress fun(archive: string, dest: string, opts?: ArchiverDecompressOpts) Decompress an archive (.zip, .tar.gz, .tar.xz, .tar.bz2)
 local archiver = {}
 
 -- semver module ------------------------------------------------------

--- a/crates/vfox/types/mise-plugin.lua
+++ b/crates/vfox/types/mise-plugin.lua
@@ -208,7 +208,7 @@ local env = {}
 -- archiver module ----------------------------------------------------
 
 ---@class ArchiverDecompressOpts
----@field strip_components? integer Number of leading archive path components to remove (0 or 1)
+---@field strip_components? integer Flatten top-level directories while retaining root files (0 or 1)
 
 ---@class archiver
 ---@field decompress fun(archive: string, dest: string, opts?: ArchiverDecompressOpts) Decompress an archive (.zip, .tar.gz, .tar.xz, .tar.bz2)

--- a/docs/plugin-lua-modules.md
+++ b/docs/plugin-lua-modules.md
@@ -433,14 +433,11 @@ The archiver module provides functionality for extracting compressed archives.
 local archiver = require("archiver")
 
 -- Extract archive to directory
-local err = archiver.decompress("archive.tar.gz", "extracted/")
-if err ~= nil then
-    error("Extraction failed: " .. err)
-end
+archiver.decompress("archive.tar.gz", "extracted/")
 
--- Extract ZIP file
-local err = archiver.decompress("package.zip", "destination/")
-if err ~= nil then
+-- Failures raise Lua errors. Use pcall only when the plugin needs to intercept one.
+local ok, err = pcall(archiver.decompress, "package.zip", "destination/")
+if not ok then
     error("ZIP extraction failed: " .. err)
 end
 ```
@@ -464,19 +461,12 @@ local http = require("http")
 function install_from_archive(download_url, install_path)
     -- Download the archive
     local archive_path = install_path .. "/download.tar.gz"
-    local err = http.download_file({
+    http.download_file({
         url = download_url
     }, archive_path)
 
-    if err ~= nil then
-        error("Download failed: " .. err)
-    end
-
     -- Extract to installation directory
-    local err = archiver.decompress(archive_path, install_path)
-    if err ~= nil then
-        error("Extraction failed: " .. err)
-    end
+    archiver.decompress(archive_path, install_path)
 
     -- Clean up archive
     os.remove(archive_path)

--- a/docs/plugin-lua-modules.md
+++ b/docs/plugin-lua-modules.md
@@ -445,8 +445,9 @@ if err ~= nil then
 end
 ```
 
-To remove a versioned directory at the root of an archive, pass
-`strip_components = 1`:
+To flatten versioned directories at the root of an archive, pass
+`strip_components = 1`. Files already at the archive root are retained, matching
+mise's built-in archive backends.
 
 ```lua
 archiver.decompress("node-v24.18.1-linux-x64.tar.gz", "destination/", {

--- a/docs/plugin-lua-modules.md
+++ b/docs/plugin-lua-modules.md
@@ -445,6 +445,15 @@ if err ~= nil then
 end
 ```
 
+To remove a versioned directory at the root of an archive, pass
+`strip_components = 1`:
+
+```lua
+archiver.decompress("node-v24.18.1-linux-x64.tar.gz", "destination/", {
+    strip_components = 1,
+})
+```
+
 ### Real-World Example: Plugin Installation
 
 ```lua
@@ -512,6 +521,31 @@ if file.exists("important_file.txt") then
 else
     print("File does not exist")
 end
+```
+
+### List and match files
+
+```lua
+local file = require("file")
+
+-- Immediate entries, returned in sorted order
+local entries = file.list("/path/to/directory")
+
+-- Paths matching a glob, returned in sorted order
+local executables = file.glob(file.join_path("/path/to/bin", "mytool-*"))
+```
+
+### Move files and directories
+
+`file.move` moves either a file or an entire directory. Parent directories for
+the destination are created automatically.
+
+```lua
+local file = require("file")
+file.move(
+    file.join_path("/path/to/bin", "mytool-linux-amd64"),
+    file.join_path("/path/to/bin", "mytool")
+)
 ```
 
 ## Environment Module


### PR DESCRIPTION
## Summary

- add optional `strip_components = 1` support to `archiver.decompress`
- expose sorted `file.list`, `file.glob`, and `file.move` operations to Lua plugins
- return a Lua error instead of panicking for unsupported archive formats
- document the new APIs and update the bundled LuaCATS definitions

## Motivation

Lua backend plugins currently need platform-specific external commands to flatten versioned archive roots or rename glob-matched executables. These APIs let plugins handle those layouts portably within mise.

Closes the implementation gap described in [discussion #11649](https://github.com/jdx/mise/discussions/11649).

## Validation

- `mise --cd crates/vfox run test`
- `mise --cd crates/vfox run lint`
- `mise --cd crates/vfox run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes plugin install paths (extract layout and file moves) used during tool installation; mistakes could break installs but scope is limited to the vfox Lua bridge with solid test coverage.
> 
> **Overview**
> Extends the vfox Lua plugin API so install scripts can flatten archives and manipulate the filesystem without shelling out.
> 
> **`archiver.decompress`** accepts an optional `{ strip_components = 1 }` table. With `1`, extraction uses a temp directory then hoists one level of top-level directories into the destination while keeping root-level files, aligned with mise’s built-in extractors. Invalid args, bad options, and destination collisions fail with Lua runtime errors; unsupported formats no longer panic via `unimplemented!`.
> 
> **`file`** gains sorted **`list`**, **`glob`** (new `glob` crate dependency), and **`move`** backed by `xx::file`. Docs and bundled LuaCATS in `mise-plugin.lua` are updated accordingly, with unit tests for strip behavior, collisions, and `pcall` on archive errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0422b7221f55dc15b11a8e89dbfebabd7095dd3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file operations for listing directories, matching paths with glob patterns, and moving files or directories.
  * Added an option to remove one leading directory component when extracting archives.
  * File moves now create missing destination directories automatically.

* **Bug Fixes**
  * Improved archive validation and error handling for invalid paths and unsupported formats.
  * Prevented archive extraction from overwriting existing destination entries.

* **Documentation**
  * Added usage examples for the new file operations and archive extraction option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->