### PR TITLE
fix(vfox): honor url replacements

### DIFF
--- a/crates/vfox/src/http.rs
+++ b/crates/vfox/src/http.rs
@@ -10,6 +10,8 @@ pub static CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .expect("Failed to create reqwest client")
 });
 
+pub(crate) const URL_REWRITER_REGISTRY_KEY: &str = "url_rewriter_fn";
+
 static HTTP_CANCELLATION: LazyLock<HttpCancellation> = LazyLock::new(Default::default);
 
 #[derive(Clone)]

--- a/crates/vfox/src/lua_mod/http.rs
+++ b/crates/vfox/src/lua_mod/http.rs
@@ -191,6 +191,79 @@ fn add_default_headers(lua: &Lua, url: &str, mut headers: HeaderMap) -> HeaderMa
     headers
 }
 
+fn add_default_headers_for_request(
+    lua: &Lua,
+    original_url: &str,
+    request_url: &str,
+    headers: HeaderMap,
+) -> HeaderMap {
+    let same_origin = Url::parse(original_url)
+        .ok()
+        .zip(Url::parse(request_url).ok())
+        .is_some_and(|(original, request)| original.origin() == request.origin());
+
+    // Do not forward credentials selected for the original origin, but retain
+    // non-sensitive plugin headers that may be required by the replacement.
+    if !same_origin {
+        return headers
+            .iter()
+            .filter(|(name, _)| !is_sensitive_header(name))
+            .map(|(name, value)| (name.clone(), value.clone()))
+            .collect();
+    }
+
+    add_default_headers(lua, original_url, headers)
+}
+
+fn is_sensitive_header(name: &HeaderName) -> bool {
+    let name = name.as_str();
+    let normalized: String = name.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+
+    matches!(
+        name,
+        "authorization"
+            | "cookie"
+            | "cookie2"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "set-cookie"
+            | "www-authenticate"
+    ) || normalized.ends_with("auth")
+        || [
+            "accesskey",
+            "accesstoken",
+            "apikey",
+            "apitoken",
+            "authtoken",
+            "authentication",
+            "authorization",
+            "bearertoken",
+            "credential",
+            "githubtoken",
+            "gitlabtoken",
+            "idtoken",
+            "privatekey",
+            "privatetoken",
+            "refreshtoken",
+            "secret",
+            "secretkey",
+            "sessionid",
+            "sessionkey",
+            "sessiontoken",
+            "subscriptionkey",
+            "vaulttoken",
+        ]
+        .iter()
+        .any(|marker| normalized.contains(marker))
+}
+
+fn rewrite_url(lua: &Lua, url: &str) -> Result<String> {
+    match lua.named_registry_value::<mlua::Function>(crate::http::URL_REWRITER_REGISTRY_KEY) {
+        Ok(rewriter) => rewriter.call(url),
+        Err(_) => Ok(url.to_string()),
+    }
+}
+
 async fn get(lua: &Lua, input: Table) -> Result<Table> {
     get_with_cancellation(lua, input, http_cancellation()).await
 }
