### PR TITLE
feat(shim): add not_found_system_fallback setting

### DIFF
--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -114,6 +114,18 @@ directory depends on [`not_found_auto_install`](/configuration/settings.html#not
 
 :::
 
+::: info
+When a shim cannot resolve a mise-managed tool (for example, a version pinned in `mise.toml` that hasn't
+been installed and [`not_found_auto_install`](/configuration/settings.html#not_found_auto_install) is
+disabled), it falls back to the first same-named executable found elsewhere on `PATH` rather than erroring.
+This is convenient for tools you also want available outside of mise, but for a tool the OS also ships
+(`python3` on Debian/Ubuntu, for example) it means the shim can silently run a completely different,
+unrelated binary instead of failing loudly.
+
+Set [`not_found_system_fallback`](/configuration/settings.html#not_found_system_fallback) to `false`,
+alongside `not_found_auto_install = false`, if you'd rather an unresolvable shim fail outright.
+:::
+
 - You can also decide to use only `shims` if you prefer, though this comes with some [limitations](/dev-tools/shims.html#shims-vs-path).
 - An alternative to [`mise activate --shims`](/cli/activate.html#shims) is to use `export PATH="$HOME/.local/share/mise/shims:$PATH"`. This can be helpful if `mise` is not yet available at that point in time.
 

--- a/e2e/cli/test_shims_system_fallback
+++ b/e2e/cli/test_shims_system_fallback
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+eval "$(mise activate bash --shims)"
+
+mise i dummy@1.0.0
+shim_dir="$MISE_DATA_DIR/shims"
+
+fake_bin="$PWD/fake-bin"
+mkdir -p "$fake_bin"
+printf '#!/bin/sh\necho fake-system-dummy\n' >"$fake_bin/dummy"
+chmod +x "$fake_bin/dummy"
+
+cat >mise.toml <<'EOF'
+[tools]
+dummy = "2.0.0"
+EOF
+
+export MISE_NOT_FOUND_AUTO_INSTALL=0
+export PATH="$shim_dir:$fake_bin:$PATH"
+
+# default behavior is preserved: system fallback still wins
+assert_contains "dummy" "fake-system-dummy"
+
+# with the fallback disabled via env var the shim must fail loudly instead of substituting
+output="$(MISE_NOT_FOUND_SYSTEM_FALLBACK=0 dummy 2>&1 || true)"
+assert_contains_text "$output" "Tool not installed for shim: dummy"
+assert_not_contains_text "$output" "fake-system-dummy"
+
+# same, but disabled via [settings] in mise.toml instead of an env var
+cat >mise.toml <<'EOF'
+[settings]
+not_found_system_fallback = false
+
+[tools]
+dummy = "2.0.0"
+EOF
+
+output="$(dummy 2>&1 || true)"
+assert_contains_text "$output" "Tool not installed for shim: dummy"
+assert_not_contains_text "$output" "fake-system-dummy"
+
+# removing the override restores the default fallback behavior
+cat >mise.toml <<'EOF'
+[tools]
+dummy = "2.0.0"
+EOF
+
+assert_contains "dummy" "fake-system-dummy"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1329,6 +1329,11 @@
           "description": "Set to false to disable the \"command not found\" handler to autoinstall missing tool versions.",
           "type": "boolean"
         },
+        "not_found_system_fallback": {
+          "default": true,
+          "description": "Set to false to stop shims from falling back to a same-named binary found elsewhere on PATH.",
+          "type": "boolean"
+        },
         "npm": {
           "type": "object",
           "unevaluatedProperties": false,

--- a/settings.toml
+++ b/settings.toml
@@ -1765,6 +1765,21 @@ This also runs in shims if the terminal is interactive.
 env = "MISE_NOT_FOUND_AUTO_INSTALL"
 type = "Bool"
 
+[not_found_system_fallback]
+default = true
+description = "Set to false to stop shims from falling back to a same-named binary found elsewhere on PATH."
+docs = """
+When a shim cannot resolve a mise-managed tool, it falls back to the first same-named executable found on
+`PATH` outside the shims directory. That is useful for tools you also want to work outside of mise, but it
+means a configured-but-uninstalled version can silently run an unrelated system binary instead of erroring
+— common for tools the OS also ships, like `python3`.
+
+Set to false, alongside [`not_found_auto_install`](#not_found_auto_install), to make an unresolvable shim
+fail loudly instead.
+"""
+env = "MISE_NOT_FOUND_SYSTEM_FALLBACK"
+type = "Bool"
+
 
 [npm.bun]
 deprecated = "Use npm.package_manager instead."

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -175,22 +175,24 @@ async fn which_shim(
         }
     }
     // fallback for "system"
-    let mise_bin = file::canonicalize_or_self(&env::MISE_BIN);
-    for path in &*env::PATH {
-        if file::is_mise_shims_dir(path) {
-            continue;
-        }
-        let bin = path.join(bin_name);
-        if bin.exists() {
-            if file::is_active_mise_shim(&bin) {
+    if Settings::get().not_found_system_fallback {
+        let mise_bin = file::canonicalize_or_self(&env::MISE_BIN);
+        for path in &*env::PATH {
+            if file::is_mise_shims_dir(path) {
                 continue;
             }
-            // Skip if this binary is a mise shim (symlink pointing to the mise binary)
-            if file::canonicalize_cached(&bin).is_some_and(|bin| bin == mise_bin) {
-                continue;
+            let bin = path.join(bin_name);
+            if bin.exists() {
+                if file::is_active_mise_shim(&bin) {
+                    continue;
+                }
+                // Skip if this binary is a mise shim (symlink pointing to the mise binary)
+                if file::canonicalize_cached(&bin).is_some_and(|bin| bin == mise_bin) {
+                    continue;
+                }
+                trace!("shim[{bin_name}] SYSTEM {bin}", bin = display_path(&bin));
+                return Ok((bin, ts));
             }
-            trace!("shim[{bin_name}] SYSTEM {bin}", bin = display_path(&bin));
-            return Ok((bin, ts));
         }
     }
     let tvs = ts.list_rtvs_with_bin(config, bin_name).await?;


### PR DESCRIPTION
## Problem
`which_shim()`'s fallback to a binary on `PATH` ([`src/shims.rs#L177-L197`](https://github.com/richid/mise/blob/76d08efa006e97b46398d55e290808c7741bb202/src/shims.rs#L177-L197)) has no setting to disable it. When a tool is pinned to a version that isn't installed and `not_found_auto_install` is disabled the shim doesn't error. Instead it walks `PATH` and then execs a same-named binary there.

We found this in our potentially unique situation. We use `mise` to created "hardened" CI images that have an explicit allowlist of tools and versions supported, enforced via `MISE_NOT_FOUND_AUTO_INSTALL=0`. We recently removed Python 3.10 because it's EOL in a couple months and realized that it would silently fall back to the system `python3` (`3.13.5`) on Debian Trixie. In our situation we want this to be a loud and immediate failure.

Note this also gates the fallback for orphaned shims left behind after a tool is removed from config entirely not just pinned-but-uninstalled versions.

## Change
Add a new boolean setting:
- config: `not_found_system_fallback`
- env: `MISE_NOT_FOUND_SYSTEM_FALLBACK`
- default: `true` (preserves current behavior)

When `false` the system-PATH lookup is skipped entirely and fails loudly rather than silently substitution the system binary. Mirrors how `not_found_auto_install` works.

## Verification
- Added `e2e/cli/test_shims_system_fallback`: default fallback still wins; disabling via env var and via `[settings]` both fail loudly instead of falling back; removing the override restores default behavior.
- `cargo test --all-features`: 2437 passed, 0 failed.
- Reran `test_shims`, `test_shims_fallback`, `test_system_shims_no_recursion`, `test_doctor_shim_shadowing`, `test_usage_completion_shim_offline` — no regressions.
- `mise run lint`, `mise run render` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to control whether unresolved tools fall back to matching executables found elsewhere on `PATH`.
  * System fallback remains enabled by default.
  * Added support for disabling fallback through configuration or the `MISE_NOT_FOUND_SYSTEM_FALLBACK` environment variable.

* **Bug Fixes**
  * Shims now report a missing-tool error instead of running an unrelated system executable when fallback is disabled.

* **Documentation**
  * Documented system fallback behavior, associated risks, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->