### PR TITLE
fix(sync): reconcile external provider links

### DIFF
--- a/docs/cli/sync/node.md
+++ b/docs/cli/sync/node.md
@@ -9,7 +9,7 @@ Symlinks all tool versions from an external tool into mise
 
 For example, use this to import all Homebrew node installs into mise
 
-This won't overwrite any existing installs but will overwrite any existing symlinks
+This won't overwrite managed installs, runtime aliases, or links from other providers.
 
 ## Flags
 

--- a/docs/cli/sync/python.md
+++ b/docs/cli/sync/python.md
@@ -9,7 +9,7 @@ Symlinks all tool versions from an external tool into mise
 
 For example, use this to import all pyenv installs into mise
 
-This won't overwrite any existing installs but will overwrite any existing symlinks
+This won't overwrite managed installs, runtime aliases, or links from other providers.
 
 ## Flags
 

--- a/e2e/sync/test_sync_nvm
+++ b/e2e/sync/test_sync_nvm
@@ -17,7 +17,7 @@ ln -s ./18.0.0 "$MISE_DATA_DIR/installs/node/provider-runtime-alias"
 install_fake_node "$NVM_DIR/versions/node/v20.0.0"
 install_fake_node "$NVM_DIR/versions/node/v21.0.0"
 install_fake_node "$NVM_DIR/versions/node/v22.0.0"
-install_fake_node "$MISE_DATA_DIR/installs/node/20.0.0/bin"
+install_fake_node "$MISE_DATA_DIR/installs/node/20.0.0"
 install_fake_node "$PWD/other-provider/21.0.0"
 ln -s "$PWD/other-provider/21.0.0" "$MISE_DATA_DIR/installs/node/21.0.0"
 

--- a/e2e/sync/test_sync_nvm
+++ b/e2e/sync/test_sync_nvm
@@ -12,13 +12,27 @@ install_fake_node "$NVM_DIR/versions/node/v18.0.0"
 mise sync node --nvm
 mise ls
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/18.0.0"
+ln -s ./18.0.0 "$MISE_DATA_DIR/installs/node/provider-runtime-alias"
 
 install_fake_node "$NVM_DIR/versions/node/v20.0.0"
+install_fake_node "$NVM_DIR/versions/node/v21.0.0"
 install_fake_node "$NVM_DIR/versions/node/v22.0.0"
-install_fake_node "$MISE_DATA_DIR/installs/node/20.0.0/bin"
+install_fake_node "$MISE_DATA_DIR/installs/node/20.0.0"
+install_fake_node "$PWD/other-provider/21.0.0"
+ln -s "$PWD/other-provider/21.0.0" "$MISE_DATA_DIR/installs/node/21.0.0"
 
 mise sync node --nvm
 mise ls
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/22.0.0"
 assert_not_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/20.0.0"
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/18.0.0"
+assert "test -L \"$MISE_DATA_DIR/installs/node/provider-runtime-alias\""
+assert_contains "readlink \"$MISE_DATA_DIR/installs/node/21.0.0\"" "other-provider/21.0.0"
+
+# Only stale links owned by nvm are removed. Managed installs and links owned
+# by other providers remain untouched.
+rm -r "$NVM_DIR/versions/node/v18.0.0"
+mise sync node --nvm
+assert "test ! -e \"$MISE_DATA_DIR/installs/node/18.0.0\" && test ! -L \"$MISE_DATA_DIR/installs/node/18.0.0\""
+assert "test -d \"$MISE_DATA_DIR/installs/node/20.0.0\""
+assert_contains "readlink \"$MISE_DATA_DIR/installs/node/21.0.0\"" "other-provider/21.0.0"

--- a/e2e/sync/test_sync_nvm
+++ b/e2e/sync/test_sync_nvm
@@ -12,13 +12,27 @@ install_fake_node "$NVM_DIR/versions/node/v18.0.0"
 mise sync node --nvm
 mise ls
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/18.0.0"
+ln -s ./18.0.0 "$MISE_DATA_DIR/installs/node/provider-runtime-alias"
 
 install_fake_node "$NVM_DIR/versions/node/v20.0.0"
+install_fake_node "$NVM_DIR/versions/node/v21.0.0"
 install_fake_node "$NVM_DIR/versions/node/v22.0.0"
 install_fake_node "$MISE_DATA_DIR/installs/node/20.0.0/bin"
+install_fake_node "$PWD/other-provider/21.0.0"
+ln -s "$PWD/other-provider/21.0.0" "$MISE_DATA_DIR/installs/node/21.0.0"
 
 mise sync node --nvm
 mise ls
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/22.0.0"
 assert_not_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/20.0.0"
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/18.0.0"
+assert "test -L \"$MISE_DATA_DIR/installs/node/provider-runtime-alias\""
+assert_contains "readlink \"$MISE_DATA_DIR/installs/node/21.0.0\"" "other-provider/21.0.0"
+
+# Only stale links owned by nvm are removed. Managed installs and links owned
+# by other providers remain untouched.
+rm -r "$NVM_DIR/versions/node/v18.0.0"
+mise sync node --nvm
+assert "test ! -e \"$MISE_DATA_DIR/installs/node/18.0.0\" && test ! -L \"$MISE_DATA_DIR/installs/node/18.0.0\""
+assert "test -d \"$MISE_DATA_DIR/installs/node/20.0.0\""
+assert_contains "readlink \"$MISE_DATA_DIR/installs/node/21.0.0\"" "other-provider/21.0.0"

--- a/e2e/sync/test_sync_nvm
+++ b/e2e/sync/test_sync_nvm
@@ -36,3 +36,12 @@ mise sync node --nvm
 assert "test ! -e \"$MISE_DATA_DIR/installs/node/18.0.0\" && test ! -L \"$MISE_DATA_DIR/installs/node/18.0.0\""
 assert "test -d \"$MISE_DATA_DIR/installs/node/20.0.0\""
 assert_contains "readlink \"$MISE_DATA_DIR/installs/node/21.0.0\"" "other-provider/21.0.0"
+
+# A stale link from a later selected provider must not block an earlier
+# provider's desired version and then disappear during the later cleanup.
+export NODENV_ROOT="$PWD/.nodenv"
+install_fake_node "$NVM_DIR/versions/node/v23.0.0"
+mkdir -p "$NODENV_ROOT/versions"
+ln -s "$NODENV_ROOT/versions/23.0.0" "$MISE_DATA_DIR/installs/node/23.0.0"
+mise sync node --nvm --nodenv
+assert_contains "readlink \"$MISE_DATA_DIR/installs/node/23.0.0\"" ".nvm/versions/node/v23.0.0"

--- a/e2e/sync/test_sync_python_uv
+++ b/e2e/sync/test_sync_python_uv
@@ -7,9 +7,18 @@ assert "mise use -g uv@0.11.8 python@3.11.3"
 assert "mise x -- uv python install 3.11.1"
 mkdir -p "$MISE_CACHE_DIR/python/3.11.1"
 touch "$MISE_CACHE_DIR/python/3.11.1/incomplete"
+test_uv_python_dir="$(mise x -- uv python dir)"
+# Multiple provider entries can map to the same mise version. Preserve the
+# first sorted entry, matching the previous create-if-missing behavior.
+mkdir -p "$test_uv_python_dir/pypy-3.11.1-linux-x86_64-gnu"
+mkdir -p "$test_uv_python_dir/unrecognized"
 export UV_PYTHON_DOWNLOADS=never
 assert "mise sync python --uv"
 assert "test ! -f \"$MISE_CACHE_DIR/python/3.11.1/incomplete\""
 assert "mise where python@3.11.1"
+assert_contains "readlink \"$MISE_DATA_DIR/installs/python/3.11.1\"" "cpython-3.11.1"
+touch "$MISE_CACHE_DIR/python/3.11.1/incomplete"
+assert "mise sync python --uv"
+assert "test ! -f \"$MISE_CACHE_DIR/python/3.11.1/incomplete\""
 assert "mise x python@3.11.1 -- python -V" "Python 3.11.1"
 assert "mise x -- uv run -p 3.11.3 -- python -V" "Python 3.11.3"

--- a/e2e/sync/test_sync_python_uv
+++ b/e2e/sync/test_sync_python_uv
@@ -22,3 +22,12 @@ assert "mise sync python --uv"
 assert "test ! -f \"$MISE_CACHE_DIR/python/3.11.1/incomplete\""
 assert "mise x python@3.11.1 -- python -V" "Python 3.11.1"
 assert "mise x -- uv run -p 3.11.3 -- python -V" "Python 3.11.3"
+
+# Joint reconciliation lets the earlier pyenv source replace a stale uv-owned
+# link before uv removes it.
+export PYENV_ROOT="$PWD/.pyenv"
+mkdir -p "$PYENV_ROOT/versions/3.11.2"
+ln -s "$test_uv_python_dir/cpython-3.11.2-linux-x86_64-gnu" \
+  "$MISE_DATA_DIR/installs/python/3.11.2"
+assert "mise sync python --pyenv --uv"
+assert_contains "readlink \"$MISE_DATA_DIR/installs/python/3.11.2\"" ".pyenv/versions/3.11.2"

--- a/e2e/sync/test_sync_python_uv
+++ b/e2e/sync/test_sync_python_uv
@@ -11,10 +11,14 @@ test_uv_python_dir="$(mise x -- uv python dir)"
 # Multiple provider entries can map to the same mise version. Preserve the
 # first sorted entry, matching the previous create-if-missing behavior.
 mkdir -p "$test_uv_python_dir/pypy-3.11.1-linux-x86_64-gnu"
