### PR TITLE
fix(ls-remote): suppress minimum_release_age warn during completions

### DIFF
--- a/e2e/cli/test_ls_remote
+++ b/e2e/cli/test_ls_remote
@@ -18,6 +18,8 @@ assert "mise ls-remote dummy@sub-1:2" "1.0.0
 assert_contains "mise ls-remote jq --minimum-release-age 2019-01-01" "1.6"
 assert_not_contains "mise ls-remote jq --minimum-release-age 2019-01-01" "1.7.1"
 assert_contains "mise ls-remote jq --minimum-release-age 2019-01-01 2>&1" "newer jq release"
+# usage complete scripts set __USAGE; warn must stay quiet during tab completion
+assert_not_contains "__USAGE=1 mise ls-remote jq --minimum-release-age 2019-01-01 2>&1" "newer jq release"
 assert_contains "mise ls-remote jq --minimum-release-age 2024-01-01" "1.7.1"
 assert_not_empty "mise ls-remote jq --minimum-release-age 1d"
 assert_contains "mise ls-remote jq --before 2019-01-01" "1.6"

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -190,7 +190,8 @@ impl LsRemote {
 }
 
 fn warn_if_versions_hidden_by_minimum_release_age(tool: &str, hidden_versions: usize) {
-    if hidden_versions == 0 {
+    // usage sets __USAGE when running complete scripts; skip so Tab does not spam stderr
+    if hidden_versions == 0 || crate::env::__USAGE.is_some() {
         return;
     }
     let s = if hidden_versions == 1 { "" } else { "s" };


### PR DESCRIPTION
Fixes spam on tab completion when usage invokes ls-remote. 

See https://github.com/jdx/mise/discussions/11723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell completion generation no longer displays version-availability warnings from `mise ls-remote`.
  * Added coverage to ensure completion output remains silent when newer releases are hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->