### PR TITLE
fix(task): make workspace task inference opt-in

### DIFF
--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -498,8 +498,8 @@ All four dependency kinds participate in the same project graph, including devel
 
 ### Node Package Scripts
 
-When experimental features are enabled, mise imports scripts from each discovered Node workspace
-package as tasks. Packages do not need their own `mise.toml`.
+When task inference and experimental features are enabled, mise imports scripts from each
+discovered Node workspace package as tasks. Packages do not need their own `mise.toml`.
 
 An imported task uses the stable project ID followed by `#` and the package script name:
 
@@ -522,10 +522,12 @@ declaration or lockfile to select the manager and falls back to npm when neither
 An explicit mise task at the package's monorepo path takes precedence over the imported script.
 Both names continue to resolve to that explicit task.
 
-This inference is currently experimental and only runs for a configured monorepo root:
+This inference is opt-in, currently experimental, and only runs for a configured monorepo root:
 
-```bash
-mise settings experimental=true
+```toml
+[settings]
+experimental = true
+task.auto_infer = ["node"]
 ```
 
 ### Root Task Defaults

--- a/e2e/tasks/test_task_group_wildcards_slow
+++ b/e2e/tasks/test_task_group_wildcards_slow
@@ -50,6 +50,9 @@ mkdir -p projects/app
 cat <<'EOF' >mise.toml
 monorepo_root = true
 
+[settings]
+task.auto_infer = ["node"]
+
 [monorepo]
 config_roots = ["projects/app"]
 EOF

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -88,12 +88,20 @@ cat <<'JSON' >packages/app/package.json
     "cache-only": "printf cached > cache-result.txt",
     "file-collision": "printf inferred > file-collision-result.txt",
     "no-deps": "printf independent > no-deps-result.txt",
+    "precedence-collision": "printf inferred > precedence-collision-result.txt",
     "test:unit": "printf tested > test-result.txt"
   }
 }
 JSON
 
-touch packages/app/mise.toml
+cat <<'TOML' >packages/app/mise.toml
+[tasks.alias-owner]
+alias = ["//packages/app:precedence-collision"]
+run = "printf alias-owner > precedence-collision-result.txt"
+
+[tasks.precedence-collision]
+run = "printf explicit > precedence-collision-result.txt"
+TOML
 mkdir -p packages/app/.config/mise/tasks
 cat <<'SH' >packages/app/.config/mise/tasks/file-collision.sh
 #!/bin/sh
@@ -174,6 +182,8 @@ mise -q run //packages/app:file-collision
 assert "cat packages/app/file-collision-result.txt" "explicit"
 mise -q run 'node:@scope/app#file-collision'
 assert "cat packages/app/file-collision-result.txt" "explicit"
+mise -q run 'node:@scope/app#precedence-collision'
+assert "cat packages/app/precedence-collision-result.txt" "explicit"
 
 cat <<'TOML' >packages/app/mise.toml
 [tasks.build]

--- a/e2e/tasks/test_task_node_workspace_scripts
+++ b/e2e/tasks/test_task_node_workspace_scripts
@@ -86,11 +86,20 @@ cat <<'JSON' >packages/app/package.json
   "scripts": {
     "build": "printf inferred > result.txt",
     "cache-only": "printf cached > cache-result.txt",
+    "file-collision": "printf inferred > file-collision-result.txt",
     "no-deps": "printf independent > no-deps-result.txt",
     "test:unit": "printf tested > test-result.txt"
   }
 }
 JSON
+
+touch packages/app/mise.toml
+mkdir -p packages/app/.config/mise/tasks
+cat <<'SH' >packages/app/.config/mise/tasks/file-collision.sh
+#!/bin/sh
+printf explicit > file-collision-result.txt
+SH
+chmod +x packages/app/.config/mise/tasks/file-collision.sh
 
 mkdir -p packages/bridge
 cat <<'JSON' >packages/bridge/package.json
@@ -120,6 +129,14 @@ run = "printf '%s' \"$ROOT_TASK_DEFAULT\" > config-root-default.txt"
 
 [tasks.template-only]
 extends = "template-only"
+TOML
+
+assert_not_contains "mise tasks --all" "node:@scope/app#build"
+assert_not_contains "MISE_TASK_AUTO_INFER=cargo mise tasks --all" "node:@scope/app#build"
+cat <<'TOML' >>mise.toml
+
+[settings]
+task.auto_infer = ["node"]
 TOML
 
 assert_contains "mise tasks --all" "node:@scope/app#build"
@@ -152,6 +169,11 @@ assert "cat workspace-task.log" $'core:run prepare --\napp:run build -- forwarde
 printf stale >packages/app/result.txt
 mise -q run //packages/app:build
 assert "cat packages/app/result.txt" "inferred"
+
+mise -q run //packages/app:file-collision
+assert "cat packages/app/file-collision-result.txt" "explicit"
+mise -q run 'node:@scope/app#file-collision'
+assert "cat packages/app/file-collision-result.txt" "explicit"
 
 cat <<'TOML' >packages/app/mise.toml
 [tasks.build]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1788,6 +1788,14 @@
           "type": "object",
           "unevaluatedProperties": false,
           "properties": {
+            "auto_infer": {
+              "default": [],
+              "description": "[experimental] Workspace providers from which to automatically infer tasks.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "cache_dir": {
               "description": "[experimental] Directory for task output cache artifacts.",
               "type": "string"

--- a/settings.toml
+++ b/settings.toml
@@ -2620,6 +2620,20 @@ it, and skips sudo entirely when already running as root (e.g. containers/CI).
 env = "MISE_SYSTEM_PACKAGES_SUDO"
 type = "Bool"
 
+[task.auto_infer]
+default = []
+description = "[experimental] Workspace providers from which to automatically infer tasks."
+docs = """
+List the workspace provider languages whose ecosystem tasks mise should import. For example,
+`["node"]` imports scripts from Node workspace `package.json` files. Inferred tasks use stable
+provider-scoped names and monorepo path aliases. Task inference is opt-in because ecosystem commands
+may overlap with explicit mise tasks.
+"""
+env = "MISE_TASK_AUTO_INFER"
+parse_env = "set_by_comma"
+rust_type = "BTreeSet<String>"
+type = "SetString"
+
 [task.cache_dir]
 description = "[experimental] Directory for task output cache artifacts."
 docs = """

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -831,10 +831,17 @@ impl Config {
             })
             .map(|t| (t.name.clone(), t))
             .collect();
-        if Settings::get().experimental {
+        let settings = Settings::get();
+        if settings.experimental && !settings.task.auto_infer.is_empty() {
             let inferred_tasks = match workspace_graph.as_ref() {
                 Some(Ok(graph)) => {
-                    inferred_workspace_tasks(&config, &task_definitions, graph).await
+                    inferred_workspace_tasks(
+                        &config,
+                        &task_definitions,
+                        graph,
+                        &settings.task.auto_infer,
+                    )
+                    .await
                 }
                 Some(Err(err)) => {
                     warn!(
@@ -866,11 +873,14 @@ impl Config {
                         .extend(available_aliases);
                     continue;
                 }
-                let explicit_name = task
-                    .aliases
-                    .iter()
-                    .find(|alias| tasks.contains_key(*alias))
-                    .cloned();
+                let explicit_name = task.aliases.iter().find_map(|alias| {
+                    tasks.iter().find_map(|(name, explicit)| {
+                        (name == alias
+                            || explicit.aliases.contains(alias)
+                            || (explicit.file.is_some() && strip_task_extension(name) == alias))
+                            .then(|| name.clone())
+                    })
+                });
                 if let Some(explicit_name) = explicit_name {
                     let explicit = tasks
                         .get_mut(&explicit_name)
@@ -3020,13 +3030,20 @@ async fn inferred_workspace_tasks(
     config: &Arc<Config>,
     task_definitions: &TaskDefinitions,
     graph: &crate::task::workspace::WorkspaceProjectGraph,
+    providers: &BTreeSet<String>,
 ) -> Vec<Task> {
     let Some(monorepo_root) = config.monorepo_root() else {
         return Vec::new();
     };
     let mut tasks = Vec::new();
 
-    for project in graph.projects() {
+    for project in graph.projects().filter(|project| {
+        project
+            .id
+            .as_str()
+            .split_once(':')
+            .is_some_and(|(provider, _)| providers.contains(provider))
+    }) {
         let project_root = monorepo_root.join(&project.root);
         let path_scope = monorepo_scope(&monorepo_root, &project_root);
         for (name, inferred) in &project.tasks {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -873,14 +873,26 @@ impl Config {
                         .extend(available_aliases);
                     continue;
                 }
-                let explicit_name = task.aliases.iter().find_map(|alias| {
-                    tasks.iter().find_map(|(name, explicit)| {
-                        (name == alias
-                            || explicit.aliases.contains(alias)
-                            || (explicit.file.is_some() && strip_task_extension(name) == alias))
-                            .then(|| name.clone())
+                let explicit_name = task
+                    .aliases
+                    .iter()
+                    .find(|alias| tasks.contains_key(*alias))
+                    .cloned()
+                    .or_else(|| {
+                        task.aliases.iter().find_map(|alias| {
+                            tasks.iter().find_map(|(name, explicit)| {
+                                (explicit.file.is_some() && strip_task_extension(name) == alias)
+                                    .then(|| name.clone())
+                            })
+                        })
                     })
-                });
+                    .or_else(|| {
+                        task.aliases.iter().find_map(|alias| {
+                            tasks.iter().find_map(|(name, explicit)| {
+                                explicit.aliases.contains(alias).then(|| name.clone())
+                            })
+                        })
+                    });
                 if let Some(explicit_name) = explicit_name {
                     let explicit = tasks
                         .get_mut(&explicit_name)


### PR DESCRIPTION
## Summary
- make workspace task inference opt-in per provider with `task.auto_infer = ["node"]`
- keep explicit mise file and TOML tasks ahead of inferred package scripts on name and alias collisions
- document the setting and regenerate the config schema

## Root cause
Node workspace scripts were imported whenever experimental features were enabled. File tasks retain their extension internally, so an inferred extensionless alias could also bypass the existing exact-name precedence check and replace the callable mise task.

Fixes the bug reported in https://github.com/jdx/mise/discussions/11705.

## Validation
- `mise run lint-fix`
- `mise run test:unit test_settings_toml_is_sorted`
- `mise run test:e2e tasks/test_task_node_workspace_scripts tasks/test_task_group_wildcards_slow`
- `mise run render:schema`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task loading and precedence in monorepo/experimental setups; behavior shifts for users who relied on implicit Node script import when only `experimental` was set.
> 
> **Overview**
> Workspace task inference is now **opt-in per provider** via `task.auto_infer` (e.g. `["node"]`) instead of running whenever `experimental` is on. Node `package.json` scripts are only imported when that list includes the provider and experimental features are enabled.
> 
> **Explicit mise tasks win over inferred scripts** on name and alias collisions, including file tasks whose internal names keep extensions and tasks that alias monorepo path names like `//packages/app:precedence-collision`.
> 
> Docs, `settings.toml`, and the JSON schema document the new setting (`MISE_TASK_AUTO_INFER`). E2E tests cover opt-in behavior and collision precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41051a5907f2ab1f0897ea19a63e11e5d17307e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental configuration for automatically inferring tasks from selected workspace providers.
  * Added support for configuring automatic task inference through settings or environment variables.
  * Automatic Node task inference now requires experimental features and the Node provider to be enabled.
  * Explicit tasks take precedence over automatically inferred tasks with the same name.

* **Documentation**
  * Updated configuration examples to show how to enable experimental Node workspace task inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->