### PR TITLE
registry: use oxlint from aqua again

### DIFF
--- a/registry/oxlint.toml
+++ b/registry/oxlint.toml
@@ -1,5 +1,3 @@
-# aqua cannot support oxlint 1.17.0 or later.
-# See https://github.com/oxc-project/oxc/discussions/14452#discussioncomment-14631344
-backends = ["npm:oxlint", "aqua:oxc-project/oxc/oxlint"]
+backends = ["aqua:oxc-project/oxc/oxlint", "npm:oxlint"]
 description = "This is the linter for oxc."
 test = { cmd = "oxlint --version", expected = "Version: {{version}}" }


### PR DESCRIPTION
Standalone executables were apparently reintroduced in 1.28.0

Refs
- https://github.com/oxc-project/oxc/releases/tag/apps_v1.28.0
- https://github.com/aquaproj/aqua-registry/pull/55311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend selection to prefer the Aqua backend over the npm backend.
  * Removed an outdated version limitation note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->