### PR TITLE
chore: release 2026.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## [2026.8.3](https://github.com/jdx/mise/compare/v2026.8.2..v2026.8.3) - 2026-08-07
+
+### 🚀 Features
+
+- **(bootstrap)** add user-scoped flatpak packages by @jdx in [#11757](https://github.com/jdx/mise/pull/11757)
+- **(brew)** support font casks on linux by @jdx in [#11758](https://github.com/jdx/mise/pull/11758)
+- **(pipx)** add per-tool registry URL by @jdx in [#11754](https://github.com/jdx/mise/pull/11754)
+- **(shim)** add not_found_system_fallback setting by @richid in [#11755](https://github.com/jdx/mise/pull/11755)
+
+### 🐛 Bug Fixes
+
+- **(config)** preserve configured runtime options by @risu729 in [#11550](https://github.com/jdx/mise/pull/11550)
+- **(copr)** submit builds without waiting by @jdx in [#11744](https://github.com/jdx/mise/pull/11744)
+- **(docs)** replace errant ripgrep url with node url in tool-stub docs by @arti5an in [#11725](https://github.com/jdx/mise/pull/11725)
+- **(github)** use published date for release age by @jdx in [#11756](https://github.com/jdx/mise/pull/11756)
+- **(lockfile)** create lockfile when explicitly enabled by @jdx in [#11746](https://github.com/jdx/mise/pull/11746)
+- **(ls-remote)** suppress minimum_release_age warn during completions by @beisenherz in [#11727](https://github.com/jdx/mise/pull/11727)
+- **(python)** skip junctions when syncing installs to uv by @risu729 in [#11683](https://github.com/jdx/mise/pull/11683)
+- **(python)** preserve locked precompiled release by @jdx in [#11747](https://github.com/jdx/mise/pull/11747)
+- **(rust)** expand tilde in home settings by @xqm32 in [#11752](https://github.com/jdx/mise/pull/11752)
+- **(task)** preserve separator for required task args by @jdx in [#11729](https://github.com/jdx/mise/pull/11729)
+- **(task)** prefer inline tasks over toml includes by @jdx in [#11734](https://github.com/jdx/mise/pull/11734)
+- **(task)** overlay local task metadata by @jdx in [#11745](https://github.com/jdx/mise/pull/11745)
+- **(use)** keep multiple tool additions sorted by @jdx in [#11713](https://github.com/jdx/mise/pull/11713)
+- **(vfox)** resolve backend aliases for custom plugins by @jdx in [#11736](https://github.com/jdx/mise/pull/11736)
+- **(vfox)** cancel http retries on ctrl-c by @jdx in [#11735](https://github.com/jdx/mise/pull/11735)
+- handle npm link <package-name> in npm shim (auto-reshim) by @cheezmil in [#11748](https://github.com/jdx/mise/pull/11748)
+
+### 🧪 Testing
+
+- **(npm)** cover embedded aube deprecation output by @jdx in [#11761](https://github.com/jdx/mise/pull/11761)
+
+### 📦️ Dependency Updates
+
+- update ghcr.io/jdx/mise:deb docker digest to c26b116 by @renovate[bot] in [#11717](https://github.com/jdx/mise/pull/11717)
+- update ghcr.io/jdx/mise:rpm docker digest to 95e8313 by @renovate[bot] in [#11718](https://github.com/jdx/mise/pull/11718)
+- update ghcr.io/jdx/mise:alpine docker digest to bf0245e by @renovate[bot] in [#11716](https://github.com/jdx/mise/pull/11716)
+- update rust crate rmcp to v3 by @renovate[bot] in [#11719](https://github.com/jdx/mise/pull/11719)
+- update aube to v1.38.0 by @jdx in [#11759](https://github.com/jdx/mise/pull/11759)
+
+### New Contributors
+
+- @richid made their first contribution in [#11755](https://github.com/jdx/mise/pull/11755)
+- @xqm32 made their first contribution in [#11752](https://github.com/jdx/mise/pull/11752)
+- @cheezmil made their first contribution in [#11748](https://github.com/jdx/mise/pull/11748)
+- @arti5an made their first contribution in [#11725](https://github.com/jdx/mise/pull/11725)
+- @beisenherz made their first contribution in [#11727](https://github.com/jdx/mise/pull/11727)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (6)
+
+- [`babarot/gh-infra`](https://github.com/babarot/gh-infra)
+- [`jolars/arity`](https://github.com/jolars/arity)
+- [`jolars/badness`](https://github.com/jolars/badness)
+- [`jolars/fatou`](https://github.com/jolars/fatou)
+- [`jolars/panache`](https://github.com/jolars/panache)
+- [`matteo-sung/lockvet`](https://github.com/matteo-sung/lockvet)
+
+#### Updated Packages (3)
+
+- [`CircleCI-Public/circleci-cli`](https://github.com/CircleCI-Public/circleci-cli)
+- [`hadolint/hadolint`](https://github.com/hadolint/hadolint)
+- [`smithy-lang/smithy`](https://github.com/smithy-lang/smithy)
+
 ## [2026.8.2](https://github.com/jdx/mise/compare/v2026.8.1..v2026.8.2) - 2026-08-04
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.2"
+version = "2026.8.3"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.2"
+version = "2026.8.3"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.2 macos-arm64 (2026-08-04)
+2026.8.3 macos-arm64 (2026-08-07)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_2.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_3.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_2.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_3.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -P usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_2.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_3.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_2.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_3.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.2";
+  version = "2026.8.3";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "31.5k",
+      stars: "32k",
     };
   },
 };

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.2
+Version: 2026.8.3
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.2"
+version: "2026.8.3"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "a2eb02ad182add07ff0be206084f63398ac0e590"
+  "tag": "6291c29d4783edb5ec04ab7a18be694722720f65"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -2067,9 +2067,21 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("< 1.0.39747-pre")
+        asset: circleci-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: circleci-cli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: circleci-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: circleci
         checksum:
           type: github_release
           asset: circleci-cli_{{trimV .Version}}_checksums.txt
@@ -18508,6 +18520,49 @@ packages:
         checksum:
           type: github_release
           asset: changed-objects_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: babarot
+    repo_name: gh-infra
+    description: Declarative GitHub infrastructure management via YAML
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: gh-infra_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gh-infra_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v0.1.1"
+        asset: gh-infra_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: gh-infra_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gh-infra_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: gh-infra_{{trimV .Version}}_checksums.txt
           algorithm: sha256
         overrides:
           - goos: windows
@@ -47535,7 +47590,7 @@ packages:
           darwin: macos
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
+          asset: checksums.sha256
           algorithm: sha256
         github_artifact_attestations:
           signer_workflow: hadolint/hadolint/\.github/workflows/release\.yml
@@ -53907,6 +53962,199 @@ packages:
           enabled: false
       - version_constraint: semver("< 2.1.3")
         no_asset: true
+  - type: github_release
+    repo_owner: jolars
+    repo_name: arity
+    description: Language server, formatter, and linter for R
+    version_filter: Version startsWith "v"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.0")
+        asset: arity-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.13.0")
+        asset: arity-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: arity-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: jolars/arity/.github/workflows/packages.yml
+  - type: github_release
+    repo_owner: jolars
+    repo_name: badness
+    description: LaTeX language server, formatter, and linter
+    version_filter: Version startsWith "v"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.11.0")
+        asset: badness-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: badness-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: jolars/badness/.github/workflows/packages.yml
+  - type: github_release
+    repo_owner: jolars
+    repo_name: fatou
+    description: Julia language server, formatter, and linter built in Rust
+    version_filter: Version startsWith "v"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.6.0")
+        asset: fatou-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: fatou-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: jolars/fatou/.github/workflows/packages.yml
+  - type: github_release
+    repo_owner: jolars
+    repo_name: panache
+    description: Language server, formatter, and linter for Markdown, Quarto, and R Markdown
+    version_filter: Version startsWith "v"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.20.0")
+        asset: panache-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.60.0")
+        asset: panache-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.61.0")
+        asset: panache-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: jolars/panache/.github/workflows/packages.yml
+      - version_constraint: "true"
+        asset: panache-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: jolars/panache/.github/workflows/packages.yml
   - type: github_release
     repo_owner: jonaslu
     repo_name: ain
@@ -63978,6 +64226,25 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: matteo-sung
+    repo_name: lockvet
+    description: Explain any lockfile change before you merge it — bumps, breaking jumps, new vulns, release ages & deprecations across 30 lockfile formats + SBOMs. CLI, GitHub Action, browser playground, and MCP server so AI assistants can vet PRs too
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: lockvet_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        files:
+          - name: lockvet
+            src: lockvet_{{.Version}}_{{.OS}}_{{.Arch}}/lockvet
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: mattermost
     repo_name: mmctl
@@ -85362,6 +85629,7 @@ packages:
     repo_owner: smithy-lang
     repo_name: smithy
     description: Smithy is a protocol-agnostic interface definition language and set of tools for generating clients, servers, and documentation for any programming language
+    windows_ext: .bat
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.47.0")


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add user-scoped flatpak packages by @jdx in [#11757](https://github.com/jdx/mise/pull/11757)
- **(brew)** support font casks on linux by @jdx in [#11758](https://github.com/jdx/mise/pull/11758)
- **(pipx)** add per-tool registry URL by @jdx in [#11754](https://github.com/jdx/mise/pull/11754)
- **(shim)** add not_found_system_fallback setting by @richid in [#11755](https://github.com/jdx/mise/pull/11755)

### 🐛 Bug Fixes

- **(config)** preserve configured runtime options by @risu729 in [#11550](https://github.com/jdx/mise/pull/11550)
- **(copr)** submit builds without waiting by @jdx in [#11744](https://github.com/jdx/mise/pull/11744)
- **(docs)** replace errant ripgrep url with node url in tool-stub docs by @arti5an in [#11725](https://github.com/jdx/mise/pull/11725)
- **(github)** use published date for release age by @jdx in [#11756](https://github.com/jdx/mise/pull/11756)
- **(lockfile)** create lockfile when explicitly enabled by @jdx in [#11746](https://github.com/jdx/mise/pull/11746)
- **(ls-remote)** suppress minimum_release_age warn during completions by @beisenherz in [#11727](https://github.com/jdx/mise/pull/11727)
- **(python)** skip junctions when syncing installs to uv by @risu729 in [#11683](https://github.com/jdx/mise/pull/11683)
- **(python)** preserve locked precompiled release by @jdx in [#11747](https://github.com/jdx/mise/pull/11747)
- **(rust)** expand tilde in home settings by @xqm32 in [#11752](https://github.com/jdx/mise/pull/11752)
- **(task)** preserve separator for required task args by @jdx in [#11729](https://github.com/jdx/mise/pull/11729)
- **(task)** prefer inline tasks over toml includes by @jdx in [#11734](https://github.com/jdx/mise/pull/11734)
- **(task)** overlay local task metadata by @jdx in [#11745](https://github.com/jdx/mise/pull/11745)
- **(use)** keep multiple tool additions sorted by @jdx in [#11713](https://github.com/jdx/mise/pull/11713)
- **(vfox)** resolve backend aliases for custom plugins by @jdx in [#11736](https://github.com/jdx/mise/pull/11736)
- **(vfox)** cancel http retries on ctrl-c by @jdx in [#11735](https://github.com/jdx/mise/pull/11735)
- handle npm link <package-name> in npm shim (auto-reshim) by @cheezmil in [#11748](https://github.com/jdx/mise/pull/11748)

### 🧪 Testing

- **(npm)** cover embedded aube deprecation output by @jdx in [#11761](https://github.com/jdx/mise/pull/11761)

### 📦️ Dependency Updates

- update ghcr.io/jdx/mise:deb docker digest to c26b116 by @renovate[bot] in [#11717](https://github.com/jdx/mise/pull/11717)
- update ghcr.io/jdx/mise:rpm docker digest to 95e8313 by @renovate[bot] in [#11718](https://github.com/jdx/mise/pull/11718)
- update ghcr.io/jdx/mise:alpine docker digest to bf0245e by @renovate[bot] in [#11716](https://github.com/jdx/mise/pull/11716)
- update rust crate rmcp to v3 by @renovate[bot] in [#11719](https://github.com/jdx/mise/pull/11719)
- update aube to v1.38.0 by @jdx in [#11759](https://github.com/jdx/mise/pull/11759)

### New Contributors

- @richid made their first contribution in [#11755](https://github.com/jdx/mise/pull/11755)
- @xqm32 made their first contribution in [#11752](https://github.com/jdx/mise/pull/11752)
- @cheezmil made their first contribution in [#11748](https://github.com/jdx/mise/pull/11748)
- @arti5an made their first contribution in [#11725](https://github.com/jdx/mise/pull/11725)
- @beisenherz made their first contribution in [#11727](https://github.com/jdx/mise/pull/11727)

## 📦 Aqua Registry Updates

### New Packages (6)

- [`babarot/gh-infra`](https://github.com/babarot/gh-infra)
- [`jolars/arity`](https://github.com/jolars/arity)
- [`jolars/badness`](https://github.com/jolars/badness)
- [`jolars/fatou`](https://github.com/jolars/fatou)
- [`jolars/panache`](https://github.com/jolars/panache)
- [`matteo-sung/lockvet`](https://github.com/matteo-sung/lockvet)

### Updated Packages (3)

- [`CircleCI-Public/circleci-cli`](https://github.com/CircleCI-Public/circleci-cli)
- [`hadolint/hadolint`](https://github.com/hadolint/hadolint)
- [`smithy-lang/smithy`](https://github.com/smithy-lang/smithy)