### PR TITLE
fix(ruby): install the highest RubyInstaller2 build revision on Windows

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1312,6 +1312,20 @@ something_else = "value"
         assert!(pick_best_numeric_build_revision(releases, "3.3.11").is_none());
     }
 
+    /// RubyInstaller2 tags releases `RubyInstaller-<version>-<revision>`, so the
+    /// caller passes the prefixed tag as the "version" (discussion #5227). The
+    /// prefix comparison must also keep 3.4.4 from matching 3.4.10.
+    #[test]
+    fn test_numeric_build_revision_handles_prefixed_tags() {
+        let releases = vec![
+            make_release("RubyInstaller-3.4.4-1"),
+            make_release("RubyInstaller-3.4.4-2"),
+            make_release("RubyInstaller-3.4.10-1"),
+        ];
+        let best = pick_best_numeric_build_revision(releases, "RubyInstaller-3.4.4").unwrap();
+        assert_eq!(best.tag_name, "RubyInstaller-3.4.4-2");
+    }
+
     #[test]
     fn test_build_revision_falls_back_to_base() {
         let releases = vec![make_release("3.3.11"), make_release("3.3.10-1")];

--- a/src/plugins/core/ruby_common.rs
+++ b/src/plugins/core/ruby_common.rs
@@ -4,28 +4,90 @@ use eyre::Result;
 
 const RUBYINSTALLER_REPO: &str = "oneclick/rubyinstaller2";
 
+/// Build revision assumed when the release list cannot be consulted. mise used
+/// this unconditionally before, so falling back to it keeps offline and
+/// API-failure behavior unchanged.
+const FALLBACK_BUILD_REVISION: u32 = 1;
+
 /// Check if a Ruby version string is a standard MRI version (starts with a digit).
 /// Non-MRI engines like jruby, truffleruby, etc. have prefixed version strings.
 pub fn is_mri_version(version: &str) -> bool {
     version.chars().next().is_some_and(|c| c.is_ascii_digit())
 }
 
-/// Build the RubyInstaller2 release tag for a given MRI version.
-pub fn rubyinstaller_tag(version: &str) -> String {
-    format!("RubyInstaller-{version}-1")
+/// The tag prefix shared by a version's RubyInstaller2 releases, which are
+/// tagged `RubyInstaller-<version>-<build revision>`.
+fn rubyinstaller_tag_prefix(version: &str) -> String {
+    format!("RubyInstaller-{version}")
 }
 
-/// Build the RubyInstaller2 asset filename for a given MRI version.
-pub fn rubyinstaller_asset_name(version: &str) -> String {
-    // RubyInstaller2 only provides x64 builds
-    format!("rubyinstaller-{version}-1-x64.7z")
+/// Build the RubyInstaller2 release tag for a version and build revision.
+pub fn rubyinstaller_tag(version: &str, revision: u32) -> String {
+    format!("{}-{revision}", rubyinstaller_tag_prefix(version))
 }
 
-/// Build the RubyInstaller2 download URL for a given MRI version.
-pub fn rubyinstaller_url(version: &str) -> String {
-    let tag = rubyinstaller_tag(version);
-    let asset = rubyinstaller_asset_name(version);
+/// Build the RubyInstaller2 asset filename for a version and build revision.
+pub fn rubyinstaller_asset_name(version: &str, revision: u32) -> String {
+    // RubyInstaller2 publishes arm and x86 archives too, but mise only installs x64.
+    format!("rubyinstaller-{version}-{revision}-x64.7z")
+}
+
+/// Build the RubyInstaller2 download URL for a version and build revision.
+pub fn rubyinstaller_url(version: &str, revision: u32) -> String {
+    let tag = rubyinstaller_tag(version, revision);
+    let asset = rubyinstaller_asset_name(version, revision);
     format!("https://github.com/{RUBYINSTALLER_REPO}/releases/download/{tag}/{asset}")
+}
+
+/// A resolved RubyInstaller2 download.
+#[derive(Debug, Clone)]
+pub struct RubyInstallerArtifact {
+    pub url: String,
+    pub checksum: Option<String>,
+    /// e.g. `rubyinstaller-3.4.4-2-x64.7z`. Only the Windows installer downloads
+    /// the archive; elsewhere this type is built solely to record lockfile info.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    pub filename: String,
+}
+
+/// Resolve the archive to download for an MRI version.
+///
+/// RubyInstaller2 republishes a corrected build of the same Ruby version as
+/// `-2`, `-3`, … and leaves the superseded `-1` release in place. Pinning `-1`
+/// therefore always installs the build that was corrected, so pick the highest
+/// build revision instead. See discussion #5227.
+pub async fn resolve_rubyinstaller_artifact(version: &str) -> RubyInstallerArtifact {
+    if let Some(artifact) = resolve_from_releases(version).await {
+        return artifact;
+    }
+    RubyInstallerArtifact {
+        url: rubyinstaller_url(version, FALLBACK_BUILD_REVISION),
+        checksum: None,
+        filename: rubyinstaller_asset_name(version, FALLBACK_BUILD_REVISION),
+    }
+}
+
+async fn resolve_from_releases(version: &str) -> Option<RubyInstallerArtifact> {
+    let prefix = rubyinstaller_tag_prefix(version);
+    // Passing the prefixed tag lets the shared build-revision picker work
+    // unchanged, and reuses the release-list cache that `_list_remote_versions`
+    // already fills, so this costs no extra request.
+    let (release, _) =
+        github::get_release_with_build_revision_status(RUBYINSTALLER_REPO, &prefix, true)
+            .await
+            .ok()?;
+    let revision: u32 = release
+        .tag_name
+        .strip_prefix(&format!("{prefix}-"))?
+        .parse()
+        .ok()?;
+    let filename = rubyinstaller_asset_name(version, revision);
+    let asset = release.assets.iter().find(|a| a.name == filename)?;
+    Some(RubyInstallerArtifact {
+        url: asset.browser_download_url.clone(),
+        checksum: asset.digest.clone(),
+        filename,
+    })
 }
 
 /// Resolve RubyInstaller2 binary URL and checksum from GitHub releases.
@@ -37,29 +99,57 @@ pub async fn resolve_rubyinstaller_lock_info(version: &str) -> Result<PlatformIn
         return Ok(PlatformInfo::default());
     }
 
-    let tag = rubyinstaller_tag(version);
-    let asset_name = rubyinstaller_asset_name(version);
-
-    if let Ok(release) = github::get_release(RUBYINSTALLER_REPO, &tag).await
-        && let Some(asset) = release.assets.iter().find(|a| a.name == asset_name)
-    {
-        return Ok(PlatformInfo {
-            url: Some(asset.browser_download_url.clone()),
-            checksum: asset.digest.clone(),
-            size: None,
-            url_api: None,
-            conda_deps: None,
-            ..Default::default()
-        });
-    }
-
-    // Fallback: construct URL without checksum
+    // Resolve through the same path the installer uses so a lockfile records the
+    // archive that would actually be downloaded.
+    let artifact = resolve_rubyinstaller_artifact(version).await;
     Ok(PlatformInfo {
-        url: Some(rubyinstaller_url(version)),
-        checksum: None,
+        url: Some(artifact.url),
+        checksum: artifact.checksum,
         size: None,
         url_api: None,
         conda_deps: None,
         ..Default::default()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn tag_and_asset_names_use_the_resolved_revision() {
+        assert_eq!(rubyinstaller_tag("3.4.4", 2), "RubyInstaller-3.4.4-2");
+        assert_eq!(
+            rubyinstaller_asset_name("3.4.4", 2),
+            "rubyinstaller-3.4.4-2-x64.7z"
+        );
+        assert_eq!(
+            rubyinstaller_url("3.4.4", 2),
+            "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.4.4-2/rubyinstaller-3.4.4-2-x64.7z"
+        );
+    }
+
+    #[test]
+    fn fallback_keeps_the_previous_revision_one_urls() {
+        assert_eq!(
+            rubyinstaller_url("3.4.4", FALLBACK_BUILD_REVISION),
+            "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.4.4-1/rubyinstaller-3.4.4-1-x64.7z"
+        );
+    }
+
+    #[test]
+    fn tag_prefix_does_not_match_a_longer_patch_version() {
+        // `3.4.4` must not pick up `3.4.10` releases when tags are compared by prefix.
+        let prefix = format!("{}-", rubyinstaller_tag_prefix("3.4.4"));
+        assert!(rubyinstaller_tag("3.4.4", 2).starts_with(&prefix));
+        assert!(!rubyinstaller_tag("3.4.10", 1).starts_with(&prefix));
+    }
+
+    #[test]
+    fn is_mri_version_rejects_named_engines() {
+        assert!(is_mri_version("3.4.4"));
+        assert!(!is_mri_version("jruby-9.4.0.0"));
+        assert!(!is_mri_version("truffleruby-24.1.1"));
+    }
 }

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -121,13 +121,27 @@ impl RubyPlugin {
     }
 
     async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
-        let artifact = super::ruby_common::resolve_rubyinstaller_artifact(&tv.version).await;
-        let filename = &artifact.filename;
-        let tarball_path = tv.download_path().join(filename);
+        // A lockfile pins the exact archive, and `verify_checksum` checks the
+        // download against the checksum recorded beside it. Resolving afresh
+        // here could pick a newer build revision than the lock describes and
+        // fail that check; the pinned URL has to win.
+        let locked = locked_archive(
+            tv.lock_platforms
+                .get(&self.get_platform_key())
+                .and_then(|pi| pi.url.as_deref()),
+        );
+        let (url, filename) = match locked {
+            Some(locked) => locked,
+            None => {
+                let artifact =
+                    super::ruby_common::resolve_rubyinstaller_artifact(&tv.version).await;
+                (artifact.url, artifact.filename)
+            }
+        };
+        let tarball_path = tv.download_path().join(&filename);
 
         pr.set_message(format!("downloading {filename}"));
-        HTTP.download_file(&artifact.url, &tarball_path, Some(pr))
-            .await?;
+        HTTP.download_file(&url, &tarball_path, Some(pr)).await?;
 
         Ok(tarball_path)
     }
@@ -272,6 +286,15 @@ fn parse_gemfile(body: &str) -> String {
     v
 }
 
+/// The archive a lockfile already pins for this platform, as `(url, filename)`.
+/// `None` when nothing is locked or the URL yields no filename, in which case
+/// the caller resolves the archive itself.
+fn locked_archive(locked_url: Option<&str>) -> Option<(String, String)> {
+    let url = locked_url?;
+    let filename = crate::backend::static_helpers::get_filename_from_url(url);
+    (!filename.is_empty()).then(|| (url.to_string(), filename))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::Config;
@@ -279,6 +302,23 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    /// A lockfile pins the archive whose checksum `verify_checksum` will apply,
+    /// so a locked URL has to be used verbatim rather than re-resolved to a
+    /// newer build revision.
+    #[test]
+    fn locked_archive_is_used_verbatim() {
+        let url = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.4.4-1/rubyinstaller-3.4.4-1-x64.7z";
+        assert_eq!(
+            locked_archive(Some(url)),
+            Some((url.to_string(), "rubyinstaller-3.4.4-1-x64.7z".to_string()))
+        );
+    }
+
+    #[test]
+    fn locked_archive_is_none_without_a_lock() {
+        assert_eq!(locked_archive(None), None);
+    }
 
     #[tokio::test]
     async fn test_list_versions_matching() {

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -121,12 +121,13 @@ impl RubyPlugin {
     }
 
     async fn download(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<PathBuf> {
-        let url = super::ruby_common::rubyinstaller_url(&tv.version);
-        let filename = url.split('/').next_back().unwrap();
+        let artifact = super::ruby_common::resolve_rubyinstaller_artifact(&tv.version).await;
+        let filename = &artifact.filename;
         let tarball_path = tv.download_path().join(filename);
 
         pr.set_message(format!("downloading {filename}"));
-        HTTP.download_file(&url, &tarball_path, Some(pr)).await?;
+        HTTP.download_file(&artifact.url, &tarball_path, Some(pr))
+            .await?;
 
         Ok(tarball_path)
     }
@@ -137,16 +138,15 @@ impl RubyPlugin {
         tv: &ToolVersion,
         tarball_path: &Path,
     ) -> Result<()> {
-        let arch = arch();
         let filename = tarball_path.file_name().unwrap().to_string_lossy();
         ctx.pr.set_message(format!("extract {filename}"));
         file::remove_all(tv.install_path())?;
         file::un7z(tarball_path, &tv.download_path(), &Default::default())?;
-        file::move_file(
-            tv.download_path()
-                .join(format!("rubyinstaller-{}-1-{arch}", tv.version)),
-            tv.install_path(),
-        )?;
+        // The archive holds a single top-level directory named after the archive
+        // itself, so derive it instead of rebuilding the version/revision/arch
+        // triple -- the build revision is no longer fixed at 1 (discussion #5227).
+        let dir_name = filename.strip_suffix(".7z").unwrap_or(&filename);
+        file::move_file(tv.download_path().join(dir_name), tv.install_path())?;
         Ok(())
     }
 
@@ -270,10 +270,6 @@ fn parse_gemfile(body: &str) -> String {
         return "".to_string();
     }
     v
-}
-
-fn arch() -> &'static str {
-    "x64"
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #5227.

## The problem

RubyInstaller2 republishes a corrected build of the same Ruby version as `-2`, `-3`, … and leaves the superseded `-1` release in place. mise hardcoded `-1` in three places — the release tag, the asset name, and the extracted directory name — so a corrected build could never be installed.

One correction to the report's framing, based on measurement: the install does **not** fail. The `-1` release still exists, so mise happily downloads it:

```console
$ curl -sI https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.4.4-1/rubyinstaller-3.4.4-1-x64.7z | head -1
HTTP/2 200
```

The defect is that mise always installs the build that was corrected. Surveying all 118 release tags in `oneclick/rubyinstaller2`, five versions have a `-2` that mise could not reach, and every one of them still has its `-1` alongside:

```
RubyInstaller-3.4.4-2   RubyInstaller-3.4.1-2   RubyInstaller-3.3.6-2
RubyInstaller-2.6.6-2   RubyInstaller-2.5.8-2
```

## The change

Resolve the release and take the highest build revision, reusing the existing [`github::get_release_with_build_revision_status`](https://github.com/jdx/mise/blob/main/src/github.rs) rather than adding new selection logic. Two things make that reuse clean:

- Its picker compares `format!("{version}-")` against tag names, so passing the **prefixed** tag `RubyInstaller-3.4.4` as the "version" selects `RubyInstaller-3.4.4-2` with no change to the shared helper. The prefix also keeps `3.4.4` from matching `3.4.10`, which a looser comparison would get wrong.
- It goes through `github::list_releases`, whose cache the Windows `_list_remote_versions` already fills for this exact repo — so resolution costs **no extra request**.

When the release list is unavailable (offline, API failure, asset missing) it falls back to `-1` with no checksum, which is what mise did unconditionally before. A correctness fix should not make the offline path worse.

## The extracted directory

This is the part that makes the change bigger than a format string. `install()` also hardcoded the revision when locating the unpacked tree:

```rust
tv.download_path().join(format!("rubyinstaller-{}-1-{arch}", tv.version))
```

so downloading `-2` would have unpacked correctly and then failed to move. It now derives the directory from the archive name. Verified against the real artifact:

```console
$ tar -tf rubyinstaller-3.4.4-2-x64.7z | head -3
rubyinstaller-3.4.4-2-x64/
rubyinstaller-3.4.4-2-x64/bin/
rubyinstaller-3.4.4-2-x64/bin/ruby_builtin_dlls/
```

The single top-level directory is the archive's own basename. This also removes a latent mismatch: the asset name hardcoded `x64` while the directory was built with `arch()`. `arch()` returned `"x64"` unconditionally and is now unused, so it is deleted — no behavior change.

`resolve_rubyinstaller_lock_info` goes through the same resolver, so a lockfile records the archive that would actually be downloaded.

## Scope

- **No way to pin `-1` explicitly.** If that is wanted it belongs to the lockfile, not here.
- **arm/x86 archives are still unsupported.** RubyInstaller2 publishes them; mise installs x64 only, as before.
- **`get_release_with_build_revision_status` and `pick_best_*` are unchanged** — only called, not modified.

## Tests

- `src/github.rs`: one test pinning that the shared picker handles prefixed tags and does not confuse `3.4.4` with `3.4.10`.
- `src/plugins/core/ruby_common.rs`: four tests over the pure name builders — the resolved revision reaches tag/asset/URL, the fallback still produces the previous `-1` URLs, the tag prefix does not match a longer patch version, and `is_mri_version` still rejects named engines.

No e2e: installing Ruby on Windows is heavy and `e2e-win` has no Ruby coverage today. Post-merge I will verify on a real Windows machine that `mise install ruby@3.4.4` fetches `rubyinstaller-3.4.4-2-x64.7z`, that `ruby -v` runs, and that a version without a `-2` (e.g. 3.4.10) still resolves to `-1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ruby Windows download resolution for builds with multiple revisions.
  * Selects the highest matching revision without confusing similar version numbers.
  * Uses the correct download URL, filename, and checksum when available.
  * Preserves valid lockfile-pinned archives during installation.
  * Falls back to revision 1 when release metadata is unavailable.
  * Improves installation handling for archives with varying extracted directory names.
  * Keeps lockfiles and installations aligned with the selected artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->