### PR TITLE
fix(task): handle azure devops remote git includes

### DIFF
--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -146,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_alt_git_ssh_sources() {
+    fn parses_azure_devops_git_ssh_sources() {
         let source = RemoteSource::parse_git(
             "git::ssh://git@dev.azure/myorg/myproj/_git/example//terraform/myfile?ref=master",
         )
@@ -157,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_alt_git_ssh_sources_without_user() {
+    fn parses_azure_devops_git_ssh_sources_without_user() {
         let source =
             RemoteSource::parse_git("git::ssh://dev.azure/myorg/myproj/_git/example//terraform/myfile")
                 .unwrap();
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_alt_git_https_sources() {
+    fn parses_azure_devops_git_https_sources() {
         let source = RemoteSource::parse_git(
             "git::https://dev.azure:8080/myorg/myproj/_git/example//terraform/myfile?ref=master",
         )
@@ -178,7 +178,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_alt_git_ref_before_additional_query_params() {
+    fn parses_azure_devops_git_ref_before_additional_query_params() {
         let source = RemoteSource::parse_git(
             "git::https://dev.azure/myorg/myproj/_git/example//terraform/myfile?ref=master&depth=1",
         )
@@ -187,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_alt_git_sources_without_paths() {
+    fn rejects_azure_devops_git_sources_without_paths() {
         assert!(
             RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example?ref=master").is_none()
         );
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_alt_git_sources_with_unsafe_paths() {
+    fn rejects_azure_devops_git_sources_with_unsafe_paths() {
         assert!(
             RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//../plugin").is_none()
         );

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -38,12 +38,12 @@ impl RemoteSource {
 
     pub(crate) fn parse_git_ssh(file: &str) -> Option<RemoteGitSource> {
         parse_git_with(&SSH_GIT_REGEX, file)
-        .or_else(|| parse_git_with(&AZURE_DEVOPS_SSH_GIT_REGEX, file))
+            .or_else(|| parse_git_with(&AZURE_DEVOPS_SSH_GIT_REGEX, file))
     }
 
     pub(crate) fn parse_git_https(file: &str) -> Option<RemoteGitSource> {
         parse_git_with(&HTTPS_GIT_REGEX, file)
-        .or_else(|| parse_git_with(&AZURE_DEVOPS_HTTPS_GIT_REGEX, file))
+            .or_else(|| parse_git_with(&AZURE_DEVOPS_HTTPS_GIT_REGEX, file))
     }
 
     pub fn parse_http(file: &str) -> Option<RemoteHttpSource> {
@@ -158,9 +158,10 @@ mod tests {
 
     #[test]
     fn parses_azure_devops_git_ssh_sources_without_user() {
-        let source =
-            RemoteSource::parse_git("git::ssh://dev.azure/myorg/myproj/_git/example//terraform/myfile")
-                .unwrap();
+        let source = RemoteSource::parse_git(
+            "git::ssh://dev.azure/myorg/myproj/_git/example//terraform/myfile",
+        )
+        .unwrap();
         assert_eq!(source.url, "ssh://dev.azure/myorg/myproj/_git/example");
         assert_eq!(source.path, "terraform/myfile");
         assert_eq!(source.git_ref, None);
@@ -172,7 +173,10 @@ mod tests {
             "git::https://dev.azure:8080/myorg/myproj/_git/example//terraform/myfile?ref=master",
         )
         .unwrap();
-        assert_eq!(source.url, "https://dev.azure:8080/myorg/myproj/_git/example");
+        assert_eq!(
+            source.url,
+            "https://dev.azure:8080/myorg/myproj/_git/example"
+        );
         assert_eq!(source.path, "terraform/myfile");
         assert_eq!(source.git_ref, Some("master".to_string()));
     }
@@ -189,27 +193,38 @@ mod tests {
     #[test]
     fn rejects_azure_devops_git_sources_without_paths() {
         assert!(
-            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example?ref=master").is_none()
+            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example?ref=master")
+                .is_none()
         );
-        assert!(RemoteSource::parse_git("git::ssh://user@dev.azure/myorg/myproj/_git/example").is_none());
+        assert!(
+            RemoteSource::parse_git("git::ssh://user@dev.azure/myorg/myproj/_git/example")
+                .is_none()
+        );
     }
 
     #[test]
     fn rejects_azure_devops_git_sources_with_unsafe_paths() {
         assert!(
-            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//../plugin").is_none()
-        );
-        assert!(
-            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//plugin/../other")
+            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//../plugin")
                 .is_none()
         );
         assert!(
-            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//plugin//other")
-                .is_none()
+            RemoteSource::parse_git(
+                "git::https://dev.azure/myorg/myproj/_git/example//plugin/../other"
+            )
+            .is_none()
         );
         assert!(
-            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//plugin/./other")
-                .is_none()
+            RemoteSource::parse_git(
+                "git::https://dev.azure/myorg/myproj/_git/example//plugin//other"
+            )
+            .is_none()
+        );
+        assert!(
+            RemoteSource::parse_git(
+                "git::https://dev.azure/myorg/myproj/_git/example//plugin/./other"
+            )
+            .is_none()
         );
     }
 

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -5,7 +5,7 @@ static SSH_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)?(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
 });
 
-static ALT_SSH_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
+static AZURE_DEVOPS_SSH_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)?(?P<host>[^/]+)/(?P<org>[^/]+)/(?P<project>[^/]+)/_git/(?P<repo>[^/]+))//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
 });
 
@@ -13,7 +13,7 @@ static HTTPS_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
 });
 
-static ALT_HTTPS_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
+static AZURE_DEVOPS_HTTPS_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<org>[^/]+)/(?P<project>[^/]+)/_git/(?P<repo>[^/]+))//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
 });
 
@@ -38,12 +38,12 @@ impl RemoteSource {
 
     pub(crate) fn parse_git_ssh(file: &str) -> Option<RemoteGitSource> {
         parse_git_with(&SSH_GIT_REGEX, file)
-        .or_else(|| parse_git_with(&ALT_SSH_GIT_REGEX, file))
+        .or_else(|| parse_git_with(&AZURE_DEVOPS_SSH_GIT_REGEX, file))
     }
 
     pub(crate) fn parse_git_https(file: &str) -> Option<RemoteGitSource> {
         parse_git_with(&HTTPS_GIT_REGEX, file)
-        .or_else(|| parse_git_with(&ALT_HTTPS_GIT_REGEX, file))
+        .or_else(|| parse_git_with(&AZURE_DEVOPS_HTTPS_GIT_REGEX, file))
     }
 
     pub fn parse_http(file: &str) -> Option<RemoteHttpSource> {

--- a/src/remote_source.rs
+++ b/src/remote_source.rs
@@ -5,8 +5,16 @@ static SSH_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)?(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
 });
 
+static ALT_SSH_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^git::(?P<url>ssh://((?P<user>[^@]+)@)?(?P<host>[^/]+)/(?P<org>[^/]+)/(?P<project>[^/]+)/_git/(?P<repo>[^/]+))//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
+});
+
 static HTTPS_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<repo>.+)\.git)//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
+});
+
+static ALT_HTTPS_GIT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^git::(?P<url>https?://(?P<host>[^/]+)/(?P<org>[^/]+)/(?P<project>[^/]+)/_git/(?P<repo>[^/]+))//(?P<path>[^?]+)(\?ref=(?P<ref>[^?&]+)(&.*)?)?$").unwrap()
 });
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,10 +38,12 @@ impl RemoteSource {
 
     pub(crate) fn parse_git_ssh(file: &str) -> Option<RemoteGitSource> {
         parse_git_with(&SSH_GIT_REGEX, file)
+        .or_else(|| parse_git_with(&ALT_SSH_GIT_REGEX, file))
     }
 
     pub(crate) fn parse_git_https(file: &str) -> Option<RemoteGitSource> {
         parse_git_with(&HTTPS_GIT_REGEX, file)
+        .or_else(|| parse_git_with(&ALT_HTTPS_GIT_REGEX, file))
     }
 
     pub fn parse_http(file: &str) -> Option<RemoteHttpSource> {
@@ -131,6 +141,74 @@ mod tests {
         );
         assert!(
             RemoteSource::parse_git("git::https://myserver.com/example.git//plugin/./other")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn parses_alt_git_ssh_sources() {
+        let source = RemoteSource::parse_git(
+            "git::ssh://git@dev.azure/myorg/myproj/_git/example//terraform/myfile?ref=master",
+        )
+        .unwrap();
+        assert_eq!(source.url, "ssh://git@dev.azure/myorg/myproj/_git/example");
+        assert_eq!(source.path, "terraform/myfile");
+        assert_eq!(source.git_ref, Some("master".to_string()));
+    }
+
+    #[test]
+    fn parses_alt_git_ssh_sources_without_user() {
+        let source =
+            RemoteSource::parse_git("git::ssh://dev.azure/myorg/myproj/_git/example//terraform/myfile")
+                .unwrap();
+        assert_eq!(source.url, "ssh://dev.azure/myorg/myproj/_git/example");
+        assert_eq!(source.path, "terraform/myfile");
+        assert_eq!(source.git_ref, None);
+    }
+
+    #[test]
+    fn parses_alt_git_https_sources() {
+        let source = RemoteSource::parse_git(
+            "git::https://dev.azure:8080/myorg/myproj/_git/example//terraform/myfile?ref=master",
+        )
+        .unwrap();
+        assert_eq!(source.url, "https://dev.azure:8080/myorg/myproj/_git/example");
+        assert_eq!(source.path, "terraform/myfile");
+        assert_eq!(source.git_ref, Some("master".to_string()));
+    }
+
+    #[test]
+    fn parses_alt_git_ref_before_additional_query_params() {
+        let source = RemoteSource::parse_git(
+            "git::https://dev.azure/myorg/myproj/_git/example//terraform/myfile?ref=master&depth=1",
+        )
+        .unwrap();
+        assert_eq!(source.git_ref, Some("master".to_string()));
+    }
+
+    #[test]
+    fn rejects_alt_git_sources_without_paths() {
+        assert!(
+            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example?ref=master").is_none()
+        );
+        assert!(RemoteSource::parse_git("git::ssh://user@dev.azure/myorg/myproj/_git/example").is_none());
+    }
+
+    #[test]
+    fn rejects_alt_git_sources_with_unsafe_paths() {
+        assert!(
+            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//../plugin").is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//plugin/../other")
+                .is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//plugin//other")
+                .is_none()
+        );
+        assert!(
+            RemoteSource::parse_git("git::https://dev.azure/myorg/myproj/_git/example//plugin/./other")
                 .is_none()
         );
     }

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -429,6 +429,11 @@ mod tests {
                 false,
             ),
             (
+                "git::ssh://git@dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
+                "git::ssh://git@dev.azure/org/project/_git/example//myfile?ref=v2.0.0",
+                false,
+            ),
+            (
                 "git::ssh://git@github.com/example.git//myfile?ref=v1.0.0",
                 "git::ssh://git@github.com/example.git//subfolder/mysecondfile?ref=v1.0.0",
                 true,
@@ -436,6 +441,11 @@ mod tests {
             (
                 "git::ssh://git@github.com/myorg/example.git//myfile?ref=v1.0.0",
                 "git::ssh://git@github.com/myorg/example.git//subfolder/mysecondfile?ref=v1.0.0",
+                true,
+            ),
+            (
+                "git::ssh://git@dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
+                "git::ssh://git@dev.azure/org/project/_git/example//subfolder/mysecondfile?ref=v1.0.0",
                 true,
             ),
         ];
@@ -465,6 +475,11 @@ mod tests {
                 false,
             ),
             (
+                "git::https://dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
+                "git::https://dev.azure/org/project/_git/example//myfile?ref=v2.0.0",
+                false,
+            ),
+            (
                 "git::https://github.com/myorg/example.git//myfile?ref=v1.0.0",
                 "git::https://github.com/myorg/example.git//subfolder/myfile?ref=v1.0.0",
                 true,
@@ -472,6 +487,11 @@ mod tests {
             (
                 "git::https://github.com/example.git//myfile?ref=v1.0.0",
                 "git::https://github.com/example.git//subfolder/myfile?ref=v1.0.0",
+                true,
+            ),
+            (
+                "git::https://dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
+                "git::https://dev.azure/org/project/_git/example//subfolder/myfile?ref=v1.0.0",
                 true,
             ),
         ];

--- a/src/task/task_file_providers/remote_task_git.rs
+++ b/src/task/task_file_providers/remote_task_git.rs
@@ -250,6 +250,12 @@ mod tests {
             "git::ssh://git@myserver.com/example.git//terraform/myfile",
             "git::ssh://user@myserver.com/example.git//myfile?ref=master",
             "git::ssh://myserver.com/example.git//myfile?ref=master",
+            "git::ssh://git@dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
+            "git::ssh://git@dev.azure/org/project/_git/example//terraform/myfile?ref=master",
+            "git::ssh://git@dev.azure:1222/org/project/_git/example//terraform/myfile?ref=master",
+            "git::ssh://git@dev.azure/org/project/_git/example//terraform/myfile",
+            "git::ssh://user@dev.azure/org/project/_git/example//myfile?ref=master",
+            "git::ssh://dev.azure/org/project/_git/example//myfile?ref=master",
         ];
 
         for url in test_cases {
@@ -267,6 +273,9 @@ mod tests {
             "git::ssh://user@myserver.com/example.git?ref=master",
             "git::ssh://user@myserver.com/example.git",
             "git::https://github.com/myorg/example.git//myfile?ref=v1.0.0",
+            "git::ssh://user@dev.azure/org/project/_git/example?ref=master",
+            "git::ssh://user@dev.azure/org/project/_git/example",
+            "git::https://dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
         ];
 
         for url in test_cases {
@@ -287,6 +296,12 @@ mod tests {
             "git::https://myserver.com/example.git//terraform/myfile",
             "git::https://myserver.com/example.git//myfile?ref=master",
             "git::http://localhost:8080/repo.git//xtasks/lint/remote-task", // HTTP support for local testing
+            "git::https://dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
+            "git::https://dev.azure/org/project/_git/example//terraform/myfile?ref=master",
+            "git::https://dev.azure:8080/org/project/_git/example//terraform/myfile?ref=master",
+            "git::https://dev.azure/org/project/_git/example//terraform/myfile",
+            "git::https://dev.azure/org/project/_git/example//myfile?ref=master",
+            "git::http://localhost:8080/org/project/_git/example//xtasks/lint/remote-task", // HTTP support for local testing
         ];
 
         for url in test_cases {
@@ -304,6 +319,9 @@ mod tests {
             "git::https://myserver.com/example.git?ref=master",
             "git::https://user@myserver.com/example.git",
             "git::ssh://git@github.com/myorg/example.git//myfile?ref=v1.0.0",
+            "git::https://dev.azure/org/project/_git/example?ref=master",
+            "git::https://user@dev.azure/org/project/_git/example",
+            "git::ssh://git@dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
         ];
 
         for url in test_cases {
@@ -364,6 +382,24 @@ mod tests {
             (
                 "git::https://myserver.com/example.git//terraform/myfile",
                 "https://myserver.com/example.git",
+                "terraform/myfile",
+                None,
+            ),
+            (
+                "git::https://dev.azure/org/project/_git/example//myfile?ref=v1.0.0",
+                "https://dev.azure/org/project/_git/example",
+                "myfile",
+                Some("v1.0.0".to_string()),
+            ),
+            (
+                "git::https://dev.azure/org/project/_git/example//terraform/myfile?ref=master",
+                "https://dev.azure/org/project/_git/example",
+                "terraform/myfile",
+                Some("master".to_string()),
+            ),
+            (
+                "git::https://dev.azure/org/project/_git/example//terraform/myfile",
+                "https://dev.azure/org/project/_git/example",
                 "terraform/myfile",
                 None,
             ),


### PR DESCRIPTION
Azure Devops uses a different URL scheme for git repositories than most other git servers. It looks something like https://dev.azure/organisation/project/_git/repository, which is typically not suffixed by `.git` (unless the literal repo name ends with `.git`). Mise currently expects the url to end with `.git` so naturally these repositories do not work as remote git sources for tasks. I wrote #11660 where I tried demonstrating this.

I opted for adding a second regex for matching the azure devops url pattern, felt easier to get it right than modifying the existing one to match both patterns.

I've built and tested this against my company instance of Azure Devops. I still have some issues getting the git include feature to fully work. One issue regarding pack files when using ssh (issue has been patched in next version of gitoxide, whenever that drops) and some issues with https auth which I have not figured out yet (likely also some issue with gitoxide though). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure DevOps Git repositories using SSH and HTTPS URLs.
  * Recognizes organization, project, repository, branch, credentials, ports, and task-file paths.
  * Supports common URL variations, including additional query parameters and optional SSH users.

* **Bug Fixes**
  * Improved Git source parsing for Azure DevOps repositories.
  * Prevents invalid or incomplete repository and task-file paths from being accepted.
  * Ensures repository caching distinguishes branches while reusing entries across task files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->