### PR TITLE
docs: mention `task_config.shell` in `task.shell` defaults

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -926,7 +926,8 @@ executes without a stable artifact key, its dependents conservatively execute.
 ### `shell`
 
 - **Type**: `string`
-- **Default**: [`unix_default_inline_shell_args`](/configuration/settings.html#unix_default_inline_shell_args) or [`windows_default_inline_shell_args`](/configuration/settings.html#windows_default_inline_shell_args)
+- **Default**: [`task_config.shell`](#task-config-shell) when set (config-scoped); otherwise
+  [`unix_default_inline_shell_args`](/configuration/settings.html#unix_default_inline_shell_args)/[`windows_default_inline_shell_args`](/configuration/settings.html#windows_default_inline_shell_args) (global-only).
 - **Note**: Only applies to toml-tasks.
 
 The shell to use to run the task. This is useful if you want to run a task with a different shell than
@@ -1180,7 +1181,7 @@ Change the default directory tasks are run from.
 dir = "{{cwd}}"
 ```
 
-### `task_config.shell`
+### `task_config.shell` {#task-config-shell}
 
 Set the default shell for tasks in this config scope. A task's explicit `shell` setting takes
 precedence, including a `shell` inherited from a task template. With `task_config.cascade = true`,


### PR DESCRIPTION
See discussion at https://github.com/jdx/mise/discussions/11657 but basically, I find that this shell option pops up more in search results, so correcting the default here should help surface the new task_config option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that task shell settings first use task-specific configuration, then fall back to platform-specific global inline-shell settings.
  * Added a heading anchor for the task shell configuration section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->