### PR TITLE
perf(cli): defer bootstrap command tree

### DIFF
--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -27,6 +27,97 @@ use crate::ui::table::MiseTable;
 use clap::{Subcommand, ValueEnum};
 
 /// Set up a machine for the current config in one command
+// The wrapper defers construction of bootstrap's large nested command tree
+// until the user actually invokes `mise bootstrap`.
+pub struct DeferredBootstrap(Bootstrap);
+
+impl DeferredBootstrap {
+    pub async fn run(self) -> Result<()> {
+        self.0.run().await
+    }
+}
+
+impl clap::FromArgMatches for DeferredBootstrap {
+    fn from_arg_matches(matches: &clap::ArgMatches) -> std::result::Result<Self, clap::Error> {
+        let mut bootstrap = <Bootstrap as clap::FromArgMatches>::from_arg_matches(matches)?;
+        bootstrap.dry_run = matches.get_flag("dry_run");
+        bootstrap.yes = matches.get_flag("yes");
+        Ok(Self(bootstrap))
+    }
+
+    fn from_arg_matches_mut(
+        matches: &mut clap::ArgMatches,
+    ) -> std::result::Result<Self, clap::Error> {
+        let dry_run = matches.get_flag("dry_run");
+        let yes = matches.get_flag("yes");
+        let mut bootstrap = <Bootstrap as clap::FromArgMatches>::from_arg_matches_mut(matches)?;
+        bootstrap.dry_run = dry_run;
+        bootstrap.yes = yes;
+        Ok(Self(bootstrap))
+    }
+
+    fn update_from_arg_matches(
+        &mut self,
+        matches: &clap::ArgMatches,
+    ) -> std::result::Result<(), clap::Error> {
+        clap::FromArgMatches::update_from_arg_matches(&mut self.0, matches)?;
+        self.0.dry_run |= matches.get_flag("dry_run");
+        self.0.yes |= matches.get_flag("yes");
+        Ok(())
+    }
+
+    fn update_from_arg_matches_mut(
+        &mut self,
+        matches: &mut clap::ArgMatches,
+    ) -> std::result::Result<(), clap::Error> {
+        let dry_run = matches.get_flag("dry_run");
+        let yes = matches.get_flag("yes");
+        clap::FromArgMatches::update_from_arg_matches_mut(&mut self.0, matches)?;
+        self.0.dry_run |= dry_run;
+        self.0.yes |= yes;
+        Ok(())
+    }
+}
+
+impl clap::Args for DeferredBootstrap {
+    fn augment_args(command: clap::Command) -> clap::Command {
+        deferred_flags(command).defer(<Bootstrap as clap::Args>::augment_args)
+    }
+
+    fn augment_args_for_update(command: clap::Command) -> clap::Command {
+        deferred_flags(command).defer(<Bootstrap as clap::Args>::augment_args_for_update)
+    }
+}
+
+// This reconstructs the command for full-tree introspection because expanding
+// the deferred parser in place is not supported. Keep its command name and any
+// variant-level metadata aligned with `Commands::Bootstrap`; `deferred_flags`
+// is shared with normal parsing so the top-level arguments cannot drift.
+pub(crate) fn full_command() -> clap::Command {
+    <Bootstrap as clap::Args>::augment_args(deferred_flags(clap::Command::new("bootstrap")))
+}
+
+fn deferred_flags(command: clap::Command) -> clap::Command {
+    command
+        .about("Set up a machine for the current config in one command")
+        .visible_alias("bs")
+        .arg(
+            clap::Arg::new("dry_run")
+                .long("dry-run")
+                .short('n')
+                .help("Print what would happen without installing anything")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            clap::Arg::new("yes")
+                .long("yes")
+                .short('y')
+                .help("Skip confirmation prompts")
+                .action(clap::ArgAction::SetTrue),
+        )
+}
+
+/// Set up a machine for the current config in one command
 ///
 /// Runs the bootstrap steps for the current config in order:
 ///
@@ -67,7 +158,6 @@ use clap::{Subcommand, ValueEnum};
 /// cannot be used together.
 #[derive(Debug, clap::Args)]
 #[clap(
-    visible_alias = "bs",
     verbatim_doc_comment,
     after_long_help = AFTER_LONG_HELP
 )]
