### PR TITLE
fix(sync): lock provider reconciliation per version

### DIFF
--- a/e2e/sync/test_sync_nvm
+++ b/e2e/sync/test_sync_nvm
@@ -12,13 +12,27 @@ install_fake_node "$NVM_DIR/versions/node/v18.0.0"
 mise sync node --nvm
 mise ls
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/18.0.0"
+ln -s ./18.0.0 "$MISE_DATA_DIR/installs/node/provider-runtime-alias"
 
 install_fake_node "$NVM_DIR/versions/node/v20.0.0"
+install_fake_node "$NVM_DIR/versions/node/v21.0.0"
 install_fake_node "$NVM_DIR/versions/node/v22.0.0"
 install_fake_node "$MISE_DATA_DIR/installs/node/20.0.0/bin"
+install_fake_node "$PWD/other-provider/21.0.0"
+ln -s "$PWD/other-provider/21.0.0" "$MISE_DATA_DIR/installs/node/21.0.0"
 
 mise sync node --nvm
 mise ls
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/22.0.0"
 assert_not_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/20.0.0"
 assert_contains "mise ls node --json | jq -r '.[] | .symlinked_to | select( . != null)'" "node/18.0.0"
+assert "test -L \"$MISE_DATA_DIR/installs/node/provider-runtime-alias\""
+assert_contains "readlink \"$MISE_DATA_DIR/installs/node/21.0.0\"" "other-provider/21.0.0"
+
+# Only stale links owned by nvm are removed. Managed installs and links owned
+# by other providers remain untouched.
+rm -r "$NVM_DIR/versions/node/v18.0.0"
+mise sync node --nvm
+assert "test ! -e \"$MISE_DATA_DIR/installs/node/18.0.0\" && test ! -L \"$MISE_DATA_DIR/installs/node/18.0.0\""
+assert "test -d \"$MISE_DATA_DIR/installs/node/20.0.0\""
+assert_contains "readlink \"$MISE_DATA_DIR/installs/node/21.0.0\"" "other-provider/21.0.0"

--- a/e2e/sync/test_sync_python_uv
+++ b/e2e/sync/test_sync_python_uv
@@ -5,7 +5,12 @@ export MISE_PYTHON_GITHUB_ATTESTATIONS=0
 # (astral-sh/uv#19278). Bump once 0.11.10 ships with attestations restored.
 assert "mise use -g uv@0.11.8 python@3.11.3"
 assert "mise x -- uv python install 3.11.1"
+test_uv_python_dir="$(mise x -- uv python dir)"
+# Multiple provider entries can map to the same mise version. Preserve the
+# first sorted entry, matching the previous create-if-missing behavior.
+mkdir -p "$test_uv_python_dir/pypy-3.11.1-linux-x86_64-gnu"
 export UV_PYTHON_DOWNLOADS=never
 assert "mise sync python --uv"
+assert_contains "readlink \"$MISE_DATA_DIR/installs/python/3.11.1\"" "cpython-3.11.1"
 assert "mise x python@3.11.1 -- python -V" "Python 3.11.1"
 assert "mise x -- uv run -p 3.11.3 -- python -V" "Python 3.11.3"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsString;
 use std::fmt::{Debug, Display, Formatter};
 use std::fs::File;
