### PR TITLE
fix(use): keep multiple tool additions sorted

### DIFF
--- a/e2e/cli/test_use
+++ b/e2e/cli/test_use
@@ -30,6 +30,20 @@ rm .mise.local.toml
 mise use dummy@1 dummy@2
 assert "mise current dummy" "1.0.0 2.0.0"
 
+# Multiple additions should preserve an already-sorted [tools] table.
+rm mise.toml
+ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
+ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny-local"
+ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny-ref"
+mise use tiny-ref@1
+mise use dummy@1 tiny-local@1 tiny@1
+assert "cat mise.toml" '[tools]
+dummy = "1"
+tiny = "1"
+tiny-local = "1"
+tiny-ref = "1"'
+rm mise.toml
+
 mise use --pin dummy@1
 assert "cat mise.toml" '[tools]
 dummy = "1.0.0"'

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -1037,6 +1037,12 @@ impl ConfigFile for MiseToml {
             .iter()
             .map(|tr| MiseTomlTool::from(tr.clone()))
             .collect();
+        if is_tools_sorted {
+            // Keep the parsed representation in sync with the document ordering. Sorting only the
+            // document leaves this map in insertion order, so a later replacement in the same
+            // `mise use` command can mistake an originally sorted table for an unsorted one.
+            tools.sort_keys();
+        }
         trace!("done replacing versions");
         let mut doc = self.doc_mut()?;
         trace!("got doc");
@@ -3611,6 +3617,29 @@ run = 'echo "template"'
         assert_snapshot!(cf);
         assert_debug_snapshot!(cf);
         file::remove_all(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_replace_versions_keeps_sorted_across_multiple_updates() {
+        let _config = Config::get().await.unwrap();
+        let p = CWD.as_ref().unwrap().join(".multiple-tool-sort.mise.toml");
+        file::write(&p, "[tools]\ntiny-ref = \"1\"\n").unwrap();
+        let cf = MiseToml::from_file(&p).unwrap();
+
+        for tool in ["dummy", "tiny-local", "tiny"] {
+            let ba = BackendArg::from(tool);
+            cf.replace_versions(
+                &ba,
+                vec![ToolRequest::new(Arc::new(ba.clone()), "1", ToolSource::Unknown).unwrap()],
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            cf.dump().unwrap(),
+            "[tools]\ndummy = \"1\"\ntiny = \"1\"\ntiny-local = \"1\"\ntiny-ref = \"1\"\n"
+        );
+        file::remove_file(&p).unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- keep the parsed `[tools]` map synchronized with the sorted TOML document
- preserve alphabetical ordering across multiple `replace_versions` calls in one `mise use`
- add unit and E2E regression coverage

## Root cause

`replace_versions` detected whether the internal `IndexMap` was sorted, but only sorted the `toml_edit` document after an insertion. A later replacement in the same command therefore saw stale insertion order and stopped preserving the document order.

When the table was already sorted, this change sorts both representations. Existing unsorted tables remain untouched.

Context: https://github.com/jdx/mise/discussions/11712

## Validation

- `mise run lint-fix`
- `RUST_TEST_THREADS=1 cargo test --all-features test_replace_versions_keeps_sorted_across_multiple_updates`
- `mise run test:e2e cli/test_use`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow config-write fix for sorted `[tools]` tables; behavior for unsorted tables is unchanged.
> 
> **Overview**
> Fixes **`mise use`** writing a scrambled `[tools]` table when several tools are added in one command while the file was already alphabetically sorted.
> 
> **`replace_versions`** in `mise_toml.rs` already re-sorted the TOML document when it detected a sorted table, but left the in-memory tools map in insertion order. The next update in the same command re-checked that map, treated the table as unsorted, and stopped maintaining alphabetical order. When the table was sorted, the parsed map is now sorted too via **`tools.sort_keys()`**; deliberately unsorted tables are unchanged.
> 
> Regression coverage: a unit test for multiple **`replace_versions`** calls and an e2e case in **`cli/test_use`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251da5b13ce905798f46965090dfcae1dfccd537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved alphabetical ordering in the `[tools]` configuration table when adding or updating multiple tools.
  - Ensured subsequent version updates maintain the existing sorted order.

- **Tests**
  - Added end-to-end and regression coverage for consistent tool ordering across multiple configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->