### PR TITLE
fix(pipx): prefer RFC3339 upload_time_iso_8601 for release-age gating

### DIFF
--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -6,6 +6,7 @@ use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::{Config, Settings};
+use crate::duration::parse_into_timestamp;
 #[cfg(unix)]
 use crate::env;
 #[cfg(unix)]
@@ -461,22 +462,28 @@ impl PIPXBackend {
             .filter(|(_, files)| files.iter().any(|f| !f.yanked))
             .sorted_by_cached_key(|(v, _)| Versioning::new(v))
             .map(|(version, files)| {
+                // Prefer the RFC3339 `upload_time_iso_8601` over the
+                // timezone-naive `upload_time`: the latter has no offset, so
+                // `parse_into_timestamp` parses it as a `civil::Date` and
+                // substitutes end-of-day UTC, dropping the real time-of-day
+                // and inflating `minimum_release_age` for same-day releases by
+                // up to ~24h. Custom indexes without the ISO field fall back to
+                // `upload_time` as before.
                 let created_at = files
                     .iter()
                     .filter(|f| !f.yanked)
-                    // Prefer the RFC3339 `upload_time_iso_8601` over the
-                    // timezone-naive `upload_time`: the latter has no offset,
-                    // so `parse_into_timestamp` parses it as a `civil::Date`
-                    // and substitutes end-of-day UTC, dropping the real
-                    // time-of-day and inflating `minimum_release_age` for
-                    // same-day releases by up to ~24h. Custom indexes without
-                    // the ISO field fall back to `upload_time` as before.
                     .filter_map(|f| {
                         f.upload_time_iso_8601
                             .clone()
                             .or_else(|| f.upload_time.clone())
                     })
-                    .min();
+                    // Pick the earliest upload as a parsed instant, not by
+                    // lexicographic string order: RFC3339 strings with
+                    // different offsets (`...00:00-05:00` vs `...04:00Z`) do
+                    // not sort chronologically, so a naive `.min()` on the raw
+                    // strings can select a later instant and over-gate.
+                    .min_by_key(|s| parse_into_timestamp(s).unwrap_or(Timestamp::MAX));
+
                 VersionInfo {
                     version,
                     created_at,
@@ -1176,6 +1183,36 @@ mod tests {
         assert_eq!(parsed[0].as_deref(), Some("2024-01-02T10:05:14.723989Z"));
         // Naive-only fallback: parses as a date, end-of-day UTC.
         assert_eq!(parsed[1].as_deref(), Some("2024-01-03T23:59:59Z"));
+    }
+
+    #[test]
+    fn test_versions_from_pypi_package_picks_earliest_instant_not_lexical_min() {
+        // A custom index may return RFC3339 timestamps with differing offsets.
+        // These two are the same instant, but lexicographic order and
+        // chronological UTC order diverge for different-offset strings, so the
+        // earliest upload must be selected by parsed instant.
+        //
+        //   "2024-01-02T00:00:00-05:00"  ==  2024-01-02T05:00:00Z
+        //   "2024-01-02T04:30:00Z"            2024-01-02T04:30:00Z  (earlier)
+        //
+        // Lexical min is the first ("-05:00" string sorts before "Z"), but the
+        // second is 30 min earlier in UTC and must win.
+        let release = |iso: &str| PypiRelease {
+            upload_time: None,
+            upload_time_iso_8601: Some(iso.to_string()),
+            yanked: false,
+        };
+        let versions = PIPXBackend::versions_from_pypi_package(pypi_package(vec![(
+            "1.0.0",
+            vec![
+                release("2024-01-02T00:00:00-05:00"),
+                release("2024-01-02T04:30:00Z"),
+            ],
+        )]));
+        assert_eq!(
+            versions[0].created_at.as_deref(),
+            Some("2024-01-02T04:30:00Z"),
+        );
     }
 
     #[test]

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -464,9 +464,19 @@ impl PIPXBackend {
                 let created_at = files
                     .iter()
                     .filter(|f| !f.yanked)
-                    .filter_map(|f| f.upload_time.as_ref())
-                    .min()
-                    .cloned();
+                    // Prefer the RFC3339 `upload_time_iso_8601` over the
+                    // timezone-naive `upload_time`: the latter has no offset,
+                    // so `parse_into_timestamp` parses it as a `civil::Date`
+                    // and substitutes end-of-day UTC, dropping the real
+                    // time-of-day and inflating `minimum_release_age` for
+                    // same-day releases by up to ~24h. Custom indexes without
+                    // the ISO field fall back to `upload_time` as before.
+                    .filter_map(|f| {
+                        f.upload_time_iso_8601
+                            .clone()
+                            .or_else(|| f.upload_time.clone())
+                    })
+                    .min();
                 VersionInfo {
                     version,
                     created_at,
@@ -755,6 +765,7 @@ struct PypiPackage {
 #[derive(serde::Deserialize)]
 struct PypiRelease {
     upload_time: Option<String>,
+    upload_time_iso_8601: Option<String>,
     #[serde(default, deserialize_with = "deserialize_pypi_yanked")]
     yanked: bool,
 }
@@ -1129,6 +1140,45 @@ mod tests {
     }
 
     #[test]
+    fn test_versions_from_pypi_package_preserves_time_of_day_from_iso_field() {
+        // PyPI's JSON carries both a naive `upload_time` (no offset) and an
+        // RFC3339 `upload_time_iso_8601`. Preferring the ISO field keeps the
+        // real upload instant; the naive field would parse as a `civil::Date`
+        // and collapse to end-of-day UTC, inflating `minimum_release_age`.
+        fn release(iso: Option<&str>, naive: Option<&str>) -> PypiRelease {
+            PypiRelease {
+                upload_time: naive.map(str::to_string),
+                upload_time_iso_8601: iso.map(str::to_string),
+                yanked: false,
+            }
+        }
+
+        let versions = PIPXBackend::versions_from_pypi_package(pypi_package(vec![
+            // Both fields present: the precise midday instant wins.
+            (
+                "1.0.0",
+                vec![release(
+                    Some("2024-01-02T10:05:14.723989Z"),
+                    Some("2024-01-02T10:05:14"),
+                )],
+            ),
+            // Index without the ISO field: naive fallback still yields a
+            // timestamp (here end-of-day UTC), so release-age gating degrades
+            // gracefully rather than disappearing.
+            ("1.1.0", vec![release(None, Some("2024-01-03"))]),
+        ]));
+
+        let parsed: Vec<_> = versions
+            .iter()
+            .map(|v| v.created_at_timestamp().map(|t| t.to_string()))
+            .collect();
+        // ISO field: real upload instant, not 2024-01-02T23:59:59Z.
+        assert_eq!(parsed[0].as_deref(), Some("2024-01-02T10:05:14.723989Z"));
+        // Naive-only fallback: parses as a date, end-of-day UTC.
+        assert_eq!(parsed[1].as_deref(), Some("2024-01-03T23:59:59Z"));
+    }
+
+    #[test]
     fn test_latest_stable_from_pypi_package_skips_yanked_and_prerelease() {
         let version = PIPXBackend::latest_stable_from_pypi_package(pypi_package(vec![
             (
@@ -1289,6 +1339,7 @@ mod tests {
     fn pypi_release(upload_time: Option<&str>, yanked: bool) -> PypiRelease {
         PypiRelease {
             upload_time: upload_time.map(str::to_string),
+            upload_time_iso_8601: upload_time.map(str::to_string),
             yanked,
         }
     }


### PR DESCRIPTION
## Problem

`minimum_release_age` over-gates freshly-released pipx packages. A release uploaded at `10:05 UTC` is recorded as `23:59:59 UTC` the same day, so it appears up to ~24h younger than it really is and the "eligible" time is pushed into the future. The cause: the pipx backend reads PyPI's **timezone-naive** `upload_time`, which `parse_into_timestamp` parses as a `civil::Date` (discarding the time-of-day) and then substitutes end-of-day UTC.

Sorry for omitting Discord discussion step. It is blocked at country of my location. I hope this fails into exception:
> unless it is something obvious

## Reproduction

`pipx:notebooklm-py` 0.8.0 was uploaded to PyPI at `2026-08-03T10:05:14Z` (confirmed via the JSON API):

```sh
$ curl -s https://pypi.org/pypi/notebooklm-py/json | jq -r '.releases["0.8.0"][].upload_time_iso_8601'
2026-08-03T10:05:14.723989Z
2026-08-03T10:05:16.496081Z
```

With `minimum_release_age = "4h"`:

```toml
[tools]
"pipx:notebooklm-py" = { version = "latest", minimum_release_age = "4h" }
```

`mise upgrade` reports:

```text
mise WARN  newer pipx:notebooklm-py release 0.8.0 (released 2026-08-03, eligible 2026-08-04 03:59 UTC) ignored by minimum_release_age (4h); latest eligible release is 0.7.3
```

`eligible = created_at + age`, so `2026-08-04 03:59 UTC − 4h = 2026-08-03 23:59:59 UTC` is the `created_at` mise holds. The real upload at `10:05:14` would make it eligible at `14:05 UTC` the same day — so the gate waits until ~04:00 the next day instead. For contrast, the aqua backend reads a real RFC3339 timestamp from the GitHub releases API and lands on the precise instant.

## Root cause

`src/backend/pipx.rs` deserialized PyPI's naive `upload_time`:

```rust
struct PypiRelease {
    upload_time: Option<String>,   // "2026-08-03T10:05:14" — no offset
    ...
}
```

PyPI provides two fields per file:

- `upload_time` — `"2026-08-03T10:05:14"` — **timezone-naive, no `Z`**
- `upload_time_iso_8601` — `"2026-08-03T10:05:14.723989Z"` — RFC3339, precise

`parse_into_timestamp` (`src/duration.rs`) then fails the RFC3339 and Zoned branches (no offset/zone) and falls through to the date-only branch:

```rust
if let Ok(civil_date) = s.parse::<jiff::civil::Date>() {        // succeeds, drops 10:05:14
    let datetime = civil_date.at(23, 59, 59, 0);                // the 23:59:59
    ...
}
```

jiff's temporal parser parses a `civil::Date` from anything containing a date — per [the jiff temporal docs](https://docs.rs/jiff/0.2/jiff/fmt/temporal/index.html):

> "Smaller types can generally be parsed from strings representing a bigger type. For example, a `civil::Date` can be parsed from `2020-08-21T02:21:58`."

So `"2026-08-03T10:05:14"` parses to `Date(2026-08-03)`, discarding `10:05:14`, and the `.at(23, 59, 59, 0)` fallback substitutes end-of-day UTC.

## Fix

Prefer `upload_time_iso_8601` (the `…Z` field), so it parses as RFC3339 on the first branch of `parse_into_timestamp`. Keep `upload_time` as a fallback for custom indexes that don't provide the ISO field. Preserves the existing `.min()`-across-files semantics and yanked-file filtering — only the timestamp *source* changes.

## Tests

Adds `test_versions_from_pypi_package_preserves_time_of_day_from_iso_field`, asserting:

- both fields present → `created_at_timestamp()` is the real instant (`2024-01-02T10:05:14.723989Z`), not end-of-day;
- ISO field absent → naive fallback still yields a timestamp (`2024-01-03T23:59:59Z`), so release-age gating degrades gracefully on indexes without the ISO field.

All 17 existing + new pipx backend tests pass.

## Scope / impact

Any pipx package whose `upload_time` carries a time-of-day (essentially all of PyPI) is gated more strictly than configured while it is less than ~24h old. Once a release is a day old the date is correct and the cooldown behaves as intended, so the effect is confined to the release edge. `upload_time_iso_8601` is a [documented field](https://docs.pypi.org/api-index-api/json/) on PyPI's JSON API.

---

Tested locally against `2026.8.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PyPI release date accuracy by prioritizing precise upload timestamps.
  * Added reliable fallback handling when precise timestamp information is unavailable.
  * Corrected release ordering across timestamps with different time zone offsets.
  * Limited date selection to valid, non-yanked release files for more dependable results.
  * Expanded validation and test coverage for precise timestamps, fallback scenarios, and updated release data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->