### PR TITLE
feat(aqua): resolve relative aqua.registries against the declaring config

### DIFF
--- a/e2e/cli/test_aqua_registries_relative_path
+++ b/e2e/cli/test_aqua_registries_relative_path
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Regression test for discussion #4306: a `registry.yaml` committed alongside the
+# project could not be referenced. A relative entry failed later as `relative URL
+# without a base`, so only an absolute -- and therefore uncommittable -- path
+# worked. Relative entries now resolve against the config root of the file that
+# declared them.
+
+touch registry.yaml
+cat <<EOF >mise.toml
+[settings]
+aqua.registries = ["registry.yaml"]
+EOF
+
+# Resolution happens while the config file is parsed, so the setting itself shows
+# the result -- no registry fetch, and no network.
+assert_contains "mise settings get aqua.registries 2>&1" "file://"
+assert_contains "mise settings get aqua.registries 2>&1" "registry.yaml"
+
+# Absolute URLs must pass through untouched.
+cat <<EOF >mise.toml
+[settings]
+aqua.registries = ["https://github.com/aquaproj/aqua-registry"]
+EOF
+
+assert_contains "mise settings get aqua.registries 2>&1" "https://github.com/aquaproj/aqua-registry"
+assert_not_contains "mise settings get aqua.registries 2>&1" "file://"

--- a/settings.toml
+++ b/settings.toml
@@ -133,6 +133,18 @@ direct URL to a `registry.yaml` or `registry.yml` file, or an absolute `file://`
 registry directory or file. For repository and directory sources, mise loads `registry.yaml` from
 the source root and falls back to `registry.yml` if needed.
 
+A source that is not a URL is read as a filesystem path, resolved against the config root of the
+file that declared it. This is how you reference a registry committed alongside the project:
+
+```toml
+[settings]
+aqua.registries = ["registry.yaml"]
+```
+
+Path resolution applies only to sources set in a config file, since only those have a config root
+to resolve against. A path given via `MISE_AQUA_REGISTRIES` or the CLI must be an absolute
+`file://` URL.
+
 Downloaded registries are cached according to `aqua.registry_cache_ttl`, which defaults to one
 week. To refresh sooner, run `mise cache clear`, set `aqua.registry_cache_ttl = "0s"`, or change
 `MISE_CACHE_DIR` to use a different cache location. Local `file://` sources bypass the downloaded

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -9,6 +9,7 @@ use confique::{Config, Layer};
 use eyre::{Result, bail};
 use indexmap::{IndexMap, indexmap};
 use itertools::Itertools;
+use path_absolutize::Absolutize;
 use serde::Serialize;
 use serde::ser::Error;
 use serde::{Deserialize, Deserializer, Serializer};
@@ -496,6 +497,59 @@ fn should_warn_ignored_global_only_value(value: &toml::Value) -> bool {
     !matches!(value, toml::Value::String(s) if s.is_empty())
 }
 
