### PR TITLE
test(bootstrap): add Linux host convergence gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -401,6 +401,21 @@ jobs:
               TOKEN_B: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
 
+  bootstrap-linux-host:
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=mise-pr-rust-linux
+    timeout-minutes: 20
+    needs: [build-ubuntu, classify-changes]
+    if: needs.classify-changes.outputs.full-ci == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: mise-ubuntu-latest
+          path: target/debug
+      - run: chmod +x target/debug/mise
+      - name: Converge a complete Linux host over SSH
+        run: scripts/test-bootstrap-linux-host.sh target/debug/mise
+
   windows-unit:
     runs-on: windows-latest
     timeout-minutes: 30
@@ -462,6 +477,7 @@ jobs:
       - nightly
       - lint
       - e2e
+      - bootstrap-linux-host
       - windows-unit
       - windows-e2e
     # Evaluate skipped and failed dependencies, but do not waste a runner when
@@ -501,6 +517,10 @@ jobs:
               echo "e2e failed or was skipped"
               exit 1
             fi
+            if [ "${{ needs.bootstrap-linux-host.result }}" != "success" ]; then
+              echo "bootstrap-linux-host failed or was skipped"
+              exit 1
+            fi
             if [ "${{ needs.windows-unit.result }}" != "success" ]; then
               echo "windows-unit failed or was skipped"
               exit 1
@@ -514,6 +534,7 @@ jobs:
               "${{ needs.build-windows.result }}" \
               "${{ needs.unit.result }}" \
               "${{ needs.e2e.result }}" \
+              "${{ needs.bootstrap-linux-host.result }}" \
               "${{ needs.windows-unit.result }}" \
               "${{ needs.windows-e2e.result }}"; do
               if [ "$result" != "skipped" ]; then

