### PR TITLE
feat(upgrade): add `upgrade.auto_prune`, and --prune to override it

### DIFF
--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -91,6 +91,15 @@ By default the old version is removed once the new one installs, unless another
 tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
 something outside of mise points at the old install directory.
 
+Set `upgrade.auto_prune = false` to make this the default.
+
+### `--prune`
+
+Uninstall the versions that were upgraded away from
+
+This is already the default. Use it to override `upgrade.auto_prune = false`
+for a single run.
+
 ### `--raw`
 
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -44,4 +44,42 @@ assert_contains "mise ls --installed dummy" "2.0.0"
 assert_contains "mise ls --installed dummy" "1.0.0"
 assert_contains "cat mise.toml" 'dummy = "2"'
 
+# `upgrade.auto_prune = false` makes that the default without a flag. Written through
+# mise.toml rather than the env var, since being settable there is the point of the setting.
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "1"
+
+[settings]
+upgrade.auto_prune = false
+EOF
+
+mise uninstall dummy --all
+mise install dummy@1.0.0
+mise upgrade dummy
+assert_contains "mise ls --installed dummy" "1.1.0"
+assert_contains "mise ls --installed dummy" "1.0.0"
+
+# the dry-run listing follows the setting, not only the flags
+mise uninstall dummy --all
+mise install dummy@1.0.0
+assert_not_contains "mise up dummy -n" "Would uninstall"
+assert_contains "mise up dummy -n" "Would install dummy@1.1.0"
+
+# --prune overrides the setting for a single run
+mise upgrade dummy --prune
+assert_contains "mise ls --installed dummy" "1.1.0"
+assert_not_contains "mise ls --installed dummy" "1.0.0"
+
+# and with the setting gone the default is back
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "1"
+EOF
+
+mise uninstall dummy --all
+mise install dummy@1.0.0
+mise upgrade dummy
+assert_not_contains "mise ls --installed dummy" "1.0.0"
+
 rm -f mise.toml

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4742,6 +4742,14 @@ Do not uninstall the versions that were upgraded away from
 By default the old version is removed once the new one installs, unless another
 tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
 something outside of mise points at the old install directory.
+
+Set `upgrade.auto_prune = false` to make this the default.
+.TP
+\fB\-\-prune\fR
+Uninstall the versions that were upgraded away from
+
+This is already the default. Use it to override `upgrade.auto_prune = false`
+for a single run.
 .TP
 \fB\-\-raw\fR
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies \-\-jobs=1

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4621,6 +4621,16 @@ Do not uninstall the versions that were upgraded away from
 By default the old version is removed once the new one installs, unless another
 tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
 something outside of mise points at the old install directory.
