### PR TITLE
fix(task): validate arguments before dependencies

### DIFF
--- a/e2e/tasks/test_task_monorepo_usage_env
+++ b/e2e/tasks/test_task_monorepo_usage_env
@@ -14,8 +14,13 @@ EOF
 
 # Create backend project with env and task using usage with env= attribute
 mkdir -p backend
+cat <<EOF >backend/source-env.sh
+echo sourced >>"$PWD/backend/source-count"
+export SOURCE_MARKER=from-source
+EOF
 cat <<EOF >backend/mise.toml
 [env]
+_.source = "./source-env.sh"
 NAME = "john"
 
 [tasks.test]
@@ -25,7 +30,15 @@ usage = '''
 run = '''
 echo "Name: {{usage.name}}"
 '''
+
+[tasks.invalid]
+usage = 'arg "<required>"'
+run = 'echo should-not-run'
 EOF
+
+# Preflight must not source the child environment before rejecting invalid usage.
+assert_fail_contains "mise run '//backend:invalid'" "Missing required arg: <required>"
+test ! -e backend/source-count
 
 # Test 1: Running monorepo task with usage env should work
 echo "=== Test 1: Monorepo task with usage env= attribute ==="

--- a/e2e/tasks/test_task_usage_preflight
+++ b/e2e/tasks/test_task_usage_preflight
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >source-env.sh
+echo sourced >>source-count
+export SOURCE_VALUE=from-source
+EOF
+
+cat <<'EOF' >mise.toml
+[tasks.dependency]
+run = 'echo dependency >> basic-runs'
+
+[tasks.parent]
+usage = 'arg "<name>"'
+depends = ["dependency"]
+run = 'echo "parent:$usage_name" >> basic-runs'
+
+[tasks.transitive-leaf]
+run = 'echo leaf >> transitive-runs'
+
+[tasks.transitive-invalid]
+usage = 'arg "<name>"'
+depends = ["transitive-leaf"]
+run = 'echo middle >> transitive-runs'
+
+[tasks.transitive-root]
+depends = ["transitive-invalid"]
+run = 'echo root >> transitive-runs'
+
+[tasks.dynamic-syntax-dependency]
+run = 'echo dependency >> dynamic-syntax-runs'
+
+[tasks.dynamic-syntax-invalid]
+usage = 'arg "<name>" {{'
+depends = ["dynamic-syntax-dependency"]
+run = 'echo invalid >> dynamic-syntax-runs'
+
+[tasks.valid-root]
+run = 'echo valid >> multi-root-runs'
+
+[tasks.invalid-root]
+usage = 'arg "<name>"'
+run = 'echo invalid >> multi-root-runs'
+
+[tasks.post-invalid]
+usage = 'arg "<name>"'
+run = 'echo post >> post-runs'
+
+[tasks.post-parent]
+depends_post = ["post-invalid"]
+run = 'echo parent >> post-runs'
+
+[tasks.wait-invalid]
+usage = 'arg "<name>"'
+run = 'echo waited >> wait-runs'
+
+[tasks.waiter]
+wait_for = ["wait-invalid"]
+run = 'echo waiter >> wait-runs'
+
+[tasks.wait-root]
+depends = ["wait-invalid", "waiter"]
+run = 'echo root >> wait-runs'
+
+[tasks.env-arg]
+usage = 'arg "<name>" env="TASK_NAME"'
+env = { TASK_NAME = "configured" }
+run = 'echo "$usage_name"'
+
+[tasks.generate-env-file]
+run = 'echo "GENERATED_VALUE=from-dependency" > generated.env'
+
+[tasks.file-env]
+usage = 'arg "<name>" env="GENERATED_VALUE"'
+depends = ["generate-env-file"]
+run = 'echo "$usage_name"'
+
+[tasks.file-env.env]
+_.file = "generated.env"
+
+[tasks.generate-mixed-env-file]
+run = 'echo "MIXED_VALUE=from-dependency" > mixed.env'
+
+[tasks.mixed-env-invalid]
+usage = 'arg "<name>" env="MIXED_VALUE"'
+depends = ["generate-mixed-env-file"]
+run = 'echo "$usage_name" >> mixed-runs'
+
+[tasks.mixed-env-invalid.env]
+_.file = "mixed.env"
+
+[tasks.source-env]
+usage = 'arg "<name>" env="SOURCE_VALUE"'
+run = 'echo "$usage_name"'
+
+[tasks.source-env.env]
+_.source = "source-env.sh"
+
+[tasks.raw]
+raw_args = true
+usage = 'arg "<name>"'
+depends = ["raw-dependency"]
+run = 'echo "raw:$@" >> raw-runs'
+
+[tasks.raw-dependency]
+run = 'echo dependency >> raw-runs'
+
+[tasks.help-passthrough]
+usage = 'arg "<name>"'
+depends = ["help-dependency"]
+run = 'echo "help:$@" >> help-runs'
+
+[tasks.help-dependency]
+run = 'echo dependency >> help-runs'
+
+[tasks.fresh]
+usage = 'arg "<name>"'
+sources = ["source"]
+outputs = ["output"]
+run = 'echo "$usage_name" >> fresh-runs; touch output'
+EOF
+
+# Invalid root arguments are rejected before any dependency command starts.
+assert_fail_contains "mise run parent" "Missing required arg: <name>"
+test ! -e basic-runs
+
+# A valid invocation retains the normal dependency ordering and argument parsing.
+mise run parent accepted
+assert "cat basic-runs" "dependency
+parent:accepted"
+
+# A usage error in a transitive dependency prevents its own prerequisites too.
+assert_fail_contains "mise run transitive-root" "Missing required arg: <name>"
+test ! -e transitive-runs
+
+# Deterministic syntax errors in dynamic usage are rejected before dependencies.
+assert_fail_contains "mise run dynamic-syntax-invalid" "invalid usage template"
+test ! -e dynamic-syntax-runs
+
+# One invalid root prevents every root in the same invocation from starting.
+assert_fail_contains "mise run valid-root ::: invalid-root" "Missing required arg: <name>"
+test ! -e multi-root-runs
+
+# Post dependencies and wait_for-linked scheduled occurrences are part of the
+# same preflight. wait_for does not schedule its target by itself, so wait-root
+# introduces both occurrences without making the invalid task a CLI root.
+assert_fail_contains "mise run post-parent" "Missing required arg: <name>"
+test ! -e post-runs
+assert_fail_contains "mise run wait-root" "Missing required arg: <name>"
+test ! -e wait-runs
+
+# Usage errors are invocation errors, not runtime failures handled by
+# --continue-on-error.
+assert_fail_contains "mise run --continue-on-error valid-root ::: invalid-root" \
+  "Missing required arg: <name>"
+test ! -e multi-root-runs
+
+# Task-level env is available while validating env= usage arguments.
+assert "mise run env-arg" "configured"
+
+# Environment inputs produced by dependencies are resolved only after those
+# dependencies run, and source directives execute only once at runtime.
+assert "mise run file-env" "from-dependency"
+
+# An unavailable env-backed input does not suppress an independent CLI error.
+assert_fail_contains "mise run mixed-env-invalid value extra" "unexpected word: extra"
+test ! -e mixed.env
+test ! -e mixed-runs
+
+assert "mise run source-env" "from-source"
+assert "cat source-count" "sourced"
+
+# Compatibility escape hatches continue to bypass the usage parser.
+mise run raw --anything
+assert "cat raw-runs" "dependency
+raw: --anything"
+mise run help-passthrough -- --help
+assert "cat help-runs" "dependency
+help: --help"
+
+# Fresh tasks are still invalid invocations when required arguments are absent.
+touch source
+mise run fresh accepted
+assert_fail_contains "mise run fresh" "Missing required arg: <name>"
+assert "cat fresh-runs" "accepted"

--- a/e2e/tasks/test_task_usage_preflight
+++ b/e2e/tasks/test_task_usage_preflight
@@ -34,6 +34,19 @@ usage = 'arg "<name>" {{'
 depends = ["dynamic-syntax-dependency"]
 run = 'echo invalid >> dynamic-syntax-runs'
 
+[tasks.dynamic-env-dependency]
+run = 'echo dependency >> dynamic-env-runs'
+
+[tasks.dynamic-env]
+usage = '''
+{% if env.DYNAMIC_USAGE == "enabled" %}
+arg "<name>"
+{% endif %}
+'''
+depends = ["dynamic-env-dependency"]
+env = { DYNAMIC_USAGE = "enabled" }
+run = 'echo "task:$usage_name" >> dynamic-env-runs'
+
 [tasks.valid-root]
 run = 'echo valid >> multi-root-runs'
 
@@ -135,6 +148,13 @@ test ! -e transitive-runs
 # Deterministic syntax errors in dynamic usage are rejected before dependencies.
 assert_fail_contains "mise run dynamic-syntax-invalid" "invalid usage template"
 test ! -e dynamic-syntax-runs
+
+# A dynamic usage template may produce a different valid spec once task env is
+# available. Its syntax is checked preflight, but argument validation is safely
+# deferred until the runtime context is available.
+mise run dynamic-env accepted
+assert "cat dynamic-env-runs" "dependency
+task:accepted"
 
 # One invalid root prevents every root in the same invocation from starting.
 assert_fail_contains "mise run valid-root ::: invalid-root" "Missing required arg: <name>"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -23,7 +23,7 @@ use crate::toolset::{InstallOptions, ResolveOptions, ToolVersion, ToolsetBuilder
 use crate::ui::{ctrlc, info, style};
 use bytesize::ByteSize;
 use clap::{CommandFactory, ValueHint};
-use eyre::{Result, bail, eyre};
+use eyre::{Context, Result, bail, eyre};
 use futures_util::FutureExt;
 use itertools::Itertools;
 use serde::Serialize;
@@ -871,6 +871,24 @@ impl Run {
 
         // Step 5: Create TaskExecutor after tool installation
         self.setup_executor()?;
+
+        // Validate every scheduled invocation before starting the scheduler so
+        // an invalid parent or dependency cannot run any task commands first.
+        let executor = self.executor.as_ref().expect("task executor initialized");
+        for task in tasks.all() {
+            if let Err(err) = executor
+                .preflight_task_usage(&config, task)
+                .await
+                .wrap_err_with(|| format!("failed to validate task {}", task.name))
+            {
+                if let Some(session) = &self.cache_session
+                    && let Err(finish_err) = session.finish().await
+                {
+                    warn!("failed to finish action cache session: {finish_err:#}");
+                }
+                return Err(err);
+            }
+        }
 
         // Disable exit-on-ctrl-c so tasks can handle SIGINT gracefully
         ctrlc::exit_on_ctrl_c(false);

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1993,6 +1993,33 @@ impl Task {
         Ok(spec)
     }
 
+    /// Parse usage metadata without resolving task- or subproject-specific
+    /// environment directives. This is used before the scheduler starts, where
+    /// source/module hooks must not run ahead of task dependencies.
+    pub(crate) async fn parse_usage_spec_for_preflight(
+        &self,
+        config: &Arc<Config>,
+    ) -> Result<usage::Spec> {
+        let mut spec = if let Some(file) = self.file_path_raw() {
+            parse_task_script_usage(&file)
+                .inspect_err(|e| {
+                    warn!(
+                        "failed to parse task file {} with usage: {e:?}",
+                        file::display_path(&file)
+                    )
+                })
+                .unwrap_or_default()
+        } else {
+            let scripts_only = self.run_script_strings();
+            TaskScriptParser::new(self.config_root.clone())
+                .parse_run_scripts_for_preflight(config, self, &scripts_only)
+                .await?
+        };
+        self.populate_spec_metadata(&mut spec);
+        self.populate_usage_about(&mut spec);
+        Ok(spec)
+    }
+
     pub async fn render_run_scripts_with_args(
         &self,
         config: &Arc<Config>,
@@ -2106,7 +2133,7 @@ impl Task {
 
     /// Get file path without templating (for display purposes)
     /// This is a non-async version used when we just need the path for display
-    fn file_path_raw(&self) -> Option<PathBuf> {
+    pub(crate) fn file_path_raw(&self) -> Option<PathBuf> {
         self.file.as_ref().map(|file| {
             if file.is_absolute() {
                 file.clone()
@@ -2124,6 +2151,14 @@ impl Task {
 
     pub(crate) async fn tera_ctx_for_usage(&self, config: &Arc<Config>) -> Result<tera::Context> {
         self.build_tera_ctx(config, !self.raw_args).await
+    }
+
+    pub(crate) fn tera_ctx_for_usage_preflight(&self, config: &Config) -> tera::Context {
+        let mut tera_ctx = config.tera_ctx.clone();
+        tera_ctx.insert("env", &EnvMap::new());
+        tera_ctx.insert("vars", &IndexMap::<String, String>::new());
+        tera_ctx.insert("config_root", &self.config_root);
+        tera_ctx
     }
 
     async fn build_tera_ctx(

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2020,6 +2020,10 @@ impl Task {
         Ok(spec)
     }
 
+    pub(crate) fn validate_template_syntax_for_preflight(&self, input: &str) -> Result<()> {
+        TaskScriptParser::new(self.config_root.clone()).validate_template_syntax(self, input)
+    }
+
     pub async fn render_run_scripts_with_args(
         &self,
         config: &Arc<Config>,

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1794,17 +1794,18 @@ impl TaskExecutor {
                     })?;
             }
         }
-        let spec = match task.parse_usage_spec_for_preflight(config).await {
-            Ok(spec) => spec,
-            Err(err) if dynamic_usage => {
-                debug!(
-                    "deferring dynamic usage validation for task {} until execution: {err:#}",
-                    task.name
-                );
-                return Ok(());
-            }
-            Err(err) => return Err(err),
-        };
+        if dynamic_usage {
+            // The side-effect-free context intentionally omits task/subproject
+            // env and vars. A dynamic template can still render successfully
+            // with those empty maps while producing a different spec from the
+            // runtime context, so only its syntax is safe to validate here.
+            debug!(
+                "deferring dynamic usage argument validation for task {} until execution",
+                task.name
+            );
+            return Ok(());
+        }
+        let spec = task.parse_usage_spec_for_preflight(config).await?;
 
         let mut env = crate::env::PRISTINE_ENV.clone();
         for directive in task.inherited_env.0.iter().chain(task.env.0.iter()) {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -22,7 +22,7 @@ use crate::task::{
     Deps, FailedTasks, GetMatchingExt, Task, TaskCacheAudit, TaskCacheMode, TaskCacheOutput,
 };
 use crate::task::{TaskCompletionState, TaskDependencyState};
-use crate::tera::{contains_template_syntax, render_str, validate_template_syntax};
+use crate::tera::{contains_template_syntax, render_str};
 use crate::toolset::Toolset;
 use crate::toolset::env_cache::CachedEnv;
 use crate::ui::{style, time};
@@ -1779,7 +1779,7 @@ impl TaskExecutor {
                     .iter()
                     .any(|script| contains_template_syntax(script)));
         if contains_template_syntax(&task.usage) {
-            validate_template_syntax(&task.usage)
+            task.validate_template_syntax_for_preflight(&task.usage)
                 .wrap_err_with(|| format!("invalid usage template for task {}", task.name))?;
         }
         if task.usage.trim().is_empty() {
@@ -1788,9 +1788,10 @@ impl TaskExecutor {
                 .into_iter()
                 .filter(|script| contains_template_syntax(script))
             {
-                validate_template_syntax(&script).wrap_err_with(|| {
-                    format!("invalid task script template for task {}", task.name)
-                })?;
+                task.validate_template_syntax_for_preflight(&script)
+                    .wrap_err_with(|| {
+                        format!("invalid task script template for task {}", task.name)
+                    })?;
             }
         }
         let spec = match task.parse_usage_spec_for_preflight(config).await {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -22,7 +22,8 @@ use crate::task::{
     Deps, FailedTasks, GetMatchingExt, Task, TaskCacheAudit, TaskCacheMode, TaskCacheOutput,
 };
 use crate::task::{TaskCompletionState, TaskDependencyState};
-use crate::tera::{contains_template_syntax, render_str};
+use crate::tera::{contains_template_syntax, render_str, validate_template_syntax};
+use crate::toolset::Toolset;
 use crate::toolset::env_cache::CachedEnv;
 use crate::ui::{style, time};
 use duct::IntoExecutablePath;
@@ -80,6 +81,13 @@ struct TaskRunEntriesContext<'a> {
     completion_state: &'a TaskCompletionState,
     semaphore: Arc<Semaphore>,
     permit: &'a mut Option<OwnedSemaphorePermit>,
+}
+
+struct PreparedTaskContext {
+    toolset: Toolset,
+    env: BTreeMap<String, String>,
+    task_env: Vec<(String, String)>,
+    extra_vars: Option<IndexMap<String, String>>,
 }
 
 #[derive(Clone, Copy)]
@@ -470,181 +478,14 @@ impl TaskExecutor {
             return Ok(TaskRunOutcome::default());
         }
 
-        let mut tools = self.tool.clone();
-        tools.extend(task.tool_args()?);
-        let ts_build_start = std::time::Instant::now();
-
-        // Check if we need special handling for monorepo tasks with config file context
-        // Remote tasks (from git::/http:/https: URLs) should NOT use config file context
-        // because they need tools from the full config hierarchy, not just the local config
-        let task_cf = if task.is_remote() {
-            None
-        } else {
-            task.cf(config)
-        };
-
-        // Build toolset - either from task's config file or standard way
-        let ts = self
-            .context_builder
-            .build_toolset_for_task(config, task, task_cf, &tools)
-            .await?;
-
-        trace!(
-            "task {} ToolsetBuilder::build took {}ms",
-            task.name,
-            ts_build_start.elapsed().as_millis()
-        );
-        let env_render_start = std::time::Instant::now();
-
-        // Build environment - either from task's config file context or standard way
-        // extra_vars contains resolved vars from the task's config hierarchy (for monorepo tasks)
-        let (mut env, task_env, extra_vars) = if let Some(task_cf) = task_cf {
-            self.context_builder
-                .resolve_task_env_with_config(config, task, task_cf, &ts)
-                .await?
-        } else {
-            // Fallback to standard behavior
-            let (env, task_env) = task.render_env(config, &ts).await?;
-            (env, task_env, None)
-        };
-
-        trace!(
-            "task {} render_env took {}ms",
-            task.name,
-            env_render_start.elapsed().as_millis()
-        );
-        let mut nested_mise_diff_exclude_keys: HashSet<String> = task_env
-            .iter()
-            .map(|(key, _)| key.clone())
-            .filter(|key| key.as_str() != crate::env::PATH_KEY.as_str())
-            .chain(once("__MISE_DIFF".to_string()))
-            .collect();
-        if !self.timings {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_TASK_TIMINGS",
-                "0".to_string(),
-            );
-        }
-        // Propagate MISE_ENV to child tasks so -E flag works for nested mise invocations
-        if !crate::env::MISE_ENV.is_empty() {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_ENV",
-                crate::env::MISE_ENV.join(","),
-            );
-        }
-        if let Some(cwd) = &*crate::dirs::CWD {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_ORIGINAL_CWD",
-                cwd.display().to_string(),
-            );
-        }
-        // Prefer the task's own config_root so MISE_PROJECT_ROOT is the directory of the
-        // mise.toml that defined the task. This keeps the value stable regardless of the
-        // cwd from which the task was invoked (important for monorepo subprojects, where
-        // config.project_root depends on cwd).
-        //
-        // Exception: for global tasks (inline in ~/.config/mise/config.toml or scripts in
-        // ~/.config/mise/tasks/) and remote tasks (loaded from git/http), task.config_root
-        // points at the global/remote location rather than the user's project. Fall back
-        // to config.project_root (the local project the user is in) for those, matching
-        // the pre-existing behavior.
-        let project_root = if task.global || task.is_remote() {
-            config.project_root.clone().or(task.config_root.clone())
-        } else {
-            task.config_root.clone().or(config.project_root.clone())
-        };
-        if let Some(root) = project_root {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_PROJECT_ROOT",
-                root.display().to_string(),
-            );
-        }
-        if let Some(monorepo_root) = config.monorepo_root() {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_MONOREPO_ROOT",
-                monorepo_root.display().to_string(),
-            );
-        }
-        Self::insert_env_excluded_from_nested_mise_diff(
-            &mut env,
-            &mut nested_mise_diff_exclude_keys,
-            "MISE_TASK_NAME",
-            task.name.clone(),
-        );
-        let task_file = task
-            .file_path(config)
-            .await?
-            .unwrap_or(task.config_source.clone());
-        Self::insert_env_excluded_from_nested_mise_diff(
-            &mut env,
-            &mut nested_mise_diff_exclude_keys,
-            "MISE_TASK_FILE",
-            task_file.display().to_string(),
-        );
-        if let Some(dir) = task_file.parent() {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_TASK_DIR",
-                dir.display().to_string(),
-            );
-        }
-        if let Some(config_root) = &task.config_root {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_CONFIG_ROOT",
-                config_root.display().to_string(),
-            );
-        }
-
-        // Ensure cache key exists for task subprocesses for nested mise invocations
-        // This matches exec.rs behavior - enables caching for subprocesses
-        if Settings::get().env_cache {
-            let key = CachedEnv::ensure_encryption_key();
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "__MISE_ENV_CACHE_KEY",
-                key,
-            );
-        }
-
-        // Embed __MISE_DIFF so a nested `mise` invocation inside this task can
-        // recover the pristine env (and pristine PATH) instead of stacking our
-        // tool dirs on top of its own. Keep task-scoped vars out of the diff:
-        // nested `mise hook-env` should not unset variables that belong to the
-        // currently running task.
-        let env_for_diff = self.env_for_nested_mise_diff(&env, &nested_mise_diff_exclude_keys);
-        if let Ok(serialized) =
-            EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env_for_diff).serialize()
-        {
-            env.insert("__MISE_DIFF".into(), serialized);
-        }
-
-        let task_file = task.file_path(config).await?;
-        let usage_args = || {
-            if let Some(file) = &task_file {
-                once(file.to_string_lossy().to_string())
-                    .chain(task.args.iter().cloned())
-                    .collect()
-            } else {
-                once(String::new())
-                    .chain(task.args.iter().cloned())
-                    .collect()
-            }
-        };
-        self.parse_usage_spec_and_init_env(config, task, &mut env, usage_args, extra_vars.clone())
+        let PreparedTaskContext {
+            toolset: ts,
+            mut env,
+            task_env,
+            extra_vars,
+        } = self.prepare_task_context(config, task).await?;
+        let task_file = self
+            .parse_task_usage(config, task, &mut env, extra_vars.clone())
             .await?;
 
         // Confirmation must happen before a cache restore because restoring
@@ -1919,6 +1760,329 @@ impl TaskExecutor {
         Ok(())
     }
 
+    /// Validate a task invocation before the scheduler starts any task commands.
+    /// Runtime execution repeats this work so configuration changes made while
+    /// dependencies run are still detected.
+    pub async fn preflight_task_usage(&self, config: &Arc<Config>, task: &Task) -> Result<()> {
+        if task.should_bypass_usage_parser() {
+            return Ok(());
+        }
+
+        // This path must remain side-effect free: a dependency may create an
+        // env file consumed by this task, and source/plugin env hooks must not
+        // run once here and again during execution. The display parser extracts
+        // the usage declaration without resolving the complete task environment.
+        let dynamic_usage = contains_template_syntax(&task.usage)
+            || (task.usage.trim().is_empty()
+                && task
+                    .run_script_strings()
+                    .iter()
+                    .any(|script| contains_template_syntax(script)));
+        if contains_template_syntax(&task.usage) {
+            validate_template_syntax(&task.usage)
+                .wrap_err_with(|| format!("invalid usage template for task {}", task.name))?;
+        }
+        if task.usage.trim().is_empty() {
+            for script in task
+                .run_script_strings()
+                .into_iter()
+                .filter(|script| contains_template_syntax(script))
+            {
+                validate_template_syntax(&script).wrap_err_with(|| {
+                    format!("invalid task script template for task {}", task.name)
+                })?;
+            }
+        }
+        let spec = match task.parse_usage_spec_for_preflight(config).await {
+            Ok(spec) => spec,
+            Err(err) if dynamic_usage => {
+                debug!(
+                    "deferring dynamic usage validation for task {} until execution: {err:#}",
+                    task.name
+                );
+                return Ok(());
+            }
+            Err(err) => return Err(err),
+        };
+
+        let mut env = crate::env::PRISTINE_ENV.clone();
+        for directive in task.inherited_env.0.iter().chain(task.env.0.iter()) {
+            Self::apply_literal_preflight_env(&mut env, directive);
+        }
+        for (directive, _) in &task.overlay_env {
+            Self::apply_literal_preflight_env(&mut env, directive);
+        }
+
+        let task_file = task.file_path_raw();
+        let usage_args: Vec<String> = if let Some(file) = &task_file {
+            once(file.to_string_lossy().to_string())
+                .chain(task.args.iter().cloned())
+                .collect()
+        } else {
+            once(String::new())
+                .chain(task.args.iter().cloned())
+                .collect()
+        };
+        match self.parse_usage_spec_and_init_env_from_spec(task, &mut env, &usage_args, &spec) {
+            Ok(()) => Ok(()),
+            Err(_) if Self::has_unavailable_required_env_input(&spec.cmd, &env) => {
+                let mut probe_env = env.clone();
+                Self::fill_unavailable_required_env_inputs(&spec.cmd, &mut probe_env);
+                match self.parse_usage_spec_and_init_env_from_spec(
+                    task,
+                    &mut probe_env,
+                    &usage_args,
+                    &spec,
+                ) {
+                    Ok(()) => {
+                        debug!(
+                            "deferring environment-backed usage validation for task {} until execution",
+                            task.name
+                        );
+                        Ok(())
+                    }
+                    Err(independent_err) => Err(independent_err),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn apply_literal_preflight_env(env: &mut BTreeMap<String, String>, directive: &EnvDirective) {
+        match directive {
+            EnvDirective::Val(key, value, _) if !contains_template_syntax(value) => {
+                env.insert(key.clone(), value.clone());
+            }
+            EnvDirective::Default(key, value, _)
+                if !contains_template_syntax(value)
+                    && env.get(key).is_none_or(|current| current.is_empty()) =>
+            {
+                env.insert(key.clone(), value.clone());
+            }
+            EnvDirective::Rm(key, _) => {
+                env.remove(key);
+            }
+            _ => {}
+        }
+    }
+
+    fn has_unavailable_required_env_input(
+        cmd: &usage::SpecCommand,
+        env: &BTreeMap<String, String>,
+    ) -> bool {
+        cmd.args
+            .iter()
+            .any(|arg| arg.required && arg.env.as_ref().is_some_and(|key| !env.contains_key(key)))
+            || cmd.flags.iter().any(|flag| {
+                flag.required && flag.env.as_ref().is_some_and(|key| !env.contains_key(key))
+            })
+            || cmd
+                .subcommands
+                .values()
+                .any(|subcmd| Self::has_unavailable_required_env_input(subcmd, env))
+    }
+
+    fn fill_unavailable_required_env_inputs(
+        cmd: &usage::SpecCommand,
+        env: &mut BTreeMap<String, String>,
+    ) {
+        for key in cmd
+            .args
+            .iter()
+            .filter(|arg| arg.required)
+            .filter_map(|arg| arg.env.as_ref())
+            .chain(
+                cmd.flags
+                    .iter()
+                    .filter(|flag| flag.required)
+                    .filter_map(|flag| flag.env.as_ref()),
+            )
+        {
+            env.entry(key.clone())
+                .or_insert_with(|| "__MISE_PREFLIGHT_ENV_INPUT__".to_string());
+        }
+        for subcmd in cmd.subcommands.values() {
+            Self::fill_unavailable_required_env_inputs(subcmd, env);
+        }
+    }
+
+    async fn prepare_task_context(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+    ) -> Result<PreparedTaskContext> {
+        let mut tools = self.tool.clone();
+        tools.extend(task.tool_args()?);
+        let ts_build_start = std::time::Instant::now();
+
+        // Remote tasks need tools from the full config hierarchy rather than a
+        // config file rooted at their downloaded source.
+        let task_cf = if task.is_remote() {
+            None
+        } else {
+            task.cf(config)
+        };
+        let toolset = self
+            .context_builder
+            .build_toolset_for_task(config, task, task_cf, &tools)
+            .await?;
+        trace!(
+            "task {} ToolsetBuilder::build took {}ms",
+            task.name,
+            ts_build_start.elapsed().as_millis()
+        );
+
+        let env_render_start = std::time::Instant::now();
+        // extra_vars contains resolved vars from the task's config hierarchy.
+        let (mut env, task_env, extra_vars) = if let Some(task_cf) = task_cf {
+            self.context_builder
+                .resolve_task_env_with_config(config, task, task_cf, &toolset)
+                .await?
+        } else {
+            let (env, task_env) = task.render_env(config, &toolset).await?;
+            (env, task_env, None)
+        };
+        trace!(
+            "task {} render_env took {}ms",
+            task.name,
+            env_render_start.elapsed().as_millis()
+        );
+
+        let mut nested_mise_diff_exclude_keys: HashSet<String> = task_env
+            .iter()
+            .map(|(key, _)| key.clone())
+            .filter(|key| key.as_str() != crate::env::PATH_KEY.as_str())
+            .chain(once("__MISE_DIFF".to_string()))
+            .collect();
+        if !self.timings {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_TASK_TIMINGS",
+                "0".to_string(),
+            );
+        }
+        if !crate::env::MISE_ENV.is_empty() {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_ENV",
+                crate::env::MISE_ENV.join(","),
+            );
+        }
+        if let Some(cwd) = &*crate::dirs::CWD {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_ORIGINAL_CWD",
+                cwd.display().to_string(),
+            );
+        }
+
+        // Prefer the task's own config root for project tasks. Global and
+        // remote tasks retain the invoking project's root.
+        let project_root = if task.global || task.is_remote() {
+            config.project_root.clone().or(task.config_root.clone())
+        } else {
+            task.config_root.clone().or(config.project_root.clone())
+        };
+        if let Some(root) = project_root {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_PROJECT_ROOT",
+                root.display().to_string(),
+            );
+        }
+        if let Some(monorepo_root) = config.monorepo_root() {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_MONOREPO_ROOT",
+                monorepo_root.display().to_string(),
+            );
+        }
+        Self::insert_env_excluded_from_nested_mise_diff(
+            &mut env,
+            &mut nested_mise_diff_exclude_keys,
+            "MISE_TASK_NAME",
+            task.name.clone(),
+        );
+        let task_file = task
+            .file_path(config)
+            .await?
+            .unwrap_or(task.config_source.clone());
+        Self::insert_env_excluded_from_nested_mise_diff(
+            &mut env,
+            &mut nested_mise_diff_exclude_keys,
+            "MISE_TASK_FILE",
+            task_file.display().to_string(),
+        );
+        if let Some(dir) = task_file.parent() {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_TASK_DIR",
+                dir.display().to_string(),
+            );
+        }
+        if let Some(config_root) = &task.config_root {
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "MISE_CONFIG_ROOT",
+                config_root.display().to_string(),
+            );
+        }
+        if Settings::get().env_cache {
+            let key = CachedEnv::ensure_encryption_key();
+            Self::insert_env_excluded_from_nested_mise_diff(
+                &mut env,
+                &mut nested_mise_diff_exclude_keys,
+                "__MISE_ENV_CACHE_KEY",
+                key,
+            );
+        }
+
+        let env_for_diff = self.env_for_nested_mise_diff(&env, &nested_mise_diff_exclude_keys);
+        if let Ok(serialized) =
+            EnvDiff::from_final_env(&crate::env::PRISTINE_ENV, &env_for_diff).serialize()
+        {
+            env.insert("__MISE_DIFF".into(), serialized);
+        }
+
+        Ok(PreparedTaskContext {
+            toolset,
+            env,
+            task_env,
+            extra_vars,
+        })
+    }
+
+    async fn parse_task_usage(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+        env: &mut BTreeMap<String, String>,
+        extra_vars: Option<IndexMap<String, String>>,
+    ) -> Result<Option<PathBuf>> {
+        let task_file = task.file_path(config).await?;
+        let usage_args = || {
+            if let Some(file) = &task_file {
+                once(file.to_string_lossy().to_string())
+                    .chain(task.args.iter().cloned())
+                    .collect()
+            } else {
+                once(String::new())
+                    .chain(task.args.iter().cloned())
+                    .collect()
+            }
+        };
+        self.parse_usage_spec_and_init_env(config, task, env, usage_args, extra_vars)
+            .await?;
+        Ok(task_file)
+    }
+
     async fn parse_usage_spec_and_init_env(
         &self,
         config: &Arc<Config>,
@@ -1936,19 +2100,31 @@ impl TaskExecutor {
         let (spec, _) = task
             .parse_usage_spec_with_vars(config, self.cd.clone(), env, extra_vars)
             .await?;
-        // raw_args tasks (and `-- --help`/`-- -h` ad-hoc invocations) must
-        // skip the usage parser so it can't intercept --help.
-        if !bypass_usage_parser
-            && (!spec.cmd.args.is_empty()
-                || !spec.cmd.flags.is_empty()
-                || !spec.cmd.subcommands.is_empty())
+        if bypass_usage_parser {
+            trace!("Usage parser bypassed");
+            return Ok(());
+        }
+        let args = get_args();
+        self.parse_usage_spec_and_init_env_from_spec(task, env, &args, &spec)
+    }
+
+    fn parse_usage_spec_and_init_env_from_spec(
+        &self,
+        task: &Task,
+        env: &mut BTreeMap<String, String>,
+        args: &[String],
+        spec: &usage::Spec,
+    ) -> Result<()> {
+        if !spec.cmd.args.is_empty()
+            || !spec.cmd.flags.is_empty()
+            || !spec.cmd.subcommands.is_empty()
         {
-            let args = task.args_for_usage_parser(&spec, &get_args());
+            let args = task.args_for_usage_parser(spec, args);
             trace!("Parsing usage spec for {:?}", args);
             // Pass env vars to Parser so it can resolve env= defaults in usage specs
             let env_map: std::collections::HashMap<String, String> =
                 env.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-            let po = usage::Parser::new(&spec)
+            let po = usage::Parser::new(spec)
                 .with_env(env_map)
                 .parse(&args)
                 .map_err(|err| eyre!(err))?;

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -560,6 +560,27 @@ impl TaskScriptParser {
         task: &Task,
         scripts: &[String],
     ) -> Result<usage::Spec> {
+        self.parse_run_scripts_for_spec_only_inner(config, task, scripts, false)
+            .await
+    }
+
+    pub async fn parse_run_scripts_for_preflight(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+        scripts: &[String],
+    ) -> Result<usage::Spec> {
+        self.parse_run_scripts_for_spec_only_inner(config, task, scripts, true)
+            .await
+    }
+
+    async fn parse_run_scripts_for_spec_only_inner(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+        scripts: &[String],
+        preflight: bool,
+    ) -> Result<usage::Spec> {
         let usage_has_template = contains_template_syntax(&task.usage);
         let scripts_have_template = scripts
             .iter()
@@ -571,7 +592,11 @@ impl TaskScriptParser {
         }
 
         let (mut tera, arg_order, input_args, input_flags) = self.setup_tera_for_spec_parsing(task);
-        let mut tera_ctx = task.tera_ctx_for_usage(config).await?;
+        let mut tera_ctx = if preflight {
+            task.tera_ctx_for_usage_preflight(config)
+        } else {
+            task.tera_ctx_for_usage(config).await?
+        };
         // First render the usage field to collect the spec
         let rendered_usage = if usage_has_template {
             Self::render_usage_with_context(&mut tera, &task.usage, &tera_ctx)?

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -574,6 +574,12 @@ impl TaskScriptParser {
             .await
     }
 
+    pub(crate) fn validate_template_syntax(&self, task: &Task, input: &str) -> Result<()> {
+        let (mut tera, _, _, _) = self.setup_tera_for_spec_parsing(task);
+        tera.validate_template_syntax("__mise_validate", input)
+            .map_err(Self::task_script_tera_error)
+    }
+
     async fn parse_run_scripts_for_spec_only_inner(
         &self,
         config: &Arc<Config>,

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -69,6 +69,15 @@ impl TeraEngine {
             }
         }
     }
+
+    pub(crate) fn validate_template_syntax(&mut self, name: &str, input: &str) -> TeraResult<()> {
+        match self {
+            Self::V2(tera) => tera.add_raw_template(name, input),
+            Self::V1(tera) => tera
+                .add_raw_template(name, input)
+                .map_err(|err| tera_err(err.to_string())),
+        }
+    }
 }
 
 pub fn render_str(tera: &mut TeraEngine, input: &str, context: &Context) -> TeraResult<String> {
@@ -77,19 +86,6 @@ pub fn render_str(tera: &mut TeraEngine, input: &str, context: &Context) -> Tera
 
 pub fn render_str_v2(tera: &mut Tera, input: &str, context: &Context) -> TeraResult<String> {
     tera.render_str(input, context, false)
-}
-
-/// Parse a template without rendering it so deterministic syntax errors can be
-/// reported before any context-dependent values or functions are evaluated.
-pub fn validate_template_syntax(input: &str) -> TeraResult<()> {
-    if use_tera_v1() {
-        let mut tera = tera1::Tera::default();
-        tera.add_raw_template("__mise_validate", input)
-            .map_err(|err| tera_err(err.to_string()))
-    } else {
-        let mut tera = Tera::default();
-        tera.add_raw_template("__mise_validate", input)
-    }
 }
 
 fn tera_err(message: impl ToString) -> tera::Error {

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -79,6 +79,19 @@ pub fn render_str_v2(tera: &mut Tera, input: &str, context: &Context) -> TeraRes
     tera.render_str(input, context, false)
 }
 
+/// Parse a template without rendering it so deterministic syntax errors can be
+/// reported before any context-dependent values or functions are evaluated.
+pub fn validate_template_syntax(input: &str) -> TeraResult<()> {
+    if use_tera_v1() {
+        let mut tera = tera1::Tera::default();
+        tera.add_raw_template("__mise_validate", input)
+            .map_err(|err| tera_err(err.to_string()))
+    } else {
+        let mut tera = Tera::default();
+        tera.add_raw_template("__mise_validate", input)
+    }
+}
+
 fn tera_err(message: impl ToString) -> tera::Error {
     tera::Error::message(message)
 }


### PR DESCRIPTION
## Summary

- validate usage arguments for every scheduled task before the scheduler starts
- extract usage specs without running task env sources, modules, plugin hooks, or tool setup during preflight
- use an environment-free preflight context for tasks from other monorepo project roots
- apply literal task environment values when they can safely satisfy `env=` inputs, while deferring dependency-produced or dynamic environment inputs to the existing runtime parse
- probe unavailable required `env=` inputs so independent CLI argument errors still fail preflight
- reject deterministic Tera syntax errors without rendering context-dependent templates
- close the action-cache session when preflight validation returns early
- preserve `raw_args` and double-dash help passthrough behavior

Previously, usage parsing happened immediately before each task command. This allowed dependencies to run before a parent or transitive task reported a missing required argument. The new preflight covers roots, normal and post dependencies, and `wait_for`-linked scheduled occurrences, and treats statically invalid usage as an invocation error even with `--continue-on-error`.

Preflight is intentionally side-effect free. It does not resolve the complete task environment, because dependencies may create env files and source/plugin hooks must not execute twice. Required environment-backed inputs that cannot be known safely before dependencies run are validated by the existing runtime parse instead.

## Testing

- `mise exec -- cargo test --all-features task_executor`
- `mise run test:e2e e2e/tasks/test_task_usage_preflight e2e/tasks/test_task_dep_args e2e/tasks/test_task_usage_double_dash e2e/tasks/test_task_raw_args e2e/tasks/test_task_usage_env_isolation e2e/tasks/test_task_monorepo_usage_env`
- `TMPDIR=/tmp mise run test:e2e e2e/tasks/test_task_action_cache_session`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/tasks/test_task_usage_preflight`
- `mise exec -- shfmt -d e2e/tasks/test_task_usage_preflight`

The preflight E2E also covers an env file created by a dependency, verifies that an `_.source` hook executes only once, rejects malformed dynamic usage before its dependency runs, and ensures an unavailable env-backed input cannot suppress an independent extra-argument error. The monorepo E2E verifies that invalid child tasks do not execute child `_.source` hooks during preflight while valid child `env=` values still resolve at runtime. The tests pass with both Tera v2 and the Tera v1 compatibility mode. The action-cache session E2E was run outside the sandbox because it binds a Unix socket.

`mise run format` and `mise run lint` reach `hk` but cannot complete because `hk` does not recognize this Sapling working copy as a Git repository; the relevant checks above were run individually.

Addresses https://github.com/jdx/mise/discussions/8139

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*
