### PR TITLE
feat(task): align task output prefixes to a common width

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1070,7 +1070,12 @@ impl Run {
                     Error::get_exit_status(err)
                 };
                 if !interrupted && !this.is_stopping() && (panicked || status.is_none()) {
-                    let prefix = task.estyled_prefix();
+                    let prefix = task.estyled_prefix_padded(
+                        this.output_handler
+                            .as_ref()
+                            .map(|h| h.prefix_width())
+                            .unwrap_or(0),
+                    );
                     if Settings::get().verbose {
                         this.eprint(&task, &prefix, &format!("{} {err:?}", style::ered("ERROR")));
                     } else {
@@ -1169,6 +1174,9 @@ impl Run {
             raw: self.raw,
             is_linear: self.is_linear,
             jobs: self.jobs,
+            // Computed once here, where the whole run is known, so every task's
+            // prefix can be padded to the same width (discussion #4397).
+            prefix_width: crate::task::max_prefix_width(tasks.all()),
         };
         self.output_handler = Some(OutputHandler::new(output_config));
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2080,8 +2080,24 @@ impl Task {
         Ok(ctx.render_spec()?)
     }
 
-    pub fn estyled_prefix(&self) -> String {
-        style::prefix(self.prefix(), &self.display_name, true)
+    /// The task's styled `[name]` prefix, right-aligned within `width` so that
+    /// the output of every task in a run starts at the same column
+    /// (discussion #4397).
+    ///
+    /// Padding goes *before* the bracket, not after it. That keeps `[name] ` and
+    /// the line it prefixes contiguous, so anything matching on `[name] output`
+    /// — mise's own e2e tests do, and user scripts plausibly do too — is
+    /// unaffected. The spaces sit outside the styled span, so they carry no
+    /// color. A run with a single task pads to its own width, i.e. not at all;
+    /// pass 0 for an unpadded prefix.
+    pub fn estyled_prefix_padded(&self, width: usize) -> String {
+        let plain = self.prefix();
+        let pad = width.saturating_sub(console::measure_text_width(&plain));
+        format!(
+            "{}{}",
+            " ".repeat(pad),
+            style::prefix(plain, &self.display_name, true)
+        )
     }
 
     pub async fn dir(&self, config: &Arc<Config>) -> Result<Option<PathBuf>> {
@@ -2840,6 +2856,17 @@ impl Task {
     }
 }
 
+/// Display width of the widest prefix among `tasks`, for aligning their output.
+///
+/// Measured rather than counted so a task named in CJK lines up with the rest.
+/// `Task::prefix` truncates to 40 characters, so this is bounded.
+pub fn max_prefix_width<'a>(tasks: impl Iterator<Item = &'a Task>) -> usize {
+    tasks
+        .map(|t| console::measure_text_width(&t.prefix()))
+        .max()
+        .unwrap_or(0)
+}
+
 pub(crate) fn clear_usage_env(env: &mut EnvMap) {
     env.retain(|key, _| !is_usage_env_key(key));
 }
@@ -3562,7 +3589,7 @@ mod tests {
     use std::sync::Mutex;
 
     use crate::task::workspace;
-    use crate::task::{RunEntry, Task, TaskRustCacheConfig, TaskWatchOptions};
+    use crate::task::{RunEntry, Task, TaskRustCacheConfig, TaskWatchOptions, max_prefix_width};
     use crate::{config::Config, dirs};
     use indexmap::IndexMap;
     use pretty_assertions::assert_eq;
@@ -6195,7 +6222,7 @@ echo "test"
                 display_name: name.to_string(),
                 ..Default::default()
             };
-            let styled = task.estyled_prefix();
+            let styled = task.estyled_prefix_padded(0);
             assert!(
                 !styled.contains(red_fg),
                 "task {name:?} prefix contains red"
@@ -6213,5 +6240,72 @@ echo "test"
                 "task {name:?} prefix contains bright yellow"
             );
         }
+    }
+
+    fn task_named(name: &str) -> Task {
+        Task {
+            display_name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// discussion #4397: prefixes from one run should line up.
+    #[test]
+    fn estyled_prefix_padded_aligns_to_width() {
+        let short = task_named("a");
+        let long = task_named("averylongtaskname");
+        let width = max_prefix_width([&short, &long].into_iter());
+
+        let padded = short.estyled_prefix_padded(width);
+        assert_eq!(console::measure_text_width(&padded), width);
+        // Padding goes before the bracket, so `[a] ` stays contiguous with whatever
+        // follows it and existing `[name] output` matchers keep working.
+        assert!(padded.starts_with("  "), "expected leading pad: {padded:?}");
+        assert!(
+            padded.contains("[a]"),
+            "lost the bracketed name: {padded:?}"
+        );
+        // Nothing is appended, so the padded and unpadded forms differ only by the
+        // leading spaces.
+        assert_eq!(
+            padded.trim_start_matches(' '),
+            short.estyled_prefix_padded(0)
+        );
+
+        // The widest task is already at the width, so it gains nothing.
+        assert_eq!(
+            long.estyled_prefix_padded(width),
+            long.estyled_prefix_padded(0),
+            "the widest prefix should be unchanged"
+        );
+    }
+
+    /// A single-task run pads to its own width, i.e. output is unchanged.
+    #[test]
+    fn estyled_prefix_padded_never_truncates() {
+        let task = task_named("averylongtaskname");
+        let unpadded = task.estyled_prefix_padded(0);
+        // A width below the prefix's own must not shorten it.
+        assert!(unpadded.contains("[averylongtaskname]"));
+        assert!(!unpadded.starts_with(' '));
+        assert_eq!(
+            task.estyled_prefix_padded(max_prefix_width([&task].into_iter())),
+            unpadded
+        );
+    }
+
+    #[test]
+    fn max_prefix_width_takes_the_widest() {
+        let a = task_named("a");
+        let b = task_named("bbb");
+        assert_eq!(max_prefix_width([&a, &b].into_iter()), "[bbb]".len());
+        assert_eq!(max_prefix_width(std::iter::empty::<&Task>()), 0);
+    }
+
+    /// Width, not character count — a CJK name is twice as wide per character.
+    #[test]
+    fn max_prefix_width_is_display_width() {
+        let cjk = task_named("ビルド");
+        assert_eq!(max_prefix_width([&cjk].into_iter()), 2 + 3 * 2);
     }
 }

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -454,7 +454,7 @@ impl TaskExecutor {
             permit,
             allow_during_interruption,
         } = ctx;
-        let prefix = task.estyled_prefix();
+        let prefix = task.estyled_prefix_padded(self.output_handler.prefix_width());
         let total_start = std::time::Instant::now();
         Self::check_interruption(allow_during_interruption)?;
         if Settings::get().task.skip.contains(&task.name) {

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -178,6 +178,8 @@ pub struct OutputHandlerConfig {
     pub raw: bool,
     pub is_linear: bool,
     pub jobs: Option<usize>,
+    /// Width every task prefix in this run is padded to, so they line up.
+    pub prefix_width: usize,
 }
 
 /// Handles task output routing, formatting, and display
@@ -193,6 +195,7 @@ pub struct OutputHandler {
     raw: bool,
     is_linear: bool,
     jobs: Option<usize>,
+    prefix_width: usize,
 }
 
 impl Clone for OutputHandler {
@@ -207,6 +210,7 @@ impl Clone for OutputHandler {
             raw: self.raw,
             is_linear: self.is_linear,
             jobs: self.jobs,
+            prefix_width: self.prefix_width,
         }
     }
 }
@@ -218,11 +222,16 @@ impl OutputHandler {
         if let Some(pr) = prs.get(task) {
             pr.clone()
         } else {
-            let pr = MultiProgressReport::get().add(&task.estyled_prefix());
+            let pr = MultiProgressReport::get().add(&task.estyled_prefix_padded(self.prefix_width));
             let pr = Arc::new(pr);
             prs.insert(task.clone(), pr.clone());
             pr
         }
+    }
+
+    /// Width task prefixes are padded to for this run.
+    pub fn prefix_width(&self) -> usize {
+        self.prefix_width
     }
 }
 
