### PR TITLE
fix(config): drop the --file alias where -f is --force

### DIFF
--- a/e2e/cli/test_config_target_aliases
+++ b/e2e/cli/test_config_target_aliases
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # `mise use` names its config-file option --path while `mise set` names it --file, so which one
-# works depends on the command. Each now accepts the other's name.
+# works depends on the command. `--path` reaches every one of them; `--file` is accepted as an
+# alias wherever `-f` is not already `--force` (which excludes `use` and `dotfiles add`).
 # See: https://github.com/jdx/mise/discussions/4881
 
 mkdir -p "$HOME/workdir/aliases"
 cd "$HOME/workdir/aliases" || exit 1
 
-# `mise use --file` is `mise use --path`
-mise use --file alias.toml dummy@1
+# `--path` is the spelling that works everywhere
+mise use --path alias.toml dummy@1
 assert "cat alias.toml" '[tools]
 dummy = "1"'
 
@@ -23,6 +24,11 @@ mise use --path alias.toml dummy@2
 assert_contains "cat alias.toml" 'dummy = "2"'
 mise set --file alias.toml ALIAS_VAR=set-via-file
 assert_contains "cat alias.toml" 'ALIAS_VAR = "set-via-file"'
+
+# `mise use` does not take --file: -f there is --force, so the alias would teach a flag that
+# does something else entirely. Match the parser's own message — a bare exit-status check
+# would also pass if --file were still accepted and the install failed for its own reasons.
+assert_fail "mise use --file alias.toml dummy@1" "unexpected argument '--file' found"
 
 # the commands that undo those two take the same pair of names
 # `mise unuse --file` is `mise unuse --path`
@@ -41,11 +47,11 @@ assert_not_contains "cat alias.toml" "dummy"
 mise unset --file alias.toml ALIAS_VAR
 assert_not_contains "cat alias.toml" "ALIAS_VAR"
 
-# all four accept a directory as well as a file, under either name: the argument resolves to
-# the config file inside that directory
+# all four accept a directory as well as a file, under whichever names they take: the argument
+# resolves to the config file inside that directory
 mkdir -p subdir
 
-mise use --file subdir dummy@1
+mise use --path subdir dummy@1
 assert_contains "cat subdir/mise.toml" 'dummy = "1"'
 mise set --path subdir SUBDIR_VAR=via-dir
 assert_contains "cat subdir/mise.toml" 'SUBDIR_VAR = "via-dir"'

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1069,7 +1069,7 @@ Print the config/source updates without writing anything
 \fB\-\-no\-apply\fR
 Add the entry without applying it
 .TP
-\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
+\fB\-p, \-\-path\fR \fI<PATH>\fR
 Write to this config file or directory
 .TP
 \fB\-s, \-\-source\fR \fI<PATH>\fR
@@ -4794,7 +4794,7 @@ Number of jobs to run in parallel
 \fB\-n, \-\-dry\-run\fR
 Perform a dry run, showing what would be installed and modified without making changes
 .TP
-\fB\-p, \-\-path, \-\-file\fR \fI<PATH>\fR
+\fB\-p, \-\-path\fR \fI<PATH>\fR
 Specify a path to a config file or directory
 
 If a directory is specified, it will look for a config file in that directory following the rules above.

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -428,7 +428,7 @@ Examples:
             }
             flag "-n --dry-run" help="Print the config/source updates without writing anything"
             flag --no-apply help="Add the entry without applying it"
