### PR TITLE
test(vfox): handle HTTP request read count

### DIFF
--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -437,7 +437,8 @@ mod tests {
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut request = [0; 1024];
-            stream.read(&mut request).unwrap();
+            let bytes_read = stream.read(&mut request).unwrap();
+            assert!(bytes_read > 0, "client closed before sending its request");
             stream
                 .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n")
                 .unwrap();


### PR DESCRIPTION
## Summary
- handle the byte count returned by the vfox HTTP cancellation test server's socket read
- assert that the client sent request data before the server replies
- clear the workspace-wide Clippy failure so the cache PR stack has a clean prerequisite

## Validation
- `cargo test -p vfox test_http_operation_is_cancelled_on_interrupt`
- `cargo clippy -p vfox --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*
