### PR TITLE
fix(go): keep `go list` diagnostics out of the default output

### DIFF
--- a/e2e/backend/test_go_install
+++ b/e2e/backend/test_go_install
@@ -38,6 +38,14 @@ assert_matches \
   "GOPROXY=direct mise install --dry-run 'go:github.com/jdx/go-example/deep/cmd/tool/v2@latest' 2>&1" \
   'go:github.com/jdx/go-example/deep/cmd/tool/v2@2\.0\.0-[0-9]{14}-[0-9a-f]+'
 
+# The parent-path walk below misses before it hits, and `go list` complains to stderr on
+# every miss. That belongs behind --verbose rather than in the default output.
+# See https://github.com/jdx/mise/discussions/5189
+# Runs before the assertion below because a warm version cache would skip `go` entirely.
+assert_not_contains \
+  "GOPROXY=direct mise install --dry-run 'go:github.com/noperator/sol/cmd/sol@latest' 2>&1" \
+  "go: module"
+
 # Package in a subdirectory of an untagged root module; direct mode must walk
 # parent paths to resolve the module's pseudo-version.
 assert_matches \

--- a/src/backend/go.rs
+++ b/src/backend/go.rs
@@ -5,7 +5,7 @@ use crate::backend::options::BackendOptions;
 use crate::backend::platform_target::PlatformTarget;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
-use crate::cmd::{CmdLineRunner, cmd};
+use crate::cmd::CmdLineRunner;
 use crate::config::Config;
 use crate::config::Settings;
 use crate::hash::hash_to_str;
@@ -18,7 +18,6 @@ use dashmap::DashMap;
 use eyre::{Result, WrapErr};
 use serde_json::Deserializer;
 use std::collections::{BTreeMap, HashMap};
-use std::ffi::OsString;
 use std::{fmt::Debug, sync::Arc};
 use tokio::sync::Semaphore;
 use versions::Versioning;
