### PR TITLE
feat(brew): support font casks on linux

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -67,6 +67,19 @@ installs app bundles into `/Applications` while recording the version under
 "brew-cask:homebrew/cask/visual-studio-code" = "latest"
 ```
 
+On Linux, initial cask support is limited to font-only casks without lifecycle
+hooks. Fonts are installed into `$XDG_DATA_HOME/fonts`, which defaults to
+`~/.local/share/fonts`:
+
+```toml
+[bootstrap.packages]
+"brew-cask:font-heavy-data-nerd-font" = "latest"
+```
+
+Other Linux casks fail with a clear unsupported-platform error. This boundary
+will expand as mise gains portable implementations for more cask artifact
+types.
+
 `brew-cask` currently supports app-bundle casks (`app` artifacts), binary and
 generated command-wrapper casks (`binary` and `command_wrapper` artifacts),
 simple macOS installer packages (`pkg` artifacts), and shell completions
@@ -259,10 +272,11 @@ operation.
 
 ## Limitations
 
-- **Cask artifact coverage is intentionally narrow.** `brew-cask` supports
-  app bundles, binary artifacts, and simple pkg installers from dmg and common
-  archive formats. Other artifact types, pkg installers without `pkgutil` IDs,
-  and pkg installers with custom choices fail explicitly.
+- **Cask artifact coverage is intentionally narrow.** On macOS, `brew-cask`
+  supports app bundles, binary artifacts, font artifacts, and simple pkg
+  installers from dmg and common archive formats. On Linux, it supports
+  font-only casks without lifecycle hooks. Other artifact types, pkg installers
+  without `pkgutil` IDs, and pkg installers with custom choices fail explicitly.
 - **`brew services` is not implemented.**
 - **Cask import/prune is not implemented.** `import` and `prune` are formulae-only
   until cask uninstall semantics can be made safe for app and pkg artifacts.

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -68,8 +68,8 @@ installs app bundles into `/Applications` while recording the version under
 ```
 
 On Linux, initial cask support is limited to font-only casks without lifecycle
