### PR TITLE
registry: add discovered bin metadata (3/4)

### DIFF
--- a/registry/kubeone.toml
+++ b/registry/kubeone.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:kubermatic/kubeone", "aqua:kubermatic/kubeone"]
+bins = ["kubeone"]
 description = "Kubermatic KubeOne automate cluster operations on all your cloud, on-prem, edge, and IoT environments"
 test = { cmd = "kubeone version | jq -r '.kubeone.gitVersion'", expected = "{{version}}" }

--- a/registry/kubergrunt.toml
+++ b/registry/kubergrunt.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:gruntwork-io/kubergrunt", "asdf:NeoHsu/asdf-kubergrunt"]
+bins = ["kubergrunt"]
 description = "Kubergrunt is a standalone go binary with a collection of commands to fill in the gaps between Terraform, Helm, and Kubectl. https://www.gruntwork.io"

--- a/registry/kubeseal.toml
+++ b/registry/kubeseal.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:bitnami-labs/sealed-secrets",
   "asdf:stefansedich/asdf-kubeseal",
 ]
+bins = ["kubeseal"]
 description = "A Kubernetes controller and tool for one-way encrypted Secrets"
 test = { cmd = "kubeseal --version", expected = "kubeseal version: {{version}}" }

--- a/registry/kubesec.toml
+++ b/registry/kubesec.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:controlplaneio/kubesec", "asdf:vitalis/asdf-kubesec"]
+bins = ["kubesec"]
 description = "Security risk analysis for Kubernetes resources"

--- a/registry/kubeshark.toml
+++ b/registry/kubeshark.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:kubeshark/kubeshark", "asdf:carnei-ro/asdf-kubeshark"]
+bins = ["kubeshark"]
 description = "The API traffic analyzer for Kubernetes providing real-time K8s protocol-level visibility, capturing and monitoring all traffic and payloads going in, out and across containers, pods, nodes and clusters. Inspired by Wireshark, purposely built for Kubernetes"

--- a/registry/kubespy.toml
+++ b/registry/kubespy.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:pulumi/kubespy", "asdf:jfreeland/asdf-kubespy"]
+bins = ["kubespy"]
 description = "Tools for observing Kubernetes resources in real time, powered by Pulumi"

--- a/registry/kubeswitch.toml
+++ b/registry/kubeswitch.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:danielfoehrKn/kubeswitch", "github:danielfoehrKn/kubeswitch"]
+bins = ["switcher"]
 description = "The kubectx for operators"
 test = { cmd = "switcher --version", expected = "switcher version v{{version}}" }

--- a/registry/kubeval.toml
+++ b/registry/kubeval.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:instrumenta/kubeval", "asdf:stefansedich/asdf-kubeval"]
+bins = ["kubeval"]
 description = "Validate your Kubernetes configuration files, supports multiple Kubernetes versions"

--- a/registry/kubevela.toml
+++ b/registry/kubevela.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:kubevela/kubevela", "asdf:gustavclausen/asdf-kubevela"]
+bins = ["vela"]
 description = "The Modern Application Platform"
 test = { cmd = "vela version", expected = "CLI Version: {{version}}" }

--- a/registry/kubie.toml
+++ b/registry/kubie.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:sbstp/kubie", "asdf:johnhamelink/asdf-kubie"]
+bins = ["kubie"]
 description = "A more powerful alternative to kubectx and kubens"

--- a/registry/kustomize.toml
+++ b/registry/kustomize.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:kubernetes-sigs/kustomize", "asdf:Banno/asdf-kustomize"]
+bins = ["kustomize"]
 description = "Customization of kubernetes YAML configurations"
 test = { cmd = "kustomize version", expected = "v{{version}}" }

--- a/registry/kwokctl.toml
+++ b/registry/kwokctl.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:kubernetes-sigs/kwok/kwokctl"]
+bins = ["kwokctl"]
 description = "kwokctl is a CLI tool designed to streamline the creation and management of clusters, with nodes simulated by kwok"
 test = { cmd = "kwokctl --version", expected = "kwok version v{{version}}" }

--- a/registry/kyverno.toml
+++ b/registry/kyverno.toml
@@ -2,4 +2,5 @@ backends = [
   "aqua:kyverno/kyverno",
   "asdf:https://github.com/hobaen/asdf-kyverno-cli.git",
 ]
+bins = ["kyverno"]
 description = "Cloud Native Policy Management"

--- a/registry/lazydocker.toml
+++ b/registry/lazydocker.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:jesseduffield/lazydocker"]
+bins = ["lazydocker"]
 description = "The lazier way to manage everything docker"
 test = { cmd = "lazydocker --version", expected = "Version: {{version}}" }

--- a/registry/lazygit.toml
+++ b/registry/lazygit.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:jesseduffield/lazygit", "asdf:nklmilojevic/asdf-lazygit"]
+bins = ["lazygit"]
 description = "simple terminal UI for git commands"

--- a/registry/lazyjournal.toml
+++ b/registry/lazyjournal.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:Lifailon/lazyjournal"]
+bins = ["lazyjournal"]
 description = "TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and grep) and coloring the output, written in Go with the gocui library"
 test = { cmd = "lazyjournal --version", expected = "{{version}}" }

--- a/registry/lazyssh.toml
+++ b/registry/lazyssh.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:Adembc/lazyssh"]
+bins = ["lazyssh"]
 description = "A terminal-based SSH manager inspired by lazydocker and k9s - Written in go"
 test = { cmd = "lazyssh --help", expected = "lazyssh [flags]" }

--- a/registry/ldc.toml
+++ b/registry/ldc.toml
@@ -1,3 +1,18 @@
 backends = ["github:ldc-developers/ldc"]
+bins = [
+  "ddemangle",
+  "dub",
+  "dustmite",
+  "ldc-build-plugin",
+  "ldc-build-runtime",
+  "ldc-profdata",
+  "ldc-profgen",
+  "ldc-prune-cache",
+  "ldc2",
+  "ldmd2",
+  "rdmd",
+  "reggae",
+  "timetrace2txt",
+]
 description = "LLVM-based compiler for the D programming language"
 test = { cmd = "ldc2 --version", expected = "{{version}}" }

--- a/registry/lefthook.toml
+++ b/registry/lefthook.toml
@@ -3,6 +3,7 @@ backends = [
   "asdf:jtzero/asdf-lefthook",
   "go:github.com/evilmartians/lefthook",
 ]
