### PR TITLE
feat(cache): add in-process cache session foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6427,6 +6427,7 @@ dependencies = [
  "walkdir",
  "which",
  "winapi",
+ "windows-sys 0.61.2",
  "xx",
  "xz2",
  "zip 8.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,11 @@ self_update = { version = "0.44", optional = true, default-features = false, fea
 ] }
 zipsign-api = "0.2"
 winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }
+windows-sys = { version = "0.61", features = [
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_System_Threading",
+] }
 
 [build-dependencies]
 aqua-registry = { path = "crates/aqua-registry" }

--- a/benchmarks/cache-shim/benchmark.sh
+++ b/benchmarks/cache-shim/benchmark.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+mise_bin=${MISE_BIN:-"$repo_root/target/release/mise"}
+runs=${CACHE_SHIM_BENCH_RUNS:-200}
+budget_ms=${CACHE_SHIM_BENCH_BUDGET_MS:-2}
+
+if [[ ! $runs =~ ^[1-9][0-9]*$ ]] || ! [[ $budget_ms =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+	echo "run count must be positive and budget must be a non-negative number" >&2
+	exit 2
+fi
+if [[ ! -x $mise_bin ]]; then
+	echo "mise benchmark binary is not executable: $mise_bin" >&2
+	exit 2
+fi
+
+fixture=$(mktemp -d "${TMPDIR:-/tmp}/mise-cache-shim-bench.XXXXXX")
+trap 'rm -rf "$fixture"' EXIT
+shim="$fixture/mise-cache-rustc"
+ln "$mise_bin" "$shim" 2>/dev/null || cp "$mise_bin" "$shim"
+
+python3 - "$shim" "$runs" "$budget_ms" <<'PY'
+import statistics
+import subprocess
+import sys
+import time
+
+shim, runs, budget_ms = sys.argv[1], int(sys.argv[2]), float(sys.argv[3])
+
+def invoke(command):
+    started = time.perf_counter_ns()
+    subprocess.run(command, check=True)
+    return (time.perf_counter_ns() - started) / 1_000_000
+
+for _ in range(10):
+    invoke(["true"])
+    invoke([shim, "true"])
+direct = [invoke(["true"]) for _ in range(runs)]
+wrapped = [invoke([shim, "true"]) for _ in range(runs)]
+direct_median = statistics.median(direct)
+wrapped_median = statistics.median(wrapped)
+overhead = wrapped_median - direct_median
+p95 = sorted(wrapped)[max(0, int(len(wrapped) * 0.95) - 1)]
+print(
+    f"cache shim warm exec: direct={direct_median:.3f}ms "
+    f"wrapped={wrapped_median:.3f}ms overhead={overhead:.3f}ms "
+    f"wrapped-p95={p95:.3f}ms runs={runs} budget={budget_ms:.3f}ms"
+)
+if overhead > budget_ms:
+    raise SystemExit(
+        f"cache shim overhead {overhead:.3f}ms exceeds {budget_ms:.3f}ms budget"
+    )
+PY

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -1,0 +1,294 @@
+use crate::{CacheDigest, LocalCas};
+use eyre::{Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+
+pub const AGENT_PROTOCOL_VERSION: u8 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentRequest {
+    Hello {
+        protocol: u8,
+        client_version: String,
+    },
+    FindBlob {
+        digest: CacheDigest,
+    },
+    StoreBlob {
+        digest: CacheDigest,
+        source: PathBuf,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentResponse {
+    Hello { protocol: u8, agent_version: String },
+    Blob { path: Option<PathBuf> },
+    Stored { path: PathBuf },
+    Error { message: String },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AgentStats {
+    pub lookups: u64,
+    pub hits: u64,
+    pub stores: u64,
+    pub stored_bytes: u64,
+}
+
+#[derive(Default)]
+struct AtomicAgentStats {
+    lookups: AtomicU64,
+    hits: AtomicU64,
+    stores: AtomicU64,
+    stored_bytes: AtomicU64,
+}
+
+/// Shared state for an agent hosted by the top-level `mise run` process.
+///
+/// Transport listeners deliberately live in mise so the task-run lifecycle owns
+/// them. This type only contains ecosystem-independent CAS and protocol logic.
+#[derive(Clone)]
+pub struct CacheAgent {
+    cas: LocalCas,
+    version: Arc<str>,
+    write_locks: Arc<Mutex<BTreeMap<CacheDigest, Weak<tokio::sync::Mutex<()>>>>>,
+    stats: Arc<AtomicAgentStats>,
+}
+
+impl CacheAgent {
+    pub fn new(cache_dir: impl Into<PathBuf>, version: impl Into<Arc<str>>) -> Self {
+        Self {
+            cas: LocalCas::new(cache_dir.into()),
+            version: version.into(),
+            write_locks: Arc::new(Mutex::new(BTreeMap::new())),
+            stats: Arc::new(AtomicAgentStats::default()),
+        }
+    }
+
+    pub fn stats(&self) -> AgentStats {
+        AgentStats {
+            lookups: self.stats.lookups.load(Ordering::Relaxed),
+            hits: self.stats.hits.load(Ordering::Relaxed),
+            stores: self.stats.stores.load(Ordering::Relaxed),
+            stored_bytes: self.stats.stored_bytes.load(Ordering::Relaxed),
+        }
+    }
+
+    fn write_lock(&self, digest: &CacheDigest) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.write_locks.lock().unwrap();
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(digest).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(digest.clone(), Arc::downgrade(&lock));
+        lock
+    }
+
+    async fn respond(&self, request: AgentRequest) -> AgentResponse {
+        let result = match request {
+            AgentRequest::FindBlob { digest } => {
+                self.stats.lookups.fetch_add(1, Ordering::Relaxed);
+                self.cas.find(&digest).map(|path| {
+                    if path.is_some() {
+                        self.stats.hits.fetch_add(1, Ordering::Relaxed);
+                    }
+                    AgentResponse::Blob { path }
+                })
+            }
+            AgentRequest::StoreBlob { digest, source } => {
+                let lock = self.write_lock(&digest);
+                let _guard = lock.lock().await;
+                if let Ok(Some(path)) = self.cas.find(&digest) {
+                    return AgentResponse::Stored { path };
+                }
+                self.cas.store_file(&digest, &source).map(|path| {
+                    self.stats.stores.fetch_add(1, Ordering::Relaxed);
+                    self.stats
+                        .stored_bytes
+                        .fetch_add(digest.size, Ordering::Relaxed);
+                    AgentResponse::Stored { path }
+                })
+            }
+            AgentRequest::Hello { .. } => {
+                Err(eyre::eyre!("hello is only valid as the first request"))
+            }
+        };
+        result.unwrap_or_else(|error| AgentResponse::Error {
+            message: error.to_string(),
+        })
+    }
+
+    pub async fn handle_connection<S>(&self, stream: S) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let (reader, mut writer) = tokio::io::split(stream);
+        let mut lines = BufReader::new(reader).lines();
+        let hello = lines
+            .next_line()
+            .await?
+            .ok_or_else(|| eyre::eyre!("connection closed before the agent handshake"))?;
+        let request: AgentRequest = serde_json::from_str(&hello)?;
+        match request {
+            AgentRequest::Hello {
+                protocol,
+                client_version,
+            } if protocol == AGENT_PROTOCOL_VERSION && client_version == self.version.as_ref() => {}
+            AgentRequest::Hello { protocol, .. } if protocol != AGENT_PROTOCOL_VERSION => {
+                send_response(
+                    &mut writer,
+                    &AgentResponse::Error {
+                        message: format!(
+                            "unsupported agent protocol {protocol}; expected {AGENT_PROTOCOL_VERSION}"
+                        ),
+                    },
+                )
+                .await?;
+                return Ok(());
+            }
+            AgentRequest::Hello { client_version, .. } => {
+                send_response(
+                    &mut writer,
+                    &AgentResponse::Error {
+                        message: format!(
+                            "cache client {client_version} does not match agent {}",
+                            self.version
+                        ),
+                    },
+                )
+                .await?;
+                return Ok(());
+            }
+            _ => bail!("the first agent request must be hello"),
+        }
+        send_response(
+            &mut writer,
+            &AgentResponse::Hello {
+                protocol: AGENT_PROTOCOL_VERSION,
+                agent_version: self.version.to_string(),
+            },
+        )
+        .await?;
+
+        while let Some(line) = lines.next_line().await? {
+            let response = match serde_json::from_str(&line) {
+                Ok(request) => self.respond(request).await,
+                Err(error) => AgentResponse::Error {
+                    message: format!("invalid agent request: {error}"),
+                },
+            };
+            send_response(&mut writer, &response).await?;
+        }
+        Ok(())
+    }
+}
+
+async fn send_response(
+    writer: &mut (impl AsyncWrite + Unpin),
+    response: &AgentResponse,
+) -> Result<()> {
+    let mut encoded = serde_json::to_vec(response)?;
+    encoded.push(b'\n');
+    writer.write_all(&encoded).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn handshake(stream: &mut (impl AsyncRead + AsyncWrite + Unpin), version: &str) {
+        let request = AgentRequest::Hello {
+            protocol: AGENT_PROTOCOL_VERSION,
+            client_version: version.to_string(),
+        };
+        let mut encoded = serde_json::to_vec(&request).unwrap();
+        encoded.push(b'\n');
+        stream.write_all(&encoded).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut response = String::new();
+        BufReader::new(stream)
+            .read_line(&mut response)
+            .await
+            .unwrap();
+        assert!(matches!(
+            serde_json::from_str(&response).unwrap(),
+            AgentResponse::Hello { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn handshake_and_blob_round_trip() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source");
+        std::fs::write(&source, b"cached object").unwrap();
+        let digest = CacheDigest::blake3(b"cached object");
+        let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+        let (mut client, server) = tokio::io::duplex(16 * 1024);
+        let server_agent = agent.clone();
+        let task = tokio::spawn(async move { server_agent.handle_connection(server).await });
+
+        handshake(&mut client, "test-version").await;
+        let request = AgentRequest::StoreBlob {
+            digest: digest.clone(),
+            source,
+        };
+        let mut encoded = serde_json::to_vec(&request).unwrap();
+        encoded.push(b'\n');
+        client.write_all(&encoded).await.unwrap();
+        let mut response = String::new();
+        BufReader::new(&mut client)
+            .read_line(&mut response)
+            .await
+            .unwrap();
+        assert!(matches!(
+            serde_json::from_str(&response).unwrap(),
+            AgentResponse::Stored { .. }
+        ));
+        drop(client);
+        task.await.unwrap().unwrap();
+        assert_eq!(
+            agent.stats(),
+            AgentStats {
+                stores: 1,
+                stored_bytes: digest.size,
+                ..AgentStats::default()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn version_skew_is_a_handshake_miss() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "agent-version");
+        let (mut client, server) = tokio::io::duplex(1024);
+        let task = tokio::spawn(async move { agent.handle_connection(server).await });
+        let request = AgentRequest::Hello {
+            protocol: AGENT_PROTOCOL_VERSION,
+            client_version: "other-version".into(),
+        };
+        let mut encoded = serde_json::to_vec(&request).unwrap();
+        encoded.push(b'\n');
+        client.write_all(&encoded).await.unwrap();
+        let mut response = String::new();
+        BufReader::new(&mut client)
+            .read_line(&mut response)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            serde_json::from_str(&response).unwrap(),
+            AgentResponse::Error { .. }
+        ));
+        task.await.unwrap().unwrap();
+    }
+}

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -15,6 +15,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::AsyncWriteExt;
 use url::{Host, Url};
 
+mod agent;
+mod local;
+
+pub use agent::{AGENT_PROTOCOL_VERSION, AgentRequest, AgentResponse, AgentStats, CacheAgent};
+pub use local::LocalCas;
+
 pub const PROTOCOL_VERSION: u8 = 1;
 const PROTOCOL_HEADER: &str = "mise-cache-protocol";
 const NAMESPACE_HEADER: &str = "mise-cache-namespace";
@@ -97,7 +103,7 @@ impl CacheDigest {
         Ok(())
     }
 
-    fn matches_bytes(&self, bytes: &[u8]) -> Result<bool> {
+    pub fn matches_bytes(&self, bytes: &[u8]) -> Result<bool> {
         self.validate()?;
         if self.size != bytes.len() as u64 {
             return Ok(false);
@@ -110,7 +116,7 @@ impl CacheDigest {
         Ok(self.hash == hash)
     }
 
-    fn matches_file(&self, path: &Path) -> Result<bool> {
+    pub fn matches_file(&self, path: &Path) -> Result<bool> {
         self.validate()?;
         if self.size != fs::metadata(path)?.len() {
             return Ok(false);

--- a/crates/mise-cache-core/src/local.rs
+++ b/crates/mise-cache-core/src/local.rs
@@ -1,0 +1,123 @@
+use crate::CacheDigest;
+use eyre::{Result, bail};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct LocalCas {
+    root: PathBuf,
+}
+
+impl LocalCas {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn path_for(&self, digest: &CacheDigest) -> Result<PathBuf> {
+        digest.validate()?;
+        Ok(self
+            .root
+            .join("cas/v1")
+            .join(&digest.algorithm)
+            .join(&digest.hash[..2])
+            .join(format!("{}-{}", digest.hash, digest.size)))
+    }
+
+    pub fn find(&self, digest: &CacheDigest) -> Result<Option<PathBuf>> {
+        let path = self.path_for(digest)?;
+        if !path.exists() {
+            return Ok(None);
+        }
+        if !digest.matches_file(&path)? {
+            bail!(
+                "local CAS blob failed digest verification: {}",
+                path.display()
+            );
+        }
+        Ok(Some(path))
+    }
+
+    pub fn store_bytes(&self, digest: &CacheDigest, bytes: &[u8]) -> Result<PathBuf> {
+        if !digest.matches_bytes(bytes)? {
+            bail!("bytes do not match the declared CAS digest");
+        }
+        self.store_with(digest, |temporary| {
+            temporary.write_all(bytes)?;
+            Ok(())
+        })
+    }
+
+    pub fn store_file(&self, digest: &CacheDigest, source: &Path) -> Result<PathBuf> {
+        if !digest.matches_file(source)? {
+            bail!(
+                "file does not match the declared CAS digest: {}",
+                source.display()
+            );
+        }
+        self.store_with(digest, |temporary| {
+            fs::copy(source, temporary.path())?;
+            Ok(())
+        })
+    }
+
+    fn store_with(
+        &self,
+        digest: &CacheDigest,
+        write: impl FnOnce(&mut tempfile::NamedTempFile) -> Result<()>,
+    ) -> Result<PathBuf> {
+        let destination = self.path_for(digest)?;
+        if let Some(existing) = self.find(digest)? {
+            return Ok(existing);
+        }
+        let parent = destination.parent().expect("CAS path has a parent");
+        fs::create_dir_all(parent)?;
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        write(&mut temporary)?;
+        temporary.flush()?;
+        temporary.as_file().sync_all()?;
+        if !digest.matches_file(temporary.path())? {
+            bail!("staged blob does not match the declared CAS digest");
+        }
+        match temporary.persist_noclobber(&destination) {
+            Ok(_) => Ok(destination),
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => self
+                .find(digest)?
+                .ok_or_else(|| eyre::eyre!("concurrent CAS write did not publish a valid blob")),
+            Err(error) => Err(error.error.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stores_and_validates_blobs_atomically() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path());
+        let digest = CacheDigest::blake3(b"cached object");
+
+        let path = cas.store_bytes(&digest, b"cached object").unwrap();
+        assert_eq!(cas.find(&digest).unwrap(), Some(path.clone()));
+        assert_eq!(fs::read(&path).unwrap(), b"cached object");
+        assert_eq!(cas.store_bytes(&digest, b"cached object").unwrap(), path);
+        assert!(cas.store_bytes(&digest, b"other object").is_err());
+    }
+
+    #[test]
+    fn rejects_corrupt_existing_blobs() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path());
+        let digest = CacheDigest::blake3(b"cached object");
+        let path = cas.store_bytes(&digest, b"cached object").unwrap();
+        fs::write(path, b"corrupt").unwrap();
+
+        assert!(cas.find(&digest).is_err());
+    }
+}

--- a/e2e/tasks/test_task_action_cache_session
+++ b/e2e/tasks/test_task_action_cache_session
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.disabled]
+run = 'test -z "${MISE_CACHE_SOCKET:-}"'
+
+[tasks.rust]
+rust_cache = true
+run = '''
+test -n "$MISE_CACHE_SOCKET"
+test -S "$MISE_CACHE_SOCKET"
+test "$(basename "$RUSTC_WRAPPER")" = mise-cache-rustc
+test "$CARGO_INCREMENTAL" = 0
+"$RUSTC_WRAPPER" true
+'''
+
+[tasks.sandboxed]
+rust_cache = true
+deny_env = true
+run = '''
+test -n "$MISE_CACHE_SOCKET"
+test "$CARGO_INCREMENTAL" = 0
+"$RUSTC_WRAPPER" true
+'''
+EOF
+
+mise run disabled
+RUSTC_WRAPPER=/usr/bin/env mise run rust
+RUSTC_WRAPPER=/usr/bin/env mise run sandboxed
+
+assert_fail_contains \
+  "MISE_EXPERIMENTAL=0 mise run rust" \
+  "Rust action caching is experimental"

--- a/mise.toml
+++ b/mise.toml
@@ -67,3 +67,13 @@ run = ["cargo build --release", "tak run --record"]
 [tasks."perf:task-cache"]
 dir = "{{config_root}}"
 run = ["cargo build --release", "bash benchmarks/task-cache/benchmark.sh"]
+
+# Measures the argv0-dispatched rustc wrapper path without config discovery or
+# runtime startup. Keep the warm median below the 2ms compiler-wrapper budget.
+[tasks."perf:cache-shim"]
+dir = "{{config_root}}"
+env = { MISE_BIN = "target/serious/mise" }
+run = [
+  "cargo build --profile serious --no-default-features --features rustls-native-roots,self_update,vfox/vendored-lua,openssl/vendored",
+  "bash benchmarks/cache-shim/benchmark.sh",
+]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -24,6 +24,8 @@ use crate::rand::random_string;
 use crate::toolset::env_cache::CachedEnv;
 use crate::{dirs, file};
 
+pub(crate) mod session;
+
 pub use mise_cache_core::RemoteCacheMode as CacheRemoteMode;
 
 #[derive(Debug)]

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -1,0 +1,556 @@
+use crate::task::Task;
+#[cfg(test)]
+use crate::task::TaskRustCacheConfig;
+use bytesize::ByteSize;
+use eyre::{Context, Result, bail};
+use mise_cache_core::{
+    AGENT_PROTOCOL_VERSION, AgentRequest, AgentResponse, AgentStats, CacheAgent,
+};
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+#[cfg(unix)]
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::sync::Mutex;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+const RUSTC_SHIM_STEM: &str = "mise-cache-rustc";
+const SOCKET_ENV: &str = "MISE_CACHE_SOCKET";
+const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Clone)]
+pub(crate) struct CacheSessionEnvironment {
+    socket: String,
+    rustc_shim: String,
+}
+
+impl CacheSessionEnvironment {
+    pub(crate) fn apply(&self, task: &Task, environment: &mut BTreeMap<String, String>) {
+        if !task.rust_cache.as_ref().is_some_and(|cache| cache.enabled) {
+            return;
+        }
+        environment.insert(SOCKET_ENV.into(), self.socket.clone());
+        if let Some(previous) = environment.insert("RUSTC_WRAPPER".into(), self.rustc_shim.clone())
+            && previous != self.rustc_shim
+        {
+            environment.insert(PREVIOUS_RUSTC_WRAPPER_ENV.into(), previous);
+        }
+        environment.insert("CARGO_INCREMENTAL".into(), "0".into());
+    }
+
+    pub(crate) fn sandbox_paths(&self) -> [PathBuf; 2] {
+        [PathBuf::from(&self.rustc_shim), PathBuf::from(&self.socket)]
+    }
+}
+
+pub(crate) struct CacheSession {
+    environment: CacheSessionEnvironment,
+    agent: CacheAgent,
+    shutdown: Mutex<Option<oneshot::Sender<()>>>,
+    server: Mutex<Option<JoinHandle<Result<()>>>>,
+}
+
+impl CacheSession {
+    pub(crate) async fn start(session_dir: &Path, cache_dir: PathBuf) -> Result<Self> {
+        let shim = install_session_shim(session_dir)?;
+        let agent = CacheAgent::new(cache_dir, VERSION);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (socket, server) = spawn_server(session_dir, agent.clone(), shutdown_rx).await?;
+        Ok(Self {
+            environment: CacheSessionEnvironment {
+                socket,
+                rustc_shim: shim.to_string_lossy().into_owned(),
+            },
+            agent,
+            shutdown: Mutex::new(Some(shutdown_tx)),
+            server: Mutex::new(Some(server)),
+        })
+    }
+
+    pub(crate) fn environment(&self) -> CacheSessionEnvironment {
+        self.environment.clone()
+    }
+
+    pub(crate) async fn finish(&self) -> Result<AgentStats> {
+        if let Some(shutdown) = self.shutdown.lock().unwrap().take() {
+            let _ = shutdown.send(());
+        }
+        let server = self.server.lock().unwrap().take();
+        if let Some(server) = server {
+            server.await??;
+        }
+        Ok(self.agent.stats())
+    }
+}
+
+impl Drop for CacheSession {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.get_mut().unwrap().take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(server) = self.server.get_mut().unwrap().take() {
+            server.abort();
+        }
+    }
+}
+
+pub(crate) fn display_stats(stats: AgentStats) {
+    if stats.lookups == 0 && stats.stores == 0 {
+        return;
+    }
+    safe_eprintln!(
+        "Action cache: {}/{} hits, {} stored ({})",
+        stats.hits,
+        stats.lookups,
+        stats.stores,
+        ByteSize::b(stats.stored_bytes).display().iec(),
+    );
+}
+
+fn install_session_shim(session_dir: &Path) -> Result<PathBuf> {
+    let executable =
+        std::env::current_exe().wrap_err("failed to locate the running mise binary")?;
+    let filename = if cfg!(windows) {
+        format!("{RUSTC_SHIM_STEM}.exe")
+    } else {
+        RUSTC_SHIM_STEM.into()
+    };
+    let shim = session_dir.join(filename);
+    if let Err(link_error) = std::fs::hard_link(&executable, &shim) {
+        std::fs::copy(&executable, &shim).wrap_err_with(|| {
+            format!("failed to install the action-cache shim by hard link ({link_error}) or copy")
+        })?;
+    }
+    Ok(shim)
+}
+
+#[cfg(unix)]
+async fn spawn_server(
+    session_dir: &Path,
+    agent: CacheAgent,
+    mut shutdown: oneshot::Receiver<()>,
+) -> Result<(String, JoinHandle<Result<()>>)> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let socket = session_dir.join("cache-agent.sock");
+    let listener = tokio::net::UnixListener::bind(&socket)?;
+    std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))?;
+    let endpoint = socket.to_string_lossy().into_owned();
+    let server = tokio::spawn(async move {
+        let _cleanup = SocketCleanup(socket);
+        loop {
+            tokio::select! {
+                accepted = listener.accept() => {
+                    let (stream, _) = accepted?;
+                    let agent = agent.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = agent.handle_connection(stream).await {
+                            debug!("action-cache agent connection failed: {error}");
+                        }
+                    });
+                }
+                _ = &mut shutdown => return Ok(()),
+            }
+        }
+    });
+    Ok((endpoint, server))
+}
+
+#[cfg(unix)]
+struct SocketCleanup(PathBuf);
+
+#[cfg(unix)]
+impl Drop for SocketCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+#[cfg(windows)]
+async fn spawn_server(
+    _session_dir: &Path,
+    agent: CacheAgent,
+    mut shutdown: oneshot::Receiver<()>,
+) -> Result<(String, JoinHandle<Result<()>>)> {
+    let endpoint = format!(
+        r"\\.\pipe\mise-cache-{}-{}",
+        std::process::id(),
+        crate::rand::random_string(12)
+    );
+    let first_server = create_named_pipe(&endpoint, true)?;
+    let server_endpoint = endpoint.clone();
+    let server = tokio::spawn(async move {
+        let mut next_server = Some(first_server);
+        loop {
+            let pipe = next_server
+                .take()
+                .expect("the next named-pipe server is always prepared");
+            tokio::select! {
+                connected = pipe.connect() => {
+                    connected?;
+                    next_server = Some(create_named_pipe(&server_endpoint, false)?);
+                    let agent = agent.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = agent.handle_connection(pipe).await {
+                            debug!("action-cache agent connection failed: {error}");
+                        }
+                    });
+                }
+                _ = &mut shutdown => return Ok(()),
+            }
+        }
+    });
+    Ok((endpoint, server))
+}
+
+#[cfg(windows)]
+fn create_named_pipe(
+    endpoint: &str,
+    first_pipe_instance: bool,
+) -> Result<tokio::net::windows::named_pipe::NamedPipeServer> {
+    use std::mem::size_of;
+    use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+
+    let security = CurrentUserSecurityDescriptor::new()?;
+    let mut attributes = SECURITY_ATTRIBUTES {
+        nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: security.0,
+        bInheritHandle: 0,
+    };
+    let mut options = tokio::net::windows::named_pipe::ServerOptions::new();
+    options.first_pipe_instance(first_pipe_instance);
+    // SAFETY: `attributes` and its owned security descriptor remain valid for
+    // the duration of CreateNamedPipeW, and the handle is not inheritable.
+    unsafe {
+        options
+            .create_with_security_attributes_raw(endpoint, (&raw mut attributes).cast())
+            .wrap_err("failed to create the current-user-only action-cache pipe")
+    }
+}
+
+#[cfg(windows)]
+struct CurrentUserSecurityDescriptor(windows_sys::Win32::Security::PSECURITY_DESCRIPTOR);
+
+#[cfg(windows)]
+impl CurrentUserSecurityDescriptor {
+    fn new() -> Result<Self> {
+        use std::mem::size_of;
+        use std::ptr::null_mut;
+        use windows_sys::Win32::Foundation::HANDLE;
+        use windows_sys::Win32::Security::Authorization::{
+            ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
+            SDDL_REVISION_1,
+        };
+        use windows_sys::Win32::Security::{
+            GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser,
+        };
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+        let mut token: HANDLE = null_mut();
+        // SAFETY: `token` is a valid out pointer and the process pseudo-handle
+        // is always valid in the calling process.
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) } == 0 {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to open the current process token");
+        }
+        let token = OwnedWindowsHandle(token);
+
+        let mut required = 0;
+        // The first call intentionally obtains the required buffer size.
+        // SAFETY: a null information pointer is required for this size query.
+        unsafe {
+            GetTokenInformation(token.0, TokenUser, null_mut(), 0, &raw mut required);
+        }
+        if required == 0 {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to size the current process user token");
+        }
+        let word_count = (required as usize).div_ceil(size_of::<usize>());
+        let mut token_information = vec![0usize; word_count];
+        // SAFETY: the aligned buffer is at least `required` bytes long and the
+        // API initializes it as TOKEN_USER on success.
+        if unsafe {
+            GetTokenInformation(
+                token.0,
+                TokenUser,
+                token_information.as_mut_ptr().cast(),
+                required,
+                &raw mut required,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to read the current process user token");
+        }
+        // SAFETY: GetTokenInformation successfully initialized the aligned
+        // buffer as TOKEN_USER and its SID remains owned by that buffer.
+        let user_sid = unsafe {
+            (*(token_information.as_ptr().cast::<TOKEN_USER>()))
+                .User
+                .Sid
+        };
+        let mut sid_string = null_mut();
+        // SAFETY: `user_sid` points into the live token-information buffer and
+        // `sid_string` is a valid out pointer.
+        if unsafe { ConvertSidToStringSidW(user_sid, &raw mut sid_string) } == 0 {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to format the current process user SID");
+        }
+        let sid_string = LocalWindowsAllocation(sid_string.cast());
+        // SAFETY: ConvertSidToStringSidW returned a valid NUL-terminated string
+        // whose allocation remains live through `sid_string`.
+        let sid = unsafe { nul_terminated_wide(sid_string.0.cast()) };
+
+        let mut sddl: Vec<u16> = "D:P(A;;GA;;;".encode_utf16().collect();
+        sddl.extend_from_slice(sid);
+        sddl.extend([')' as u16, 0]);
+        let mut descriptor = null_mut();
+        // SAFETY: the SDDL is NUL-terminated, `descriptor` is a valid out
+        // pointer, and the returned allocation is owned by LocalFree.
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                sddl.as_ptr(),
+                SDDL_REVISION_1,
+                &raw mut descriptor,
+                null_mut(),
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("failed to restrict the action-cache pipe to the current user");
+        }
+        drop(token);
+        drop(sid_string);
+        debug_assert!(!descriptor.is_null());
+        Ok(Self(descriptor))
+    }
+}
+
+#[cfg(windows)]
+impl Drop for CurrentUserSecurityDescriptor {
+    fn drop(&mut self) {
+        // SAFETY: this allocation came from
+        // ConvertStringSecurityDescriptorToSecurityDescriptorW.
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0.cast());
+        }
+    }
+}
+
+#[cfg(windows)]
+struct OwnedWindowsHandle(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for OwnedWindowsHandle {
+    fn drop(&mut self) {
+        // SAFETY: this handle came from OpenProcessToken and is owned here.
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct LocalWindowsAllocation(windows_sys::Win32::Foundation::HLOCAL);
+
+#[cfg(windows)]
+impl Drop for LocalWindowsAllocation {
+    fn drop(&mut self) {
+        // SAFETY: this allocation came from a Win32 API documented to use
+        // LocalAlloc and has not previously been freed.
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+unsafe fn nul_terminated_wide<'a>(value: *const u16) -> &'a [u16] {
+    let mut length = 0;
+    // SAFETY: the caller guarantees that `value` points to a valid
+    // NUL-terminated UTF-16 string.
+    while unsafe { *value.add(length) } != 0 {
+        length += 1;
+    }
+    // SAFETY: the scan above established the initialized string length.
+    unsafe { std::slice::from_raw_parts(value, length) }
+}
+
+pub(crate) fn is_rustc_shim() -> bool {
+    std::env::args_os()
+        .next()
+        .as_deref()
+        .map(Path::new)
+        .and_then(Path::file_stem)
+        .is_some_and(|stem| stem == OsStr::new(RUSTC_SHIM_STEM))
+}
+
+/// Ultra-early argv0 path used by Cargo's `RUSTC_WRAPPER` integration.
+///
+/// This runs before mise creates a Tokio runtime, installs logging, or discovers
+/// configuration. The Rust adapter will replace the transparent compiler call;
+/// until then this establishes and benchmarks the final process/session shape.
+pub(crate) fn run_rustc_shim() -> ExitCode {
+    if let Err(_error) = handshake_from_environment() {
+        #[cfg(debug_assertions)]
+        eprintln!("mise action-cache shim is running uncached: {_error}");
+    }
+
+    let mut arguments = std::env::args_os().skip(1);
+    let Some(rustc) = arguments.next() else {
+        eprintln!("mise action-cache shim expected the rustc executable as its first argument");
+        return ExitCode::from(1);
+    };
+    let mut command = if let Some(wrapper) = std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV) {
+        let mut command = Command::new(wrapper);
+        command.arg(rustc);
+        command
+    } else {
+        Command::new(rustc)
+    };
+    command.args(arguments);
+    command.env_remove(PREVIOUS_RUSTC_WRAPPER_ENV);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        let error = command.exec();
+        eprintln!("mise action-cache shim failed to execute rustc: {error}");
+        ExitCode::from(1)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawHandle as _;
+        use windows_sys::Win32::System::Threading::GetExitCodeProcess;
+
+        match command.spawn().and_then(|mut child| {
+            child.wait()?;
+            let mut exit_code = 1;
+            // SAFETY: the child owns a valid process handle until it is
+            // dropped, and `exit_code` is a valid out pointer.
+            if unsafe { GetExitCodeProcess(child.as_raw_handle().cast(), &raw mut exit_code) } == 0
+            {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(exit_code)
+            }
+        }) {
+            Ok(exit_code) => {
+                // SAFETY: This process is only a transparent compiler wrapper.
+                // ExitProcess is required to preserve Windows exception codes,
+                // which cannot be represented by stable Rust's ExitCode API.
+                unsafe { windows_sys::Win32::System::Threading::ExitProcess(exit_code) }
+            }
+            Err(error) => {
+                eprintln!("mise action-cache shim failed to execute rustc: {error}");
+                ExitCode::from(1)
+            }
+        }
+    }
+}
+
+fn handshake_from_environment() -> Result<()> {
+    let socket =
+        std::env::var_os(SOCKET_ENV).ok_or_else(|| eyre::eyre!("{SOCKET_ENV} is not set"))?;
+    handshake(&socket)
+}
+
+#[cfg(unix)]
+fn handshake(socket: &OsString) -> Result<()> {
+    let stream = std::os::unix::net::UnixStream::connect(Path::new(socket))
+        .wrap_err("failed to connect to the action-cache session")?;
+    sync_handshake(stream)
+}
+
+#[cfg(windows)]
+fn handshake(socket: &OsString) -> Result<()> {
+    let endpoint = socket.to_string_lossy().into_owned();
+    tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()?
+        .block_on(async move {
+            use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+            let mut stream = tokio::net::windows::named_pipe::ClientOptions::new()
+                .open(&endpoint)
+                .wrap_err("failed to connect to the action-cache session")?;
+            let request = AgentRequest::Hello {
+                protocol: AGENT_PROTOCOL_VERSION,
+                client_version: VERSION.into(),
+            };
+            let mut encoded = serde_json::to_vec(&request)?;
+            encoded.push(b'\n');
+            stream.write_all(&encoded).await?;
+            stream.flush().await?;
+            let mut response = String::new();
+            tokio::io::BufReader::new(stream)
+                .read_line(&mut response)
+                .await?;
+            validate_handshake_response(&response)
+        })
+}
+
+#[cfg(unix)]
+fn sync_handshake(mut stream: impl std::io::Read + Write) -> Result<()> {
+    let request = AgentRequest::Hello {
+        protocol: AGENT_PROTOCOL_VERSION,
+        client_version: VERSION.into(),
+    };
+    serde_json::to_writer(&mut stream, &request)?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+    let mut response = String::new();
+    BufReader::new(stream).read_line(&mut response)?;
+    validate_handshake_response(&response)
+}
+
+fn validate_handshake_response(response: &str) -> Result<()> {
+    match serde_json::from_str(response)? {
+        AgentResponse::Hello {
+            protocol,
+            agent_version,
+        } if protocol == AGENT_PROTOCOL_VERSION && agent_version == VERSION => Ok(()),
+        AgentResponse::Error { message } => bail!(message),
+        _ => bail!("action-cache agent returned an incompatible handshake"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_environment_is_scoped_to_selected_adapters() {
+        let environment = CacheSessionEnvironment {
+            socket: "socket".into(),
+            rustc_shim: "shim".into(),
+        };
+        let mut task = Task::default();
+        let mut values = BTreeMap::from([("RUSTC_WRAPPER".into(), "existing".into())]);
+        environment.apply(&task, &mut values);
+        assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
+
+        task.rust_cache = Some(TaskRustCacheConfig { enabled: false });
+        environment.apply(&task, &mut values);
+        assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
+
+        task.rust_cache = Some(TaskRustCacheConfig { enabled: true });
+        environment.apply(&task, &mut values);
+        assert_eq!(values.get(SOCKET_ENV).unwrap(), "socket");
+        assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "shim");
+        assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
+        assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");
+    }
+
+    #[test]
+    fn handshake_rejects_version_skew() {
+        let response = serde_json::to_string(&AgentResponse::Hello {
+            protocol: AGENT_PROTOCOL_VERSION,
+            agent_version: "another-version".into(),
+        })
+        .unwrap();
+        assert!(validate_handshake_response(&response).is_err());
+    }
+}

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1643,6 +1643,7 @@ impl Bootstrap {
             output_handler: None,
             context_builder: Default::default(),
             executor: None,
+            cache_session: None,
             no_cache: Default::default(),
             task_cache: crate::task::TaskCacheMode::from_env()?,
             task_cache_explain: false,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -807,6 +807,7 @@ impl Cli {
                         output_handler: None,
                         context_builder: Default::default(),
                         executor: None,
+                        cache_session: None,
                         no_cache: Default::default(),
                         task_cache: crate::task::TaskCacheMode::from_env()?,
                         task_cache_explain: false,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -293,6 +293,9 @@ pub struct Run {
 
     #[clap(skip)]
     pub executor: Option<crate::task::task_executor::TaskExecutor>,
+
+    #[clap(skip)]
+    pub cache_session: Option<crate::cache::session::CacheSession>,
 }
 
 fn affected_task_args(args: &[String]) -> Vec<String> {
@@ -862,7 +865,11 @@ impl Run {
                 .await?;
         }
 
-        // Step 4: Create TaskExecutor after tool installation
+        // Step 4: Bracket action caching with this top-level task run. The
+        // session owns the local agent and is flushed before results report.
+        self.setup_cache_session(&tasks).await?;
+
+        // Step 5: Create TaskExecutor after tool installation
         self.setup_executor()?;
 
         // Disable exit-on-ctrl-c so tasks can handle SIGINT gracefully
@@ -872,7 +879,7 @@ impl Run {
         let this = Arc::new(self);
         let config = config.clone();
 
-        // Step 4: Initialize scheduler and run tasks
+        // Step 6: Initialize scheduler and run tasks
         let mut scheduler = crate::task::task_scheduler::Scheduler::new(this.jobs());
         let main_deps = Arc::new(Mutex::new(tasks));
 
@@ -903,9 +910,13 @@ impl Run {
             )
             .await?;
 
-        scheduler.join_all(this.continue_on_error).await?;
+        let join_result = scheduler.join_all(this.continue_on_error).await;
+        if let Some(session) = &this.cache_session {
+            crate::cache::session::display_stats(session.finish().await?);
+        }
+        join_result?;
 
-        // Step 5: Display results and handle failures
+        // Step 7: Display results and handle failures
         let results_display = crate::task::task_results_display::TaskResultsDisplay::new(
             this.output_handler.clone().unwrap(),
             this.executor.as_ref().unwrap().failed_tasks.clone(),
@@ -1196,6 +1207,10 @@ impl Run {
             task_cache: self.task_cache,
             task_cache_explain: self.task_cache_explain,
             task_cache_explain_json: self.task_cache_explain_json,
+            cache_session: self
+                .cache_session
+                .as_ref()
+                .map(crate::cache::session::CacheSession::environment),
             sandbox: crate::sandbox::SandboxConfig::from_settings_and_cli(
                 &Settings::get().sandbox,
                 self.deny_all,
@@ -1219,6 +1234,24 @@ impl Run {
             executor_config,
         ));
 
+        Ok(())
+    }
+
+    async fn setup_cache_session(&mut self, tasks: &Deps) -> Result<()> {
+        let enabled = !self.dry_run
+            && tasks
+                .all()
+                .any(|task| task.rust_cache.as_ref().is_some_and(|cache| cache.enabled));
+        if !enabled {
+            return Ok(());
+        }
+        self.cache_session = Some(
+            crate::cache::session::CacheSession::start(
+                &self.tmpdir,
+                crate::task::task_cache::task_cache_dir().join("actions"),
+            )
+            .await?,
+        );
         Ok(())
     }
 
@@ -1303,6 +1336,9 @@ impl Run {
         use crate::ui;
         if self.task_cache.enabled() && task.cache.as_ref().is_some_and(|cache| cache.enabled) {
             Settings::get().ensure_experimental("task artifact caching")?;
+        }
+        if task.rust_cache.as_ref().is_some_and(|cache| cache.enabled) {
+            Settings::get().ensure_experimental("Rust action caching")?;
         }
         if !task.pass_through_env.is_empty() {
             Settings::get().ensure_experimental("task environment pass-through")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,11 @@ pub(crate) use crate::result::Result;
 use crate::ui::multi_progress_report::MultiProgressReport;
 
 fn main() -> ExitCode {
+    // Cargo invokes the Rust cache wrapper hundreds or thousands of times per
+    // build. Dispatch on argv0 before runtime, logging, clap, or config startup.
+    if cache::session::is_rustc_shim() {
+        return cache::session::run_rustc_shim();
+    }
     let nprocs = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or_default();

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -215,6 +215,7 @@ pub struct TaskExecutorConfig {
     pub task_cache: TaskCacheMode,
     pub task_cache_explain: bool,
     pub task_cache_explain_json: bool,
+    pub cache_session: Option<crate::cache::session::CacheSessionEnvironment>,
     /// CLI-level sandbox overrides (merged with task-level sandbox config)
     pub sandbox: crate::sandbox::SandboxConfig,
 }
@@ -239,6 +240,7 @@ pub struct TaskExecutor {
     pub task_cache: TaskCacheMode,
     pub task_cache_explain: bool,
     pub task_cache_explain_json: bool,
+    pub cache_session: Option<crate::cache::session::CacheSessionEnvironment>,
     pub sandbox: crate::sandbox::SandboxConfig,
 }
 
@@ -291,6 +293,7 @@ impl TaskExecutor {
             task_cache: config.task_cache,
             task_cache_explain: config.task_cache_explain,
             task_cache_explain_json: config.task_cache_explain_json,
+            cache_session: config.cache_session,
             sandbox: config.sandbox,
         }
     }
@@ -393,6 +396,24 @@ impl TaskExecutor {
                 .cloned()
                 .collect(),
         };
+        if task.rust_cache.as_ref().is_some_and(|cache| cache.enabled)
+            && let Some(session) = &self.cache_session
+        {
+            if sandbox.effective_deny_read() {
+                sandbox.allow_read.extend(session.sandbox_paths());
+            }
+            if sandbox.effective_deny_write() {
+                sandbox.allow_write.extend(session.sandbox_paths());
+            }
+            if sandbox.effective_deny_env() {
+                sandbox.pass_through_env.extend([
+                    "MISE_CACHE_SOCKET".into(),
+                    "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER".into(),
+                    "RUSTC_WRAPPER".into(),
+                    "CARGO_INCREMENTAL".into(),
+                ]);
+            }
+        }
         sandbox.resolve_paths();
         Ok(sandbox)
     }
@@ -784,6 +805,9 @@ impl TaskExecutor {
             .as_ref()
             .filter(|_| self.task_cache.writes())
             .map(|_| Arc::new(StdMutex::new(Vec::new())));
+        if let Some(session) = &self.cache_session {
+            session.apply(task, &mut env);
+        }
         let exec_ctx = TaskExecContext {
             task,
             env: &env,

--- a/tasks.md
+++ b/tasks.md
@@ -106,6 +106,10 @@ Lint HK files
 
 - **Usage**: `perf`
 
+## `perf:cache-shim`
+
+- **Usage**: `perf:cache-shim`
+
 ## `perf:record`
 
 - **Usage**: `perf:record`


### PR DESCRIPTION
## Summary
- host the generic CAS agent inside the top-level `mise run` process, with no daemon, buddy executable, or additional release artifact
- install a session-local hardlink to the exact running mise binary (copy fallback) and dispatch its Rust-wrapper argv0 path before Tokio, clap, logging, or config discovery
- use an exact protocol/version handshake, permission-restricted Unix sockets or Windows named pipes, per-digest write deduplication, lifecycle shutdown, and session statistics
- inject `RUSTC_WRAPPER` and `CARGO_INCREMENTAL=0` only for tasks with enabled `rust_cache`, chain an existing wrapper, and preserve access through task sandboxes
- gate the shipped-profile warm wrapper overhead at 2 ms; the measured overhead on this branch is 1.771 ms

This PR establishes the final in-process session and shim shape. Compiler-specific keying, cache-hit materialization, remote prefetch/upload, and Go `GOCACHEPROG` support remain adapter follow-ups. The Go adapter will introduce its own `go_cache` field when it is functional.

## Validation
- `cargo test -p mise-cache-core`
- `cargo test --quiet session_environment_is_scoped_to_selected_adapters`
- `mise run test:e2e e2e/tasks/test_task_action_cache_session`
- `cargo clippy -p mise-cache-core --all-features --all-targets -- -D warnings`
- `cargo clippy -p mise --all-features --bin mise -- -D warnings`
- `mise run perf:cache-shim` (1.771 ms median overhead, 2 ms budget)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task execution env, sandbox allowances, and Windows security descriptors for named pipes; behavior is gated experimental but the shim runs on every Cargo compile when enabled.
> 
> **Overview**
> Adds an **in-process action-cache session** for `mise run` when any task enables `rust_cache`, without a separate daemon or binary.
> 
> **`mise-cache-core`** gains a local CAS (`LocalCas`), a JSON-line **`CacheAgent`** (handshake, find/store blobs, per-digest locks, stats), and public digest helpers.
> 
> **`src/cache/session.rs`** starts the agent on a session Unix socket or a **current-user-only** Windows named pipe, installs a session-local **`mise-cache-rustc`** hardlink to the running binary, and injects `MISE_CACHE_SOCKET`, `RUSTC_WRAPPER`, `CARGO_INCREMENTAL=0` (chaining any prior wrapper). **`main`** dispatches that argv0 path before Tokio/config; the shim handshakes then transparently runs rustc.
> 
> **`mise run`** brackets the scheduler with `CacheSession`, passes session env into the executor, allows sandbox access to shim/socket, gates **`rust_cache`** behind experimental, and prints action-cache stats after tasks. Adds **`perf:cache-shim`** (2ms warm overhead budget) and an e2e session test.
> 
> Compiler cache hits/materialization are not implemented yet—the shim only establishes session shape and benchmarks wrapper cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3a24c0943b90708a76c088c5e33b5f07abf7f50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->