### PR TITLE
fix(brew): relocate text in skip-relocation bottles

### DIFF
--- a/src/system/packages/brew/pour.rs
+++ b/src/system/packages/brew/pour.rs
@@ -229,18 +229,15 @@ pub async fn pour(
     crate::file::rename(&inner, &tmp)?;
     crate::file::remove_all(&scratch)?;
 
-    // ":any_skip_relocation" bottles need no relocation — except on Linux,
-    // where bottles built by Homebrew < 5.1.15 are incorrectly tagged and
-    // still carry placeholder ELF linkage (brew applies the same version
-    // check in extend/os/linux/bottle_specification.rb)
-    let skip_relocation = bottle.cellar == ":any_skip_relocation"
+    // ":any_skip_relocation" skips binary linkage relocation, but Homebrew
+    // still replaces placeholders in text files. On Linux, bottles built by
+    // Homebrew < 5.1.15 are incorrectly tagged and still need ELF linkage
+    // relocation (brew applies the same version check in
+    // extend/os/linux/bottle_specification.rb).
+    let skip_linkage = bottle.cellar == ":any_skip_relocation"
         && (cfg!(target_os = "macos") || bottled_by_homebrew_at_least(&tmp, (5, 1, 15)));
-    let report = if skip_relocation {
-        relocate::RelocationReport::default()
-    } else {
-        pr.set_message("relocate".to_string());
-        relocate::relocate_keg(&tmp, name)?
-    };
+    pr.set_message("relocate".to_string());
+    let report = relocate::relocate_keg(&tmp, name, skip_linkage)?;
     // arm64 macOS kills binaries whose signature doesn't match; Linux ELF
     // files have no signatures to fix
     if cfg!(target_os = "macos") && !report.changed_machos.is_empty() {

--- a/src/system/packages/brew/relocate.rs
+++ b/src/system/packages/brew/relocate.rs
@@ -192,9 +192,23 @@ fn replace_in_binary(
     Ok(changed)
 }
 
-/// Walk a poured keg and replace placeholders in all files.
-pub fn relocate_keg(keg: &Path, formula_name: &str) -> Result<RelocationReport> {
-    let replacements = standard_replacements();
+/// Walk a poured keg and replace placeholders. `skip_linkage` leaves binary
+/// linkage untouched while still relocating text files, matching Homebrew's
+/// handling of `:any_skip_relocation` bottles.
+pub fn relocate_keg(
+    keg: &Path,
+    formula_name: &str,
+    skip_linkage: bool,
+) -> Result<RelocationReport> {
+    relocate_keg_with_replacements(keg, formula_name, skip_linkage, &standard_replacements())
+}
+
+fn relocate_keg_with_replacements(
+    keg: &Path,
+    formula_name: &str,
+    skip_linkage: bool,
+    replacements: &[Replacement],
+) -> Result<RelocationReport> {
     let elf_opts = super::elf::LinkageOpts::for_formula(formula_name);
     // brew never patches glibc's own files — rewriting the dynamic linker
     // breaks it (extend/os/linux/keg_relocate.rb)
@@ -221,6 +235,9 @@ pub fn relocate_keg(keg: &Path, formula_name: &str) -> Result<RelocationReport> 
         let macho = is_macho(&content);
         let elf = cfg!(target_os = "linux") && super::elf::is_elf(&content);
         let shebang_end = text_executable_shebang_end(&content);
+        if skip_linkage && (macho || elf || (content.contains(&0) && shebang_end.is_none())) {
+            continue;
+        }
         if macho || (!elf && content.contains(&0) && shebang_end.is_none()) {
             // Non-ELF files containing NUL bytes are treated as binaries unless
             // their shebang makes them text executables (for example zipapps).
@@ -325,6 +342,29 @@ pub(super) mod tests {
             String::from_utf8_lossy(&out),
             "#!/opt/homebrew/bin/bash\nCELLAR=/opt/homebrew/Cellar/foo\n"
         );
+    }
+
+    #[test]
+    fn test_skip_linkage_still_relocates_text_files() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let text = tmp.path().join("script");
+        let binary = tmp.path().join("binary");
+        crate::file::write(&text, "CELLAR=@@HOMEBREW_CELLAR@@/formula/1.0\n")?;
+        let mut binary_content = 0xfeedfacf_u32.to_be_bytes().to_vec();
+        binary_content.extend_from_slice(b"@@HOMEBREW_PREFIX@@/lib/libformula.dylib\0");
+        crate::file::write(&binary, &binary_content)?;
+
+        let report =
+            relocate_keg_with_replacements(tmp.path(), "formula", true, &test_replacements())?;
+
+        assert_eq!(
+            crate::file::read_to_string(&text)?,
+            "CELLAR=/opt/homebrew/Cellar/formula/1.0\n"
+        );
+        assert_eq!(crate::file::read(&binary)?, binary_content);
+        assert_eq!(report.changed_files, vec![text]);
+        assert!(report.changed_machos.is_empty());
+        Ok(())
     }
 
     #[test]

--- a/src/system/packages/brew/relocate.rs
+++ b/src/system/packages/brew/relocate.rs
@@ -224,6 +224,12 @@ fn relocate_keg_with_replacements(
         if !contains_any_placeholder(&content, &replacements) {
             continue;
         }
+        let macho = is_macho(&content);
+        let elf = cfg!(target_os = "linux") && super::elf::is_elf(&content);
+        let shebang_end = text_executable_shebang_end(&content);
+        if skip_linkage && (macho || elf || (content.contains(&0) && shebang_end.is_none())) {
+            continue;
+        }
         let perms = path.metadata()?.permissions();
         // bottle files are often read-only; lift that while we patch
         let mut writable = perms.clone();
@@ -232,12 +238,6 @@ fn relocate_keg_with_replacements(
             std::os::unix::fs::PermissionsExt::mode(&perms) | 0o200,
         );
         std::fs::set_permissions(path, writable)?;
-        let macho = is_macho(&content);
-        let elf = cfg!(target_os = "linux") && super::elf::is_elf(&content);
-        let shebang_end = text_executable_shebang_end(&content);
-        if skip_linkage && (macho || elf || (content.contains(&0) && shebang_end.is_none())) {
-            continue;
-        }
         if macho || (!elf && content.contains(&0) && shebang_end.is_none()) {
             // Non-ELF files containing NUL bytes are treated as binaries unless
             // their shebang makes them text executables (for example zipapps).
@@ -318,6 +318,7 @@ pub fn codesign(files: &[PathBuf]) -> Result<()> {
 pub(super) mod tests {
     use super::*;
     use std::io::{Cursor, Read, Write};
+    use std::os::unix::fs::PermissionsExt;
 
     /// fixed macOS-style replacements so tests behave the same on all hosts
     pub(in super::super) fn test_replacements() -> Vec<Replacement> {
@@ -353,6 +354,7 @@ pub(super) mod tests {
         let mut binary_content = 0xfeedfacf_u32.to_be_bytes().to_vec();
         binary_content.extend_from_slice(b"@@HOMEBREW_PREFIX@@/lib/libformula.dylib\0");
         crate::file::write(&binary, &binary_content)?;
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o444))?;
 
         let report =
             relocate_keg_with_replacements(tmp.path(), "formula", true, &test_replacements())?;
@@ -362,6 +364,7 @@ pub(super) mod tests {
             "CELLAR=/opt/homebrew/Cellar/formula/1.0\n"
         );
         assert_eq!(crate::file::read(&binary)?, binary_content);
+        assert_eq!(binary.metadata()?.permissions().mode() & 0o777, 0o444);
         assert_eq!(report.changed_files, vec![text]);
         assert!(report.changed_machos.is_empty());
         Ok(())

--- a/src/system/packages/brew/relocate.rs
+++ b/src/system/packages/brew/relocate.rs
@@ -221,7 +221,7 @@ fn relocate_keg_with_replacements(
         }
         let path = entry.path();
         let content = crate::file::read(path)?;
-        if !contains_any_placeholder(&content, &replacements) {
+        if !contains_any_placeholder(&content, replacements) {
             continue;
         }
         let macho = is_macho(&content);
@@ -246,8 +246,8 @@ fn relocate_keg_with_replacements(
             // replacement is longer; then the generic in-place pass for
             // strings in data sections.
             let mut content = content;
-            let mut changed = macho && super::macho::patch(&mut content, &replacements, path)?;
-            changed |= replace_in_binary(&mut content, &replacements, path)?;
+            let mut changed = macho && super::macho::patch(&mut content, replacements, path)?;
+            changed |= replace_in_binary(&mut content, replacements, path)?;
             if changed {
                 crate::file::write(path, &content)?;
                 if macho {
@@ -271,9 +271,9 @@ fn relocate_keg_with_replacements(
             let new_content = if content.contains(&0) {
                 // A valid shebang is the only way a NUL-backed file reaches
                 // this branch. Preserve the opaque binary payload byte-for-byte.
-                replace_shebang(&content, shebang_end.unwrap(), &replacements)
+                replace_shebang(&content, shebang_end.unwrap(), replacements)
             } else {
-                replace_text(&content, &replacements)
+                replace_text(&content, replacements)
             };
             if new_content != content {
                 crate::file::write(path, &new_content)?;


### PR DESCRIPTION
## Summary

- always run text placeholder relocation for Homebrew bottles
- treat `:any_skip_relocation` as skipping only binary linkage relocation
- add regression coverage proving text files are changed while Mach-O content remains untouched

## Root cause

The brew pour path skipped `relocate_keg` entirely for macOS bottles tagged `:any_skip_relocation`. Homebrew uses that tag only to suppress dynamic linkage relocation; it still replaces text placeholders such as `@@HOMEBREW_PREFIX@@` and `@@HOMEBREW_CELLAR@@`.

This left scripts and configuration files containing unresolved placeholders and produced an empty `changed_files` receipt entry.

Reported in https://github.com/jdx/mise/discussions/11656.

## Validation

- `cargo test system::packages::brew::relocate::tests` (8 passed)
- `mise run format`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Homebrew bottle pour/relocation path used on every install; behavior change is intentional and covered by a regression test, but wrong linkage skipping could still break binaries on edge-case bottles.
> 
> **Overview**
> **Fixes `:any_skip_relocation` bottles leaving `@@HOMEBREW_*@@` placeholders in scripts and config** by always running relocation during pour instead of skipping it entirely on macOS (and on Linux when the bottle was built by Homebrew ≥ 5.1.15).
> 
> `relocate_keg` now takes a **`skip_linkage`** flag: when set, Mach-O, ELF, and other binary linkage paths are left unchanged, but **text files and shebang-only executables** still get placeholder replacement—matching Homebrew’s meaning of `:any_skip_relocation`. The pour path always invokes relocation and passes `skip_linkage` from the bottle cellar tag (with the existing Linux Homebrew version gate for mis-tagged older bottles).
> 
> Adds **`test_skip_linkage_still_relocates_text_files`** to assert text is rewritten, Mach-O bytes and permissions stay untouched, and receipts list only changed text files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08427d30b574a39b1e36a2ba7d8bd07a89db513e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bottle relocation to preserve text placeholder replacements while safely skipping binary linkage updates when required.
  - Prevented unintended changes to Mach-O, ELF, and other binary files during relocation.
  - Continued relocating text files and shebang-based executables as expected.
  - Updated relocation results to report only files that were actually modified.
  - Preserved file permissions during relocation and improved compatibility across supported Homebrew and Linux environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->