### PR TITLE
fix(python): preserve locked precompiled release

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -626,7 +626,7 @@ impl PythonPlugin {
         &self,
         version: &str,
         target: &PlatformTarget,
-        locked_release: Option<&str>,
+        locked_filename: Option<&str>,
     ) -> eyre::Result<Option<(String, String)>> {
         let settings = Settings::get();
 
@@ -652,19 +652,19 @@ impl PythonPlugin {
 
         let flavor = settings.python.precompiled_flavor.clone();
 
-        // Prefer the PBS release already recorded in the lockfile so a plain
+        // Prefer the PBS artifact already recorded in the lockfile so a plain
         // `mise lock` refreshes the same artifact. `mise lock --bump` resolves
-        // without the existing lockfile, so locked_release is None and the
+        // without the existing lockfile, so locked_filename is None and the
         // newest build wins.
         let result =
-            select_python_precompiled(&raw, version, &platform, flavor.as_deref(), locked_release);
-        if let Some(locked_release) = locked_release
+            select_python_precompiled(&raw, version, &platform, flavor.as_deref(), locked_filename);
+        if let Some(locked_filename) = locked_filename
             && result
                 .as_ref()
-                .is_some_and(|(release, _)| release != locked_release)
+                .is_some_and(|(_, filename)| filename != locked_filename)
         {
             debug!(
-                "locked python-build-standalone release {locked_release} not found for python {version} on {platform}, finding latest"
+                "locked python-build-standalone artifact {locked_filename} not found for python {version} on {platform}, finding latest"
             );
         }
         Ok(result)
@@ -1009,15 +1009,15 @@ impl Backend for PythonPlugin {
         target: &PlatformTarget,
     ) -> Result<PlatformInfo> {
         let version = &tv.version;
-        let locked_release = tv
+        let locked_filename = tv
             .lock_platforms
             .get(&target.to_key())
             .and_then(|info| info.url.as_deref())
-            .and_then(|url| python_precompiled_release_from_url(url, version));
+            .and_then(|url| python_precompiled_filename_from_url(url, version));
 
         // Look up the precompiled release for this version and target platform
         let Some((tag, filename)) = self
-            .fetch_precompiled_for_target(version, target, locked_release)
+            .fetch_precompiled_for_target(version, target, locked_filename)
             .await?
         else {
             return Ok(PlatformInfo::default());
@@ -1081,7 +1081,7 @@ fn python_precompiled_created_at(date: &str) -> Option<String> {
     ))
 }
 
-fn python_precompiled_release_from_url<'a>(url: &'a str, version: &str) -> Option<&'a str> {
+fn python_precompiled_filename_from_url<'a>(url: &'a str, version: &str) -> Option<&'a str> {
     let (release, filename) = url
         .strip_prefix(PBS_RELEASE_DOWNLOAD_URL)?
         .split_once('/')?;
@@ -1090,7 +1090,7 @@ fn python_precompiled_release_from_url<'a>(url: &'a str, version: &str) -> Optio
     }
     filename
         .starts_with(&format!("cpython-{version}+{release}-"))
