### PR TITLE
registry: add discovered bin metadata (1/4)

### DIFF
--- a/registry/1password.toml
+++ b/registry/1password.toml
@@ -1,4 +1,5 @@
 aliases = ["1password-cli", "op"]
 backends = ["vfox:mise-plugins/vfox-1password", "aqua:1password/cli"]
+bins = ["op"]
 description = "Password manager developed by AgileBits Inc"
 test = { cmd = "op --version", expected = "{{version}}" }

--- a/registry/aapt2.toml
+++ b/registry/aapt2.toml
@@ -1,3 +1,4 @@
 backends = ["vfox:mise-plugins/vfox-aapt2"]
+bins = ["aapt2"]
 description = "Android Asset Packaging Tool (aapt)"
 test = { cmd = "aapt2 version", expected = "Android Asset Packaging Tool (aapt)" } # version doesn't match

--- a/registry/acli.toml
+++ b/registry/acli.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:atlassian.com/acli"]
+bins = ["acli"]
 description = "Software to interact with Atlassian Cloud from the terminal"
 os = ["linux", "macos"]
 test = { cmd = "acli --version", expected = "acli version {{version}}" }

--- a/registry/act.toml
+++ b/registry/act.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:nektos/act", "asdf:gr1m0h/asdf-act"]
+bins = ["act"]
 description = "Run your GitHub Actions locally"
 test = { cmd = "act --version", expected = "act version {{version}}" }

--- a/registry/action-validator.toml
+++ b/registry/action-validator.toml
@@ -3,6 +3,7 @@ backends = [
   "asdf:mpalmer/action-validator",
   "cargo:action-validator",
 ]
+bins = ["action-validator"]
 description = "Tool to validate GitHub Action and Workflow YAML files"
 os = ["linux", "macos"]
 test = { cmd = "action-validator --version", expected = "action-validator {{version}}" }

--- a/registry/actionlint.toml
+++ b/registry/actionlint.toml
@@ -3,5 +3,6 @@ backends = [
   "asdf:crazy-matt/asdf-actionlint",
   "go:github.com/rhysd/actionlint/cmd/actionlint",
 ]
+bins = ["actionlint"]
 description = ":octocat: Static checker for GitHub Actions workflow files"
 test = { cmd = "actionlint --version", expected = "{{version}}" }

--- a/registry/adr-tools.toml
+++ b/registry/adr-tools.toml
@@ -2,5 +2,16 @@ backends = [
   "aqua:npryce/adr-tools",
   "asdf:https://gitlab.com/td7x/asdf/adr-tools",
 ]
+bins = [
+  "adr",
+  "adr-config",
+  "adr-generate",
+  "adr-help",
+  "adr-init",
+  "adr-link",
+  "adr-list",
+  "adr-new",
+  "adr-upgrade-repository",
+]
 description = "Command-line tools for working with Architecture Decision Records"
 test = { cmd = "adr help", expected = "adr help" }

--- a/registry/age.toml
+++ b/registry/age.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:FiloSottile/age", "asdf:threkk/asdf-age"]
+bins = ["age", "age-inspect", "age-keygen", "age-plugin-batchpass"]
 description = "A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability"
 test = { cmd = "age --version", expected = "v{{version}}" }

--- a/registry/agebox.toml
+++ b/registry/agebox.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:slok/agebox", "asdf:slok/asdf-agebox"]
+bins = ["agebox"]
 description = "Age based repository file encryption gitops tool"
 test = { cmd = "agebox --version", expected = "v{{version}}" }

--- a/registry/aichat.toml
+++ b/registry/aichat.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:sigoden/aichat"]
+bins = ["aichat"]
 description = "Use GPT-4(V), Gemini, LocalAI, Ollama and other LLMs in the terminal"
 test = { cmd = "aichat --version", expected = "{{version}}" }

--- a/registry/air.toml
+++ b/registry/air.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:air-verse/air", "asdf:pdemagny/asdf-air"]
+bins = ["air"]
 description = "Live reload for Go apps"
 test = { cmd = "air -v", expected = "{{version}}" }

--- a/registry/aks-engine.toml
+++ b/registry/aks-engine.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:Azure/aks-engine", "asdf:robsonpeixoto/asdf-aks-engine"]
+bins = ["aks-engine"]
 description = "AKS Engine deploys and manages Kubernetes clusters in Azure"
 test = { cmd = "aks-engine version", expected = "Version: v{{version}}" }

--- a/registry/allure.toml
+++ b/registry/allure.toml
@@ -1,3 +1,4 @@
 backends = ["github:allure-framework/allure2", "asdf:mise-plugins/mise-allure"]
+bins = ["allure"]
 description = "Allure Report is a popular open source tool for visualizing the results of a test run"
 test = { cmd = "allure --version", expected = "{{version}}" }

--- a/registry/allurectl.toml
+++ b/registry/allurectl.toml
@@ -1,3 +1,4 @@
 backends = ["github:allure-framework/allurectl"]
+bins = ["allurectl"]
 description = "allurectl is the command line wrapper of Allure TestOps' API allowing you to upload the test results in real time from a build job, and managing entities on Allure TestOps side (test cases, launches, projects)"
 test = { cmd = "allurectl --version", expected = "allurectl version {{version}}" }

--- a/registry/alp.toml
+++ b/registry/alp.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:tkuchiki/alp", "asdf:asdf-community/asdf-alp"]
+bins = ["alp"]
 description = "Access Log Profiler"
 test = { cmd = "alp --version", expected = "{{version}}" }

--- a/registry/amass.toml
+++ b/registry/amass.toml
@@ -1,3 +1,4 @@
 backends = ["github:owasp-amass/amass", "asdf:dhoeric/asdf-amass"]
+bins = ["amass"]
 description = "In-depth attack surface mapping and asset discovery"
 test = { cmd = "amass -version", expected = "v" } # version is wrong from the CLI

--- a/registry/amazon-ecr-credential-helper.toml
+++ b/registry/amazon-ecr-credential-helper.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:awslabs/amazon-ecr-credential-helper",
   "asdf:dex4er/asdf-amazon-ecr-credential-helper",
 ]
+bins = ["docker-credential-ecr-login"]
 description = "Automatically gets credentials for Amazon ECR on docker push/docker pull"
 test = { cmd = "docker-credential-ecr-login version", expected = "docker-credential-ecr-login (github.com/awslabs/amazon-ecr-credential-helper/ecr-login) {{version}}" }

--- a/registry/amazon-ecs-cli.toml
+++ b/registry/amazon-ecs-cli.toml
@@ -1,4 +1,5 @@
 aliases = ["ecs-cli"]
 backends = ["aqua:aws/amazon-ecs-cli"]
+bins = ["ecs-cli"]
 description = "The Amazon ECS CLI enables users to run their applications on ECS/Fargate using the Docker Compose file format, quickly provision resources, push/pull images in ECR, and monitor running applications on ECS/Fargate."
 test = { cmd = "ecs-cli --version", expected = "ecs-cli version {{version}}" }

--- a/registry/android-sdk.toml
+++ b/registry/android-sdk.toml
@@ -1,3 +1,15 @@
 backends = ["vfox:mise-plugins/vfox-android-sdk"]
+bins = [
+  "apkanalyzer",
+  "avdmanager",
+  "d8",
+  "lint",
+  "profgen",
+  "r8",
+  "resourceshrinker",
+  "retrace",
+  "screenshot2",
+  "sdkmanager",
+]
 description = "Android Command-line tools"
 test = { cmd = "sdkmanager --version", expected = ".0", tools = ["java"] }

--- a/registry/ansible-core.toml
+++ b/registry/ansible-core.toml
@@ -1,4 +1,16 @@
 aliases = ["ansible-base"]
 backends = ["pipx:ansible-core"]
+bins = [
+  "ansible",
+  "ansible-config",
+  "ansible-console",
+  "ansible-doc",
+  "ansible-galaxy",
+  "ansible-inventory",
+  "ansible-playbook",
+  "ansible-pull",
+  "ansible-test",
+  "ansible-vault",
+]
 description = "ansible-core python package contains the core runtime and CLI tools, such as ansible and ansible-playbook"
 test = { cmd = "ansible --version", expected = "ansible [core {{version}}]" }

--- a/registry/ansible.toml
+++ b/registry/ansible.toml
@@ -1,6 +1,19 @@
 description = "ansible python package contains the core runtime and CLI tools, such as ansible and ansible-playbook and extra modules, plugins, and roles"
 test = { cmd = "ansible --version", expected = "ansible" }
 
+bins = [
+  "ansible",
+  "ansible-community",
+  "ansible-config",
+  "ansible-console",
+  "ansible-doc",
+  "ansible-galaxy",
+  "ansible-inventory",
+  "ansible-playbook",
+  "ansible-pull",
+  "ansible-test",
+  "ansible-vault",
+]
 [[backends]]
 full = "pipx:ansible"
 

--- a/registry/ant.toml
+++ b/registry/ant.toml
@@ -1,3 +1,4 @@
 backends = ["vfox:mise-plugins/vfox-ant"]
+bins = ["ant"]
 description = "Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other"
 test = { cmd = "ant -version", expected = "Apache Ant(TM) version {{version}}" }

--- a/registry/antigravity-cli.toml
+++ b/registry/antigravity-cli.toml
@@ -1,4 +1,5 @@
 aliases = ["agy"]
 backends = ["aqua:google-antigravity/antigravity-cli"]
+bins = ["agy", "antigravity"]
 description = "Google's agentic development platform CLI companion"
 test = { cmd = "agy --version", expected = "{{version}}" }

--- a/registry/apko.toml
+++ b/registry/apko.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:chainguard-dev/apko", "asdf:omissis/asdf-apko"]
+bins = ["apko"]
 description = "Build OCI images from APK packages directly without Dockerfile"
 test = { cmd = "apko version", expected = "GitVersion:    v{{version}}" }

--- a/registry/apm.toml
+++ b/registry/apm.toml
@@ -1,3 +1,4 @@
 backends = ["github:microsoft/apm"]
+bins = ["apm"]
 description = "Agent Package Manager"
 test = { cmd = "apm --version", expected = "{{version}}" }

--- a/registry/apollo-router.toml
+++ b/registry/apollo-router.toml
@@ -1,3 +1,4 @@
 backends = ["github:apollographql/router", "asdf:safx/asdf-apollo-router"]
+bins = ["router"]
 description = "A configurable, high-performance routing runtime for Apollo Federation"
 test = { cmd = "router --version", expected = "{{version}}" }