+bins = ["lefthook"]
 description = "Fast and powerful Git hooks manager for any type of projects"
 idiomatic_files = [
   { path = "lefthook.yml", version_regex = '''(?m)^\s*["']?min_version["']?\s*[:=]\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },

--- a/registry/leiningen.toml
+++ b/registry/leiningen.toml
@@ -1,2 +1,3 @@
 backends = ["vfox:mise-plugins/vfox-leiningen", "asdf:mise-plugins/mise-lein"]
+bins = ["lein"]
 description = "for automating Clojure projects without setting your hair on fire"

--- a/registry/libsql-server.toml
+++ b/registry/libsql-server.toml
@@ -2,6 +2,7 @@ description = "server mode of libSQL, which is a fork of SQLite that is both Ope
 os = ["linux", "macos"]
 test = { cmd = "sqld --version", expected = "sqld sqld {{version}}" }
 
+bins = ["sqld"]
 [[backends]]
 full = "github:tursodatabase/libsql"
 

--- a/registry/lima.toml
+++ b/registry/lima.toml
@@ -1,4 +1,13 @@
 backends = ["aqua:lima-vm/lima", "asdf:CrouchingMuppet/asdf-lima"]
+bins = [
+  "apptainer.lima",
+  "docker.lima",
+  "kubectl.lima",
+  "lima",
+  "limactl",
+  "nerdctl.lima",
+  "podman.lima",
+]
 description = "Linux virtual machines, with a focus on running containers"
 # TODO: re-enable once limactl exposes a version command that works as root in CI.
 # test = { cmd = "limactl --version", expected = "limactl version {{version}}" }

--- a/registry/linkerd.toml
+++ b/registry/linkerd.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:linkerd/linkerd2", "asdf:kforsthoevel/asdf-linkerd"]
+bins = ["linkerd"]
 description = "Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x"

--- a/registry/liquibase.toml
+++ b/registry/liquibase.toml
@@ -1,4 +1,5 @@
 backends = ["github:liquibase/liquibase", "asdf:mise-plugins/mise-liquibase"]
+bins = ["liquibase"]
 description = "Liquibase helps millions of developers track, version, and deploy database schema changes"
 test = { cmd = "liquibase --version", expected = "Liquibase Version: {{version}}", tools = [
   "java",

--- a/registry/lisette.toml
+++ b/registry/lisette.toml
@@ -1,6 +1,7 @@
 description = "Little language inspired by Rust that compiles to Go"
 test = { cmd = "lis version", expected = "lis {{version}}" }
 
+bins = ["lis"]
 [[backends]]
 full = "github:ivov/lisette"
 

--- a/registry/litestream.toml
+++ b/registry/litestream.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:benbjohnson/litestream", "asdf:threkk/asdf-litestream"]
+bins = ["litestream"]
 description = "Streaming replication for SQLite"

--- a/registry/llama.cpp.toml
+++ b/registry/llama.cpp.toml
@@ -1,6 +1,30 @@
 description = "LLM inference in C/C++"
 test = { cmd = "llama-cli --version", expected = "version: {{version}}" }
 
+bins = [
+  "ggml-rpc-server",
+  "llama",
+  "llama-batched-bench",
+  "llama-bench",
+  "llama-cli",
+  "llama-debug-template-parser",
+  "llama-fit-params",
+  "llama-gemma3-cli",
+  "llama-gguf-split",
+  "llama-imatrix",
+  "llama-llava-cli",
+  "llama-minicpmv-cli",
+  "llama-mtmd-cli",
+  "llama-mtmd-debug",
+  "llama-perplexity",
+  "llama-quantize",
+  "llama-qwen2vl-cli",
+  "llama-results",
+  "llama-server",
+  "llama-template-analysis",
+  "llama-tokenize",
+  "llama-tts",
+]
 [[backends]]
 full = "github:ggml-org/llama.cpp"
 

--- a/registry/llmfit.toml
+++ b/registry/llmfit.toml
@@ -1,5 +1,6 @@
 description = "A terminal tool that right-sizes LLM models to your system's RAM, CPU, and GPU"
 test = { cmd = "llmfit --version", expected = "llmfit {{version}}" }
 
+bins = ["llmfit"]
 [[backends]]
 full = "github:AlexsJones/llmfit"

--- a/registry/lnav.toml
+++ b/registry/lnav.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:tstack/lnav"]
+bins = ["lnav"]
 description = "Log file navigator"
 test = { cmd = "lnav --version", expected = "lnav {{version}}" }

--- a/registry/localstack.toml
+++ b/registry/localstack.toml
@@ -5,3 +5,4 @@ backends = [
   "aqua:localstack/localstack-cli",
   "github:localstack/localstack-cli",
 ]
+bins = ["localstack"]

--- a/registry/loki-logcli.toml
+++ b/registry/loki-logcli.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:grafana/loki/logcli", "asdf:comdotlinux/asdf-loki-logcli"]
+bins = ["logcli"]
 description = "LogCLI is a command-line tool for querying and exploring logs in Grafana Loki"

--- a/registry/longbridge-terminal.toml
+++ b/registry/longbridge-terminal.toml
@@ -3,5 +3,6 @@ backends = [
   "cargo:longbridge-terminal",
 ]
 bin = "longbridge"
+bins = ["longbridge"]
 description = "AI-native CLI for Longbridge Securities — real-time market data, portfolio, and trading"
 test = { cmd = "longbridge --version", expected = "longbridge {{version}}" }

--- a/registry/lore.toml
+++ b/registry/lore.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:EpicGames/lore"]
+bins = ["lore"]
 description = "A next-generation open source version control system from Epic Games"
 test = { cmd = "lore --version", expected = "{{version}}" }

--- a/registry/ls-lint.toml
+++ b/registry/ls-lint.toml
@@ -3,5 +3,6 @@ backends = [
   "npm:@ls-lint/ls-lint",
   "asdf:Ameausoone/asdf-ls-lint",
 ]
+bins = ["ls-lint"]
 description = "An extremely fast directory and filename linter - Bring some structure to your project filesystem"
 test = { cmd = "ls-lint --version", expected = "ls-lint v{{version}}" }

--- a/registry/lsd.toml
+++ b/registry/lsd.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:lsd-rs/lsd", "asdf:mise-plugins/asdf-lsd", "cargo:lsd"]
+bins = ["lsd"]
 description = "The next gen ls command"

--- a/registry/lua-language-server.toml
+++ b/registry/lua-language-server.toml
@@ -2,4 +2,5 @@ backends = [
   "aqua:LuaLS/lua-language-server",
   "asdf:bellini666/asdf-lua-language-server",
 ]
+bins = ["lua-language-server"]
 description = "A language server that offers Lua language support - programmed in Lua"

--- a/registry/lua.toml
+++ b/registry/lua.toml
@@ -1,2 +1,3 @@
 backends = ["vfox:mise-plugins/vfox-lua", "asdf:mise-plugins/mise-lua"]
+bins = ["lua", "luac", "luarocks", "luarocks-admin"]
 description = "Lua language"

--- a/registry/luajit.toml
+++ b/registry/luajit.toml
@@ -1,3 +1,4 @@
 backends = ["conda:luajit", "asdf:mise-plugins/mise-luaJIT"]
+bins = ["luajit"]
 description = "a Just-In-Time Compiler for Lua"
 test = { cmd = "luajit -v", expected = "LuaJIT" }

--- a/registry/luau.toml
+++ b/registry/luau.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:luau-lang/luau"]
+bins = ["luau", "luau-analyze", "luau-ast", "luau-compile"]
 description = "A fast, small, safe, gradually typed embeddable scripting language derived from Lua"
 test = { cmd = "echo 'print(_VERSION)' | luau", expected = "Luau" }

--- a/registry/lychee.toml
+++ b/registry/lychee.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:lycheeverse/lychee", "cargo:lychee"]
+bins = ["lychee"]
 description = "Fast, async, stream-based link checker written in Rust. Finds broken URLs and mail addresses inside Markdown, HTML, reStructuredText, websites and more"
 test = { cmd = "lychee --version", expected = "lychee {{version}}" }

--- a/registry/maestro.toml
+++ b/registry/maestro.toml
@@ -1,2 +1,3 @@
 backends = ["github:mobile-dev-inc/maestro", "asdf:dotanuki-labs/asdf-maestro"]
+bins = ["maestro"]
 description = "Painless E2E Automation for Mobile and Web"

--- a/registry/mage.toml
+++ b/registry/mage.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:magefile/mage", "asdf:mathew-fleisch/asdf-mage"]
+bins = ["mage"]
 description = "a Make/rake-like dev tool using Go"

--- a/registry/mago.toml
+++ b/registry/mago.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:carthage-software/mago"]
+bins = ["mago"]
 description = "A blazing fast linter, formatter, and static analyzer for PHP, written in Rust"
 test = { cmd = "mago --version", expected = "mago {{version}}" }

--- a/registry/make.toml
+++ b/registry/make.toml
@@ -1,2 +1,3 @@
 backends = ["conda:make", "asdf:mise-plugins/mise-make"]
+bins = ["make"]
 description = "GNU Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files"

--- a/registry/mani.toml
+++ b/registry/mani.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:alajmo/mani", "asdf:anweber/asdf-mani"]
+bins = ["mani"]
 description = "CLI tool to help you manage repositories"
 test = { cmd = "mani --version", expected = "Version: {{version}}" }

--- a/registry/mark.toml
+++ b/registry/mark.toml
@@ -3,5 +3,6 @@ backends = [
   "github:kovetskiy/mark",
   "asdf:jfreeland/asdf-mark",
 ]
+bins = ["mark"]
 description = "Sync your markdown files with Confluence pages"
 test = { cmd = "mark --version", expected = "{{version}}" }

--- a/registry/markdownlint-cli2.toml
+++ b/registry/markdownlint-cli2.toml
@@ -2,5 +2,6 @@ backends = [
   "npm:markdownlint-cli2",
   "asdf:paulo-ferraz-oliveira/asdf-markdownlint-cli2",
 ]
+bins = ["markdownlint-cli2"]
 description = "A fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library"
 test = { cmd = "markdownlint-cli2 --version", expected = "markdownlint-cli2 v{{version}}" }

--- a/registry/marksman.toml
+++ b/registry/marksman.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:artempyanykh/marksman"]
+bins = ["marksman"]
 description = "Write Markdown with code assist and intelligence in the comfort of your favourite editor"
 test = { cmd = "marksman --version", expected = "" }

--- a/registry/marp-cli.toml
+++ b/registry/marp-cli.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:marp-team/marp-cli", "asdf:xataz/asdf-marp-cli"]
+bins = ["marp"]
 description = "A CLI interface for Marp and Marpit based converters"

--- a/registry/mask.toml
+++ b/registry/mask.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:jacobdeichert/mask", "asdf:aaaaninja/asdf-mask"]
+bins = ["mask"]
 description = "A CLI task runner defined by a simple markdown file"
 test = { cmd = "mask --version", expected = "mask {{version}}" }

--- a/registry/maturin.toml
+++ b/registry/maturin.toml
@@ -1,3 +1,4 @@
 backends = ["github:PyO3/maturin"]
+bins = ["maturin"]
 description = "Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages with minimal configuration."
 test = { cmd = "maturin --version", expected = "maturin {{version}}" }

--- a/registry/maven.toml
+++ b/registry/maven.toml
@@ -3,5 +3,6 @@ backends = [
   "asdf:mise-plugins/mise-maven",
   "vfox:mise-plugins/vfox-maven",
 ]
+bins = ["mvn", "mvnDebug", "mvnyjp"]
 description = "Apache Maven core"
 test = { cmd = "mvn --version", expected = "Apache Maven {{version}}" }

--- a/registry/mc.toml
+++ b/registry/mc.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:minio/mc", "asdf:mise-plugins/mise-mc"]
+bins = ["mc"]
 description = "Unix like utilities for object store (minio)"

--- a/registry/mdbook-linkcheck.toml
+++ b/registry/mdbook-linkcheck.toml
@@ -1,6 +1,7 @@
 description = "A backend for `mdbook` which will check your links for you"
 test = { cmd = "mdbook-linkcheck --version", expected = "mdbook-linkcheck {{version}}" }
 
+bins = ["mdbook-linkcheck"]
 [[backends]]
 full = "github:Michael-F-Bryan/mdbook-linkcheck"
 

--- a/registry/mdbook.toml
+++ b/registry/mdbook.toml
@@ -3,5 +3,6 @@ backends = [
   "asdf:cipherstash/asdf-mdbook",
   "cargo:mdbook",
 ]
+bins = ["mdbook"]
 description = "Create book from markdown files. Like Gitbook but implemented in Rust"
 test = { cmd = "mdbook --version", expected = "mdbook v{{version}}" }

--- a/registry/melange.toml
+++ b/registry/melange.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:chainguard-dev/melange", "asdf:omissis/asdf-melange"]
+bins = ["melange"]
 description = "build APKs from source code"
 os = ["linux", "macos"]
 test = { cmd = "melange version", expected = "GitVersion:    v{{version}}" }

--- a/registry/mermaid-ascii.toml
+++ b/registry/mermaid-ascii.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:AlexanderGrooff/mermaid-ascii",
   "github:AlexanderGrooff/mermaid-ascii",
 ]
+bins = ["mermaid-ascii"]
 description = "Render Mermaid graphs inside your terminal"
 test = { cmd = "which mermaid-ascii", expected = "mermaid-ascii" }

--- a/registry/meson.toml
+++ b/registry/meson.toml
@@ -1,2 +1,3 @@
 backends = ["pipx:meson", "asdf:mise-plugins/mise-meson"]
+bins = ["meson"]
 description = "Meson is an open source build system meant to be both extremely fast, and, even more importantly, as user friendly as possible"

--- a/registry/micro.toml
+++ b/registry/micro.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:micro-editor/micro"]
+bins = ["micro"]
 description = "A modern and intuitive terminal-based text editor"
 test = { cmd = "micro -version", expected = "Version: {{version}}" }

--- a/registry/micromamba.toml
+++ b/registry/micromamba.toml
@@ -1,3 +1,4 @@
 backends = ["github:mamba-org/micromamba-releases"]
+bins = ["micromamba"]
 description = "Lightweight conda-compatible package manager"
 test = { cmd = "micromamba --version", expected = "{{ version | split(pat='-') | first }}" }

--- a/registry/micronaut.toml
+++ b/registry/micronaut.toml
@@ -1,6 +1,7 @@
 description = "A modern, JVM-based, full-stack framework for building modular, easily testable microservice and serverless applications"
 # test = { cmd = "mn --version", expected = "Micronaut Version: {{version}}" }
 
+bins = ["mn"]
 [[backends]]
 full = "github:micronaut-projects/micronaut-starter"
 

--- a/registry/microsandbox.toml
+++ b/registry/microsandbox.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:superradcompany/microsandbox"]
+bins = ["msb"]
 description = "Easy, fast and local-first microVM runtime"
 test = { cmd = "msb --version", expected = "msb {{version}}" }

--- a/registry/miller.toml
+++ b/registry/miller.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:johnkerl/miller"]
+bins = ["mlr"]
 description = "Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON"
 test = { cmd = "mlr version", expected = "mlr version {{version}}" }

--- a/registry/mimirtool.toml
+++ b/registry/mimirtool.toml
@@ -2,6 +2,7 @@ backends = [
   "aqua:grafana/mimir/mimirtool",
   "asdf:asdf-community/asdf-mimirtool",
 ]
+bins = ["mimirtool"]
 description = "Mimirtool is a command-line tool that operators and tenants can use to execute a number of common tasks that involve Grafana Mimir or Grafana Cloud Metrics"
 os = ["linux", "macos"]
 test = { cmd = "mimirtool version", expected = "Mimirtool, version {{version}}" }

--- a/registry/minify.toml
+++ b/registry/minify.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:tdewolff/minify", "asdf:axilleas/asdf-minify"]
+bins = ["minify"]
 description = "Go minifiers for web formats"

--- a/registry/minikube.toml
+++ b/registry/minikube.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:kubernetes/minikube", "asdf:alvarobp/asdf-minikube"]
+bins = ["minikube"]
 description = "Run Kubernetes locally"

--- a/registry/minio.toml
+++ b/registry/minio.toml
@@ -1,3 +1,4 @@
 backends = ["conda:minio-server", "asdf:mise-plugins/mise-minio"]
+bins = ["minio"]
 description = "MinIO AIStor is a high-performance S3-compatible object store licensed under the MinIO Commercial License"
 test = { cmd = "minio --version", expected = "minio" }

--- a/registry/miniserve.toml
+++ b/registry/miniserve.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:svenstaro/miniserve"]
+bins = ["miniserve"]
 description = "For when you really just want to serve some files over HTTP right now!"
 test = { cmd = "miniserve --version", expected = "miniserve {{version}}" }

--- a/registry/minishift.toml
+++ b/registry/minishift.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:minishift/minishift", "asdf:sqtran/asdf-minishift"]
+bins = ["minishift"]
 description = "Run OpenShift 3.x locally"

--- a/registry/minisign.toml
+++ b/registry/minisign.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:jedisct1/minisign"]
+bins = ["minisign"]
 description = "A dead simple tool to sign files and verify digital signatures"

--- a/registry/mint.toml
+++ b/registry/mint.toml
@@ -1,2 +1,3 @@
 backends = ["github:mint-lang/mint", "asdf:mint-lang/asdf-mint"]
+bins = ["mint"]
 description = "🍃 A refreshing programming language for the front-end web"

--- a/registry/mirrord.toml
+++ b/registry/mirrord.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:metalbear-co/mirrord", "asdf:metalbear-co/asdf-mirrord"]
+bins = ["mirrord"]
 description = "Connect your local process and your cloud environment, and run local code in cloud conditions"
 # test = ["mirrord --version", "mirrord {{version}}"]

--- a/registry/mitmproxy.toml
+++ b/registry/mitmproxy.toml
@@ -1,2 +1,3 @@
 backends = ["pipx:mitmproxy", "asdf:mise-plugins/mise-mitmproxy"]
+bins = ["mitmdump", "mitmproxy", "mitmweb"]
 description = "mitmproxy is a free and open source interactive HTTPS proxy"

--- a/registry/mkcert.toml
+++ b/registry/mkcert.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:FiloSottile/mkcert", "asdf:salasrod/asdf-mkcert"]
+bins = ["mkcert"]
 description = "A simple zero-config tool to make locally trusted development certificates with any names you'd like"
 test = { cmd = "mkcert --version", expected = "v{{version}}" }

--- a/registry/mockery.toml
+++ b/registry/mockery.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:vektra/mockery", "asdf:cabify/asdf-mockery"]
+bins = ["mockery"]
 description = "A mock code autogenerator for Go"

--- a/registry/mockolo.toml
+++ b/registry/mockolo.toml
@@ -1,4 +1,5 @@
 backends = ["github:uber/mockolo", "asdf:mise-plugins/mise-mockolo"]
+bins = ["mockolo"]
 description = "Efficient Mock Generator for Swift"
 # TODO: re-enable once the e2e image has a practical Swift runtime for libswiftCore.so.
 # test = { cmd = "mockolo --help", expected = "Show help information" }

--- a/registry/mold.toml
+++ b/registry/mold.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:rui314/mold"]
+bins = ["ld.mold", "mold"]
 description = "Mold: A Modern Linker"
 test = { cmd = "mold --version", expected = "mold {{version}}" }

--- a/registry/mongodb.toml
+++ b/registry/mongodb.toml
@@ -1,2 +1,3 @@
 backends = ["vfox:jdx/vfox-mongod", "asdf:mise-plugins/mise-mongodb"]
+bins = ["mongod", "mongos"]
 description = "MongoDB"

--- a/registry/mongosh.toml
+++ b/registry/mongosh.toml
@@ -1,2 +1,3 @@
 backends = ["github:mongodb-js/mongosh", "asdf:itspngu/asdf-mongosh"]
+bins = ["mongosh"]
 description = "The MongoDB Shell"

--- a/registry/mprocs.toml
+++ b/registry/mprocs.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:pvolok/mprocs"]
+bins = ["mprocs"]
 description = "Run multiple commands in parallel"
 test = { cmd = "mprocs --version", expected = "mprocs {{version}}" }

--- a/registry/mssqldef.toml
+++ b/registry/mssqldef.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:sqldef/sqldef/mssqldef"]
+bins = ["mssqldef"]
 description = "Idempotent schema management for MsSQL and more"

--- a/registry/mutagen.toml
+++ b/registry/mutagen.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:mutagen-io/mutagen", "github:mutagen-io/mutagen"]
+bins = ["mutagen"]
 description = "Fast file synchronization and network forwarding for remote development"
 test = { cmd = "mutagen version", expected = "{{version}}" }

--- a/registry/mvnd.toml
+++ b/registry/mvnd.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:apache/maven-mvnd", "asdf:joschi/asdf-mvnd"]
+bins = ["mvnd", "mvnd.sh"]
 description = "Apache Maven Daemon"

--- a/registry/mysql-client.toml
+++ b/registry/mysql-client.toml
@@ -1,3 +1,21 @@
 backends = ["conda:mysql-client"]
+bins = [
+  "myisam_ftdump",
+  "myisamchk",
+  "myisamlog",
+  "myisampack",
+  "mysql",
+  "mysql_config_editor",
+  "mysql_migrate_keyring",
+  "mysql_secure_installation",
+  "mysql_tzinfo_to_sql",
+  "mysqladmin",
+  "mysqlbinlog",
+  "mysqlcheck",
+  "mysqldump",
+  "mysqlimport",
+  "mysqlshow",
+  "mysqlslap",
+]
 description = "MySQL Client"
 test = { cmd = "mysql --version", expected = "{{version}}" }

--- a/registry/mysql.toml
+++ b/registry/mysql.toml
@@ -1,3 +1,31 @@
 backends = ["vfox:jdx/vfox-mysql", "asdf:mise-plugins/mise-mysql"]
+bins = [
+  "ibd2sdi",
+  "innochecksum",
+  "my_print_defaults",
+  "myisam_ftdump",
+  "myisamchk",
+  "myisamlog",
+  "myisampack",
+  "mysql",
+  "mysql_config",
+  "mysql_config_editor",
+  "mysql_migrate_keyring",
+  "mysql_secure_installation",
+  "mysql_tzinfo_to_sql",
+  "mysqladmin",
+  "mysqlbinlog",
+  "mysqlcheck",
+  "mysqld",
+  "mysqld-debug",
+  "mysqld_multi",
+  "mysqld_safe",
+  "mysqldump",
+  "mysqldumpslow",
+  "mysqlimport",
+  "mysqlshow",
+  "mysqlslap",
+  "perror",
+]
 description = "MySQL Database"
 test = { cmd = "mysql --version", expected = "{{version}}" }

--- a/registry/mysqldef.toml
+++ b/registry/mysqldef.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:sqldef/sqldef/mysqldef"]
+bins = ["mysqldef"]
 description = "Idempotent schema management for MySQL and more"

--- a/registry/nancy.toml
+++ b/registry/nancy.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:sonatype-nexus-community/nancy", "asdf:iilyak/asdf-nancy"]
+bins = ["nancy"]
 description = "A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index"

--- a/registry/navi.toml
+++ b/registry/navi.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:denisidoro/navi", "cargo:navi"]
+bins = ["navi"]
 description = "An interactive cheatsheet tool for the command-line"
 test = { cmd = "navi --version", expected = "navi {{version}}" }

--- a/registry/neko.toml
+++ b/registry/neko.toml
@@ -1,2 +1,3 @@
 backends = ["github:HaxeFoundation/neko", "asdf:asdf-community/asdf-neko"]
+bins = ["neko", "nekoc", "nekoml", "nekotools"]
 description = "The Neko Virtual Machine"

--- a/registry/nelm.toml
+++ b/registry/nelm.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:werf/nelm"]
+bins = ["nelm"]
 description = "Nelm is a Helm 4 alternative - it is a Kubernetes deployment tool that manages Helm Charts and deploys them to Kubernetes"

--- a/registry/neo4j.toml
+++ b/registry/neo4j.toml
@@ -1,6 +1,7 @@
 description = "Neo4j is a high-performance, native graph database with full ACID transactions, Cypher query language, and a flexible property graph model"
 test = { cmd = "neo4j --version", expected = "{{version}}" }
 
+bins = ["cypher-shell", "neo4j", "neo4j-admin", "neo4j-import"]
 [[backends]]
 full = "http:neo4j"
 platforms = ["linux", "macos"]

--- a/registry/neonctl.toml
+++ b/registry/neonctl.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:neondatabase/neonctl"]
+bins = ["neonctl"]
 description = "Neon CLI tool. The Neon CLI is a command-line interface that lets you manage Neon Serverless Postgres directly from the terminal"
 test = { cmd = "neonctl --version", expected = "{{version}}" }

--- a/registry/neovim.toml
+++ b/registry/neovim.toml
@@ -1,2 +1,3 @@
 backends = ["vfox:mise-plugins/vfox-neovim", "aqua:neovim/neovim"]
+bins = ["nvim"]
 description = "Vim-fork focused on extensibility and usability"

--- a/registry/nerdctl.toml
+++ b/registry/nerdctl.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:containerd/nerdctl", "asdf:dmpe/asdf-nerdctl"]
+bins = ["containerd-rootless-setuptool.sh", "containerd-rootless.sh", "nerdctl"]
 description = "contaiNERD CTL - Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, "
 test = { cmd = "nerdctl --version", expected = "nerdctl version {{version}}" }

--- a/registry/newrelic.toml
+++ b/registry/newrelic.toml
@@ -1,4 +1,5 @@
 aliases = ["newrelic-cli"]
 backends = ["aqua:newrelic/newrelic-cli", "asdf:NeoHsu/asdf-newrelic-cli"]
+bins = ["newrelic"]
 description = "The New Relic Command Line Interface"
 test = { cmd = "newrelic --version", expected = "newrelic version {{version}}" }

--- a/registry/nfpm.toml
+++ b/registry/nfpm.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:goreleaser/nfpm", "asdf:ORCID/asdf-nfpm"]
+bins = ["nfpm"]
 description = "nFPM is Not FPM - a simple deb, rpm and apk packager written in Go"
 test = { cmd = "nfpm --version", expected = "{{version}}" }

--- a/registry/ni.toml
+++ b/registry/ni.toml
@@ -1,3 +1,4 @@
 backends = ["npm:@antfu/ni"]
+bins = ["na", "nci", "nd", "ni", "nlx", "nr", "nun", "nup"]
 description = "ni - use the right package manager"
 test = { cmd = "ni --version", expected = "@antfu/ni  v{{version}}" }

--- a/registry/ninja.toml
+++ b/registry/ninja.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:ninja-build/ninja", "asdf:asdf-community/asdf-ninja"]
+bins = ["ninja"]
 description = "a small build system with a focus on speed"

--- a/registry/node.toml
+++ b/registry/node.toml
@@ -1,4 +1,5 @@
 backends = ["core:node"]
+bins = ["node", "npm", "npx"]
 description = "Node.js® is a free, open-source, cross-platform JavaScript runtime environment that lets developers create servers, web apps, command line tools and scripts (Builtin plugin)"
 detect = ["package.json", ".nvmrc", ".node-version"]
 idiomatic_files = [".nvmrc", ".node-version", "package.json"]

--- a/registry/nomad-pack.toml
+++ b/registry/nomad-pack.toml
@@ -1,6 +1,7 @@
 description = "Nomad Pack is a templating and packaging tool used with HashiCorp Nomad"
 test = { cmd = "nomad-pack version", expected = "{{version}}" }
 
+bins = ["nomad-pack"]
 [[backends]]
 full = "http:nomad-pack"
 

--- a/registry/nomad.toml
+++ b/registry/nomad.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:hashicorp/nomad", "asdf:mise-plugins/mise-hashicorp"]
+bins = ["nomad"]
 description = "Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice, batch, containerized, and non-containerized applications. Nomad is easy to operate and scale and has native Consul and Vault integrations"

--- a/registry/nono.toml
+++ b/registry/nono.toml
@@ -1,3 +1,4 @@
 backends = ["github:nolabs-ai/nono"]
+bins = ["nono"]
 description = "Sandbox any AI agent in seconds - zero setup, zero latency."
 test = { cmd = "nono --version", expected = "nono {{version}}" }

--- a/registry/notation.toml
+++ b/registry/notation.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:notaryproject/notation", "asdf:bodgit/asdf-notation"]
+bins = ["notation"]
 description = "A CLI tool to sign and verify artifacts"

--- a/registry/nova.toml
+++ b/registry/nova.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:FairwindsOps/nova", "asdf:elementalvoid/asdf-nova"]
+bins = ["nova"]
 description = "Find outdated or deprecated Helm charts running in your cluster"

--- a/registry/nsc.toml
+++ b/registry/nsc.toml
@@ -1,2 +1,3 @@
 backends = ["github:nats-io/nsc", "asdf:dex4er/asdf-nsc"]
+bins = ["nsc"]
 description = "Tool for creating nkey/jwt based configurations"

--- a/registry/nub.toml
+++ b/registry/nub.toml
@@ -3,5 +3,6 @@ backends = [
     "@nubjs/nub",
   ] } },
 ]
+bins = ["nub", "nubx"]
 description = "A Rust CLI that augments Node.js - a fast script runner, a TypeScript-just-works runtime, and a pnpm-compatible package manager"
 test = { cmd = "nub --version", expected = "{{version}}" }

--- a/registry/numbat.toml
+++ b/registry/numbat.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:sharkdp/numbat", "cargo:numbat-cli"]
+bins = ["numbat"]
 description = "A statically typed programming language for scientific computations with first class support for physical dimensions and units"
 test = { cmd = "numbat --version", expected = "numbat {{version}}" }

--- a/registry/oapi-codegen.toml
+++ b/registry/oapi-codegen.toml
@@ -2,4 +2,5 @@ backends = [
   "go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen",
   "asdf:dylanrayboss/asdf-oapi-codegen",
 ]
+bins = ["oapi-codegen"]
 description = "oapi-codegen is a command-line tool and library to convert OpenAPI specifications to Go code, be it server-side implementations, API clients, or simply HTTP models"

--- a/registry/oauth2c.toml
+++ b/registry/oauth2c.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:cloudentity/oauth2c"]
+bins = ["oauth2c"]
 description = "User-friendly OAuth2 CLI"
 test = { cmd = "oauth2c version", expected = "oauth2c version {{version}}" }

--- a/registry/oc.toml
+++ b/registry/oc.toml
@@ -2,6 +2,7 @@ description = "OpenShift Client CLI (oc)"
 os = ["linux", "macos", "windows"]
 test = { cmd = "oc version --client", expected = "{{version}}" }
 
+bins = ["oc"]
 [[backends]]
 full = "http:oc"
 

--- a/registry/octosql.toml
+++ b/registry/octosql.toml
@@ -1,3 +1,4 @@
 backends = ["github:cube2222/octosql"]
+bins = ["octosql"]
 description = "OctoSQL is a query tool that allows you to join, analyse and transform data from multiple databases and file formats using SQL"
 test = { cmd = "octosql --version", expected = "octosql version {{version}}" }

--- a/registry/odin.toml
+++ b/registry/odin.toml
@@ -1,6 +1,7 @@
 description = "Odin Programming Language"
 # test = { cmd = "odin version", expected = "version {{version}}" }
 
+bins = ["odin"]
 [[backends]]
 full = "github:odin-lang/Odin"
 

--- a/registry/odo.toml
+++ b/registry/odo.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:redhat-developer/odo", "asdf:rm3l/asdf-odo"]
+bins = ["odo"]
 description = "A fast, and iterative CLI tool for container-based application development"

--- a/registry/oh-my-pi.toml
+++ b/registry/oh-my-pi.toml
@@ -1,6 +1,7 @@
 description = "AI coding agent for the terminal — hash-anchored edits, optimized tool harness, LSP, Python, browser, subagents, and more"
 test = { cmd = "omp --version", expected = "omp/{{version}}" }
 
+bins = ["omp"]
 [[backends]]
 full = "github:can1357/oh-my-pi"
 

--- a/registry/oh-my-posh.toml
+++ b/registry/oh-my-posh.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:JanDeDobbeleer/oh-my-posh"]
+bins = ["oh-my-posh"]
 description = "The most customizable and fastest prompt engine for any shell"
 test = { cmd = "oh-my-posh version", expected = "{{version}}" }

--- a/registry/oha.toml
+++ b/registry/oha.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:hatoo/oha", "github:hatoo/oha"]
+bins = ["oha"]
 description = "Ohayou(おはよう), HTTP load generator, inspired by rakyll/hey with tui animation"
 test = { cmd = "oha --version", expected = "oha {{version}}" }

--- a/registry/okta-aws.toml
+++ b/registry/okta-aws.toml
@@ -3,4 +3,5 @@ backends = [
   "aqua:okta/okta-aws-cli",
   "asdf:bennythejudge/asdf-plugin-okta-aws-cli",
 ]
+bins = ["okta-aws-cli"]
 description = "A CLI for having Okta as the IdP for AWS CLI operations"

--- a/registry/okteto.toml
+++ b/registry/okteto.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:okteto/okteto", "asdf:BradenM/asdf-okteto"]
+bins = ["okteto"]
 description = "Develop your applications directly in your Kubernetes Cluster"

--- a/registry/ollama.toml
+++ b/registry/ollama.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:ollama/ollama", "asdf:virtualstaticvoid/asdf-ollama"]
+bins = ["ollama"]
 description = "Get up and running with Llama 3.1, Mistral, Gemma 2, and other large language models"

--- a/registry/om.toml
+++ b/registry/om.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:pivotal-cf/om", "asdf:mise-plugins/tanzu-plug-in-for-asdf"]
+bins = ["om"]
 description = "General command line utility for working with VMware Tanzu Operations Manager"
 test = { cmd = "om version", expected = "{{version}}" }

--- a/registry/omnictl.toml
+++ b/registry/omnictl.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:siderolabs/omni/omnictl"]
+bins = ["omnictl"]
 description = "CLI for Omni - SideroLabs' Kubernetes management platform for bare metal deployments"
 test = { cmd = "omnictl --version", expected = "omnictl version v{{version}}" }

--- a/registry/onyx.toml
+++ b/registry/onyx.toml
@@ -1,2 +1,3 @@
 backends = ["github:onyx-lang/onyx", "asdf:jtakakura/asdf-onyx"]
+bins = ["onyx"]
 description = "The compiler and developer toolchain for Onyx"

--- a/registry/opa.toml
+++ b/registry/opa.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:open-policy-agent/opa", "asdf:tochukwuvictor/asdf-opa"]
+bins = ["opa"]
 description = "Open Policy Agent (OPA) is an open source, general-purpose policy engine"

--- a/registry/opam.toml
+++ b/registry/opam.toml
@@ -1,6 +1,7 @@
 description = "(ocaml) opam is a source-based package manager. It supports multiple simultaneous compiler installations, flexible package constraints, and a Git-friendly development workflow"
 test = { cmd = "opam --version", expected = "{{version}}" }
 
+bins = ["opam"]
 [[backends]]
 full = "github:ocaml/opam"
 

--- a/registry/openbao.toml
+++ b/registry/openbao.toml
@@ -2,3 +2,4 @@ description = "OpenBao exists to provide a software solution to manage, store, a
 test = { cmd = "bao version", expected = "OpenBao v{{version}}" }
 
 backends = ["aqua:openbao/openbao/bao", "github:openbao/openbao"]
+bins = ["bao"]

--- a/registry/opencode.toml
+++ b/registry/opencode.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:anomalyco/opencode"]
+bins = ["opencode"]
 description = "AI coding agent, built for the terminal"
 test = { cmd = "opencode --version", expected = "{{version}}" }

--- a/registry/openfaas-cli.toml
+++ b/registry/openfaas-cli.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:openfaas/faas-cli", "asdf:zekker6/asdf-faas-cli"]
+bins = ["faas-cli"]
 description = "Official CLI for OpenFaaS"

--- a/registry/openfga.toml
+++ b/registry/openfga.toml
@@ -1,3 +1,4 @@
 backends = ["github:openfga/openfga"]
+bins = ["openfga"]
 description = "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar"
 test = { cmd = "openfga version 2>&1", expected = "v{{version}}" }

--- a/registry/opengrep.toml
+++ b/registry/opengrep.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:opengrep/opengrep"]
+bins = ["opengrep"]
 description = "Static code analysis engine to find security issues in code"
 test = { cmd = "opengrep --version", expected = "{{version}}" }

--- a/registry/opensearch-cli.toml
+++ b/registry/opensearch-cli.toml
@@ -2,5 +2,6 @@ backends = [
   "github:opensearch-project/opensearch-cli",
   "asdf:mise-plugins/mise-opensearch-cli",
 ]
+bins = ["opensearch-cli"]
 description = "A full-featured command line interface (CLI) for OpenSearch"
 test = { cmd = "opensearch-cli --version", expected = "opensearch-cli version {{version}}" }

--- a/registry/openshift-install.toml
+++ b/registry/openshift-install.toml
@@ -2,6 +2,7 @@ description = "OpenShift installer for deploying OpenShift clusters"
 os = ["linux", "macos"]
 test = { cmd = "openshift-install version", expected = "{{version}}" }
 
+bins = ["openshift-install"]
 [[backends]]
 full = "http:openshift-install"
 

--- a/registry/opentofu.toml
+++ b/registry/opentofu.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:opentofu/opentofu", "asdf:virtualroot/asdf-opentofu"]
+bins = ["tofu"]
 description = "OpenTofu lets you declaratively manage your cloud infrastructure"
 idiomatic_files = [".opentofu-version"]
 test = { cmd = "tofu --version", expected = "OpenTofu v{{version}}" }

--- a/registry/operator-sdk.toml
+++ b/registry/operator-sdk.toml
@@ -2,4 +2,5 @@ backends = [
   "aqua:operator-framework/operator-sdk",
   "asdf:Medium/asdf-operator-sdk",
 ]
+bins = ["operator-sdk"]
 description = "SDK for building Kubernetes applications. Provides high level APIs, useful abstractions, and project scaffolding"

--- a/registry/oras.toml
+++ b/registry/oras.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:oras-project/oras", "asdf:bodgit/asdf-oras"]
+bins = ["oras"]
 description = "ORAS CLI"

--- a/registry/ormolu.toml
+++ b/registry/ormolu.toml
@@ -1,3 +1,4 @@
 backends = ["github:tweag/ormolu"]
+bins = ["ormolu"]
 description = "A formatter for Haskell source code"
 test = { cmd = "ormolu --version", expected = "ormolu {{version}}" }

--- a/registry/orval.toml
+++ b/registry/orval.toml
@@ -1,6 +1,7 @@
 description = "Generate type-safe TypeScript clients from OpenAPI specifications provided by https://orval.dev"
 test = { cmd = "orval --version", expected = "{{version}}", tools = ["aube"] }
 
+bins = ["orval"]
 [[backends]]
 full = "npm:orval"
 

--- a/registry/osv-scanner.toml
+++ b/registry/osv-scanner.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:google/osv-scanner"]
+bins = ["osv-scanner"]
 description = "Vulnerability scanner written in Go which uses the data provided by https://osv.dev"
 test = { cmd = "osv-scanner --version", expected = "osv-scanner version: {{version}}" }

--- a/registry/overmind.toml
+++ b/registry/overmind.toml
@@ -1,2 +1,3 @@
 backends = ["github:DarthSim/overmind", "go:github.com/DarthSim/overmind/v2"]
+bins = ["overmind"]
 description = "Process manager for Procfile-based applications and tmux"

--- a/registry/oxfmt.toml
+++ b/registry/oxfmt.toml
@@ -1,3 +1,4 @@
 backends = ["npm:oxfmt"]
+bins = ["oxfmt"]
 description = "This is the formatter for oxc."
 test = { cmd = "oxfmt --version", expected = "Version: {{version}}" }

--- a/registry/oxipng.toml
+++ b/registry/oxipng.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:oxipng/oxipng", "cargo:oxipng"]
+bins = ["oxipng"]
 description = "Oxipng is a multithreaded lossless PNG/APNG compression optimizer"
 test = { cmd = "oxipng --version", expected = "oxipng {{version}}" }

--- a/registry/oxker.toml
+++ b/registry/oxker.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:mrjackwills/oxker", "cargo:oxker"]
+bins = ["oxker"]
 description = "A simple tui to view & control docker containers"
 test = { cmd = "oxker --version", expected = "oxker {{version}}" }

--- a/registry/oxlint.toml
+++ b/registry/oxlint.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:oxc-project/oxc/oxlint", "npm:oxlint"]
+bins = ["oxlint"]
 description = "This is the linter for oxc."
 test = { cmd = "oxlint --version", expected = "Version: {{version}}" }

--- a/registry/packer.toml
+++ b/registry/packer.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:hashicorp/packer", "asdf:mise-plugins/mise-hashicorp"]
+bins = ["packer"]
 description = "Packer is a tool for creating identical machine images for multiple platforms from a single source configuration"
 idiomatic_files = [".packer-version"]
 test = { cmd = "packer --version", expected = "Packer v{{version}}" }

--- a/registry/pandoc.toml
+++ b/registry/pandoc.toml
@@ -1,2 +1,3 @@
 backends = ["github:jgm/pandoc", "asdf:Fbrisset/asdf-pandoc"]
+bins = ["pandoc", "pandoc-lua", "pandoc-server"]
 description = "Universal markup converter"

--- a/registry/patat.toml
+++ b/registry/patat.toml
@@ -1,2 +1,3 @@
 backends = ["github:jaspervdj/patat", "asdf:airtonix/asdf-patat"]
+bins = ["patat"]
 description = "Terminal-based presentations using Pandoc"

--- a/registry/pdm.toml
+++ b/registry/pdm.toml
@@ -1,3 +1,4 @@
 backends = ["pipx:pdm", "asdf:1oglop1/asdf-pdm"]
+bins = ["pdm"]
 description = "A modern Python package and dependency manager supporting the latest PEP standards"
 test = { cmd = "pdm --version", expected = "PDM, version {{version}}" }

--- a/registry/peco.toml
+++ b/registry/peco.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:peco/peco", "asdf:asdf-community/asdf-peco"]
+bins = ["peco"]
 description = "Simplistic interactive filtering tool"

--- a/registry/perl.toml
+++ b/registry/perl.toml
@@ -1,4 +1,38 @@
 backends = ["aqua:skaji/relocatable-perl", "asdf:ouest/asdf-perl"]
+bins = [
+  "change-shebang",
+  "corelist",
+  "cpan",
+  "cpanm",
+  "enc2xs",
+  "encguess",
+  "h2ph",
+  "h2xs",
+  "instmodsh",
+  "json_pp",
+  "libnetcfg",
+  "perl",
+  "perlbug",
+  "perldoc",
+  "perlivp",
+  "perlthanks",
+  "piconv",
+  "pl2pm",
+  "pod2html",
+  "pod2man",
+  "pod2text",
+  "pod2usage",
+  "podchecker",
+  "prove",
+  "ptar",
+  "ptardiff",
+  "ptargrep",
+  "shasum",
+  "splain",
+  "streamzip",
+  "xsubpp",
+  "zipdetails",
+]
 description = "self-contained, portable perl binaries"
 detect = [".perl-version"]
 idiomatic_files = [".perl-version"]

--- a/registry/pgroll.toml
+++ b/registry/pgroll.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:xataio/pgroll"]
+bins = ["pgroll"]
 description = "PostgreSQL zero-downtime migrations made easy"
 test = { cmd = "pgroll --version", expected = "pgroll version {{version}}" }

--- a/registry/pi.toml
+++ b/registry/pi.toml
@@ -3,5 +3,6 @@ backends = [
   "github:earendil-works/pi",
   "npm:@earendil-works/pi-coding-agent",
 ]
+bins = ["pi"]
 description = "Pi is a minimal terminal coding harness"
 test = { cmd = "pi --version", expected = "{{version}}" }

--- a/registry/pinact.toml
+++ b/registry/pinact.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:suzuki-shunsuke/pinact"]
+bins = ["pinact"]
 description = "pinact is a CLI to edit GitHub Workflow and Composite action files and pin versions of Actions and Reusable Workflows. pinact can also update their versions and verify version annotations"
 test = { cmd = "pinact version", expected = "{{version}}" }

--- a/registry/pinniped.toml
+++ b/registry/pinniped.toml
@@ -1,3 +1,4 @@
 backends = ["github:vmware/pinniped"]
+bins = ["pinniped-cli"]
 description = "Pinniped is the easy, secure way to log in to your Kubernetes clusters"
 test = { cmd = "pinniped-cli version", expected = "v{{version}}" }

--- a/registry/pint.toml
+++ b/registry/pint.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:cloudflare/pint", "asdf:sam-burrell/asdf-pint"]
+bins = ["pint"]
 description = "Prometheus rule linter/validator"

--- a/registry/pipectl.toml
+++ b/registry/pipectl.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:pipe-cd/pipecd/pipectl", "asdf:pipe-cd/asdf-pipectl"]
+bins = ["pipectl"]
 description = "The One CD for All {applications, platforms, operations}"
 os = ["linux", "macos"]
 # TODO: re-enable once upstream aquaproj/aqua-registry filters pipecd module tags from pipectl versions.

--- a/registry/pipx.toml
+++ b/registry/pipx.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:pypa/pipx", "asdf:mise-plugins/mise-pipx"]
+bins = ["pipx"]
 description = "Install and Run Python Applications in Isolated Environments"
 test = { cmd = "pipx --version", expected = "{{version}}", tools = ["python"] }

--- a/registry/pitchfork.toml
+++ b/registry/pitchfork.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:jdx/pitchfork"]
+bins = ["pitchfork"]
 description = "Daemons with DX"
 test = { cmd = "pitchfork --version", expected = "pitchfork {{version}}" }

--- a/registry/pivnet.toml
+++ b/registry/pivnet.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:pivotal-cf/pivnet-cli",
   "asdf:mise-plugins/tanzu-plug-in-for-asdf",
 ]
+bins = ["pivnet"]
 description = "CLI to interact with Tanzu Network API V2 interface"
 test = { cmd = "pivnet version", expected = "{{version}}" }

--- a/registry/pixi.toml
+++ b/registry/pixi.toml
@@ -1,4 +1,5 @@
 backends = ["github:prefix-dev/pixi"]
+bins = ["pixi"]
 description = "Package management made easy"
 idiomatic_files = [
   { path = "pixi.toml", version_regex = '''(?m)^\s*requires-pixi\s*=\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },

--- a/registry/pkl.toml
+++ b/registry/pkl.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:apple/pkl", "asdf:mise-plugins/asdf-pkl"]
+bins = ["pkl"]
 description = "A configuration as code language with rich validation and tooling"
 test = { cmd = "pkl --version", expected = "Pkl {{version}}" }

--- a/registry/please.toml
+++ b/registry/please.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:thought-machine/please", "asdf:asdf-community/asdf-please"]
+bins = ["build_langserver", "please", "please_sandbox"]
 description = "High-performance extensible build system for reproducible multi-language builds"

--- a/registry/pluto.toml
+++ b/registry/pluto.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:FairwindsOps/pluto", "asdf:FairwindsOps/asdf-pluto"]
+bins = ["pluto"]
 description = "A cli tool to help discover deprecated apiVersions in Kubernetes"
 test = { cmd = "pluto version", expected = "Version:{{version}}" }

--- a/registry/pnpm.toml
+++ b/registry/pnpm.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:pnpm/pnpm", "npm:pnpm"]
+bins = ["pn", "pnpm", "pnpx", "pnx"]
 description = "Fast, disk space efficient package manager"
 detect = ["pnpm-lock.yaml", "pnpm-workspace.yaml"]
 idiomatic_files = ["package.json"]

--- a/registry/pocketbase.toml
+++ b/registry/pocketbase.toml
@@ -1,3 +1,4 @@
 backends = ["github:pocketbase/pocketbase"]
+bins = ["pocketbase"]
 description = "Open Source realtime backend in 1 file"
 test = { cmd = "pocketbase --version", expected = "pocketbase version {{version}}" }

--- a/registry/podlet.toml
+++ b/registry/podlet.toml
@@ -3,5 +3,6 @@ backends = [
   "github:containers/podlet",
   "cargo:podlet",
 ]
+bins = ["podlet"]
 description = "Generate Podman Quadlet files from a Podman command, compose file, or existing object"
 test = { cmd = "podlet --version", expected = "podlet {{version}}" }

--- a/registry/podman-tui.toml
+++ b/registry/podman-tui.toml
@@ -1,3 +1,4 @@
 backends = ["github:containers/podman-tui"]
+bins = ["podman-tui"]
 description = "Podman Terminal UI"
 test = { cmd = "podman-tui version", expected = "podman-tui v{{version}}" }

--- a/registry/podman.toml
+++ b/registry/podman.toml
@@ -1,6 +1,7 @@
 description = "Podman: A tool for managing OCI containers and pods"
 test = { cmd = "podman-remote --version", expected = "podman-remote version {{version}}" }
 
+bins = ["podman", "podman-remote"]
 [[backends]]
 full = "github:podman-container-tools/podman"
 

--- a/registry/polaris.toml
+++ b/registry/polaris.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:FairwindsOps/polaris", "asdf:particledecay/asdf-polaris"]
+bins = ["polaris"]
 description = "Validation of best practices in your Kubernetes clusters"

--- a/registry/popeye.toml
+++ b/registry/popeye.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:derailed/popeye", "asdf:nlamirault/asdf-popeye"]
+bins = ["popeye"]
 description = "A Kubernetes cluster resource sanitizer"

--- a/registry/porter.toml
+++ b/registry/porter.toml
@@ -1,6 +1,7 @@
 description = "CNAB bundle authoring and management tool"
 test = { cmd = "porter version", expected = "porter v{{version}}" }
 
+bins = ["porter"]
 [[backends]]
 full = "aqua:getporter/porter/porter"
 

--- a/registry/portless.toml
+++ b/registry/portless.toml
@@ -1,3 +1,4 @@
 backends = ["npm:portless"]
+bins = ["portless"]
 description = "Replace port numbers with stable, named .localhost URLs. For humans and agents."
 test = { cmd = "portless --version", expected = "{{version}}" }

--- a/registry/powerline-go.toml
+++ b/registry/powerline-go.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:justjanne/powerline-go", "asdf:dex4er/asdf-powerline-go"]
+bins = ["powerline-go"]
 description = "A beautiful and useful low-latency prompt for your shell, written in go"

--- a/registry/powerpipe.toml
+++ b/registry/powerpipe.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:turbot/powerpipe", "asdf:jc00ke/asdf-powerpipe"]
+bins = ["powerpipe"]
 description = "Powerpipe: Dashboards for DevOps. Visualize cloud configurations. Assess security posture against a massive library of benchmarks. Build custom dashboards with code"

--- a/registry/powershell-core.toml
+++ b/registry/powershell-core.toml
@@ -3,5 +3,6 @@ backends = [
   "aqua:PowerShell/PowerShell",
   "asdf:daveneeley/asdf-powershell-core",
 ]
+bins = ["pwsh"]
 description = "PowerShell for every system"
 test = { cmd = "pwsh --version", expected = "PowerShell {{version}}" }

--- a/registry/pre-commit.toml
+++ b/registry/pre-commit.toml
@@ -3,6 +3,7 @@ backends = [
   "asdf:jonathanmorley/asdf-pre-commit",
   "pipx:pre-commit",
 ]
+bins = ["pre-commit"]
 description = "A framework for managing and maintaining multi-language pre-commit hooks"
 idiomatic_files = [
   { path = ".pre-commit-config.yaml", version_regex = '''(?m)^\s*minimum_pre_commit_version\s*:\s*["']?v?([0-9][0-9A-Za-z.+-]*)''' },

--- a/registry/prek.toml
+++ b/registry/prek.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:j178/prek"]
+bins = ["prek"]
 description = "⚡ A fast Git hook manager written in Rust, designed as a drop-in alternative to pre-commit, reimagined."
 test = { cmd = "prek --version", expected = "prek {{version}}" }

--- a/registry/prettier.toml
+++ b/registry/prettier.toml
@@ -1,3 +1,4 @@
 backends = ["npm:prettier"]
+bins = ["prettier"]
 description = "Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary"
 test = { cmd = "prettier --version", expected = "{{version}}" }

--- a/registry/process-compose.toml
+++ b/registry/process-compose.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:F1bonacc1/process-compose",
   "github:F1bonacc1/process-compose",
 ]
+bins = ["process-compose"]
 description = "Process Compose is a simple and flexible scheduler and orchestrator to manage non-containerized applications."
 test = { cmd = "process-compose version --short", expected = "{{version}}" }

--- a/registry/promtool.toml
+++ b/registry/promtool.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:prometheus/prometheus", "asdf:asdf-community/asdf-promtool"]
+bins = ["prometheus", "promtool"]
 description = "The Prometheus monitoring system and time series database"
 test = { cmd = "promtool --version", expected = "promtool, version {{version}}" }

--- a/registry/protoc-gen-connect-go.toml
+++ b/registry/protoc-gen-connect-go.toml
@@ -2,4 +2,5 @@ backends = [
   "go:connectrpc.com/connect/cmd/protoc-gen-connect-go",
   "asdf:dylanrayboss/asdf-protoc-gen-connect-go",
 ]
+bins = ["protoc-gen-connect-go"]
 description = "The Go implementation of Connect: Protobuf RPC that works"

--- a/registry/protoc-gen-go-grpc.toml
+++ b/registry/protoc-gen-go-grpc.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:grpc/grpc-go/protoc-gen-go-grpc",
   "asdf:pbr0ck3r/asdf-protoc-gen-go-grpc",
 ]
