### PR TITLE
docs: fix dead bootstrap package-plugin example URLs

### DIFF
--- a/docs/bootstrap/packages/plugins.md
+++ b/docs/bootstrap/packages/plugins.md
@@ -9,8 +9,8 @@ Declare the plugin source and packages together:
 
 ```toml
 [bootstrap.plugins]
-vscode = "https://github.com/mise-plugins/mise-vscode-extensions"
-krew = "https://github.com/mise-plugins/mise-krew"
+vscode = "https://github.com/example/mise-vscode-extensions"
+krew = "https://github.com/example/mise-krew"
 
 [bootstrap.packages]
 "vscode:ms-python.python" = "latest"
@@ -35,7 +35,7 @@ mise bootstrap packages apply
 You can install a plugin without declaring it:
 
 ```sh
-mise plugin install package:vscode https://github.com/mise-plugins/mise-vscode-extensions
+mise plugin install package:vscode https://github.com/example/mise-vscode-extensions
 ```
 
 Package plugins install into the host application's own state directory. They

--- a/docs/bootstrap/packages/plugins.md
+++ b/docs/bootstrap/packages/plugins.md
@@ -5,12 +5,14 @@ without adding a manager to mise core. They are useful for machine-global
 state owned by another tool, such as VS Code extensions, Helm plugins, krew
 plugins, and GitHub CLI extensions.
 
-Declare the plugin source and packages together:
+Declare the plugin source and packages together. The `example/*` repository
+URLs below are **placeholders** for syntax only — replace them with maintained,
+installable plugin repositories before running these commands:
 
 ```toml
 [bootstrap.plugins]
-vscode = "https://github.com/example/mise-vscode-extensions"
-krew = "https://github.com/example/mise-krew"
+vscode = "https://github.com/example/mise-vscode-extensions" # placeholder
+krew = "https://github.com/example/mise-krew" # placeholder
 
 [bootstrap.packages]
 "vscode:ms-python.python" = "latest"
@@ -35,6 +37,7 @@ mise bootstrap packages apply
 You can install a plugin without declaring it:
 
 ```sh
+# placeholder URL — replace with a real package-plugin repository
 mise plugin install package:vscode https://github.com/example/mise-vscode-extensions
 ```
 


### PR DESCRIPTION
Two bootstrap.plugins example URLs (mise-plugins/mise-vscode-extensions, mise-plugins/mise-krew) return 404. Replace with generic placeholders.

Proof: both URLs return HTTP 404.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 72h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated plugin documentation with placeholder repository URLs for the VS Code and krew plugins.
  * Added warnings to replace placeholder URLs with maintained, installable repositories before use.
  * Updated the manual installation example to include the same repository warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->