### PR TITLE
feat(cache): restore local rustc action hits

### DIFF
--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -453,15 +453,22 @@ mod tests {
     async fn missing_action_result_is_a_cache_miss() {
         let directory = tempfile::tempdir().unwrap();
         let agent = CacheAgent::new(directory.path(), "test-version");
+        let action = CacheDigest::blake3(b"missing action");
         let response = agent
             .respond(AgentRequest::FindActionResult {
-                action: CacheDigest::blake3(b"missing action"),
+                action: action.clone(),
             })
             .await;
 
         assert!(matches!(
             response,
             AgentResponse::ActionResult { result: None }
+        ));
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionHit { action })
+                .await,
+            AgentResponse::Error { .. }
         ));
         assert_eq!(
             agent.stats(),

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -29,6 +29,12 @@ pub enum AgentRequest {
         digest: CacheDigest,
         source: PathBuf,
     },
+    FindActionResult {
+        action: CacheDigest,
+    },
+    RecordActionHit {
+        action: CacheDigest,
+    },
     StoreActionResult {
         result: RemoteActionResult,
     },
@@ -50,6 +56,8 @@ pub enum AgentResponse {
     Hello { protocol: u8, agent_version: String },
     Blob { path: Option<PathBuf> },
     Stored { path: PathBuf },
+    ActionResult { result: Option<RemoteActionResult> },
+    ActionHitRecorded,
     ActionStored { path: PathBuf },
     ExecutableIdentity { stdout: Option<Vec<u8>> },
     Error { message: String },
@@ -58,9 +66,9 @@ pub enum AgentResponse {
 /// Aggregate cache activity for one task session.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct AgentStats {
-    /// Number of content-addressed storage lookups.
+    /// Number of action-result lookups.
     pub lookups: u64,
-    /// Number of lookups that found a valid local object.
+    /// Number of lookups that found a valid local action result.
     pub hits: u64,
     /// Number of newly stored content-addressed objects.
     pub stores: u64,
@@ -133,15 +141,10 @@ impl CacheAgent {
 
     async fn respond(&self, request: AgentRequest) -> AgentResponse {
         let result = match request {
-            AgentRequest::FindBlob { digest } => {
-                self.stats.lookups.fetch_add(1, Ordering::Relaxed);
-                self.cas.find(&digest).map(|path| {
-                    if path.is_some() {
-                        self.stats.hits.fetch_add(1, Ordering::Relaxed);
-                    }
-                    AgentResponse::Blob { path }
-                })
-            }
+            AgentRequest::FindBlob { digest } => self
+                .cas
+                .find(&digest)
+                .map(|path| AgentResponse::Blob { path }),
             AgentRequest::StoreBlob { digest, source } => {
                 let lock = self.write_lock(&digest);
                 let _guard = lock.lock().await;
@@ -156,6 +159,13 @@ impl CacheAgent {
                     AgentResponse::Stored { path }
                 })
             }
+            AgentRequest::FindActionResult { action } => {
+                self.stats.lookups.fetch_add(1, Ordering::Relaxed);
+                self.actions
+                    .find(&action)
+                    .map(|result| AgentResponse::ActionResult { result })
+            }
+            AgentRequest::RecordActionHit { action } => self.record_action_hit(&action),
             AgentRequest::StoreActionResult { result } => self
                 .actions
                 .store(&result)
@@ -176,6 +186,14 @@ impl CacheAgent {
         result.unwrap_or_else(|error| AgentResponse::Error {
             message: error.to_string(),
         })
+    }
+
+    fn record_action_hit(&self, action: &CacheDigest) -> Result<AgentResponse> {
+        if self.actions.find(action)?.is_none() {
+            bail!("cannot record a hit for a missing action result");
+        }
+        self.stats.hits.fetch_add(1, Ordering::Relaxed);
+        Ok(AgentResponse::ActionHitRecorded)
     }
 
     fn executable_identity_key(
@@ -402,7 +420,56 @@ mod tests {
             })
             .await;
         assert!(matches!(response, AgentResponse::ActionStored { .. }));
-        assert!(agent.actions.find(&action).unwrap().is_some());
+        let response = agent
+            .respond(AgentRequest::FindActionResult {
+                action: action.clone(),
+            })
+            .await;
+        assert!(matches!(
+            response,
+            AgentResponse::ActionResult {
+                result: Some(result)
+            } if result.action == action
+        ));
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionHit {
+                    action: action.clone()
+                })
+                .await,
+            AgentResponse::ActionHitRecorded
+        ));
+        assert_eq!(
+            agent.stats(),
+            AgentStats {
+                lookups: 1,
+                hits: 1,
+                ..AgentStats::default()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_action_result_is_a_cache_miss() {
+        let directory = tempfile::tempdir().unwrap();
+        let agent = CacheAgent::new(directory.path(), "test-version");
+        let response = agent
+            .respond(AgentRequest::FindActionResult {
+                action: CacheDigest::blake3(b"missing action"),
+            })
+            .await;
+
+        assert!(matches!(
+            response,
+            AgentResponse::ActionResult { result: None }
+        ));
+        assert_eq!(
+            agent.stats(),
+            AgentStats {
+                lookups: 1,
+                ..AgentStats::default()
+            }
+        );
     }
 
     #[tokio::test]

--- a/e2e/tasks/test_task_rust_cache_restore
+++ b/e2e/tasks/test_task_rust_cache_restore
@@ -16,35 +16,50 @@ invoke() {
     "$PWD/lib.rs"
 }
 
+export CACHE_TEST_ENV=first
 first="$(invoke 2>&1)"
 test "$first" = "$(printf 'cached stdout\ncached stderr')"
 test "$(cat compile-count)" = 1
-test "$(cat out/libdemo.rlib)" = 'cached artifact'
+test "$(cat out/libdemo.rlib)" = 'cached artifact first'
 
 printf 'stale artifact' >out/libdemo.rlib
 second="$(invoke 2>&1)"
 test "$second" = "$first"
 test "$(cat compile-count)" = 1
-test "$(cat out/libdemo.rlib)" = 'cached artifact'
+test "$(cat out/libdemo.rlib)" = 'cached artifact first'
 
+export CACHE_TEST_ENV=second
+third="$(invoke 2>&1)"
+test "$third" = "$first"
+test "$(cat compile-count)" = 2
+test "$(cat out/libdemo.rlib)" = 'cached artifact second'
+
+cache_blob_root="$(mise cache path)/task-artifacts/v2/actions/cas/v1/blake3"
+if ! test -d "$cache_blob_root"; then
+  echo "cache blob layout was not found: $cache_blob_root" >&2
+  exit 1
+fi
 artifact_blob=''
-for blob in "$(mise cache path)"/task-artifacts/v2/actions/cas/v1/blake3/*/*; do
+for blob in "$cache_blob_root"/*/*; do
   if test -f "$blob" && cmp -s "$blob" out/libdemo.rlib; then
     artifact_blob="$blob"
     break
   fi
 done
-test -n "$artifact_blob"
+if test -z "$artifact_blob"; then
+  echo "cached artifact blob was not found under: $cache_blob_root/*/*" >&2
+  exit 1
+fi
 rm "$artifact_blob"
 printf 'stale artifact' >out/libdemo.rlib
 
-third="$(invoke 2>&1)"
-case "$third" in
+fourth="$(invoke 2>&1)"
+case "$fourth" in
   *'result was not restored'*) ;;
   *) exit 1 ;;
 esac
-test "$(cat compile-count)" = 2
-test "$(cat out/libdemo.rlib)" = 'cached artifact'
+test "$(cat compile-count)" = 3
+test "$(cat out/libdemo.rlib)" = 'cached artifact second'
 '''
 EOF
 
@@ -75,8 +90,9 @@ if [[ -f compile-count ]]; then
 fi
 printf '%s\n' "$((count + 1))" >compile-count
 mkdir -p out
-printf 'cached artifact' >out/libdemo.rlib
+printf 'cached artifact %s' "${CACHE_TEST_ENV-}" >out/libdemo.rlib
 printf '%s: %s\n' "$PWD/out/libdemo.rlib" "$PWD/lib.rs" >out/demo.d
+printf '# env-dep:CACHE_TEST_ENV=%s\n' "${CACHE_TEST_ENV-}" >>out/demo.d
 printf 'cached stdout\n'
 printf 'cached stderr\n' >&2
 EOF

--- a/e2e/tasks/test_task_rust_cache_restore
+++ b/e2e/tasks/test_task_rust_cache_restore
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.restore]
+rust_cache = true
+run = '''
+invoke() {
+  "$RUSTC_WRAPPER" "$PWD/fake-rustc" \
+    --crate-name demo \
+    --crate-type lib \
+    --emit=dep-info,link \
+    --out-dir "$PWD/out" \
+    "$PWD/lib.rs"
+}
+
+first="$(invoke 2>&1)"
+test "$first" = "$(printf 'cached stdout\ncached stderr')"
+test "$(cat compile-count)" = 1
+test "$(cat out/libdemo.rlib)" = 'cached artifact'
+
+printf 'stale artifact' >out/libdemo.rlib
+second="$(invoke 2>&1)"
+test "$second" = "$first"
+test "$(cat compile-count)" = 1
+test "$(cat out/libdemo.rlib)" = 'cached artifact'
+
+artifact_blob=''
+for blob in "$(mise cache path)"/task-artifacts/v2/actions/cas/v1/blake3/*/*; do
+  if test -f "$blob" && cmp -s "$blob" out/libdemo.rlib; then
+    artifact_blob="$blob"
+    break
+  fi
+done
+test -n "$artifact_blob"
+rm "$artifact_blob"
+printf 'stale artifact' >out/libdemo.rlib
+
+third="$(invoke 2>&1)"
+case "$third" in
+  *'result was not restored'*) ;;
+  *) exit 1 ;;
+esac
+test "$(cat compile-count)" = 2
+test "$(cat out/libdemo.rlib)" = 'cached artifact'
+'''
+EOF
+
+cat <<'EOF' >lib.rs
+pub fn cached_library() -> usize { 42 }
+EOF
+
+cat <<'EOF' >fake-rustc
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${1:-} == -vV ]]; then
+  cat <<'IDENTITY'
+rustc 1.97.0 (cache-test 2026-08-01)
+binary: rustc
+commit-hash: cache-test
+commit-date: 2026-08-01
+host: x86_64-unknown-linux-gnu
+release: 1.97.0
+LLVM version: 22.0.0
+IDENTITY
+  exit 0
+fi
+
+count=0
+if [[ -f compile-count ]]; then
+  count="$(cat compile-count)"
+fi
+printf '%s\n' "$((count + 1))" >compile-count
+mkdir -p out
+printf 'cached artifact' >out/libdemo.rlib
+printf '%s: %s\n' "$PWD/out/libdemo.rlib" "$PWD/lib.rs" >out/demo.d
+printf 'cached stdout\n'
+printf 'cached stderr\n' >&2
+EOF
+chmod +x fake-rustc
+
+assert_contains "mise run restore 2>&1" "Action cache: 1/2 hits"

--- a/src/cache/rustc.rs
+++ b/src/cache/rustc.rs
@@ -5,19 +5,39 @@ use mise_cache_core::{
     RustcMetadata, canonical_json,
 };
 use mise_cache_rustc::{
-    ActionContext, CompilerIdentity, PathMapping, RustcDepInfo, RustcInvocation,
+    ActionContext, CompilerIdentity, DiscoveredInputs, PathMapping, RustcAction, RustcDepInfo,
+    RustcInvocation, RustcOutputs,
 };
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{OsStr, OsString};
-use std::io::Write as _;
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, ExitStatus, Output};
 use std::time::SystemTime;
 
-pub(super) fn compile_miss(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
+pub(super) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
     let invocation = RustcInvocation::parse(arguments)?;
     let working_dir = std::env::current_dir()?;
     let outputs = invocation.outputs(&working_dir)?;
+
+    if outputs.dep_info.is_file()
+        && let Ok((action, discovered)) =
+            action_from_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)
+    {
+        match restore_result(&action, &outputs, &discovered) {
+            Ok(Some((stdout, stderr))) => {
+                replay_bytes(&stdout, &stderr)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!("mise rustc cache warning: result was not restored: {error:#}");
+            }
+        }
+    }
+
     let compilation_started = SystemTime::now();
     let output = Command::new(rustc)
         .args(arguments)
@@ -27,18 +47,9 @@ pub(super) fn compile_miss(rustc: &OsStr, arguments: &[OsString]) -> Result<Exit
     let _ = replay_output(&output);
     if output.status.success() {
         let publication = (|| {
-            let dep_info = RustcDepInfo::read(&outputs.dep_info)?;
-            let discovered = invocation.discover_inputs(&dep_info, &working_dir)?;
+            let (action, discovered) =
+                action_from_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)?;
             discovered.verify_not_modified_since(compilation_started)?;
-            let mut context = ActionContext {
-                compiler: compiler_identity(rustc)?,
-                working_dir: working_dir.clone(),
-                path_mappings: path_mappings(&working_dir),
-                environment: BTreeMap::new(),
-                inputs: Vec::new(),
-            };
-            discovered.clone().apply_to(&mut context)?;
-            let action = invocation.action(context)?;
             discovered.verify()?;
             publish_result(&action.digest, &action.bytes, &outputs.files, &output)
         })();
@@ -47,6 +58,199 @@ pub(super) fn compile_miss(rustc: &OsStr, arguments: &[OsString]) -> Result<Exit
         }
     }
     Ok(exit_code(output.status))
+}
+
+fn action_from_dep_info(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    dep_info: &Path,
+    working_dir: &Path,
+) -> Result<(RustcAction, DiscoveredInputs)> {
+    let dep_info = RustcDepInfo::read(dep_info)?;
+    let discovered = invocation.discover_inputs(&dep_info, working_dir)?;
+    let mut context = ActionContext {
+        compiler: compiler_identity(rustc)?,
+        working_dir: working_dir.to_path_buf(),
+        path_mappings: path_mappings(working_dir),
+        environment: BTreeMap::new(),
+        inputs: Vec::new(),
+    };
+    discovered.clone().apply_to(&mut context)?;
+    let action = invocation.action(context)?;
+    Ok((action, discovered))
+}
+
+fn restore_result(
+    action: &RustcAction,
+    outputs: &RustcOutputs,
+    discovered: &DiscoveredInputs,
+) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+    let responses = session::request_agent(&[AgentRequest::FindActionResult {
+        action: action.digest.clone(),
+    }])?;
+    let Some(response) = responses.into_iter().next() else {
+        bail!("cache agent did not return an action lookup response");
+    };
+    let result = match response {
+        AgentResponse::ActionResult { result } => match result {
+            Some(result) => result,
+            None => return Ok(None),
+        },
+        AgentResponse::Error { message } => bail!(message),
+        _ => bail!("cache agent returned an unexpected action lookup response"),
+    };
+    if result.version != 1 || result.action != action.digest {
+        bail!("cached rustc action result has an invalid identity");
+    }
+    let metadata_digest = result
+        .metadata
+        .ok_or_else(|| eyre::eyre!("cached rustc action result has no metadata"))?;
+    let output_root_digest = result
+        .output_root
+        .ok_or_else(|| eyre::eyre!("cached rustc action result has no output root"))?;
+    let roots = find_blobs(&[
+        action.digest.clone(),
+        metadata_digest.clone(),
+        output_root_digest.clone(),
+    ])?;
+    let cached_action = read_verified_blob(&roots[0], &action.digest, "action descriptor")?;
+    if cached_action != action.bytes {
+        bail!("cached rustc action descriptor does not match the invocation");
+    }
+    let metadata: RustcMetadata =
+        read_canonical_blob(&roots[1], &metadata_digest, "rustc metadata")?;
+    if metadata.version != 1 || metadata.kind != "rustc" {
+        bail!("cached rustc metadata is unsupported");
+    }
+    let directory: CacheDirectory =
+        read_canonical_blob(&roots[2], &output_root_digest, "output directory")?;
+    let files = validated_outputs(directory, outputs)?;
+
+    let mut digests = vec![metadata.stdout.clone(), metadata.stderr.clone()];
+    digests.extend(files.iter().map(|(node, _)| node.digest.clone()));
+    let blobs = find_blobs(&digests)?;
+    let stdout = read_verified_blob(&blobs[0], &metadata.stdout, "stdout")?;
+    let stderr = read_verified_blob(&blobs[1], &metadata.stderr, "stderr")?;
+
+    std::fs::create_dir_all(&outputs.directory)?;
+    let mut staged = Vec::with_capacity(files.len());
+    for ((node, destination), source) in files.into_iter().zip(&blobs[2..]) {
+        let mut temporary = tempfile::NamedTempFile::new_in(&outputs.directory)?;
+        let mut source = std::fs::File::open(source)?;
+        std::io::copy(&mut source, temporary.as_file_mut())?;
+        temporary.flush()?;
+        temporary.as_file().sync_all()?;
+        if !node.digest.matches_file(temporary.path())? {
+            bail!(
+                "cached rustc output failed digest verification: {}",
+                node.name
+            );
+        }
+        apply_file_mode(&temporary, node.mode)?;
+        staged.push((temporary, destination));
+    }
+
+    discovered.verify()?;
+    for (temporary, destination) in staged {
+        temporary
+            .persist(&destination)
+            .map_err(|error| error.error)
+            .wrap_err_with(|| format!("failed to atomically restore {}", destination.display()))?;
+    }
+    let responses = session::request_agent(&[AgentRequest::RecordActionHit {
+        action: action.digest.clone(),
+    }])?;
+    match responses.into_iter().next() {
+        Some(AgentResponse::ActionHitRecorded) => {}
+        Some(AgentResponse::Error { message }) => bail!(message),
+        _ => bail!("cache agent did not record the restored action hit"),
+    }
+    Ok(Some((stdout, stderr)))
+}
+
+fn find_blobs(digests: &[CacheDigest]) -> Result<Vec<PathBuf>> {
+    let requests = digests
+        .iter()
+        .cloned()
+        .map(|digest| AgentRequest::FindBlob { digest })
+        .collect::<Vec<_>>();
+    let responses = session::request_agent(&requests)?;
+    if responses.len() != digests.len() {
+        bail!("cache agent returned an incomplete blob lookup response");
+    }
+    responses
+        .into_iter()
+        .zip(digests)
+        .map(|(response, digest)| match response {
+            AgentResponse::Blob { path: Some(path) } => Ok(path),
+            AgentResponse::Blob { path: None } => {
+                bail!("cached rustc action is missing blob {}", digest.hash)
+            }
+            AgentResponse::Error { message } => bail!(message),
+            _ => bail!("cache agent returned an unexpected blob lookup response"),
+        })
+        .collect()
+}
+
+fn read_canonical_blob<T>(path: &Path, digest: &CacheDigest, description: &str) -> Result<T>
+where
+    T: DeserializeOwned + Serialize,
+{
+    let bytes = read_verified_blob(path, digest, description)?;
+    let value = serde_json::from_slice(&bytes)
+        .wrap_err_with(|| format!("cached {description} is not valid JSON"))?;
+    if canonical_json(&value)? != bytes {
+        bail!("cached {description} is not canonical JSON");
+    }
+    Ok(value)
+}
+
+fn read_verified_blob(path: &Path, digest: &CacheDigest, description: &str) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)?.read_to_end(&mut bytes)?;
+    if !digest.matches_bytes(&bytes)? {
+        bail!("cached {description} failed digest verification");
+    }
+    Ok(bytes)
+}
+
+fn validated_outputs(
+    directory: CacheDirectory,
+    outputs: &RustcOutputs,
+) -> Result<Vec<(CacheFileNode, PathBuf)>> {
+    if directory.version != 1 || !directory.directories.is_empty() || !directory.symlinks.is_empty()
+    {
+        bail!("cached rustc output directory has unsupported entries");
+    }
+    let mut expected = outputs
+        .files
+        .iter()
+        .map(|path| {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| eyre::eyre!("expected rustc output name is not UTF-8"))?;
+            if path.parent() != Some(outputs.directory.as_path()) {
+                bail!("expected rustc output escapes its output directory");
+            }
+            Ok((name.to_string(), path.clone()))
+        })
+        .collect::<Result<BTreeMap<_, _>>>()?;
+    if directory.files.len() != expected.len() {
+        bail!("cached rustc output set does not match the invocation");
+    }
+    let mut files = Vec::with_capacity(directory.files.len());
+    for node in directory.files {
+        validate_file_mode(&node)?;
+        let destination = expected
+            .remove(&node.name)
+            .ok_or_else(|| eyre::eyre!("cached rustc output is unexpected: {}", node.name))?;
+        files.push((node, destination));
+    }
+    if !expected.is_empty() {
+        bail!("cached rustc output set is incomplete");
+    }
+    Ok(files)
 }
 
 fn compiler_identity(rustc: &OsStr) -> Result<CompilerIdentity> {
@@ -171,11 +375,15 @@ fn add_mapping(
 }
 
 fn replay_output(output: &Output) -> Result<()> {
+    replay_bytes(&output.stdout, &output.stderr)
+}
+
+fn replay_bytes(stdout_bytes: &[u8], stderr_bytes: &[u8]) -> Result<()> {
     let mut stdout = std::io::stdout().lock();
-    stdout.write_all(&output.stdout)?;
+    stdout.write_all(stdout_bytes)?;
     stdout.flush()?;
     let mut stderr = std::io::stderr().lock();
-    stderr.write_all(&output.stderr)?;
+    stderr.write_all(stderr_bytes)?;
     stderr.flush()?;
     Ok(())
 }
@@ -297,6 +505,36 @@ fn file_mode(_metadata: &std::fs::Metadata) -> u32 {
 }
 
 #[cfg(unix)]
+fn validate_file_mode(node: &CacheFileNode) -> Result<()> {
+    if node.executable || node.mode & !0o777 != 0 || node.mode & 0o111 != 0 {
+        bail!("cached rustc output has an unsafe file mode: {}", node.name);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn validate_file_mode(node: &CacheFileNode) -> Result<()> {
+    if node.executable || node.mode != 0 {
+        bail!("cached rustc output has an unsafe file mode: {}", node.name);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_file_mode(temporary: &tempfile::NamedTempFile, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    temporary
+        .as_file()
+        .set_permissions(std::fs::Permissions::from_mode(mode))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn apply_file_mode(_temporary: &tempfile::NamedTempFile, _mode: u32) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
 fn exit_code(status: ExitStatus) -> ExitCode {
     use std::os::unix::process::ExitStatusExt as _;
     ExitCode::from(
@@ -316,6 +554,33 @@ fn exit_code(status: ExitStatus) -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_outputs(root: &Path) -> RustcOutputs {
+        let directory = root.join("out");
+        RustcOutputs {
+            files: vec![directory.join("libdemo.rlib")],
+            dep_info: directory.join("demo.d"),
+            directory,
+        }
+    }
+
+    fn test_file(name: &str) -> CacheFileNode {
+        CacheFileNode {
+            digest: CacheDigest::blake3(b"artifact"),
+            executable: false,
+            mode: if cfg!(unix) { 0o644 } else { 0 },
+            name: name.into(),
+        }
+    }
+
+    fn test_directory(files: Vec<CacheFileNode>) -> CacheDirectory {
+        CacheDirectory {
+            directories: Vec::new(),
+            files,
+            symlinks: Vec::new(),
+            version: 1,
+        }
+    }
 
     #[test]
     fn parses_verbose_rustc_identity() {
@@ -342,5 +607,35 @@ mod tests {
             .map(|mapping| &mapping.placeholder)
             .collect::<BTreeSet<_>>();
         assert_eq!(placeholders.len(), mappings.len());
+    }
+
+    #[test]
+    fn validates_exact_rustc_output_set() {
+        let root = tempfile::tempdir().unwrap();
+        let outputs = test_outputs(root.path());
+        let files =
+            validated_outputs(test_directory(vec![test_file("libdemo.rlib")]), &outputs).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].1, outputs.files[0]);
+    }
+
+    #[test]
+    fn rejects_cached_output_path_traversal() {
+        let root = tempfile::tempdir().unwrap();
+        let outputs = test_outputs(root.path());
+        assert!(
+            validated_outputs(test_directory(vec![test_file("../libdemo.rlib")]), &outputs,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_executable_rustc_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let outputs = test_outputs(root.path());
+        let mut file = test_file("libdemo.rlib");
+        file.executable = true;
+        assert!(validated_outputs(test_directory(vec![file]), &outputs).is_err());
     }
 }

--- a/src/cache/rustc.rs
+++ b/src/cache/rustc.rs
@@ -24,11 +24,11 @@ pub(super) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
 
     if outputs.dep_info.is_file()
         && let Ok((action, discovered)) =
-            action_from_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)
+            action_from_current_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)
     {
         match restore_result(&action, &outputs, &discovered) {
             Ok(Some((stdout, stderr))) => {
-                replay_bytes(&stdout, &stderr)?;
+                let _ = replay_bytes(&stdout, &stderr);
                 return Ok(ExitCode::SUCCESS);
             }
             Ok(None) => {}
@@ -67,7 +67,27 @@ fn action_from_dep_info(
     working_dir: &Path,
 ) -> Result<(RustcAction, DiscoveredInputs)> {
     let dep_info = RustcDepInfo::read(dep_info)?;
-    let discovered = invocation.discover_inputs(&dep_info, working_dir)?;
+    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir)
+}
+
+fn action_from_current_dep_info(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    dep_info: &Path,
+    working_dir: &Path,
+) -> Result<(RustcAction, DiscoveredInputs)> {
+    let dep_info = RustcDepInfo::read(dep_info)?;
+    verify_environment(&dep_info.environment)?;
+    action_from_parsed_dep_info(rustc, invocation, &dep_info, working_dir)
+}
+
+fn action_from_parsed_dep_info(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    dep_info: &RustcDepInfo,
+    working_dir: &Path,
+) -> Result<(RustcAction, DiscoveredInputs)> {
+    let discovered = invocation.discover_inputs(dep_info, working_dir)?;
     let mut context = ActionContext {
         compiler: compiler_identity(rustc)?,
         working_dir: working_dir.to_path_buf(),
@@ -78,6 +98,22 @@ fn action_from_dep_info(
     discovered.clone().apply_to(&mut context)?;
     let action = invocation.action(context)?;
     Ok((action, discovered))
+}
+
+fn verify_environment(environment: &BTreeMap<String, Option<String>>) -> Result<()> {
+    for (name, expected) in environment {
+        let actual = std::env::var_os(name)
+            .map(|value| {
+                value.into_string().map_err(|_| {
+                    eyre::eyre!("compiler environment input is not valid UTF-8: {name}")
+                })
+            })
+            .transpose()?;
+        if &actual != expected {
+            bail!("compiler environment input changed: {name}");
+        }
+    }
+    Ok(())
 }
 
 fn restore_result(
@@ -151,21 +187,53 @@ fn restore_result(
     }
 
     discovered.verify()?;
+    verify_environment(&discovered.environment)?;
+    persist_outputs(staged)?;
+    record_action_hit(&action.digest);
+    Ok(Some((stdout, stderr)))
+}
+
+fn persist_outputs(staged: Vec<(tempfile::NamedTempFile, PathBuf)>) -> Result<()> {
+    let destinations = staged
+        .iter()
+        .map(|(_, destination)| destination.clone())
+        .collect::<Vec<_>>();
     for (temporary, destination) in staged {
-        temporary
+        let persisted = temporary
             .persist(&destination)
             .map_err(|error| error.error)
-            .wrap_err_with(|| format!("failed to atomically restore {}", destination.display()))?;
+            .wrap_err_with(|| format!("failed to atomically restore {}", destination.display()));
+        if let Err(error) = persisted {
+            for destination in &destinations {
+                match std::fs::remove_file(destination) {
+                    Ok(()) => {}
+                    Err(remove_error) if remove_error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(remove_error) => eprintln!(
+                        "mise rustc cache warning: failed to roll back {}: {remove_error}",
+                        destination.display()
+                    ),
+                }
+            }
+            return Err(error);
+        }
     }
+    Ok(())
+}
+
+fn record_action_hit(action: &CacheDigest) {
     let responses = session::request_agent(&[AgentRequest::RecordActionHit {
-        action: action.digest.clone(),
-    }])?;
-    match responses.into_iter().next() {
-        Some(AgentResponse::ActionHitRecorded) => {}
-        Some(AgentResponse::Error { message }) => bail!(message),
-        _ => bail!("cache agent did not record the restored action hit"),
+        action: action.clone(),
+    }]);
+    match responses.map(|responses| responses.into_iter().next()) {
+        Ok(Some(AgentResponse::ActionHitRecorded)) => {}
+        Ok(Some(AgentResponse::Error { message })) => {
+            eprintln!("mise rustc cache warning: hit was not recorded: {message}");
+        }
+        Ok(_) => eprintln!("mise rustc cache warning: hit was not recorded"),
+        Err(error) => {
+            eprintln!("mise rustc cache warning: hit was not recorded: {error:#}");
+        }
     }
-    Ok(Some((stdout, stderr)))
 }
 
 fn find_blobs(digests: &[CacheDigest]) -> Result<Vec<PathBuf>> {
@@ -496,7 +564,7 @@ fn staged_bytes(directory: &Path, name: &str, bytes: &[u8]) -> Result<(CacheDige
 #[cfg(unix)]
 fn file_mode(metadata: &std::fs::Metadata) -> u32 {
     use std::os::unix::fs::PermissionsExt as _;
-    metadata.permissions().mode() & 0o777
+    metadata.permissions().mode() & 0o644
 }
 
 #[cfg(windows)]
@@ -506,7 +574,11 @@ fn file_mode(_metadata: &std::fs::Metadata) -> u32 {
 
 #[cfg(unix)]
 fn validate_file_mode(node: &CacheFileNode) -> Result<()> {
-    if node.executable || node.mode & !0o777 != 0 || node.mode & 0o111 != 0 {
+    if node.executable
+        || node.mode & !0o777 != 0
+        || node.mode & 0o111 != 0
+        || node.mode & 0o022 != 0
+    {
         bail!("cached rustc output has an unsafe file mode: {}", node.name);
     }
     Ok(())
@@ -637,5 +709,48 @@ mod tests {
         let mut file = test_file("libdemo.rlib");
         file.executable = true;
         assert!(validated_outputs(test_directory(vec![file]), &outputs).is_err());
+    }
+
+    #[test]
+    fn rejects_group_or_world_writable_rustc_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let outputs = test_outputs(root.path());
+        let mut file = test_file("libdemo.rlib");
+        file.mode = 0o666;
+        assert!(validated_outputs(test_directory(vec![file]), &outputs).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publication_masks_unsafe_rustc_output_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        file.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o666))
+            .unwrap();
+        assert_eq!(file_mode(&file.as_file().metadata().unwrap()), 0o644);
+    }
+
+    #[test]
+    fn rolls_back_outputs_after_a_partial_persist() {
+        let root = tempfile::tempdir().unwrap();
+        let first_destination = root.path().join("first.rlib");
+        let blocked_destination = root.path().join("blocked.rmeta");
+        std::fs::create_dir(&blocked_destination).unwrap();
+        let mut first = tempfile::NamedTempFile::new_in(root.path()).unwrap();
+        first.write_all(b"first").unwrap();
+        let mut second = tempfile::NamedTempFile::new_in(root.path()).unwrap();
+        second.write_all(b"second").unwrap();
+
+        assert!(
+            persist_outputs(vec![
+                (first, first_destination.clone()),
+                (second, blocked_destination.clone()),
+            ])
+            .is_err()
+        );
+        assert!(!first_destination.exists());
+        assert!(blocked_destination.is_dir());
     }
 }

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -401,8 +401,8 @@ pub(crate) fn is_rustc_shim() -> bool {
 /// Ultra-early argv0 path used by Cargo's `RUSTC_WRAPPER` integration.
 ///
 /// This runs before mise creates a Tokio runtime, installs logging, or discovers
-/// configuration. Cacheable misses publish through the task-scoped agent;
-/// unsupported invocations remain transparent compiler calls.
+/// configuration. Cacheable invocations restore from or publish through the
+/// task-scoped agent; unsupported invocations remain transparent compiler calls.
 pub(crate) fn run_rustc_shim() -> ExitCode {
     let mut arguments = std::env::args_os().skip(1);
     let Some(rustc) = arguments.next() else {
@@ -411,7 +411,7 @@ pub(crate) fn run_rustc_shim() -> ExitCode {
     };
     let arguments = arguments.collect::<Vec<_>>();
     if std::env::var_os(PREVIOUS_RUSTC_WRAPPER_ENV).is_none() {
-        match crate::cache::rustc::compile_miss(&rustc, &arguments) {
+        match crate::cache::rustc::compile(&rustc, &arguments) {
             Ok(exit_code) => return exit_code,
             Err(_error) => {
                 #[cfg(debug_assertions)]


### PR DESCRIPTION
## Summary
- add task-scoped local action-result lookup and completed-hit accounting
- validate canonical rustc metadata, exact output names, safe modes, and every referenced digest before restoring
- atomically replace cached rlib/rmeta outputs and replay compiler diagnostics byte-for-byte
- warn and transparently run the real compiler when a cached result is incomplete, corrupt, or unsafe

## Why
The rustc adapter could publish successful compilation misses but could not consume those results. This adds the local restore half of the loop while keeping remote traffic and cold-CI prefetch out of scope.

## Validation
- `cargo test -p mise-cache-core agent::tests`
- `cargo test --bin mise cache::rustc::tests`
- `mise run test:e2e tasks/test_task_rust_cache_restore`
- `mise run test:e2e tasks/test_task_action_cache_session`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rust compilation can restore verified outputs and captured compiler output from the task cache.
  * Successful cache restorations are recorded for improved cache reporting.
* **Bug Fixes**
  * Invalid, incomplete, tampered, or unexpected cached files now safely trigger recompilation.
  * Cache statistics now accurately track action lookups and hits.
* **Tests**
  * Added end-to-end coverage for restoring Rust artifacts, stale outputs, dependency changes, and cache misses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores compiler artifacts from the local CAS with digest and permission checks, but incorrect validation could still write wrong files or skip recompilation; failures degrade to transparent `rustc` with warnings.
> 
> **Overview**
> Completes the **local rustc action cache loop**: the `RUSTC_WRAPPER` shim now tries to **restore** a prior compilation before invoking the real compiler, and records **action-result** lookups/hits through the task cache agent instead of treating blob `FindBlob` as a hit.
> 
> The cache agent gains **`FindActionResult`** / **`RecordActionHit`** (hits increment only after a successful restore). **`compile`** rebuilds the action from existing `dep-info`, checks env inputs, loads verified CAS blobs (action descriptor, metadata, outputs, stdout/stderr), validates output names/modes/digests, **atomically persists** artifacts with rollback on failure, replays captured stdout/stderr, then records the hit. Incomplete or corrupt cache entries **warn and fall through** to a normal `rustc` run (publish path unchanged).
> 
> Adds unit tests around output validation, permission masking, and partial persist rollback, plus an **e2e** task that exercises hit restore, env/input invalidation, and missing blob recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0615e74f1f9aa78189258c8387ad03bd6eb73470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->