### PR TITLE
fix(core): treat zero jobs as one

### DIFF
--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -34,6 +34,7 @@ Command string to execute
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 
 ### `--allow-env… <VAR>`

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -25,7 +25,7 @@ Set the environment for loading `mise.<ENV>.toml`
 
 ### `-j --jobs <JOBS>`
 
-How many jobs to run in parallel [default: 8]
+How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
 
 ### `-q --quiet`
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -31,6 +31,7 @@ Force reinstall even if already installed
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 
 ### `-n --dry-run`

--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -30,6 +30,7 @@ By default, only the active project config root is locked
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 
 ### `-n --dry-run`
 

--- a/docs/cli/plugins/install.md
+++ b/docs/cli/plugins/install.md
@@ -40,6 +40,7 @@ Reinstall even if plugin exists
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 
 ### `-v --verbose…`
 

--- a/docs/cli/plugins/update.md
+++ b/docs/cli/plugins/update.md
@@ -21,6 +21,7 @@ Plugin(s) to update
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 Default: 4
 
 Examples:

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -74,6 +74,7 @@ Force the tasks to run even if outputs are up to date
 ### `-j --jobs <JOBS>`
 
 Number of tasks to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 Configure with `jobs` config or `MISE_JOBS` env var
 

--- a/docs/cli/shell.md
+++ b/docs/cli/shell.md
@@ -24,6 +24,7 @@ Tool(s) to use
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 
 ### `-u --unset`

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -88,6 +88,7 @@ Force the tasks to run even if outputs are up to date
 ### `-j --jobs <JOBS>`
 
 Number of tasks to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 Configure with `jobs` config or `MISE_JOBS` env var
 

--- a/docs/cli/test-tool.md
+++ b/docs/cli/test-tool.md
@@ -21,6 +21,7 @@ Test every tool specified in registry/
 ### `-j --jobs <JOBS>`
 
 Number of tool tests to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 
 ### `--all-config`

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -31,6 +31,7 @@ Display multiselect menu to choose which tools to upgrade
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 
 ### `-l --bump`

--- a/docs/cli/use.md
+++ b/docs/cli/use.md
@@ -58,6 +58,7 @@ Use the global config file (`~/.config/mise/config.toml`) instead of the local o
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 
 ### `-n --dry-run`

--- a/e2e/cli/test_jobs_zero
+++ b/e2e/cli/test_jobs_zero
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.first]
+run = '''
+if ! mkdir "$SERIAL_LOCK" 2>/dev/null; then
+  echo "tasks overlapped" >&2
+  exit 1
+fi
+sleep 0.1
+rmdir "$SERIAL_LOCK"
+touch "$FIRST_MARKER"
+'''
+
+[tasks.second]
+run = '''
+if ! mkdir "$SERIAL_LOCK" 2>/dev/null; then
+  echo "tasks overlapped" >&2
+  exit 1
+fi
+sleep 0.1
+rmdir "$SERIAL_LOCK"
+touch "$SECOND_MARKER"
+'''
+
+[tasks.interrupt]
+run = '''
+touch "$READY_FILE"
+sleep 5
+'''
+EOF
+
+serial_lock="$PWD/serial-lock"
+first_marker="$PWD/first-complete"
+second_marker="$PWD/second-complete"
+
+assert_tasks_completed() {
+  [[ -f $first_marker ]] || fail "first task did not complete"
+  [[ -f $second_marker ]] || fail "second task did not complete"
+  rm -f "$first_marker" "$second_marker"
+}
+
+FIRST_MARKER="$first_marker" SECOND_MARKER="$second_marker" SERIAL_LOCK="$serial_lock" \
+  mise run --jobs 0 first ::: second
+assert_tasks_completed
+FIRST_MARKER="$first_marker" SECOND_MARKER="$second_marker" SERIAL_LOCK="$serial_lock" \
+  MISE_JOBS=0 mise run first ::: second
+assert_tasks_completed
+
+cat <<'EOF' >>mise.toml
+
+[settings]
+jobs = 0
+EOF
+
+assert "mise settings get jobs" "1"
+FIRST_MARKER="$first_marker" SECOND_MARKER="$second_marker" SERIAL_LOCK="$serial_lock" \
+  mise run first ::: second
+assert_tasks_completed
+
+interrupt_dir="$PWD/jobs-zero-interrupt"
+mkdir -p "$interrupt_dir"
+ready_file="$interrupt_dir/ready"
+output_file="$interrupt_dir/output"
+READY_FILE="$ready_file" mise run --jobs 0 interrupt >"$output_file" 2>&1 &
+mise_pid=$!
+wait_for_file "$ready_file" "task started with --jobs 0" 30 "$mise_pid"
+kill -INT "$mise_pid"
+
+status=0
+wait "$mise_pid" || status=$?
+if [[ $status -ne 130 ]]; then
+  fail "mise run expected exit code 130 after Ctrl-C, got $status: $(cat "$output_file")"
+fi
+
+rm -rf "$MISE_DATA_DIR/installs/dummy/1.0.0"
+mise install dummy@1.0.0 --jobs 0
+assert_contains "mise ls --installed dummy" "1.0.0"

