### PR TITLE
fix(lockfile): create lockfile when explicitly enabled

### DIFF
--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -1,6 +1,6 @@
 # mise.lock Lockfile
 
-`mise.lock` is a lockfile that pins exact versions and checksums of tools for reproducible environments. When `lockfile = true` is explicitly configured, mise creates and maintains project lockfiles as tools are installed or upgraded. When the setting is unset, mise maintains existing lockfiles but does not create new ones; run `mise lock` to generate one explicitly. Global lockfiles are only created with `mise lock --global`.
+`mise.lock` is a lockfile that pins exact versions and checksums of tools for reproducible environments. When `lockfile = true` is explicitly configured in a TOML settings file, mise creates and maintains project lockfiles as tools are installed or upgraded. When the setting is unset, mise maintains existing lockfiles but does not create new ones; run `mise lock` to generate one explicitly. `MISE_LOCKFILE=1` retains this existing-lockfile behavior for backwards compatibility. Global lockfiles are only created with `mise lock --global`.
 
 ## Overview
 

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -1,6 +1,6 @@
 # mise.lock Lockfile
 
-`mise.lock` is a lockfile that pins exact versions and checksums of tools for reproducible environments. Lockfiles are not created automatically—you must run `mise lock` to generate them. Once a lockfile exists, mise will keep it updated as tools are installed or upgraded.
+`mise.lock` is a lockfile that pins exact versions and checksums of tools for reproducible environments. When `lockfile = true` is explicitly configured, mise creates and maintains project lockfiles as tools are installed or upgraded. When the setting is unset, mise maintains existing lockfiles but does not create new ones; run `mise lock` to generate one explicitly. Global lockfiles are only created with `mise lock --global`.
 
 ## Overview
 
@@ -26,7 +26,7 @@ lockfile = true
 
 ## How It Works
 
