### PR TITLE
registry: fix haxe and neko integration

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -327,6 +327,89 @@ fn codegen_registry() {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+        let depends = info
+            .get("depends")
+            .map(|depends| {
+                depends
+                    .as_array()
+                    .unwrap_or_else(|| panic!("[{short}] 'depends' must be an array"))
+                    .iter()
+                    .map(|dependency| {
+                        dependency
+                            .as_str()
+                            .unwrap_or_else(|| {
+                                panic!("[{short}] 'depends' must contain only strings")
+                            })
+                            .to_string()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let env_paths = info
+            .get("env_paths")
+            .map(|env_paths| {
+                env_paths
+                    .as_array()
+                    .unwrap_or_else(|| panic!("[{short}] 'env_paths' must be an array"))
+                    .iter()
+                    .map(|entry| {
+                        let entry = entry.as_table().unwrap_or_else(|| {
+                            panic!("[{short}] 'env_paths' entries must be tables")
+                        });
+                        for key in entry.keys() {
+                            assert!(
+                                matches!(key.as_str(), "name" | "paths" | "os"),
+                                "[{short}] unknown env_paths field: {key}"
+                            );
+                        }
+                        let name = entry
+                            .get("name")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_else(|| {
+                                panic!("[{short}] 'env_paths.name' must be a string")
+                            });
+                        let string_array = |key: &str| {
+                            entry
+                                .get(key)
+                                .map(|value| {
+                                    value
+                                        .as_array()
+                                        .unwrap_or_else(|| {
+                                            panic!("[{short}] 'env_paths.{key}' must be an array")
+                                        })
+                                        .iter()
+                                        .map(|value| {
+                                            value.as_str().unwrap_or_else(|| {
+                                                panic!(
+                                                    "[{short}] 'env_paths.{key}' must contain only strings"
+                                                )
+                                            })
+                                        })
+                                        .collect::<Vec<_>>()
+                                })
+                                .unwrap_or_default()
+                        };
+                        let paths = string_array("paths");
+                        assert!(!paths.is_empty(), "[{short}] 'env_paths.paths' must not be empty");
+                        let env_os = string_array("os");
+                        format!(
+                            "RegistryEnvPath {{ name: {}, paths: &[{}], os: &[{}] }}",
+                            raw_string_literal(name),
+                            paths
+                                .iter()
+                                .map(|path| raw_string_literal(path))
+                                .collect::<Vec<_>>()
+                                .join(", "),
+                            env_os
+                                .iter()
+                                .map(|os| raw_string_literal(os))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
         let overrides = info
             .get("overrides")
             .map(|overrides| {
@@ -339,7 +422,7 @@ fn codegen_registry() {
             })
             .unwrap_or_default();
         let rt = format!(
-            r#"RegistryTool{{short: "{short}", description: {description}, version_order: {version_order}, backends: &[{backends}], bins: &[{bins}], aliases: &[{aliases}], test: &{test}, os: &[{os}], idiomatic_files: &[{idiomatic_files}], detect: &[{detect}], overrides: &[{overrides}]}}"#,
+            r#"RegistryTool{{short: "{short}", description: {description}, version_order: {version_order}, backends: &[{backends}], bins: &[{bins}], aliases: &[{aliases}], test: &{test}, os: &[{os}], idiomatic_files: &[{idiomatic_files}], detect: &[{detect}], depends: &[{depends}], env_paths: &[{env_paths}], overrides: &[{overrides}]}}"#,
             version_order = version_order,
             description = description
                 .map(|d| format!("Some({})", raw_string_literal(&d)))
@@ -378,6 +461,12 @@ fn codegen_registry() {
                 .map(|f| format!("\"{f}\""))
                 .collect::<Vec<_>>()
                 .join(", "),
+            depends = depends
+                .iter()
+                .map(|dependency| raw_string_literal(dependency))
+                .collect::<Vec<_>>()
+                .join(", "),
+            env_paths = env_paths.join(", "),
             overrides = overrides
                 .iter()
                 .map(|f| format!("\"{f}\""))

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -739,6 +739,14 @@ backends = [
 test = { cmd = "your-tool --version", expected = "{{version}}" }
 aliases = ["alt-name"] # Optional alternative names
 os = ["linux", "macos"] # Optional OS restrictions
+depends = ["runtime"] # Optional mise tools that must install first when configured
+
+# Optional path-valued runtime environment entries. Relative paths are resolved
+# from the selected tool's install root and prepended to any existing value.
+env_paths = [
+    { name = "TOOL_HOME", paths = ["."] },
+    { name = "LD_LIBRARY_PATH", paths = ["lib"], os = ["linux"] },
+]
 ```
 
 Every registry entry must explicitly set `version_order` to `semver` or
@@ -748,6 +756,10 @@ two-component versions, channels, refs, tool-specific formats, mixed histories,
 or whenever the convention is uncertain. Semantic ordering currently affects
 the Aqua, GitHub, GitLab, Forgejo, and HTTP backends; the field still documents
 the policy for tools whose current backend owns version ordering itself.
+
+`depends` orders tools that are already part of the current install set; it does not implicitly
+add a tool to the user's configuration. `env_paths` entries may be restricted with `os`, use the
+platform path separator, preserve existing values, and remove duplicate paths.
 
 #### Idiomatic version files
 

--- a/e2e/env/test_registry_env_paths
+++ b/e2e/env/test_registry_env_paths
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cat >mise.toml <<'EOF'
+[tools]
+neko = "2-4-1"
+EOF
+
+neko_root="$MISE_DATA_DIR/installs/neko/2-4-1"
+existing="$PWD/existing"
+expected="$neko_root:$existing"
+cache_key="dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXRlc3Q="
+
+# A cache created before installation must not hide registry environment paths
+# after the configured tool becomes installed.
+assert_not_contains "MISE_OFFLINE=1 MISE_ENV_CACHE=1 __MISE_ENV_CACHE_KEY='$cache_key' NEKOPATH='$existing' mise env -s bash" "$neko_root"
+mkdir -p "$neko_root"
+assert_contains "MISE_OFFLINE=1 MISE_ENV_CACHE=1 __MISE_ENV_CACHE_KEY='$cache_key' NEKOPATH='$existing' mise env -s bash" "export NEKOPATH='$expected'"
+
+assert "NEKOPATH='$existing' mise exec -- sh -c 'printf %s \"\$NEKOPATH\"'" "$expected"
+
+case "$(uname -s)" in
+  Darwin)
+    assert_contains "DYLD_LIBRARY_PATH='$existing' mise env -s bash" "export DYLD_LIBRARY_PATH='$expected'"
+    assert_not_contains "mise env -s bash" "export LD_LIBRARY_PATH="
+    ;;
+  Linux)
+    assert_contains "LD_LIBRARY_PATH='$existing' mise env -s bash" "export LD_LIBRARY_PATH='$expected'"
+    assert_not_contains "mise env -s bash" "export DYLD_LIBRARY_PATH="
+    ;;
+esac
+
+# The inherited value participates in the env cache identity.
+assert "MISE_ENV_CACHE=1 __MISE_ENV_CACHE_KEY='$cache_key' NEKOPATH='$PWD/cache-a' mise exec -- sh -c 'printf %s \"\$NEKOPATH\"'" "$neko_root:$PWD/cache-a"
+assert "MISE_ENV_CACHE=1 __MISE_ENV_CACHE_KEY='$cache_key' NEKOPATH='$PWD/cache-b' mise exec -- sh -c 'printf %s \"\$NEKOPATH\"'" "$neko_root:$PWD/cache-b"
+
+# An explicit project environment remains authoritative over registry defaults.
+cat >>mise.toml <<'EOF'
+
+[env]
+NEKOPATH = "project-override"
+EOF
+assert "NEKOPATH='$existing' mise exec -- sh -c 'printf %s \"\$NEKOPATH\"'" "project-override"

--- a/registry/haxe.toml
+++ b/registry/haxe.toml
@@ -1,5 +1,6 @@
 backends = ["github:HaxeFoundation/haxe", "asdf:mise-plugins/mise-haxe"]
 bins = ["haxe", "haxelib"]
+depends = ["neko"]
 description = "Haxe - The Cross-Platform Toolkit"
 test = { cmd = "haxe --version", expected = "{{version}}" }
 version_order = "source"

--- a/registry/neko.toml
+++ b/registry/neko.toml
@@ -2,3 +2,17 @@ backends = ["github:HaxeFoundation/neko", "asdf:asdf-community/asdf-neko"]
 bins = ["neko", "nekoc", "nekoml", "nekotools"]
 description = "The Neko Virtual Machine"
 version_order = "source"
+
+[[env_paths]]
+name = "NEKOPATH"
+paths = ["."]
+
+[[env_paths]]
+name = "LD_LIBRARY_PATH"
+os = ["linux"]
+paths = ["."]
+
+[[env_paths]]
+name = "DYLD_LIBRARY_PATH"
+os = ["macos"]
+paths = ["."]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -134,6 +134,21 @@ pub struct RegistryTool {
     pub os: &'static [&'static str],
     pub idiomatic_files: &'static [RegistryIdiomaticFile],
     pub detect: &'static [&'static str],
+    pub depends: &'static [&'static str],
+    pub env_paths: &'static [RegistryEnvPath],
+}
+
+#[derive(Debug, Clone)]
+pub struct RegistryEnvPath {
+    pub name: &'static str,
+    pub paths: &'static [&'static str],
+    pub os: &'static [&'static str],
+}
+
+impl RegistryEnvPath {
+    pub fn is_supported_os(&self) -> bool {
+        self.os.is_empty() || self.os.contains(&OS)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -378,6 +393,8 @@ fn parse_registry_tool(short: &str, value: &toml::Value) -> Result<(RegistryTool
     let os = string_array(table.get("os"), "os")?;
     let idiomatic_files = parse_registry_idiomatic_files(table.get("idiomatic_files"))?;
     let detect = string_array(table.get("detect"), "detect")?;
+    let depends = string_array(table.get("depends"), "depends")?;
+    let env_paths = parse_registry_env_paths(table.get("env_paths"))?;
     let description = table
         .get("description")
         .map(|value| {
@@ -401,8 +418,46 @@ fn parse_registry_tool(short: &str, value: &toml::Value) -> Result<(RegistryTool
         os: leak_vec(os),
         idiomatic_files: leak_vec(idiomatic_files),
         detect: leak_vec(detect),
+        depends: leak_vec(depends),
+        env_paths: leak_vec(env_paths),
     };
     Ok((tool, missing_version_order))
+}
+
+fn parse_registry_env_paths(value: Option<&toml::Value>) -> Result<Vec<RegistryEnvPath>> {
+    value
+        .map(|value| {
+            value
+                .as_array()
+                .ok_or_else(|| eyre::eyre!("env_paths must be an array"))?
+                .iter()
+                .map(|value| {
+                    let table = value
+                        .as_table()
+                        .ok_or_else(|| eyre::eyre!("env_paths entries must be tables"))?;
+                    for key in table.keys() {
+                        ensure!(
+                            matches!(key.as_str(), "name" | "paths" | "os"),
+                            "unknown env_paths field: {key}"
+                        );
+                    }
+                    let name = table
+                        .get("name")
+                        .and_then(toml::Value::as_str)
+                        .ok_or_else(|| eyre::eyre!("env_paths.name must be a string"))?;
+                    let paths = string_array(table.get("paths"), "env_paths.paths")?;
+                    ensure!(!paths.is_empty(), "env_paths.paths must not be empty");
+                    let os = string_array(table.get("os"), "env_paths.os")?;
+                    Ok(RegistryEnvPath {
+                        name: leak_string(name.to_string()),
+                        paths: leak_vec(paths),
+                        os: leak_vec(os),
+                    })
+                })
+                .collect()
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
 }
 
 fn parse_registry_idiomatic_files(
@@ -827,6 +882,11 @@ aliases = ["example-alias"]
 description = "Example tool"
 version_order = "semver"
 bins = ["example", "example-helper"]
+depends = ["runtime"]
+env_paths = [
+  { name = "EXAMPLE_HOME", paths = ["."] },
+  { name = "LD_LIBRARY_PATH", paths = ["lib"], os = ["linux"] },
+]
 backends = [
   "aqua:example/tool",
   { full = "github:example/tool", platforms = ["linux-x64"], options = { bin = "example" } },
@@ -846,6 +906,11 @@ test = { cmd = "example --version", expected = "{{version}}", tools = ["node"] }
         assert_eq!(tool.short, "example");
         assert_eq!(tool.description, Some("Example tool"));
         assert_eq!(tool.bins, &["example", "example-helper"]);
+        assert_eq!(tool.depends, &["runtime"]);
+        assert_eq!(tool.env_paths[0].name, "EXAMPLE_HOME");
+        assert_eq!(tool.env_paths[0].paths, &["."]);
+        assert!(tool.env_paths[0].os.is_empty());
+        assert_eq!(tool.env_paths[1].os, &["linux"]);
         assert!(tool.provides_bin("example"));
         assert!(!tool.provides_bin("other"));
         if cfg!(windows) {
@@ -1128,6 +1193,8 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
             os: &[],
             idiomatic_files: &[],
             detect: &[],
+            depends: &[],
+            env_paths: &[],
         };
 
         let opts = tool.backend_options("github:owner/repo");
@@ -1176,6 +1243,8 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
             os: &[],
             idiomatic_files: &[],
             detect: &[],
+            depends: &[],
+            env_paths: &[],
         };
 
         assert_eq!(

--- a/src/toolset/tool_deps.rs
+++ b/src/toolset/tool_deps.rs
@@ -5,6 +5,7 @@ use tokio::sync::mpsc;
 
 use crate::cli::args::BackendArg;
 use crate::deps_graph::DepsGraph;
+use crate::registry::REGISTRY;
 use crate::toolset::tool_request::ToolRequest;
 
 /// Unique key for a tool request (tool short name + version)
@@ -48,7 +49,12 @@ impl ToolDeps {
             if let Ok(backend) = tr.backend()
                 && let Ok(deps) = backend.get_all_dependencies(true)
             {
-                for dep_ba in deps {
+                let registry_deps = REGISTRY
+                    .get(tr.ba().short.as_str())
+                    .into_iter()
+                    .flat_map(|tool| tool.depends)
+                    .map(BackendArg::from);
+                for dep_ba in deps.into_iter().chain(registry_deps) {
                     let dep_fulls = dep_ba.all_fulls();
                     if dep_fulls.iter().any(|full| versions_hash.contains(full)) {
                         for other_tr in &requests {
@@ -129,6 +135,56 @@ mod tests {
     #[test]
     fn test_empty_deps() {
         let _deps = ToolDeps::new(vec![]).unwrap();
+    }
+
+    #[test]
+    fn test_registry_dependencies_order_configured_tools() {
+        let source = ToolSource::Argument;
+        let haxe = ToolRequest::Version {
+            backend: Arc::new(BackendArg::new(
+                "haxe".to_string(),
+                Some("github:HaxeFoundation/haxe".to_string()),
+            )),
+            version: "4.3.7".to_string(),
+            options: ToolVersionOptions::default(),
+            source: source.clone(),
+        };
+        let neko = ToolRequest::Version {
+            backend: Arc::new(BackendArg::new(
+                "neko".to_string(),
+                Some("github:HaxeFoundation/neko".to_string()),
+            )),
+            version: "2-4-1".to_string(),
+            options: ToolVersionOptions::default(),
+            source,
+        };
+
+        let mut deps = ToolDeps::new(vec![haxe.clone(), neko.clone()]).unwrap();
+        let mut rx = deps.subscribe();
+        assert_eq!(rx.try_recv().unwrap().unwrap().ba().short, "neko");
+        assert!(rx.try_recv().is_err());
+        deps.complete_success(&neko);
+        assert_eq!(rx.try_recv().unwrap().unwrap().ba().short, "haxe");
+    }
+
+    #[test]
+    fn test_registry_dependencies_do_not_add_missing_tools() {
+        let haxe = ToolRequest::Version {
+            backend: Arc::new(BackendArg::new(
+                "haxe".to_string(),
+                Some("github:HaxeFoundation/haxe".to_string()),
+            )),
+            version: "4.3.7".to_string(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+
+        let backend_deps = haxe.backend().unwrap().get_all_dependencies(true).unwrap();
+        assert!(backend_deps.iter().all(|dep| dep.short != "neko"));
+
+        let mut deps = ToolDeps::new(vec![haxe]).unwrap();
+        let mut rx = deps.subscribe();
+        assert_eq!(rx.try_recv().unwrap().unwrap().ba().short, "haxe");
     }
 
     #[tokio::test]

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -1,18 +1,20 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use eyre::Result;
 
+use crate::backend::Backend;
 use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::{Config, Settings};
 use crate::env::{PATH_KEY, WARN_ON_MISSING_REQUIRED_ENV};
 use crate::env_diff::EnvMap;
 use crate::path_env::PathEnv;
-use crate::toolset::Toolset;
+use crate::registry::{REGISTRY, RegistryEnvPath};
 use crate::toolset::env_cache::{CachedEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::tool_request::ToolRequest;
+use crate::toolset::{ToolVersion, Toolset};
 use crate::{env, github, parallel, uv};
 
 /// PATH with mise-managed install dirs filtered out. mise re-adds the current
@@ -29,7 +31,98 @@ fn pristine_path_without_install_dirs() -> Vec<PathBuf> {
         .collect()
 }
 
+fn merge_registry_env_paths(
+    backend_env: Vec<(String, String, String)>,
+    registry_paths: Vec<(String, PathBuf, String)>,
+) -> Vec<(String, String, String)> {
+    if registry_paths.is_empty() {
+        return backend_env;
+    }
+
+    // env() gives the first tool's value precedence by reversing this list before
+    // collecting it. Reproduce that precedence when a registry path augments an
+    // environment variable that a backend already emitted.
+    let mut effective_backend_env = BTreeMap::new();
+    for (key, value, _) in backend_env.iter().rev() {
+        effective_backend_env.insert(key.clone(), value.clone());
+    }
+
+    let mut paths_by_name: BTreeMap<String, (Vec<PathBuf>, String)> = BTreeMap::new();
+    for (name, path, source) in registry_paths {
+        let (paths, current_source) = paths_by_name.entry(name).or_default();
+        paths.push(path);
+        if current_source.is_empty() {
+            *current_source = source;
+        }
+    }
+
+    let names = paths_by_name.keys().cloned().collect::<HashSet<_>>();
+    let mut merged = Vec::with_capacity(paths_by_name.len() + backend_env.len());
+    for (name, (registry_paths, source)) in paths_by_name {
+        let inherited = effective_backend_env
+            .get(&name)
+            .cloned()
+            .or_else(|| env::PRISTINE_ENV.get(&name).cloned());
+        let mut seen = HashSet::new();
+        let paths = registry_paths
+            .into_iter()
+            .chain(inherited.iter().flat_map(env::split_paths))
+            .filter(|path| seen.insert(path.clone()))
+            .collect::<Vec<_>>();
+        match env::join_paths(paths) {
+            Ok(value) => merged.push((name, value.to_string_lossy().into_owned(), source)),
+            Err(err) => warn!("failed to construct registry environment path: {err}"),
+        }
+    }
+    merged.extend(
+        backend_env
+            .into_iter()
+            .filter(|(name, _, _)| !names.contains(name)),
+    );
+    merged
+}
+
+type RegistryEnvCacheContext = BTreeMap<String, Vec<(Vec<String>, Vec<String>, Option<String>)>>;
+
+fn extend_registry_env_cache_context(
+    context: &mut RegistryEnvCacheContext,
+    tool: &str,
+    env_paths: &[RegistryEnvPath],
+) {
+    for entry in env_paths.iter().filter(|entry| entry.is_supported_os()) {
+        context
+            .entry(format!("{tool}:{}", entry.name))
+            .or_default()
+            .push((
+                entry.paths.iter().map(|path| path.to_string()).collect(),
+                entry.os.iter().map(|os| os.to_string()).collect(),
+                env::PRISTINE_ENV.get(entry.name).cloned(),
+            ));
+    }
+}
+
+fn settings_hash_with_registry_env_context(
+    mut settings_hash: String,
+    context: &RegistryEnvCacheContext,
+) -> String {
+    if !context.is_empty() {
+        settings_hash.push_str("\nregistry-env-paths:");
+        settings_hash.push_str(&format!("{context:?}"));
+    }
+    settings_hash
+}
+
 impl Toolset {
+    fn list_registry_env_versions(
+        &self,
+        config: &Arc<Config>,
+    ) -> Vec<(Arc<dyn Backend>, ToolVersion)> {
+        self.list_current_installed_versions(config)
+            .into_iter()
+            .filter(|(_, tv)| !matches!(tv.request, ToolRequest::System { .. }))
+            .collect()
+    }
+
     pub async fn full_env(&self, config: &Arc<Config>) -> Result<EnvMap> {
         let mut env = env::PRISTINE_ENV.clone().into_iter().collect::<EnvMap>();
         env.extend(self.env_with_path(config).await?.clone());
@@ -270,14 +363,30 @@ impl Toolset {
             .collect();
 
         // Collect tool versions
-        let tool_versions: Vec<(String, String)> = self
-            .list_current_versions()
-            .into_iter()
+        let current_versions = self.list_current_versions();
+        let tool_versions: Vec<(String, String)> = current_versions
+            .iter()
             .map(|(b, tv)| (b.id().to_string(), tv.version.clone()))
             .collect();
 
-        // Get settings hash
-        let settings_hash = compute_settings_hash();
+        // Floating registry metadata can change independently of the config and
+        // selected version. Include both the applicable declarations and the
+        // inherited values they augment so the cache never reuses an environment
+        // produced with stale runtime paths.
+        let mut registry_env_context = BTreeMap::new();
+        for (_, tv) in self.list_registry_env_versions(config) {
+            let Some(tool) = REGISTRY.get(tv.ba().short.as_str()) else {
+                continue;
+            };
+            extend_registry_env_cache_context(
+                &mut registry_env_context,
+                tool.short,
+                tool.env_paths,
+            );
+        }
+
+        let settings_hash =
+            settings_hash_with_registry_env_context(compute_settings_hash(), &registry_env_context);
 
         // Get base PATH using platform-appropriate separator
         let base_path = std::env::join_paths(env::PATH.iter())
@@ -309,10 +418,39 @@ impl Toolset {
 
     pub async fn env_from_tools(&self, config: &Arc<Config>) -> Vec<(String, String, String)> {
         let this = Arc::new(self.clone());
-        let items: Vec<_> = self
-            .list_current_installed_versions(config)
+        let installed = self.list_registry_env_versions(config);
+        let registry_env_paths = installed
+            .iter()
+            .flat_map(|(_, tv)| {
+                REGISTRY
+                    .get(tv.ba().short.as_str())
+                    .into_iter()
+                    .flat_map(move |tool| {
+                        tool.env_paths
+                            .iter()
+                            .filter(|entry| entry.is_supported_os())
+                            .flat_map(move |entry| {
+                                entry.paths.iter().map(move |path| {
+                                    let path = PathBuf::from(path);
+                                    let path = if path.is_absolute() {
+                                        path
+                                    } else if path == std::path::Path::new(".") {
+                                        tv.runtime_path()
+                                    } else {
+                                        tv.runtime_path().join(path)
+                                    };
+                                    (
+                                        entry.name.to_string(),
+                                        path,
+                                        format!("registry:{}", tool.short),
+                                    )
+                                })
+                            })
+                    })
+            })
+            .collect::<Vec<_>>();
+        let items: Vec<_> = installed
             .into_iter()
-            .filter(|(_, tv)| !matches!(tv.request, ToolRequest::System { .. }))
             .map(|(b, tv)| (config.clone(), this.clone(), b, tv))
             .collect();
 
@@ -332,10 +470,12 @@ impl Toolset {
         .await
         .unwrap_or_default();
 
-        envs.into_iter()
+        let envs = envs
+            .into_iter()
             .flatten()
             .filter(|(k, _, _)| k.to_uppercase() != "PATH")
-            .collect()
+            .collect();
+        merge_registry_env_paths(envs, registry_env_paths)
     }
 
     pub async fn env(&self, config: &Arc<Config>) -> Result<(EnvMap, Vec<PathBuf>)> {
@@ -498,5 +638,106 @@ impl Toolset {
             .into_iter()
             .map(|(k, (v, _))| (k, v))
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_registry_env_paths_prepends_preserves_and_deduplicates() {
+        let existing = env::join_paths(["/existing", "/duplicate"])
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let merged = merge_registry_env_paths(
+            vec![
+                ("NEKOPATH".to_string(), existing, "backend:neko".to_string()),
+                (
+                    "OTHER".to_string(),
+                    "value".to_string(),
+                    "backend".to_string(),
+                ),
+            ],
+            vec![
+                (
+                    "NEKOPATH".to_string(),
+                    PathBuf::from("/runtime/neko"),
+                    "registry:neko".to_string(),
+                ),
+                (
+                    "NEKOPATH".to_string(),
+                    PathBuf::from("/duplicate"),
+                    "registry:neko".to_string(),
+                ),
+            ],
+        );
+
+        let value = merged
+            .iter()
+            .find(|(name, _, _)| name == "NEKOPATH")
+            .unwrap();
+        assert_eq!(value.2, "registry:neko");
+        assert_eq!(
+            env::split_paths(&value.1).collect::<Vec<_>>(),
+            [
+                PathBuf::from("/runtime/neko"),
+                PathBuf::from("/duplicate"),
+                PathBuf::from("/existing"),
+            ]
+        );
+        assert!(merged.iter().any(|entry| entry.0 == "OTHER"));
+    }
+
+    #[test]
+    fn test_registry_env_cache_context_preserves_duplicate_declarations() {
+        let original = [
+            RegistryEnvPath {
+                name: "LIBRARY_PATH",
+                paths: &["lib/first"],
+                os: &[],
+            },
+            RegistryEnvPath {
+                name: "LIBRARY_PATH",
+                paths: &["lib/second"],
+                os: &[],
+            },
+        ];
+        let changed = [
+            RegistryEnvPath {
+                name: "LIBRARY_PATH",
+                paths: &["lib/changed"],
+                os: &[],
+            },
+            RegistryEnvPath {
+                name: "LIBRARY_PATH",
+                paths: &["lib/second"],
+                os: &[],
+            },
+        ];
+
+        let cache_key = |entries: &[RegistryEnvPath]| {
+            let mut context = RegistryEnvCacheContext::new();
+            extend_registry_env_cache_context(&mut context, "example", entries);
+            let settings_hash =
+                settings_hash_with_registry_env_context("settings".to_string(), &context);
+            (
+                context,
+                CachedEnv::compute_cache_key(&[], &[], &settings_hash, ""),
+            )
+        };
+
+        let (original_context, original_key) = cache_key(&original);
+        let (changed_context, changed_key) = cache_key(&changed);
+
+        assert_eq!(original_context["example:LIBRARY_PATH"].len(), 2);
+        assert_eq!(original_context["example:LIBRARY_PATH"][0].0, ["lib/first"]);
+        assert_eq!(
+            original_context["example:LIBRARY_PATH"][1].0,
+            ["lib/second"]
+        );
+        assert_ne!(original_key, changed_key);
+        assert_ne!(original_context, changed_context);
     }
 }


### PR DESCRIPTION
## Summary

- add reusable registry `depends` metadata so configured tools can declare install ordering without implicitly adding dependencies
- add OS-aware registry `env_paths` metadata that prepends runtime-root-relative paths while preserving and deduplicating inherited values
- configure Haxe to install after Neko when both are selected, and expose the Neko runtime through `NEKOPATH` plus the platform loader path
- include applied registry environment metadata and inherited path values in the environment cache identity
- apply the metadata at the toolset layer so both the GitHub backend and asdf fallback receive the same runtime environment

## Context

The earlier GitHub backend migration already fixed incomplete archive extraction for Haxe and Neko. The remaining failure was runtime loading: `haxelib` could not locate `libneko.2.dylib` on macOS or `libneko.so.2` on Linux.

Keeping the fix as registry metadata avoids Haxe-specific binary rewriting and makes dependency ordering and path-valued runtime environment additions reusable by other registry tools. Dependencies only order tools already present in the install set; they do not modify user configuration.

## Verification

- `mise exec -- cargo test --all-features registry::tests`
- `mise exec -- cargo test --all-features toolset::tool_deps::tests`
- `mise exec -- cargo test --all-features toolset::toolset_env::tests`
- `mise run test:e2e e2e/env/test_registry_env_paths`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- Rustfmt, Taplo, Prettier, markdownlint, ShellCheck, and shfmt checks
- macOS arm64: installed Haxe 4.3.7 and Neko 2.4.1 from official releases; `haxe --version`, `neko -version`, and `haxelib version` returned `4.3.7`, `2.4.1`, and `4.1.1`
- Docker/Linux arm64: installed the same official releases with the modified Linux build; Neko installed before Haxe and the same three commands returned `4.3.7`, `2.4.1`, and `4.1.1`

The aggregate `mise run format` and `mise run lint` commands could not run their `hk` step because this Sapling working copy is not recognized as a Git working copy; all relevant checks were run individually and passed.

Addresses https://github.com/jdx/mise/discussions/4982

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for declaring tool dependencies in the registry, with installation ordering based on those relationships.
  * Added configurable environment paths for installed tools, including platform-specific settings and automatic path deduplication.
  * Environment paths now resolve relative to each tool’s installation directory and integrate with existing project and system environment values.

* **Bug Fixes**
  * Improved environment cache invalidation when installations or registry settings change.

* **Documentation**
  * Updated registry contribution guidance with dependency and environment path configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->