### PR TITLE
fix(task): prefer inline tasks over toml includes

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1300,6 +1300,11 @@ Global config files are loaded independently, so each global config file uses it
 Entries are evaluated in order, and when more than one include defines a task with the same name the **last** entry in the list wins.
 This applies uniformly to directory, toml-file, and `git::` includes, so to override a task coming from a `git::` include with a local one, list the local directory after the `git::` entry:
 
+An inline `[tasks.<name>]` definition takes precedence over a same-named task
+from an included TOML file. For executable file tasks, the script remains the
+task's command and the inline definition overlays metadata such as its
+description, environment, and dependencies.
+
 ```toml
 [task_config]
 includes = [

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1300,10 +1300,12 @@ Global config files are loaded independently, so each global config file uses it
 Entries are evaluated in order, and when more than one include defines a task with the same name the **last** entry in the list wins.
 This applies uniformly to directory, toml-file, and `git::` includes, so to override a task coming from a `git::` include with a local one, list the local directory after the `git::` entry:
 
-An inline `[tasks.<name>]` definition takes precedence over a same-named task
-from an included TOML file. For executable file tasks, the script remains the
-task's command and the inline definition overlays metadata such as its
-description, environment, and dependencies.
+An inline `[tasks.<name>]` command takes precedence over a same-named task from
+an included TOML file when it comes from the config that selected the include
+or a higher-precedence config. An inline block without `run`, `run_windows`, or
+`file` instead overlays metadata such as description, environment, and
+dependencies. For executable file tasks, the script also remains the task's
+command and the inline definition overlays its metadata.
 
 ```toml
 [task_config]

--- a/e2e/tasks/test_task_toml_include_inline_precedence
+++ b/e2e/tasks/test_task_toml_include_inline_precedence
@@ -1,14 +1,31 @@
 #!/usr/bin/env bash
 
+mkdir -p .config .mise
+
+cat <<'EOF' >metadata-file
+#!/usr/bin/env bash
+echo included metadata file
+EOF
+chmod +x metadata-file
+
 cat <<'EOF' >tasks.toml
 [plain]
 run = "echo included plain"
 
 [with-file]
 file = "does-not-exist"
+
+[metadata]
+run = "echo included metadata"
+
+[metadata-file]
+file = "./metadata-file"
+
+[higher-include]
+run = "echo higher include"
 EOF
 
-cat <<'EOF' >mise.toml
+cat <<'EOF' >.mise/config.toml
 [task_config]
 includes = ["tasks.toml"]
 
@@ -17,6 +34,17 @@ run = "echo inline plain"
 
 [tasks.with-file]
 run = "echo inline file"
+
+[tasks.metadata]
+description = "inline metadata"
+
+[tasks.metadata-file]
+description = "inline file metadata"
+EOF
+
+cat <<'EOF' >.config/mise.toml
+[tasks.higher-include]
+run = "echo lower inline"
 EOF
 
 # Inline tasks override same-named TOML includes, including included tasks
@@ -24,3 +52,34 @@ EOF
 # not be used as task-source provenance.
 assert "mise run plain" "inline plain"
 assert "mise run with-file" "inline file"
+
+# An inline block without its own command decorates the included task instead
+# of replacing its command with an empty task.
+assert "mise run metadata" "included metadata"
+assert_contains "mise tasks metadata" "inline metadata"
+assert "mise run metadata-file" "included metadata file"
+assert_contains "mise tasks metadata-file" "inline file metadata"
+
+# A lower-precedence config cannot replace a TOML task included by a
+# higher-precedence config.
+assert "mise run higher-include" "higher include"
+
+# Conversely, a higher-precedence inline task overrides a TOML include selected
+# by a lower-precedence config.
+cat <<'EOF' >.mise/config.toml
+[tasks.higher-inline]
+run = "echo higher inline"
+EOF
+
+cat <<'EOF' >.config/mise.toml
+[task_config]
+includes = ["tasks.toml"]
+EOF
+
+cat <<'EOF' >>tasks.toml
+
+[higher-inline]
+run = "echo lower include"
+EOF
+
+assert "mise run higher-inline" "higher inline"

--- a/e2e/tasks/test_task_toml_include_inline_precedence
+++ b/e2e/tasks/test_task_toml_include_inline_precedence
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >tasks.toml
+[plain]
+run = "echo included plain"
+
+[with-file]
+file = "does-not-exist"
+EOF
+
+cat <<'EOF' >mise.toml
+[task_config]
+includes = ["tasks.toml"]
+
+[tasks.plain]
+run = "echo inline plain"
+
+[tasks.with-file]
+run = "echo inline file"
+EOF
+
+# Inline tasks override same-named TOML includes, including included tasks
+# whose execution type sets `file`. That field describes execution and must
+# not be used as task-source provenance.
+assert "mise run plain" "inline plain"
+assert "mise run with-file" "inline file"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3699,11 +3699,17 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
         if !seen_config_task_names.insert(t.name.clone()) {
             continue;
         }