@@ -76,11 +166,11 @@ pub struct Bootstrap {
     command: Option<Commands>,
 
     /// Print what would happen without installing anything
-    #[clap(long, short = 'n')]
+    #[clap(skip)]
     dry_run: bool,
 
     /// Skip confirmation prompts
-    #[clap(long, short)]
+    #[clap(skip)]
     yes: bool,
 
     /// Overwrite existing files that conflict with whole-file dotfile entries
@@ -2651,5 +2741,39 @@ fn file_state_json(state: &FileState) -> &'static str {
         FileState::Missing => "missing",
         FileState::SourceMissing => "source_missing",
         FileState::Differs(_) => "differs",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Args, FromArgMatches};
+
+    use super::DeferredBootstrap;
+
+    fn matches(args: &[&str]) -> clap::ArgMatches {
+        <DeferredBootstrap as Args>::augment_args(clap::Command::new("bootstrap"))
+            .try_get_matches_from(args)
+            .unwrap()
+    }
+
+    #[test]
+    fn deferred_bootstrap_preserves_dry_run_and_yes_flags() {
+        let parsed = DeferredBootstrap::from_arg_matches(&matches(&[
+            "bootstrap",
+            "--dry-run",
+            "--yes",
+            "status",
+        ]))
+        .unwrap();
+        assert!(parsed.0.dry_run);
+        assert!(parsed.0.yes);
+
+        let mut updated =
+            DeferredBootstrap::from_arg_matches(&matches(&["bootstrap", "status"])).unwrap();
+        updated
+            .update_from_arg_matches(&matches(&["bootstrap", "--dry-run", "--yes", "status"]))
+            .unwrap();
+        assert!(updated.0.dry_run);
+        assert!(updated.0.yes);
     }
 }