@@ -328,20 +327,29 @@ impl GoBackend {
         cache
             .get_or_try_init_async(async || {
                 let go = self.spawn_program(config, None, "go").await;
-                let raw = match cmd!(
-                    go,
-                    "list",
-                    "-mod=readonly",
-                    "-m",
-                    "-versions",
-                    "-json",
-                    mod_path
+                let raw = match crate::cmd::cmd_read_async(
+                    &go,
+                    &[
+                        "list",
+                        "-mod=readonly",
+                        "-m",
+                        "-versions",
+                        "-json",
+                        mod_path,
+                    ],
+                    self.go_list_env(config).await?,
                 )
-                .full_env(self.go_list_env(config).await?)
-                .read()
+                .await
                 {
                     Ok(raw) => raw,
-                    Err(_) => return Ok(None),
+                    Err(err) => {
+                        // `_list_remote_versions` calls this once per module-path candidate, so a
+                        // valid setup routinely produces misses. `go` writes its own complaint to
+                        // stderr for each one; capturing it into the error keeps the default output
+                        // clean and leaves it readable under `--verbose`.
+                        debug!("go list -versions failed for {mod_path}: {err:#}");
+                        return Ok(None);
+                    }
                 };
 
                 let mod_info = match serde_json::from_str::<GoModInfo>(&raw) {
@@ -370,16 +378,13 @@ impl GoBackend {
     ) -> eyre::Result<Option<Vec<VersionInfo>>> {
         let env = self.go_list_env(config).await?;
         let go = self.spawn_program(config, None, "go").await;
-        let raw = cmd!(
-            go,
-            "list",
-            "-mod=readonly",
-            "-m",
-            "-json",
-            format!("{mod_path}@latest")
+        let latest = format!("{mod_path}@latest");
+        let raw = crate::cmd::cmd_read_async(
+            &go,
+            &["list", "-mod=readonly", "-m", "-json", latest.as_str()],
+            env,
         )
-        .full_env(env)
-        .read()
+        .await
         .wrap_err_with(|| format!("failed to resolve latest Go module version for {mod_path}"))?;
         let info = serde_json::from_str::<GoModuleVersionMetadata>(&raw).wrap_err_with(|| {
             format!("failed to parse latest Go module metadata for {mod_path}")
@@ -415,16 +420,21 @@ impl GoBackend {
         let mut metadata_by_version = HashMap::with_capacity(versions.len());
         for chunk in versions.chunks(GO_LIST_VERSION_INFO_BATCH_SIZE) {
             let mut args = vec![
-                OsString::from("list"),
-                OsString::from("-mod=readonly"),
-                OsString::from("-m"),
-                OsString::from("-json"),
+                "list".to_string(),
+                "-mod=readonly".to_string(),
+                "-m".to_string(),
+                "-json".to_string(),
             ];
             for version in chunk {
-                args.push(format!("{mod_path}@{version}").into());
+                args.push(format!("{mod_path}@{version}"));
             }
-            let Ok(raw) = cmd(&go, args).full_env(&env).read() else {
-                continue;
+            let args: Vec<&str> = args.iter().map(String::as_str).collect();
+            let raw = match crate::cmd::cmd_read_async(&go, &args, &env).await {
+                Ok(raw) => raw,
+                Err(err) => {
+                    debug!("go list metadata batch failed for {mod_path}: {err:#}");
+                    continue;
+                }
             };
             let Ok(infos) = Deserializer::from_str(&raw)
                 .into_iter::<GoModuleVersionMetadata>()


### PR DESCRIPTION
Closes #5189.

## What is left of the problem

Most of that report is already fixed. Version resolution goes through `$GOPROXY` now, so on a default setup `go` is never spawned and none of the reporter's three cases produce output. Measured on **v2026.8.2** with their exact examples:

```console
$ mise ls-remote go:github.com/erning/gorun          # case 1
0.0.0-20230315023741-02445e31634f
$ mise ls-remote go:rsc.io/rf                        # case 2
0.0.0-20260710193434-85dbf8d53aee
$ mise ls-remote go:golang.org/x/tools/cmd/godoc     # case 3
0.1.0-deprecated
```

The `GOPROXY=direct` fallback is the part that still leaks, and it reproduces on one of the reporter's own tools:

```console
$ mise ls-remote go:github.com/davidrjenni/reftools/cmd/fillswitch
go: module github.com/davidrjenni/reftools/cmd/fillswitch: no matching versions for query "latest"
go: module github.com/davidrjenni/reftools/cmd: no matching versions for query "latest"
0.0.0-20250907133731-34b10582faa4
```

Splitting the streams locates it — the version is the only thing on stdout, and those two lines come from `go` itself:

```console
$ mise ls-remote <same> 2>/dev/null
0.0.0-20250907133731-34b10582faa4

$ mise ls-remote <same> 1>/dev/null
go: module github.com/davidrjenni/reftools/cmd/fillswitch: no matching versions for query "latest"
go: module github.com/davidrjenni/reftools/cmd: no matching versions for query "latest"
```

Note this is a **valid** setup producing that noise: `_list_remote_versions` walks the package path and its parents, so misses are the normal path to a hit, not a fault.

## Cause

Three `go list` calls used duct's `.read()`, which captures stdout and **inherits stderr**. mise's own per-candidate message was already demoted to `debug!`, so the subprocess output was the only thing still reaching the terminal.

## The change

Those three calls now use `crate::cmd::cmd_read_async`, which already exists for exactly this shape — its doc comment says to use it "for backends that pass a full env from `dependency_env()`", which is what `go_list_env()` builds. `gem.rs` is the existing caller.

It maps onto the duct call one-for-one — `env_clear().envs(env)` for `.full_env()`, same trailing-newline trim — with two differences that matter here: stderr is piped rather than inherited, and a non-zero exit produces an error whose message carries that stderr. Since the call sites already route their failures into `debug!`, go's explanation lands behind `--verbose` instead of on stdout, which is what the issue asks for.

The one place it can still surface at default verbosity is the existing summary `warn!` in `_list_remote_versions`, which fires only when *every* candidate failed — a genuine error where go's reason is the useful part.

## Scope

- `go install` is untouched. That path uses `CmdLineRunner` and its output is something the user wants to see.
- No new setting or flag, so there is no generated-file churn — the diff is `src/backend/go.rs` plus one e2e assertion.
- **Trade-off worth flagging:** stderr from a *successful* `go list` is now dropped entirely rather than debug-logged. In practice that is download-progress chatter. If you would rather keep it at debug level, that is a small addition, but it means not reusing the shared helper.
- Secondary effect: `.read()` is blocking and was being called from `async fn`, so the `run_with_timeout_async` wrapper around `_list_remote_versions` could not actually interrupt it. `cmd_read_async` uses `tokio::process`. I have not measured any speed difference and am not claiming one.

## Tests

`e2e/backend/test_go_install` already exercises the parent-path walk under `GOPROXY=direct`. Added an `assert_not_contains` for `"go: module"` against that same command.

It is placed **before** the existing `assert_matches` on purpose: mise caches resolved versions to disk, so running it second would skip `go` entirely and the assertion would pass without testing anything.

The match string avoids a false positive on mise's own `go:github.com/...` output, which has no space after the colon.

No unit tests — all three call sites are a `go` invocation with no separable pure logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Direct installation of Go packages no longer displays `go list` module-walk errors in the default output.
  - Go package metadata lookups now handle non-critical errors more gracefully while continuing with available information.
  - Latest-version resolution provides clearer error context when it cannot determine a version.
  - Added automated coverage to verify clean installation output and reliable version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->