### PR TITLE
fix(config): make `ignored_config_paths` match on Windows

### DIFF
--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -504,21 +504,39 @@ pub fn is_trusted_via_config_paths(path: &Path) -> bool {
     }
 }
 
+/// Whether `path` sits under one of `ignored`.
+///
+/// Compared twice: as written, then with both sides canonicalized.
+///
+/// `Path::starts_with` is component-wise, so the as-written pass already handles
+/// separator and case conventions for ordinary input — it is what the
+/// directory-level checks in `config` do. The canonical pass is what lets a
+/// plainly-written setting value match a candidate that arrives canonicalized:
+/// on Windows `canonicalize` yields a `\\?\` verbatim path that no plain prefix
+/// matches, and on unix it resolves symlinks. `Settings::trusted_config_paths`
+/// canonicalizes its own entries for the same reason.
+fn path_is_under_any(path: &Path, ignored: &[PathBuf]) -> bool {
+    if ignored.iter().any(|p| path.starts_with(p)) {
+        return true;
+    }
+    let Some(canonical) = file::canonicalize_cached(path) else {
+        // Nothing on disk to resolve — the as-written pass above was the only
+        // chance to match.
+        return false;
+    };
+    ignored
+        .iter()
+        .filter_map(|p| file::canonicalize_cached(p))
+        .any(|p| canonical.starts_with(p))
+}
+
 /// Whether `path` is under an explicitly-configured `ignored_config_paths`
 /// (`MISE_IGNORED_CONFIG_PATHS`) entry.
 ///
 /// This is an explicit "never load this config" instruction and is a hard
 /// block: it takes precedence over `trusted_config_paths`.
 pub fn is_ignored_via_setting(path: &Path) -> bool {
-    match path.canonicalize() {
-        Ok(path) => env::MISE_IGNORED_CONFIG_PATHS
-            .iter()
-            .any(|p| path.starts_with(p)),
-        Err(_) => {
-            debug!("is_ignored_via_setting: path canonicalize failed");
-            false
-        }
-    }
+    path_is_under_any(path, &env::MISE_IGNORED_CONFIG_PATHS)
 }
 
 /// Whether `path` is in the persisted ignore list.
@@ -790,6 +808,93 @@ pub struct TaskConfig {
     pub global_pass_through_env: Vec<String>,
     pub global_inputs: Vec<String>,
     pub input_groups: IndexMap<String, Vec<String>>,
+}
+
+/// Deliberately not `#[cfg(unix)]` like the module below: the bug these cover is
+/// one that only shows up once `canonicalize` rewrites the path, which is the
+/// normal case on Windows.
+#[cfg(test)]
+mod ignored_config_path_tests {
+    use super::*;
+
+    /// The setting is written as an ordinary path while the candidate can arrive
+    /// canonicalized — `is_trusted` passes one straight in. On Windows that is a
+    /// `\\?\` verbatim path; on macOS a tempdir under `/var` resolves to
+    /// `/private/var`. Neither matches a plainly-written prefix, so the two sides
+    /// have to be resolved together.
+    #[test]
+    fn plain_entry_matches_canonicalized_candidate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ignored_dir = tmp.path().join("cfgdir");
+        std::fs::create_dir_all(&ignored_dir).unwrap();
+        let cfg = ignored_dir.join("config.toml");
+        std::fs::write(&cfg, "").unwrap();
+
+        let ignored = vec![ignored_dir];
+        assert!(path_is_under_any(&cfg, &ignored));
+        assert!(path_is_under_any(&cfg.canonicalize().unwrap(), &ignored));
+    }
+
+    #[test]
+    fn sibling_directory_is_not_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ignored_dir = tmp.path().join("cfgdir");
+        let other_dir = tmp.path().join("other");
+        std::fs::create_dir_all(&ignored_dir).unwrap();
+        std::fs::create_dir_all(&other_dir).unwrap();
+        let cfg = other_dir.join("config.toml");
+        std::fs::write(&cfg, "").unwrap();
+
+        let ignored = vec![ignored_dir];
+        assert!(!path_is_under_any(&cfg, &ignored));
+        assert!(!path_is_under_any(&cfg.canonicalize().unwrap(), &ignored));
+    }
+
+    /// The same defect without leaving unix: an entry that reaches its directory
+    /// through a symlink never matches a candidate expressed by its real path.
+    ///
+    /// This is the case that fails on an ordinary Linux runner. The test above
+    /// only bites where the platform rewrites the path on its own — a `\\?\`
+    /// prefix on Windows, `/var` → `/private/var` on macOS — so on Linux it
+    /// passes with or without the fix.
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_entry_matches_real_candidate() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target_dir = tmp.path().join("target");
+        let ignored_link = tmp.path().join("ignored-link");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        symlink(&target_dir, &ignored_link).unwrap();
+
+        let cfg = target_dir.join("config.toml");
+        std::fs::write(&cfg, "").unwrap();
+
+        let ignored = vec![ignored_link];
+        // The as-written pass cannot see through the link...
+        assert!(!cfg.starts_with(&ignored[0]));
+        // ...so only resolving both sides finds the match.
+        assert!(path_is_under_any(&cfg, &ignored));
+    }
+
+    /// A path that does not exist cannot be canonicalized, so the as-written
+    /// comparison is the only one that can match it.
+    #[test]
+    fn missing_path_still_matches_as_written() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ignored_dir = tmp.path().join("cfgdir");
+
+        let ignored = vec![ignored_dir.clone()];
+        assert!(path_is_under_any(
+            &ignored_dir.join("config.toml"),
+            &ignored
+        ));
+        assert!(!path_is_under_any(
+            &tmp.path().join("other").join("config.toml"),
+            &ignored
+        ));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## The problem

