### PR TITLE
fix(npm): isolate embedded aube storage

### DIFF
--- a/e2e/backend/test_npm_aube
+++ b/e2e/backend/test_npm_aube
@@ -12,3 +12,8 @@ assert_succeed "test -d '$install_dir/node_modules'"
 assert_succeed "test -x '$install_dir/node_modules/.bin/cowsay'"
 assert_succeed "test -f '$install_dir/aube-lock.yaml'"
 assert_contains "cat '$install_dir/aube-lock.yaml'" "cowsay@1.6.0"
+
+# Regenerable aube state stays under mise's npm cache root, where
+# `mise cache prune npm` owns its lifecycle.
+assert_succeed "test -d '$MISE_CACHE_DIR/npm/aube/cache/packuments-full-v1'"
+assert_succeed "test -d '$MISE_CACHE_DIR/npm/aube/store/v1/files'"

--- a/src/backend/aube_host.rs
+++ b/src/backend/aube_host.rs
@@ -10,11 +10,9 @@
 //! `engines.aube` against the aube crate version.
 //!
 //! Only the branding and the four embedder-fixed behavior toggles differ from
-//! [`aube::embed::AUBE`]. Everything that names something on disk — the store
-//! and cache namespaces, the lockfile filename, the `package.json` config
-//! namespace mise writes `allowBuilds` into — is deliberately inherited
-//! verbatim, so an existing `npm:` install and its populated content store
-//! stay valid across this change.
+//! [`aube::embed::AUBE`]. Config and manifest names stay compatible with aube;
+//! embedded npm installs separately pass invocation-scoped mise-owned cache
+//! and store paths and disable aube's global virtual store.
 
 use std::sync::Once;
 
