### PR TITLE
fix(tera): honor `pat` on v1 trim_start/trim_end

### DIFF
--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1046,6 +1046,9 @@ static TERA1: Lazy<tera1::Tera> = Lazy::new(|| {
             ))
         },
     );
+    // Override v1's builtins, which drop `pat` silently. See tera1_trim_filter.
+    tera.register_filter("trim_start", tera1_trim_filter(TrimSide::Start));
+    tera.register_filter("trim_end", tera1_trim_filter(TrimSide::End));
     tera.register_filter(
         "last_modified",
         move |value: &JsonValue, _: &HashMap<String, JsonValue>| {
@@ -1184,6 +1187,37 @@ fn tera1_path_filter(
     move |value, _| {
         let p = f(Path::new(json_path(value)?)).map_err(|e| tera1_err(e.to_string()))?;
         Ok(json!(p.to_string_lossy().to_string()))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TrimSide {
+    Start,
+    End,
+}
+
+/// Tera v2 accepts an optional `pat` on `trim_start`/`trim_end`, and that is the
+/// spelling mise recommends — `trim_start_matches`/`trim_end_matches` are only
+/// registered on v2 as deprecated aliases pointing at it. v1's builtins take no
+/// `pat` and ignore it silently, so a template written the recommended way
+/// becomes a no-op under `tera_v1` rather than failing loudly. Registry entries
+/// depend on it (azd, clickhouse, magika).
+///
+/// Without `pat` this keeps v1's existing whitespace-trimming behavior.
+fn tera1_trim_filter(
+    side: TrimSide,
+) -> impl Fn(&JsonValue, &HashMap<String, JsonValue>) -> tera1::Result<JsonValue> {
+    move |value, args| {
+        let s = value
+            .as_str()
+            .ok_or_else(|| tera1_err("trim filters expect a string"))?;
+        let trimmed = match (args.get("pat").and_then(JsonValue::as_str), side) {
+            (Some(pat), TrimSide::Start) => s.trim_start_matches(pat),
+            (Some(pat), TrimSide::End) => s.trim_end_matches(pat),
+            (None, TrimSide::Start) => s.trim_start(),
+            (None, TrimSide::End) => s.trim_end(),
+        };
+        Ok(json!(trimmed))
     }
 }
 
@@ -2044,6 +2078,16 @@ mod tests {
         render_str(&mut tera, s, &tera_ctx).unwrap()
     }
 
+    /// Render through the v1 engine explicitly. `render` goes through
+    /// `get_tera`, which picks the engine from settings; selecting v1 here
+    /// directly keeps these tests from mutating process-wide state.
+    fn render_v1(s: &str) -> String {
+        let mut tera = TeraEngine::V1(Box::new(get_tera_v1(None)));
+        let mut tera_ctx = BASE_CONTEXT.clone();
+        tera_ctx.insert("cwd", "/");
+        render_str(&mut tera, s, &tera_ctx).unwrap()
+    }
+
     #[test]
     fn test_tera_v1_setting_selects_v1_engine() {
         let _guard = SettingsGuard::tera_v1();
@@ -2179,6 +2223,40 @@ mod tests {
         );
         assert_eq!(render("{{ {'ok': true} is object }}"), "true");
         assert_eq!(render("{{ 6 is divisibleby(divisor=3) }}"), "true");
+    }
+
+    /// v1's builtin `trim_start`/`trim_end` take no `pat` and drop it silently,
+    /// which turned the spelling mise recommends into a no-op under `tera_v1`.
+    /// Failing here also means the v1 builtins can no longer be overridden.
+    #[test]
+    fn test_tera_v1_trim_honors_pat() {
+        assert_eq!(render_v1("{{ 'v1.2.3' | trim_start(pat='v') }}"), "1.2.3");
+        assert_eq!(
+            render_v1("{{ '3.27.2-stable' | trim_end(pat='-stable') }}"),
+            "3.27.2"
+        );
+        // A pattern that is not present leaves the value alone, as in v2.
+        assert_eq!(
+            render_v1("{{ '1.2.3' | trim_end(pat='-stable') }}"),
+            "1.2.3"
+        );
+    }
+
+    /// Without `pat` these must keep trimming whitespace, as v1 always has.
+    #[test]
+    fn test_tera_v1_trim_without_pat_still_trims_whitespace() {
+        assert_eq!(render_v1("[{{ '  x  ' | trim_start }}]"), "[x  ]");
+        assert_eq!(render_v1("[{{ '  x  ' | trim_end }}]"), "[  x]");
+    }
+
+    /// The engines must agree on the shape registry entries use (azd,
+    /// clickhouse, magika), so a template does not silently render differently
+    /// under `tera_v1`.
+    #[test]
+    fn test_tera_engines_agree_on_the_registry_trim_pattern() {
+        let template = "{{ '3.27.2-stable' | trim_end(pat='-stable') }}-stable";
+        assert_eq!(render(template), "3.27.2-stable");
+        assert_eq!(render_v1(template), "3.27.2-stable");
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -2088,6 +2088,15 @@ mod tests {
         render_str(&mut tera, s, &tera_ctx).unwrap()
     }
 
+    /// The v2 counterpart of [`render_v1`]. A cross-engine comparison must pin
+    /// both sides, or with `tera_v1` set it would compare v1 against itself.
+    fn render_v2(s: &str) -> String {
+        let mut tera = TeraEngine::V2(Box::new(get_tera_v2(None)));
+        let mut tera_ctx = BASE_CONTEXT.clone();
+        tera_ctx.insert("cwd", "/");
+        render_str(&mut tera, s, &tera_ctx).unwrap()
+    }
+
     #[test]
     fn test_tera_v1_setting_selects_v1_engine() {
         let _guard = SettingsGuard::tera_v1();
@@ -2255,7 +2264,7 @@ mod tests {
     #[test]
     fn test_tera_engines_agree_on_the_registry_trim_pattern() {
         let template = "{{ '3.27.2-stable' | trim_end(pat='-stable') }}-stable";
-        assert_eq!(render(template), "3.27.2-stable");
+        assert_eq!(render_v2(template), "3.27.2-stable");
         assert_eq!(render_v1(template), "3.27.2-stable");
     }
 


### PR DESCRIPTION
Found while responding to review on #11808.

## The problem

`trim_start(pat=…)` / `trim_end(pat=…)` is the spelling mise recommends — `trim_start_matches` / `trim_end_matches` exist on the v2 engine only as deprecated aliases whose warning text says *"Use `trim_end(pat=...)` instead."*

Tera v1's builtins take no `pat`. They accept the keyword and **ignore it silently**, so a template written the recommended way renders as if the filter were not there. No error, no warning.

Measured on **v2026.8.2** through the rendering path a registry `url` takes, using an inline `http:` tool option so nothing needs rebuilding:

| engine | filter | `3.27.2-stable` renders as |
|---|---|---|
| v2 | `trim_end(pat='-stable')` | `f_3.27.2-stable.zip` ✅ |
| **v1** | **`trim_end(pat='-stable')`** | **`f_3.27.2-stable-stable.zip`** ❌ |
| v2 | `trim_start(pat='v')` on `v1.2.3` | `f_1.2.3.zip` ✅ |
| **v1** | **`trim_start(pat='v')` on `v1.2.3`** | **`f_v1.2.3.zip`** ❌ |

## Who this affects today

Registry entries already depend on the filter, so they render differently depending on which engine the user selected:

- `registry/azd.toml` — `trim_start(pat='azure-dev-cli_')`
- `registry/clickhouse.toml` — `trim_end(pat='-lts') | trim_end(pat='-stable')`
- `registry/magika.toml` — `trim_start(pat='v')`

## The change

Register `trim_start` and `trim_end` on the v1 engine, overriding its builtins. With `pat` they delegate to `str::trim_start_matches` / `str::trim_end_matches`; without it they keep v1's existing whitespace trim, so nothing regresses.

The registration sits with the other v1 filters in the `TERA1` block and follows the shape of `tera1_path_filter`.

## Why not put `trim_end_matches` in the registry instead

That was the first suggestion on #11808, and it does work on both engines today — but it is on a removal schedule, and it is the *same* schedule as the setting that motivates reaching for it:

| | `deprecated_warn_at` | `deprecated_remove_at` |
|---|---|---|
| `trim_end_matches` (`warn_tera_v1_filter`) | 2026.10.0 | 2027.4.0 |
| `tera_v1` (`settings.toml`) | 2026.10.0 | 2027.4.0 |

Using it in the registry would start warning **every** user on the default v2 engine from 2026.10.0 and hard-fail at 2027.4.0, to serve a cohort whose escape hatch disappears at that same release. Fixing the engine keeps one spelling that works everywhere and needs no follow-up.

## Scope

- **Only `trim_start` / `trim_end`.** No broader audit of v1↔v2 filter differences here.
- **No registry entries are changed.** The flutter fix stays in #11808.
- **`tera_v1`'s own deprecation is untouched.** This only stops the escape hatch from silently corrupting templates while it exists.
- **No deprecation warning on these filters** — this is the recommended syntax; it should simply work.

## Tests

Three tests in `src/tera.rs`, using a new `render_v1` helper that selects the v1 engine directly rather than mutating process-wide settings:

- `pat` is honored on both filters under v1, and a pattern that is not present leaves the value alone.
- Without `pat`, whitespace trimming still behaves as before.
- Both engines agree on the shape registry entries use.

The first of these is also what verifies the approach at all: if v1 builtins could not be overridden by same-name registration, it would fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the `trim_start` and `trim_end` filters to support optional custom patterns.
  * Preserved existing whitespace-trimming behavior when no pattern is provided.
  * Pattern-based trimming now supports matching behavior consistent across supported Tera versions.

* **Bug Fixes**
  * Improved consistency between Tera v1 and v2 trimming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->