### PR TITLE
fix(settings): refuse config-file writes for env-only settings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -770,6 +770,10 @@ pub static SETTINGS_META: Lazy<IndexMap<&'static str, SettingsMeta>> = Lazy::new
                 .get("global_only")
                 .is_some_and(|v| v.as_bool().unwrap())
         ));
+        lines.push(format!(
+            "        env_only: {},",
+            props.get("env_only").is_some_and(|v| v.as_bool().unwrap())
+        ));
     }
     fn emit_settings_meta(lines: &mut Vec<String>, table: &toml::Table, prefix: &str) {
         for (key, value) in table {

--- a/e2e/cli/test_settings_env_only
+++ b/e2e/cli/test_settings_env_only
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Settings the config loader consumes before any config file is read cannot be set in one.
+# Writing them used to succeed and then be ignored, and `mise settings get` echoed the stored
+# value back as if it were live.
+#
+# See: https://github.com/jdx/mise/discussions/5791
+
+# the write is refused, and the message names the variable that does work
+assert_fail "mise settings set default_config_filename .mise.toml" "MISE_DEFAULT_CONFIG_FILENAME"
+assert_fail "mise settings add default_config_filename .mise.toml" "MISE_DEFAULT_CONFIG_FILENAME"
+assert_fail "mise settings set global_config_file /tmp/elsewhere.toml" "MISE_GLOBAL_CONFIG_FILE"
+
+# hand-writing it into a config is dropped at load rather than reported as active — this is the
+# half that matters, since `settings get` returning the value is what convinced the reporter it
+# had taken effect
+cat <<'EOF' >"$MISE_CONFIG_DIR/config.toml"
+[settings]
+default_config_filename = ".mise.toml"
+EOF
+assert_not_contains "mise settings get default_config_filename" ".mise.toml"
+assert "mise settings get default_config_filename" "mise.toml"
+
+# the env var is the supported route and is untouched. The config above is left in place on
+# purpose: its value is dropped at load, so this also covers the env var still working while a
+# config file names the same setting.
+mkdir -p envonly
+cd envonly || exit 1
+MISE_DEFAULT_CONFIG_FILENAME=.mise.toml mise use dummy@1
+assert_contains "cat .mise.toml" 'dummy = "1"'
+assert_fail "test -f mise.toml"
+cd .. || exit 1

--- a/schema/mise-settings.json
+++ b/schema/mise-settings.json
@@ -117,6 +117,10 @@
           "type": "string",
           "description": "Environment variable name that can set this setting"
         },
+        "env_only": {
+          "type": "boolean",
+          "description": "Setting is read before config files load, so it only works as an environment variable; a value in a config file is dropped with a warning"
+        },
         "hide": {
           "type": "boolean",
           "description": "Whether to hide this setting from documentation"

--- a/settings.toml
+++ b/settings.toml
@@ -461,12 +461,14 @@ type = "Bool"
 default = "mise.toml"
 description = "The default config filename read. `mise use` and other commands that create new config files will use this value. This must be an env var."
 env = "MISE_DEFAULT_CONFIG_FILENAME"
+env_only = true
 type = "String"
 
 [default_tool_versions_filename]
 default = ".tool-versions"
 description = "The default .tool-versions filename read. This will not ignore .tool-versions—use override_tool_versions_filename for that. This must be an env var."
 env = "MISE_DEFAULT_TOOL_VERSIONS_FILENAME"
+env_only = true
 type = "String"
 
 [disable_backends]
@@ -1036,12 +1038,14 @@ type = "Bool"
 [global_config_file]
 description = "Path to the global mise config file. Default is `~/.config/mise/config.toml`. This must be an env var."
 env = "MISE_GLOBAL_CONFIG_FILE"
+env_only = true
 optional = true
 type = "Path"
 
 [global_config_root]
 description = "Path which is used as `{{config_root}}` for the global config file. Default is `$HOME`. This must be an env var."
 env = "MISE_GLOBAL_CONFIG_ROOT"
+env_only = true
 optional = true
 type = "Path"
 
@@ -2571,6 +2575,7 @@ type = "String"
 [system_config_file]
 description = "Path to the system mise config file. Default is `/etc/mise/config.toml`. This must be an env var."
 env = "MISE_SYSTEM_CONFIG_FILE"
+env_only = true
 optional = true
 type = "Path"
 

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -47,6 +47,17 @@ pub fn set(mut key: &str, value: &str, add: bool, local: bool) -> Result<()> {
         }
     };
 
+    // Writing it would succeed and then be ignored, and `mise settings get` would report the
+    // stored value as if it were live. See https://github.com/jdx/mise/discussions/5791.
+    // `mise settings unset` is deliberately still allowed, so anyone who already has one of
+    // these in a config can remove it.
+    if meta.env_only {
+        bail!(
+            "{key} cannot be set in a config file: mise reads it before config files load. Use the {} environment variable instead.",
+            meta.env.unwrap_or("matching MISE_*")
+        );
+    }
+
     let value = match meta.type_ {
         SettingsType::Bool => parse_bool(value)?,
         SettingsType::Integer => parse_i64(value)?,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -54,6 +54,8 @@ pub struct SettingsMeta {
     pub deprecated_warn_at: Option<&'static str>,
     pub deprecated_remove_at: Option<&'static str>,
     pub global_only: bool,
+    /// Consumed before config files are read, so a value in one can never apply.
+    pub env_only: bool,
 }
 
 #[derive(
@@ -463,6 +465,23 @@ fn strip_local_only_settings(settings: &mut toml::Table, path: &Path, is_global:
     }
 }
 
+/// Drop settings the config loader consumes *before* any config file is read — the config
+/// filenames and paths. A value written here can never take effect, and leaving it in the
+/// partial makes `mise settings get` report it as if it were live, which is what
+/// <https://github.com/jdx/mise/discussions/5791> ran into. Unlike the global-only strip this
+/// applies to every config, global included: the ordering problem is the same either way.
+fn strip_env_only_settings(settings: &mut toml::Table, path: &Path) {
+    for (key, meta) in SETTINGS_META.iter().filter(|(_, meta)| meta.env_only) {
+        if remove_nested_toml_value(settings, key).is_some() {
+            warn!(
+                "{key} in {} is ignored: mise reads it before config files load. Set {} instead.",
+                file::display_path(path),
+                meta.env.unwrap_or("the matching MISE_* variable")
+            );
+        }
+    }
+}
+
 fn remove_nested_toml_value(table: &mut toml::Table, key: &str) -> Option<toml::Value> {
     let mut parts = key.split('.').collect_vec();
     let last = parts.pop()?;
@@ -801,6 +820,7 @@ impl Settings {
         let tera_v1_from_env = tera_v1_from_env_config(&raw);
         if let Some(settings) = raw.get_mut("settings").and_then(toml::Value::as_table_mut) {
             strip_local_only_settings(settings, path, crate::config::is_global_config(path));
+            strip_env_only_settings(settings, path);
         }
         let deprecated = deprecated_settings_in_toml_config(&raw);
         let settings_file: SettingsFile = raw.try_into()?;
@@ -1562,6 +1582,43 @@ mod tests {
     #[test]
     fn test_split_default_shell_or_fallback_reports_parse_errors() {
         assert!(split_default_shell_or_fallback("\"unterminated", "cmd /c").is_err());
+    }
+
+    /// The shape #5791 reported: the setting is accepted into the file, so without this it
+    /// survives into the partial and `mise settings get` echoes it back while the config
+    /// loader — which already ran — never saw it.
+    #[test]
+    fn test_parse_settings_file_strips_env_only_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".mise.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [settings]
+            default_config_filename = ".mise.toml"
+            default_tool_versions_filename = ".tool-versions-custom"
+            "#,
+        )
+        .unwrap();
+
+        let partial = Settings::parse_settings_file(&path).unwrap();
+
+        assert_eq!(partial.default_config_filename, None);
+        assert_eq!(partial.default_tool_versions_filename, None);
+    }
+
+    /// Unlike `global_only`, being in the *global* config does not rescue these — the loader
+    /// has read the file by the time the value would be applied either way.
+    #[test]
+    fn test_parse_settings_file_strips_env_only_settings_from_global_too() {
+        let mut settings = toml::Table::new();
+        settings.insert(
+            "global_config_file".to_string(),
+            toml::Value::String("/tmp/elsewhere.toml".to_string()),
+        );
+        strip_env_only_settings(&mut settings, Path::new("/tmp/global-config.toml"));
+
+        assert!(settings.get("global_config_file").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Draft — the behaviour is settled, the open questions at the bottom are not.

From #5791. Five settings are consumed while the config loader is deciding *which files to read*, so a value written into a config file can never apply. Their descriptions already say **"This must be an env var."** — but mise still accepts the write, and then reports it back as if it were live. Measured on v2026.8.0:

```console
$ mise settings set default_config_filename .mise.toml
$ echo $?
0

$ mise settings get default_config_filename
.mise.toml

$ mise use jq@1.7
mise .../mise.toml tools: jq@1.7      # ignored — the loader had already run
```

The second line is the part that matters. A description in the docs cannot compete with mise itself answering "yes, that setting is `.mise.toml`". The reporter had every reason to believe it had taken effect.

@jdx answered the design question in the thread in 2025-07:

> we should remove this as a setting in the docs, anything that affects the order config files load must be env vars

The docs half of that is done. This is the other half.

## Change

`env_only = true` on the five — `default_config_filename`, `default_tool_versions_filename`, `global_config_file`, `global_config_root`, `system_config_file` — handled in the two places that can observe it:

- **`mise settings set` / `settings add` refuse**, naming the variable that does work. Both route through `settings::set()`, so one guard covers them.
- **The config loader drops the key with a warning** rather than carrying it into the resolved settings, which is what removes the false answer from `mise settings get`.

This is `global_only`'s shape reused: a flag in `SettingsMeta`, emitted by `build.rs`, and a strip at `parse_settings_file`. One deliberate difference — `strip_local_only_settings` returns early for the global config, and `strip_env_only_settings` does not. Being in the global config does not help here; the loader has read the file either way.

**`mise settings unset` is untouched on purpose**, so anyone who already has one of these in a config can still remove it.

## Tests

- unit, in `settings.rs`: the reporter's exact shape is stripped from the parsed partial, and a second case pins that the global config is not exempt
- e2e `e2e/cli/test_settings_env_only`: the write is refused and the message names `MISE_DEFAULT_CONFIG_FILENAME`; a hand-written config no longer makes `settings get` echo the value; and `MISE_DEFAULT_CONFIG_FILENAME=.mise.toml mise use dummy@1` still creates `.mise.toml`, so the supported route is intact

## Note on the schema

`schema/mise-settings.json` gained `env_only`. Worth flagging that **`global_only` is missing from that schema** and has been for a while — nothing validates `settings.toml` against it (`hk`'s `schema` step only `ajv compile`s the schema files themselves), so it went unnoticed. I have not fixed that here since it is unrelated to this change.

## Open questions — why this is a draft

1. **Warning frequency.** `strip_local_only_settings` uses a plain `warn!`, so anyone who leaves one of these in a config sees it on every invocation. I mirrored that for consistency. `warn_once!` is the obvious alternative — which do you want?
2. **`mise config set settings.<key>` is a second door.** It writes raw TOML through `toml_edit` and never reaches `settings::set()`, so the refusal does not apply there. The load-time strip means no real harm, but it could refuse at write time too.
3. **Marking versus removing.** Your comment said "remove this as a setting". Deleting the entries would make `mise settings set default_config_filename` say *"Unknown setting"* — cleaner, but it loses the pointer to the environment variable, which is the thing the reporter needed. I chose to keep them and explain; say the word if you would rather they were gone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for environment-variable-only settings.
  * Settings metadata now indicates whether a setting must be configured through an environment variable.

* **Bug Fixes**
  * Configuration-file values for environment-only settings are ignored with a warning.
  * CLI attempts to set these settings now provide the corresponding environment-variable name.
  * Environment-based configuration continues to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->