### PR TITLE
fix(rust): serialize concurrent toolchain installs

### DIFF
--- a/e2e/core/test_rust_parallel_install
+++ b/e2e/core/test_rust_parallel_install
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export MISE_RUSTUP_HOME="$PWD/rustup"
+export MISE_CARGO_HOME="$PWD/cargo"
+
+SERVER_ROOT="$PWD/server"
+PORT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/mise-rustup-init.XXXXXX")
+PORT_FILE="$PORT_DIR/port"
+mkdir -p "$SERVER_ROOT"
+
+cat >"$SERVER_ROOT/rustup-init" <<'INIT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p "$RUSTUP_HOME" "$CARGO_HOME/bin"
+echo init >>"$RUSTUP_HOME/init.log"
+# Widen the race so a second mise process would also try to initialize rustup.
+sleep 1
+
+cat >"$CARGO_HOME/bin/rustup" <<'RUSTUP'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-} ${2:-}" in
+	"toolchain install")
+		version="$3"
+		if ! mkdir "$RUSTUP_HOME/install-in-progress" 2>/dev/null; then
+			echo "concurrent rustup toolchain install" >&2
+			exit 88
+		fi
+		trap 'rmdir "$RUSTUP_HOME/install-in-progress"' EXIT
+		echo "$version" >>"$RUSTUP_HOME/toolchain-installs.log"
+		sleep 1
+		mkdir -p "$RUSTUP_HOME/toolchains/$version"
+		;;
+	"component list" | "target list")
+		;;
+	*)
+		echo "unexpected rustup args: $*" >&2
+		exit 1
+		;;
+esac
+RUSTUP
+
+cat >"$CARGO_HOME/bin/rustc" <<'RUSTC'
+#!/usr/bin/env bash
+set -euo pipefail
+
+test -d "$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN"
+echo "rustc $RUSTUP_TOOLCHAIN"
+RUSTC
+
+cat >"$CARGO_HOME/bin/cargo" <<'CARGO'
+#!/usr/bin/env bash
+echo cargo
+CARGO
+
+chmod +x "$CARGO_HOME/bin/rustup" "$CARGO_HOME/bin/rustc" "$CARGO_HOME/bin/cargo"
+touch "$RUSTUP_HOME/settings.toml"
+INIT
+
+python3 - "$SERVER_ROOT" "$PORT_FILE" <<'PY' &
+import http.server
+import os
+import socketserver
+import sys
+
+root, port_file = sys.argv[1:]
+os.chdir(root)
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler) as httpd:
+    with open(port_file, "w") as file:
+        file.write(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+cleanup() {
+  kill "$SERVER_PID" 2>/dev/null || true
+  rm -rf "$PORT_DIR"
+}
+trap cleanup EXIT
+
+wait_for_file "$PORT_FILE" "rustup-init HTTP server port" 30 "$SERVER_PID"
+SERVER_PORT=$(cat "$PORT_FILE")
+
+cat >mise.toml <<EOF
+[settings]
+url_replacements = { 'regex:^https://sh\.rustup\.rs/?$' = "http://127.0.0.1:$SERVER_PORT/rustup-init" }
+EOF
+
+mise install rust@1.80.0 >install-1.log 2>&1 &
+PID_1=$!
+mise install rust@1.81.0 >install-2.log 2>&1 &
+PID_2=$!
+
+STATUS_1=0
+STATUS_2=0
+wait "$PID_1" || STATUS_1=$?
+wait "$PID_2" || STATUS_2=$?
+if [[ $STATUS_1 -ne 0 || $STATUS_2 -ne 0 ]]; then
+  cat install-1.log install-2.log
+  fail "parallel Rust installs failed: $STATUS_1, $STATUS_2"
+fi
+
+assert_contains "wc -l <'$MISE_RUSTUP_HOME/init.log'" "1"
+assert_contains "sort '$MISE_RUSTUP_HOME/toolchain-installs.log'" "1.80.0"
+assert_contains "sort '$MISE_RUSTUP_HOME/toolchain-installs.log'" "1.81.0"
+assert "test -L '$MISE_DATA_DIR/installs/rust/1.80.0'"
+assert "test -L '$MISE_DATA_DIR/installs/rust/1.81.0'"
+assert_contains "mise x rust@1.80.0 -- rustc -V" "rustc 1.80.0"
+assert_contains "mise x rust@1.81.0 -- rustc -V" "rustc 1.81.0"
+assert "test ! -e '$MISE_RUSTUP_HOME/install-in-progress'"
+assert_not_contains "cat install-1.log install-2.log" "Permission denied"

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -10,6 +10,7 @@ use crate::cmd::{CmdLineRunner, cmd};
 use crate::config::{Config, Settings};
 use crate::http::HTTP;
 use crate::install_context::InstallContext;
+use crate::lock_file::LockFile;
 use crate::toolset::outdated_info::OutdatedInfo;
 use crate::toolset::{ResolveOptions, ToolRequest, ToolVersion, ToolVersionOptions, Toolset};
 use crate::ui::progress_report::SingleReport;
@@ -105,7 +106,21 @@ impl RustPlugin {
 
     async fn setup_rustup(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
         let settings = Settings::get();
-        if rustup_home().join("settings.toml").exists() && cargo_bin().exists() {
+        if rustup_is_initialized() {
+            return Ok(());
+        }
+        let _installer_lock = tokio::task::spawn_blocking(|| {
+            LockFile::new(&rustup_path())
+                .with_callback(|path| {
+                    debug!(
+                        "waiting for rustup-init lock on {}",
+                        file::display_path(path)
+                    );
+                })
+                .lock()
+        })
+        .await??;
+        if rustup_is_initialized() {
             return Ok(());
         }
         ctx.pr.set_message("Downloading rustup-init".into());
@@ -349,6 +364,7 @@ impl Backend for RustPlugin {
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
+        let _state_locks = lock_rust_state().await?;
         self.setup_rustup(ctx, &tv).await?;
         let ts = ctx.config.get_toolset().await?;
 
@@ -573,6 +589,41 @@ fn rustup_url(settings: &Settings) -> String {
 
 fn rustup_path() -> PathBuf {
     dirs::CACHE.join("rust").join(RUSTUP_INIT_BIN)
+}
+
+fn rustup_is_initialized() -> bool {
+    rustup_home().join("settings.toml").exists() && cargo_bin().exists()
+}
+
+fn rust_state_lock_identities(rustup_home: &Path, cargo_home: &Path) -> Vec<PathBuf> {
+    let mut identities = vec![
+        file::desymlink_path(rustup_home),
+        file::desymlink_path(cargo_home),
+    ];
+    identities.sort();
+    identities.dedup();
+    identities
+}
+
+async fn lock_rust_state() -> Result<Vec<fslock::LockFile>> {
+    let identities = rust_state_lock_identities(&rustup_home(), &cargo_home());
+    tokio::task::spawn_blocking(move || {
+        identities
+            .into_iter()
+            .map(|identity| {
+                let display_identity = identity.clone();
+                LockFile::new(&identity)
+                    .with_callback(move |_| {
+                        debug!(
+                            "waiting for Rust state lock on {}",
+                            file::display_path(&display_identity)
+                        );
+                    })
+                    .lock()
+            })
+            .collect()
+    })
+    .await?
 }
 
 fn rustup_home() -> PathBuf {
@@ -881,6 +932,52 @@ targets = ["wasm32-wasip1", " wasm32-wasip1 "]
         assert_eq!(
             resolve_rust_home(PathBuf::from("~/.rustup-custom")),
             dirs::HOME.join(".rustup-custom")
+        );
+    }
+
+    #[test]
+    fn rust_state_locks_are_shared_by_either_home() {
+        let first = rust_state_lock_identities(Path::new("/rustup/shared"), Path::new("/cargo/a"));
+        let same_rustup =
+            rust_state_lock_identities(Path::new("/rustup/shared"), Path::new("/cargo/b"));
+        let same_cargo =
+            rust_state_lock_identities(Path::new("/rustup/other"), Path::new("/cargo/a"));
+        let separate =
+            rust_state_lock_identities(Path::new("/rustup/other"), Path::new("/cargo/b"));
+
+        assert!(first.iter().any(|identity| same_rustup.contains(identity)));
+        assert!(first.iter().any(|identity| same_cargo.contains(identity)));
+        assert!(!first.iter().any(|identity| separate.contains(identity)));
+    }
+
+    #[test]
+    fn rust_state_locks_are_ordered_and_deduplicated() {
+        let cargo = file::desymlink_path(Path::new("/a/cargo"));
+        let rustup = file::desymlink_path(Path::new("/z/rustup"));
+        assert_eq!(
+            rust_state_lock_identities(Path::new("/z/rustup"), Path::new("/a/cargo")),
+            vec![cargo, rustup]
+        );
+        assert_eq!(
+            rust_state_lock_identities(Path::new("/shared"), Path::new("/shared")),
+            vec![file::desymlink_path(Path::new("/shared"))]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rust_state_locks_resolve_filesystem_aliases() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let state = root.path().join("state");
+        let alias = root.path().join("alias");
+        std::fs::create_dir_all(&state).unwrap();
+        symlink(&state, &alias).unwrap();
+
+        assert_eq!(
+            rust_state_lock_identities(&state, &state),
+            rust_state_lock_identities(&alias, &alias)
         );
     }
 }


### PR DESCRIPTION
## Summary

- serialize Rust toolchain changes that share a resolved `RUSTUP_HOME` or `CARGO_HOME`
- protect the shared cached `rustup-init` across otherwise isolated Rust homes
- re-check initialized state after acquiring the installer lock so waiting processes avoid duplicate downloads and initialization

## Problem

mise already locks installs by tool and version, so separate processes installing different Rust versions can run concurrently. Those installs still mutate the same rustup settings, toolchain state, and Cargo proxy binaries. rustup does not support concurrent mutations of that shared state (see rust-lang/rustup#988), which can leave incomplete installs or produce errors such as `Permission denied` while the shared `rustup-init` is being replaced or executed.

## Solution

The Rust backend now acquires cross-process locks for the resolved Rustup and Cargo homes before setup and keeps them through `rustup toolchain install`, mise symlink creation, and `rustc -V` verification. Lock identities are sorted and deduplicated, so processes sharing either home serialize without deadlocking, while fully isolated homes can still proceed concurrently.

A shorter cache-level lock protects `rustup-init`. After acquiring it, setup checks `settings.toml` and the Cargo binary again before downloading or executing the installer. Both locks use RAII, so failures release them for later retries, and `--force` does not bypass shared-state safety.

## Validation

- `mise exec -- cargo test --all-features plugins::core::rust::tests`
- `mise run test:e2e e2e/core/test_rust_parallel_install`
- `mise run test:e2e e2e/core/test_rust_components_reconcile e2e/core/test_rust`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d e2e/core/test_rust_parallel_install`
- `mise exec -- shellcheck e2e/core/test_rust_parallel_install`
- Linux arm64 Docker: built with all features and passed `e2e/core/test_rust_parallel_install`

The full `mise run format` and `mise run lint` wrappers could not run locally because hk does not recognize the Sapling working copy as a Git repository; the underlying Rustfmt, shfmt, ShellCheck, Cargo check, and Clippy checks passed individually.

Addresses https://github.com/jdx/mise/discussions/8513

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when installing multiple Rust toolchains concurrently.
  * Prevented race conditions during Rust initialization and shared state updates.
  * Reduced the risk of permission errors and incomplete installations.

* **Tests**
  * Added end-to-end coverage for parallel Rust installations, including isolated setup, executable resolution, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->