### PR TITLE
fix(pacman): force C locale when parsing pacman -Q output

### DIFF
--- a/src/system/packages/pacman.rs
+++ b/src/system/packages/pacman.rs
@@ -100,6 +100,9 @@ impl SystemPackageManager for PacmanManager {
         debug!("$ pacman {}", args.join(" "));
         let output = tokio::process::Command::new("pacman")
             .args(&args)
+            // pacman localizes its messages via gettext, so the "was not
+            // found" check below only works against the untranslated output.
+            .env("LC_ALL", "C")
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
## Problem

`installed()` separates "not installed" from real errors (corrupt db, lock file) by matching `pacman -Q` stderr against `"was not found"`. pacman translates that message via gettext (the de/es/ru/zh_CN/tr/ko/ja catalogs all translate it), so in non-English locales `[bootstrap.packages]` bails as soon as one package is missing:

```
mise ERROR pacman -Q failed: エラー: パッケージ 'tcpdump' は見つかりませんでした
```

The Japanese text is pacman's translation of `error: package 'tcpdump' was not found`.

Exit codes offer no replacement for the check: `pacman -Q` exits 1 for missing packages, and real errors such as an unresolvable `--dbpath` exit 1 as well; pacman(8) documents no exit statuses.

Report with full repro: #11672

## Fix

Run this one `pacman -Q` under `LC_ALL=C` so the check sees untranslated output. Install and upgrade via `sudo pacman` keep the user's locale. (`LC_ALL` rather than `LC_MESSAGES`: a user-set `LC_ALL` overrides `LC_MESSAGES`.)

Substring-matching human-facing stderr is fragile, and this path already relies on it; pinning the locale that produces the output is the smallest fix. rustc and the Rust `cc` crate do the same when they spawn linkers and compilers.

## Testing

- Repro above: bails on main, reports missing/installed with this change
- `cargo test --all-features test_parse_pacman_query`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo fmt --check`, `mise run render`, `mise run lint-fix`: clean

No new unit test: the change is env plumbing on a spawned process, and the package-backend tests here cover pure parse helpers only.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.220.*