@@ -2200,6 +2200,65 @@ pub trait Backend: Debug + Send + Sync {
         file::create_dir_all(link.parent().unwrap())?;
         let link = file::make_symlink(target, &link)?;
         Ok(Some(link))
+    }
+    fn sync_symlinks(
+        &self,
+        target_prefix: &Path,
+        links: Vec<(String, PathBuf)>,
+    ) -> Result<BTreeSet<String>> {
+        let mut desired = BTreeMap::new();
+        for (version, target) in links {
+            // Preserve the first provider entry for a version, matching the
+            // previous create-if-missing loop when providers expose duplicates.
+            desired.entry(version).or_insert(target);
+        }
+        let installs_path = &self.ba().installs_path;
+        let mut versions = desired.keys().cloned().collect::<BTreeSet<_>>();
+
+        if installs_path.exists() {
+            for entry in installs_path.read_dir()? {
+                let path = entry?.path();
+                if !is_runtime_symlink(&path)
+                    && file::is_symlink_to_prefix(&path, target_prefix)?
+                    && let Some(version) = path.file_name().and_then(|v| v.to_str())
+                {
+                    versions.insert(version.to_string());
+                }
+            }
+        }
+
+        file::create_dir_all(installs_path)?;
+        let mut changed = BTreeSet::new();
+        for version in versions {
+            let link = installs_path.join(&version);
+            let runtime_link = is_runtime_symlink(&link);
+            let provider_link = !runtime_link && file::is_symlink_to_prefix(&link, target_prefix)?;
+            let Some(target) = desired.get(&version) else {
+                if provider_link {
+                    file::remove_symlink_or_junction(&link)?;
+                }
+                continue;
+            };
+
+            if !runtime_link && target.exists() && file::is_symlink_to(&link, target) {
+                continue;
+            }
+
+            let entry_exists = std::fs::symlink_metadata(&link).is_ok();
+            if entry_exists && !provider_link {
+                // Never overwrite a managed install, runtime alias, or link
+                // owned by another sync provider.
+                continue;
+            }
+
+            if entry_exists {
+                file::make_symlink(target, &link)?;
+                changed.insert(version);
+            } else if self.create_symlink(&version, target)?.is_some() {
+                changed.insert(version);
+            }
+        }
+        Ok(changed)
     }
     fn list_installed_versions_matching(&self, query: &str) -> Vec<String> {
         let versions = self.list_installed_versions();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2230,6 +2230,7 @@ pub trait Backend: Debug + Send + Sync {
         file::create_dir_all(installs_path)?;
         let mut changed = BTreeSet::new();
         for version in versions {
+            let _state_lock = install_state::lock_tool_version(&self.ba().short, &version)?;
             let link = installs_path.join(&version);
             let runtime_link = is_runtime_symlink(&link);
             let provider_link = !runtime_link && file::is_symlink_to_prefix(&link, target_prefix)?;

--- a/src/cli/sync/node.rs
+++ b/src/cli/sync/node.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use eyre::Result;
 use itertools::sorted;
 
-use crate::{backend, config, dirs, file};
+use crate::{backend, config, file};
 use crate::{config::Config, config::Settings};
 
 /// Symlinks all tool versions from an external tool into mise
@@ -61,11 +61,9 @@ impl SyncNode {
         let node = backend::get(&"node".into()).unwrap();
 
         let brew_prefix = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
-        let installed_versions_path = dirs::INSTALLS.join("node");
-
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &brew_prefix)?;
 
         let subdirs = file::dir_subdirs(&brew_prefix)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
@@ -74,9 +72,10 @@ impl SyncNode {
                 continue;
             }
             let v = entry.trim_start_matches("node@");
-            if node.create_symlink(v, &brew_prefix.join(&entry))?.is_some() {
-                miseprintln!("Synced node@{} from Homebrew", v);
-            }
+            links.push((v.to_string(), brew_prefix.join(&entry)));
+        }
+        for v in node.sync_symlinks(&brew_prefix, links)? {
+            miseprintln!("Synced node@{} from Homebrew", v);
         }
         Ok(())
     }
@@ -88,31 +87,18 @@ impl SyncNode {
         let nvm_versions_path = file::replace_path(&settings.node.nvm_dir)
             .join("versions")
             .join("node");
-        let installed_versions_path = dirs::INSTALLS.join("node");
 
-        let removed =
-            file::remove_symlinks_with_target_prefix(&installed_versions_path, &nvm_versions_path)?;
-        if !removed.is_empty() {
-            debug!("Removed symlinks: {removed:?}");
-        }
-
-        let mut created = vec![];
         let subdirs = file::dir_subdirs(&nvm_versions_path)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
             }
             let v = entry.trim_start_matches('v');
-            let symlink = node.create_symlink(v, &nvm_versions_path.join(&entry))?;
-            if let Some(symlink) = symlink {
-                created.push(symlink);
-                miseprintln!("Synced node@{} from nvm", v);
-            } else {
-                info!("Skipping node@{v} from nvm because it already exists in mise");
-            }
+            links.push((v.to_string(), nvm_versions_path.join(&entry)));
         }