@@ -34,11 +32,10 @@ static MISE_HOST: Host = Host {
     version: env!("CARGO_PKG_VERSION"),
     user_agent: concat!("mise/", env!("CARGO_PKG_VERSION")),
 
-    // On-disk and config surface: inherited so this profile is not a
-    // migration. Changing `cache_namespace`/`data_namespace` would orphan the
-    // already-populated content store, and changing `manifest_namespace`
-    // would strand the `aube.allowBuilds` key that
-    // `write_aube_embed_project` writes into every install's `package.json`.
+    // Config surface: inherited so `aube.allowBuilds` and the generated
+    // lockfile keep their canonical names. Embedded npm installs override
+    // their cache/store paths per invocation instead of relying on these
+    // process-wide namespace defaults.
     self_names: AUBE.self_names,
     compatible_names: AUBE.compatible_names,
     lockfile_basename: AUBE.lockfile_basename,
@@ -92,9 +89,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn mise_host_keeps_aube_on_disk_layout() {
-        // These are what an already-installed `npm:` tool and the shared
-        // content store are keyed on — a rename here is a silent migration.
+    fn mise_host_keeps_aube_config_names() {
         assert_eq!(MISE_HOST.cache_namespace, AUBE.cache_namespace);
         assert_eq!(MISE_HOST.data_namespace, AUBE.data_namespace);
         assert_eq!(MISE_HOST.manifest_namespace, AUBE.manifest_namespace);

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -19,7 +19,7 @@ use crate::timeout;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
 use async_trait::async_trait;
-use aube::embed::EmbedderRuntime;
+use aube::embed::{EmbedderInstallOverrides, EmbedderRuntime};
 use bytesize::ByteSize;
 use jiff::Timestamp;
 use serde_json::Value;
@@ -973,7 +973,12 @@ impl NPMBackend {
         opts.ignore_scripts = matches!(allow_builds, AllowBuilds::None);
 
         let package = format!("{}@{}", self.tool_name(), tv.version);
-        let install = aube::embed::add(&install_path, std::slice::from_ref(&package), opts);
+        let install = aube::embed::add_with_overrides(
+            &install_path,
+            std::slice::from_ref(&package),
+            opts,
+            Self::aube_embed_install_overrides(),
+        );
         tokio::pin!(install);
         // Drain events alongside the install rather than after it: the
         // reporter only enqueues (it must never wait on us while holding an
@@ -1066,6 +1071,18 @@ impl NPMBackend {
         let ts = self.dependency_toolset(&ctx.config).await.ok()?;
         let node = ts.which_bin(&ctx.config, "node").await?;
         node.parent().map(EmbedderRuntime::selector)
+    }
+
+    /// Keep embedded aube's regenerable state inside mise's npm cache tree.
+    /// Project-local materialization means installed tools no longer depend on
+    /// this store, so `mise cache prune npm` can reclaim it by normal cache age.
+    fn aube_embed_install_overrides() -> EmbedderInstallOverrides {
+        let root = crate::dirs::CACHE.join("npm").join("aube");
+        EmbedderInstallOverrides {
+            use_global_virtual_store: Some(false),
+            cache_dir: Some(root.join("cache")),
+            store_dir: Some(root.join("store")),
+        }
     }
 
     /// Write the throwaway project's `package.json` + `.npmrc` for an embedded
@@ -1617,6 +1634,16 @@ mod tests {
         let backend = create_npm_backend("prettier");
         let deps = backend.get_dependencies().unwrap();
         assert_eq!(deps, vec!["node"]);
+    }
+
+    #[test]
+    fn embedded_aube_uses_mise_owned_cache_and_store() {
+        let overrides = NPMBackend::aube_embed_install_overrides();
+        let root = crate::dirs::CACHE.join("npm").join("aube");
+
+        assert_eq!(overrides.use_global_virtual_store, Some(false));
+        assert_eq!(overrides.cache_dir, Some(root.join("cache")));
+        assert_eq!(overrides.store_dir, Some(root.join("store")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- call aube v1.38.0 with invocation-scoped storage overrides
- disable aube's global virtual store so npm tools are materialized inside their mise install directories
- keep aube metadata and CAS data under mise's shared `npm/aube` cache subtree
- verify the ownership boundary in unit and end-to-end tests

## Root cause

Embedded aube previously inherited aube's process-wide cache/data namespaces and global virtual store. Removing a mise-managed npm tool therefore left package data owned by aube outside mise's cache-prune lifecycle, and standalone `aube store prune` could not reliably infer when mise installations disappeared.

With project-local materialization, installed tools do not depend on the regenerable CAS after installation. `mise cache prune npm` can now reclaim that state according to mise's configured cache age.

Fixes https://github.com/jdx/mise/discussions/11737

## Stack

Depends on #11759, which updates the embedded aube crates to v1.38.0.

## Validation
- `cargo test embedded_aube_uses_mise_owned_cache_and_store`
- `mise run test:e2e e2e/backend/test_npm_aube`
- `cargo check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm install storage and materialization behavior; misconfiguration could affect install layout or cache pruning, but scope is limited to embedded aube and is covered by e2e/unit tests.
> 
> **Overview**
> **Embedded aube installs** no longer lean on aube's process-wide global virtual store or default cache/data namespaces for package materialization. Installs call **`add_with_overrides`** with **`EmbedderInstallOverrides`**: `use_global_virtual_store: false` so tools land in each mise install dir (`node_modules`), and cache/store under **`$MISE_CACHE_DIR/npm/aube/{cache,store}`** so regenerable CAS/metadata is owned by mise's npm cache lifecycle.
> 
> **`aube_host.rs`** docs and tests are updated to reflect that on-disk layout is per-invocation overrides, while lockfile/manifest naming (`aube.allowBuilds`, `aube-lock.yaml`) stays compatible with standalone aube.
> 
> **Tests** add a unit check for override paths and e2e assertions that packument cache and store files exist under the mise npm cache tree after `npm:cowsay` install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e07649204aec7c6f227e02d2096a57112991725f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->