### PR TITLE
fix(copr): submit builds without waiting

### DIFF
--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -88,7 +88,7 @@ jobs:
           if [ -n "${CHROOTS:-}" ]; then
             args+=(--chroots "${CHROOTS}")
           fi
-          ./packaging/copr/build-copr.sh "${args[@]}"
+          ./packaging/copr/build-copr.sh --nowait "${args[@]}"
         env:
           COPR_API_LOGIN: ${{ secrets.COPR_API_LOGIN }}
           COPR_API_TOKEN: ${{ secrets.COPR_API_TOKEN }}

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -15,6 +15,7 @@ COPR_OWNER="${COPR_OWNER:-jdxcode}"
 COPR_PROJECT="${COPR_PROJECT:-mise}"
 COPR_BUILD_TIMEOUT="${COPR_BUILD_TIMEOUT:-180000}"
 DRY_RUN="${DRY_RUN:-false}"
+WAIT_FOR_BUILD="${WAIT_FOR_BUILD:-true}"
 
 # Store the repository root directory
 REPO_ROOT="$(pwd)"
@@ -32,6 +33,7 @@ usage() {
 	echo "  -n, --name NAME              Package name (default: mise)"
 	echo "  -m, --maintainer-name NAME   Maintainer name (default: mise Release Bot)"
 	echo "  -e, --maintainer-email EMAIL Maintainer email (default: noreply@mise.jdx.dev)"
+	echo "      --nowait                 Return after COPR accepts the build"
 	echo "  -d, --dry-run                Build SRPM only, don't submit to COPR"
 	echo "  -h, --help                   Show this help"
 	echo ""
@@ -79,6 +81,10 @@ while [[ $# -gt 0 ]]; do
 		MAINTAINER_EMAIL="$2"
 		shift 2
 		;;
+	--nowait)
+		WAIT_FOR_BUILD="false"
+		shift
+		;;
 	-d | --dry-run)
 		DRY_RUN="true"
 		shift
@@ -109,6 +115,7 @@ echo "COPR Owner: $COPR_OWNER"
 echo "COPR Project: $COPR_PROJECT"
 echo "COPR Build Timeout: $COPR_BUILD_TIMEOUT"
 echo "Maintainer: $MAINTAINER_NAME <$MAINTAINER_EMAIL>"
+echo "Wait for build: $WAIT_FOR_BUILD"
 echo "Dry Run: $DRY_RUN"
 echo ""
 
@@ -323,6 +330,9 @@ if [ "$DRY_RUN" != "true" ]; then
 	# conservative chroot pattern before forwarding to copr-cli.
 	IFS=' ' read -ra chroot_array <<<"$CHROOTS"
 	copr_args=("build" "--timeout" "$COPR_BUILD_TIMEOUT")
+	if [ "$WAIT_FOR_BUILD" != "true" ]; then
+		copr_args+=("--nowait")
+	fi
 	for chroot in "${chroot_array[@]}"; do
 		[ -z "$chroot" ] && continue
 		if ! [[ "$chroot" =~ ^[A-Za-z0-9._+-]+$ ]]; then


### PR DESCRIPTION
## Summary

- add a `--nowait` option to the COPR packaging script
- have the COPR publish workflow return after COPR accepts the build
- preserve synchronous behavior for direct script callers unless they opt out

## Why

COPR builds can run for many hours, especially Fedora Rust builds under memory pressure. The release workflow only needs to submit the build successfully; waiting for every chroot ties up the GitHub Actions job and can exceed its timeout even though COPR continues processing the build.

## Validation

- `mise run lint-fix`
- confirmed the current `copr-cli` build command supports `--nowait`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging/CI-only change with no runtime impact; the workflow will no longer fail or succeed based on eventual COPR build outcomes.
> 
> **Overview**
> **COPR publish no longer blocks on long chroot builds.** The `copr-publish` workflow now invokes `build-copr.sh` with `--nowait`, so the job finishes once COPR accepts the SRPM instead of polling until every chroot completes.
> 
> `packaging/copr/build-copr.sh` gains a **`--nowait`** flag (and `WAIT_FOR_BUILD`, default `true`) that forwards **`copr-cli build --nowait`** when opted out. Direct script use stays synchronous unless `--nowait` is passed; usage text and config output document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e233af4159ee569056f328c0da72d7444407273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated COPR publishing to submit builds without waiting for completion.
  * Added an option to control whether the build process waits for results.
  * The build script now reports the selected waiting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->