### PR TITLE
fix(vfox): resolve backend aliases for custom plugins

### DIFF
--- a/e2e/plugins/test_plugins_section_local
+++ b/e2e/plugins/test_plugins_section_local
@@ -143,3 +143,53 @@ EOF
   [[ ! -L "$MISE_DATA_DIR/plugins/local-path-ref" ]]
   [[ -d "$MISE_DATA_DIR/plugins/local-path-ref/.git" ]]
 )
+
+mkdir backend-alias-case
+(
+  cd backend-alias-case
+  mkdir -p local-backend/hooks
+  cat >local-backend/metadata.lua <<'EOF'
+PLUGIN = {}
+PLUGIN.name = "chainguard"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = ""
+PLUGIN.license = "Apache 2.0"
+PLUGIN.description = "Backend alias test plugin"
+PLUGIN.minRuntimeVersion = "0.3.0"
+PLUGIN.notes = {}
+PLUGIN.legacyFilenames = {}
+EOF
+  cat >local-backend/hooks/backend_list_versions.lua <<'EOF'
+function PLUGIN:BackendListVersions(ctx)
+  if ctx.tool == "jq" then
+    return { versions = { "1.7.1" } }
+  end
+  return { versions = {} }
+end
+EOF
+  cat >local-backend/hooks/backend_install.lua <<'EOF'
+function PLUGIN:BackendInstall(ctx)
+  return {}
+end
+EOF
+  cat >local-backend/hooks/backend_exec_env.lua <<'EOF'
+function PLUGIN:BackendExecEnv(ctx)
+  return { env_vars = {} }
+end
+EOF
+  cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[plugins]
+"vfox-backend:chainguard" = "$PWD/local-backend"
+
+[tool_alias]
+jq = "chainguard:jq"
+EOF
+  cat >mise.toml <<'EOF'
+[tools]
+jq = "latest"
+EOF
+
+  mise plugin install chainguard
+  mise install
+  assert "mise ls-remote jq" "1.7.1"
+)

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -497,12 +497,9 @@ impl VfoxBackend {
         plugin.full = Some(ba.full());
         let plugin = Arc::new(plugin);
 
-        // Extract tool name for plugin:tool format
-        let tool_name = if ba.short.contains(':') {
-            ba.short.split_once(':').map(|(_, tool)| tool.to_string())
-        } else {
-            None
-        };
+        // Extract the tool name from the resolved backend so aliases from a bare
+        // name to a backend plugin still provide the plugin:tool identifier.
+        let tool_name = backend_plugin_name.as_ref().map(|_| ba.tool_name());
 
         Self {
             exec_env_cache: Default::default(),

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -209,6 +209,19 @@ fn parse_backend_components_fallible(
     Ok((short, tool_name.to_string(), opts))
 }
 
+fn plugin_backend_type(identifier: &str) -> Option<BackendType> {
+    let (plugin_name, _tool_name) = identifier.split_once(':')?;
+    if config::is_loaded() && Config::get_().get_repo_url(plugin_name).is_some() {
+        return Some(BackendType::VfoxBackend(plugin_name.to_string()));
+    }
+    install_state::get_plugin_type(plugin_name).map(|plugin_type| match plugin_type {
+        PluginType::Vfox => BackendType::Vfox,
+        PluginType::VfoxBackend => BackendType::VfoxBackend(plugin_name.to_string()),
+        PluginType::Asdf => BackendType::Asdf,
+        PluginType::Package => BackendType::Unknown,
+    })
+}
+
 impl BackendArg {
     pub fn matches_bin_name(&self, bin_name: &str) -> bool {
         let exe_suffix = std::env::consts::EXE_SUFFIX;
@@ -365,19 +378,9 @@ impl BackendArg {
         }
 
         // Then check if this is a vfox plugin:tool format
-        if let Some((plugin_name, _tool_name)) = self.short.split_once(':') {
-            // we cannot reliably determine backend type within install state so we check config first
-            if config::is_loaded() && Config::get_().get_repo_url(plugin_name).is_some() {
-                return BackendType::VfoxBackend(plugin_name.to_string());
-            }
-            if let Some(plugin_type) = install_state::get_plugin_type(plugin_name) {
-                return match plugin_type {
-                    PluginType::Vfox => BackendType::Vfox,
-                    PluginType::VfoxBackend => BackendType::VfoxBackend(plugin_name.to_string()),
-                    PluginType::Asdf => BackendType::Asdf,
-                    PluginType::Package => BackendType::Unknown,
-                };
-            }
+        // We cannot reliably determine backend type within install state so we check config first.
+        if let Some(backend_type) = plugin_backend_type(&self.short) {
+            return backend_type;
         }
 
         // Derive the backend type from the same resolved identifier used by
@@ -387,6 +390,9 @@ impl BackendArg {
         if let Some((backend, _)) = full.split_once(':')
             && let Ok(backend_type) = backend.parse()
         {
+            return backend_type;
+        }
+        if let Some(backend_type) = plugin_backend_type(&full) {
             return backend_type;
         }
 

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -211,15 +211,26 @@ fn parse_backend_components_fallible(
 
 fn plugin_backend_type(identifier: &str) -> Option<BackendType> {
     let (plugin_name, _tool_name) = identifier.split_once(':')?;
-    if config::is_loaded() && Config::get_().get_repo_url(plugin_name).is_some() {
-        return Some(BackendType::VfoxBackend(plugin_name.to_string()));
+    if config::is_loaded() {
+        let config = Config::get_();
+        if let Some(plugin_type) = config.get_configured_plugin_type(plugin_name) {
+            return Some(plugin_type_to_backend_type(plugin_name, plugin_type));
+        }
+        if config.get_repo_url(plugin_name).is_some() {
+            return Some(BackendType::VfoxBackend(plugin_name.to_string()));
+        }
     }
-    install_state::get_plugin_type(plugin_name).map(|plugin_type| match plugin_type {
+    install_state::get_plugin_type(plugin_name)
+        .map(|plugin_type| plugin_type_to_backend_type(plugin_name, plugin_type))
+}
+
+fn plugin_type_to_backend_type(plugin_name: &str, plugin_type: PluginType) -> BackendType {
+    match plugin_type {
         PluginType::Vfox => BackendType::Vfox,
         PluginType::VfoxBackend => BackendType::VfoxBackend(plugin_name.to_string()),
         PluginType::Asdf => BackendType::Asdf,
         PluginType::Package => BackendType::Unknown,
-    })
+    }
 }
 
 impl BackendArg {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -422,6 +422,13 @@ impl Config {
             .map(crate::toolset::parse_tool_options)
     }
 
+    pub fn get_configured_plugin_type(&self, plugin_name: &str) -> Option<PluginType> {
+        self.repo_urls.keys().find_map(|key| {
+            let (plugin_type, name) = PluginType::from_plugin_config(key);
+            (key != name && name == plugin_name).then_some(plugin_type)
+        })
+    }
+
     pub fn get_repo_url(&self, plugin_name: &str) -> Option<String> {
         if let Some(url) = self.repo_urls.get(plugin_name)
             && (Path::new(url).is_absolute() || url.starts_with("file://"))
@@ -5713,6 +5720,14 @@ config_roots = ["apps/api", "apps/web"]
                 "vfox:remote-vfox".to_string(),
                 "owner/vfox-plugin".to_string(),
             ),
+            (
+                "asdf:explicit-asdf".to_string(),
+                "owner/asdf-plugin".to_string(),
+            ),
+            (
+                "vfox-backend:explicit-backend".to_string(),
+                "owner/backend-plugin".to_string(),
+            ),
         ]);
         let config = Config {
             tera_ctx: BASE_CONTEXT.clone(),
@@ -5751,6 +5766,19 @@ config_roots = ["apps/api", "apps/web"]
             config.get_repo_url("remote-vfox").as_deref(),
             Some("https://github.com/owner/vfox-plugin.git")
         );
+        assert_eq!(
+            config.get_configured_plugin_type("local-vfox"),
+            Some(PluginType::Vfox)
+        );
+        assert_eq!(
+            config.get_configured_plugin_type("explicit-asdf"),
+            Some(PluginType::Asdf)
+        );
+        assert_eq!(
+            config.get_configured_plugin_type("explicit-backend"),
+            Some(PluginType::VfoxBackend)
+        );
+        assert_eq!(config.get_configured_plugin_type("local-asdf"), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- resolve bare tool aliases that target custom vfox backend plugins
- derive the backend plugin tool name from the resolved `plugin:tool` identifier
- cover global backend aliases used by project tool declarations with a local backend plugin regression test

## Root cause

`BackendArg::full()` resolved an alias such as `jq` to `chainguard:jq`, but backend classification only recognized custom plugin identifiers from the original short name. After classification, `VfoxBackend` also extracted its tool name from that original bare alias instead of the resolved backend identifier.

## Testing

- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run test:e2e plugins/test_plugins_section_local`
- repository formatting and static checks via `mise run format`

Fixes the behavior reported in https://github.com/jdx/mise/discussions/11733.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how backend type and vfox-backend tool names are derived for aliased tools; behavior is narrow but sits on core install/resolution paths for custom plugins.
> 
> **Overview**
> Fixes bare **tool aliases** (e.g. `jq = "chainguard:jq"`) so they route to custom **vfox backend** plugins instead of failing or misclassifying the tool.
> 
> **`BackendArg::backend_type()`** now classifies `plugin:tool` identifiers using the same **resolved** id as `full()` / `tool_name()`, via shared **`plugin_backend_type`** helpers and a new **`Config::get_configured_plugin_type`** that understands prefixed plugin keys like `vfox-backend:chainguard`.
> 
> **`VfoxBackend`** sets its internal tool name from **`ba.tool_name()`** (resolved backend) when a backend plugin is in play, not from the original short alias.
> 
> Adds an **e2e** case (local Chainguard-style backend + global alias + `mise install` / `mise ls-remote jq`) and **unit** coverage for configured plugin type lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b06cea46bd2cf0773ec0f7d0741bcc7abefff24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resolving local backend aliases when installing tools.
  - Improved recognition of configured and installed plugin backend types.
  - Tool aliases now correctly retain their intended tool name during backend resolution.
  - Added support for explicit plugin identifiers, including `asdf:` and `vfox-backend:` formats.

- **Tests**
  - Added end-to-end coverage for installing `jq` through a local Chainguard backend alias and verifying version `1.7.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->