--- a/e2e/cli/test_lock_jobs_zero
+++ b/e2e/cli/test_lock_jobs_zero
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+
+cat <<'EOF' >mise.toml
+[tools]
+dummy = "1.0.0"
+EOF
+
+mise lock dummy --jobs 0
+assert_contains "cat mise.lock" "1.0.0"

--- a/e2e/plugins/test_plugin_batch_failures
+++ b/e2e/plugins/test_plugin_batch_failures
@@ -26,7 +26,7 @@ git config --global \
   url."file://$PWD/sources/missing-zeta".insteadOf \
   "https://gitlab.com/td7x/asdf/adr-tools"
 
-if output="$(mise plugins install adr-tools action-validator act --jobs 1 2>&1)"; then
+if output="$(mise plugins install adr-tools action-validator act --jobs 0 2>&1)"; then
   fail "expected batch plugin install to fail"
 fi
 assert_contains_text "$output" \
@@ -47,7 +47,7 @@ git -C "$PWD/sources/update-good" add updated
 git -C "$PWD/sources/update-good" commit -qm "update plugin"
 expected_sha="$(git -C "$PWD/sources/update-good" rev-parse HEAD)"
 
-if output="$(mise plugins update update-bad update-good --jobs 1 2>&1)"; then
+if output="$(mise plugins update update-bad update-good --jobs 0 2>&1)"; then
   fail "expected batch plugin update to fail"
 fi
 assert_contains_text "$output" "[update-bad] plugin update"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -21,7 +21,7 @@ Set the environment for loading `mise.<ENV>.toml`
 Force the operation
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
-How many jobs to run in parallel [default: 8]
+How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
 .TP
 \fB\-n, \-\-dry\-run\fR
 Dry run, don't actually do anything
@@ -2038,6 +2038,7 @@ Command string to execute
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 .TP
 \fB\-\-allow\-env\fR \fI<VAR>\fR
@@ -2417,6 +2418,7 @@ Force reinstall even if already installed
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 .TP
 \fB\-n, \-\-dry\-run\fR
@@ -2543,6 +2545,7 @@ By default, only the active project config root is locked
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 .TP
 \fB\-n, \-\-dry\-run\fR
 Show what would be updated without making changes
@@ -2997,6 +3000,7 @@ Reinstall even if plugin exists
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 .TP
 \fB\-v, \-\-verbose\fR
 Show installation output
@@ -3115,6 +3119,7 @@ note: this updates the plugin itself, not the runtime versions
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 Default: 4
 \fBArguments:\fR
 .PP
@@ -3394,6 +3399,7 @@ Force the tasks to run even if outputs are up to date
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of tasks to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 Configure with `jobs` config or `MISE_JOBS` env var
 .TP
@@ -3808,6 +3814,7 @@ such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by 
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 .TP
 \fB\-u, \-\-unset\fR
@@ -4215,6 +4222,7 @@ Force the tasks to run even if outputs are up to date
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of tasks to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 Configure with `jobs` config or `MISE_JOBS` env var
 .TP
