### PR TITLE
fix(rust): resolve homes from config environment

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -6,6 +6,16 @@ variables for the home directories and falls back to their standard location (`~
 not set. You can change this by setting the `MISE_RUSTUP_HOME` and `MISE_CARGO_HOME` environment variables if you'd like
 to isolate mise's rustup/cargo from your other rustup/cargo installations.
 
+These variables can also be set in mise configuration. They are applied to Rust operations in the same mise invocation:
+
+```toml
+[env]
+MISE_RUSTUP_HOME = "{{env.HOME}}/.local/share/rustup"
+MISE_CARGO_HOME = "{{env.HOME}}/.local/share/cargo"
+```
+
+Explicit `RUSTUP_HOME` and `CARGO_HOME` values in `[env]` take precedence over their corresponding `MISE_` variables.
+
 Unlike most tools, these won't exist inside of `~/.local/share/mise/installs` because they are managed by rustup.
 mise keeps a symlink there for install tracking, sets the `RUSTUP_TOOLCHAIN` environment variable to the requested
 version, and asks rustup to install any configured components or targets when you run `mise install`.

--- a/e2e/core/test_rust_config_env_homes
+++ b/e2e/core/test_rust_config_env_homes
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+unset MISE_CARGO_HOME MISE_RUSTUP_HOME
+export MISE_OFFLINE=1
+
+CONFIG_CARGO_HOME="$PWD/config-cargo"
+CONFIG_RUSTUP_HOME="$PWD/config-rustup"
+mkdir -p "$CONFIG_CARGO_HOME/bin" "$CONFIG_RUSTUP_HOME"
+touch "$CONFIG_RUSTUP_HOME/settings.toml"
+
+cat >"$CONFIG_CARGO_HOME/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo cargo
+EOF
+
+cat >"$CONFIG_CARGO_HOME/bin/rustc" <<'EOF'
+#!/usr/bin/env bash
+echo "rustc ${RUSTUP_TOOLCHAIN:-unknown}"
+EOF
+
+cat >"$CONFIG_CARGO_HOME/bin/rustup" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "$*" >>"$CARGO_HOME/rustup.log"
+
+case "$1 $2" in
+	"component list")
+		echo rustfmt
+		;;
+	"toolchain install")
+		mkdir -p "$RUSTUP_HOME/toolchains/$3"
+		;;
+	"toolchain uninstall")
+		;;
+	*)
+		echo "unexpected rustup args: $*" >&2
+		exit 1
+		;;
+esac
+EOF
+
+chmod +x "$CONFIG_CARGO_HOME/bin/cargo" "$CONFIG_CARGO_HOME/bin/rustc" "$CONFIG_CARGO_HOME/bin/rustup"
+
+cat >mise.toml <<EOF
+[env]
+MISE_CARGO_HOME = "$CONFIG_CARGO_HOME"
+MISE_RUSTUP_HOME = "$CONFIG_RUSTUP_HOME"
+
+[tools]
+rust = { version = "1.81.0", components = ["rustfmt"] }
+EOF
+
+mise install
+assert_contains "cat '$CONFIG_CARGO_HOME/rustup.log'" "toolchain install 1.81.0"
+assert "mise exec -- rustc -V" "rustc 1.81.0"
+
+assert_contains "mise env --dotenv" "CARGO_HOME=$CONFIG_CARGO_HOME"
+assert_contains "mise env --dotenv" "RUSTUP_HOME=$CONFIG_RUSTUP_HOME"
+assert_contains "mise env --dotenv" "MISE_CARGO_HOME=$CONFIG_CARGO_HOME"
+assert_contains "mise env --dotenv" "MISE_RUSTUP_HOME=$CONFIG_RUSTUP_HOME"
+
+INSTALL_PATH=$(mise where rust@1.81.0)
+assert "readlink '$INSTALL_PATH'" "$CONFIG_CARGO_HOME/bin"
+
+mise install
+assert "grep -c '^toolchain install' '$CONFIG_CARGO_HOME/rustup.log'" "1"
+
+DIRECT_CARGO_HOME="$PWD/direct-cargo"
+DIRECT_RUSTUP_HOME="$PWD/direct-rustup"
+mkdir -p "$DIRECT_CARGO_HOME/bin" "$DIRECT_RUSTUP_HOME"
+cp "$CONFIG_CARGO_HOME/bin/cargo" "$CONFIG_CARGO_HOME/bin/rustc" "$CONFIG_CARGO_HOME/bin/rustup" "$DIRECT_CARGO_HOME/bin/"
+touch "$DIRECT_RUSTUP_HOME/settings.toml"
+
+cat >mise.toml <<EOF
+[env]
+MISE_CARGO_HOME = "$CONFIG_CARGO_HOME"
+MISE_RUSTUP_HOME = "$CONFIG_RUSTUP_HOME"
+CARGO_HOME = "$DIRECT_CARGO_HOME"
+RUSTUP_HOME = "$DIRECT_RUSTUP_HOME"
+
+[tools]
+rust = { version = "1.81.0", components = ["rustfmt"] }
+EOF
+
+mise install
+assert_contains "cat '$DIRECT_CARGO_HOME/rustup.log'" "toolchain install 1.81.0"
+INSTALL_PATH=$(mise where rust@1.81.0)
+assert "readlink '$INSTALL_PATH'" "$DIRECT_CARGO_HOME/bin"
+assert "mise exec -- rustc -V" "rustc 1.81.0"
+assert_contains "mise env --dotenv" "CARGO_HOME=$DIRECT_CARGO_HOME"
+assert_contains "mise env --dotenv" "RUSTUP_HOME=$DIRECT_RUSTUP_HOME"
+
+mise uninstall --yes rust@1.81.0
+assert_contains "cat '$DIRECT_CARGO_HOME/rustup.log'" "toolchain uninstall 1.81.0"

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -17,6 +17,7 @@ use crate::ui::progress_report::SingleReport;
 use crate::{dirs, env, file, github, plugins};
 use async_trait::async_trait;
 use eyre::Result;
+use indexmap::IndexMap;
 use xx::regex;
 
 #[derive(Debug)]
@@ -104,9 +105,14 @@ impl RustPlugin {
         }
     }
 
-    async fn setup_rustup(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
+    async fn setup_rustup(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+        homes: &RustHomes,
+    ) -> Result<()> {
         let settings = Settings::get();
-        if rustup_is_initialized() {
+        if rustup_is_initialized(homes) {
             return Ok(());
         }
         let _installer_lock = tokio::task::spawn_blocking(|| {
@@ -120,15 +126,14 @@ impl RustPlugin {
                 .lock()
         })
         .await??;
-        if rustup_is_initialized() {
+        if rustup_is_initialized(homes) {
             return Ok(());
         }
         ctx.pr.set_message("Downloading rustup-init".into());
         HTTP.download_file(rustup_url(&settings), &rustup_path(), Some(ctx.pr.as_ref()))
             .await?;
         file::make_executable(rustup_path())?;
-        file::create_dir_all(rustup_home())?;
-        let ts = ctx.config.get_toolset().await?;
+        file::create_dir_all(&homes.rustup)?;
         let mut cmd = CmdLineRunner::new(rustup_path())
             .with_pr(ctx.pr.as_ref())
             .arg("--no-modify-path")
@@ -136,7 +141,7 @@ impl RustPlugin {
             .arg("none")
             .arg("-y")
             .env_values(tv.install_env())
-            .envs(self.exec_env(&ctx.config, ts, tv).await?);
+            .envs(rustup_env(homes, &tv.version));
         if let Some(host) = settings.rust.default_host.as_ref() {
             cmd = cmd.arg("--default-host").arg(host);
         }
@@ -144,15 +149,19 @@ impl RustPlugin {
         Ok(())
     }
 
-    async fn test_rust(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<()> {
+    async fn test_rust(
+        &self,
+        ctx: &InstallContext,
+        tv: &ToolVersion,
+        homes: &RustHomes,
+    ) -> Result<()> {
         ctx.pr.set_message(format!("{RUSTC_BIN} -V"));
-        let ts = ctx.config.get_toolset().await?;
         CmdLineRunner::new(RUSTC_BIN)
             .with_pr(ctx.pr.as_ref())
             .arg("-V")
             .env_values(tv.install_env())
-            .envs(self.exec_env(&ctx.config, ts, tv).await?)
-            .prepend_path(self.list_bin_paths(&ctx.config, tv).await?)?
+            .envs(rustup_env(homes, &tv.version))
+            .prepend_path(vec![homes.cargo_bindir()])?
             .execute()
     }
 
@@ -164,6 +173,7 @@ impl RustPlugin {
         &self,
         tv: &ToolVersion,
         subcommand: &str,
+        homes: &RustHomes,
     ) -> Result<Option<BTreeSet<String>>> {
         let args = vec![
             subcommand.to_string(),
@@ -173,11 +183,11 @@ impl RustPlugin {
             tv.version.clone(),
         ];
         let mut cmd = cmd(RUSTUP_BIN, args)
-            .env("PATH", rustup_path_env()?)
+            .env("PATH", rustup_path_env(homes)?)
             .stdout_capture()
             .stderr_capture()
             .unchecked();
-        for (key, value) in rustup_env(&tv.version) {
+        for (key, value) in rustup_env(homes, &tv.version) {
             cmd = cmd.env(key, value);
         }
         let output = match cmd.run() {
@@ -254,13 +264,22 @@ impl Backend for RustPlugin {
             return Ok(false);
         }
 
+        let homes = RustHomes::resolve(config).await?;
+        if !file::is_symlink_to(&tv.install_path(), &homes.cargo_bindir()) {
+            debug!(
+                "{} points outside the configured Cargo home",
+                tv.install_path().display()
+            );
+            return Ok(false);
+        }
+
         let raw_opts = tv.request.options();
         let (_, components, targets) = RustOptions::new(&raw_opts).install_args();
 
         if let Some(components) = components
             && !components.is_empty()
         {
-            let Some(installed) = self.rustup_installed_items(tv, "component")? else {
+            let Some(installed) = self.rustup_installed_items(tv, "component", &homes)? else {
                 return Ok(false);
             };
             let missing = self.missing_components(&components, &installed);
@@ -277,7 +296,7 @@ impl Backend for RustPlugin {
         if let Some(targets) = targets
             && !targets.is_empty()
         {
-            let Some(installed) = self.rustup_installed_items(tv, "target")? else {
+            let Some(installed) = self.rustup_installed_items(tv, "target", &homes)? else {
                 return Ok(false);
             };
             let missing = self.missing_targets(&targets, &installed);
@@ -364,9 +383,9 @@ impl Backend for RustPlugin {
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
-        let _state_locks = lock_rust_state().await?;
-        self.setup_rustup(ctx, &tv).await?;
-        let ts = ctx.config.get_toolset().await?;
+        let homes = RustHomes::resolve(&ctx.config).await?;
+        let _state_locks = lock_rust_state(&homes).await?;
+        self.setup_rustup(ctx, &tv, &homes).await?;
 
         let raw_opts = tv.request.options();
         let (profile, components, targets) = RustOptions::new(&raw_opts).install_args();
@@ -378,18 +397,18 @@ impl Backend for RustPlugin {
             .arg(&tv.version)
             .opt_args("--component", components)
             .opt_args("--target", targets)
-            .prepend_path(self.list_bin_paths(&ctx.config, &tv).await?)?
+            .prepend_path(vec![homes.cargo_bindir()])?
             .env_values(tv.install_env())
-            .envs(self.exec_env(&ctx.config, ts, &tv).await?);
+            .envs(rustup_env(&homes, &tv.version));
         if let Some(profile) = profile.as_ref() {
             cmd = cmd.arg("--profile").arg(profile);
         }
         cmd.execute()?;
 
         file::remove_all(tv.install_path())?;
-        file::make_symlink(&cargo_home().join("bin"), &tv.install_path())?;
+        file::make_symlink(&homes.cargo_bindir(), &tv.install_path())?;
 
-        self.test_rust(ctx, &tv).await?;
+        self.test_rust(ctx, &tv, &homes).await?;
 
         Ok(tv)
     }
@@ -400,34 +419,34 @@ impl Backend for RustPlugin {
         pr: &dyn SingleReport,
         tv: &ToolVersion,
     ) -> Result<()> {
-        let ts = config.get_toolset().await?;
-        let mut env = self.exec_env(config, ts, tv).await?;
+        let homes = RustHomes::resolve(config).await?;
+        let mut env = rustup_env(&homes, &tv.version);
         env.remove("RUSTUP_TOOLCHAIN");
         CmdLineRunner::new(RUSTUP_BIN)
             .with_pr(pr)
             .arg("toolchain")
             .arg("uninstall")
             .arg(&tv.version)
-            .prepend_path(self.list_bin_paths(config, tv).await?)?
+            .prepend_path(vec![homes.cargo_bindir()])?
             .envs(env)
             .execute()
     }
 
     async fn list_bin_paths(
         &self,
-        _config: &Arc<Config>,
+        config: &Arc<Config>,
         _tv: &ToolVersion,
     ) -> Result<Vec<PathBuf>> {
-        Ok(vec![cargo_bindir()])
+        Ok(vec![RustHomes::resolve(config).await?.cargo_bindir()])
     }
 
     async fn exec_env(
         &self,
-        _config: &Arc<Config>,
+        config: &Arc<Config>,
         _ts: &Toolset,
         tv: &ToolVersion,
     ) -> Result<BTreeMap<String, String>> {
-        Ok(rustup_env(&tv.version))
+        Ok(rustup_env(&RustHomes::resolve(config).await?, &tv.version))
     }
 
     async fn outdated_info(
@@ -591,10 +610,6 @@ fn rustup_path() -> PathBuf {
     dirs::CACHE.join("rust").join(RUSTUP_INIT_BIN)
 }
 
-fn rustup_is_initialized() -> bool {
-    rustup_home().join("settings.toml").exists() && cargo_bin().exists()
-}
-
 fn rust_state_lock_identities(rustup_home: &Path, cargo_home: &Path) -> Vec<PathBuf> {
     let mut identities = vec![
         file::desymlink_path(rustup_home),
@@ -605,8 +620,8 @@ fn rust_state_lock_identities(rustup_home: &Path, cargo_home: &Path) -> Vec<Path
     identities
 }
 
-async fn lock_rust_state() -> Result<Vec<fslock::LockFile>> {
-    let identities = rust_state_lock_identities(&rustup_home(), &cargo_home());
+async fn lock_rust_state(homes: &RustHomes) -> Result<Vec<fslock::LockFile>> {
+    let identities = rust_state_lock_identities(&homes.rustup, &homes.cargo);
     tokio::task::spawn_blocking(move || {
         identities
             .into_iter()
@@ -626,26 +641,81 @@ async fn lock_rust_state() -> Result<Vec<fslock::LockFile>> {
     .await?
 }
 
-fn rustup_home() -> PathBuf {
-    resolve_rust_home(
-        Settings::get()
-            .rust
-            .rustup_home
-            .clone()
-            .or(env::var_path("RUSTUP_HOME"))
-            .unwrap_or(dirs::HOME.join(".rustup")),
-    )
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RustHomes {
+    cargo: PathBuf,
+    rustup: PathBuf,
 }
 
-fn cargo_home() -> PathBuf {
-    resolve_rust_home(
-        Settings::get()
-            .rust
-            .cargo_home
-            .clone()
-            .or(env::var_path("CARGO_HOME"))
-            .unwrap_or(dirs::HOME.join(".cargo")),
-    )
+impl RustHomes {
+    async fn resolve(config: &Arc<Config>) -> Result<Self> {
+        let config_env = config.env().await?;
+        let settings = Settings::get();
+        Ok(Self::from_sources(
+            &config_env,
+            settings.rust.cargo_home.clone(),
+            env::var_path("CARGO_HOME"),
+            settings.rust.rustup_home.clone(),
+            env::var_path("RUSTUP_HOME"),
+        ))
+    }
+
+    fn from_sources(
+        config_env: &IndexMap<String, String>,
+        configured_cargo: Option<PathBuf>,
+        ambient_cargo: Option<PathBuf>,
+        configured_rustup: Option<PathBuf>,
+        ambient_rustup: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            cargo: select_rust_home(
+                config_env,
+                "CARGO_HOME",
+                "MISE_CARGO_HOME",
+                configured_cargo,
+                ambient_cargo,
+                dirs::HOME.join(".cargo"),
+            ),
+            rustup: select_rust_home(
+                config_env,
+                "RUSTUP_HOME",
+                "MISE_RUSTUP_HOME",
+                configured_rustup,
+                ambient_rustup,
+                dirs::HOME.join(".rustup"),
+            ),
+        }
+    }
+
+    fn cargo_bindir(&self) -> PathBuf {
+        self.cargo.join("bin")
+    }
+
+    fn cargo_bin(&self) -> PathBuf {
+        self.cargo_bindir().join(CARGO_BIN)
+    }
+}
+
+fn rustup_is_initialized(homes: &RustHomes) -> bool {
+    homes.rustup.join("settings.toml").exists() && homes.cargo_bin().exists()
+}
+
+fn select_rust_home(
+    config_env: &IndexMap<String, String>,
+    direct_key: &str,
+    mise_key: &str,
+    configured: Option<PathBuf>,
+    ambient: Option<PathBuf>,
+    default: PathBuf,
+) -> PathBuf {
+    let path = config_env
+        .get(direct_key)
+        .or_else(|| config_env.get(mise_key))
+        .map(PathBuf::from)
+        .or(configured)
+        .or(ambient)
+        .unwrap_or(default);
+    resolve_rust_home(path)
 }
 
 fn resolve_rust_home(path: PathBuf) -> PathBuf {
@@ -659,31 +729,24 @@ fn resolve_rust_home(path: PathBuf) -> PathBuf {
     }
 }
 
-fn cargo_bin() -> PathBuf {
-    cargo_bindir().join(CARGO_BIN)
-}
-fn cargo_bindir() -> PathBuf {
-    cargo_home().join("bin")
-}
-
-fn rustup_env(toolchain: &str) -> BTreeMap<String, String> {
+fn rustup_env(homes: &RustHomes, toolchain: &str) -> BTreeMap<String, String> {
     [
         (
             "CARGO_HOME".to_string(),
-            cargo_home().to_string_lossy().to_string(),
+            homes.cargo.to_string_lossy().to_string(),
         ),
         (
             "RUSTUP_HOME".to_string(),
-            rustup_home().to_string_lossy().to_string(),
+            homes.rustup.to_string_lossy().to_string(),
         ),
         ("RUSTUP_TOOLCHAIN".to_string(), toolchain.to_string()),
     ]
     .into()
 }
 
-fn rustup_path_env() -> Result<OsString> {
+fn rustup_path_env(homes: &RustHomes) -> Result<OsString> {
     Ok(env::join_paths(
-        std::iter::once(cargo_bindir()).chain(env::PATH.clone()),
+        std::iter::once(homes.cargo_bindir()).chain(env::PATH.clone()),
     )?)
 }
 
@@ -978,6 +1041,72 @@ targets = ["wasm32-wasip1", " wasm32-wasip1 "]
         assert_eq!(
             rust_state_lock_identities(&state, &state),
             rust_state_lock_identities(&alias, &alias)
+        );
+    }
+
+    #[test]
+    fn rust_homes_use_defaults_without_overrides() {
+        let homes = RustHomes::from_sources(&indexmap::IndexMap::new(), None, None, None, None);
+
+        assert_eq!(homes.cargo, dirs::HOME.join(".cargo"));
+        assert_eq!(homes.rustup, dirs::HOME.join(".rustup"));
+    }
+
+    #[test]
+    fn rust_homes_follow_config_environment_precedence() {
+        let config_env = indexmap::IndexMap::from([
+            (
+                "MISE_CARGO_HOME".to_string(),
+                "/config/mise-cargo".to_string(),
+            ),
+            ("CARGO_HOME".to_string(), "/config/cargo".to_string()),
+            (
+                "MISE_RUSTUP_HOME".to_string(),
+                "/config/mise-rustup".to_string(),
+            ),
+            ("RUSTUP_HOME".to_string(), "/config/rustup".to_string()),
+        ]);
+
+        let homes = RustHomes::from_sources(
+            &config_env,
+            Some("/settings/cargo".into()),
+            Some("/ambient/cargo".into()),
+            Some("/settings/rustup".into()),
+            Some("/ambient/rustup".into()),
+        );
+
+        assert_eq!(
+            homes.cargo,
+            resolve_rust_home(PathBuf::from("/config/cargo"))
+        );
+        assert_eq!(
+            homes.rustup,
+            resolve_rust_home(PathBuf::from("/config/rustup"))
+        );
+    }
+
+    #[test]
+    fn rust_homes_use_config_mise_environment_before_existing_sources() {
+        let config_env = indexmap::IndexMap::from([(
+            "MISE_CARGO_HOME".to_string(),
+            "/config/cargo".to_string(),
+        )]);
+
+        let homes = RustHomes::from_sources(
+            &config_env,
+            Some("/settings/cargo".into()),
+            Some("/ambient/cargo".into()),
+            Some("/settings/rustup".into()),
+            Some("/ambient/rustup".into()),
+        );
+
+        assert_eq!(
+            homes.cargo,
+            resolve_rust_home(PathBuf::from("/config/cargo"))
+        );
+        assert_eq!(
+            homes.rustup,
+            resolve_rust_home(PathBuf::from("/settings/rustup"))
         );
     }
 }


### PR DESCRIPTION
## Summary

- Resolve Cargo and Rustup homes from the fully evaluated config environment before Rust backend operations.
- Reuse the same resolved homes for rustup setup, installation, component and target checks, execution, outdated checks, and uninstall.
- Reinstall an already tracked toolchain when its mise install symlink points to a previous Cargo home.
- Document config-level Rust home overrides and their precedence.

## Problem

MISE_CARGO_HOME and MISE_RUSTUP_HOME set in [env] were emitted by mise, but the Rust backend resolved its homes earlier from settings and the ambient process environment. As a result, the same mise invocation could report the configured values while rustup operations continued using the default homes.

## Resolution order

Each home is now selected in this order:

1. Direct CARGO_HOME or RUSTUP_HOME from the evaluated config environment
2. MISE_CARGO_HOME or MISE_RUSTUP_HOME from the evaluated config environment
3. The existing rust settings value, including ambient MISE_* overrides
4. Ambient CARGO_HOME or RUSTUP_HOME
5. ~/.cargo or ~/.rustup

The existing tilde and relative-path expansion behavior is preserved. A resolved pair is shared throughout each install operation so setup, install, symlink creation, and validation cannot disagree.

## Verification

- Rust backend unit tests, including defaults and precedence cases
- Offline E2E covering config-only MISE_* homes, installation, environment output, component checks, execution, direct-home precedence, symlink migration, and uninstall
- Existing Rust component reconciliation E2E
- cargo check --all-features
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- Rustfmt, ShellCheck, shfmt, Prettier, and markdownlint for changed files

The repository-wide mise run lint command still cannot identify this Sapling working copy as a Git repository; all relevant individual checks above pass.

Addresses https://github.com/jdx/mise/discussions/8943

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rust tool installations now support configuring Cargo and rustup home directories through mise environment settings.
  * Rust commands and installations consistently use the configured directories, including their binary paths.

* **Bug Fixes**
  * Explicit `CARGO_HOME` and `RUSTUP_HOME` settings now correctly take precedence over mise-specific configuration.
  * Rust installation, validation, reinstallation, and removal now behave consistently with customized home directories.

* **Documentation**
  * Added guidance for configuring Rust home directories and explaining environment-variable precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->