### PR TITLE
registry: use aqua for oxfmt

### DIFF
--- a/registry/oxfmt.toml
+++ b/registry/oxfmt.toml
@@ -1,3 +1,3 @@
-backends = ["npm:oxfmt"]
+backends = ["aqua:oxc-project/oxc/oxfmt", "npm:oxfmt"]
 description = "This is the formatter for oxc."
 test = { cmd = "oxfmt --version", expected = "Version: {{version}}" }


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/54864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for both Aqua and npm `oxfmt` formatter backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->