--- a/registry/apollo-rover.toml
+++ b/registry/apollo-rover.toml
@@ -1,3 +1,4 @@
 backends = ["github:apollographql/rover"]
+bins = ["rover"]
 description = "The CLI for Apollo GraphOS"
 test = { cmd = "rover --version", expected = "Rover {{version}}" }

--- a/registry/aqua.toml
+++ b/registry/aqua.toml
@@ -1,3 +1,4 @@
 backends = ["github:aquaproj/aqua"]
+bins = ["aqua"]
 description = "Declarative CLI Version manager written in Go. Support Lazy Install, Registry, and continuous update with Renovate. CLI version is switched seamlessly"
 test = { cmd = "aqua version", expected = "{{version}}" }

--- a/registry/arduino.toml
+++ b/registry/arduino.toml
@@ -1,4 +1,5 @@
 aliases = ["arduino-cli"]
 backends = ["aqua:arduino/arduino-cli", "asdf:egnor/asdf-arduino-cli"]
+bins = ["arduino-cli"]
 description = "Arduino command line tool"
 test = { cmd = "arduino-cli version", expected = "arduino-cli  Version: {{version}}" }

--- a/registry/argc.toml
+++ b/registry/argc.toml
@@ -1,3 +1,4 @@
 backends = ["github:sigoden/argc"]
+bins = ["argc"]
 description = "A Bash CLI framework, also a Bash command runner"
 test = { cmd = "argc --argc-version", expected = "argc {{version}}" }

--- a/registry/argo-rollouts.toml
+++ b/registry/argo-rollouts.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:argoproj/argo-rollouts", "asdf:abatilo/asdf-argo-rollouts"]
+bins = ["kubectl-argo-rollouts"]
 description = "Progressive Delivery for Kubernetes"
 test = { cmd = "kubectl-argo-rollouts version", expected = "kubectl-argo-rollouts: v{{version}}" }

--- a/registry/argo.toml
+++ b/registry/argo.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:argoproj/argo-workflows", "asdf:sudermanjr/asdf-argo"]
+bins = ["argo"]
 description = "Argo Workflows CLI. Workflow engine for Kubernetes"
 test = { cmd = "argo version", expected = "argo: v{{version}}" }

--- a/registry/argocd.toml
+++ b/registry/argocd.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:argoproj/argo-cd", "asdf:beardix/asdf-argocd"]
+bins = ["argocd"]
 description = "Declarative continuous deployment for Kubernetes"
 test = { cmd = "argocd version --client", expected = "argocd: v{{version}}" }

--- a/registry/asciidoctorj.toml
+++ b/registry/asciidoctorj.toml
@@ -2,5 +2,6 @@ backends = [
   "vfox:mise-plugins/vfox-asciidoctorj",
   "asdf:mise-plugins/mise-asciidoctorj",
 ]
+bins = ["asciidoctorj"]
 description = "AsciidoctorJ is the official library for running Asciidoctor on the JVM. Using AsciidoctorJ, you can convert AsciiDoc content or analyze the structure of a parsed AsciiDoc document from Java and other JVM languages"
 test = { cmd = "asciidoctorj --version", expected = "AsciidoctorJ {{version}}" }

--- a/registry/aspire.toml
+++ b/registry/aspire.toml
@@ -2,3 +2,4 @@ description = "Aspire is the tool for code-first, extensible, observable dev and
 test = { cmd = "aspire --version", expected = "{{version}}" }
 
 backends = ["github:microsoft/aspire"]
+bins = ["aspire"]

--- a/registry/assh.toml
+++ b/registry/assh.toml
@@ -1,3 +1,4 @@
 backends = ["github:moul/assh", "asdf:mise-plugins/mise-assh"]
+bins = ["assh"]
 description = "make your ssh client smarter"
 test = { cmd = "assh --version", expected = "assh version " } # 2.16.0 reports version n/a

--- a/registry/ast-grep.toml
+++ b/registry/ast-grep.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:ast-grep/ast-grep", "cargo:ast-grep", "pipx:ast-grep-cli"]
+bins = ["ast-grep", "sg"]
 description = "A CLI tool for code structural search, lint and rewriting. Written in Rust"
 test = { cmd = "sg --version", expected = "ast-grep {{version}}" }

--- a/registry/astro.toml
+++ b/registry/astro.toml
@@ -1,5 +1,6 @@
 description = "CLI that makes it easy to create, test and deploy Airflow DAGs to Astronomer"
 test = { cmd = "astro version", expected = "Astro CLI Version: {{version}}" }
 
+bins = ["astro"]
 [[backends]]
 full = "github:astronomer/astro-cli"

--- a/registry/atlas-community.toml
+++ b/registry/atlas-community.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:ariga/atlas/community"]
+bins = ["atlas"]
 description = "A modern tool for managing database schemas (Community Edition)"
 test = { cmd = "atlas version", expected = "version v{{version}}" }

--- a/registry/atlas.toml
+++ b/registry/atlas.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:ariga/atlas", "asdf:komi1230/asdf-atlas"]
+bins = ["atlas"]
 description = "A modern tool for managing database schemas"
 test = { cmd = "atlas version", expected = "atlas version v{{version}}" }

--- a/registry/atmos.toml
+++ b/registry/atmos.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:cloudposse/atmos", "asdf:cloudposse/asdf-atmos"]
+bins = ["atmos"]
 description = "Workflow automation tool for DevOps. Keep configuration DRY with hierarchical imports of configurations, inheritance, and WAY more. Native support for Terraform and Helmfile"
 idiomatic_files = [".atmos-version"]
 test = { cmd = "atmos version", expected = "Atmos {{version}}" }

--- a/registry/atuin.toml
+++ b/registry/atuin.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:atuinsh/atuin", "cargo:atuin"]
+bins = ["atuin"]
 description = "✨ Magical shell history"
 test = { cmd = "atuin --version", expected = "atuin {{version}}" }

--- a/registry/aube.toml
+++ b/registry/aube.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:jdx/aube", "github:jdx/aube", "cargo:aube"]
+bins = ["aube", "aubr", "aubx"]
 description = "A fast Node.js package manager"
 test = { cmd = "aube --version", expected = "{{version}}" }

--- a/registry/auto-doc.toml
+++ b/registry/auto-doc.toml
@@ -1,3 +1,4 @@
 backends = ["github:tj-actions/auto-doc", "asdf:mise-plugins/mise-auto-doc"]
+bins = ["auto-doc"]
 description = "GitHub action that turns your reusable workflows and custom actions into easy to read markdown tables"
 test = { cmd = "auto-doc --help", expected = "auto-doc [flags]" }

--- a/registry/aws-amplify.toml
+++ b/registry/aws-amplify.toml
@@ -2,6 +2,7 @@ aliases = ["amplify"]
 description = "The AWS Amplify CLI is a toolchain for simplifying serverless web and mobile development"
 # test = ["amplify --version", "{{version}}"]  # hangs in CI
 
+bins = ["amplify"]
 [[backends]]
 full = "github:aws-amplify/amplify-cli"
 

--- a/registry/aws-cdk.toml
+++ b/registry/aws-cdk.toml
@@ -3,5 +3,6 @@ description = "AWS CDK CLI, the command line tool for CDK apps"
 detect = ["cdk.json"]
 test = { cmd = "cdk --version", expected = "{{version}}" }
 
+bins = ["cdk"]
 [[backends]]
 full = "npm:aws-cdk"

--- a/registry/aws-cli.toml
+++ b/registry/aws-cli.toml
@@ -3,6 +3,7 @@ backends = [
   { full = "aqua:aws/aws-cli", options = { symlink_bins = "true" } },
   "asdf:MetricMike/asdf-awscli",
 ]
+bins = ["aws", "aws_completer"]
 description = "The AWS Command Line Interface (AWS CLI v2) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services"
 os = ["linux", "macos"]
 test = { cmd = "aws --version", expected = "aws-cli/{{version}}" }

--- a/registry/aws-copilot.toml
+++ b/registry/aws-copilot.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:aws/copilot-cli", "asdf:NeoHsu/asdf-copilot"]
+bins = ["copilot"]
 description = "The AWS Copilot CLI is a tool for developers to build, release and operate production ready containerized applications on AWS App Runner, Amazon ECS, and AWS Fargate"
 test = { cmd = "copilot --version", expected = "copilot version: v{{version}}" }

--- a/registry/aws-iam-authenticator.toml
+++ b/registry/aws-iam-authenticator.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:kubernetes-sigs/aws-iam-authenticator",
   "asdf:zekker6/asdf-aws-iam-authenticator",
 ]
+bins = ["aws-iam-authenticator"]
 description = "A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster"
 test = { cmd = "aws-iam-authenticator version", expected = '"Version":"{{version}}"' }

--- a/registry/aws-nuke.toml
+++ b/registry/aws-nuke.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:ekristen/aws-nuke", "asdf:bersalazar/asdf-aws-nuke"]
+bins = ["aws-nuke"]
 description = "Remove all the resources from an AWS account"
 test = { cmd = "aws-nuke --version", expected = "aws-nuke version v{{version}}" }

--- a/registry/aws-sam.toml
+++ b/registry/aws-sam.toml
@@ -7,5 +7,6 @@ backends = [
   "pipx:aws-sam-cli",
   "asdf:mise-plugins/mise-pyapp",
 ]
+bins = ["sam"]
 description = "CLI tool to build, test, debug, and deploy Serverless applications using AWS SAM"
 test = { cmd = "sam --version", expected = "SAM CLI, version {{version}}" }

--- a/registry/aws-sso.toml
+++ b/registry/aws-sso.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:synfinatic/aws-sso-cli", "asdf:adamcrews/asdf-aws-sso-cli"]
+bins = ["aws-sso"]
 description = "A powerful tool for using AWS Identity Center for the CLI and web console"
 test = { cmd = "aws-sso version", expected = "AWS SSO CLI Version {{version}}" }

--- a/registry/aws-vault.toml
+++ b/registry/aws-vault.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:ByteNess/aws-vault"]
+bins = ["aws-vault"]
 description = "A vault for securely storing and accessing AWS credentials in development environments"
 # test = ["aws-vault --version", "v{{version}}"] # TODO: re-enable after versions host update

--- a/registry/awscli-local.toml
+++ b/registry/awscli-local.toml
@@ -1,6 +1,7 @@
 description = "This package provides the awslocal command, which is a thin wrapper around the aws command line interface for use with LocalStack"
 test = { cmd = "awslocal --version", expected = "aws-cli/" }
 
