### PR TITLE
registry: add bin metadata for shim auto-install

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -232,6 +232,20 @@ fn codegen_registry() {
         let description = info
             .get("description")
             .map(|d| d.as_str().unwrap().to_string());
+        let bins = info
+            .get("bins")
+            .map(|bins| {
+                bins.as_array()
+                    .unwrap_or_else(|| panic!("[{short}] 'bins' must be an array"))
+                    .iter()
+                    .map(|bin| {
+                        bin.as_str()
+                            .unwrap_or_else(|| panic!("[{short}] 'bins' must contain only strings"))
+                            .to_string()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
         let idiomatic_files = info
             .get("idiomatic_files")
             .map(|idiomatic_files| {
@@ -317,11 +331,16 @@ fn codegen_registry() {
             })
             .unwrap_or_default();
         let rt = format!(
-            r#"RegistryTool{{short: "{short}", description: {description}, backends: &[{backends}], aliases: &[{aliases}], test: &{test}, os: &[{os}], idiomatic_files: &[{idiomatic_files}], detect: &[{detect}], overrides: &[{overrides}]}}"#,
+            r#"RegistryTool{{short: "{short}", description: {description}, backends: &[{backends}], bins: &[{bins}], aliases: &[{aliases}], test: &{test}, os: &[{os}], idiomatic_files: &[{idiomatic_files}], detect: &[{detect}], overrides: &[{overrides}]}}"#,
             description = description
                 .map(|d| format!("Some({})", raw_string_literal(&d)))
                 .unwrap_or("None".to_string()),
             backends = backends.into_iter().collect::<Vec<_>>().join(", "),
+            bins = bins
+                .iter()
+                .map(|bin| raw_string_literal(bin))
+                .collect::<Vec<_>>()
+                .join(", "),
             aliases = aliases
                 .iter()
                 .map(|a| format!("\"{a}\""))

--- a/e2e/registry/test_overrides_shims
+++ b/e2e/registry/test_overrides_shims
@@ -21,3 +21,8 @@ EOF
 mise install
 mise reshim
 assert_contains "$MISE_DATA_DIR/shims/npm --version" "10.9.0"
+
+# Test 3: a missing explicit npm is installed before falling back to Node's bundled npm
+mise uninstall npm@10.9.0
+assert_contains "$MISE_DATA_DIR/shims/npm --version" "10.9.0"
+assert_contains "mise ls npm --installed" "10.9.0"

--- a/registry/npm.toml
+++ b/registry/npm.toml
@@ -5,6 +5,7 @@ backends = [
   ] },
   "npm:npm",
 ]
+bins = ["npm", "npx"]
 description = "the package manager for JavaScript"
 idiomatic_files = ["package.json"]
 overrides = ["node"]

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -133,6 +133,15 @@
       "description": "List of backends that can install this tool",
       "minItems": 1
     },
+    "bins": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[^/\\\\]+$"
+      },
+      "uniqueItems": true,
+      "description": "Executable names provided by this tool. Used as discovery hints for shim auto-install."
+    },
     "description": {
       "type": "string",
       "description": "A brief description of the tool"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -116,6 +116,7 @@ pub struct RegistryTool {
     pub short: &'static str,
     pub description: Option<&'static str>,
     pub backends: &'static [RegistryBackend],
+    pub bins: &'static [&'static str],
     #[allow(unused)]
     pub aliases: &'static [&'static str],
     pub overrides: &'static [&'static str],
@@ -349,6 +350,7 @@ fn parse_registry_tool(short: &str, value: &toml::Value) -> Result<RegistryTool>
     ensure!(!backends.is_empty(), "backends must not be empty");
 
     let aliases = string_array(table.get("aliases"), "aliases")?;
+    let bins = string_array(table.get("bins"), "bins")?;
     let overrides = string_array(table.get("overrides"), "overrides")?;
     let os = string_array(table.get("os"), "os")?;
     let idiomatic_files = parse_registry_idiomatic_files(table.get("idiomatic_files"))?;
@@ -368,6 +370,7 @@ fn parse_registry_tool(short: &str, value: &toml::Value) -> Result<RegistryTool>
         short: leak_string(short.to_string()),
         description,
         backends: leak_vec(backends),
+        bins: leak_vec(bins),
         aliases: leak_vec(aliases),
         overrides: leak_vec(overrides),
         test: Box::leak(Box::new(test)),
@@ -527,6 +530,26 @@ static ENV_BACKENDS: Lazy<Mutex<HashMap<String, &'static str>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 impl RegistryTool {
+    pub fn provides_bin(&self, bin_name: &str) -> bool {
+        let exe_suffix = std::env::consts::EXE_SUFFIX;
+        let bin_name = if exe_suffix.is_empty() {
+            bin_name
+        } else {
+            let suffix_start = bin_name.len().saturating_sub(exe_suffix.len());
+            match (bin_name.get(..suffix_start), bin_name.get(suffix_start..)) {
+                (Some(name), Some(suffix)) if suffix.eq_ignore_ascii_case(exe_suffix) => name,
+                _ => bin_name,
+            }
+        };
+        self.bins.iter().any(|bin| {
+            if cfg!(windows) {
+                bin.eq_ignore_ascii_case(bin_name)
+            } else {
+                *bin == bin_name
+            }
+        })
+    }
+
     pub fn backends(&self) -> Vec<&'static str> {
         // Check for environment variable override first
         // e.g., MISE_BACKENDS_GRAPHITE='github:withgraphite/homebrew-tap[exe=gt]'
@@ -765,6 +788,7 @@ mod tests {
             r#"
 aliases = ["example-alias"]
 description = "Example tool"
+bins = ["example", "example-helper"]
 backends = [
   "aqua:example/tool",
   { full = "github:example/tool", platforms = ["linux-x64"], options = { bin = "example" } },
@@ -783,6 +807,12 @@ test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
         let tool = registry.get("example-alias").unwrap();
         assert_eq!(tool.short, "example");
         assert_eq!(tool.description, Some("Example tool"));
+        assert_eq!(tool.bins, &["example", "example-helper"]);
+        assert!(tool.provides_bin("example"));
+        assert!(!tool.provides_bin("other"));
+        if cfg!(windows) {
+            assert!(tool.provides_bin("EXAMPLE.EXE"));
+        }
         assert_eq!(tool.backends[0].full, "aqua:example/tool");
         assert_eq!(tool.backends[1].platforms, &["linux-x64"]);
         assert_eq!(
@@ -1023,6 +1053,7 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
             short: "test",
             description: None,
             backends: BACKENDS,
+            bins: &[],
             aliases: &[],
             overrides: &[],
             test: &None,

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -123,6 +123,30 @@ async fn which_shim(
         .with_resolve_options(resolve_options)
         .build(config)
         .await?;
+    // A configured tool may intentionally override an executable bundled by another installed
+    // tool (for example, a pinned npm overrides Node's npm). Install a missing provider declared
+    // by the registry before resolving an incidental installed provider.
+    if !completion_offline
+        && Settings::get().not_found_auto_install
+        && ts
+            .should_install_missing_registry_bin_provider(config, bin_name)
+            .await?
+    {
+        for tv in ts
+            .install_missing_bin(config, bin_name)
+            .await?
+            .unwrap_or_default()
+        {
+            let p = tv.backend()?;
+            if let Some(bin) = p.which(config, &tv, bin_name).await? {
+                trace!(
+                    "shim[{bin_name}] REGISTRY ToolVersion: {tv} bin: {bin}",
+                    bin = display_path(&bin)
+                );
+                return Ok((bin, ts));
+            }
+        }
+    }
     if let Some((p, tv)) = ts.which(config, bin_name).await
         && let Some(bin) = p.which(config, &tv, bin_name).await?
     {

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -13,6 +13,7 @@ use crate::errors::Error;
 use crate::hooks::{Hooks, InstalledToolInfo};
 use crate::install_context::InstallContext;
 use crate::plugins::PluginType;
+use crate::registry::REGISTRY;
 use crate::toolset::Toolset;
 use crate::toolset::helpers::{preflight_system_deps, show_python_install_hint};
 use crate::toolset::install_options::InstallOptions;
@@ -24,6 +25,43 @@ use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{backend, config, hooks, runtime_symlinks};
 
 impl Toolset {
+    pub async fn should_install_missing_registry_bin_provider(
+        &self,
+        config: &Arc<Config>,
+        bin_name: &str,
+    ) -> Result<bool> {
+        let mut providers = vec![];
+        for (backend, tv) in self.list_current_versions() {
+            if backend.is_version_installed(config, &tv, true) {
+                if backend
+                    .which(config, &tv, bin_name)
+                    .await
+                    .ok()
+                    .flatten()
+                    .is_some()
+                {
+                    providers.push((backend, tv));
+                }
+            } else if REGISTRY
+                .get(&tv.ba().short)
+                .is_some_and(|tool| tool.provides_bin(bin_name))
+                && match &Settings::get().auto_install_disable_tools {
+                    Some(disable_tools) => !disable_tools.contains(&tv.ba().short),
+                    None => true,
+                }
+            {
+                providers.push((backend, tv));
+            }
+        }
+        Self::sort_by_overrides(&mut providers)?;
+        Ok(providers.first().is_some_and(|(backend, tv)| {
+            !backend.is_version_installed(config, tv, true)
+                && REGISTRY
+                    .get(&tv.ba().short)
+                    .is_some_and(|tool| tool.provides_bin(bin_name))
+        }))
+    }
+
     #[async_backtrace::framed]
     /// Installs missing tool versions and returns (installed_versions, still_missing_versions).
     /// This avoids callers needing to re-compute the missing versions list.
@@ -540,19 +578,36 @@ impl Toolset {
         config: &mut Arc<Config>,
         bin_name: &str,
     ) -> Result<Option<Vec<ToolVersion>>> {
-        // Strategy: Find backends that could provide this bin by checking:
-        // 1. Any currently installed versions that provide the bin
-        // 2. Any requested backends with installed versions (even if not current)
+        // Registry bin metadata is the only provider signal available before a tool has ever
+        // been installed. Prefer those configured providers, applying registry override order,
+        // before falling back to executable discovery from existing installs.
         let mut plugins = IndexSet::new();
+        let mut registry_providers = self
+            .list_missing_versions(config)
+            .await
+            .into_iter()
+            .filter(|tv| {
+                REGISTRY
+                    .get(&tv.ba().short)
+                    .is_some_and(|tool| tool.provides_bin(bin_name))
+            })
+            .filter(|tv| match &Settings::get().auto_install_disable_tools {
+                Some(disable_tools) => !disable_tools.contains(&tv.ba().short),
+                None => true,
+            })
+            .map(|tv| eyre::Ok((tv.backend()?, tv)))
+            .collect::<Result<Vec<_>>>()?;
+        Self::sort_by_overrides(&mut registry_providers)?;
+        plugins.extend(registry_providers.into_iter().map(|(backend, _)| backend));
 
-        // First check currently active installed versions
+        // Check currently active installed versions.
         for (p, tv) in self.list_current_installed_versions(config) {
             if let Ok(Some(_bin)) = p.which(config, &tv, bin_name).await {
                 plugins.insert(p);
             }
         }
 
-        // Also check backends that are requested but not currently active
+        // Also check backends that are requested but not currently active.
         // This handles the case where a user has tool@v1 globally and tool@v2 locally (not installed)
         // When looking for a bin provided by the tool, we check if any installed version provides it
         let all_installed = self.list_installed_versions(config).await?;
@@ -603,7 +658,12 @@ impl Toolset {
                     )
                     .await?;
                 }
-                return Ok(Some(versions));
+                for tv in &versions {
+                    let backend = tv.backend()?;
+                    if backend.which(config, tv, bin_name).await?.is_some() {
+                        return Ok(Some(versions));
+                    }
+                }
             }
         }
         Ok(None)


### PR DESCRIPTION
## Summary
- add optional `bins` metadata to registry tools and the registry schema
- use declared bins to identify missing shim providers before falling back to incidental executables from installed tools
- preserve registry `overrides` ordering, verify installed candidates actually provide the requested executable, and declare npm's `npm`/`npx` bins
- cover the case where pinned npm is missing while Node's bundled npm is available

## Why

In [discussion #11493](https://github.com/jdx/mise/discussions/11493), invoking the `npm` shim could install or execute Node's bundled npm instead of the explicitly configured npm version. `install_missing_bin` previously learned executable ownership only from prior installs, so provider selection depended on local install history and did not have a pre-install discovery signal.

Registry bin metadata provides that signal. It is treated as a discovery hint: after installation, mise verifies the backend actually exposes the requested executable before returning it.

Follow-up: [registry-wide executable discovery in isolated sandboxes](https://github.com/jdx/mise/discussions/11667).

## Validation
- `cargo test registry::tests::`
- `mise run test:e2e e2e/registry/test_overrides_shims`
- `mise run lint-fix`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*