### PR TITLE
fix(cache): align task phase protocol examples

### DIFF
--- a/docs/tasks/remote-cache-protocol.md
+++ b/docs/tasks/remote-cache-protocol.md
@@ -143,7 +143,7 @@ kinds without changing the CAS or action-result APIs:
   "version": 1,
   "kind": "task",
   "task": "build",
-  "phase": "run",
+  "phase": "normal",
   "run": [{ "task": "cargo build --release" }],
   "args": [],
   "shell": null,

--- a/scripts/task-cache-remote-compat.sh
+++ b/scripts/task-cache-remote-compat.sh
@@ -100,7 +100,7 @@ directory_hash=$(digest_file sha256 "$temp_dir/directory.json")
 directory_size=$(wc -c <"$temp_dir/directory.json" | tr -d '[:space:]')
 
 jq -cnSj --arg nonce "$nonce" \
-	'{arch:"x86_64",args:[],command_inputs:[],dependency_keys:[],environment:{},kind:"task",os:"linux",outputs:["artifact.txt"],phase:"run",root:".",run:[{task:"compatibility"}],shell:null,source_hash:("sha256:"+$nonce),task:"remote-cache-compat",tools:[],vars:{},version:1}' \
+	'{arch:"x86_64",args:[],command_inputs:[],dependency_keys:[],environment:{},kind:"task",os:"linux",outputs:["artifact.txt"],phase:"normal",root:".",run:[{task:"compatibility"}],shell:null,source_hash:("sha256:"+$nonce),task:"remote-cache-compat",tools:[],vars:{},version:1}' \
 	>"$temp_dir/action.json"
 action_hash=$(digest_file blake3 "$temp_dir/action.json")
 action_size=$(wc -c <"$temp_dir/action.json" | tr -d '[:space:]')


### PR DESCRIPTION
## Summary
- use the serialized `TaskRunPhase::Normal` value in the protocol example
- make the remote compatibility script exercise the same task action descriptor emitted by `mise`

## Validation
- `bash -n scripts/task-cache-remote-compat.sh`
- compatibility script passed against the protocol-synchronized `mise-cache` server

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test fixture string changes only; no production code paths affected.
> 
> **Overview**
> Corrects the **task action descriptor** `phase` field in protocol documentation and the executable conformance harness so they match the canonical value clients and servers expect.
> 
> The example JSON in `docs/tasks/remote-cache-protocol.md` and the synthetic action built by `scripts/task-cache-remote-compat.sh` now set `"phase": "normal"` rather than `"run"`. No runtime or schema logic changes—only docs and the remote-cache compatibility script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1c3256cffcb5a7af0279c6452f6e6a57586f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the remote cache protocol example to use the correct `normal` action phase.

* **Bug Fixes**
  * Updated generated task action descriptors to emit the correct `normal` phase for improved remote cache compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->