-hooks. Fonts are installed into `$XDG_DATA_HOME/fonts`, which defaults to
-`~/.local/share/fonts`:
+hooks or structured `preflight_steps` or `postflight_steps`. Fonts are installed
+into `$XDG_DATA_HOME/fonts`, which defaults to `~/.local/share/fonts`:
 
 ```toml
 [bootstrap.packages]
@@ -275,8 +275,9 @@ operation.
 - **Cask artifact coverage is intentionally narrow.** On macOS, `brew-cask`
   supports app bundles, binary artifacts, font artifacts, and simple pkg
   installers from dmg and common archive formats. On Linux, it supports
-  font-only casks without lifecycle hooks. Other artifact types, pkg installers
-  without `pkgutil` IDs, and pkg installers with custom choices fail explicitly.
+  font-only casks without lifecycle hooks or structured `preflight_steps` or
+  `postflight_steps`. Other artifact types, pkg installers without `pkgutil`
+  IDs, and pkg installers with custom choices fail explicitly.
 - **`brew services` is not implemented.**
 - **Cask import/prune is not implemented.** `import` and `prune` are formulae-only
   until cask uninstall semantics can be made safe for app and pkg artifacts.

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -55,7 +55,7 @@ declarative sections work the same way:
 | `dnf`          | Fedora, RHEL, CentOS, Rocky, Alma                              | [dnf](/bootstrap/packages/dnf.html)                 |
 | `pacman`       | Arch, Manjaro                                                  | [pacman](/bootstrap/packages/pacman.html)           |
 | `brew`         | macOS (arm64), Linux (x86_64/arm64) — **no Homebrew required** | [brew](/bootstrap/packages/brew.html)               |
-| `brew-cask`    | macOS — **no Homebrew required**                               | [brew](/bootstrap/packages/brew.html)               |
+| `brew-cask`    | macOS; Linux (font casks) — **no Homebrew required**           | [brew](/bootstrap/packages/brew.html)               |
 | `flatpak`      | Linux with the `flatpak` CLI on `PATH` (system scope)          | [Flatpak](/bootstrap/packages/flatpak.html)         |
 | `flatpak-user` | Linux with the `flatpak` CLI on `PATH` (user scope)            | [Flatpak](/bootstrap/packages/flatpak.html)         |
 | `mas`          | macOS with the `mas` CLI on `PATH`                             | [mas](/bootstrap/packages/mas.html)                 |
@@ -73,9 +73,10 @@ declarative sections work the same way:
 - **OS-filtered** — entries for a manager that isn't available on the current
   machine are not acted on, so the same config works across platforms: `apt`
   entries are ignored on macOS, `dnf` entries on Ubuntu, and so on. `brew`
-  works on both macOS and Linux; `brew-cask` works on macOS; `flatpak` and
-  `flatpak-user` work on Linux when the `flatpak` CLI is on `PATH`; `mas`
-  works on macOS when the `mas` CLI is on `PATH`. Status commands still list
+  works on both macOS and Linux; `brew-cask` works on macOS and supports
+  font-only casks on Linux; `flatpak` and `flatpak-user` work on Linux when the
+  `flatpak` CLI is on `PATH`; `mas` works on macOS when the `mas` CLI is on
+  `PATH`. Status commands still list
   unavailable managers so nothing is silently invisible.
 - **Manual installation only** — mise never installs system packages
   implicitly. `mise install` will print a one-time hint when packages are

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -74,9 +74,10 @@ declarative sections work the same way:
   machine are not acted on, so the same config works across platforms: `apt`
   entries are ignored on macOS, `dnf` entries on Ubuntu, and so on. `brew`
   works on both macOS and Linux; `brew-cask` works on macOS and supports
-  font-only casks on Linux; `flatpak` and `flatpak-user` work on Linux when the
-  `flatpak` CLI is on `PATH`; `mas` works on macOS when the `mas` CLI is on
-  `PATH`. Status commands still list
+  font-only casks without lifecycle hooks or structured flight steps on Linux;
+  `flatpak` and `flatpak-user` work on Linux when the `flatpak` CLI is on
+  `PATH`; `mas` works on macOS when the `mas` CLI is on `PATH`. Status commands
+  still list
   unavailable managers so nothing is silently invisible.
 - **Manual installation only** — mise never installs system packages
   implicitly. `mise install` will print a one-time hint when packages are

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -242,6 +242,7 @@ impl BrewCaskManager {
     ) -> Result<String> {
         let cask = fetch_cask(req).await?;
         let artifacts = cask_artifacts(&cask)?;
+        validate_platform_support(&cask, &artifacts)?;
         if homebrew_metadata_present(&cask.token) {
             bail!(
                 "brew-cask:{}: Homebrew owns this cask; remove it with Homebrew before installing it with mise",
@@ -517,11 +518,11 @@ impl SystemPackageManager for BrewCaskManager {
     }
 
     fn is_available(&self) -> bool {
-        cfg!(target_os = "macos")
+        cfg!(any(target_os = "macos", target_os = "linux"))
     }
 
     fn unavailable_reason(&self) -> String {
-        "only available on macos".to_string()
+        "only available on macos and linux".to_string()
     }
 
     fn supports_version_pins(&self) -> bool {
@@ -533,6 +534,7 @@ impl SystemPackageManager for BrewCaskManager {
         for req in pkgs {
             let cask = fetch_cask(req).await?;
             let artifacts = cask_artifacts(&cask)?;
+            validate_platform_support(&cask, &artifacts)?;
             let version = installed_cask_version(&cask, &artifacts)?;
             let state = match version {
                 Some(version) => match &req.version {
@@ -1078,8 +1080,21 @@ fn remove_artifact_target_elevating(path: &Path) -> Result<()> {
     with_sudo_fallback(result, "rm", &args)
 }
 
-/// Copy a directory using macOS `ditto`, which preserves resource forks, extended attributes,
-/// and HFS+ metadata that a plain recursive copy would strip.
+/// Copy a cask artifact while preserving macOS metadata where it matters.
+///
+/// Linux cask support currently covers font files, which do not need the
+/// resource-fork and extended-attribute handling provided by `ditto`.
+fn copy_cask_artifact(from: &Path, to: &Path) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        ditto(from, to)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        file::copy(from, to)
+    }
+}
+
 fn ditto(from: &Path, to: &Path) -> Result<()> {
     let status = std::process::Command::new("ditto")
         .arg(from)
@@ -1116,7 +1131,7 @@ fn stage_font(stage: &Path, caskroom: &Path, font: &FontArtifact) -> Result<()> 
     }
     let source = find_file_artifact(stage, &font.source)
         .ok_or_else(|| eyre!("brew-cask: font artifact '{}' was not found", font.source))?;
-    ditto(&source, &caskroom_font)?;
+    copy_cask_artifact(&source, &caskroom_font)?;
     Ok(())
 }
 
@@ -1139,7 +1154,7 @@ fn link_font(caskroom: &Path, font: &FontArtifact) -> Result<()> {
     if target.exists() {
         file::rename(&target, &old_target)?;
     }
-    if let Err(e) = ditto(&caskroom_font, &target) {
+    if let Err(e) = copy_cask_artifact(&caskroom_font, &target) {
         if old_target.exists() {
             let _ = file::rename(&old_target, &target);
         }
@@ -1218,9 +1233,9 @@ fn remove_obsolete_fonts(
             continue;
         }
         // Only remove the file if it was staged by us — check that it
-        // resides under ~/Library/Fonts and the caskroom still has a
+        // resides under the platform font directory and the caskroom still has a
         // staged copy (from the previous version directory).
-        let fonts_dir = crate::dirs::HOME.join("Library").join("Fonts");
+        let fonts_dir = font_dir();
         if !target.starts_with(&fonts_dir) {
             continue;
         }
@@ -1252,10 +1267,15 @@ fn font_target_path(font: &FontArtifact) -> Result<PathBuf> {
     {
         bail!("brew-cask: invalid font target '{}'", name);
     }
-    Ok(crate::dirs::HOME
-        .join("Library")
-        .join("Fonts")
-        .join(name_path))
+    Ok(font_dir().join(name_path))
+}
+
+fn font_dir() -> PathBuf {
+    if cfg!(target_os = "linux") {
+        crate::env::XDG_DATA_HOME.join("fonts")
+    } else {
+        crate::dirs::HOME.join("Library").join("Fonts")
+    }
 }
 
 #[cfg(test)]
@@ -2504,6 +2524,32 @@ fn cask_artifacts(cask: &Cask) -> Result<CaskArtifacts> {
         );
     }
     Ok(artifacts)
+}
+
+fn validate_platform_support(cask: &Cask, artifacts: &CaskArtifacts) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        let font_only = !artifacts.fonts.is_empty()
+            && artifacts.apps.is_empty()
+            && artifacts.binaries.is_empty()
+            && artifacts.command_wrappers.is_empty()
+            && artifacts.pkgs.is_empty()
+            && artifacts.completions.is_empty()
+            && artifacts.generated_completions.is_empty()
+            && artifacts.preflight_steps.is_empty()
+            && artifacts.postflight_steps.is_empty()
+            && !has_lifecycle_hook(cask, "preflight")
+            && !has_lifecycle_hook(cask, "postflight");
+        if !font_only {
+            bail!(
+                "brew-cask:{}: only font-only casks without lifecycle hooks are supported on linux",
+                cask.token
+            );
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = (cask, artifacts);
+    Ok(())
 }
 
 fn artifact_target(value: &Value, values: &[Value]) -> Option<String> {
@@ -6271,10 +6317,7 @@ end
             source: "MyFont.ttf".to_string(),
             target: Some("MyFont.ttf".to_string()),
         };
-        let expected = crate::dirs::HOME
-            .join("Library")
-            .join("Fonts")
-            .join("MyFont.ttf");
+        let expected = font_dir().join("MyFont.ttf");
         assert_eq!(font_target_path(&font)?, expected);
         Ok(())
     }
@@ -6285,10 +6328,7 @@ end
             source: "FontAwesome.otf".to_string(),
             target: None,
         };
-        let expected = crate::dirs::HOME
-            .join("Library")
-            .join("Fonts")
-            .join("FontAwesome.otf");
+        let expected = font_dir().join("FontAwesome.otf");
         assert_eq!(font_target_path(&font)?, expected);
         Ok(())
     }
@@ -6302,10 +6342,7 @@ end
             source: "JetBrainsMono.ttf".to_string(),
             target: Some(target),
         };
-        let expected = crate::dirs::HOME
-            .join("Library")
-            .join("Fonts")
-            .join("JetBrainsMono.ttf");
+        let expected = font_dir().join("JetBrainsMono.ttf");
         assert_eq!(font_target_path(&font)?, expected);
         Ok(())
     }
@@ -6318,11 +6355,38 @@ end
             source: "TildeFont.ttf".to_string(),
             target: Some(target),
         };
-        let expected = crate::dirs::HOME
-            .join("Library")
-            .join("Fonts")
-            .join("TildeFont.ttf");
+        let expected = font_dir().join("TildeFont.ttf");
         assert_eq!(font_target_path(&font)?, expected);
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_font_dir_uses_xdg_data_home() {
+        assert_eq!(font_dir(), crate::env::XDG_DATA_HOME.join("fonts"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_supports_font_only_casks() -> Result<()> {
+        let mut cask = test_cask("font-test", "1.0.0");
+        cask.artifacts = vec![serde_json::json!({"font": "TestFont.ttf"})];
+        let artifacts = cask_artifacts(&cask)?;
+
+        validate_platform_support(&cask, &artifacts)
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_rejects_non_font_casks() -> Result<()> {
+        let mut cask = test_cask("example", "1.0.0");
+        cask.artifacts = vec![serde_json::json!({"app": "Example.app"})];
+        let artifacts = cask_artifacts(&cask)?;
+
+        let err = validate_platform_support(&cask, &artifacts)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("only font-only casks"));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1181,9 +1181,11 @@ fn font_filename(font: &FontArtifact) -> Result<String> {
             }
             let expanded_path = Path::new(&expanded);
             if expanded_path.is_absolute() {
-                let fonts_dir = crate::dirs::HOME.join("Library").join("Fonts");
-                if let Ok(relative) = expanded_path.strip_prefix(&fonts_dir) {
-                    return Ok(relative.to_string_lossy().to_string());
+                let macos_fonts_dir = crate::dirs::HOME.join("Library").join("Fonts");
+                for fonts_dir in [font_dir(), macos_fonts_dir] {
+                    if let Ok(relative) = expanded_path.strip_prefix(fonts_dir) {
+                        return Ok(relative.to_string_lossy().to_string());
+                    }
                 }
                 return expanded_path
                     .file_name()
@@ -1240,15 +1242,15 @@ fn remove_obsolete_fonts(
             continue;
         }
         // Check if any version directory under the token dir contains this font
-        // filename, indicating it was staged by a previous version of this cask.
-        let filename = target.file_name();
+        // path, indicating it was staged by a previous version of this cask.
+        let relative = target.strip_prefix(&fonts_dir).ok();
         let has_staged_copy = std::fs::read_dir(&token_dir)
             .ok()
             .into_iter()
             .flatten()
             .filter_map(|entry| entry.ok())
             .filter(|entry| entry.file_type().is_ok_and(|ft| ft.is_dir()))
-            .any(|entry| filename.is_some_and(|f| entry.path().join(f).is_file()));
+            .any(|entry| relative.is_some_and(|path| entry.path().join(path).is_file()));
         if has_staged_copy {
             file::remove_file(target)?;
         }
@@ -6364,6 +6366,20 @@ end
     #[test]
     fn linux_font_dir_uses_xdg_data_home() {
         assert_eq!(font_dir(), crate::env::XDG_DATA_HOME.join("fonts"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_font_target_preserves_xdg_subdirectories() -> Result<()> {
+        let target = font_dir().join("nerd-fonts").join("NestedFont.ttf");
+        let font = FontArtifact {
+            source: "NestedFont.ttf".to_string(),
+            target: Some(target.to_string_lossy().to_string()),
+        };
+
+        assert_eq!(font_filename(&font)?, "nerd-fonts/NestedFont.ttf");
+        assert_eq!(font_target_path(&font)?, target);
+        Ok(())
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

- make the built-in `brew-cask` package manager available on Linux
- support font-only casks without lifecycle hooks on Linux
- install Linux cask fonts under `$XDG_DATA_HOME/fonts` using portable file copies
- retain macOS cask behavior and reject unsupported Linux artifact sets clearly
- document the initial Linux compatibility boundary

## Why

Homebrew supports font casks on Linux, but mise treated the entire `brew-cask` manager as macOS-only. This caused `mise bootstrap packages use brew-cask:font-heavy-data-nerd-font` to add the package without installing it even though the same cask works through Linuxbrew.

This is the first slice of broader Linux cask support discussed in https://github.com/jdx/mise/discussions/11749.

## Validation

- `cargo test --all-features system::packages::brew::cask::tests` (120 passed)
- `cargo run --all-features -- bootstrap packages apply brew-cask:font-heavy-data-nerd-font --dry-run --yes`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Linux font casks with strict validation; macOS keeps `ditto` and existing behavior. Main risk is incorrect font paths or cleanup under XDG, not auth or data integrity.
> 
> **Overview**
> **`brew-cask` on Linux** is no longer macOS-only: the manager reports available on Linux and runs install/status through the same paths as macOS, with a new **`validate_platform_support`** gate that only allows **font-only** casks—no apps, binaries, pkgs, completions, structured flight steps, or `preflight`/`postflight` hooks. Anything else fails with an explicit unsupported-platform error.
> 
> **Font install paths and copying** change by OS: Linux uses **`font_dir()`** → `$XDG_DATA_HOME/fonts` (default `~/.local/share/fonts`) for targets, uninstall cleanup, and resolving absolute/`~/Library/Fonts`-style targets against both macOS and XDG font dirs. Staging/linking uses **`copy_cask_artifact`** (plain `file::copy` on non-macOS; `ditto` on macOS) instead of always calling `ditto`.
> 
> **Docs** document Linux font cask examples, update the packages index table and OS-filtered semantics, and clarify limitations (macOS full cask set vs Linux font-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbca8a99a04caba7765a895e8cd16deb2a947ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux support for font-only Homebrew casks without lifecycle hooks or structured installation steps.
  - Linux fonts are installed to `$XDG_DATA_HOME/fonts`, while macOS fonts continue using the system font directory.
  - Added platform-specific validation for supported casks during installation and installed-state checks.

- **Documentation**
  - Clarified supported operating systems, font-only cask requirements, artifact coverage, and unsupported package conditions for Homebrew casks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->