-            flag "-p --path --file" help="Write to this config file or directory" {
+            flag "-p --path" help="Write to this config file or directory" {
                 arg <PATH>
             }
             flag "-s --source" help="Source path to use for a single target" {
@@ -1214,7 +1214,7 @@ Examples:
         }
         flag "-n --dry-run" help="Print the config/source updates without writing anything"
         flag --no-apply help="Add the entry without applying it"
-        flag "-p --path --file" help="Write to this config file or directory" {
+        flag "-p --path" help="Write to this config file or directory" {
             arg <PATH>
         }
         flag "-s --source" help="Source path to use for a single target" {
@@ -4693,7 +4693,7 @@ Number of jobs to run in parallel
         arg <JOBS>
     }
     flag "-n --dry-run" help="Perform a dry run, showing what would be installed and modified without making changes"
-    flag "-p --path --file" help="Specify a path to a config file or directory" {
+    flag "-p --path" help="Specify a path to a config file or directory" {
         long_help #"""
 Specify a path to a config file or directory
 

--- a/src/cli/dotfiles/add.rs
+++ b/src/cli/dotfiles/add.rs
@@ -50,7 +50,10 @@ pub struct DotfilesAdd {
     pub(super) no_apply: bool,
 
     /// Write to this config file or directory
-    #[clap(long, short, visible_alias = "file", value_name = "PATH", conflicts_with_all = ["global", "local"])]
+    // No `--file` alias here: `-f` on this command is `--force`, and `targets` accepts any
+    // string, so `-f <path>` silently adds the config file as a dotfile instead of writing
+    // to it. See `mise unset --path` for the commands where the short form is free.
+    #[clap(long, short, value_name = "PATH", conflicts_with_all = ["global", "local"])]
     pub(super) path: Option<PathBuf>,
 
     /// Source path to use for a single target

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1036,14 +1036,14 @@ mod tests {
     #[test]
     fn test_config_target_options_accept_both_names() {
         // (command path, argument id, expected alias, available on this platform)
+        // `use` and `dotfiles add` are deliberately absent: `-f` is `--force` on both, so
+        // they carry `--path` only. See the shadowing test below.
         let cases: &[(&[&str], &str, &str, bool)] = &[
-            (&["use"], "path", "file", true),
             (&["unuse"], "path", "file", true),
             (&["set"], "file", "path", true),
             (&["unset"], "file", "path", true),
             (&["config", "get"], "file", "path", true),
             (&["config", "set"], "file", "path", true),
-            (&["dotfiles", "add"], "path", "file", true),
             (&["bootstrap", "packages", "use"], "path", "file", true),
             (&["bootstrap", "packages", "import"], "path", "file", true),
             // the brew manager is not registered on Windows
@@ -1084,6 +1084,52 @@ mod tests {
                 path.join(" ")
             );
         }
+    }
+
+    /// A `--file`/`--path` alias whose natural short form belongs to a *different* argument
+    /// on the same command teaches the wrong flag. `mise dotfiles add` carried `--file` as an
+    /// alias of `--path` while `-f` was `--force`, and because its targets accept any string,
+    /// `mise dotfiles add -f <path>` silently adopted that config file as a dotfile instead of
+    /// writing to it — no error, and `--force` meant no prompt either.
+    ///
+    /// Walks the whole CLI rather than a fixed list, so re-adding the alias anywhere fails
+    /// even if the case table above is left alone.
+    #[test]
+    fn config_target_aliases_do_not_shadow_another_short_flag() {
+        fn check(command: &clap::Command, path: &mut Vec<String>) {
+            for arg in command.get_arguments() {
+                let Some(aliases) = arg.get_visible_aliases() else {
+                    continue;
+                };
+                for alias in aliases {
+                    // Only this vocabulary — an unrelated alias sharing a letter with some
+                    // other flag is ordinary and not what this is about.
+                    if alias != "file" && alias != "path" {
+                        continue;
+                    }
+                    let short = alias.chars().next().unwrap();
+                    if let Some(owner) = command.get_arguments().find(|other| {
+                        other.get_id() != arg.get_id() && other.get_short() == Some(short)
+                    }) {
+                        panic!(
+                            "mise {}: --{alias} aliases --{}, but -{short} is --{} — \
+                             drop the alias or the collision",
+                            path.join(" "),
+                            arg.get_id().as_str(),
+                            owner.get_id().as_str()
+                        );
+                    }
+                }
+            }
+            for subcommand in command.get_subcommands() {
+                path.push(subcommand.get_name().to_string());
+                check(subcommand, path);
+                path.pop();
+            }
+        }
+
+        let root = expand_deferred_subcommands(Cli::command());
+        check(&root, &mut Vec::new());
     }
 
     #[test]

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -79,7 +79,10 @@ pub struct Use {
     ///
     /// If a directory is specified, it will look for a config file in that directory following
     /// the rules above.
-    #[clap(short, long, visible_alias = "file", overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
+    // No `--file` alias here: `-f` on this command is `--force`, so offering `--file`
+    // invites `-f <path>`, which is a different action. See `mise unset --path` for the
+    // commands where the short form is free.
+    #[clap(short, long, overrides_with_all = & ["global", "env"], value_hint = clap::ValueHint::FilePath)]
     path: Option<PathBuf>,
 
     /// Like --dry-run but exits with code 1 if there are changes to make


### PR DESCRIPTION
Follow-up to the #4881 series. Two of the eleven commands that gained a `--file`/`--path` alias already used `-f` for `--force`, which turns the alias into a lesson in the wrong flag.

## `mise dotfiles add` — silently does something else

Measured on 2026.8.3. Intent: write the dotfiles entry into `~/dots/config.toml`.

```console
$ mise dotfiles add -n --file ~/dots/config.toml "~/.bashrc"
~/dots/config.toml: "~/.bashrc" = {}
ln -sf ~/.dotfiles/.bashrc ~/.bashrc

$ mise dotfiles add -n -f ~/dots/config.toml
~/.config/mise/config.toml: "~/dots/config.toml" = {}
cp ~/dots/config.toml ~/.dotfiles/dots/config.toml
ln -sf ~/.dotfiles/dots/config.toml ~/dots/config.toml
```

`targets` accepts any string, so the path is swallowed as a target. The write goes to the **global** config instead of the file that was named, the file meant to be written *into* is adopted into the dotfiles tree, and since `-f` is "overwrite existing sources without prompting" there is no prompt either. No error at any point.

## `mise use` — fails, but not usefully

```console
$ mise use -n -f other.toml jq@1.7
mise ERROR Failed to install other.toml@latest: other.toml not found in mise tool registry
Did you mean?  okteto
```

Here the swallowed value has to resolve as a tool, so it cannot silently misbehave. But the error names neither the flag nor the actual mistake — it is the confusion @jdx described when declining `-f` for `mise set` in #11648:

> not sure about this, it could make users think `--force`

Read consistently, that rules out offering `--file` on a command where `-f` already **is** `--force`.

## Scope: exactly these two

Enumerating the short flags of all eleven commands in the series, the rule *"a long alias may only be offered when its natural short form is not already taken by a different argument on the same command"* selects `use` and `dotfiles add` and nothing else. The other nine keep both spellings, so no exception list is needed.

**`--path` still reaches all eleven** — canonical on `use`, `unuse`, `dotfiles add` and the `bootstrap packages` commands, aliased on `set`, `unset`, `config get` and `config set`. #4881 asked for one spelling that works on both `use` and `set`; that is `--path`.

This does withdraw `mise use --file`, which #11577 added and which the discussion names. I have not tried to hide that — I will correct the comment on #4881 once this lands.

## Guard

A new test walks the whole command tree, not a fixed list, so the alias cannot be reintroduced anywhere without the build failing:

```
mise dotfiles add: --file aliases --path, but -f is --force — drop the alias or the collision
```

It is restricted to the `file`/`path` vocabulary so an unrelated alias sharing a letter with some other flag does not trip it.

## Also

`e2e/cli/test_config_target_aliases` now asserts `mise use --file` is rejected, alongside the existing coverage. Generated `mise.usage.kdl` and `man/man1/mise.1` are updated for the three affected renderings (`dotfiles add` appears in both the `bootstrap` and legacy trees). `docs/cli/**` is unchanged — usage-lib does not render aliases into the Markdown headings and no help text changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CLI Updates**
  - Removed the `--file` alias from dotfile creation commands and `use`.
  - Use `--path` or `-p` to specify a file or directory path.
  - Prevents conflicts with command-specific `-f` options.

- **Documentation**
  - Updated command-line help and manual pages to show supported option names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->