### PR TITLE
refactor(cache): extract remote cache client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6357,6 +6357,7 @@ dependencies = [
  "md-5 0.11.0",
  "miette",
  "minisign-verify",
+ "mise-cache-core",
  "mise-interactive-config",
  "mise-sigstore",
  "mockito",
@@ -6431,6 +6432,28 @@ dependencies = [
  "zip 8.6.0",
  "zipsign-api 0.2.1",
  "zstd",
+]
+
+[[package]]
+name = "mise-cache-core"
+version = "0.1.0"
+dependencies = [
+ "base64 0.23.0",
+ "blake3",
+ "eyre",
+ "hex",
+ "log",
+ "mockito",
+ "rand 0.10.2",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "strum 0.28.0",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+  "crates/mise-cache-core",
   "crates/vfox",
   "crates/aqua-registry",
   "crates/mise-interactive-config",
@@ -114,6 +115,7 @@ filetime = "0.2"
 flate2 = "1"
 futures-util = "0.3.32"
 mise-sigstore = { path = "crates/mise-sigstore", default-features = false }
+mise-cache-core = { path = "crates/mise-cache-core", default-features = false }
 fslock = "0.2.1"
 gix = { version = "<1", features = ["worktree-mutation"] }
 glob = "0.3"
@@ -286,6 +288,7 @@ native-tls = [
   "rattler/native-tls",
   "rattler_repodata_gateway/native-tls",
   "mise-sigstore/native-tls",
+  "mise-cache-core/native-tls",
   "ubi/native-tls",
   "vfox/native-tls",
   "xx/native-tls",
@@ -297,6 +300,7 @@ rustls = [
   "rattler/rustls",
   "rattler_repodata_gateway/rustls",
   "mise-sigstore/rustls",
+  "mise-cache-core/rustls",
   "ubi/rustls-tls",
   "vfox/rustls",
   "xx/rustls",
@@ -308,6 +312,7 @@ rustls-native-roots = [
   "rattler/rustls",
   "rattler_repodata_gateway/rustls",
   "mise-sigstore/rustls",
+  "mise-cache-core/rustls-native-roots",
   "ubi/rustls-tls",
   "vfox/rustls-native-roots",
   "xx/rustls-native-roots",

--- a/crates/mise-cache-core/Cargo.toml
+++ b/crates/mise-cache-core/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "mise-cache-core"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Action cache protocol, CAS, authentication, and transport primitives for mise"
+homepage = "https://github.com/jdx/mise"
+repository = "https://github.com/jdx/mise"
+publish = false
+
+[dependencies]
+base64 = "0.23"
+blake3 = "1"
+eyre = "0.6"
+hex = "0.4"
+log = "0.4"
+rand = "0.10"
+reqwest = { version = "0.13", default-features = false, features = [
+  "json",
+  "stream",
+] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.11"
+strum = { version = "0.28", features = ["derive"] }
+tempfile = "3"
+tokio = { version = "1", features = ["fs", "io-util", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["io"] }
+url = "2"
+
+[dev-dependencies]
+mockito = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = ["rustls"]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls"]
+rustls-native-roots = ["reqwest/rustls"]

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -1,0 +1,868 @@
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use eyre::{Result, bail, eyre};
+use log::warn;
+use reqwest::StatusCode;
+use reqwest::header::{
+    ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, IF_NONE_MATCH,
+};
+use serde::{Deserialize, Serialize};
+use sha2::Digest as _;
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::io::AsyncWriteExt;
+use url::{Host, Url};
+
+pub const PROTOCOL_VERSION: u8 = 1;
+const PROTOCOL_HEADER: &str = "mise-cache-protocol";
+const NAMESPACE_HEADER: &str = "mise-cache-namespace";
+pub const ACTION_RESULT_MEDIA_TYPE: &str = "application/vnd.mise.cache-action-result.v1+json";
+pub const DIRECTORY_MEDIA_TYPE: &str = "application/vnd.mise.cache-directory.v1+json";
+pub const CLIENT_METADATA_MEDIA_TYPE: &str = "application/vnd.mise.cache-client-metadata.v1+json";
+pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Default,
+    strum::EnumString,
+    strum::Display,
+    PartialEq,
+    Eq,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum RemoteCacheMode {
+    #[default]
+    ReadWrite,
+    ReadOnly,
+    WriteOnly,
+}
+
+impl RemoteCacheMode {
+    pub fn reads(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::ReadOnly)
+    }
+
+    pub fn writes(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::WriteOnly)
+    }
+}
+
+pub struct RemoteCacheConfig {
+    pub base_url: Url,
+    pub namespace: String,
+    pub token: Option<String>,
+    pub token_file: Option<PathBuf>,
+    pub oidc_audience: Option<String>,
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub download_timeout: Duration,
+    pub retries: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct CacheDigest {
+    pub algorithm: String,
+    pub hash: String,
+    pub size: u64,
+}
+
+impl CacheDigest {
+    pub fn blake3(bytes: &[u8]) -> Self {
+        Self {
+            algorithm: "blake3".into(),
+            hash: blake3::hash(bytes).to_hex().to_string(),
+            size: bytes.len() as u64,
+        }
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.algorithm != "blake3" && self.algorithm != "sha256" {
+            bail!("unsupported remote cache digest algorithm");
+        }
+        if self.hash.len() != 64
+            || !self
+                .hash
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            bail!("invalid remote cache digest");
+        }
+        Ok(())
+    }
+
+    fn matches_bytes(&self, bytes: &[u8]) -> Result<bool> {
+        self.validate()?;
+        if self.size != bytes.len() as u64 {
+            return Ok(false);
+        }
+        let hash = match self.algorithm.as_str() {
+            "blake3" => blake3::hash(bytes).to_hex().to_string(),
+            "sha256" => hex::encode(sha2::Sha256::digest(bytes)),
+            _ => unreachable!("digest algorithm was validated"),
+        };
+        Ok(self.hash == hash)
+    }
+
+    fn matches_file(&self, path: &Path) -> Result<bool> {
+        self.validate()?;
+        if self.size != fs::metadata(path)?.len() {
+            return Ok(false);
+        }
+        let hash = match self.algorithm.as_str() {
+            "blake3" => hash_file_blake3(path)?,
+            "sha256" => hash_file_sha256(path)?,
+            _ => unreachable!("digest algorithm was validated"),
+        };
+        Ok(self.hash == hash)
+    }
+}
+
+fn hash_file_blake3(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0; 64 * 1024];
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn hash_file_sha256(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = sha2::Sha256::new();
+    let mut buffer = [0; 64 * 1024];
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RemoteActionResult {
+    pub action: CacheDigest,
+    #[serde(default)]
+    pub metadata: Option<CacheDigest>,
+    #[serde(default)]
+    pub output_root: Option<CacheDigest>,
+    pub version: u8,
+}
+
+pub enum BlobSource {
+    Bytes(Vec<u8>),
+    File(tempfile::NamedTempFile),
+}
+
+pub struct BlobUpload {
+    pub digest: CacheDigest,
+    pub source: BlobSource,
+}
+
+pub struct RemoteCacheClient {
+    base_url: Url,
+    namespace: String,
+    client: reqwest::Client,
+    credential: RemoteCacheCredential,
+    download_timeout: Duration,
+    retries: i64,
+}
+
+impl RemoteCacheClient {
+    pub fn new(config: RemoteCacheConfig) -> Result<Self> {
+        let authenticated = config
+            .token
+            .as_deref()
+            .is_some_and(|token| !token.trim().is_empty())
+            || config.token_file.is_some()
+            || config
+                .oidc_audience
+                .as_deref()
+                .is_some_and(|audience| !audience.trim().is_empty());
+        validate_remote_url(&config.base_url, authenticated)?;
+        let client = reqwest::Client::builder()
+            .connect_timeout(config.connect_timeout)
+            .read_timeout(config.read_timeout)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+        let credential = remote_credential(&config, client.clone())?;
+        Ok(Self {
+            base_url: normalized_base_url(config.base_url),
+            namespace: config.namespace,
+            client,
+            credential,
+            download_timeout: config.download_timeout,
+            retries: config.retries,
+        })
+    }
+
+    fn action_result_endpoint(&self, action: &CacheDigest) -> Result<Url> {
+        action.validate()?;
+        if action.algorithm != "blake3" {
+            bail!("remote cache action keys must use blake3");
+        }
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        ))?)
+    }
+
+    fn blob_endpoint(&self, digest: &CacheDigest) -> Result<Url> {
+        digest.validate()?;
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/blobs/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        ))?)
+    }
+
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        url: Url,
+        media_type: &'static str,
+    ) -> Result<reqwest::RequestBuilder> {
+        let request = self
+            .client
+            .request(method, url)
+            .header(PROTOCOL_HEADER, u16::from(PROTOCOL_VERSION))
+            .header(NAMESPACE_HEADER, &self.namespace)
+            .header(ACCEPT, media_type);
+        if let Some(authorization) = self.credential.authorization().await? {
+            Ok(request.header(AUTHORIZATION, authorization))
+        } else {
+            Ok(request)
+        }
+    }
+
+    pub async fn get_action_result(
+        &self,
+        action: &CacheDigest,
+    ) -> Result<Option<RemoteActionResult>> {
+        let url = self.action_result_endpoint(action)?;
+        let result = retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::GET, url.clone(), ACTION_RESULT_MEDIA_TYPE)
+                .await?
+                .send()
+                .await?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            Ok(Some(
+                response
+                    .error_for_status()?
+                    .json::<RemoteActionResult>()
+                    .await?,
+            ))
+        })
+        .await?;
+        if let Some(result) = &result
+            && (result.version != 1 || result.action != *action)
+        {
+            bail!("remote action result does not match requested action");
+        }
+        Ok(result)
+    }
+
+    pub async fn put_action_result(&self, result: &RemoteActionResult) -> Result<()> {
+        let url = self.action_result_endpoint(&result.action)?;
+        let body = serde_json::to_vec(result)?;
+        retry_async("PUT", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::PUT, url.clone(), ACTION_RESULT_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, ACTION_RESULT_MEDIA_TYPE)
+                .header(IF_NONE_MATCH, "*")
+                .body(body.clone())
+                .send()
+                .await?;
+            if response.status() != StatusCode::PRECONDITION_FAILED {
+                response.error_for_status()?;
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn get_blob(
+        &self,
+        digest: &CacheDigest,
+        media_type: &'static str,
+    ) -> Result<Vec<u8>> {
+        digest.validate()?;
+        let url = self.blob_endpoint(digest)?;
+        retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .request(reqwest::Method::GET, url.clone(), media_type)
+                .await?
+                .send()
+                .await?
+                .error_for_status()?;
+            let bytes = response.bytes().await?.to_vec();
+            if !digest.matches_bytes(&bytes)? {
+                bail!("remote cache blob failed digest verification");
+            }
+            Ok(bytes)
+        })
+        .await
+    }
+
+    pub async fn get_blob_file(
+        &self,
+        digest: &CacheDigest,
+        staging_dir: &Path,
+    ) -> Result<tempfile::NamedTempFile> {
+        let url = self.blob_endpoint(digest)?;
+        let download = retry_async("GET", &url, self.retries, || async {
+            let mut response = self
+                .request(reqwest::Method::GET, url.clone(), BLOB_MEDIA_TYPE)
+                .await?
+                .send()
+                .await?;
+            response.error_for_status_ref()?;
+            fs::create_dir_all(staging_dir)?;
+            let temporary = tempfile::NamedTempFile::new_in(staging_dir)?;
+            let mut output = tokio::fs::File::from_std(temporary.reopen()?);
+            while let Some(chunk) = response.chunk().await? {
+                output.write_all(&chunk).await?;
+            }
+            output.flush().await?;
+            drop(output);
+            if !digest.matches_file(temporary.path())? {
+                bail!("remote cache blob failed digest verification");
+            }
+            Ok(temporary)
+        });
+        tokio::time::timeout(self.download_timeout, download)
+            .await
+            .map_err(|_| eyre!("remote cache blob download timed out for {url}"))?
+    }
+
+    pub async fn put_blob(&self, upload: &BlobUpload) -> Result<()> {
+        let url = self.blob_endpoint(&upload.digest)?;
+        retry_async("PUT", &url, self.retries, || async {
+            let (length, body) = match &upload.source {
+                BlobSource::Bytes(bytes) => {
+                    (bytes.len() as u64, reqwest::Body::from(bytes.clone()))
+                }
+                BlobSource::File(file) => {
+                    let file = tokio::fs::File::open(file.path()).await?;
+                    let length = file.metadata().await?.len();
+                    let stream = tokio_util::io::ReaderStream::new(file);
+                    (length, reqwest::Body::wrap_stream(stream))
+                }
+            };
+            let response = self
+                .request(reqwest::Method::PUT, url.clone(), BLOB_MEDIA_TYPE)
+                .await?
+                .header(CONTENT_TYPE, BLOB_MEDIA_TYPE)
+                .header(CONTENT_LENGTH, length)
+                .header(IF_NONE_MATCH, "*")
+                .body(body)
+                .send()
+                .await?;
+            if response.status() != StatusCode::PRECONDITION_FAILED {
+                response.error_for_status()?;
+            }
+            Ok(())
+        })
+        .await
+    }
+}
+
+#[derive(Clone)]
+enum RemoteCacheCredential {
+    None,
+    Static(HeaderValue),
+    File(PathBuf),
+    GithubActions(Arc<GithubActionsOidcCredential>),
+}
+
+struct GithubActionsOidcCredential {
+    audience: String,
+    request_url: Url,
+    request_token: HeaderValue,
+    client: reqwest::Client,
+    retries: i64,
+    cached: tokio::sync::Mutex<Option<CachedOidcToken>>,
+}
+
+struct CachedOidcToken {
+    authorization: HeaderValue,
+    expires_at: u64,
+}
+
+#[derive(Deserialize)]
+struct GithubActionsOidcResponse {
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct JwtExpiry {
+    exp: u64,
+}
+
+fn remote_credential(
+    config: &RemoteCacheConfig,
+    client: reqwest::Client,
+) -> Result<RemoteCacheCredential> {
+    if let Some(authorization) = authorization_header(config.token.as_deref())? {
+        return Ok(RemoteCacheCredential::Static(authorization));
+    }
+    if let Some(path) = &config.token_file {
+        return Ok(RemoteCacheCredential::File(path.clone()));
+    }
+    let Some(audience) = config
+        .oidc_audience
+        .as_deref()
+        .map(str::trim)
+        .filter(|audience| !audience.is_empty())
+    else {
+        return Ok(RemoteCacheCredential::None);
+    };
+    Ok(RemoteCacheCredential::GithubActions(Arc::new(
+        GithubActionsOidcCredential::from_env(audience, client, config.retries)?,
+    )))
+}
+
+fn authorization_header(token: Option<&str>) -> Result<Option<HeaderValue>> {
+    let Some(token) = token.map(str::trim).filter(|token| !token.is_empty()) else {
+        return Ok(None);
+    };
+    let mut value = HeaderValue::from_str(&format!("Bearer {token}"))?;
+    value.set_sensitive(true);
+    Ok(Some(value))
+}
+
+impl RemoteCacheCredential {
+    async fn authorization(&self) -> Result<Option<HeaderValue>> {
+        match self {
+            Self::None => Ok(None),
+            Self::Static(value) => Ok(Some(value.clone())),
+            Self::File(path) => {
+                let token = tokio::fs::read_to_string(path).await.map_err(|err| {
+                    eyre!(
+                        "failed to read remote cache token file {}: {err}",
+                        path.display()
+                    )
+                })?;
+                authorization_header(Some(&token))?
+                    .ok_or_else(|| eyre!("remote cache token file {} is empty", path.display()))
+                    .map(Some)
+            }
+            Self::GithubActions(credential) => credential.authorization().await.map(Some),
+        }
+    }
+}
+
+impl GithubActionsOidcCredential {
+    fn from_env(audience: &str, client: reqwest::Client, retries: i64) -> Result<Self> {
+        let request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
+            eyre!(
+                "remote cache OIDC audience requires GitHub Actions OIDC; \
+                 grant `id-token: write` or set MISE_TASK_CACHE_REMOTE_TOKEN"
+            )
+        })?;
+        let request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| {
+            eyre!(
+                "remote cache OIDC audience requires GitHub Actions OIDC; \
+                 ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing"
+            )
+        })?;
+        let request_url: Url = request_url
+            .parse()
+            .map_err(|err| eyre!("invalid GitHub Actions OIDC request URL: {err}"))?;
+        Self::new(audience, request_url, &request_token, client, retries)
+    }
+
+    fn new(
+        audience: &str,
+        mut request_url: Url,
+        request_token: &str,
+        client: reqwest::Client,
+        retries: i64,
+    ) -> Result<Self> {
+        validate_oidc_request_url(&request_url)?;
+        let query = request_url
+            .query_pairs()
+            .filter(|(key, _)| key != "audience")
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+        request_url.set_query(None);
+        request_url
+            .query_pairs_mut()
+            .extend_pairs(query)
+            .append_pair("audience", audience);
+        let request_token = authorization_header(Some(request_token))?
+            .ok_or_else(|| eyre!("GitHub Actions OIDC request token is empty"))?;
+        Ok(Self {
+            audience: audience.to_string(),
+            request_url,
+            request_token,
+            client,
+            retries,
+            cached: tokio::sync::Mutex::new(None),
+        })
+    }
+
+    async fn authorization(&self) -> Result<HeaderValue> {
+        const REFRESH_LEEWAY_SECONDS: u64 = 60;
+        let mut cached = self.cached.lock().await;
+        let now = unix_timestamp()?;
+        if let Some(token) = cached.as_ref()
+            && token.expires_at > now.saturating_add(REFRESH_LEEWAY_SECONDS)
+        {
+            return Ok(token.authorization.clone());
+        }
+        let response: GithubActionsOidcResponse =
+            retry_async("GET", &self.request_url, self.retries, || async {
+                Ok(self
+                    .client
+                    .get(self.request_url.clone())
+                    .header(AUTHORIZATION, self.request_token.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json()
+                    .await?)
+            })
+            .await
+            .map_err(|err| {
+                eyre!(
+                    "failed to acquire GitHub Actions OIDC token for audience {:?}: {err}",
+                    self.audience
+                )
+            })?;
+        let expires_at = jwt_expiry(&response.value)?;
+        if expires_at <= now.saturating_add(REFRESH_LEEWAY_SECONDS) {
+            bail!("GitHub Actions OIDC token expires too soon");
+        }
+        let authorization = authorization_header(Some(&response.value))?
+            .ok_or_else(|| eyre!("GitHub Actions returned an empty OIDC token"))?;
+        *cached = Some(CachedOidcToken {
+            authorization: authorization.clone(),
+            expires_at,
+        });
+        Ok(authorization)
+    }
+}
+
+fn jwt_expiry(token: &str) -> Result<u64> {
+    let payload = token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| eyre!("GitHub Actions returned a malformed OIDC token"))?;
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| eyre!("GitHub Actions returned a malformed OIDC token"))?;
+    let claims: JwtExpiry = serde_json::from_slice(&payload)
+        .map_err(|_| eyre!("GitHub Actions OIDC token is missing a valid expiry"))?;
+    Ok(claims.exp)
+}
+
+fn unix_timestamp() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| eyre!("system clock is before the Unix epoch: {err}"))?
+        .as_secs())
+}
+
+fn validate_oidc_request_url(url: &Url) -> Result<()> {
+    if url.scheme() == "https"
+        || url.scheme() == "http"
+            && url.host().is_some_and(|host| match host {
+                Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+                Host::Ipv4(address) => address.is_loopback(),
+                Host::Ipv6(address) => address.is_loopback(),
+            })
+    {
+        Ok(())
+    } else {
+        bail!("GitHub Actions OIDC request URL must use HTTPS")
+    }
+}
+
+fn validate_remote_url(base_url: &Url, authenticated: bool) -> Result<()> {
+    if base_url.scheme() == "https" {
+        return Ok(());
+    }
+    if base_url.scheme() != "http" {
+        bail!("remote cache URL must use HTTPS");
+    }
+    let is_loopback = base_url.host().is_some_and(|host| match host {
+        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+        Host::Ipv4(address) => address.is_loopback(),
+        Host::Ipv6(address) => address.is_loopback(),
+    });
+    if !is_loopback && authenticated {
+        bail!("remote cache URL must use HTTPS except for loopback development servers");
+    }
+    if !is_loopback {
+        warn!(
+            "using an unauthenticated remote build cache over plain HTTP; cache traffic can be read \
+             or modified in transit"
+        );
+    }
+    Ok(())
+}
+
+fn normalized_base_url(mut url: Url) -> Url {
+    if !url.path().ends_with('/') {
+        url.set_path(&format!("{}/", url.path()));
+    }
+    url
+}
+
+fn retry_delays(retries: i64) -> impl Iterator<Item = Duration> {
+    [200u64, 1_000, 4_000, 15_000]
+        .into_iter()
+        .chain(std::iter::repeat(15_000))
+        .map(Duration::from_millis)
+        .map(|duration| {
+            let factor = 0.5 + rand::random::<f64>() * 0.5;
+            Duration::from_secs_f64(duration.as_secs_f64() * factor)
+        })
+        .take(retries.max(0) as usize)
+}
+
+/// hyper-util exposes DNS failures in the error chain as a `dns error` source,
+/// but reqwest intentionally erases the concrete connector type. Match that
+/// stable connector error label rather than platform-specific resolver text.
+fn is_dns_error(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(source) = current {
+        if source.to_string() == "dns error" {
+            return true;
+        }
+        current = source.source();
+    }
+    false
+}
+
+fn is_transient(error: &eyre::Report) -> bool {
+    // An unavailable hostname is a deterministic configuration error. reqwest
+    // categorizes it as a connect error, but retrying only delays the diagnosis.
+    if is_dns_error(error.as_ref()) {
+        return false;
+    }
+    error.chain().any(|source| {
+        let Some(error) = source.downcast_ref::<reqwest::Error>() else {
+            return false;
+        };
+        if error.is_timeout() || error.is_connect() || error.is_body() {
+            return true;
+        }
+        error.status().is_some_and(|status| {
+            let status = status.as_u16();
+            status == 408 || status == 429 || (500..600).contains(&status)
+        })
+    })
+}
+
+async fn retry_async<F, Fut, T>(verb: &str, url: &Url, retries: i64, mut operation: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut delays = retry_delays(retries);
+    let mut attempt = 1;
+    loop {
+        let started_at = Instant::now();
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(error) if is_transient(&error) => {
+                let Some(delay) = delays.next() else {
+                    return Err(error);
+                };
+                warn!(
+                    "HTTP {verb} {url} attempt {attempt} failed after {:?} (transient): {error}; retrying in {delay:?}",
+                    started_at.elapsed()
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dns_errors_are_not_transient() {
+        #[derive(Debug)]
+        struct DnsError;
+
+        impl std::fmt::Display for DnsError {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("dns error")
+            }
+        }
+
+        impl std::error::Error for DnsError {}
+
+        let error = eyre::Report::new(DnsError);
+        assert!(is_dns_error(error.as_ref()));
+        assert!(!is_transient(&error));
+    }
+
+    #[test]
+    fn cache_digest_verifies_its_declared_algorithm() {
+        let bytes = b"remote cache blob";
+        let sha256 = CacheDigest {
+            algorithm: "sha256".into(),
+            hash: hex::encode(sha2::Sha256::digest(bytes)),
+            size: bytes.len() as u64,
+        };
+        assert!(sha256.matches_bytes(bytes).unwrap());
+        assert!(!sha256.matches_bytes(b"different").unwrap());
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        fs::write(file.path(), bytes).unwrap();
+        assert!(sha256.matches_file(file.path()).unwrap());
+    }
+
+    #[test]
+    fn action_result_keys_require_blake3() {
+        let client = RemoteCacheClient::new(RemoteCacheConfig {
+            base_url: "http://127.0.0.1:1".parse().unwrap(),
+            namespace: "test".into(),
+            token: None,
+            token_file: None,
+            oidc_audience: None,
+            connect_timeout: Duration::from_secs(1),
+            read_timeout: Duration::from_secs(1),
+            download_timeout: Duration::from_secs(1),
+            retries: 0,
+        })
+        .unwrap();
+        let action = CacheDigest {
+            algorithm: "sha256".into(),
+            hash: "0".repeat(64),
+            size: 0,
+        };
+
+        assert!(
+            client
+                .action_result_endpoint(&action)
+                .unwrap_err()
+                .to_string()
+                .contains("must use blake3")
+        );
+    }
+
+    #[test]
+    fn bearer_authorization_headers_are_sensitive() {
+        let header = authorization_header(Some(" test-token ")).unwrap().unwrap();
+        assert_eq!(header, "Bearer test-token");
+        assert!(header.is_sensitive());
+        assert!(authorization_header(Some(" ")).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn token_file_credentials_are_reloaded() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cache-token");
+        fs::write(&path, "first-token\n").unwrap();
+        let credential = RemoteCacheCredential::File(path.clone());
+
+        let first = credential.authorization().await.unwrap().unwrap();
+        assert_eq!(first, "Bearer first-token");
+        assert!(first.is_sensitive());
+
+        fs::write(path, "rotated-token\n").unwrap();
+        let rotated = credential.authorization().await.unwrap().unwrap();
+        assert_eq!(rotated, "Bearer rotated-token");
+    }
+
+    #[tokio::test]
+    async fn github_actions_oidc_tokens_are_acquired_and_cached() {
+        let mut server = mockito::Server::new_async().await;
+        let expires_at = unix_timestamp().unwrap() + 3600;
+        let token = test_jwt(expires_at);
+        let token_response = serde_json::json!({"value":token}).to_string();
+        let request = server
+            .mock("GET", "/oidc")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "audience".into(),
+                "https://cache.example.com".into(),
+            ))
+            .match_header("authorization", "Bearer request-secret")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(token_response)
+            .expect(1)
+            .create_async()
+            .await;
+        let credential = GithubActionsOidcCredential::new(
+            "https://cache.example.com",
+            format!("{}/oidc?api-version=1&audience=old", server.url())
+                .parse()
+                .unwrap(),
+            "request-secret",
+            reqwest::Client::new(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            credential.request_url.query_pairs().collect::<Vec<_>>(),
+            vec![
+                ("api-version".into(), "1".into()),
+                ("audience".into(), "https://cache.example.com".into()),
+            ]
+        );
+
+        let first = credential.authorization().await.unwrap();
+        let second = credential.authorization().await.unwrap();
+
+        assert_eq!(first, format!("Bearer {token}"));
+        assert_eq!(first, second);
+        assert!(first.is_sensitive());
+        request.assert_async().await;
+    }
+
+    #[test]
+    fn oidc_request_urls_require_https_except_for_loopback() {
+        validate_oidc_request_url(&"https://example.com/oidc".parse().unwrap()).unwrap();
+        validate_oidc_request_url(&"http://127.0.0.1:3000/oidc".parse().unwrap()).unwrap();
+        assert!(validate_oidc_request_url(&"http://example.com/oidc".parse().unwrap()).is_err());
+    }
+
+    fn test_jwt(expires_at: u64) -> String {
+        let header = URL_SAFE_NO_PAD.encode(b"{}");
+        let claims = URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&serde_json::json!({"exp":expires_at})).unwrap());
+        format!("{header}.{claims}.signature")
+    }
+
+    #[test]
+    fn remote_urls_require_https_for_authenticated_requests() {
+        for url in [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://[::1]:3000",
+            "https://cache.example.com",
+        ] {
+            validate_remote_url(&url.parse().unwrap(), true).unwrap();
+        }
+        let insecure: Url = "http://cache.example.com".parse().unwrap();
+        assert!(validate_remote_url(&insecure, true).is_err());
+        validate_remote_url(&insecure, false).unwrap();
+        assert!(validate_remote_url(&"ftp://localhost/cache".parse().unwrap(), false).is_err());
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,16 +4,15 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use eyre::{Result, bail};
+use eyre::Result;
 use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use path_absolutize::Absolutize;
+use serde::Serialize;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use sha2::Digest as _;
 use std::sync::LazyLock as Lazy;
 
 use crate::build_time::built_info;
@@ -25,94 +24,7 @@ use crate::rand::random_string;
 use crate::toolset::env_cache::CachedEnv;
 use crate::{dirs, file};
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    Serialize,
-    Deserialize,
-    Default,
-    strum::EnumString,
-    strum::Display,
-    PartialEq,
-    Eq,
-)]
-#[serde(rename_all = "kebab-case")]
-#[strum(serialize_all = "kebab-case")]
-pub enum CacheRemoteMode {
-    #[default]
-    ReadWrite,
-    ReadOnly,
-    WriteOnly,
-}
-
-impl CacheRemoteMode {
-    pub(crate) fn reads(self) -> bool {
-        matches!(self, Self::ReadWrite | Self::ReadOnly)
-    }
-
-    pub(crate) fn writes(self) -> bool {
-        matches!(self, Self::ReadWrite | Self::WriteOnly)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub(crate) struct CacheDigest {
-    pub(crate) algorithm: String,
-    pub(crate) hash: String,
-    pub(crate) size: u64,
-}
-
-impl CacheDigest {
-    pub(crate) fn blake3(bytes: &[u8]) -> Self {
-        Self {
-            algorithm: "blake3".into(),
-            hash: blake3::hash(bytes).to_hex().to_string(),
-            size: bytes.len() as u64,
-        }
-    }
-
-    pub(crate) fn validate(&self) -> Result<()> {
-        if self.algorithm != "blake3" && self.algorithm != "sha256" {
-            bail!("unsupported remote cache digest algorithm");
-        }
-        if self.hash.len() != 64
-            || !self
-                .hash
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-        {
-            bail!("invalid remote cache digest");
-        }
-        Ok(())
-    }
-
-    pub(crate) fn matches_bytes(&self, bytes: &[u8]) -> Result<bool> {
-        self.validate()?;
-        if self.size != bytes.len() as u64 {
-            return Ok(false);
-        }
-        let hash = match self.algorithm.as_str() {
-            "blake3" => blake3::hash(bytes).to_hex().to_string(),
-            "sha256" => hex::encode(sha2::Sha256::digest(bytes)),
-            _ => unreachable!("digest algorithm was validated"),
-        };
-        Ok(self.hash == hash)
-    }
-
-    pub(crate) fn matches_file(&self, path: &Path) -> Result<bool> {
-        self.validate()?;
-        if self.size != path.metadata()?.len() {
-            return Ok(false);
-        }
-        let hash = match self.algorithm.as_str() {
-            "blake3" => crate::hash::file_hash_blake3(path, None)?,
-            "sha256" => crate::hash::file_hash_sha256(path, None)?,
-            _ => unreachable!("digest algorithm was validated"),
-        };
-        Ok(self.hash == hash)
-    }
-}
+pub use mise_cache_core::RemoteCacheMode as CacheRemoteMode;
 
 #[derive(Debug)]
 pub struct CacheManagerBuilder {

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -18,6 +18,7 @@ use eyre::{Context, Report, Result, bail, eyre};
 use glob::glob;
 use ignore::overrides::Override;
 use jdx_tar::{Builder, EntryType, Header};
+use mise_cache_core::RemoteCacheConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -406,13 +407,19 @@ impl TaskArtifactCacheBuilder {
                 })?
                 .to_string();
             Some(RemoteTaskCacheConfig {
-                base_url: base_url.parse().wrap_err("invalid task.cache.remote_url")?,
-                namespace,
+                remote: RemoteCacheConfig {
+                    base_url: base_url.parse().wrap_err("invalid task.cache.remote_url")?,
+                    namespace,
+                    token: settings.task.cache.remote_token.clone(),
+                    token_file: settings.task.cache.remote_token_file.clone(),
+                    oidc_audience: settings.task.cache.remote_oidc_audience.clone(),
+                    connect_timeout: settings.http_timeout(),
+                    read_timeout: settings.http_timeout(),
+                    download_timeout: settings.http_download_timeout(),
+                    retries: settings.http_retries(),
+                },
                 staging_dir: cache_dir.join("remote"),
                 mode: settings.task.cache.remote_mode,
-                token: settings.task.cache.remote_token.clone(),
-                token_file: settings.task.cache.remote_token_file.clone(),
-                oidc_audience: settings.task.cache.remote_oidc_audience.clone(),
             })
         } else {
             None

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -1,17 +1,15 @@
-use crate::cache::{CacheDigest, CacheRemoteMode};
+use crate::cache::CacheRemoteMode;
 use crate::file;
 use crate::task::task_cache::{
     CACHE_FORMAT_VERSION, CacheManifest, TaskCacheOutput, calculate_artifact_checksum,
     canonical_json,
 };
-use crate::{config::Settings, http};
 use async_trait::async_trait;
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use eyre::{Result, bail, eyre};
 use jdx_tar::{Archive, Builder, EntryType, Header};
-use reqwest::StatusCode;
-use reqwest::header::{
-    ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, IF_NONE_MATCH,
+use mise_cache_core::{
+    BlobSource, BlobUpload, CLIENT_METADATA_MEDIA_TYPE, CacheDigest, DIRECTORY_MEDIA_TYPE,
+    RemoteActionResult, RemoteCacheClient, RemoteCacheConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -19,73 +17,14 @@ use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex, Weak};
-use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::io::AsyncWriteExt;
-use url::{Host, Url};
-
-const REMOTE_CACHE_PROTOCOL_VERSION: u8 = 1;
-const REMOTE_CACHE_PROTOCOL_HEADER: &str = "mise-cache-protocol";
-const REMOTE_CACHE_NAMESPACE_HEADER: &str = "mise-cache-namespace";
-const REMOTE_CACHE_ACTION_RESULT_MEDIA_TYPE: &str =
-    "application/vnd.mise.cache-action-result.v1+json";
-const REMOTE_CACHE_DIRECTORY_MEDIA_TYPE: &str = "application/vnd.mise.cache-directory.v1+json";
-const REMOTE_CACHE_CLIENT_METADATA_MEDIA_TYPE: &str =
-    "application/vnd.mise.cache-client-metadata.v1+json";
-const REMOTE_CACHE_BLOB_MEDIA_TYPE: &str = "application/octet-stream";
-
 /// Version of the cache-store contract. This is independent of the artifact
 /// manifest format so stores and transports can evolve without changing keys.
 pub(crate) const TASK_CACHE_STORE_VERSION: u8 = 1;
 
 pub(crate) struct RemoteTaskCacheConfig {
-    pub(crate) base_url: Url,
-    pub(crate) namespace: String,
+    pub(crate) remote: RemoteCacheConfig,
     pub(crate) staging_dir: PathBuf,
     pub(crate) mode: CacheRemoteMode,
-    pub(crate) token: Option<String>,
-    pub(crate) token_file: Option<PathBuf>,
-    pub(crate) oidc_audience: Option<String>,
-}
-
-#[derive(Clone)]
-enum RemoteTaskCacheCredential {
-    None,
-    Static(HeaderValue),
-    File(PathBuf),
-    GithubActions(Arc<GithubActionsOidcCredential>),
-}
-
-struct GithubActionsOidcCredential {
-    audience: String,
-    request_url: Url,
-    request_token: HeaderValue,
-    client: reqwest::Client,
-    cached: tokio::sync::Mutex<Option<CachedOidcToken>>,
-}
-
-struct CachedOidcToken {
-    authorization: HeaderValue,
-    expires_at: u64,
-}
-
-#[derive(Deserialize)]
-struct GithubActionsOidcResponse {
-    value: String,
-}
-
-#[derive(Deserialize)]
-struct JwtExpiry {
-    exp: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct RemoteActionResult {
-    action: CacheDigest,
-    #[serde(default)]
-    metadata: Option<CacheDigest>,
-    #[serde(default)]
-    output_root: Option<CacheDigest>,
-    version: u8,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -165,16 +104,6 @@ struct RemoteSymlinkNode {
     mode: u32,
     name: String,
     target: String,
-}
-
-enum CasBlobSource {
-    Bytes(Vec<u8>),
-    File(tempfile::NamedTempFile),
-}
-
-struct CasBlobUpload {
-    digest: CacheDigest,
-    source: CasBlobSource,
 }
 
 enum ArchiveNode {
@@ -461,400 +390,20 @@ pub(crate) fn compose_task_cache_stores(
 ) -> Result<Arc<dyn TaskCacheStore>> {
     match remote {
         Some(remote_config) => {
-            let authenticated = remote_config
-                .token
-                .as_deref()
-                .is_some_and(|token| !token.trim().is_empty())
-                || remote_config.token_file.is_some()
-                || remote_config
-                    .oidc_audience
-                    .as_deref()
-                    .is_some_and(|audience| !audience.trim().is_empty());
-            validate_remote_url(&remote_config.base_url, authenticated)?;
-            let client = reqwest::Client::builder()
-                .connect_timeout(Settings::get().http_timeout())
-                .read_timeout(Settings::get().http_timeout())
-                .redirect(reqwest::redirect::Policy::none())
-                .build()?;
-            let credential = remote_credential(&remote_config, client.clone())?;
+            let mode = remote_config.mode;
             let remote = Arc::new(HttpTaskCacheStore {
-                base_url: normalized_base_url(remote_config.base_url),
-                namespace: remote_config.namespace,
+                client: RemoteCacheClient::new(remote_config.remote)?,
                 staging_dir: remote_config.staging_dir,
-                client,
-                credential,
             });
-            Ok(Arc::new(CompositeTaskCacheStore::new(
-                local,
-                remote,
-                remote_config.mode,
-            )?))
+            Ok(Arc::new(CompositeTaskCacheStore::new(local, remote, mode)?))
         }
         None => Ok(local),
     }
 }
 
-fn remote_credential(
-    config: &RemoteTaskCacheConfig,
-    client: reqwest::Client,
-) -> Result<RemoteTaskCacheCredential> {
-    if let Some(authorization) = authorization_header(config.token.as_deref())? {
-        return Ok(RemoteTaskCacheCredential::Static(authorization));
-    }
-    if let Some(path) = &config.token_file {
-        return Ok(RemoteTaskCacheCredential::File(path.clone()));
-    }
-    let Some(audience) = config
-        .oidc_audience
-        .as_deref()
-        .map(str::trim)
-        .filter(|audience| !audience.is_empty())
-    else {
-        return Ok(RemoteTaskCacheCredential::None);
-    };
-    Ok(RemoteTaskCacheCredential::GithubActions(Arc::new(
-        GithubActionsOidcCredential::from_env(audience, client)?,
-    )))
-}
-
-fn authorization_header(token: Option<&str>) -> Result<Option<HeaderValue>> {
-    let Some(token) = token.map(str::trim).filter(|token| !token.is_empty()) else {
-        return Ok(None);
-    };
-    let mut value = HeaderValue::from_str(&format!("Bearer {token}"))?;
-    value.set_sensitive(true);
-    Ok(Some(value))
-}
-
-impl RemoteTaskCacheCredential {
-    async fn authorization(&self) -> Result<Option<HeaderValue>> {
-        match self {
-            Self::None => Ok(None),
-            Self::Static(value) => Ok(Some(value.clone())),
-            Self::File(path) => {
-                let token = tokio::fs::read_to_string(path).await.map_err(|err| {
-                    eyre!(
-                        "failed to read remote cache token file {}: {err}",
-                        path.display()
-                    )
-                })?;
-                authorization_header(Some(&token))?
-                    .ok_or_else(|| eyre!("remote cache token file {} is empty", path.display()))
-                    .map(Some)
-            }
-            Self::GithubActions(credential) => credential.authorization().await.map(Some),
-        }
-    }
-}
-
-impl GithubActionsOidcCredential {
-    fn from_env(audience: &str, client: reqwest::Client) -> Result<Self> {
-        let request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
-            eyre!(
-                "task.cache.remote_oidc_audience requires GitHub Actions OIDC; \
-                 grant `id-token: write` or set MISE_TASK_CACHE_REMOTE_TOKEN"
-            )
-        })?;
-        let request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| {
-            eyre!(
-                "task.cache.remote_oidc_audience requires GitHub Actions OIDC; \
-                 ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing"
-            )
-        })?;
-        let request_url: Url = request_url
-            .parse()
-            .map_err(|err| eyre!("invalid GitHub Actions OIDC request URL: {err}"))?;
-        Self::new(audience, request_url, &request_token, client)
-    }
-
-    fn new(
-        audience: &str,
-        mut request_url: Url,
-        request_token: &str,
-        client: reqwest::Client,
-    ) -> Result<Self> {
-        validate_oidc_request_url(&request_url)?;
-        let query = request_url
-            .query_pairs()
-            .filter(|(key, _)| key != "audience")
-            .map(|(key, value)| (key.into_owned(), value.into_owned()))
-            .collect::<Vec<_>>();
-        request_url.set_query(None);
-        request_url
-            .query_pairs_mut()
-            .extend_pairs(query)
-            .append_pair("audience", audience);
-        let request_token = authorization_header(Some(request_token))?
-            .ok_or_else(|| eyre!("GitHub Actions OIDC request token is empty"))?;
-        Ok(Self {
-            audience: audience.to_string(),
-            request_url,
-            request_token,
-            client,
-            cached: tokio::sync::Mutex::new(None),
-        })
-    }
-
-    async fn authorization(&self) -> Result<HeaderValue> {
-        const REFRESH_LEEWAY_SECONDS: u64 = 60;
-        let mut cached = self.cached.lock().await;
-        let now = unix_timestamp()?;
-        if let Some(token) = cached.as_ref()
-            && token.expires_at > now.saturating_add(REFRESH_LEEWAY_SECONDS)
-        {
-            return Ok(token.authorization.clone());
-        }
-        let response: GithubActionsOidcResponse =
-            http::retry_async("GET", &self.request_url, || async {
-                Ok(self
-                    .client
-                    .get(self.request_url.clone())
-                    .header(AUTHORIZATION, self.request_token.clone())
-                    .send()
-                    .await?
-                    .error_for_status()?
-                    .json()
-                    .await?)
-            })
-            .await
-            .map_err(|err| {
-                eyre!(
-                    "failed to acquire GitHub Actions OIDC token for audience {:?}: {err}",
-                    self.audience
-                )
-            })?;
-        let expires_at = jwt_expiry(&response.value)?;
-        if expires_at <= now.saturating_add(REFRESH_LEEWAY_SECONDS) {
-            bail!("GitHub Actions OIDC token expires too soon");
-        }
-        let authorization = authorization_header(Some(&response.value))?
-            .ok_or_else(|| eyre!("GitHub Actions returned an empty OIDC token"))?;
-        *cached = Some(CachedOidcToken {
-            authorization: authorization.clone(),
-            expires_at,
-        });
-        Ok(authorization)
-    }
-}
-
-fn jwt_expiry(token: &str) -> Result<u64> {
-    let payload = token
-        .split('.')
-        .nth(1)
-        .ok_or_else(|| eyre!("GitHub Actions returned a malformed OIDC token"))?;
-    let payload = URL_SAFE_NO_PAD
-        .decode(payload)
-        .map_err(|_| eyre!("GitHub Actions returned a malformed OIDC token"))?;
-    let claims: JwtExpiry = serde_json::from_slice(&payload)
-        .map_err(|_| eyre!("GitHub Actions OIDC token is missing a valid expiry"))?;
-    Ok(claims.exp)
-}
-
-fn unix_timestamp() -> Result<u64> {
-    Ok(SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|err| eyre!("system clock is before the Unix epoch: {err}"))?
-        .as_secs())
-}
-
-fn validate_oidc_request_url(url: &Url) -> Result<()> {
-    if url.scheme() == "https"
-        || url.scheme() == "http"
-            && url.host().is_some_and(|host| match host {
-                Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
-                Host::Ipv4(address) => address.is_loopback(),
-                Host::Ipv6(address) => address.is_loopback(),
-            })
-    {
-        Ok(())
-    } else {
-        bail!("GitHub Actions OIDC request URL must use HTTPS")
-    }
-}
-
-fn validate_remote_url(base_url: &Url, authenticated: bool) -> Result<()> {
-    if base_url.scheme() == "https" {
-        return Ok(());
-    }
-    if base_url.scheme() != "http" {
-        bail!("task.cache.remote_url must use HTTPS");
-    }
-    let is_loopback = base_url.host().is_some_and(|host| match host {
-        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
-        Host::Ipv4(address) => address.is_loopback(),
-        Host::Ipv6(address) => address.is_loopback(),
-    });
-    if !is_loopback && authenticated {
-        bail!("task.cache.remote_url must use HTTPS except for loopback development servers");
-    }
-    if !is_loopback {
-        warn!(
-            "using an unauthenticated remote build cache over plain HTTP; cache traffic can be read \
-             or modified in transit"
-        );
-    }
-    Ok(())
-}
-
 struct HttpTaskCacheStore {
-    base_url: Url,
-    namespace: String,
+    client: RemoteCacheClient,
     staging_dir: PathBuf,
-    client: reqwest::Client,
-    credential: RemoteTaskCacheCredential,
-}
-
-impl HttpTaskCacheStore {
-    fn action_result_endpoint(&self, key: &str, action_size: u64) -> Result<Url> {
-        validate_remote_key(key)?;
-        Ok(self.base_url.join(&format!(
-            "v{REMOTE_CACHE_PROTOCOL_VERSION}/action-results/blake3/{key}/{action_size}"
-        ))?)
-    }
-
-    fn blob_endpoint(&self, digest: &CacheDigest) -> Result<Url> {
-        digest.validate()?;
-        Ok(self.base_url.join(&format!(
-            "v{REMOTE_CACHE_PROTOCOL_VERSION}/blobs/{}/{}/{}",
-            digest.algorithm, digest.hash, digest.size
-        ))?)
-    }
-
-    async fn request(
-        &self,
-        method: reqwest::Method,
-        url: Url,
-        media_type: &'static str,
-    ) -> Result<reqwest::RequestBuilder> {
-        let request = self
-            .client
-            .request(method, url)
-            .header(
-                REMOTE_CACHE_PROTOCOL_HEADER,
-                REMOTE_CACHE_PROTOCOL_VERSION.to_string(),
-            )
-            .header(REMOTE_CACHE_NAMESPACE_HEADER, &self.namespace)
-            .header(ACCEPT, media_type);
-        if let Some(authorization) = self.credential.authorization().await? {
-            Ok(request.header(AUTHORIZATION, authorization))
-        } else {
-            Ok(request)
-        }
-    }
-
-    async fn get_blob(&self, digest: &CacheDigest, media_type: &'static str) -> Result<Vec<u8>> {
-        digest.validate()?;
-        let url = self.blob_endpoint(digest)?;
-        http::retry_async("GET", &url, || async {
-            let response = self
-                .request(reqwest::Method::GET, url.clone(), media_type)
-                .await?
-                .send()
-                .await?
-                .error_for_status()?;
-            let bytes = response.bytes().await?.to_vec();
-            if !digest.matches_bytes(&bytes)? {
-                bail!("remote cache blob failed digest verification");
-            }
-            Ok(bytes)
-        })
-        .await
-    }
-
-    async fn get_blob_file(&self, digest: &CacheDigest) -> Result<tempfile::NamedTempFile> {
-        let url = self.blob_endpoint(digest)?;
-        let download = http::retry_async("GET", &url, || async {
-            let mut response = self
-                .request(
-                    reqwest::Method::GET,
-                    url.clone(),
-                    REMOTE_CACHE_BLOB_MEDIA_TYPE,
-                )
-                .await?
-                .send()
-                .await?;
-            response.error_for_status_ref()?;
-            file::create_dir_all(&self.staging_dir)?;
-            let temporary = tempfile::NamedTempFile::new_in(&self.staging_dir)?;
-            let mut output = tokio::fs::File::from_std(temporary.reopen()?);
-            while let Some(chunk) = response.chunk().await? {
-                output.write_all(&chunk).await?;
-            }
-            output.flush().await?;
-            drop(output);
-            if !digest.matches_file(temporary.path())? {
-                bail!("remote cache blob failed digest verification");
-            }
-            Ok(temporary)
-        });
-        tokio::time::timeout(Settings::get().http_download_timeout(), download)
-            .await
-            .map_err(|_| eyre!("remote task cache blob download timed out for {url}"))?
-    }
-
-    async fn put_blob(&self, upload: &CasBlobUpload) -> Result<()> {
-        let url = self.blob_endpoint(&upload.digest)?;
-        http::retry_async("PUT", &url, || async {
-            let (length, body) = match &upload.source {
-                CasBlobSource::Bytes(bytes) => {
-                    (bytes.len() as u64, reqwest::Body::from(bytes.clone()))
-                }
-                CasBlobSource::File(file) => {
-                    let file = tokio::fs::File::open(file.path()).await?;
-                    let length = file.metadata().await?.len();
-                    let stream = tokio_util::io::ReaderStream::new(file);
-                    (length, reqwest::Body::wrap_stream(stream))
-                }
-            };
-            let response = self
-                .request(
-                    reqwest::Method::PUT,
-                    url.clone(),
-                    REMOTE_CACHE_BLOB_MEDIA_TYPE,
-                )
-                .await?
-                .header(CONTENT_TYPE, REMOTE_CACHE_BLOB_MEDIA_TYPE)
-                .header(CONTENT_LENGTH, length)
-                .header(IF_NONE_MATCH, "*")
-                .body(body)
-                .send()
-                .await?;
-            if response.status() != StatusCode::PRECONDITION_FAILED {
-                response.error_for_status()?;
-            }
-            Ok(())
-        })
-        .await
-    }
-
-    async fn put_action_result(
-        &self,
-        key: &str,
-        action_size: u64,
-        result: &RemoteActionResult,
-    ) -> Result<()> {
-        let url = self.action_result_endpoint(key, action_size)?;
-        let body = serde_json::to_vec(result)?;
-        http::retry_async("PUT", &url, || async {
-            let response = self
-                .request(
-                    reqwest::Method::PUT,
-                    url.clone(),
-                    REMOTE_CACHE_ACTION_RESULT_MEDIA_TYPE,
-                )
-                .await?
-                .header(CONTENT_TYPE, REMOTE_CACHE_ACTION_RESULT_MEDIA_TYPE)
-                .header(IF_NONE_MATCH, "*")
-                .body(body.clone())
-                .send()
-                .await?;
-            if response.status() != StatusCode::PRECONDITION_FAILED {
-                response.error_for_status()?;
-            }
-            Ok(())
-        })
-        .await
-    }
 }
 
 #[async_trait]
@@ -864,39 +413,21 @@ impl TaskCacheStore for HttpTaskCacheStore {
     }
 
     async fn get(&self, key: &str, action_size: u64) -> Result<Option<TaskCacheStoreEntry>> {
-        let url = self.action_result_endpoint(key, action_size)?;
-        let envelope = http::retry_async("GET", &url, || async {
-            let response = self
-                .request(
-                    reqwest::Method::GET,
-                    url.clone(),
-                    REMOTE_CACHE_ACTION_RESULT_MEDIA_TYPE,
-                )
-                .await?
-                .send()
-                .await?;
-            if response.status() == StatusCode::NOT_FOUND {
-                return Ok(None);
-            }
-            Ok(Some(response.error_for_status()?.json().await?))
-        })
-        .await?;
-        let Some(result): Option<RemoteActionResult> = envelope else {
+        let action = CacheDigest {
+            algorithm: "blake3".into(),
+            hash: key.to_string(),
+            size: action_size,
+        };
+        let Some(result) = self.client.get_action_result(&action).await? else {
             return Ok(None);
         };
-        if result.version != 1
-            || result.action.algorithm != "blake3"
-            || result.action.hash != key
-            || result.action.size != action_size
-        {
-            bail!("remote action result does not match requested action");
-        }
         let metadata = result
             .metadata
             .as_ref()
             .ok_or_else(|| eyre!("remote action result is missing client metadata"))?;
         let metadata_bytes = self
-            .get_blob(metadata, REMOTE_CACHE_CLIENT_METADATA_MEDIA_TYPE)
+            .client
+            .get_blob(metadata, CLIENT_METADATA_MEDIA_TYPE)
             .await?;
         let metadata: RemoteClientMetadata = serde_json::from_slice(&metadata_bytes)?;
         if canonical_json(&serde_json::to_value(&metadata)?)? != metadata_bytes {
@@ -953,13 +484,13 @@ impl TaskCacheStore for HttpTaskCacheStore {
             RemoteClientMetadata::from_manifest(&manifest),
         )?)?;
         let mut uploads = vec![
-            CasBlobUpload {
+            BlobUpload {
                 digest: action_digest.clone(),
-                source: CasBlobSource::Bytes(action.to_vec()),
+                source: BlobSource::Bytes(action.to_vec()),
             },
-            CasBlobUpload {
+            BlobUpload {
                 digest: CacheDigest::blake3(&metadata),
-                source: CasBlobSource::Bytes(metadata),
+                source: BlobSource::Bytes(metadata),
             },
         ];
         let metadata = uploads[1].digest.clone();
@@ -974,20 +505,17 @@ impl TaskCacheStore for HttpTaskCacheStore {
         let mut published = BTreeSet::new();
         for upload in &uploads {
             if published.insert(upload.digest.clone()) {
-                self.put_blob(upload).await?;
+                self.client.put_blob(upload).await?;
             }
         }
-        self.put_action_result(
-            key,
-            action.len() as u64,
-            &RemoteActionResult {
+        self.client
+            .put_action_result(&RemoteActionResult {
                 action: action_digest,
                 metadata: Some(metadata),
                 output_root,
                 version: 1,
-            },
-        )
-        .await
+            })
+            .await
     }
 
     async fn remove(&self, _key: &str) -> Result<()> {
@@ -1058,7 +586,7 @@ fn validate_cache_symlink_target(path: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
-fn archive_to_cas(path: &Path, staging_dir: &Path) -> Result<(CacheDigest, Vec<CasBlobUpload>)> {
+fn archive_to_cas(path: &Path, staging_dir: &Path) -> Result<(CacheDigest, Vec<BlobUpload>)> {
     file::create_dir_all(staging_dir)?;
     let decoder = zstd::Decoder::new(File::open(path)?)?;
     let mut archive = Archive::new(decoder);
@@ -1124,7 +652,7 @@ fn archive_to_cas(path: &Path, staging_dir: &Path) -> Result<(CacheDigest, Vec<C
     fn build_directory(
         path: &Path,
         nodes: &BTreeMap<PathBuf, ArchiveNode>,
-        directory_uploads: &mut Vec<CasBlobUpload>,
+        directory_uploads: &mut Vec<BlobUpload>,
     ) -> Result<CacheDigest> {
         let mut directories = Vec::new();
         let mut files = Vec::new();
@@ -1169,9 +697,9 @@ fn archive_to_cas(path: &Path, staging_dir: &Path) -> Result<(CacheDigest, Vec<C
         })?;
         let bytes = canonical_json(&directory)?;
         let digest = CacheDigest::blake3(&bytes);
-        directory_uploads.push(CasBlobUpload {
+        directory_uploads.push(BlobUpload {
             digest: digest.clone(),
-            source: CasBlobSource::Bytes(bytes),
+            source: BlobSource::Bytes(bytes),
         });
         Ok(digest)
     }
@@ -1180,9 +708,9 @@ fn archive_to_cas(path: &Path, staging_dir: &Path) -> Result<(CacheDigest, Vec<C
     let root = build_directory(Path::new(""), &nodes, &mut uploads)?;
     for node in nodes.into_values() {
         if let ArchiveNode::File { digest, file, .. } = node {
-            uploads.push(CasBlobUpload {
+            uploads.push(BlobUpload {
                 digest,
-                source: CasBlobSource::File(file),
+                source: BlobSource::File(file),
             });
         }
     }
@@ -1214,9 +742,7 @@ async fn materialize_remote_tree(
         if !ancestors.insert(digest.clone()) {
             bail!("remote cache directory graph contains a cycle");
         }
-        let bytes = store
-            .get_blob(&digest, REMOTE_CACHE_DIRECTORY_MEDIA_TYPE)
-            .await?;
+        let bytes = store.client.get_blob(&digest, DIRECTORY_MEDIA_TYPE).await?;
         let directory: RemoteDirectory = serde_json::from_slice(&bytes)?;
         if canonical_json(&serde_json::to_value(&directory)?)? != bytes {
             bail!("remote cache directory is not canonical JSON");
@@ -1279,7 +805,13 @@ async fn materialize_remote_tree(
     let mut downloaded = BTreeMap::new();
     for (path, node) in &nodes {
         if let RestoredNode::File { digest, .. } = node {
-            downloaded.insert(path.clone(), store.get_blob_file(digest).await?);
+            downloaded.insert(
+                path.clone(),
+                store
+                    .client
+                    .get_blob_file(digest, &store.staging_dir)
+                    .await?,
+            );
         }
     }
 
@@ -1325,14 +857,6 @@ async fn materialize_remote_tree(
     let encoder = archive.into_inner()?;
     encoder.finish()?;
     Ok(archive_file)
-}
-
-fn normalized_base_url(mut url: Url) -> Url {
-    if !url.path().ends_with('/') {
-        let path = format!("{}/", url.path());
-        url.set_path(&path);
-    }
-    url
 }
 
 fn validate_remote_key(key: &str) -> Result<()> {
@@ -1441,122 +965,8 @@ fn remove_file(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sha2::Digest as _;
-
-    #[test]
-    fn cache_digest_verifies_its_declared_algorithm() {
-        let bytes = b"remote cache blob";
-        let sha256 = CacheDigest {
-            algorithm: "sha256".into(),
-            hash: hex::encode(sha2::Sha256::digest(bytes)),
-            size: bytes.len() as u64,
-        };
-        assert!(sha256.matches_bytes(bytes).unwrap());
-        assert!(!sha256.matches_bytes(b"different").unwrap());
-
-        let file = tempfile::NamedTempFile::new().unwrap();
-        fs::write(file.path(), bytes).unwrap();
-        assert!(sha256.matches_file(file.path()).unwrap());
-    }
-
-    #[test]
-    fn bearer_authorization_headers_are_sensitive() {
-        let header = authorization_header(Some(" test-token ")).unwrap().unwrap();
-        assert_eq!(header, "Bearer test-token");
-        assert!(header.is_sensitive());
-        assert!(authorization_header(Some(" ")).unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn token_file_credentials_are_reloaded() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("cache-token");
-        fs::write(&path, "first-token\n").unwrap();
-        let credential = RemoteTaskCacheCredential::File(path.clone());
-
-        let first = credential.authorization().await.unwrap().unwrap();
-        assert_eq!(first, "Bearer first-token");
-        assert!(first.is_sensitive());
-
-        fs::write(path, "rotated-token\n").unwrap();
-        let rotated = credential.authorization().await.unwrap().unwrap();
-        assert_eq!(rotated, "Bearer rotated-token");
-    }
-
-    #[tokio::test]
-    async fn github_actions_oidc_tokens_are_acquired_and_cached() {
-        let mut server = mockito::Server::new_async().await;
-        let expires_at = unix_timestamp().unwrap() + 3600;
-        let token = test_jwt(expires_at);
-        let token_response = serde_json::json!({"value":token}).to_string();
-        let request = server
-            .mock("GET", "/oidc")
-            .match_query(mockito::Matcher::UrlEncoded(
-                "audience".into(),
-                "https://cache.example.com".into(),
-            ))
-            .match_header("authorization", "Bearer request-secret")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(token_response)
-            .expect(1)
-            .create_async()
-            .await;
-        let credential = GithubActionsOidcCredential::new(
-            "https://cache.example.com",
-            format!("{}/oidc?api-version=1&audience=old", server.url())
-                .parse()
-                .unwrap(),
-            "request-secret",
-            reqwest::Client::new(),
-        )
-        .unwrap();
-        assert_eq!(
-            credential.request_url.query_pairs().collect::<Vec<_>>(),
-            vec![
-                ("api-version".into(), "1".into()),
-                ("audience".into(), "https://cache.example.com".into()),
-            ]
-        );
-
-        let first = credential.authorization().await.unwrap();
-        let second = credential.authorization().await.unwrap();
-
-        assert_eq!(first, format!("Bearer {token}"));
-        assert_eq!(first, second);
-        assert!(first.is_sensitive());
-        request.assert_async().await;
-    }
-
-    #[test]
-    fn oidc_request_urls_require_https_except_for_loopback() {
-        validate_oidc_request_url(&"https://example.com/oidc".parse().unwrap()).unwrap();
-        validate_oidc_request_url(&"http://127.0.0.1:3000/oidc".parse().unwrap()).unwrap();
-        assert!(validate_oidc_request_url(&"http://example.com/oidc".parse().unwrap()).is_err());
-    }
-
-    fn test_jwt(expires_at: u64) -> String {
-        let header = URL_SAFE_NO_PAD.encode(b"{}");
-        let claims = URL_SAFE_NO_PAD
-            .encode(serde_json::to_vec(&serde_json::json!({"exp":expires_at})).unwrap());
-        format!("{header}.{claims}.signature")
-    }
-
-    #[test]
-    fn remote_urls_require_https_for_authenticated_requests() {
-        for url in [
-            "http://localhost:3000",
-            "http://127.0.0.1:3000",
-            "http://[::1]:3000",
-            "https://cache.example.com",
-        ] {
-            validate_remote_url(&url.parse().unwrap(), true).unwrap();
-        }
-        let insecure: Url = "http://cache.example.com".parse().unwrap();
-        assert!(validate_remote_url(&insecure, true).is_err());
-        validate_remote_url(&insecure, false).unwrap();
-        assert!(validate_remote_url(&"ftp://localhost/cache".parse().unwrap(), false).is_err());
-    }
+    use mise_cache_core::{ACTION_RESULT_MEDIA_TYPE, BLOB_MEDIA_TYPE};
+    use std::time::Duration;
 
     struct FailingTaskCacheStore {
         inner: LocalTaskCacheStore,
@@ -1774,8 +1184,8 @@ mod tests {
             .iter()
             .find_map(|upload| {
                 (upload.digest == root).then(|| match &upload.source {
-                    CasBlobSource::Bytes(bytes) => bytes.as_slice(),
-                    CasBlobSource::File(_) => panic!("directory object must be in memory"),
+                    BlobSource::Bytes(bytes) => bytes.as_slice(),
+                    BlobSource::File(_) => panic!("directory object must be in memory"),
                 })
             })
             .unwrap();
@@ -1787,8 +1197,8 @@ mod tests {
             .iter()
             .find_map(|upload| {
                 (&upload.digest == dist_digest).then(|| match &upload.source {
-                    CasBlobSource::Bytes(bytes) => bytes.as_slice(),
-                    CasBlobSource::File(_) => panic!("directory object must be in memory"),
+                    BlobSource::Bytes(bytes) => bytes.as_slice(),
+                    BlobSource::File(_) => panic!("directory object must be in memory"),
                 })
             })
             .unwrap();
@@ -1874,7 +1284,7 @@ mod tests {
         let result_body = serde_json::to_vec(&result).unwrap();
         let result_put = server
             .mock("PUT", result_path.as_str())
-            .match_header("content-type", REMOTE_CACHE_ACTION_RESULT_MEDIA_TYPE)
+            .match_header("content-type", ACTION_RESULT_MEDIA_TYPE)
             .match_header("if-none-match", "*")
             .match_body(result_body.clone())
             .with_status(201)
@@ -1883,7 +1293,7 @@ mod tests {
             .await;
         let result_get = server
             .mock("GET", result_path.as_str())
-            .match_header("accept", REMOTE_CACHE_ACTION_RESULT_MEDIA_TYPE)
+            .match_header("accept", ACTION_RESULT_MEDIA_TYPE)
             .with_status(200)
             .with_body(result_body)
             .expect(1)
@@ -1898,13 +1308,19 @@ mod tests {
             .await;
         let staging = tempfile::tempdir().unwrap();
         let store = HttpTaskCacheStore {
-            base_url: normalized_base_url(server.url().parse().unwrap()),
-            namespace: "test-namespace".into(),
+            client: RemoteCacheClient::new(RemoteCacheConfig {
+                base_url: server.url().parse().unwrap(),
+                namespace: "test-namespace".into(),
+                token: Some("test-token".into()),
+                token_file: None,
+                oidc_audience: None,
+                connect_timeout: Duration::from_secs(1),
+                read_timeout: Duration::from_secs(1),
+                download_timeout: Duration::from_secs(1),
+                retries: 0,
+            })
+            .unwrap(),
             staging_dir: staging.path().to_path_buf(),
-            client: reqwest::Client::new(),
-            credential: RemoteTaskCacheCredential::Static(HeaderValue::from_static(
-                "Bearer test-token",
-            )),
         };
         let write = store.begin_write(key).unwrap();
 
@@ -1941,15 +1357,24 @@ mod tests {
             .await;
         let staging = tempfile::tempdir().unwrap();
         let store = HttpTaskCacheStore {
-            base_url: normalized_base_url(server.url().parse().unwrap()),
-            namespace: "test-namespace".into(),
+            client: RemoteCacheClient::new(RemoteCacheConfig {
+                base_url: server.url().parse().unwrap(),
+                namespace: "test-namespace".into(),
+                token: None,
+                token_file: None,
+                oidc_audience: None,
+                connect_timeout: Duration::from_secs(1),
+                read_timeout: Duration::from_secs(1),
+                download_timeout: Duration::from_secs(1),
+                retries: 0,
+            })
+            .unwrap(),
             staging_dir: staging.path().to_path_buf(),
-            client: reqwest::Client::new(),
-            credential: RemoteTaskCacheCredential::None,
         };
 
         let err = store
-            .get_blob(&digest, REMOTE_CACHE_BLOB_MEDIA_TYPE)
+            .client
+            .get_blob(&digest, BLOB_MEDIA_TYPE)
             .await
             .unwrap_err();
 


### PR DESCRIPTION
## Summary
- add `crates/mise-cache-core` as the compiler-agnostic home for action/CAS types, protocol version 1 transport, retries, timeouts, and OIDC credential refresh
- expose the shared remote access mode from the core crate while keeping task-specific archive and metadata conversion in mise
- preserve TLS feature selection across native-tls and rustls builds
- fail DNS errors immediately instead of retrying deterministic resolution failures

## Validation
- `cargo check --all-features`
- `cargo test -p mise-cache-core`
- `cargo test --all-features task_cache`
- `mise run test:e2e tasks/test_task_artifact_cache_remote_modes`
- `cargo clippy -p mise-cache-core --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of remote task cache networking and auth with behavior change on DNS failures; protocol and digest verification paths must stay equivalent for cache hits/misses.
> 
> **Overview**
> Introduces **`mise-cache-core`** as a shared crate for remote action-cache protocol v1: `CacheDigest`, CAS blob upload/download, `RemoteCacheClient`, bearer/token-file/GitHub Actions OIDC auth, URL validation, and HTTP retries with configurable timeouts.
> 
> **Task remote caching** no longer implements that stack inline in `task_cache_store.rs`; it builds a `RemoteCacheConfig` from settings (including HTTP timeouts/retries) and delegates GET/PUT for action results and blobs to `RemoteCacheClient`. Task-specific archive/metadata conversion stays in mise.
> 
> **`src/cache.rs`** re-exports `RemoteCacheMode` from the core crate instead of defining `CacheRemoteMode` and `CacheDigest` locally.
> 
> **Behavior tweak:** DNS resolution failures are treated as non-transient so they are not retried. TLS feature flags on the main crate forward to `mise-cache-core` like other workspace crates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 128ca91593757bc0b92f3d5b66384b186d2e6a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->