### PR TITLE
test(npm): cover embedded aube deprecation output

### DIFF
--- a/e2e/backend/test_npm_aube
+++ b/e2e/backend/test_npm_aube
@@ -17,3 +17,9 @@ assert_contains "cat '$install_dir/aube-lock.yaml'" "cowsay@1.6.0"
 # `mise cache prune npm` owns its lifecycle.
 assert_succeed "test -d '$MISE_CACHE_DIR/npm/aube/cache/packuments-full-v1'"
 assert_succeed "test -d '$MISE_CACHE_DIR/npm/aube/store/v1/files'"
+
+# Aube warnings flow through mise's event renderer without suggesting an aube
+# subcommand that mise does not expose.
+deprecation_output="$(mise install npm:inflight@1.0.6 2>&1)"
+assert_contains_text "$deprecation_output" "deprecated inflight@1.0.6"
+assert_not_contains_text "$deprecation_output" "mise deprecations"


### PR DESCRIPTION
## Summary
- install a known deprecated npm package through mise's embedded aube path
- verify aube's warning arrives through mise's output pipeline
- guard against suggesting the nonexistent `mise deprecations` command

## Why

aube v1.38.0 routes install-time deprecation warnings through structured embedder events and suppresses standalone aube command hints for embedded hosts. This regression test exercises the full mise integration boundary, including the progress renderer that the old direct stderr write corrupted.

Regression coverage for https://github.com/jdx/mise/discussions/11742 and jdx/aube#1236.

## Stack

Depends on #11760, which depends on the aube v1.38.0 bump in #11759.

## Validation
- `mise run test:e2e e2e/backend/test_npm_aube`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior impact.
> 
> **Overview**
> Extends **`e2e/backend/test_npm_aube`** with integration checks for install-time deprecation warnings on the embedded aube path.
> 
> After **`mise install npm:inflight@1.0.6`**, the test captures combined stdout/stderr and asserts the output includes **`deprecated inflight@1.0.6`** and does **not** mention **`mise deprecations`**, so warnings go through mise’s renderer without bogus CLI hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d663483d5f6e44d35eaf6b8a4e939ace75c0210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->