### PR TITLE
fix(registry): stop flutter URLs doubling the -stable suffix

### DIFF
--- a/registry/flutter.toml
+++ b/registry/flutter.toml
@@ -9,25 +9,28 @@ full = "http:flutter"
 # Each platform's sha256 lives in its OS-specific releases manifest, matched by
 # the resolved artifact's archive path (checksum_url is set per platform below).
 checksum_expr = '"sha256:" + filter(fromJSON(body).releases, { #.archive endsWith filename })[0].sha256'
+# version_expr strips the channel suffix, and the URLs below append it back, so a
+# version that already carries it (as the older vfox backend listed them) would
+# otherwise produce `...-stable-stable`. trim_end makes appending idempotent.
 version_expr = 'fromJSON(body).releases | filter({ #.channel == "stable" }) | map({ replace(#.version, "-stable", "") }) | sortVersions()'
 version_list_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json"
 
 # Linux uses .tar.xz instead of .zip
 [backends.options.platforms.linux-x64]
 checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json"
-url = 'https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_{{ version }}-stable.tar.xz'
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_{{ version | trim_end(pat='-stable') }}-stable.tar.xz"
 
 [backends.options.platforms.macos-x64]
 checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_macos.json"
-url = 'https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_{{ version }}-stable.zip'
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_{{ version | trim_end(pat='-stable') }}-stable.zip"
 
 [backends.options.platforms.macos-arm64]
 checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_macos.json"
-url = 'https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_{{ version }}-stable.zip'
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_{{ version | trim_end(pat='-stable') }}-stable.zip"
 
 [backends.options.platforms.windows-x64]
 checksum_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_windows.json"
-url = 'https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_{{ version }}-stable.zip'
+url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_{{ version | trim_end(pat='-stable') }}-stable.zip"
 
 [[backends]]
 full = "asdf:mise-plugins/mise-flutter"

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -2261,11 +2261,19 @@ mod tests {
     /// The engines must agree on the shape registry entries use (azd,
     /// clickhouse, magika), so a template does not silently render differently
     /// under `tera_v1`.
+    ///
+    /// `registry/flutter.toml` leans on this: `version_expr` strips the channel
+    /// suffix and the URLs append it back, so appending has to be idempotent for
+    /// a version that already carries it and for one that does not (#4170).
     #[test]
     fn test_tera_engines_agree_on_the_registry_trim_pattern() {
-        let template = "{{ '3.27.2-stable' | trim_end(pat='-stable') }}-stable";
-        assert_eq!(render_v2(template), "3.27.2-stable");
-        assert_eq!(render_v1(template), "3.27.2-stable");
+        let suffixed = "{{ '3.27.2-stable' | trim_end(pat='-stable') }}-stable";
+        assert_eq!(render_v2(suffixed), "3.27.2-stable");
+        assert_eq!(render_v1(suffixed), "3.27.2-stable");
+
+        let bare = "{{ '3.27.2' | trim_end(pat='-stable') }}-stable";
+        assert_eq!(render_v2(bare), "3.27.2-stable");
+        assert_eq!(render_v1(bare), "3.27.2-stable");
     }
 
     #[test]


### PR DESCRIPTION
Refs #4170.

## What is wrong

`registry/flutter.toml` strips the channel suffix from listed versions and appends it back when building download URLs:

```toml
version_expr = '… map({ replace(#.version, "-stable", "") }) | sortVersions()'
url = '…/flutter_windows_{{ version }}-stable.zip'
```

That assumes `version` never carries the suffix. A version pinned **with** it — the form the older `vfox:` backend listed, and what #4170's reporter had — produces a doubled suffix and 404s. Measured on **v2026.8.2 windows-x64**:

```console
PS> mise install flutter@3.27.2-stable
mise ERROR ... 404 Not Found ... flutter_windows_3.27.2-stable-stable.zip

PS> mise install flutter@3.27.2
mise flutter@3.27.2  [2/3] extract flutter_windows_3.27.2-stable.zip     # succeeds
```

Confirmed against the upstream bucket:

| URL | response |
|---|---|
| `…/flutter_windows_3.27.2-stable.zip` | **200** |
| `…/flutter_windows_3.27.2-stable-stable.zip` | **404** |

This is not Windows-specific — linux, macos-x64 and macos-arm64 build their URLs the same way.

## The change

Make appending idempotent with `trim_end`, on all four platform URLs:

```diff
-url = '…/flutter_windows_{{ version }}-stable.zip'
+url = "…/flutter_windows_{{ version | trim_end(pat='-stable') }}-stable.zip"
```

`trim_end(pat=…)` is mise's current recommended filter — `src/tera.rs` registers `trim_end_matches` only as a deprecated alias pointing at it — and `registry/clickhouse.toml` already uses the same construct. It wraps Rust's `trim_end_matches`, so it strips every trailing occurrence and is a no-op when there is none.

Verified on the released binary through the same rendering path a registry option takes (`template_string_for_target`), using an inline tool option so nothing has to be rebuilt:

```console
$ mise install "http:probe[url=https://mise-probe.invalid/f_{{version|trim_end(pat='-stable')}}-stable.zip]@3.27.2-stable"
mise http:probe@3.27.2-stable [1/3] download f_3.27.2-stable.zip

$ mise install "http:probe[url=…same…]@3.27.2"
mise http:probe@3.27.2 [1/3] download f_3.27.2-stable.zip

$ mise install "http:probe[url=https://mise-probe.invalid/f_{{version}}-stable.zip]@3.27.2-stable"
mise http:probe@3.27.2-stable [1/3] download f_3.27.2-stable-stable.zip     # today's bug
```

`checksum_expr` matches on `#.archive endsWith filename`, and `filename` follows from the URL, so it corrects itself — the upstream manifest lists `stable/windows/flutter_windows_3.27.2-stable.zip`.

## Scope

- **`version_expr` is unchanged.** `mise ls-remote flutter` returning bare versions is correct, and a fresh `mise use flutter` already works today. What this fixes is a pin carried over from the vfox era.
- **Only the stable channel**, as before. beta/dev are not modelled in this entry.
- **The `asdf:` and `vfox:` fallback backends are untouched.**
- **`dart` is unaffected** — flutter is the only registry entry that strips and re-appends a channel suffix (grepped `registry/`).

## Note on #4170

The crash in that report — `vfox … pre_install.rs: Expected table` — is already gone: flutter resolves through `http:` rather than `vfox:` now, and #11793 replaced those panics with errors. But flutter still would not install for the reporter's pinned `3.27.2-stable`, for the unrelated reason above. This PR covers that second half.

## Tests

One test in `src/tera.rs` pinning the invariant the registry relies on: appending `-stable` after `trim_end(pat='-stable')` is idempotent for both `3.27.2` and `3.27.2-stable`.

No e2e — the Flutter SDK is over a gigabyte and does not belong in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Flutter download links across Linux, macOS, and Windows to prevent duplicated `-stable` version suffixes.
  * Ensured both suffixed and unsuffixed Flutter versions resolve to the correct download URLs.
  * Standardized download URL formatting for more consistent artifact retrieval.

* **Tests**
  * Added regression coverage for Flutter version suffix handling across supported template engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->