### PR TITLE
fix(vfox): cancel http retries on ctrl-c

### DIFF
--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -48,7 +48,13 @@ serde = "1"
 serde_json = "1"
 toml = "1.0"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "fs", "io-util", "time"] }
+tokio = { version = "1", features = [
+  "macros",
+  "fs",
+  "io-util",
+  "sync",
+  "time",
+] }
 url = "2"
 xx = { version = "2", default-features = false, features = [
   "archive",

--- a/crates/vfox/src/http.rs
+++ b/crates/vfox/src/http.rs
@@ -10,19 +10,43 @@ pub static CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .expect("Failed to create reqwest client")
 });
 
-static HTTP_CANCELLED: LazyLock<watch::Sender<bool>> = LazyLock::new(|| watch::channel(false).0);
+static HTTP_CANCELLATION: LazyLock<HttpCancellation> = LazyLock::new(Default::default);
+
+#[derive(Clone)]
+pub(crate) struct HttpCancellation {
+    generation: watch::Sender<u64>,
+}
+
+impl Default for HttpCancellation {
+    fn default() -> Self {
+        Self {
+            generation: watch::channel(0).0,
+        }
+    }
+}
+
+impl HttpCancellation {
+    pub(crate) fn cancel(&self) {
+        self.generation
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        let mut generation = self.generation.subscribe();
+        let current = *generation.borrow_and_update();
+        let _ = generation
+            .wait_for(|generation| *generation != current)
+            .await;
+    }
+}
 
 /// Cancel in-flight HTTP operations started by vfox plugins.
 pub fn cancel_http_requests() {
-    HTTP_CANCELLED.send_replace(true);
+    HTTP_CANCELLATION.cancel();
 }
 
-pub(crate) async fn http_requests_cancelled() {
-    let mut cancelled = HTTP_CANCELLED.subscribe();
-    if *cancelled.borrow() {
-        return;
-    }
-    let _ = cancelled.wait_for(|cancelled| *cancelled).await;
+pub(crate) fn http_cancellation() -> &'static HttpCancellation {
+    &HTTP_CANCELLATION
 }
 
 /// Default retry attempts when MISE_HTTP_RETRIES is unset. Mirrors the

--- a/crates/vfox/src/http.rs
+++ b/crates/vfox/src/http.rs
@@ -1,6 +1,7 @@
 use reqwest::{Client, ClientBuilder, StatusCode};
 use std::sync::LazyLock;
 use std::time::Duration;
+use tokio::sync::watch;
 
 pub static CLIENT: LazyLock<Client> = LazyLock::new(|| {
     ClientBuilder::new()
@@ -8,6 +9,21 @@ pub static CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .build()
         .expect("Failed to create reqwest client")
 });
+
+static HTTP_CANCELLED: LazyLock<watch::Sender<bool>> = LazyLock::new(|| watch::channel(false).0);
+
+/// Cancel in-flight HTTP operations started by vfox plugins.
+pub fn cancel_http_requests() {
+    HTTP_CANCELLED.send_replace(true);
+}
+
+pub(crate) async fn http_requests_cancelled() {
+    let mut cancelled = HTTP_CANCELLED.subscribe();
+    if *cancelled.borrow() {
+        return;
+    }
+    let _ = cancelled.wait_for(|cancelled| *cancelled).await;
+}
 
 /// Default retry attempts when MISE_HTTP_RETRIES is unset. Mirrors the
 /// `http_retries` setting default in the main mise crate.