+mkdir -p "$test_uv_python_dir/unrecognized"
 export UV_PYTHON_DOWNLOADS=never
 assert "mise sync python --uv"
 assert "test ! -f \"$MISE_CACHE_DIR/python/3.11.1/incomplete\""
 assert "mise where python@3.11.1"
 assert_contains "readlink \"$MISE_DATA_DIR/installs/python/3.11.1\"" "cpython-3.11.1"
+touch "$MISE_CACHE_DIR/python/3.11.1/incomplete"
+assert "mise sync python --uv"
+assert "test ! -f \"$MISE_CACHE_DIR/python/3.11.1/incomplete\""
 assert "mise x python@3.11.1 -- python -V" "Python 3.11.1"
 assert "mise x -- uv run -p 3.11.3 -- python -V" "Python 3.11.3"

--- a/e2e/sync/test_sync_python_uv
+++ b/e2e/sync/test_sync_python_uv
@@ -7,9 +7,14 @@ assert "mise use -g uv@0.11.8 python@3.11.3"
 assert "mise x -- uv python install 3.11.1"
 mkdir -p "$MISE_CACHE_DIR/python/3.11.1"
 touch "$MISE_CACHE_DIR/python/3.11.1/incomplete"
+test_uv_python_dir="$(mise x -- uv python dir)"
+# Multiple provider entries can map to the same mise version. Preserve the
+# first sorted entry, matching the previous create-if-missing behavior.
+mkdir -p "$test_uv_python_dir/pypy-3.11.1-linux-x86_64-gnu"
 export UV_PYTHON_DOWNLOADS=never
 assert "mise sync python --uv"
 assert "test ! -f \"$MISE_CACHE_DIR/python/3.11.1/incomplete\""
 assert "mise where python@3.11.1"
+assert_contains "readlink \"$MISE_DATA_DIR/installs/python/3.11.1\"" "cpython-3.11.1"
 assert "mise x python@3.11.1 -- python -V" "Python 3.11.1"
 assert "mise x -- uv run -p 3.11.3 -- python -V" "Python 3.11.3"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3943,7 +3943,7 @@ Symlinks all tool versions from an external tool into mise
 
 For example, use this to import all Homebrew node installs into mise
 
-This won't overwrite any existing installs but will overwrite any existing symlinks
+This won't overwrite managed installs, runtime aliases, or links from other providers.
 .PP
 \fBUsage:\fR mise sync node [OPTIONS]
 .PP
@@ -3963,7 +3963,7 @@ Symlinks all tool versions from an external tool into mise
 
 For example, use this to import all pyenv installs into mise
 
-This won't overwrite any existing installs but will overwrite any existing symlinks
+This won't overwrite managed installs, runtime aliases, or links from other providers.
 .PP
 \fBUsage:\fR mise sync python [OPTIONS]
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3795,7 +3795,7 @@ Symlinks all tool versions from an external tool into mise
 
 For example, use this to import all Homebrew node installs into mise
 
-This won't overwrite any existing installs but will overwrite any existing symlinks
+This won't overwrite managed installs, runtime aliases, or links from other providers.
 """#
         after_long_help #"""
 Examples:
@@ -3815,7 +3815,7 @@ Symlinks all tool versions from an external tool into mise
 
 For example, use this to import all pyenv installs into mise
 
-This won't overwrite any existing installs but will overwrite any existing symlinks
+This won't overwrite managed installs, runtime aliases, or links from other providers.
 """#
         after_long_help #"""
 Examples:

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2208,6 +2208,16 @@ pub trait Backend: Debug + Send + Sync {
         }
         Ok(Some(link))
     }
+    /// Reconciles provider-owned version links under the backend's installs path.
+    ///
+    /// `target_prefix` defines ownership: only links whose resolved targets are
+    /// within it may be removed or replaced. Managed installs, runtime aliases,
+    /// and links owned by another provider are preserved.
+    ///
+    /// If multiple entries in `links` map to the same version, the first entry
+    /// wins, so callers must supply entries in a deterministic order.
+    ///
+    /// Returns versions whose links were created or changed.
     fn sync_symlinks(
         &self,
         target_prefix: &Path,
@@ -2248,6 +2258,7 @@ pub trait Backend: Debug + Send + Sync {
             };
 
             if !runtime_link && target.exists() && file::is_symlink_to(&link, target) {
+                install_state::clear_incomplete_marker(&self.ba().short, &version)?;
                 continue;
             }
 
@@ -2260,6 +2271,9 @@ pub trait Backend: Debug + Send + Sync {
 
             if entry_exists {
                 file::make_symlink(target, &link)?;
+                if target.exists() {
+                    install_state::clear_incomplete_marker(&self.ba().short, &version)?;
+                }
                 changed.insert(version);
             } else if self.create_symlink(&version, target)?.is_some() {
                 changed.insert(version);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsString;
 use std::fmt::{Debug, Display, Formatter};
 use std::fs::File;
@@ -2207,6 +2207,65 @@ pub trait Backend: Debug + Send + Sync {
             install_state::clear_incomplete_marker(&self.ba().short, version)?;
         }
         Ok(Some(link))
+    }
+    fn sync_symlinks(
+        &self,
+        target_prefix: &Path,
+        links: Vec<(String, PathBuf)>,
+    ) -> Result<BTreeSet<String>> {
+        let mut desired = BTreeMap::new();
+        for (version, target) in links {
+            // Preserve the first provider entry for a version, matching the
+            // previous create-if-missing loop when providers expose duplicates.
+            desired.entry(version).or_insert(target);
+        }
+        let installs_path = &self.ba().installs_path;
+        let mut versions = desired.keys().cloned().collect::<BTreeSet<_>>();
+
+        if installs_path.exists() {
+            for entry in installs_path.read_dir()? {
+                let path = entry?.path();
+                if !is_runtime_symlink(&path)
+                    && file::is_symlink_to_prefix(&path, target_prefix)?
+                    && let Some(version) = path.file_name().and_then(|v| v.to_str())
+                {
+                    versions.insert(version.to_string());
+                }
+            }
+        }
+
+        file::create_dir_all(installs_path)?;
+        let mut changed = BTreeSet::new();
+        for version in versions {
+            let link = installs_path.join(&version);
+            let runtime_link = is_runtime_symlink(&link);
+            let provider_link = !runtime_link && file::is_symlink_to_prefix(&link, target_prefix)?;
+            let Some(target) = desired.get(&version) else {
+                if provider_link {
+                    file::remove_symlink_or_junction(&link)?;
+                }
+                continue;
+            };
+
+            if !runtime_link && target.exists() && file::is_symlink_to(&link, target) {
+                continue;
+            }
+
+            let entry_exists = std::fs::symlink_metadata(&link).is_ok();
+            if entry_exists && !provider_link {
+                // Never overwrite a managed install, runtime alias, or link
+                // owned by another sync provider.
+                continue;
+            }
+
+            if entry_exists {
+                file::make_symlink(target, &link)?;
+                changed.insert(version);
+            } else if self.create_symlink(&version, target)?.is_some() {
+                changed.insert(version);
+            }
+        }
+        Ok(changed)
     }
     fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {
         let versions = self.list_installed_versions();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2557,22 +2557,6 @@ pub trait Backend: Debug + Send + Sync {
         }
         None
     }
-    fn create_symlink(&self, version: &str, target: &Path) -> Result<Option<(PathBuf, PathBuf)>> {
-        let _state_lock = install_state::lock_tool_version(&self.ba().short, version)?;
-        let link = self.ba().installs_path.join(version);
-        if link.exists() {
-            if target.exists() && file::is_symlink_to(&link, target) {
-                install_state::clear_incomplete_marker(&self.ba().short, version)?;
-            }
-            return Ok(None);
-        }
-        file::create_dir_all(link.parent().unwrap())?;
-        let link = file::make_symlink(target, &link)?;
-        if target.exists() {
-            install_state::clear_incomplete_marker(&self.ba().short, version)?;
-        }
-        Ok(Some(link))
-    }
     fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {
         let versions = self.list_installed_versions();
         // No async config lookup available here; fall back to inline/registry

--- a/src/cli/sync/mod.rs
+++ b/src/cli/sync/mod.rs
@@ -3,6 +3,7 @@ use eyre::Result;
 
 mod node;
 mod python;
+mod reconcile;
 mod ruby;
 
 #[derive(Debug, clap::Args)]

--- a/src/cli/sync/node.rs
+++ b/src/cli/sync/node.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use eyre::Result;
 use itertools::sorted;
 
-use crate::{backend, config, dirs, file};
+use crate::{backend, config, file};
 use crate::{config::Config, config::Settings};
 
 /// Symlinks all tool versions from an external tool into mise
@@ -61,11 +61,9 @@ impl SyncNode {
         let node = backend::get(&"node".into()).unwrap();
 
         let brew_prefix = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
-        let installed_versions_path = dirs::INSTALLS.join("node");
-
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &brew_prefix)?;
 
         let subdirs = file::dir_subdirs(&brew_prefix)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
@@ -74,9 +72,10 @@ impl SyncNode {
                 continue;
             }
             let v = entry.trim_start_matches("node@");
-            if node.create_symlink(v, &brew_prefix.join(&entry))?.is_some() {
-                miseprintln!("Synced node@{} from Homebrew", v);
-            }
+            links.push((v.to_string(), brew_prefix.join(&entry)));
+        }
+        for v in node.sync_symlinks(&brew_prefix, links)? {
+            miseprintln!("Synced node@{} from Homebrew", v);
         }
         Ok(())
     }
@@ -88,31 +87,18 @@ impl SyncNode {
         let nvm_versions_path = file::replace_path(&settings.node.nvm_dir)
             .join("versions")
             .join("node");
-        let installed_versions_path = dirs::INSTALLS.join("node");
 
-        let removed =
-            file::remove_symlinks_with_target_prefix(&installed_versions_path, &nvm_versions_path)?;
-        if !removed.is_empty() {
-            debug!("Removed symlinks: {removed:?}");
-        }
-
-        let mut created = vec![];
         let subdirs = file::dir_subdirs(&nvm_versions_path)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
             }
             let v = entry.trim_start_matches('v');
-            let symlink = node.create_symlink(v, &nvm_versions_path.join(&entry))?;
-            if let Some(symlink) = symlink {
-                created.push(symlink);
-                miseprintln!("Synced node@{} from nvm", v);
-            } else {
-                info!("Skipping node@{v} from nvm because it already exists in mise");
-            }
+            links.push((v.to_string(), nvm_versions_path.join(&entry)));
         }
