### PR TITLE
fix(task): overlay local task metadata

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1310,8 +1310,9 @@ command and the inline definition overlays its metadata.
 The same overlay rule applies across layered inline task definitions. For
 example, a metadata-only task in `mise.local.toml` overlays the nearest
 lower-precedence command-bearing definition in `mise.toml`. A higher-precedence
-definition with its own command still replaces the lower task, and definitions
-below the selected command-bearing base do not contribute metadata.
+definition with its own command still replaces the lower task. All metadata-only
+definitions above the selected command-bearing base contribute in precedence
+order, while definitions below it do not contribute metadata.
 
 ```toml
 [task_config]

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -1307,6 +1307,12 @@ or a higher-precedence config. An inline block without `run`, `run_windows`, or
 dependencies. For executable file tasks, the script also remains the task's
 command and the inline definition overlays its metadata.
 
+The same overlay rule applies across layered inline task definitions. For
+example, a metadata-only task in `mise.local.toml` overlays the nearest
+lower-precedence command-bearing definition in `mise.toml`. A higher-precedence
+definition with its own command still replaces the lower task, and definitions
+below the selected command-bearing base do not contribute metadata.
+
 ```toml
 [task_config]
 includes = [

--- a/e2e/tasks/test_task_inline_metadata_overlay
+++ b/e2e/tasks/test_task_inline_metadata_overlay
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-mkdir -p .config
+mkdir -p .config .mise
 
 cat <<'EOF' >.config/mise.toml
 [tasks.hello]
@@ -12,6 +12,7 @@ cat <<'EOF' >mise.toml
 description = "base description"
 run = '''
 echo "BASE_ONLY=$BASE_ONLY"
+echo "INTERMEDIATE_ONLY=$INTERMEDIATE_ONLY"
 echo "LOCAL_ONLY=$LOCAL_ONLY"
 echo "OVERRIDE=$OVERRIDE"
 echo "LEAKED=${LEAKED:-unset}"
@@ -21,6 +22,11 @@ env = { BASE_ONLY = "base", OVERRIDE = "base" }
 [tasks.replaced]
 run = 'echo "BASE_ONLY=${BASE_ONLY:-unset}"'
 env = { BASE_ONLY = "base" }
+EOF
+
+cat <<'EOF' >.mise/config.local.toml
+[tasks.hello]
+env = { INTERMEDIATE_ONLY = "intermediate", OVERRIDE = "intermediate" }
 EOF
 
 cat <<'EOF' >mise.local.toml
@@ -37,6 +43,7 @@ EOF
 # the selected command-bearing base do not leak into the task.
 assert_contains "mise tasks hello" "local description"
 assert_contains "mise run hello" "BASE_ONLY=base"
+assert_contains "mise run hello" "INTERMEDIATE_ONLY=intermediate"
 assert_contains "mise run hello" "LOCAL_ONLY=local"
 assert_contains "mise run hello" "OVERRIDE=local"
 assert_contains "mise run hello" "LEAKED=unset"

--- a/e2e/tasks/test_task_inline_metadata_overlay
+++ b/e2e/tasks/test_task_inline_metadata_overlay
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+mkdir -p .config
+
+cat <<'EOF' >.config/mise.toml
+[tasks.hello]
+env = { LEAKED = "lower" }
+EOF
+
+cat <<'EOF' >mise.toml
+[tasks.hello]
+description = "base description"
+run = '''
+echo "BASE_ONLY=$BASE_ONLY"
+echo "LOCAL_ONLY=$LOCAL_ONLY"
+echo "OVERRIDE=$OVERRIDE"
+echo "LEAKED=${LEAKED:-unset}"
+'''
+env = { BASE_ONLY = "base", OVERRIDE = "base" }
+
+[tasks.replaced]
+run = 'echo "BASE_ONLY=${BASE_ONLY:-unset}"'
+env = { BASE_ONLY = "base" }
+EOF
+
+cat <<'EOF' >mise.local.toml
+[tasks.hello]
+description = "local description"
+env = { LOCAL_ONLY = "local", OVERRIDE = "local" }
+
+[tasks.replaced]
+run = 'echo local command'
+EOF
+
+# A metadata-only higher-precedence definition overlays the nearest lower
+# command-bearing task. Values from the overlay win, while definitions below
+# the selected command-bearing base do not leak into the task.
+assert_contains "mise tasks hello" "local description"
+assert_contains "mise run hello" "BASE_ONLY=base"
+assert_contains "mise run hello" "LOCAL_ONLY=local"
+assert_contains "mise run hello" "OVERRIDE=local"
+assert_contains "mise run hello" "LEAKED=unset"
+
+# A higher-precedence definition with its own command still replaces the lower
+# task wholesale.
+assert "mise run replaced" "local command"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3689,8 +3689,9 @@ async fn load_global_tasks(config: &Arc<Config>, templates: &TaskDefinitions) ->
 /// the script stays as the base and the TOML block is overlaid via
 /// [`Task::merge_toml_overlay`]. An inline block replaces a same-named task from
 /// an included TOML file. When the same name appears in multiple inline blocks
-/// (e.g. `.config/mise.toml` and `.mise/config.toml`), the first entry wins and
-/// later ones are skipped.
+/// (e.g. `mise.toml` and `mise.local.toml`), the highest-precedence block wins.
+/// If that block has no command, it overlays the nearest lower-precedence
+/// command-bearing block; definitions below that selected base are skipped.
 /// When the same name appears in more than one file task (e.g. a local
 /// `.mise/tasks` script and a same-named task from a `git::` include), the last
 /// one wins. Callers load `file_tasks` in declared `task_config.includes`
@@ -3702,8 +3703,21 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
         by_name.insert(t.name.clone(), t);
     }
     let mut seen_config_task_names = BTreeSet::new();
+    let mut pending_inline_overlays = BTreeSet::new();
     for t in config_tasks {
         if !seen_config_task_names.insert(t.name.clone()) {
+            if pending_inline_overlays.contains(&t.name)
+                && (!t.run.is_empty() || !t.run_windows.is_empty() || t.file.is_some())
+            {
+                let overlay = by_name
+                    .get(&t.name)
+                    .expect("pending inline overlay should be present")
+                    .clone();
+                let mut base = t;
+                base.merge_toml_overlay(overlay);
+                pending_inline_overlays.remove(&base.name);
+                by_name.insert(base.name.clone(), base);
+            }
             continue;
         }
         if let Some(existing) = by_name
@@ -3722,6 +3736,9 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
                 existing.merge_toml_overlay(t);
             }
         } else {
+            if t.run.is_empty() && t.run_windows.is_empty() && t.file.is_none() {
+                pending_inline_overlays.insert(t.name.clone());
+            }
             by_name.insert(t.name.clone(), t);
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3703,20 +3703,21 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
         by_name.insert(t.name.clone(), t);
     }
     let mut seen_config_task_names = BTreeSet::new();
-    let mut pending_inline_overlays = BTreeSet::new();
+    let mut pending_inline_overlays: IndexMap<String, Vec<Task>> = IndexMap::new();
     for t in config_tasks {
         if !seen_config_task_names.insert(t.name.clone()) {
-            if pending_inline_overlays.contains(&t.name)
-                && (!t.run.is_empty() || !t.run_windows.is_empty() || t.file.is_some())
-            {
-                let overlay = by_name
-                    .get(&t.name)
-                    .expect("pending inline overlay should be present")
-                    .clone();
+            let has_command = !t.run.is_empty() || !t.run_windows.is_empty() || t.file.is_some();
+            if pending_inline_overlays.contains_key(&t.name) && has_command {
+                let overlays = pending_inline_overlays
+                    .shift_remove(&t.name)
+                    .expect("pending inline overlays should be present");
                 let mut base = t;
-                base.merge_toml_overlay(overlay);
-                pending_inline_overlays.remove(&base.name);
+                for overlay in overlays.into_iter().rev() {
+                    base.merge_toml_overlay(overlay);
+                }
                 by_name.insert(base.name.clone(), base);
+            } else if let Some(overlays) = pending_inline_overlays.get_mut(&t.name) {
+                overlays.push(t);
             }
             continue;
         }
@@ -3737,7 +3738,10 @@ fn merge_file_and_config_tasks(file_tasks: Vec<Task>, config_tasks: Vec<Task>) -
             }
         } else {
             if t.run.is_empty() && t.run_windows.is_empty() && t.file.is_none() {
-                pending_inline_overlays.insert(t.name.clone());
+                pending_inline_overlays
+                    .entry(t.name.clone())
+                    .or_default()
+                    .push(t.clone());
             }
             by_name.insert(t.name.clone(), t);
         }


### PR DESCRIPTION
## Summary

- let a metadata-only higher-precedence inline task overlay the nearest lower-precedence command-bearing definition
- keep command-bearing higher-precedence tasks as full replacements
- stop after selecting the command-bearing base so still-lower task metadata cannot leak in
- document the rule and add end-to-end coverage for `mise.local.toml`

## Root cause

Inline task definitions were selected strictly first-wins across layered config files. A metadata-only task in `mise.local.toml` therefore replaced the complete task from `mise.toml`, including its `run` command.

The existing metadata overlay path already handles task environment precedence and source provenance, but layered inline tasks never reached it.

## Behavior

Given:

```toml
# mise.toml
[tasks.hello]
run = 'echo "$FOO"'
```

```toml
# mise.local.toml
[tasks.hello.env]
FOO = "bar"
```

`mise run hello` now retains the base command and applies the local environment.

A local task that defines `run`, `run_windows`, or `file` still replaces the lower task wholesale. Metadata below the selected command-bearing base remains excluded, preserving the precedence guarantee from #11103.

Addresses https://github.com/jdx/mise/discussions/11738

## Validation

- `mise run test:e2e e2e/tasks/test_task_inline_metadata_overlay e2e/tasks/test_task_config_precedence e2e/tasks/test_task_toml_include_inline_precedence`
- `mise run lint-fix`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task merge semantics for duplicate inline task names across config layers; behavior is covered by new e2e tests but could affect projects that relied on first-wins metadata-only blocks.
> 
> **Overview**
> Fixes layered inline tasks so a **metadata-only** definition in a higher-precedence file (e.g. `mise.local.toml`) no longer drops the `run` from a lower file. `merge_file_and_config_tasks` now buffers command-less inline blocks and applies them onto the **nearest lower-precedence command-bearing** task via `merge_toml_overlay`, with higher overlays winning on conflicts and metadata from definitions **below** that base excluded.
> 
> A higher-precedence block that defines `run`, `run_windows`, or `file` still **fully replaces** the lower task. Docs describe the cross-file overlay rules; a new e2e test covers multi-layer env/description merging and wholesale replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3eb072d7d2d6ede7658a931c564bf3d0851205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved inline task configuration layering so metadata-only definitions inherit from the nearest command-bearing task.
  * Higher-precedence command definitions now fully replace lower-precedence task definitions.
* **Documentation**
  * Added guidance on precedence rules and command-base selection for duplicate inline task definitions.
* **Tests**
  * Added end-to-end coverage for metadata merging, precedence handling, and task replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->