-        if !created.is_empty() {
-            debug!("Created symlinks: {created:?}");
+        for v in node.sync_symlinks(&nvm_versions_path, links)? {
+            miseprintln!("Synced node@{} from nvm", v);
         }
         Ok(())
     }
@@ -122,21 +108,17 @@ impl SyncNode {
         let settings = Settings::get();
 
         let nodenv_versions_path = file::replace_path(&settings.node.nodenv_root).join("versions");
-        let installed_versions_path = dirs::INSTALLS.join("node");
-
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &nodenv_versions_path)?;
 
         let subdirs = file::dir_subdirs(&nodenv_versions_path)?;
+        let mut links = vec![];
         for v in sorted(subdirs) {
             if v.starts_with(".") {
                 continue;
             }
-            if node
-                .create_symlink(&v, &nodenv_versions_path.join(&v))?
-                .is_some()
-            {
-                miseprintln!("Synced node@{} from nodenv", v);
-            }
+            links.push((v.clone(), nodenv_versions_path.join(&v)));
+        }
+        for v in node.sync_symlinks(&nodenv_versions_path, links)? {
+            miseprintln!("Synced node@{} from nodenv", v);
         }
         Ok(())
     }

--- a/src/cli/sync/python.rs
+++ b/src/cli/sync/python.rs
@@ -46,19 +46,16 @@ impl SyncPython {
         let python = backend::get(&"python".into()).unwrap();
 
         let pyenv_versions_path = PYENV_ROOT.join("versions");
-        let installed_python_versions_path = dirs::INSTALLS.join("python");
-
-        file::remove_symlinks_with_target_prefix(
-            &installed_python_versions_path,
-            &pyenv_versions_path,
-        )?;
 
         let subdirs = file::dir_subdirs(&pyenv_versions_path)?;
+        let mut links = vec![];
         for v in sorted(subdirs) {
             if v.starts_with(".") {
                 continue;
             }
-            python.create_symlink(&v, &pyenv_versions_path.join(&v))?;
+            links.push((v.clone(), pyenv_versions_path.join(&v)));
+        }
+        for v in python.sync_symlinks(&pyenv_versions_path, links)? {
             miseprintln!("Synced python@{} from pyenv", v);
         }
         Ok(())
@@ -69,24 +66,18 @@ impl SyncPython {
         let uv_versions_path = &*env::UV_PYTHON_INSTALL_DIR;
         let installed_python_versions_path = dirs::INSTALLS.join("python");
 
-        file::remove_symlinks_with_target_prefix(
-            &installed_python_versions_path,
-            uv_versions_path,
-        )?;
-
         let subdirs = file::dir_subdirs(uv_versions_path)?;
+        let mut links = vec![];
         for name in sorted(subdirs) {
             if name.starts_with(".") {
                 continue;
             }
             // name is like cpython-3.13.1-macos-aarch64-none
             let v = name.split('-').nth(1).unwrap();
-            if python
-                .create_symlink(v, &uv_versions_path.join(&name))?
-                .is_some()
-            {
-                miseprintln!("Synced python@{v} from uv to mise");
-            }
+            links.push((v.to_string(), uv_versions_path.join(&name)));
+        }
+        for v in python.sync_symlinks(uv_versions_path, links)? {
+            miseprintln!("Synced python@{v} from uv to mise");
         }
 
         let subdirs = file::dir_subdirs(&installed_python_versions_path)?;

--- a/src/cli/sync/ruby.rs
+++ b/src/cli/sync/ruby.rs
@@ -6,7 +6,7 @@ use itertools::sorted;
 use crate::{
     backend,
     config::{self, Config},
-    dirs, file,
+    file,
 };
 
 /// Symlinks all ruby tool versions from an external tool into mise
@@ -46,11 +46,9 @@ impl SyncRuby {
         let ruby = backend::get(&"ruby".into()).unwrap();
 
         let brew_prefix = PathBuf::from(cmd!("brew", "--prefix").read()?).join("opt");
-        let installed_versions_path = dirs::INSTALLS.join("ruby");
-
-        file::remove_symlinks_with_target_prefix(&installed_versions_path, &brew_prefix)?;
 
         let subdirs = file::dir_subdirs(&brew_prefix)?;
+        let mut links = vec![];
         for entry in sorted(subdirs) {
             if entry.starts_with(".") {
                 continue;
@@ -59,9 +57,10 @@ impl SyncRuby {
                 continue;
             }
             let v = entry.trim_start_matches("ruby@");
-            if ruby.create_symlink(v, &brew_prefix.join(&entry))?.is_some() {
-                miseprintln!("Synced ruby@{} from Homebrew", v);
-            }
+            links.push((v.to_string(), brew_prefix.join(&entry)));
+        }
+        for v in ruby.sync_symlinks(&brew_prefix, links)? {
+            miseprintln!("Synced ruby@{} from Homebrew", v);
         }
         Ok(())
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -714,8 +714,7 @@ fn create_windows_dir_link(target: &Path, link: &Path) -> std::io::Result<()> {
 pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
     if let Err(err) = create_windows_dir_link(target, link) {
         if err.kind() == std::io::ErrorKind::AlreadyExists {
-            let _ = fs::remove_file(link);
-            let _ = fs::remove_dir(link);
+            remove_symlink_or_junction(link)?;
             create_windows_dir_link(target, link)
         } else {
             Err(err)
@@ -751,7 +750,7 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
-    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
+    is_symlink_or_junction(link) && paths_refer_to_same_entry(link, target)
 }
 
 #[cfg(unix)]
@@ -770,26 +769,140 @@ pub fn make_symlink_or_file(target: &Path, link: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn remove_symlinks_with_target_prefix(
-    symlink_dir: &Path,
-    target_prefix: &Path,
-) -> Result<Vec<PathBuf>> {
-    if !symlink_dir.exists() {
-        return Ok(vec![]);
-    }
-    let mut removed = vec![];
-    for entry in symlink_dir.read_dir()? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_symlink() {
-            let target = path.read_link()?;
-            if target.starts_with(target_prefix) {
-                fs::remove_file(&path)?;
-                removed.push(path);
+pub fn is_symlink_to_prefix(link: &Path, target_prefix: &Path) -> Result<bool> {
+    let Some(target) = dir_link_target(link)? else {
+        return Ok(false);
+    };
+    // Broken provider links cannot be canonicalized in full. Resolve the
+    // longest existing ancestor so symlinks in the existing portion still
+    // participate in ownership checks, then append only a safe normal tail.
+    // If that cannot establish ownership, preserve the link because this
+    // predicate controls destructive provider cleanup.
+    let Some(target) = canonicalize_with_missing_tail(&target)? else {
+        return Ok(false);
+    };
+    let Some(target_prefix) = canonicalize_with_missing_tail(target_prefix)? else {
+        return Ok(false);
+    };
+    Ok(path_is_within(&target, &target_prefix))
+}
+
+fn path_is_within(path: &Path, prefix: &Path) -> bool {
+    path.starts_with(prefix)
+        || path
+            .ancestors()
+            .any(|ancestor| paths_refer_to_same_entry(ancestor, prefix))
+}
+
+fn paths_refer_to_same_entry(a: &Path, b: &Path) -> bool {
+    same_file::is_same_file(a, b).unwrap_or(false)
+}
+
+fn canonicalize_with_missing_tail(path: &Path) -> Result<Option<PathBuf>> {
+    for ancestor in path.ancestors() {
+        match ancestor.canonicalize() {
+            Ok(mut resolved) => {
+                for component in path.strip_prefix(ancestor)?.components() {
+                    match component {
+                        std::path::Component::Normal(component) => {
+                            let candidate = resolved.join(component);
+                            // A link or junction in the unresolved tail may
+                            // redirect outside the provider. Its destination
+                            // cannot be established, so preserve the outer
+                            // link instead of claiming provider ownership.
+                            if dir_link_target(&candidate)?.is_some() {
+                                return Ok(None);
+                            }
+                            resolved.push(component);
+                        }
+                        std::path::Component::CurDir => {}
+                        std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_) => return Ok(None),
+                    }
+                }
+                return Ok(Some(resolved));
             }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Ok(None),
         }
     }
-    Ok(removed)
+    Ok(None)
+}
+
+#[cfg(unix)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    if !metadata.file_type().is_symlink() {
+        return Ok(None);
+    }
+    let target = fs::read_link(link)
+        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+#[cfg(windows)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
+
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    let target = if metadata.file_type().is_symlink() {
+        fs::read_link(link)
+            .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?
+    } else {
+        match junction::get_target(link) {
+            Ok(target) => target,
+            Err(err)
+                if err.kind() == std::io::ErrorKind::NotFound
+                    || err.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
+                    || (err.kind() == std::io::ErrorKind::Other
+                        && err.raw_os_error().is_none()) =>
+            {
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(err).wrap_err_with(|| {
+                    format!("failed to inspect junction: {}", display_path(link))
+                });
+            }
+        }
+    };
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
+    if target.is_absolute() {
+        target
+    } else {
+        link.parent().unwrap_or(link).join(target)
+    }
+}
+
+#[cfg(unix)]
+pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    fs::remove_file(link)
+        .wrap_err_with(|| format!("failed to remove symlink: {}", display_path(link)))
+}
+
+#[cfg(windows)]
+pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    fs::remove_file(link)
+        .or_else(|_| fs::remove_dir(link))
+        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
 }
 
 #[cfg(unix)]
@@ -2335,6 +2448,69 @@ mod tests {
             err.downcast_ref::<std::io::Error>().map(|err| err.kind()),
             Some(std::io::ErrorKind::DirectoryNotEmpty)
         );
+    }
+
+    #[test]
+    fn test_is_symlink_to_requires_a_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+        assert!(!is_symlink_to(&target, &target));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_is_symlink_to_resolves_relative_target_from_link_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink("target", &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+    }
+
+    #[test]
+    fn test_symlink_prefix_detection_and_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let target = prefix.join("version");
+        let other = dir.path().join("other");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&other).unwrap();
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to_prefix(&link, &prefix).unwrap());
+        assert!(!is_symlink_to_prefix(&link, &other).unwrap());
+
+        remove_symlink_or_junction(&link).unwrap();
+        assert!(std::fs::symlink_metadata(&link).is_err());
+        assert!(target.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_symlink_prefix_detection_rejects_escapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let foreign = dir.path().join("foreign");
+        let escaped = dir.path().join("escaped");
+        let redirected = dir.path().join("redirected");
+        fs::create_dir_all(&prefix).unwrap();
+        fs::create_dir_all(&foreign).unwrap();
+
+        std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
+        assert!(!is_symlink_to_prefix(&escaped, &prefix).unwrap());
+
+        std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
+        std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
+        assert!(!is_symlink_to_prefix(&redirected, &prefix).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- acquire the existing tool-version transaction lock before classifying or mutating each provider-linked version
- release each lock before moving to the next version instead of holding a whole batch of locks

## Bug

Provider reconciliation in #11682 checks who owns an install path and then may remove or replace it. Without the same version lock used by install, uninstall, and `mise link`, another process can change that path after the ownership check but before sync mutates it.

For example:

```text
process A: mise sync node --nvm sees node@22 as an nvm-owned link
process B: mise install --force node@22 replaces that path
process A: sync continues using its stale ownership decision
```

Before this fix, sync can fail or mutate a path whose ownership changed concurrently. After this fix, both operations serialize on the `node@22` transaction lock. Other versions remain independent and are not locked as a batch.

## Stack

This PR is stacked on #11682, which introduces provider-owned reconciliation. Review the final commit for the locking change; the parent diff will disappear after #11682 merges and this branch is rebased onto `main`.

#11687 builds on this guarantee to aggregate marker cleanup errors without losing successfully reconciled versions.

## Testing

- `mise run lint-fix`
- `mise run test:e2e e2e/sync/test_sync_nvm`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*