--- a/src/cli/command_effects.rs
+++ b/src/cli/command_effects.rs
@@ -311,7 +311,10 @@ mod tests {
     /// still runnable, and `bootstrap launchd`/`systemd`/`macos-defaults` are
     /// hidden compatibility spellings of commands that change system state.
     fn all_commands() -> Vec<String> {
-        let spec: usage::Spec = crate::cli::Cli::command().into();
+        let command = crate::cli::expand_deferred_subcommands(
+            crate::cli::Cli::command().disable_help_subcommand(true),
+        );
+        let spec: usage::Spec = command.into();
         let mut out = vec![];
         collect(&spec.cmd, &mut vec![], &mut out);
         out
@@ -331,7 +334,10 @@ mod tests {
     /// actually transfers them.
     #[test]
     fn apply_annotates_the_spec() {
-        let mut spec: usage::Spec = crate::cli::Cli::command().into();
+        let command = crate::cli::expand_deferred_subcommands(
+            crate::cli::Cli::command().disable_help_subcommand(true),
+        );
+        let mut spec: usage::Spec = command.into();
         apply(&mut spec);
 
         let cmd = |name: &str| {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -211,7 +211,7 @@ pub enum Commands {
     Asdf(asdf::Asdf),
     Backends(backends::Backends),
     BinPaths(bin_paths::BinPaths),
-    Bootstrap(bootstrap::Bootstrap),
+    Bootstrap(bootstrap::DeferredBootstrap),
     Cache(cache::Cache),
     Completion(completion::Completion),
     Config(config::Config),
@@ -276,6 +276,15 @@ pub enum Commands {
     Watch(Box<watch::Watch>),
     Where(r#where::Where),
     Which(which::Which),
+}
+
+/// Expand command sections that are deferred during normal startup. Use this
+/// only for full-tree introspection such as generated docs and validation.
+pub(crate) fn expand_deferred_subcommands(mut command: clap::Command) -> clap::Command {
+    *command
+        .find_subcommand_mut("bootstrap")
+        .expect("bootstrap command is registered") = bootstrap::full_command();
+    command
 }
 
 impl Commands {
@@ -983,6 +992,38 @@ mod tests {
                 clap_sort::assert_sorted(subcmd);
             }
         }
+        let cmd = expand_deferred_subcommands(Cli::command());
+        let bootstrap = cmd
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == "bootstrap")
+            .unwrap();
+        for subcommand in bootstrap.get_subcommands() {
+            clap_sort::assert_sorted(subcommand);
+        }
+    }
+
+    #[test]
+    fn test_bootstrap_command_tree_is_deferred_until_parsing() {
+        let cmd = Cli::command();
+        let bootstrap = cmd
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == "bootstrap")
+            .unwrap();
+        assert_eq!(bootstrap.get_subcommands().count(), 0);
+
+        let alias_args = vec![
+            "mise".to_string(),
+            "bs".to_string(),
+            "status".to_string(),
+            "--json".to_string(),
+        ];
+        assert_eq!(preprocess_args_for_naked_run(&cmd, &alias_args), alias_args);
+        assert!(cmd.clone().try_get_matches_from(alias_args).is_ok());
+
+        assert!(
+            cmd.try_get_matches_from(["mise", "bootstrap", "status", "--json"])
+                .is_ok()
+        );
     }
 
     /// Commands that name a config file to write to accept both spellings, so it
@@ -1018,7 +1059,7 @@ mod tests {
                 cfg!(not(windows)),
             ),
         ];
-        let root = Cli::command();
+        let root = expand_deferred_subcommands(Cli::command());
 
         for (path, arg_name, alias, available) in cases {
             if !available {

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -109,11 +109,12 @@ fn render_command_ts() -> String {
         }};
         "#});
     doc.push_str("export const commands: { [key: string]: Command } = {\n");
-    let mut cli = Cli::command()
+    let cli = Cli::command()
         .term_width(80)
         .max_term_width(80)
         .disable_help_subcommand(true)
         .disable_help_flag(true);
+    let mut cli = super::expand_deferred_subcommands(cli);
     for command in cli
         .get_subcommands_mut()
         .sorted_by_cached_key(|c| c.get_name().to_string())

--- a/src/cli/usage.rs
+++ b/src/cli/usage.rs
@@ -17,7 +17,10 @@ pub struct Usage {}
 /// an agent reads is the one that must not.
 pub fn spec() -> usage::Spec {
     {
-        let cli = Cli::command().version(Resettable::Reset);
+        let cli = Cli::command()
+            .version(Resettable::Reset)
+            .disable_help_subcommand(true);
+        let cli = super::expand_deferred_subcommands(cli);
         let mut spec: usage::Spec = cli.into();
 
         // Enable "naked" task completions: `mise foo` completes like `mise run foo`


### PR DESCRIPTION
## Summary
- defer construction of the nested bootstrap command tree until `mise bootstrap` is selected
- preserve complete command introspection for usage generation, command effects, and tests
- keep bootstrap-local `--dry-run` and `--yes` behavior unchanged

## Validation
- `cargo test cli::tests::test_bootstrap_command_tree_is_deferred_until_parsing`
- `cargo test cli::tests::test_subcommands_are_sorted`
- `cargo test cli::tests::test_config_target_options_accept_both_names`
- `cargo test cli::command_effects::tests`
- `mise run render:usage` (no generated changes)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved CLI startup by loading Bootstrap subcommands only when needed.
  * Preserved support for `--dry-run` and `--yes` options during command parsing and execution.

* **Bug Fixes**
  * Ensured help output, command discovery, validation, and usage specifications include all available subcommands.
  * Prevented automatically generated help subcommands from appearing in usage specifications.
  * Improved consistency between displayed command information and available CLI functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only CLI wiring with explicit tests for deferred parsing, flag preservation, and expanded introspection; bootstrap runtime behavior is delegated unchanged to the existing `Bootstrap` implementation.
> 
> **Overview**
> **Defers building the large nested `bootstrap` CLI** until the user actually runs `mise bootstrap` (or `bs`), so normal `mise` startup no longer pays the cost of registering every bootstrap subcommand up front.
> 
> A **`DeferredBootstrap` wrapper** uses clap’s deferred parser for the full `Bootstrap` tree while **`deferred_flags`** still exposes top-level `--dry-run` / `--yes` (and the `bs` alias) on the outer command; those flags are merged into the inner `Bootstrap` struct during `FromArgMatches` because they’re marked `#[clap(skip)]` on `Bootstrap` itself.
> 
> **Full-tree introspection** is unchanged via **`expand_deferred_subcommands`**, which swaps in `bootstrap::full_command()` for usage generation, command-effect validation, rendered help, and tests that need the complete subcommand tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b587636a1b54a9a6f3a3e73ffa1f8f20cabdd294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->