--- a/crates/vfox/src/http.rs
+++ b/crates/vfox/src/http.rs
@@ -14,29 +14,36 @@ static HTTP_CANCELLATION: LazyLock<HttpCancellation> = LazyLock::new(Default::de
 
 #[derive(Clone)]
 pub(crate) struct HttpCancellation {
-    generation: watch::Sender<u64>,
+    signal: watch::Sender<()>,
+}
+
+pub(crate) struct HttpCancellationReceiver {
+    signal: watch::Receiver<()>,
 }
 
 impl Default for HttpCancellation {
     fn default() -> Self {
         Self {
-            generation: watch::channel(0).0,
+            signal: watch::channel(()).0,
         }
     }
 }
 
 impl HttpCancellation {
     pub(crate) fn cancel(&self) {
-        self.generation
-            .send_modify(|generation| *generation = generation.wrapping_add(1));
+        self.signal.send_replace(());
     }
 
-    pub(crate) async fn cancelled(&self) {
-        let mut generation = self.generation.subscribe();
-        let current = *generation.borrow_and_update();
-        let _ = generation
-            .wait_for(|generation| *generation != current)
-            .await;
+    pub(crate) fn subscribe(&self) -> HttpCancellationReceiver {
+        HttpCancellationReceiver {
+            signal: self.signal.subscribe(),
+        }
+    }
+}
+
+impl HttpCancellationReceiver {
+    pub(crate) async fn cancelled(&mut self) {
+        let _ = self.signal.changed().await;
     }
 }
 

--- a/crates/vfox/src/lib.rs
+++ b/crates/vfox/src/lib.rs
@@ -18,6 +18,8 @@ pub use plugin::Plugin;
 pub use vfox::InstallResult;
 pub use vfox::Vfox;
 
+pub use http::cancel_http_requests;
+
 mod config;
 mod context;
 pub mod embedded_plugins;

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -14,7 +14,8 @@ async fn cancel_on_interrupt<T, F>(operation: F) -> Result<T>
 where
     F: Future<Output = std::result::Result<T, reqwest::Error>>,
 {
-    cancel_on_signal(operation, http_cancellation().cancelled()).await
+    let mut cancellation = http_cancellation().subscribe();
+    cancel_on_signal(operation, cancellation.cancelled()).await
 }
 
 async fn cancel_on_signal<T, F, C>(operation: F, cancelled: C) -> Result<T>
@@ -199,6 +200,7 @@ async fn get_with_cancellation(
     input: Table,
     cancellation: &HttpCancellation,
 ) -> Result<Table> {
+    let mut cancellation = cancellation.subscribe();
     let url: String = input.get("url").into_lua_err()?;
     let headers = match input.get::<Option<Table>>("headers").into_lua_err()? {
         Some(tbl) => into_headers(&tbl)?,
@@ -265,13 +267,27 @@ async fn head(lua: &Lua, input: Table) -> Result<Table> {
 }
 
 async fn try_get(lua: &Lua, input: Table) -> Result<MultiValue> {
+    try_get_with_cancellation(lua, input, http_cancellation()).await
+}
+
+async fn try_get_with_cancellation(
+    lua: &Lua,
+    input: Table,
+    cancellation: &HttpCancellation,
+) -> Result<MultiValue> {
+    let mut cancellation = cancellation.subscribe();
     let url: String = input.get("url").into_lua_err()?;
     let headers = match input.get::<Option<Table>>("headers").into_lua_err()? {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = match cancel_on_interrupt(send_with_retry(CLIENT.get(&url).headers(headers))).await {
+    let resp = match cancel_on_signal(
+        send_with_retry(CLIENT.get(&url).headers(headers)),
+        cancellation.cancelled(),
+    )
+    .await
+    {
         Ok(resp) => resp,
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
@@ -283,7 +299,7 @@ async fn try_get(lua: &Lua, input: Table) -> Result<MultiValue> {
     let t = lua.create_table()?;
     t.set("status_code", resp.status().as_u16())?;
     t.set("headers", get_headers(lua, resp.headers())?)?;
-    match cancel_on_interrupt(resp.text()).await {
+    match cancel_on_signal(resp.text(), cancellation.cancelled()).await {
         Ok(body) => t.set("body", body)?,
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
@@ -422,6 +438,11 @@ mod tests {
             let (mut stream, _) = listener.accept().unwrap();
             let mut request = [0; 1024];
             stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n")
+                .unwrap();
+            stream.flush().unwrap();
+            thread::sleep(Duration::from_millis(50));
             trigger.cancel();
             release_rx.recv().unwrap();
         });
@@ -434,8 +455,9 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.to_string(), "runtime error: interrupted");
+        let mut later = cancellation.subscribe();
         assert!(
-            tokio::time::timeout(Duration::from_millis(10), cancellation.cancelled())
+            tokio::time::timeout(Duration::from_millis(10), later.cancelled())
                 .await
                 .is_err(),
             "a later operation should wait for the next cancellation generation"

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -6,15 +6,15 @@ use reqwest::{RequestBuilder, Response};
 use url::Url;
 
 use crate::http::{
-    CLIENT, http_requests_cancelled, http_retry_attempts, is_transient, retry_async, retry_delay,
-    should_retry_status,
+    CLIENT, HttpCancellation, http_cancellation, http_retry_attempts, is_transient, retry_async,
+    retry_delay, should_retry_status,
 };
 
 async fn cancel_on_interrupt<T, F>(operation: F) -> Result<T>
 where
     F: Future<Output = std::result::Result<T, reqwest::Error>>,
 {
-    cancel_on_signal(operation, http_requests_cancelled()).await
+    cancel_on_signal(operation, http_cancellation().cancelled()).await
 }
 
 async fn cancel_on_signal<T, F, C>(operation: F, cancelled: C) -> Result<T>
@@ -191,17 +191,29 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
 }
 
 async fn get(lua: &Lua, input: Table) -> Result<Table> {
+    get_with_cancellation(lua, input, http_cancellation()).await
+}
+
+async fn get_with_cancellation(
+    lua: &Lua,
+    input: Table,
+    cancellation: &HttpCancellation,
+) -> Result<Table> {
     let url: String = input.get("url").into_lua_err()?;
     let headers = match input.get::<Option<Table>>("headers").into_lua_err()? {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = cancel_on_interrupt(send_with_retry(CLIENT.get(&url).headers(headers))).await?;
+    let resp = cancel_on_signal(
+        send_with_retry(CLIENT.get(&url).headers(headers)),
+        cancellation.cancelled(),
+    )
+    .await?;
     let t = lua.create_table()?;
     t.set("status_code", resp.status().as_u16())?;
     t.set("headers", get_headers(lua, resp.headers())?)?;
-    let body = cancel_on_interrupt(resp.text()).await?;
+    let body = cancel_on_signal(resp.text(), cancellation.cancelled()).await?;
     t.set("body", body)?;
     Ok(t)
 }
@@ -391,23 +403,45 @@ fn get_headers(lua: &Lua, headers: &reqwest::header::HeaderMap) -> Result<Table>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::future;
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    use std::sync::mpsc;
     use std::thread;
+    use std::time::Duration;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
     async fn test_http_operation_is_cancelled_on_interrupt() {
-        let err = cancel_on_signal(
-            future::pending::<std::result::Result<(), reqwest::Error>>(),
-            future::ready(()),
-        )
-        .await
-        .unwrap_err();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/pending", listener.local_addr().unwrap());
+        let cancellation = HttpCancellation::default();
+        let trigger = cancellation.clone();
+        let (release_tx, release_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            stream.read(&mut request).unwrap();
+            trigger.cancel();
+            release_rx.recv().unwrap();
+        });
+
+        let lua = Lua::new();
+        let input = lua.create_table().unwrap();
+        input.set("url", url).unwrap();
+        let err = get_with_cancellation(&lua, input, &cancellation)
+            .await
+            .unwrap_err();
 
         assert_eq!(err.to_string(), "runtime error: interrupted");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), cancellation.cancelled())
+                .await
+                .is_err(),
+            "a later operation should wait for the next cancellation generation"
+        );
+        release_tx.send(()).unwrap();
+        server.join().unwrap();
     }
 
     #[tokio::test]

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -1,11 +1,32 @@
+use std::future::Future;
+
 use mlua::{BorrowedStr, ExternalResult, Lua, MultiValue, Result, Table, Value};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
 use reqwest::{RequestBuilder, Response};
 use url::Url;
 
 use crate::http::{
-    CLIENT, http_retry_attempts, is_transient, retry_async, retry_delay, should_retry_status,
+    CLIENT, http_requests_cancelled, http_retry_attempts, is_transient, retry_async, retry_delay,
+    should_retry_status,
 };
+
+async fn cancel_on_interrupt<T, F>(operation: F) -> Result<T>
+where
+    F: Future<Output = std::result::Result<T, reqwest::Error>>,
+{
+    cancel_on_signal(operation, http_requests_cancelled()).await
+}
+
+async fn cancel_on_signal<T, F, C>(operation: F, cancelled: C) -> Result<T>
+where
+    F: Future<Output = std::result::Result<T, reqwest::Error>>,
+    C: Future<Output = ()>,
+{
+    tokio::select! {
+        result = operation => result.into_lua_err(),
+        () = cancelled => Err(mlua::Error::runtime("interrupted")),
+    }
+}
 
 async fn send_with_retry(builder: RequestBuilder) -> std::result::Result<Response, reqwest::Error> {
     let url = builder
@@ -176,13 +197,12 @@ async fn get(lua: &Lua, input: Table) -> Result<Table> {
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = send_with_retry(CLIENT.get(&url).headers(headers))
-        .await
-        .into_lua_err()?;
+    let resp = cancel_on_interrupt(send_with_retry(CLIENT.get(&url).headers(headers))).await?;
     let t = lua.create_table()?;
     t.set("status_code", resp.status().as_u16())?;
     t.set("headers", get_headers(lua, resp.headers())?)?;
-    t.set("body", resp.text().await.into_lua_err()?)?;
+    let body = cancel_on_interrupt(resp.text()).await?;
+    t.set("body", body)?;
     Ok(t)
 }
 
@@ -197,13 +217,12 @@ async fn download_file(lua: &Lua, input: MultiValue) -> Result<()> {
     let path: String = input.iter().nth(1).unwrap().to_string()?;
     // Retry the whole flow (request + body) so a mid-stream drop restarts the
     // download instead of failing.
-    let bytes = retry_async(&url, || async {
+    let bytes = cancel_on_interrupt(retry_async(&url, || async {
         let resp = CLIENT.get(&url).headers(headers.clone()).send().await?;
         let resp = resp.error_for_status()?;
         resp.bytes().await
-    })
-    .await
-    .into_lua_err()?;
+    }))
+    .await?;
     // Create the parent directory so plugins don't have to shell out to `mkdir`
     // before downloading into a fresh install path.
     if let Some(parent) = std::path::Path::new(&path).parent() {
@@ -226,9 +245,7 @@ async fn head(lua: &Lua, input: Table) -> Result<Table> {
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = send_with_retry(CLIENT.head(&url).headers(headers))
-        .await
-        .into_lua_err()?;
+    let resp = cancel_on_interrupt(send_with_retry(CLIENT.head(&url).headers(headers))).await?;
     let t = lua.create_table()?;
     t.set("status_code", resp.status().as_u16())?;
     t.set("headers", get_headers(lua, resp.headers())?)?;
@@ -242,7 +259,7 @@ async fn try_get(lua: &Lua, input: Table) -> Result<MultiValue> {
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = match send_with_retry(CLIENT.get(&url).headers(headers)).await {
+    let resp = match cancel_on_interrupt(send_with_retry(CLIENT.get(&url).headers(headers))).await {
         Ok(resp) => resp,
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
@@ -254,7 +271,7 @@ async fn try_get(lua: &Lua, input: Table) -> Result<MultiValue> {
     let t = lua.create_table()?;
     t.set("status_code", resp.status().as_u16())?;
     t.set("headers", get_headers(lua, resp.headers())?)?;
-    match resp.text().await {
+    match cancel_on_interrupt(resp.text()).await {
         Ok(body) => t.set("body", body)?,
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
@@ -273,7 +290,8 @@ async fn try_head(lua: &Lua, input: Table) -> Result<MultiValue> {
         None => HeaderMap::default(),
     };
     let headers = add_default_headers(lua, &url, headers);
-    let resp = match send_with_retry(CLIENT.head(&url).headers(headers)).await {
+    let resp = match cancel_on_interrupt(send_with_retry(CLIENT.head(&url).headers(headers))).await
+    {
         Ok(resp) => resp,
         Err(e) => {
             return Ok(MultiValue::from_vec(vec![
@@ -313,11 +331,11 @@ async fn try_download_file(lua: &Lua, input: MultiValue) -> Result<MultiValue> {
             ]));
         }
     };
-    let bytes = match retry_async(&url, || async {
+    let bytes = match cancel_on_interrupt(retry_async(&url, || async {
         let resp = CLIENT.get(&url).headers(headers.clone()).send().await?;
         let resp = resp.error_for_status()?;
         resp.bytes().await
-    })
+    }))
     .await
     {
         Ok(bytes) => bytes,
@@ -373,11 +391,24 @@ fn get_headers(lua: &Lua, headers: &reqwest::header::HeaderMap) -> Result<Table>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn test_http_operation_is_cancelled_on_interrupt() {
+        let err = cancel_on_signal(
+            future::pending::<std::result::Result<(), reqwest::Error>>(),
+            future::ready(()),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "runtime error: interrupted");
+    }
 
     #[tokio::test]
     async fn test_get() {

--- a/src/ui/ctrlc.rs
+++ b/src/ui/ctrlc.rs
@@ -17,6 +17,7 @@ pub async fn exit_signal() -> i32 {
         // Record the first task-mode interrupt before signalling children so
         // their exit handlers can distinguish cancellation from task failure.
         let should_exit = EXIT.load(Ordering::Relaxed) || CANCELLED.swap(true, Ordering::Relaxed);
+        vfox::cancel_http_requests();
         CmdLineRunner::kill_all(nix::sys::signal::SIGINT);
         if should_exit {
             debug!("Ctrl-C pressed, exiting...");


### PR DESCRIPTION
## Summary

- propagate mise cancellation into vfox plugin HTTP operations
- interrupt requests, response-body reads, and retry backoff immediately on Ctrl-C
- add focused coverage for cancellation of a pending HTTP operation

## Root cause

Mise handled Ctrl-C at the command level and signalled child processes, but vfox's in-process Lua HTTP operations had no explicit cancellation signal. A plugin waiting through transient HTTP retries could therefore remain inside request or backoff work instead of stopping promptly.

## User impact

Shell activation and other mise commands using vfox backend plugins no longer wait through HTTP retry schedules after Ctrl-C.

## Validation

- `mise --cd crates/vfox run test`
- `mise --cd crates/vfox run lint`
- `cargo check --workspace --all-features --all-targets`
- `mise run lint-fix`

Related: https://github.com/jdx/mise/discussions/11731

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized interrupt plumbing on the vfox Lua HTTP path; no auth or data-model changes, though retry backoff inside existing retry loops is not separately cancelled mid-sleep.
> 
> **Overview**
> **Ctrl-C now stops vfox plugin HTTP work** instead of leaving Lua-backed requests (and their retries) running while mise tears down.
> 
> The vfox crate adds a global **`HttpCancellation`** signal (`tokio::sync::watch`) and exports **`cancel_http_requests()`**, which mise invokes from **`exit_signal`** on each Ctrl-C before signalling child processes. Plugin **`http`** helpers (`get`, `head`, downloads, and `try_*` variants) race network I/O against that signal via **`tokio::select!`**, surfacing a Lua **`interrupted`** runtime error when cancellation wins—including while reading response bodies.
> 
> A focused test exercises cancellation during a pending **`get`**, and **`tokio`** gains the **`sync`** feature for the watch channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2320ecb2b0b9068e60f38f04cb1f7a69f77c0b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation support for active HTTP requests, downloads, and response-body reads.
  * Ctrl-C now interrupts in-progress network operations before exiting.
* **Bug Fixes**
  * Interrupted operations now report a clear error while preserving expected error-return formats.
  * Cancellation takes precedence over pending requests without disrupting retry behavior.
  * Improved consistency when cancellation occurs during request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->