+bins = ["awslocal"]
 [[backends]]
 full = "pipx:awscli-local"
 

--- a/registry/awsebcli.toml
+++ b/registry/awsebcli.toml
@@ -1,3 +1,4 @@
 backends = ["pipx:awsebcli", "asdf:mise-plugins/mise-pyapp"]
+bins = ["eb", "ebp"]
 description = "The AWS Elastic Beanstalk Command Line Interface (EB CLI) is a tool that helps you deploy and manage your Elastic Beanstalk applications and environments. It also provides integration with Git"
 test = { cmd = "eb --version", expected = "EB CLI {{version}}" }

--- a/registry/awsls.toml
+++ b/registry/awsls.toml
@@ -1,3 +1,4 @@
 backends = ["github:jckuester/awsls", "asdf:chessmango/asdf-awsls"]
+bins = ["awsls"]
 description = "A list command for AWS resources"
 test = { cmd = "awsls --version", expected = "version: {{version}}" }

--- a/registry/awsrm.toml
+++ b/registry/awsrm.toml
@@ -1,3 +1,4 @@
 backends = ["github:jckuester/awsrm", "asdf:chessmango/asdf-awsrm"]
+bins = ["awsrm"]
 description = "A remove command for AWS resources"
 test = { cmd = "awsrm --version", expected = "version: {{version}}" }

--- a/registry/awsweeper.toml
+++ b/registry/awsweeper.toml
@@ -1,3 +1,4 @@
 backends = ["github:jckuester/awsweeper", "asdf:chessmango/asdf-awsweeper"]
+bins = ["awsweeper"]
 description = "A tool for cleaning your AWS account"
 test = { cmd = "awsweeper --version", expected = "version: {{version}}" }

--- a/registry/azd.toml
+++ b/registry/azd.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:Azure/azure-dev"]
+bins = ["azd"]
 description = "Azure Developer CLI - developer-centric command-line tool for creating Azure applications"
 test = { cmd = "azd version", expected = "azd version {{ version | trim_start(pat='azure-dev-cli_') }}" }

--- a/registry/azure-functions-core-tools.toml
+++ b/registry/azure-functions-core-tools.toml
@@ -2,4 +2,5 @@ backends = [
   "vfox:mise-plugins/vfox-azure-functions-core-tools",
   "asdf:mise-plugins/mise-azure-functions-core-tools",
 ]
+bins = ["func"]
 description = "Command line tools for Azure Functions"

--- a/registry/azure-kubelogin.toml
+++ b/registry/azure-kubelogin.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:Azure/kubelogin", "asdf:sechmann/asdf-kubelogin"]
+bins = ["kubelogin"]
 description = "A Kubernetes credential (exec) plugin implementing azure authentication"
 test = { cmd = "kubelogin --version", expected = "git hash: v{{version}}" }

--- a/registry/azure.toml
+++ b/registry/azure.toml
@@ -2,6 +2,7 @@ aliases = ["azure-cli"]
 description = "azure-cli (az)"
 test = { cmd = "az --version", expected = "azure-cli                         {{version}}" }
 
+bins = ["az"]
 [[backends]]
 full = "pipx:azure-cli"
 

--- a/registry/babashka.toml
+++ b/registry/babashka.toml
@@ -1,6 +1,7 @@
 description = "Native, fast starting Clojure interpreter for scripting"
 test = { cmd = "bb --version", expected = "babashka v{{version}}" }
 
+bins = ["bb"]
 [[backends]]
 full = "github:babashka/babashka"
 

--- a/registry/balena.toml
+++ b/registry/balena.toml
@@ -1,4 +1,5 @@
 aliases = ["balena-cli"]
 backends = ["github:balena-io/balena-cli", "asdf:jaredallard/asdf-balena-cli"]
+bins = ["balena"]
 description = "The balena CLI is a Command Line Interface for balenaCloud or openBalena"
 test = { cmd = "balena --version", expected = "{{version}}" }

--- a/registry/bashbot.toml
+++ b/registry/bashbot.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:mathew-fleisch/bashbot", "asdf:mathew-fleisch/asdf-bashbot"]
+bins = ["bashbot"]
 description = "A slack-bot written in golang for infrastructure/devops teams"
 test = { cmd = "bashbot version", expected = "v{{version}}" }

--- a/registry/bashly.toml
+++ b/registry/bashly.toml
@@ -1,3 +1,4 @@
 backends = ["gem:bashly"]
+bins = ["bashly"]
 description = "Bashly is a command line application (written in Ruby) that lets you generate feature-rich bash command line tools"
 # test = ["bashly --version", "{{version}}"]  # not working in CI

--- a/registry/bat-extras.toml
+++ b/registry/bat-extras.toml
@@ -1,3 +1,12 @@
 backends = ["aqua:eth-p/bat-extras", "asdf:mise-plugins/mise-bat-extras"]
+bins = [
+  "bat-modules",
+  "batdiff",
+  "batgrep",
+  "batman",
+  "batpipe",
+  "batwatch",
+  "prettybat",
+]
 description = "Bash scripts that integrate bat with various command line tools"
 test = { cmd = "batman --version", expected = "batman {{version}}" }

--- a/registry/bat.toml
+++ b/registry/bat.toml
@@ -3,5 +3,6 @@ backends = [
   "cargo:bat",
   "asdf:https://gitlab.com/wt0f/asdf-bat",
 ]
+bins = ["bat"]
 description = "A cat(1) clone with wings"
 test = { cmd = "bat --version", expected = "bat {{version}}" }

--- a/registry/bats.toml
+++ b/registry/bats.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:bats-core/bats-core", "asdf:timgluz/asdf-bats"]
+bins = ["bats"]
 description = "Bash Automated Testing System"
 os = ["linux", "macos"]
 test = { cmd = "bats -v", expected = "Bats" }

--- a/registry/bazel-watcher.toml
+++ b/registry/bazel-watcher.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:bazelbuild/bazel-watcher"]
+bins = ["ibazel"]
 description = "Tools for building Bazel targets when source files change"
 test = { cmd = "ibazel version", expected = "iBazel - Version v{{version}}" }

--- a/registry/bazel.toml
+++ b/registry/bazel.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:bazelbuild/bazel", "asdf:rajatvig/asdf-bazel"]
+bins = ["bazel"]
 description = "a fast, scalable, multi-language and extensible build system"
 test = { cmd = "bazel --version", expected = "bazel {{version}}" }

--- a/registry/bazelisk.toml
+++ b/registry/bazelisk.toml
@@ -3,5 +3,6 @@ backends = [
   "npm:@bazel/bazelisk",
   "asdf:josephtate/asdf-bazelisk",
 ]
+bins = ["bazelisk"]
 description = "A user-friendly launcher for Bazel"
 test = { cmd = "bazelisk --version", expected = "bazel" } # shows bazel version, not bazelisk version

--- a/registry/betterleaks.toml
+++ b/registry/betterleaks.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:betterleaks/betterleaks", "github:betterleaks/betterleaks"]
+bins = ["betterleaks"]
 description = "Betterleaks scans code, past or present, for secrets"
 test = { cmd = "betterleaks --version", expected = "betterleaks version {{version}}" }

--- a/registry/bfs.toml
+++ b/registry/bfs.toml
@@ -1,4 +1,5 @@
 backends = ["vfox:mise-plugins/vfox-bfs", "asdf:mise-plugins/mise-bfs"]
+bins = ["bfs"]
 description = "Breadth-first search for your files"
 # TODO: re-enable once bfs reports the full resolved version; 4.1.1 currently reports "bfs 4.1".
 # test = { cmd = "bfs --version", expected = "bfs {{version}}" }

--- a/registry/bibtex-tidy.toml
+++ b/registry/bibtex-tidy.toml
@@ -1,6 +1,7 @@
 description = "Cleaner and Formatter for BibTeX files"
 test = { cmd = "bibtex-tidy --version", expected = "v{{version}}" }
 
+bins = ["bibtex-tidy"]
 [[backends]]
 full = "npm:bibtex-tidy"
 

--- a/registry/binnacle.toml
+++ b/registry/binnacle.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:Traackr/binnacle", "asdf:Traackr/asdf-binnacle"]
+bins = ["binnacle"]
 description = "An opinionated tool to interact with Kubernetes' Helm"
 test = { cmd = "binnacle --version", expected = "binnacle version {{version}}" }

--- a/registry/biome.toml
+++ b/registry/biome.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:biomejs/biome", "npm:@biomejs/biome"]
+bins = ["biome"]
 description = "A toolchain for web projects, aimed to provide functionalities to maintain them. Biome offers formatter and linter, usable via CLI and LSP"
 test = { cmd = "biome --version", expected = "Version: {{version}}" }

--- a/registry/bitwarden-secrets-manager.toml
+++ b/registry/bitwarden-secrets-manager.toml
@@ -1,6 +1,7 @@
 description = "CLI for interacting with the Bitwarden Secrets Manager"
 test = { cmd = "bws --version", expected = "bws {{version}}" }
 
+bins = ["bws"]
 [[backends]]
 full = "aqua:bitwarden/sdk-sm"
 

--- a/registry/bitwarden.toml
+++ b/registry/bitwarden.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:bitwarden/clients", "asdf:vixus0/asdf-bitwarden"]
+bins = ["bw"]
 description = "Bitwarden CLI"
 test = { cmd = "bw --version", expected = "{{version}}" }

--- a/registry/black.toml
+++ b/registry/black.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:psf/black"]
+bins = ["black"]
 description = "The uncompromising Python code formatter"
 test = { cmd = "black --version", expected = "black, {{version}}" }

--- a/registry/blender.toml
+++ b/registry/blender.toml
@@ -1,3 +1,9 @@
 backends = ["aqua:blender/blender"]
+bins = [
+  "blender",
+  "blender-launcher",
+  "blender-system-info.sh",
+  "blender-thumbnailer",
+]
 description = "Blender is a free and open-source 3D computer graphics software"
 test = { cmd = "blender --version", expected = "Blender {{version}}" }

--- a/registry/bob.toml
+++ b/registry/bob.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:MordechaiHadad/bob", "cargo:bob-nvim"]
+bins = ["bob"]
 description = "A version manager for neovim"
 test = { cmd = "bob --version", expected = "bob-nvim {{version}}" }

--- a/registry/boilerplate.toml
+++ b/registry/boilerplate.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:gruntwork-io/boilerplate"]
+bins = ["boilerplate"]
 description = 'A tool for generating files and folders ("boilerplate") from a set of templates'
 test = { cmd = "boilerplate --version", expected = "boilerplate version v{{version}}" }

