### PR TITLE
fix(hooks): parse arrays before run tables

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -70,9 +70,9 @@ impl HookScripts {
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(untagged)]
 pub enum HookDef {
-    One(HookDefItem),
     /// Array of hook definitions: `enter = ["echo hello", { task = "setup" }]`
     Array(Vec<HookDefItem>),
+    One(HookDefItem),
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -801,6 +801,34 @@ mod tests {
             }
             action => panic!("expected run hook, got {action:?}"),
         }
+    }
+
+    #[test]
+    fn three_string_array_is_parsed_as_three_hooks() {
+        let parsed: TestHook = toml::from_str(
+            r#"
+            hook = ["echo ONE", "echo TWO", "echo THREE"]
+            "#,
+        )
+        .unwrap();
+        let hooks = parsed.hook.into_hooks(Hooks::Postinstall);
+
+        assert_eq!(hooks.len(), 3);
+        let runs = hooks
+            .into_iter()
+            .map(|hook| match hook.action {
+                HookAction::Run { run, .. } => run,
+                action => panic!("expected run hook, got {action:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            runs,
+            [
+                Some("echo ONE".into()),
+                Some("echo TWO".into()),
+                Some("echo THREE".into())
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Untagged HookDef variants are deserialized in declaration order. Commit c7f9de056 introduced the run-table form, and c313cde0a added run_windows. Together, they allowed three-string hook arrays to match HookRunTable positionally: entries became run, run_windows, and shell instead of three hooks.

Try `Array` before `One` so arrays are parsed as collections of hook definitions while preserving explicit run/run_windows/shell table support. Add regression coverage for three-string arrays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that three-string hook arrays are parsed and executed in the declared order.

* **Documentation**
  * Improved the presentation and ordering of array hook documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->