### PR TITLE
feat(bootstrap): add user-scoped flatpak packages

### DIFF
--- a/docs/bootstrap/packages/flatpak.md
+++ b/docs/bootstrap/packages/flatpak.md
@@ -1,39 +1,46 @@
 # Flatpak
 
-Flatpak applications and runtimes installed system-wide via the
+Flatpak applications and runtimes installed system-wide or for the current user via the
 [`flatpak`](https://docs.flatpak.org/en/latest/flatpak-command-reference.html) CLI.
 
 ```toml
 [bootstrap.packages]
 "flatpak:org.mozilla.firefox" = "latest"
-"flatpak:org.gnome.Builder" = "latest"
+"flatpak-user:org.gnome.Builder" = "latest"
 ```
 
-Flatpak packages are part of `[bootstrap.packages]`, just like apt packages,
-Homebrew formulae, and Mac App Store apps. The package name is an application
-or runtime ID accepted by `flatpak install` and `flatpak update`.
+Use the `flatpak` manager for the default system-wide installation and
+`flatpak-user` for the current user's installation. The scopes are separate,
+so a config can manage packages in either or both, including the same ID in
+both scopes. The package name is an application or runtime ID accepted by
+`flatpak install` and `flatpak update`.
 
 mise does not install Flatpak or configure remotes implicitly. Install the
 `flatpak` CLI and add the required remote (commonly Flathub) before applying
 the config:
 
 ```sh
-flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 mise bootstrap packages use flatpak:org.mozilla.firefox
+mise bootstrap packages use flatpak-user:org.gnome.Builder
 ```
 
 ## Commands
 
 ```sh
 mise bootstrap packages status --manager flatpak
+mise bootstrap packages status --manager flatpak-user
 mise bootstrap packages apply --manager flatpak
+mise bootstrap packages apply --manager flatpak-user
 mise bootstrap packages upgrade --manager flatpak
+mise bootstrap packages upgrade --manager flatpak-user
 ```
 
-mise manages the system-wide Flatpak installation. `apply` runs
-`flatpak install --system --noninteractive <id>` for missing packages, while
-`upgrade` runs `flatpak update --system --noninteractive <id>` for installed
-packages. Flatpak resolves the configured ID from the system remotes.
+mise always passes an explicit scope to Flatpak so status, installation, and
+upgrades operate on the same installation. `flatpak` passes `--system`, while
+`flatpak-user` passes `--user`. Flatpak resolves the configured ID from the
+remotes configured for that scope.
 
 Flatpak does not expose installation of arbitrary historical versions through
 these commands, so version pins are not supported. Use `"latest"` in config.

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -1,6 +1,6 @@
 # Bootstrap Packages
 
-mise can ensure machine-global system packages are installed via the
+mise can ensure host packages are installed via the
 `[bootstrap.packages]` section of `mise.toml`, applied by
 `mise bootstrap packages apply` or as part of
 [`mise bootstrap`](/bootstrap.html):
@@ -14,6 +14,7 @@ mise can ensure machine-global system packages are installed via the
 "brew:ffmpeg" = "latest"
 "brew-cask:firefox" = "latest"
 "flatpak:org.mozilla.firefox" = "latest"
+"flatpak-user:org.gnome.Builder" = "latest"
 "mas:497799835" = "latest"
 ```
 
@@ -22,13 +23,13 @@ and the value is a version: `"latest"` for whatever the manager installs, or
 a pin in the manager's native format where supported (see the per-manager
 pages).
 
-System packages are intentionally separate from [`[tools]`](/configuration.html):
-they are not version-pinned per-project, do not get shims, and are installed
-machine-globally by the platform's package manager — or, for `brew` and
+Host packages are intentionally separate from [`[tools]`](/configuration.html):
+they are not version-pinned per-project, do not get shims, and are managed
+outside the project by the platform's package manager — or, for `brew` and
 `brew-cask`, by mise's built-in Homebrew installers, which don't require
-Homebrew itself. Use them for shared libraries, build dependencies, and
-machine-global GUI apps (`libssl-dev`, `postgresql`, `ffmpeg`, `firefox`),
-not for project dev tools — those belong in `[tools]`.
+Homebrew itself. Use them for shared libraries, build dependencies, and host
+GUI apps (`libssl-dev`, `postgresql`, `ffmpeg`, `firefox`), not for project dev
+tools — those belong in `[tools]`.
 
 The manager list is extensible through [package manager plugins](./plugins.md),
 which cover host-owned state such as VS Code extensions, Helm plugins, krew
@@ -47,17 +48,18 @@ declarative sections work the same way:
 
 ## Supported package managers
 
-| Manager     | Platform                                                       | Page                                                |
-| ----------- | -------------------------------------------------------------- | --------------------------------------------------- |
-| `apk`       | Alpine Linux                                                   | [apk](/bootstrap/packages/apk.html)                 |
-| `apt`       | Debian, Ubuntu                                                 | [apt](/bootstrap/packages/apt.html)                 |
-| `dnf`       | Fedora, RHEL, CentOS, Rocky, Alma                              | [dnf](/bootstrap/packages/dnf.html)                 |
-| `pacman`    | Arch, Manjaro                                                  | [pacman](/bootstrap/packages/pacman.html)           |
-| `brew`      | macOS (arm64), Linux (x86_64/arm64) — **no Homebrew required** | [brew](/bootstrap/packages/brew.html)               |
-| `brew-cask` | macOS — **no Homebrew required**                               | [brew](/bootstrap/packages/brew.html)               |
-| `flatpak`   | Linux with the `flatpak` CLI on `PATH`                         | [Flatpak](/bootstrap/packages/flatpak.html)         |
-| `mas`       | macOS with the `mas` CLI on `PATH`                             | [mas](/bootstrap/packages/mas.html)                 |
-| plugin      | Declared by the plugin                                         | [Package plugins](/bootstrap/packages/plugins.html) |
+| Manager        | Platform                                                       | Page                                                |
+| -------------- | -------------------------------------------------------------- | --------------------------------------------------- |
+| `apk`          | Alpine Linux                                                   | [apk](/bootstrap/packages/apk.html)                 |
+| `apt`          | Debian, Ubuntu                                                 | [apt](/bootstrap/packages/apt.html)                 |
+| `dnf`          | Fedora, RHEL, CentOS, Rocky, Alma                              | [dnf](/bootstrap/packages/dnf.html)                 |
+| `pacman`       | Arch, Manjaro                                                  | [pacman](/bootstrap/packages/pacman.html)           |
+| `brew`         | macOS (arm64), Linux (x86_64/arm64) — **no Homebrew required** | [brew](/bootstrap/packages/brew.html)               |
+| `brew-cask`    | macOS — **no Homebrew required**                               | [brew](/bootstrap/packages/brew.html)               |
+| `flatpak`      | Linux with the `flatpak` CLI on `PATH` (system scope)          | [Flatpak](/bootstrap/packages/flatpak.html)         |
+| `flatpak-user` | Linux with the `flatpak` CLI on `PATH` (user scope)            | [Flatpak](/bootstrap/packages/flatpak.html)         |
+| `mas`          | macOS with the `mas` CLI on `PATH`                             | [mas](/bootstrap/packages/mas.html)                 |
+| plugin         | Declared by the plugin                                         | [Package plugins](/bootstrap/packages/plugins.html) |
 
 ## Semantics
 
@@ -71,9 +73,9 @@ declarative sections work the same way:
 - **OS-filtered** — entries for a manager that isn't available on the current
   machine are not acted on, so the same config works across platforms: `apt`
   entries are ignored on macOS, `dnf` entries on Ubuntu, and so on. `brew`
-  works on both macOS and Linux; `brew-cask` works on macOS; `flatpak` works
-  on Linux when the `flatpak` CLI is on `PATH`; `mas` works on
-  macOS when the `mas` CLI is on `PATH`. Status commands still list
+  works on both macOS and Linux; `brew-cask` works on macOS; `flatpak` and
+  `flatpak-user` work on Linux when the `flatpak` CLI is on `PATH`; `mas`
+  works on macOS when the `mas` CLI is on `PATH`. Status commands still list
   unavailable managers so nothing is silently invisible.
 - **Manual installation only** — mise never installs system packages
   implicitly. `mise install` will print a one-time hint when packages are
@@ -104,7 +106,7 @@ mise bootstrap packages apply --yes     # skip the confirmation prompt
 mise bootstrap packages apply --manager apt
 mise bootstrap packages apply --update  # refresh package manager metadata first
 
-mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835
+mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835
 mise bootstrap packages use -g brew:ffmpeg     # write globally
 mise bootstrap packages use apt:curl@8.5.0-2   # pin a version
     # (brew pins via the formula name instead: brew:postgresql@17)
@@ -121,6 +123,7 @@ mise bootstrap packages upgrade           # upgrade installed packages to curren
 mise bootstrap packages upgrade --manager brew
 mise bootstrap packages upgrade --manager brew-cask
 mise bootstrap packages upgrade --manager flatpak
+mise bootstrap packages upgrade --manager flatpak-user
 mise bootstrap packages upgrade --manager mas
 ```
 
@@ -148,12 +151,13 @@ declarative cleanup command, similar in spirit to
 `mise bootstrap packages upgrade` refreshes package manager metadata and upgrades the
 configured packages that are already installed to the newest available
 version — apk, apt, and dnf also honor a version pinned in config (pacman, brew,
-brew-cask, flatpak, and mas [can't install pins](/bootstrap/packages/pacman.html), so
+brew-cask, flatpak, flatpak-user, and mas [can't install pins](/bootstrap/packages/pacman.html), so
 pinned entries are skipped with a warning). Packages that aren't installed
 yet are skipped — that's `mise bootstrap packages apply`'s job. For brew
 this pours the formula's current bottle and replaces the old keg; for
-brew-cask this installs the current cask artifact; for flatpak this updates the
-configured applications and runtimes; for mas this runs `mas upgrade`.
+brew-cask this installs the current cask artifact; for flatpak and flatpak-user
+this updates the configured applications and runtimes in their respective
+scopes; for mas this runs `mas upgrade`.
 
 `mise doctor` also reports configured system packages and warns when any are
 missing.

--- a/docs/cli/bootstrap/packages/apply.md
+++ b/docs/cli/bootstrap/packages/apply.md
@@ -45,7 +45,7 @@ Examples:
 
 ```
 mise bootstrap packages apply
-mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835
+mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835
 mise bootstrap packages apply --dry-run
 mise bootstrap packages apply --manager apt --yes
 ```

--- a/docs/cli/bootstrap/packages/upgrade.md
+++ b/docs/cli/bootstrap/packages/upgrade.md
@@ -12,7 +12,7 @@ Refreshes package manager metadata and upgrades the configured packages
 that are already installed: apk/apt/dnf/pacman upgrade to the newest available
 version (apk, apt, and dnf honor a version pinned in config), brew pours the
 formula's current bottle and replaces the old keg, brew-cask installs
-the current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that
+the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
 are not installed yet are skipped — use `mise bootstrap packages apply`
 for those.
 

--- a/docs/cli/bootstrap/packages/use.md
+++ b/docs/cli/bootstrap/packages/use.md
@@ -49,7 +49,7 @@ Skip the confirmation prompt
 Examples:
 
 ```
-mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835
+mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835
 mise bootstrap packages use -g brew:postgresql@17
 mise bootstrap packages use apt:curl@8.5.0-2
 ```

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -67,7 +67,7 @@
 
 - [Overview](https://mise.jdx.dev/bootstrap.html): mise bootstrap sets up a machine for the current config in one command: Linux users and groups, OS packages, privileged files and directories, system services, Linux host firewall policy, Docker…
 - [Remote Hosts](https://mise.jdx.dev/bootstrap/remote.html): mise bootstrap remote applies a bootstrap project to one or more machines through the locally installed OpenSSH client.
-- [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): mise can ensure machine-global system packages are installed via the [bootstrap.packages] section of mise.toml, applied by mise bootstrap packages apply or as part of mise bootstrap.
+- [Bootstrap Packages](https://mise.jdx.dev/bootstrap/packages/): mise can ensure host packages are installed via the [bootstrap.packages] section of mise.toml, applied by mise bootstrap packages apply or as part of mise bootstrap.
 - [apk](https://mise.jdx.dev/bootstrap/packages/apk.html): System packages for Alpine Linux.
 - [apt](https://mise.jdx.dev/bootstrap/packages/apt.html): System packages for Debian-family Linux (Debian, Ubuntu, Mint, ...).
 - [dnf](https://mise.jdx.dev/bootstrap/packages/dnf.html): System packages for RedHat-family Linux (Fedora, RHEL, CentOS Stream, Rocky, Alma, ...).

--- a/docs/tool-plugin-development.md
+++ b/docs/tool-plugin-development.md
@@ -378,7 +378,7 @@ Optional fields:
 
 - **`version`** — a constraint (`>=3.0`, `>3`, `<=1.2`, `=3.0`, or a bare `3.0` meaning `>=3.0`) for `bin` and `pkgconfig`. mise runs `<bin> --version` / `pkg-config --modversion` and compares. If a version can't be extracted, the dependency is treated as satisfied (presence is enough) rather than blocking the install.
 - **`optional`** — a short reason string. Missing optional dependencies never prompt or fail; they surface as a single informational line, letting users build without features they don't need (e.g. Erlang's `wxWidgets` GUI).
-- **`packages`** — a map of package-manager name (`brew`, `brew-cask`, `apt`, `dnf`, `pacman`, `apk`, `flatpak`, `mas`) to the package that provides the capability.
+- **`packages`** — a map of package-manager name (`brew`, `brew-cask`, `apt`, `dnf`, `pacman`, `apk`, `flatpak`, `flatpak-user`, `mas`) to the package that provides the capability.
 
 **Detection is the source of truth.** A check that passes is satisfied no matter how the capability was installed — Homebrew, apt, nix, MacPorts, or from source all pass without ceremony, and mise never asks _how_ it got there. The `packages` map is only consulted to _offer_ installing the missing subset; it is a remediation hint, not a declaration that the tool must come from that package manager.
 

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1475,7 +1475,7 @@ Refreshes package manager metadata and upgrades the configured packages
 that are already installed: apk/apt/dnf/pacman upgrade to the newest available
 version (apk, apt, and dnf honor a version pinned in config), brew pours the
 formula's current bottle and replaces the old keg, brew\-cask installs
-the current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that
+the current cask artifact, flatpak and flatpak\-user update applications and runtimes, and mas upgrades App Store apps. Packages that
 are not installed yet are skipped — use `mise bootstrap packages apply`
 for those.
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -627,7 +627,7 @@ only. `install` is accepted as an alias for this command.
 Examples:
 
     $ mise bootstrap packages apply
-    $ mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835
+    $ mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835
     $ mise bootstrap packages apply --dry-run
     $ mise bootstrap packages apply --manager apt --yes
 
@@ -757,7 +757,7 @@ Refreshes package manager metadata and upgrades the configured packages
 that are already installed: apk/apt/dnf/pacman upgrade to the newest available
 version (apk, apt, and dnf honor a version pinned in config), brew pours the
 formula's current bottle and replaces the old keg, brew-cask installs
-the current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that
+the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
 are not installed yet are skipped — use `mise bootstrap packages apply`
 for those.
 
@@ -799,7 +799,7 @@ a mise version selector. mas uses numeric ADAM IDs and does not support pins.
             after_long_help #"""
 Examples:
 
-    $ mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835
+    $ mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835
     $ mise bootstrap packages use -g brew:postgresql@17
     $ mise bootstrap packages use apt:curl@8.5.0-2
 

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -434,7 +434,7 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
     $ <bold>mise bootstrap packages apply</bold>
-    $ <bold>mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835</bold>
+    $ <bold>mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835</bold>
     $ <bold>mise bootstrap packages apply --dry-run</bold>
     $ <bold>mise bootstrap packages apply --manager apt --yes</bold>
 "#

--- a/src/cli/system/upgrade.rs
+++ b/src/cli/system/upgrade.rs
@@ -10,7 +10,7 @@ use crate::system;
 /// that are already installed: apk/apt/dnf/pacman upgrade to the newest available
 /// version (apk, apt, and dnf honor a version pinned in config), brew pours the
 /// formula's current bottle and replaces the old keg, brew-cask installs
-/// the current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that
+/// the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
 /// are not installed yet are skipped — use `mise bootstrap packages apply`
 /// for those.
 ///

--- a/src/cli/system/use.rs
+++ b/src/cli/system/use.rs
@@ -148,7 +148,7 @@ impl SystemUse {
 static AFTER_LONG_HELP: &str = color_print::cstr!(
     r#"<bold><underline>Examples:</underline></bold>
 
-    $ <bold>mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835</bold>
+    $ <bold>mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835</bold>
     $ <bold>mise bootstrap packages use -g brew:postgresql@17</bold>
     $ <bold>mise bootstrap packages use apt:curl@8.5.0-2</bold>
 "#

--- a/src/system/packages/flatpak.rs
+++ b/src/system/packages/flatpak.rs
@@ -7,12 +7,35 @@ use eyre::bail;
 use super::{InstallOpts, PackageRequest, PackageState, PackageStatus, SystemPackageManager};
 use crate::result::Result;
 
-/// Flatpak applications and runtimes installed system-wide.
-pub struct FlatpakManager {}
+#[derive(Clone, Copy)]
+enum FlatpakScope {
+    System,
+    User,
+}
+
+/// Flatpak applications and runtimes installed system-wide or for the current user.
+pub struct FlatpakManager {
+    scope: FlatpakScope,
+}
 
 impl FlatpakManager {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            scope: FlatpakScope::System,
+        }
+    }
+
+    pub fn new_user() -> Self {
+        Self {
+            scope: FlatpakScope::User,
+        }
+    }
+
+    fn scope_arg(&self) -> &'static str {
+        match self.scope {
+            FlatpakScope::System => "--system",
+            FlatpakScope::User => "--user",
+        }
     }
 }
 
@@ -75,7 +98,10 @@ async fn run_flatpak(args: &[String], action: &str) -> Result<()> {
 #[async_trait(?Send)]
 impl SystemPackageManager for FlatpakManager {
     fn name(&self) -> &str {
-        "flatpak"
+        match self.scope {
+            FlatpakScope::System => "flatpak",
+            FlatpakScope::User => "flatpak-user",
+        }
     }
 
     fn is_available(&self) -> bool {
@@ -98,7 +124,7 @@ impl SystemPackageManager for FlatpakManager {
         if pkgs.is_empty() {
             return Ok(vec![]);
         }
-        let args = ["list", "--system", "--columns=application,version"];
+        let args = ["list", self.scope_arg(), "--columns=application,version"];
         debug!("$ flatpak {}", args.join(" "));
         let output = tokio::process::Command::new("flatpak")
             .args(args)
@@ -123,7 +149,7 @@ impl SystemPackageManager for FlatpakManager {
         }
         let mut args = vec![
             "install".to_string(),
-            "--system".to_string(),
+            self.scope_arg().to_string(),
             "--noninteractive".to_string(),
         ];
         args.extend(pkgs.iter().map(|pkg| pkg.name.clone()));
@@ -143,7 +169,7 @@ impl SystemPackageManager for FlatpakManager {
         }
         let mut args = vec![
             "update".to_string(),
-            "--system".to_string(),
+            self.scope_arg().to_string(),
             "--noninteractive".to_string(),
         ];
         args.extend(pkgs.iter().map(|pkg| pkg.name.clone()));
@@ -165,6 +191,17 @@ mod tests {
             version: version.map(str::to_string),
             tap_url: None,
         }
+    }
+
+    #[test]
+    fn test_scope_names_and_args() {
+        let system = FlatpakManager::new();
+        assert_eq!(system.name(), "flatpak");
+        assert_eq!(system.scope_arg(), "--system");
+
+        let user = FlatpakManager::new_user();
+        assert_eq!(user.name(), "flatpak-user");
+        assert_eq!(user.scope_arg(), "--user");
     }
 
     #[test]

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -1,6 +1,6 @@
-//! System package managers (apk, apt, brew, brew-cask, flatpak, mas) for the `[bootstrap.packages]` config section.
+//! Host package managers (apk, apt, brew, brew-cask, flatpak, flatpak-user, mas) for the `[bootstrap.packages]` config section.
 //!
-//! These are machine-global, unversioned packages — deliberately separate from
+//! These are host-owned, unversioned packages — deliberately separate from
 //! the `Backend` system, which manages per-project, version-pinned dev tools.
 
 use std::sync::Arc;
@@ -143,6 +143,7 @@ pub fn builtin_managers() -> Vec<Arc<dyn SystemPackageManager>> {
         Arc::new(brew::BrewCaskManager::new()),
         Arc::new(dnf::DnfManager::new()),
         Arc::new(flatpak::FlatpakManager::new()),
+        Arc::new(flatpak::FlatpakManager::new_user()),
         Arc::new(mas::MasManager::new()),
         Arc::new(pacman::PacmanManager::new()),
     ]


### PR DESCRIPTION
## Summary
- add a `flatpak-user` bootstrap package manager for per-user Flatpak installations
- keep the existing `flatpak` manager explicitly system-scoped for backward compatibility
- allow system and user Flatpaks, including the same application ID, to be managed at the same time
- document scope-specific remotes, commands, and generated CLI examples

## Why
The existing Flatpak manager always passes `--system`, so it cannot manage per-user installations used by immutable and user-oriented Linux setups. A global scope switch would also prevent a single config from managing both scopes.

Using separate manager names keeps each package declaration unambiguous and ensures status, install, and upgrade consistently pass the same Flatpak scope.

Addresses https://github.com/jdx/mise/discussions/10936#discussioncomment-17927686.

## User impact
Existing `flatpak:<id>` entries continue to manage the system installation. Users can add `flatpak-user:<id>` entries to manage the current user's installation, and can use either or both managers in the same config.

## Validation
- `mise run format`
- `mise run render:usage`
- `cargo test system::packages::flatpak` (4 passed)

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive bootstrap feature with backward-compatible `flatpak:` behavior; limited to Linux Flatpak CLI integration and documentation.
> 
> **Overview**
> Adds **`flatpak-user`** as a bootstrap package manager for per-user Flatpak installs, alongside the existing **`flatpak`** manager which remains explicitly **system**-scoped (`--system` vs `--user` on all list/install/update commands).
> 
> Configs can declare **`flatpak:<id>`** and **`flatpak-user:<id>`** in the same file, including the same app ID in both scopes. **`FlatpakManager`** is refactored around a scope enum with **`new()`** / **`new_user()`**, and both managers are registered in **`builtin_managers()`**.
> 
> Docs and generated help (Flatpak page, packages index, CLI examples, **`mise.usage.kdl`**, man page) describe the two managers, scope-specific remotes, and **`--manager flatpak-user`**. Tool-plugin dependency **`packages`** maps may reference **`flatpak-user`**; bootstrap wording shifts slightly from “system” to “host” packages in places.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac63a47fa6ff082a0a3d2e66a5cd59c5dba99027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing Flatpak applications and runtimes in separate system-wide and per-user scopes.
  * Added the `flatpak-user` package manager option for installing, applying, checking, and upgrading packages.
  * Added support for configuring the same Flatpak application ID in both scopes.

* **Documentation**
  * Updated package management guides, CLI help, and examples to explain Flatpak scopes and usage.
  * Clarified host-package terminology and platform support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->