--- a/registry/bombardier.toml
+++ b/registry/bombardier.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:codesenberg/bombardier", "asdf:NeoHsu/asdf-bombardier"]
+bins = ["bombardier"]
 description = "Fast cross-platform HTTP benchmarking tool written in Go"
 test = { cmd = "bombardier --version", expected = "bombardier version" } # shows "unspecified"

--- a/registry/borg.toml
+++ b/registry/borg.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:borgbackup/borg", "asdf:lwiechec/asdf-borg"]
+bins = ["borg"]
 description = "Deduplicating archiver with compression and authenticated encryption"
 test = { cmd = "borg --version", expected = "borg {{version}}" }

--- a/registry/bosh.toml
+++ b/registry/bosh.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:cloudfoundry/bosh-cli",
   "asdf:mise-plugins/tanzu-plug-in-for-asdf",
 ]
+bins = ["bosh"]
 description = "The bosh CLI is the command line tool used for interacting with all things BOSH, from deployment operations to software release management"
 test = { cmd = "bosh --version", expected = "version {{version}}" }

--- a/registry/bottom.toml
+++ b/registry/bottom.toml
@@ -3,6 +3,7 @@ backends = [
   "asdf:carbonteq/asdf-btm",
   "cargo:bottom",
 ]
+bins = ["btm"]
 description = "Yet another cross-platform graphical process/system monitor"
 # TODO: re-enable once latest resolves to a release whose binary reports the same version string.
 # test = { cmd = "btm --version", expected = "bottom {{version}}" }

--- a/registry/boundary.toml
+++ b/registry/boundary.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:hashicorp/boundary", "asdf:mise-plugins/mise-hashicorp"]
+bins = ["boundary"]
 description = "Boundary enables identity-based access management for dynamic infrastructure"
 test = { cmd = "boundary version", expected = "Version Number:      {{version}}" }

--- a/registry/bpkg.toml
+++ b/registry/bpkg.toml
@@ -1,3 +1,22 @@
 backends = ["vfox:mise-plugins/vfox-bpkg", "asdf:mise-plugins/mise-bpkg"]
+bins = [
+  "bpkg",
+  "bpkg-env",
+  "bpkg-getdeps",
+  "bpkg-init",
+  "bpkg-install",
+  "bpkg-json",
+  "bpkg-list",
+  "bpkg-package",
+  "bpkg-realpath",
+  "bpkg-run",
+  "bpkg-show",
+  "bpkg-source",
+  "bpkg-suggest",
+  "bpkg-term",
+  "bpkg-update",
+  "bpkg-utils",
+  "bpkg.sh",
+]
 description = "Lightweight bash package manager"
 test = { cmd = "bpkg --version", expected = "{{version}}" }

--- a/registry/btop.toml
+++ b/registry/btop.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:aristocratos/btop"]
+bins = ["btop"]
 description = "A monitor of resources"
 # TODO: re-enable once upstream aquaproj/aqua-registry uses the current .tar.gz assets for recent btop releases.
 # test = { cmd = "btop --version", expected = "btop version: {{version}}" }

--- a/registry/buck2.toml
+++ b/registry/buck2.toml
@@ -2,6 +2,7 @@ description = "A fast, hermetic, multi-language build system"
 # test disabled: facebook replaces assets in-place on "latest" tag causing checksum race conditions
 # test = ["buck2 --version", "buck2"]
 
+bins = ["buck2"]
 [[backends]]
 full = "aqua:facebook/buck2"
 

--- a/registry/buf.toml
+++ b/registry/buf.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:bufbuild/buf", "asdf:truepay/asdf-buf"]
+bins = ["buf", "protoc-gen-buf-breaking", "protoc-gen-buf-lint"]
 description = "The best way of working with Protocol Buffers"
 test = { cmd = "buf --version", expected = "{{version}}" }

--- a/registry/buildifier.toml
+++ b/registry/buildifier.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:bazelbuild/buildtools/buildifier"]
+bins = ["buildifier"]
 description = "buildifier: For formatting BUILD, BUILD.bazel and BUCK files in a standard way"
 test = { cmd = "buildifier --version", expected = "buildifier version: {{version}}" }

--- a/registry/buildpack.toml
+++ b/registry/buildpack.toml
@@ -1,4 +1,5 @@
 aliases = ["pack", "buildpacks"]
 backends = ["aqua:buildpacks/pack", "asdf:johnlayton/asdf-buildpack"]
+bins = ["pack"]
 description = "CLI for building apps using Cloud Native Buildpacks"
 test = { cmd = "pack --version", expected = "{{version}}" }

--- a/registry/bun.toml
+++ b/registry/bun.toml
@@ -1,4 +1,5 @@
 backends = ["core:bun"]
+bins = ["bun", "bunx"]
 description = "Bun is a fast JavaScript all-in-one toolkit"
 detect = ["bun.lock", "bun.lockb", "bunfig.toml"]
 idiomatic_files = [".bun-version", "package.json"]

--- a/registry/bundler.toml
+++ b/registry/bundler.toml
@@ -1,4 +1,5 @@
 backends = ["gem:bundler"]
+bins = ["bundle", "bundler"]
 description = "The best way to manage a Ruby application's gems"
 overrides = ["ruby"]
 test = { cmd = "bundle --version", expected = "{{version}}" }

--- a/registry/cabal.toml
+++ b/registry/cabal.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:haskell/cabal/cabal-install"]
+bins = ["cabal"]
 description = "Cabal(haskell): Common Architecture for Building Applications and Libraries"
 test = { cmd = "cabal --version", expected = "cabal-install version {{version}}" }

--- a/registry/caddy.toml
+++ b/registry/caddy.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:caddyserver/caddy", "asdf:salasrod/asdf-caddy"]
+bins = ["caddy"]
 description = "Fast, multi-platform web server with automatic HTTPS"
 test = { cmd = "caddy --version", expected = "v{{version}}" }

--- a/registry/calendarsync.toml
+++ b/registry/calendarsync.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:inovex/CalendarSync", "asdf:FeryET/asdf-calendarsync"]
+bins = ["CalendarSync"]
 description = "Stateless CLI tool to sync calendars across different calendaring systems"
 test = { cmd = "CalendarSync --version", expected = "Version: {{version}}" }

--- a/registry/calicoctl.toml
+++ b/registry/calicoctl.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:projectcalico/calico/calicoctl",
   "asdf:TheCubicleJockey/asdf-calicoctl",
 ]
+bins = ["calicoctl"]
 description = "Cloud native networking and network security"
 test = { cmd = "calicoctl version", expected = "Client Version:    v{{version}}" }

--- a/registry/carapace.toml
+++ b/registry/carapace.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:carapace-sh/carapace-bin"]
+bins = ["carapace"]
 description = "A multi-shell completion binary"
 test = { cmd = "carapace --version", expected = "carapace-bin {{version}}" }

--- a/registry/cargo-binstall.toml
+++ b/registry/cargo-binstall.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:cargo-bins/cargo-binstall", "cargo:cargo-binstall"]
+bins = ["cargo-binstall"]
 description = "Binary installation for rust projects"
 test = { cmd = "cargo binstall -V", expected = "{{version}}" }

--- a/registry/cargo-dist.toml
+++ b/registry/cargo-dist.toml
@@ -3,5 +3,6 @@ backends = [
   "github:axodotdev/cargo-dist",
   "cargo:cargo-dist",
 ]
+bins = ["dist"]
 description = "📦 shippable application packaging"
 test = { cmd = "dist --version", expected = "cargo-dist {{version}}" }

--- a/registry/cargo-insta.toml
+++ b/registry/cargo-insta.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:mitsuhiko/insta", "cargo:insta"]
+bins = ["cargo-insta"]
 description = "A snapshot testing library for rust"
 test = { cmd = "cargo insta --version", expected = "cargo-insta {{version}}" }

--- a/registry/cargo-make.toml
+++ b/registry/cargo-make.toml
@@ -3,5 +3,6 @@ backends = [
   "asdf:mise-plugins/asdf-cargo-make",
   "cargo:cargo-make",
 ]
+bins = ["cargo-make", "makers"]
 description = "Rust task runner and build tool"
 test = { cmd = "makers --version", expected = "cargo-make {{version}}" }

--- a/registry/cargo-msrv.toml
+++ b/registry/cargo-msrv.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:foresterre/cargo-msrv", "cargo:cargo-msrv"]
+bins = ["cargo-msrv"]
 description = "Find the minimum supported Rust version for your project"
 test = { cmd = "cargo msrv --version", expected = "cargo-msrv {{version}}" }

--- a/registry/ccache.toml
+++ b/registry/ccache.toml
@@ -1,3 +1,4 @@
 backends = ["github:ccache/ccache", "asdf:asdf-community/asdf-ccache"]
+bins = ["ccache"]
 description = "ccache – a fast compiler cache"
 test = { cmd = "ccache --version", expected = "ccache version {{version}}" }

--- a/registry/certstrap.toml
+++ b/registry/certstrap.toml
@@ -1,3 +1,4 @@
 backends = ["github:square/certstrap", "asdf:carnei-ro/asdf-certstrap"]
+bins = ["certstrap"]
 description = "Tools to bootstrap CAs, certificate requests, and signed certificates"
 test = { cmd = "certstrap --version", expected = "certstrap version {{version}}" }

--- a/registry/cf.toml
+++ b/registry/cf.toml
@@ -1,3 +1,4 @@
 backends = ["github:cloudfoundry/cli", "asdf:mise-plugins/mise-cf"]
+bins = ["cf", "cf8"]
 description = "The official command line client for Cloud Foundry"
 test = { cmd = "cf version", expected = "cf version {{version}}" }

--- a/registry/cfn-lint.toml
+++ b/registry/cfn-lint.toml
@@ -1,3 +1,4 @@
 backends = ["pipx:cfn-lint"]
+bins = ["cfn-lint"]
 description = "Checks CloudFormation templates for practices and behaviour that could potentially be improved"
 # test = ["cfn-lint --version", "cfn-lint {{version}}"] # disabled: failing in CI

--- a/registry/cfssl.toml
+++ b/registry/cfssl.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:cloudflare/cfssl/cfssl", "asdf:mathew-fleisch/asdf-cfssl"]
+bins = ["cfssl"]
 description = "CFSSL: Cloudflare's PKI and TLS toolkit"

