### PR TITLE
fix(rust): expand tilde in home settings

### DIFF
--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -701,20 +701,6 @@ const RUST_TARGET_ARCHES: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::settings::SettingsPartial;
-    use confique::Layer;
-
-    static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    struct SettingsResetGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl Drop for SettingsResetGuard {
-        fn drop(&mut self) {
-            Settings::reset(None);
-        }
-    }
 
     fn opts_with(key: &str, value: &str) -> ToolVersionOptions {
         let mut opts = ToolVersionOptions::default();
@@ -884,17 +870,14 @@ targets = ["wasm32-wasip1", " wasm32-wasip1 "]
     }
 
     #[test]
-    fn rust_home_settings_expand_tilde() {
-        let lock = TEST_SETTINGS_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let _guard = SettingsResetGuard { _lock: lock };
-        let mut settings = SettingsPartial::empty();
-        settings.rust.cargo_home = Some(PathBuf::from("~/.cargo-custom"));
-        settings.rust.rustup_home = Some(PathBuf::from("~/.rustup-custom"));
-        Settings::reset(Some(settings));
-
-        assert_eq!(cargo_home(), dirs::HOME.join(".cargo-custom"));
-        assert_eq!(rustup_home(), dirs::HOME.join(".rustup-custom"));
+    fn rust_home_paths_expand_tilde() {
+        assert_eq!(
+            resolve_rust_home(PathBuf::from("~/.cargo-custom")),
+            dirs::HOME.join(".cargo-custom")
+        );
+        assert_eq!(
+            resolve_rust_home(PathBuf::from("~/.rustup-custom")),
+            dirs::HOME.join(".rustup-custom")
+        );
     }
 }

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -573,28 +573,29 @@ fn rustup_path() -> PathBuf {
 }
 
 fn rustup_home() -> PathBuf {
-    let path = Settings::get()
-        .rust
-        .rustup_home
-        .clone()
-        .or(env::var_path("RUSTUP_HOME"))
-        .unwrap_or(dirs::HOME.join(".rustup"));
-    if path.is_relative() {
-        std::env::current_dir()
-            .map(|cwd| cwd.join(&path))
-            .unwrap_or(path)
-    } else {
-        path
-    }
+    resolve_rust_home(
+        Settings::get()
+            .rust
+            .rustup_home
+            .clone()
+            .or(env::var_path("RUSTUP_HOME"))
+            .unwrap_or(dirs::HOME.join(".rustup")),
+    )
 }
 
 fn cargo_home() -> PathBuf {
-    let path = Settings::get()
-        .rust
-        .cargo_home
-        .clone()
-        .or(env::var_path("CARGO_HOME"))
-        .unwrap_or(dirs::HOME.join(".cargo"));
+    resolve_rust_home(
+        Settings::get()
+            .rust
+            .cargo_home
+            .clone()
+            .or(env::var_path("CARGO_HOME"))
+            .unwrap_or(dirs::HOME.join(".cargo")),
+    )
+}
+
+fn resolve_rust_home(path: PathBuf) -> PathBuf {
+    let path = file::replace_path(path);
     if path.is_relative() {
         std::env::current_dir()
             .map(|cwd| cwd.join(&path))
@@ -700,6 +701,20 @@ const RUST_TARGET_ARCHES: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::settings::SettingsPartial;
+    use confique::Layer;
+
+    static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct SettingsResetGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for SettingsResetGuard {
+        fn drop(&mut self) {
+            Settings::reset(None);
+        }
+    }
 
     fn opts_with(key: &str, value: &str) -> ToolVersionOptions {
         let mut opts = ToolVersionOptions::default();
@@ -866,5 +881,20 @@ targets = ["wasm32-wasip1", " wasm32-wasip1 "]
         let opts = opts_with("profile", "");
 
         assert_eq!(RustOptions::new(&opts).lockfile_options(), BTreeMap::new());
+    }
+
+    #[test]
+    fn rust_home_settings_expand_tilde() {
+        let lock = TEST_SETTINGS_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _guard = SettingsResetGuard { _lock: lock };
+        let mut settings = SettingsPartial::empty();
+        settings.rust.cargo_home = Some(PathBuf::from("~/.cargo-custom"));
+        settings.rust.rustup_home = Some(PathBuf::from("~/.rustup-custom"));
+        Settings::reset(Some(settings));
+
+        assert_eq!(cargo_home(), dirs::HOME.join(".cargo-custom"));
+        assert_eq!(rustup_home(), dirs::HOME.join(".rustup-custom"));
     }
 }


### PR DESCRIPTION
## Summary

- expand `~` in the Rust plugin's `cargo_home` and `rustup_home` settings
- preserve current-directory resolution for ordinary relative paths
- add regression coverage for tilde-prefixed Rust home paths

## Problem

Given:

```toml
[settings.rust]
cargo_home = "~/.cargo-custom"
rustup_home = "~/.rustup-custom"
```

mise treated these values as ordinary relative paths and resolved them to:

```text
<current-directory>/~/.cargo-custom
<current-directory>/~/.rustup-custom
```

instead of paths under the user's home directory.

Direct `CARGO_HOME` and `RUSTUP_HOME` values already expand `~` through `env::var_path()`, but values loaded through the Rust settings—including `MISE_CARGO_HOME` and `MISE_RUSTUP_HOME`—did not.

## Fix

Pass the selected Rust home path through `file::replace_path()` before checking whether it is relative. This expands `~` first while retaining the existing behavior of resolving paths such as `.cargo` against the current directory.

## Tests

- `cargo fmt --all -- --check`
- `cargo test plugins::core::rust::tests`
- `cargo clippy --bin mise -- -D warnings`

*AI-assisted — Tool: Shelley; model: openai/gpt-5.6-sol; version: 0.925.927026316.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom Cargo and rustup home directories.
  * Paths using `~` are now expanded correctly before being resolved, including values provided through environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->