### PR TITLE
docs(brew): link homebrew cask cookbook for cask lifecycle concepts

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -68,8 +68,10 @@ installs app bundles into `/Applications` while recording the version under
 ```
 
 On Linux, initial cask support is limited to font-only casks without lifecycle
-hooks or structured `preflight_steps` or `postflight_steps`. Fonts are installed
-into `$XDG_DATA_HOME/fonts`, which defaults to `~/.local/share/fonts`:
+hooks or structured `preflight_steps` or `postflight_steps` — concepts from
+Homebrew's cask DSL, documented in the
+[Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook). Fonts are
+installed into `$XDG_DATA_HOME/fonts`, which defaults to `~/.local/share/fonts`:
 
 ```toml
 [bootstrap.packages]


### PR DESCRIPTION
The brew bootstrap packages docs mention `preflight`/`postflight` lifecycle hooks and structured `preflight_steps`/`postflight_steps` without explaining that these are concepts from Homebrew's cask DSL.

This proposes to add a link to the [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook) at their first mention so readers can find the upstream reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Linux cask limitations, including unsupported lifecycle hooks and structured preflight/postflight steps.
  * Added a link to the Homebrew Cask Cookbook for additional guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->