### PR TITLE
registry: add android-cli

### DIFF
--- a/registry/android-cli.toml
+++ b/registry/android-cli.toml
@@ -1,0 +1,38 @@
+description = "Official Android command-line tool for creating, building, and running Android apps, managing emulators, and installing SDK packages"
+os = ["linux", "macos", "windows"]
+# The version baked into the binary lags the published build number (1.0.15985488
+# reports 1.0.15857036), so it cannot be asserted against {{version}}.
+test = { cmd = "android --version", expected = "1." }
+
+bins = ["android"]
+[[backends]]
+full = "http:android-cli"
+platforms = ["macos", "linux-x64", "windows-x64"]
+
+[backends.options]
+bin = "android"
+# dl.google.com publishes no version index for the raw binaries, but the apt
+# repo behind the documented `apt-get install android-cli` carries the current
+# build number, and older builds stay downloadable at their versioned URLs.
+version_list_url = "https://dl.google.com/android/cli/latest/debian/dists/stable/main/binary-amd64/Packages"
+version_regex = '(?m)^Version: (\S+)$'
+
+# Google ships only these four targets -- there is no linux-arm64 or
+# windows-arm64 build -- so each URL is declared per platform rather than
+# templated, to keep `mise lock` from recording targets that 404.
+[backends.options.platforms.linux-x64]
+checksum_url = "https://dl.google.com/android/cli/{{ version }}/linux_x86_64/android.sha256"
+url = "https://dl.google.com/android/cli/{{ version }}/linux_x86_64/android"
+
+[backends.options.platforms.macos-arm64]
+checksum_url = "https://dl.google.com/android/cli/{{ version }}/darwin_arm64/android.sha256"
+url = "https://dl.google.com/android/cli/{{ version }}/darwin_arm64/android"
+
+[backends.options.platforms.macos-x64]
+checksum_url = "https://dl.google.com/android/cli/{{ version }}/darwin_x86_64/android.sha256"
+url = "https://dl.google.com/android/cli/{{ version }}/darwin_x86_64/android"
+
+[backends.options.platforms.windows-x64]
+bin = "android.exe"
+checksum_url = "https://dl.google.com/android/cli/{{ version }}/windows_x86_64/android.exe.sha256"
+url = "https://dl.google.com/android/cli/{{ version }}/windows_x86_64/android.exe"


### PR DESCRIPTION
Adds [Android CLI](https://developer.android.com/tools/agents/android-cli), Google's official Android command-line tool (`android`), for creating and running Android projects, driving emulators, and installing SDK packages.

## Popularity

- **Official first-party Google tool**, documented on developer.android.com; stable 1.0 announced at Google I/O '26 on 2026-05-19 ([blog](https://android-developers.googleblog.com/2026/05/android-cli-stable-1-0-agent-development.html)). No GitHub repo exists (closed-source binaries hosted on `dl.google.com`), so there is no star count to cite.
- **Homebrew** (90d installs): `android/tap/android-cli` 1,050 (Google's own tap, rank #610); `android-cli` cask 177.
- **winget**: `Google.AndroidCLI`, 6 releases published since 0.7 (April 2026); latest `1.0.15985488`, released 2026-07-31.
- **apt**: Google-hosted repo at `dl.google.com/android/cli/latest/debian`, maintained by `Android Developer Tools <android-devtools@google.com>`.
- **Bundled with Google Antigravity 2.0** as an optional Android resource bundle.

Flagging honestly: absolute install counts are modest because the tool is only a few months past 1.0. Happy to close this if it's below the bar.

## Backend choice

`http:`, because tier-1 backends do not apply:

- Not in the aqua registry, and there is no GitHub/GitLab release — Google serves raw binaries from `dl.google.com`.
- The documented install path only advertises `latest`, but **versioned URLs exist and resolve**: `https://dl.google.com/android/cli/{version}/{platform}/android`, each with a `.sha256` sidecar.

### Version listing

`dl.google.com` publishes no version index for the raw binaries. The apt repo behind Google's documented `apt-get install android-cli` does, and it is first-party:

```
$ curl -fsSL https://dl.google.com/android/cli/latest/debian/dists/stable/main/binary-amd64/Packages
Package: android-cli
Version: 1.0.15985488
Maintainer: Android Developer Tools <android-devtools@google.com>
...
```

I also looked at the winget manifests (full 6-version history) and the Homebrew cask API, but both are community-maintained, and the winget route would put `api.github.com` rate limits on every `ls-remote`. The Google-hosted index seemed the better provenance.

### Platform matrix

Google ships only four targets — there is no linux-arm64 or windows-arm64 build (both 404). URLs are therefore declared per platform instead of templated, so `mise lock` does not record targets that 404.

### Note on `test`

The version baked into the binary lags the published build number: the build served at `1.0.15985488` self-reports `1.0.15857036` (confirmed by downloading both builds — different sha256s, same reported version). So `expected` cannot assert `{{version}}`.

## Verification

```
$ mise ls-remote android-cli
1.0.15985488

$ mise install android-cli@latest
mise android-cli@1.0.15985488 ✓ installed

$ mise exec android-cli@latest -- android --version
1.0.15857036
```

`mise lock` resolves published checksums for all five platform entries from Google's `.sha256` sidecars; the windows-x64 result (`098109eb64be2dac…`) matches the `InstallerSha256` in Google's winget manifest. Installing an explicitly pinned older version (`1.0.15857036`) also works. `taplo fmt --check` and `taplo check` pass.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android CLI support across Linux, macOS, and Windows.
  * Added platform-specific downloads, checksums, version detection, and Windows executable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->