+
+Set `upgrade.auto_prune = false` to make this the default.
+"""#
+    }
+    flag --prune help="Uninstall the versions that were upgraded away from" {
+        long_help #"""
+Uninstall the versions that were upgraded away from
+
+This is already the default. Use it to override `upgrade.auto_prune = false`
+for a single run.
 """#
     }
     flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2049,6 +2049,17 @@
           "description": "Default shell arguments for Unix to be used for inline commands. For example, `sh -c` for sh.",
           "type": "string"
         },
+        "upgrade": {
+          "type": "object",
+          "unevaluatedProperties": false,
+          "properties": {
+            "auto_prune": {
+              "default": true,
+              "description": "Uninstall the version `mise upgrade` replaced once the new one has installed.",
+              "type": "boolean"
+            }
+          }
+        },
         "url_replacements": {
           "description": "Map of URL patterns to replacement URLs applied to all requests.",
           "type": "object",

--- a/settings.toml
+++ b/settings.toml
@@ -3151,6 +3151,20 @@ env = "MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS"
 global_only = true
 type = "String"
 
+[upgrade.auto_prune]
+default = true
+description = "Uninstall the version `mise upgrade` replaced once the new one has installed."
+docs = """
+`mise upgrade` removes the version it upgraded away from, deleting its install directory. Set this
+to `false` when something outside of mise resolves through that path — a virtualenv built from a
+mise-managed interpreter, for example — and the old version is left in place instead.
+
+Versions that another tracked config or tool stub still needs are kept regardless of this setting.
+`mise upgrade --prune` overrides it for a single run, and `--no-prune` does the opposite.
+"""
+env = "MISE_UPGRADE_AUTO_PRUNE"
+type = "Bool"
+
 [url_replacements]
 description = "Map of URL patterns to replacement URLs applied to all requests."
 docs = '''

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::backend::pipx::PIPXBackend;
 use crate::cli::args::{BackendArg, ToolArg};
-use crate::config::{Config, config_file};
+use crate::config::{Config, Settings, config_file};
 use crate::errors::split_install_result;
 use crate::file::display_path;
 use crate::install_before::{
@@ -107,8 +107,17 @@ pub struct Upgrade {
     /// By default the old version is removed once the new one installs, unless another
     /// tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
     /// something outside of mise points at the old install directory.
-    #[clap(long, verbatim_doc_comment)]
+    ///
+    /// Set `upgrade.auto_prune = false` to make this the default.
+    #[clap(long, verbatim_doc_comment, overrides_with = "prune")]
     no_prune: bool,
+
+    /// Uninstall the versions that were upgraded away from
+    ///
+    /// This is already the default. Use it to override `upgrade.auto_prune = false`
+    /// for a single run.
+    #[clap(long, verbatim_doc_comment, overrides_with = "no_prune")]
+    prune: bool,
 
     /// Connect backend install command stdin/stdout/stderr directly to the terminal
     /// Implies --jobs=1
@@ -119,6 +128,12 @@ pub struct Upgrade {
 impl Upgrade {
     fn is_dry_run(&self) -> bool {
         self.dry_run || self.dry_run_code
+    }
+
+    /// Whether the version being upgraded away from should be uninstalled. Either flag wins
+    /// over the setting, and `overrides_with` makes the later of the two win over the other.
+    fn should_prune(&self) -> bool {
+        self.prune || !self.no_prune && Settings::get().upgrade.auto_prune
     }
 
     fn scope(&self) -> ConfigScope {
@@ -252,7 +267,7 @@ impl Upgrade {
 
         // Determine which old versions should be uninstalled after upgrade
         // Skip uninstall when current == latest (channel-based versions that update in-place)
-        let to_remove: Vec<_> = if self.no_prune {
+        let to_remove: Vec<_> = if !self.should_prune() {
             vec![]
         } else {
             outdated


### PR DESCRIPTION
Closes the other half of #5840. That thread asked for two things — a setting to stop `mise upgrade` deleting the version it replaced, and a `--prune` flag to force the removal back on when the setting is off. #11639 (v2026.8.1) deliberately shipped only `--no-prune`; this is the rest.

```toml
[settings]
upgrade.auto_prune = false
```

`MISE_UPGRADE_AUTO_PRUNE=false` and `mise settings set upgrade.auto_prune false` work as usual.

## Why the setting matters separately from the flag

The reporter's case is a virtualenv built from a mise-managed Python: `mise upgrade` deletes the interpreter's install directory and the venv stops working. A flag fixes that only if you remember it every time, which is exactly what an unattended or scripted upgrade will not do.

## Naming

The thread proposed a top-level `auto_prune_old_versions`. I went with a group instead, because that is where `settings.toml` has moved:

- **163 grouped settings against 128 flat**
- command- and feature-scoped groups are established: `task.*` (31), `status.*` (5), `sandbox.*` (5), `oci.*` (3), `dotfiles.*` (2), `hook_env.*` (2)
- single-member groups are normal: `conda.*`, `erlang.*`, `java.*`, `spm.*`, `tools.*`, `zig.use_community_mirrors`
- keys do not repeat the group name — `hook_env.chpwd_only`, `task.auto_infer`

`upgrade.auto_prune` also carries information the flat name loses: this affects `mise upgrade` and nothing else. `mise prune` is a separate command and `mise unuse` has its own `--no-prune`, so a top-level `auto_prune_old_versions` would read as if it governed those too. Happy to rename if you would rather match the thread verbatim.

## Implementation

`--pin`/`--fuzzy` on `mise use` is the existing shape for "two opposing flags over a setting", so this follows it — each flag `overrides_with` the other, so the later one on the command line wins:

```rust
fn should_prune(&self) -> bool {
    self.prune || !self.no_prune && Settings::get().upgrade.auto_prune
}
```

It replaces the `self.no_prune` check on `to_remove` rather than guarding the uninstall loop. That keeps `--dry-run` honest: with the setting off, `mise upgrade -n` no longer prints a `Would uninstall` line for something it will not do.

`default = true`, so behaviour is unchanged for anyone who does not set it — the existing e2e assertion that a plain `mise upgrade` still removes the old version guards that.

## Tests

`e2e/cli/test_upgrade_no_prune` gains the setting written **through `mise.toml`** rather than the env var, since being settable there is the point:

- the setting alone keeps the old version, with no flag
- the dry-run listing follows the setting, not only the flags
- `--prune` overrides it for a single run
- removing the setting restores the default

## Note on generated files

`mise.usage.kdl`, `man/man1/mise.1` and `docs/cli/upgrade.md` are regenerated for `--prune`. `schema/mise.json` also needs the new group, and it is worth flagging that **`xtasks/render/schema.ts` is not part of `mise run render` or of any CI step** — `hk`'s `schema` step only validates the checked-in files with `ajv`. So the schema will not be caught by the "render produces no diff" gate if someone forgets it. `docs/configuration/settings.md` needs nothing; it renders from a component rather than from `settings.toml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of replaced tool versions after upgrades, enabled by default.
  * Added `--prune` and `--no-prune` options to control cleanup for individual upgrades.
  * Added the `upgrade.auto_prune` setting, including environment-variable configuration.
  * Versions still required by tracked configurations or tool stubs are retained.

* **Documentation**
  * Updated upgrade command documentation and configuration schema with pruning behavior and options.

* **Tests**
  * Added coverage for configuration-based pruning, dry runs, and command-line overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->