--- a/scripts/test-bootstrap-linux-host.sh
+++ b/scripts/test-bootstrap-linux-host.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+mise_bin=${1:-$repo_root/target/debug/mise}
+
+if [[ ! -x $mise_bin ]]; then
+	echo "mise binary is not executable: $mise_bin" >&2
+	exit 1
+fi
+mise_bin=$(cd "$(dirname "$mise_bin")" && pwd)/$(basename "$mise_bin")
+for command in docker ssh ssh-keygen; do
+	if ! command -v "$command" >/dev/null; then
+		echo "required command is unavailable: $command" >&2
+		exit 1
+	fi
+done
+
+test_tmp_root=${RUNNER_TEMP:-/tmp}
+case_dir=$(mktemp -d "$test_tmp_root/mise-bootstrap-host.XXXXXXXX")
+container="mise-bootstrap-host-$RANDOM-$$"
+image="mise-bootstrap-host:test-$RANDOM-$$"
+
+cleanup() {
+	status=$?
+	if ((status != 0)); then
+		docker logs "$container" >&2 2>/dev/null || true
+		docker exec "$container" systemctl --failed --no-pager >&2 2>/dev/null || true
+	fi
+	docker rm --force "$container" >/dev/null 2>&1 || true
+	docker image rm --force "$image" >/dev/null 2>&1 || true
+	case "$case_dir" in
+	"$test_tmp_root"/mise-bootstrap-host.*) rm -rf -- "$case_dir" ;;
+	*) echo "refusing to remove unexpected test directory: $case_dir" >&2 ;;
+	esac
+	return "$status"
+}
+trap cleanup EXIT
+
+ssh-keygen -q -t ed25519 -N '' -f "$case_dir/id_ed25519"
+
+cat >"$case_dir/mise.toml" <<'TOML'
+[bootstrap.groups.mise-case]
+system = true
+
+[bootstrap.users.mise-case]
+system = true
+group = "mise-case"
+home = "/var/lib/mise-case"
+shell = "/usr/sbin/nologin"
+comment = "mise bootstrap host acceptance test"
+create_home = true
+
+[bootstrap.directories."/opt/mise-case"]
+owner = "mise-case"
+group = "mise-case"
+mode = "0750"
+
+[bootstrap.files."/etc/mise-case.conf"]
+content = "generation=1\n"
+owner = "root"
+group = "root"
+mode = "0640"
+notify = ["mise-case"]
+
+[bootstrap.files."/etc/systemd/system/mise-case.service"]
+content = '''
+[Unit]
+Description=mise bootstrap host acceptance service
+
+[Service]
+ExecStart=/usr/bin/tail -f /dev/null
+
+[Install]
+WantedBy=multi-user.target
+'''
+owner = "root"
+group = "root"
+mode = "0644"
+notify = ["mise-case"]
+
+[bootstrap.files."/opt/mise-case/compose.yaml"]
+source = "./compose.yaml"
+owner = "mise-case"
+group = "mise-case"
+mode = "0640"
+
+[bootstrap.services.docker]
+state = "running"
+enabled = true
+
+[bootstrap.services.mise-case]
+state = "running"
+enabled = true
+on_change = "restart"
+
+[bootstrap.linux.firewall]
+backend = "nftables"
+state = "enabled"
+default_incoming = "deny"
+default_outgoing = "allow"
+
+[[bootstrap.linux.firewall.rules]]
+name = "ssh"
+direction = "incoming"
+action = "allow"
+port = 22
+protocol = "tcp"
+
+[bootstrap.compose.smoke]
+project_dir = "/opt/mise-case"
+files = ["compose.yaml"]
+project_name = "mise-bootstrap-smoke"
+state = "running"
+pull = "missing"
+wait = true
+wait_timeout = 60
+depends_on = ["service:docker"]
+TOML
+
+cat >"$case_dir/compose.yaml" <<'YAML'
+services:
+  smoke:
+    image: busybox:1.36.1
+    command: ["sh", "-c", "while true; do sleep 3600; done"]
+YAML
+
+docker build --tag "$image" "$repo_root/test/fixtures/bootstrap-linux-host"
+docker run --detach \
+	--name "$container" \
+	--privileged \
+	--cgroupns=host \
+	--tmpfs /run \
+	--tmpfs /run/lock \
+	--volume /sys/fs/cgroup:/sys/fs/cgroup:rw \
+	"$image" >/dev/null
+docker cp "$mise_bin" "$container:/opt/mise"
+docker exec "$container" chmod 0755 /opt/mise
+
+for _ in {1..60}; do
+	system_state=$(docker exec "$container" systemctl is-system-running 2>/dev/null || true)
+	if [[ $system_state == running || $system_state == degraded ]]; then
+		break
+	fi
+	sleep 1
+done
+system_state=$(docker exec "$container" systemctl is-system-running 2>/dev/null || true)
+if [[ $system_state != running && $system_state != degraded ]]; then
+	echo "container systemd failed to start: $system_state" >&2
+	exit 1
+fi
+
+docker exec --interactive "$container" bash -c \
+	'install -d -m 0700 /root/.ssh && install -m 0600 /dev/stdin /root/.ssh/authorized_keys' \
+	<"$case_dir/id_ed25519.pub"
+
+host=$(docker inspect "$container" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+host_key=$(docker exec "$container" cat /etc/ssh/ssh_host_ed25519_key.pub)
+printf '%s %s\n' "$host" "$host_key" >"$case_dir/known_hosts"
+ssh_args=(
+	-i "$case_dir/id_ed25519"
+	-o BatchMode=yes
+	-o StrictHostKeyChecking=yes
+	-o "UserKnownHostsFile=$case_dir/known_hosts"
+	-o SendEnv=-\*
+	-o LogLevel=ERROR
+	"root@$host"
+)
+
+for _ in {1..30}; do
+	if ssh "${ssh_args[@]}" true 2>/dev/null; then
+		break
+	fi
+	sleep 1
+done
+ssh "${ssh_args[@]}" true
+
+remote_bootstrap() {
+	"$mise_bin" bootstrap remote \
+		--host "root@$host" \
+		--identity-file "$case_dir/id_ed25519" \
+		--source "$case_dir" \
+		--remote-mise /opt/mise \
+		--ssh-option StrictHostKeyChecking=yes \
+		--ssh-option "UserKnownHostsFile=$case_dir/known_hosts" \
+		--ssh-option 'SendEnv=-*' \
+		--ssh-option LogLevel=ERROR \
+		--only accounts,files,services,firewall,compose \
+		--yes
+}
+
+remote_bootstrap
+remote_bootstrap
+
+ssh "${ssh_args[@]}" \
+	'getent passwd mise-case >/dev/null
+   test "$(stat -c %U:%G:%a /opt/mise-case)" = mise-case:mise-case:750
+   test "$(stat -c %U:%G:%a /etc/mise-case.conf)" = root:root:640
+   systemctl is-active --quiet mise-case.service
+   systemctl is-enabled --quiet mise-case.service
+   systemctl is-active --quiet docker.service
+   nft list table inet mise_bootstrap | grep -q mise-bootstrap
+   docker compose --project-directory /opt/mise-case --file /opt/mise-case/compose.yaml --project-name mise-bootstrap-smoke ps --status running --quiet | grep -q .'
+
+ssh "${ssh_args[@]}" \
+	'printf "drift\n" >/etc/mise-case.conf
+   systemctl stop mise-case.service
+   nft add rule inet mise_bootstrap input tcp dport 9 accept comment '"'"'manual-drift'"'"''
+
+remote_bootstrap
+
+ssh "${ssh_args[@]}" \
+	'test "$(cat /etc/mise-case.conf)" = generation=1
+   systemctl is-active --quiet mise-case.service
+   ! nft list table inet mise_bootstrap | grep -q manual-drift
+   docker compose --project-directory /opt/mise-case --file /opt/mise-case/compose.yaml --project-name mise-bootstrap-smoke ps --status running --quiet | grep -q .'

--- a/scripts/test-bootstrap-linux-host.sh
+++ b/scripts/test-bootstrap-linux-host.sh
@@ -193,7 +193,8 @@ remote_bootstrap
 remote_bootstrap
 
 ssh "${ssh_args[@]}" \
-	'getent passwd mise-case >/dev/null
+	'set -eu
+   getent passwd mise-case >/dev/null
    test "$(stat -c %U:%G:%a /opt/mise-case)" = mise-case:mise-case:750
    test "$(stat -c %U:%G:%a /etc/mise-case.conf)" = root:root:640
    systemctl is-active --quiet mise-case.service
@@ -203,14 +204,16 @@ ssh "${ssh_args[@]}" \
    docker compose --project-directory /opt/mise-case --file /opt/mise-case/compose.yaml --project-name mise-bootstrap-smoke ps --status running --quiet | grep -q .'
 
 ssh "${ssh_args[@]}" \
-	'printf "drift\n" >/etc/mise-case.conf
+	'set -eu
+   printf "drift\n" >/etc/mise-case.conf
    systemctl stop mise-case.service
    nft add rule inet mise_bootstrap input tcp dport 9 accept comment '"'"'manual-drift'"'"''
 
 remote_bootstrap
 
 ssh "${ssh_args[@]}" \
-	'test "$(cat /etc/mise-case.conf)" = generation=1
+	'set -eu
+   test "$(cat /etc/mise-case.conf)" = generation=1
    systemctl is-active --quiet mise-case.service
    ! nft list table inet mise_bootstrap | grep -q manual-drift
    docker compose --project-directory /opt/mise-case --file /opt/mise-case/compose.yaml --project-name mise-bootstrap-smoke ps --status running --quiet | grep -q .'

--- a/test/fixtures/bootstrap-linux-host/Dockerfile
+++ b/test/fixtures/bootstrap-linux-host/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
+
+ENV container=docker
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        docker-compose-v2 \
+        docker.io \
+        nftables \
+        openssh-server \
+        sudo \
+        systemd \
+        systemd-sysv \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && systemctl enable docker.service ssh.service
+
+COPY daemon.json /etc/docker/daemon.json
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/test/fixtures/bootstrap-linux-host/daemon.json
+++ b/test/fixtures/bootstrap-linux-host/daemon.json
@@ -1,0 +1,3 @@
+{
+  "storage-driver": "vfs"
+}


### PR DESCRIPTION
## Summary
- add a required Linux host convergence job to the pull-request test workflow
- boot a pinned Ubuntu 24.04 systemd container and exercise the exact built mise artifact over verified SSH
- prove idempotence and drift repair across users/groups, privileged files, systemd services, nftables, and Docker Compose
- collect container and failed-unit diagnostics automatically when the acceptance test fails

## Validation
- `scripts/test-bootstrap-linux-host.sh target/debug/mise` (passed twice locally)
- `mise run lint-fix`
- `shellcheck scripts/test-bootstrap-linux-host.sh`
- `actionlint .github/workflows/test.yml`
- `git diff --check`

## Stack
Depends on #11694 and validates the complete bootstrap stack on a real Linux host boundary.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI and test scripts/fixtures; no production bootstrap behavior is modified, though a flaky or slow job could block full-ci PRs.
> 
> **Overview**
> Adds a **required** `bootstrap-linux-host` CI job (full-ci only) that downloads the built `mise` artifact and runs `scripts/test-bootstrap-linux-host.sh`. The aggregate `test-ci` gate now treats that job like e2e/windows jobs—success required on full CI, skipped on docs-only changes.
> 
> The new script boots a **privileged systemd Ubuntu container** (pinned fixture image), copies `mise` in, wires SSH with strict host-key checking, and drives **`mise bootstrap remote`** over SSH for accounts, files, services, nftables firewall, and Docker Compose. It runs bootstrap twice for idempotence, then simulates drift (file, stopped service, manual nft rule) and converges again. Failures dump container logs and `systemctl --failed`.
> 
> Fixture adds `test/fixtures/bootstrap-linux-host` (Ubuntu 24.04, docker-compose-v2, nftables, openssh, systemd; Docker `vfs` storage for nested docker).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f9ab75c4056ed5d5547a51b3468b5ce28a99d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->