+bins = ["protoc-gen-go-grpc"]
 description = "This tool generates Go language bindings of services in protobuf definition files for gRPC"
 test = { cmd = "protoc-gen-go-grpc --version", expected = "protoc-gen-go-grpc {{version}}" }

--- a/registry/protoc-gen-go.toml
+++ b/registry/protoc-gen-go.toml
@@ -2,4 +2,5 @@ backends = [
   "aqua:protocolbuffers/protobuf-go/protoc-gen-go",
   "asdf:pbr0ck3r/asdf-protoc-gen-go",
 ]
+bins = ["protoc-gen-go"]
 description = "protoc-gen-go is a plugin for the Google protocol buffer compiler to generate Go code"

--- a/registry/protoc-gen-validate.toml
+++ b/registry/protoc-gen-validate.toml
@@ -2,5 +2,11 @@ backends = [
   "aqua:bufbuild/protoc-gen-validate",
   "go:github.com/envoyproxy/protoc-gen-validate",
 ]
+bins = [
+  "protoc-gen-validate",
+  "protoc-gen-validate-cpp",
+  "protoc-gen-validate-go",
+  "protoc-gen-validate-java",
+]
 description = "Protocol Buffer Validation - Being replaced by github.com/bufbuild/protovalidate"
 test = { cmd = "which protoc-gen-validate", expected = "protoc-gen-validate" }

