### PR TITLE
feat(ruby): require precompiled binaries with ruby.compile=false

### DIFF
--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -59,6 +59,9 @@ With this setting:
 If you set a custom `ruby.precompiled_url` template, mise cannot enumerate available versions and
 version listings are left unfiltered.
 
+`ruby.compile` has no effect on Windows, which installs Ruby from
+[RubyInstaller2](https://rubyinstaller.org/) rather than from `jdx/ruby` or ruby-build.
+
 ### Precompiled build revisions
 
 Precompiled Ruby binaries are released from `jdx/ruby`. Sometimes the binary for a Ruby version is rebuilt without changing the Ruby version itself. Those rebuilds use build revision release tags like `3.3.11-1` or `3.3.11-2`.

--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -38,6 +38,27 @@ for the following platforms:
 If a precompiled binary is not available for your platform or Ruby version, mise automatically
 falls back to compiling from source using ruby-build.
 
+### Precompiled binaries only
+
+Set `ruby.compile=false` to opt out of source builds entirely. This is useful on hosts without a
+build toolchain, where a silent fallback to ruby-build would fail late or pull in build
+dependencies you deliberately don't have:
+
+```sh
+mise settings ruby.compile=false
+```
+
+With this setting:
+
+- Installs error out when no precompiled binary exists for the requested version and platform,
+  instead of falling back to ruby-build.
+- `mise ls-remote ruby` and fuzzy versions only consider versions that have a precompiled
+  binary, so `ruby = "4.0"` resolves to the newest 4.0.x that actually has a binary rather than
+  a version that would have to be built from source.
+
+If you set a custom `ruby.precompiled_url` template, mise cannot enumerate available versions and
+version listings are left unfiltered.
+
 ### Precompiled build revisions
 
 Precompiled Ruby binaries are released from `jdx/ruby`. Sometimes the binary for a Ruby version is rebuilt without changing the Ruby version itself. Those rebuilds use build revision release tags like `3.3.11-1` or `3.3.11-2`.
@@ -91,6 +112,9 @@ To always compile from source even when precompiled binaries are available:
 ```sh
 mise settings ruby.compile=true
 ```
+
+To require precompiled binaries and never compile, see
+[Precompiled binaries only](#precompiled-binaries-only).
 
 You can also use a custom source for precompiled binaries by setting `ruby.precompiled_url` to
 either a GitHub repo (e.g., `owner/repo`) or a full URL template.

--- a/e2e/core/test_ruby_precompiled_only
+++ b/e2e/core/test_ruby_precompiled_only
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Test that ruby.compile=false requires precompiled binaries with no ruby-build fallback
+export MISE_RUBY_COMPILE=false
+
+# 1.9.3 is a ruby-build definition that will never have a precompiled binary, so the
+# install must fail instead of quietly compiling from source
+assert_fail_contains "mise install ruby@1.9.3" "no precompiled ruby found"
+
+# fuzzy versions only resolve to versions that actually have a precompiled binary
+assert_not_contains "mise ls-remote ruby" "1.9.3"
+assert_contains "mise ls-remote ruby" "3.4."

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1545,7 +1545,7 @@
               "type": "string"
             },
             "compile": {
-              "description": "Set to true to compile ruby from source, false to use precompiled binaries.",
+              "description": "If true, compile ruby from source. If false, require precompiled binaries. If not set, use precompiled binaries if available.",
               "type": "boolean"
             },
             "default_packages_file": {

--- a/settings.toml
+++ b/settings.toml
@@ -2204,11 +2204,13 @@ optional = true
 type = "String"
 
 [ruby.compile]
-description = "Set to true to compile ruby from source, false to use precompiled binaries."
+description = "If true, compile ruby from source. If false, require precompiled binaries. If not set, use precompiled binaries if available."
 docs = """
 Controls whether Ruby is compiled from source or downloaded as precompiled binaries.
 
-- If `false`: Try precompiled binaries first, fall back to compiling if unavailable
+- If `false`: Only use precompiled binaries. Installs error out instead of falling back to
+  ruby-build, and version listings only include versions that have a precompiled binary for
+  the current platform.
 - If `true`: Always compile from source using ruby-build
 - If unset: Try precompiled binaries first, fall back to compiling if unavailable
 """

--- a/settings.toml
+++ b/settings.toml
@@ -2213,6 +2213,8 @@ Controls whether Ruby is compiled from source or downloaded as precompiled binar
   the current platform.
 - If `true`: Always compile from source using ruby-build
 - If unset: Try precompiled binaries first, fall back to compiling if unavailable
+
+This setting has no effect on Windows, which installs Ruby from RubyInstaller2.
 """
 env = "MISE_RUBY_COMPILE"
 optional = true

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -1,10 +1,10 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env::temp_dir;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use eyre::{Result, WrapErr, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 use itertools::Itertools;
 use xx::regex;
 
@@ -451,6 +451,14 @@ impl RubyPlugin {
         Settings::get().ruby.compile != Some(true)
     }
 
+    /// Check if precompiled binaries are required, with no fallback to compiling.
+    /// `ruby.compile = false` is a strict opt-in: installs fail instead of falling back
+    /// to ruby-build, and remote version listings only offer versions that have a
+    /// precompiled binary for this platform.
+    fn precompiled_only(&self) -> bool {
+        Settings::get().ruby.compile == Some(false)
+    }
+
     /// Get platform identifier for precompiled binaries
     /// Returns platform in jdx/ruby format: "macos", "arm64_linux", or "x86_64_linux"
     fn precompiled_platform(&self) -> Option<String> {
@@ -560,8 +568,76 @@ impl RubyPlugin {
     }
 
     fn is_build_revision_tag(version: &str, tag: &str) -> bool {
-        tag.strip_prefix(&format!("{version}-"))
-            .is_some_and(|suffix| suffix.parse::<u32>().is_ok())
+        matches!(Self::split_build_revision_tag(tag), (v, true) if v == version)
+    }
+
+    /// Split a release tag into its version and whether it carries a build revision.
+    ///
+    /// `3.3.11-1` -> `("3.3.11", true)`, `3.3.11` -> `("3.3.11", false)`.
+    /// Non-numeric suffixes are part of the version: `3.4.0-preview1` -> `("3.4.0-preview1", false)`.
+    fn split_build_revision_tag(tag: &str) -> (&str, bool) {
+        match tag.rsplit_once('-') {
+            Some((version, revision)) if revision.parse::<u32>().is_ok() => (version, true),
+            _ => (tag, false),
+        }
+    }
+
+    /// Collect the versions that have a precompiled asset for `platform`.
+    ///
+    /// Mirrors the asset lookup in [`Self::find_precompiled_asset_in_repo`] so a version is
+    /// only reported as available when an install would actually find a binary for it.
+    fn precompiled_versions_from_releases(
+        releases: &[GithubRelease],
+        requires_build_revision: bool,
+        platform: &str,
+    ) -> HashSet<String> {
+        let mut versions = HashSet::new();
+        for release in releases {
+            let (version, has_build_revision) = Self::split_build_revision_tag(&release.tag_name);
+            if requires_build_revision && !has_build_revision {
+                continue;
+            }
+            let asset_name = format!("ruby-{version}.{platform}.tar.gz");
+            if release.assets.iter().any(|asset| asset.name == asset_name) {
+                versions.insert(version.to_string());
+            }
+        }
+        versions
+    }
+
+    /// Restrict a version list to versions that have a precompiled binary for this platform.
+    ///
+    /// Entries are only removed, never reordered, so `latest` and prefix resolution keep the
+    /// same ordering semantics as a source install.
+    async fn retain_precompiled_versions(
+        &self,
+        versions: Vec<VersionInfo>,
+    ) -> Result<Vec<VersionInfo>> {
+        let settings = Settings::get();
+        let source = &settings.ruby.precompiled_url;
+        if source.contains("://") {
+            // A URL template can't be enumerated, so every version is assumed available.
+            return Ok(versions);
+        }
+        let Some(platform) = self.precompiled_platform() else {
+            bail!(
+                "no precompiled ruby is available for this platform\n\
+                 To compile ruby from source, run: mise settings ruby.compile=true"
+            );
+        };
+        // Only the releases `list_releases` returns are considered. Without
+        // MISE_LIST_ALL_VERSIONS that is the most recent page, which is where the
+        // precompiled builds live.
+        let releases = github::list_releases(source).await?;
+        let available = Self::precompiled_versions_from_releases(
+            &releases,
+            Self::source_requires_build_revision(source),
+            &platform,
+        );
+        Ok(versions
+            .into_iter()
+            .filter(|v| available.contains(&v.version))
+            .collect())
     }
 
     /// Find precompiled asset from a GitHub repo's releases.
@@ -895,6 +971,12 @@ impl Backend for RubyPlugin {
         features
     }
 
+    async fn remote_version_cache_context(&self, _config: &Arc<Config>) -> Result<Option<String>> {
+        // Strict precompiled mode lists a subset of the versions ruby-build knows about, so it
+        // must not share a cache — or the shared versions host list — with source installs.
+        Ok(self.precompiled_only().then(|| "precompiled".to_string()))
+    }
+
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
         timeout::run_with_timeout_async(
             async || {
@@ -920,7 +1002,7 @@ impl Backend for RubyPlugin {
                     .collect();
 
                 // Map versions to VersionInfo with created_at timestamps
-                let version_infos = versions
+                let version_infos: Vec<VersionInfo> = versions
                     .into_iter()
                     .map(|version| {
                         let created_at = release_dates.get(&version).cloned();
@@ -931,6 +1013,10 @@ impl Backend for RubyPlugin {
                         }
                     })
                     .collect();
+
+                if self.precompiled_only() {
+                    return self.retain_precompiled_versions(version_infos).await;
+                }
 
                 Ok(version_infos)
             },
@@ -960,23 +1046,36 @@ impl Backend for RubyPlugin {
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         let mut tv = tv;
         // Try precompiled unless source compilation was explicitly requested.
-        if self.should_try_precompiled()
-            && let Some(installed_tv) = self.install_precompiled(ctx, &mut tv).await?
-        {
-            hint!(
-                "ruby_precompiled",
-                "installing precompiled ruby from jdx/ruby\n\
+        if self.should_try_precompiled() {
+            if let Some(installed_tv) = self.install_precompiled(ctx, &mut tv).await? {
+                hint!(
+                    "ruby_precompiled",
+                    "installing precompiled ruby from jdx/ruby\n\
                     if you experience issues, switch to ruby-build by running",
-                "mise settings ruby.compile=true"
-            );
-            self.install_rubygems_hook(&installed_tv)?;
-            if let Err(err) = self
-                .install_default_gems(&ctx.config, &installed_tv, ctx.pr.as_ref())
-                .await
-            {
-                warn!("failed to install default ruby gems {err:#}");
+                    "mise settings ruby.compile=true"
+                );
+                self.install_rubygems_hook(&installed_tv)?;
+                if let Err(err) = self
+                    .install_default_gems(&ctx.config, &installed_tv, ctx.pr.as_ref())
+                    .await
+                {
+                    warn!("failed to install default ruby gems {err:#}");
+                }
+                return Ok(installed_tv);
             }
-            return Ok(installed_tv);
+            // `ruby.compile = false` opts out of source builds entirely, so a missing
+            // precompiled binary is an error instead of a silent ruby-build fallback.
+            if self.precompiled_only() {
+                hint!(
+                    "ruby_compile",
+                    "To compile ruby from source, run",
+                    "mise settings ruby.compile=true"
+                );
+                match self.precompiled_platform() {
+                    Some(platform) => bail!("no precompiled ruby found for {tv} on {platform}"),
+                    None => bail!("no precompiled ruby is available for this platform"),
+                }
+            }
         }
         // No precompiled available, fall through to compile from source
 
@@ -1187,6 +1286,36 @@ mod tests {
         backend.resolve_lockfile_options(&request, &target).unwrap()
     }
 
+    fn ruby_precompiled_only(compile: Option<bool>) -> bool {
+        let lock = TEST_SETTINGS_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut settings = SettingsPartial::empty();
+        settings.ruby.compile = compile;
+        Settings::reset(Some(settings));
+        let _guard = SettingsResetGuard { _lock: lock };
+
+        RubyPlugin::new().precompiled_only()
+    }
+
+    fn release(tag: &str, assets: &[&str]) -> GithubRelease {
+        GithubRelease {
+            tag_name: tag.to_string(),
+            draft: false,
+            prerelease: false,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            assets: assets
+                .iter()
+                .map(|name| crate::github::GithubAsset {
+                    name: (*name).to_string(),
+                    browser_download_url: format!("https://example.com/{name}"),
+                    url: format!("https://api.example.com/{name}"),
+                    digest: None,
+                })
+                .collect(),
+        }
+    }
+
     fn non_current_platform_target() -> PlatformTarget {
         let platform = ["linux-x64", "macos-arm64", "windows-x64"]
             .into_iter()
@@ -1298,6 +1427,63 @@ mod tests {
             DEFAULT_RUBY_PRECOMPILED_URL
         ));
         assert!(!RubyPlugin::source_requires_build_revision("acme/ruby"));
+    }
+
+    #[test]
+    fn test_ruby_split_build_revision_tag() {
+        assert_eq!(
+            RubyPlugin::split_build_revision_tag("3.3.11-1"),
+            ("3.3.11", true)
+        );
+        assert_eq!(
+            RubyPlugin::split_build_revision_tag("3.3.11-12"),
+            ("3.3.11", true)
+        );
+        assert_eq!(
+            RubyPlugin::split_build_revision_tag("3.3.11"),
+            ("3.3.11", false)
+        );
+        assert_eq!(
+            RubyPlugin::split_build_revision_tag("3.4.0-preview1"),
+            ("3.4.0-preview1", false)
+        );
+    }
+
+    #[test]
+    fn test_ruby_precompiled_versions_require_build_revision_for_default_source() {
+        let releases = vec![
+            release("3.3.11", &["ruby-3.3.11.x86_64_linux.tar.gz"]),
+            release("3.3.12-1", &["ruby-3.3.12.x86_64_linux.tar.gz"]),
+            release("4.0.6-2", &["ruby-4.0.6.macos.tar.gz"]),
+        ];
+
+        // The default source only ships usable binaries under build revision tags, so the
+        // plain `3.3.11` tag is not offered.
+        let versions =
+            RubyPlugin::precompiled_versions_from_releases(&releases, true, "x86_64_linux");
+        assert_eq!(versions, HashSet::from(["3.3.12".to_string()]));
+
+        // Custom sources have no build revision requirement.
+        let versions =
+            RubyPlugin::precompiled_versions_from_releases(&releases, false, "x86_64_linux");
+        assert_eq!(
+            versions,
+            HashSet::from(["3.3.11".to_string(), "3.3.12".to_string()])
+        );
+
+        // Only assets for the requested platform count.
+        let versions = RubyPlugin::precompiled_versions_from_releases(&releases, true, "macos");
+        assert_eq!(versions, HashSet::from(["4.0.6".to_string()]));
+        let versions =
+            RubyPlugin::precompiled_versions_from_releases(&releases, true, "arm64_linux");
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn test_ruby_precompiled_only_requires_explicit_false() {
+        assert!(!ruby_precompiled_only(None));
+        assert!(!ruby_precompiled_only(Some(true)));
+        assert!(ruby_precompiled_only(Some(false)));
     }
 
     #[test]

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -568,41 +568,73 @@ impl RubyPlugin {
     }
 
     fn is_build_revision_tag(version: &str, tag: &str) -> bool {
-        matches!(Self::split_build_revision_tag(tag), (v, true) if v == version)
+        matches!(Self::split_build_revision_tag(tag), (v, Some(_)) if v == version)
     }
 
-    /// Split a release tag into its version and whether it carries a build revision.
+    /// Split a release tag into its version and build revision.
     ///
-    /// `3.3.11-1` -> `("3.3.11", true)`, `3.3.11` -> `("3.3.11", false)`.
-    /// Non-numeric suffixes are part of the version: `3.4.0-preview1` -> `("3.4.0-preview1", false)`.
-    fn split_build_revision_tag(tag: &str) -> (&str, bool) {
+    /// `3.3.11-1` -> `("3.3.11", Some(1))`, `3.3.11` -> `("3.3.11", None)`.
+    /// Non-numeric suffixes are part of the version: `3.4.0-preview1` -> `("3.4.0-preview1", None)`.
+    fn split_build_revision_tag(tag: &str) -> (&str, Option<u32>) {
         match tag.rsplit_once('-') {
-            Some((version, revision)) if revision.parse::<u32>().is_ok() => (version, true),
-            _ => (tag, false),
+            Some((version, revision)) => match revision.parse::<u32>() {
+                Ok(revision) => (version, Some(revision)),
+                Err(_) => (tag, None),
+            },
+            None => (tag, None),
         }
     }
 
     /// Collect the versions that have a precompiled asset for `platform`.
     ///
-    /// Mirrors the asset lookup in [`Self::find_precompiled_asset_in_repo`] so a version is
-    /// only reported as available when an install would actually find a binary for it.
+    /// An install resolves a version to exactly one release — the highest build revision, or
+    /// the base tag when revisions aren't required — so availability is decided by that same
+    /// release. A newer revision that is missing an asset for this platform means the version
+    /// is not installable even when an older revision has one, which keeps this list from
+    /// offering versions [`Self::find_precompiled_asset_in_repo`] would reject.
     fn precompiled_versions_from_releases(
         releases: &[GithubRelease],
         requires_build_revision: bool,
         platform: &str,
     ) -> HashSet<String> {
-        let mut versions = HashSet::new();
+        let mut best: HashMap<&str, (Option<u32>, bool)> = HashMap::new();
         for release in releases {
-            let (version, has_build_revision) = Self::split_build_revision_tag(&release.tag_name);
-            if requires_build_revision && !has_build_revision {
+            let (version, revision) = Self::split_build_revision_tag(&release.tag_name);
+            if requires_build_revision && revision.is_none() {
                 continue;
             }
-            let asset_name = format!("ruby-{version}.{platform}.tar.gz");
-            if release.assets.iter().any(|asset| asset.name == asset_name) {
-                versions.insert(version.to_string());
+            match best.get(version) {
+                // `None` (the base tag) sorts below every numeric revision, matching how
+                // installs prefer `3.3.11-2` over `3.3.11-1` over `3.3.11`.
+                Some((best_revision, _)) if *best_revision >= revision => continue,
+                _ => {}
             }
+            let asset_name = format!("ruby-{version}.{platform}.tar.gz");
+            let has_asset = release.assets.iter().any(|asset| asset.name == asset_name);
+            best.insert(version, (revision, has_asset));
         }
-        versions
+        best.into_iter()
+            .filter(|(_, (_, has_asset))| *has_asset)
+            .map(|(version, _)| version.to_string())
+            .collect()
+    }
+
+    /// Cache key context for strict precompiled version listings.
+    ///
+    /// The filtered list depends on which source is queried and which platform's assets are
+    /// looked for, so a change to any of those must not reuse the previous list.
+    fn precompiled_cache_context(&self) -> Option<String> {
+        if !self.precompiled_only() {
+            return None;
+        }
+        let settings = Settings::get();
+        Some(hash::hash_to_str(&(
+            "ruby-precompiled",
+            &settings.ruby.precompiled_url,
+            &settings.ruby.precompiled_arch,
+            &settings.ruby.precompiled_os,
+            self.precompiled_platform(),
+        )))
     }
 
     /// Restrict a version list to versions that have a precompiled binary for this platform.
@@ -974,7 +1006,7 @@ impl Backend for RubyPlugin {
     async fn remote_version_cache_context(&self, _config: &Arc<Config>) -> Result<Option<String>> {
         // Strict precompiled mode lists a subset of the versions ruby-build knows about, so it
         // must not share a cache — or the shared versions host list — with source installs.
-        Ok(self.precompiled_only().then(|| "precompiled".to_string()))
+        Ok(self.precompiled_cache_context())
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
@@ -1286,16 +1318,34 @@ mod tests {
         backend.resolve_lockfile_options(&request, &target).unwrap()
     }
 
-    fn ruby_precompiled_only(compile: Option<bool>) -> bool {
+    fn with_ruby_settings<T>(
+        configure_settings: impl FnOnce(&mut SettingsPartial),
+        f: impl FnOnce(&RubyPlugin) -> T,
+    ) -> T {
         let lock = TEST_SETTINGS_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut settings = SettingsPartial::empty();
-        settings.ruby.compile = compile;
+        configure_settings(&mut settings);
         Settings::reset(Some(settings));
         let _guard = SettingsResetGuard { _lock: lock };
 
-        RubyPlugin::new().precompiled_only()
+        f(&RubyPlugin::new())
+    }
+
+    fn ruby_precompiled_only(compile: Option<bool>) -> bool {
+        with_ruby_settings(
+            |settings| settings.ruby.compile = compile,
+            |backend| backend.precompiled_only(),
+        )
+    }
+
+    fn ruby_precompiled_cache_context(
+        configure_settings: impl FnOnce(&mut SettingsPartial),
+    ) -> Option<String> {
+        with_ruby_settings(configure_settings, |backend| {
+            backend.precompiled_cache_context()
+        })
     }
 
     fn release(tag: &str, assets: &[&str]) -> GithubRelease {
@@ -1433,20 +1483,69 @@ mod tests {
     fn test_ruby_split_build_revision_tag() {
         assert_eq!(
             RubyPlugin::split_build_revision_tag("3.3.11-1"),
-            ("3.3.11", true)
+            ("3.3.11", Some(1))
         );
         assert_eq!(
             RubyPlugin::split_build_revision_tag("3.3.11-12"),
-            ("3.3.11", true)
+            ("3.3.11", Some(12))
         );
         assert_eq!(
             RubyPlugin::split_build_revision_tag("3.3.11"),
-            ("3.3.11", false)
+            ("3.3.11", None)
         );
         assert_eq!(
             RubyPlugin::split_build_revision_tag("3.4.0-preview1"),
-            ("3.4.0-preview1", false)
+            ("3.4.0-preview1", None)
         );
+    }
+
+    #[test]
+    fn test_ruby_precompiled_versions_use_highest_build_revision_only() {
+        // An install resolves 3.3.12 to the -2 release, which has no asset for this platform,
+        // so 3.3.12 must not be listed even though -1 does have one.
+        let releases = vec![
+            release("3.3.12-1", &["ruby-3.3.12.x86_64_linux.tar.gz"]),
+            release("3.3.12-2", &["ruby-3.3.12.macos.tar.gz"]),
+        ];
+        let versions =
+            RubyPlugin::precompiled_versions_from_releases(&releases, true, "x86_64_linux");
+        assert!(versions.is_empty());
+
+        // Release order must not change the answer.
+        let reversed = releases.into_iter().rev().collect_vec();
+        let versions =
+            RubyPlugin::precompiled_versions_from_releases(&reversed, true, "x86_64_linux");
+        assert!(versions.is_empty());
+        let versions = RubyPlugin::precompiled_versions_from_releases(&reversed, true, "macos");
+        assert_eq!(versions, HashSet::from(["3.3.12".to_string()]));
+    }
+
+    #[test]
+    fn test_ruby_precompiled_cache_context_tracks_source_and_platform() {
+        assert_eq!(ruby_precompiled_cache_context(|_| {}), None);
+
+        let default_source = ruby_precompiled_cache_context(|settings| {
+            settings.ruby.compile = Some(false);
+        });
+        let same = ruby_precompiled_cache_context(|settings| {
+            settings.ruby.compile = Some(false);
+        });
+        assert!(default_source.is_some());
+        assert_eq!(default_source, same);
+
+        let custom_source = ruby_precompiled_cache_context(|settings| {
+            settings.ruby.compile = Some(false);
+            settings.ruby.precompiled_url = Some("acme/ruby".to_string());
+        });
+        assert_ne!(default_source, custom_source);
+
+        let custom_platform = ruby_precompiled_cache_context(|settings| {
+            settings.ruby.compile = Some(false);
+            settings.ruby.precompiled_arch = Some("arm64".to_string());
+            settings.ruby.precompiled_os = Some("linux".to_string());
+        });
+        assert_ne!(default_source, custom_platform);
+        assert_ne!(custom_source, custom_platform);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

[#8754](https://github.com/jdx/mise/discussions/8754) asked for a way to disable Ruby's source-compilation fallback, and the plan there was a three-way `ruby.compile`: `true` = always source, unset = precompiled-then-fallback, `false` = precompiled only, error if unavailable.

`false` never got the strict meaning. `should_try_precompiled()` is `compile != Some(true)`, so once precompiled became the default in 2026.8.0 (#11584) `false` and unset became identical — the setting is a no-op today, and `settings.toml` documents both values with the same sentence.

This gives `false` the meaning `python.compile == Some(false)` already has:

- **Installs error out** with `no precompiled ruby found for <tv> on <platform>` instead of silently falling back to ruby-build.
- **Version listings are filtered** to versions that actually have a precompiled binary for the current platform, so `ruby = "4.0"` resolves to the newest 4.0.x with a binary instead of one that has to be built from source — the second half of the discussion request.

## Notes

- Filtering *removes* entries from ruby-build's list rather than building a new list, so ordering — and therefore `latest`/prefix resolution — is unchanged. No new version-ordering assumptions.
- Availability is computed with the same asset/build-revision rules `find_precompiled_asset_in_repo` uses, so a version is only offered when an install would really find a binary for it.
- `remote_version_cache_context` returns `Some("precompiled")` in strict mode, which partitions the remote-version cache and skips the shared versions host (whose list is the unfiltered ruby-build one).
- A custom `ruby.precompiled_url` **template** can't be enumerated, so those listings are left unfiltered; documented in `docs/lang/ruby.md`.
- Unchanged for `compile=true` and unset. Windows uses `ruby_windows.rs` (RubyInstaller2) and is unaffected.

## Validation

- `cargo test --all-features` — 2379 passed
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- `mise run lint`
- `mise run test:e2e test_ruby_precompiled_only` — passes
- Manual, against real releases: `mise ls-remote ruby` goes 692 → 42 versions under `MISE_RUBY_COMPILE=false` (matching the 42 build-revision versions in `jdx/ruby`), `mise latest ruby@4.0` → `4.0.6` in both modes, and `mise install ruby@3.2.0` (no binary) fails with `no precompiled ruby found for core:ruby@3.2.0 on x86_64_linux` instead of compiling.

Refs #8754

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5; version: 2.1.220.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Ruby install and version-resolution behavior for users who set `ruby.compile=false`; mistakes could hide valid versions or block installs that previously compiled from source.
> 
> **Overview**
> **`ruby.compile=false` is now a strict precompiled-only mode** (aligned with `python.compile`), instead of behaving the same as unset.
> 
> With **`ruby.compile=false`**, Ruby installs **fail** with `no precompiled ruby found` when no `jdx/ruby` asset exists for the version and platform—they no longer fall back to **ruby-build**. **`mise ls-remote ruby`** and fuzzy resolution **drop** versions that lack a precompiled binary for this machine, using the same build-revision and asset rules as install.
> 
> Remote version caching gets a **dedicated context** in this mode so filtered lists are not shared with default/source installs. **Docs**, **settings/schema** text, an **e2e** test, and **unit tests** cover build-revision parsing and availability logic. **Windows** (RubyInstaller2) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a296bac1312d67f3cd7f9d46c818b92b2646b829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a precompiled-binaries-only mode for Ruby with `ruby.compile = false`.
  * Ruby installations now fail when no compatible binary is available instead of compiling from source.
  * Version listings and matching are limited to binaries available for the current platform.
  * Custom precompiled sources remain unfiltered, and this setting does not affect Windows.

* **Documentation**
  * Clarified Ruby compilation behavior, including the default setting and its effects on installation and version listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->