### PR TITLE
fix(config): match runtime options by configured version

### DIFF
--- a/e2e/cli/test_install_postinstall_cli_version
+++ b/e2e/cli/test_install_postinstall_cli_version
@@ -59,24 +59,28 @@ EOF
 
 # Test 4: An explicit install selects options from its matching configured version
 rm -rf "$MISE_DATA_DIR/installs/dummy"
-output=$(mise install dummy@2.0.0 2>&1)
+status=0
+output=$(mise install dummy@2.0.0 2>&1) || status=$?
 
-if [[ $output == *"MATCHED_POSTINSTALL=yes"* && $output != *"WRONG_POSTINSTALL=yes"* ]]; then
+if [[ $status -eq 0 && $output == *"MATCHED_POSTINSTALL=yes"* && $output != *"WRONG_POSTINSTALL=yes"* ]]; then
   echo "✓ install used options from its matching configured version"
 else
   echo "✗ install used options from the wrong configured version"
+  echo "Status: $status"
   echo "Output: $output"
   exit 1
 fi
 
 # Test 5: The exec builder applies the same matching policy
 rm -rf "$MISE_DATA_DIR/installs/dummy"
-output=$(mise x dummy@2.0.0 -- dummy 2>&1)
+status=0
+output=$(mise x dummy@2.0.0 -- dummy 2>&1) || status=$?
 
-if [[ $output == *"MATCHED_POSTINSTALL=yes"* && $output != *"WRONG_POSTINSTALL=yes"* ]]; then
+if [[ $status -eq 0 && $output == *"MATCHED_POSTINSTALL=yes"* && $output != *"WRONG_POSTINSTALL=yes"* ]]; then
   echo "✓ exec used options from its matching configured version"
 else
   echo "✗ exec used options from the wrong configured version"
+  echo "Status: $status"
   echo "Output: $output"
   exit 1
 fi

--- a/e2e/cli/test_install_postinstall_cli_version
+++ b/e2e/cli/test_install_postinstall_cli_version
@@ -52,15 +52,15 @@ fi
 cat <<EOF >mise.toml
 [tools]
 dummy = [
-  { version = "1.0.0", postinstall = "echo WRONG_POSTINSTALL=yes" },
-  { version = "2.0.0", postinstall = "echo MATCHED_POSTINSTALL=yes" },
+  { version = "2.0.0", postinstall = "echo WRONG_POSTINSTALL=yes" },
+  { version = "1.0.0", postinstall = "echo MATCHED_POSTINSTALL=yes" },
+  { version = "1.1.0", postinstall = "echo MATCHED_POSTINSTALL=yes" },
 ]
 EOF
 
 # Test 4: An explicit install selects options from its matching configured version
-rm -rf "$MISE_DATA_DIR/installs/dummy"
 status=0
-output=$(mise install dummy@2.0.0 2>&1) || status=$?
+output=$(mise install dummy@1.0.0 2>&1) || status=$?
 
 if [[ $status -eq 0 && $output == *"MATCHED_POSTINSTALL=yes"* && $output != *"WRONG_POSTINSTALL=yes"* ]]; then
   echo "✓ install used options from its matching configured version"
@@ -72,9 +72,8 @@ else
 fi
 
 # Test 5: The exec builder applies the same matching policy
-rm -rf "$MISE_DATA_DIR/installs/dummy"
 status=0
-output=$(mise x dummy@2.0.0 -- dummy 2>&1) || status=$?
+output=$(mise x dummy@1.1.0 -- dummy 2>&1) || status=$?
 
 if [[ $status -eq 0 && $output == *"MATCHED_POSTINSTALL=yes"* && $output != *"WRONG_POSTINSTALL=yes"* ]]; then
   echo "✓ exec used options from its matching configured version"

--- a/e2e/cli/test_install_postinstall_cli_version
+++ b/e2e/cli/test_install_postinstall_cli_version
@@ -23,6 +23,19 @@ else
   exit 1
 fi
 
+# Test 2: Existing runtime options must not prevent config options from merging
+rm -rf "$MISE_DATA_DIR/installs/dummy"
+
+output=$(mise install 'dummy[foo=bar]@latest' 2>&1)
+
+if [[ $output == *"POSTINSTALL_RAN=yes"* ]]; then
+  echo "✓ postinstall ran with explicit CLI and backend options"
+else
+  echo "✗ postinstall did NOT run with explicit CLI and backend options"
+  echo "Output: $output"
+  exit 1
+fi
+
 # Clean up and test again without explicit version to confirm it still works
 rm -rf "$MISE_DATA_DIR/installs/dummy"
 

