### PR TITLE
feat(bootstrap): prune mise-owned brew casks

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -201,6 +201,21 @@ This command is mise's declarative cleanup for bootstrap packages, similar to
 [`brew bundle cleanup`](https://docs.brew.sh/Manpage). It is not upstream
 `brew prune`, which Homebrew removed in favor of cleanup commands.
 
+`mise bootstrap packages prune --manager brew-cask` applies the same merged
+config model to direct cask artifacts, with a deliberately narrower ownership
+boundary. A cask is removed only when its install-time `.mise-cask.toml`
+receipt explicitly marks it safe to prune and every recorded target still has
+the exact content fingerprint mise recorded after installation. The command
+removes those targets and the cask's Caskroom entry; `--dry-run` previews the
+plan and `--yes` skips confirmation.
+
+Casks installed before their receipt included prune metadata are skipped until
+a later upgrade or reinstall refreshes the receipt. Casks with pkg artifacts,
+install or uninstall lifecycle actions, pending transactions, Homebrew
+`.metadata`, changed targets, or targets shared with another mise cask are also
+skipped with a reason. Prune never runs `zap` metadata and never reconstructs
+historical uninstall behavior from the current Homebrew API.
+
 ## How pouring works
 
 For each formula in the dependency closure (dependencies first):
@@ -281,8 +296,10 @@ operation.
   `postflight_steps`. Other artifact types, pkg installers without `pkgutil`
   IDs, and pkg installers with custom choices fail explicitly.
 - **`brew services` is not implemented.**
-- **Cask import/prune is not implemented.** `import` and `prune` are formulae-only
-  until cask uninstall semantics can be made safe for app and pkg artifacts.
+- **Cask import is not implemented.** Cask prune is limited to mise-owned direct
+  artifacts whose install-time receipt proves they can be removed safely. Pkg
+  artifacts and casks with lifecycle actions are skipped until their uninstall
+  semantics are supported.
 - **Source builds cover the common formula shapes.** mise's formula shim
   implements the widely-used subset of the DSL (see
   [Source formulae](#source-formulae)); formulae that reach beyond it fail

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -210,11 +210,12 @@ removes those targets and the cask's Caskroom entry; `--dry-run` previews the
 plan and `--yes` skips confirmation.
 
 Casks installed before their receipt included prune metadata are skipped until
-a later upgrade or reinstall refreshes the receipt. Casks with pkg artifacts,
-install or uninstall lifecycle actions, pending transactions, Homebrew
-`.metadata`, changed targets, or targets shared with another mise cask are also
-skipped with a reason. Prune never runs `zap` metadata and never reconstructs
-historical uninstall behavior from the current Homebrew API.
+a later upgrade or reinstall refreshes the receipt. Casks with pkg or command
+wrapper artifacts, install or uninstall lifecycle actions, pending
+transactions, Homebrew `.metadata`, changed targets, or targets shared with
+another mise cask are also skipped with a reason. Prune never runs `zap`
+metadata and never reconstructs historical uninstall behavior from the current
+Homebrew API.
 
 ## How pouring works
 

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -154,9 +154,10 @@ declarative cleanup command, similar in spirit to
 
 `mise bootstrap packages prune --manager brew-cask` removes only mise-owned
 direct artifacts backed by a current install-time receipt and unchanged content
-fingerprints. It skips older receipts, Homebrew-owned casks, pkg artifacts,
-casks with lifecycle actions, changed or shared targets, and incomplete
-transactions. Skips include a reason, and `zap` metadata is never applied.
+fingerprints. It skips older receipts, Homebrew-owned casks, pkg and command
+wrapper artifacts, casks with lifecycle actions, changed or shared targets,
+and incomplete transactions. Skips include a reason, and `zap` metadata is
+never applied.
 
 `mise bootstrap packages upgrade` refreshes package manager metadata and upgrades the
 configured packages that are already installed to the newest available

--- a/docs/bootstrap/packages/index.md
+++ b/docs/bootstrap/packages/index.md
@@ -67,9 +67,9 @@ declarative sections work the same way:
   [config hierarchy](/configuration.html) (global → project) as a union of
   keys. A project can add packages on top of the global list (and override a
   global entry's version pin) but not remove them. For Homebrew formulae,
-  `mise bootstrap packages prune --manager brew` is an explicit destructive command
-  that removes linked formulae no longer needed by the current config or by
-  trusted, loadable tracked configs.
+  `mise bootstrap packages prune` is an explicit destructive command that
+  removes linked formulae or safely prunable mise-owned casks no longer needed
+  by the current config or by trusted, loadable tracked configs.
 - **OS-filtered** — entries for a manager that isn't available on the current
   machine are not acted on, so the same config works across platforms: `apt`
   entries are ignored on macOS, `dnf` entries on Ubuntu, and so on. `brew`
@@ -120,6 +120,8 @@ mise bootstrap packages import --manager brew --dry-run
 mise bootstrap packages prune --manager brew    # remove unneeded linked brew formulae
 mise bootstrap packages prune --manager brew --dry-run
 mise bootstrap packages prune --manager brew --yes
+mise bootstrap packages prune --manager brew-cask # remove safely prunable mise casks
+mise bootstrap packages prune --manager brew-cask --dry-run
 
 mise bootstrap packages upgrade           # upgrade installed packages to current versions
 mise bootstrap packages upgrade --manager brew
@@ -149,6 +151,12 @@ configs. This includes formulae installed by a real Homebrew. It is mise's
 declarative cleanup command, similar in spirit to
 [Homebrew Bundle cleanup](https://docs.brew.sh/Manpage), not the old upstream
 `brew prune` command, which Homebrew removed.
+
+`mise bootstrap packages prune --manager brew-cask` removes only mise-owned
+direct artifacts backed by a current install-time receipt and unchanged content
+fingerprints. It skips older receipts, Homebrew-owned casks, pkg artifacts,
+casks with lifecycle actions, changed or shared targets, and incomplete
+transactions. Skips include a reason, and `zap` metadata is never applied.
 
 `mise bootstrap packages upgrade` refreshes package manager metadata and upgrades the
 configured packages that are already installed to the newest available

--- a/docs/cli/bootstrap/packages/prune.md
+++ b/docs/cli/bootstrap/packages/prune.md
@@ -7,19 +7,20 @@
 
 Prune installed system packages no longer declared in `[bootstrap.packages]`
 
-Currently supports Homebrew formulae only. Pruning removes linked formulae
-that are not needed by the current config or by trusted, loadable tracked
-configs.
+Supports Homebrew formulae and conservatively removable, mise-owned casks.
+Pruning keeps packages needed by the current config or by trusted, loadable
+tracked configs.
 
 ## Flags
 
 ### `-m --manager <MANAGER>`
 
-Only prune packages for this manager. Currently only `brew` is supported
+Only prune packages for this manager
 
 **Choices:**
 
 - `brew`
+- `brew-cask`
 
 **Default:** `brew`
 
@@ -37,4 +38,5 @@ Examples:
 mise bootstrap packages prune --manager brew
 mise bootstrap packages prune --manager brew --dry-run
 mise bootstrap packages prune --manager brew --yes
+mise bootstrap packages prune --manager brew-cask --dry-run
 ```

--- a/e2e/cli/test_system_prune_brew_cask
+++ b/e2e/cli/test_system_prune_brew_cask
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+if [[ "$(uname)" != "Linux" ]]; then
+  exit 0
+fi
+
+prefix="$PWD/brew-prefix"
+version_dir="$prefix/Caskroom/example/1.0.0"
+binary="$version_dir/bin/example"
+target="$prefix/bin/example"
+state="$PWD/state"
+
+mkdir -p "$version_dir/bin" "$prefix/bin"
+printf '#!/bin/sh\n' >"$binary"
+ln -s "$binary" "$target"
+digest="$(printf %s "$binary" | sha256sum | cut -d' ' -f1)"
+
+cat >"$version_dir/.mise-cask.toml" <<EOF
+schema_version = 3
+version = "1.0.0"
+binaries = ["$target"]
+prune_safe = true
+
+[[targets]]
+path = "$target"
+
+[targets.fingerprint]
+kind = "symlink"
+digest = "$digest"
+EOF
+
+cat >mise.toml <<EOF
+[bootstrap.packages]
+EOF
+
+assert_contains \
+  "MISE_SYSTEM_BREW_PREFIX=$prefix MISE_STATE_DIR=$state mise bootstrap packages prune --manager brew-cask --dry-run" \
+  "remove brew-cask:example@1.0.0"
+assert_succeed \
+  "MISE_SYSTEM_BREW_PREFIX=$prefix MISE_STATE_DIR=$state mise bootstrap packages prune --manager brew-cask --yes"
+assert_fail "test -e $target"
+assert_fail "test -e $prefix/Caskroom/example"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1435,9 +1435,9 @@ Write to this config file or directory
 .SH "MISE BOOTSTRAP PACKAGES PRUNE"
 Prune installed system packages no longer declared in `[bootstrap.packages]`
 
-Currently supports Homebrew formulae only. Pruning removes linked formulae
-that are not needed by the current config or by trusted, loadable tracked
-configs.
+Supports Homebrew formulae and conservatively removable, mise\-owned casks.
+Pruning keeps packages needed by the current config or by trusted, loadable
+tracked configs.
 .PP
 \fBUsage:\fR mise bootstrap packages prune [OPTIONS]
 .PP
@@ -1445,7 +1445,7 @@ configs.
 .PP
 .TP
 \fB\-m, \-\-manager\fR \fI<MANAGER>\fR
-Only prune packages for this manager. Currently only `brew` is supported
+Only prune packages for this manager
 .RS
 \fIDefault: \fRbrew
 .RE

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -715,9 +715,9 @@ Examples:
             long_help #"""
 Prune installed system packages no longer declared in `[bootstrap.packages]`
 
-Currently supports Homebrew formulae only. Pruning removes linked formulae
-that are not needed by the current config or by trusted, loadable tracked
-configs.
+Supports Homebrew formulae and conservatively removable, mise-owned casks.
+Pruning keeps packages needed by the current config or by trusted, loadable
+tracked configs.
 """#
             after_long_help #"""
 Examples:
@@ -725,11 +725,12 @@ Examples:
     $ mise bootstrap packages prune --manager brew
     $ mise bootstrap packages prune --manager brew --dry-run
     $ mise bootstrap packages prune --manager brew --yes
+    $ mise bootstrap packages prune --manager brew-cask --dry-run
 
 """#
-            flag "-m --manager" help="Only prune packages for this manager. Currently only `brew` is supported" default=brew {
+            flag "-m --manager" help="Only prune packages for this manager" default=brew {
                 arg <MANAGER> {
-                    choices brew
+                    choices brew brew-cask
                 }
             }
             flag "-n --dry-run" help="Print what would be removed without deleting anything"

--- a/src/cli/system/prune.rs
+++ b/src/cli/system/prune.rs
@@ -14,14 +14,14 @@ use crate::ui::prompt;
 
 /// Prune installed system packages no longer declared in `[bootstrap.packages]`
 ///
-/// Currently supports Homebrew formulae only. Pruning removes linked formulae
-/// that are not needed by the current config or by trusted, loadable tracked
-/// configs.
+/// Supports Homebrew formulae and conservatively removable, mise-owned casks.
+/// Pruning keeps packages needed by the current config or by trusted, loadable
+/// tracked configs.
 #[derive(Debug, clap::Args)]
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct SystemPrune {
-    /// Only prune packages for this manager. Currently only `brew` is supported.
-    #[clap(long, short, default_value = "brew", value_parser = ["brew"])]
+    /// Only prune packages for this manager
+    #[clap(long, short, default_value = "brew", value_parser = ["brew", "brew-cask"])]
     manager: String,
 
     /// Print what would be removed without deleting anything
@@ -46,7 +46,11 @@ impl SystemPrune {
                 self.manager
             );
         }
-        self.run_brew().await
+        match self.manager.as_str() {
+            "brew" => self.run_brew().await,
+            "brew-cask" => self.run_brew_cask().await,
+            _ => unreachable!(),
+        }
     }
 
     #[cfg(unix)]
@@ -90,10 +94,62 @@ impl SystemPrune {
         Ok(())
     }
 
+    #[cfg(unix)]
+    async fn run_brew_cask(self) -> Result<()> {
+        debug_assert_eq!(self.manager, "brew-cask");
+        let manager = brew::BrewCaskManager::new();
+        if !manager.is_available() {
+            bail!(
+                "brew-cask is not available: {}",
+                manager.unavailable_reason()
+            );
+        }
+        let config = Config::get().await?;
+        let configured = system::packages_from_config_and_tracked_config_files(&config)
+            .await?
+            .into_iter()
+            .find(|mp| mp.manager.name() == "brew-cask")
+            .map(|mp| mp.requests)
+            .unwrap_or_default();
+        let plan = brew::cask_prune_plan(&configured).await?;
+        for skipped in &plan.skipped {
+            warn!("brew-cask:{}: skipped: {}", skipped.token, skipped.reason);
+        }
+        if plan.is_empty() {
+            info!("brew-cask: nothing to prune");
+            return Ok(());
+        }
+        if self.dry_run {
+            brew::apply_cask_prune_plan(&plan, true)?;
+            return Ok(());
+        }
+        let remove = plan
+            .remove
+            .iter()
+            .map(|candidate| format!("{}@{}", candidate.token, candidate.version))
+            .collect::<Vec<_>>();
+        if !self.yes && !Settings::get().yes && console::user_attended_stderr() {
+            let msg = format!("brew-cask: prune {}?", remove.join(", "));
+            if !prompt::confirm(msg)? {
+                info!("brew-cask: skipped");
+                return Ok(());
+            }
+        }
+        let removed = brew::apply_cask_prune_plan(&plan, false)?;
+        info!("brew-cask: pruned {removed} casks");
+        Ok(())
+    }
+
     #[cfg(not(unix))]
     async fn run_brew(self) -> Result<()> {
         let _ = self.manager;
         bail!("brew prune is not supported on windows")
+    }
+
+    #[cfg(not(unix))]
+    async fn run_brew_cask(self) -> Result<()> {
+        let _ = self.manager;
+        bail!("brew-cask prune is not supported on windows")
     }
 }
 
@@ -103,5 +159,6 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>mise bootstrap packages prune --manager brew</bold>
     $ <bold>mise bootstrap packages prune --manager brew --dry-run</bold>
     $ <bold>mise bootstrap packages prune --manager brew --yes</bold>
+    $ <bold>mise bootstrap packages prune --manager brew-cask --dry-run</bold>
 "#
 );

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -4413,6 +4413,9 @@ fn validate_cask_prune_claims(candidate: &CaskPruneCandidate) -> Result<()> {
 }
 
 fn validate_cask_prune_candidate(candidate: &CaskPruneCandidate) -> Result<()> {
+    if homebrew_metadata_present(&candidate.token) {
+        bail!("Homebrew now owns this cask");
+    }
     let receipt = &candidate.receipt;
     if read_receipt(&candidate.version_dir)?.as_ref() != Some(receipt) {
         bail!("ownership receipt has changed");
@@ -7459,6 +7462,24 @@ end
         assert_eq!(apply_cask_prune_plan_in(&plan, false, &state_dir)?, 0);
         assert!(target.exists());
         assert!(caskroom_token_dir("planned").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn cask_prune_rechecks_homebrew_ownership_before_removal() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let state_dir = tmp.path().join("state");
+        let target = write_test_app_receipt(&test_cask("claimed", "1.0.0"), "Claimed.app")?;
+        let plan = cask_prune_plan_from_tokens(&BTreeSet::new(), &state_dir)?;
+        assert_eq!(plan.remove.len(), 1);
+
+        file::create_dir_all(caskroom_token_dir("claimed").join(".metadata"))?;
+
+        assert_eq!(apply_cask_prune_plan_in(&plan, false, &state_dir)?, 0);
+        assert!(target.exists());
+        assert!(caskroom_token_dir("claimed").exists());
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -196,7 +196,7 @@ struct CaskArtifacts {
     pkg_ids: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 struct CaskReceipt {
     #[serde(default)]
     schema_version: u8,
@@ -3829,6 +3829,9 @@ fn cask_prune_blocker(cask: &Cask, artifacts: &CaskArtifacts) -> Option<String> 
     if !artifacts.pkgs.is_empty() {
         return Some("pkg artifacts require uninstall support".to_string());
     }
+    if !artifacts.command_wrappers.is_empty() {
+        return Some("command wrapper artifacts are not supported for pruning".to_string());
+    }
     if !artifacts.preflight_steps.is_empty()
         || !artifacts.postflight_steps.is_empty()
         || has_lifecycle_hook(cask, "preflight")
@@ -4090,6 +4093,34 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
             continue;
         }
         let configured = keep.contains(&token);
+        let Ok(version_entries) = std::fs::read_dir(entry.path()) else {
+            if !configured {
+                plan.skipped.push(CaskPruneSkip {
+                    token,
+                    reason: "Caskroom directory could not be read".to_string(),
+                });
+            }
+            continue;
+        };
+        let versions = version_entries
+            .filter_map(|version| version.ok())
+            .filter(|version| {
+                version.file_type().is_ok_and(|kind| kind.is_dir())
+                    && !version.file_name().to_string_lossy().starts_with('.')
+            })
+            .collect::<Vec<_>>();
+        let mut receipts = BTreeMap::new();
+        for version in &versions {
+            if let Some(receipt) = read_receipt(&version.path())? {
+                for target in &receipt.targets {
+                    claims
+                        .entry(target.path.clone())
+                        .or_default()
+                        .insert(token.clone());
+                }
+                receipts.insert(version.path(), receipt);
+            }
+        }
         if entry.path().join(".metadata").symlink_metadata().is_ok() {
             if !configured {
                 plan.skipped.push(CaskPruneSkip {
@@ -4099,13 +4130,6 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
             }
             continue;
         }
-        let versions = std::fs::read_dir(entry.path())?
-            .filter_map(|version| version.ok())
-            .filter(|version| {
-                version.file_type().is_ok_and(|kind| kind.is_dir())
-                    && !version.file_name().to_string_lossy().starts_with('.')
-            })
-            .collect::<Vec<_>>();
         let [version] = versions.as_slice() else {
             if !configured {
                 plan.skipped.push(CaskPruneSkip {
@@ -4116,7 +4140,7 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
             continue;
         };
         let version_dir = version.path();
-        let Some(receipt) = read_receipt(&version_dir)? else {
+        let Some(receipt) = receipts.remove(&version_dir) else {
             if !configured {
                 plan.skipped.push(CaskPruneSkip {
                     token,
@@ -4125,12 +4149,6 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
             }
             continue;
         };
-        for target in &receipt.targets {
-            claims
-                .entry(target.path.clone())
-                .or_default()
-                .insert(token.clone());
-        }
         if configured {
             continue;
         }
@@ -4225,7 +4243,9 @@ fn apply_cask_prune_plan_in(
 
     let mut removed = 0;
     for candidate in &plan.remove {
-        if let Err(reason) = validate_cask_prune_candidate(candidate) {
+        if let Err(reason) = validate_cask_prune_candidate(candidate)
+            .and_then(|_| validate_cask_prune_claims(candidate))
+        {
             warn!(
                 "brew-cask:{}: skipped because recorded artifacts changed after planning: {reason:#}",
                 candidate.token
@@ -4254,8 +4274,48 @@ fn apply_cask_prune_plan_in(
     Ok(removed)
 }
 
+fn validate_cask_prune_claims(candidate: &CaskPruneCandidate) -> Result<()> {
+    let caskroom = prefix::prefix().join("Caskroom");
+    let mut claims = BTreeMap::<PathBuf, BTreeSet<String>>::new();
+    for entry in std::fs::read_dir(&caskroom)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let token = entry.file_name().to_string_lossy().to_string();
+        for version in std::fs::read_dir(entry.path())? {
+            let version = version?;
+            if !version.file_type()?.is_dir()
+                || version.file_name().to_string_lossy().starts_with('.')
+            {
+                continue;
+            }
+            if let Some(receipt) = read_receipt(&version.path())? {
+                for target in receipt.targets {
+                    claims.entry(target.path).or_default().insert(token.clone());
+                }
+            }
+        }
+    }
+    for target in &candidate.receipt.targets {
+        if claims
+            .get(&target.path)
+            .is_some_and(|tokens| tokens.iter().any(|token| token != &candidate.token))
+        {
+            bail!(
+                "artifact target is now claimed by another cask: {}",
+                target.path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
 fn validate_cask_prune_candidate(candidate: &CaskPruneCandidate) -> Result<()> {
     let receipt = &candidate.receipt;
+    if read_receipt(&candidate.version_dir)?.as_ref() != Some(receipt) {
+        bail!("ownership receipt has changed");
+    }
     if receipt.schema_version != 3 || !receipt.prune_safe || !receipt.pkg_ids.is_empty() {
         bail!("receipt is not marked safe for direct-artifact pruning");
     }
@@ -4659,6 +4719,28 @@ mod tests {
             tap_git_head: None,
             raw_base: None,
         }
+    }
+
+    fn write_test_app_receipt(cask: &Cask, app_name: &str) -> Result<PathBuf> {
+        let app = AppArtifact {
+            source: app_name.to_string(),
+            target: Some(format!("$HOMEBREW_PREFIX/Applications/{app_name}")),
+        };
+        let target = app_target_path(app.target_name())?;
+        file::create_dir_all(&target)?;
+        file::write(target.join("version"), "1.0.0")?;
+        let version_dir = caskroom_version_dir(&cask.token, &cask.version);
+        file::create_dir_all(version_dir.join(app_name))?;
+        file::write(version_dir.join(app_name).join("version"), "1.0.0")?;
+        write_receipt(
+            &version_dir,
+            cask,
+            &CaskArtifacts {
+                apps: vec![app],
+                ..Default::default()
+            },
+        )?;
+        Ok(target)
     }
 
     #[test]
@@ -7220,6 +7302,66 @@ end
     }
 
     #[test]
+    fn cask_prune_skips_shared_targets_and_pending_transactions() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let state_dir = tmp.path().join("state");
+
+        write_test_app_receipt(&test_cask("shared-a", "1.0.0"), "Shared.app")?;
+        write_test_app_receipt(&test_cask("shared-b", "1.0.0"), "Shared.app")?;
+        write_test_app_receipt(&test_cask("single", "1.0.0"), "Multi.app")?;
+        write_test_app_receipt(&test_cask("multi", "1.0.0"), "Multi.app")?;
+        write_test_app_receipt(&test_cask("multi", "2.0.0"), "Multi.app")?;
+        write_test_app_receipt(&test_cask("pending", "1.0.0"), "Pending.app")?;
+        let journal_dir = state_dir.join("brew-cask/pending");
+        file::create_dir_all(&journal_dir)?;
+        file::write(journal_dir.join("1.0.0.json"), "{}")?;
+
+        let plan = cask_prune_plan_from_tokens(&BTreeSet::new(), &state_dir)?;
+        assert!(plan.remove.is_empty());
+        assert_eq!(plan.skipped.len(), 5);
+        for token in ["shared-a", "shared-b"] {
+            assert!(plan.skipped.iter().any(|skip| {
+                skip.token == token && skip.reason.contains("also claimed by another cask")
+            }));
+        }
+        assert!(plan.skipped.iter().any(|skip| {
+            skip.token == "pending"
+                && skip
+                    .reason
+                    .contains("incomplete cask transaction is pending")
+        }));
+        assert!(plan.skipped.iter().any(|skip| {
+            skip.token == "single" && skip.reason.contains("also claimed by another cask")
+        }));
+        assert!(
+            plan.skipped.iter().any(|skip| {
+                skip.token == "multi" && skip.reason.contains("expected exactly one")
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cask_prune_rechecks_shared_targets_before_removal() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let state_dir = tmp.path().join("state");
+        let target = write_test_app_receipt(&test_cask("planned", "1.0.0"), "Shared.app")?;
+        let plan = cask_prune_plan_from_tokens(&BTreeSet::new(), &state_dir)?;
+        assert_eq!(plan.remove.len(), 1);
+
+        write_test_app_receipt(&test_cask("late-claim", "1.0.0"), "Shared.app")?;
+
+        assert_eq!(apply_cask_prune_plan_in(&plan, false, &state_dir)?, 0);
+        assert!(target.exists());
+        assert!(caskroom_token_dir("planned").exists());
+        Ok(())
+    }
+
+    #[test]
     fn cask_prune_receipt_rejects_pkg_and_lifecycle_casks() -> Result<()> {
         let mut cask = test_cask("example", "1.0.0");
         let direct = CaskArtifacts {
@@ -7243,6 +7385,22 @@ end
             ..Default::default()
         };
         assert!(cask_prune_blocker(&cask, &pkg).is_some());
+
+        let wrapper = CaskArtifacts {
+            command_wrappers: vec![CommandWrapperArtifact {
+                name: "example".to_string(),
+                target: None,
+                content: None,
+                executable: Some("$APPDIR/Example.app/Contents/MacOS/example".to_string()),
+                args: Vec::new(),
+                env: BTreeMap::new(),
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            cask_prune_blocker(&cask, &wrapper).as_deref(),
+            Some("command wrapper artifacts are not supported for pruning")
+        );
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -4077,6 +4077,7 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
     let mut plan = CaskPrunePlan::default();
     let mut candidates = Vec::new();
     let mut claims = BTreeMap::<PathBuf, BTreeSet<String>>::new();
+    let mut claims_complete = true;
     let caskroom = prefix::prefix().join("Caskroom");
     let Ok(tokens) = std::fs::read_dir(&caskroom) else {
         return Ok(plan);
@@ -4110,16 +4111,31 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
             })
             .collect::<Vec<_>>();
         let mut receipts = BTreeMap::new();
+        let mut receipt_error = None;
         for version in &versions {
-            if let Some(receipt) = read_receipt(&version.path())? {
-                for target in &receipt.targets {
-                    claims
-                        .entry(target.path.clone())
-                        .or_default()
-                        .insert(token.clone());
+            match read_receipt(&version.path()) {
+                Ok(Some(receipt)) => {
+                    for target in &receipt.targets {
+                        claims
+                            .entry(target.path.clone())
+                            .or_default()
+                            .insert(token.clone());
+                    }
+                    receipts.insert(version.path(), receipt);
                 }
-                receipts.insert(version.path(), receipt);
+                Ok(None) => {}
+                Err(err) => {
+                    claims_complete = false;
+                    receipt_error =
+                        Some(format!("mise ownership receipt could not be read: {err:#}"));
+                }
             }
+        }
+        if let Some(reason) = receipt_error {
+            if !configured {
+                plan.skipped.push(CaskPruneSkip { token, reason });
+            }
+            continue;
         }
         if entry.path().join(".metadata").symlink_metadata().is_ok() {
             if !configured {
@@ -4193,6 +4209,13 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
     }
 
     for candidate in candidates {
+        if !claims_complete {
+            plan.skipped.push(CaskPruneSkip {
+                token: candidate.token,
+                reason: "cask ownership receipts could not be indexed completely".to_string(),
+            });
+            continue;
+        }
         let shared = candidate
             .receipt
             .targets
@@ -7358,6 +7381,29 @@ end
         assert_eq!(apply_cask_prune_plan_in(&plan, false, &state_dir)?, 0);
         assert!(target.exists());
         assert!(caskroom_token_dir("planned").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn cask_prune_fails_closed_when_a_receipt_is_corrupt() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let state_dir = tmp.path().join("state");
+        write_test_app_receipt(&test_cask("clean", "1.0.0"), "Clean.app")?;
+        let corrupt_dir = caskroom_version_dir("corrupt", "1.0.0");
+        file::create_dir_all(&corrupt_dir)?;
+        file::write(corrupt_dir.join(".mise-cask.toml"), "not = [valid")?;
+
+        let plan = cask_prune_plan_from_tokens(&BTreeSet::new(), &state_dir)?;
+
+        assert!(plan.remove.is_empty());
+        assert!(plan.skipped.iter().any(|skip| {
+            skip.token == "corrupt" && skip.reason.contains("receipt could not be read")
+        }));
+        assert!(plan.skipped.iter().any(|skip| {
+            skip.token == "clean" && skip.reason.contains("could not be indexed completely")
+        }));
         Ok(())
     }
 

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -327,10 +327,22 @@ impl BrewCaskManager {
             return Ok(cask.version);
         }
         prefix::bootstrap(false)?;
+        let stage = fetch_and_stage(&cask, pr).await?;
+        let _caskroom_lock = lock_caskroom()?;
+        if homebrew_metadata_present(&cask.token) {
+            file::remove_all(&stage)?;
+            bail!(
+                "brew-cask:{}: Homebrew took ownership of this cask while installation was pending",
+                cask.token
+            );
+        }
+        if installed_cask_version(&cask, &artifacts)?.as_deref() == Some(cask.version.as_str()) {
+            file::remove_all(stage)?;
+            return Ok(cask.version);
+        }
         let previous_binaries = previous_binary_targets(&cask)?;
         let previous_fonts = previous_font_targets(&cask)?;
         let previous_completions = previous_completion_targets(&cask)?;
-        let stage = fetch_and_stage(&cask, pr).await?;
         let caskroom_token = caskroom_token_dir(&cask.token);
         let caskroom = caskroom_version_dir(&cask.token, &cask.version);
         let tmp_caskroom = caskroom_tmp_dir(&cask);
@@ -4083,11 +4095,38 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
         return Ok(plan);
     };
 
-    for entry in tokens.filter_map(|entry| entry.ok()) {
-        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+    for entry in tokens {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                claims_complete = false;
+                plan.skipped.push(CaskPruneSkip {
+                    token: "Caskroom".to_string(),
+                    reason: format!("Caskroom entry could not be read: {err}"),
+                });
+                continue;
+            }
+        };
+        let kind = match entry.file_type() {
+            Ok(kind) => kind,
+            Err(err) => {
+                claims_complete = false;
+                plan.skipped.push(CaskPruneSkip {
+                    token: entry.file_name().to_string_lossy().to_string(),
+                    reason: format!("Caskroom entry type could not be read: {err}"),
+                });
+                continue;
+            }
+        };
+        if !kind.is_dir() {
             continue;
         }
         let Some(token) = entry.file_name().to_str().map(str::to_string) else {
+            claims_complete = false;
+            plan.skipped.push(CaskPruneSkip {
+                token: entry.file_name().to_string_lossy().to_string(),
+                reason: "Caskroom token name is not valid UTF-8".to_string(),
+            });
             continue;
         };
         if token.starts_with('.') {
@@ -4095,6 +4134,7 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
         }
         let configured = keep.contains(&token);
         let Ok(version_entries) = std::fs::read_dir(entry.path()) else {
+            claims_complete = false;
             if !configured {
                 plan.skipped.push(CaskPruneSkip {
                     token,
@@ -4103,13 +4143,38 @@ fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Res
             }
             continue;
         };
-        let versions = version_entries
-            .filter_map(|version| version.ok())
-            .filter(|version| {
-                version.file_type().is_ok_and(|kind| kind.is_dir())
-                    && !version.file_name().to_string_lossy().starts_with('.')
-            })
-            .collect::<Vec<_>>();
+        let mut versions = Vec::new();
+        let mut version_error = None;
+        for version in version_entries {
+            let version = match version {
+                Ok(version) => version,
+                Err(err) => {
+                    claims_complete = false;
+                    version_error =
+                        Some(format!("Caskroom version entry could not be read: {err}"));
+                    continue;
+                }
+            };
+            let kind = match version.file_type() {
+                Ok(kind) => kind,
+                Err(err) => {
+                    claims_complete = false;
+                    version_error = Some(format!(
+                        "Caskroom version entry type could not be read: {err}"
+                    ));
+                    continue;
+                }
+            };
+            if kind.is_dir() && !version.file_name().to_string_lossy().starts_with('.') {
+                versions.push(version);
+            }
+        }
+        if let Some(reason) = version_error {
+            if !configured {
+                plan.skipped.push(CaskPruneSkip { token, reason });
+            }
+            continue;
+        }
         let mut receipts = BTreeMap::new();
         let mut receipt_error = None;
         for version in &versions {
@@ -4264,6 +4329,7 @@ fn apply_cask_prune_plan_in(
         return Ok(0);
     }
 
+    let _caskroom_lock = lock_caskroom()?;
     let mut removed = 0;
     for candidate in &plan.remove {
         if let Err(reason) = validate_cask_prune_candidate(candidate)
@@ -4295,6 +4361,18 @@ fn apply_cask_prune_plan_in(
         removed += 1;
     }
     Ok(removed)
+}
+
+fn lock_caskroom() -> Result<fslock::LockFile> {
+    let caskroom = prefix::prefix().join("Caskroom");
+    file::create_dir_all(&caskroom)?;
+    let path = caskroom.join(".mise.lock");
+    let mut lock = fslock::LockFile::open(&path)?;
+    if !lock.try_lock()? {
+        debug!("waiting for brew-cask lock on {}", path.display());
+        lock.lock()?;
+    }
+    Ok(lock)
 }
 
 fn validate_cask_prune_claims(candidate: &CaskPruneCandidate) -> Result<()> {
@@ -7400,6 +7478,34 @@ end
         assert!(plan.remove.is_empty());
         assert!(plan.skipped.iter().any(|skip| {
             skip.token == "corrupt" && skip.reason.contains("receipt could not be read")
+        }));
+        assert!(plan.skipped.iter().any(|skip| {
+            skip.token == "clean" && skip.reason.contains("could not be indexed completely")
+        }));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cask_prune_fails_closed_when_a_token_directory_is_unreadable() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let state_dir = tmp.path().join("state");
+        write_test_app_receipt(&test_cask("clean", "1.0.0"), "Clean.app")?;
+        let unreadable = caskroom_token_dir("unreadable");
+        file::create_dir_all(&unreadable)?;
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000))?;
+
+        let plan = cask_prune_plan_from_tokens(&BTreeSet::new(), &state_dir);
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o755))?;
+        let plan = plan?;
+
+        assert!(plan.remove.is_empty());
+        assert!(plan.skipped.iter().any(|skip| {
+            skip.token == "unreadable" && skip.reason.contains("directory could not be read")
         }));
         assert!(plan.skipped.iter().any(|skip| {
             skip.token == "clean" && skip.reason.contains("could not be indexed completely")

--- a/src/system/packages/brew/cask.rs
+++ b/src/system/packages/brew/cask.rs
@@ -1,7 +1,10 @@
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Component, Path, PathBuf};
 use std::process::Stdio;
-use std::{borrow::Cow, collections::BTreeMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use async_trait::async_trait;
 use eyre::{WrapErr, bail, eyre};
@@ -210,6 +213,10 @@ struct CaskReceipt {
     pkg_ids: Vec<String>,
     #[serde(default)]
     targets: Vec<CaskTargetRecord>,
+    #[serde(default)]
+    prune_safe: bool,
+    #[serde(default)]
+    prune_blocker: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -238,6 +245,32 @@ struct CaskTransactionJournal<'a> {
     token: &'a str,
     version: &'a str,
     completed: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CaskPruneCandidate {
+    pub token: String,
+    pub version: String,
+    version_dir: PathBuf,
+    receipt: CaskReceipt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaskPruneSkip {
+    pub token: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CaskPrunePlan {
+    pub remove: Vec<CaskPruneCandidate>,
+    pub skipped: Vec<CaskPruneSkip>,
+}
+
+impl CaskPrunePlan {
+    pub fn is_empty(&self) -> bool {
+        self.remove.is_empty()
+    }
 }
 
 impl BrewCaskManager {
@@ -3761,7 +3794,7 @@ fn installed_cask_version_in(
     let version_dir = caskroom_version_dir(&cask.token, &version);
     match read_receipt(&version_dir)? {
         Some(receipt) => {
-            if receipt.schema_version > 2 {
+            if receipt.schema_version > 3 {
                 return Ok(None);
             }
             if receipt.schema_version >= 2 {
@@ -3792,6 +3825,32 @@ fn installed_cask_version_in(
     }
 }
 
+fn cask_prune_blocker(cask: &Cask, artifacts: &CaskArtifacts) -> Option<String> {
+    if !artifacts.pkgs.is_empty() {
+        return Some("pkg artifacts require uninstall support".to_string());
+    }
+    if !artifacts.preflight_steps.is_empty()
+        || !artifacts.postflight_steps.is_empty()
+        || has_lifecycle_hook(cask, "preflight")
+        || has_lifecycle_hook(cask, "postflight")
+    {
+        return Some("install lifecycle actions may have untracked side effects".to_string());
+    }
+    if cask.artifacts.iter().any(|artifact| {
+        matches!(
+            artifact_type(artifact).as_str(),
+            "uninstall"
+                | "uninstall_preflight"
+                | "uninstall_preflight_steps"
+                | "uninstall_postflight"
+                | "uninstall_postflight_steps"
+        )
+    }) {
+        return Some("uninstall lifecycle actions are not supported".to_string());
+    }
+    None
+}
+
 fn write_receipt(caskroom: &Path, cask: &Cask, artifacts: &CaskArtifacts) -> Result<()> {
     let mut target_paths = artifacts
         .apps
@@ -3818,8 +3877,9 @@ fn write_receipt(caskroom: &Path, cask: &Cask, artifacts: &CaskArtifacts) -> Res
             })
         })
         .collect::<Result<Vec<_>>>()?;
+    let prune_blocker = cask_prune_blocker(cask, artifacts);
     let receipt = CaskReceipt {
-        schema_version: 2,
+        schema_version: 3,
         version: cask.version.clone(),
         apps: artifacts
             .apps
@@ -3835,6 +3895,8 @@ fn write_receipt(caskroom: &Path, cask: &Cask, artifacts: &CaskArtifacts) -> Res
         completions: completion_target_paths(cask, artifacts)?,
         pkg_ids: artifacts.pkg_ids.clone(),
         targets,
+        prune_safe: prune_blocker.is_none(),
+        prune_blocker,
     };
     let body = toml::to_string_pretty(&receipt)?;
     write_durable_file(&caskroom.join(".mise-cask.toml"), body.as_bytes())?;
@@ -3936,14 +3998,26 @@ fn cask_journal_pending_in(state_dir: &Path, token: &str) -> bool {
 }
 
 fn write_cask_journal(journal: &CaskTransactionJournal<'_>) -> Result<()> {
-    let path = cask_journal_path_in(&crate::dirs::STATE, journal.token, journal.version);
+    write_cask_journal_in(&crate::dirs::STATE, journal)
+}
+
+fn write_cask_journal_in(state_dir: &Path, journal: &CaskTransactionJournal<'_>) -> Result<()> {
+    let path = cask_journal_path_in(state_dir, journal.token, journal.version);
     let body = serde_json::to_vec_pretty(journal)?;
     write_durable_file(&path, &body)
 }
 
 fn record_cask_action(journal: &mut CaskTransactionJournal<'_>, action: &str) -> Result<()> {
+    record_cask_action_in(&crate::dirs::STATE, journal, action)
+}
+
+fn record_cask_action_in(
+    state_dir: &Path,
+    journal: &mut CaskTransactionJournal<'_>,
+    action: &str,
+) -> Result<()> {
     journal.completed.push(action.to_string());
-    write_cask_journal(journal)
+    write_cask_journal_in(state_dir, journal)
 }
 
 fn remove_cask_journals(token: &str) -> Result<()> {
@@ -3986,6 +4060,329 @@ fn read_receipt(caskroom: &Path) -> Result<Option<CaskReceipt>> {
     toml::from_str(&body)
         .map(Some)
         .wrap_err_with(|| format!("failed to parse {}", path.display()))
+}
+
+pub async fn cask_prune_plan(configured: &[PackageRequest]) -> Result<CaskPrunePlan> {
+    let mut keep = BTreeSet::new();
+    for request in configured {
+        keep.insert(fetch_cask(request).await?.token);
+    }
+    cask_prune_plan_from_tokens(&keep, &crate::dirs::STATE)
+}
+
+fn cask_prune_plan_from_tokens(keep: &BTreeSet<String>, state_dir: &Path) -> Result<CaskPrunePlan> {
+    let mut plan = CaskPrunePlan::default();
+    let mut candidates = Vec::new();
+    let mut claims = BTreeMap::<PathBuf, BTreeSet<String>>::new();
+    let caskroom = prefix::prefix().join("Caskroom");
+    let Ok(tokens) = std::fs::read_dir(&caskroom) else {
+        return Ok(plan);
+    };
+
+    for entry in tokens.filter_map(|entry| entry.ok()) {
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let Some(token) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        if token.starts_with('.') {
+            continue;
+        }
+        let configured = keep.contains(&token);
+        if entry.path().join(".metadata").symlink_metadata().is_ok() {
+            if !configured {
+                plan.skipped.push(CaskPruneSkip {
+                    token,
+                    reason: "Homebrew owns this cask".to_string(),
+                });
+            }
+            continue;
+        }
+        let versions = std::fs::read_dir(entry.path())?
+            .filter_map(|version| version.ok())
+            .filter(|version| {
+                version.file_type().is_ok_and(|kind| kind.is_dir())
+                    && !version.file_name().to_string_lossy().starts_with('.')
+            })
+            .collect::<Vec<_>>();
+        let [version] = versions.as_slice() else {
+            if !configured {
+                plan.skipped.push(CaskPruneSkip {
+                    token,
+                    reason: "expected exactly one installed Caskroom version".to_string(),
+                });
+            }
+            continue;
+        };
+        let version_dir = version.path();
+        let Some(receipt) = read_receipt(&version_dir)? else {
+            if !configured {
+                plan.skipped.push(CaskPruneSkip {
+                    token,
+                    reason: "mise ownership receipt is missing".to_string(),
+                });
+            }
+            continue;
+        };
+        for target in &receipt.targets {
+            claims
+                .entry(target.path.clone())
+                .or_default()
+                .insert(token.clone());
+        }
+        if configured {
+            continue;
+        }
+        if cask_journal_pending_in(state_dir, &token) {
+            plan.skipped.push(CaskPruneSkip {
+                token,
+                reason: "an incomplete cask transaction is pending".to_string(),
+            });
+            continue;
+        }
+        if receipt.schema_version != 3 {
+            plan.skipped.push(CaskPruneSkip {
+                token,
+                reason: "receipt predates safe prune metadata; upgrade or reinstall first"
+                    .to_string(),
+            });
+            continue;
+        }
+        if !receipt.prune_safe {
+            let reason = receipt
+                .prune_blocker
+                .clone()
+                .unwrap_or_else(|| "receipt does not permit pruning".to_string());
+            plan.skipped.push(CaskPruneSkip { token, reason });
+            continue;
+        }
+        let version = version.file_name().to_string_lossy().to_string();
+        let candidate = CaskPruneCandidate {
+            token,
+            version,
+            version_dir,
+            receipt,
+        };
+        if let Err(reason) = validate_cask_prune_candidate(&candidate) {
+            plan.skipped.push(CaskPruneSkip {
+                token: candidate.token,
+                reason: format!("recorded artifacts cannot be removed safely: {reason:#}"),
+            });
+            continue;
+        }
+        candidates.push(candidate);
+    }
+
+    for candidate in candidates {
+        let shared = candidate
+            .receipt
+            .targets
+            .iter()
+            .filter_map(|target| {
+                claims
+                    .get(&target.path)
+                    .filter(|tokens| tokens.len() > 1)
+                    .map(|_| target.path.clone())
+            })
+            .collect::<Vec<_>>();
+        if shared.is_empty() {
+            plan.remove.push(candidate);
+        } else {
+            plan.skipped.push(CaskPruneSkip {
+                token: candidate.token,
+                reason: format!(
+                    "recorded artifact target is also claimed by another cask: {}",
+                    shared
+                        .iter()
+                        .map(|path| path.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            });
+        }
+    }
+    plan.remove.sort_by(|a, b| a.token.cmp(&b.token));
+    plan.skipped.sort_by(|a, b| a.token.cmp(&b.token));
+    Ok(plan)
+}
+
+pub fn apply_cask_prune_plan(plan: &CaskPrunePlan, dry_run: bool) -> Result<usize> {
+    apply_cask_prune_plan_in(plan, dry_run, &crate::dirs::STATE)
+}
+
+fn apply_cask_prune_plan_in(
+    plan: &CaskPrunePlan,
+    dry_run: bool,
+    state_dir: &Path,
+) -> Result<usize> {
+    if dry_run {
+        for candidate in &plan.remove {
+            miseprintln!("remove brew-cask:{}@{}", candidate.token, candidate.version);
+        }
+        return Ok(0);
+    }
+
+    let mut removed = 0;
+    for candidate in &plan.remove {
+        if let Err(reason) = validate_cask_prune_candidate(candidate) {
+            warn!(
+                "brew-cask:{}: skipped because recorded artifacts changed after planning: {reason:#}",
+                candidate.token
+            );
+            continue;
+        }
+        let mut journal = CaskTransactionJournal {
+            schema_version: 1,
+            token: &candidate.token,
+            version: &candidate.version,
+            completed: Vec::new(),
+        };
+        write_cask_journal_in(state_dir, &journal)?;
+        for (index, target) in candidate.receipt.targets.iter().enumerate() {
+            remove_artifact_target_elevating(&target.path)?;
+            record_cask_action_in(state_dir, &mut journal, &format!("prune_target[{index}]"))?;
+        }
+        file::remove_all(&candidate.version_dir)?;
+        record_cask_action_in(state_dir, &mut journal, "prune_caskroom")?;
+        if let Some(token_dir) = candidate.version_dir.parent() {
+            file::remove_dir(token_dir)?;
+        }
+        remove_cask_journals_in(state_dir, &candidate.token)?;
+        removed += 1;
+    }
+    Ok(removed)
+}
+
+fn validate_cask_prune_candidate(candidate: &CaskPruneCandidate) -> Result<()> {
+    let receipt = &candidate.receipt;
+    if receipt.schema_version != 3 || !receipt.prune_safe || !receipt.pkg_ids.is_empty() {
+        bail!("receipt is not marked safe for direct-artifact pruning");
+    }
+    let records = receipt
+        .targets
+        .iter()
+        .map(|record| (record.path.clone(), record))
+        .collect::<BTreeMap<_, _>>();
+    let expected = receipt
+        .apps
+        .iter()
+        .chain(&receipt.binaries)
+        .chain(&receipt.fonts)
+        .chain(&receipt.completions)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if expected.is_empty()
+        || records.len() != receipt.targets.len()
+        || records.len() != expected.len()
+    {
+        bail!("receipt target inventory is incomplete or duplicated");
+    }
+    if records.keys().any(|path| !expected.contains(path)) {
+        bail!("receipt target inventory contains an unclassified path");
+    }
+
+    for path in &receipt.apps {
+        let record = records
+            .get(path)
+            .ok_or_else(|| eyre!("missing app target record"))?;
+        if record.fingerprint.kind != CaskTargetKind::Directory
+            || !allowed_appdir_roots()
+                .iter()
+                .any(|root| path_is_below(path, root))
+            || !path.file_name().is_some_and(|name| {
+                staged_target_matches(record, &candidate.version_dir.join(name))
+            })
+        {
+            bail!(
+                "app target is outside an allowed Applications directory: {}",
+                path.display()
+            );
+        }
+    }
+    for path in &receipt.binaries {
+        let record = records
+            .get(path)
+            .ok_or_else(|| eyre!("missing binary target record"))?;
+        if record.fingerprint.kind != CaskTargetKind::Symlink
+            || !allowed_binary_target_roots()
+                .iter()
+                .any(|root| path_is_below(path, root))
+            || !symlink_resolves_below(path, &candidate.version_dir)
+        {
+            bail!(
+                "binary target is not an owned Caskroom symlink: {}",
+                path.display()
+            );
+        }
+    }
+    for path in &receipt.fonts {
+        let record = records
+            .get(path)
+            .ok_or_else(|| eyre!("missing font target record"))?;
+        let fonts = font_dir();
+        if record.fingerprint.kind != CaskTargetKind::File
+            || !path_is_below(path, &fonts)
+            || !path.strip_prefix(&fonts).is_ok_and(|relative| {
+                staged_target_matches(record, &candidate.version_dir.join(relative))
+            })
+        {
+            bail!(
+                "font target is outside the platform font directory: {}",
+                path.display()
+            );
+        }
+    }
+    let completion_roots = [
+        CompletionShell::Bash,
+        CompletionShell::Fish,
+        CompletionShell::Zsh,
+        CompletionShell::Pwsh,
+    ]
+    .map(default_completion_dir);
+    for path in &receipt.completions {
+        let record = records
+            .get(path)
+            .ok_or_else(|| eyre!("missing completion target record"))?;
+        if record.fingerprint.kind != CaskTargetKind::Symlink
+            || !completion_roots
+                .iter()
+                .any(|root| path_is_below(path, root))
+            || !symlink_resolves_below(path, &candidate.version_dir)
+        {
+            bail!(
+                "completion target is not an owned Caskroom symlink: {}",
+                path.display()
+            );
+        }
+    }
+    for record in &receipt.targets {
+        if !cask_target_record_matches(record)? {
+            bail!("artifact target has changed: {}", record.path.display());
+        }
+    }
+    Ok(())
+}
+
+fn path_is_below(path: &Path, root: &Path) -> bool {
+    path.strip_prefix(root)
+        .is_ok_and(|relative| relative.components().next().is_some())
+}
+
+fn staged_target_matches(record: &CaskTargetRecord, staged: &Path) -> bool {
+    cask_target_fingerprint(staged).is_ok_and(|fingerprint| fingerprint == record.fingerprint)
+}
+
+fn symlink_resolves_below(path: &Path, root: &Path) -> bool {
+    let Ok(target) = std::fs::read_link(path) else {
+        return false;
+    };
+    let target = if target.is_absolute() {
+        target
+    } else {
+        path.parent().unwrap_or_else(|| Path::new("/")).join(target)
+    };
+    path_starts_with_resolved_root(&target, root)
 }
 
 fn caskroom_token_dir(token: &str) -> PathBuf {
@@ -6656,6 +7053,8 @@ end
             completions: vec![],
             pkg_ids: vec![],
             targets: Vec::new(),
+            prune_safe: false,
+            prune_blocker: None,
         };
         crate::file::write(
             caskroom.join(".mise-cask.toml"),
@@ -6684,7 +7083,7 @@ end
         let caskroom = caskroom_version_dir(&cask.token, &cask.version);
         file::create_dir_all(&caskroom)?;
         let receipt = CaskReceipt {
-            schema_version: 3,
+            schema_version: 4,
             version: cask.version.clone(),
             apps: Vec::new(),
             binaries: Vec::new(),
@@ -6692,6 +7091,8 @@ end
             completions: Vec::new(),
             pkg_ids: Vec::new(),
             targets: Vec::new(),
+            prune_safe: false,
+            prune_blocker: None,
         };
         file::write(
             caskroom.join(".mise-cask.toml"),
@@ -6702,6 +7103,146 @@ end
             installed_cask_version(&cask, &CaskArtifacts::default())?,
             None
         );
+        Ok(())
+    }
+
+    #[test]
+    fn cask_prune_removes_only_receipt_owned_direct_artifacts() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let state_dir = tmp.path().join("state");
+        let cask = test_cask("example", "1.0.0");
+        let app = AppArtifact {
+            source: "Example.app".to_string(),
+            target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+        };
+        let target = app_target_path(app.target_name())?;
+        file::create_dir_all(&target)?;
+        file::write(target.join("version"), "1.0.0")?;
+        let version_dir = caskroom_version_dir(&cask.token, &cask.version);
+        file::create_dir_all(version_dir.join("Example.app"))?;
+        file::write(version_dir.join("Example.app/version"), "1.0.0")?;
+        write_receipt(
+            &version_dir,
+            &cask,
+            &CaskArtifacts {
+                apps: vec![app],
+                ..Default::default()
+            },
+        )?;
+
+        let plan = cask_prune_plan_from_tokens(&BTreeSet::new(), &state_dir)?;
+        assert_eq!(plan.remove.len(), 1);
+        assert!(plan.skipped.is_empty());
+        assert_eq!(apply_cask_prune_plan_in(&plan, true, &state_dir)?, 0);
+        assert!(target.exists());
+
+        assert_eq!(apply_cask_prune_plan_in(&plan, false, &state_dir)?, 1);
+        assert!(!target.exists());
+        assert!(!caskroom_token_dir(&cask.token).exists());
+        assert!(!cask_journal_pending_in(&state_dir, &cask.token));
+        Ok(())
+    }
+
+    #[test]
+    fn cask_prune_skips_configured_drifted_and_legacy_casks() -> Result<()> {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir()?;
+        let _guard = BrewPrefixGuard::set(tmp.path());
+        let state_dir = tmp.path().join("state");
+
+        let configured = test_cask("configured", "1.0.0");
+        let configured_dir = caskroom_version_dir(&configured.token, &configured.version);
+        let configured_target = tmp.path().join("Applications/Configured.app");
+        file::create_dir_all(&configured_target)?;
+        file::create_dir_all(configured_dir.join("Configured.app"))?;
+        write_receipt(
+            &configured_dir,
+            &configured,
+            &CaskArtifacts {
+                apps: vec![AppArtifact {
+                    source: "Configured.app".to_string(),
+                    target: Some("$HOMEBREW_PREFIX/Applications/Configured.app".to_string()),
+                }],
+                ..Default::default()
+            },
+        )?;
+
+        let drifted = test_cask("drifted", "1.0.0");
+        let drifted_dir = caskroom_version_dir(&drifted.token, &drifted.version);
+        let drifted_target = tmp.path().join("Applications/Drifted.app");
+        file::create_dir_all(&drifted_target)?;
+        file::create_dir_all(drifted_dir.join("Drifted.app"))?;
+        write_receipt(
+            &drifted_dir,
+            &drifted,
+            &CaskArtifacts {
+                apps: vec![AppArtifact {
+                    source: "Drifted.app".to_string(),
+                    target: Some("$HOMEBREW_PREFIX/Applications/Drifted.app".to_string()),
+                }],
+                ..Default::default()
+            },
+        )?;
+        file::write(drifted_target.join("changed"), "changed")?;
+
+        let legacy = test_cask("legacy", "1.0.0");
+        let legacy_dir = caskroom_version_dir(&legacy.token, &legacy.version);
+        file::create_dir_all(&legacy_dir)?;
+        file::write(
+            legacy_dir.join(".mise-cask.toml"),
+            toml::to_string_pretty(&CaskReceipt {
+                schema_version: 2,
+                version: legacy.version.clone(),
+                apps: Vec::new(),
+                binaries: Vec::new(),
+                fonts: Vec::new(),
+                completions: Vec::new(),
+                pkg_ids: Vec::new(),
+                targets: Vec::new(),
+                prune_safe: false,
+                prune_blocker: None,
+            })?,
+        )?;
+
+        let plan =
+            cask_prune_plan_from_tokens(&BTreeSet::from([configured.token.clone()]), &state_dir)?;
+        assert!(plan.remove.is_empty());
+        assert_eq!(
+            plan.skipped
+                .iter()
+                .map(|skip| skip.token.as_str())
+                .collect::<Vec<_>>(),
+            vec!["drifted", "legacy"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cask_prune_receipt_rejects_pkg_and_lifecycle_casks() -> Result<()> {
+        let mut cask = test_cask("example", "1.0.0");
+        let direct = CaskArtifacts {
+            apps: vec![AppArtifact {
+                source: "Example.app".to_string(),
+                target: None,
+            }],
+            ..Default::default()
+        };
+        assert_eq!(cask_prune_blocker(&cask, &direct), None);
+
+        cask.artifacts = vec![serde_json::json!({"uninstall": [{"quit": "com.example"}]})];
+        assert!(cask_prune_blocker(&cask, &direct).is_some());
+
+        cask.artifacts.clear();
+        let pkg = CaskArtifacts {
+            pkgs: vec![PkgArtifact {
+                source: "Example.pkg".to_string(),
+            }],
+            pkg_ids: vec!["com.example.pkg".to_string()],
+            ..Default::default()
+        };
+        assert!(cask_prune_blocker(&cask, &pkg).is_some());
         Ok(())
     }
 
@@ -6791,6 +7332,8 @@ end
             completions: Vec::new(),
             pkg_ids: Vec::new(),
             targets: Vec::new(),
+            prune_safe: false,
+            prune_blocker: None,
         };
         file::write(
             caskroom.join(".mise-cask.toml"),
@@ -7078,6 +7621,8 @@ end
             completions: vec![],
             pkg_ids: vec![],
             targets: Vec::new(),
+            prune_safe: false,
+            prune_blocker: None,
         };
         crate::file::write(
             caskroom.join(".mise-cask.toml"),
@@ -7200,6 +7745,8 @@ end
             completions: Vec::new(),
             pkg_ids: Vec::new(),
             targets: Vec::new(),
+            prune_safe: false,
+            prune_blocker: None,
         };
         file::write(
             caskroom.join(".mise-cask.toml"),

--- a/src/system/packages/brew/mod.rs
+++ b/src/system/packages/brew/mod.rs
@@ -39,7 +39,7 @@ mod source;
 mod tag;
 
 pub struct BrewManager {}
-pub use cask::BrewCaskManager;
+pub use cask::{BrewCaskManager, apply_cask_prune_plan, cask_prune_plan};
 pub use maintenance::{apply_prune_plan, default_tap_url, linked_formulae, prune_plan};
 
 impl BrewManager {


### PR DESCRIPTION
## Summary

- add `mise bootstrap packages prune --manager brew-cask` for conservatively removable, mise-owned direct cask artifacts
- persist install-time prune eligibility in schema-3 cask receipts instead of reconstructing historical uninstall behavior from current API metadata
- revalidate receipt inventories, allowed target roots, staged copies, content fingerprints, Caskroom symlink ownership, shared claims, and transaction state before deletion
- skip Homebrew-owned, legacy-receipt, pkg, lifecycle, drifted, shared-target, and interrupted casks with an explicit reason
- add focused unit and E2E coverage plus generated CLI and Homebrew documentation

## Safety boundary

Prune only considers casks whose install-time receipt explicitly records that the install had no pkg artifacts or install/uninstall lifecycle actions. Each target must remain byte-for-byte identical to its recorded fingerprint and must still correspond to its staged Caskroom artifact. The same checks run during planning and immediately before removal.

Removal writes a durable cask transaction journal before mutating external targets. `zap` metadata is never executed, Homebrew `.metadata` is never adopted or removed, and older receipts remain non-prunable until a future upgrade or reinstall records the new safety metadata.

## Validation

- `cargo test -q system::packages::brew::cask::tests -- --test-threads=1` — 125 passed
- `mise run test:e2e e2e/cli/test_system_prune_brew_cask`
- `mise run render`
- `mise run render:usage`
- `mise run render:completions`
- `mise run lint-fix`
- `mise run lint`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `git diff --check`

Discussion: https://github.com/jdx/mise/discussions/11784

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive filesystem operations on cask artifacts, but gated by receipt metadata, fingerprint checks, shared-target indexing, and re-validation at apply time; skips fail closed when ownership or receipts are ambiguous.
> 
> **Overview**
> **`mise bootstrap packages prune`** now accepts **`--manager brew-cask`**, using the same merged config model as formula prune to drop casks no longer declared in `[bootstrap.packages]` (including tracked configs).
> 
> Cask cleanup is intentionally narrow: install-time **`.mise-cask.toml` receipts** bump to **schema version 3** with **`prune_safe`** / **`prune_blocker`** metadata. Prune only removes direct artifacts when every recorded target still matches its fingerprint, ownership is mise-only (no Homebrew `.metadata`), there is a single Caskroom version, no pending transaction journal, and targets are not shared with another cask. Pkg installs, command wrappers, install/uninstall lifecycle hooks, legacy receipts, drifted files, and corrupt/unreadable Caskroom state are **skipped with explicit reasons**; **`zap` is never run**. Apply re-validates before deletion and journals removals under a Caskroom lock.
> 
> Docs, usage specs, man page, and an E2E dry-run/apply test are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4735c0aa568cfee5adc4baf2bd354d9d1f24c6db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for safely pruning mise-owned Homebrew casks.
  - Added `brew-cask` as a package-pruning option.
  - Added dry-run, confirmation, removal reporting, and skip-reason handling.
  - Added safeguards for ownership, configuration requirements, fingerprints, shared targets, supported artifacts, and incomplete transactions.

- **Documentation**
  - Updated CLI help, manual pages, and package-pruning guides with cask support, examples, limitations, and safety behavior.

- **Tests**
  - Added end-to-end coverage for dry-run and confirmed Homebrew cask removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->