@@ -4381,6 +4389,7 @@ Test every tool specified in registry/
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of tool tests to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 .TP
 \fB\-\-all\-config\fR
@@ -4692,6 +4701,7 @@ Display multiselect menu to choose which tools to upgrade
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 .TP
 \fB\-l, \-\-bump\fR
@@ -4789,6 +4799,7 @@ Use the global config file (`~/.config/mise/config.toml`) instead of the local o
 .TP
 \fB\-j, \-\-jobs\fR \fI<JOBS>\fR
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 .TP
 \fB\-n, \-\-dry\-run\fR

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -13,7 +13,7 @@ flag "-E --env" help="Set the environment for loading `mise.<ENV>.toml`" var=#tr
     arg <ENV>
 }
 flag "-f --force" help="Force the operation" hide=#true
-flag "-j --jobs" help="How many jobs to run in parallel [default: 8]" global=#true {
+flag "-j --jobs" help="How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]" global=#true {
     arg <JOBS>
 }
 flag "-n --dry-run" help="Dry run, don't actually do anything" hide=#true
@@ -1421,6 +1421,7 @@ Examples:
     }
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 """# {
         arg <JOBS>
@@ -1934,6 +1935,7 @@ Examples:
     flag "-f --force" help="Force reinstall even if already installed"
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 """# {
         arg <JOBS>
@@ -2142,7 +2144,10 @@ Examples:
 Target only global config lockfiles (~/.config/mise/mise.lock and system config)
 By default, only the active project config root is locked
 """#
-    flag "-j --jobs" help="Number of jobs to run in parallel" {
+    flag "-j --jobs" help=#"""
+Number of jobs to run in parallel
+Values below 1 are treated as 1
+"""# {
         arg <JOBS>
     }
     flag "-n --dry-run" help="Show what would be updated without making changes"
@@ -2794,7 +2799,10 @@ This will only install plugins that have matching shorthands.
 i.e.: they don't need the full git repo url
 """#
         flag "-f --force" help="Reinstall even if plugin exists"