--- a/registry/cfssljson.toml
+++ b/registry/cfssljson.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:cloudflare/cfssl/cfssljson"]
+bins = ["cfssljson"]
 description = "cfssljson: Takes the JSON output from Cloudflare's cfssl and multirootca programs and writes certificates, keys, CSRs, and bundles to disk."
 test = { cmd = "cfssljson -version", expected = "Version: {{version}}" }

--- a/registry/chamber.toml
+++ b/registry/chamber.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:segmentio/chamber", "asdf:mintel/asdf-chamber"]
+bins = ["chamber"]
 description = "CLI for managing secrets"
 test = { cmd = "chamber version", expected = "chamber v{{version}}" }

--- a/registry/changie.toml
+++ b/registry/changie.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:miniscruff/changie", "asdf:pdemagny/asdf-changie"]
+bins = ["changie"]
 description = "Automated changelog tool for preparing releases with lots of customization options"
 test = { cmd = "changie --version", expected = "changie version v{{version}}" }

--- a/registry/cheat.toml
+++ b/registry/cheat.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:cheat/cheat", "asdf:jmoratilla/asdf-cheat-plugin"]
+bins = ["cheat"]
 description = "cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind *nix system administrators of options for commands that they use frequently, but not frequently enough to remember"

--- a/registry/checkmake.toml
+++ b/registry/checkmake.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:checkmake/checkmake"]
+bins = ["checkmake"]
 description = "Linter/analyzer for Makefiles"
 test = { cmd = "checkmake --version", expected = "checkmake v{{version}}" }

--- a/registry/checkov.toml
+++ b/registry/checkov.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:bridgecrewio/checkov", "asdf:bosmak/asdf-checkov"]
+bins = ["checkov"]
 description = "Prevent cloud misconfigurations and find vulnerabilities during build-time in infrastructure as code, container images and open source packages with Checkov by Bridgecrew"
 test = { cmd = "checkov --help", expected = "usage: checkov" }