--- a/registry/protoc.toml
+++ b/registry/protoc.toml
@@ -3,4 +3,5 @@ backends = [
   "aqua:protocolbuffers/protobuf/protoc",
   "asdf:paxosglobal/asdf-protoc",
 ]
+bins = ["protoc"]
 description = "Protocol Buffers Compiler - Google's data interchange format"

--- a/registry/protolint.toml
+++ b/registry/protolint.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:yoheimuta/protolint", "asdf:spencergilbert/asdf-protolint"]
+bins = ["protoc-gen-protolint", "protolint"]
 description = "A pluggable linter and fixer to enforce Protocol Buffer style and conventions"

--- a/registry/psqldef.toml
+++ b/registry/psqldef.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:sqldef/sqldef/psqldef"]
+bins = ["psqldef"]
 description = "Idempotent schema management for PostgreSQL"

--- a/registry/pulumi.toml
+++ b/registry/pulumi.toml
@@ -1,3 +1,18 @@
 backends = ["aqua:pulumi/pulumi", "asdf:canha/asdf-pulumi"]
+bins = [
+  "pulumi",
+  "pulumi-language-bun",
+  "pulumi-language-dotnet",
+  "pulumi-language-go",
+  "pulumi-language-java",
+  "pulumi-language-nodejs",
+  "pulumi-language-pcl",
+  "pulumi-language-python",
+  "pulumi-language-python-exec",
+  "pulumi-language-yaml",
+  "pulumi-resource-pulumi-nodejs",
+  "pulumi-resource-pulumi-python",
+  "pulumi-watch",
+]
 description = "Pulumi - Infrastructure as Code in any programming language"
 test = { cmd = "pulumi version", expected = "v{{version}}" }