--- a/e2e/cli/test_install_postinstall_cli_version
+++ b/e2e/cli/test_install_postinstall_cli_version
@@ -48,3 +48,35 @@ else
   echo "Output: $output"
   exit 1
 fi
+
+cat <<EOF >mise.toml
+[tools]
+dummy = [
+  { version = "1.0.0", postinstall = "echo WRONG_POSTINSTALL=yes" },
+  { version = "2.0.0", postinstall = "echo MATCHED_POSTINSTALL=yes" },
+]
+EOF
+
+# Test 4: An explicit install selects options from its matching configured version
+rm -rf "$MISE_DATA_DIR/installs/dummy"
+output=$(mise install dummy@2.0.0 2>&1)
+
+if [[ $output == *"MATCHED_POSTINSTALL=yes"* && $output != *"WRONG_POSTINSTALL=yes"* ]]; then
+  echo "✓ install used options from its matching configured version"
+else
+  echo "✗ install used options from the wrong configured version"
+  echo "Output: $output"
+  exit 1
+fi
+
+# Test 5: The exec builder applies the same matching policy
+rm -rf "$MISE_DATA_DIR/installs/dummy"
+output=$(mise x dummy@2.0.0 -- dummy 2>&1)
+
+if [[ $output == *"MATCHED_POSTINSTALL=yes"* && $output != *"WRONG_POSTINSTALL=yes"* ]]; then
+  echo "✓ exec used options from its matching configured version"
+else
+  echo "✗ exec used options from the wrong configured version"
+  echo "Output: $output"
+  exit 1
+fi

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -7,6 +7,7 @@ use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, ConfigMap};
 use crate::env_diff::EnvMap;
 use crate::errors::Error;
+use crate::toolset::tool_request_set::configured_options_for_runtime_request;
 use crate::toolset::{ResolveOptions, ToolRequest, ToolSource, Toolset, tool_from_env_var_name};
 use crate::{config, env};
 
