### PR TITLE
feat(cache): discover rustc action inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6464,6 +6464,7 @@ version = "0.1.0"
 dependencies = [
  "mise-cache-core",
  "serde",
+ "tempfile",
  "thiserror 2.0.19",
 ]
 

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -96,6 +96,16 @@ impl CacheDigest {
         }
     }
 
+    /// Hash a file while counting the bytes read in the same streaming pass.
+    pub fn blake3_file(path: &Path) -> Result<Self> {
+        let (hash, size) = hash_file_blake3(path)?;
+        Ok(Self {
+            algorithm: "blake3".into(),
+            hash,
+            size,
+        })
+    }
+
     pub fn validate(&self) -> Result<()> {
         if self.algorithm != "blake3" && self.algorithm != "sha256" {
             bail!("unsupported remote cache digest algorithm");
@@ -126,44 +136,45 @@ impl CacheDigest {
 
     pub fn matches_file(&self, path: &Path) -> Result<bool> {
         self.validate()?;
-        if self.size != fs::metadata(path)?.len() {
-            return Ok(false);
-        }
-        let hash = match self.algorithm.as_str() {
+        let (hash, size) = match self.algorithm.as_str() {
             "blake3" => hash_file_blake3(path)?,
             "sha256" => hash_file_sha256(path)?,
             _ => unreachable!("digest algorithm was validated"),
         };
-        Ok(self.hash == hash)
+        Ok(self.size == size && self.hash == hash)
     }
 }
 
-fn hash_file_blake3(path: &Path) -> Result<String> {
+fn hash_file_blake3(path: &Path) -> Result<(String, u64)> {
     let mut file = File::open(path)?;
     let mut hasher = blake3::Hasher::new();
     let mut buffer = [0; 64 * 1024];
+    let mut size = 0;
     loop {
         let count = file.read(&mut buffer)?;
         if count == 0 {
             break;
         }
         hasher.update(&buffer[..count]);
+        size += count as u64;
     }
-    Ok(hasher.finalize().to_hex().to_string())
+    Ok((hasher.finalize().to_hex().to_string(), size))
 }
 
-fn hash_file_sha256(path: &Path) -> Result<String> {
+fn hash_file_sha256(path: &Path) -> Result<(String, u64)> {
     let mut file = File::open(path)?;
     let mut hasher = sha2::Sha256::new();
     let mut buffer = [0; 64 * 1024];
+    let mut size = 0;
     loop {
         let count = file.read(&mut buffer)?;
         if count == 0 {
             break;
         }
         hasher.update(&buffer[..count]);
+        size += count as u64;
     }
-    Ok(hex::encode(hasher.finalize()))
+    Ok((hex::encode(hasher.finalize()), size))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -758,6 +769,16 @@ mod tests {
         let file = tempfile::NamedTempFile::new().unwrap();
         fs::write(file.path(), bytes).unwrap();
         assert!(sha256.matches_file(file.path()).unwrap());
+        assert_eq!(
+            CacheDigest::blake3_file(file.path()).unwrap().size,
+            bytes.len() as u64
+        );
+        assert!(
+            CacheDigest::blake3_file(file.path())
+                .unwrap()
+                .matches_bytes(bytes)
+                .unwrap()
+        );
     }
 
     #[test]

--- a/crates/mise-cache-rustc/Cargo.toml
+++ b/crates/mise-cache-rustc/Cargo.toml
@@ -13,6 +13,9 @@ mise-cache-core = { path = "../mise-cache-core", default-features = false }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 default = ["rustls"]
 native-tls = ["mise-cache-core/native-tls"]

--- a/crates/mise-cache-rustc/src/dep_info.rs
+++ b/crates/mise-cache-rustc/src/dep_info.rs
@@ -217,11 +217,12 @@ impl RustcInvocation {
             .iter()
             .chain(&self.required_inputs)
             .map(|path| {
-                if path.is_absolute() {
-                    normalize_components(path)
+                let absolute = if path.is_absolute() {
+                    path.to_path_buf()
                 } else {
-                    normalize_components(&working_dir.join(path))
-                }
+                    working_dir.join(path)
+                };
+                normalize_components(&absolute)
             })
             .collect::<BTreeSet<_>>();
         let mut inputs = Vec::with_capacity(paths.len());
@@ -422,6 +423,28 @@ mod tests {
     }
 
     #[test]
+    fn discovery_resolves_parent_components_against_the_working_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("project");
+        let shared = directory.path().join("shared.rs");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(&shared, "pub fn shared() {}\n").unwrap();
+
+        let invocation = RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=metadata",
+            "../shared.rs",
+        ]))
+        .unwrap();
+        let dep_info = RustcDepInfo::parse("output: ../shared.rs\n").unwrap();
+        let discovered = invocation.discover_inputs(&dep_info, &root).unwrap();
+
+        assert_eq!(discovered.inputs.len(), 1);
+        assert_eq!(discovered.inputs[0].path, shared);
+    }
+
+    #[test]
     fn rustc_dep_info_round_trip_discovers_real_inputs() {
         let directory = tempfile::tempdir().unwrap();
         let root = directory.path();
@@ -445,13 +468,17 @@ mod tests {
         let dep_info_path = root.join("discovery inputs.d");
         let discovery_command = invocation.dep_info_command(&dep_info_path).unwrap();
         let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
-        let output = Command::new(rustc)
+        let output = match Command::new(rustc)
             .args(discovery_command.arguments())
             .current_dir(root)
             .env("MISE_CACHE_DISCOVERY_TEST", "observed")
             .env_remove("MISE_CACHE_DISCOVERY_UNSET")
             .output()
-            .unwrap();
+        {
+            Ok(output) => output,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+            Err(error) => panic!("failed to execute rustc: {error}"),
+        };
         assert!(
             output.status.success(),
             "{}",

--- a/crates/mise-cache-rustc/src/dep_info.rs
+++ b/crates/mise-cache-rustc/src/dep_info.rs
@@ -1,0 +1,499 @@
+use super::{
+    ActionContext, ActionInput, Argument, BypassReason, RustcInvocation, normalize_components,
+};
+use mise_cache_core::CacheDigest;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// A side-effect-minimized rustc invocation that emits only dependency data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DepInfoCommand {
+    arguments: Vec<OsString>,
+    output: PathBuf,
+}
+
+impl DepInfoCommand {
+    /// Arguments for the real compiler, excluding the compiler executable.
+    pub fn arguments(&self) -> &[OsString] {
+        &self.arguments
+    }
+
+    /// Exact file the compiler must populate with dep-info.
+    pub fn output(&self) -> &Path {
+        &self.output
+    }
+}
+
+/// The source and environment inputs reported by rustc's dep-info output.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RustcDepInfo {
+    pub files: Vec<PathBuf>,
+    pub environment: BTreeMap<String, Option<String>>,
+}
+
+impl RustcDepInfo {
+    /// Read and parse a dep-info file, treating missing or non-UTF-8 output as
+    /// an explicit cache bypass.
+    pub fn read(path: &Path) -> Result<Self, BypassReason> {
+        let contents =
+            std::fs::read_to_string(path).map_err(|error| BypassReason::DepInfoRead {
+                path: path.to_path_buf(),
+                message: error.to_string(),
+            })?;
+        Self::parse(&contents)
+    }
+
+    /// Parse rustc's Makefile-style dep-info format.
+    ///
+    /// This intentionally follows Cargo's parser contract: the first target
+    /// rule contains all source dependencies, spaces are escaped with a
+    /// trailing backslash on each token fragment, and `# env-dep:` records
+    /// contain the environment observed by `env!` and `option_env!`.
+    pub fn parse(contents: &str) -> Result<Self, BypassReason> {
+        let mut files = BTreeSet::new();
+        let mut environment = BTreeMap::new();
+        let mut found_dependencies = false;
+
+        for line in contents.lines() {
+            if let Some(record) = line.strip_prefix("# env-dep:") {
+                let (name, value) = record
+                    .split_once('=')
+                    .map_or((record, None), |(name, value)| (name, Some(value)));
+                let name = unescape_environment(name)?;
+                if name.is_empty() {
+                    return Err(BypassReason::MalformedDepInfo(
+                        "environment input has an empty name".into(),
+                    ));
+                }
+                let value = value.map(unescape_environment).transpose()?;
+                if environment
+                    .insert(name.clone(), value.clone())
+                    .is_some_and(|previous| previous != value)
+                {
+                    return Err(BypassReason::ConflictingEnvironment(name));
+                }
+                continue;
+            }
+
+            let Some(separator) = line.find(": ") else {
+                continue;
+            };
+            if found_dependencies {
+                continue;
+            }
+            found_dependencies = true;
+            let mut fragments = line[separator + 2..].split_whitespace();
+            while let Some(fragment) = fragments.next() {
+                let mut file = fragment.to_string();
+                while file.ends_with('\\') {
+                    file.pop();
+                    let continuation = fragments.next().ok_or_else(|| {
+                        BypassReason::MalformedDepInfo(
+                            "dependency path ends with an unterminated escape".into(),
+                        )
+                    })?;
+                    file.push(' ');
+                    file.push_str(continuation);
+                }
+                if file.is_empty() {
+                    return Err(BypassReason::MalformedDepInfo(
+                        "dependency path is empty".into(),
+                    ));
+                }
+                files.insert(PathBuf::from(file));
+            }
+        }
+
+        if !found_dependencies {
+            return Err(BypassReason::MalformedDepInfo(
+                "dependency rule is missing".into(),
+            ));
+        }
+        if files.is_empty() {
+            return Err(BypassReason::MalformedDepInfo(
+                "dependency rule contains no inputs".into(),
+            ));
+        }
+        Ok(Self {
+            files: files.into_iter().collect(),
+            environment,
+        })
+    }
+}
+
+/// A complete, content-addressed compiler input manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredInputs {
+    working_dir: PathBuf,
+    pub inputs: Vec<ActionInput>,
+    pub environment: BTreeMap<String, Option<String>>,
+}
+
+impl DiscoveredInputs {
+    /// Rehash every discovered file after compilation and before publication.
+    /// This closes the discovery/compile race by degrading changed inputs to a
+    /// cache miss rather than storing outputs beneath a stale action key.
+    pub fn verify(&self) -> Result<(), BypassReason> {
+        for input in &self.inputs {
+            let matches = input.digest.matches_file(&input.path).map_err(|error| {
+                BypassReason::InputRead {
+                    path: input.path.clone(),
+                    message: error.to_string(),
+                }
+            })?;
+            if !matches {
+                return Err(BypassReason::InputChanged(input.path.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Merge the manifest into an action context after verifying that both use
+    /// the same compiler working directory.
+    pub fn apply_to(self, context: &mut ActionContext) -> Result<(), BypassReason> {
+        if normalize_components(&context.working_dir) != self.working_dir {
+            return Err(BypassReason::DiscoveryWorkingDirectory);
+        }
+        for (name, value) in &self.environment {
+            if context
+                .environment
+                .get(name)
+                .is_some_and(|previous| previous != value)
+            {
+                return Err(BypassReason::ConflictingEnvironment(name.clone()));
+            }
+        }
+        context.environment.extend(self.environment);
+        context.inputs.extend(self.inputs);
+        Ok(())
+    }
+}
+
+impl RustcInvocation {
+    /// Replace the original output flags with a single explicit dep-info file.
+    pub fn dep_info_command(&self, output: &Path) -> Result<DepInfoCommand, BypassReason> {
+        if !output.is_absolute() {
+            return Err(BypassReason::RelativeDepInfoPath(output.to_path_buf()));
+        }
+        let output_text = output
+            .to_str()
+            .ok_or_else(|| BypassReason::NonUtf8Path(output.to_path_buf()))?;
+        if output_text.contains(',') {
+            return Err(BypassReason::UnsafeDepInfoPath(output.to_path_buf()));
+        }
+
+        let mut arguments = Vec::new();
+        for argument in &self.arguments {
+            match argument {
+                Argument::Emit(_) => {}
+                Argument::Path { flag, .. } if flag == "--out-dir" || flag == "-o" => {}
+                argument => arguments.push(render_argument(argument)?),
+            }
+        }
+        arguments.push(format!("--emit=dep-info={output_text}").into());
+        arguments.push(self.source.clone().into_os_string());
+        Ok(DepInfoCommand {
+            arguments,
+            output: output.to_path_buf(),
+        })
+    }
+
+    /// Hash dep-info sources plus every direct compiler input already modeled
+    /// by the invocation (`--extern` artifacts and custom target specs).
+    pub fn discover_inputs(
+        &self,
+        dep_info: &RustcDepInfo,
+        working_dir: &Path,
+    ) -> Result<DiscoveredInputs, BypassReason> {
+        if !working_dir.is_absolute() {
+            return Err(BypassReason::RelativeWorkingDirectory(
+                working_dir.to_path_buf(),
+            ));
+        }
+        let working_dir = normalize_components(working_dir);
+        let paths = dep_info
+            .files
+            .iter()
+            .chain(&self.required_inputs)
+            .map(|path| {
+                if path.is_absolute() {
+                    normalize_components(path)
+                } else {
+                    normalize_components(&working_dir.join(path))
+                }
+            })
+            .collect::<BTreeSet<_>>();
+        let mut inputs = Vec::with_capacity(paths.len());
+        for path in paths {
+            let metadata = std::fs::metadata(&path).map_err(|error| BypassReason::InputRead {
+                path: path.clone(),
+                message: error.to_string(),
+            })?;
+            if !metadata.is_file() {
+                return Err(BypassReason::InputRead {
+                    path,
+                    message: "input is not a regular file".into(),
+                });
+            }
+            let digest =
+                CacheDigest::blake3_file(&path).map_err(|error| BypassReason::InputRead {
+                    path: path.clone(),
+                    message: error.to_string(),
+                })?;
+            inputs.push(ActionInput { path, digest });
+        }
+        Ok(DiscoveredInputs {
+            working_dir,
+            inputs,
+            environment: dep_info.environment.clone(),
+        })
+    }
+}
+
+fn render_argument(argument: &Argument) -> Result<OsString, BypassReason> {
+    let rendered = match argument {
+        Argument::Plain(value) => value.clone(),
+        Argument::Path { flag, path } => format!(
+            "{flag}={}",
+            path.to_str()
+                .ok_or_else(|| BypassReason::NonUtf8Path(path.clone()))?
+        ),
+        Argument::SearchPath { kind, path } => format!(
+            "-L{kind}={}",
+            path.to_str()
+                .ok_or_else(|| BypassReason::NonUtf8Path(path.clone()))?
+        ),
+        Argument::Extern { name, path } => match path {
+            Some(path) => format!(
+                "--extern={name}={}",
+                path.to_str()
+                    .ok_or_else(|| BypassReason::NonUtf8Path(path.clone()))?
+            ),
+            None => format!("--extern={name}"),
+        },
+        Argument::Emit(_) => unreachable!("emit arguments are removed before rendering"),
+        Argument::RemapPath { from, to } => format!(
+            "--remap-path-prefix={}={to}",
+            from.to_str()
+                .ok_or_else(|| BypassReason::NonUtf8Path(from.clone()))?
+        ),
+    };
+    Ok(rendered.into())
+}
+
+fn unescape_environment(value: &str) -> Result<String, BypassReason> {
+    let mut output = String::with_capacity(value.len());
+    let mut characters = value.chars();
+    while let Some(character) = characters.next() {
+        if character != '\\' {
+            output.push(character);
+            continue;
+        }
+        match characters.next() {
+            Some('\\') => output.push('\\'),
+            Some('n') => output.push('\n'),
+            Some('r') => output.push('\r'),
+            Some(character) => {
+                return Err(BypassReason::MalformedDepInfo(format!(
+                    "unknown environment escape \\{character}"
+                )));
+            }
+            None => {
+                return Err(BypassReason::MalformedDepInfo(
+                    "environment input ends with an unterminated escape".into(),
+                ));
+            }
+        }
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn args(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn parses_files_spaces_and_environment_records() {
+        let parsed = RustcDepInfo::parse(
+            "target/lib.rlib: src/lib.rs src/a\\ file.rs generated.rs\n\
+             src/lib.rs:\n\
+             # env-dep:SET=value\\nnext\n\
+             # env-dep:UNSET\n\
+             # env-dep:SLASH=a\\\\b\n",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed.files,
+            vec![
+                PathBuf::from("generated.rs"),
+                PathBuf::from("src/a file.rs"),
+                PathBuf::from("src/lib.rs"),
+            ]
+        );
+        assert_eq!(parsed.environment["SET"], Some("value\nnext".into()));
+        assert_eq!(parsed.environment["UNSET"], None);
+        assert_eq!(parsed.environment["SLASH"], Some(r"a\b".into()));
+    }
+
+    #[test]
+    fn malformed_dep_info_bypasses_caching() {
+        for contents in [
+            "",
+            "target: ",
+            "target: src/trailing\\\n",
+            "target: src/lib.rs\n# env-dep:NAME=bad\\q\n",
+        ] {
+            assert!(RustcDepInfo::parse(contents).is_err(), "{contents:?}");
+        }
+    }
+
+    #[test]
+    fn discovery_command_removes_real_outputs() {
+        let invocation = RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+            "--out-dir=target/debug/deps",
+            "-o",
+            "target/debug/libwidget.rlib",
+            "src/lib.rs",
+        ]))
+        .unwrap();
+        let output = if cfg!(windows) {
+            PathBuf::from(r"C:\tmp\mise cache\inputs.d")
+        } else {
+            PathBuf::from("/tmp/mise cache/inputs.d")
+        };
+        let command = invocation.dep_info_command(&output).unwrap();
+        let arguments = command
+            .arguments()
+            .iter()
+            .map(|value| value.to_string_lossy())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            arguments,
+            vec![
+                "--crate-name=widget",
+                "--crate-type=lib",
+                &format!("--emit=dep-info={}", output.display()),
+                "src/lib.rs",
+            ]
+        );
+    }
+
+    #[test]
+    fn discovery_hashes_externs_and_custom_targets() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let source = root.join("src/lib.rs");
+        let external = root.join("target/libdependency.rlib");
+        let target = root.join("targets/custom.json");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(external.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&source, "pub fn library() {}\n").unwrap();
+        std::fs::write(&external, "dependency artifact\n").unwrap();
+        std::fs::write(&target, "{}\n").unwrap();
+
+        let invocation = RustcInvocation::parse(&[
+            "--crate-name=widget".into(),
+            "--crate-type=lib".into(),
+            "--emit=metadata".into(),
+            format!("--extern=dependency={}", external.display()).into(),
+            format!("--target={}", target.display()).into(),
+            source.clone().into_os_string(),
+        ])
+        .unwrap();
+        let dep_info = RustcDepInfo::parse(&format!("output: {}\n", source.display())).unwrap();
+        let discovered = invocation.discover_inputs(&dep_info, root).unwrap();
+        assert_eq!(discovered.inputs.len(), 3);
+
+        std::fs::remove_file(&external).unwrap();
+        assert!(matches!(
+            invocation.discover_inputs(&dep_info, root),
+            Err(BypassReason::InputRead { path, .. }) if path == external
+        ));
+    }
+
+    #[test]
+    fn rustc_dep_info_round_trip_discovers_real_inputs() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        std::fs::write(
+            root.join("lib.rs"),
+            "mod child; const _: &str = include_str!(\"data file.txt\"); \
+             const _: &str = env!(\"MISE_CACHE_DISCOVERY_TEST\"); \
+             const _: Option<&str> = option_env!(\"MISE_CACHE_DISCOVERY_UNSET\");",
+        )
+        .unwrap();
+        std::fs::write(root.join("child.rs"), "pub fn child() {}\n").unwrap();
+        std::fs::write(root.join("data file.txt"), "included\n").unwrap();
+
+        let invocation = RustcInvocation::parse(&args(&[
+            "--crate-name=mise_cache_discovery_test",
+            "--crate-type=lib",
+            "--emit=metadata,link",
+            "lib.rs",
+        ]))
+        .unwrap();
+        let dep_info_path = root.join("discovery inputs.d");
+        let discovery_command = invocation.dep_info_command(&dep_info_path).unwrap();
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let output = Command::new(rustc)
+            .args(discovery_command.arguments())
+            .current_dir(root)
+            .env("MISE_CACHE_DISCOVERY_TEST", "observed")
+            .env_remove("MISE_CACHE_DISCOVERY_UNSET")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let parsed = RustcDepInfo::read(&dep_info_path).unwrap();
+        let discovered = invocation.discover_inputs(&parsed, root).unwrap();
+        assert_eq!(
+            discovered.environment["MISE_CACHE_DISCOVERY_TEST"],
+            Some("observed".into())
+        );
+        assert_eq!(discovered.environment["MISE_CACHE_DISCOVERY_UNSET"], None);
+        assert_eq!(discovered.inputs.len(), 3);
+        assert!(
+            discovered
+                .inputs
+                .iter()
+                .all(|input| input.digest.algorithm == "blake3")
+        );
+        let mut context = ActionContext {
+            compiler: crate::CompilerIdentity {
+                toolchain: "core:rust@test".into(),
+                rustc_version: "test".into(),
+                host: std::env::consts::ARCH.into(),
+            },
+            working_dir: root.to_path_buf(),
+            path_mappings: vec![crate::PathMapping::new(root, "workspace")],
+            environment: BTreeMap::new(),
+            inputs: Vec::new(),
+        };
+        discovered.clone().apply_to(&mut context).unwrap();
+        let action = invocation.action(context).unwrap();
+        assert!(
+            String::from_utf8(action.bytes)
+                .unwrap()
+                .contains(r#""MISE_CACHE_DISCOVERY_TEST":"observed""#)
+        );
+        discovered.verify().unwrap();
+        std::fs::write(root.join("child.rs"), "pub fn changed() {}\n").unwrap();
+        assert_eq!(
+            discovered.verify(),
+            Err(BypassReason::InputChanged(root.join("child.rs")))
+        );
+    }
+}

--- a/crates/mise-cache-rustc/src/lib.rs
+++ b/crates/mise-cache-rustc/src/lib.rs
@@ -5,6 +5,10 @@ use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 
+mod dep_info;
+
+pub use dep_info::{DepInfoCommand, DiscoveredInputs, RustcDepInfo};
+
 pub const ACTION_SCHEMA_VERSION: u8 = 1;
 pub const ADAPTER_VERSION: u8 = 1;
 
@@ -91,6 +95,22 @@ pub enum BypassReason {
     InvalidInputDigest(String),
     #[error("compiler input appears more than once with different content: {0}")]
     ConflictingInput(String),
+    #[error("rustc dep-info is malformed: {0}")]
+    MalformedDepInfo(String),
+    #[error("failed to read rustc dep-info {path}: {message}")]
+    DepInfoRead { path: PathBuf, message: String },
+    #[error("rustc dep-info output path must be absolute: {0}")]
+    RelativeDepInfoPath(PathBuf),
+    #[error("rustc dep-info output path cannot contain a comma: {0}")]
+    UnsafeDepInfoPath(PathBuf),
+    #[error("failed to read compiler input {path}: {message}")]
+    InputRead { path: PathBuf, message: String },
+    #[error("compiler input changed after discovery: {0}")]
+    InputChanged(PathBuf),
+    #[error("discovered inputs were collected from a different working directory")]
+    DiscoveryWorkingDirectory,
+    #[error("compiler environment input has conflicting values: {0}")]
+    ConflictingEnvironment(String),
     #[error("failed to serialize the rustc action: {0}")]
     Serialization(String),
 }
@@ -534,6 +554,7 @@ impl<'a> ActionBuilder<'a> {
             .iter()
             .map(|argument| self.normalize_argument(argument))
             .collect::<Result<Vec<_>, _>>()?;
+        let environment = self.normalize_environment()?;
 
         let mut inputs = BTreeMap::<String, CacheDigest>::new();
         for input in &self.context.inputs {
@@ -572,7 +593,7 @@ impl<'a> ActionBuilder<'a> {
                 host: self.context.compiler.host,
             },
             arguments,
-            environment: self.context.environment,
+            environment,
             inputs,
         };
         let bytes = canonical_json(&descriptor)
@@ -639,6 +660,27 @@ impl<'a> ActionBuilder<'a> {
                 to
             )),
         }
+    }
+
+    fn normalize_environment(&self) -> Result<BTreeMap<String, Option<String>>, BypassReason> {
+        self.context
+            .environment
+            .iter()
+            .map(|(name, value)| {
+                let value = value
+                    .as_deref()
+                    .map(|value| {
+                        let paths = std::env::split_paths(value).collect::<Vec<_>>();
+                        if paths.len() == 1 && paths[0].is_absolute() {
+                            self.normalize_path(&paths[0])
+                        } else {
+                            Ok(value.to_string())
+                        }
+                    })
+                    .transpose()?;
+                Ok((name.clone(), value))
+            })
+            .collect()
     }
 
     fn normalize_path(&self, path: &Path) -> Result<String, BypassReason> {
@@ -790,12 +832,20 @@ mod tests {
 
     #[test]
     fn equivalent_worktrees_produce_the_same_action_key() {
-        let first = common_invocation()
-            .action(context(&[
-                ("src/lib.rs", "source"),
-                ("target/debug/deps/libserde.rlib", "serde"),
-            ]))
-            .unwrap();
+        let mut first_context = context(&[
+            ("src/lib.rs", "source"),
+            ("target/debug/deps/libserde.rlib", "serde"),
+        ]);
+        first_context.environment.insert(
+            "OUT_DIR".into(),
+            Some(
+                workspace()
+                    .join("target/debug/build/widget/out")
+                    .display()
+                    .to_string(),
+            ),
+        );
+        let first = common_invocation().action(first_context).unwrap();
         let other = absolute(&["other", "checkout"]);
         let output = other.join("target/debug/deps");
         let invocation = RustcInvocation::parse(&[
@@ -816,7 +866,16 @@ mod tests {
         let mut second_context = context(&[]);
         second_context.working_dir = other.clone();
         second_context.path_mappings[0].root = other.join("target");
-        second_context.path_mappings[1].root = other;
+        second_context.path_mappings[1].root = other.clone();
+        second_context.environment.insert(
+            "OUT_DIR".into(),
+            Some(
+                other
+                    .join("target/debug/build/widget/out")
+                    .display()
+                    .to_string(),
+            ),
+        );
         second_context.inputs = vec![
             ActionInput {
                 path: "src/lib.rs".into(),

--- a/crates/mise-cache-rustc/src/lib.rs
+++ b/crates/mise-cache-rustc/src/lib.rs
@@ -554,7 +554,9 @@ impl<'a> ActionBuilder<'a> {
             .iter()
             .map(|argument| self.normalize_argument(argument))
             .collect::<Result<Vec<_>, _>>()?;
-        let environment = self.normalize_environment()?;
+        // rustc may embed these values verbatim through `env!`; unlike paths
+        // used to locate inputs and outputs, changing them changes the artifact.
+        let environment = self.context.environment.clone();
 
         let mut inputs = BTreeMap::<String, CacheDigest>::new();
         for input in &self.context.inputs {
@@ -660,27 +662,6 @@ impl<'a> ActionBuilder<'a> {
                 to
             )),
         }
-    }
-
-    fn normalize_environment(&self) -> Result<BTreeMap<String, Option<String>>, BypassReason> {
-        self.context
-            .environment
-            .iter()
-            .map(|(name, value)| {
-                let value = value
-                    .as_deref()
-                    .map(|value| {
-                        let paths = std::env::split_paths(value).collect::<Vec<_>>();
-                        if paths.len() == 1 && paths[0].is_absolute() {
-                            self.normalize_path(&paths[0])
-                        } else {
-                            Ok(value.to_string())
-                        }
-                    })
-                    .transpose()?;
-                Ok((name.clone(), value))
-            })
-            .collect()
     }
 
     fn normalize_path(&self, path: &Path) -> Result<String, BypassReason> {
@@ -832,19 +813,10 @@ mod tests {
 
     #[test]
     fn equivalent_worktrees_produce_the_same_action_key() {
-        let mut first_context = context(&[
+        let first_context = context(&[
             ("src/lib.rs", "source"),
             ("target/debug/deps/libserde.rlib", "serde"),
         ]);
-        first_context.environment.insert(
-            "OUT_DIR".into(),
-            Some(
-                workspace()
-                    .join("target/debug/build/widget/out")
-                    .display()
-                    .to_string(),
-            ),
-        );
         let first = common_invocation().action(first_context).unwrap();
         let other = absolute(&["other", "checkout"]);
         let output = other.join("target/debug/deps");
@@ -867,15 +839,6 @@ mod tests {
         second_context.working_dir = other.clone();
         second_context.path_mappings[0].root = other.join("target");
         second_context.path_mappings[1].root = other.clone();
-        second_context.environment.insert(
-            "OUT_DIR".into(),
-            Some(
-                other
-                    .join("target/debug/build/widget/out")
-                    .display()
-                    .to_string(),
-            ),
-        );
         second_context.inputs = vec![
             ActionInput {
                 path: "src/lib.rs".into(),
@@ -888,6 +851,34 @@ mod tests {
         ];
         let second = invocation.action(second_context).unwrap();
         assert_eq!(first.digest, second.digest);
+    }
+
+    #[test]
+    fn absolute_environment_values_remain_literal_action_inputs() {
+        let invocation = common_invocation();
+        let mut first_context = context(&[
+            ("src/lib.rs", "source"),
+            ("target/debug/deps/libserde.rlib", "serde"),
+        ]);
+        let first_out_dir = workspace().join("target/debug/build/widget/out");
+        first_context
+            .environment
+            .insert("OUT_DIR".into(), Some(first_out_dir.display().to_string()));
+        let first = invocation.action(first_context).unwrap();
+
+        let mut second_context = context(&[
+            ("src/lib.rs", "source"),
+            ("target/debug/deps/libserde.rlib", "serde"),
+        ]);
+        second_context.environment.insert(
+            "OUT_DIR".into(),
+            Some(absolute(&["other", "out"]).display().to_string()),
+        );
+        let second = invocation.action(second_context).unwrap();
+
+        let descriptor = String::from_utf8(first.bytes).unwrap();
+        assert!(descriptor.contains(&first_out_dir.display().to_string()));
+        assert_ne!(first.digest, second.digest);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- derive a side-effect-minimized rustc invocation that replaces real outputs with one explicit dep-info file
- parse rustc Makefile dependencies and `# env-dep:` records using Cargo-compatible escaping rules
- hash discovered source/module/include files together with explicit extern artifacts and custom target specs
- normalize path-valued environment inputs such as `OUT_DIR` so equivalent worktrees retain the same action key
- revalidate the complete manifest after compilation so changed inputs bypass publication instead of being stored under a stale key
- make streaming file digests derive the hash and byte count from the same read pass

This remains correctness infrastructure only: the shim still executes rustc transparently and cannot serve cache hits. Compiler execution, diagnostics capture/replay, artifact materialization, and local/remote action lookup remain follow-ups.

## Validation
- `cargo test -p mise-cache-core -p mise-cache-rustc` (includes a real-rustc dep-info round trip)
- `cargo clippy -p mise-cache-core -p mise-cache-rustc --all-features --all-targets -- -D warnings`
- `cargo check --workspace --all-features`
- `mise run lint-fix`

## References
- [rustc `--emit=dep-info`](https://doc.rust-lang.org/rustc/command-line-arguments.html#--emit-specifies-the-types-of-output-files-to-generate)
- [Cargo rustc dep-info parser](https://doc.rust-lang.org/stable/nightly-rustc/src/cargo/core/compiler/fingerprint/dep_info.rs.html#385-460)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Rust compilation caching by automatically discovering source-file and environment dependencies.
  * Cache validation now accounts for relevant input changes, helping ensure builds use correct results.
  * Added efficient incremental file hashing with size tracking.
* **Bug Fixes**
  * Prevented stale or invalid cached results when tracked files, environment values, or dependency metadata change.
  * Added clearer handling for malformed dependency information and unavailable or unsafe inputs.
* **Tests**
  * Expanded coverage for dependency discovery, environment tracking, file hashing, and change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache key correctness (input hashing, dep-info parsing, post-compile verification); mistakes could cause wrong hits or excess bypasses, but changes are confined to cache crates with broad tests and no production shim path yet.
> 
> **Overview**
> Adds **rustc input discovery** for the remote cache adapter: build a dep-info-only compiler argv (strip real `--emit` / `-o` / `--out-dir`), parse Makefile deps and `# env-dep:` lines (Cargo-style escaping), and produce a **content-addressed manifest** of sources plus `--extern` / custom `--target` files via `CacheDigest::blake3_file`.
> 
> **`DiscoveredInputs`** merges into `ActionContext`, and **`verify()`** re-hashes inputs after compile so races become bypass/`InputChanged` instead of publishing under a stale key. New **`BypassReason`** variants cover malformed dep-info, I/O, and conflicts.
> 
> In **`mise-cache-core`**, file digests now derive **hash and byte count in one streaming read** (`blake3_file`, updated `matches_file`). Action key building keeps **`env!` / `option_env!` values literal** in the serialized environment (new test for differing `OUT_DIR`). Still **correctness infrastructure only**—no shim cache hits yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16b68430b283856d35870b0f3467ed91fcb2dfd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->