--- a/registry/purescript.toml
+++ b/registry/purescript.toml
@@ -1,6 +1,7 @@
 description = "A strongly-typed language that compiles to JavaScript"
 # test = { cmd = "purs --version", expected = "{{version}}" }
 
+bins = ["purs"]
 [[backends]]
 full = "github:purescript/purescript"
 

--- a/registry/purty.toml
+++ b/registry/purty.toml
@@ -1,6 +1,7 @@
 description = "PureScript pretty-printer"
 test = { cmd = "purty version", expected = "Purty version: {{version}}" }
 
+bins = ["purty"]
 [[backends]]
 full = "npm:purty"
 

--- a/registry/python.toml
+++ b/registry/python.toml
@@ -1,4 +1,5 @@
 backends = ["core:python"]
+bins = ["idle3", "pip", "pip3", "pydoc3", "python", "python3", "python3-config"]
 description = "python language"
 detect = ["pyproject.toml", ".python-version", "setup.py", "requirements.txt"]
 idiomatic_files = [".python-version", ".python-versions"]

--- a/registry/qdns.toml
+++ b/registry/qdns.toml
@@ -1,2 +1,3 @@
 backends = ["github:natesales/q", "asdf:moritz-makandra/asdf-plugin-qdns"]
+bins = ["q"]
 description = "A tiny command line DNS client with support for UDP, TCP, DoT, DoH, DoQ and ODoH"