-        flag "-j --jobs" help="Number of jobs to run in parallel" {
+        flag "-j --jobs" help=#"""
+Number of jobs to run in parallel
+Values below 1 are treated as 1
+"""# {
             arg <JOBS>
         }
         flag "-v --verbose" help="Show installation output" var=#true count=#true
@@ -2919,6 +2927,7 @@ Examples:
 """#
         flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 Default: 4
 """# {
             arg <JOBS>
@@ -3213,6 +3222,7 @@ Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
     flag "-f --force" help="Force the tasks to run even if outputs are up to date"
     flag "-j --jobs" help=#"""
 Number of tasks to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 Configure with `jobs` config or `MISE_JOBS` env var
 """# {
@@ -3640,6 +3650,7 @@ Examples:
 """#
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 """# {
         arg <JOBS>
@@ -4066,6 +4077,7 @@ Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
         flag "-f --force" help="Force the tasks to run even if outputs are up to date"
         flag "-j --jobs" help=#"""
 Number of tasks to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 Configure with `jobs` config or `MISE_JOBS` env var
 """# {
@@ -4234,6 +4246,7 @@ Examples:
     flag "-a --all" help="Test every tool specified in registry/"
     flag "-j --jobs" help=#"""
 Number of tool tests to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 """# {
         arg <JOBS>
@@ -4563,6 +4576,7 @@ Examples:
     flag "-i --interactive" help="Display multiselect menu to choose which tools to upgrade"
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 """# {
         arg <JOBS>
@@ -4688,6 +4702,7 @@ Examples:
     flag "-g --global" help="Use the global config file (`~/.config/mise/config.toml`) instead of the local one"
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 """# {
         arg <JOBS>

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1161,7 +1161,7 @@
         },
         "jobs": {
           "default": 8,
-          "description": "How many jobs to run concurrently such as tool installs.",
+          "description": "How many jobs to run concurrently such as tool installs. Values below 1 are treated as 1.",
           "type": "integer"
         },
         "legacy_version_file": {

--- a/settings.toml
+++ b/settings.toml
@@ -1330,7 +1330,7 @@ type = "String"
 
 [jobs]
 default = 8
-description = "How many jobs to run concurrently such as tool installs."
+description = "How many jobs to run concurrently such as tool installs. Values below 1 are treated as 1."
 env = "MISE_JOBS"
 rust_type = "usize"
 type = "Integer"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -46,6 +46,7 @@ pub struct Exec {
     pub c: Option<String>,
 
     /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
     /// [default: 4]
     #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     pub jobs: Option<usize>,

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -40,6 +40,7 @@ pub struct Install {
     force: bool,
 
     /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
     /// [default: 4]
     #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     jobs: Option<usize>,

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -45,6 +45,7 @@ pub struct Lock {
     pub global: bool,
 
     /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
     #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     pub jobs: Option<usize>,
 
@@ -1074,7 +1075,7 @@ impl Lock {
         platforms: &[Platform],
         lockfile: &mut Lockfile,
     ) -> Result<(Vec<LockTaskResult>, Vec<String>)> {
-        let jobs = self.jobs.unwrap_or(settings.jobs);
+        let jobs = crate::jobs::resolve(settings.jobs, self.jobs);
         let semaphore = Arc::new(Semaphore::new(jobs));
         let mut jset: JoinSet<LockResolutionResult> = JoinSet::new();
         let mut results = Vec::new();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -121,7 +121,7 @@ pub struct Cli {
     /// Force the operation
     #[clap(long, short, hide = true)]
     pub force: bool,
-    /// How many jobs to run in parallel [default: 8]
+    /// How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
     #[clap(long, short, global = true, env = "MISE_JOBS")]
     pub jobs: Option<usize>,
     /// Dry run, don't actually do anything

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -54,6 +54,7 @@ pub struct PluginsInstall {
     force: bool,
 
     /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
     #[clap(long, short, verbatim_doc_comment)]
     jobs: Option<usize>,
 
@@ -105,7 +106,8 @@ impl PluginsInstall {
     ) -> Result<()> {
         let mut jset: JoinSet<PluginTaskResult> = JoinSet::new();
         let mut task_names = PluginTaskNames::new();
-        let semaphore = Arc::new(Semaphore::new(self.jobs.unwrap_or(Settings::get().jobs)));
+        let jobs = crate::jobs::resolve(Settings::get().jobs, self.jobs);
+        let semaphore = Arc::new(Semaphore::new(jobs));
         for plugin in plugins {
             let this = self.clone();
             let config = config.clone();

--- a/src/cli/plugins/update.rs
+++ b/src/cli/plugins/update.rs
@@ -22,6 +22,7 @@ pub struct Update {
     plugin: Option<Vec<String>>,
 
     /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
     /// Default: 4
     #[clap(long, short, verbatim_doc_comment)]
     jobs: Option<usize>,
@@ -46,7 +47,8 @@ impl Update {
         let settings = Settings::try_get()?;
         let mut jset: JoinSet<PluginTaskResult> = JoinSet::new();
         let mut task_names = PluginTaskNames::new();
-        let semaphore = Arc::new(Semaphore::new(self.jobs.unwrap_or(settings.jobs)));
+        let jobs = crate::jobs::resolve(settings.jobs, self.jobs);
+        let semaphore = Arc::new(Semaphore::new(jobs));
         for (short, ref_) in plugins {
             let semaphore = semaphore.clone();
             let plugin_name = short.clone();

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -166,7 +166,7 @@ impl Registry {
 
         let mut outputs: Vec<RegistryToolOutput> = Vec::with_capacity(tools.len());
         if self.security {
-            let semaphore = Arc::new(Semaphore::new(Settings::get().jobs));
+            let semaphore = Arc::new(Semaphore::new(crate::jobs::normalize(Settings::get().jobs)));
             let mut jset: JoinSet<RegistryToolOutput> = JoinSet::new();
             for tool in tools {
                 let permit = semaphore.clone().acquire_owned().await?;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -121,6 +121,7 @@ pub struct Run {
     pub force: bool,
 
     /// Number of tasks to run in parallel
+    /// Values below 1 are treated as 1
     /// [default: 4]
     /// Configure with `jobs` config or `MISE_JOBS` env var
     #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -22,6 +22,7 @@ pub struct Shell {
     tool: Vec<ToolArg>,
 
     /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
     /// [default: 4]
     #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     jobs: Option<usize>,

--- a/src/cli/test_tool.rs
+++ b/src/cli/test_tool.rs
@@ -23,6 +23,7 @@ pub struct TestTool {
     #[clap(long, short, conflicts_with = "tools", conflicts_with = "all_config")]
     pub all: bool,
     /// Number of tool tests to run in parallel
+    /// Values below 1 are treated as 1
     /// [default: 4]
     #[clap(long, short, env = "MISE_TEST_TOOL_JOBS", verbatim_doc_comment)]
     pub jobs: Option<usize>,
@@ -300,7 +301,7 @@ impl TestTool {
         if self.raw {
             1
         } else {
-            self.jobs.unwrap_or(4).max(1)
+            crate::jobs::resolve(4, self.jobs)
         }
     }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -48,6 +48,7 @@ pub struct Upgrade {
     interactive: bool,
 
     /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
     /// [default: 4]
     #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     jobs: Option<usize>,

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -67,6 +67,7 @@ pub struct Use {
     global: bool,
 
     /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
     /// [default: 4]
     #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
     jobs: Option<usize>,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -552,6 +552,8 @@ impl Settings {
         }
         if settings.raw {
             settings.jobs = 1;
+        } else {
+            settings.jobs = crate::jobs::normalize(settings.jobs);
         }
         // Handle NO_COLOR environment variable
         if *env::NO_COLOR {

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -830,7 +830,7 @@ impl DepsEngine {
         }
 
         let mut rx = deps.subscribe();
-        let semaphore = Arc::new(Semaphore::new(Settings::get().jobs));
+        let semaphore = Arc::new(Semaphore::new(crate::jobs::normalize(Settings::get().jobs)));
         let mut join_set: JoinSet<JobOutput> = JoinSet::new();
         // Track which tokio task ID maps to which provider ID for JoinError recovery
         let mut inflight: HashMap<tokio::task::Id, String> = HashMap::new();

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,0 +1,35 @@
+/// Normalize a requested concurrency limit to the minimum usable value.
+///
+/// A Tokio semaphore with zero permits can never start its first job, so all
+/// user-facing job counts treat zero as serial execution.
+pub fn normalize(jobs: usize) -> usize {
+    jobs.max(1)
+}
+
+/// Resolve a command-specific override before applying the minimum.
+pub fn resolve(configured: usize, override_: Option<usize>) -> usize {
+    normalize(override_.unwrap_or(configured))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_zero_to_one() {
+        assert_eq!(normalize(0), 1);
+    }
+
+    #[test]
+    fn preserves_positive_values() {
+        assert_eq!(normalize(1), 1);
+        assert_eq!(normalize(8), 8);
+    }
+
+    #[test]
+    fn override_takes_precedence_before_normalization() {
+        assert_eq!(resolve(8, Some(2)), 2);
+        assert_eq!(resolve(8, Some(0)), 1);
+        assert_eq!(resolve(0, None), 1);
+    }
+}

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -2391,7 +2391,7 @@ pub async fn auto_lock_new_versions(
     }
 
     let settings = Settings::get();
-    let jobs = settings.jobs;
+    let jobs = crate::jobs::normalize(settings.jobs);
     let deferred_retry_only = new_versions.is_empty();
     let mut all_provenance_errors: Vec<String> = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ mod hooks;
 mod http;
 mod install_before;
 mod install_context;
+mod jobs;
 mod lock_file;
 mod lockfile;
 pub(crate) mod logger;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -11,7 +11,7 @@ where
     F: Fn(T) -> Fut + Send + Copy + 'static,
     Fut: Future<Output = Result<U>> + Send + 'static,
 {
-    let semaphore = Arc::new(Semaphore::new(Settings::get().jobs));
+    let semaphore = Arc::new(Semaphore::new(crate::jobs::normalize(Settings::get().jobs)));
     let mut jset = JoinSet::new();
     let mut results = input.iter().map(|_| None).collect::<Vec<_>>();
     for item in input.into_iter().enumerate() {

--- a/src/system/packages/brew/source.rs
+++ b/src/system/packages/brew/source.rs
@@ -383,7 +383,7 @@ fn build_env(
         ldflags.push(format!("-Wl,-rpath,{}", prefix.join("lib").display()));
     }
 
-    let jobs = Settings::get().jobs.max(1);
+    let jobs = crate::jobs::normalize(Settings::get().jobs);
     let stable_version = rf.formula.versions.stable.clone().unwrap_or_default();
     let mut env = HashMap::from(
         [

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -442,7 +442,7 @@ impl OutputHandler {
         if self.raw {
             1
         } else {
-            self.jobs.unwrap_or(Settings::get().jobs)
+            crate::jobs::resolve(Settings::get().jobs, self.jobs)
         }
     }
 }

--- a/src/task/task_scheduler.rs
+++ b/src/task/task_scheduler.rs
@@ -39,7 +39,7 @@ impl Scheduler {
     pub fn new(jobs: usize) -> Self {
         let (sched_tx, sched_rx) = mpsc::unbounded_channel::<SchedMsg>();
         Self {
-            semaphore: Arc::new(Semaphore::new(jobs)),
+            semaphore: Arc::new(Semaphore::new(crate::jobs::normalize(jobs))),
             jset: Arc::new(Mutex::new(JoinSet::new())),
             sched_tx: Arc::new(sched_tx),
             sched_rx: Some(sched_rx),

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -405,7 +405,7 @@ impl Toolset {
         let raw = opts.raw || Settings::get().raw;
         let jobs = match raw {
             true => 1,
-            false => opts.jobs.unwrap_or(Settings::get().jobs),
+            false => crate::jobs::resolve(Settings::get().jobs, opts.jobs),
         };
         let semaphore = Arc::new(Semaphore::new(jobs));
         let ts = Arc::new(self.clone());


### PR DESCRIPTION
## Summary

- normalize zero job counts to one before creating task, install, lock, plugin, dependency, and shared-work semaphores
- apply the same rule to `--jobs 0`, `MISE_JOBS=0`, and `settings.jobs = 0`
- document the normalization in CLI help and the generated settings schema

## Problem

A Tokio semaphore created with zero permits can never grant the first permit. As a result, `mise --jobs 0 run <task>` waited forever before starting a task and could not reach the normal task interruption path.

Some isolated code paths already clamped zero to one, but the behavior was not shared by the task scheduler or the other job-limited operations.

## Solution

A shared job-count helper now treats zero as serial execution. Settings are normalized after loading, command-specific overrides are normalized after precedence is resolved, and semaphore construction boundaries retain a defensive normalization.

Positive job counts and the existing `raw` mode behavior are unchanged.

## Verification

- `mise exec -- cargo test --all-features jobs::tests`
- `mise run test:e2e e2e/cli/test_jobs_zero e2e/cli/test_lock_jobs_zero e2e/plugins/test_plugin_batch_failures`
- `mise run test:e2e e2e/tasks/test_task_sequence_jobs1 e2e/cli/test_run_subtask_jobs1`
- `mise run test:e2e e2e/cli/test_exit_status e2e/cli/test_tool_depends`
- `mise run test:e2e e2e/config/test_schema_integer_settings`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all --check`
- ShellCheck and shfmt on the changed E2E tests

`mise run format` and `mise run lint` reach `hk`, which cannot identify this Sapling working copy as a Git repository. The corresponding Rustfmt, Clippy, ShellCheck, shfmt, schema, and targeted test checks above passed individually.

Addresses https://github.com/jdx/mise/discussions/8350

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Job counts below one now consistently run with one concurrent job across commands, task execution, locking, and installation workflows.
  * Command-specific job overrides are applied consistently.
  * Improved handling of zero-job execution, interruption, lockfile generation, and plugin installation.

* **Documentation**
  * Updated CLI help and configuration descriptions to clarify that job values below one are treated as one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->