### PR TITLE
fix(docs): replace errant ripgrep url with node url in tool-stub docs

### DIFF
--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -125,7 +125,7 @@ mise generate tool-stub ./bin/node \
 
 # Auto-detect platform from URL (detects as 'linux-x64')
 mise generate tool-stub ./bin/node \
-  --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-linux-arm64.tar.gz
+  --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-linux-x64.tar.gz
 ```
 
 Or build them incrementally by adding platforms one at a time:

--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -125,7 +125,7 @@ mise generate tool-stub ./bin/node \
 
 # Auto-detect platform from URL (detects as 'linux-x64')
 mise generate tool-stub ./bin/node \
-  --platform-url https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-unknown-linux-musl.tar.gz
+  --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-linux-arm64.tar.gz
 ```
 
 Or build them incrementally by adding platforms one at a time:


### PR DESCRIPTION
While learning about this feature I discovered a mistake in one of the examples and figured I'd submit a correction in case others don't spot it and are confused by the copy/pasted command's behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Linux platform example to reference the Node.js v22.17.1 x64 archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->