`ignored_config_paths` is documented as the strong lever — "an explicit 'never load this config' instruction and is a hard block: it takes precedence over `trusted_config_paths`". On Windows it silently does nothing unless you write the path in `\\?\` verbatim form.

Measured on **v2026.8.2** (windows-x64), same config file in every run, only the setting value changing:

```console
plain     C:\Users\me\.config\mise           -> STILL LOADED
verbatim  \\?\C:\Users\me\.config\mise       -> ignored OK
plain     C:\Users\me\.config\mise\config.toml     -> STILL LOADED
verbatim  \\?\C:\Users\me\.config\mise\config.toml -> ignored OK
```

## Cause

`is_ignored_via_setting` canonicalized the *candidate* but compared it against the setting entries as written. `std::fs::canonicalize` returns a `\\?\` verbatim path on Windows, and no plainly-written prefix matches one.

The neighbouring `Settings::trusted_config_paths` does not have this problem because it canonicalizes its entries (`.filter_map(|p| file::canonicalize_cached(&p))`) before they are compared. The two functions are read together and were doing different things.

This is not strictly Windows-only: `canonicalize` also resolves symlinks, so a unix path whose resolution crosses one — a symlinked `$HOME`, or `/var` → `/private/var` on macOS — misses the same way.

## Scope: one of three comparison sites was wrong

| | comparison | state |
|---|---|---|
| `config_file::is_ignored_via_setting` | canonical vs as-written | **broken** |
| `config::config_dir_is_ignored` | as-written vs as-written | consistent, works |
| `config::load_config_paths` (dir filter) | as-written vs as-written | consistent, works |

The two directory-level checks are self-consistent and I found no failure for them, so they are untouched.

That split also explains why `~/.config/mise/config.toml` kept loading despite the setting: the ancestor walk hands `config_dir_is_ignored` the *ancestor directory* (`C:\Users\me`), not `C:\Users\me\.config\mise`, so the directory check never fires for it. The per-file check is the only one positioned to block it, and that is the broken one.

## The fix

Compare as written first, then with both sides canonicalized:

```rust
fn path_is_under_any(path: &Path, ignored: &[PathBuf]) -> bool {
    if ignored.iter().any(|p| path.starts_with(p)) {
        return true;
    }
    let Some(canonical) = file::canonicalize_cached(path) else {
        return false;
    };
    ignored
        .iter()
        .filter_map(|p| file::canonicalize_cached(p))
        .any(|p| canonical.starts_with(p))
}
```

`Path::starts_with` is component-wise, so the as-written pass already covers ordinary input and matches what the directory-level checks do. The canonical pass is what makes the Windows and symlink cases work. Setting values are left as the user wrote them and resolved at the comparison, mirroring `trusted_config_paths`.

## Intentional behaviour change

Previously a candidate that could not be canonicalized returned `false` immediately. Now the as-written comparison can still match it — relevant for paths that do not exist yet.

That is the safe direction for a "never load this" block, and it makes the per-file check agree with the directory-level one, which has always matched as-written. `e2e/config/test_config_ignore_write_target` covers this shape: it expects a warning for a write target under an ignored path that does not exist yet, and today the directory check is what produces it. After this change the file check agrees rather than disagreeing.

## Tests

Four unit tests, in a module deliberately **not** gated on `#[cfg(unix)]` — the existing test module in that file is, and this bug only appears once `canonicalize` rewrites the path. `windows-unit` runs `cargo test`, so the regression is covered on the platform where it happened.

- a plainly-written entry matches a canonicalized candidate
- an entry reaching its directory through a symlink matches a candidate expressed by its real path (unix only)
- a sibling directory is not ignored, in both forms
- a path that does not exist still matches as written, and a non-matching one still does not

The first fails without this change on Windows and macOS, where the platform rewrites the path on its own — a `\\?\` prefix, or `/var` → `/private/var` for `tempfile::tempdir()`. On an ordinary Linux runner neither happens, so that test passes with or without the fix; the symlink test is the one that covers the defect there.

## Notes

- No `settings.toml` change: the documentation was already correct, this makes the behaviour match it. So no `schema/mise.json` regeneration, and the diff stays inside `src/`.
- `mise generate bootstrap` emits `MISE_IGNORED_CONFIG_PATHS="$HOME/.config/mise"`, which means the generated isolation was not taking effect on Windows.
- Found while answering #5199, where reproducing a CI environment locally needs exactly this setting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ignored-path detection when paths use different formats or include canonicalized locations.
  * Correctly handles sibling directories and paths that do not yet exist.
  * Added coverage for these path-matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->