### PR TITLE
docs(settings): describe what libc detection actually does

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -1373,8 +1373,19 @@ type = "SetString"
 default_docs = '"glibc" | "musl"'
 description = "Libc implementation to use for precompiled Linux binaries."
 docs = """
-Libc implementation to use for precompiled Linux binaries. This is used by backends that publish
-separate glibc and musl builds. If unset, mise will detect the current system's libc.
+Libc implementation to use for precompiled Linux binaries, for backends that publish separate
+glibc and musl builds.
+
+mise detects the host libc, but only a musl result is carried through: a glibc host is left
+unqualified rather than pinned to glibc. That distinction matters when a backend selects an asset
+by name, because an unqualified target can still match a musl artifact on a glibc host. Set this
+to `gnu` when you need the glibc build specifically — for example when a package publishes both
+glibc and musl builds and the musl one misbehaves:
+
+```toml
+[settings]
+libc = "gnu"
+```
 
 `gnu` is accepted as an alias for `glibc`.
 """


### PR DESCRIPTION
Found while answering #4537, where the answer is "set `libc = "gnu"`" — but the setting's own documentation makes that read like a no-op.

## What the docs claimed

> Libc implementation to use for precompiled Linux binaries. This is used by backends that publish separate glibc and musl builds. **If unset, mise will detect the current system's libc.**

That last sentence reads as though leaving it unset already gets you glibc on a glibc host. It does not.

## What actually happens

`detect_libc()` can identify **either** libc — it looks for `ld-linux-*` and `ld-musl-*` under `/lib` and `/lib64`. But `Platform::current()` only carries a musl result through:

```rust
let qualifier = if os == "linux" {
    match settings.libc() {
        Some("musl") => Some("musl".to_string()),
        Some("gnu") => None,
        _ if is_musl_system() => Some("musl".to_string()),
        _ => None,                       // glibc host lands here
    }
} else {
    None
};
```

`is_musl_system()` is `detect_libc() == Some("musl")`, so a `gnu` detection is discarded. A glibc host ends up **unqualified**, and `Platform::libc()` returns `None` rather than `Some("gnu")`.

Unqualified is not the same as glibc: it does not exclude musl assets. A backend that selects by name can still match a musl artifact. Measured on Ubuntu with **GLIBC 2.39**, installing `eza@0.21.0` three times into fresh isolated directories:

```
MISE_LIBC unset -> eza_x86_64-unknown-linux-musl.tar.gz
MISE_LIBC=gnu   -> eza_x86_64-unknown-linux-gnu.tar.gz
MISE_LIBC=musl  -> eza_x86_64-unknown-linux-musl.tar.gz
```

So `libc = "gnu"` is doing real work on a glibc host, which the old wording argued against.

## The change

Only `[libc].docs` in `settings.toml`. It now says what unset does, why that differs from pinning glibc, and when to set `gnu` — with an example.

## Scope

- **No behavior change.** Whether aqua *should* prefer the glibc asset on a glibc host is a separate question. Changing `Platform::current()` to carry `gnu` would touch every `libc() == Some("musl")` site (java, node, erlang, swift) and the `unwrap_or("gnu")` ones (python), so it does not belong in a docs correction.
- **`description` is untouched** — that string is embedded in `schema/mise.json`, and editing it would produce a generated-file diff. Only the long-form `docs` changed, which `docs/settings.data.ts` reads from `settings.toml` at docs-build time and which `build.rs` does not consume.
- No other setting's docs are touched.

## Verification

`settings.toml` is the single input `build.rs` reads, so a syntax error would fail every job. Parsed it independently before pushing:

```console
$ python3 -c "import tomllib; d=tomllib.load(open('settings.toml','rb')); print(len(d))"
148
```

No tests: the change is prose with no behavior to assert. The `build` job covers the TOML parse and `docs` covers rendering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified host libc detection behavior: only musl is automatically propagated.
  * Documented that glibc hosts remain unqualified by default.
  * Added guidance for explicitly selecting glibc builds with `libc = "gnu"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->