--- a/registry/qsv.toml
+++ b/registry/qsv.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:dathere/qsv", "github:dathere/qsv", "asdf:vjda/asdf-qsv"]
+bins = ["qsv", "qsvdp", "qsvlite", "qsvp", "qsvpdp", "qsvplite"]
 description = "Blazing-fast Data-Wrangling toolkit"
 test = { cmd = "qsv --version", expected = "qsv {{version}}" }

--- a/registry/quarkus.toml
+++ b/registry/quarkus.toml
@@ -1,2 +1,3 @@
 backends = ["github:quarkusio/quarkus", "asdf:mise-plugins/mise-quarkus"]
+bins = ["quarkus"]
 description = "The quarkus command lets you create projects, manage extensions and do essential build and development tasks using the underlying project build tool"

--- a/registry/quicktype.toml
+++ b/registry/quicktype.toml
@@ -1,3 +1,4 @@
 backends = ["npm:quicktype"]
+bins = ["quicktype"]
 description = "Generate types and converters from JSON, Schema, and GraphQL provided by https://quicktype.io"
 test = { cmd = "quicktype --version", expected = "quicktype version {{version}}" }

--- a/registry/qwen.toml
+++ b/registry/qwen.toml
@@ -1,4 +1,5 @@
 aliases = ["qwen-code"]
 backends = ["npm:@qwen-code/qwen-code"]