-        if !created.is_empty() {
-            debug!("Created symlinks: {created:?}");
+        for v in node.sync_symlinks(&nvm_versions_path, links)? {
+            miseprintln!("Synced node@{} from nvm", v);
         }
         Ok(())
     }
@@ -122,21 +108,17 @@ impl SyncNode {
         let settings = Settings::get();
 
         let nodenv_versions_path = file::replace_path(&settings.node.nodenv_root).join("versions");
-        let installed_versions_path = dirs::INSTALLS.join("node");
-
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &nodenv_versions_path)?;
 
         let subdirs = file::dir_subdirs(&nodenv_versions_path)?;
+        let mut links = vec![];
         for v in sorted(subdirs) {
             if v.starts_with(".") {
                 continue;
             }
-            if node
-                .create_symlink(&v, &nodenv_versions_path.join(&v))?
-                .is_some()
-            {
-                miseprintln!("Synced node@{} from nodenv", v);
-            }
+            links.push((v.clone(), nodenv_versions_path.join(&v)));
+        }
+        for v in node.sync_symlinks(&nodenv_versions_path, links)? {
+            miseprintln!("Synced node@{} from nodenv", v);
         }
         Ok(())
     }

--- a/src/cli/sync/node.rs
+++ b/src/cli/sync/node.rs
@@ -3,8 +3,10 @@ use std::path::PathBuf;
 use eyre::Result;
 use itertools::sorted;
 
-use crate::{backend, config, dirs, file};
+use crate::{backend, config, file};
 use crate::{config::Config, config::Settings};
+
+use super::reconcile;
 
 /// Symlinks all tool versions from an external tool into mise
 ///
@@ -60,12 +62,10 @@ impl SyncNode {
     async fn run_brew(&self) -> Result<()> {
         let node = backend::get(&"node".into()).unwrap();
 
-        let brew_prefix = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
-        let installed_versions_path = dirs::INSTALLS.join("node");
+        let brew_opt = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
 
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &brew_prefix)?;
-
-        let subdirs = file::dir_subdirs(&brew_prefix)?;
+        let subdirs = file::dir_subdirs(&brew_opt)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
@@ -74,9 +74,11 @@ impl SyncNode {
                 continue;
             }
             let v = entry.trim_start_matches("node@");
-            if node.create_symlink(v, &brew_prefix.join(&entry))?.is_some() {
-                miseprintln!("Synced node@{} from Homebrew", v);
-            }
+            links.push((v.to_string(), brew_opt.join(&entry)));
+        }
+        let ownership = reconcile::LinkOwnership::direct(&brew_opt);
+        for v in reconcile::reconcile(node.ba(), ownership, links)? {
+            miseprintln!("Synced node@{} from Homebrew", v);
         }
         Ok(())
     }
@@ -88,31 +90,19 @@ impl SyncNode {
         let nvm_versions_path = file::replace_path(&settings.node.nvm_dir)
             .join("versions")
             .join("node");
-        let installed_versions_path = dirs::INSTALLS.join("node");
 
-        let removed =
-            file::remove_symlinks_with_target_prefix(&installed_versions_path, &nvm_versions_path)?;
-        if !removed.is_empty() {
-            debug!("Removed symlinks: {removed:?}");
-        }
-
-        let mut created = vec![];
         let subdirs = file::dir_subdirs(&nvm_versions_path)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
             }
             let v = entry.trim_start_matches('v');
-            let symlink = node.create_symlink(v, &nvm_versions_path.join(&entry))?;
-            if let Some(symlink) = symlink {
-                created.push(symlink);
-                miseprintln!("Synced node@{} from nvm", v);
-            } else {
-                info!("Skipping node@{v} from nvm because it already exists in mise");
-            }
+            links.push((v.to_string(), nvm_versions_path.join(&entry)));
         }
-        if !created.is_empty() {
-            debug!("Created symlinks: {created:?}");
+        let ownership = reconcile::LinkOwnership::resolved(&nvm_versions_path);
+        for v in reconcile::reconcile(node.ba(), ownership, links)? {
+            miseprintln!("Synced node@{} from nvm", v);
         }
         Ok(())
     }
@@ -122,21 +112,18 @@ impl SyncNode {
         let settings = Settings::get();
 
         let nodenv_versions_path = file::replace_path(&settings.node.nodenv_root).join("versions");
-        let installed_versions_path = dirs::INSTALLS.join("node");
-
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &nodenv_versions_path)?;
 
         let subdirs = file::dir_subdirs(&nodenv_versions_path)?;
+        let mut links = vec![];
         for v in sorted(subdirs) {
             if v.starts_with(".") {
                 continue;
             }
-            if node
-                .create_symlink(&v, &nodenv_versions_path.join(&v))?
-                .is_some()
-            {
-                miseprintln!("Synced node@{} from nodenv", v);
-            }
+            links.push((v.clone(), nodenv_versions_path.join(&v)));
+        }
+        let ownership = reconcile::LinkOwnership::resolved(&nodenv_versions_path);
+        for v in reconcile::reconcile(node.ba(), ownership, links)? {
+            miseprintln!("Synced node@{} from nodenv", v);
         }
         Ok(())
     }

