### PR TITLE
fix(task): preserve separator for required task args

### DIFF
--- a/e2e/tasks/test_task_usage_double_dash
+++ b/e2e/tasks/test_task_usage_double_dash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.extract]
+usage = '''
+arg "[bundletool]" double_dash="required" help="some double dash required arg"
+'''
+run = 'echo "bundletool=$usage_bundletool"'
+EOF
+
+assert "mise run extract -- --mode=universal" "bundletool=--mode=universal"
+# shellcheck disable=SC2016
+assert_fail_contains "mise run extract --mode=universal" \
+  'Argument <bundletool> can only be set after a `--` separator'

--- a/e2e/tasks/test_task_usage_double_dash
+++ b/e2e/tasks/test_task_usage_double_dash
@@ -12,3 +12,22 @@ assert "mise run extract -- --mode=universal" "bundletool=--mode=universal"
 # shellcheck disable=SC2016
 assert_fail_contains "mise run extract --mode=universal" \
   'Argument <bundletool> can only be set after a `--` separator'
+
+cat <<'EOF' >mise.toml
+[tasks.consume]
+usage = 'arg "<bundletool>"'
+run = 'echo "dependency=$usage_bundletool"'
+
+[tasks.extract]
+usage = '''
+cmd "bundle" {
+  arg "[bundletool]" double_dash="required" help="some double dash required arg"
+}
+'''
+depends = [{ task = "consume", args = ["{{usage.bundletool}}"] }]
+run = 'echo "bundletool=$usage_bundletool"'
+EOF
+
+output=$(mise run extract bundle -- --mode=universal 2>&1)
+assert_contains "echo \"$output\"" "dependency=--mode=universal"
+assert_contains "echo \"$output\"" "bundletool=--mode=universal"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -18,7 +18,7 @@ use crate::task::task_helpers::task_needs_permit;
 use crate::task::task_list::{get_task_lists, resolve_depends};
 use crate::task::task_output::TaskOutput;
 use crate::task::task_output_handler::OutputHandler;
-use crate::task::{Deps, Task, TaskCacheMode};
+use crate::task::{Deps, Task, TaskCacheMode, usage_command_for_args};
 use crate::toolset::{InstallOptions, ResolveOptions, ToolVersion, ToolsetBuilder};
 use crate::ui::{ctrlc, info, style};
 use bytesize::ByteSize;
@@ -1404,59 +1404,6 @@ fn display_task_help(task: &Task) -> Result<()> {
 fn render_usage_help(spec: &usage::Spec, args: &[String]) -> String {
     let cmd = usage_command_for_args(spec, args);
     usage::docs::cli::render_help(spec, cmd, true)
-}
-
-fn usage_command_for_args<'a>(spec: &'a usage::Spec, args: &[String]) -> &'a usage::SpecCommand {
-    let mut cmd = &spec.cmd;
-    let mut idx = 0;
-    let mut used_default_subcommand = false;
-
-    while idx < args.len() {
-        let arg = &args[idx];
-        if arg == "-h" || arg == "--help" {
-            break;
-        }
-        if let Some(subcommand) = cmd.find_subcommand(arg) {
-            cmd = subcommand;
-            idx += 1;
-            continue;
-        }
-        if arg.starts_with('-') {
-            if !arg.contains('=')
-                && (flag_takes_value(&spec.cmd, arg) || flag_takes_value(cmd, arg))
-            {
-                idx += 1;
-            }
-            idx += 1;
-            continue;
-        }
-        if !used_default_subcommand
-            && let Some(default_name) = &spec.default_subcommand
-            && let Some(subcommand) = cmd.find_subcommand(default_name)
-        {
-            cmd = subcommand;
-            used_default_subcommand = true;
-            continue;
-        }
-        break;
-    }
-
-    cmd
-}
-
-fn flag_takes_value(cmd: &usage::SpecCommand, flag: &str) -> bool {
-    let flag = flag.split_once('=').map(|(flag, _)| flag).unwrap_or(flag);
-    if let Some(long) = flag.strip_prefix("--") {
-        cmd.flags
-            .iter()
-            .any(|f| f.arg.is_some() && f.long.iter().any(|f| f == long))
-    } else if let Some(short) = flag.strip_prefix('-').and_then(|f| f.chars().next()) {
-        cmd.flags
-            .iter()
-            .any(|f| f.arg.is_some() && f.short.contains(&short))
-    } else {
-        false
-    }
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1111,6 +1111,62 @@ fn normalize_root_mount_node(line: &str) -> String {
     }
 }
 
