### PR TITLE
fix(task): detect incomplete task outputs

### DIFF
--- a/e2e/tasks/test_task_source_freshness_multi_output
+++ b/e2e/tasks/test_task_source_freshness_multi_output
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# A task with multiple static outputs must rerun when any declared output is
+# missing, even if another output is newer than every source.
+cat <<EOF >mise.toml
+[tasks.static]
+run = 'touch output output2 && echo built'
+sources = ['source']
+outputs = ['output', 'output2']
+EOF
+
+echo source >source
+
+assert "mise run -q static" "built"
+assert_empty "mise run -q static"
+
+rm output2
+assert "mise run -q static" "built"
+[ -f output2 ]
+assert_empty "mise run -q static"
+
+# Each positive glob must match at least one output. A separate static output
+# must not make the task fresh when the glob no longer matches anything.
+cat <<EOF >>mise.toml
+
+[tasks.glob]
+run = 'touch marker matched.generated && echo glob-built'
+sources = ['glob-source']
+outputs = ['marker', '*.generated']
+EOF
+
+echo source >glob-source
+
+assert "mise run -q glob" "glob-built"
+assert_empty "mise run -q glob"
+
+rm matched.generated
+assert "mise run -q glob" "glob-built"
+[ -f matched.generated ]
+assert_empty "mise run -q glob"

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -1088,7 +1088,8 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
     let mut file_modified = Vec::new();
     let mut directory_modified = Vec::new();
     for pattern in output_glob_patterns(patterns_or_paths) {
-        let candidates = if is_glob_pattern(&pattern) {
+        let is_glob = is_glob_pattern(&pattern);
+        let candidates = if is_glob {
             let mut candidates = Vec::new();
             for expanded in expand_glob_braces(&pattern)? {
                 let expanded = resolve_task_path(root, expanded);
@@ -1100,10 +1101,12 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
         } else {
             vec![resolve_task_path(root, &pattern)]
         };
+        let mut found_candidate = false;
         for candidate in candidates {
             if fs::symlink_metadata(&candidate).is_err() {
                 continue;
             }
+            found_candidate = true;
             for entry in WalkDir::new(candidate).follow_links(true) {
                 let entry = entry?;
                 let metadata = entry.metadata()?;
@@ -1115,6 +1118,17 @@ fn get_last_modified(root: &Path, patterns_or_paths: &[String]) -> Result<Option
                     }
                 }
             }
+        }
+        // Every positive output pattern represents a required artifact root.
+        // Excluded static paths are the exception; the ordered matcher makes
+        // those optional even though they remain in the enumeration list.
+        if !found_candidate
+            && (is_glob || {
+                let path = resolve_task_path(root, &pattern);
+                is_output(&matcher, &path, false) || is_output(&matcher, &path, true)
+            })
+        {
+            return Ok(None);
         }
     }
     let last_mod = file_modified.into_iter().chain(directory_modified).max();
@@ -1343,6 +1357,82 @@ mod tests {
             .unwrap();
 
         assert_eq!(modified, SystemTime::from(directory_mtime));
+    }
+
+    #[test]
+    fn output_mtime_requires_all_selected_static_paths() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("present.txt"), "present").unwrap();
+
+        let modified = get_last_modified(
+            root.path(),
+            &["present.txt".to_string(), "missing.txt".to_string()],
+        )
+        .unwrap();
+
+        assert!(modified.is_none());
+    }
+
+    #[test]
+    fn output_mtime_requires_each_positive_glob_to_match() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("present.txt"), "present").unwrap();
+
+        let modified = get_last_modified(
+            root.path(),
+            &["present.txt".to_string(), "*.generated".to_string()],
+        )
+        .unwrap();
+
+        assert!(modified.is_none());
+    }
+
+    #[test]
+    fn output_mtime_allows_missing_excluded_static_paths() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("present.txt"), "present").unwrap();
+
+        let modified = get_last_modified(
+            root.path(),
+            &[
+                "present.txt".to_string(),
+                "missing.txt".to_string(),
+                "!missing.txt".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert!(modified.is_some());
+    }
+
+    #[test]
+    fn output_mtime_brace_alternatives_require_any_match() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("a.out"), "a").unwrap();
+
+        let modified = get_last_modified(root.path(), &["{a,b}.out".to_string()]).unwrap();
+
+        assert!(modified.is_some());
+    }
+
+    #[test]
+    fn output_mtime_allows_glob_matches_that_are_all_excluded() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("present.txt"), "present").unwrap();
+        fs::create_dir(root.path().join("dist")).unwrap();
+        fs::write(root.path().join("dist/vendor.js"), "vendor").unwrap();
+
+        let modified = get_last_modified(
+            root.path(),
+            &[
+                "present.txt".to_string(),
+                "dist/*.js".to_string(),
+                "!dist/vendor.js".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert!(modified.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat every positive task output pattern as a required artifact root in the default mtime freshness mode
- rerun tasks when a selected static output is missing or a positive output glob has no matches
- preserve ordered exclusions, brace-alternative semantics, directory outputs, and the existing content-hash path

## Root cause

The mtime freshness path collected timestamps from whichever declared outputs still existed and returned their maximum. It did not record whether every positive output pattern had produced a candidate. As a result, one newer surviving output could make a task fresh even when another declared output was missing.

The content-hash path already checks output completeness. This change brings the default mtime path in line without hashing file contents or changing its performance model.

## Behavior

Given:

```toml
[tasks.gen]
run = "touch output output2"
sources = ["source"]
outputs = ["output", "output2"]
```

removing `output2` now makes `gen` stale and reruns it, even when `output` is newer than `source`.

A positive glob similarly requires at least one match. Missing static paths that are excluded by the ordered output matcher remain optional, and brace alternatives remain satisfied when any alternative matches.

## Test plan

- [x] `mise exec -- cargo test --all-features task_source_checker`
- [x] `mise run test:e2e e2e/tasks/test_task_source_freshness_multi_output e2e/tasks/test_task_source_freshness e2e/tasks/test_task_source_freshness_hash_contents_multi_output`
- [x] `mise exec -- cargo check --all-features`
- [x] `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `mise exec -- cargo fmt --all -- --check`
- [x] `mise exec -- shellcheck e2e/tasks/test_task_source_freshness_multi_output`
- [x] `mise exec -- shfmt -d e2e/tasks/test_task_source_freshness_multi_output`

`mise run format` and `mise run lint` were also attempted, but the local `hk` wrapper cannot recognize this Sapling working copy as a Git repository (`failed to find git repository`). The corresponding Rustfmt, ShellCheck, shfmt, Cargo check, and Clippy checks passed individually.

Addresses https://github.com/jdx/mise/discussions/7656

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*