### PR TITLE
feat(cache): store rustc compilation misses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6358,6 +6358,7 @@ dependencies = [
  "miette",
  "minisign-verify",
  "mise-cache-core",
+ "mise-cache-rustc",
  "mise-interactive-config",
  "mise-sigstore",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ flate2 = "1"
 futures-util = "0.3.32"
 mise-sigstore = { path = "crates/mise-sigstore", default-features = false }
 mise-cache-core = { path = "crates/mise-cache-core", default-features = false }
+mise-cache-rustc = { path = "crates/mise-cache-rustc" }
 fslock = "0.2.1"
 gix = { version = "<1", features = ["worktree-mutation"] }
 glob = "0.3"

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -7,6 +7,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 
+const MAX_EXECUTABLE_IDENTITIES: usize = 64;
+const MAX_EXECUTABLE_IDENTITY_SIZE: usize = 64 * 1024;
+const MAX_EXECUTABLE_IDENTITY_BYTES: usize = 256 * 1024;
+
 /// Wire protocol version used between an in-process cache agent and its shims.
 pub const AGENT_PROTOCOL_VERSION: u8 = 1;
 
@@ -212,15 +216,21 @@ impl CacheAgent {
         environment: BTreeMap<String, Option<String>>,
         stdout: Vec<u8>,
     ) -> Result<AgentResponse> {
-        const MAX_IDENTITY_SIZE: usize = 64 * 1024;
-        if stdout.len() > MAX_IDENTITY_SIZE {
-            bail!("executable identity exceeds {MAX_IDENTITY_SIZE} bytes");
+        if stdout.len() > MAX_EXECUTABLE_IDENTITY_SIZE {
+            bail!("executable identity exceeds {MAX_EXECUTABLE_IDENTITY_SIZE} bytes");
         }
         let key = self.executable_identity_key(executable, environment)?;
-        self.executable_identities
-            .lock()
-            .unwrap()
-            .insert(key, stdout.clone());
+        let mut identities = self.executable_identities.lock().unwrap();
+        let is_new = !identities.contains_key(&key);
+        let previous_size = identities.get(&key).map_or(0, Vec::len);
+        if is_new && identities.len() >= MAX_EXECUTABLE_IDENTITIES {
+            bail!("executable identity cache contains too many entries");
+        }
+        let retained_bytes = identities.values().map(Vec::len).sum::<usize>();
+        if retained_bytes - previous_size + stdout.len() > MAX_EXECUTABLE_IDENTITY_BYTES {
+            bail!("executable identity cache contains too many bytes");
+        }
+        identities.insert(key, stdout.clone());
         Ok(AgentResponse::ExecutableIdentity {
             stdout: Some(stdout),
         })
@@ -439,6 +449,56 @@ mod tests {
                 stdout: Some(stdout)
             } if stdout == b"rustc identity"
         ));
+    }
+
+    #[test]
+    fn bounds_executable_identity_entry_count() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        for index in 0..MAX_EXECUTABLE_IDENTITIES {
+            agent
+                .store_executable_identity(
+                    directory.path().join(format!("rustc-{index}")),
+                    BTreeMap::new(),
+                    vec![b'x'],
+                )
+                .unwrap();
+        }
+
+        assert!(
+            agent
+                .store_executable_identity(
+                    directory.path().join("one-too-many"),
+                    BTreeMap::new(),
+                    vec![b'x'],
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn bounds_executable_identity_retained_bytes() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        for index in 0..MAX_EXECUTABLE_IDENTITY_BYTES / MAX_EXECUTABLE_IDENTITY_SIZE {
+            agent
+                .store_executable_identity(
+                    directory.path().join(format!("rustc-{index}")),
+                    BTreeMap::new(),
+                    vec![b'x'; MAX_EXECUTABLE_IDENTITY_SIZE],
+                )
+                .unwrap();
+        }
+
+        assert!(
+            agent
+                .store_executable_identity(
+                    directory.path().join("one-byte-too-many"),
+                    BTreeMap::new(),
+                    vec![b'x'],
+                )
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -7,8 +7,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 
+/// Wire protocol version used between an in-process cache agent and its shims.
 pub const AGENT_PROTOCOL_VERSION: u8 = 1;
 
+/// A request accepted by the task-scoped cache agent.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentRequest {
@@ -26,13 +28,18 @@ pub enum AgentRequest {
     StoreActionResult {
         result: RemoteActionResult,
     },
-    IdentifyExecutable {
+    FindExecutableIdentity {
         executable: PathBuf,
-        arguments: Vec<String>,
         environment: BTreeMap<String, Option<String>>,
+    },
+    StoreExecutableIdentity {
+        executable: PathBuf,
+        environment: BTreeMap<String, Option<String>>,
+        stdout: Vec<u8>,
     },
 }
 
+/// A response returned by the task-scoped cache agent.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentResponse {
@@ -40,15 +47,20 @@ pub enum AgentResponse {
     Blob { path: Option<PathBuf> },
     Stored { path: PathBuf },
     ActionStored { path: PathBuf },
-    ExecutableIdentity { stdout: Vec<u8> },
+    ExecutableIdentity { stdout: Option<Vec<u8>> },
     Error { message: String },
 }
 
+/// Aggregate cache activity for one task session.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct AgentStats {
+    /// Number of content-addressed storage lookups.
     pub lookups: u64,
+    /// Number of lookups that found a valid local object.
     pub hits: u64,
+    /// Number of newly stored content-addressed objects.
     pub stores: u64,
+    /// Total size of newly stored objects.
     pub stored_bytes: u64,
 }
 
@@ -77,11 +89,11 @@ pub struct CacheAgent {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct ExecutableIdentityKey {
     executable: PathBuf,
-    arguments: Vec<String>,
     environment: BTreeMap<String, Option<String>>,
 }
 
 impl CacheAgent {
+    /// Create an agent backed by the cache rooted at `cache_dir`.
     pub fn new(cache_dir: impl Into<PathBuf>, version: impl Into<Arc<str>>) -> Self {
         let cache_dir = cache_dir.into();
         Self {
@@ -94,6 +106,7 @@ impl CacheAgent {
         }
     }
 
+    /// Return a snapshot of this session's cache activity.
     pub fn stats(&self) -> AgentStats {
         AgentStats {
             lookups: self.stats.lookups.load(Ordering::Relaxed),
@@ -143,13 +156,15 @@ impl CacheAgent {
                 .actions
                 .store(&result)
                 .map(|path| AgentResponse::ActionStored { path }),
-            AgentRequest::IdentifyExecutable {
+            AgentRequest::FindExecutableIdentity {
                 executable,
-                arguments,
                 environment,
-            } => self
-                .identify_executable(executable, arguments, environment)
-                .map(|stdout| AgentResponse::ExecutableIdentity { stdout }),
+            } => self.find_executable_identity(executable, environment),
+            AgentRequest::StoreExecutableIdentity {
+                executable,
+                environment,
+                stdout,
+            } => self.store_executable_identity(executable, environment, stdout),
             AgentRequest::Hello { .. } => {
                 Err(eyre::eyre!("hello is only valid as the first request"))
             }
@@ -159,49 +174,59 @@ impl CacheAgent {
         })
     }
 
-    fn identify_executable(
+    fn executable_identity_key(
         &self,
         executable: PathBuf,
-        arguments: Vec<String>,
         environment: BTreeMap<String, Option<String>>,
-    ) -> Result<Vec<u8>> {
-        let key = ExecutableIdentityKey {
-            executable: executable.clone(),
-            arguments: arguments.clone(),
-            environment: environment.clone(),
-        };
-        if let Some(stdout) = self
+    ) -> Result<ExecutableIdentityKey> {
+        if !environment
+            .keys()
+            .all(|name| matches!(name.as_str(), "RUSTUP_HOME" | "RUSTUP_TOOLCHAIN"))
+        {
+            bail!("executable identity contains an unsupported environment variable");
+        }
+        Ok(ExecutableIdentityKey {
+            executable,
+            environment,
+        })
+    }
+
+    fn find_executable_identity(
+        &self,
+        executable: PathBuf,
+        environment: BTreeMap<String, Option<String>>,
+    ) -> Result<AgentResponse> {
+        let key = self.executable_identity_key(executable, environment)?;
+        let stdout = self
             .executable_identities
             .lock()
             .unwrap()
             .get(&key)
-            .cloned()
-        {
-            return Ok(stdout);
+            .cloned();
+        Ok(AgentResponse::ExecutableIdentity { stdout })
+    }
+
+    fn store_executable_identity(
+        &self,
+        executable: PathBuf,
+        environment: BTreeMap<String, Option<String>>,
+        stdout: Vec<u8>,
+    ) -> Result<AgentResponse> {
+        const MAX_IDENTITY_SIZE: usize = 64 * 1024;
+        if stdout.len() > MAX_IDENTITY_SIZE {
+            bail!("executable identity exceeds {MAX_IDENTITY_SIZE} bytes");
         }
-        let mut command = std::process::Command::new(&executable);
-        command.args(&arguments);
-        for (name, value) in environment {
-            if let Some(value) = value {
-                command.env(name, value);
-            } else {
-                command.env_remove(name);
-            }
-        }
-        let output = command.output()?;
-        if !output.status.success() {
-            bail!(
-                "executable identity command failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
+        let key = self.executable_identity_key(executable, environment)?;
         self.executable_identities
             .lock()
             .unwrap()
-            .insert(key, output.stdout.clone());
-        Ok(output.stdout)
+            .insert(key, stdout.clone());
+        Ok(AgentResponse::ExecutableIdentity {
+            stdout: Some(stdout),
+        })
     }
 
+    /// Serve newline-delimited protocol requests on an authenticated session stream.
     pub async fn handle_connection<S>(&self, stream: S) -> Result<()>
     where
         S: AsyncRead + AsyncWrite + Unpin,
@@ -368,6 +393,52 @@ mod tests {
             .await;
         assert!(matches!(response, AgentResponse::ActionStored { .. }));
         assert!(agent.actions.find(&action).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn memoizes_client_observed_executable_identities() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        let executable = directory.path().join("rustc");
+        let environment = BTreeMap::from([("RUSTUP_TOOLCHAIN".into(), Some("stable".into()))]);
+
+        let response = agent
+            .respond(AgentRequest::FindExecutableIdentity {
+                executable: executable.clone(),
+                environment: environment.clone(),
+            })
+            .await;
+        assert!(matches!(
+            response,
+            AgentResponse::ExecutableIdentity { stdout: None }
+        ));
+
+        let response = agent
+            .respond(AgentRequest::StoreExecutableIdentity {
+                executable: executable.clone(),
+                environment: environment.clone(),
+                stdout: b"rustc identity".to_vec(),
+            })
+            .await;
+        assert!(matches!(
+            response,
+            AgentResponse::ExecutableIdentity {
+                stdout: Some(stdout)
+            } if stdout == b"rustc identity"
+        ));
+
+        let response = agent
+            .respond(AgentRequest::FindExecutableIdentity {
+                executable,
+                environment,
+            })
+            .await;
+        assert!(matches!(
+            response,
+            AgentResponse::ExecutableIdentity {
+                stdout: Some(stdout)
+            } if stdout == b"rustc identity"
+        ));
     }
 
     #[tokio::test]

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -1,4 +1,4 @@
-use crate::{CacheDigest, LocalCas};
+use crate::{CacheDigest, LocalActionCache, LocalCas, RemoteActionResult};
 use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -23,6 +23,14 @@ pub enum AgentRequest {
         digest: CacheDigest,
         source: PathBuf,
     },
+    StoreActionResult {
+        result: RemoteActionResult,
+    },
+    IdentifyExecutable {
+        executable: PathBuf,
+        arguments: Vec<String>,
+        environment: BTreeMap<String, Option<String>>,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -31,6 +39,8 @@ pub enum AgentResponse {
     Hello { protocol: u8, agent_version: String },
     Blob { path: Option<PathBuf> },
     Stored { path: PathBuf },
+    ActionStored { path: PathBuf },
+    ExecutableIdentity { stdout: Vec<u8> },
     Error { message: String },
 }
 
@@ -57,18 +67,30 @@ struct AtomicAgentStats {
 #[derive(Clone)]
 pub struct CacheAgent {
     cas: LocalCas,
+    actions: LocalActionCache,
     version: Arc<str>,
     write_locks: Arc<Mutex<BTreeMap<CacheDigest, Weak<tokio::sync::Mutex<()>>>>>,
     stats: Arc<AtomicAgentStats>,
+    executable_identities: Arc<Mutex<BTreeMap<ExecutableIdentityKey, Vec<u8>>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ExecutableIdentityKey {
+    executable: PathBuf,
+    arguments: Vec<String>,
+    environment: BTreeMap<String, Option<String>>,
 }
 
 impl CacheAgent {
     pub fn new(cache_dir: impl Into<PathBuf>, version: impl Into<Arc<str>>) -> Self {
+        let cache_dir = cache_dir.into();
         Self {
-            cas: LocalCas::new(cache_dir.into()),
+            cas: LocalCas::new(cache_dir.clone()),
+            actions: LocalActionCache::new(cache_dir),
             version: version.into(),
             write_locks: Arc::new(Mutex::new(BTreeMap::new())),
             stats: Arc::new(AtomicAgentStats::default()),
+            executable_identities: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
@@ -117,6 +139,17 @@ impl CacheAgent {
                     AgentResponse::Stored { path }
                 })
             }
+            AgentRequest::StoreActionResult { result } => self
+                .actions
+                .store(&result)
+                .map(|path| AgentResponse::ActionStored { path }),
+            AgentRequest::IdentifyExecutable {
+                executable,
+                arguments,
+                environment,
+            } => self
+                .identify_executable(executable, arguments, environment)
+                .map(|stdout| AgentResponse::ExecutableIdentity { stdout }),
             AgentRequest::Hello { .. } => {
                 Err(eyre::eyre!("hello is only valid as the first request"))
             }
@@ -124,6 +157,49 @@ impl CacheAgent {
         result.unwrap_or_else(|error| AgentResponse::Error {
             message: error.to_string(),
         })
+    }
+
+    fn identify_executable(
+        &self,
+        executable: PathBuf,
+        arguments: Vec<String>,
+        environment: BTreeMap<String, Option<String>>,
+    ) -> Result<Vec<u8>> {
+        let key = ExecutableIdentityKey {
+            executable: executable.clone(),
+            arguments: arguments.clone(),
+            environment: environment.clone(),
+        };
+        if let Some(stdout) = self
+            .executable_identities
+            .lock()
+            .unwrap()
+            .get(&key)
+            .cloned()
+        {
+            return Ok(stdout);
+        }
+        let mut command = std::process::Command::new(&executable);
+        command.args(&arguments);
+        for (name, value) in environment {
+            if let Some(value) = value {
+                command.env(name, value);
+            } else {
+                command.env_remove(name);
+            }
+        }
+        let output = command.output()?;
+        if !output.status.success() {
+            bail!(
+                "executable identity command failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        self.executable_identities
+            .lock()
+            .unwrap()
+            .insert(key, output.stdout.clone());
+        Ok(output.stdout)
     }
 
     pub async fn handle_connection<S>(&self, stream: S) -> Result<()>
@@ -264,6 +340,34 @@ mod tests {
                 ..AgentStats::default()
             }
         );
+    }
+
+    #[tokio::test]
+    async fn publishes_a_complete_action_result() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path().join("cache"), "test-version");
+        let action = CacheDigest::blake3(b"action");
+        let metadata = CacheDigest::blake3(b"metadata");
+        let output_root = CacheDigest::blake3(b"directory");
+        for (digest, contents) in [
+            (&action, b"action".as_slice()),
+            (&metadata, b"metadata".as_slice()),
+            (&output_root, b"directory".as_slice()),
+        ] {
+            agent.cas.store_bytes(digest, contents).unwrap();
+        }
+        let response = agent
+            .respond(AgentRequest::StoreActionResult {
+                result: RemoteActionResult {
+                    action: action.clone(),
+                    metadata: Some(metadata),
+                    output_root: Some(output_root),
+                    version: 1,
+                },
+            })
+            .await;
+        assert!(matches!(response, AgentResponse::ActionStored { .. }));
+        assert!(agent.actions.find(&action).unwrap().is_some());
     }
 
     #[tokio::test]

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -19,7 +19,7 @@ mod agent;
 mod local;
 
 pub use agent::{AGENT_PROTOCOL_VERSION, AgentRequest, AgentResponse, AgentStats, CacheAgent};
-pub use local::LocalCas;
+pub use local::{LocalActionCache, LocalCas};
 
 pub const PROTOCOL_VERSION: u8 = 1;
 const PROTOCOL_HEADER: &str = "mise-cache-protocol";
@@ -177,7 +177,8 @@ fn hash_file_sha256(path: &Path) -> Result<(String, u64)> {
     Ok((hex::encode(hasher.finalize()), size))
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RemoteActionResult {
     pub action: CacheDigest,
     #[serde(default)]
@@ -185,6 +186,49 @@ pub struct RemoteActionResult {
     #[serde(default)]
     pub output_root: Option<CacheDigest>,
     pub version: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheDirectory {
+    pub directories: Vec<CacheDirectoryNode>,
+    pub files: Vec<CacheFileNode>,
+    pub symlinks: Vec<CacheSymlinkNode>,
+    pub version: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheDirectoryNode {
+    pub digest: CacheDigest,
+    pub mode: u32,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheFileNode {
+    pub digest: CacheDigest,
+    pub executable: bool,
+    pub mode: u32,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheSymlinkNode {
+    pub mode: u32,
+    pub name: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcMetadata {
+    pub version: u8,
+    pub kind: String,
+    pub stdout: CacheDigest,
+    pub stderr: CacheDigest,
 }
 
 pub enum BlobSource {

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -177,6 +177,7 @@ fn hash_file_sha256(path: &Path) -> Result<(String, u64)> {
     Ok((hex::encode(hasher.finalize()), size))
 }
 
+/// A canonical action-result record referencing objects in the CAS.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RemoteActionResult {
@@ -188,6 +189,7 @@ pub struct RemoteActionResult {
     pub version: u8,
 }
 
+/// A canonical directory object stored in the CAS.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CacheDirectory {
@@ -197,6 +199,7 @@ pub struct CacheDirectory {
     pub version: u8,
 }
 
+/// A child directory entry in a canonical cache directory.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CacheDirectoryNode {
@@ -205,6 +208,7 @@ pub struct CacheDirectoryNode {
     pub name: String,
 }
 
+/// A file entry in a canonical cache directory.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CacheFileNode {
@@ -214,6 +218,7 @@ pub struct CacheFileNode {
     pub name: String,
 }
 
+/// A symbolic-link entry in a canonical cache directory.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CacheSymlinkNode {
@@ -222,6 +227,7 @@ pub struct CacheSymlinkNode {
     pub target: String,
 }
 
+/// Rust-specific action metadata stored alongside compiled outputs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RustcMetadata {

--- a/crates/mise-cache-core/src/local.rs
+++ b/crates/mise-cache-core/src/local.rs
@@ -4,11 +4,13 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+/// A validated, content-addressed store on the local filesystem.
 #[derive(Debug, Clone)]
 pub struct LocalCas {
     root: PathBuf,
 }
 
+/// A local index from action digests to their referenced cache objects.
 #[derive(Debug, Clone)]
 pub struct LocalActionCache {
     root: PathBuf,
@@ -16,14 +18,17 @@ pub struct LocalActionCache {
 }
 
 impl LocalCas {
+    /// Create a local content-addressed store beneath `root`.
     pub fn new(root: impl Into<PathBuf>) -> Self {
         Self { root: root.into() }
     }
 
+    /// Return the root shared by this store and its action-result index.
     pub fn root(&self) -> &Path {
         &self.root
     }
 
+    /// Resolve the storage path for a validated digest.
     pub fn path_for(&self, digest: &CacheDigest) -> Result<PathBuf> {
         digest.validate()?;
         Ok(self
@@ -34,6 +39,7 @@ impl LocalCas {
             .join(format!("{}-{}", digest.hash, digest.size)))
     }
 
+    /// Find and verify a stored object.
     pub fn find(&self, digest: &CacheDigest) -> Result<Option<PathBuf>> {
         let path = self.path_for(digest)?;
         if !path.exists() {
@@ -48,6 +54,7 @@ impl LocalCas {
         Ok(Some(path))
     }
 
+    /// Atomically store bytes after verifying their declared digest.
     pub fn store_bytes(&self, digest: &CacheDigest, bytes: &[u8]) -> Result<PathBuf> {
         if !digest.matches_bytes(bytes)? {
             bail!("bytes do not match the declared CAS digest");
@@ -58,6 +65,7 @@ impl LocalCas {
         })
     }
 
+    /// Atomically store a file after verifying its declared digest.
     pub fn store_file(&self, digest: &CacheDigest, source: &Path) -> Result<PathBuf> {
         if !digest.matches_file(source)? {
             bail!(
@@ -100,6 +108,7 @@ impl LocalCas {
 }
 
 impl LocalActionCache {
+    /// Create an action-result index beneath `root`.
     pub fn new(root: impl Into<PathBuf>) -> Self {
         let root = root.into();
         Self {
@@ -108,6 +117,7 @@ impl LocalActionCache {
         }
     }
 
+    /// Resolve the storage path for an action digest.
     pub fn path_for(&self, action: &CacheDigest) -> Result<PathBuf> {
         action.validate()?;
         if action.algorithm != "blake3" {
@@ -121,6 +131,7 @@ impl LocalActionCache {
             .join(format!("{}-{}.json", action.hash, action.size)))
     }
 
+    /// Find and strictly validate a canonical action result.
     pub fn find(&self, action: &CacheDigest) -> Result<Option<RemoteActionResult>> {
         let path = self.path_for(action)?;
         if !path.exists() {
@@ -134,6 +145,7 @@ impl LocalActionCache {
         Ok(Some(result))
     }
 
+    /// Atomically publish an action result after validating all referenced objects.
     pub fn store(&self, result: &RemoteActionResult) -> Result<PathBuf> {
         if result.version != 1 {
             bail!("unsupported local action result version");
@@ -151,12 +163,16 @@ impl LocalActionCache {
             }
         }
         let destination = self.path_for(&result.action)?;
-        if let Some(existing) = self.find(&result.action)? {
-            if existing == *result {
-                return Ok(destination);
+        let replace_invalid = match self.find(&result.action) {
+            Ok(Some(existing)) => {
+                if existing == *result {
+                    return Ok(destination);
+                }
+                bail!("local action key already has a different result");
             }
-            bail!("local action key already has a different result");
-        }
+            Ok(None) => false,
+            Err(_) => true,
+        };
         let parent = destination
             .parent()
             .expect("action-result path has a parent");
@@ -165,6 +181,12 @@ impl LocalActionCache {
         temporary.write_all(&canonical_json(result)?)?;
         temporary.flush()?;
         temporary.as_file().sync_all()?;
+        if replace_invalid {
+            temporary
+                .persist(&destination)
+                .map_err(|error| error.error)?;
+            return Ok(destination);
+        }
         match temporary.persist_noclobber(&destination) {
             Ok(_) => Ok(destination),
             Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => self
@@ -225,6 +247,28 @@ mod tests {
         cas.store_bytes(&metadata, b"metadata").unwrap();
         cas.store_bytes(&output_root, b"directory").unwrap();
         actions.store(&result).unwrap();
+        assert_eq!(actions.find(&action).unwrap(), Some(result));
+    }
+
+    #[test]
+    fn atomically_replaces_a_corrupt_action_result() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path());
+        let actions = LocalActionCache::new(directory.path());
+        let action = CacheDigest::blake3(b"action");
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: None,
+            output_root: None,
+            version: 1,
+        };
+        cas.store_bytes(&action, b"action").unwrap();
+        let path = actions.path_for(&action).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"truncated").unwrap();
+
+        assert!(actions.find(&action).is_err());
+        assert_eq!(actions.store(&result).unwrap(), path);
         assert_eq!(actions.find(&action).unwrap(), Some(result));
     }
 }

--- a/crates/mise-cache-core/src/local.rs
+++ b/crates/mise-cache-core/src/local.rs
@@ -1,4 +1,4 @@
-use crate::CacheDigest;
+use crate::{CacheDigest, RemoteActionResult, canonical_json};
 use eyre::{Result, bail};
 use std::fs;
 use std::io::Write;
@@ -7,6 +7,12 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone)]
 pub struct LocalCas {
     root: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalActionCache {
+    root: PathBuf,
+    cas: LocalCas,
 }
 
 impl LocalCas {
@@ -93,6 +99,84 @@ impl LocalCas {
     }
 }
 
+impl LocalActionCache {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        let root = root.into();
+        Self {
+            cas: LocalCas::new(root.clone()),
+            root,
+        }
+    }
+
+    pub fn path_for(&self, action: &CacheDigest) -> Result<PathBuf> {
+        action.validate()?;
+        if action.algorithm != "blake3" {
+            bail!("local action keys must use blake3");
+        }
+        Ok(self
+            .root
+            .join("action-results/v1")
+            .join(&action.algorithm)
+            .join(&action.hash[..2])
+            .join(format!("{}-{}.json", action.hash, action.size)))
+    }
+
+    pub fn find(&self, action: &CacheDigest) -> Result<Option<RemoteActionResult>> {
+        let path = self.path_for(action)?;
+        if !path.exists() {
+            return Ok(None);
+        }
+        let bytes = fs::read(&path)?;
+        let result: RemoteActionResult = serde_json::from_slice(&bytes)?;
+        if result.version != 1 || result.action != *action || canonical_json(&result)? != bytes {
+            bail!("local action result is invalid: {}", path.display());
+        }
+        Ok(Some(result))
+    }
+
+    pub fn store(&self, result: &RemoteActionResult) -> Result<PathBuf> {
+        if result.version != 1 {
+            bail!("unsupported local action result version");
+        }
+        for digest in [
+            Some(&result.action),
+            result.metadata.as_ref(),
+            result.output_root.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if self.cas.find(digest)?.is_none() {
+                bail!("cannot publish an action result with a missing blob");
+            }
+        }
+        let destination = self.path_for(&result.action)?;
+        if let Some(existing) = self.find(&result.action)? {
+            if existing == *result {
+                return Ok(destination);
+            }
+            bail!("local action key already has a different result");
+        }
+        let parent = destination
+            .parent()
+            .expect("action-result path has a parent");
+        fs::create_dir_all(parent)?;
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        temporary.write_all(&canonical_json(result)?)?;
+        temporary.flush()?;
+        temporary.as_file().sync_all()?;
+        match temporary.persist_noclobber(&destination) {
+            Ok(_) => Ok(destination),
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => self
+                .find(&result.action)?
+                .filter(|existing| existing == result)
+                .map(|_| destination)
+                .ok_or_else(|| eyre::eyre!("concurrent action write was invalid or conflicting")),
+            Err(error) => Err(error.error.into()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,5 +203,28 @@ mod tests {
         fs::write(path, b"corrupt").unwrap();
 
         assert!(cas.find(&digest).is_err());
+    }
+
+    #[test]
+    fn publishes_action_results_after_referenced_blobs() {
+        let directory = tempfile::tempdir().unwrap();
+        let cas = LocalCas::new(directory.path());
+        let actions = LocalActionCache::new(directory.path());
+        let action = CacheDigest::blake3(b"action");
+        let metadata = CacheDigest::blake3(b"metadata");
+        let output_root = CacheDigest::blake3(b"directory");
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: Some(metadata.clone()),
+            output_root: Some(output_root.clone()),
+            version: 1,
+        };
+
+        assert!(actions.store(&result).is_err());
+        cas.store_bytes(&action, b"action").unwrap();
+        cas.store_bytes(&metadata, b"metadata").unwrap();
+        cas.store_bytes(&output_root, b"directory").unwrap();
+        actions.store(&result).unwrap();
+        assert_eq!(actions.find(&action).unwrap(), Some(result));
     }
 }

--- a/crates/mise-cache-rustc/src/dep_info.rs
+++ b/crates/mise-cache-rustc/src/dep_info.rs
@@ -5,6 +5,7 @@ use mise_cache_core::CacheDigest;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 /// A side-effect-minimized rustc invocation that emits only dependency data.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -131,6 +132,29 @@ pub struct DiscoveredInputs {
 }
 
 impl DiscoveredInputs {
+    /// Reject inputs whose modification time overlaps the compiler invocation.
+    ///
+    /// Input contents are first hashed after rustc reports their paths. This
+    /// timestamp barrier prevents a post-compile write from being mistaken for
+    /// the contents that produced the artifact. `verify` closes the remaining
+    /// race after hashing.
+    pub fn verify_not_modified_since(&self, started_at: SystemTime) -> Result<(), BypassReason> {
+        for input in &self.inputs {
+            let modified = std::fs::metadata(&input.path)
+                .and_then(|metadata| metadata.modified())
+                .map_err(|error| BypassReason::InputRead {
+                    path: input.path.clone(),
+                    message: error.to_string(),
+                })?;
+            if modified >= started_at {
+                return Err(BypassReason::InputModifiedDuringCompilation(
+                    input.path.clone(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Rehash every discovered file after compilation and before publication.
     /// This closes the discovery/compile race by degrading changed inputs to a
     /// cache miss rather than storing outputs beneath a stale action key.
@@ -420,6 +444,30 @@ mod tests {
             invocation.discover_inputs(&dep_info, root),
             Err(BypassReason::InputRead { path, .. }) if path == external
         ));
+    }
+
+    #[test]
+    fn discovery_rejects_inputs_modified_during_compilation() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("lib.rs");
+        std::fs::write(&source, "pub fn library() {}\n").unwrap();
+        let invocation = RustcInvocation::parse(&[
+            "--crate-name=widget".into(),
+            "--crate-type=lib".into(),
+            "--emit=dep-info,metadata".into(),
+            source.clone().into_os_string(),
+        ])
+        .unwrap();
+        let dep_info = RustcDepInfo::parse(&format!("output: {}\n", source.display())).unwrap();
+        let discovered = invocation
+            .discover_inputs(&dep_info, directory.path())
+            .unwrap();
+        let modified = std::fs::metadata(&source).unwrap().modified().unwrap();
+
+        assert_eq!(
+            discovered.verify_not_modified_since(modified),
+            Err(BypassReason::InputModifiedDuringCompilation(source))
+        );
     }
 
     #[test]

--- a/crates/mise-cache-rustc/src/lib.rs
+++ b/crates/mise-cache-rustc/src/lib.rs
@@ -73,6 +73,8 @@ pub enum BypassReason {
     UnsupportedEmit(String),
     #[error("rustc invocation does not emit an rlib or metadata artifact")]
     NoCacheableOutput,
+    #[error("rustc invocation does not emit dependency information")]
+    NoDepInfo,
     #[error("rustc output paths do not share one directory")]
     SplitOutputDirectories,
     #[error("rustc output path has no file name: {0}")]
@@ -147,10 +149,12 @@ pub struct RustcInvocation {
     emits: Vec<Emit>,
 }
 
+/// The cacheable files and dependency manifest produced by a rustc invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustcOutputs {
     pub directory: PathBuf,
     pub files: Vec<PathBuf>,
+    pub dep_info: PathBuf,
 }
 
 impl RustcInvocation {
@@ -164,6 +168,7 @@ impl RustcInvocation {
         Parser::new(arguments).parse()
     }
 
+    /// Return the source input passed to rustc.
     pub fn source(&self) -> &Path {
         &self.source
     }
@@ -178,13 +183,42 @@ impl RustcInvocation {
                 working_dir.to_path_buf(),
             ));
         }
-        let output_directory = self
-            .out_dir
+        let explicit_output = self
+            .explicit_output
             .as_deref()
-            .map(|path| absolute_path(path, working_dir))
+            .map(|path| absolute_path(path, working_dir));
+        let output_directory = explicit_output
+            .as_deref()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .or_else(|| {
+                self.out_dir
+                    .as_deref()
+                    .map(|path| absolute_path(path, working_dir))
+            })
             .unwrap_or_else(|| normalize_components(working_dir));
         let mut files = BTreeSet::new();
+        let mut dep_info = None;
         for emit in &self.emits {
+            if emit.kind == "dep-info" {
+                let path = emit.path.as_ref().map_or_else(
+                    || {
+                        explicit_output.clone().map_or_else(
+                            || {
+                                output_directory
+                                    .join(format!("{}{}.d", self.crate_name, self.extra_filename))
+                            },
+                            |path| path.with_extension("d"),
+                        )
+                    },
+                    |path| absolute_path(path, working_dir),
+                );
+                if path.file_name().is_none() {
+                    return Err(BypassReason::InvalidOutputPath(path));
+                }
+                dep_info = Some(path);
+                continue;
+            }
             let extension = match emit.kind.as_str() {
                 "link" => "rlib",
                 "metadata" => "rmeta",
@@ -192,27 +226,24 @@ impl RustcInvocation {
             };
             let path = if let Some(path) = &emit.path {
                 absolute_path(path, working_dir)
-            } else if emit.kind == "link"
-                && let Some(path) = &self.explicit_output
-            {
-                absolute_path(path, working_dir)
             } else {
                 output_directory.join(format!(
                     "lib{}{}.{}",
                     self.crate_name, self.extra_filename, extension
                 ))
             };
-            if path.parent() != Some(output_directory.as_path()) {
-                return Err(BypassReason::SplitOutputDirectories);
-            }
             if path.file_name().is_none() {
                 return Err(BypassReason::InvalidOutputPath(path));
+            }
+            if path.parent() != Some(output_directory.as_path()) {
+                return Err(BypassReason::SplitOutputDirectories);
             }
             files.insert(path);
         }
         Ok(RustcOutputs {
             directory: output_directory,
             files: files.into_iter().collect(),
+            dep_info: dep_info.ok_or(BypassReason::NoDepInfo)?,
         })
     }
 
@@ -233,6 +264,7 @@ pub struct PathMapping {
 }
 
 impl PathMapping {
+    /// Map an absolute host path to a stable cache-key placeholder.
     pub fn new(root: impl Into<PathBuf>, placeholder: impl Into<String>) -> Self {
         Self {
             root: root.into(),
@@ -349,7 +381,7 @@ impl<'a> Parser<'a> {
                 source
                     .file_stem()
                     .and_then(|name| name.to_str())
-                    .map(ToOwned::to_owned)
+                    .map(|name| name.replace('-', "_"))
                     .ok_or_else(|| BypassReason::NonUtf8Path(source.clone()))
             },
             Ok,
@@ -947,6 +979,49 @@ mod tests {
                     working_dir.join("target/debug/deps/libwidget-abc123.rlib"),
                     working_dir.join("target/debug/deps/libwidget-abc123.rmeta"),
                 ],
+                dep_info: working_dir.join("target/debug/deps/widget-abc123.d"),
+            }
+        );
+    }
+
+    #[test]
+    fn infers_a_valid_crate_name_from_a_hyphenated_source() {
+        let working_dir = absolute(&["workspace"]);
+        let invocation = RustcInvocation::parse(&args(&[
+            "--crate-type=lib",
+            "--emit=dep-info,metadata",
+            "my-library.rs",
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            invocation.outputs(&working_dir).unwrap().dep_info,
+            working_dir.join("my_library.d")
+        );
+    }
+
+    #[test]
+    fn resolves_multiple_outputs_with_an_explicit_output_stem() {
+        let working_dir = absolute(&["workspace"]);
+        let invocation = RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+            "-o",
+            "target/custom.rlib",
+            "src/lib.rs",
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            invocation.outputs(&working_dir).unwrap(),
+            RustcOutputs {
+                directory: working_dir.join("target"),
+                files: vec![
+                    working_dir.join("target/libwidget.rlib"),
+                    working_dir.join("target/libwidget.rmeta"),
+                ],
+                dep_info: working_dir.join("target/custom.d"),
             }
         );
     }

--- a/crates/mise-cache-rustc/src/lib.rs
+++ b/crates/mise-cache-rustc/src/lib.rs
@@ -113,6 +113,8 @@ pub enum BypassReason {
     InputRead { path: PathBuf, message: String },
     #[error("compiler input changed after discovery: {0}")]
     InputChanged(PathBuf),
+    #[error("compiler input was modified during compilation: {0}")]
+    InputModifiedDuringCompilation(PathBuf),
     #[error("discovered inputs were collected from a different working directory")]
     DiscoveryWorkingDirectory,
     #[error("compiler environment input has conflicting values: {0}")]

--- a/crates/mise-cache-rustc/src/lib.rs
+++ b/crates/mise-cache-rustc/src/lib.rs
@@ -73,6 +73,10 @@ pub enum BypassReason {
     UnsupportedEmit(String),
     #[error("rustc invocation does not emit an rlib or metadata artifact")]
     NoCacheableOutput,
+    #[error("rustc output paths do not share one directory")]
+    SplitOutputDirectories,
+    #[error("rustc output path has no file name: {0}")]
+    InvalidOutputPath(PathBuf),
     #[error("native library lookup is not cacheable yet")]
     NativeLibrary,
     #[error("rustc search path kind is not cacheable yet: {0}")]
@@ -136,6 +140,17 @@ pub struct RustcInvocation {
     arguments: Vec<Argument>,
     source: PathBuf,
     required_inputs: Vec<PathBuf>,
+    crate_name: String,
+    extra_filename: String,
+    out_dir: Option<PathBuf>,
+    explicit_output: Option<PathBuf>,
+    emits: Vec<Emit>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RustcOutputs {
+    pub directory: PathBuf,
+    pub files: Vec<PathBuf>,
 }
 
 impl RustcInvocation {
@@ -151,6 +166,54 @@ impl RustcInvocation {
 
     pub fn source(&self) -> &Path {
         &self.source
+    }
+
+    /// Resolve the rlib/rmeta files produced by this invocation.
+    ///
+    /// The initial cache tier requires one output directory so its artifact can
+    /// be represented by one protocol directory and restored atomically later.
+    pub fn outputs(&self, working_dir: &Path) -> Result<RustcOutputs, BypassReason> {
+        if !working_dir.is_absolute() {
+            return Err(BypassReason::RelativeWorkingDirectory(
+                working_dir.to_path_buf(),
+            ));
+        }
+        let output_directory = self
+            .out_dir
+            .as_deref()
+            .map(|path| absolute_path(path, working_dir))
+            .unwrap_or_else(|| normalize_components(working_dir));
+        let mut files = BTreeSet::new();
+        for emit in &self.emits {
+            let extension = match emit.kind.as_str() {
+                "link" => "rlib",
+                "metadata" => "rmeta",
+                _ => continue,
+            };
+            let path = if let Some(path) = &emit.path {
+                absolute_path(path, working_dir)
+            } else if emit.kind == "link"
+                && let Some(path) = &self.explicit_output
+            {
+                absolute_path(path, working_dir)
+            } else {
+                output_directory.join(format!(
+                    "lib{}{}.{}",
+                    self.crate_name, self.extra_filename, extension
+                ))
+            };
+            if path.parent() != Some(output_directory.as_path()) {
+                return Err(BypassReason::SplitOutputDirectories);
+            }
+            if path.file_name().is_none() {
+                return Err(BypassReason::InvalidOutputPath(path));
+            }
+            files.insert(path);
+        }
+        Ok(RustcOutputs {
+            directory: output_directory,
+            files: files.into_iter().collect(),
+        })
     }
 
     /// Build canonical action bytes after precise input discovery has run.
@@ -239,6 +302,10 @@ struct Parser<'a> {
     emits: Vec<Emit>,
     required_inputs: Vec<PathBuf>,
     test: bool,
+    crate_name: Option<String>,
+    extra_filename: String,
+    out_dir: Option<PathBuf>,
+    explicit_output: Option<PathBuf>,
 }
 
 impl<'a> Parser<'a> {
@@ -252,6 +319,10 @@ impl<'a> Parser<'a> {
             emits: Vec::new(),
             required_inputs: Vec::new(),
             test: false,
+            crate_name: None,
+            extra_filename: String::new(),
+            out_dir: None,
+            explicit_output: None,
         }
     }
 
@@ -273,11 +344,26 @@ impl<'a> Parser<'a> {
 
         let source = self.source.clone().ok_or(BypassReason::MissingInput)?;
         self.classify()?;
+        let crate_name = self.crate_name.clone().map_or_else(
+            || {
+                source
+                    .file_stem()
+                    .and_then(|name| name.to_str())
+                    .map(ToOwned::to_owned)
+                    .ok_or_else(|| BypassReason::NonUtf8Path(source.clone()))
+            },
+            Ok,
+        )?;
         self.required_inputs.push(source.clone());
         Ok(RustcInvocation {
             arguments: self.parsed,
             source,
             required_inputs: self.required_inputs,
+            crate_name,
+            extra_filename: self.extra_filename,
+            out_dir: self.out_dir,
+            explicit_output: self.explicit_output,
+            emits: self.emits,
         })
     }
 
@@ -318,7 +404,14 @@ impl<'a> Parser<'a> {
                 self.parsed.push(Argument::Plain(rendered_flag));
                 Ok(())
             }
-            "cfg" | "check-cfg" | "crate-name" | "edition" | "error-format" | "json" | "color"
+            "crate-name" => {
+                let value = self.take_value(&rendered_flag, inline)?;
+                self.crate_name = Some(value.clone());
+                self.parsed
+                    .push(Argument::Plain(format!("{rendered_flag}={value}")));
+                Ok(())
+            }
+            "cfg" | "check-cfg" | "edition" | "error-format" | "json" | "color"
             | "diagnostic-width" | "remap-path-scope" | "allow" | "warn" | "force-warn"
             | "deny" | "forbid" | "cap-lints" => {
                 let value = self.take_value(&rendered_flag, inline)?;
@@ -356,7 +449,16 @@ impl<'a> Parser<'a> {
                 self.parsed.push(Argument::Emit(emits));
                 Ok(())
             }
-            "out-dir" | "sysroot" => {
+            "out-dir" => {
+                let path = PathBuf::from(self.take_value(&rendered_flag, inline)?);
+                self.out_dir = Some(path.clone());
+                self.parsed.push(Argument::Path {
+                    flag: rendered_flag,
+                    path,
+                });
+                Ok(())
+            }
+            "sysroot" => {
                 let path = self.take_value(&rendered_flag, inline)?;
                 self.parsed.push(Argument::Path {
                     flag: rendered_flag,
@@ -443,6 +545,7 @@ impl<'a> Parser<'a> {
         }
         if let Some(attached) = value.strip_prefix("-o") {
             let path = self.take_value("-o", (!attached.is_empty()).then_some(attached))?;
+            self.explicit_output = Some(path.clone().into());
             self.parsed.push(Argument::Path {
                 flag: "-o".into(),
                 path: path.into(),
@@ -462,6 +565,11 @@ impl<'a> Parser<'a> {
         }
         self.parsed
             .push(Argument::Plain(format!("--codegen={value}")));
+        if name == "extra-filename" {
+            self.extra_filename = value
+                .split_once('=')
+                .map_or(String::new(), |(_, value)| value.to_string());
+        }
         Ok(())
     }
 
@@ -699,6 +807,14 @@ fn normalize_components(path: &Path) -> PathBuf {
     normalized
 }
 
+fn absolute_path(path: &Path, working_dir: &Path) -> PathBuf {
+    if path.is_absolute() {
+        normalize_components(path)
+    } else {
+        normalize_components(&working_dir.join(path))
+    }
+}
+
 fn slash_path(path: &Path) -> Result<String, BypassReason> {
     path.components()
         .filter_map(|component| match component {
@@ -809,6 +925,30 @@ mod tests {
         assert!(json.contains(r#""--out-dir=${target}/debug/deps""#));
         assert!(json.contains(r#""--extern=serde=${target}/debug/deps/libserde.rlib""#));
         assert_eq!(action.digest.algorithm, "blake3");
+    }
+
+    #[test]
+    fn resolves_cargo_library_outputs() {
+        let working_dir = absolute(&["workspace"]);
+        let invocation = RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+            "--out-dir=target/debug/deps",
+            "-Cextra-filename=-abc123",
+            "src/lib.rs",
+        ]))
+        .unwrap();
+        assert_eq!(
+            invocation.outputs(&working_dir).unwrap(),
+            RustcOutputs {
+                directory: working_dir.join("target/debug/deps"),
+                files: vec![
+                    working_dir.join("target/debug/deps/libwidget-abc123.rlib"),
+                    working_dir.join("target/debug/deps/libwidget-abc123.rmeta"),
+                ],
+            }
+        );
     }
 
     #[test]

--- a/e2e/tasks/test_task_action_cache_session
+++ b/e2e/tasks/test_task_action_cache_session
@@ -22,14 +22,41 @@ rust_cache = true
 deny_env = true
 run = '''
 test -n "$MISE_CACHE_SOCKET"
+test -n "$MISE_CACHE_STAGING_DIR"
 test "$CARGO_INCREMENTAL" = 0
 "$RUSTC_WRAPPER" true
 '''
+
+[tasks.compile]
+rust_cache = true
+deny_write = true
+allow_write = ["target"]
+run = '''
+cargo build
+test -f target/debug/libcache_e2e.rlib
+'''
+EOF
+
+cat <<'EOF' >Cargo.toml
+[package]
+name = "cache-e2e"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "lib.rs"
+EOF
+
+cat <<'EOF' >lib.rs
+pub fn cached_library() -> usize { 42 }
 EOF
 
 mise run disabled
 RUSTC_WRAPPER=/usr/bin/env mise run rust
 RUSTC_WRAPPER=/usr/bin/env mise run sandboxed
+assert_contains "mise run compile 2>&1" "stored"
+assert_not_empty \
+  "find \"$(mise cache path)/task-artifacts/v2/actions/action-results\" -type f -name '*.json' -print -quit"
 
 assert_fail_contains \
   "MISE_EXPERIMENTAL=0 mise run rust" \

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -24,6 +24,7 @@ use crate::rand::random_string;
 use crate::toolset::env_cache::CachedEnv;
 use crate::{dirs, file};
 
+pub(crate) mod rustc;
 pub(crate) mod session;
 
 pub use mise_cache_core::RemoteCacheMode as CacheRemoteMode;

--- a/src/cache/rustc.rs
+++ b/src/cache/rustc.rs
@@ -12,11 +12,13 @@ use std::ffi::{OsStr, OsString};
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, ExitStatus, Output};
+use std::time::SystemTime;
 
 pub(super) fn compile_miss(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
     let invocation = RustcInvocation::parse(arguments)?;
     let working_dir = std::env::current_dir()?;
     let outputs = invocation.outputs(&working_dir)?;
+    let compilation_started = SystemTime::now();
     let output = Command::new(rustc)
         .args(arguments)
         .current_dir(&working_dir)
@@ -27,6 +29,7 @@ pub(super) fn compile_miss(rustc: &OsStr, arguments: &[OsString]) -> Result<Exit
         let publication = (|| {
             let dep_info = RustcDepInfo::read(&outputs.dep_info)?;
             let discovered = invocation.discover_inputs(&dep_info, &working_dir)?;
+            discovered.verify_not_modified_since(compilation_started)?;
             let mut context = ActionContext {
                 compiler: compiler_identity(rustc)?,
                 working_dir: working_dir.clone(),

--- a/src/cache/rustc.rs
+++ b/src/cache/rustc.rs
@@ -1,0 +1,337 @@
+use super::session;
+use eyre::{Context, Result, bail};
+use mise_cache_core::{
+    AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode, RemoteActionResult,
+    RustcMetadata, canonical_json,
+};
+use mise_cache_rustc::{
+    ActionContext, CompilerIdentity, PathMapping, RustcDepInfo, RustcInvocation,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::{OsStr, OsString};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode, ExitStatus, Output};
+
+pub(super) fn compile_miss(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
+    let invocation = RustcInvocation::parse(arguments)?;
+    let working_dir = std::env::current_dir()?.canonicalize()?;
+    let outputs = invocation.outputs(&working_dir)?;
+    let discovery_dir = staging_directory()?;
+    let dep_info_path = discovery_dir.path().join("inputs.d");
+    let discovery_command = invocation.dep_info_command(&dep_info_path)?;
+    let discovery = Command::new(rustc)
+        .args(discovery_command.arguments())
+        .current_dir(&working_dir)
+        .output()
+        .wrap_err("failed to run rustc input discovery")?;
+    if !discovery.status.success() {
+        bail!("rustc input discovery did not succeed");
+    }
+
+    let dep_info = RustcDepInfo::read(&dep_info_path)?;
+    let discovered = invocation.discover_inputs(&dep_info, &working_dir)?;
+    let mut context = ActionContext {
+        compiler: compiler_identity(rustc)?,
+        working_dir: working_dir.clone(),
+        path_mappings: path_mappings(&working_dir),
+        environment: BTreeMap::new(),
+        inputs: Vec::new(),
+    };
+    discovered.clone().apply_to(&mut context)?;
+    let action = invocation.action(context)?;
+
+    let output = Command::new(rustc)
+        .args(arguments)
+        .current_dir(&working_dir)
+        .output()
+        .wrap_err("failed to execute rustc")?;
+    let status = exit_code(output.status);
+    let _ = replay_output(&output);
+    if output.status.success() {
+        let publication = discovered
+            .verify()
+            .map_err(eyre::Report::from)
+            .and_then(|()| publish_result(&action.digest, &action.bytes, &outputs.files, &output));
+        if let Err(error) = publication {
+            eprintln!("mise rustc cache warning: result was not stored: {error:#}");
+        }
+    }
+    Ok(status)
+}
+
+fn compiler_identity(rustc: &OsStr) -> Result<CompilerIdentity> {
+    let responses = session::request_agent(&[AgentRequest::IdentifyExecutable {
+        executable: resolve_executable(rustc)?,
+        arguments: vec!["-vV".into()],
+        environment: ["RUSTUP_HOME", "RUSTUP_TOOLCHAIN"]
+            .into_iter()
+            .map(|name| (name.into(), std::env::var(name).ok()))
+            .collect(),
+    }])?;
+    let Some(AgentResponse::ExecutableIdentity { stdout }) = responses.into_iter().next() else {
+        bail!("cache agent did not return the rustc identity");
+    };
+    let verbose = std::str::from_utf8(&stdout).wrap_err("rustc identity is not UTF-8")?;
+    let release = identity_field(verbose, "release")?;
+    let host = identity_field(verbose, "host")?;
+    let rustc_version = verbose
+        .lines()
+        .filter(|line| {
+            line.starts_with("rustc ")
+                || line.starts_with("commit-hash:")
+                || line.starts_with("commit-date:")
+                || line.starts_with("LLVM version:")
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    if rustc_version.is_empty() {
+        bail!("rustc identity is missing its version");
+    }
+    let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| release.to_string());
+    Ok(CompilerIdentity {
+        toolchain,
+        rustc_version,
+        host: host.to_string(),
+    })
+}
+
+fn identity_field<'a>(verbose: &'a str, field: &str) -> Result<&'a str> {
+    verbose
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{field}: ")))
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| eyre::eyre!("rustc identity is missing {field}"))
+}
+
+fn path_mappings(working_dir: &Path) -> Vec<PathMapping> {
+    let mut mappings = Vec::new();
+    let mut roots = BTreeSet::new();
+    add_mapping(
+        &mut mappings,
+        &mut roots,
+        working_dir.to_path_buf(),
+        "workspace",
+    );
+    for (name, placeholder) in [
+        ("CARGO_HOME", "cargo_home"),
+        ("RUSTUP_HOME", "rustup_home"),
+        ("HOME", "home"),
+        ("USERPROFILE", "home"),
+    ] {
+        if let Some(root) = std::env::var_os(name).map(PathBuf::from)
+            && root.is_absolute()
+        {
+            add_mapping(&mut mappings, &mut roots, root, placeholder);
+        }
+    }
+    mappings
+}
+
+fn add_mapping(
+    mappings: &mut Vec<PathMapping>,
+    roots: &mut BTreeSet<PathBuf>,
+    root: PathBuf,
+    placeholder: &str,
+) {
+    if roots.insert(root.clone())
+        && !mappings
+            .iter()
+            .any(|mapping| mapping.placeholder == placeholder)
+    {
+        mappings.push(PathMapping::new(root, placeholder));
+    }
+}
+
+fn replay_output(output: &Output) -> Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(&output.stdout)?;
+    stdout.flush()?;
+    let mut stderr = std::io::stderr().lock();
+    stderr.write_all(&output.stderr)?;
+    stderr.flush()?;
+    Ok(())
+}
+
+fn staging_directory() -> Result<tempfile::TempDir> {
+    let root = std::env::var_os("MISE_CACHE_STAGING_DIR")
+        .map(PathBuf::from)
+        .ok_or_else(|| eyre::eyre!("MISE_CACHE_STAGING_DIR is not set"))?;
+    Ok(tempfile::tempdir_in(root)?)
+}
+
+fn resolve_executable(executable: &OsStr) -> Result<PathBuf> {
+    let executable = PathBuf::from(executable);
+    if executable.is_absolute() {
+        return Ok(executable);
+    }
+    if executable.components().count() > 1 {
+        return Ok(std::env::current_dir()?.join(executable));
+    }
+    let path = std::env::var_os("PATH").ok_or_else(|| eyre::eyre!("PATH is not set"))?;
+    for directory in std::env::split_paths(&path) {
+        let candidate = directory.join(&executable);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+        #[cfg(windows)]
+        {
+            let candidate = candidate.with_extension("exe");
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+    }
+    bail!(
+        "failed to resolve compiler executable {}",
+        executable.display()
+    )
+}
+
+fn publish_result(
+    action: &CacheDigest,
+    action_bytes: &[u8],
+    outputs: &[PathBuf],
+    output: &Output,
+) -> Result<()> {
+    if outputs.is_empty() {
+        bail!("rustc produced no cacheable outputs");
+    }
+    let staging = staging_directory()?;
+    let mut blobs = vec![staged_bytes(staging.path(), "action.json", action_bytes)?];
+    let stdout = staged_bytes(staging.path(), "stdout", &output.stdout)?;
+    let stderr = staged_bytes(staging.path(), "stderr", &output.stderr)?;
+    blobs.extend([stdout.clone(), stderr.clone()]);
+
+    let mut files = Vec::with_capacity(outputs.len());
+    for path in outputs {
+        let metadata = std::fs::metadata(path)
+            .wrap_err_with(|| format!("failed to inspect rustc output {}", path.display()))?;
+        if !metadata.is_file() {
+            bail!("rustc output is not a regular file: {}", path.display());
+        }
+        let digest = CacheDigest::blake3_file(path)?;
+        blobs.push((digest.clone(), path.clone()));
+        files.push(CacheFileNode {
+            digest,
+            executable: false,
+            mode: file_mode(&metadata),
+            name: path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| eyre::eyre!("rustc output name is not UTF-8"))?
+                .to_string(),
+        });
+    }
+    files.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let metadata = canonical_json(&RustcMetadata {
+        version: 1,
+        kind: "rustc".into(),
+        stdout: stdout.0,
+        stderr: stderr.0,
+    })?;
+    let metadata = staged_bytes(staging.path(), "metadata.json", &metadata)?;
+    blobs.push(metadata.clone());
+    let directory = canonical_json(&CacheDirectory {
+        directories: Vec::new(),
+        files,
+        symlinks: Vec::new(),
+        version: 1,
+    })?;
+    let directory = staged_bytes(staging.path(), "directory.json", &directory)?;
+    blobs.push(directory.clone());
+
+    let mut requests = Vec::new();
+    let mut published = BTreeSet::new();
+    for (digest, source) in blobs {
+        if published.insert(digest.clone()) {
+            requests.push(AgentRequest::StoreBlob { digest, source });
+        }
+    }
+    requests.push(AgentRequest::StoreActionResult {
+        result: RemoteActionResult {
+            action: action.clone(),
+            metadata: Some(metadata.0),
+            output_root: Some(directory.0),
+            version: 1,
+        },
+    });
+    for response in session::request_agent(&requests)? {
+        match response {
+            AgentResponse::Stored { .. } | AgentResponse::ActionStored { .. } => {}
+            AgentResponse::Error { message } => bail!(message),
+            _ => bail!("cache agent returned an unexpected publish response"),
+        }
+    }
+    Ok(())
+}
+
+fn staged_bytes(directory: &Path, name: &str, bytes: &[u8]) -> Result<(CacheDigest, PathBuf)> {
+    let path = directory.join(name);
+    std::fs::write(&path, bytes)?;
+    Ok((CacheDigest::blake3(bytes), path))
+}
+
+#[cfg(unix)]
+fn file_mode(metadata: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt as _;
+    metadata.permissions().mode() & 0o777
+}
+
+#[cfg(windows)]
+fn file_mode(_metadata: &std::fs::Metadata) -> u32 {
+    0
+}
+
+#[cfg(unix)]
+fn exit_code(status: ExitStatus) -> ExitCode {
+    use std::os::unix::process::ExitStatusExt as _;
+    ExitCode::from(
+        status
+            .code()
+            .unwrap_or_else(|| 128 + status.signal().unwrap_or(1)) as u8,
+    )
+}
+
+#[cfg(windows)]
+fn exit_code(status: ExitStatus) -> ExitCode {
+    // SAFETY: this process is only a compiler wrapper and must preserve the
+    // compiler's full Windows status code, which stable ExitCode cannot hold.
+    unsafe { windows_sys::Win32::System::Threading::ExitProcess(status.code().unwrap_or(1) as u32) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_verbose_rustc_identity() {
+        let verbose = "rustc 1.97.0 (abc 2026-08-01)\n\
+                       binary: rustc\n\
+                       commit-hash: abc\n\
+                       commit-date: 2026-08-01\n\
+                       host: x86_64-unknown-linux-gnu\n\
+                       release: 1.97.0\n\
+                       LLVM version: 22.0.0\n";
+        assert_eq!(identity_field(verbose, "release").unwrap(), "1.97.0");
+        assert_eq!(
+            identity_field(verbose, "host").unwrap(),
+            "x86_64-unknown-linux-gnu"
+        );
+    }
+
+    #[test]
+    fn mappings_do_not_duplicate_home_placeholders() {
+        let directory = tempfile::tempdir().unwrap();
+        let mappings = path_mappings(directory.path());
+        let placeholders = mappings
+            .iter()
+            .map(|mapping| &mapping.placeholder)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(placeholders.len(), mappings.len());
+    }
+}

--- a/src/cache/rustc.rs
+++ b/src/cache/rustc.rs
@@ -15,62 +15,83 @@ use std::process::{Command, ExitCode, ExitStatus, Output};
 
 pub(super) fn compile_miss(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
     let invocation = RustcInvocation::parse(arguments)?;
-    let working_dir = std::env::current_dir()?.canonicalize()?;
+    let working_dir = std::env::current_dir()?;
     let outputs = invocation.outputs(&working_dir)?;
-    let discovery_dir = staging_directory()?;
-    let dep_info_path = discovery_dir.path().join("inputs.d");
-    let discovery_command = invocation.dep_info_command(&dep_info_path)?;
-    let discovery = Command::new(rustc)
-        .args(discovery_command.arguments())
-        .current_dir(&working_dir)
-        .output()
-        .wrap_err("failed to run rustc input discovery")?;
-    if !discovery.status.success() {
-        bail!("rustc input discovery did not succeed");
-    }
-
-    let dep_info = RustcDepInfo::read(&dep_info_path)?;
-    let discovered = invocation.discover_inputs(&dep_info, &working_dir)?;
-    let mut context = ActionContext {
-        compiler: compiler_identity(rustc)?,
-        working_dir: working_dir.clone(),
-        path_mappings: path_mappings(&working_dir),
-        environment: BTreeMap::new(),
-        inputs: Vec::new(),
-    };
-    discovered.clone().apply_to(&mut context)?;
-    let action = invocation.action(context)?;
-
     let output = Command::new(rustc)
         .args(arguments)
         .current_dir(&working_dir)
         .output()
         .wrap_err("failed to execute rustc")?;
-    let status = exit_code(output.status);
     let _ = replay_output(&output);
     if output.status.success() {
-        let publication = discovered
-            .verify()
-            .map_err(eyre::Report::from)
-            .and_then(|()| publish_result(&action.digest, &action.bytes, &outputs.files, &output));
+        let publication = (|| {
+            let dep_info = RustcDepInfo::read(&outputs.dep_info)?;
+            let discovered = invocation.discover_inputs(&dep_info, &working_dir)?;
+            let mut context = ActionContext {
+                compiler: compiler_identity(rustc)?,
+                working_dir: working_dir.clone(),
+                path_mappings: path_mappings(&working_dir),
+                environment: BTreeMap::new(),
+                inputs: Vec::new(),
+            };
+            discovered.clone().apply_to(&mut context)?;
+            let action = invocation.action(context)?;
+            discovered.verify()?;
+            publish_result(&action.digest, &action.bytes, &outputs.files, &output)
+        })();
         if let Err(error) = publication {
             eprintln!("mise rustc cache warning: result was not stored: {error:#}");
         }
     }
-    Ok(status)
+    Ok(exit_code(output.status))
 }
 
 fn compiler_identity(rustc: &OsStr) -> Result<CompilerIdentity> {
-    let responses = session::request_agent(&[AgentRequest::IdentifyExecutable {
-        executable: resolve_executable(rustc)?,
-        arguments: vec!["-vV".into()],
-        environment: ["RUSTUP_HOME", "RUSTUP_TOOLCHAIN"]
-            .into_iter()
-            .map(|name| (name.into(), std::env::var(name).ok()))
-            .collect(),
+    let executable = resolve_executable(rustc)?;
+    let environment = ["RUSTUP_HOME", "RUSTUP_TOOLCHAIN"]
+        .into_iter()
+        .map(|name| (name.into(), std::env::var(name).ok()))
+        .collect::<BTreeMap<_, _>>();
+    let responses = session::request_agent(&[AgentRequest::FindExecutableIdentity {
+        executable: executable.clone(),
+        environment: environment.clone(),
     }])?;
     let Some(AgentResponse::ExecutableIdentity { stdout }) = responses.into_iter().next() else {
         bail!("cache agent did not return the rustc identity");
+    };
+    let stdout = if let Some(stdout) = stdout {
+        stdout
+    } else {
+        let mut command = Command::new(&executable);
+        command.arg("-vV");
+        for (name, value) in &environment {
+            if let Some(value) = value {
+                command.env(name, value);
+            } else {
+                command.env_remove(name);
+            }
+        }
+        let output = command
+            .output()
+            .wrap_err("failed to query the rustc identity")?;
+        if !output.status.success() {
+            bail!(
+                "rustc identity command failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let responses = session::request_agent(&[AgentRequest::StoreExecutableIdentity {
+            executable,
+            environment,
+            stdout: output.stdout,
+        }])?;
+        let Some(AgentResponse::ExecutableIdentity {
+            stdout: Some(stdout),
+        }) = responses.into_iter().next()
+        else {
+            bail!("cache agent did not store the rustc identity");
+        };
+        stdout
     };
     let verbose = std::str::from_utf8(&stdout).wrap_err("rustc identity is not UTF-8")?;
     let release = identity_field(verbose, "release")?;
@@ -157,9 +178,9 @@ fn replay_output(output: &Output) -> Result<()> {
 }
 
 fn staging_directory() -> Result<tempfile::TempDir> {
-    let root = std::env::var_os("MISE_CACHE_STAGING_DIR")
+    let root = std::env::var_os(session::STAGING_ENV)
         .map(PathBuf::from)
-        .ok_or_else(|| eyre::eyre!("MISE_CACHE_STAGING_DIR is not set"))?;
+        .ok_or_else(|| eyre::eyre!("{} is not set", session::STAGING_ENV))?;
     Ok(tempfile::tempdir_in(root)?)
 }
 
@@ -168,27 +189,12 @@ fn resolve_executable(executable: &OsStr) -> Result<PathBuf> {
     if executable.is_absolute() {
         return Ok(executable);
     }
-    if executable.components().count() > 1 {
-        return Ok(std::env::current_dir()?.join(executable));
-    }
-    let path = std::env::var_os("PATH").ok_or_else(|| eyre::eyre!("PATH is not set"))?;
-    for directory in std::env::split_paths(&path) {
-        let candidate = directory.join(&executable);
-        if candidate.is_file() {
-            return Ok(candidate);
-        }
-        #[cfg(windows)]
-        {
-            let candidate = candidate.with_extension("exe");
-            if candidate.is_file() {
-                return Ok(candidate);
-            }
-        }
-    }
-    bail!(
-        "failed to resolve compiler executable {}",
-        executable.display()
-    )
+    which::which(&executable).wrap_err_with(|| {
+        format!(
+            "failed to resolve compiler executable {}",
+            executable.display()
+        )
+    })
 }
 
 fn publish_result(

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -18,7 +18,7 @@ use tokio::task::JoinHandle;
 
 const RUSTC_SHIM_STEM: &str = "mise-cache-rustc";
 const SOCKET_ENV: &str = "MISE_CACHE_SOCKET";
-const STAGING_ENV: &str = "MISE_CACHE_STAGING_DIR";
+pub(super) const STAGING_ENV: &str = "MISE_CACHE_STAGING_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -18,6 +18,7 @@ use tokio::task::JoinHandle;
 
 const RUSTC_SHIM_STEM: &str = "mise-cache-rustc";
 const SOCKET_ENV: &str = "MISE_CACHE_SOCKET";
+const STAGING_ENV: &str = "MISE_CACHE_STAGING_DIR";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -25,6 +26,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub(crate) struct CacheSessionEnvironment {
     socket: String,
     rustc_shim: String,
+    staging: String,
 }
 
 impl CacheSessionEnvironment {
@@ -33,6 +35,7 @@ impl CacheSessionEnvironment {
             return;
         }
         environment.insert(SOCKET_ENV.into(), self.socket.clone());
+        environment.insert(STAGING_ENV.into(), self.staging.clone());
         if let Some(previous) = environment.insert("RUSTC_WRAPPER".into(), self.rustc_shim.clone())
             && previous != self.rustc_shim
         {
@@ -41,8 +44,12 @@ impl CacheSessionEnvironment {
         environment.insert("CARGO_INCREMENTAL".into(), "0".into());
     }
 
-    pub(crate) fn sandbox_paths(&self) -> [PathBuf; 2] {
-        [PathBuf::from(&self.rustc_shim), PathBuf::from(&self.socket)]
+    pub(crate) fn sandbox_paths(&self) -> [PathBuf; 3] {
+        [
+            PathBuf::from(&self.rustc_shim),
+            PathBuf::from(&self.socket),
+            PathBuf::from(&self.staging),
+        ]
     }
 }
 
@@ -56,6 +63,8 @@ pub(crate) struct CacheSession {
 impl CacheSession {
     pub(crate) async fn start(session_dir: &Path, cache_dir: PathBuf) -> Result<Self> {
         let shim = install_session_shim(session_dir)?;
+        let staging = session_dir.join("staging");
+        std::fs::create_dir(&staging)?;
         let agent = CacheAgent::new(cache_dir, VERSION);
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (socket, server) = spawn_server(session_dir, agent.clone(), shutdown_rx).await?;
@@ -63,6 +72,7 @@ impl CacheSession {
             environment: CacheSessionEnvironment {
                 socket,
                 rustc_shim: shim.to_string_lossy().into_owned(),
+                staging: staging.to_string_lossy().into_owned(),
             },
             agent,
             shutdown: Mutex::new(Some(shutdown_tx)),
@@ -391,25 +401,35 @@ pub(crate) fn is_rustc_shim() -> bool {
 /// Ultra-early argv0 path used by Cargo's `RUSTC_WRAPPER` integration.
 ///
 /// This runs before mise creates a Tokio runtime, installs logging, or discovers
-/// configuration. The Rust adapter will replace the transparent compiler call;
-/// until then this establishes and benchmarks the final process/session shape.
+/// configuration. Cacheable misses publish through the task-scoped agent;
+/// unsupported invocations remain transparent compiler calls.
 pub(crate) fn run_rustc_shim() -> ExitCode {
-    if let Err(_error) = handshake_from_environment() {
-        #[cfg(debug_assertions)]
-        eprintln!("mise action-cache shim is running uncached: {_error}");
-    }
-
     let mut arguments = std::env::args_os().skip(1);
     let Some(rustc) = arguments.next() else {
         eprintln!("mise action-cache shim expected the rustc executable as its first argument");
         return ExitCode::from(1);
     };
+    let arguments = arguments.collect::<Vec<_>>();
+    if std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV).is_none() {
+        match crate::cache::rustc::compile_miss(&rustc, &arguments) {
+            Ok(exit_code) => return exit_code,
+            Err(_error) => {
+                #[cfg(debug_assertions)]
+                eprintln!("mise rustc cache bypassed: {_error:#}");
+            }
+        }
+    }
+
+    run_transparent_rustc(rustc, arguments)
+}
+
+fn run_transparent_rustc(rustc: OsString, arguments: Vec<OsString>) -> ExitCode {
     let mut command = if let Some(wrapper) = std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV) {
         let mut command = Command::new(wrapper);
-        command.arg(rustc);
+        command.arg(&rustc);
         command
     } else {
-        Command::new(rustc)
+        Command::new(&rustc)
     };
     command.args(arguments);
     command.env_remove(PREVIOUS_RUSTC_WRAPPER_ENV);
@@ -452,21 +472,25 @@ pub(crate) fn run_rustc_shim() -> ExitCode {
     }
 }
 
-fn handshake_from_environment() -> Result<()> {
+pub(super) fn request_agent(requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
     let socket =
         std::env::var_os(SOCKET_ENV).ok_or_else(|| eyre::eyre!("{SOCKET_ENV} is not set"))?;
-    handshake(&socket)
+    request_agent_at(&socket, requests)
 }
 
 #[cfg(unix)]
-fn handshake(socket: &OsString) -> Result<()> {
-    let stream = std::os::unix::net::UnixStream::connect(Path::new(socket))
+fn request_agent_at(socket: &OsString, requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
+    let mut stream = std::os::unix::net::UnixStream::connect(Path::new(socket))
         .wrap_err("failed to connect to the action-cache session")?;
-    sync_handshake(stream)
+    sync_handshake(&mut stream)?;
+    requests
+        .iter()
+        .map(|request| sync_request(&mut stream, request))
+        .collect()
 }
 
 #[cfg(windows)]
-fn handshake(socket: &OsString) -> Result<()> {
+fn request_agent_at(socket: &OsString, requests: &[AgentRequest]) -> Result<Vec<AgentResponse>> {
     let endpoint = socket.to_string_lossy().into_owned();
     tokio::runtime::Builder::new_current_thread()
         .enable_io()
@@ -485,25 +509,51 @@ fn handshake(socket: &OsString) -> Result<()> {
             stream.write_all(&encoded).await?;
             stream.flush().await?;
             let mut response = String::new();
-            tokio::io::BufReader::new(stream)
+            tokio::io::BufReader::new(&mut stream)
                 .read_line(&mut response)
                 .await?;
-            validate_handshake_response(&response)
+            validate_handshake_response(&response)?;
+            let mut responses = Vec::with_capacity(requests.len());
+            for request in requests {
+                let mut encoded = serde_json::to_vec(request)?;
+                encoded.push(b'\n');
+                stream.write_all(&encoded).await?;
+                stream.flush().await?;
+                let mut response = String::new();
+                tokio::io::BufReader::new(&mut stream)
+                    .read_line(&mut response)
+                    .await?;
+                responses.push(serde_json::from_str(&response)?);
+            }
+            Ok(responses)
         })
 }
 
 #[cfg(unix)]
-fn sync_handshake(mut stream: impl std::io::Read + Write) -> Result<()> {
+fn sync_handshake(stream: &mut (impl std::io::Read + Write)) -> Result<()> {
     let request = AgentRequest::Hello {
         protocol: AGENT_PROTOCOL_VERSION,
         client_version: VERSION.into(),
     };
-    serde_json::to_writer(&mut stream, &request)?;
+    serde_json::to_writer(&mut *stream, &request)?;
     stream.write_all(b"\n")?;
     stream.flush()?;
     let mut response = String::new();
-    BufReader::new(stream).read_line(&mut response)?;
+    BufReader::new(&mut *stream).read_line(&mut response)?;
     validate_handshake_response(&response)
+}
+
+#[cfg(unix)]
+fn sync_request(
+    stream: &mut (impl std::io::Read + Write),
+    request: &AgentRequest,
+) -> Result<AgentResponse> {
+    serde_json::to_writer(&mut *stream, request)?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+    let mut response = String::new();
+    BufReader::new(&mut *stream).read_line(&mut response)?;
+    Ok(serde_json::from_str(&response)?)
 }
 
 fn validate_handshake_response(response: &str) -> Result<()> {
@@ -526,6 +576,7 @@ mod tests {
         let environment = CacheSessionEnvironment {
             socket: "socket".into(),
             rustc_shim: "shim".into(),
+            staging: "staging".into(),
         };
         let mut task = Task::default();
         let mut values = BTreeMap::from([("RUSTC_WRAPPER".into(), "existing".into())]);
@@ -539,6 +590,7 @@ mod tests {
         task.rust_cache = Some(TaskRustCacheConfig { enabled: true });
         environment.apply(&task, &mut values);
         assert_eq!(values.get(SOCKET_ENV).unwrap(), "socket");
+        assert_eq!(values.get(STAGING_ENV).unwrap(), "staging");
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "shim");
         assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
         assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -8,7 +8,9 @@ use async_trait::async_trait;
 use eyre::{Result, bail, eyre};
 use jdx_tar::{Archive, Builder, EntryType, Header};
 use mise_cache_core::{
-    BlobSource, BlobUpload, CLIENT_METADATA_MEDIA_TYPE, CacheDigest, DIRECTORY_MEDIA_TYPE,
+    BlobSource, BlobUpload, CLIENT_METADATA_MEDIA_TYPE, CacheDigest,
+    CacheDirectory as RemoteDirectory, CacheDirectoryNode as RemoteDirectoryNode,
+    CacheFileNode as RemoteFileNode, CacheSymlinkNode as RemoteSymlinkNode, DIRECTORY_MEDIA_TYPE,
     RemoteActionResult, RemoteCacheClient, RemoteCacheConfig,
 };
 use serde::{Deserialize, Serialize};
@@ -74,36 +76,6 @@ impl RemoteClientMetadata {
             execution_duration_ns: self.execution_duration_ns,
         })
     }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct RemoteDirectory {
-    directories: Vec<RemoteDirectoryNode>,
-    files: Vec<RemoteFileNode>,
-    symlinks: Vec<RemoteSymlinkNode>,
-    version: u8,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct RemoteDirectoryNode {
-    digest: CacheDigest,
-    mode: u32,
-    name: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct RemoteFileNode {
-    digest: CacheDigest,
-    executable: bool,
-    mode: u32,
-    name: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct RemoteSymlinkNode {
-    mode: u32,
-    name: String,
-    target: String,
 }
 
 enum ArchiveNode {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -416,6 +416,7 @@ impl TaskExecutor {
             if sandbox.effective_deny_env() {
                 sandbox.pass_through_env.extend([
                     "MISE_CACHE_SOCKET".into(),
+                    "MISE_CACHE_STAGING_DIR".into(),
                     "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER".into(),
                     "RUSTC_WRAPPER".into(),
                     "CARGO_INCREMENTAL".into(),


### PR DESCRIPTION
## Summary

- execute cacheable rustc misses through the task-scoped mise cache session
- discover and verify compiler inputs before publishing canonical rustc actions
- store rlib/rmeta outputs plus byte-exact diagnostics in the local CAS before atomically publishing the action result
- share the protocol directory model with task caching and use a sandbox-approved session staging directory

## Behavior

This intentionally remains miss-only. It never restores a cached compiler result and performs no remote cache traffic. Unsupported invocations and pre-execution cache errors transparently fall back to the real compiler. Once rustc has executed, a publication failure warns without executing the compiler a second time.

Existing Rust compiler wrappers continue to be chained without action caching until their behavior can be represented safely in the action key.

## Validation

- `cargo test -p mise-cache-core -p mise-cache-rustc`
- `cargo test --bin mise task_cache_store`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run test:e2e e2e/tasks/test_task_action_cache_session`
- `mise run lint-fix`

The e2e test runs a real `cargo build` under task sandbox write restrictions and verifies that a local action-result record is committed.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Rust compiler caching to speed up repeated Rust builds.
  - Cached compilation results can now be restored, including generated libraries, metadata, and dependency information.
  - Added executable identity detection to improve cache correctness across compiler invocations.
  - Added support for staging directories during sandboxed cache operations.

- **Bug Fixes**
  - Improved handling of Rust output paths and build artifacts.
  - Builds with unsupported, ambiguous, or modified inputs now safely bypass caching.
  - Cache results are validated before storage to prevent incomplete or inconsistent restores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler wrapper execution, input verification races, and atomic cache publication; miss-only limits user impact but incorrect keys or storage could poison future restores.
> 
> **Overview**
> **Miss-only rustc action caching** for cacheable Cargo library compiles: the `mise-cache-rustc` shim always runs the real compiler first, then optionally **stores** a canonical action result; it does not restore cached artifacts yet.
> 
> **Cache agent & local index** gain `StoreActionResult` / `LocalActionCache`, shared `CacheDirectory` / `RustcMetadata` types, and **session-scoped rustc `-vV` identity** memoization (bounded in-memory cache).
> 
> **`mise-cache-rustc`** now resolves **rlib/rmeta + dep-info paths**, rejects inputs **modified during compile** (mtime barrier + post-compile rehash), and tightens bypass reasons for bad output layouts.
> 
> **`src/cache/rustc`** wires publication: dep-info discovery, compiler identity, path placeholders, staging under `MISE_CACHE_STAGING_DIR`, CAS blobs + atomic action-result commit through the task agent. Unsupported invocations or publish failures **fall back** to transparent rustc (warn on post-success store failure).
> 
> E2E adds a sandboxed `cargo build` that expects **stored** output and an on-disk action-result JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30a4446330f93da9e9de65806938b239073f014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->