--- a/src/cli/sync/node.rs
+++ b/src/cli/sync/node.rs
@@ -60,9 +60,10 @@ impl SyncNode {
     async fn run_brew(&self) -> Result<()> {
         let node = backend::get(&"node".into()).unwrap();
 
-        let brew_prefix = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
+        let brew_opt = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
+        let brew_cellar = PathBuf::from(cmd!("brew", "--cellar").read()?);
 
-        let subdirs = file::dir_subdirs(&brew_prefix)?;
+        let subdirs = file::dir_subdirs(&brew_opt)?;
         let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
@@ -72,9 +73,9 @@ impl SyncNode {
                 continue;
             }
             let v = entry.trim_start_matches("node@");
-            links.push((v.to_string(), brew_prefix.join(&entry)));
+            links.push((v.to_string(), brew_opt.join(&entry)));
         }
-        for v in node.sync_symlinks(&brew_prefix, links)? {
+        for v in node.sync_symlinks(&brew_cellar, links)? {
             miseprintln!("Synced node@{} from Homebrew", v);
         }
         Ok(())

--- a/src/cli/sync/node.rs
+++ b/src/cli/sync/node.rs
@@ -12,7 +12,7 @@ use super::reconcile;
 ///
 /// For example, use this to import all Homebrew node installs into mise
 ///
-/// This won't overwrite any existing installs but will overwrite any existing symlinks
+/// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct SyncNode {
@@ -38,14 +38,32 @@ pub struct SyncNodeType {
 
 impl SyncNode {
     pub async fn run(self) -> Result<()> {
+        let node = backend::get(&"node".into()).unwrap();
+        let mut providers = vec![];
         if self._type.brew {
-            self.run_brew().await?;
+            providers.push(self.brew_links()?);
         }
         if self._type.nvm {
-            self.run_nvm().await?;
+            providers.push(self.nvm_links()?);
         }
         if self._type.nodenv {
-            self.run_nodenv().await?;
+            providers.push(self.nodenv_links()?);
+        }
+        let mut changed = reconcile::reconcile_all(node.ba(), providers)?.into_iter();
+        if self._type.brew {
+            for v in changed.next().unwrap_or_default() {
+                miseprintln!("Synced node@{} from Homebrew", v);
+            }
+        }
+        if self._type.nvm {
+            for v in changed.next().unwrap_or_default() {
+                miseprintln!("Synced node@{} from nvm", v);
+            }
+        }
+        if self._type.nodenv {
+            for v in changed.next().unwrap_or_default() {
+                miseprintln!("Synced node@{} from nodenv", v);
+            }
         }
         let config = Config::reset().await?;
         let ts = config.get_toolset().await?;
@@ -59,9 +77,7 @@ impl SyncNode {
         Ok(())
     }
 
-    async fn run_brew(&self) -> Result<()> {
-        let node = backend::get(&"node".into()).unwrap();
-
+    fn brew_links(&self) -> Result<reconcile::ProviderLinks> {
         let brew_opt = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
 
         let subdirs = file::dir_subdirs(&brew_opt)?;
@@ -76,15 +92,11 @@ impl SyncNode {
             let v = entry.trim_start_matches("node@");
             links.push((v.to_string(), brew_opt.join(&entry)));
         }
-        let ownership = reconcile::LinkOwnership::direct(&brew_opt);
-        for v in reconcile::reconcile(node.ba(), ownership, links)? {
-            miseprintln!("Synced node@{} from Homebrew", v);
-        }
-        Ok(())
+        let ownership = reconcile::LinkOwnership::in_namespace(&brew_opt);
+        Ok(reconcile::ProviderLinks::new(ownership, links))
     }
 
-    async fn run_nvm(&self) -> Result<()> {
-        let node = backend::get(&"node".into()).unwrap();
+    fn nvm_links(&self) -> Result<reconcile::ProviderLinks> {
         let settings = Settings::get();
 
         let nvm_versions_path = file::replace_path(&settings.node.nvm_dir)
@@ -100,15 +112,11 @@ impl SyncNode {
             let v = entry.trim_start_matches('v');
             links.push((v.to_string(), nvm_versions_path.join(&entry)));
         }
-        let ownership = reconcile::LinkOwnership::resolved(&nvm_versions_path);
-        for v in reconcile::reconcile(node.ba(), ownership, links)? {
-            miseprintln!("Synced node@{} from nvm", v);
-        }
-        Ok(())
+        let ownership = reconcile::LinkOwnership::in_namespace(&nvm_versions_path);
+        Ok(reconcile::ProviderLinks::new(ownership, links))
     }
 
-    async fn run_nodenv(&self) -> Result<()> {
-        let node = backend::get(&"node".into()).unwrap();
+    fn nodenv_links(&self) -> Result<reconcile::ProviderLinks> {
         let settings = Settings::get();
 
         let nodenv_versions_path = file::replace_path(&settings.node.nodenv_root).join("versions");
@@ -121,11 +129,8 @@ impl SyncNode {
             }
             links.push((v.clone(), nodenv_versions_path.join(&v)));
         }
-        let ownership = reconcile::LinkOwnership::resolved(&nodenv_versions_path);
-        for v in reconcile::reconcile(node.ba(), ownership, links)? {
-            miseprintln!("Synced node@{} from nodenv", v);
-        }
-        Ok(())
+        let ownership = reconcile::LinkOwnership::in_namespace(&nodenv_versions_path);
+        Ok(reconcile::ProviderLinks::new(ownership, links))
     }
 }
 

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -11,7 +11,7 @@ use super::reconcile;
 ///
 /// For example, use this to import all pyenv installs into mise
 ///
-/// This won't overwrite any existing installs but will overwrite any existing symlinks
+/// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct SyncPython {
@@ -26,11 +26,25 @@ pub struct SyncPython {
 
 impl SyncPython {
     pub async fn run(self) -> Result<()> {
+        let python = backend::get(&"python".into()).unwrap();
+        let mut providers = vec![];
         if self.pyenv {
-            self.pyenv().await?;
+            providers.push(self.pyenv_links()?);
         }
         if self.uv {
-            self.uv().await?;
+            providers.push(self.uv_links()?);
+        }
+        let mut changed = reconcile::reconcile_all(python.ba(), providers)?.into_iter();
+        if self.pyenv {
+            for v in changed.next().unwrap_or_default() {
+                miseprintln!("Synced python@{} from pyenv", v);
+            }
+        }
+        if self.uv {
+            for v in changed.next().unwrap_or_default() {
+                miseprintln!("Synced python@{v} from uv to mise");
+            }
+            self.mise_to_uv()?;
         }
         let config = Config::get().await?;
         let ts = config.get_toolset().await?;
@@ -44,9 +58,7 @@ impl SyncPython {
         Ok(())
     }
 
-    async fn pyenv(&self) -> Result<()> {
-        let python = backend::get(&"python".into()).unwrap();
-
+    fn pyenv_links(&self) -> Result<reconcile::ProviderLinks> {
         let pyenv_versions_path = PYENV_ROOT.join("versions");
 
         let subdirs = file::dir_subdirs(&pyenv_versions_path)?;
@@ -57,17 +69,12 @@ impl SyncPython {
             }
             links.push((v.clone(), pyenv_versions_path.join(&v)));
         }
-        let ownership = reconcile::LinkOwnership::resolved(&pyenv_versions_path);
-        for v in reconcile::reconcile(python.ba(), ownership, links)? {
-            miseprintln!("Synced python@{} from pyenv", v);
-        }
-        Ok(())
+        let ownership = reconcile::LinkOwnership::in_namespace(&pyenv_versions_path);
+        Ok(reconcile::ProviderLinks::new(ownership, links))
     }
 
-    async fn uv(&self) -> Result<()> {
-        let python = backend::get(&"python".into()).unwrap();
+    fn uv_links(&self) -> Result<reconcile::ProviderLinks> {
         let uv_versions_path = &*env::UV_PYTHON_INSTALL_DIR;
-        let installed_python_versions_path = dirs::INSTALLS.join("python");
 
         let subdirs = file::dir_subdirs(uv_versions_path)?;
         let mut links = vec![];
@@ -82,11 +89,13 @@ impl SyncPython {
             };
             links.push((v.to_string(), uv_versions_path.join(&name)));
         }
-        let ownership = reconcile::LinkOwnership::resolved(uv_versions_path);
-        for v in reconcile::reconcile(python.ba(), ownership, links)? {
-            miseprintln!("Synced python@{v} from uv to mise");
-        }
+        let ownership = reconcile::LinkOwnership::in_namespace(uv_versions_path);
+        Ok(reconcile::ProviderLinks::new(ownership, links))
+    }
 
+    fn mise_to_uv(&self) -> Result<()> {
+        let uv_versions_path = &*env::UV_PYTHON_INSTALL_DIR;
+        let installed_python_versions_path = dirs::INSTALLS.join("python");
         let subdirs = file::dir_subdirs(&installed_python_versions_path)?;
         for v in sorted(subdirs) {
             if v.starts_with(".") {

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -46,19 +46,16 @@ impl SyncPython {
         let python = backend::get(&"python".into()).unwrap();
 
         let pyenv_versions_path = PYENV_ROOT.join("versions");
-        let installed_python_versions_path = dirs::INSTALLS.join("python");
-
-        file::remove_symlinks_with_target_prefix(
-            &installed_python_versions_path,
-            &pyenv_versions_path,
-        )?;
 
         let subdirs = file::dir_subdirs(&pyenv_versions_path)?;
+        let mut links = vec![];
         for v in sorted(subdirs) {
             if v.starts_with(".") {
                 continue;
             }
-            python.create_symlink(&v, &pyenv_versions_path.join(&v))?;
+            links.push((v.clone(), pyenv_versions_path.join(&v)));
+        }
+        for v in python.sync_symlinks(&pyenv_versions_path, links)? {
             miseprintln!("Synced python@{} from pyenv", v);
         }
         Ok(())
@@ -69,24 +66,18 @@ impl SyncPython {
         let uv_versions_path = &*env::UV_PYTHON_INSTALL_DIR;
         let installed_python_versions_path = dirs::INSTALLS.join("python");
 
-        file::remove_symlinks_with_target_prefix(
-            &installed_python_versions_path,
-            uv_versions_path,
-        )?;
-
         let subdirs = file::dir_subdirs(uv_versions_path)?;
+        let mut links = vec![];
         for name in sorted(subdirs) {
             if name.starts_with(".") {
                 continue;
             }
             // name is like cpython-3.13.1-macos-aarch64-none
             let v = name.split('-').nth(1).unwrap();
-            if python
-                .create_symlink(v, &uv_versions_path.join(&name))?
-                .is_some()
-            {
-                miseprintln!("Synced python@{v} from uv to mise");
-            }
+            links.push((v.to_string(), uv_versions_path.join(&name)));
+        }
+        for v in python.sync_symlinks(uv_versions_path, links)? {
+            miseprintln!("Synced python@{v} from uv to mise");
         }
 
         let subdirs = file::dir_subdirs(&installed_python_versions_path)?;

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -44,7 +44,7 @@ impl SyncPython {
             for v in changed.next().unwrap_or_default() {
                 miseprintln!("Synced python@{v} from uv to mise");
             }
-            self.mise_to_uv()?;
+            self.sync_mise_installs_to_uv()?;
         }
         let config = Config::get().await?;
         let ts = config.get_toolset().await?;
@@ -93,7 +93,7 @@ impl SyncPython {
         Ok(reconcile::ProviderLinks::new(ownership, links))
     }
 
-    fn mise_to_uv(&self) -> Result<()> {
+    fn sync_mise_installs_to_uv(&self) -> Result<()> {
         let uv_versions_path = &*env::UV_PYTHON_INSTALL_DIR;
         let installed_python_versions_path = dirs::INSTALLS.join("python");
         let subdirs = file::dir_subdirs(&installed_python_versions_path)?;

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -5,6 +5,8 @@ use std::env::consts::{ARCH, OS};
 use crate::{backend, config, dirs, env, file};
 use crate::{config::Config, env::PYENV_ROOT};
 
+use super::reconcile;
+
 /// Symlinks all tool versions from an external tool into mise
 ///
 /// For example, use this to import all pyenv installs into mise
@@ -46,19 +48,17 @@ impl SyncPython {
         let python = backend::get(&"python".into()).unwrap();
 
         let pyenv_versions_path = PYENV_ROOT.join("versions");
-        let installed_python_versions_path = dirs::INSTALLS.join("python");
-
-        file::remove_symlinks_with_target_prefix(
-            &installed_python_versions_path,
-            &pyenv_versions_path,
-        )?;
 
         let subdirs = file::dir_subdirs(&pyenv_versions_path)?;
+        let mut links = vec![];
         for v in sorted(subdirs) {
             if v.starts_with(".") {
                 continue;
             }
-            python.create_symlink(&v, &pyenv_versions_path.join(&v))?;
+            links.push((v.clone(), pyenv_versions_path.join(&v)));
+        }
+        let ownership = reconcile::LinkOwnership::resolved(&pyenv_versions_path);
+        for v in reconcile::reconcile(python.ba(), ownership, links)? {
             miseprintln!("Synced python@{} from pyenv", v);
         }
         Ok(())
@@ -69,24 +69,22 @@ impl SyncPython {
         let uv_versions_path = &*env::UV_PYTHON_INSTALL_DIR;
         let installed_python_versions_path = dirs::INSTALLS.join("python");
 
-        file::remove_symlinks_with_target_prefix(
-            &installed_python_versions_path,
-            uv_versions_path,
-        )?;
-
         let subdirs = file::dir_subdirs(uv_versions_path)?;
+        let mut links = vec![];
         for name in sorted(subdirs) {
             if name.starts_with(".") {
                 continue;
             }
             // name is like cpython-3.13.1-macos-aarch64-none
-            let v = name.split('-').nth(1).unwrap();
-            if python
-                .create_symlink(v, &uv_versions_path.join(&name))?
-                .is_some()
-            {
-                miseprintln!("Synced python@{v} from uv to mise");
-            }
+            let Some(v) = name.split('-').nth(1).filter(|v| !v.is_empty()) else {
+                debug!("skipping unrecognized uv python dir: {name}");
+                continue;
+            };
+            links.push((v.to_string(), uv_versions_path.join(&name)));
+        }
+        let ownership = reconcile::LinkOwnership::resolved(uv_versions_path);
+        for v in reconcile::reconcile(python.ba(), ownership, links)? {
+            miseprintln!("Synced python@{v} from uv to mise");
         }
 
         let subdirs = file::dir_subdirs(&installed_python_versions_path)?;

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -73,7 +73,10 @@ impl SyncPython {
                 continue;
             }
             // name is like cpython-3.13.1-macos-aarch64-none
-            let v = name.split('-').nth(1).unwrap();
+            let Some(v) = name.split('-').nth(1).filter(|v| !v.is_empty()) else {
+                debug!("skipping unrecognized uv python dir: {name}");
+                continue;
+            };
             links.push((v.to_string(), uv_versions_path.join(&name)));
         }
         for v in python.sync_symlinks(uv_versions_path, links)? {

--- a/src/cli/sync/reconcile.rs
+++ b/src/cli/sync/reconcile.rs
@@ -8,36 +8,34 @@ use crate::file;
 use crate::runtime_symlinks::is_runtime_symlink;
 use crate::toolset::install_state;
 
-pub(super) struct LinkOwnership<'a> {
-    direct_root: Option<&'a Path>,
-    resolved_root: Option<&'a Path>,
+pub(super) struct LinkOwnership {
+    root: PathBuf,
 }
 
-impl<'a> LinkOwnership<'a> {
-    pub(super) fn resolved(root: &'a Path) -> Self {
+impl LinkOwnership {
+    /// Own links whose immediate target is under the provider namespace.
+    ///
+    /// This intentionally includes dangling terminal entries and does not
+    /// resolve a provider entry that itself redirects elsewhere.
+    pub(super) fn in_namespace(root: &Path) -> Self {
         Self {
-            direct_root: None,
-            resolved_root: Some(root),
-        }
-    }
-
-    pub(super) fn direct(root: &'a Path) -> Self {
-        Self {
-            direct_root: Some(root),
-            resolved_root: None,
+            root: root.to_path_buf(),
         }
     }
 
     fn owns(&self, link: &Path) -> Result<bool> {
-        if let Some(root) = self.direct_root
-            && file::is_symlink_target_within(link, root)?
-        {
-            return Ok(true);
-        }
-        match self.resolved_root {
-            Some(root) => file::is_symlink_target_within(link, root),
-            None => Ok(false),
-        }
+        file::is_symlink_target_within(link, &self.root)
+    }
+}
+
+pub(super) struct ProviderLinks {
+    ownership: LinkOwnership,
+    links: Vec<(String, PathBuf)>,
+}
+
+impl ProviderLinks {
+    pub(super) fn new(ownership: LinkOwnership, links: Vec<(String, PathBuf)>) -> Self {
+        Self { ownership, links }
     }
 }
 
@@ -52,14 +50,35 @@ impl<'a> LinkOwnership<'a> {
 /// Returns versions whose links were created or changed.
 pub(super) fn reconcile(
     tool: &BackendArg,
-    ownership: LinkOwnership<'_>,
+    ownership: LinkOwnership,
     links: Vec<(String, PathBuf)>,
 ) -> Result<BTreeSet<String>> {
+    Ok(
+        reconcile_all(tool, vec![ProviderLinks::new(ownership, links)])?
+            .pop()
+            .unwrap_or_default(),
+    )
+}
+
+/// Reconciles multiple selected providers as one operation.
+///
+/// Earlier providers take precedence when multiple sources expose the same
+/// version. Ownership from every selected provider is considered before any
+/// link is removed or replaced, so a stale link from a later provider cannot
+/// block an earlier provider's desired version.
+pub(super) fn reconcile_all(
+    tool: &BackendArg,
+    providers: Vec<ProviderLinks>,
+) -> Result<Vec<BTreeSet<String>>> {
     let mut desired = BTreeMap::new();
-    for (version, target) in links {
-        // Preserve the first source entry for a version, matching the previous
-        // create-if-missing loop when a source exposes duplicates.
-        desired.entry(version).or_insert(target);
+    for (provider_index, provider) in providers.iter().enumerate() {
+        for (version, target) in &provider.links {
+            // Preserve the first source entry for a version, matching the
+            // previous create-if-missing provider precedence.
+            desired
+                .entry(version.clone())
+                .or_insert_with(|| (provider_index, target.clone()));
+        }
     }
     let installs_path = &tool.installs_path;
     let mut versions = desired.keys().cloned().collect::<BTreeSet<_>>();
@@ -68,7 +87,7 @@ pub(super) fn reconcile(
         for entry in installs_path.read_dir()? {
             let path = entry?.path();
             if !is_runtime_symlink(&path)
-                && ownership.owns(&path)?
+                && providers_own(&providers, &path)?
                 && let Some(version) = path.file_name().and_then(|v| v.to_str())
             {
                 versions.insert(version.to_string());
@@ -77,13 +96,13 @@ pub(super) fn reconcile(
     }
 
     file::create_dir_all(installs_path)?;
-    let mut changed = BTreeSet::new();
+    let mut changed = vec![BTreeSet::new(); providers.len()];
     for version in versions {
         let _state_lock = install_state::lock_tool_version(&tool.short, &version)?;
         let link = installs_path.join(&version);
         let runtime_link = is_runtime_symlink(&link);
-        let source_link = !runtime_link && ownership.owns(&link)?;
-        let Some(target) = desired.get(&version) else {
+        let source_link = !runtime_link && providers_own(&providers, &link)?;
+        let Some((provider_index, target)) = desired.get(&version) else {
             if source_link {
                 file::remove_symlink_or_junction(&link)?;
             }
@@ -106,9 +125,18 @@ pub(super) fn reconcile(
         if target.exists() {
             install_state::clear_incomplete_marker(&tool.short, &version)?;
         }
-        changed.insert(version);
+        changed[*provider_index].insert(version);
     }
     Ok(changed)
+}
+
+fn providers_own(providers: &[ProviderLinks], link: &Path) -> Result<bool> {
+    for provider in providers {
+        if provider.ownership.owns(link)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 #[cfg(test)]
@@ -135,7 +163,7 @@ mod tests {
         let mut tool = BackendArg::from("node");
         tool.installs_path = installs_path.clone();
 
-        reconcile(&tool, LinkOwnership::resolved(&source_root), vec![]).unwrap();
+        reconcile(&tool, LinkOwnership::in_namespace(&source_root), vec![]).unwrap();
 
         assert!(std::fs::symlink_metadata(installs_path.join("1.0.0")).is_err());
         assert!(file::is_symlink_or_junction(&installs_path.join("2.0.0")));
@@ -161,7 +189,7 @@ mod tests {
         tool.installs_path = installs_path.clone();
         std::fs::remove_file(&direct_target).unwrap();
 
-        reconcile(&tool, LinkOwnership::direct(&direct_root), vec![]).unwrap();
+        reconcile(&tool, LinkOwnership::in_namespace(&direct_root), vec![]).unwrap();
 
         assert!(std::fs::symlink_metadata(installs_path.join("22")).is_err());
     }
@@ -181,11 +209,45 @@ mod tests {
         let mut tool = BackendArg::from("node");
         tool.installs_path = installs_path.clone();
 
-        reconcile(&tool, LinkOwnership::direct(&direct_root), vec![]).unwrap();
+        reconcile(&tool, LinkOwnership::in_namespace(&direct_root), vec![]).unwrap();
 
         assert!(file::is_symlink_to(
             &installs_path.join("22"),
             &storage_target
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn later_provider_stale_link_does_not_block_earlier_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let earlier_root = dir.path().join("earlier");
+        let later_root = dir.path().join("later");
+        let installs_path = dir.path().join("installs");
+        let desired_target = earlier_root.join("1.0.0");
+        let stale_target = later_root.join("1.0.0");
+        file::create_dir_all(&desired_target).unwrap();
+        file::create_dir_all(&later_root).unwrap();
+        file::create_dir_all(&installs_path).unwrap();
+        file::make_symlink(&stale_target, &installs_path.join("1.0.0")).unwrap();
+
+        let mut tool = BackendArg::from("node");
+        tool.installs_path = installs_path.clone();
+        let providers = vec![
+            ProviderLinks::new(
+                LinkOwnership::in_namespace(&earlier_root),
+                vec![("1.0.0".to_string(), desired_target.clone())],
+            ),
+            ProviderLinks::new(LinkOwnership::in_namespace(&later_root), vec![]),
+        ];
+
+        let changed = reconcile_all(&tool, providers).unwrap();
+
+        assert_eq!(changed[0], BTreeSet::from(["1.0.0".to_string()]));
+        assert!(changed[1].is_empty());
+        assert!(file::is_symlink_to(
+            &installs_path.join("1.0.0"),
+            &desired_target
         ));
     }
 
@@ -209,7 +271,7 @@ mod tests {
             ready_tx.send(()).unwrap();
             let result = reconcile(
                 &tool,
-                LinkOwnership::resolved(&source_root),
+                LinkOwnership::in_namespace(&source_root),
                 vec![("1.0.0".to_string(), target)],
             );
             done_tx.send(result).unwrap();

--- a/src/cli/sync/reconcile.rs
+++ b/src/cli/sync/reconcile.rs
@@ -30,7 +30,7 @@ impl<'a> LinkOwnership<'a> {
 
     fn owns(&self, link: &Path) -> Result<bool> {
         if let Some(root) = self.direct_root
-            && file::is_symlink_target_directly_within(link, root)?
+            && file::is_symlink_target_within(link, root)?
         {
             return Ok(true);
         }

--- a/src/cli/sync/reconcile.rs
+++ b/src/cli/sync/reconcile.rs
@@ -1,0 +1,235 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use eyre::Result;
+
+use crate::cli::args::BackendArg;
+use crate::file;
+use crate::runtime_symlinks::is_runtime_symlink;
+use crate::toolset::install_state;
+
+pub(super) struct LinkOwnership<'a> {
+    direct_root: Option<&'a Path>,
+    resolved_root: Option<&'a Path>,
+}
+
+impl<'a> LinkOwnership<'a> {
+    pub(super) fn resolved(root: &'a Path) -> Self {
+        Self {
+            direct_root: None,
+            resolved_root: Some(root),
+        }
+    }
+
+    pub(super) fn direct(root: &'a Path) -> Self {
+        Self {
+            direct_root: Some(root),
+            resolved_root: None,
+        }
+    }
+
+    fn owns(&self, link: &Path) -> Result<bool> {
+        if let Some(root) = self.direct_root
+            && file::is_symlink_target_directly_within(link, root)?
+        {
+            return Ok(true);
+        }
+        match self.resolved_root {
+            Some(root) => file::is_symlink_target_within(link, root),
+            None => Ok(false),
+        }
+    }
+}
+
+/// Reconciles links from one external source under a tool's installs path.
+///
+/// `ownership` defines which existing links this operation owns. Managed
+/// installs, runtime aliases, and links from other sources are preserved.
+///
+/// If multiple entries in `links` map to the same version, the first entry
+/// wins, so callers must supply entries in a deterministic order.
+///
+/// Returns versions whose links were created or changed.
+pub(super) fn reconcile(
+    tool: &BackendArg,
+    ownership: LinkOwnership<'_>,
+    links: Vec<(String, PathBuf)>,
+) -> Result<BTreeSet<String>> {
+    let mut desired = BTreeMap::new();
+    for (version, target) in links {
+        // Preserve the first source entry for a version, matching the previous
+        // create-if-missing loop when a source exposes duplicates.
+        desired.entry(version).or_insert(target);
+    }
+    let installs_path = &tool.installs_path;
+    let mut versions = desired.keys().cloned().collect::<BTreeSet<_>>();
+
+    if installs_path.exists() {
+        for entry in installs_path.read_dir()? {
+            let path = entry?.path();
+            if !is_runtime_symlink(&path)
+                && ownership.owns(&path)?
+                && let Some(version) = path.file_name().and_then(|v| v.to_str())
+            {
+                versions.insert(version.to_string());
+            }
+        }
+    }
+
+    file::create_dir_all(installs_path)?;
+    let mut changed = BTreeSet::new();
+    for version in versions {
+        let _state_lock = install_state::lock_tool_version(&tool.short, &version)?;
+        let link = installs_path.join(&version);
+        let runtime_link = is_runtime_symlink(&link);
+        let source_link = !runtime_link && ownership.owns(&link)?;
+        let Some(target) = desired.get(&version) else {
+            if source_link {
+                file::remove_symlink_or_junction(&link)?;
+            }
+            continue;
+        };
+
+        if !runtime_link && target.exists() && file::is_symlink_to(&link, target) {
+            install_state::clear_incomplete_marker(&tool.short, &version)?;
+            continue;
+        }
+
+        let entry_exists = std::fs::symlink_metadata(&link).is_ok();
+        if entry_exists && !source_link {
+            // Never overwrite a managed install, runtime alias, or link from
+            // another external source.
+            continue;
+        }
+
+        if entry_exists {
+            file::make_symlink(target, &link)?;
+            if target.exists() {
+                install_state::clear_incomplete_marker(&tool.short, &version)?;
+            }
+            changed.insert(version);
+        } else {
+            file::make_symlink(target, &link)?;
+            if target.exists() {
+                install_state::clear_incomplete_marker(&tool.short, &version)?;
+            }
+            changed.insert(version);
+        }
+    }
+    Ok(changed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    #[cfg(unix)]
+    fn removes_only_stale_links_from_the_current_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let other_root = dir.path().join("other");
+        let installs_path = dir.path().join("installs");
+        file::create_dir_all(&source_root).unwrap();
+        file::create_dir_all(&other_root).unwrap();
+        file::create_dir_all(installs_path.join("3.0.0")).unwrap();
+
+        file::make_symlink(&source_root.join("1.0.0"), &installs_path.join("1.0.0")).unwrap();
+        file::make_symlink(&other_root.join("2.0.0"), &installs_path.join("2.0.0")).unwrap();
+        file::make_symlink_or_file(Path::new("./3.0.0"), &installs_path.join("latest")).unwrap();
+
+        let mut tool = BackendArg::from("node");
+        tool.installs_path = installs_path.clone();
+
+        reconcile(&tool, LinkOwnership::resolved(&source_root), vec![]).unwrap();
+
+        assert!(std::fs::symlink_metadata(installs_path.join("1.0.0")).is_err());
+        assert!(file::is_symlink_or_junction(&installs_path.join("2.0.0")));
+        assert!(installs_path.join("3.0.0").is_dir());
+        assert!(is_runtime_symlink(&installs_path.join("latest")));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn removes_stale_links_after_a_direct_source_entry_disappears() {
+        let dir = tempfile::tempdir().unwrap();
+        let direct_root = dir.path().join("opt");
+        let resolved_target = dir.path().join("Cellar/node@22/22.0.0");
+        let direct_target = direct_root.join("node@22");
+        let installs_path = dir.path().join("installs");
+        file::create_dir_all(&resolved_target).unwrap();
+        file::create_dir_all(&direct_root).unwrap();
+        file::create_dir_all(&installs_path).unwrap();
+        file::make_symlink(&resolved_target, &direct_target).unwrap();
+        file::make_symlink(&direct_target, &installs_path.join("22")).unwrap();
+
+        let mut tool = BackendArg::from("node");
+        tool.installs_path = installs_path.clone();
+        std::fs::remove_file(&direct_target).unwrap();
+
+        reconcile(&tool, LinkOwnership::direct(&direct_root), vec![]).unwrap();
+
+        assert!(std::fs::symlink_metadata(installs_path.join("22")).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn preserves_links_that_resolve_within_storage_but_bypass_the_direct_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let direct_root = dir.path().join("opt");
+        let storage_target = dir.path().join("Cellar/node@22/22.0.0");
+        let installs_path = dir.path().join("installs");
+        file::create_dir_all(&direct_root).unwrap();
+        file::create_dir_all(&storage_target).unwrap();
+        file::create_dir_all(&installs_path).unwrap();
+        file::make_symlink(&storage_target, &installs_path.join("22")).unwrap();
+
+        let mut tool = BackendArg::from("node");
+        tool.installs_path = installs_path.clone();
+
+        reconcile(&tool, LinkOwnership::direct(&direct_root), vec![]).unwrap();
+
+        assert!(file::is_symlink_to(
+            &installs_path.join("22"),
+            &storage_target
+        ));
+    }
+
+    #[test]
+    fn waits_for_the_version_lock_before_reconciling() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let target = source_root.join("1.0.0");
+        let mut tool = BackendArg::from("node");
+        tool.short = format!(
+            "sync-lock-test-{}",
+            dir.path().file_name().unwrap().to_string_lossy()
+        );
+        tool.installs_path = dir.path().join("installs");
+        file::create_dir_all(&target).unwrap();
+
+        let held_lock = install_state::lock_tool_version(&tool.short, "1.0.0").unwrap();
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            ready_tx.send(()).unwrap();
+            let result = reconcile(
+                &tool,
+                LinkOwnership::resolved(&source_root),
+                vec![("1.0.0".to_string(), target)],
+            );
+            done_tx.send(result).unwrap();
+        });
+
+        ready_rx.recv().unwrap();
+        assert!(done_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        drop(held_lock);
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+            .unwrap();
+        handle.join().unwrap();
+    }
+}

--- a/src/cli/sync/reconcile.rs
+++ b/src/cli/sync/reconcile.rs
@@ -102,19 +102,11 @@ pub(super) fn reconcile(
             continue;
         }
 
-        if entry_exists {
-            file::make_symlink(target, &link)?;
-            if target.exists() {
-                install_state::clear_incomplete_marker(&tool.short, &version)?;
-            }
-            changed.insert(version);
-        } else {
-            file::make_symlink(target, &link)?;
-            if target.exists() {
-                install_state::clear_incomplete_marker(&tool.short, &version)?;
-            }
-            changed.insert(version);
+        file::make_symlink(target, &link)?;
+        if target.exists() {
+            install_state::clear_incomplete_marker(&tool.short, &version)?;
         }
+        changed.insert(version);
     }
     Ok(changed)
 }

--- a/src/cli/sync/ruby.rs
+++ b/src/cli/sync/ruby.rs
@@ -6,7 +6,7 @@ use itertools::sorted;
 use crate::{
     backend,
     config::{self, Config},
-    dirs, file,
+    file,
 };
 
 /// Symlinks all ruby tool versions from an external tool into mise
@@ -46,11 +46,9 @@ impl SyncRuby {
         let ruby = backend::get(&"ruby".into()).unwrap();
 
         let brew_prefix = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
-        let installed_versions_path = dirs::INSTALLS.join("ruby");
-
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &brew_prefix)?;
 
         let subdirs = file::dir_subdirs(&brew_prefix)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
@@ -59,9 +57,10 @@ impl SyncRuby {
                 continue;
             }
             let v = entry.trim_start_matches("ruby@");
-            if ruby.create_symlink(v, &brew_prefix.join(&entry))?.is_some() {
-                miseprintln!("Synced ruby@{} from Homebrew", v);
-            }
+            links.push((v.to_string(), brew_prefix.join(&entry)));
+        }
+        for v in ruby.sync_symlinks(&brew_prefix, links)? {
+            miseprintln!("Synced ruby@{} from Homebrew", v);
         }
         Ok(())
     }

--- a/src/cli/sync/ruby.rs
+++ b/src/cli/sync/ruby.rs
@@ -6,8 +6,10 @@ use itertools::sorted;
 use crate::{
     backend,
     config::{self, Config},
-    dirs, file,
+    file,
 };
+
+use super::reconcile;
 
 /// Symlinks all ruby tool versions from an external tool into mise
 #[derive(Debug, clap::Args)]
@@ -45,12 +47,10 @@ impl SyncRuby {
     async fn run_brew(&self) -> Result<()> {
         let ruby = backend::get(&"ruby".into()).unwrap();
 
-        let brew_prefix = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
-        let installed_versions_path = dirs::INSTALLS.join("ruby");
+        let brew_opt = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
 
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &brew_prefix)?;
-
-        let subdirs = file::dir_subdirs(&brew_prefix)?;
+        let subdirs = file::dir_subdirs(&brew_opt)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
@@ -59,9 +59,11 @@ impl SyncRuby {
                 continue;
             }
             let v = entry.trim_start_matches("ruby@");
-            if ruby.create_symlink(v, &brew_prefix.join(&entry))?.is_some() {
-                miseprintln!("Synced ruby@{} from Homebrew", v);
-            }
+            links.push((v.to_string(), brew_opt.join(&entry)));
+        }
+        let ownership = reconcile::LinkOwnership::direct(&brew_opt);
+        for v in reconcile::reconcile(ruby.ba(), ownership, links)? {
+            miseprintln!("Synced ruby@{} from Homebrew", v);
         }
         Ok(())
     }

--- a/src/cli/sync/ruby.rs
+++ b/src/cli/sync/ruby.rs
@@ -45,9 +45,10 @@ impl SyncRuby {
     async fn run_brew(&self) -> Result<()> {
         let ruby = backend::get(&"ruby".into()).unwrap();
 
-        let brew_prefix = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
+        let brew_opt = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
+        let brew_cellar = PathBuf::from(cmd!("brew", "--cellar").read()?);
 
-        let subdirs = file::dir_subdirs(&brew_prefix)?;
+        let subdirs = file::dir_subdirs(&brew_opt)?;
         let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
@@ -57,9 +58,9 @@ impl SyncRuby {
                 continue;
             }
             let v = entry.trim_start_matches("ruby@");
-            links.push((v.to_string(), brew_prefix.join(&entry)));
+            links.push((v.to_string(), brew_opt.join(&entry)));
         }
-        for v in ruby.sync_symlinks(&brew_prefix, links)? {
+        for v in ruby.sync_symlinks(&brew_cellar, links)? {
             miseprintln!("Synced ruby@{} from Homebrew", v);
         }
         Ok(())

--- a/src/cli/sync/ruby.rs
+++ b/src/cli/sync/ruby.rs
@@ -61,7 +61,7 @@ impl SyncRuby {
             let v = entry.trim_start_matches("ruby@");
             links.push((v.to_string(), brew_opt.join(&entry)));
         }
-        let ownership = reconcile::LinkOwnership::direct(&brew_opt);
+        let ownership = reconcile::LinkOwnership::in_namespace(&brew_opt);
         for v in reconcile::reconcile(ruby.ba(), ownership, links)? {
             miseprintln!("Synced ruby@{} from Homebrew", v);
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -2496,6 +2496,24 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn test_symlink_prefix_detection_follows_an_indirect_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let cellar = dir.path().join("Cellar");
+        let target = cellar.join("node@22").join("22.0.0");
+        let opt = dir.path().join("opt");
+        let opt_entry = opt.join("node@22");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&opt).unwrap();
+        std::os::unix::fs::symlink(&target, &opt_entry).unwrap();
+        std::os::unix::fs::symlink(&opt_entry, &link).unwrap();
+
+        assert!(is_symlink_to_prefix(&link, &cellar).unwrap());
+        assert!(!is_symlink_to_prefix(&link, &opt).unwrap());
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn test_symlink_prefix_detection_rejects_escapes() {
         let dir = tempfile::tempdir().unwrap();
         let prefix = dir.path().join("provider");
@@ -2511,6 +2529,12 @@ mod tests {
         std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
         std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
         assert!(!is_symlink_to_prefix(&redirected, &prefix).unwrap());
+
+        let dangling = prefix.join("dangling");
+        let redirected_tail = dir.path().join("redirected-tail");
+        std::os::unix::fs::symlink(prefix.join("missing"), &dangling).unwrap();
+        std::os::unix::fs::symlink(dangling.join("child"), &redirected_tail).unwrap();
+        assert!(!is_symlink_to_prefix(&redirected_tail, &prefix).unwrap());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1282,24 +1282,6 @@ fn remove_open_link(file: File) -> std::io::Result<()> {
     Ok(())
 }
 
-pub fn remove_symlinks_with_target_prefix(
-    symlink_dir: &Path,
-    target_prefix: &Path,
-) -> Result<Vec<PathBuf>> {
-    if !symlink_dir.exists() {
-        return Ok(vec![]);
-    }
-    let mut removed = vec![];
-    for entry in symlink_dir.read_dir()? {
-        let path = entry?.path();
-        if is_symlink_target_within(&path, target_prefix)? {
-            remove_symlink_or_junction(&path)?;
-            removed.push(path);
-        }
-    }
-    Ok(removed)
-}
-
 #[cfg(unix)]
 pub fn is_executable(path: &Path) -> bool {
     if let Ok(metadata) = path.metadata() {
@@ -3061,26 +3043,6 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_symlinks_with_target_prefix() {
-        let dir = tempfile::tempdir().unwrap();
-        let prefix = dir.path().join("provider");
-        let target = prefix.join("version");
-        let other = dir.path().join("other");
-        let link = dir.path().join("link");
-        let other_link = dir.path().join("other-link");
-        fs::create_dir_all(&target).unwrap();
-        fs::create_dir_all(&other).unwrap();
-        make_symlink(&target, &link).unwrap();
-        make_symlink(&other, &other_link).unwrap();
-
-        let removed = remove_symlinks_with_target_prefix(dir.path(), &prefix).unwrap();
-        assert_eq!(removed, vec![link.clone()]);
-        assert!(std::fs::symlink_metadata(&link).is_err());
-        assert!(std::fs::symlink_metadata(&other_link).is_ok());
-        assert!(target.exists());
-    }
-
-    #[test]
     #[cfg(windows)]
     fn test_symlink_prefix_detection_uses_filesystem_casing() {
         let dir = tempfile::tempdir().unwrap();
@@ -3160,7 +3122,6 @@ mod tests {
             Ok(())
         }
     }
-
     #[test]
     #[cfg(unix)]
     fn test_symlink_prefix_detection_uses_the_immediate_target() {

--- a/src/file.rs
+++ b/src/file.rs
@@ -714,8 +714,7 @@ fn create_windows_dir_link(target: &Path, link: &Path) -> std::io::Result<()> {
 pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
     if let Err(err) = create_windows_dir_link(target, link) {
         if err.kind() == std::io::ErrorKind::AlreadyExists {
-            let _ = fs::remove_file(link);
-            let _ = fs::remove_dir(link);
+            remove_symlink_or_junction(link)?;
             create_windows_dir_link(target, link)
         } else {
             Err(err)
@@ -751,7 +750,7 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
-    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
+    is_symlink_or_junction(link) && paths_refer_to_same_entry(link, target)
 }
 
 #[cfg(unix)]
@@ -770,26 +769,140 @@ pub fn make_symlink_or_file(target: &Path, link: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn remove_symlinks_with_target_prefix(
-    symlink_dir: &Path,
-    target_prefix: &Path,
-) -> Result<Vec<PathBuf>> {
-    if !symlink_dir.exists() {
-        return Ok(vec![]);
-    }
-    let mut removed = vec![];
-    for entry in symlink_dir.read_dir()? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_symlink() {
-            let target = path.read_link()?;
-            if target.starts_with(target_prefix) {
-                fs::remove_file(&path)?;
-                removed.push(path);
+pub fn is_symlink_to_prefix(link: &Path, target_prefix: &Path) -> Result<bool> {
+    let Some(target) = dir_link_target(link)? else {
+        return Ok(false);
+    };
+    // Broken provider links cannot be canonicalized in full. Resolve the
+    // longest existing ancestor so symlinks in the existing portion still
+    // participate in ownership checks, then append only a safe normal tail.
+    // If that cannot establish ownership, preserve the link because this
+    // predicate controls destructive provider cleanup.
+    let Some(target) = canonicalize_with_missing_tail(&target)? else {
+        return Ok(false);
+    };
+    let Some(target_prefix) = canonicalize_with_missing_tail(target_prefix)? else {
+        return Ok(false);
+    };
+    Ok(path_is_within(&target, &target_prefix))
+}
+
+fn path_is_within(path: &Path, prefix: &Path) -> bool {
+    path.starts_with(prefix)
+        || path
+            .ancestors()
+            .any(|ancestor| paths_refer_to_same_entry(ancestor, prefix))
+}
+
+fn paths_refer_to_same_entry(a: &Path, b: &Path) -> bool {
+    same_file::is_same_file(a, b).unwrap_or(false)
+}
+
+fn canonicalize_with_missing_tail(path: &Path) -> Result<Option<PathBuf>> {
+    for ancestor in path.ancestors() {
+        match ancestor.canonicalize() {
+            Ok(mut resolved) => {
+                for component in path.strip_prefix(ancestor)?.components() {
+                    match component {
+                        std::path::Component::Normal(component) => {
+                            let candidate = resolved.join(component);
+                            // A link or junction in the unresolved tail may
+                            // redirect outside the provider. Its destination
+                            // cannot be established, so preserve the outer
+                            // link instead of claiming provider ownership.
+                            if dir_link_target(&candidate)?.is_some() {
+                                return Ok(None);
+                            }
+                            resolved.push(component);
+                        }
+                        std::path::Component::CurDir => {}
+                        std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_) => return Ok(None),
+                    }
+                }
+                return Ok(Some(resolved));
             }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Ok(None),
         }
     }
-    Ok(removed)
+    Ok(None)
+}
+
+#[cfg(unix)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    if !metadata.file_type().is_symlink() {
+        return Ok(None);
+    }
+    let target = fs::read_link(link)
+        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+#[cfg(windows)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
+
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    let target = if metadata.file_type().is_symlink() {
+        fs::read_link(link)
+            .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?
+    } else {
+        match junction::get_target(link) {
+            Ok(target) => target,
+            Err(err)
+                if err.kind() == std::io::ErrorKind::NotFound
+                    || err.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
+                    || (err.kind() == std::io::ErrorKind::Other
+                        && err.raw_os_error().is_none()) =>
+            {
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(err).wrap_err_with(|| {
+                    format!("failed to inspect junction: {}", display_path(link))
+                });
+            }
+        }
+    };
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
+    if target.is_absolute() {
+        target
+    } else {
+        link.parent().unwrap_or(link).join(target)
+    }
+}
+
+#[cfg(unix)]
+pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    fs::remove_file(link)
+        .wrap_err_with(|| format!("failed to remove symlink: {}", display_path(link)))
+}
+
+#[cfg(windows)]
+pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    fs::remove_file(link)
+        .or_else(|_| fs::remove_dir(link))
+        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
 }
 
 #[cfg(unix)]
@@ -2335,6 +2448,69 @@ mod tests {
             err.downcast_ref::<std::io::Error>().map(|err| err.kind()),
             Some(std::io::ErrorKind::DirectoryNotEmpty)
         );
+    }
+
+    #[test]
+    fn test_is_symlink_to_requires_a_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+        assert!(!is_symlink_to(&target, &target));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_is_symlink_to_resolves_relative_target_from_link_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink("target", &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+    }
+
+    #[test]
+    fn test_symlink_prefix_detection_and_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let target = prefix.join("version");
+        let other = dir.path().join("other");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&other).unwrap();
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to_prefix(&link, &prefix).unwrap());
+        assert!(!is_symlink_to_prefix(&link, &other).unwrap());
+
+        remove_symlink_or_junction(&link).unwrap();
+        assert!(std::fs::symlink_metadata(&link).is_err());
+        assert!(target.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_symlink_prefix_detection_rejects_escapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let foreign = dir.path().join("foreign");
+        let escaped = dir.path().join("escaped");
+        let redirected = dir.path().join("redirected");
+        fs::create_dir_all(&prefix).unwrap();
+        fs::create_dir_all(&foreign).unwrap();
+
+        std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
+        assert!(!is_symlink_to_prefix(&escaped, &prefix).unwrap());
+
+        std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
+        std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
+        assert!(!is_symlink_to_prefix(&redirected, &prefix).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- move external-provider reconciliation out of `Backend` and into the `sync` CLI
- preserve managed installs, runtime aliases, and links owned by another provider
- serialize every per-version inspection and mutation with the install-state lock
- identify Homebrew ownership through the immediate `opt` target, including dangling entries
- remove the legacy all-links-first cleanup helper replaced by reconciliation

The backend layer remains provider-agnostic; provider discovery and ownership policy stay in the CLI commands that know about Homebrew, nvm, nodenv, pyenv, and uv.

## Stack

This PR now sits directly on `main`. It builds on the filesystem-safe link ownership and removal primitives merged in #11715.

#11686 is superseded because per-version locking is required for reconciliation to be safe and is included here.

## Bug

The old sync flow removed every link matching a provider prefix before rebuilding desired links. It could delete links owned by another source and exposed a race where a concurrent install or `mise link --force` changed an entry after classification but before deletion or replacement.

Homebrew adds another edge case: mise links to stable entries under `opt`, which resolve into `Cellar` while installed but become dangling under `opt` after unlink or uninstall. Direct user links into Cellar must remain untouched.

### Concrete multi-provider failure

Suppose nvm has Node 23, nodenv no longer has Node 23, and mise still has a dangling link left by nodenv:

```text
$NVM_DIR/versions/node/v23.0.0                 # valid nvm install
$NODENV_ROOT/versions/23.0.0                   # absent
$MISE_DATA_DIR/installs/node/23.0.0
  -> $NODENV_ROOT/versions/23.0.0               # stale, dangling nodenv link
```

Running `mise sync node --nvm --nodenv` previously processed the providers sequentially:

1. nvm saw an existing link owned by another provider and preserved it instead of linking Node 23 from nvm.
2. nodenv then recognized its own link as stale and removed it.
3. The command succeeded but left no mise link for Node 23, even though nvm had a valid install.

This PR gathers the desired links and ownership namespaces for all selected providers before mutating anything. Under the per-version lock, the stale link is known to belong to a selected provider, nvm wins the documented provider precedence, and the link is replaced with `$NVM_DIR/versions/node/v23.0.0`. Managed installs, runtime aliases, and links from providers that were not selected remain untouched.

The final block of `e2e/sync/test_sync_nvm` reproduces this exact dangling-nodenv-link scenario and verifies that the resulting link points to nvm. `e2e/sync/test_sync_python_uv` covers the equivalent pyenv/uv case.

## Testing

- `mise run lint-fix`
- `cargo test --all-features --bin mise cli::sync::reconcile::tests`
- `mise run test:e2e e2e/sync/test_sync_nvm e2e/sync/test_sync_python_uv`
- full GitHub Actions test matrix, including Linux e2e, Windows build/unit/e2e, macOS unit, Clippy, MSRV, and generated-file checks

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved runtime synchronization for Node, Python, and Ruby across multiple runtime managers.
  * Preserves aliases, managed installations, and externally maintained links.
  * Applies configured version ordering and reports synchronized versions.
  * Improves handling of incomplete or unrecognized installation directories.
  * Supports more reliable executable detection, including Windows command resolution.

* **Bug Fixes**
  * Prevents valid links and external installations from being overwritten or removed.
  * Cleans up stale provider-owned links.
  * Improves repeated synchronization after interrupted installations.

* **Documentation**
  * Clarified synchronization behavior and remote bootstrap options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
