### PR TITLE
chore: release 2026.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## [2026.8.2](https://github.com/jdx/mise/compare/v2026.8.1..v2026.8.2) - 2026-08-04
+
+### 🚀 Features
+
+- **(bootstrap)** add declarative resource plans by @jdx in [#11669](https://github.com/jdx/mise/pull/11669)
+- **(bootstrap)** manage privileged files and directories by @jdx in [#11674](https://github.com/jdx/mise/pull/11674)
+- **(bootstrap)** add secret inputs for managed files by @jdx in [#11680](https://github.com/jdx/mise/pull/11680)
+- **(bootstrap)** manage linux users and groups by @jdx in [#11681](https://github.com/jdx/mise/pull/11681)
+- **(bootstrap)** manage system services by @jdx in [#11688](https://github.com/jdx/mise/pull/11688)
+- **(bootstrap)** manage compose projects by @jdx in [#11689](https://github.com/jdx/mise/pull/11689)
+- **(bootstrap)** run bootstrap over ssh by @jdx in [#11690](https://github.com/jdx/mise/pull/11690)
+- **(bootstrap)** resolve remote mise artifacts by @jdx in [#11693](https://github.com/jdx/mise/pull/11693)
+- **(bootstrap)** manage Linux firewall rules by @jdx in [#11694](https://github.com/jdx/mise/pull/11694)
+- **(ruby)** require precompiled binaries with ruby.compile=false by @jdx in [#11710](https://github.com/jdx/mise/pull/11710)
+
+### 🐛 Bug Fixes
+
+- **(brew)** relocate text in skip-relocation bottles by @jdx in [#11665](https://github.com/jdx/mise/pull/11665)
+- **(brew-cask)** detect extensionless DMG downloads by @jacobbednarz in [#11692](https://github.com/jdx/mise/pull/11692)
+- **(completions)** stop `--` from hijacking task argument completion by @jdx in [#11711](https://github.com/jdx/mise/pull/11711)
+- **(lock)** reject platform regressions during relock by @jdx in [#11664](https://github.com/jdx/mise/pull/11664)
+- **(pacman)** force C locale when parsing pacman -Q output by @rarandeyo in [#11673](https://github.com/jdx/mise/pull/11673)
+- **(pipx)** prefer RFC3339 upload_time_iso_8601 for release-age gating by @Guria in [#11662](https://github.com/jdx/mise/pull/11662)
+- **(sync)** clear stale incomplete markers for external links by @risu729 in [#11172](https://github.com/jdx/mise/pull/11172)
+- **(task)** make workspace task inference opt-in by @jdx in [#11706](https://github.com/jdx/mise/pull/11706)
+
+### ⚡ Performance
+
+- **(cli)** defer bootstrap command tree by @jdx in [#11684](https://github.com/jdx/mise/pull/11684)
+
+### 🧪 Testing
+
+- **(bootstrap)** add Linux host convergence gate by @jdx in [#11704](https://github.com/jdx/mise/pull/11704)
+
+### 📦️ Dependency Updates
+
+- update zizmorcore/zizmor-action action to v0.6.1 by @renovate[bot] in [#11700](https://github.com/jdx/mise/pull/11700)
+- update node.js to v24.18.1 by @renovate[bot] in [#11699](https://github.com/jdx/mise/pull/11699)
+- update ghcr.io/jdx/mise:deb docker digest to c87709c by @renovate[bot] in [#11696](https://github.com/jdx/mise/pull/11696)
+- update rust crate base64 to 0.23 by @renovate[bot] in [#11702](https://github.com/jdx/mise/pull/11702)
+- update ghcr.io/jdx/mise:alpine docker digest to e46827b by @renovate[bot] in [#11695](https://github.com/jdx/mise/pull/11695)
+- update jdx/mise-action action to v4.2.3 by @renovate[bot] in [#11698](https://github.com/jdx/mise/pull/11698)
+- update ghcr.io/jdx/mise:rpm docker digest to 6ddbe45 by @renovate[bot] in [#11697](https://github.com/jdx/mise/pull/11697)
+- update rattler (major) by @renovate[bot] in [#11703](https://github.com/jdx/mise/pull/11703)
+
+### 📦 Registry
+
+- add bin metadata for shim auto-install by @jdx in [#11666](https://github.com/jdx/mise/pull/11666)
+- add discovered bin metadata (1/4) by @jdx in [#11671](https://github.com/jdx/mise/pull/11671)
+- add discovered bin metadata (2/4) by @jdx in [#11676](https://github.com/jdx/mise/pull/11676)
+- add discovered bin metadata (3/4) by @jdx in [#11677](https://github.com/jdx/mise/pull/11677)
+- add discovered bin metadata (4/4) by @jdx in [#11678](https://github.com/jdx/mise/pull/11678)
+
+### New Contributors
+
+- @jacobbednarz made their first contribution in [#11692](https://github.com/jdx/mise/pull/11692)
+- @rarandeyo made their first contribution in [#11673](https://github.com/jdx/mise/pull/11673)
+
 ## [2026.8.1](https://github.com/jdx/mise/compare/v2026.8.0..v2026.8.1) - 2026-08-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6291,7 +6291,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.1"
+version = "2026.8.2"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.1"
+version = "2026.8.2"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.1 macos-arm64 (2026-08-03)
+2026.8.2 macos-arm64 (2026-08-04)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_1.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_2.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_1.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_2.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -P usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_1.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_2.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_1.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_2.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.1";
+  version = "2026.8.2";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.1
+Version: 2026.8.2
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.1"
+version: "2026.8.2"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "3ffe9062426d630471a3c06912a5ddbcd854a9ee"
+  "tag": "a2eb02ad182add07ff0be206084f63398ac0e590"
 }


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add declarative resource plans by @jdx in [#11669](https://github.com/jdx/mise/pull/11669)
- **(bootstrap)** manage privileged files and directories by @jdx in [#11674](https://github.com/jdx/mise/pull/11674)
- **(bootstrap)** add secret inputs for managed files by @jdx in [#11680](https://github.com/jdx/mise/pull/11680)
- **(bootstrap)** manage linux users and groups by @jdx in [#11681](https://github.com/jdx/mise/pull/11681)
- **(bootstrap)** manage system services by @jdx in [#11688](https://github.com/jdx/mise/pull/11688)
- **(bootstrap)** manage compose projects by @jdx in [#11689](https://github.com/jdx/mise/pull/11689)
- **(bootstrap)** run bootstrap over ssh by @jdx in [#11690](https://github.com/jdx/mise/pull/11690)
- **(bootstrap)** resolve remote mise artifacts by @jdx in [#11693](https://github.com/jdx/mise/pull/11693)
- **(bootstrap)** manage Linux firewall rules by @jdx in [#11694](https://github.com/jdx/mise/pull/11694)
- **(ruby)** require precompiled binaries with ruby.compile=false by @jdx in [#11710](https://github.com/jdx/mise/pull/11710)

### 🐛 Bug Fixes

- **(brew)** relocate text in skip-relocation bottles by @jdx in [#11665](https://github.com/jdx/mise/pull/11665)
- **(brew-cask)** detect extensionless DMG downloads by @jacobbednarz in [#11692](https://github.com/jdx/mise/pull/11692)
- **(completions)** stop `--` from hijacking task argument completion by @jdx in [#11711](https://github.com/jdx/mise/pull/11711)
- **(lock)** reject platform regressions during relock by @jdx in [#11664](https://github.com/jdx/mise/pull/11664)
- **(pacman)** force C locale when parsing pacman -Q output by @rarandeyo in [#11673](https://github.com/jdx/mise/pull/11673)
- **(pipx)** prefer RFC3339 upload_time_iso_8601 for release-age gating by @Guria in [#11662](https://github.com/jdx/mise/pull/11662)
- **(sync)** clear stale incomplete markers for external links by @risu729 in [#11172](https://github.com/jdx/mise/pull/11172)
- **(task)** make workspace task inference opt-in by @jdx in [#11706](https://github.com/jdx/mise/pull/11706)

### ⚡ Performance

- **(cli)** defer bootstrap command tree by @jdx in [#11684](https://github.com/jdx/mise/pull/11684)

### 🧪 Testing

- **(bootstrap)** add Linux host convergence gate by @jdx in [#11704](https://github.com/jdx/mise/pull/11704)

### 📦️ Dependency Updates

- update zizmorcore/zizmor-action action to v0.6.1 by @renovate[bot] in [#11700](https://github.com/jdx/mise/pull/11700)
- update node.js to v24.18.1 by @renovate[bot] in [#11699](https://github.com/jdx/mise/pull/11699)
- update ghcr.io/jdx/mise:deb docker digest to c87709c by @renovate[bot] in [#11696](https://github.com/jdx/mise/pull/11696)
- update rust crate base64 to 0.23 by @renovate[bot] in [#11702](https://github.com/jdx/mise/pull/11702)
- update ghcr.io/jdx/mise:alpine docker digest to e46827b by @renovate[bot] in [#11695](https://github.com/jdx/mise/pull/11695)
- update jdx/mise-action action to v4.2.3 by @renovate[bot] in [#11698](https://github.com/jdx/mise/pull/11698)
- update ghcr.io/jdx/mise:rpm docker digest to 6ddbe45 by @renovate[bot] in [#11697](https://github.com/jdx/mise/pull/11697)
- update rattler (major) by @renovate[bot] in [#11703](https://github.com/jdx/mise/pull/11703)

### 📦 Registry

- add bin metadata for shim auto-install by @jdx in [#11666](https://github.com/jdx/mise/pull/11666)
- add discovered bin metadata (1/4) by @jdx in [#11671](https://github.com/jdx/mise/pull/11671)
- add discovered bin metadata (2/4) by @jdx in [#11676](https://github.com/jdx/mise/pull/11676)
- add discovered bin metadata (3/4) by @jdx in [#11677](https://github.com/jdx/mise/pull/11677)
- add discovered bin metadata (4/4) by @jdx in [#11678](https://github.com/jdx/mise/pull/11678)

### New Contributors

- @jacobbednarz made their first contribution in [#11692](https://github.com/jdx/mise/pull/11692)
- @rarandeyo made their first contribution in [#11673](https://github.com/jdx/mise/pull/11673)