+bins = ["qwen"]
 description = "Qwen Code, an AI coding assistant for CLI and IDE"
 test = { cmd = "qwen --version", expected = "{{version}}" }

--- a/registry/racket.toml
+++ b/registry/racket.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:racket/racket/minimal"]
+bins = ["racket", "raco"]
 description = "Minimal Racket distribution"
 test = { cmd = "racket --version", expected = "Welcome to Racket v{{version}}" }

--- a/registry/railway.toml
+++ b/registry/railway.toml
@@ -1,6 +1,7 @@
 description = "Railway CLI"
 test = { cmd = "railway --version", expected = "railway {{version}}" }
 
+bins = ["railway"]
 [[backends]]
 full = "github:railwayapp/cli"
 

--- a/registry/rancher.toml
+++ b/registry/rancher.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:rancher/cli", "asdf:abinet/asdf-rancher"]
+bins = ["rancher"]
 description = "Rancher CLI"
 test = { cmd = "rancher --version", expected = "rancher version v{{version}}" }

--- a/registry/rbac-lookup.toml
+++ b/registry/rbac-lookup.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:FairwindsOps/rbac-lookup", "asdf:looztra/asdf-rbac-lookup"]
+bins = ["rbac-lookup"]
 description = "Easily find roles and cluster roles attached to any user, service account, or group name in your Kubernetes cluster"

--- a/registry/rclone.toml
+++ b/registry/rclone.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:rclone/rclone", "asdf:johnlayton/asdf-rclone"]
+bins = ["rclone"]
 description = '"rsync for cloud storage" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Yandex Files'
 test = { cmd = "rclone version", expected = "rclone v{{version}}" }

--- a/registry/rebar.toml
+++ b/registry/rebar.toml
@@ -1,6 +1,7 @@
 backends = [
   { full = "github:erlang/rebar3", options = { asset_pattern = "rebar3" } },
 ]