@@ -206,9 +279,10 @@ async fn get_with_cancellation(
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
-    let headers = add_default_headers(lua, &url, headers);
+    let request_url = rewrite_url(lua, &url)?;
+    let headers = add_default_headers_for_request(lua, &url, &request_url, headers);
     let resp = cancel_on_signal(
-        send_with_retry(CLIENT.get(&url).headers(headers)),
+        send_with_retry(CLIENT.get(&request_url).headers(headers)),
         cancellation.cancelled(),
     )
     .await?;
@@ -227,12 +301,17 @@ async fn download_file(lua: &Lua, input: MultiValue) -> Result<()> {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
-    let headers = add_default_headers(lua, &url, headers);
+    let request_url = rewrite_url(lua, &url)?;
+    let headers = add_default_headers_for_request(lua, &url, &request_url, headers);
     let path: String = input.iter().nth(1).unwrap().to_string()?;
     // Retry the whole flow (request + body) so a mid-stream drop restarts the
     // download instead of failing.
-    let bytes = cancel_on_interrupt(retry_async(&url, || async {
-        let resp = CLIENT.get(&url).headers(headers.clone()).send().await?;
+    let bytes = cancel_on_interrupt(retry_async(&request_url, || async {
+        let resp = CLIENT
+            .get(&request_url)
+            .headers(headers.clone())
+            .send()
+            .await?;
         let resp = resp.error_for_status()?;
         resp.bytes().await
     }))
@@ -258,8 +337,10 @@ async fn head(lua: &Lua, input: Table) -> Result<Table> {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
-    let headers = add_default_headers(lua, &url, headers);
-    let resp = cancel_on_interrupt(send_with_retry(CLIENT.head(&url).headers(headers))).await?;
+    let request_url = rewrite_url(lua, &url)?;
+    let headers = add_default_headers_for_request(lua, &url, &request_url, headers);
+    let resp =
+        cancel_on_interrupt(send_with_retry(CLIENT.head(&request_url).headers(headers))).await?;
     let t = lua.create_table()?;
     t.set("status_code", resp.status().as_u16())?;
     t.set("headers", get_headers(lua, resp.headers())?)?;
@@ -281,9 +362,10 @@ async fn try_get_with_cancellation(
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
-    let headers = add_default_headers(lua, &url, headers);
+    let request_url = rewrite_url(lua, &url)?;
+    let headers = add_default_headers_for_request(lua, &url, &request_url, headers);
     let resp = match cancel_on_signal(
-        send_with_retry(CLIENT.get(&url).headers(headers)),
+        send_with_retry(CLIENT.get(&request_url).headers(headers)),
         cancellation.cancelled(),
     )
     .await
@@ -317,8 +399,12 @@ async fn try_head(lua: &Lua, input: Table) -> Result<MultiValue> {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
-    let headers = add_default_headers(lua, &url, headers);
-    let resp = match cancel_on_interrupt(send_with_retry(CLIENT.head(&url).headers(headers))).await
+    let request_url = rewrite_url(lua, &url)?;
+    let headers = add_default_headers_for_request(lua, &url, &request_url, headers);
+    let resp = match cancel_on_interrupt(send_with_retry(
+        CLIENT.head(&request_url).headers(headers),
+    ))
+    .await
     {
         Ok(resp) => resp,
         Err(e) => {
@@ -349,7 +435,8 @@ async fn try_download_file(lua: &Lua, input: MultiValue) -> Result<MultiValue> {
         Some(tbl) => into_headers(&tbl)?,
         None => HeaderMap::default(),
     };
-    let headers = add_default_headers(lua, &url, headers);
+    let request_url = rewrite_url(lua, &url)?;
+    let headers = add_default_headers_for_request(lua, &url, &request_url, headers);
     let path = match input.get(1).and_then(|v| v.to_string().ok()) {
         Some(p) => p,
         None => {
@@ -359,8 +446,12 @@ async fn try_download_file(lua: &Lua, input: MultiValue) -> Result<MultiValue> {
             ]));
         }
     };
-    let bytes = match cancel_on_interrupt(retry_async(&url, || async {
-        let resp = CLIENT.get(&url).headers(headers.clone()).send().await?;
+    let bytes = match cancel_on_interrupt(retry_async(&request_url, || async {
+        let resp = CLIENT
+            .get(&request_url)
+            .headers(headers.clone())
+            .send()
+            .await?;
         let resp = resp.error_for_status()?;
         resp.bytes().await
     }))
@@ -498,6 +589,193 @@ mod tests {
         .exec_async()
         .await
         .unwrap();
+    }
+
+    #[test]
+    fn test_rewrite_url_defaults_to_original() {
+        let lua = Lua::new();
+        let url = "https://upstream.example/resource";
+        assert_eq!(rewrite_url(&lua, url).unwrap(), url);
+    }
+
+    #[tokio::test]
+    async fn test_url_rewriter_applies_to_all_lua_http_methods() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/resource"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("rewritten"))
+            .expect(4)
+            .mount(&server)
+            .await;
+        Mock::given(method("HEAD"))
+            .and(path("/resource"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let lua = Lua::new();
+        mod_http(&lua).unwrap();
+        lua.set_named_registry_value("github_token", "original-host")
+            .unwrap();
+        let replacement_origin = server.uri();
+        let rewriter = lua
+            .create_function(move |_, url: String| {
+                Ok(url.replacen("https://api.github.com", &replacement_origin, 1))
+            })
+            .unwrap();
+        lua.set_named_registry_value(crate::http::URL_REWRITER_REGISTRY_KEY, rewriter)
+            .unwrap();
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let download_path = temp_dir.path().join("download.txt");
+        let try_download_path = temp_dir.path().join("try-download.txt");
+        let download_path_str = download_path.to_string_lossy().to_string();
+        let try_download_path_str = try_download_path.to_string_lossy().to_string();
+        let url = "https://api.github.com/resource";
+
+        lua.load(mlua::chunk! {
+            local http = require("http")
+            local request = {
+                url = $url,
+                headers = {
+                    ["Accept"] = "application/vnd.vfox+json",
+                    ["Authorization"] = "Bearer plugin-token",
+                    ["Cookie"] = "session=secret",
+                    ["Cookie2"] = "session2=secret",
+                    ["Proxy-Authorization"] = "Basic proxy-secret",
+                    ["WWW-Authenticate"] = "Bearer challenge-secret",
+                    ["X-Api-Key"] = "service-secret",
+                    ["X-ApiKey"] = "service-secret-without-delimiter",
+                    ["X-Gitlab-Token"] = "gitlab-secret",
+                    ["X-Session-Id"] = "session-secret",
+                    ["X-Vault-Token"] = "vault-secret",
+                    ["X-Auth-Method"] = "mirror-v1",
+                    ["X-Cache-Key"] = "cache-entry",
+                    ["X-Request-Key"] = "request-route",
+                    ["X-Vfox-Test"] = "required",
+                },
+            }
+
+            local get_resp = http.get(request)
+            assert(get_resp.status_code == 200)
+            assert(get_resp.body == "rewritten")
+
+            local try_get_resp, try_get_err = http.try_get(request)
+            assert(try_get_err == nil)
+            assert(try_get_resp.body == "rewritten")
+
+            assert(http.head(request).status_code == 200)
+            local try_head_resp, try_head_err = http.try_head(request)
+            assert(try_head_err == nil)
+            assert(try_head_resp.status_code == 200)
+
+            assert(http.download_file(request, $download_path_str) == nil)
+            local ok, try_download_err = http.try_download_file(
+                request,
+                $try_download_path_str
+            )
+            assert(ok == true)
+            assert(try_download_err == nil)
+        })
+        .exec_async()
+        .await
+        .unwrap();
+
+        assert_eq!(
+            tokio::fs::read_to_string(download_path).await.unwrap(),
+            "rewritten"
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(try_download_path).await.unwrap(),
+            "rewritten"
+        );
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 6);
+        for request in requests {
+            assert_eq!(
+                request
+                    .headers
+                    .get("accept")
+                    .and_then(|value| value.to_str().ok()),
+                Some("application/vnd.vfox+json")
+            );
+            assert!(!request.headers.contains_key(AUTHORIZATION));
+            assert!(!request.headers.contains_key("cookie"));
+            assert!(!request.headers.contains_key("cookie2"));
+            assert!(!request.headers.contains_key("proxy-authorization"));
+            assert!(!request.headers.contains_key("www-authenticate"));
+            assert!(!request.headers.contains_key("x-api-key"));
+            assert!(!request.headers.contains_key("x-apikey"));
+            assert!(!request.headers.contains_key("x-gitlab-token"));
+            assert!(!request.headers.contains_key("x-session-id"));
+            assert!(!request.headers.contains_key("x-vault-token"));
+            assert_eq!(
+                request
+                    .headers
+                    .get("x-auth-method")
+                    .and_then(|value| value.to_str().ok()),
+                Some("mirror-v1")
+            );
+            assert_eq!(
+                request
+                    .headers
+                    .get("x-cache-key")
+                    .and_then(|value| value.to_str().ok()),
+                Some("cache-entry")
+            );
+            assert_eq!(
+                request
+                    .headers
+                    .get("x-request-key")
+                    .and_then(|value| value.to_str().ok()),
+                Some("request-route")
+            );
+            assert_eq!(
+                request
+                    .headers
+                    .get("x-vfox-test")
+                    .and_then(|value| value.to_str().ok()),
+                Some("required")
+            );
+            assert!(!request.headers.contains_key("x-github-api-version"));
+        }
+    }
+
+    #[test]
+    fn test_same_origin_rewrite_keeps_default_github_headers() {
+        let lua = Lua::new();
+        lua.set_named_registry_value("github_token", "same-origin")
+            .unwrap();
+        let mut input_headers = HeaderMap::new();
+        input_headers.insert("x-api-key", HeaderValue::from_static("same-origin-secret"));
+
+        let headers = add_default_headers_for_request(
+            &lua,
+            "https://api.github.com/repos/owner/repo",
+            "https://api.github.com/mirror/owner/repo",
+            input_headers,
+        );
+
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer same-origin")
+        );
+        assert_eq!(
+            headers
+                .get("x-github-api-version")
+                .and_then(|value| value.to_str().ok()),
+            Some("2022-11-28")
+        );
+        assert_eq!(
+            headers
+                .get("x-api-key")
+                .and_then(|value| value.to_str().ok()),
+            Some("same-origin-secret")
+        );
     }
 
     #[tokio::test]

--- a/crates/vfox/src/plugin.rs
+++ b/crates/vfox/src/plugin.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use mlua::chunk::AsChunk;
 use mlua::{FromLuaMulti, IntoLua, Lua, Table, Value};
 use once_cell::sync::OnceCell;
+use url::Url;
 
 use crate::config::Config;
 use crate::context::Context;
@@ -14,6 +15,7 @@ use crate::error::Result;
 use crate::metadata::Metadata;
 use crate::runtime::Runtime;
 use crate::sdk_info::SdkInfo;
+use crate::vfox::UrlRewriter;
 use crate::{VfoxError, config, error, lua_mod};
 
 #[derive(Debug)]
@@ -136,6 +138,16 @@ impl Plugin {
             .lua
             .create_function(move |_, ()| Ok(resolver().unwrap_or_default()))?;
         self.lua.set_named_registry_value("github_token_fn", func)?;
+        Ok(())
+    }
+
+    /// Register the URL rewriter used by the Lua http module.
+    pub(crate) fn set_url_rewriter(&self, rewriter: UrlRewriter) -> Result<()> {
+        let func = self
+            .lua
+            .create_function(move |_, value: String| Ok(rewrite_url(value, &rewriter)))?;
+        self.lua
+            .set_named_registry_value(crate::http::URL_REWRITER_REGISTRY_KEY, func)?;
         Ok(())
     }
 
@@ -308,6 +320,14 @@ impl Plugin {
     }
 }
 
+fn rewrite_url(value: String, rewriter: &UrlRewriter) -> String {
+    let Ok(mut url) = Url::parse(&value) else {
+        return value;
+    };
+    rewriter(&mut url);
+    url.to_string()
+}
+
 fn get_package(lua: &Lua) -> Result<Table> {
     let package = lua.globals().get::<Table>("package")?;
     Ok(package)
@@ -348,5 +368,19 @@ impl PartialOrd for Plugin {
 impl Ord for Plugin {
     fn cmp(&self, other: &Self) -> Ordering {
         self.name.cmp(&other.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_rewriter_preserves_invalid_urls() {
+        let rewriter: UrlRewriter = Arc::new(|url| {
+            url.set_host(Some("mirror.example")).unwrap();
+        });
+
+        assert_eq!(rewrite_url("not a url".to_string(), &rewriter), "not a url");
     }
 }

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -68,8 +68,11 @@ pub struct Vfox {
     pub github_token_resolver: Option<Arc<dyn Fn() -> Option<String> + Send + Sync>>,
     /// Optional runtime env type (`gnu` or `musl`) exposed to plugin hooks.
     pub runtime_env_type: Option<String>,
+    url_rewriter: Option<UrlRewriter>,
     log_tx: Option<mpsc::Sender<String>>,
 }
+
+pub(crate) type UrlRewriter = Arc<dyn Fn(&mut Url) + Send + Sync>;
 
 impl std::fmt::Debug for Vfox {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -87,6 +90,10 @@ impl std::fmt::Debug for Vfox {
                 &self.github_token_resolver.as_ref().map(|_| "<closure>"),
             )
             .field("runtime_env_type", &self.runtime_env_type)
+            .field(
+                "url_rewriter",
+                &self.url_rewriter.as_ref().map(|_| "<closure>"),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -100,6 +107,19 @@ impl Vfox {
         let (tx, rx) = mpsc::channel();
         self.log_tx = Some(tx);
         rx
+    }
+
+    pub fn set_url_rewriter<F>(&mut self, rewriter: F)
+    where
+        F: Fn(&mut Url) + Send + Sync + 'static,
+    {
+        self.url_rewriter = Some(Arc::new(rewriter));
+    }
+
+    fn rewrite_url(&self, url: &mut Url) {
+        if let Some(rewriter) = &self.url_rewriter {
+            rewriter(url);
+        }
     }
 
     fn log_emit(&self, msg: String) {
@@ -159,6 +179,9 @@ impl Vfox {
         let mut plugin = Plugin::from_name_or_dir(name, &self.plugin_dir.join(name))?;
         plugin.runtime_env_type = self.runtime_env_type.clone();
         self.set_cmd_shell(&plugin)?;
+        if let Some(rewriter) = &self.url_rewriter {
+            plugin.set_url_rewriter(rewriter.clone())?;
+        }
         Ok(plugin)
     }
 
@@ -537,11 +560,13 @@ impl Vfox {
         version: &str,
         download_dir: &Path,
     ) -> Result<PathBuf> {
-        self.log_emit(format!("Downloading {url}"));
         let path = Self::download_path_for(download_dir, &sdk.name, version, url)?;
-        let url_str = url.to_string();
+        let mut request_url = url.clone();
+        self.rewrite_url(&mut request_url);
+        self.log_emit(format!("Downloading {request_url}"));
+        let url_str = request_url.to_string();
         let bytes = retry_async(&url_str, || async {
-            let resp = CLIENT.get(url.clone()).send().await?;
+            let resp = CLIENT.get(request_url.clone()).send().await?;
             let resp = resp.error_for_status()?;
             resp.bytes().await
         })
@@ -743,6 +768,7 @@ impl Default for Vfox {
             github_token: None,
             github_token_resolver: None,
             runtime_env_type: None,
+            url_rewriter: None,
             log_tx: None,
         }
     }
@@ -791,6 +817,7 @@ mod tests {
                 github_token: None,
                 github_token_resolver: None,
                 runtime_env_type: None,
+                url_rewriter: None,
                 log_tx: None,
             }
         }
@@ -822,6 +849,21 @@ mod tests {
         std::fs::write(&file, ABC).unwrap();
         let vfox = Vfox::test();
         vfox.verify(&pre_install, &file).await.map(|_| ())
+    }
+
+    #[test]
+    fn url_rewriter_defaults_to_noop_and_can_be_set() {
+        let mut vfox = Vfox::test();
+        let original = Url::parse("https://upstream.example/tool.tar.gz").unwrap();
+        let mut url = original.clone();
+        vfox.rewrite_url(&mut url);
+        assert_eq!(url, original);
+
+        vfox.set_url_rewriter(|url| {
+            url.set_host(Some("mirror.example")).unwrap();
+        });
+        vfox.rewrite_url(&mut url);
+        assert_eq!(url.as_str(), "https://mirror.example/tool.tar.gz");
     }
 
     /// Both of these arms used to be `unimplemented!()`, so a plugin returning either checksum

--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -103,6 +103,12 @@ For more information, see:
 - [Plugin Development](../../tool-plugin-development.md) - Developer guide
 - [Plugin Template](https://github.com/jdx/mise-tool-plugin-template) - Quick start template for creating plugins
 
+## URL replacements
+
+The vfox backend honors mise's [`url_replacements`](/url-replacements.html) setting for both
+tool artifact downloads and requests made through the plugin's built-in Lua HTTP module. This
+includes `http.get`, `http.head`, `http.download_file`, and their `try_*` variants.
+
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `vfox` backend—these

--- a/e2e/backend/test_vfox_url_replacements
+++ b/e2e/backend/test_vfox_url_replacements
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PLUGIN_DIR="$PWD/vfox-url-replacements"
+SERVER_ROOT="$PWD/server"
+PORT_FILE="$PWD/server-port"
+mkdir -p "$PLUGIN_DIR/hooks" "$SERVER_ROOT/archive/bin"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "url-replacements"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = "https://example.com/url-replacements"
+PLUGIN.license = "MIT"
+PLUGIN.description = "URL replacements test plugin"
+LUA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
+function PLUGIN:Available(ctx)
+	local http = require("http")
+	local response = http.get({ url = "https://upstream.invalid/versions.txt" })
+	return {
+		{ version = response.body:match("([^\r\n]+)") },
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/pre_install.lua" <<'LUA'
+function PLUGIN:PreInstall(ctx)
+	return {
+		version = ctx.version,
+		url = "https://upstream.invalid/tool.tar.gz",
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/post_install.lua" <<'LUA'
+function PLUGIN:PostInstall(ctx)
+	local http = require("http")
+	http.download_file(
+		{ url = "https://upstream.invalid/supplement.txt" },
+		ctx.rootPath .. "/supplement.txt"
+	)
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'LUA'
+function PLUGIN:EnvKeys(ctx)
+	return {
+		{ key = "PATH", value = ctx.path .. "/bin" },
+	}
+end
+LUA
+
+git -C "$PLUGIN_DIR" init -q
+git -C "$PLUGIN_DIR" add .
+git -C "$PLUGIN_DIR" -c user.name=mise -c user.email=mise@example.com commit -q -m "initial plugin"
+
+cat >"$SERVER_ROOT/archive/bin/vfox-url-test" <<'SH'
+#!/usr/bin/env sh
+echo direct-artifact
+SH
+chmod +x "$SERVER_ROOT/archive/bin/vfox-url-test"
+printf 'keep archive root\n' >"$SERVER_ROOT/archive/README"
+tar -czf "$SERVER_ROOT/tool.tar.gz" -C "$SERVER_ROOT/archive" .
+cp "$SERVER_ROOT/tool.tar.gz" "$SERVER_ROOT/mirrored-artifact"
+printf '1.0.0\n' >"$SERVER_ROOT/versions.txt"
+printf 'lua-http-download\n' >"$SERVER_ROOT/supplement.txt"
+
+python3 - "$SERVER_ROOT" "$PORT_FILE" <<'PY' &
+import http.server
+import os
+import socketserver
+import sys
+
+root, port_file = sys.argv[1:]
+os.chdir(root)
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler) as httpd:
+    with open(port_file, "w") as file:
+        file.write(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+wait_for_file "$PORT_FILE" "vfox URL replacement server port" 30 "$SERVER_PID"
+SERVER_PORT=$(cat "$PORT_FILE")
+
+cat >mise.toml <<EOF
+[settings.url_replacements]
+"https://upstream.invalid/tool.tar.gz" = "http://127.0.0.1:$SERVER_PORT/mirrored-artifact"
+"https://upstream.invalid/" = "http://127.0.0.1:$SERVER_PORT/"
+
+[tools]
+"vfox:file://$PLUGIN_DIR" = "1.0.0"
+EOF
+
+assert_contains "mise ls-remote 'vfox:file://$PLUGIN_DIR'" "1.0.0"
+mise install
+assert "mise x 'vfox:file://$PLUGIN_DIR@1.0.0' -- vfox-url-test" "direct-artifact"
+INSTALL_PATH=$(mise where "vfox:file://$PLUGIN_DIR@1.0.0")
+assert "cat '$INSTALL_PATH/supplement.txt'" "lua-http-download"

--- a/src/plugins/vfox_plugin.rs
+++ b/src/plugins/vfox_plugin.rs
@@ -149,6 +149,7 @@ impl VfoxPlugin {
         vfox.github_token_resolver = Some(Arc::new(|| {
             crate::github::resolve_token("github.com").map(|(token, _)| token)
         }));
+        vfox.set_url_rewriter(crate::http::apply_url_replacements);
         let rx = vfox.log_subscribe();
         Ok((vfox, rx))
     }


### PR DESCRIPTION
## Summary

- inject mise's existing URL replacement callback into the vfox runtime instead of duplicating settings or regex handling in the vfox crate
- apply replacements to direct artifact downloads and all built-in Lua HTTP APIs (`get`, `try_get`, `head`, `try_head`, `download_file`, and `try_download_file`)
- only attach automatically resolved GitHub credentials when URL rewriting stays on the same origin, while keeping artifact filenames based on the original URL

## Problem

The vfox backend owns separate reqwest clients for artifact downloads and Lua HTTP helpers. Those requests bypassed mise's shared HTTP layer, so `settings.url_replacements` had no effect for vfox plugins.

## Implementation

Vfox now accepts an optional URL-rewriter callback. Mise supplies its existing `http::apply_url_replacements` implementation, while standalone users of the vfox library and CLI retain the previous no-op behavior.

Lua requests apply the rewrite before resolving default GitHub authentication. Automatically resolved GitHub credentials are attached only when the rewritten URL retains the original scheme, host, and effective port; cross-origin mirrors receive no implicit token. Cross-origin rewrites remove known credential-bearing plugin headers while retaining required non-credential headers. Direct artifact downloads determine their local filename from the original URL, then use the rewritten URL for requests, retries, and logging. This allows mirrors whose paths do not preserve the upstream filename or extension.

## Testing

- `mise --cd crates/vfox run test` (110 passed, 2 ignored)
- `mise run test:e2e e2e/backend/test_vfox_url_replacements`
- `mise run test:e2e e2e/backend/test_vfox_install_env e2e/backend/test_vfox_rolling_install`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise --cd crates/vfox run lint`
- `mise exec -- cargo fmt --all --check`
- `mise exec -- shfmt -d e2e/backend/test_vfox_url_replacements`
- `mise exec -- shellcheck e2e/backend/test_vfox_url_replacements`

The repository-level `mise run format` and `mise run lint` wrappers could not run `hk` because it does not recognize this Sapling working copy as a Git repository. The corresponding Rustfmt, Clippy, shfmt, ShellCheck, and vfox lint checks were run individually as listed above.

Addresses https://github.com/jdx/mise/discussions/8427

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added URL replacement support for vfox artifact downloads and Lua HTTP requests.
  - URL replacements apply to GET, HEAD, download, and retryable HTTP operations.
  - Requests preserve existing behavior when no replacements are configured.
  - GitHub credentials are retained for same-origin rewritten requests and protected from cross-origin forwarding.

- **Documentation**
  - Documented URL replacement support across vfox downloads and HTTP operations.

- **Tests**
  - Added coverage for URL rewriting, downloads, plugin workflows, default behavior, and authorization handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
