### PR TITLE
fix(vfox): return an error instead of panicking on a non-table hook response

### DIFF
--- a/crates/vfox/src/hooks/available.rs
+++ b/crates/vfox/src/hooks/available.rs
@@ -48,7 +48,11 @@ impl FromLua for AvailableVersion {
                     checksum,
                 })
             }
-            _ => panic!("Expected table"),
+            _ => Err(LuaError::FromLuaConversionError {
+                from: value.type_name(),
+                to: "AvailableVersion".to_string(),
+                message: Some("Expected table".to_string()),
+            }),
         }
     }
 }
@@ -56,6 +60,15 @@ impl FromLua for AvailableVersion {
 #[cfg(test)]
 mod tests {
     use crate::Plugin;
+    use crate::hooks::available::AvailableVersion;
+    use mlua::{FromLua, Lua, Value};
+
+    #[test]
+    fn test_available_version_rejects_non_table() {
+        let lua = Lua::new();
+        let result = AvailableVersion::from_lua(Value::Boolean(true), &lua);
+        assert!(result.is_err(), "a non-table response must not panic");
+    }
 
     #[test]
     fn dummy() {

--- a/crates/vfox/src/hooks/env_keys.rs
+++ b/crates/vfox/src/hooks/env_keys.rs
@@ -59,7 +59,23 @@ impl FromLua for EnvKey {
                 key: table.get::<String>("key")?,
                 value: table.get::<String>("value")?,
             }),
-            _ => panic!("Expected table"),
+            _ => Err(LuaError::FromLuaConversionError {
+                from: value.type_name(),
+                to: "EnvKey".to_string(),
+                message: Some("Expected table".to_string()),
+            }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_env_key_rejects_non_table() {
+        let lua = Lua::new();
+        let result = EnvKey::from_lua(Value::Boolean(true), &lua);
+        assert!(result.is_err(), "a non-table response must not panic");
     }
 }

--- a/crates/vfox/src/hooks/parse_legacy_file.rs
+++ b/crates/vfox/src/hooks/parse_legacy_file.rs
@@ -77,7 +77,11 @@ impl FromLua for ParseLegacyFileResponse {
             Value::Table(table) => Ok(ParseLegacyFileResponse {
                 version: table.get::<Option<String>>("version")?,
             }),
-            _ => panic!("Expected table"),
+            _ => Err(LuaError::FromLuaConversionError {
+                from: value.type_name(),
+                to: "ParseLegacyFileResponse".to_string(),
+                message: Some("Expected table".to_string()),
+            }),
         }
     }
 }
@@ -86,6 +90,13 @@ impl FromLua for ParseLegacyFileResponse {
 mod tests {
     use super::*;
     use crate::Vfox;
+
+    #[test]
+    fn test_parse_legacy_file_response_rejects_non_table() {
+        let lua = Lua::new();
+        let result = ParseLegacyFileResponse::from_lua(Value::Boolean(true), &lua);
+        assert!(result.is_err(), "a non-table response must not panic");
+    }
 
     #[tokio::test]
     async fn test_parse_legacy_file_test_nodejs() {

--- a/crates/vfox/src/hooks/pre_install.rs
+++ b/crates/vfox/src/hooks/pre_install.rs
@@ -238,7 +238,11 @@ impl FromLua for PreInstall {
                     // addition,
                 })
             }
-            _ => panic!("Expected table"),
+            _ => Err(LuaError::FromLuaConversionError {
+                from: value.type_name(),
+                to: "PreInstall".into(),
+                message: Some("Expected table".to_string()),
+            }),
         }
     }
 }
@@ -403,6 +407,13 @@ mod tests {
             err.contains("slsa_min_level requires slsa_provenance_path"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    async fn test_pre_install_rejects_non_table() {
+        let lua = Lua::new();
+        let result = PreInstall::from_lua(mlua::Value::Boolean(true), &lua);
+        assert!(result.is_err(), "a non-table response must not panic");
     }
 
     async fn run(plugin: &str, v: &str) -> PreInstall {


### PR DESCRIPTION
## Problem

A vfox plugin that returns the wrong type from a hook takes down the whole mise process.

Reported in https://github.com/jdx/mise/discussions/5876 (`mise install flutter` on Windows):

```
The application panicked (crashed).
Message:  Expected table
Location: crates\vfox\src\hooks\pre_install.rs:56
```

`flutter` itself no longer reaches this path — its registry entry moved to the `http:` backend — but the panic is still reachable through an explicit vfox backend, e.g. `mise use vfox:mise-plugins/vfox-flutter`.

## Current state

The crate is split on how it handles this exact condition:

| form | sites |
| --- | --- |
| `panic!("Expected table")` | `pre_install.rs`, `available.rs`, `env_keys.rs`, `parse_legacy_file.rs` |
| `Err(LuaError::FromLuaConversionError { .. })` | `backend_install.rs`, `backend_exec_env.rs`, `backend_list_versions.rs`, `package.rs` (×2) |
| `Err(LuaError::RuntimeError(..))` | `mise_env.rs` |

I went through the history of each of these files: there is no commit that converted panics to errors and deliberately left some behind. The error-returning ones are the newer backend-plugin hooks, written that way from the start. So this looks like drift rather than a decision anyone made.

## Change

The four `panic!`s now return `LuaError::FromLuaConversionError`, using the shape already in `backend_install.rs`, plus one test per type asserting the non-table path is an error. Those tests fail — by panicking — without the fix.

Success paths are untouched, so existing snapshots should be unaffected.

Out of scope: the two other `panic!`s in `crates/vfox/src` are `bin.rs:21` (intentional stop when the `cli` feature is off) and `lua_mod/http.rs:860` (a test helper).

## Why draft

1. **Message granularity.** All the existing sites use a bare `"Expected table"`. Naming the hook would help plugin authors, but that means touching the existing ones too — kept identical for now.
2. **Scope.** Limited to `panic!("Expected table")`. I have not audited `unwrap()`-driven aborts in the same crate.
3. **`available.rs`.** It converts a list of versions; whether one bad element should fail the whole list or just be skipped is a design call I did not want to make unilaterally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid hook responses.
  * Non-table values now produce clear errors instead of causing crashes.
  * Added regression coverage to ensure invalid boolean inputs are rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->