-        .then_some(release)
+        .then_some(filename)
 }
 
 fn select_python_precompiled(
@@ -1098,7 +1098,7 @@ fn select_python_precompiled(
     version: &str,
     platform: &str,
     flavor: Option<&str>,
-    locked_release: Option<&str>,
+    locked_filename: Option<&str>,
 ) -> Option<(String, String)> {
     let flavor = flavor.map(str::to_string);
     let candidates = manifest
@@ -1118,10 +1118,10 @@ fn select_python_precompiled(
         })
         .filter(|(candidate, _, _)| candidate == version)
         .collect_vec();
-    let select = |release: Option<&str>| {
+    let select = |filename: Option<&str>| {
         candidates
             .iter()
-            .filter(|(_, date, _)| release.is_none_or(|release| date == release))
+            .filter(|(_, _, candidate)| filename.is_none_or(|filename| candidate == filename))
             .min_by_key(|(_, date, name)| {
                 let install_type = if let Some(flavor) = flavor.as_deref() {
                     let name_without_ext = name.trim_end_matches(".tar.gz");
@@ -1138,7 +1138,7 @@ fn select_python_precompiled(
             })
             .map(|(_, release, filename)| (release.clone(), filename.clone()))
     };
-    select(locked_release).or_else(|| select(None))
+    select(locked_filename).or_else(|| select(None))
 }
 
 fn python_precompiled_url_path(settings: &Settings) -> String {
@@ -1376,15 +1376,15 @@ plugins/python-build/share/python-build/patches/3.14.5/foo.patch
     }
 
     #[test]
-    fn parses_python_precompiled_release_from_url() {
+    fn parses_python_precompiled_filename_from_url() {
         let url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz";
         assert_eq!(
-            python_precompiled_release_from_url(url, "3.12.13"),
-            Some("20260728")
+            python_precompiled_filename_from_url(url, "3.12.13"),
+            Some("cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz")
         );
-        assert_eq!(python_precompiled_release_from_url(url, "3.12.12"), None);
+        assert_eq!(python_precompiled_filename_from_url(url, "3.12.12"), None);
         assert_eq!(
-            python_precompiled_release_from_url(
+            python_precompiled_filename_from_url(
                 "https://example.com/releases/download/20260728/cpython-3.12.13+20260728.tar.gz",
                 "3.12.13"
             ),
@@ -1402,15 +1402,36 @@ cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz
         let platform = "x86_64-unknown-linux-gnu";
 
         assert_eq!(
-            select_python_precompiled(manifest, "3.12.13", platform, None, Some("20260728")),
+            select_python_precompiled(
+                manifest,
+                "3.12.13",
+                platform,
+                None,
+                Some("cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only.tar.gz")
+            ),
             Some((
                 "20260728".to_string(),
-                "cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-                    .to_string()
+                "cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only.tar.gz".to_string()
             ))
         );
         assert_eq!(
             select_python_precompiled(manifest, "3.12.13", platform, None, None),
+            Some((
+                "20260805".to_string(),
+                "cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+                    .to_string()
+            ))
+        );
+        assert_eq!(
+            select_python_precompiled(
+                manifest,
+                "3.12.13",
+                platform,
+                None,
+                Some(
+                    "cpython-3.12.13+20250101-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+                )
+            ),
             Some((
                 "20260805".to_string(),
                 "cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -32,6 +32,8 @@ use xx::regex;
 
 const ATTESTATION_HELP: &str = "To disable attestation verification, set MISE_PYTHON_GITHUB_ATTESTATIONS=false\n\
     or add `python.github_attestations = false` under [settings] in mise.toml";
+const PBS_RELEASE_DOWNLOAD_URL: &str =
+    "https://github.com/astral-sh/python-build-standalone/releases/download/";
 
 #[derive(Debug)]
 pub struct PythonPlugin {
@@ -624,6 +626,7 @@ impl PythonPlugin {
         &self,
         version: &str,
         target: &PlatformTarget,
+        locked_release: Option<&str>,
     ) -> eyre::Result<Option<(String, String)>> {
         let settings = Settings::get();
 
@@ -649,46 +652,21 @@ impl PythonPlugin {
 
         let flavor = settings.python.precompiled_flavor.clone();
 
-        // Find all entries matching this version, then pick the best one
-        let result = raw
-            .lines()
-            .filter(|v| v.contains(&platform))
-            .filter(|v| filter_freethreaded(v, &flavor))
-            .flat_map(|v| {
-                regex!(r"^cpython-(\d+\.\d+\.[\da-z]+)\+(\d+).*")
-                    .captures(v)
-                    .map(|caps| {
-                        (
-                            caps[1].to_string(),
-                            caps[2].to_string(),
-                            caps[0].to_string(),
-                        )
-                    })
-            })
-            .filter(|(v, _, _)| v == version)
-            .min_by_key(|(_, date, name)| {
-                let install_type = if let Some(ref flavor) = flavor {
-                    // When flavor is set, prefer exact match
-                    let name_without_ext = name.trim_end_matches(".tar.gz");
-                    if name_without_ext.ends_with(flavor.as_str()) {
-                        0
-                    } else {
-                        1
-                    }
-                } else {
-                    // Default: prefer install_only_stripped > install_only > other
-                    if name.contains("install_only_stripped") {
-                        0
-                    } else if name.contains("install_only") {
-                        1
-                    } else {
-                        2
-                    }
-                };
-                let date = date.parse::<i64>().unwrap_or_default();
-                (install_type, -date)
-            })
-            .map(|(_, tag, filename)| (tag, filename));
+        // Prefer the PBS release already recorded in the lockfile so a plain
+        // `mise lock` refreshes the same artifact. `mise lock --bump` resolves
+        // without the existing lockfile, so locked_release is None and the
+        // newest build wins.
+        let result =
+            select_python_precompiled(&raw, version, &platform, flavor.as_deref(), locked_release);
+        if let Some(locked_release) = locked_release
+            && result
+                .as_ref()
+                .is_some_and(|(release, _)| release != locked_release)
+        {
+            debug!(
+                "locked python-build-standalone release {locked_release} not found for python {version} on {platform}, finding latest"
+            );
+        }
         Ok(result)
     }
 
@@ -1031,9 +1009,16 @@ impl Backend for PythonPlugin {
         target: &PlatformTarget,
     ) -> Result<PlatformInfo> {
         let version = &tv.version;
+        let locked_release = tv
+            .lock_platforms
+            .get(&target.to_key())
+            .and_then(|info| info.url.as_deref())
+            .and_then(|url| python_precompiled_release_from_url(url, version));
 
         // Look up the precompiled release for this version and target platform
-        let Some((tag, filename)) = self.fetch_precompiled_for_target(version, target).await?
+        let Some((tag, filename)) = self
+            .fetch_precompiled_for_target(version, target, locked_release)
+            .await?
         else {
             return Ok(PlatformInfo::default());
         };
@@ -1094,6 +1079,66 @@ fn python_precompiled_created_at(date: &str) -> Option<String> {
         &date[4..6],
         &date[6..]
     ))
+}
+
+fn python_precompiled_release_from_url<'a>(url: &'a str, version: &str) -> Option<&'a str> {
+    let (release, filename) = url
+        .strip_prefix(PBS_RELEASE_DOWNLOAD_URL)?
+        .split_once('/')?;
+    if release.len() != 8 || !release.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    filename
+        .starts_with(&format!("cpython-{version}+{release}-"))
+        .then_some(release)
+}
+
+fn select_python_precompiled(
+    manifest: &str,
+    version: &str,
+    platform: &str,
+    flavor: Option<&str>,
+    locked_release: Option<&str>,
+) -> Option<(String, String)> {
+    let flavor = flavor.map(str::to_string);
+    let candidates = manifest
+        .lines()
+        .filter(|line| line.contains(platform))
+        .filter(|line| filter_freethreaded(line, &flavor))
+        .flat_map(|line| {
+            regex!(r"^cpython-(\d+\.\d+\.[\da-z]+)\+(\d+).*")
+                .captures(line)
+                .map(|captures| {
+                    (
+                        captures[1].to_string(),
+                        captures[2].to_string(),
+                        captures[0].to_string(),
+                    )
+                })
+        })
+        .filter(|(candidate, _, _)| candidate == version)
+        .collect_vec();
+    let select = |release: Option<&str>| {
+        candidates
+            .iter()
+            .filter(|(_, date, _)| release.is_none_or(|release| date == release))
+            .min_by_key(|(_, date, name)| {
+                let install_type = if let Some(flavor) = flavor.as_deref() {
+                    let name_without_ext = name.trim_end_matches(".tar.gz");
+                    usize::from(!name_without_ext.ends_with(flavor))
+                } else if name.contains("install_only_stripped") {
+                    0
+                } else if name.contains("install_only") {
+                    1
+                } else {
+                    2
+                };
+                let date = date.parse::<i64>().unwrap_or_default();
+                (install_type, -date)
+            })
+            .map(|(_, release, filename)| (release.clone(), filename.clone()))
+    };
+    select(locked_release).or_else(|| select(None))
 }
 
 fn python_precompiled_url_path(settings: &Settings) -> String {
@@ -1328,6 +1373,50 @@ plugins/python-build/share/python-build/patches/3.14.5/foo.patch
         );
         assert_eq!(python_precompiled_created_at("2026-06-11"), None);
         assert_eq!(python_precompiled_created_at("notadate"), None);
+    }
+
+    #[test]
+    fn parses_python_precompiled_release_from_url() {
+        let url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz";
+        assert_eq!(
+            python_precompiled_release_from_url(url, "3.12.13"),
+            Some("20260728")
+        );
+        assert_eq!(python_precompiled_release_from_url(url, "3.12.12"), None);
+        assert_eq!(
+            python_precompiled_release_from_url(
+                "https://example.com/releases/download/20260728/cpython-3.12.13+20260728.tar.gz",
+                "3.12.13"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn selects_locked_python_precompiled_release() {
+        let manifest = "\
+cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only.tar.gz
+cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz
+cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz
+";
+        let platform = "x86_64-unknown-linux-gnu";
+
+        assert_eq!(
+            select_python_precompiled(manifest, "3.12.13", platform, None, Some("20260728")),
+            Some((
+                "20260728".to_string(),
+                "cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+                    .to_string()
+            ))
+        );
+        assert_eq!(
+            select_python_precompiled(manifest, "3.12.13", platform, None, None),
+            Some((
+                "20260805".to_string(),
+                "cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+                    .to_string()
+            ))
+        );
     }
 
     #[test]

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -1104,7 +1104,6 @@ fn select_python_precompiled(
     let candidates = manifest
         .lines()
         .filter(|line| line.contains(platform))
-        .filter(|line| filter_freethreaded(line, &flavor))
         .flat_map(|line| {
             regex!(r"^cpython-(\d+\.\d+\.[\da-z]+)\+(\d+).*")
                 .captures(line)
@@ -1121,7 +1120,12 @@ fn select_python_precompiled(
     let select = |filename: Option<&str>| {
         candidates
             .iter()
-            .filter(|(_, _, candidate)| filename.is_none_or(|filename| candidate == filename))
+            .filter(|(_, _, candidate)| {
+                filename.map_or_else(
+                    || filter_freethreaded(candidate, &flavor),
+                    |filename| candidate == filename,
+                )
+            })
             .min_by_key(|(_, date, name)| {
                 let install_type = if let Some(flavor) = flavor.as_deref() {
                     let name_without_ext = name.trim_end_matches(".tar.gz");
@@ -1397,6 +1401,7 @@ plugins/python-build/share/python-build/patches/3.14.5/foo.patch
         let manifest = "\
 cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only.tar.gz
 cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz
+cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped+freethreaded.tar.gz
 cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz
 ";
         let platform = "x86_64-unknown-linux-gnu";
@@ -1419,6 +1424,22 @@ cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz
             Some((
                 "20260805".to_string(),
                 "cpython-3.12.13+20260805-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+                    .to_string()
+            ))
+        );
+        assert_eq!(
+            select_python_precompiled(
+                manifest,
+                "3.12.13",
+                platform,
+                None,
+                Some(
+                    "cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped+freethreaded.tar.gz"
+                )
+            ),
+            Some((
+                "20260728".to_string(),
+                "cpython-3.12.13+20260728-x86_64-unknown-linux-gnu-install_only_stripped+freethreaded.tar.gz"
                     .to_string()
             ))
         );


### PR DESCRIPTION
## Summary
- preserve the python-build-standalone release already recorded for each locked platform
- keep selecting the newest compatible PBS release when no lock hint exists, including `mise lock --bump`
- add regression coverage for locked release parsing and artifact selection

## Root cause
`core:python` selected the newest PBS build date every time it regenerated lock metadata. PBS can publish several artifacts for one CPython version, so a plain `mise lock` replaced URLs and checksums even though the resolved Python version had not changed.

## Impact
A normal relock now refreshes metadata for the existing PBS artifact instead of churning `mise.lock`. Users can explicitly advance the PBS build with `mise lock --bump`.

Addresses https://github.com/jdx/mise/discussions/11743

## Validation
- `cargo test plugins::core::python::tests`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo build`
- `mise run lint-fix`
- manual reproduction against the live PBS manifest: plain lock retained 20260728; `--bump` advanced to 20260805

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how lock metadata is resolved for precompiled Python downloads (URLs/checksums), but scope is limited to lock regeneration with tests and a safe fallback when a locked artifact disappears.
> 
> **Overview**
> **Plain `mise lock` no longer bumps python-build-standalone (PBS) build dates** when the CPython version is unchanged. Lock resolution now reads the PBS tarball filename from each platform’s existing lock URL and **prefers that artifact** when it still appears in the manifest, so URLs and checksums refresh without swapping to a newer PBS release.
> 
> Selection logic moves into **`select_python_precompiled`**, with **`python_precompiled_filename_from_url`** to parse PBS GitHub download URLs. **`fetch_precompiled_for_target`** takes an optional locked filename; **`resolve_lock_info`** supplies it from `lock_platforms`. If the locked artifact is gone from the manifest, behavior **falls back to the newest compatible build** (same as before, with a debug log). **`mise lock --bump`** still picks the latest because no lock hint is passed.
> 
> Unit tests cover URL parsing and locked-vs-latest selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 758c5756d65e8c338bd67df1e9fa8b5aab112395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python Build Standalone releases now honor locked versions during lockfile refreshes.
  * If a locked release is unavailable, the latest compatible release is selected automatically.
  * Version bumps continue to select the newest matching release.

* **Tests**
  * Added coverage for release URL parsing and locked-versus-latest release selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->