### PR TITLE
feat(bootstrap): add platform filters to packages

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -78,9 +78,12 @@ installed into `$XDG_DATA_HOME/fonts`, which defaults to `~/.local/share/fonts`:
 "brew-cask:font-heavy-data-nerd-font" = "latest"
 ```
 
-Other Linux casks fail with a clear unsupported-platform error. This boundary
-will expand as mise gains portable implementations for more cask artifact
-types.
+Other Linux casks are reported as unavailable and skipped when they come from
+`[bootstrap.packages]`, allowing macOS and Linux to share a package list. An
+explicit request such as `mise bootstrap packages apply brew-cask:firefox`
+still fails with a clear unsupported-platform error. You can also mark macOS
+casks explicitly with `{ os = "macos" }`. This boundary will expand as mise
+gains portable implementations for more cask artifact types.
 
 `brew-cask` currently supports app-bundle casks (`app` artifacts), binary and
 generated command-wrapper casks (`binary` and `command_wrapper` artifacts),

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -23,6 +23,18 @@ and the value is a version: `"latest"` for whatever the manager installs, or
 a pin in the manager's native format where supported (see the per-manager
 pages).
 
+Use the table form to restrict an individual package by operating system or
+OS/architecture. `os` accepts one value or a list and uses the same names and
+aliases as `[tools]` (`linux`, `macos`, `windows`, `linux/x64`,
+`macos/arm64`, and so on). `version` defaults to `"latest"` when omitted:
+
+```toml
+[bootstrap.packages]
+"brew:coreutils" = "latest"
+"brew-cask:1password" = { os = "macos" }
+"brew-cask:font-jetbrains-mono" = { os = ["linux", "macos"] }
+```
+
 Host packages are intentionally separate from [`[tools]`](/configuration.html):
 they are not version-pinned per-project, do not get shims, and are managed
 outside the project by the platform's package manager — or, for `brew` and
@@ -70,11 +82,12 @@ declarative sections work the same way:
   `mise bootstrap packages prune` is an explicit destructive command that
   removes linked formulae or safely prunable mise-owned casks no longer needed
   by the current config or by trusted, loadable tracked configs.
-- **OS-filtered** — entries for a manager that isn't available on the current
-  machine are not acted on, so the same config works across platforms: `apt`
-  entries are ignored on macOS, `dnf` entries on Ubuntu, and so on. `brew`
-  works on both macOS and Linux; `brew-cask` works on macOS and supports
-  font-only casks without lifecycle hooks or structured flight steps on Linux;
+- **OS-filtered** — entries whose `os` selector does not match and entries for
+  a manager that isn't available on the current machine are not acted on, so
+  the same config works across platforms: `apt` entries are ignored on macOS,
+  `dnf` entries on Ubuntu, and so on. `brew` works on both macOS and Linux;
+  `brew-cask` works on macOS and supports font-only casks without lifecycle
+  hooks or structured flight steps on Linux;
   `flatpak` and `flatpak-user` work on Linux when the `flatpak` CLI is on
   `PATH`; `mas` works on macOS when the `mas` CLI is on `PATH`. Status commands
   still list

--- a/e2e/cli/test_system_status
+++ b/e2e/cli/test_system_status
@@ -65,14 +65,14 @@ assert_contains "mise bootstrap packages status 2>&1" "invalid system package sp
 
 # package-level OS selectors are applied before manager resolution
 case "$(uname)" in
-Darwin)
-  active_os=macos
-  inactive_os=linux
-  ;;
-*)
-  active_os=linux
-  inactive_os=macos
-  ;;
+  Darwin)
+    active_os=macos
+    inactive_os=linux
+    ;;
+  *)
+    active_os=linux
+    inactive_os=macos
+    ;;
 esac
 cat <<EOF >mise.toml
 [bootstrap.packages]

--- a/e2e/cli/test_system_status
+++ b/e2e/cli/test_system_status
@@ -63,6 +63,25 @@ EOF
 assert_succeed "mise bootstrap packages status"
 assert_contains "mise bootstrap packages status 2>&1" "invalid system package spec"
 
+# package-level OS selectors are applied before manager resolution
+case "$(uname)" in
+Darwin)
+  active_os=macos
+  inactive_os=linux
+  ;;
+*)
+  active_os=linux
+  inactive_os=macos
+  ;;
+esac
+cat <<EOF >mise.toml
+[bootstrap.packages]
+"apt:active" = { os = "$active_os" }
+"not-a-real-manager:inactive" = { version = "latest", os = ["$inactive_os"] }
+EOF
+assert_contains "mise bootstrap packages status" "active"
+assert_not_contains "mise bootstrap packages status 2>&1" "unknown bootstrap package manager"
+
 # empty [bootstrap.packages] section
 cat <<EOF >mise.toml
 [bootstrap.packages]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3868,8 +3868,34 @@
             "pattern": "^[A-Za-z0-9_-]+:.+$"
           },
           "additionalProperties": {
-            "type": "string",
-            "description": "version pin in the manager's native format, or \"latest\""
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "version pin in the manager's native format, or \"latest\""
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "version": {
+                    "type": "string",
+                    "default": "latest",
+                    "description": "version pin in the manager's native format, or \"latest\""
+                  },
+                  "os": {
+                    "description": "operating system or OS/architecture selectors",
+                    "oneOf": [
+                      { "type": "string" },
+                      {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
           }
         },
         "repos": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3884,10 +3884,14 @@
                   "os": {
                     "description": "operating system or OS/architecture selectors",
                     "oneOf": [
-                      { "type": "string" },
+                      {
+                        "$ref": "#/$defs/os_filter_item"
+                      },
                       {
                         "type": "array",
-                        "items": { "type": "string" },
+                        "items": {
+                          "$ref": "#/$defs/os_filter_item"
+                        },
                         "minItems": 1
                       }
                     ]

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -2763,29 +2763,39 @@ impl BootstrapStatus {
             let statuses = mp.manager.installed(&mp.requests).await?;
             let mut json_pkgs = vec![];
             for s in statuses {
-                let (installed_version, state, missing) = match &s.state {
-                    PackageState::Installed { version } => (version.clone(), "installed", false),
-                    PackageState::Missing => ("".to_string(), "missing", true),
+                let (installed_version, state, reason, missing) = match &s.state {
+                    PackageState::Installed { version } => {
+                        (version.clone(), "installed", None, false)
+                    }
+                    PackageState::Missing => ("".to_string(), "missing", None, true),
                     PackageState::NeedsRepair { installed } => {
-                        (installed.clone(), "needs repair", true)
+                        (installed.clone(), "needs repair", None, true)
                     }
                     PackageState::VersionMismatch { installed } => {
-                        (installed.clone(), "version mismatch", true)
+                        (installed.clone(), "version mismatch", None, true)
+                    }
+                    PackageState::Unavailable { reason } => {
+                        ("".to_string(), "skipped", Some(reason.as_str()), false)
                     }
                 };
                 report.row(
                     "packages",
                     format!("{name}:{}", s.request),
                     installed_version.clone(),
-                    state,
+                    reason
+                        .map_or_else(|| state.to_string(), |reason| format!("{state} ({reason})")),
                     missing,
                 );
-                json_pkgs.push(json!({
+                let mut package = json!({
                     "package": s.request.name,
                     "requested_version": s.request.version.clone().unwrap_or_else(|| "latest".to_string()),
                     "state": state.replace(' ', "_"),
                     "installed_version": installed_version,
-                }));
+                });
+                if let Some(reason) = reason {
+                    package["reason"] = json!(reason);
+                }
+                json_pkgs.push(package);
             }
             json_out.insert(
                 name.to_string(),

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -2767,7 +2767,7 @@ impl BootstrapStatus {
             for s in statuses {
                 let (installed_version, state, reason, missing) = match &s.state {
                     PackageState::Installed { version } => {
-                        (version.clone(), "installed", None, false)
+                        (version.clone(), "installed", None::<&str>, false)
                     }
                     PackageState::Missing => ("".to_string(), "missing", None, true),
                     PackageState::NeedsRepair { installed } => {

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -2776,6 +2776,7 @@ impl BootstrapStatus {
                     PackageState::VersionMismatch { installed } => {
                         (installed.clone(), "version mismatch", None, true)
                     }
+                    #[cfg(unix)]
                     PackageState::Unavailable { reason } => {
                         ("".to_string(), "skipped", Some(reason.as_str()), false)
                     }

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -1263,6 +1263,7 @@ impl Bootstrap {
                 let opts = DriverOpts {
                     manager: None,
                     explicit: false,
+                    allow_unavailable_manager: false,
                     dry_run: self.dry_run,
                     update: self.update,
                     yes: self.yes,
@@ -1551,6 +1552,7 @@ impl Bootstrap {
                     &DriverOpts {
                         manager: None,
                         explicit: false,
+                        allow_unavailable_manager: false,
                         dry_run: self.dry_run,
                         update: self.update,
                         yes: self.yes,

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -502,8 +502,7 @@ impl Doctor {
                             !matches!(
                                 s.state,
                                 crate::system::packages::PackageState::Installed { .. }
-                                    | crate::system::packages::PackageState::Unavailable { .. }
-                            )
+                            ) && !s.state.is_unavailable()
                         })
                         .count();
                     total_missing += missing;
@@ -734,8 +733,7 @@ impl Doctor {
                             !matches!(
                                 s.state,
                                 crate::system::packages::PackageState::Installed { .. }
-                                    | crate::system::packages::PackageState::Unavailable { .. }
-                            )
+                            ) && !s.state.is_unavailable()
                         })
                         .count();
                     lines.push(format!(

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -502,6 +502,7 @@ impl Doctor {
                             !matches!(
                                 s.state,
                                 crate::system::packages::PackageState::Installed { .. }
+                                    | crate::system::packages::PackageState::Unavailable { .. }
                             )
                         })
                         .count();
@@ -733,6 +734,7 @@ impl Doctor {
                             !matches!(
                                 s.state,
                                 crate::system::packages::PackageState::Installed { .. }
+                                    | crate::system::packages::PackageState::Unavailable { .. }
                             )
                         })
                         .count();

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -195,6 +195,7 @@ impl Install {
                             !matches!(
                                 s.state,
                                 crate::system::packages::PackageState::Installed { .. }
+                                    | crate::system::packages::PackageState::Unavailable { .. }
                             )
                         })
                         .count();

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -195,8 +195,7 @@ impl Install {
                             !matches!(
                                 s.state,
                                 crate::system::packages::PackageState::Installed { .. }
-                                    | crate::system::packages::PackageState::Unavailable { .. }
-                            )
+                            ) && !s.state.is_unavailable()
                         })
                         .count();
                 }

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -88,20 +88,37 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
             continue;
         }
         let statuses = mp.manager.installed(&mp.requests).await?;
+        if (d.manager.is_some() || d.explicit)
+            && let Some(status) = statuses
+                .iter()
+                .find(|status| matches!(status.state, PackageState::Unavailable { .. }))
+            && let PackageState::Unavailable { reason } = &status.state
+        {
+            bail!("{reason}");
+        }
         let mut targets: Vec<_> = statuses
             .iter()
             .filter(|s| match action {
-                Action::Install => !matches!(s.state, PackageState::Installed { .. }),
+                Action::Install => !matches!(
+                    s.state,
+                    PackageState::Installed { .. } | PackageState::Unavailable { .. }
+                ),
                 // upgrade acts on whatever is present (the manager no-ops
                 // already-current packages); missing packages are skipped
                 // below with a pointer at `install`
-                Action::Upgrade => !matches!(s.state, PackageState::Missing),
+                Action::Upgrade => !matches!(
+                    s.state,
+                    PackageState::Missing | PackageState::Unavailable { .. }
+                ),
             })
             .collect();
-        let skipped = statuses.len() - targets.len();
-        if action == Action::Upgrade && skipped > 0 {
+        let missing = statuses
+            .iter()
+            .filter(|status| matches!(status.state, PackageState::Missing))
+            .count();
+        if action == Action::Upgrade && missing > 0 {
             warn!(
-                "{name}: {skipped} package(s) not installed — run `mise bootstrap packages apply` first"
+                "{name}: {missing} package(s) not installed — run `mise bootstrap packages apply` first"
             );
         }
         // a pin this manager can never satisfy must not block the rest
@@ -122,8 +139,12 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                 }
             });
         }
-        if action == Action::Install && skipped > 0 {
-            info!("{name}: {skipped} package(s) already installed");
+        let installed = statuses
+            .iter()
+            .filter(|status| matches!(status.state, PackageState::Installed { .. }))
+            .count();
+        if action == Action::Install && installed > 0 {
+            info!("{name}: {installed} package(s) already installed");
         }
         if targets.is_empty() {
             continue;
@@ -158,7 +179,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                         | PackageState::VersionMismatch { installed: version } => {
                             Some((s.request.name.clone(), version.clone()))
                         }
-                        PackageState::Missing => None,
+                        PackageState::Missing | PackageState::Unavailable { .. } => None,
                     })
                     .collect();
                 mp.manager.upgrade(&targets, &opts).await?;
@@ -174,7 +195,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                                 (old != version)
                                     .then(|| format!("{} {old} -> {version}", s.request.name))
                             }
-                            PackageState::Missing => None,
+                            PackageState::Missing | PackageState::Unavailable { .. } => None,
                         })
                         .collect();
                     if changed.is_empty() {

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -6,7 +6,7 @@ use eyre::{Result, bail};
 
 use crate::config::Settings;
 use crate::system::ManagerPackages;
-use crate::system::packages::{InstallOpts, PackageState};
+use crate::system::packages::{InstallOpts, PackageState, PackageStatus};
 use crate::ui::prompt;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -30,9 +30,29 @@ pub(crate) struct DriverOpts {
     /// packages were named explicitly on the CLI — unavailable managers are
     /// then a hard error instead of a silent (cross-platform config) skip
     pub explicit: bool,
+    /// An explicitly named manager may still be written to shared config on a
+    /// platform where that manager is unavailable.
+    pub allow_unavailable_manager: bool,
     pub dry_run: bool,
     pub update: bool,
     pub yes: bool,
+}
+
+fn unavailable_manager_is_error(d: &DriverOpts) -> bool {
+    (d.manager.is_some() || d.explicit) && !d.allow_unavailable_manager
+}
+
+fn unavailable_package_reason<'a>(
+    d: &DriverOpts,
+    statuses: &'a [PackageStatus],
+) -> Option<&'a str> {
+    if d.manager.is_none() && !d.explicit {
+        return None;
+    }
+    statuses.iter().find_map(|status| match &status.state {
+        PackageState::Unavailable { reason } => Some(reason.as_str()),
+        _ => None,
+    })
 }
 
 /// Run `action` for every manager in `mgrs`, honoring the `--manager` filter,
@@ -79,7 +99,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
             continue;
         }
         if let Some(reason) = mp.manager.unavailable_reason_async().await {
-            if d.manager.is_some() || d.explicit {
+            if unavailable_manager_is_error(d) {
                 // explicitly requested (via --manager or manager:package
                 // specs) — failing silently would be a lie
                 bail!("{name} is not available: {}", reason);
@@ -88,12 +108,7 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
             continue;
         }
         let statuses = mp.manager.installed(&mp.requests).await?;
-        if (d.manager.is_some() || d.explicit)
-            && let Some(status) = statuses
-                .iter()
-                .find(|status| matches!(status.state, PackageState::Unavailable { .. }))
-            && let PackageState::Unavailable { reason } = &status.state
-        {
+        if let Some(reason) = unavailable_package_reason(d, &statuses) {
             bail!("{reason}");
         }
         let mut targets: Vec<_> = statuses
@@ -208,4 +223,38 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::system::packages::PackageRequest;
+
+    #[test]
+    fn use_allows_unavailable_manager_but_rejects_unavailable_package() {
+        let opts = DriverOpts {
+            manager: None,
+            explicit: true,
+            allow_unavailable_manager: true,
+            dry_run: false,
+            update: false,
+            yes: true,
+        };
+        let statuses = vec![PackageStatus {
+            request: PackageRequest {
+                name: "example".to_string(),
+                version: None,
+                tap_url: None,
+            },
+            state: PackageState::Unavailable {
+                reason: "unsupported on this platform".to_string(),
+            },
+        }];
+
+        assert!(!unavailable_manager_is_error(&opts));
+        assert_eq!(
+            unavailable_package_reason(&opts, &statuses),
+            Some("unsupported on this platform")
+        );
+    }
 }

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -226,12 +226,11 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use crate::system::packages::PackageRequest;
 
-    #[cfg(unix)]
     #[test]
     fn use_allows_unavailable_manager_but_rejects_unavailable_package() {
         let opts = DriverOpts {

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -49,10 +49,9 @@ fn unavailable_package_reason<'a>(
     if d.manager.is_none() && !d.explicit {
         return None;
     }
-    statuses.iter().find_map(|status| match &status.state {
-        PackageState::Unavailable { reason } => Some(reason.as_str()),
-        _ => None,
-    })
+    statuses
+        .iter()
+        .find_map(|status| status.state.unavailable_reason())
 }
 
 /// Run `action` for every manager in `mgrs`, honoring the `--manager` filter,
@@ -114,17 +113,15 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
         let mut targets: Vec<_> = statuses
             .iter()
             .filter(|s| match action {
-                Action::Install => !matches!(
-                    s.state,
-                    PackageState::Installed { .. } | PackageState::Unavailable { .. }
-                ),
+                Action::Install => {
+                    !matches!(s.state, PackageState::Installed { .. }) && !s.state.is_unavailable()
+                }
                 // upgrade acts on whatever is present (the manager no-ops
                 // already-current packages); missing packages are skipped
                 // below with a pointer at `install`
-                Action::Upgrade => !matches!(
-                    s.state,
-                    PackageState::Missing | PackageState::Unavailable { .. }
-                ),
+                Action::Upgrade => {
+                    !matches!(s.state, PackageState::Missing) && !s.state.is_unavailable()
+                }
             })
             .collect();
         let missing = statuses
@@ -194,7 +191,9 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                         | PackageState::VersionMismatch { installed: version } => {
                             Some((s.request.name.clone(), version.clone()))
                         }
-                        PackageState::Missing | PackageState::Unavailable { .. } => None,
+                        PackageState::Missing => None,
+                        #[cfg(unix)]
+                        PackageState::Unavailable { .. } => None,
                     })
                     .collect();
                 mp.manager.upgrade(&targets, &opts).await?;
@@ -210,7 +209,9 @@ pub(crate) async fn run(mgrs: Vec<ManagerPackages>, action: Action, d: &DriverOp
                                 (old != version)
                                     .then(|| format!("{} {old} -> {version}", s.request.name))
                             }
-                            PackageState::Missing | PackageState::Unavailable { .. } => None,
+                            PackageState::Missing => None,
+                            #[cfg(unix)]
+                            PackageState::Unavailable { .. } => None,
                         })
                         .collect();
                     if changed.is_empty() {
@@ -230,6 +231,7 @@ mod tests {
     use super::*;
     use crate::system::packages::PackageRequest;
 
+    #[cfg(unix)]
     #[test]
     fn use_allows_unavailable_manager_but_rejects_unavailable_package() {
         let opts = DriverOpts {

--- a/src/cli/system/driver.rs
+++ b/src/cli/system/driver.rs
@@ -46,7 +46,7 @@ fn unavailable_package_reason<'a>(
     d: &DriverOpts,
     statuses: &'a [PackageStatus],
 ) -> Option<&'a str> {
-    if d.manager.is_none() && !d.explicit {
+    if !d.explicit {
         return None;
     }
     statuses
@@ -232,8 +232,8 @@ mod tests {
     use crate::system::packages::PackageRequest;
 
     #[test]
-    fn use_allows_unavailable_manager_but_rejects_unavailable_package() {
-        let opts = DriverOpts {
+    fn explicit_packages_reject_unavailable_entries_but_manager_filters_skip_them() {
+        let explicit_opts = DriverOpts {
             manager: None,
             explicit: true,
             allow_unavailable_manager: true,
@@ -252,10 +252,21 @@ mod tests {
             },
         }];
 
-        assert!(!unavailable_manager_is_error(&opts));
+        assert!(!unavailable_manager_is_error(&explicit_opts));
         assert_eq!(
-            unavailable_package_reason(&opts, &statuses),
+            unavailable_package_reason(&explicit_opts, &statuses),
             Some("unsupported on this platform")
         );
+
+        let manager_opts = DriverOpts {
+            manager: Some("brew-cask".to_string()),
+            explicit: false,
+            allow_unavailable_manager: false,
+            dry_run: false,
+            update: false,
+            yes: true,
+        };
+        assert!(unavailable_manager_is_error(&manager_opts));
+        assert_eq!(unavailable_package_reason(&manager_opts, &statuses), None);
     }
 }

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -20,6 +20,8 @@ use crate::file::display_path;
 #[cfg(unix)]
 use crate::system;
 #[cfg(unix)]
+use crate::system::PackageTomlConfig;
+#[cfg(unix)]
 use crate::system::packages::SystemPackageManager;
 #[cfg(unix)]
 use crate::system::packages::brew;
@@ -128,7 +130,7 @@ impl SystemImport {
                 let key = formula.config_key();
                 if target_packages
                     .get(&key)
-                    .is_some_and(|version| version == "latest")
+                    .is_some_and(|package| package.version() == "latest")
                 {
                     continue;
                 }
@@ -192,13 +194,13 @@ fn target_brew_taps(path: &Path) -> Result<BTreeMap<String, String>> {
 }
 
 #[cfg(unix)]
-fn target_bootstrap_packages(path: &Path) -> Result<BTreeMap<String, String>> {
+fn target_bootstrap_packages(path: &Path) -> Result<BTreeMap<String, PackageTomlConfig>> {
     let mut packages = BTreeMap::new();
     if path.exists() {
         let cf = MiseToml::from_file(path)?;
         if let Some(sys) = cf.bootstrap_config() {
-            for (spec, version) in sys.packages {
-                packages.insert(spec, version.version().to_string());
+            for (spec, package) in sys.packages {
+                packages.insert(spec, package);
             }
         }
     }

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -104,6 +104,8 @@ impl SystemImport {
         })?;
 
         let configured_taps = configured_brew_taps(&path).await?;
+        let config = Config::get().await?;
+        let configured_packages = system::package_configs_from_config(&config);
         let target_taps = target_brew_taps(&path)?;
         let target_packages = target_bootstrap_packages(&path)?;
         let mut taps = BTreeMap::new();
@@ -148,7 +150,12 @@ impl SystemImport {
             cf.update_bootstrap_brew_tap(tap, url)?;
         }
         for formula in &formulae {
-            cf.update_bootstrap_package(&formula.config_key(), "latest")?;
+            let key = formula.config_key();
+            cf.update_bootstrap_package_with_fallback(
+                &key,
+                "latest",
+                configured_packages.get(&key),
+            )?;
         }
         cf.save()?;
         info!(

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -25,6 +25,8 @@ use crate::system::PackageTomlConfig;
 use crate::system::packages::SystemPackageManager;
 #[cfg(unix)]
 use crate::system::packages::brew;
+#[cfg(unix)]
+use toml_edit::{Array, InlineTable, Value};
 
 /// Import installed system packages into `[bootstrap.packages]`
 ///
@@ -136,7 +138,11 @@ impl SystemImport {
                 {
                     continue;
                 }
-                miseprintln!("{}: \"{}\" = \"latest\"", display_path(&path), key);
+                let package = imported_package_value(
+                    target_packages.get(&key),
+                    configured_packages.get(&key),
+                );
+                miseprintln!("{}: \"{}\" = {}", display_path(&path), key, package);
             }
             return Ok(());
         }
@@ -171,6 +177,32 @@ impl SystemImport {
         let _ = self.manager;
         bail!("brew import is not supported on windows")
     }
+}
+
+#[cfg(unix)]
+fn imported_package_value(
+    target: Option<&PackageTomlConfig>,
+    configured: Option<&PackageTomlConfig>,
+) -> Value {
+    let options = match target {
+        Some(PackageTomlConfig::Options(options)) => Some(options),
+        Some(PackageTomlConfig::Version(_)) => None,
+        None => match configured {
+            Some(PackageTomlConfig::Options(options)) if !options.os.is_empty() => Some(options),
+            _ => None,
+        },
+    };
+    let Some(options) = options else {
+        return Value::from("latest");
+    };
+    let mut table = InlineTable::new();
+    table.insert("version", Value::from("latest"));
+    if !options.os.is_empty() {
+        let mut os = Array::new();
+        os.extend(options.os.clone());
+        table.insert("os", Value::Array(os));
+    }
+    Value::InlineTable(table)
 }
 
 #[cfg(unix)]
@@ -212,6 +244,24 @@ fn target_bootstrap_packages(path: &Path) -> Result<BTreeMap<String, PackageToml
         }
     }
     Ok(packages)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::system::PackageOptionsTomlConfig;
+
+    #[test]
+    fn dry_run_preserves_inherited_selectors() {
+        let inherited = PackageTomlConfig::Options(PackageOptionsTomlConfig {
+            version: "1.0.0".to_string(),
+            os: vec!["macos".to_string()],
+        });
+        assert_eq!(
+            imported_package_value(None, Some(&inherited)).to_string(),
+            r#"{ version = "latest", os = ["macos"] }"#
+        );
+    }
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -107,7 +107,7 @@ impl SystemImport {
 
         let configured_taps = configured_brew_taps(&path).await?;
         let config = Config::get().await?;
-        let configured_packages = system::package_configs_from_config(&config);
+        let configured_packages = system::package_configs_for_target(&config, &path);
         let target_taps = target_brew_taps(&path)?;
         let target_packages = target_bootstrap_packages(&path)?;
         let mut taps = BTreeMap::new();

--- a/src/cli/system/import.rs
+++ b/src/cli/system/import.rs
@@ -198,7 +198,7 @@ fn target_bootstrap_packages(path: &Path) -> Result<BTreeMap<String, String>> {
         let cf = MiseToml::from_file(path)?;
         if let Some(sys) = cf.bootstrap_config() {
             for (spec, version) in sys.packages {
-                packages.insert(spec, version);
+                packages.insert(spec, version.version().to_string());
             }
         }
     }

--- a/src/cli/system/install.rs
+++ b/src/cli/system/install.rs
@@ -59,6 +59,7 @@ impl SystemInstall {
         let opts = DriverOpts {
             manager: self.manager.clone(),
             explicit: !self.packages.is_empty(),
+            allow_unavailable_manager: false,
             dry_run: self.dry_run,
             update: self.update,
             yes: self.yes,

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -54,34 +54,44 @@ impl SystemStatus {
             let statuses = mp.manager.installed(&mp.requests).await?;
             let mut json_pkgs = vec![];
             for s in statuses {
-                let (installed_version, state) = match &s.state {
-                    PackageState::Installed { version } => (version.clone(), "installed"),
+                let (installed_version, state, reason) = match &s.state {
+                    PackageState::Installed { version } => (version.clone(), "installed", None),
                     PackageState::Missing => {
                         any_missing = true;
-                        ("".to_string(), "missing")
+                        ("".to_string(), "missing", None)
                     }
                     PackageState::NeedsRepair { installed } => {
                         any_missing = true;
-                        (installed.clone(), "needs repair")
+                        (installed.clone(), "needs repair", None)
                     }
                     PackageState::VersionMismatch { installed } => {
                         any_missing = true;
-                        (installed.clone(), "version mismatch")
+                        (installed.clone(), "version mismatch", None)
+                    }
+                    PackageState::Unavailable { reason } => {
+                        ("".to_string(), "skipped", Some(reason.as_str()))
                     }
                 };
                 if self.json {
-                    json_pkgs.push(json!({
+                    let mut package = json!({
                         "package": s.request.name,
                         "requested_version": s.request.version.clone().unwrap_or_else(|| "latest".to_string()),
                         "state": state.replace(' ', "_"),
                         "installed_version": installed_version,
-                    }));
+                    });
+                    if let Some(reason) = reason {
+                        package["reason"] = json!(reason);
+                    }
+                    json_pkgs.push(package);
                 } else {
                     rows.push(vec![
                         name.to_string(),
                         s.request.to_string(),
                         installed_version,
-                        state.to_string(),
+                        reason.map_or_else(
+                            || state.to_string(),
+                            |reason| format!("{state} ({reason})"),
+                        ),
                     ]);
                 }
             }

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -68,6 +68,7 @@ impl SystemStatus {
                         any_missing = true;
                         (installed.clone(), "version mismatch", None)
                     }
+                    #[cfg(unix)]
                     PackageState::Unavailable { reason } => {
                         ("".to_string(), "skipped", Some(reason.as_str()))
                     }

--- a/src/cli/system/status.rs
+++ b/src/cli/system/status.rs
@@ -55,7 +55,9 @@ impl SystemStatus {
             let mut json_pkgs = vec![];
             for s in statuses {
                 let (installed_version, state, reason) = match &s.state {
-                    PackageState::Installed { version } => (version.clone(), "installed", None),
+                    PackageState::Installed { version } => {
+                        (version.clone(), "installed", None::<&str>)
+                    }
                     PackageState::Missing => {
                         any_missing = true;
                         ("".to_string(), "missing", None)

--- a/src/cli/system/upgrade.rs
+++ b/src/cli/system/upgrade.rs
@@ -48,6 +48,7 @@ impl SystemUpgrade {
         let opts = DriverOpts {
             manager: self.manager,
             explicit: !self.packages.is_empty(),
+            allow_unavailable_manager: false,
             dry_run: self.dry_run,
             // upgrades refresh metadata themselves (stale lists would make
             // them silent no-ops), so no separate --update flag

--- a/src/cli/system/use.rs
+++ b/src/cli/system/use.rs
@@ -136,7 +136,8 @@ impl SystemUse {
         }
         let opts = DriverOpts {
             manager: None,
-            explicit: false,
+            explicit: true,
+            allow_unavailable_manager: true,
             dry_run: self.dry_run,
             update: false,
             yes: self.yes,

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -686,6 +686,53 @@ impl MiseToml {
         Ok(())
     }
 
+    /// Update a package while inheriting table-form options when this file does not declare it.
+    pub fn update_bootstrap_package_with_fallback(
+        &mut self,
+        spec: &str,
+        version: &str,
+        fallback: Option<&PackageTomlConfig>,
+    ) -> eyre::Result<()> {
+        let is_missing = self
+            .bootstrap
+            .as_ref()
+            .is_none_or(|bootstrap| !bootstrap.packages.contains_key(spec));
+        if is_missing && let Some(PackageTomlConfig::Options(options)) = fallback {
+            let mut options = options.clone();
+            options.version = version.to_string();
+            self.bootstrap
+                .get_or_insert_with(Default::default)
+                .packages
+                .insert(
+                    spec.to_string(),
+                    PackageTomlConfig::Options(options.clone()),
+                );
+
+            let mut doc = self.doc_mut()?;
+            let bootstrap = doc
+                .get_mut()
+                .unwrap()
+                .entry("bootstrap")
+                .or_insert_with(table)
+                .as_table_mut()
+                .unwrap();
+            bootstrap.set_implicit(true);
+            let packages = bootstrap
+                .entry("packages")
+                .or_insert_with(table)
+                .as_table_mut()
+                .unwrap();
+            let mut value = InlineTable::new();
+            value.insert("version", Value::from(version));
+            let mut os = Array::new();
+            os.extend(options.os);
+            value.insert("os", Value::Array(os));
+            packages.insert(spec, Item::Value(Value::InlineTable(value)));
+            return Ok(());
+        }
+        self.update_bootstrap_package(spec, version)
+    }
+
     /// Set `[bootstrap.brew.taps]."<owner>/<tap>" = "<url>"`, creating the
     /// tables as needed. Only used by the `#[cfg(unix)]` brew CLI commands.
     #[cfg(unix)]
