### PR TITLE
fix(file): safely inspect and remove directory links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,8 +264,11 @@ self_update = { version = "0.44", optional = true, default-features = false, fea
 zipsign-api = "0.2"
 winapi = { version = "0.3", features = ["consoleapi", "minwindef"] }
 windows-sys = { version = "0.61", features = [
+  "Win32_Globalization",
   "Win32_Security",
   "Win32_Security_Authorization",
+  "Win32_Storage_FileSystem",
+  "Win32_System_SystemServices",
   "Win32_System_Threading",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,8 @@ windows-sys = { version = "0.61", features = [
   "Win32_Security",
   "Win32_Security_Authorization",
   "Win32_Storage_FileSystem",
+  "Win32_System_IO",
+  "Win32_System_Ioctl",
   "Win32_System_SystemServices",
   "Win32_System_Threading",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,8 +268,6 @@ windows-sys = { version = "0.61", features = [
   "Win32_Security",
   "Win32_Security_Authorization",
   "Win32_Storage_FileSystem",
-  "Win32_System_IO",
-  "Win32_System_Ioctl",
   "Win32_System_SystemServices",
   "Win32_System_Threading",
 ] }

--- a/src/file.rs
+++ b/src/file.rs
@@ -20,6 +20,7 @@ use filetime::{FileTime, set_file_times};
 use flate2::read::GzDecoder;
 use itertools::Itertools;
 use jdx_tar::{Archive, EntryType, UnpackOptions};
+use path_absolutize::Absolutize;
 use sha2::{Digest, Sha256};
 use std::sync::LazyLock as Lazy;
 use walkdir::WalkDir;
@@ -920,33 +921,9 @@ pub fn is_symlink_target_within(link: &Path, root: &Path) -> Result<bool> {
     let Some(target) = dir_link_target(link)? else {
         return Ok(false);
     };
-    let Some(target) = lexical_normalize(&target) else {
-        return Ok(false);
-    };
-    let Some(root) = lexical_normalize(root) else {
-        return Ok(false);
-    };
-    Ok(target.starts_with(root))
-}
-
-fn lexical_normalize(path: &Path) -> Option<PathBuf> {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                if !matches!(
-                    normalized.components().next_back(),
-                    Some(std::path::Component::Normal(_))
-                ) {
-                    return None;
-                }
-                normalized.pop();
-            }
-            component => normalized.push(component.as_os_str()),
-        }
-    }
-    Some(normalized)
+    let target = target.absolutize()?;
+    let root = root.absolutize()?;
+    Ok(target.starts_with(root.as_ref()))
 }
 
 #[cfg(unix)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1103,8 +1103,8 @@ pub fn remove_symlinks_with_target_prefix(
     let mut removed = vec![];
     for entry in symlink_dir.read_dir()? {
         let path = entry?.path();
-        if let Some(target) = dir_link_target(&path)?
-            && target.starts_with(target_prefix)
+        if is_symlink_target_directly_within(&path, target_prefix)?
+            || is_symlink_target_within(&path, target_prefix)?
         {
             remove_symlink_or_junction(&path)?;
             removed.push(path);

--- a/src/file.rs
+++ b/src/file.rs
@@ -789,16 +789,21 @@ fn symlink_or_junction_target(link: &Path) -> Result<Option<PathBuf>> {
 
 #[cfg(unix)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    if !link.is_symlink() {
+        bail!("not a symlink: {}", display_path(link));
+    }
     fs::remove_file(link)
         .wrap_err_with(|| format!("failed to remove symlink: {}", display_path(link)))
 }
 
 #[cfg(windows)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
-    if junction::get_target(link).is_ok() {
+    if link.is_symlink() {
+        fs::remove_file(link).or_else(|_| fs::remove_dir(link))
+    } else if junction::get_target(link).is_ok() {
         junction::delete(link)
     } else {
-        fs::remove_file(link).or_else(|_| fs::remove_dir(link))
+        bail!("not a symlink or junction: {}", display_path(link));
     }
     .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
 }
@@ -2387,6 +2392,20 @@ mod tests {
         assert!(std::fs::symlink_metadata(&link).is_err());
         assert!(std::fs::symlink_metadata(&other_link).is_ok());
         assert!(target.exists());
+    }
+
+    #[test]
+    fn test_remove_symlink_or_junction_rejects_non_links() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file");
+        let directory = dir.path().join("directory");
+        fs::write(&file, "contents").unwrap();
+        fs::create_dir(&directory).unwrap();
+
+        assert!(remove_symlink_or_junction(&file).is_err());
+        assert!(remove_symlink_or_junction(&directory).is_err());
+        assert!(file.is_file());
+        assert!(directory.is_dir());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -972,9 +972,9 @@ fn path_starts_with(path: &Path, root: &Path) -> bool {
         return false;
     }
 
-    match same_file::is_same_file(&candidate, root) {
+    match same_file::is_same_file(&candidate, &root) {
         Ok(same) => same,
-        Err(_) => dangling_paths_share_case_insensitive_parent(&candidate, root),
+        Err(_) => dangling_paths_share_case_insensitive_parent(&candidate, &root),
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1066,6 +1066,9 @@ fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
 
 #[cfg(unix)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    if dir_link_target(link)?.is_none() {
+        bail!("refusing to remove non-link: {}", display_path(link));
+    }
     fs::remove_file(link)
         .wrap_err_with(|| format!("failed to remove symlink: {}", display_path(link)))
 }
@@ -2915,6 +2918,20 @@ mod tests {
         assert!(is_symlink_target_directly_within(&link, &root).unwrap());
         fs::remove_file(&direct_target).unwrap();
         assert!(is_symlink_target_directly_within(&link, &root).unwrap());
+    }
+
+    #[test]
+    fn test_remove_symlink_or_junction_rejects_non_links() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file");
+        let directory = dir.path().join("directory");
+        fs::write(&file, "contents").unwrap();
+        fs::create_dir(&directory).unwrap();
+
+        assert!(remove_symlink_or_junction(&file).is_err());
+        assert!(remove_symlink_or_junction(&directory).is_err());
+        assert!(file.is_file());
+        assert!(directory.is_dir());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -897,7 +897,7 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
-    is_symlink_or_junction(link) && paths_refer_to_same_entry(link, target)
+    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
 }
 
 #[cfg(unix)]
@@ -916,126 +916,21 @@ pub fn make_symlink_or_file(target: &Path, link: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn is_symlink_to_prefix(link: &Path, target_prefix: &Path) -> Result<bool> {
-    let Some(target) = dir_link_target(link)? else {
-        return Ok(false);
-    };
-    // Broken provider links cannot be canonicalized in full. Resolve the
-    // longest existing ancestor so symlinks in the existing portion still
-    // participate in ownership checks, then append only a safe normal tail.
-    // If that cannot establish ownership, preserve the link because this
-    // predicate controls destructive provider cleanup.
-    let Some(target) = canonicalize_with_missing_tail(&target)? else {
-        return Ok(false);
-    };
-    let Some(target_prefix) = canonicalize_with_missing_tail(target_prefix)? else {
-        return Ok(false);
-    };
-    Ok(path_is_within(&target, &target_prefix))
-}
-
-fn path_is_within(path: &Path, prefix: &Path) -> bool {
-    path.starts_with(prefix)
-        || path
-            .ancestors()
-            .any(|ancestor| paths_refer_to_same_entry(ancestor, prefix))
-}
-
-fn paths_refer_to_same_entry(a: &Path, b: &Path) -> bool {
-    same_file::is_same_file(a, b).unwrap_or(false)
-}
-
-fn canonicalize_with_missing_tail(path: &Path) -> Result<Option<PathBuf>> {
-    for ancestor in path.ancestors() {
-        match ancestor.canonicalize() {
-            Ok(mut resolved) => {
-                for component in path.strip_prefix(ancestor)?.components() {
-                    match component {
-                        std::path::Component::Normal(component) => {
-                            let candidate = resolved.join(component);
-                            // A link or junction in the unresolved tail may
-                            // redirect outside the provider. Its destination
-                            // cannot be established, so preserve the outer
-                            // link instead of claiming provider ownership.
-                            if dir_link_target(&candidate)?.is_some() {
-                                return Ok(None);
-                            }
-                            resolved.push(component);
-                        }
-                        std::path::Component::CurDir => {}
-                        std::path::Component::ParentDir
-                        | std::path::Component::RootDir
-                        | std::path::Component::Prefix(_) => return Ok(None),
-                    }
-                }
-                return Ok(Some(resolved));
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(_) => return Ok(None),
-        }
-    }
-    Ok(None)
-}
-
 #[cfg(unix)]
-fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
-    let metadata = match fs::symlink_metadata(link) {
-        Ok(metadata) => metadata,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => {
-            return Err(err)
-                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
-        }
-    };
-    if !metadata.file_type().is_symlink() {
-        return Ok(None);
+fn symlink_or_junction_target(link: &Path) -> Result<Option<PathBuf>> {
+    if link.is_symlink() {
+        Ok(Some(fs::read_link(link)?))
+    } else {
+        Ok(None)
     }
-    let target = fs::read_link(link)
-        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
-    Ok(Some(resolve_relative_link_target(link, target)))
 }
 
 #[cfg(windows)]
-fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
-    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
-
-    let metadata = match fs::symlink_metadata(link) {
-        Ok(metadata) => metadata,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => {
-            return Err(err)
-                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
-        }
-    };
-    let target = if metadata.file_type().is_symlink() {
-        fs::read_link(link)
-            .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?
+fn symlink_or_junction_target(link: &Path) -> Result<Option<PathBuf>> {
+    if link.is_symlink() {
+        Ok(Some(fs::read_link(link)?))
     } else {
-        match junction::get_target(link) {
-            Ok(target) => target,
-            Err(err)
-                if err.kind() == std::io::ErrorKind::NotFound
-                    || err.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
-                    || (err.kind() == std::io::ErrorKind::Other
-                        && err.raw_os_error().is_none()) =>
-            {
-                return Ok(None);
-            }
-            Err(err) => {
-                return Err(err).wrap_err_with(|| {
-                    format!("failed to inspect junction: {}", display_path(link))
-                });
-            }
-        }
-    };
-    Ok(Some(resolve_relative_link_target(link, target)))
-}
-
-fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
-    if target.is_absolute() {
-        target
-    } else {
-        link.parent().unwrap_or(link).join(target)
+        Ok(junction::get_target(link).ok())
     }
 }
 
@@ -1047,9 +942,12 @@ pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
 
 #[cfg(windows)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
-    fs::remove_file(link)
-        .or_else(|_| fs::remove_dir(link))
-        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
+    if junction::get_target(link).is_ok() {
+        junction::delete(link)
+    } else {
+        fs::remove_file(link).or_else(|_| fs::remove_dir(link))
+    }
+    .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
 }
 
 pub fn remove_symlinks_with_target_prefix(
@@ -1063,7 +961,9 @@ pub fn remove_symlinks_with_target_prefix(
     for entry in symlink_dir.read_dir()? {
         let entry = entry?;
         let path = entry.path();
-        if is_symlink_to_prefix(&path, target_prefix)? {
+        if let Some(target) = symlink_or_junction_target(&path)?
+            && target.starts_with(target_prefix)
+        {
             remove_symlink_or_junction(&path)?;
             removed.push(path);
         }
@@ -2779,91 +2679,23 @@ mod tests {
     }
 
     #[test]
-    fn test_is_symlink_to_requires_a_link() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target");
-        let link = dir.path().join("link");
-        fs::create_dir(&target).unwrap();
-
-        make_symlink(&target, &link).unwrap();
-
-        assert!(is_symlink_to(&link, &target));
-        assert!(!is_symlink_to(&target, &target));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_is_symlink_to_resolves_relative_target_from_link_parent() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target");
-        let link = dir.path().join("link");
-        fs::create_dir(&target).unwrap();
-        std::os::unix::fs::symlink("target", &link).unwrap();
-
-        assert!(is_symlink_to(&link, &target));
-    }
-
-    #[test]
-    fn test_symlink_prefix_detection_and_removal() {
+    fn test_remove_symlinks_with_target_prefix() {
         let dir = tempfile::tempdir().unwrap();
         let prefix = dir.path().join("provider");
         let target = prefix.join("version");
         let other = dir.path().join("other");
         let link = dir.path().join("link");
+        let other_link = dir.path().join("other-link");
         fs::create_dir_all(&target).unwrap();
         fs::create_dir_all(&other).unwrap();
         make_symlink(&target, &link).unwrap();
-
-        assert!(is_symlink_to_prefix(&link, &prefix).unwrap());
-        assert!(!is_symlink_to_prefix(&link, &other).unwrap());
+        make_symlink(&other, &other_link).unwrap();
 
         let removed = remove_symlinks_with_target_prefix(dir.path(), &prefix).unwrap();
         assert_eq!(removed, vec![link.clone()]);
         assert!(std::fs::symlink_metadata(&link).is_err());
+        assert!(std::fs::symlink_metadata(&other_link).is_ok());
         assert!(target.exists());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_symlink_prefix_detection_follows_an_indirect_target() {
-        let dir = tempfile::tempdir().unwrap();
-        let cellar = dir.path().join("Cellar");
-        let target = cellar.join("node@22").join("22.0.0");
-        let opt = dir.path().join("opt");
-        let opt_entry = opt.join("node@22");
-        let link = dir.path().join("link");
-        fs::create_dir_all(&target).unwrap();
-        fs::create_dir_all(&opt).unwrap();
-        std::os::unix::fs::symlink(&target, &opt_entry).unwrap();
-        std::os::unix::fs::symlink(&opt_entry, &link).unwrap();
-
-        assert!(is_symlink_to_prefix(&link, &cellar).unwrap());
-        assert!(!is_symlink_to_prefix(&link, &opt).unwrap());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_symlink_prefix_detection_rejects_escapes() {
-        let dir = tempfile::tempdir().unwrap();
-        let prefix = dir.path().join("provider");
-        let foreign = dir.path().join("foreign");
-        let escaped = dir.path().join("escaped");
-        let redirected = dir.path().join("redirected");
-        fs::create_dir_all(&prefix).unwrap();
-        fs::create_dir_all(&foreign).unwrap();
-
-        std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
-        assert!(!is_symlink_to_prefix(&escaped, &prefix).unwrap());
-
-        std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
-        std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
-        assert!(!is_symlink_to_prefix(&redirected, &prefix).unwrap());
-
-        let dangling = prefix.join("dangling");
-        let redirected_tail = dir.path().join("redirected-tail");
-        std::os::unix::fs::symlink(prefix.join("missing"), &dangling).unwrap();
-        std::os::unix::fs::symlink(dangling.join("child"), &redirected_tail).unwrap();
-        assert!(!is_symlink_to_prefix(&redirected_tail, &prefix).unwrap());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -936,16 +936,21 @@ fn symlink_or_junction_target(link: &Path) -> Result<Option<PathBuf>> {
 
 #[cfg(unix)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    if !link.is_symlink() {
+        bail!("not a symlink: {}", display_path(link));
+    }
     fs::remove_file(link)
         .wrap_err_with(|| format!("failed to remove symlink: {}", display_path(link)))
 }
 
 #[cfg(windows)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
-    if junction::get_target(link).is_ok() {
+    if link.is_symlink() {
+        fs::remove_file(link).or_else(|_| fs::remove_dir(link))
+    } else if junction::get_target(link).is_ok() {
         junction::delete(link)
     } else {
-        fs::remove_file(link).or_else(|_| fs::remove_dir(link))
+        bail!("not a symlink or junction: {}", display_path(link));
     }
     .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
 }
@@ -2696,6 +2701,20 @@ mod tests {
         assert!(std::fs::symlink_metadata(&link).is_err());
         assert!(std::fs::symlink_metadata(&other_link).is_ok());
         assert!(target.exists());
+    }
+
+    #[test]
+    fn test_remove_symlink_or_junction_rejects_non_links() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file");
+        let directory = dir.path().join("directory");
+        fs::write(&file, "contents").unwrap();
+        fs::create_dir(&directory).unwrap();
+
+        assert!(remove_symlink_or_junction(&file).is_err());
+        assert!(remove_symlink_or_junction(&directory).is_err());
+        assert!(file.is_file());
+        assert!(directory.is_dir());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1106,6 +1106,9 @@ fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
 
 #[cfg(unix)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    // POSIX has no standard unlink-by-handle operation, so a concurrent replacement can still
+    // occur between this check and remove_file. The latter cannot remove directories; callers
+    // must keep the parent directory protected from untrusted writers.
     if dir_link_target(link)?.is_none() {
         bail!("refusing to remove non-link: {}", display_path(link));
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -861,8 +861,7 @@ fn create_windows_dir_link(target: &Path, link: &Path) -> std::io::Result<()> {
 pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
     if let Err(err) = create_windows_dir_link(target, link) {
         if err.kind() == std::io::ErrorKind::AlreadyExists {
-            let _ = fs::remove_file(link);
-            let _ = fs::remove_dir(link);
+            remove_symlink_or_junction(link)?;
             create_windows_dir_link(target, link)
         } else {
             Err(err)
@@ -898,7 +897,7 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
-    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
+    is_symlink_or_junction(link) && paths_refer_to_same_entry(link, target)
 }
 
 #[cfg(unix)]
@@ -917,6 +916,142 @@ pub fn make_symlink_or_file(target: &Path, link: &Path) -> Result<()> {
     Ok(())
 }
 
+pub fn is_symlink_to_prefix(link: &Path, target_prefix: &Path) -> Result<bool> {
+    let Some(target) = dir_link_target(link)? else {
+        return Ok(false);
+    };
+    // Broken provider links cannot be canonicalized in full. Resolve the
+    // longest existing ancestor so symlinks in the existing portion still
+    // participate in ownership checks, then append only a safe normal tail.
+    // If that cannot establish ownership, preserve the link because this
+    // predicate controls destructive provider cleanup.
+    let Some(target) = canonicalize_with_missing_tail(&target)? else {
+        return Ok(false);
+    };
+    let Some(target_prefix) = canonicalize_with_missing_tail(target_prefix)? else {
+        return Ok(false);
+    };
+    Ok(path_is_within(&target, &target_prefix))
+}
+
+fn path_is_within(path: &Path, prefix: &Path) -> bool {
+    path.starts_with(prefix)
+        || path
+            .ancestors()
+            .any(|ancestor| paths_refer_to_same_entry(ancestor, prefix))
+}
+
+fn paths_refer_to_same_entry(a: &Path, b: &Path) -> bool {
+    same_file::is_same_file(a, b).unwrap_or(false)
+}
+
+fn canonicalize_with_missing_tail(path: &Path) -> Result<Option<PathBuf>> {
+    for ancestor in path.ancestors() {
+        match ancestor.canonicalize() {
+            Ok(mut resolved) => {
+                for component in path.strip_prefix(ancestor)?.components() {
+                    match component {
+                        std::path::Component::Normal(component) => {
+                            let candidate = resolved.join(component);
+                            // A link or junction in the unresolved tail may
+                            // redirect outside the provider. Its destination
+                            // cannot be established, so preserve the outer
+                            // link instead of claiming provider ownership.
+                            if dir_link_target(&candidate)?.is_some() {
+                                return Ok(None);
+                            }
+                            resolved.push(component);
+                        }
+                        std::path::Component::CurDir => {}
+                        std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_) => return Ok(None),
+                    }
+                }
+                return Ok(Some(resolved));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Ok(None),
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(unix)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    if !metadata.file_type().is_symlink() {
+        return Ok(None);
+    }
+    let target = fs::read_link(link)
+        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+#[cfg(windows)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
+
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    let target = if metadata.file_type().is_symlink() {
+        fs::read_link(link)
+            .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?
+    } else {
+        match junction::get_target(link) {
+            Ok(target) => target,
+            Err(err)
+                if err.kind() == std::io::ErrorKind::NotFound
+                    || err.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
+                    || (err.kind() == std::io::ErrorKind::Other
+                        && err.raw_os_error().is_none()) =>
+            {
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(err).wrap_err_with(|| {
+                    format!("failed to inspect junction: {}", display_path(link))
+                });
+            }
+        }
+    };
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
+    if target.is_absolute() {
+        target
+    } else {
+        link.parent().unwrap_or(link).join(target)
+    }
+}
+
+#[cfg(unix)]
+pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    fs::remove_file(link)
+        .wrap_err_with(|| format!("failed to remove symlink: {}", display_path(link)))
+}
+
+#[cfg(windows)]
+pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    fs::remove_file(link)
+        .or_else(|_| fs::remove_dir(link))
+        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
+}
+
 pub fn remove_symlinks_with_target_prefix(
     symlink_dir: &Path,
     target_prefix: &Path,
@@ -928,12 +1063,9 @@ pub fn remove_symlinks_with_target_prefix(
     for entry in symlink_dir.read_dir()? {
         let entry = entry?;
         let path = entry.path();
-        if path.is_symlink() {
-            let target = path.read_link()?;
-            if target.starts_with(target_prefix) {
-                fs::remove_file(&path)?;
-                removed.push(path);
-            }
+        if is_symlink_to_prefix(&path, target_prefix)? {
+            remove_symlink_or_junction(&path)?;
+            removed.push(path);
         }
     }
     Ok(removed)
@@ -2644,6 +2776,94 @@ mod tests {
             err.downcast_ref::<std::io::Error>().map(|err| err.kind()),
             Some(std::io::ErrorKind::DirectoryNotEmpty)
         );
+    }
+
+    #[test]
+    fn test_is_symlink_to_requires_a_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+        assert!(!is_symlink_to(&target, &target));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_is_symlink_to_resolves_relative_target_from_link_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink("target", &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+    }
+
+    #[test]
+    fn test_symlink_prefix_detection_and_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let target = prefix.join("version");
+        let other = dir.path().join("other");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&other).unwrap();
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to_prefix(&link, &prefix).unwrap());
+        assert!(!is_symlink_to_prefix(&link, &other).unwrap());
+
+        let removed = remove_symlinks_with_target_prefix(dir.path(), &prefix).unwrap();
+        assert_eq!(removed, vec![link.clone()]);
+        assert!(std::fs::symlink_metadata(&link).is_err());
+        assert!(target.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_symlink_prefix_detection_follows_an_indirect_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let cellar = dir.path().join("Cellar");
+        let target = cellar.join("node@22").join("22.0.0");
+        let opt = dir.path().join("opt");
+        let opt_entry = opt.join("node@22");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&opt).unwrap();
+        std::os::unix::fs::symlink(&target, &opt_entry).unwrap();
+        std::os::unix::fs::symlink(&opt_entry, &link).unwrap();
+
+        assert!(is_symlink_to_prefix(&link, &cellar).unwrap());
+        assert!(!is_symlink_to_prefix(&link, &opt).unwrap());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_symlink_prefix_detection_rejects_escapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let foreign = dir.path().join("foreign");
+        let escaped = dir.path().join("escaped");
+        let redirected = dir.path().join("redirected");
+        fs::create_dir_all(&prefix).unwrap();
+        fs::create_dir_all(&foreign).unwrap();
+
+        std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
+        assert!(!is_symlink_to_prefix(&escaped, &prefix).unwrap());
+
+        std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
+        std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
+        assert!(!is_symlink_to_prefix(&redirected, &prefix).unwrap());
+
+        let dangling = prefix.join("dangling");
+        let redirected_tail = dir.path().join("redirected-tail");
+        std::os::unix::fs::symlink(prefix.join("missing"), &dangling).unwrap();
+        std::os::unix::fs::symlink(dangling.join("child"), &redirected_tail).unwrap();
+        assert!(!is_symlink_to_prefix(&redirected_tail, &prefix).unwrap());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -2743,50 +2743,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_symlink_to_requires_a_link() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target");
-        let link = dir.path().join("link");
-        fs::create_dir(&target).unwrap();
-
-        make_symlink(&target, &link).unwrap();
-
-        assert!(is_symlink_to(&link, &target));
-        assert!(!is_symlink_to(&target, &target));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_is_symlink_to_resolves_relative_target_from_link_parent() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target");
-        let link = dir.path().join("link");
-        fs::create_dir(&target).unwrap();
-        std::os::unix::fs::symlink("target", &link).unwrap();
-
-        assert!(is_symlink_to(&link, &target));
-    }
-
-    #[test]
-    fn test_symlink_prefix_detection_and_removal() {
-        let dir = tempfile::tempdir().unwrap();
-        let prefix = dir.path().join("source");
-        let target = prefix.join("version");
-        let other = dir.path().join("other");
-        let link = dir.path().join("link");
-        fs::create_dir_all(&target).unwrap();
-        fs::create_dir_all(&other).unwrap();
-        make_symlink(&target, &link).unwrap();
-
-        assert!(is_symlink_target_within(&link, &prefix).unwrap());
-        assert!(!is_symlink_target_within(&link, &other).unwrap());
-
-        remove_symlink_or_junction(&link).unwrap();
-        assert!(std::fs::symlink_metadata(&link).is_err());
-        assert!(target.exists());
-    }
-
-    #[test]
     fn test_remove_symlinks_with_target_prefix() {
         let dir = tempfile::tempdir().unwrap();
         let prefix = dir.path().join("provider");
@@ -2839,17 +2795,6 @@ mod tests {
         assert!(remove_symlink_or_junction(&directory).is_err());
         assert!(file.is_file());
         assert!(directory.is_dir());
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_remove_symlink_or_junction_rejects_an_ordinary_directory() {
-        let dir = tempfile::tempdir().unwrap();
-        let ordinary_dir = dir.path().join("ordinary");
-        fs::create_dir(&ordinary_dir).unwrap();
-
-        assert!(remove_symlink_or_junction(&ordinary_dir).is_err());
-        assert!(ordinary_dir.is_dir());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -714,8 +714,7 @@ fn create_windows_dir_link(target: &Path, link: &Path) -> std::io::Result<()> {
 pub fn make_symlink(target: &Path, link: &Path) -> Result<(PathBuf, PathBuf)> {
     if let Err(err) = create_windows_dir_link(target, link) {
         if err.kind() == std::io::ErrorKind::AlreadyExists {
-            let _ = fs::remove_file(link);
-            let _ = fs::remove_dir(link);
+            remove_symlink_or_junction(link)?;
             create_windows_dir_link(target, link)
         } else {
             Err(err)
@@ -751,7 +750,7 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
-    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
+    is_symlink_or_junction(link) && paths_refer_to_same_entry(link, target)
 }
 
 #[cfg(unix)]
@@ -770,6 +769,142 @@ pub fn make_symlink_or_file(target: &Path, link: &Path) -> Result<()> {
     Ok(())
 }
 
+pub fn is_symlink_to_prefix(link: &Path, target_prefix: &Path) -> Result<bool> {
+    let Some(target) = dir_link_target(link)? else {
+        return Ok(false);
+    };
+    // Broken provider links cannot be canonicalized in full. Resolve the
+    // longest existing ancestor so symlinks in the existing portion still
+    // participate in ownership checks, then append only a safe normal tail.
+    // If that cannot establish ownership, preserve the link because this
+    // predicate controls destructive provider cleanup.
+    let Some(target) = canonicalize_with_missing_tail(&target)? else {
+        return Ok(false);
+    };
+    let Some(target_prefix) = canonicalize_with_missing_tail(target_prefix)? else {
+        return Ok(false);
+    };
+    Ok(path_is_within(&target, &target_prefix))
+}
+
+fn path_is_within(path: &Path, prefix: &Path) -> bool {
+    path.starts_with(prefix)
+        || path
+            .ancestors()
+            .any(|ancestor| paths_refer_to_same_entry(ancestor, prefix))
+}
+
+fn paths_refer_to_same_entry(a: &Path, b: &Path) -> bool {
+    same_file::is_same_file(a, b).unwrap_or(false)
+}
+
+fn canonicalize_with_missing_tail(path: &Path) -> Result<Option<PathBuf>> {
+    for ancestor in path.ancestors() {
+        match ancestor.canonicalize() {
+            Ok(mut resolved) => {
+                for component in path.strip_prefix(ancestor)?.components() {
+                    match component {
+                        std::path::Component::Normal(component) => {
+                            let candidate = resolved.join(component);
+                            // A link or junction in the unresolved tail may
+                            // redirect outside the provider. Its destination
+                            // cannot be established, so preserve the outer
+                            // link instead of claiming provider ownership.
+                            if dir_link_target(&candidate)?.is_some() {
+                                return Ok(None);
+                            }
+                            resolved.push(component);
+                        }
+                        std::path::Component::CurDir => {}
+                        std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_) => return Ok(None),
+                    }
+                }
+                return Ok(Some(resolved));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Ok(None),
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(unix)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    if !metadata.file_type().is_symlink() {
+        return Ok(None);
+    }
+    let target = fs::read_link(link)
+        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+#[cfg(windows)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
+
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    let target = if metadata.file_type().is_symlink() {
+        fs::read_link(link)
+            .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?
+    } else {
+        match junction::get_target(link) {
+            Ok(target) => target,
+            Err(err)
+                if err.kind() == std::io::ErrorKind::NotFound
+                    || err.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
+                    || (err.kind() == std::io::ErrorKind::Other
+                        && err.raw_os_error().is_none()) =>
+            {
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(err).wrap_err_with(|| {
+                    format!("failed to inspect junction: {}", display_path(link))
+                });
+            }
+        }
+    };
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
+    if target.is_absolute() {
+        target
+    } else {
+        link.parent().unwrap_or(link).join(target)
+    }
+}
+
+#[cfg(unix)]
+pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    fs::remove_file(link)
+        .wrap_err_with(|| format!("failed to remove symlink: {}", display_path(link)))
+}
+
+#[cfg(windows)]
+pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
+    fs::remove_file(link)
+        .or_else(|_| fs::remove_dir(link))
+        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
+}
+
 pub fn remove_symlinks_with_target_prefix(
     symlink_dir: &Path,
     target_prefix: &Path,
@@ -781,12 +916,9 @@ pub fn remove_symlinks_with_target_prefix(
     for entry in symlink_dir.read_dir()? {
         let entry = entry?;
         let path = entry.path();
-        if path.is_symlink() {
-            let target = path.read_link()?;
-            if target.starts_with(target_prefix) {
-                fs::remove_file(&path)?;
-                removed.push(path);
-            }
+        if is_symlink_to_prefix(&path, target_prefix)? {
+            remove_symlink_or_junction(&path)?;
+            removed.push(path);
         }
     }
     Ok(removed)
@@ -2335,6 +2467,94 @@ mod tests {
             err.downcast_ref::<std::io::Error>().map(|err| err.kind()),
             Some(std::io::ErrorKind::DirectoryNotEmpty)
         );
+    }
+
+    #[test]
+    fn test_is_symlink_to_requires_a_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+        assert!(!is_symlink_to(&target, &target));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_is_symlink_to_resolves_relative_target_from_link_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink("target", &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+    }
+
+    #[test]
+    fn test_symlink_prefix_detection_and_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let target = prefix.join("version");
+        let other = dir.path().join("other");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&other).unwrap();
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to_prefix(&link, &prefix).unwrap());
+        assert!(!is_symlink_to_prefix(&link, &other).unwrap());
+
+        let removed = remove_symlinks_with_target_prefix(dir.path(), &prefix).unwrap();
+        assert_eq!(removed, vec![link.clone()]);
+        assert!(std::fs::symlink_metadata(&link).is_err());
+        assert!(target.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_symlink_prefix_detection_follows_an_indirect_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let cellar = dir.path().join("Cellar");
+        let target = cellar.join("node@22").join("22.0.0");
+        let opt = dir.path().join("opt");
+        let opt_entry = opt.join("node@22");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&opt).unwrap();
+        std::os::unix::fs::symlink(&target, &opt_entry).unwrap();
+        std::os::unix::fs::symlink(&opt_entry, &link).unwrap();
+
+        assert!(is_symlink_to_prefix(&link, &cellar).unwrap());
+        assert!(!is_symlink_to_prefix(&link, &opt).unwrap());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_symlink_prefix_detection_rejects_escapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let foreign = dir.path().join("foreign");
+        let escaped = dir.path().join("escaped");
+        let redirected = dir.path().join("redirected");
+        fs::create_dir_all(&prefix).unwrap();
+        fs::create_dir_all(&foreign).unwrap();
+
+        std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
+        assert!(!is_symlink_to_prefix(&escaped, &prefix).unwrap());
+
+        std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
+        std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
+        assert!(!is_symlink_to_prefix(&redirected, &prefix).unwrap());
+
+        let dangling = prefix.join("dangling");
+        let redirected_tail = dir.path().join("redirected-tail");
+        std::os::unix::fs::symlink(prefix.join("missing"), &dangling).unwrap();
+        std::os::unix::fs::symlink(dangling.join("child"), &redirected_tail).unwrap();
+        assert!(!is_symlink_to_prefix(&redirected_tail, &prefix).unwrap());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -750,7 +750,7 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
-    is_symlink_or_junction(link) && paths_refer_to_same_entry(link, target)
+    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
 }
 
 #[cfg(unix)]
@@ -769,126 +769,21 @@ pub fn make_symlink_or_file(target: &Path, link: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn is_symlink_to_prefix(link: &Path, target_prefix: &Path) -> Result<bool> {
-    let Some(target) = dir_link_target(link)? else {
-        return Ok(false);
-    };
-    // Broken provider links cannot be canonicalized in full. Resolve the
-    // longest existing ancestor so symlinks in the existing portion still
-    // participate in ownership checks, then append only a safe normal tail.
-    // If that cannot establish ownership, preserve the link because this
-    // predicate controls destructive provider cleanup.
-    let Some(target) = canonicalize_with_missing_tail(&target)? else {
-        return Ok(false);
-    };
-    let Some(target_prefix) = canonicalize_with_missing_tail(target_prefix)? else {
-        return Ok(false);
-    };
-    Ok(path_is_within(&target, &target_prefix))
-}
-
-fn path_is_within(path: &Path, prefix: &Path) -> bool {
-    path.starts_with(prefix)
-        || path
-            .ancestors()
-            .any(|ancestor| paths_refer_to_same_entry(ancestor, prefix))
-}
-
-fn paths_refer_to_same_entry(a: &Path, b: &Path) -> bool {
-    same_file::is_same_file(a, b).unwrap_or(false)
-}
-
-fn canonicalize_with_missing_tail(path: &Path) -> Result<Option<PathBuf>> {
-    for ancestor in path.ancestors() {
-        match ancestor.canonicalize() {
-            Ok(mut resolved) => {
-                for component in path.strip_prefix(ancestor)?.components() {
-                    match component {
-                        std::path::Component::Normal(component) => {
-                            let candidate = resolved.join(component);
-                            // A link or junction in the unresolved tail may
-                            // redirect outside the provider. Its destination
-                            // cannot be established, so preserve the outer
-                            // link instead of claiming provider ownership.
-                            if dir_link_target(&candidate)?.is_some() {
-                                return Ok(None);
-                            }
-                            resolved.push(component);
-                        }
-                        std::path::Component::CurDir => {}
-                        std::path::Component::ParentDir
-                        | std::path::Component::RootDir
-                        | std::path::Component::Prefix(_) => return Ok(None),
-                    }
-                }
-                return Ok(Some(resolved));
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(_) => return Ok(None),
-        }
-    }
-    Ok(None)
-}
-
 #[cfg(unix)]
-fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
-    let metadata = match fs::symlink_metadata(link) {
-        Ok(metadata) => metadata,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => {
-            return Err(err)
-                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
-        }
-    };
-    if !metadata.file_type().is_symlink() {
-        return Ok(None);
+fn symlink_or_junction_target(link: &Path) -> Result<Option<PathBuf>> {
+    if link.is_symlink() {
+        Ok(Some(fs::read_link(link)?))
+    } else {
+        Ok(None)
     }
-    let target = fs::read_link(link)
-        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
-    Ok(Some(resolve_relative_link_target(link, target)))
 }
 
 #[cfg(windows)]
-fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
-    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
-
-    let metadata = match fs::symlink_metadata(link) {
-        Ok(metadata) => metadata,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => {
-            return Err(err)
-                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
-        }
-    };
-    let target = if metadata.file_type().is_symlink() {
-        fs::read_link(link)
-            .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?
+fn symlink_or_junction_target(link: &Path) -> Result<Option<PathBuf>> {
+    if link.is_symlink() {
+        Ok(Some(fs::read_link(link)?))
     } else {
-        match junction::get_target(link) {
-            Ok(target) => target,
-            Err(err)
-                if err.kind() == std::io::ErrorKind::NotFound
-                    || err.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
-                    || (err.kind() == std::io::ErrorKind::Other
-                        && err.raw_os_error().is_none()) =>
-            {
-                return Ok(None);
-            }
-            Err(err) => {
-                return Err(err).wrap_err_with(|| {
-                    format!("failed to inspect junction: {}", display_path(link))
-                });
-            }
-        }
-    };
-    Ok(Some(resolve_relative_link_target(link, target)))
-}
-
-fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
-    if target.is_absolute() {
-        target
-    } else {
-        link.parent().unwrap_or(link).join(target)
+        Ok(junction::get_target(link).ok())
     }
 }
 
@@ -900,9 +795,12 @@ pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
 
 #[cfg(windows)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
-    fs::remove_file(link)
-        .or_else(|_| fs::remove_dir(link))
-        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
+    if junction::get_target(link).is_ok() {
+        junction::delete(link)
+    } else {
+        fs::remove_file(link).or_else(|_| fs::remove_dir(link))
+    }
+    .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
 }
 
 pub fn remove_symlinks_with_target_prefix(
@@ -916,7 +814,9 @@ pub fn remove_symlinks_with_target_prefix(
     for entry in symlink_dir.read_dir()? {
         let entry = entry?;
         let path = entry.path();
-        if is_symlink_to_prefix(&path, target_prefix)? {
+        if let Some(target) = symlink_or_junction_target(&path)?
+            && target.starts_with(target_prefix)
+        {
             remove_symlink_or_junction(&path)?;
             removed.push(path);
         }
@@ -2470,91 +2370,23 @@ mod tests {
     }
 
     #[test]
-    fn test_is_symlink_to_requires_a_link() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target");
-        let link = dir.path().join("link");
-        fs::create_dir(&target).unwrap();
-
-        make_symlink(&target, &link).unwrap();
-
-        assert!(is_symlink_to(&link, &target));
-        assert!(!is_symlink_to(&target, &target));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_is_symlink_to_resolves_relative_target_from_link_parent() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target");
-        let link = dir.path().join("link");
-        fs::create_dir(&target).unwrap();
-        std::os::unix::fs::symlink("target", &link).unwrap();
-
-        assert!(is_symlink_to(&link, &target));
-    }
-
-    #[test]
-    fn test_symlink_prefix_detection_and_removal() {
+    fn test_remove_symlinks_with_target_prefix() {
         let dir = tempfile::tempdir().unwrap();
         let prefix = dir.path().join("provider");
         let target = prefix.join("version");
         let other = dir.path().join("other");
         let link = dir.path().join("link");
+        let other_link = dir.path().join("other-link");
         fs::create_dir_all(&target).unwrap();
         fs::create_dir_all(&other).unwrap();
         make_symlink(&target, &link).unwrap();
-
-        assert!(is_symlink_to_prefix(&link, &prefix).unwrap());
-        assert!(!is_symlink_to_prefix(&link, &other).unwrap());
+        make_symlink(&other, &other_link).unwrap();
 
         let removed = remove_symlinks_with_target_prefix(dir.path(), &prefix).unwrap();
         assert_eq!(removed, vec![link.clone()]);
         assert!(std::fs::symlink_metadata(&link).is_err());
+        assert!(std::fs::symlink_metadata(&other_link).is_ok());
         assert!(target.exists());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_symlink_prefix_detection_follows_an_indirect_target() {
-        let dir = tempfile::tempdir().unwrap();
-        let cellar = dir.path().join("Cellar");
-        let target = cellar.join("node@22").join("22.0.0");
-        let opt = dir.path().join("opt");
-        let opt_entry = opt.join("node@22");
-        let link = dir.path().join("link");
-        fs::create_dir_all(&target).unwrap();
-        fs::create_dir_all(&opt).unwrap();
-        std::os::unix::fs::symlink(&target, &opt_entry).unwrap();
-        std::os::unix::fs::symlink(&opt_entry, &link).unwrap();
-
-        assert!(is_symlink_to_prefix(&link, &cellar).unwrap());
-        assert!(!is_symlink_to_prefix(&link, &opt).unwrap());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_symlink_prefix_detection_rejects_escapes() {
-        let dir = tempfile::tempdir().unwrap();
-        let prefix = dir.path().join("provider");
-        let foreign = dir.path().join("foreign");
-        let escaped = dir.path().join("escaped");
-        let redirected = dir.path().join("redirected");
-        fs::create_dir_all(&prefix).unwrap();
-        fs::create_dir_all(&foreign).unwrap();
-
-        std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
-        assert!(!is_symlink_to_prefix(&escaped, &prefix).unwrap());
-
-        std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
-        std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
-        assert!(!is_symlink_to_prefix(&redirected, &prefix).unwrap());
-
-        let dangling = prefix.join("dangling");
-        let redirected_tail = dir.path().join("redirected-tail");
-        std::os::unix::fs::symlink(prefix.join("missing"), &dangling).unwrap();
-        std::os::unix::fs::symlink(dangling.join("child"), &redirected_tail).unwrap();
-        assert!(!is_symlink_to_prefix(&redirected_tail, &prefix).unwrap());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -967,7 +967,74 @@ fn path_starts_with(path: &Path, root: &Path) -> bool {
         ) == CSTR_EQUAL
     };
 
-    equal_ignoring_case && same_file::is_same_file(&candidate, root).unwrap_or(false)
+    if !equal_ignoring_case {
+        return false;
+    }
+
+    match same_file::is_same_file(&candidate, root) {
+        Ok(same) => same,
+        Err(_) => dangling_paths_share_case_insensitive_parent(&candidate, root),
+    }
+}
+
+#[cfg(windows)]
+fn dangling_paths_share_case_insensitive_parent(path: &Path, root: &Path) -> bool {
+    let Some((path_parent, path_missing_components)) = nearest_existing_directory(path) else {
+        return false;
+    };
+    let Some((root_parent, root_missing_components)) = nearest_existing_directory(root) else {
+        return false;
+    };
+
+    path_missing_components == root_missing_components
+        && same_file::is_same_file(&path_parent, &root_parent).unwrap_or(false)
+        && directory_is_case_sensitive(&path_parent) == Some(false)
+}
+
+#[cfg(windows)]
+fn nearest_existing_directory(path: &Path) -> Option<(PathBuf, usize)> {
+    let mut path = path;
+    let mut missing_components = 0;
+    loop {
+        match fs::metadata(path) {
+            Ok(metadata) if metadata.is_dir() => {
+                return Some((path.to_path_buf(), missing_components));
+            }
+            Ok(_) => return None,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                path = path.parent()?;
+                missing_components += 1;
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+#[cfg(windows)]
+fn directory_is_case_sensitive(path: &Path) -> Option<bool> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_CASE_SENSITIVE_INFO, FILE_FLAG_BACKUP_SEMANTICS, FileCaseSensitiveInfo,
+        GetFileInformationByHandleEx,
+    };
+    use windows_sys::Win32::System::SystemServices::FILE_CS_FLAG_CASE_SENSITIVE_DIR;
+
+    let directory = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)
+        .ok()?;
+    let mut case_info = FILE_CASE_SENSITIVE_INFO::default();
+    let inspected = unsafe {
+        GetFileInformationByHandleEx(
+            directory.as_raw_handle(),
+            FileCaseSensitiveInfo,
+            std::ptr::from_mut(&mut case_info).cast(),
+            std::mem::size_of::<FILE_CASE_SENSITIVE_INFO>() as u32,
+        )
+    };
+    (inspected != 0).then_some(case_info.Flags & FILE_CS_FLAG_CASE_SENSITIVE_DIR != 0)
 }
 
 #[cfg(unix)]
@@ -2869,6 +2936,71 @@ mod tests {
             is_symlink_target_within(&link, &dir.path().join("PROVIDER")).unwrap(),
             "Windows path containment should honor filesystem casing semantics"
         );
+
+        fs::remove_dir_all(&prefix).unwrap();
+        assert!(
+            is_symlink_target_within(&link, &dir.path().join("PROVIDER")).unwrap(),
+            "dangling Windows targets should retain case-insensitive containment"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_dangling_symlink_prefix_detection_honors_case_sensitive_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let case_sensitive_parent = dir.path().join("case-sensitive");
+        fs::create_dir(&case_sensitive_parent).unwrap();
+        if enable_directory_case_sensitivity(&case_sensitive_parent).is_err() {
+            return;
+        }
+        assert_eq!(
+            directory_is_case_sensitive(&case_sensitive_parent),
+            Some(true)
+        );
+
+        let prefix = case_sensitive_parent.join("Provider");
+        let target = prefix.join("version");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        junction::create(&target, &link).unwrap();
+        fs::remove_dir_all(&prefix).unwrap();
+
+        assert!(
+            !is_symlink_target_within(&link, &case_sensitive_parent.join("PROVIDER")).unwrap(),
+            "case-sensitive directories must not equate differently-cased dangling paths"
+        );
+    }
+
+    #[cfg(windows)]
+    fn enable_directory_case_sensitivity(path: &Path) -> std::io::Result<()> {
+        use std::os::windows::fs::OpenOptionsExt;
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_CASE_SENSITIVE_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_WRITE_ATTRIBUTES,
+            FileCaseSensitiveInfo, SetFileInformationByHandle,
+        };
+        use windows_sys::Win32::System::SystemServices::FILE_CS_FLAG_CASE_SENSITIVE_DIR;
+
+        let directory = fs::OpenOptions::new()
+            .access_mode(FILE_WRITE_ATTRIBUTES)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+            .open(path)?;
+        let case_info = FILE_CASE_SENSITIVE_INFO {
+            Flags: FILE_CS_FLAG_CASE_SENSITIVE_DIR,
+        };
+        let updated = unsafe {
+            SetFileInformationByHandle(
+                directory.as_raw_handle(),
+                FileCaseSensitiveInfo,
+                std::ptr::from_ref(&case_info).cast(),
+                std::mem::size_of::<FILE_CASE_SENSITIVE_INFO>() as u32,
+            )
+        };
+        if updated == 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -923,7 +923,51 @@ pub fn is_symlink_target_within(link: &Path, root: &Path) -> Result<bool> {
     };
     let target = target.absolutize()?;
     let root = root.absolutize()?;
-    Ok(target.starts_with(root.as_ref()))
+    Ok(path_starts_with(&target, &root))
+}
+
+#[cfg(unix)]
+fn path_starts_with(path: &Path, root: &Path) -> bool {
+    path.starts_with(root)
+}
+
+#[cfg(windows)]
+fn path_starts_with(path: &Path, root: &Path) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
+
+    if path.starts_with(root) {
+        return true;
+    }
+
+    let root_component_count = root.components().count();
+    let candidate = path
+        .components()
+        .take(root_component_count)
+        .collect::<PathBuf>();
+    if candidate.components().count() != root_component_count {
+        return false;
+    }
+
+    let candidate_wide = candidate.as_os_str().encode_wide().collect::<Vec<_>>();
+    let root_wide = root.as_os_str().encode_wide().collect::<Vec<_>>();
+    let Ok(candidate_len) = i32::try_from(candidate_wide.len()) else {
+        return false;
+    };
+    let Ok(root_len) = i32::try_from(root_wide.len()) else {
+        return false;
+    };
+    let equal_ignoring_case = unsafe {
+        CompareStringOrdinal(
+            candidate_wide.as_ptr(),
+            candidate_len,
+            root_wide.as_ptr(),
+            root_len,
+            1,
+        ) == CSTR_EQUAL
+    };
+
+    equal_ignoring_case && same_file::is_same_file(&candidate, root).unwrap_or(false)
 }
 
 #[cfg(unix)]
@@ -999,22 +1043,71 @@ pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
 
 #[cfg(windows)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
-    use std::os::windows::fs::FileTypeExt;
+    let link_handle = open_link_for_removal(link)?;
+    remove_open_link(link_handle)
+        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
+}
 
-    let metadata = fs::symlink_metadata(link)
-        .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)))?;
-    if dir_link_target(link)?.is_none() {
-        bail!(
-            "refusing to remove non-link directory: {}",
-            display_path(link)
-        );
+#[cfg(windows)]
+fn open_link_for_removal(link: &Path) -> Result<File> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        DELETE, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FileAttributeTagInfo, GetFileInformationByHandleEx,
+    };
+    use windows_sys::Win32::System::SystemServices::{
+        IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_SYMLINK,
+    };
+
+    let file = fs::OpenOptions::new()
+        .access_mode(DELETE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)
+        .open(link)
+        .wrap_err_with(|| format!("failed to open link: {}", display_path(link)))?;
+    let mut tag_info = FILE_ATTRIBUTE_TAG_INFO::default();
+    let inspected = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileAttributeTagInfo,
+            std::ptr::from_mut(&mut tag_info).cast(),
+            std::mem::size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    };
+    if inspected == 0 {
+        return Err(std::io::Error::last_os_error())
+            .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
     }
-    if metadata.file_type().is_symlink_file() {
-        fs::remove_file(link)
-    } else {
-        fs::remove_dir(link)
+    if !matches!(
+        tag_info.ReparseTag,
+        IO_REPARSE_TAG_SYMLINK | IO_REPARSE_TAG_MOUNT_POINT
+    ) {
+        bail!("refusing to remove non-link: {}", display_path(link));
     }
-    .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
+    Ok(file)
+}
+
+#[cfg(windows)]
+fn remove_open_link(file: File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_DISPOSITION_INFO, FileDispositionInfo, SetFileInformationByHandle,
+    };
+
+    let disposition = FILE_DISPOSITION_INFO { DeleteFile: true };
+    let removed = unsafe {
+        SetFileInformationByHandle(
+            file.as_raw_handle(),
+            FileDispositionInfo,
+            std::ptr::from_ref(&disposition).cast(),
+            std::mem::size_of::<FILE_DISPOSITION_INFO>() as u32,
+        )
+    };
+    if removed == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    drop(file);
+    Ok(())
 }
 
 pub fn remove_symlinks_with_target_prefix(
@@ -2763,6 +2856,22 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
+    fn test_symlink_prefix_detection_uses_filesystem_casing() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("Provider");
+        let target = prefix.join("version");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        junction::create(&target, &link).unwrap();
+
+        assert!(
+            is_symlink_target_within(&link, &dir.path().join("PROVIDER")).unwrap(),
+            "Windows path containment should honor filesystem casing semantics"
+        );
+    }
+
+    #[test]
     #[cfg(unix)]
     fn test_symlink_prefix_detection_uses_the_immediate_target() {
         let dir = tempfile::tempdir().unwrap();
@@ -2812,6 +2921,26 @@ mod tests {
 
         remove_symlink_or_junction(&link).unwrap();
         assert!(fs::symlink_metadata(&link).is_err());
+        assert!(target.is_dir());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_remove_open_link_preserves_path_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        let moved_link = dir.path().join("moved-link");
+        fs::create_dir(&target).unwrap();
+        junction::create(&target, &link).unwrap();
+
+        let link_handle = open_link_for_removal(&link).unwrap();
+        fs::rename(&link, &moved_link).unwrap();
+        fs::create_dir(&link).unwrap();
+        remove_open_link(link_handle).unwrap();
+
+        assert!(link.is_dir());
+        assert!(fs::symlink_metadata(&moved_link).is_err());
         assert!(target.is_dir());
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -897,7 +897,7 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
-    is_symlink_or_junction(link) && paths_refer_to_same_entry(link, target)
+    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
 }
 
 #[cfg(unix)]
@@ -920,86 +920,33 @@ pub fn is_symlink_target_within(link: &Path, root: &Path) -> Result<bool> {
     let Some(target) = dir_link_target(link)? else {
         return Ok(false);
     };
-    // Broken links cannot be canonicalized in full. Resolve the
-    // longest existing ancestor so symlinks in the existing portion still
-    // participate in ownership checks, then append only a safe normal tail.
-    // If that cannot establish containment, preserve the link because this
-    // predicate controls destructive cleanup.
-    let Some(target) = canonicalize_with_missing_tail(&target)? else {
+    let Some(target) = lexical_normalize(&target) else {
         return Ok(false);
     };
-    let Some(root) = canonicalize_with_missing_tail(root)? else {
+    let Some(root) = lexical_normalize(root) else {
         return Ok(false);
     };
-    Ok(path_is_within(&target, &root))
+    Ok(target.starts_with(root))
 }
 
-/// Returns whether a link's immediate target is within `root` without
-/// following the target's final path component.
-///
-/// This recognizes links into namespaces such as Homebrew's `opt` directory
-/// even after the terminal entry becomes dangling, while still resolving the
-/// parent path to reject redirects and `..` escapes.
-pub fn is_symlink_target_directly_within(link: &Path, root: &Path) -> Result<bool> {
-    let Some(target) = dir_link_target(link)? else {
-        return Ok(false);
-    };
-    let Some(parent) = target.parent() else {
-        return Ok(false);
-    };
-    let Some(file_name) = target.file_name() else {
-        return Ok(false);
-    };
-    let Some(parent) = canonicalize_with_missing_tail(parent)? else {
-        return Ok(false);
-    };
-    let Some(root) = canonicalize_with_missing_tail(root)? else {
-        return Ok(false);
-    };
-    Ok(path_is_within(&parent.join(file_name), &root))
-}
-
-fn path_is_within(path: &Path, prefix: &Path) -> bool {
-    path.starts_with(prefix)
-        || path
-            .ancestors()
-            .any(|ancestor| paths_refer_to_same_entry(ancestor, prefix))
-}
-
-fn paths_refer_to_same_entry(a: &Path, b: &Path) -> bool {
-    same_file::is_same_file(a, b).unwrap_or(false)
-}
-
-fn canonicalize_with_missing_tail(path: &Path) -> Result<Option<PathBuf>> {
-    for ancestor in path.ancestors() {
-        match ancestor.canonicalize() {
-            Ok(mut resolved) => {
-                for component in path.strip_prefix(ancestor)?.components() {
-                    match component {
-                        std::path::Component::Normal(component) => {
-                            let candidate = resolved.join(component);
-                            // A link or junction in the unresolved tail may
-                            // redirect outside the root. Its destination
-                            // cannot be established, so preserve the outer
-                            // link instead of claiming that it is contained.
-                            if dir_link_target(&candidate)?.is_some() {
-                                return Ok(None);
-                            }
-                            resolved.push(component);
-                        }
-                        std::path::Component::CurDir => {}
-                        std::path::Component::ParentDir
-                        | std::path::Component::RootDir
-                        | std::path::Component::Prefix(_) => return Ok(None),
-                    }
+fn lexical_normalize(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !matches!(
+                    normalized.components().next_back(),
+                    Some(std::path::Component::Normal(_))
+                ) {
+                    return None;
                 }
-                return Ok(Some(resolved));
+                normalized.pop();
             }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(_) => return Ok(None),
+            component => normalized.push(component.as_os_str()),
         }
     }
-    Ok(None)
+    Some(normalized)
 }
 
 #[cfg(unix)]
@@ -1103,9 +1050,7 @@ pub fn remove_symlinks_with_target_prefix(
     let mut removed = vec![];
     for entry in symlink_dir.read_dir()? {
         let path = entry?.path();
-        if is_symlink_target_directly_within(&path, target_prefix)?
-            || is_symlink_target_within(&path, target_prefix)?
-        {
+        if is_symlink_target_within(&path, target_prefix)? {
             remove_symlink_or_junction(&path)?;
             removed.push(path);
         }
@@ -2886,7 +2831,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn test_symlink_prefix_detection_follows_an_indirect_target() {
+    fn test_symlink_prefix_detection_uses_the_immediate_target() {
         let dir = tempfile::tempdir().unwrap();
         let cellar = dir.path().join("Cellar");
         let target = cellar.join("node@22").join("22.0.0");
@@ -2898,26 +2843,11 @@ mod tests {
         std::os::unix::fs::symlink(&target, &opt_entry).unwrap();
         std::os::unix::fs::symlink(&opt_entry, &link).unwrap();
 
-        assert!(is_symlink_target_within(&link, &cellar).unwrap());
-        assert!(!is_symlink_target_within(&link, &opt).unwrap());
-    }
+        assert!(!is_symlink_target_within(&link, &cellar).unwrap());
+        assert!(is_symlink_target_within(&link, &opt).unwrap());
 
-    #[test]
-    #[cfg(unix)]
-    fn test_direct_symlink_target_detection_does_not_follow_terminal_entry() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().join("opt");
-        let storage = dir.path().join("Cellar/node@22/22.0.0");
-        let direct_target = root.join("node@22");
-        let link = dir.path().join("link");
-        fs::create_dir_all(&root).unwrap();
-        fs::create_dir_all(&storage).unwrap();
-        std::os::unix::fs::symlink(&storage, &direct_target).unwrap();
-        std::os::unix::fs::symlink(&direct_target, &link).unwrap();
-
-        assert!(is_symlink_target_directly_within(&link, &root).unwrap());
-        fs::remove_file(&direct_target).unwrap();
-        assert!(is_symlink_target_directly_within(&link, &root).unwrap());
+        fs::remove_file(&opt_entry).unwrap();
+        assert!(is_symlink_target_within(&link, &opt).unwrap());
     }
 
     #[test]
@@ -2970,22 +2900,11 @@ mod tests {
         let prefix = dir.path().join("source");
         let foreign = dir.path().join("foreign");
         let escaped = dir.path().join("escaped");
-        let redirected = dir.path().join("redirected");
         fs::create_dir_all(&prefix).unwrap();
         fs::create_dir_all(&foreign).unwrap();
 
         std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
         assert!(!is_symlink_target_within(&escaped, &prefix).unwrap());
-
-        std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
-        std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
-        assert!(!is_symlink_target_within(&redirected, &prefix).unwrap());
-
-        let dangling = prefix.join("dangling");
-        let redirected_tail = dir.path().join("redirected-tail");
-        std::os::unix::fs::symlink(prefix.join("missing"), &dangling).unwrap();
-        std::os::unix::fs::symlink(dangling.join("child"), &redirected_tail).unwrap();
-        assert!(!is_symlink_target_within(&redirected_tail, &prefix).unwrap());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -921,6 +921,10 @@ pub fn is_symlink_target_within(link: &Path, root: &Path) -> Result<bool> {
     let Some(target) = dir_link_target(link)? else {
         return Ok(false);
     };
+    target_path_is_within(&target, root)
+}
+
+fn target_path_is_within(target: &Path, root: &Path) -> Result<bool> {
     let target = target.absolutize()?;
     let root = root.absolutize()?;
     Ok(path_starts_with(&target, &root))
@@ -941,6 +945,7 @@ fn path_starts_with(path: &Path, root: &Path) -> bool {
     }
 
     let root_component_count = root.components().count();
+    let root = root.components().collect::<PathBuf>();
     let candidate = path
         .components()
         .take(root_component_count)
@@ -1177,6 +1182,130 @@ fn remove_open_link(file: File) -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
+fn open_link_target(file: &File) -> std::io::Result<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+    use windows_sys::Win32::System::Ioctl::FSCTL_GET_REPARSE_POINT;
+    use windows_sys::Win32::System::SystemServices::{
+        IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_SYMLINK,
+    };
+
+    let mut data = [0_u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE as usize];
+    let mut bytes_returned = 0;
+    let inspected = unsafe {
+        DeviceIoControl(
+            file.as_raw_handle(),
+            FSCTL_GET_REPARSE_POINT,
+            std::ptr::null(),
+            0,
+            data.as_mut_ptr().cast(),
+            data.len() as u32,
+            &mut bytes_returned,
+            std::ptr::null_mut(),
+        )
+    };
+    if inspected == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let data = data
+        .get(..bytes_returned as usize)
+        .ok_or_else(invalid_reparse_data)?;
+    let reparse_data_length = usize::from(read_reparse_u16(data, 4)?);
+    let data = data
+        .get(..8_usize.saturating_add(reparse_data_length))
+        .ok_or_else(invalid_reparse_data)?;
+    let path_buffer_offset = match read_reparse_u32(data, 0)? {
+        IO_REPARSE_TAG_MOUNT_POINT => 16,
+        IO_REPARSE_TAG_SYMLINK => 20,
+        _ => return Err(invalid_reparse_data()),
+    };
+    let target_offset = usize::from(read_reparse_u16(data, 8)?);
+    let target_length = usize::from(read_reparse_u16(data, 10)?);
+    if target_offset % 2 != 0 || target_length % 2 != 0 {
+        return Err(invalid_reparse_data());
+    }
+    let target_start = path_buffer_offset
+        .checked_add(target_offset)
+        .ok_or_else(invalid_reparse_data)?;
+    let target_end = target_start
+        .checked_add(target_length)
+        .ok_or_else(invalid_reparse_data)?;
+    let target = data
+        .get(target_start..target_end)
+        .ok_or_else(invalid_reparse_data)?
+        .chunks_exact(2)
+        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+        .collect::<Vec<_>>();
+
+    const NT_PREFIX: &[u16] = &[b'\\' as u16, b'?' as u16, b'?' as u16, b'\\' as u16];
+    const NT_UNC_PREFIX: &[u16] = &[
+        b'\\' as u16,
+        b'?' as u16,
+        b'?' as u16,
+        b'\\' as u16,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        b'\\' as u16,
+    ];
+    let target = if let Some(target) = target.strip_prefix(NT_UNC_PREFIX) {
+        let mut normalized = vec![b'\\' as u16, b'\\' as u16];
+        normalized.extend_from_slice(target);
+        normalized
+    } else if let Some(target) = target.strip_prefix(NT_PREFIX) {
+        target.to_vec()
+    } else {
+        target
+    };
+    Ok(PathBuf::from(OsString::from_wide(&target)))
+}
+
+#[cfg(windows)]
+fn read_reparse_u16(data: &[u8], offset: usize) -> std::io::Result<u16> {
+    let bytes = data
+        .get(offset..offset.saturating_add(2))
+        .ok_or_else(invalid_reparse_data)?;
+    Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+}
+
+#[cfg(windows)]
+fn read_reparse_u32(data: &[u8], offset: usize) -> std::io::Result<u32> {
+    let bytes = data
+        .get(offset..offset.saturating_add(4))
+        .ok_or_else(invalid_reparse_data)?;
+    Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+}
+
+#[cfg(windows)]
+fn invalid_reparse_data() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "invalid directory link reparse data",
+    )
+}
+
+#[cfg(windows)]
+fn remove_open_link_with_target_prefix(
+    file: File,
+    link: &Path,
+    target_prefix: &Path,
+) -> Result<bool> {
+    let target = open_link_target(&file)
+        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
+    let target = resolve_relative_link_target(link, target);
+    if !target_path_is_within(&target, target_prefix)? {
+        return Ok(false);
+    }
+    remove_open_link(file)
+        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))?;
+    Ok(true)
+}
+
 pub fn remove_symlinks_with_target_prefix(
     symlink_dir: &Path,
     target_prefix: &Path,
@@ -1188,6 +1317,15 @@ pub fn remove_symlinks_with_target_prefix(
     for entry in symlink_dir.read_dir()? {
         let path = entry?.path();
         if is_symlink_target_within(&path, target_prefix)? {
+            #[cfg(windows)]
+            if !remove_open_link_with_target_prefix(
+                open_link_for_removal(&path)?,
+                &path,
+                target_prefix,
+            )? {
+                continue;
+            }
+            #[cfg(unix)]
             remove_symlink_or_junction(&path)?;
             removed.push(path);
         }
@@ -3077,6 +3215,28 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
+    fn test_remove_open_link_revalidates_replacement_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("provider");
+        let target = prefix.join("version");
+        let foreign = dir.path().join("foreign");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir(&foreign).unwrap();
+        junction::create(&target, &link).unwrap();
+        assert!(is_symlink_target_within(&link, &prefix).unwrap());
+
+        remove_symlink_or_junction(&link).unwrap();
+        junction::create(&foreign, &link).unwrap();
+        let link_handle = open_link_for_removal(&link).unwrap();
+
+        assert!(!remove_open_link_with_target_prefix(link_handle, &link, &prefix).unwrap());
+        assert!(is_symlink_or_junction(&link));
+        assert!(foreign.is_dir());
+    }
+
+    #[test]
     #[cfg(unix)]
     fn test_symlink_prefix_detection_rejects_escapes() {
         let dir = tempfile::tempdir().unwrap();
@@ -3088,6 +3248,14 @@ mod tests {
 
         std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
         assert!(!is_symlink_target_within(&escaped, &prefix).unwrap());
+
+        let relative_inside = dir.path().join("relative-inside");
+        std::os::unix::fs::symlink("source/version", &relative_inside).unwrap();
+        assert!(is_symlink_target_within(&relative_inside, &prefix).unwrap());
+
+        let relative_escape = dir.path().join("relative-escape");
+        std::os::unix::fs::symlink("source/../foreign", &relative_escape).unwrap();
+        assert!(!is_symlink_target_within(&relative_escape, &prefix).unwrap());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -921,10 +921,6 @@ pub fn is_symlink_target_within(link: &Path, root: &Path) -> Result<bool> {
     let Some(target) = dir_link_target(link)? else {
         return Ok(false);
     };
-    target_path_is_within(&target, root)
-}
-
-fn target_path_is_within(target: &Path, root: &Path) -> Result<bool> {
     let target = target.absolutize()?;
     let root = root.absolutize()?;
     Ok(path_starts_with(&target, &root))
@@ -1185,130 +1181,6 @@ fn remove_open_link(file: File) -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg(windows)]
-fn open_link_target(file: &File) -> std::io::Result<PathBuf> {
-    use std::ffi::OsString;
-    use std::os::windows::ffi::OsStringExt;
-    use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::Storage::FileSystem::MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
-    use windows_sys::Win32::System::IO::DeviceIoControl;
-    use windows_sys::Win32::System::Ioctl::FSCTL_GET_REPARSE_POINT;
-    use windows_sys::Win32::System::SystemServices::{
-        IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_SYMLINK,
-    };
-
-    let mut data = [0_u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE as usize];
-    let mut bytes_returned = 0;
-    let inspected = unsafe {
-        DeviceIoControl(
-            file.as_raw_handle(),
-            FSCTL_GET_REPARSE_POINT,
-            std::ptr::null(),
-            0,
-            data.as_mut_ptr().cast(),
-            data.len() as u32,
-            &mut bytes_returned,
-            std::ptr::null_mut(),
-        )
-    };
-    if inspected == 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    let data = data
-        .get(..bytes_returned as usize)
-        .ok_or_else(invalid_reparse_data)?;
-    let reparse_data_length = usize::from(read_reparse_u16(data, 4)?);
-    let data = data
-        .get(..8_usize.saturating_add(reparse_data_length))
-        .ok_or_else(invalid_reparse_data)?;
-    let path_buffer_offset = match read_reparse_u32(data, 0)? {
-        IO_REPARSE_TAG_MOUNT_POINT => 16,
-        IO_REPARSE_TAG_SYMLINK => 20,
-        _ => return Err(invalid_reparse_data()),
-    };
-    let target_offset = usize::from(read_reparse_u16(data, 8)?);
-    let target_length = usize::from(read_reparse_u16(data, 10)?);
-    if target_offset % 2 != 0 || target_length % 2 != 0 {
-        return Err(invalid_reparse_data());
-    }
-    let target_start = path_buffer_offset
-        .checked_add(target_offset)
-        .ok_or_else(invalid_reparse_data)?;
-    let target_end = target_start
-        .checked_add(target_length)
-        .ok_or_else(invalid_reparse_data)?;
-    let target = data
-        .get(target_start..target_end)
-        .ok_or_else(invalid_reparse_data)?
-        .chunks_exact(2)
-        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
-        .collect::<Vec<_>>();
-
-    const NT_PREFIX: &[u16] = &[b'\\' as u16, b'?' as u16, b'?' as u16, b'\\' as u16];
-    const NT_UNC_PREFIX: &[u16] = &[
-        b'\\' as u16,
-        b'?' as u16,
-        b'?' as u16,
-        b'\\' as u16,
-        b'U' as u16,
-        b'N' as u16,
-        b'C' as u16,
-        b'\\' as u16,
-    ];
-    let target = if let Some(target) = target.strip_prefix(NT_UNC_PREFIX) {
-        let mut normalized = vec![b'\\' as u16, b'\\' as u16];
-        normalized.extend_from_slice(target);
-        normalized
-    } else if let Some(target) = target.strip_prefix(NT_PREFIX) {
-        target.to_vec()
-    } else {
-        target
-    };
-    Ok(PathBuf::from(OsString::from_wide(&target)))
-}
-
-#[cfg(windows)]
-fn read_reparse_u16(data: &[u8], offset: usize) -> std::io::Result<u16> {
-    let bytes = data
-        .get(offset..offset.saturating_add(2))
-        .ok_or_else(invalid_reparse_data)?;
-    Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
-}
-
-#[cfg(windows)]
-fn read_reparse_u32(data: &[u8], offset: usize) -> std::io::Result<u32> {
-    let bytes = data
-        .get(offset..offset.saturating_add(4))
-        .ok_or_else(invalid_reparse_data)?;
-    Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
-}
-
-#[cfg(windows)]
-fn invalid_reparse_data() -> std::io::Error {
-    std::io::Error::new(
-        std::io::ErrorKind::InvalidData,
-        "invalid directory link reparse data",
-    )
-}
-
-#[cfg(windows)]
-fn remove_open_link_with_target_prefix(
-    file: File,
-    link: &Path,
-    target_prefix: &Path,
-) -> Result<bool> {
-    let target = open_link_target(&file)
-        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
-    let target = resolve_relative_link_target(link, target);
-    if !target_path_is_within(&target, target_prefix)? {
-        return Ok(false);
-    }
-    remove_open_link(file)
-        .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))?;
-    Ok(true)
-}
-
 pub fn remove_symlinks_with_target_prefix(
     symlink_dir: &Path,
     target_prefix: &Path,
@@ -1320,15 +1192,6 @@ pub fn remove_symlinks_with_target_prefix(
     for entry in symlink_dir.read_dir()? {
         let path = entry?.path();
         if is_symlink_target_within(&path, target_prefix)? {
-            #[cfg(windows)]
-            if !remove_open_link_with_target_prefix(
-                open_link_for_removal(&path)?,
-                &path,
-                target_prefix,
-            )? {
-                continue;
-            }
-            #[cfg(unix)]
             remove_symlink_or_junction(&path)?;
             removed.push(path);
         }
@@ -3215,28 +3078,6 @@ mod tests {
         assert!(link.is_dir());
         assert!(fs::symlink_metadata(&moved_link).is_err());
         assert!(target.is_dir());
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn test_remove_open_link_revalidates_replacement_target() {
-        let dir = tempfile::tempdir().unwrap();
-        let prefix = dir.path().join("provider");
-        let target = prefix.join("version");
-        let foreign = dir.path().join("foreign");
-        let link = dir.path().join("link");
-        fs::create_dir_all(&target).unwrap();
-        fs::create_dir(&foreign).unwrap();
-        junction::create(&target, &link).unwrap();
-        assert!(is_symlink_target_within(&link, &prefix).unwrap());
-
-        remove_symlink_or_junction(&link).unwrap();
-        junction::create(&foreign, &link).unwrap();
-        let link_handle = open_link_for_removal(&link).unwrap();
-
-        assert!(!remove_open_link_with_target_prefix(link_handle, &link, &prefix).unwrap());
-        assert!(is_symlink_or_junction(&link));
-        assert!(foreign.is_dir());
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -897,7 +897,7 @@ pub fn resolve_symlink(link: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub fn is_symlink_to(link: &Path, target: &Path) -> bool {
-    is_symlink_or_junction(link) && same_file::is_same_file(link, target).unwrap_or(false)
+    is_symlink_or_junction(link) && paths_refer_to_same_entry(link, target)
 }
 
 #[cfg(unix)]
@@ -916,41 +916,176 @@ pub fn make_symlink_or_file(target: &Path, link: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
-fn symlink_or_junction_target(link: &Path) -> Result<Option<PathBuf>> {
-    if link.is_symlink() {
-        Ok(Some(fs::read_link(link)?))
-    } else {
-        Ok(None)
+pub fn is_symlink_target_within(link: &Path, root: &Path) -> Result<bool> {
+    let Some(target) = dir_link_target(link)? else {
+        return Ok(false);
+    };
+    // Broken links cannot be canonicalized in full. Resolve the
+    // longest existing ancestor so symlinks in the existing portion still
+    // participate in ownership checks, then append only a safe normal tail.
+    // If that cannot establish containment, preserve the link because this
+    // predicate controls destructive cleanup.
+    let Some(target) = canonicalize_with_missing_tail(&target)? else {
+        return Ok(false);
+    };
+    let Some(root) = canonicalize_with_missing_tail(root)? else {
+        return Ok(false);
+    };
+    Ok(path_is_within(&target, &root))
+}
+
+/// Returns whether a link's immediate target is within `root` without
+/// following the target's final path component.
+///
+/// This recognizes links into namespaces such as Homebrew's `opt` directory
+/// even after the terminal entry becomes dangling, while still resolving the
+/// parent path to reject redirects and `..` escapes.
+pub fn is_symlink_target_directly_within(link: &Path, root: &Path) -> Result<bool> {
+    let Some(target) = dir_link_target(link)? else {
+        return Ok(false);
+    };
+    let Some(parent) = target.parent() else {
+        return Ok(false);
+    };
+    let Some(file_name) = target.file_name() else {
+        return Ok(false);
+    };
+    let Some(parent) = canonicalize_with_missing_tail(parent)? else {
+        return Ok(false);
+    };
+    let Some(root) = canonicalize_with_missing_tail(root)? else {
+        return Ok(false);
+    };
+    Ok(path_is_within(&parent.join(file_name), &root))
+}
+
+fn path_is_within(path: &Path, prefix: &Path) -> bool {
+    path.starts_with(prefix)
+        || path
+            .ancestors()
+            .any(|ancestor| paths_refer_to_same_entry(ancestor, prefix))
+}
+
+fn paths_refer_to_same_entry(a: &Path, b: &Path) -> bool {
+    same_file::is_same_file(a, b).unwrap_or(false)
+}
+
+fn canonicalize_with_missing_tail(path: &Path) -> Result<Option<PathBuf>> {
+    for ancestor in path.ancestors() {
+        match ancestor.canonicalize() {
+            Ok(mut resolved) => {
+                for component in path.strip_prefix(ancestor)?.components() {
+                    match component {
+                        std::path::Component::Normal(component) => {
+                            let candidate = resolved.join(component);
+                            // A link or junction in the unresolved tail may
+                            // redirect outside the root. Its destination
+                            // cannot be established, so preserve the outer
+                            // link instead of claiming that it is contained.
+                            if dir_link_target(&candidate)?.is_some() {
+                                return Ok(None);
+                            }
+                            resolved.push(component);
+                        }
+                        std::path::Component::CurDir => {}
+                        std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_) => return Ok(None),
+                    }
+                }
+                return Ok(Some(resolved));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Ok(None),
+        }
     }
+    Ok(None)
+}
+
+#[cfg(unix)]
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    if !metadata.file_type().is_symlink() {
+        return Ok(None);
+    }
+    let target = fs::read_link(link)
+        .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?;
+    Ok(Some(resolve_relative_link_target(link, target)))
 }
 
 #[cfg(windows)]
-fn symlink_or_junction_target(link: &Path) -> Result<Option<PathBuf>> {
-    if link.is_symlink() {
-        Ok(Some(fs::read_link(link)?))
+fn dir_link_target(link: &Path) -> Result<Option<PathBuf>> {
+    const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
+
+    let metadata = match fs::symlink_metadata(link) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)));
+        }
+    };
+    let target = if metadata.file_type().is_symlink() {
+        fs::read_link(link)
+            .wrap_err_with(|| format!("failed to read link: {}", display_path(link)))?
     } else {
-        Ok(junction::get_target(link).ok())
+        match junction::get_target(link) {
+            Ok(target) => target,
+            Err(err)
+                if err.kind() == std::io::ErrorKind::NotFound
+                    || err.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT)
+                    || (err.kind() == std::io::ErrorKind::Other
+                        && err.raw_os_error().is_none()) =>
+            {
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(err).wrap_err_with(|| {
+                    format!("failed to inspect junction: {}", display_path(link))
+                });
+            }
+        }
+    };
+    Ok(Some(resolve_relative_link_target(link, target)))
+}
+
+fn resolve_relative_link_target(link: &Path, target: PathBuf) -> PathBuf {
+    if target.is_absolute() {
+        target
+    } else {
+        link.parent().unwrap_or(link).join(target)
     }
 }
 
 #[cfg(unix)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
-    if !link.is_symlink() {
-        bail!("not a symlink: {}", display_path(link));
-    }
     fs::remove_file(link)
         .wrap_err_with(|| format!("failed to remove symlink: {}", display_path(link)))
 }
 
 #[cfg(windows)]
 pub fn remove_symlink_or_junction(link: &Path) -> Result<()> {
-    if link.is_symlink() {
-        fs::remove_file(link).or_else(|_| fs::remove_dir(link))
-    } else if junction::get_target(link).is_ok() {
-        junction::delete(link)
+    use std::os::windows::fs::FileTypeExt;
+
+    let metadata = fs::symlink_metadata(link)
+        .wrap_err_with(|| format!("failed to inspect link: {}", display_path(link)))?;
+    if dir_link_target(link)?.is_none() {
+        bail!(
+            "refusing to remove non-link directory: {}",
+            display_path(link)
+        );
+    }
+    if metadata.file_type().is_symlink_file() {
+        fs::remove_file(link)
     } else {
-        bail!("not a symlink or junction: {}", display_path(link));
+        fs::remove_dir(link)
     }
     .wrap_err_with(|| format!("failed to remove link or junction: {}", display_path(link)))
 }
@@ -964,9 +1099,8 @@ pub fn remove_symlinks_with_target_prefix(
     }
     let mut removed = vec![];
     for entry in symlink_dir.read_dir()? {
-        let entry = entry?;
-        let path = entry.path();
-        if let Some(target) = symlink_or_junction_target(&path)?
+        let path = entry?.path();
+        if let Some(target) = dir_link_target(&path)?
             && target.starts_with(target_prefix)
         {
             remove_symlink_or_junction(&path)?;
@@ -2684,6 +2818,50 @@ mod tests {
     }
 
     #[test]
+    fn test_is_symlink_to_requires_a_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+        assert!(!is_symlink_to(&target, &target));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_is_symlink_to_resolves_relative_target_from_link_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink("target", &link).unwrap();
+
+        assert!(is_symlink_to(&link, &target));
+    }
+
+    #[test]
+    fn test_symlink_prefix_detection_and_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("source");
+        let target = prefix.join("version");
+        let other = dir.path().join("other");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&other).unwrap();
+        make_symlink(&target, &link).unwrap();
+
+        assert!(is_symlink_target_within(&link, &prefix).unwrap());
+        assert!(!is_symlink_target_within(&link, &other).unwrap());
+
+        remove_symlink_or_junction(&link).unwrap();
+        assert!(std::fs::symlink_metadata(&link).is_err());
+        assert!(target.exists());
+    }
+
+    #[test]
     fn test_remove_symlinks_with_target_prefix() {
         let dir = tempfile::tempdir().unwrap();
         let prefix = dir.path().join("provider");
@@ -2704,17 +2882,93 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_symlink_or_junction_rejects_non_links() {
+    #[cfg(unix)]
+    fn test_symlink_prefix_detection_follows_an_indirect_target() {
         let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("file");
-        let directory = dir.path().join("directory");
-        fs::write(&file, "contents").unwrap();
-        fs::create_dir(&directory).unwrap();
+        let cellar = dir.path().join("Cellar");
+        let target = cellar.join("node@22").join("22.0.0");
+        let opt = dir.path().join("opt");
+        let opt_entry = opt.join("node@22");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&opt).unwrap();
+        std::os::unix::fs::symlink(&target, &opt_entry).unwrap();
+        std::os::unix::fs::symlink(&opt_entry, &link).unwrap();
 
-        assert!(remove_symlink_or_junction(&file).is_err());
-        assert!(remove_symlink_or_junction(&directory).is_err());
-        assert!(file.is_file());
-        assert!(directory.is_dir());
+        assert!(is_symlink_target_within(&link, &cellar).unwrap());
+        assert!(!is_symlink_target_within(&link, &opt).unwrap());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_direct_symlink_target_detection_does_not_follow_terminal_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("opt");
+        let storage = dir.path().join("Cellar/node@22/22.0.0");
+        let direct_target = root.join("node@22");
+        let link = dir.path().join("link");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&storage).unwrap();
+        std::os::unix::fs::symlink(&storage, &direct_target).unwrap();
+        std::os::unix::fs::symlink(&direct_target, &link).unwrap();
+
+        assert!(is_symlink_target_directly_within(&link, &root).unwrap());
+        fs::remove_file(&direct_target).unwrap();
+        assert!(is_symlink_target_directly_within(&link, &root).unwrap());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_remove_symlink_or_junction_rejects_an_ordinary_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let ordinary_dir = dir.path().join("ordinary");
+        fs::create_dir(&ordinary_dir).unwrap();
+
+        assert!(remove_symlink_or_junction(&ordinary_dir).is_err());
+        assert!(ordinary_dir.is_dir());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_remove_symlink_or_junction_removes_a_directory_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::create_dir(&target).unwrap();
+        match std::os::windows::fs::symlink_dir(&target, &link) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return,
+            Err(err) => panic!("failed to create directory symlink: {err}"),
+        }
+
+        remove_symlink_or_junction(&link).unwrap();
+        assert!(fs::symlink_metadata(&link).is_err());
+        assert!(target.is_dir());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_symlink_prefix_detection_rejects_escapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().join("source");
+        let foreign = dir.path().join("foreign");
+        let escaped = dir.path().join("escaped");
+        let redirected = dir.path().join("redirected");
+        fs::create_dir_all(&prefix).unwrap();
+        fs::create_dir_all(&foreign).unwrap();
+
+        std::os::unix::fs::symlink(prefix.join("..").join("foreign"), &escaped).unwrap();
+        assert!(!is_symlink_target_within(&escaped, &prefix).unwrap());
+
+        std::os::unix::fs::symlink(&foreign, prefix.join("hop")).unwrap();
+        std::os::unix::fs::symlink(prefix.join("hop").join("missing"), &redirected).unwrap();
+        assert!(!is_symlink_target_within(&redirected, &prefix).unwrap());
+
+        let dangling = prefix.join("dangling");
+        let redirected_tail = dir.path().join("redirected-tail");
+        std::os::unix::fs::symlink(prefix.join("missing"), &dangling).unwrap();
+        std::os::unix::fs::symlink(dangling.join("child"), &redirected_tail).unwrap();
+        assert!(!is_symlink_target_within(&redirected_tail, &prefix).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- inspect the immediate target of Unix symlinks and Windows junctions
- resolve relative link targets against the link parent, then compare lexically normalized paths
- honor Windows filesystem casing while preserving direct-target ownership semantics
- reject ordinary files and directories in the shared removal helper
- validate and delete the same Windows reparse-point handle to avoid pathname replacement races
- retain the existing prefix-cleanup API until the stacked sync refactor replaces it

## Bug

Provider cleanup previously compared raw link targets and removed Windows paths with unchecked file/directory fallbacks. Relative targets and parent components could be misclassified, Windows junctions were not recognized, and replacement could attempt to remove an ordinary directory.

This PR deliberately does not infer ownership from fully resolved filesystem paths. It compares only the immediate link target after lexical normalization, so dangling links remain classifiable without provider-specific policy in the filesystem layer. On Windows, a case-insensitive lexical match is accepted only when the candidate prefix and configured root identify the same filesystem object.

Windows removal opens the reparse point directly, validates its tag through that handle, and marks that same handle for deletion. A concurrent pathname replacement is therefore preserved.

## Stack

1. This PR: filesystem link inspection and removal safety
2. #11682: CLI-local external provider reconciliation
3. #11687: aggregate incomplete-marker cleanup errors

## Testing

- `mise run lint-fix`
- `cargo test --all-features --bin mise system::files::tests -- --nocapture`
- `cargo test --all-features --bin mise file::tests -- --nocapture`
- `cargo check --target x86_64-pc-windows-gnu --no-default-features --features rustls-native-roots,self_update,vfox/vendored-lua`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of symbolic links and Windows junctions during cleanup.
  * Prevented cleanup from following links that escape the requested directory.
  * Added safer removal checks to avoid deleting ordinary files or directories.
  * Improved support for dangling links and filesystem-specific path casing.
  * Limited prefix cleanup to links whose immediate targets are within the selected location.
  * Improved link inspection across Unix and Windows filesystems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->