+pub(crate) fn usage_command_for_args<'a>(
+    spec: &'a usage::Spec,
+    args: &[String],
+) -> &'a usage::SpecCommand {
+    let mut cmd = &spec.cmd;
+    let mut idx = 0;
+    let mut used_default_subcommand = false;
+
+    while idx < args.len() {
+        let arg = &args[idx];
+        if arg == "-h" || arg == "--help" {
+            break;
+        }
+        if let Some(subcommand) = cmd.find_subcommand(arg) {
+            cmd = subcommand;
+            idx += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            if !arg.contains('=')
+                && (usage_flag_takes_value(&spec.cmd, arg) || usage_flag_takes_value(cmd, arg))
+            {
+                idx += 1;
+            }
+            idx += 1;
+            continue;
+        }
+        if !used_default_subcommand
+            && let Some(default_name) = &spec.default_subcommand
+            && let Some(subcommand) = cmd.find_subcommand(default_name)
+        {
+            cmd = subcommand;
+            used_default_subcommand = true;
+            continue;
+        }
+        break;
+    }
+
+    cmd
+}
+
+fn usage_flag_takes_value(cmd: &usage::SpecCommand, flag: &str) -> bool {
+    let flag = flag.split_once('=').map(|(flag, _)| flag).unwrap_or(flag);
+    if let Some(long) = flag.strip_prefix("--") {
+        cmd.flags
+            .iter()
+            .any(|f| f.arg.is_some() && f.long.iter().any(|f| f == long))
+    } else if let Some(short) = flag.strip_prefix('-').and_then(|f| f.chars().next()) {
+        cmd.flags
+            .iter()
+            .any(|f| f.arg.is_some() && f.short.contains(&short))
+    } else {
+        false
+    }
+}
+
 impl Task {
     pub fn config_sources(&self) -> Vec<&Path> {
         once(self.config_source.as_path())
@@ -1690,8 +1746,8 @@ impl Task {
     }
 
     /// Reconstruct the command-line separator clap consumed before populating
-    /// `trailing_args`, so usage can enforce `double_dash="required"`.
-    pub fn args_for_usage_parser(&self, args: &[String]) -> Vec<String> {
+    /// `trailing_args` when the active usage command requires it.
+    pub fn args_for_usage_parser(&self, spec: &usage::Spec, args: &[String]) -> Vec<String> {
         if self.trailing_args.is_empty() {
             return args.to_vec();
         }
@@ -1703,6 +1759,13 @@ impl Task {
         let Some(prefix) = args.strip_suffix(self.trailing_args.as_slice()) else {
             return args.to_vec();
         };
+        if !usage_command_for_args(spec, prefix)
+            .args
+            .iter()
+            .any(|arg| arg.double_dash == usage::SpecDoubleDashChoices::Required)
+        {
+            return args.to_vec();
+        }
 
         prefix
             .iter()
@@ -1844,7 +1907,7 @@ impl Task {
         if !self.should_bypass_usage_parser() && has_any_args_defined(&spec) {
             let mut env = env.clone();
             clear_usage_env(&mut env);
-            let args = self.args_for_usage_parser(args);
+            let args = self.args_for_usage_parser(&spec, args);
             let parser_dir = match cwd {
                 Some(cwd) => Some(cwd),
                 None => self.dir(config).await?,
@@ -3312,7 +3375,7 @@ pub async fn parse_usage_values_from_task(
     }
     // Build args list with empty first element (usage parser expects argv[0] to be the command)
     let args: Vec<String> = once(String::new())
-        .chain(task.args_for_usage_parser(&task.args))
+        .chain(task.args_for_usage_parser(&spec, &task.args))
         .collect();
     let po = match usage::Parser::new(&spec).parse(&args) {
         Ok(po) => po,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1689,6 +1689,29 @@ impl Task {
             .any(|a| a == "--help" || a == "-h")
     }
 
+    /// Reconstruct the command-line separator clap consumed before populating
+    /// `trailing_args`, so usage can enforce `double_dash="required"`.
+    pub fn args_for_usage_parser(&self, args: &[String]) -> Vec<String> {
+        if self.trailing_args.is_empty() {
+            return args.to_vec();
+        }
+
+        debug_assert!(
+            args.ends_with(&self.trailing_args),
+            "task trailing_args must be a suffix of the arguments passed to usage"
+        );
+        let Some(prefix) = args.strip_suffix(self.trailing_args.as_slice()) else {
+            return args.to_vec();
+        };
+
+        prefix
+            .iter()
+            .cloned()
+            .chain(once("--".to_string()))
+            .chain(self.trailing_args.iter().cloned())
+            .collect()
+    }
+
     fn populate_spec_metadata(&self, spec: &mut usage::Spec) {
         spec.name = self.display_name.clone();
         spec.bin = self.display_name.clone();
@@ -1821,13 +1844,14 @@ impl Task {
         if !self.should_bypass_usage_parser() && has_any_args_defined(&spec) {
             let mut env = env.clone();
             clear_usage_env(&mut env);
+            let args = self.args_for_usage_parser(args);
             let parser_dir = match cwd {
                 Some(cwd) => Some(cwd),
                 None => self.dir(config).await?,
             };
             let scripts_only = self.run_script_strings();
             let scripts = Self::make_script_parser(parser_dir, extra_vars)
-                .parse_run_scripts_with_args(config, self, &scripts_only, &env, args, &spec)
+                .parse_run_scripts_with_args(config, self, &scripts_only, &env, &args, &spec)
                 .await?;
             Ok(scripts.into_iter().map(|s| (s, vec![])).collect())
         } else {
@@ -3288,7 +3312,7 @@ pub async fn parse_usage_values_from_task(
     }
     // Build args list with empty first element (usage parser expects argv[0] to be the command)
     let args: Vec<String> = once(String::new())
-        .chain(task.args.iter().cloned())
+        .chain(task.args_for_usage_parser(&task.args))
         .collect();
     let po = match usage::Parser::new(&spec).parse(&args) {
         Ok(po) => po,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1130,9 +1130,18 @@ pub(crate) fn usage_command_for_args<'a>(
             continue;
         }
         if arg.starts_with('-') {
-            if !arg.contains('=')
-                && (usage_flag_takes_value(&spec.cmd, arg) || usage_flag_takes_value(cmd, arg))
+            let flag_takes_value =
+                usage_flag_takes_value(&spec.cmd, arg) || usage_flag_takes_value(cmd, arg);
+            if !flag_takes_value
+                && !used_default_subcommand
+                && let Some(default_name) = &spec.default_subcommand
+                && let Some(subcommand) = cmd.find_subcommand(default_name)
             {
+                cmd = subcommand;
+                used_default_subcommand = true;
+                continue;
+            }
+            if !arg.contains('=') && flag_takes_value {
                 idx += 1;
             }
             idx += 1;
@@ -1759,7 +1768,14 @@ impl Task {
         let Some(prefix) = args.strip_suffix(self.trailing_args.as_slice()) else {
             return args.to_vec();
         };
-        if !usage_command_for_args(spec, prefix)
+        debug_assert!(
+            self.args.ends_with(&self.trailing_args),
+            "task trailing_args must be a suffix of task args"
+        );
+        let Some(task_prefix) = self.args.strip_suffix(self.trailing_args.as_slice()) else {
+            return args.to_vec();
+        };
+        if !usage_command_for_args(spec, task_prefix)
             .args
             .iter()
             .any(|arg| arg.double_dash == usage::SpecDoubleDashChoices::Required)

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -612,14 +612,15 @@ impl TaskExecutor {
         }
 
         let task_file = task.file_path(config).await?;
+        let task_args = task.args_for_usage_parser(&task.args);
         let usage_args = || {
             if let Some(file) = &task_file {
                 once(file.to_string_lossy().to_string())
-                    .chain(task.args.iter().cloned())
+                    .chain(task_args.iter().cloned())
                     .collect()
             } else {
                 once(String::new())
-                    .chain(task.args.iter().cloned())
+                    .chain(task_args.iter().cloned())
                     .collect()
             }
         };

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -612,15 +612,14 @@ impl TaskExecutor {
         }
 
         let task_file = task.file_path(config).await?;
-        let task_args = task.args_for_usage_parser(&task.args);
         let usage_args = || {
             if let Some(file) = &task_file {
                 once(file.to_string_lossy().to_string())
-                    .chain(task_args.iter().cloned())
+                    .chain(task.args.iter().cloned())
                     .collect()
             } else {
                 once(String::new())
-                    .chain(task_args.iter().cloned())
+                    .chain(task.args.iter().cloned())
                     .collect()
             }
         };
@@ -1920,7 +1919,7 @@ impl TaskExecutor {
                 || !spec.cmd.flags.is_empty()
                 || !spec.cmd.subcommands.is_empty())
         {
-            let args: Vec<String> = get_args();
+            let args = task.args_for_usage_parser(&spec, &get_args());
             trace!("Parsing usage spec for {:?}", args);
             // Pass env vars to Parser so it can resolve env= defaults in usage specs
             let env_map: std::collections::HashMap<String, String> =


### PR DESCRIPTION
## Summary

- reconstruct the command-line `--` separator before parsing task usage arguments
- apply the reconstructed argument list consistently during environment initialization, script rendering, and dependency-template usage parsing
- add an end-to-end regression test for `double_dash="required"`

## Root cause

Clap consumes the separator used by `mise run <task> -- ...` and mise stores only the following values in `task.args` plus `task.trailing_args`. After the usage-lib 5 upgrade began enforcing `double_dash="required"`, mise passed the trailing values to usage without the consumed separator, so valid post-separator arguments were rejected as if they appeared before `--`.

## User impact

Tasks declaring `double_dash="required"` once again accept values passed after the separator while still rejecting the same values when no separator is supplied.

Fixes https://github.com/jdx/mise/discussions/11724

## Testing

- `mise run test:e2e tasks/test_task_usage_double_dash`
- `cargo test task::task_script_parser::tests::test_usage_arg_renders -- --nocapture`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core task CLI/usage parsing paths used at run time and for dependency templates; behavior change is scoped to tasks with `double_dash="required"` and trailing args, with regression tests added.
> 
> **Overview**
> Fixes task argument parsing when usage specs declare `double_dash="required"`. Clap strips the `--` from `mise run <task> -- ...`, so mise was feeding only the trailing tokens to usage and valid invocations were rejected.
> 
> **`Task::args_for_usage_parser`** re-inserts `--` before `trailing_args` when the active usage command (including nested subcommands) requires it. That reconstructed argv is used everywhere usage parses task args: script rendering, executor env setup, and `{{usage.*}}` for dependencies.
> 
> **`usage_command_for_args`** moves from `run.rs` into `task/mod.rs` with a tweak: boolean flags that do not take a value can still advance into a default subcommand before parsing stops—so help and subcommand selection stay aligned with the args the user actually passed.
> 
> Adds e2e coverage for plain tasks and for forwarding parsed values into dependency `args`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a22cd7d26b4ca67b706547765d33ad9ff876c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task argument parsing around `--`, including standalone and command-scoped tasks.
  * Required arguments are now correctly accepted after `--` and rejected when supplied before it.
  * Preserved correct handling for task files, empty leading arguments, subcommands, and flags that consume values.
  * Parsed arguments now propagate correctly to dependent tasks.

* **Tests**
  * Added end-to-end coverage for valid and invalid double-dash argument usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->