@@ -3312,6 +3359,15 @@ mod tests {
         cf.update_bootstrap_package("brew:ripgrep", "latest")
             .unwrap();
         cf.update_bootstrap_package("brew:fd", "latest").unwrap();
+        let inherited = cf
+            .bootstrap_config()
+            .unwrap()
+            .packages
+            .get("brew:ripgrep")
+            .unwrap()
+            .clone();
+        cf.update_bootstrap_package_with_fallback("brew:bat", "latest", Some(&inherited))
+            .unwrap();
 
         let dump = cf.dump().unwrap();
         assert!(
@@ -3326,6 +3382,10 @@ mod tests {
             dump.contains(r#"os = ["macos"] # keep selector comment"#),
             "nested package selectors should survive: {dump}"
         );
+        assert!(
+            dump.contains(r#""brew:bat" = { version = "latest", os = ["macos"] }"#),
+            "inherited package selectors should be written locally: {dump}"
+        );
         assert!(matches!(
             cf.bootstrap_config()
                 .unwrap()
@@ -3335,6 +3395,10 @@ mod tests {
         ));
         assert!(matches!(
             cf.bootstrap_config().unwrap().packages.get("brew:fd"),
+            Some(PackageTomlConfig::Options(options)) if options.version == "latest" && options.os == ["macos"]
+        ));
+        assert!(matches!(
+            cf.bootstrap_config().unwrap().packages.get("brew:bat"),
             Some(PackageTomlConfig::Options(options)) if options.version == "latest" && options.os == ["macos"]
         ));
         file::remove_file(&p).unwrap();

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -687,6 +687,7 @@ impl MiseToml {
     }
 
     /// Update a package while inheriting table-form options when this file does not declare it.
+    #[cfg(unix)]
     pub fn update_bootstrap_package_with_fallback(
         &mut self,
         spec: &str,
@@ -3359,15 +3360,18 @@ mod tests {
         cf.update_bootstrap_package("brew:ripgrep", "latest")
             .unwrap();
         cf.update_bootstrap_package("brew:fd", "latest").unwrap();
-        let inherited = cf
-            .bootstrap_config()
-            .unwrap()
-            .packages
-            .get("brew:ripgrep")
-            .unwrap()
-            .clone();
-        cf.update_bootstrap_package_with_fallback("brew:bat", "latest", Some(&inherited))
-            .unwrap();
+        #[cfg(unix)]
+        {
+            let inherited = cf
+                .bootstrap_config()
+                .unwrap()
+                .packages
+                .get("brew:ripgrep")
+                .unwrap()
+                .clone();
+            cf.update_bootstrap_package_with_fallback("brew:bat", "latest", Some(&inherited))
+                .unwrap();
+        }
 
         let dump = cf.dump().unwrap();
         assert!(
@@ -3382,6 +3386,7 @@ mod tests {
             dump.contains(r#"os = ["macos"] # keep selector comment"#),
             "nested package selectors should survive: {dump}"
         );
+        #[cfg(unix)]
         assert!(
             dump.contains(r#""brew:bat" = { version = "latest", os = ["macos"] }"#),
             "inherited package selectors should be written locally: {dump}"
@@ -3397,6 +3402,7 @@ mod tests {
             cf.bootstrap_config().unwrap().packages.get("brew:fd"),
             Some(PackageTomlConfig::Options(options)) if options.version == "latest" && options.os == ["macos"]
         ));
+        #[cfg(unix)]
         assert!(matches!(
             cf.bootstrap_config().unwrap().packages.get("brew:bat"),
             Some(PackageTomlConfig::Options(options)) if options.version == "latest" && options.os == ["macos"]

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -639,13 +639,20 @@ impl MiseToml {
     /// Set `[bootstrap.packages]."<manager>:<package>" = "<version>"`,
     /// creating the tables as needed ("latest" means no pin)
     pub fn update_bootstrap_package(&mut self, spec: &str, version: &str) -> eyre::Result<()> {
-        self.bootstrap
-            .get_or_insert_with(Default::default)
-            .packages
-            .insert(
-                spec.to_string(),
-                PackageTomlConfig::Version(version.to_string()),
-            );
+        let packages = &mut self.bootstrap.get_or_insert_with(Default::default).packages;
+        let preserve_options = match packages.get_mut(spec) {
+            Some(PackageTomlConfig::Options(options)) => {
+                options.version = version.to_string();
+                true
+            }
+            _ => {
+                packages.insert(
+                    spec.to_string(),
+                    PackageTomlConfig::Version(version.to_string()),
+                );
+                false
+            }
+        };
         let mut doc = self.doc_mut()?;
         let bootstrap = doc
             .get_mut()
@@ -661,6 +668,16 @@ impl MiseToml {
             .or_insert_with(table)
             .as_table_mut()
             .unwrap();
+        if preserve_options && let Some(item) = packages.get_mut(spec) {
+            if let Some(options) = item.as_value_mut().and_then(Value::as_inline_table_mut) {
+                options.insert("version", Value::from(version));
+                return Ok(());
+            }
+            if let Some(options) = item.as_table_mut() {
+                options.insert("version", value(version));
+                return Ok(());
+            }
+        }
         let key = get_key_with_decor(packages, spec);
         let value_decor = get_value_decor(packages, spec);
         let mut item = toml_edit::value(version);
@@ -3268,6 +3285,41 @@ mod tests {
             system.packages.get("apt:curl").unwrap().version(),
             "8.5.0-2"
         );
+        file::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_update_bootstrap_package_preserves_options() {
+        let _config = Config::get().await.unwrap();
+        let p = CWD
+            .as_ref()
+            .unwrap()
+            .join(".bootstrap-package-options.mise.toml");
+        file::write(
+            &p,
+            formatdoc! {r#"
+            [bootstrap.packages]
+            "brew:ripgrep" = {{ version = "14.0.0", os = ["macos"] }} # keep me
+            "apt:curl" = "8.5.0"
+            "#},
+        )
+        .unwrap();
+        let mut cf = MiseToml::from_file(&p).unwrap();
+        cf.update_bootstrap_package("brew:ripgrep", "latest")
+            .unwrap();
+
+        let dump = cf.dump().unwrap();
+        assert!(
+            dump.contains(r#""brew:ripgrep" = { version = "latest", os = ["macos"] } # keep me"#),
+            "package selectors and comments should survive: {dump}"
+        );
+        assert!(matches!(
+            cf.bootstrap_config()
+                .unwrap()
+                .packages
+                .get("brew:ripgrep"),
+            Some(PackageTomlConfig::Options(options)) if options.version == "latest" && options.os == ["macos"]
+        ));
         file::remove_file(&p).unwrap();
     }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -698,7 +698,10 @@ impl MiseToml {
             .bootstrap
             .as_ref()
             .is_none_or(|bootstrap| !bootstrap.packages.contains_key(spec));
-        if is_missing && let Some(PackageTomlConfig::Options(options)) = fallback {
+        if is_missing
+            && let Some(PackageTomlConfig::Options(options)) = fallback
+            && !options.os.is_empty()
+        {
             let mut options = options.clone();
             options.version = version.to_string();
             self.bootstrap
@@ -3371,6 +3374,20 @@ mod tests {
                 .clone();
             cf.update_bootstrap_package_with_fallback("brew:bat", "latest", Some(&inherited))
                 .unwrap();
+            #[cfg(unix)]
+            {
+                let inherited_without_selector =
+                    PackageTomlConfig::Options(crate::system::PackageOptionsTomlConfig {
+                        version: "1.0.0".to_string(),
+                        os: vec![],
+                    });
+                cf.update_bootstrap_package_with_fallback(
+                    "brew:tree",
+                    "latest",
+                    Some(&inherited_without_selector),
+                )
+                .unwrap();
+            }
         }
 
         let dump = cf.dump().unwrap();
@@ -3391,6 +3408,13 @@ mod tests {
             dump.contains(r#""brew:bat" = { version = "latest", os = ["macos"] }"#),
             "inherited package selectors should be written locally: {dump}"
         );
+        #[cfg(unix)]
+        assert!(
+            dump.contains(r#""brew:tree" = "latest""#),
+            "an inherited options table without selectors should use scalar form: {dump}"
+        );
+        #[cfg(unix)]
+        MiseToml::from_str(&dump, &p).expect("updated package config should parse");
         assert!(matches!(
             cf.bootstrap_config()
                 .unwrap()

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -35,7 +35,7 @@ use crate::hooks::{Hook, HookDef, Hooks};
 use crate::oci::OciConfig;
 use crate::redactions::Redactions;
 use crate::registry::REGISTRY;
-use crate::system::{BootstrapTomlConfig, DotfilesTomlConfig};
+use crate::system::{BootstrapTomlConfig, DotfilesTomlConfig, PackageTomlConfig};
 use crate::task::workspace::WorkspaceProjectOverride;
 use crate::task::{Task, TaskTemplate, TaskTomlBoolPresence};
 use crate::tera::{BASE_CONTEXT, contains_template_syntax, get_tera, render_str};
@@ -642,7 +642,10 @@ impl MiseToml {
         self.bootstrap
             .get_or_insert_with(Default::default)
             .packages
-            .insert(spec.to_string(), version.to_string());
+            .insert(
+                spec.to_string(),
+                PackageTomlConfig::Version(version.to_string()),
+            );
         let mut doc = self.doc_mut()?;
         let bootstrap = doc
             .get_mut()
@@ -2986,6 +2989,8 @@ mod tests {
         "apt:libssl-dev" = "latest"
         "apt:curl" = "8.5.0-2"
         "brew:postgresql@17" = "latest"
+        "brew-cask:1password" = { version = "latest", os = "macos" }
+        "brew-cask:font-example" = { os = ["linux", "macos"] }
         "future-manager:whatever" = "latest"
 
         [bootstrap.brew.taps]
@@ -3004,9 +3009,34 @@ mod tests {
         .unwrap();
         let cf = MiseToml::from_file(&p).unwrap();
         let system = cf.bootstrap_config().unwrap();
-        assert_eq!(system.packages.get("apt:libssl-dev").unwrap(), "latest");
-        assert_eq!(system.packages.get("apt:curl").unwrap(), "8.5.0-2");
-        assert_eq!(system.packages.get("brew:postgresql@17").unwrap(), "latest");
+        assert_eq!(
+            system.packages.get("apt:libssl-dev").unwrap().version(),
+            "latest"
+        );
+        assert_eq!(
+            system.packages.get("apt:curl").unwrap().version(),
+            "8.5.0-2"
+        );
+        assert_eq!(
+            system.packages.get("brew:postgresql@17").unwrap().version(),
+            "latest"
+        );
+        assert_eq!(
+            system
+                .packages
+                .get("brew-cask:1password")
+                .unwrap()
+                .version(),
+            "latest"
+        );
+        assert_eq!(
+            system
+                .packages
+                .get("brew-cask:font-example")
+                .unwrap()
+                .version(),
+            "latest"
+        );
         assert_eq!(
             system.brew.taps.get("railwaycat/emacsmacport").unwrap(),
             "https://github.com/railwaycat/homebrew-emacsmacport"
@@ -3022,7 +3052,11 @@ mod tests {
         assert_eq!(system.user.login_shell, None);
         // unknown managers parse fine (forward compatibility)
         assert_eq!(
-            system.packages.get("future-manager:whatever").unwrap(),
+            system
+                .packages
+                .get("future-manager:whatever")
+                .unwrap()
+                .version(),
             "latest"
         );
 
@@ -3230,7 +3264,10 @@ mod tests {
         "brew:postgresql@17" = "latest"
         "#);
         let system = cf.bootstrap_config().unwrap();
-        assert_eq!(system.packages.get("apt:curl").unwrap(), "8.5.0-2");
+        assert_eq!(
+            system.packages.get("apt:curl").unwrap().version(),
+            "8.5.0-2"
+        );
         file::remove_file(&p).unwrap();
     }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -673,8 +673,8 @@ impl MiseToml {
                 options.insert("version", Value::from(version));
                 return Ok(());
             }
-            if let Some(options) = item.as_table_mut() {
-                options.insert("version", value(version));
+            if item.as_table().is_some() {
+                insert_preserving_decor(item, "version", value(version));
                 return Ok(());
             }
         }
@@ -3301,23 +3301,40 @@ mod tests {
             [bootstrap.packages]
             "brew:ripgrep" = {{ version = "14.0.0", os = ["macos"] }} # keep me
             "apt:curl" = "8.5.0"
+
+            [bootstrap.packages."brew:fd"]
+            version = "10.0.0" # keep version comment
+            os = ["macos"] # keep selector comment
             "#},
         )
         .unwrap();
         let mut cf = MiseToml::from_file(&p).unwrap();
         cf.update_bootstrap_package("brew:ripgrep", "latest")
             .unwrap();
+        cf.update_bootstrap_package("brew:fd", "latest").unwrap();
 
         let dump = cf.dump().unwrap();
         assert!(
             dump.contains(r#""brew:ripgrep" = { version = "latest", os = ["macos"] } # keep me"#),
             "package selectors and comments should survive: {dump}"
         );
+        assert!(
+            dump.contains(r#"version = "latest" # keep version comment"#),
+            "nested package version comments should survive: {dump}"
+        );
+        assert!(
+            dump.contains(r#"os = ["macos"] # keep selector comment"#),
+            "nested package selectors should survive: {dump}"
+        );
         assert!(matches!(
             cf.bootstrap_config()
                 .unwrap()
                 .packages
                 .get("brew:ripgrep"),
+            Some(PackageTomlConfig::Options(options)) if options.version == "latest" && options.os == ["macos"]
+        ));
+        assert!(matches!(
+            cf.bootstrap_config().unwrap().packages.get("brew:fd"),
             Some(PackageTomlConfig::Options(options)) if options.version == "latest" && options.os == ["macos"]
         ));
         file::remove_file(&p).unwrap();

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -404,10 +404,14 @@ pub fn packages_from_config(config: &Config) -> Vec<ManagerPackages> {
     packages_from_config_files_with_brew_taps(&config.config_files, &brew_taps)
 }
 
-/// Merge raw `[bootstrap.packages]` declarations without applying host filters.
+/// Merge raw `[bootstrap.packages]` declarations inherited by `target` without
+/// applying host filters. Configs more local than the target are excluded.
 #[cfg(unix)]
-pub(crate) fn package_configs_from_config(config: &Config) -> IndexMap<String, PackageTomlConfig> {
-    package_configs_from_config_files(&config.config_files)
+pub(crate) fn package_configs_for_target(
+    config: &Config,
+    target: &Path,
+) -> IndexMap<String, PackageTomlConfig> {
+    package_configs_from_config_files_for_target(&config.config_files, target)
 }
 
 /// Package requests for declared package plugins that are not installed yet.
@@ -561,9 +565,24 @@ fn package_requests_from_config_files(
 fn package_configs_from_config_files(
     config_files: &ConfigMap,
 ) -> IndexMap<String, PackageTomlConfig> {
+    merge_package_configs(config_files.values())
+}
+
+#[cfg(unix)]
+fn package_configs_from_config_files_for_target(
+    config_files: &ConfigMap,
+    target: &Path,
+) -> IndexMap<String, PackageTomlConfig> {
+    let target_index = config_files.get_index_of(target).unwrap_or(0);
+    merge_package_configs(config_files.values().skip(target_index))
+}
+
+fn merge_package_configs<'a>(
+    config_files: impl DoubleEndedIterator<Item = &'a Arc<dyn crate::config::config_file::ConfigFile>>,
+) -> IndexMap<String, PackageTomlConfig> {
     let mut merged: IndexMap<String, PackageTomlConfig> = IndexMap::new();
     // config_files is ordered local -> global; reverse for global -> local
-    for cf in config_files.values().rev() {
+    for cf in config_files.rev() {
         if let Some(sys) = cf.bootstrap_config() {
             for (spec, version) in sys.packages {
                 merged.insert(spec, version);
@@ -1594,6 +1613,7 @@ mod tests {
                 r#"
                     [bootstrap.packages]
                     "brew:jq" = "latest"
+                    "brew-cask:1password" = { version = "latest", os = ["linux"] }
                 "#,
             ),
             (
@@ -1605,11 +1625,22 @@ mod tests {
             ),
         ])?;
 
-        let packages = package_configs_from_config_files(&config_files);
+        let local_path = config_files.get_index(0).unwrap().0.clone();
+        let global_path = config_files.get_index(1).unwrap().0.clone();
+
+        let packages = package_configs_from_config_files_for_target(&config_files, &local_path);
         assert!(matches!(
             packages.get("brew-cask:1password"),
+            Some(PackageTomlConfig::Options(options)) if options.os == ["linux"]
+        ));
+
+        let global_packages =
+            package_configs_from_config_files_for_target(&config_files, &global_path);
+        assert!(matches!(
+            global_packages.get("brew-cask:1password"),
             Some(PackageTomlConfig::Options(options)) if options.os == ["macos"]
         ));
+        assert!(!global_packages.contains_key("brew:jq"));
         Ok(())
     }
 

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -94,11 +94,11 @@ pub struct BootstrapTomlConfig {
     /// Package manager plugins that must be installed, keyed by manager name.
     #[serde(default)]
     pub plugins: IndexMap<String, String>,
-    /// `"manager:package"` -> version (`"latest"` or a manager-native pin).
+    /// `"manager:package"` -> version/options (`"latest"` or a manager-native pin).
     /// String-keyed so configs using managers from newer mise versions (dnf,
     /// pacman, winget, ...) parse fine on older ones.
     #[serde(default)]
-    pub packages: IndexMap<String, String>,
+    pub packages: IndexMap<String, PackageTomlConfig>,
     /// Absolute target path -> declarative managed file.
     #[serde(default)]
     pub files: IndexMap<String, managed_files::ManagedFileTomlConfig>,
@@ -128,6 +128,93 @@ pub struct BootstrapTomlConfig {
     /// warn and be skipped without rejecting the whole config.
     #[serde(default)]
     pub hooks: IndexMap<String, toml::Value>,
+}
+
+/// A `[bootstrap.packages]` value. The string form remains the concise default;
+/// the table form adds platform selection without changing package keys.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum PackageTomlConfig {
+    Version(String),
+    Options(PackageOptionsTomlConfig),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageOptionsTomlConfig {
+    #[serde(default = "latest_package_version")]
+    pub version: String,
+    #[serde(default, deserialize_with = "deserialize_package_os")]
+    pub os: Vec<String>,
+}
+
+impl PackageTomlConfig {
+    pub fn version(&self) -> &str {
+        match self {
+            Self::Version(version) => version,
+            Self::Options(options) => &options.version,
+        }
+    }
+
+    fn is_os_supported(&self) -> bool {
+        let Self::Options(options) = self else {
+            return true;
+        };
+        options.os.is_empty() || options.os.iter().any(|entry| package_os_matches(entry))
+    }
+}
+
+fn latest_package_version() -> String {
+    "latest".to_string()
+}
+
+fn deserialize_package_os<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    let values = match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(value) => vec![value],
+        OneOrMany::Many(values) => values,
+    };
+    if values.is_empty() || values.iter().any(|value| value.is_empty()) {
+        return Err(serde::de::Error::custom(
+            "package os must contain at least one non-empty selector",
+        ));
+    }
+    Ok(values)
+}
+
+fn package_os_matches(entry: &str) -> bool {
+    let current_os = crate::cli::version::OS.as_str();
+    let current_arch = crate::cli::version::ARCH.as_str();
+    if let Some((os, arch)) = entry.split_once('/') {
+        normalize_package_os(os) == current_os && normalize_package_arch(arch) == current_arch
+    } else {
+        normalize_package_os(entry) == current_os
+    }
+}
+
+fn normalize_package_os(os: &str) -> &str {
+    match os {
+        "darwin" | "macos" => "macos",
+        "windows" | "win" => "windows",
+        other => other,
+    }
+}
+
+fn normalize_package_arch(arch: &str) -> &str {
+    match arch {
+        "x86_64" | "amd64" | "x64" => "x64",
+        "aarch64" | "arm64" => "arm64",
+        other => other,
+    }
 }
 
 pub fn plugins_from_config(config: &Config) -> IndexMap<String, String> {
@@ -307,7 +394,7 @@ pub fn attach_brew_tap_urls(config: &Config, by_mgr: &mut IndexMap<String, Vec<P
 
 /// Aggregate `[bootstrap.packages]` across all loaded config files.
 ///
-/// Keys union global -> local; a more local config overrides the version pin
+/// Keys union global -> local; a more local config overrides the declaration
 /// of a key the global config declared. Malformed keys and unknown managers
 /// warn (forward compatibility) and are skipped. The
 /// `system_packages.managers` setting restricts which managers are used at
@@ -433,7 +520,7 @@ fn package_requests_from_config_files(
     config_files: &ConfigMap,
     brew_taps: &IndexMap<String, String>,
 ) -> IndexMap<String, Vec<PackageRequest>> {
-    let mut merged: IndexMap<String, String> = IndexMap::new();
+    let mut merged: IndexMap<String, PackageTomlConfig> = IndexMap::new();
     // config_files is ordered local -> global; reverse for global -> local
     for cf in config_files.values().rev() {
         if let Some(sys) = cf.bootstrap_config() {
@@ -443,10 +530,15 @@ fn package_requests_from_config_files(
         }
     }
     let mut by_mgr: IndexMap<String, Vec<PackageRequest>> = IndexMap::new();
-    for (spec, version) in merged {
+    for (spec, package) in merged {
+        if !package.is_os_supported() {
+            debug!("[bootstrap.packages]: skipping '{spec}', not enabled for this platform");
+            continue;
+        }
         match parse_spec(&spec) {
             Ok((mgr, name)) => {
-                let version = (version != "latest").then_some(version);
+                let version = package.version();
+                let version = (version != "latest").then(|| version.to_string());
                 if let Err(err) = validate_package_name(&mgr, &name) {
                     warn!("[bootstrap.packages]: {err}");
                     continue;
@@ -1476,6 +1568,50 @@ mod tests {
                 ),
                 ("ffmpeg", None),
             ]
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_packages_from_config_files_filters_os_and_arch() -> Result<()> {
+        let current_os = crate::cli::version::OS.as_str();
+        let current_arch = crate::cli::version::ARCH.as_str();
+        let inactive_os = if current_os == "linux" {
+            "macos"
+        } else {
+            "linux"
+        };
+        let inactive_arch = if current_arch == "x64" {
+            "arm64"
+        } else {
+            "x64"
+        };
+        let config = format!(
+            r#"
+                [bootstrap.packages]
+                "brew:active-os" = {{ os = "{current_os}" }}
+                "brew:active-platform" = {{ version = "1", os = ["{current_os}/{current_arch}", "windows"] }}
+                "brew:inactive-os" = {{ os = ["{inactive_os}"] }}
+                "brew:inactive-arch" = {{ os = "{current_os}/{inactive_arch}" }}
+            "#
+        );
+        let (_dir, config_files) = config_map_from_toml(&[("config.toml", &config)])?;
+
+        let packages = packages_from_config_files(&config_files);
+        let brew = packages
+            .into_iter()
+            .find(|mp| mp.manager.name() == "brew")
+            .unwrap();
+        let requests = brew
+            .requests
+            .iter()
+            .map(|request| (request.name.as_str(), request.version.as_deref()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            requests,
+            vec![("active-os", None), ("active-platform", Some("1"))]
         );
         Ok(())
     }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -404,6 +404,12 @@ pub fn packages_from_config(config: &Config) -> Vec<ManagerPackages> {
     packages_from_config_files_with_brew_taps(&config.config_files, &brew_taps)
 }
 
+/// Merge raw `[bootstrap.packages]` declarations without applying host filters.
+#[cfg(unix)]
+pub(crate) fn package_configs_from_config(config: &Config) -> IndexMap<String, PackageTomlConfig> {
+    package_configs_from_config_files(&config.config_files)
+}
+
 /// Package requests for declared package plugins that are not installed yet.
 ///
 /// During a bootstrap dry run, plugin installation is intentionally not
@@ -520,15 +526,7 @@ fn package_requests_from_config_files(
     config_files: &ConfigMap,
     brew_taps: &IndexMap<String, String>,
 ) -> IndexMap<String, Vec<PackageRequest>> {
-    let mut merged: IndexMap<String, PackageTomlConfig> = IndexMap::new();
-    // config_files is ordered local -> global; reverse for global -> local
-    for cf in config_files.values().rev() {
-        if let Some(sys) = cf.bootstrap_config() {
-            for (spec, version) in sys.packages {
-                merged.insert(spec, version);
-            }
-        }
-    }
+    let merged = package_configs_from_config_files(config_files);
     let mut by_mgr: IndexMap<String, Vec<PackageRequest>> = IndexMap::new();
     for (spec, package) in merged {
         if !package.is_os_supported() {
@@ -558,6 +556,21 @@ fn package_requests_from_config_files(
         }
     }
     by_mgr
+}
+
+fn package_configs_from_config_files(
+    config_files: &ConfigMap,
+) -> IndexMap<String, PackageTomlConfig> {
+    let mut merged: IndexMap<String, PackageTomlConfig> = IndexMap::new();
+    // config_files is ordered local -> global; reverse for global -> local
+    for cf in config_files.values().rev() {
+        if let Some(sys) = cf.bootstrap_config() {
+            for (spec, version) in sys.packages {
+                merged.insert(spec, version);
+            }
+        }
+    }
+    merged
 }
 
 /// Aggregate `[bootstrap.macos.defaults]` across all loaded config files.
@@ -1569,6 +1582,34 @@ mod tests {
                 ("ffmpeg", None),
             ]
         );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_package_configs_preserve_inherited_selectors() -> Result<()> {
+        let (_dir, config_files) = config_map_from_toml(&[
+            (
+                "local.toml",
+                r#"
+                    [bootstrap.packages]
+                    "brew:jq" = "latest"
+                "#,
+            ),
+            (
+                "global.toml",
+                r#"
+                    [bootstrap.packages]
+                    "brew-cask:1password" = { version = "latest", os = ["macos"] }
+                "#,
+            ),
+        ])?;
+
+        let packages = package_configs_from_config_files(&config_files);
+        assert!(matches!(
+            packages.get("brew-cask:1password"),
+            Some(PackageTomlConfig::Options(options)) if options.os == ["macos"]
+        ));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -589,7 +589,13 @@ impl SystemPackageManager for BrewCaskManager {
         for req in pkgs {
             let cask = fetch_cask(req).await?;
             let artifacts = cask_artifacts(&cask)?;
-            validate_platform_support(&cask, &artifacts)?;
+            if let Some(state) = platform_unavailable_state(&cask, &artifacts) {
+                statuses.push(PackageStatus {
+                    request: req.clone(),
+                    state,
+                });
+                continue;
+            }
             let version = installed_cask_version(&cask, &artifacts)?;
             let state = match version {
                 Some(version) => match &req.version {
@@ -2660,6 +2666,14 @@ fn validate_platform_support(cask: &Cask, artifacts: &CaskArtifacts) -> Result<(
     #[cfg(not(target_os = "linux"))]
     let _ = (cask, artifacts);
     Ok(())
+}
+
+fn platform_unavailable_state(cask: &Cask, artifacts: &CaskArtifacts) -> Option<PackageState> {
+    validate_platform_support(cask, artifacts)
+        .err()
+        .map(|err| PackageState::Unavailable {
+            reason: err.to_string(),
+        })
 }
 
 fn artifact_target(value: &Value, values: &[Value]) -> Option<String> {
@@ -7050,6 +7064,10 @@ end
             .unwrap_err()
             .to_string();
         assert!(err.contains("only font-only casks"));
+        assert!(matches!(
+            platform_unavailable_state(&cask, &artifacts),
+            Some(PackageState::Unavailable { .. })
+        ));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -2671,9 +2671,7 @@ fn validate_platform_support(cask: &Cask, artifacts: &CaskArtifacts) -> Result<(
 fn platform_unavailable_state(cask: &Cask, artifacts: &CaskArtifacts) -> Option<PackageState> {
     validate_platform_support(cask, artifacts)
         .err()
-        .map(|err| PackageState::Unavailable {
-            reason: err.to_string(),
-        })
+        .map(|err| PackageState::unavailable(err.to_string()))
 }
 
 fn artifact_target(value: &Value, values: &[Value]) -> Option<String> {

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -62,16 +62,34 @@ pub enum PackageState {
     },
     /// The manager is available on this host, but this individual package is
     /// not supported on the current platform.
+    #[cfg(unix)]
     Unavailable {
         reason: String,
     },
 }
 
 impl PackageState {
+    #[cfg(unix)]
     pub fn unavailable(reason: impl Into<String>) -> Self {
         Self::Unavailable {
             reason: reason.into(),
         }
+    }
+
+    pub fn is_unavailable(&self) -> bool {
+        #[cfg(unix)]
+        if matches!(self, Self::Unavailable { .. }) {
+            return true;
+        }
+        false
+    }
+
+    pub fn unavailable_reason(&self) -> Option<&str> {
+        #[cfg(unix)]
+        if let Self::Unavailable { reason } = self {
+            return Some(reason);
+        }
+        None
     }
 }
 

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -67,6 +67,14 @@ pub enum PackageState {
     },
 }
 
+impl PackageState {
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self::Unavailable {
+            reason: reason.into(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PackageStatus {
     pub request: PackageRequest,

--- a/src/system/packages/mod.rs
+++ b/src/system/packages/mod.rs
@@ -60,6 +60,11 @@ pub enum PackageState {
     VersionMismatch {
         installed: String,
     },
+    /// The manager is available on this host, but this individual package is
+    /// not supported on the current platform.
+    Unavailable {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -595,6 +595,9 @@ fn package_resource_state(
             ResourceAction::Unknown,
         ),
         PackageState::VersionMismatch { installed } => (installed, ResourceAction::Update),
+        PackageState::Unavailable { reason } => {
+            (format!("skipped ({reason})"), ResourceAction::Unknown)
+        }
     }
 }
 

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -595,6 +595,7 @@ fn package_resource_state(
             ResourceAction::Unknown,
         ),
         PackageState::VersionMismatch { installed } => (installed, ResourceAction::Update),
+        #[cfg(unix)]
         PackageState::Unavailable { reason } => {
             (format!("skipped ({reason})"), ResourceAction::Unknown)
         }

--- a/src/toolset/helpers.rs
+++ b/src/toolset/helpers.rs
@@ -153,6 +153,7 @@ async fn preflight_system_deps_inner(
     let driver_opts = crate::cli::system::driver::DriverOpts {
         manager: None,
         explicit: false,
+        allow_unavailable_manager: false,
         dry_run: opts.dry_run,
         update: false,
         yes: matches!(mode, SystemDepsMode::Auto) || opts.yes,


### PR DESCRIPTION
## Summary
- add `[bootstrap.packages]` table values with `version` and `[tools]`-style `os` selectors
- treat platform-incompatible casks as package-level unavailable entries during shared-config apply/status runs
- preserve hard errors for explicit requests for unsupported packages
- document the syntax and update the JSON schema

## Root cause

Linux font-cask support made the `brew-cask` manager available on Linux, but its batch status query returned an error for the first non-font cask. A shared macOS/Linux config therefore aborted instead of skipping macOS-only casks.

This adds an `Unavailable` package state so configured unsupported casks remain visible in status output without being counted as missing or selected for installation. Explicit package or manager requests still surface the unsupported-platform error.

Context: https://github.com/jdx/mise/discussions/11749#discussioncomment-17942775

## Validation
- `cargo test --all-features test_packages_from_config_files_filters_os_and_arch`
- `cargo test --all-features linux_rejects_non_font_casks`
- `cargo test --all-features test_bootstrap_packages`
- `mise run test:e2e e2e/cli/test_system_status`
- `mise run lint-fix`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bootstrap package resolution, install/status semantics, and brew-cask behavior on Linux across many CLI paths; mistakes could skip installs silently or miscount missing packages, though explicit requests still error.
> 
> **Overview**
> Adds **`[bootstrap.packages]` table entries** with optional `version` and **`[tools]`-style `os` selectors**, so one config can target macOS-only casks and Linux fonts without separate files. Entries that don’t match the host are dropped during aggregation; the JSON schema documents both string and table forms.
> 
> **Platform-incompatible packages** (notably non-font `brew-cask` on Linux) now surface as **`PackageState::Unavailable`** instead of failing batch status/apply. Install, upgrade, status, bootstrap report, doctor, and `mise install` hints **skip** them with reasons and **do not** count them as missing; **explicit** `mise bootstrap packages apply brew-cask:…` still errors. The system driver gains `allow_unavailable_manager` so `packages use` can write config on the wrong platform while still failing on explicit unsupported package names.
> 
> Config editing and **brew import** preserve `os` selectors when bumping versions or inheriting from parent configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc40f0269b8cb647c9b2a9c52c181654b1f4177d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bootstrap package entries support OS and architecture filters, optional versions, and a default version of `latest`.
  - Platform aliases are normalized, and unsupported packages are skipped automatically.
  - macOS-only Homebrew casks can be declared explicitly.

- **Bug Fixes**
  - Unavailable packages are no longer reported as missing.
  - Install, upgrade, diagnostics, and status commands display clear skip reasons.
  - Explicit requests for unsupported packages return actionable errors.
  - Package options, selectors, versions, and comments are preserved when configurations are updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->