@@ -238,6 +247,7 @@ impl OutputHandler {
             raw: config.raw,
             is_linear: config.is_linear,
             jobs: config.jobs,
+            prefix_width: config.prefix_width,
         }
     }
 
@@ -460,6 +470,7 @@ mod tests {
             raw: false,
             is_linear: true,
             jobs: None,
+            prefix_width: 0,
         });
         let task = Task::default();
 

--- a/src/task/task_results_display.rs
+++ b/src/task/task_results_display.rs
@@ -77,7 +77,7 @@ impl TaskResultsDisplay {
         let count = failed.len();
         safe_eprintln!("{} {} task(s) failed:", style::ered("ERROR"), count);
         for (task, status) in &failed {
-            let prefix = task.estyled_prefix();
+            let prefix = task.estyled_prefix_padded(self.output_handler.prefix_width());
             let status_str = status
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| "unknown".to_string());
@@ -88,7 +88,7 @@ impl TaskResultsDisplay {
     /// Request a failing exit status if any tasks failed
     fn exit_if_failed(&self) -> Result<()> {
         if let Some((task, status)) = self.failed_tasks.lock().unwrap().first() {
-            let prefix = task.estyled_prefix();
+            let prefix = task.estyled_prefix_padded(self.output_handler.prefix_width());
             self.eprint(
                 task,
                 &prefix,


### PR DESCRIPTION
Closes #4397.

## The problem

Running tasks concurrently prefixes each output line with the task name, but the prefixes are not padded — so output the tasks themselves have carefully aligned stops lining up as soon as the names differ in length. Measured on **v2026.8.2**:

```console
$ mise run all
[a] $ echo one
[averylongtaskname] $ echo three
[a] one
[averylongtaskname] three
[a] $ echo two
```

`task.output` offers `prefix`, `interleave`, `keep-order`, `replacing` and `timed`, and none of them pads; there is no setting for it either.

## The change

Right-align each prefix within the run's widest:

```console
              [a] $ echo one
[averylongtaskname] $ echo three
              [a] one
[averylongtaskname] three
```

The width is computed in `cli/run.rs` where the whole dependency graph is already in scope — four lines below the same `tasks.all()` iteration that decides whether to spawn the timed-output printer — and rides along on `OutputHandler`, so the executor, the progress reporter and the failure summary all use the same number rather than each deriving one.

Ordering matters here and works out: `Deps::mark_ambiguous_prefixes()`, which can append args to a prefix to disambiguate `[test-docker 4.1]` from `[test-docker 4.2]`, runs while the graph is built, before the width is measured.

## Why the padding goes *before* the bracket

This is the part worth reviewing. I first implemented it the conventional way — left-aligned name, trailing spaces — and it broke three of mise's own e2e tests:

- `tasks/test_task_delegation_dedup` filters the command echo with `grep -v '^\[setup\] \$'`
- `tasks/test_task_deps` asserts on `"[hello:1] Hello from 1"`
- `tasks/test_task_nested_quiet` asserts on `"[dep1] dep1"`

All three break for the same reason: trailing padding lands *between* `[name]` and the line it prefixes. If mise's own test suite depends on `[name] output` being contiguous in three places, user scripts and log pipelines plausibly do too.

Right-aligning avoids that entirely. `[a] one` remains a contiguous substring, every existing matcher keeps working, and the output still lines up — which was the actual request. No e2e test needed changing.

The cost is a ragged left edge. If you would rather have the conventional look and accept the output-format break, the change is a one-line swap in `estyled_prefix_padded` plus updating those three tests.

## Other properties

- **A single-task run is unchanged**, because the widest prefix is its own. Padding only appears when more than one task runs — which is the only time it helps.
- **Padding carries no color**: it sits outside the styled span.
- **The width is bounded**: `Task::prefix` already truncates to 40 characters, so the pad can never exceed 42 columns.
- Width is measured with `console::measure_text_width` rather than counting characters, so a task named in CJK lines up with the rest.

## No new setting

Deliberately: adding one would mean regenerating `schema/mise.json` (and `mise.usage.kdl` / `man` / `docs/cli` if a flag came with it), as #11788 did. This change is confined to `src/`. If you would rather have it behind a setting I am happy to add one — just say which default you want.

## Tests

Four unit tests in `src/task/mod.rs`:

- the short prefix pads to exactly the run width, the pad is leading, and stripping it reproduces the unpadded form
- padding never truncates, and a single-task width is a no-op
- `max_prefix_width` picks the widest and returns 0 for an empty run
- the width is display width, not character count (CJK)

`Task::estyled_prefix()` is gone — `estyled_prefix_padded(0)` is the same thing, and keeping both left the old one dead in non-test builds.

No e2e: alignment assertions would be tied to ANSI handling and terminal width, which makes for a brittle test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved task output alignment by padding task prefixes to a consistent width.
  * Error messages, progress updates, and failure summaries now line up more clearly.
  * Alignment accounts for display widths of truncated and non-Latin task names, ensuring consistent formatting across varied task names.
  * Improved readability when monitoring multiple tasks or reviewing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->