--- a/registry/checkstyle.toml
+++ b/registry/checkstyle.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:checkstyle/checkstyle"]
+bins = ["checkstyle"]
 description = "Checks Java source code against a coding standard"
 test = { cmd = 'java -jar "$(command -v checkstyle)" --version', expected = "Checkstyle version: {{version}}", tools = [
   "java",

--- a/registry/chezmoi.toml
+++ b/registry/chezmoi.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:twpayne/chezmoi", "asdf:joke/asdf-chezmoi"]
+bins = ["chezmoi"]
 description = "Manage your dotfiles across multiple diverse machines, securely"
 idiomatic_files = [".chezmoiversion"]
 test = { cmd = "chezmoi --version", expected = "chezmoi version v{{version}}" }

--- a/registry/chicken.toml
+++ b/registry/chicken.toml
@@ -1,4 +1,15 @@
 backends = ["vfox:mise-plugins/vfox-chicken"]
+bins = [
+  "chicken",
+  "chicken-do",
+  "chicken-install",
+  "chicken-profile",
+  "chicken-status",
+  "chicken-uninstall",
+  "csc",
+  "csi",
+  "feathers",
+]
 description = "CHICKEN is a compiler for the Scheme programming language"
 os = ["linux", "macos", "freebsd", "openbsd"]
 test = { cmd = "csi -version", expected = "Version" }

--- a/registry/chisel.toml
+++ b/registry/chisel.toml
@@ -3,5 +3,6 @@ backends = [
   "go:github.com/jpillora/chisel",
   "asdf:lwiechec/asdf-chisel",
 ]
+bins = ["chisel"]
 description = "A fast TCP/UDP tunnel over HTTP"
 test = { cmd = "chisel --version", expected = "{{version}}" }

--- a/registry/choose.toml
+++ b/registry/choose.toml
@@ -3,5 +3,6 @@ backends = [
   "cargo:choose",
   "asdf:carbonteq/asdf-choose",
 ]
+bins = ["choose"]
 description = "A human-friendly and fast alternative to cut (and sometimes awk)"
 test = { cmd = "choose --version", expected = "{{version}}" }

--- a/registry/chromedriver.toml
+++ b/registry/chromedriver.toml
@@ -2,5 +2,6 @@ backends = [
   "vfox:mise-plugins/vfox-chromedriver",
   "asdf:mise-plugins/mise-chromedriver",
 ]
+bins = ["chromedriver"]
 description = "ChromeDriver is a standalone server that implements the W3C WebDriver and WebDriver BiDi standards"
 test = { cmd = "chromedriver --version", expected = "ChromeDriver {{version}}" }

--- a/registry/cidr-merger.toml
+++ b/registry/cidr-merger.toml
@@ -1,3 +1,4 @@
 backends = ["github:zhanhb/cidr-merger", "asdf:ORCID/asdf-cidr-merger"]
+bins = ["cidr-merger"]
 description = "A simple command line tool to merge ip/ip cidr/ip range, supports IPv4/IPv6"
 test = { cmd = "cidr-merger --version", expected = "cidr merger {{version}}" }

--- a/registry/cidrchk.toml
+++ b/registry/cidrchk.toml
@@ -1,3 +1,4 @@
 backends = ["github:mhausenblas/cidrchk", "asdf:ORCID/asdf-cidrchk"]
+bins = ["cidrchk"]
 description = "CLI tool for CIDR range operations (check, generate)"
 test = { cmd = "cidrchk --version", expected = "{{version}}," }

--- a/registry/cilium-cli.toml
+++ b/registry/cilium-cli.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:cilium/cilium-cli", "asdf:carnei-ro/asdf-cilium-cli"]
+bins = ["cilium"]
 description = "CLI to install, manage & troubleshoot Kubernetes clusters running Cilium"
 test = { cmd = "cilium version", expected = "cilium-cli: v{{version}}" }

--- a/registry/cilium-hubble.toml
+++ b/registry/cilium-hubble.toml
@@ -3,5 +3,6 @@ backends = [
   "github:cilium/hubble",
   "asdf:NitriKx/asdf-cilium-hubble",
 ]
+bins = ["hubble"]
 description = "Hubble - Network, Service & Security Observability for Kubernetes using eBPF"
 test = { cmd = "hubble --version", expected = "{{version}}" }

--- a/registry/circleci.toml
+++ b/registry/circleci.toml
@@ -1,4 +1,5 @@
 aliases = ["circleci-cli"]
 backends = ["aqua:CircleCI-Public/circleci-cli", "asdf:ucpr/asdf-circleci-cli"]
+bins = ["circleci"]
 description = "Use CircleCI from the command line"
 test = { cmd = "circleci version", expected = "{{version}}" }

--- a/registry/claude-powerline.toml
+++ b/registry/claude-powerline.toml
@@ -1,3 +1,4 @@
 backends = ["npm:@owloops/claude-powerline"]
+bins = ["claude-powerline"]
 description = "Beautiful vim-style powerline statusline for Claude Code"
 test = { cmd = "claude-powerline --help", expected = "claude-powerline [options]" }

--- a/registry/claude-squad.toml
+++ b/registry/claude-squad.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:smtg-ai/claude-squad"]
+bins = ["claude-squad", "cs"]
 description = "Manage multiple AI agents like Claude Code, Aider, Codex, and Amp. 10x your productivity"
 test = { cmd = "claude-squad version", expected = """
 claude-squad version {{version}}

--- a/registry/claude.toml
+++ b/registry/claude.toml
@@ -3,6 +3,7 @@ description = "Claude Code is an agentic coding tool that lives in your terminal
 os = ["linux", "macos", "windows"]
 test = { cmd = "claude --version", expected = "{{version}} (Claude Code)" }
 
+bins = ["claude"]
 [[backends]]
 full = "aqua:anthropics/claude-code"
 platforms = ["linux", "macos"]

--- a/registry/clickhouse.toml
+++ b/registry/clickhouse.toml
@@ -2,5 +2,15 @@ backends = [
   "vfox:mise-plugins/vfox-clickhouse",
   "asdf:mise-plugins/mise-clickhouse",
 ]
+bins = [
+  "clickhouse",
+  "clickhouse-benchmark",
+  "clickhouse-client",
+  "clickhouse-compressor",
+  "clickhouse-format",
+  "clickhouse-local",
+  "clickhouse-obfuscator",
+  "clickhouse-server",
+]
 description = "ClickHouse® is a high-performance, column-oriented SQL database management system (DBMS) for online analytical processing (OLAP)"
 test = { cmd = "clickhouse --version", expected = "ClickHouse local version {{version | trim_end(pat='-lts') | trim_end(pat='-stable')}}" }

--- a/registry/clj-kondo.toml
+++ b/registry/clj-kondo.toml
@@ -1,3 +1,4 @@
 backends = ["github:clj-kondo/clj-kondo", "asdf:rynkowsg/asdf-clj-kondo"]
+bins = ["clj-kondo"]
 description = "Static analyzer and linter for Clojure code that sparks joy"
 test = { cmd = "clj-kondo --version", expected = "{{version}}" }

--- a/registry/cljstyle.toml
+++ b/registry/cljstyle.toml
@@ -1,4 +1,5 @@
 backends = ["github:greglook/cljstyle", "asdf:abogoyavlensky/asdf-cljstyle"]
+bins = ["cljstyle"]
 description = "A tool for formatting Clojure code"
 os = ["linux", "macos"]
 test = { cmd = "cljstyle version", expected = "mvxcvi/cljstyle {{version}}" }

--- a/registry/clojure.toml
+++ b/registry/clojure.toml
@@ -1,2 +1,3 @@
 backends = ["vfox:jdx/vfox-clojure", "asdf:mise-plugins/mise-clojure"]
+bins = ["clj", "clojure"]
 description = "The Clojure Programming Language"

--- a/registry/cloud-sql-proxy.toml
+++ b/registry/cloud-sql-proxy.toml
@@ -2,4 +2,5 @@ backends = [
   "aqua:GoogleCloudPlatform/cloud-sql-proxy",
   "asdf:pbr0ck3r/asdf-cloud-sql-proxy",
 ]
+bins = ["cloud-sql-proxy"]
 description = "A utility for connecting securely to your Cloud SQL instances"

--- a/registry/cloudflared.toml
+++ b/registry/cloudflared.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:cloudflare/cloudflared", "asdf:threkk/asdf-cloudflared"]
+bins = ["cloudflared"]
 description = "cloudflared connects your machine or user identity to Cloudflare's global network"
 test = { cmd = "cloudflared -v", expected = "cloudflared version {{version}}" }

--- a/registry/clusterawsadm.toml
+++ b/registry/clusterawsadm.toml
@@ -1,12 +1,13 @@
 description = "clusterawsadm provides helpers for bootstrapping Kubernetes Cluster API Provider AWS"
-test = { cmd = "cluster-api-provider-aws version", expected = "clusterawsadm version:" }
+test = { cmd = "clusterawsadm version", expected = "clusterawsadm version:" }
 
+bins = ["clusterawsadm"]
 [[backends]]
 full = "github:kubernetes-sigs/cluster-api-provider-aws"
 
 [backends.options]
 asset_pattern = "clusterawsadm-{darwin_os}-{amd64_arch}"
-bin = "cluster-api-provider-aws"
+bin = "clusterawsadm"
 
 [[backends]]
 full = "asdf:kahun/asdf-clusterawsadm"

--- a/registry/clusterctl.toml
+++ b/registry/clusterctl.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:kubernetes-sigs/cluster-api",
   "asdf:pfnet-research/asdf-clusterctl",
 ]
+bins = ["clusterctl"]
 description = "Home for Cluster API, a subproject of sig-cluster-lifecycle"
 test = { cmd = "clusterctl version", expected = "{{version}}" }

--- a/registry/cmake.toml
+++ b/registry/cmake.toml
@@ -3,6 +3,7 @@ backends = [
   "asdf:mise-plugins/mise-cmake",
   "vfox:mise-plugins/vfox-cmake",
 ]
+bins = ["ccmake", "cmake", "cmake-gui", "cpack", "ctest"]
 description = "CMake is a tool to manage building of source code. Originally, CMake was designed as a generator for various dialects of Makefile, today CMake generates modern buildsystems such as Ninja as well as project files for IDEs such as Visual Studio and Xcode"
 idiomatic_files = [
   { path = "CMakeLists.txt", version_regex = '''(?im)^\s*cmake_minimum_required\s*\(\s*VERSION\s+v?([0-9]+(?:\.[0-9]+){0,3})''' },

--- a/registry/cmctl.toml
+++ b/registry/cmctl.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:cert-manager/cmctl", "asdf:asdf-community/asdf-cmctl"]
+bins = ["cmctl"]
 description = "the command line utility that makes cert-manager'ing easier"

--- a/registry/cmdx.toml
+++ b/registry/cmdx.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:suzuki-shunsuke/cmdx"]
+bins = ["cmdx"]
 description = "Task runner. It provides useful help messages and supports interactive prompts and validation of arguments"
 test = { cmd = "cmdx version", expected = "cmdx version {{version}}" }

--- a/registry/cockroach.toml
+++ b/registry/cockroach.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:cockroachdb/cockroach", "asdf:salasrod/asdf-cockroach"]
+bins = ["cockroach"]
 description = "A distributed SQL database designed for speed, scale, and survival"
 test = { cmd = "cockroach version", expected = "v{{version}}" }

--- a/registry/cocogitto.toml
+++ b/registry/cocogitto.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:cocogitto/cocogitto"]
+bins = ["cog"]
 description = "The Conventional Commits toolbox"
 test = { cmd = "cog --version", expected = "cog {{version}}" }

--- a/registry/code-review-graph.toml
+++ b/registry/code-review-graph.toml
@@ -1,3 +1,4 @@
+bins = ["code-review-graph", "crg-daemon"]
 description = "code-review-graph: Stop burning tokens. Start reviewing smarter."
 test = { cmd = "code-review-graph --version", expected = "code-review-graph {{version}}" }
 [[backends]]

--- a/registry/code.toml
+++ b/registry/code.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:just-every/code"]
+bins = ["code"]
 description = "Fast, effective, mind-blowing, coding CLI. Browser integration, multi-agents, theming, and reasoning control. Orchestrate agents from OpenAI, Claude, Gemini or any provider."
 test = { cmd = "code --version", expected = "code {{version}}" }

--- a/registry/codebuff.toml
+++ b/registry/codebuff.toml
@@ -1,5 +1,6 @@
 description = "Codebuff is a CLI tool that writes code for you"
 
+bins = ["cb", "codebuff"]
 [[backends]]
 full = "npm:codebuff"
 

--- a/registry/codefresh.toml
+++ b/registry/codefresh.toml
@@ -1,5 +1,6 @@
 description = "The Codefresh CLI provides a full and flexible interface to interact with Codefresh"
 
+bins = ["codefresh"]
 [[backends]]
 full = "github:codefresh-io/cli"
 

--- a/registry/codeql.toml
+++ b/registry/codeql.toml
@@ -1,6 +1,7 @@
 description = "CodeQL CLI"
 test = { cmd = "codeql --version", expected = "CodeQL command-line toolchain release {{version}}" }
 
+bins = ["codeql"]
 [[backends]]
 full = "github:github/codeql-cli-binaries"
 

--- a/registry/coder.toml
+++ b/registry/coder.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:coder/coder", "asdf:mise-plugins/asdf-coder"]
+bins = ["coder"]
 description = "Provision remote development environments via Terraform"

--- a/registry/codex.toml
+++ b/registry/codex.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:openai/codex", "npm:@openai/codex"]
+bins = ["codex", "codex-code-mode-host"]
 description = "Lightweight coding agent that runs in your terminal"
 test = { cmd = "codex --version", expected = "codex-cli {{version}}" }

--- a/registry/codon.toml
+++ b/registry/codon.toml
@@ -1,4 +1,5 @@
 backends = ["github:exaloop/codon"]
+bins = ["codon"]
 description = "A high-performance, zero-overhead, extensible Python compiler with built-in NumPy support"
 os = ["linux", "macos"]
 test = { cmd = "codon --version", expected = "{{version}}" }

--- a/registry/colima.toml
+++ b/registry/colima.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:abiosoft/colima", "asdf:CrouchingMuppet/asdf-colima"]
+bins = ["colima"]
 description = "Container runtimes on macOS (and Linux) with minimal setup"
 test = { cmd = "colima --version", expected = "colima version v{{version}}" }

--- a/registry/committed.toml
+++ b/registry/committed.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:crate-ci/committed"]
+bins = ["committed"]
 description = "Nitpicking commit history since beabf39"

--- a/registry/communique.toml
+++ b/registry/communique.toml
@@ -1,3 +1,4 @@
 backends = ["github:jdx/communique"]
+bins = ["communique"]
 description = "Editorialized release notes powered by AI"
 test = { cmd = "communique --version", expected = "communique {{version}}" }

--- a/registry/conan.toml
+++ b/registry/conan.toml
@@ -1,3 +1,4 @@
 backends = ["pipx:conan", "asdf:mise-plugins/mise-pyapp"]
+bins = ["conan"]
 description = "Decentralized, open-source (MIT), C/C++ package manager"
 test = { cmd = "conan --version", expected = "Conan version {{version}}" }

--- a/registry/conftest.toml
+++ b/registry/conftest.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:open-policy-agent/conftest", "asdf:looztra/asdf-conftest"]
+bins = ["conftest"]
 description = "Write tests against structured configuration data using the Open Policy Agent Rego query language"

--- a/registry/consul.toml
+++ b/registry/consul.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:hashicorp/consul", "asdf:mise-plugins/mise-hashicorp"]
+bins = ["consul"]
 description = "Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure"

--- a/registry/container-structure-test.toml
+++ b/registry/container-structure-test.toml
@@ -2,4 +2,5 @@ backends = [
   "aqua:GoogleContainerTools/container-structure-test",
   "asdf:FeryET/asdf-container-structure-test",
 ]
+bins = ["container-structure-test"]
 description = "validate the structure of your container images"

--- a/registry/container-use.toml
+++ b/registry/container-use.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:dagger/container-use"]
+bins = ["container-use", "cu"]
 description = "Development environments for coding agents. Enable multiple agents to work safely and independently with your preferred stack."
 test = { cmd = "container-use --version", expected = "container-use version {{version}}" }

--- a/registry/cookiecutter.toml
+++ b/registry/cookiecutter.toml
@@ -1,2 +1,3 @@
 backends = ["pipx:cookiecutter", "asdf:shawon-crosen/asdf-cookiecutter"]
+bins = ["cookiecutter"]
 description = "Create projects swiftly from cookiecutters (project templates) with this command-line utility. Ideal for generating Python package projects and more"

--- a/registry/copier.toml
+++ b/registry/copier.toml
@@ -1,3 +1,4 @@
 backends = ["pipx:copier", "asdf:looztra/asdf-copier"]
+bins = ["copier"]
 description = "A library and CLI app for rendering project templates"
 test = { cmd = "copier --version", expected = "copier {{version}}" }

--- a/registry/copilot.toml
+++ b/registry/copilot.toml
@@ -4,5 +4,6 @@ backends = [
   "github:github/copilot-cli",
   "npm:@github/copilot",
 ]
+bins = ["copilot"]
 description = "GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal."
 test = { cmd = "copilot --version", expected = "GitHub Copilot CLI {{version}}" }

--- a/registry/coredns.toml
+++ b/registry/coredns.toml
@@ -1,3 +1,4 @@
 backends = ["github:coredns/coredns", "asdf:s3than/asdf-coredns"]
+bins = ["coredns"]
 description = "CoreDNS: DNS and Service Discovery"
 test = { cmd = "coredns --version", expected = "CoreDNS-{{version}}" }

--- a/registry/coreutils.toml
+++ b/registry/coreutils.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:uutils/coreutils"]
+bins = ["coreutils"]
 description = "Cross-platform Rust rewrite of the GNU coreutils"

--- a/registry/cosign.toml
+++ b/registry/cosign.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:sigstore/cosign", "asdf:https://gitlab.com/wt0f/asdf-cosign"]
+bins = ["cosign"]
 description = "Code signing and transparency for containers and binaries"
 test = { cmd = "cosign version", expected = "v{{version}}" }

--- a/registry/coursier.toml
+++ b/registry/coursier.toml
@@ -1,6 +1,7 @@
 description = "Pure Scala Artifact Fetching"
 # test = { cmd = "cs --help", expected = "Coursier is the Scala application" }
 
+bins = ["cs"]
 [[backends]]
 full = "github:coursier/coursier"
 

--- a/registry/cowsay.toml
+++ b/registry/cowsay.toml
@@ -1,2 +1,3 @@
 backends = ["npm:cowsay"]
+bins = ["cowsay", "cowthink"]
 description = "cowsay is a configurable talking cow, originally written in Perl by Tony Monroe"

--- a/registry/cpz.toml
+++ b/registry/cpz.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:SUPERCILEX/fuc/cpz"]
+bins = ["cpz"]
 description = "A zippy alternative to cp, a tool to copy files and directories"
 test = { cmd = "cpz --version", expected = "cpz {{version}}" }

--- a/registry/crane.toml
+++ b/registry/crane.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:google/go-containerregistry", "asdf:dmpe/asdf-crane"]
+bins = ["crane", "gcrane", "krane"]
 description = "Go library and CLIs for working with container registries"
 test = { cmd = "crane version", expected = "{{version}}" }

--- a/registry/crictl.toml
+++ b/registry/crictl.toml
@@ -2,4 +2,5 @@ backends = [
   "aqua:kubernetes-sigs/cri-tools/crictl",
   "asdf:FairwindsOps/asdf-crictl",
 ]
+bins = ["crictl"]
 description = "crictl is a command-line interface for CRI-compatible container runtimes. You can use it to inspect and debug container runtimes and applications on a Kubernetes node"

--- a/registry/croc.toml
+++ b/registry/croc.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:schollz/croc"]
+bins = ["croc"]
 description = "Easily and securely send things from one computer to another 🐊 📦"
 test = { cmd = "croc --version", expected = "croc version {{version}}" }

--- a/registry/crossplane.toml
+++ b/registry/crossplane.toml
@@ -1,3 +1,4 @@
 aliases = ["crossplane-cli"]
 backends = ["aqua:crossplane/crossplane", "asdf:joke/asdf-crossplane-cli"]
+bins = ["crossplane"]
 description = "The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages"

--- a/registry/crush.toml
+++ b/registry/crush.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:charmbracelet/crush"]
+bins = ["crush"]
 description = "The glamourous AI coding agent for your favourite terminal"
 test = { cmd = "crush --version", expected = "v{{version}}" }

--- a/registry/crystal.toml
+++ b/registry/crystal.toml
@@ -3,5 +3,6 @@ backends = [
   "asdf:mise-plugins/mise-crystal",
   "vfox:mise-plugins/vfox-crystal",
 ]
+bins = ["crystal", "shards"]
 description = "Crystal: A language for humans and computers"
 idiomatic_files = [".crystal-version"]

--- a/registry/cspell.toml
+++ b/registry/cspell.toml
@@ -1,3 +1,4 @@
 backends = ["npm:cspell"]
+bins = ["cspell", "cspell-esm"]
 description = "A Spell Checker for Code!"
 test = { cmd = "cspell --version", expected = "{{version}}" }

--- a/registry/ctlptl.toml
+++ b/registry/ctlptl.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:tilt-dev/ctlptl", "asdf:ezcater/asdf-ctlptl"]
+bins = ["ctlptl"]
 description = "Making local Kubernetes clusters fun and easy to set up"

--- a/registry/ctop.toml
+++ b/registry/ctop.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:bcicen/ctop", "asdf:NeoHsu/asdf-ctop"]
+bins = ["ctop"]
 description = "Top-like interface for container metrics"
 test = { cmd = "ctop -v", expected = "ctop version {{version}}" }

--- a/registry/cue.toml
+++ b/registry/cue.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:cue-lang/cue", "asdf:asdf-community/asdf-cue"]
+bins = ["cue"]
 description = "The home of the CUE language! Validate and define text-based and dynamic configuration"

--- a/registry/curlie.toml
+++ b/registry/curlie.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:rs/curlie"]
+bins = ["curlie"]
 description = "The power of curl, the ease of use of httpie"
 test = { cmd = "curlie version", expected = "curlie {{version}}" }

--- a/registry/cyclonedx.toml
+++ b/registry/cyclonedx.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:CycloneDX/cyclonedx-cli", "asdf:xeedio/asdf-cyclonedx"]
+bins = ["cyclonedx"]
 description = "CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions"
 # TODO: re-enable test when aqua-registry is updated to use gnu instead of musl
 # test = ["cyclonedx --version", "{{version}}"]

--- a/registry/d2.toml
+++ b/registry/d2.toml
@@ -1,6 +1,7 @@
 description = "Modern diagram scripting language that turns text to diagrams"
 test = { cmd = "d2 --version", expected = "v{{version}}" }
 
+bins = ["d2"]
 [[backends]]
 full = "aqua:terrastruct/d2"
 

--- a/registry/dagger.toml
+++ b/registry/dagger.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:dagger/dagger", "asdf:virtualstaticvoid/asdf-dagger"]
+bins = ["dagger"]
 description = "A portable devkit for CI/CD pipelines"
 idiomatic_files = [
   { path = "dagger.json", version_regex = '"engineVersion"\s*:\s*"v?([^"]+)"' },

--- a/registry/dagu.toml
+++ b/registry/dagu.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:dagu-org/dagu"]
+bins = ["dagu"]
 description = "Yet another cron alternative with a Web UI, but with much more capabilities. It aims to solve greater problems"
 test = { cmd = "dagu version", expected = "{{version}}" }

--- a/registry/danger-js.toml
+++ b/registry/danger-js.toml
@@ -1,2 +1,13 @@
 backends = ["npm:danger"]
+bins = [
+  "danger",
+  "danger-ci",
+  "danger-init",
+  "danger-js",
+  "danger-local",
+  "danger-pr",
+  "danger-process",
+  "danger-reset-status",
+  "danger-runner",
+]
 description = "Danger runs during your CI process, and gives teams the chance to automate common code review chores"

--- a/registry/dapr.toml
+++ b/registry/dapr.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:dapr/cli", "asdf:asdf-community/asdf-dapr-cli"]
+bins = ["dapr"]
 description = "Command-line tools for Dapr"
 test = { cmd = "dapr --version", expected = "CLI version: {{version}}" }

--- a/registry/dart.toml
+++ b/registry/dart.toml
@@ -1,5 +1,13 @@
 description = "An approachable, portable, and productive language for high-quality apps on any platform"
 
+bins = [
+  "dart",
+  "dartaotruntime",
+  "dartaotruntime_asan",
+  "dartaotruntime_msan",
+  "dartaotruntime_tsan",
+  "dartvm",
+]
 [[backends]]
 full = "http:dart"
 

--- a/registry/dasel.toml
+++ b/registry/dasel.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:TomWright/dasel", "asdf:asdf-community/asdf-dasel"]
+bins = ["dasel"]
 description = "Select, put and delete data from JSON, TOML, YAML, XML and CSV files with a single tool. Supports conversion between formats and can be used as a Go package"

--- a/registry/databricks-cli.toml
+++ b/registry/databricks-cli.toml
@@ -1,6 +1,7 @@
 description = "Databricks CLI"
 test = { cmd = "databricks --version", expected = "Databricks CLI v{{version}}" }
 
+bins = ["databricks"]
 [[backends]]
 full = "aqua:databricks/cli"
 

--- a/registry/daytona.toml
+++ b/registry/daytona.toml
@@ -1,6 +1,7 @@
 description = "Daytona is a Secure and Elastic Infrastructure for Running AI-Generated Code"
 test = { cmd = "daytona version", expected = "Daytona CLI version v{{version}}" }
 
+bins = ["daytona"]
 [[backends]]
 full = "github:daytonaio/daytona"
 

--- a/registry/dbmate.toml
+++ b/registry/dbmate.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:amacneil/dbmate", "asdf:juusujanar/asdf-dbmate"]
+bins = ["dbmate"]
 description = "A lightweight, framework-agnostic database migration tool"

--- a/registry/dbt-fusion.toml
+++ b/registry/dbt-fusion.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:getdbt.com/dbt-fusion"]
+bins = ["dbt"]
 description = "dbt Fusion is a fast, integrated dbt runtime"
 test = { cmd = "dbt --version", expected = "dbt-fusion {{version}}" }

--- a/registry/deck.toml
+++ b/registry/deck.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:Kong/deck", "asdf:nutellinoit/asdf-deck"]
+bins = ["deck"]
 description = "decK: Configuration management and drift detection for Kong"

--- a/registry/delta.toml
+++ b/registry/delta.toml
@@ -3,5 +3,6 @@ backends = [
   "asdf:andweeb/asdf-delta",
   "cargo:git-delta",
 ]
+bins = ["delta"]
 description = "A syntax-highlighting pager for git, diff, and grep output"
 test = { cmd = "delta --version", expected = "delta {{version}}" }

--- a/registry/deno.toml
+++ b/registry/deno.toml
@@ -1,3 +1,4 @@
 backends = ["core:deno"]
+bins = ["deno"]
 description = "A modern runtime for JavaScript and TypeScript (Builtin plugin)"
 idiomatic_files = [".deno-version", "package.json"]

--- a/registry/dependency-check.toml
+++ b/registry/dependency-check.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:dependency-check/DependencyCheck"]
+bins = ["dependency-check", "dependency-check.sh"]
 description = "Software composition analysis utility that detects publicly disclosed vulnerabilities in application dependencies"
 test = { cmd = "dependency-check --version", expected = "Dependency-Check Core version {{version}}" }

--- a/registry/depot.toml
+++ b/registry/depot.toml
@@ -1,6 +1,7 @@
 description = "Depot CLI, build your Docker images in the cloud"
 test = { cmd = "depot --version", expected = "depot version {{version}}" }
 
+bins = ["depot"]
 [[backends]]
 full = "github:depot/cli"
 

--- a/registry/desk.toml
+++ b/registry/desk.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:jamesob/desk", "asdf:endorama/asdf-desk"]
+bins = ["desk"]
 description = "A lightweight workspace manager for the shell"
 os = ["linux", "macos"]
 test = { cmd = "desk version", expected = "desk {{version}}" }

--- a/registry/devcontainer-cli.toml
+++ b/registry/devcontainer-cli.toml
@@ -1,3 +1,4 @@
 backends = ["npm:@devcontainers/cli"]
+bins = ["devcontainer"]
 description = "CLI for creating and configuring dev containers from devcontainer.json"
 test = { cmd = "devcontainer --version", expected = "{{version}}" }

--- a/registry/devspace.toml
+++ b/registry/devspace.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:devspace-sh/devspace", "asdf:NeoHsu/asdf-devspace"]
+bins = ["devspace"]
 description = "DevSpace - The Fastest Developer Tool for Kubernetes  Automate your deployment workflow with DevSpace and develop software directly inside Kubernetes"

--- a/registry/dhall.toml
+++ b/registry/dhall.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:dhall-lang/dhall-haskell", "asdf:mise-plugins/mise-dhall"]
+bins = ["dhall"]
 description = "Maintainable configuration files (haskell)"
 test = { cmd = "dhall --version", expected = "{{version}}" }

--- a/registry/diffoci.toml
+++ b/registry/diffoci.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:reproducible-containers/diffoci"]
+bins = ["diffoci"]
 description = "diff for Docker and OCI container images"
 test = { cmd = "diffoci --version", expected = "diffoci version v{{version}}" }

--- a/registry/difftastic.toml
+++ b/registry/difftastic.toml
@@ -3,5 +3,6 @@ backends = [
   "asdf:volf52/asdf-difftastic",
   "cargo:difftastic",
 ]
+bins = ["difft"]
 description = "a structural diff that understands syntax"
 test = { cmd = "difft --version", expected = "Difftastic {{version}}" }

--- a/registry/direnv.toml
+++ b/registry/direnv.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:direnv/direnv", "asdf:asdf-community/asdf-direnv"]
+bins = ["direnv"]
 description = "unclutter your .profile"

--- a/registry/dive.toml
+++ b/registry/dive.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:wagoodman/dive", "asdf:looztra/asdf-dive"]
+bins = ["dive"]
 description = "A tool for exploring each layer in a docker image"
 test = { cmd = "dive --version", expected = "dive {{version}}" }

--- a/registry/docker-cli.toml
+++ b/registry/docker-cli.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:docker/cli"]
+bins = ["docker"]
 description = "Docker CE CLI"
 test = { cmd = "docker --version | awk '{print $3}' | tr -d ','", expected = "{{version}}" }

--- a/registry/docker-compose.toml
+++ b/registry/docker-compose.toml
@@ -1,3 +1,4 @@
 backends = ["github:docker/compose"]
+bins = ["docker-compose"]
 description = "Define and run multi-container applications with Docker"
 test = { cmd = "docker-compose --version", expected = "Docker Compose version" }

--- a/registry/docker-slim.toml
+++ b/registry/docker-slim.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:mintoolkit/mint", "asdf:xataz/asdf-docker-slim"]
+bins = ["docker-slim", "mint", "mint-sensor", "slim"]
 description = "minT(oolkit): Mint awesome, secure and production ready containers just the way you need them! Don't change anything in your container image and minify it by up to 30x (and for compiled languages even more) making it secure too! (free and open source)"
 os = ["linux", "macos"]
 test = { cmd = "slim --version", expected = "" } # prints out weird version of mint or something

--- a/registry/dockle.toml
+++ b/registry/dockle.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:goodwithtech/dockle", "asdf:mathew-fleisch/asdf-dockle"]
+bins = ["dockle"]
 description = "Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start"

--- a/registry/doctl.toml
+++ b/registry/doctl.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:digitalocean/doctl", "asdf:maristgeek/asdf-doctl"]
+bins = ["doctl"]
 description = "The official command line interface for the DigitalOcean API"
 test = { cmd = "doctl version", expected = "doctl version {{version}}" }

--- a/registry/docuum.toml
+++ b/registry/docuum.toml
@@ -3,5 +3,6 @@ backends = [
   "cargo:docuum",
   "asdf:bradym/asdf-docuum",
 ]
+bins = ["docuum"]
 description = "Docuum performs least recently used (LRU) eviction of Docker images"
 test = { cmd = "docuum --version", expected = "docuum {{version}}" }

--- a/registry/doggo.toml
+++ b/registry/doggo.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:mr-karan/doggo"]
+bins = ["doggo"]
 description = ":dog: Command-line DNS Client for Humans. Written in Golang"
 test = { cmd = "doggo --version | awk '{print $1}'", expected = "v{{version}}" }

--- a/registry/doppler.toml
+++ b/registry/doppler.toml
@@ -1,6 +1,7 @@
 description = "The official CLI for interacting with your Doppler secrets and configuration"
 test = { cmd = "doppler --version", expected = "v{{version}}" }
 
+bins = ["doppler"]
 [[backends]]
 full = "github:DopplerHQ/cli"
 

--- a/registry/dotenv-linter.toml
+++ b/registry/dotenv-linter.toml
@@ -3,5 +3,6 @@ backends = [
   "asdf:wesleimp/asdf-dotenv-linter",
   "cargo:dotenv-linter",
 ]
+bins = ["dotenv-linter"]
 description = "Lightning-fast linter for .env files. Written in Rust"
 test = { cmd = "dotenv-linter --version", expected = "dotenv-linter {{version}}" }

--- a/registry/dotenvx.toml
+++ b/registry/dotenvx.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:dotenvx/dotenvx"]
+bins = ["dotenvx"]
 description = "a secure dotenv–from the creator of `dotenv`"
 test = { cmd = "dotenvx --version", expected = "{{version}}" }

--- a/registry/dotslash.toml
+++ b/registry/dotslash.toml
@@ -1,3 +1,4 @@
 backends = ["github:facebook/dotslash"]
+bins = ["dotslash"]
 description = "Simplified executable deployment"
 test = { cmd = "dotslash --version", expected = "DotSlash" }

--- a/registry/dprint.toml
+++ b/registry/dprint.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:dprint/dprint", "asdf:asdf-community/asdf-dprint"]
+bins = ["dprint"]
 description = "Pluggable and configurable code formatting platform written in Rust"

--- a/registry/driftctl.toml
+++ b/registry/driftctl.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:snyk/driftctl", "asdf:nlamirault/asdf-driftctl"]
+bins = ["driftctl"]
 description = "Detect, track and alert on infrastructure drift"

--- a/registry/drone.toml
+++ b/registry/drone.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:harness/drone-cli", "asdf:virtualstaticvoid/asdf-drone"]
+bins = ["drone"]
 description = "Command Line Tools for Drone CI"
 test = { cmd = "drone --version", expected = "drone version {{version}}" }

--- a/registry/dt.toml
+++ b/registry/dt.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:so-dang-cool/dt", "asdf:so-dang-cool/asdf-dt"]
+bins = ["dt"]
 description = "dt - duct tape for your unix pipes"

--- a/registry/dua.toml
+++ b/registry/dua.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:Byron/dua-cli", "cargo:dua-cli"]
+bins = ["dua"]
 description = "View disk space usage and delete unwanted data, fast"
 test = { cmd = "dua --version", expected = "dua {{version}}" }

--- a/registry/duckdb.toml
+++ b/registry/duckdb.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:duckdb/duckdb"]
+bins = ["duckdb"]
 description = "DuckDB is an analytical in-process SQL database management system"
 test = { cmd = "duckdb --version", expected = "{{version}}" }

--- a/registry/duf.toml
+++ b/registry/duf.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:muesli/duf", "asdf:NeoHsu/asdf-duf"]
+bins = ["duf"]
 description = "Disk Usage/Free Utility - a better 'df' alternative"

--- a/registry/dust.toml
+++ b/registry/dust.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:bootandy/dust", "asdf:looztra/asdf-dust", "cargo:du-dust"]
+bins = ["dust"]
 description = "A more intuitive version of du in rust"
 test = { cmd = "dust --version", expected = "Dust {{version}}" }

--- a/registry/dvc.toml
+++ b/registry/dvc.toml
@@ -1,3 +1,4 @@
 backends = ["pipx:dvc"]
+bins = ["dvc"]
 description = "Data Versioning and ML Experiments"
 test = { cmd = "dvc version", expected = "{{version}}" }

--- a/registry/dyff.toml
+++ b/registry/dyff.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:homeport/dyff", "asdf:https://gitlab.com/wt0f/asdf-dyff"]
+bins = ["dyff"]
 description = "A diff tool for YAML files, and sometimes JSON"

--- a/registry/dynatrace-monaco.toml
+++ b/registry/dynatrace-monaco.toml
@@ -1,6 +1,7 @@
 description = "Monaco—This is the native Dynatrace Configuration as Code tool. Monaco is also the recommended tool for migrating from Dynatrace Managed to Dynatrace SaaS"
 # test = { cmd = "monaco version", expected = "monaco version {{version}}" }
 
+bins = ["monaco"]
 [[backends]]
 full = "github:Dynatrace/dynatrace-configuration-as-code"
 

--- a/registry/e1s.toml
+++ b/registry/e1s.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:keidarcy/e1s", "asdf:tbobm/asdf-e1s"]
+bins = ["e1s"]
 description = "E1S - Easily Manage AWS ECS Resources in Terminal(~k9s for ECS)"


### PR DESCRIPTION
## Summary

This is part of a four-PR stack that adds explicit `bin` metadata discovered from installed registry tools.

The discovery and isolation machinery was local-only and is not included in the codebase. Results were filtered conservatively: uncertain entries were omitted, including version- or platform-specific artifacts, documentation, shared libraries, wrappers, completion helpers, installers, and incidental dependency executables.

Validation:
- `mise run lint-fix`
- `cargo test --all-features registry` (79 passed)
- pruning dry-run reports no remaining matches
- each commit changes only `registry/*.toml`

This slice covers 228 files, alphabetically from `1password` through `e1s`.

## Feedback addressed

- Removed executable-looking documentation and non-command artifacts.
- Removed version-specific Python, Perl, Godot, and Elasticsearch names.
- Removed platform/architecture-suffixed duplicates and incidental dependency binaries.
- Split the original 911-file change into four reviewable PRs below the 300-file review limit.

Stack: #11671 → #11676 → #11677 → #11678

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added executable recognition for a broad range of cloud, container, development, infrastructure, security, scripting, and data tools.
  * Added support for primary commands, aliases, helper utilities, scripts, and bundled command-line executables.
  * Improved installation behavior so supported tools expose the correct binaries for terminal use.
  * Expanded coverage for AWS, Azure, Android SDK, Ansible, Docker, Kubernetes, CMake, Bun, Deno, and many more.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only TOML metadata and one naming fix; no install/runtime code changes in this slice.
> 
> **Overview**
> Adds a **`bins`** array to **228** mise registry entries (alphabetically **`1password`** through **`e1s`**) so each tool declares the command-line executables it installs—primary CLIs, common aliases, and bundled helpers (e.g. **`ansible-*`**, Android **`sdkmanager`** / **`d8`**, **`aws`** / **`aws_completer`**, **`bun`** / **`bunx`**).
> 
> Most entries gain a single name; multi-binary packages list the full set discovered from installs, with uncertain artifacts omitted per the stack’s conservative rules.
> 
> **`clusterawsadm`** is corrected alongside metadata: the health check and GitHub backend **`bin`** now use **`clusterawsadm`** instead of the wrong **`cluster-api-provider-aws`** name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3815486739e1808ed617c4171c1f949b69293985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->