-        if by_name
-            .get(&t.name)
-            .is_some_and(|existing| existing.is_toml_include)
+        if let Some(existing) = by_name
+            .get_mut(&t.name)
+            .filter(|existing| existing.is_toml_include)
         {
-            by_name.insert(t.name.clone(), t);
+            if t.config_precedence <= existing.config_precedence {
+                if t.run.is_empty() && t.run_windows.is_empty() && t.file.is_none() {
+                    existing.merge_toml_overlay(t);
+                } else {
+                    *existing = t;
+                }
+            }
         } else if let Some(existing) = by_name.get_mut(&t.name) {
             if existing.file.is_some() {
                 existing.merge_toml_overlay(t);
@@ -4384,10 +4390,11 @@ async fn load_task_sources_from_configs(
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
-    let (includes, resolve_dir) = configs
+    let (includes, resolve_dir, include_config_precedence) = configs
         .iter()
-        .find_map(|cf| match cf.task_config_includes() {
-            Ok(Some(includes)) => Some(Ok((includes, cf.config_root()))),
+        .enumerate()
+        .find_map(|(precedence, cf)| match cf.task_config_includes() {
+            Ok(Some(includes)) => Some(Ok((includes, cf.config_root(), precedence))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         })
@@ -4397,10 +4404,10 @@ async fn load_task_sources_from_configs(
                 tc.task_config
                     .includes
                     .clone()
-                    .map(|includes| (includes, tc.includes_root.clone()))
+                    .map(|includes| (includes, tc.includes_root.clone(), configs.len()))
             })
         })
-        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf()));
+        .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), configs.len()));
 
     // Resolve task defaults once for the config root so inline tasks from
     // lower-precedence overlay files use the same defaults as file tasks.
@@ -4425,20 +4432,22 @@ async fn load_task_sources_from_configs(
     };
 
     let mut config_tasks = vec![];