+bins = ["rebar3"]
 description = "Erlang build tool that makes it easy to compile and test Erlang applications and releases"
 test = { cmd = "rebar3 --version", expected = "rebar {{version}}", tools = [
   "erlang",

--- a/registry/reckoner.toml
+++ b/registry/reckoner.toml
@@ -1,2 +1,3 @@
 backends = ["github:FairwindsOps/reckoner", "asdf:FairwindsOps/asdf-reckoner"]
+bins = ["reckoner"]
 description = "Declaratively install and manage multiple Helm chart releases"

--- a/registry/redis.toml
+++ b/registry/redis.toml
@@ -1,2 +1,10 @@
 backends = ["vfox:mise-plugins/vfox-redis", "asdf:mise-plugins/mise-redis"]
+bins = [
+  "redis-benchmark",
+  "redis-check-aof",
+  "redis-check-rdb",
+  "redis-cli",
+  "redis-sentinel",
+  "redis-server",
+]
 description = "Cache & in-memory datastore"

--- a/registry/redpanda-connect.toml
+++ b/registry/redpanda-connect.toml
@@ -1,4 +1,5 @@
 aliases = ["benthos"]
 backends = ["aqua:redpanda-data/connect", "asdf:benthosdev/benthos-asdf"]
+bins = ["benthos", "redpanda-connect"]
 description = "Fancy stream processing made operationally mundane"
 test = { cmd = "redpanda-connect --version", expected = "Version: {{version}}" }

--- a/registry/reg.toml
+++ b/registry/reg.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:genuinetools/reg", "asdf:looztra/asdf-reg"]
+bins = ["reg"]
 description = "Docker registry v2 command line client and repo listing generator with security checks"

--- a/registry/regal.toml
+++ b/registry/regal.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:open-policy-agent/regal", "asdf:mise-plugins/mise-regal"]
+bins = ["regal"]
 description = "Regal is a linter and language server for Rego, with the goal of making your Rego magnificent"

--- a/registry/regctl.toml
+++ b/registry/regctl.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:regclient/regclient/regctl", "asdf:ORCID/asdf-regctl"]
+bins = ["regctl"]
 description = "Docker and OCI Registry Client in Go and tooling using those libraries"

--- a/registry/regsync.toml
+++ b/registry/regsync.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:regclient/regclient/regsync", "asdf:rsrchboy/asdf-regsync"]
+bins = ["regsync"]
 description = "regsync is a registry synchronization utility used to update mirrors of OCI compatible container registries"

--- a/registry/release-plz.toml
+++ b/registry/release-plz.toml
@@ -3,5 +3,6 @@ backends = [
   "github:release-plz/release-plz",
   "cargo:release-plz",
 ]
+bins = ["release-plz"]
 description = "Publish Rust crates from CI with a Release PR."
 test = { cmd = "release-plz --version", expected = "release-plz {{version}}" }

--- a/registry/restic.toml
+++ b/registry/restic.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:restic/restic", "asdf:xataz/asdf-restic"]
+bins = ["restic"]
 description = "Fast, secure, efficient backup program"
 test = { cmd = "restic version", expected = "restic {{version}}" }

--- a/registry/restish.toml
+++ b/registry/restish.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:rest-sh/restish", "go:github.com/danielgtaylor/restish"]
+bins = ["restish"]
 description = "Restish is a CLI for interacting with REST-ish HTTP APIs with some nice features built-in"
 test = { cmd = "restish --version", expected = "restish version {{version}}" }

--- a/registry/resvg.toml
+++ b/registry/resvg.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:linebender/resvg", "cargo:resvg"]
+bins = ["resvg"]
 description = "An SVG rendering library."
 test = { cmd = "resvg --version", expected = "{{version}}" }

--- a/registry/revive.toml
+++ b/registry/revive.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:mgechev/revive", "asdf:bjw-s/asdf-revive"]
+bins = ["revive"]
 description = "~6x faster, stricter, configurable, extensible, and beautiful drop-in replacement for golint"

--- a/registry/richgo.toml
+++ b/registry/richgo.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:kyoh86/richgo", "asdf:paxosglobal/asdf-richgo"]
+bins = ["richgo"]
 description = "Enrich `go test` outputs with text decorations"

--- a/registry/ripgrep-all.toml
+++ b/registry/ripgrep-all.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:phiresky/ripgrep-all", "cargo:ripgrep_all"]
+bins = ["rga", "rga-fzf", "rga-fzf-open", "rga-preproc"]
 description = "rga: ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, etc"
 test = { cmd = "rga --version", expected = "ripgrep-all {{version}}" }

--- a/registry/ripgrep.toml
+++ b/registry/ripgrep.toml
@@ -4,5 +4,6 @@ backends = [
   "asdf:https://gitlab.com/wt0f/asdf-ripgrep",
   "cargo:ripgrep",
 ]
+bins = ["rg"]
 description = "ripgrep recursively searches directories for a regex pattern while respecting your gitignore"
 test = { cmd = "rg --version", expected = "ripgrep {{version}}" }

--- a/registry/ripsecrets.toml
+++ b/registry/ripsecrets.toml
@@ -2,5 +2,6 @@ backends = [
   "aqua:sirwart/ripsecrets",
   "asdf:https://github.com/boris-smidt-klarrio/asdf-ripsecrets",
 ]
+bins = ["ripsecrets"]
 description = "A command-line tool to prevent committing secret keys into your source code"
 test = { cmd = "ripsecrets --version", expected = "ripsecrets {{version}}" }

--- a/registry/rmz.toml
+++ b/registry/rmz.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:SUPERCILEX/fuc/rmz"]
+bins = ["rmz"]
 description = "A zippy alternative to rm, a tool to remove files and directories"
 test = { cmd = "rmz --version", expected = "rmz {{version}}" }

--- a/registry/rpk.toml
+++ b/registry/rpk.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:redpanda-data/redpanda"]
+bins = ["rpk"]
 description = "Redpanda CLI and toolbox"
 test = { cmd = "rpk --version", expected = "rpk version (Redpanda CLI): v{{version}}" }

--- a/registry/rtk.toml
+++ b/registry/rtk.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:rtk-ai/rtk", "github:rtk-ai/rtk"]
+bins = ["rtk"]
 description = "High-performance CLI proxy that reduces LLM token consumption by 60-90%"
 test = { cmd = "rtk --version", expected = "rtk {{version}}" }

--- a/registry/ruby.toml
+++ b/registry/ruby.toml
@@ -1,4 +1,22 @@
 backends = ["core:ruby"]
+bins = [
+  "bundle",
+  "bundler",
+  "erb",
+  "gem",
+  "irb",
+  "minitest",
+  "racc",
+  "rake",
+  "rbs",
+  "rdbg",
+  "rdoc",
+  "ri",
+  "ruby",
+  "syntax_suggest",
+  "test-unit",
+  "typeprof",
+]
 description = "Ruby language"
 detect = ["Gemfile", ".ruby-version", "Rakefile"]
 idiomatic_files = [".ruby-version", "Gemfile"]

--- a/registry/ruff.toml
+++ b/registry/ruff.toml
@@ -1,4 +1,5 @@
 backends = ["aqua:astral-sh/ruff", "asdf:simhem/asdf-ruff"]
+bins = ["ruff"]
 description = "An extremely fast Python linter and code formatter, written in Rust"
 idiomatic_files = [
   { path = "ruff.toml", version_regex = '''(?m)^\s*required-version\s*=\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },

--- a/registry/rumdl.toml
+++ b/registry/rumdl.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:rvben/rumdl", "github:rvben/rumdl"]
+bins = ["rumdl"]
 description = "Markdown Linter and Formatter written in Rust"
 test = { cmd = "rumdl --version", expected = "rumdl {{version}}" }

--- a/registry/rush.toml
+++ b/registry/rush.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:shenwei356/rush"]
+bins = ["rush"]
 description = "A cross-platform command-line tool for executing jobs in parallel"
 test = { cmd = "rush --help", expected = "rush -- a cross-platform command-line tool for executing jobs in parallel" }

--- a/registry/rust-analyzer.toml
+++ b/registry/rust-analyzer.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:rust-lang/rust-analyzer", "asdf:Xyven1/asdf-rust-analyzer"]
+bins = ["rust-analyzer"]
 description = "A Rust compiler front-end for IDEs"

--- a/registry/rust.toml
+++ b/registry/rust.toml
@@ -1,3 +1,19 @@
 backends = ["core:rust", "asdf:code-lever/asdf-rust"]
+bins = [
+  "cargo",
+  "cargo-clippy",
+  "cargo-fmt",
+  "cargo-miri",
+  "clippy-driver",
+  "rls",
+  "rust-analyzer",
+  "rust-gdb",
+  "rust-gdbgui",
+  "rust-lldb",
+  "rustc",
+  "rustdoc",
+  "rustfmt",
+  "rustup",
+]
 description = "Rust language"
 idiomatic_files = ["rust-toolchain.toml"]

--- a/registry/rustic.toml
+++ b/registry/rustic.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:rustic-rs/rustic", "cargo:rustic-rs"]
+bins = ["rustic"]
 description = "rustic - fast, encrypted, and deduplicated backups powered by Rust"
 test = { cmd = "rustic --version", expected = "rustic v{{version}}" }

--- a/registry/rye.toml
+++ b/registry/rye.toml
@@ -1,2 +1,3 @@
 backends = ["aqua:astral-sh/rye", "asdf:Azuki-bar/asdf-rye", "cargo:rye"]
+bins = ["rye"]
 description = "a Hassle-Free Python Experience"

--- a/registry/s5cmd.toml
+++ b/registry/s5cmd.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:peak/s5cmd"]
+bins = ["s5cmd"]
 description = "Parallel S3 and local filesystem execution tool"
 test = { cmd = "s5cmd version", expected = "v{{version}}" }


### PR DESCRIPTION
## Summary

This is part of a four-PR stack that adds explicit `bin` metadata discovered from installed registry tools.

The discovery and isolation machinery was local-only and is not included in the codebase. Results were filtered conservatively: uncertain entries were omitted, including version- or platform-specific artifacts, documentation, shared libraries, wrappers, completion helpers, installers, and incidental dependency executables.

Validation:
- `mise run lint-fix`
- `cargo test --all-features registry` (79 passed)
- pruning dry-run reports no remaining matches
- each commit changes only `registry/*.toml`

This slice covers 228 files, alphabetically from `kubeone` through `s5cmd`.

Stack: #11671 → #11676 → #11677 → #11678

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Declarative-only changes to registry TOML; no auth, install, or runtime code paths modified in this slice.
> 
> **Overview**
> Adds explicit **`bins`** arrays to **228** registry entries (`kubeone` through `s5cmd`) so mise can declare which executables each tool installs without inferring them at runtime.
> 
> Most entries list a single primary CLI; several bundles enumerate multiple commands (e.g. **`lima`**, **`llama.cpp`**, **`mysql`** / **`mysql-client`**, **`perl`**, **`pulumi`**, **`ruby`**, **`rust`**, **`node`**, **`python`**). **`longbridge-terminal`** keeps existing **`bin`** and also adds matching **`bins`**.
> 
> No backends, tests, or install logic change—only registry metadata, consistent with the broader bin-discovery stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20261a219146396a22f3ca2950881bdd4cf55e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added executable recognition for a broad range of Kubernetes, cloud, database, development, networking, security, and productivity tools.
  * Registered single- and multi-command packages, including Node.js, Python, Ruby, Rust, Perl, MySQL, Redis, Lima, Pulumi, and Llama-related tooling.
  * Improved support for alternate command names and companion utilities, enabling more complete installation and management across the catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->