### PR TITLE
fix(link): reject install path aliases

### DIFF
--- a/e2e/cli/test_link
+++ b/e2e/cli/test_link
@@ -45,6 +45,14 @@ assert_fail "mise link --force tiny@3.1.0 \"$MISE_DATA_DIR/installs/tiny/3.1.0\"
 assert_directory_exists "$MISE_DATA_DIR/installs/tiny/3.1.0"
 assert "test -f \"$MISE_CACHE_DIR/tiny/3.1.0/incomplete\""
 
+# A filesystem alias to the managed install is still the install itself.
+# In particular, --force must not remove the directory before replacing it
+# with a link back through the alias.
+touch "$MISE_DATA_DIR/installs/tiny/3.1.0/sentinel"
+ln -s "$MISE_DATA_DIR/installs/tiny/3.1.0" tmp/tiny-managed-alias
+assert_fail "mise link --force tiny@3.1.0 tmp/tiny-managed-alias"
+assert "test -f \"$MISE_DATA_DIR/installs/tiny/3.1.0/sentinel\""
+
 # Request-style versions use their normalized install pathname for both the
 # symlink and incomplete marker.
 mkdir -p tmp/tiny-ref

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -68,7 +68,7 @@ impl Link {
             );
         }
         let target = self.tool.ba.installs_path.join(&version_pathname);
-        if file::paths_eq(&path, &target) {
+        if !file::is_symlink_to(&target, &path) && file::same_file(&path, &target) {
             bail!("cannot link {} to its own install path", self.tool.style());
         }
         {


### PR DESCRIPTION
## Summary

- compare the link source and install target by filesystem identity instead of lexical path
- prevent `mise link --force` from deleting a managed install reached through a symlink or junction alias
- add a regression that verifies an aliased self-link is rejected without removing existing contents

## Validation

- Ran: `cargo build`
- Ran: `cargo fmt --all -- --check`
- Ran: `git diff --check`
- Ran: `bash -n e2e/cli/test_link`
- Checked: Windows junction reproduction changed from success with the sentinel deleted to rejection with the sentinel preserved

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented forced tool linking from deleting managed installations when the source path resolves to the same location.
  * Improved detection of links targeting an existing managed installation, including valid symlink targets.
  * Safely rejects self-referential forced links while preserving the installation and its supporting files.

* **Tests**
  * Added an end-to-end regression test covering safe rejection of self-referential forced links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->