### PR TITLE
fix(generate): forward hook arguments in generated git hooks

### DIFF
--- a/e2e/generate/test_generate_git_pre_commit
+++ b/e2e/generate/test_generate_git_pre_commit
@@ -7,6 +7,9 @@ assert_contains "mise generate git-pre-commit --quiet" "exec mise run pre-commit
 assert_contains "mise generate git-pre-commit --write" "Wrote to"
 test -x .git/hooks/pre-commit
 assert_contains "cat .git/hooks/pre-commit" "exec mise run pre-commit"
+# git hands most hooks arguments — a commit-msg hook gets the message file — and they have
+# to reach the task. pre-commit itself is called with none, so this expands to nothing there.
+assert_contains "cat .git/hooks/pre-commit" 'exec mise run pre-commit "$@"'
 
 assert_contains "mise generate git-pre-commit --write" "Moving existing hook"
 test -f .git/hooks/pre-commit.old

--- a/src/cli/generate/git_pre_commit.rs
+++ b/src/cli/generate/git_pre_commit.rs
@@ -55,12 +55,16 @@ impl GitPreCommit {
 
     fn generate(&self) -> String {
         let task = &self.task;
+        // `"$@"` forwards whatever git passes the hook. `pre-commit` is called with no
+        // arguments so it is unaffected, but every other `--hook` target gets some — a
+        // `commit-msg` hook is handed the path to the message file, for instance — and
+        // without this they are dropped before the task ever sees them.
         format!(
             r#"#!/bin/sh
 STAGED="$(git diff-index --cached --name-only -z HEAD | xargs -0)"
 export STAGED
 export MISE_PRE_COMMIT=1
-exec mise run {task}
+exec mise run {task} "$@"
 "#
         )
     }
@@ -73,3 +77,36 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>git commit -m "feat: add new feature"</bold> <dim># runs `mise run pre-commit`</dim>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::GitPreCommit;
+
+    fn generate(task: &str, hook: &str) -> String {
+        GitPreCommit {
+            task: task.to_string(),
+            write: false,
+            hook: hook.to_string(),
+        }
+        .generate()
+    }
+
+    #[test]
+    fn forwards_hook_arguments_to_the_task() {
+        // Without the passthrough a `commit-msg` hook cannot reach the message file git
+        // hands it, which is the whole point of that hook.
+        let out = generate("lint-commit-msg", "commit-msg");
+        assert!(
+            out.contains(r#"exec mise run lint-commit-msg "$@""#),
+            "hook arguments must reach the task:\n{out}"
+        );
+    }
+
+    #[test]
+    fn pre_commit_output_is_unchanged_in_substance() {
+        let out = generate("pre-commit", "pre-commit");
+        assert!(out.starts_with("#!/bin/sh\n"), "{out}");
+        assert!(out.contains("export MISE_PRE_COMMIT=1"), "{out}");
+        assert!(out.contains("STAGED="), "{out}");
+    }
+}


### PR DESCRIPTION
## Problem

`mise generate git-pre-commit` takes a `--hook <HOOK>` flag documented as *"Which hook to generate
(saves to `.git/hooks/$hook`)"*. It only changes the destination filename — `generate()` in
`src/cli/generate/git_pre_commit.rs` is a fixed `format!` with no hook-specific branch:

```sh
STAGED="$(git diff-index --cached --name-only -z HEAD | xargs -0)"
export STAGED
export MISE_PRE_COMMIT=1
exec mise run {task}
```

There is no `"$@"`, so whatever git passes the hook is dropped before the task runs. Measured on
**v2026.8.3** with `mise` on `PATH` and an existing `HEAD`:

```console
$ mise generate git-pre-commit --write --hook commit-msg --task lint-commit-msg
Wrote to .../.git/hooks/commit-msg

$ git commit -m "subject line here"
[lint-commit-msg] $ echo "TASK RAN. arg1=[$1] MISE_PRE_COMMIT=$MISE_PRE_COMMIT STAGED=[$STAGED]"
TASK RAN. arg1=[] MISE_PRE_COMMIT=1 STAGED=[f.txt]
```

The hook fires, but the commit-message path git handed it never arrives — which is the whole point
of a `commit-msg` hook.

## Change

Append `"$@"`.

- **`pre-commit` is unchanged in substance.** git calls it with no arguments, so `"$@"` expands to
  nothing.
- **Arguments land on the task's command line, not in `$1`.** That is mise's normal task-argument
  behaviour, not something this PR changes: `mise run show /tmp/COMMIT_EDITMSG` renders as
  `[show] $ echo "…" /tmp/COMMIT_EDITMSG`. So a task like `run = 'commitlint --edit'` becomes
  `commitlint --edit <path to message>`.
- **No `--` separator is needed.** `Run`'s `args: Vec<String>` (`src/cli/run.rs`) is declared
  `allow_hyphen_values = true`, so a hook argument starting with `-` is taken as a task argument
  rather than parsed as a mise flag.

## Tests

`git_pre_commit.rs` had no test module; this adds one.

- `forwards_hook_arguments_to_the_task` — asserts the generated script contains
  `exec mise run lint-commit-msg "$@"`. **This fails without the change**, which is the point of it.
- `pre_commit_output_is_unchanged_in_substance` — shebang, `MISE_PRE_COMMIT=1` and `STAGED=` all
  still present.
- `e2e/generate/test_generate_git_pre_commit` gains one assertion on the written file. Its existing
  assertions are `assert_contains` on `exec mise run pre-commit`, which the new line still contains,
  so they are unaffected.

No generated output changes: this edits a runtime `format!` string, not a doc comment.

## Deliberately not included

- **`MISE_PRE_COMMIT=1` and `STAGED` are set for every hook target.** A `commit-msg` hook gets
  `MISE_PRE_COMMIT=1`, and `STAGED` is a pre-commit concept. Whether to emit hook-specific bodies is
  a design call, not a bug fix.
- **The `STAGED` line uses `HEAD`, so the generated hook errors on a repository's first commit** —
  `fatal: ambiguous argument 'HEAD': unknown revision`, measured. A separate defect.
- **`--write`'s help still reads *"write to .git/hooks/pre-commit"***, which predates `--hook`.
  That is a doc comment, so changing it moves `man/man1/mise.1`, `mise.usage.kdl` and `docs/cli/*`;
  `mise run render` cannot be run on this machine (`mise usage` drops the Homebrew subcommands on
  Windows), so it is left for someone who can regenerate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git pre-commit hooks now correctly pass provided arguments to configured tasks.
  * Existing pre-commit output behavior is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->