### PR TITLE
fix(python): skip junctions when syncing installs to uv

### DIFF
--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -95,7 +95,7 @@ impl SyncPython {
                 continue;
             }
             let src = installed_python_versions_path.join(&v);
-            if src.is_symlink() {
+            if file::is_symlink_or_junction(&src) {
                 continue;
             }
             // ~/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none


### PR DESCRIPTION
## Summary

- treat Windows directory junctions like symlinks while syncing mise Python installs to uv
- avoid cloning a junction-backed external install into uv as if it were a mise-managed directory

This Windows-specific fix was extracted from #11172 so it can be reviewed independently from incomplete-marker and provider-link reconciliation changes.

## Bug

On Windows, mise represents some external directory links as junctions. `Path::is_symlink()` returns false for a junction, so the mise-to-uv half of sync mistakes an externally linked Python installation for a mise-managed directory and attempts to clone it into uv.

For example, if this is a junction:

```text
%MISE_DATA_DIR%\installs\python\3.11.1
  -> %UV_PYTHON_INSTALL_DIR%\cpython-3.11.1-windows-x86_64-none
```

Before this fix, `mise sync python --uv` can process the junction as a local mise install and clone it back into uv. After this fix, junctions are skipped just like Unix symlinks.

## Testing

- `mise run lint-fix`
- `cargo check --target x86_64-pc-windows-gnu --no-default-features --features rustls-native-roots,self_update,vfox/vendored-lua`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*