@@ -128,14 +129,14 @@ impl ToolsetBuilder {
     fn load_runtime_args(&self, ts: &mut Toolset) -> eyre::Result<()> {
         for (_, args) in self.args.iter().into_group_map_by(|arg| arg.ba.clone()) {
             let mut arg_ts = Toolset::new(ToolSource::Argument);
-            // carry over options (e.g. filter_bins) from config for this tool
-            let config_options = ts
+            let configured = ts
                 .versions
                 .get(&args[0].ba)
-                .and_then(|tvl| tvl.requests.first())
-                .map(|tvr| tvr.options());
+                .map(|tvl| tvl.requests.clone())
+                .unwrap_or_default();
             let apply_arg_options = |mut tvr: ToolRequest, ba: &BackendArg| {
-                tvr.set_options(ba.opts_with_config(config_options.clone()));
+                let config_options = configured_options_for_runtime_request(&configured, &tvr);
+                tvr.set_options(ba.opts_with_config(config_options));
                 tvr
             };
             for arg in args {

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -152,6 +152,7 @@ impl ToolsetBuilder {
                     let current_active = ts
                         .list_current_requests()
                         .into_iter()
+                        .filter(|tvr| tvr.is_os_supported())
                         .find(|tvr| tvr.ba() == &arg.ba);
 
                     if let Some(current_active) = current_active {
@@ -174,5 +175,48 @@ impl ToolsetBuilder {
             ts.merge(arg_ts);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::toolset::parse_tool_options;
+
+    #[tokio::test]
+    async fn test_bare_runtime_arg_uses_platform_supported_configured_version() {
+        crate::toolset::install_state::init().await.unwrap();
+        let ba = Arc::new(BackendArg::from("dummy"));
+        let inactive_os = match crate::cli::version::OS.as_str() {
+            "linux" => "macos",
+            _ => "linux",
+        };
+        let mut inactive_options = parse_tool_options(r#"selected="inactive""#);
+        inactive_options.core.os = Some(vec![inactive_os.to_string()]);
+        let inactive =
+            ToolRequest::new_opts(ba.clone(), "1.0.0", inactive_options, ToolSource::Unknown)
+                .unwrap();
+        let active = ToolRequest::new_opts(
+            ba.clone(),
+            "2.0.0",
+            parse_tool_options(r#"selected="active""#),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let mut toolset = Toolset::new(ToolSource::Unknown);
+        toolset.add_version(inactive);
+        toolset.add_version(active);
+
+        let arg = "dummy".parse::<ToolArg>().unwrap();
+        ToolsetBuilder::new()
+            .with_args(&[arg])
+            .with_default_to_latest(true)
+            .load_runtime_args(&mut toolset)
+            .unwrap();
+
+        let requests = &toolset.versions.get(&ba).unwrap().requests;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].version(), "2.0.0");
+        assert_eq!(requests[0].options().get("selected"), Some("active"));
     }
 }

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -248,7 +248,7 @@ impl ToolRequestSetBuilder {
             let mut arg_ts = ToolRequestSet::new();
             for arg in args {
                 if let Some(tvr) = &arg.tvr {
-                    let tvr = apply_config_options_to_runtime_arg(&trs, arg, tvr.clone());
+                    let tvr = apply_config_options_to_runtime_arg(&trs, tvr.clone());
                     arg_ts.add_version(tvr, &ToolSource::Argument);
                 } else if self.default_to_latest {
                     // this logic is required for `mise x` because with that specific command mise
@@ -269,7 +269,7 @@ impl ToolRequestSetBuilder {
         let mut arg_trs = ToolRequestSet::new();
         for arg in tool_args.iter() {
             if let Some(tvr) = &arg.tvr {
-                let tvr = apply_config_options_to_runtime_arg(&trs, arg, tvr.clone());
+                let tvr = apply_config_options_to_runtime_arg(&trs, tvr.clone());
                 arg_trs.add_version(tvr, &ToolSource::Argument);
             } else if !trs.tools.contains_key(&arg.ba) {
                 // no active version, so use "latest"
@@ -289,15 +289,36 @@ impl ToolRequestSetBuilder {
 /// defaults, so option emptiness cannot indicate whether config should apply.
 /// `opts_with_config` preserves the normal precedence and reapplies explicit
 /// inline backend options last.
-fn apply_config_options_to_runtime_arg(
-    trs: &ToolRequestSet,
-    arg: &ToolArg,
-    mut tvr: ToolRequest,
-) -> ToolRequest {
-    if let Some(config_tvr) = trs.tools.get(&arg.ba).and_then(|versions| versions.first()) {
-        tvr.set_options(arg.ba.opts_with_config(Some(config_tvr.options())));
+fn apply_config_options_to_runtime_arg(trs: &ToolRequestSet, mut tvr: ToolRequest) -> ToolRequest {
+    if let Some(config_options) = trs
+        .tools
+        .get(tvr.ba())
+        .and_then(|requests| configured_options_for_runtime_request(requests, &tvr))
+    {
+        tvr.set_options(tvr.ba().opts_with_config(Some(config_options)));
     }
     tvr
+}
+
+/// Select configured options for an explicit runtime request without assuming
+/// that version selectors are ordered or semver-compatible.
+///
+/// An exact opaque selector match wins. A sole configured request is also a
+/// valid fallback because its options act as the tool-level defaults when a
+/// command requests another version. Multiple unmatched requests are
+/// ambiguous, so none of their options are applied arbitrarily.
+pub(super) fn configured_options_for_runtime_request(
+    configured: &[ToolRequest],
+    runtime: &ToolRequest,
+) -> Option<crate::toolset::ToolVersionOptions> {
+    configured
+        .iter()
+        .find(|request| request.version() == runtime.version())
+        .or_else(|| match configured {
+            [only] => Some(only),
+            _ => None,
+        })
+        .map(ToolRequest::options)
 }
 
 fn merge(mut a: ToolRequestSet, mut b: ToolRequestSet) -> ToolRequestSet {
@@ -475,7 +496,7 @@ mod tests {
         let registry_arg = "solidity@0.8.1".parse::<ToolArg>().unwrap();
         let registry_request = registry_arg.tvr.clone().unwrap();
         assert!(!registry_request.options().is_empty());
-        let layered = apply_config_options_to_runtime_arg(&trs, &registry_arg, registry_request);
+        let layered = apply_config_options_to_runtime_arg(&trs, registry_request);
         assert_eq!(layered.options().get("bin"), Some("config"));
         assert_eq!(
             layered.options().get("postinstall"),
@@ -486,11 +507,60 @@ mod tests {
         let inline_arg = "solidity[bin=inline,inline_only=inline]@0.8.1"
             .parse::<ToolArg>()
             .unwrap();
-        let layered =
-            apply_config_options_to_runtime_arg(&trs, &inline_arg, inline_arg.tvr.clone().unwrap());
+        let layered = apply_config_options_to_runtime_arg(&trs, inline_arg.tvr.clone().unwrap());
         assert_eq!(layered.options().get("bin"), Some("inline"));
         assert_eq!(layered.options().get("config_only"), Some("config"));
         assert_eq!(layered.options().get("inline_only"), Some("inline"));
+    }
+
+    #[tokio::test]
+    async fn test_runtime_arg_options_match_configured_version() {
+        crate::toolset::install_state::init().await.unwrap();
+        let ba = Arc::new(BackendArg::from("dummy"));
+        let first = ToolRequest::new_opts(
+            ba.clone(),
+            "1.0.0",
+            parse_tool_options(r#"postinstall="echo one",selected="one""#),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let second = ToolRequest::new_opts(
+            ba.clone(),
+            "2.0.0",
+            parse_tool_options(r#"postinstall="echo two",selected="two""#),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let mut trs = ToolRequestSet::new();
+        trs.add_version(first.clone(), &ToolSource::Unknown);
+        trs.add_version(second, &ToolSource::Unknown);
+
+        let matching = "dummy[inline_only=inline]@2.0.0"
+            .parse::<ToolArg>()
+            .unwrap()
+            .tvr
+            .unwrap();
+        let matching = apply_config_options_to_runtime_arg(&trs, matching);
+        assert_eq!(matching.options().get("postinstall"), Some("echo two"));
+        assert_eq!(matching.options().get("selected"), Some("two"));
+        assert_eq!(matching.options().get("inline_only"), Some("inline"));
+
+        let unmatched = "dummy[inline_only=inline]@3.0.0"
+            .parse::<ToolArg>()
+            .unwrap()
+            .tvr
+            .unwrap();
+        let unmatched = apply_config_options_to_runtime_arg(&trs, unmatched);
+        assert_eq!(unmatched.options().get("postinstall"), None);
+        assert_eq!(unmatched.options().get("selected"), None);
+        assert_eq!(unmatched.options().get("inline_only"), Some("inline"));
+
+        let mut sole = ToolRequestSet::new();
+        sole.add_version(first, &ToolSource::Unknown);
+        let fallback = "dummy@3.0.0".parse::<ToolArg>().unwrap().tvr.unwrap();
+        let fallback = apply_config_options_to_runtime_arg(&sole, fallback);
+        assert_eq!(fallback.options().get("postinstall"), Some("echo one"));
+        assert_eq!(fallback.options().get("selected"), Some("one"));
     }
 
     fn unknown_tool_request(os: Option<Vec<String>>) -> (Arc<BackendArg>, Vec<ToolRequest>) {

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -248,7 +248,8 @@ impl ToolRequestSetBuilder {
             let mut arg_ts = ToolRequestSet::new();
             for arg in args {
                 if let Some(tvr) = &arg.tvr {
-                    arg_ts.add_version(tvr.clone(), &ToolSource::Argument);
+                    let tvr = apply_config_options_to_runtime_arg(&trs, arg, tvr.clone());
+                    arg_ts.add_version(tvr, &ToolSource::Argument);
                 } else if self.default_to_latest {
                     // this logic is required for `mise x` because with that specific command mise
                     // should default to installing the "latest" version if no version is specified
@@ -268,17 +269,7 @@ impl ToolRequestSetBuilder {
         let mut arg_trs = ToolRequestSet::new();
         for arg in tool_args.iter() {
             if let Some(tvr) = &arg.tvr {
-                let mut tvr = tvr.clone();
-                // When CLI specifies a version for a tool that's in config,
-                // merge config options (e.g. postinstall) into the CLI request
-                if tvr.options().is_empty()
-                    && let Some(config_tvr) = trs.tools.get(&arg.ba).and_then(|v| v.first())
-                {
-                    let config_opts = config_tvr.options();
-                    if !config_opts.is_empty() {
-                        tvr.set_options(config_opts);
-                    }
-                }
+                let tvr = apply_config_options_to_runtime_arg(&trs, arg, tvr.clone());
                 arg_trs.add_version(tvr, &ToolSource::Argument);
             } else if !trs.tools.contains_key(&arg.ba) {
                 // no active version, so use "latest"
@@ -290,6 +281,23 @@ impl ToolRequestSetBuilder {
 
         Ok(trs)
     }
+}
+
+/// Overlay configured tool options onto an explicit runtime version request.
+///
+/// A request can already contain registry, install-manifest, or backend-alias
+/// defaults, so option emptiness cannot indicate whether config should apply.
+/// `opts_with_config` preserves the normal precedence and reapplies explicit
+/// inline backend options last.
+fn apply_config_options_to_runtime_arg(
+    trs: &ToolRequestSet,
+    arg: &ToolArg,
+    mut tvr: ToolRequest,
+) -> ToolRequest {
+    if let Some(config_tvr) = trs.tools.get(&arg.ba).and_then(|versions| versions.first()) {
+        tvr.set_options(arg.ba.opts_with_config(Some(config_tvr.options())));
+    }
+    tvr
 }
 
 fn merge(mut a: ToolRequestSet, mut b: ToolRequestSet) -> ToolRequestSet {
@@ -335,7 +343,7 @@ pub fn tool_env_vars() -> impl Iterator<Item = (String, String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::toolset::{CoreToolOptions, ToolVersionOptions};
+    use crate::toolset::{CoreToolOptions, ToolVersionOptions, parse_tool_options};
 
     #[test]
     fn test_tool_env_var_name_round_trip() {
@@ -443,6 +451,46 @@ mod tests {
             std::env::remove_var("HOMEBREW_INSTALL_BADGE");
             std::env::remove_var("SOME_OTHER_VAR");
         }
+    }
+
+    #[tokio::test]
+    async fn test_runtime_arg_options_layer_registry_config_and_inline() {
+        crate::toolset::install_state::init().await.unwrap();
+        let config_ba = Arc::new(BackendArg::from("solidity"));
+        assert_eq!(config_ba.registry_opts().get("bin"), Some("solc"));
+
+        let config_options = parse_tool_options(
+            r#"bin="config",postinstall="echo configured",config_only="config""#,
+        );
+        let config_request = ToolRequest::new_opts(
+            config_ba.clone(),
+            "0.8.0",
+            config_options,
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let mut trs = ToolRequestSet::new();
+        trs.add_version(config_request, &ToolSource::Unknown);
+
+        let registry_arg = "solidity@0.8.1".parse::<ToolArg>().unwrap();
+        let registry_request = registry_arg.tvr.clone().unwrap();
+        assert!(!registry_request.options().is_empty());
+        let layered = apply_config_options_to_runtime_arg(&trs, &registry_arg, registry_request);
+        assert_eq!(layered.options().get("bin"), Some("config"));
+        assert_eq!(
+            layered.options().get("postinstall"),
+            Some("echo configured")
+        );
+        assert_eq!(layered.options().get("config_only"), Some("config"));
+
+        let inline_arg = "solidity[bin=inline,inline_only=inline]@0.8.1"
+            .parse::<ToolArg>()
+            .unwrap();
+        let layered =
+            apply_config_options_to_runtime_arg(&trs, &inline_arg, inline_arg.tvr.clone().unwrap());
+        assert_eq!(layered.options().get("bin"), Some("inline"));
+        assert_eq!(layered.options().get("config_only"), Some("config"));
+        assert_eq!(layered.options().get("inline_only"), Some("inline"));
     }
 
     fn unknown_tool_request(os: Option<Vec<String>>) -> (Arc<BackendArg>, Vec<ToolRequest>) {

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -303,21 +303,26 @@ fn apply_config_options_to_runtime_arg(trs: &ToolRequestSet, mut tvr: ToolReques
 /// Select configured options for an explicit runtime request without assuming
 /// that version selectors are ordered or semver-compatible.
 ///
-/// An exact opaque selector match wins. A sole configured request is also a
-/// valid fallback because its options act as the tool-level defaults when a
-/// command requests another version. Multiple unmatched requests are
-/// ambiguous, so none of their options are applied arbitrarily.
+/// A unique, platform-supported exact opaque selector match wins. A sole
+/// supported configured request is also a valid fallback because its options
+/// act as the tool-level defaults when a command requests another version.
+/// Multiple supported exact matches or unmatched requests are ambiguous, so
+/// none of their options are applied arbitrarily.
 pub(super) fn configured_options_for_runtime_request(
     configured: &[ToolRequest],
     runtime: &ToolRequest,
 ) -> Option<crate::toolset::ToolVersionOptions> {
-    configured
-        .iter()
-        .find(|request| request.version() == runtime.version())
-        .or_else(|| match configured {
-            [only] => Some(only),
-            _ => None,
-        })
+    let runtime_version = runtime.version();
+    let supported = || {
+        configured
+            .iter()
+            .filter(|request| request.is_os_supported())
+    };
+    supported()
+        .filter(|request| request.version() == runtime_version)
+        .exactly_one()
+        .ok()
+        .or_else(|| supported().exactly_one().ok())
         .map(ToolRequest::options)
 }
 
@@ -561,6 +566,29 @@ mod tests {
         let fallback = apply_config_options_to_runtime_arg(&sole, fallback);
         assert_eq!(fallback.options().get("postinstall"), Some("echo one"));
         assert_eq!(fallback.options().get("selected"), Some("one"));
+
+        let mut inactive_options =
+            parse_tool_options(r#"postinstall="echo inactive",selected="inactive""#);
+        inactive_options.core.os = Some(vec![inactive_os()]);
+        let inactive =
+            ToolRequest::new_opts(ba.clone(), "4.0.0", inactive_options, ToolSource::Unknown)
+                .unwrap();
+        let active = ToolRequest::new_opts(
+            ba.clone(),
+            "4.0.0",
+            parse_tool_options(r#"postinstall="echo active",selected="active""#),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let runtime = "dummy@4.0.0".parse::<ToolArg>().unwrap().tvr.unwrap();
+        let selected =
+            configured_options_for_runtime_request(&[inactive, active.clone()], &runtime).unwrap();
+        assert_eq!(selected.get("postinstall"), Some("echo active"));
+        assert_eq!(selected.get("selected"), Some("active"));
+
+        assert!(
+            configured_options_for_runtime_request(&[active.clone(), active], &runtime).is_none()
+        );
     }
 
     fn unknown_tool_request(os: Option<Vec<String>>) -> (Arc<BackendArg>, Vec<ToolRequest>) {

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -125,17 +125,27 @@ impl Toolset {
     pub(super) fn init_request_options(&self, requests: &mut Vec<ToolRequest>) {
         for tr in requests {
             if let Some(tvl) = self.versions.get(tr.ba()) {
-                // Use config request options if available, falling back to backend arg opts.
-                // This ensures tool options like postinstall from mise.toml are preserved
-                // when installing with an explicit CLI version (e.g. `mise install tool@latest`).
-                let config_options =
+                // Requests cloned from this toolset already carry their own
+                // per-entry options, including platform filters. Do not
+                // collapse duplicate selectors onto another config entry.
+                if tvl.requests.contains(tr) {
+                    continue;
+                }
+                // Use matching config options when available. If selection is
+                // ambiguous, preserve options already carried by the request;
+                // synthesize backend defaults only for an empty request.
+                if let Some(config_options) =
                     super::tool_request_set::configured_options_for_runtime_request(
                         &tvl.requests,
                         tr,
-                    );
-                let options = tr.ba().opts_with_config(config_options);
-                if tr.options().is_empty() || tr.options() != options {
-                    tr.set_options(options);
+                    )
+                {
+                    let options = tr.ba().opts_with_config(Some(config_options));
+                    if tr.options() != options {
+                        tr.set_options(options);
+                    }
+                } else if tr.options().is_empty() {
+                    tr.set_options(tr.ba().opts_with_config(None));
                 }
             }
         }
@@ -754,5 +764,70 @@ fn transitive_dependency_before_date(
         }
         ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => None,
         _ => tv.before_date,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::BackendArg;
+    use crate::toolset::parse_tool_options;
+
+    #[tokio::test]
+    async fn test_init_request_options_preserves_unmatched_request_options() {
+        crate::toolset::install_state::init().await.unwrap();
+        let ba = Arc::new(BackendArg::from("dummy"));
+        let mut toolset = Toolset::new(ToolSource::Unknown);
+        for version in ["1.0.0", "2.0.0"] {
+            toolset.add_version(
+                ToolRequest::new_opts(
+                    ba.clone(),
+                    version,
+                    parse_tool_options(&format!(r#"postinstall="echo configured {version}""#)),
+                    ToolSource::Unknown,
+                )
+                .unwrap(),
+            );
+        }
+
+        let mut requests = vec![
+            ToolRequest::new_opts(
+                ba.clone(),
+                "3.0.0",
+                parse_tool_options(r#"postinstall="echo carried""#),
+                ToolSource::Argument,
+            )
+            .unwrap(),
+        ];
+        toolset.init_request_options(&mut requests);
+
+        assert_eq!(
+            requests[0].options().get("postinstall"),
+            Some("echo carried")
+        );
+
+        let mut inactive_options = parse_tool_options(r#"postinstall="echo inactive""#);
+        let inactive_os = match crate::cli::version::OS.as_str() {
+            "linux" => "macos",
+            _ => "linux",
+        };
+        inactive_options.core.os = Some(vec![inactive_os.to_string()]);
+        let inactive =
+            ToolRequest::new_opts(ba.clone(), "4.0.0", inactive_options, ToolSource::Unknown)
+                .unwrap();
+        let active = ToolRequest::new_opts(
+            ba,
+            "4.0.0",
+            parse_tool_options(r#"postinstall="echo active""#),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let mut toolset = Toolset::new(ToolSource::Unknown);
+        toolset.add_version(inactive.clone());
+        toolset.add_version(active.clone());
+        let mut requests = vec![inactive.clone(), active.clone()];
+        toolset.init_request_options(&mut requests);
+
+        assert_eq!(requests, vec![inactive, active]);
     }
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -87,17 +87,27 @@ impl Toolset {
     pub(super) fn init_request_options(&self, requests: &mut Vec<ToolRequest>) {
         for tr in requests {
             if let Some(tvl) = self.versions.get(tr.ba()) {
-                // Use config request options if available, falling back to backend arg opts.
-                // This ensures tool options like postinstall from mise.toml are preserved
-                // when installing with an explicit CLI version (e.g. `mise install tool@latest`).
-                let config_options =
+                // Requests cloned from this toolset already carry their own
+                // per-entry options, including platform filters. Do not
+                // collapse duplicate selectors onto another config entry.
+                if tvl.requests.contains(tr) {
+                    continue;
+                }
+                // Use matching config options when available. If selection is
+                // ambiguous, preserve options already carried by the request;
+                // synthesize backend defaults only for an empty request.
+                if let Some(config_options) =
                     super::tool_request_set::configured_options_for_runtime_request(
                         &tvl.requests,
                         tr,
-                    );
-                let options = tr.ba().opts_with_config(config_options);
-                if tr.options().is_empty() || tr.options() != options {
-                    tr.set_options(options);
+                    )
+                {
+                    let options = tr.ba().opts_with_config(Some(config_options));
+                    if tr.options() != options {
+                        tr.set_options(options);
+                    }
+                } else if tr.options().is_empty() {
+                    tr.set_options(tr.ba().opts_with_config(None));
                 }
             }
         }
@@ -673,5 +683,70 @@ fn transitive_dependency_before_date(
         }
         ToolRequest::Ref { .. } | ToolRequest::Path { .. } | ToolRequest::System { .. } => None,
         _ => tv.before_date,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::BackendArg;
+    use crate::toolset::parse_tool_options;
+
+    #[tokio::test]
+    async fn test_init_request_options_preserves_unmatched_request_options() {
+        crate::toolset::install_state::init().await.unwrap();
+        let ba = Arc::new(BackendArg::from("dummy"));
+        let mut toolset = Toolset::new(ToolSource::Unknown);
+        for version in ["1.0.0", "2.0.0"] {
+            toolset.add_version(
+                ToolRequest::new_opts(
+                    ba.clone(),
+                    version,
+                    parse_tool_options(&format!(r#"postinstall="echo configured {version}""#)),
+                    ToolSource::Unknown,
+                )
+                .unwrap(),
+            );
+        }
+
+        let mut requests = vec![
+            ToolRequest::new_opts(
+                ba.clone(),
+                "3.0.0",
+                parse_tool_options(r#"postinstall="echo carried""#),
+                ToolSource::Argument,
+            )
+            .unwrap(),
+        ];
+        toolset.init_request_options(&mut requests);
+
+        assert_eq!(
+            requests[0].options().get("postinstall"),
+            Some("echo carried")
+        );
+
+        let mut inactive_options = parse_tool_options(r#"postinstall="echo inactive""#);
+        let inactive_os = match crate::cli::version::OS.as_str() {
+            "linux" => "macos",
+            _ => "linux",
+        };
+        inactive_options.core.os = Some(vec![inactive_os.to_string()]);
+        let inactive =
+            ToolRequest::new_opts(ba.clone(), "4.0.0", inactive_options, ToolSource::Unknown)
+                .unwrap();
+        let active = ToolRequest::new_opts(
+            ba,
+            "4.0.0",
+            parse_tool_options(r#"postinstall="echo active""#),
+            ToolSource::Unknown,
+        )
+        .unwrap();
+        let mut toolset = Toolset::new(ToolSource::Unknown);
+        toolset.add_version(inactive.clone());
+        toolset.add_version(active.clone());
+        let mut requests = vec![inactive.clone(), active.clone()];
+        toolset.init_request_options(&mut requests);
+
+        assert_eq!(requests, vec![inactive, active]);
     }
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -125,18 +125,14 @@ impl Toolset {
     pub(super) fn init_request_options(&self, requests: &mut Vec<ToolRequest>) {
         for tr in requests {
             if let Some(tvl) = self.versions.get(tr.ba()) {
-                if tvl.requests.len() != 1 {
-                    // TODO: handle this case with multiple versions
-                    continue;
-                }
                 // Use config request options if available, falling back to backend arg opts.
                 // This ensures tool options like postinstall from mise.toml are preserved
                 // when installing with an explicit CLI version (e.g. `mise install tool@latest`).
-                let config_options = tvl
-                    .requests
-                    .first()
-                    .map(|r| r.options())
-                    .filter(|opts| !opts.is_empty());
+                let config_options =
+                    super::tool_request_set::configured_options_for_runtime_request(
+                        &tvl.requests,
+                        tr,
+                    );
                 let options = tr.ba().opts_with_config(config_options);
                 if tr.options().is_empty() || tr.options() != options {
                     tr.set_options(options);

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -87,18 +87,14 @@ impl Toolset {
     pub(super) fn init_request_options(&self, requests: &mut Vec<ToolRequest>) {
         for tr in requests {
             if let Some(tvl) = self.versions.get(tr.ba()) {
-                if tvl.requests.len() != 1 {
-                    // TODO: handle this case with multiple versions
-                    continue;
-                }
                 // Use config request options if available, falling back to backend arg opts.
                 // This ensures tool options like postinstall from mise.toml are preserved
                 // when installing with an explicit CLI version (e.g. `mise install tool@latest`).
-                let config_options = tvl
-                    .requests
-                    .first()
-                    .map(|r| r.options())
-                    .filter(|opts| !opts.is_empty());
+                let config_options =
+                    super::tool_request_set::configured_options_for_runtime_request(
+                        &tvl.requests,
+                        tr,
+                    );
                 let options = tr.ba().opts_with_config(config_options);
                 if tr.options().is_empty() || tr.options() != options {
                     tr.set_options(options);


### PR DESCRIPTION
## Summary

- match explicit runtime requests to options from the same configured version
- consider only platform-supported entries and reject ambiguous duplicate matches
- preserve the single supported configured version as a tool-level fallback
- preserve options already carried by config and unmatched requests
- use the same selection policy for request construction, toolset construction, and install option initialization

## Bug

Given:

```toml
[tools]
dummy = [
  { version = "1.0.0", postinstall = "echo one" },
  { version = "2.0.0", postinstall = "echo two" },
]
```

`mise install dummy@2.0.0` and `mise x dummy@2.0.0 -- dummy` could use options from the first configured request or skip configured options, rather than selecting the options attached to `2.0.0`.

Version selectors are treated as opaque strings: a unique platform-supported exact selector match wins. If only one supported configured request exists, its options remain the fallback for explicitly requested versions. Multiple supported unmatched or duplicate exact requests are ambiguous, so no configured request is chosen arbitrarily. Requests already carrying config or upgrade options retain them when no unique selection can be made.

## Stack

Stacked on #11550, which introduces runtime option layering. This PR changes that layering to select the matching configured request and applies the same policy to the other construction paths.

#11551 is related but handles a later stage: preserving the options already attached to each request while resolving it through a backend.

## Tests

- `mise run test:unit -- test_runtime_arg_options_match_configured_version`
- `mise run test:unit -- test_init_request_options_preserves_unmatched_request_options`
- `mise run test:e2e e2e/cli/test_install_postinstall_cli_version`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version-specific tool configuration during installation and execution.
  * Prevented unrelated, ambiguous, or unsupported platform options from being applied.
  * Improved fallback behavior when a single supported configuration is available.
  * Preserved existing settings while ensuring inline options take precedence across platforms.

* **Tests**
  * Added coverage for version matching, option precedence, platform filtering, duplicate configurations, and version-specific postinstall behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->