+/// `aqua.registries` entries must be URLs — `github_repo_slug` requires a
+/// parseable `https` URL, and anything else fails later with `relative URL
+/// without a base`. A value that is not a URL is therefore dead today, so
+/// reading it as a path relative to the config file that declared it is a pure
+/// widening: it lets a registry committed alongside the project be referenced
+/// portably, without changing any config that works now. See discussion #4306.
+///
+/// Returns `None` when the value should be left as written.
+fn resolve_registry_source(value: &str, config_root: &Path) -> Option<String> {
+    let looks_like_path = match Url::parse(value) {
+        Err(_) => true,
+        // A Windows path such as `C:\registry.yaml` parses as a URL whose scheme
+        // is the drive letter. No real URL scheme is a single character.
+        Ok(url) => url.scheme().len() == 1,
+    };
+    if !looks_like_path {
+        return None;
+    }
+    // Joining an absolute path returns it unchanged, so absolute entries are
+    // normalized rather than rebased onto the config root.
+    let joined = config_root.join(value);
+    let absolute = joined
+        .absolutize()
+        .map(|p| p.into_owned())
+        .unwrap_or(joined);
+    // Leave the value alone if it cannot be expressed as a file URL rather than
+    // substituting something the user did not write.
+    Url::from_file_path(&absolute).ok().map(String::from)
+}
+
+/// Rewrite relative `aqua.registries` entries so they resolve against the config
+/// root of the file that declared them. Both `aqua.registries = [..]` under
+/// `[settings]` and `[settings.aqua]` + `registries = [..]` parse to the same
+/// nested table, so navigating the table covers either spelling.
+fn resolve_aqua_registry_paths(settings: &mut toml::Table, path: &Path) {
+    let Some(registries) = settings
+        .get_mut("aqua")
+        .and_then(toml::Value::as_table_mut)
+        .and_then(|aqua| aqua.get_mut("registries"))
+        .and_then(toml::Value::as_array_mut)
+    else {
+        return;
+    };
+    let config_root = crate::config::config_file::config_root::config_root(path);
+    for entry in registries.iter_mut() {
+        if let Some(value) = entry.as_str()
+            && let Some(resolved) = resolve_registry_source(value, &config_root)
+        {
+            *entry = toml::Value::String(resolved);
+        }
+    }
+}
+
 impl Settings {
     const UNIX_DEFAULT_FILE_SHELL_ARGS: &'static str = "sh";
     const UNIX_DEFAULT_INLINE_SHELL_ARGS: &'static str = "sh -c -o errexit";
@@ -823,6 +877,9 @@ impl Settings {
         if let Some(settings) = raw.get_mut("settings").and_then(toml::Value::as_table_mut) {
             strip_local_only_settings(settings, path, crate::config::is_global_config(path));
             strip_env_only_settings(settings, path);
+            // After the strips, so a setting that will not survive them is
+            // never rewritten.
+            resolve_aqua_registry_paths(settings, path);
         }
         let deprecated = deprecated_settings_in_toml_config(&raw);
         let settings_file: SettingsFile = raw.try_into()?;
@@ -1786,6 +1843,114 @@ mod tests {
         let partial = Settings::parse_settings_file(&path).unwrap();
 
         assert_eq!(partial.tera_v1, Some(false));
+    }
+
+    /// Run the rewrite over a `[settings]` block and return the resulting
+    /// `aqua.registries` entries, as `parse_settings_file` would see them.
+    fn rewritten_registries(dir: &Path, body: &str) -> Vec<String> {
+        let mut settings = toml::from_str::<toml::Table>(body).unwrap();
+        resolve_aqua_registry_paths(&mut settings, &dir.join(".mise.toml"));
+        settings["aqua"]["registries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect()
+    }
+
+    /// discussion #4306: a registry committed next to the project could not be
+    /// referenced, because a relative entry failed as `relative URL without a
+    /// base`.
+    #[test]
+    fn relative_aqua_registry_resolves_against_config_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let registries = rewritten_registries(dir.path(), r#"aqua.registries = ["registry.yaml"]"#);
+
+        let expected = Url::from_file_path(dir.path().join("registry.yaml"))
+            .unwrap()
+            .to_string();
+        assert_eq!(registries, vec![expected]);
+    }
+
+    /// `aqua.registries = [..]` and `[aqua]` + `registries = [..]` parse to the
+    /// same nested table, so both spellings must be picked up.
+    #[test]
+    fn table_form_registries_also_resolve() {
+        let dir = tempfile::tempdir().unwrap();
+        let registries = rewritten_registries(
+            dir.path(),
+            r#"
+            [aqua]
+            registries = ["registry.yaml"]
+            "#,
+        );
+
+        let expected = Url::from_file_path(dir.path().join("registry.yaml"))
+            .unwrap()
+            .to_string();
+        assert_eq!(registries, vec![expected]);
+    }
+
+    #[test]
+    fn absolute_registry_urls_are_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let registries = rewritten_registries(
+            dir.path(),
+            r#"
+            aqua.registries = [
+              "https://github.com/aquaproj/aqua-registry",
+              "file:///somewhere/registry.yaml",
+            ]
+            "#,
+        );
+
+        assert_eq!(
+            registries,
+            vec![
+                "https://github.com/aquaproj/aqua-registry".to_string(),
+                "file:///somewhere/registry.yaml".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parent_relative_registry_path_is_normalized() {
+        let dir = tempfile::tempdir().unwrap();
+        let registries = rewritten_registries(
+            dir.path(),
+            r#"aqua.registries = ["../shared/registry.yaml"]"#,
+        );
+
+        assert!(
+            !registries[0].contains(".."),
+            "expected `..` to be normalized away, got {}",
+            registries[0]
+        );
+    }
+
+    #[test]
+    fn registries_without_aqua_table_are_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut settings = toml::from_str::<toml::Table>("offline = true").unwrap();
+        resolve_aqua_registry_paths(&mut settings, &dir.path().join(".mise.toml"));
+        assert_eq!(settings["offline"].as_bool(), Some(true));
+    }
+
+    /// A drive-letter path parses as a URL whose scheme is one character, so it
+    /// must not be mistaken for an absolute URL and left unusable.
+    #[cfg(windows)]
+    #[test]
+    fn windows_drive_registry_path_is_treated_as_a_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let registries =
+            rewritten_registries(dir.path(), r#"aqua.registries = ['C:\reg\registry.yaml']"#);
+
+        assert_eq!(registries.len(), 1);
+        assert!(
+            registries[0].starts_with("file:///C:/reg/"),
+            "expected a file URL, got {}",
+            registries[0]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #4306.

## The problem

#4306 asks how to use a `registry.yaml` **committed inside the project's own repository**. Today that cannot be expressed. Measured on **v2026.8.3**, each case with a **cleared cache** — registry results are cached per URL, which otherwise makes a broken config look like it works:

| `[settings] aqua.registries` | result |
|---|---|
| `"file:///abs/path/registry.yaml"` | works, but the path is machine-specific and cannot be committed |
| `"registry.yaml"` | `invalid aqua registry URL registry.yaml: relative URL without a base` |
| `"file://{{config_root}}/registry.yaml"` | not rendered — the literal `{{config_root}}` is used |
| `[env] MISE_AQUA_REGISTRIES = "file://{{config_root}}/…"` | no effect; settings are read before `[env]` is applied |

The third row is the surprising one, since `{{config_root}}` **does** render in `[env]` in the very same file:

```console
$ mise env | grep PROOF
export PROOF=/home/me/proj
```

## The change

A source that is not a URL is now read as a filesystem path, resolved against the config root of the file that declared it:

```toml
[settings]
aqua.registries = ["registry.yaml"]
```

This is done in `Settings::parse_settings_file`, which already has the declaring file's path, and already calls `is_global_config(path)` — the one dependency `config_root()` needs. `config_root()` is pure path arithmetic with no settings dependency, so no new coupling and no cycle.

## Why this is a pure widening

`aqua.registries` entries **must** be URLs: `github_repo_slug` requires a parseable `https` URL, and anything else fails with `relative URL without a base`. So a non-URL entry is already dead — there is no currently-working configuration whose meaning changes. Absolute `https://` and `file://` entries are passed through untouched, which the tests pin down.

## Why not template rendering

Making `{{config_root}}` work in `[settings]` would be the more general fix, and it does not work as things stand: `get_tera()` → `use_tera_v1()` → `Settings::try_get()`, and [`try_get`](https://github.com/jdx/mise/blob/main/src/config/settings.rs) has no reentrancy guard. Calling it while `all_settings_files()` is still running re-enters the whole settings load and recurses without bound. Templating `[settings]` would need that load restructured, so this PR does the narrow thing instead.

## Scope

- **Only `aqua.registries`.** Generalizing to other path/URL settings is deliberately left out.
- **Only config-file sources.** `MISE_AQUA_REGISTRIES` and CLI values have no config root and are unchanged — an absolute `file://` URL is still required there. This is stated in the setting's docs.
- **`aqua.registry_url`** (deprecated) is untouched.
- **Safe mode is unaffected.** `[settings]` from non-global config is already dropped there, so a project-local registry only applies to trusted config. Not changed here.
- `mise settings get aqua.registries` now reports the resolved absolute URL, which is the value actually used.

## Docs

`settings.toml` gains the explanation under `[aqua.registries].docs`. Only the long-form `docs` is edited, not `description` — `description` is embedded in `schema/mise.json`, while `docs` is read straight from `settings.toml` by `docs/settings.data.ts` at docs-build time and is not committed anywhere generated. So no `mise run render` is needed and no generated file changes.

## Tests

- 6 unit tests over the rewrite: relative entry resolves under the config root; the `[settings.aqua]` table spelling resolves too; `https://` and `file://` entries are left alone; `../` is normalized away; a config with no `aqua` table is untouched; and (Windows) `C:\reg\registry.yaml` is treated as a path rather than a URL whose scheme is the drive letter.
- `e2e/cli/test_aqua_registries_relative_path` covers the wiring through `mise settings get`. Resolution happens at parse time, so the test needs no registry fetch and **no network**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry sources can now be specified as relative or Windows-style filesystem paths.
  * Paths are resolved relative to the configuration file and converted to absolute file URLs, while existing URLs remain unchanged.

* **Documentation**
  * Expanded registry configuration guidance with path-resolution behavior, examples, and usage restrictions.

* **Tests**
  * Added coverage for relative paths, absolute URLs, parent-relative paths, shorthand and table syntax, and Windows paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->