### PR TITLE
fix(github): use published date for release age

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -350,7 +350,7 @@ impl Backend for AquaBackend {
         // Always fetch the pre-release superset; the shared remote-versions
         // cache stores it untouched and the trait's read path filters on
         // `VersionInfo.prerelease` based on the current tool opts.
-        let tags_with_timestamps = match get_tags_with_created_at(&pkg).await {
+        let tags_with_timestamps = match get_tags_with_release_dates(&pkg).await {
             Ok(tags) => tags,
             Err(e) => {
                 if strict_metadata() {
@@ -4442,7 +4442,7 @@ packages:
 }
 
 async fn get_tags(pkg: &AquaPackage) -> Result<Vec<String>> {
-    Ok(get_tags_with_created_at(pkg)
+    Ok(get_tags_with_release_dates(pkg)
         .await?
         .into_iter()
         .map(|(tag, _, _)| tag)
@@ -4489,15 +4489,15 @@ fn package_has_asset(pkg: &AquaPackage) -> bool {
     !pkg.no_asset.unwrap_or(false) && pkg.error_message.is_none()
 }
 
-/// Get tags with optional created_at timestamps and a pre-release flag.
-/// Returns `(tag_name, Option<created_at>, prerelease)` triples.
+/// Get tags with optional release timestamps and a pre-release flag.
+/// Returns `(tag_name, Option<released_at>, prerelease)` triples.
 ///
 /// Always fetches the pre-release superset so the shared remote-versions cache
 /// is independent of the `prerelease` tool option; callers filter on the
 /// returned `prerelease` bit at read time. Git tags (the `github_tag` version
 /// source) carry no pre-release flag, so those entries are reported as
 /// `prerelease = false` and rely on the shared regex-based fuzzy-match filter.
-async fn get_tags_with_created_at(
+async fn get_tags_with_release_dates(
     pkg: &AquaPackage,
 ) -> Result<Vec<(String, Option<String>, bool)>> {
     if let Some("github_tag") = pkg.version_source.as_deref() {
@@ -4509,7 +4509,10 @@ async fn get_tags_with_created_at(
     let releases = github::list_releases_including_prereleases(&repo).await?;
     Ok(releases
         .into_iter()
-        .map(|r| (r.tag_name, Some(r.created_at), r.prerelease))
+        .map(|r| {
+            let released_at = r.released_at().to_string();
+            (r.tag_name, Some(released_at), r.prerelease)
+        })
         .collect())
 }
 

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -510,12 +510,15 @@ impl Backend for UnifiedGitBackend {
                 .await?
                 .into_iter()
                 .filter(|r| version_prefix.is_none_or(|p| r.tag_name.starts_with(p)))
-                .map(|r| VersionInfo {
-                    version: self.strip_version_prefix(&r.tag_name, &opts),
-                    created_at: Some(r.created_at),
-                    release_url: Some(format!("{}/releases/tag/{}", web_url_base, r.tag_name)),
-                    prerelease: r.prerelease,
-                    ..Default::default()
+                .map(|r| {
+                    let created_at = Some(r.released_at().to_string());
+                    VersionInfo {
+                        version: self.strip_version_prefix(&r.tag_name, &opts),
+                        created_at,
+                        release_url: Some(format!("{}/releases/tag/{}", web_url_base, r.tag_name)),
+                        prerelease: r.prerelease,
+                        ..Default::default()
+                    }
                 })
                 .collect()
         };
@@ -576,7 +579,10 @@ impl Backend for UnifiedGitBackend {
                 .get_github_release_for_url(&api_url, &repo, "latest")
                 .await
             {
-                Ok(r) => Some((r.tag_name, r.created_at, r.prerelease)),
+                Ok(r) => {
+                    let released_at = r.released_at().to_string();
+                    Some((r.tag_name, released_at, r.prerelease))
+                }
                 Err(e) => {
                     debug!("Failed to fetch latest GitHub release for {repo}: {e}");
                     None

--- a/src/backend/pipx.rs
+++ b/src/backend/pipx.rs
@@ -505,10 +505,13 @@ impl PIPXBackend {
         releases
             .into_iter()
             .rev()
-            .map(|r| VersionInfo {
-                version: r.tag_name,
-                created_at: Some(r.created_at),
-                ..Default::default()
+            .map(|r| {
+                let created_at = Some(r.released_at().to_string());
+                VersionInfo {
+                    version: r.tag_name,
+                    created_at,
+                    ..Default::default()
+                }
             })
             .collect()
     }
@@ -1360,6 +1363,7 @@ mod tests {
             draft: false,
             prerelease: false,
             created_at: created_at.to_string(),
+            published_at: None,
             assets: vec![],
         }
     }

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -209,10 +209,13 @@ impl Backend for SPMBackend {
             _ => github::list_releases_from_url(&provider.api_url, repo.shorthand.as_str())
                 .await?
                 .into_iter()
-                .map(|r| VersionInfo {
-                    version: r.tag_name,
-                    created_at: Some(r.created_at),
-                    ..Default::default()
+                .map(|r| {
+                    let created_at = Some(r.released_at().to_string());
+                    VersionInfo {
+                        version: r.tag_name,
+                        created_at,
+                        ..Default::default()
+                    }
                 })
                 .rev()
                 .collect(),

--- a/src/backend/ubi.rs
+++ b/src/backend/ubi.rs
@@ -212,9 +212,10 @@ impl Backend for UbiBackend {
                             .map(|r| {
                                 let release_url =
                                     format!("{}/releases/tag/{}", release_url_base, r.tag_name);
+                                let created_at = Some(r.released_at().to_string());
                                 VersionInfo {
                                     version: strip_v_prefix(&r.tag_name),
-                                    created_at: Some(r.created_at),
+                                    created_at,
                                     release_url: Some(release_url),
                                     ..Default::default()
                                 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -26,8 +26,17 @@ pub struct GithubRelease {
     pub draft: bool,
     pub prerelease: bool,
     pub created_at: String,
-    // pub published_at: Option<String>,
+    #[serde(default)]
+    pub published_at: Option<String>,
     pub assets: Vec<GithubAsset>,
+}
+
+impl GithubRelease {
+    /// The time this release became public. GitHub's `created_at` is the date
+    /// of the tagged commit, which may be much older than the publication date.
+    pub fn released_at(&self) -> &str {
+        self.published_at.as_deref().unwrap_or(&self.created_at)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1240,8 +1249,40 @@ something_else = "value"
             draft: false,
             prerelease: false,
             created_at: String::new(),
+            published_at: None,
             assets: vec![],
         }
+    }
+
+    #[test]
+    fn release_date_prefers_published_at() {
+        let mut release = make_release("v1.0.0");
+        release.created_at = "2026-06-28T17:38:00Z".into();
+        release.published_at = Some("2026-08-06T09:16:56Z".into());
+
+        assert_eq!(release.released_at(), "2026-08-06T09:16:56Z");
+    }
+
+    #[test]
+    fn release_date_falls_back_to_created_at() {
+        let mut release = make_release("v1.0.0");
+        release.created_at = "2026-06-28T17:38:00Z".into();
+
+        assert_eq!(release.released_at(), "2026-06-28T17:38:00Z");
+    }
+
+    #[test]
+    fn release_without_published_at_remains_deserializable() {
+        let release: GithubRelease = serde_json::from_value(serde_json::json!({
+            "tag_name": "v1.0.0",
+            "draft": false,
+            "prerelease": false,
+            "created_at": "2026-06-28T17:38:00Z",
+            "assets": []
+        }))
+        .unwrap();
+
+        assert_eq!(release.released_at(), "2026-06-28T17:38:00Z");
     }
 
     #[test]

--- a/src/plugins/core/bun.rs
+++ b/src/plugins/core/bun.rs
@@ -180,9 +180,10 @@ impl Backend for BunPlugin {
             .await?
             .into_iter()
             .filter_map(|r| {
+                let released_at = r.released_at().to_string();
                 r.tag_name
                     .strip_prefix("bun-v")
-                    .map(|v| (v.to_string(), r.created_at))
+                    .map(|v| (v.to_string(), released_at))
             })
             .unique_by(|(v, _)| v.clone())
             .sorted_by_cached_key(|(s, _)| (Versioning::new(s), s.to_string()))

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -576,9 +576,10 @@ impl Backend for ErlangPlugin {
                 .await?
                 .into_iter()
                 .filter_map(|r| {
+                    let released_at = r.released_at().to_string();
                     r.tag_name
                         .strip_prefix("OTP-")
-                        .map(|s| (s.to_string(), Some(r.created_at)))
+                        .map(|s| (s.to_string(), Some(released_at)))
                 })
                 .map(|(version, created_at)| VersionInfo {
                     version,

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -792,14 +792,14 @@ impl RubyPlugin {
         }
     }
 
-    /// Fetch created_at timestamps for Ruby versions from GitHub releases
+    /// Fetch publication timestamps for Ruby versions from GitHub releases.
     async fn fetch_ruby_release_dates(&self) -> Result<HashMap<String, String>> {
         let mut dates = HashMap::new();
         match github::list_releases("ruby/ruby").await {
             Ok(releases) => {
                 for release in releases {
                     if let Some(version) = Self::tag_to_version(&release.tag_name) {
-                        dates.insert(version, release.created_at);
+                        dates.insert(version, release.released_at().to_string());
                     }
                 }
             }
@@ -1354,6 +1354,7 @@ mod tests {
             draft: false,
             prerelease: false,
             created_at: "2026-01-01T00:00:00Z".to_string(),
+            published_at: None,
             assets: assets
                 .iter()
                 .map(|name| crate::github::GithubAsset {

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -171,13 +171,14 @@ impl Backend for RubyPlugin {
         let versions = releases
             .into_iter()
             .filter_map(|r| {
+                let created_at = Some(r.released_at().to_string());
                 regex!(r"RubyInstaller-([0-9.]+)-.*")
                     .replace(&r.tag_name, "$1")
                     .parse::<String>()
                     .ok()
                     .map(|version| VersionInfo {
                         version,
-                        created_at: Some(r.created_at),
+                        created_at,
                         ..Default::default()
                     })
             })

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -292,11 +292,14 @@ impl Backend for RustPlugin {
         let versions: Vec<VersionInfo> = github::list_releases("rust-lang/rust")
             .await?
             .into_iter()
-            .map(|r| VersionInfo {
-                release_url: Some(format!("https://releases.rs/docs/{}/", r.tag_name)),
-                version: r.tag_name,
-                created_at: Some(r.created_at),
-                ..Default::default()
+            .map(|r| {
+                let created_at = Some(r.released_at().to_string());
+                VersionInfo {
+                    release_url: Some(format!("https://releases.rs/docs/{}/", r.tag_name)),
+                    version: r.tag_name,
+                    created_at,
+                    ..Default::default()
+                }
             })
             .rev()
             .chain(vec![

--- a/src/plugins/core/swift.rs
+++ b/src/plugins/core/swift.rs
@@ -283,10 +283,11 @@ impl Backend for SwiftPlugin {
             .await?
             .into_iter()
             .filter_map(|r| {
+                let released_at = r.released_at().to_string();
                 r.tag_name
                     .strip_prefix("swift-")
                     .and_then(|v| v.strip_suffix("-RELEASE"))
-                    .map(|v| (v.to_string(), r.created_at))
+                    .map(|v| (v.to_string(), released_at))
             })
             .rev()
             .map(|(version, created_at)| VersionInfo {

--- a/src/versions_host.rs
+++ b/src/versions_host.rs
@@ -785,6 +785,7 @@ mod tests {
             draft: false,
             prerelease: false,
             created_at: "2026-01-01T00:00:00Z".into(),
+            published_at: None,
             assets: vec![],
         };
 
@@ -802,6 +803,7 @@ mod tests {
             draft: false,
             prerelease: false,
             created_at: "2026-01-01T00:00:00Z".into(),
+            published_at: None,
             assets: vec![],
         };
 


### PR DESCRIPTION
## Summary

- use GitHub's `published_at` timestamp when applying release-age filters
- fall back to `created_at` for older cached data and GitHub-compatible servers that omit `published_at`
- apply the corrected timestamp consistently across Aqua, GitHub, Ubi, SPM, Pipx, and GitHub-backed core tools

## Root cause

GitHub defines `created_at` as the date of the commit used for a release, not the date the release was published. mise used that value as the release date, so a newly published release pointing at an older commit could bypass `minimum_release_age`.

Addresses https://github.com/jdx/mise/discussions/11750

## Validation

- `cargo test github::tests::` (65 passed)
- `mise run lint-fix`
- reproduced the reported Aqua case with a fresh cache and confirmed v6.0.3 is hidden while v6.0.2 remains eligible

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timestamp semantics for version listing and release-age gates across many backends; behavior is mitigated by falling back to `created_at` when `published_at` is absent.
> 
> **Overview**
> Fixes **release-age filtering** (`minimum_release_age` and related version metadata) by treating GitHub releases as “new” when they were **published**, not when the underlying tag commit was created.
> 
> **`GithubRelease`** now deserializes optional **`published_at`** and exposes **`released_at()`**, which prefers `published_at` and falls back to `created_at` for older API payloads or GitHub-compatible hosts that omit publication time. Aqua, GitHub, Ubi, SPM, Pipx, and GitHub-backed core plugins (Bun, Erlang, Ruby, Rust, Swift, etc.) populate **`VersionInfo.created_at`** from **`released_at()`** instead of raw `created_at`. Aqua renames tag fetching to **`get_tags_with_release_dates`** with the same semantics.
> 
> Unit tests cover preference, fallback, and backward-compatible deserialization without `published_at`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60aabd0f35a690b88844fa75bad4b9bdac9d3623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version metadata now displays the release publication date instead of the repository creation date.
  - Release dates are more accurate and consistent across supported tools and version sources.
  - Existing releases without publication dates remain compatible by using their creation date as a fallback.
  - Tag filtering, release URLs, version selection, and pre-release handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->