### PR TITLE
fix(task): match project-qualified monorepo tasks without //

### DIFF
--- a/e2e/tasks/test_task_monorepo_optional_slash_prefix
+++ b/e2e/tasks/test_task_monorepo_optional_slash_prefix
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Test that the leading '//' is optional when running a monorepo task by its
+# project-qualified name, e.g. "web:build" as well as "//web:build".
+
+export MISE_EXPERIMENTAL=1
+
+cat <<'EOF' >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["web", "api"]
+
+[tasks."release:notes"]
+run = 'echo "root release:notes task"'
+EOF
+
+mkdir -p web
+cat <<'EOF' >web/mise.toml
+[tasks.build]
+run = 'echo "web build task"'
+
+[tasks.dev]
+run = 'echo "web dev task"'
+EOF
+
+mkdir -p api
+cat <<'EOF' >api/mise.toml
+[tasks.build]
+run = 'echo "api build task"'
+EOF
+
+# Test 1: project-qualified name without the '//' prefix
+assert_contains "mise run web:build" "web build task"
+assert_contains "mise run api:build" "api build task"
+
+# Test 2: equivalent to the '//' form
+assert_contains "mise run //web:build" "web build task"
+
+# Test 3: works as a shorthand too, without 'run'
+assert_contains "mise web:build" "web build task"
+
+# Test 4: wildcards stay scoped to the named project
+OUTPUT=$(mise run 'web:*')
+assert_contains "mise run 'web:*'" "web build task"
+assert_contains "mise run 'web:*'" "web dev task"
+if echo "$OUTPUT" | grep -q "api build task"; then
+  echo "ERROR: 'web:*' matched a task outside the web project"
+  exit 1
+fi
+
+# Test 5: a root task whose name contains ':' is not shadowed by the project
+# interpretation of the same syntax
+assert_contains "mise run release:notes" "root release:notes task"
+
+# Test 6: unknown project or task still fails
+assert_fail_contains "mise run web:missing" "no task"
+assert_fail_contains "mise run missing:build" "no task"

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -3304,12 +3304,19 @@ where
             if !exact.is_empty() {
                 return Ok(exact);
             }
-            return Ok(self
+            let ext_stripped: Vec<&T> = self
                 .iter()
                 .filter(|(name, _)| task_name_matches(&matcher, name, true))
                 .map(|(_, task)| task)
                 .unique()
-                .collect());
+                .collect();
+            if !ext_stripped.is_empty() {
+                return Ok(ext_stripped);
+            }
+            if self.keys().any(|k| k.starts_with("//")) {
+                return self.get_matching(&format!("//{pat}"));
+            }
+            return Ok(vec![]);
         }
 
         // === Parse monorepo pattern ===
@@ -5920,6 +5927,49 @@ echo "test"
                 &"node:@scope/app#test:units:local".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn test_get_matching_monorepo_project_without_slash_prefix() {
+        use std::collections::BTreeMap;
+
+        use super::GetMatchingExt;
+
+        let tasks = BTreeMap::from([
+            ("//web:build".to_string(), "//web:build".to_string()),
+            ("//web:dev".to_string(), "//web:dev".to_string()),
+            ("//api:build".to_string(), "//api:build".to_string()),
+        ]);
+
+        assert_eq!(
+            tasks.get_matching("web:build").unwrap(),
+            vec![&"//web:build".to_string()]
+        );
+        assert_eq!(
+            tasks.get_matching("web:*").unwrap(),
+            vec![&"//web:build".to_string(), &"//web:dev".to_string()]
+        );
+        assert_eq!(
+            tasks.get_matching("api:build").unwrap(),
+            vec![&"//api:build".to_string()]
+        );
+        assert!(tasks.get_matching("web:missing").unwrap().is_empty());
+        assert!(tasks.get_matching("missing:build").unwrap().is_empty());
+
+        // A root task whose name contains `:` still wins over the project
+        // interpretation of the same pattern.
+        let shadowed = BTreeMap::from([
+            ("//web:build".to_string(), "//web:build".to_string()),
+            ("web:build".to_string(), "web:build".to_string()),
+        ]);
+        assert_eq!(
+            shadowed.get_matching("web:build").unwrap(),
+            vec![&"web:build".to_string()]
+        );
+
+        // Outside a monorepo the pattern must not gain a `//` interpretation.
+        let flat = BTreeMap::from([("test:units".to_string(), "test:units".to_string())]);
+        assert!(flat.get_matching("web:build").unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`mise run web:build` no longer resolves `//web:build`. Project-qualified task names without the `//` prefix regressed in 2026.8.1 (#11581); this restores them, keeping the group-boundary semantics that PR introduced.

Still worked throughout, for contrast: `//web:build` from anywhere, and `build` or `:build` from inside the project.

## Repro

```
mise.toml           monorepo_root = true, config_roots = ["web"]
web/mise.toml       [tasks.build]
```
```
mise run web:build  # 2026.8.0: runs it. 

2026.8.1+: 
no task //:web:build found
Did you mean one of these?
  - //web:build
```

*AI-assisted — Tool: Claude Code; model: Anthropic/claude-opus-5[1m]; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for referencing monorepo tasks with optional `//` prefixes.
  * Improved task matching for project-qualified patterns, wildcard scopes, and root task names containing colons.

* **Bug Fixes**
  * Prevented incorrect matches when exact task names shadow project-qualified tasks.
  * Added clearer handling for unknown projects and tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->