-    for cf in &configs {
+    for (precedence, cf) in configs.iter().enumerate() {
         let dir = dir.to_path_buf();
         let monorepo_cf = monorepo_context.then_some(*cf);
-        config_tasks.extend(
-            load_config_tasks(
-                config,
-                (*cf).clone(),
-                &dir,
-                templates,
-                monorepo_cf,
-                &task_config,
-            )
-            .await?,
-        );
+        let mut loaded = load_config_tasks(
+            config,
+            (*cf).clone(),
+            &dir,
+            templates,
+            monorepo_cf,
+            &task_config,
+        )
+        .await?;
+        for task in &mut loaded {
+            task.config_precedence = precedence;
+        }
+        config_tasks.extend(loaded);
     }
 
     let mut file_tasks = vec![];
@@ -4468,6 +4477,9 @@ async fn load_task_sources_from_configs(
             )
             .await?;
             for task in &mut loaded {
+                if task.is_toml_include {
+                    task.config_precedence = include_config_precedence;
+                }
                 apply_task_config_inputs(task, config, &task_config.inputs).await?;
                 apply_task_config_cache_default(task, &task_config.cache);
                 task_config.environment.apply(task)?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3678,11 +3678,12 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
 /// files) with inline `[tasks.*]` blocks.
 ///
 /// `config_tasks` are collected in config-file precedence order (highest first).
-/// When a name appears in both a script file task
-/// (`file.is_some()`) and an inline block, the script stays as the base and the
-/// TOML block is overlaid via [`Task::merge_toml_overlay`]. When the same name
-/// appears in multiple inline blocks (e.g. `.config/mise.toml` and
-/// `.mise/config.toml`), the first entry wins and later ones are skipped.
+/// When a name appears in both an executable script task and an inline block,
+/// the script stays as the base and the TOML block is overlaid via
+/// [`Task::merge_toml_overlay`]. An inline block replaces a same-named task from
+/// an included TOML file. When the same name appears in multiple inline blocks
+/// (e.g. `.config/mise.toml` and `.mise/config.toml`), the first entry wins and
+/// later ones are skipped.
 /// When the same name appears in more than one file task (e.g. a local
 /// `.mise/tasks` script and a same-named task from a `git::` include), the last
 /// one wins. Callers load `file_tasks` in declared `task_config.includes`
@@ -3698,7 +3699,12 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
         if !seen_config_task_names.insert(t.name.clone()) {
             continue;
         }
-        if let Some(existing) = by_name.get_mut(&t.name) {
+        if by_name
+            .get(&t.name)
+            .is_some_and(|existing| existing.is_toml_include)
+        {
+            by_name.insert(t.name.clone(), t);
+        } else if let Some(existing) = by_name.get_mut(&t.name) {
             if existing.file.is_some() {
                 existing.merge_toml_overlay(t);
             }
@@ -4521,6 +4527,7 @@ async fn load_task_file(
         task.name = name.clone();
         task.config_source = path.to_path_buf();
         task.config_root = Some(config_root.to_path_buf());
+        task.is_toml_include = true;
         if let Some(monorepo_cf) = monorepo_cf {
             task.cf = Some(monorepo_cf.clone());
         }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -695,6 +695,12 @@ pub struct Task {
     #[serde(skip)]
     pub(crate) is_toml_include: bool,
 
+    /// Relative precedence of the config that defined this task or selected
+    /// its TOML include. Lower values have higher precedence. This is scoped
+    /// to one config root and is only used while task sources are merged.
+    #[serde(skip)]
+    pub(crate) config_precedence: usize,
+
     // Store the original remote file source (git::/http:/https:) before it's replaced with local path
     // This is used to determine if the task should use monorepo config file context
     #[serde(skip)]
@@ -2984,6 +2990,7 @@ impl Default for Task {
             args: vec![],
             file: None,
             is_toml_include: false,
+            config_precedence: usize::MAX,
             quiet: false,
             tools: Default::default(),
             usage: "".to_string(),

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -687,6 +687,14 @@ pub struct Task {
     #[serde(default)]
     pub file: Option<PathBuf>,
 
+    /// This task was loaded from a TOML file in `task_config.includes`.
+    ///
+    /// Included TOML tasks and executable file tasks share the same loading
+    /// pipeline, but inline config tasks override the former while only
+    /// contributing metadata to the latter.
+    #[serde(skip)]
+    pub(crate) is_toml_include: bool,
+
     // Store the original remote file source (git::/http:/https:) before it's replaced with local path
     // This is used to determine if the task should use monorepo config file context
     #[serde(skip)]
@@ -2975,6 +2983,7 @@ impl Default for Task {
             run_windows: vec![],
             args: vec![],
             file: None,
+            is_toml_include: false,
             quiet: false,
             tools: Default::default(),
             usage: "".to_string(),


### PR DESCRIPTION
## Summary

- track whether tasks came from TOML files in `task_config.includes`
- let inline `[tasks.<name>]` definitions replace same-named TOML includes
- preserve metadata-overlay behavior for executable file tasks
- document the precedence and add regression coverage, including an imported task with `file` set

## Root cause

Included TOML tasks and executable file tasks shared the same `file_tasks` pipeline, while the merge logic used `Task.file` as a proxy for source provenance. TOML includes normally leave `file` unset, so a same-named inline task was silently discarded. An included TOML task can also explicitly set `file`, making that field unsuitable as a provenance marker.

This addresses [discussion #11730](https://github.com/jdx/mise/discussions/11730).

## Verification

- `mise run test:e2e tasks/test_task_toml_include_inline_precedence tasks/test_task_file_toml_merge tasks/test_task_config_precedence`
- `mise run lint-fix`
- `hk fix docs/tasks/task-configuration.md`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task discovery/merge behavior for all projects using `task_config.includes` and inline tasks; wrong precedence could change which command runs, though behavior aligns with documented intent and is covered by new e2e tests.
> 
> **Overview**
> Fixes task merging so inline `[tasks.<name>]` blocks are no longer dropped when a same-named task comes from an included TOML file. The loader now marks included TOML tasks with **`is_toml_include`** and records **`config_precedence`** on inline and included tasks so merge logic can tell TOML includes apart from executable file tasks (which still use **`merge_toml_overlay`** for metadata).
> 
> When names collide, a higher-precedence inline task **replaces** the included TOML task if it defines `run`, `run_windows`, or `file`; an inline block with only metadata **overlays** the included command instead of wiping it. Included TOML tasks that set `file` for execution are treated like other includes, not as file-task provenance. A lower-precedence config cannot override a TOML task selected by a higher-precedence config’s includes.
> 
> Documentation in **`task-configuration.md`** describes these rules, and a new e2e test covers inline override, metadata overlay, `file` on includes, and cross-config precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3dac738023865bdb71fc38e16a73aa76e1d3954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline task definitions now take precedence over same-named tasks from included TOML files.
  * Executable file-based tasks retain their scripts while receiving supported metadata overlays, including descriptions, environment variables, and dependencies.

* **Documentation**
  * Added documentation explaining task name conflict and precedence rules.

* **Tests**
  * Added end-to-end coverage for inline task precedence, including tasks configured from executable files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->