-1. **Lockfile Updates**: Once a `mise.lock` file exists, running `mise install` or `mise use` updates it with the exact versions installed
+1. **Lockfile Creation and Updates**: With `lockfile = true`, running `mise install` or `mise use` creates or updates `mise.lock` with the exact versions installed. When `lockfile` is unset, these commands update an existing lockfile without creating one
 2. **Version Resolution**: If a `mise.lock` exists, mise will prefer locked versions over version ranges in `mise.toml`
 3. **Checksum Verification**: For supported backends, mise stores and verifies checksums of downloaded tools
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -26,7 +26,7 @@
 - [Tool Stubs](https://mise.jdx.dev/dev-tools/tool-stubs.html): Tool stubs allow you to create executable files with embedded TOML configuration for tool execution. They provide a convenient way to define tool versions, backends, and execution parameters directly…
 - [Registry](https://mise.jdx.dev/registry.html): List of all tools aliased by default in mise.
 - [GitHub Tokens](https://mise.jdx.dev/dev-tools/github-tokens.html): Many tools in mise are hosted on GitHub. For public releases, mise uses mise-versions by default as a shared cache for version lists, release metadata, and GitHub artifact attestations.
-- [mise.lock Lockfile](https://mise.jdx.dev/dev-tools/mise-lock.html): mise.lock is a lockfile that pins exact versions and checksums of tools for reproducible environments. Lockfiles are not created automatically—you must run mise lock to generate them.
+- [mise.lock Lockfile](https://mise.jdx.dev/dev-tools/mise-lock.html): mise.lock is a lockfile that pins exact versions and checksums of tools for reproducible environments.
 - [Security](https://mise.jdx.dev/security.html): mise includes several supply-chain controls for installing and managing tools. These controls have different coverage depending on the backend and the metadata available from upstream.
 - [OCI Images (experimental)](https://mise.jdx.dev/dev-tools/mise-oci.html): mise oci build turns a mise.toml into a container image, with one OCI layer per installed tool.
 - [Deps](https://mise.jdx.dev/dev-tools/deps.html): The mise deps command manages project dependencies by hashing source files (e.g., package-lock.json) and running install commands when changes are detected.

--- a/e2e/lockfile/test_lockfile_auto_create
+++ b/e2e/lockfile/test_lockfile_auto_create
@@ -25,11 +25,15 @@ assert "test ! -e $MISE_CONFIG_DIR/mise.lock"
 cat <<EOF >mise.toml
 [settings]
 lockfile = true
+
+[tools]
+dummy = "1"
 EOF
 
 mise install
-assert "test ! -e mise.lock"
+assert "test -f mise.lock"
 
+rm mise.lock
 cat <<EOF >mise.toml
 [tools]
 tiny = "1"
@@ -37,3 +41,21 @@ EOF
 
 mise install
 assert "test ! -e mise.lock"
+
+cat <<EOF >mise.toml
+[settings]
+lockfile = true
+
+[tools]
+dummy = "1"
+EOF
+cat <<EOF >mise.dev.toml
+[tools]
+tiny = "2"
+EOF
+
+mise use --env dev --pin tiny@2
+assert "test -f mise.lock"
+assert "test -f mise.dev.lock"
+assert_contains "cat mise.lock" '[[tools.dummy]]'
+assert_contains "cat mise.dev.lock" '[[tools.tiny]]'

--- a/e2e/lockfile/test_lockfile_auto_create
+++ b/e2e/lockfile/test_lockfile_auto_create
@@ -42,6 +42,18 @@ EOF
 mise install
 assert "test ! -e mise.lock"
 
+MISE_LOCKFILE=1 mise install
+assert "test ! -e mise.lock"
+
+cat <<EOF >"$MISE_CONFIG_DIR/config.toml"
+[settings]
+lockfile = true
+EOF
+
+mise install
+assert "test -f mise.lock"
+rm mise.lock "$MISE_CONFIG_DIR/config.toml"
+
 cat <<EOF >mise.toml
 [settings]
 lockfile = true

--- a/e2e/lockfile/test_lockfile_auto_create
+++ b/e2e/lockfile/test_lockfile_auto_create
@@ -6,16 +6,30 @@ cat <<EOF >mise.toml
 [settings]
 lockfile = true
 EOF
+cat <<EOF >mise.local.toml
+[env]
+LOCKFILE_TEST = "1"
+EOF
 
 assert "test ! -e mise.lock"
 mise use --pin tiny@1
 assert "test -f mise.lock"
+assert "test ! -e mise.local.lock"
 assert_contains "cat mise.lock" 'version = "1.1.0"'
 
+rm mise.lock
 mise use --global --pin tiny@2
+assert "test ! -e mise.lock"
 assert "test ! -e $MISE_CONFIG_DIR/mise.lock"
 
-rm mise.lock
+cat <<EOF >mise.toml
+[settings]
+lockfile = true
+EOF
+
+mise install
+assert "test ! -e mise.lock"
+
 cat <<EOF >mise.toml
 [tools]
 tiny = "1"

--- a/e2e/lockfile/test_lockfile_auto_create
+++ b/e2e/lockfile/test_lockfile_auto_create
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+unset MISE_LOCKFILE
+
+cat <<EOF >mise.toml
+[settings]
+lockfile = true
+EOF
+
+assert "test ! -e mise.lock"
+mise use --pin tiny@1
+assert "test -f mise.lock"
+assert_contains "cat mise.lock" 'version = "1.1.0"'
+
+mise use --global --pin tiny@2
+assert "test ! -e $MISE_CONFIG_DIR/mise.lock"
+
+rm mise.lock
+cat <<EOF >mise.toml
+[tools]
+tiny = "1"
+EOF
+
+mise install
+assert "test ! -e mise.lock"

--- a/settings.toml
+++ b/settings.toml
@@ -1439,7 +1439,7 @@ gh = "latest"
 But you'd like the versions installed to be consistent within a project. When this is enabled, mise will update mise.lock
 files next to mise.toml files containing pinned versions. When installing tools, mise will reference this lockfile if it exists and this setting is enabled to resolve versions.
 
-When set to `true`, project lockfiles are created and maintained automatically. When unset, existing lockfiles are read and updated but new lockfiles are not created. To generate one explicitly, run:
+When set to `true` in a TOML settings file, project lockfiles are created and maintained automatically. When unset, existing lockfiles are read and updated but new lockfiles are not created. `MISE_LOCKFILE=1` retains this existing-lockfile behavior for backwards compatibility. To generate one explicitly, run:
 
 ```sh
 mise lock

--- a/settings.toml
+++ b/settings.toml
@@ -1439,11 +1439,13 @@ gh = "latest"
 But you'd like the versions installed to be consistent within a project. When this is enabled, mise will update mise.lock
 files next to mise.toml files containing pinned versions. When installing tools, mise will reference this lockfile if it exists and this setting is enabled to resolve versions.
 
-The lockfiles are not created automatically. To generate them, run the following (assuming the config file is `mise.toml`):
+When set to `true`, project lockfiles are created and maintained automatically. When unset, existing lockfiles are read and updated but new lockfiles are not created. To generate one explicitly, run:
 
 ```sh
-touch mise.lock && mise install
+mise lock
 ```
+
+Global lockfiles are only created with `mise lock --global`.
 
 The lockfile is named the same as the config file but with `.lock` instead of `.toml` as the extension, e.g.:
 
@@ -1451,9 +1453,9 @@ The lockfile is named the same as the config file but with `.lock` instead of `.
 - `mise.local.toml` -> `mise.local.lock`
 - `.config/mise.toml` -> `.config/mise.lock`
 
-When set to `true`, lockfiles are read and written. When set to `false`, lockfiles are explicitly disabled—this
+When set to `true`, project lockfiles are created, read, and written. When set to `false`, lockfiles are explicitly disabled—this
 will cause an error if `locked = true` is also set, since locked mode requires reading lockfiles.
-When unset (the default), lockfiles are enabled (same as `true`) but there is no conflict with `locked` mode.
+When unset (the default), existing lockfiles are read and written, but new lockfiles are not created.
 """
 env = "MISE_LOCKFILE"
 optional = true

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -946,6 +946,10 @@ impl ConfigFile for MiseToml {
         self.min_version.as_ref()
     }
 
+    fn settings(&self) -> Option<&SettingsPartial> {
+        Some(&self.settings)
+    }
+
     fn plugins(&self) -> eyre::Result<HashMap<String, String>> {
         self.plugins
             .clone()

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -103,6 +103,10 @@ pub trait ConfigFile: Debug + Send + Sync {
         Ok(Default::default())
     }
 
+    fn settings(&self) -> Option<&settings::SettingsPartial> {
+        None
+    }
+
     fn shell_aliases(&self) -> eyre::Result<IndexMap<String, String>> {
         Ok(Default::default())
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -594,6 +594,18 @@ impl Config {
         }
     }
 
+    /// Returns true when lockfile creation is enabled by a TOML settings file.
+    ///
+    /// `MISE_LOCKFILE=1` predates automatic creation and continues to mean
+    /// "read and maintain existing lockfiles" for backwards compatibility.
+    pub fn lockfile_creation_enabled(&self) -> bool {
+        Settings::get().lockfile_creation_enabled()
+            && self.config_files.values().any(|cf| {
+                cf.settings()
+                    .is_some_and(|settings| settings.lockfile == Some(true))
+            })
+    }
+
     pub(crate) fn monorepo_config_root_dirs_for_lockfiles(&self) -> Result<Vec<PathBuf>> {
         self.monorepo_config_root_dirs(None)
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -846,6 +846,10 @@ impl Settings {
         self.lockfile.unwrap_or(true)
     }
 
+    pub fn lockfile_creation_enabled(&self) -> bool {
+        self.lockfile == Some(true)
+    }
+
     /// Returns configured lockfile platforms parsed into Platform structs, or None for defaults.
     /// Errors on invalid platform strings (same validation as `mise lock --platform`).
     pub fn lockfile_platforms(&self) -> Result<Option<Vec<Platform>>> {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1762,7 +1762,7 @@ pub fn update_lockfiles(
                 && tools_by_source
                     .iter()
                     .any(|(source, tools)| !tools.is_empty() && source_maps_to_lockfile(source));
-            let create_project_lockfile = Settings::get().lockfile_creation_enabled()
+            let create_project_lockfile = config.lockfile_creation_enabled()
                 && configs
                     .iter()
                     .any(|path| !crate::config::is_global_config(path))

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1751,15 +1751,17 @@ pub fn update_lockfiles(
                 lockfile_path_for_tool_source(config, source)
                     .is_some_and(|(path, _)| path == lockfile_path)
             };
-            let has_tool_contribution = if new_versions.is_empty() {
-                tools_by_source
+            let updates_project_lockfiles = new_versions.is_empty()
+                || new_versions.iter().any(|tv| {
+                    tv.request
+                        .source()
+                        .path()
+                        .is_some_and(|path| !crate::config::is_global_config(path))
+                });
+            let has_tool_contribution = updates_project_lockfiles
+                && tools_by_source
                     .iter()
-                    .any(|(source, tools)| !tools.is_empty() && source_maps_to_lockfile(source))
-            } else {
-                new_versions
-                    .iter()
-                    .any(|tv| source_maps_to_lockfile(tv.request.source()))
-            };
+                    .any(|(source, tools)| !tools.is_empty() && source_maps_to_lockfile(source));
             let create_project_lockfile = Settings::get().lockfile_creation_enabled()
                 && configs
                     .iter()

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1747,10 +1747,24 @@ pub fn update_lockfiles(
         // lockfile creation too; global lockfiles remain explicit via the
         // `mise lock --global` command.
         if !lockfile_path.exists() {
+            let source_maps_to_lockfile = |source: &ToolSource| {
+                lockfile_path_for_tool_source(config, source)
+                    .is_some_and(|(path, _)| path == lockfile_path)
+            };
+            let has_tool_contribution = if new_versions.is_empty() {
+                tools_by_source
+                    .iter()
+                    .any(|(source, tools)| !tools.is_empty() && source_maps_to_lockfile(source))
+            } else {
+                new_versions
+                    .iter()
+                    .any(|tv| source_maps_to_lockfile(tv.request.source()))
+            };
             let create_project_lockfile = Settings::get().lockfile_creation_enabled()
                 && configs
                     .iter()
-                    .any(|path| !crate::config::is_global_config(path));
+                    .any(|path| !crate::config::is_global_config(path))
+                && has_tool_contribution;
             if !create_project_lockfile {
                 continue;
             }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1741,10 +1741,19 @@ pub fn update_lockfiles(
     let mut provenance_errors: Vec<String> = Vec::new();
     let mut has_deferred_provenance = false;
 
-    for (lockfile_path, _configs) in lockfile_configs {
-        // Only update existing lockfiles - creation is done elsewhere (e.g., by `mise lock`)
+    for (lockfile_path, configs) in lockfile_configs {
+        // When lockfiles are enabled implicitly, only maintain files the user has
+        // already created. An explicit `lockfile = true` opts into project
+        // lockfile creation too; global lockfiles remain explicit via the
+        // `mise lock --global` command.
         if !lockfile_path.exists() {
-            continue;
+            let create_project_lockfile = Settings::get().lockfile_creation_enabled()
+                && configs
+                    .iter()
+                    .any(|path| !crate::config::is_global_config(path));
+            if !create_project_lockfile {
+                continue;
+            }
         }
         let is_monorepo_root_lockfile = config
             .monorepo_lockfile_root()


### PR DESCRIPTION
## Summary

- create project lockfiles during `mise use`, `mise install`, and upgrade flows when `lockfile = true` is explicitly configured
- preserve the default behavior where an unset setting updates existing lockfiles without creating new ones
- keep global lockfile creation explicit through `mise lock --global`
- document the tri-state behavior and add end-to-end regression coverage

## Context

This addresses the behavior reported in https://github.com/jdx/mise/discussions/11739. The lockfile updater previously skipped every missing lockfile, making explicit `lockfile = true` behave the same as the unset default for creation.

## Validation

- `mise run lint-fix`
- `mise run test:e2e e2e/lockfile/test_lockfile_auto_create`
- `mise run test:e2e e2e/lockfile/test_lockfile_use e2e/lockfile/test_lockfile_auto_lock`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when lockfiles appear on disk and how unset vs explicit `lockfile` interact with `locked` mode docs; behavior is nuanced but covered by new e2e tests rather than security-critical paths.
> 
> **Overview**
> **Lockfile creation is now opt-in via an explicit `lockfile = true` in a project (or global) TOML settings block**, instead of always skipping missing lockfiles during install/use/upgrade updates.
> 
> When that flag is set, `mise install`, `mise use`, and related flows **create** the appropriate project lockfiles (including per-env files like `mise.dev.lock`) when tools from those configs are installed. **Unset `lockfile` and `MISE_LOCKFILE=1` keep the prior behavior**: read and update existing lockfiles only—no new files. **`mise use --global` still does not create project or implicit global lockfiles**; global lockfiles remain **`mise lock --global`**.
> 
> Implementation adds **`lockfile_creation_enabled()`** (`lockfile == Some(true)` plus a loaded config with `lockfile = true`), **`ConfigFile::settings()`** so project TOML can drive that check, and expanded logic in the lockfile updater to decide when to create a missing file. Docs and **`e2e/lockfile/test_lockfile_auto_create`** document and cover the tri-state behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ea16dc70ee353abf8de21378c077532af8a23a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Project lockfiles are automatically created when lockfile support is explicitly enabled and local tool configuration requires one.
  - Environment-specific configurations create corresponding environment lockfiles.
  - Global-only configuration does not create project or configuration-directory lockfiles.
  - `mise lock` remains available for explicit project or global lockfile generation.

- **Documentation**
  - Clarified enabled, disabled, and unset lockfile behaviors, including handling of existing lockfiles.
  - Documented how `mise install` and `mise use` create or update project lockfiles when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->