### PR TITLE
fix(settings): correct the `go.set_gopath` deprecation message

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -1078,7 +1078,7 @@ optional = true
 type = "Bool"
 
 [go.set_gopath]
-deprecated = "Use env._go.set_goroot instead."
+deprecated = "mise no longer manages GOPATH. Set GOPATH in [env] if you need a specific value."
 description = "[deprecated] Set to true to set GOPATH=~/.local/share/mise/installs/go/.../packages."
 env = "MISE_GO_SET_GOPATH"
 type = "Bool"


### PR DESCRIPTION
## Problem

`settings.toml`, `[go.set_gopath]`:

```toml
deprecated = "Use env._go.set_goroot instead."
```

That is wrong twice over.

1. It names **`set_goroot`** as the replacement for a **`set_gopath`** setting — a different
   setting, and one that is not deprecated (`go.set_goroot` still defaults to `true`).
2. **`env._go` does not exist.** The env directives are `file`, `module`, `path`, `source` and
   `venv` (`src/config/env_directive/`), and there is no path that resolves `_go.set_*`.
   `set_goroot` is a *setting*, not a directive or a tool option — `schema/mise.json` has it under
   `settings` alongside the other `go.*` entries. The string `env._go.set_goroot` occurred **exactly
   once in the whole repository**, in that line.

So anyone acting on it finds nothing.

## Change

There is no replacement setting to point at, because not managing GOPATH is the intent. From
#1638, which is the design doc this deprecation came out of:

> GOPATH really doesn't make sense to manage via mise at all. mise should not set this at all unless
> `MISE_GO_SET_GOPATH=true`. Even then, we should deprecate that configuration and show a warning
> —not all the time—but when installing a new go version with mise.
>
> - [x] change default behavior to not set GOPATH if it is not already set

Measured on **v2026.8.3** with `go = "1.24"` installed: `mise env` emits `GOROOT` and `GOBIN` and no
`GOPATH` at all. So the message now states that and points at `[env]` for anyone who wants a
specific value:

```toml
deprecated = "mise no longer manages GOPATH. Set GOPATH in [env] if you need a specific value."
```

The shape follows the existing *semantic* deprecations (as opposed to flat→grouped renames) — e.g.
`[node.default_packages_file]`, which states what is deprecated and then what to do instead.

Deprecation messages live only in `settings.toml`; `schema/mise.json` carries `"deprecated": true`
without the text and `docs/` does not include it, so no generated output changes.

## Deliberately not included

**This message is never actually printed today, and I did not change that.**
`warn_deprecated_now` (`src/config/settings.rs:374-380`) only emits when `deprecated`,
`deprecated_warn_at` **and** `deprecated_remove_at` are all present, and `[go.set_gopath]` has only
the first. Adding the other two would arm the standard path — which warns on every settings load —
and that contradicts the *"not all the time—but when installing a new go version"* wording above.

The warning users do see comes from `src/plugins/core/go.rs:181-183`, inside `verify()`, i.e. at
install time, which is exactly what #1638 asked for. It carries no guidance
(`warn!("setting go.set_gopath is deprecated")`), so the corrected text does not reach anyone
through it either.

Both of those are maintainer calls — the removal version, and whether the guidance should be folded
into the install-time warning — so this PR is draft and limited to correcting text that is simply
untrue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `go.set_gopath` deprecation notice to clarify that GOPATH is no longer managed automatically.
  * Added guidance to configure GOPATH under the `[env]` section when a specific value is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->