### PR TITLE
chore(deps): update aube and simplify version requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,23 @@ All commit messages and PR titles MUST follow conventional commit format:
 3. Use `mise run test:e2e [test_filename]...` for running specific e2e tests
 4. Never run e2e tests by executing them directly - always use the mise task
 
+### Dependency Updates
+
+- Use the lowest-specificity dependency requirement that expresses compatibility in `Cargo.toml` (for example, prefer `"1"` over `"1.2.3"`, and `"0.12"` over `"0.12.1"` for a pre-1.0 crate).
+- Routine dependency updates should only change `Cargo.lock`. If the existing `Cargo.toml` requirement accepts the target version, do not change it merely to force or record the update; use `cargo update -p <crate> --precise <version>` instead.
+- Keep lockfile updates focused on the requested dependency and its required transitive changes. Remove unrelated resolver churn before committing.
+
+#### Updating embedded aube
+
+- Update `aube` and `aube-registry` together and refresh all aube workspace crates in `Cargo.lock`.
+- Review the upstream changes for embedder API or behavior changes and make any required mise integration changes.
+- Do not update the standalone `aube` tool entry in `mise.lock` unless the development tool is also intentionally being updated.
+- Run these focused checks:
+  - `cargo check --locked`
+  - `cargo test --locked --bin mise aube`
+  - `cargo test --locked --bin mise task::workspace::node::tests`
+  - `mise run test:e2e e2e/backend/test_npm_aube`
+
 ## Deprecation Policy
 
 When deprecating a feature or backend:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120880a13990a17ab58abbd8a1f569a308903b04ac7ac58a819712524a251b07"
+checksum = "a2d1a6a6b2c833a6c81b44e51d3310cf59104c498f45e54a203133ca7c3c8fbb"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4623667e836e5139bfff18fd062f336b8cd005a2671935b477ded6766a03f2df"
+checksum = "1dab0ae089e0c6e47211a85592e7b39fd2d05c838cd51a56498e3225a01182a1"
 dependencies = [
  "serde",
  "serde_json",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9958ab7546ac4c943cb0b0d059a4b8fac3b056200beed57164ef8b04fda83c59"
+checksum = "bd6388f0e3bfa7dfa5d0a6c48b4385dc1019832589dfcdcb155d030e9b41a164"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e887595a39c3838789a9173fa2c312ef62fe54714fb809d3aa679752f332b50"
+checksum = "833554cade0267488817f55bb2b4759f28a1bf531d07584b1c9af739ab3d3239"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36b2f01e2d9eb4b0337b843136ca842b4be2057b3a05000b50a69df0bc24657"
+checksum = "4ece343eae75df129905ad9af19b6f100e5fbf733bbf0c745a95943963392474"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edc6b967253b8256aa5b44336db2aebd614e7bc73b3a6d40e2dbb988de856e0"
+checksum = "54d9f228eb52a28c3971c2b06d419335d2c44cdf2426579b06d70a64f05cc48a"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185a6c70714f1a06f406a0e2b6e97f272c9ffb3be5dd2f4d15d6bf6262c88c01"
+checksum = "018eef3bc8c4e18dca50e2505bcab069a1c44a38ddf3aaa7d6153b8644fe1cab"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90f7d6ae64c880d3dd4aa9cfc8cb7bfcaabadad9184547da831cd86090f31e4"
+checksum = "c71c8ef31cd884024d42c24ca47679dcff224090157b09a9aaa4e5a7c8dce3f0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564564f9bd8817e62ba6f3322f73c8bd33a20ebefb19571b865aa32f8e95f962"
+checksum = "209c75e6287985beb10008c8a301f9502602379752271beef5c4f2b03e8d6204"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ff6498dc172722c01283c11c6c110850e104bff4b190481f65577f25ae17a"
+checksum = "86b4f0a637331dc40c9728797cf675ada1adb3e97ba8895523b949a95d55cb8f"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60572865c83e58356884d4e08813f52feb8a2f73f3b7937243f95a1868a50469"
+checksum = "3089af6fdf3c1a76cc361bff0f51b9eff89cbf72b8d238239e81996f62ad3bac"
 dependencies = [
  "aube-util",
  "base64 0.23.0",
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946f9718b5f05e7c81746810fddd4258b3b06632ae59669ef413572c4e81497e"
+checksum = "001c6fafcdee4149823948f26ef9646483a566d46331f2d1e27459f3498cf922"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f1a622b01b408680c6fb21645ae70dfd782348a18233832f22f8bcc9b126d1"
+checksum = "7961d837ffc63183a1de84e324c60447abce20c206dbb222a61b0283465f38d2"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,13 +69,13 @@ opt-level = 3
 [dependencies]
 age = { version = "0.12", features = ["ssh"] }
 aho-corasick = "1"
-aube-registry = { version = "1.38", default-features = false, features = [
+aube-registry = { version = "1", default-features = false, features = [
   "rustls",
 ] }
-aube = { version = "1.38", default-features = false, features = ["rustls"] }
+aube = { version = "1", default-features = false, features = ["rustls"] }
 async-backtrace = "0.2"
 async-trait = "0.1"
-aws-config = { version = "1.5", default-features = false, features = [
+aws-config = { version = "1", default-features = false, features = [
   "behavior-version-latest",
   "default-https-client",
   "rt-tokio",
@@ -106,19 +106,19 @@ console = "0.16"
 contracts = "0.6"
 dashmap = "6"
 demand = "2"
-digest = "0.11.0"
+digest = "0.11"
 dotenvy = "0.15"
-duct = "1.0"
+duct = "1"
 homedir = "0.3"
 expr-lang = "1"
 eyre = "0.6"
 filetime = "0.2"
 flate2 = "1"
-futures-util = "0.3.32"
+futures-util = "0.3"
 mise-sigstore = { path = "crates/mise-sigstore", default-features = false }
 mise-cache-core = { path = "crates/mise-cache-core", default-features = false }
 mise-cache-rustc = { path = "crates/mise-cache-rustc" }
-fslock = "0.2.1"
+fslock = "0.2"
 gix = { version = "<1", features = ["worktree-mutation"] }
 glob = "0.3"
 globset = "0.4"
@@ -131,7 +131,7 @@ ipnet = { version = "2", features = ["serde"] }
 clx = "3"
 indoc = "2"
 itertools = "0.15"
-jdx-tar = "1.1.0"
+jdx-tar = "1"
 jiff = "0.2"
 junction = "2"
 log = "0.4"
@@ -139,7 +139,7 @@ minisign-verify = "0.2"
 md-5 = "0.11"
 miette = { version = "7", features = ["fancy"] }
 netrc-rs = "0.1"
-nodejs-semver = "5.0"
+nodejs-semver = "5"
 nucleo-matcher = "0.3"
 num_cpus = "1"
 once_cell = "1"
@@ -172,7 +172,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "stream",
   "system-proxy",
 ] }
-rmcp = { version = "3.0", features = ["server", "transport-io", "schemars"] }
+rmcp = { version = "3", features = ["server", "transport-io", "schemars"] }
 rmp-serde = "1"
 rops = { version = "0.1", default-features = false, features = [
   "aes-gcm",
@@ -203,7 +203,7 @@ tabled = { version = "0.21", features = ["ansi"] }
 taplo = "0.14"
 tempfile = "3"
 tera = "2"
-tera1 = { package = "tera", version = "1.20.1" }
+tera1 = { package = "tera", version = "1" }
 tera-contrib = { version = "0.2", features = [
   "base64",
   "date",
@@ -219,7 +219,7 @@ terminal_size = "0.4"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
-toml = { version = "1.0", features = ["parse", "preserve_order"] }
+toml = { version = "1", features = ["parse", "preserve_order"] }
 toml_edit = { version = "0.25", features = ["parse"] }
 # 1.28.0 requires Rust 1.97, newer than mise's MSRV.
 tree-sitter-iter = "=1.27.0"
@@ -230,10 +230,10 @@ usage-lib = { version = "5", features = ["clap", "docs"] }
 versions = { version = "7", features = ["serde"] }
 vfox = { path = "crates/vfox", default-features = false }
 aqua-registry = { path = "crates/aqua-registry" }
-mise-interactive-config = { path = "crates/mise-interactive-config", version = "2026.1.12" }
+mise-interactive-config = { path = "crates/mise-interactive-config", version = "2026" }
 walkdir = "2"
 which = "8"
-xx = { version = "2.5", default-features = false, features = ["glob"] }
+xx = { version = "2", default-features = false, features = ["glob"] }
 xz2 = "0.1"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 zstd = "0.13"
@@ -260,7 +260,7 @@ self_update = { version = "0.44", optional = true, default-features = false, fea
   "reqwest",
 ] }
 zipsign-api = "0.2"
-winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }
+winapi = { version = "0.3", features = ["consoleapi", "minwindef"] }
 windows-sys = { version = "0.61", features = [
   "Win32_Security",
   "Win32_Security_Authorization",
@@ -277,7 +277,7 @@ indexmap = "2"
 phf_codegen = "0.14"
 serde = "1"
 serde_yaml = "0.9"
-toml = "1.0"
+toml = "1"
 
 [dev-dependencies]
 clap-sort = "1"

--- a/crates/mise-interactive-config/Cargo.toml
+++ b/crates/mise-interactive-config/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1", features = [
 ] } # Async runtime for spawn_blocking
 toml_edit = { version = "0.25", features = ["parse"] }
 unicode-width = "0.2" # Text width calculation for cursor positioning
-xx = { version = "2.5", default-features = false } # For display_path
+xx = { version = "2", default-features = false } # For display_path
 
 [build-dependencies]
 serde_json = "1"

--- a/crates/vfox/Cargo.toml
+++ b/crates/vfox/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] } # TODO: replace with xx
 serde = "1"
 serde_json = "1"
-toml = "1.0"
+toml = "1"
 thiserror = "2"
 tokio = { version = "1", features = [
   "macros",


### PR DESCRIPTION
## Summary
- update the embedded aube workspace crates from v1.38.0 to v1.38.1 in `Cargo.lock`
- simplify Cargo dependency requirements across the workspace to the lowest compatibility-significant specificity
- document the dependency-update policy and focused embedded-aube workflow in `CLAUDE.md` / `AGENTS.md`

## Details

Stable dependencies now use major-only requirements such as `"1"`; pre-1.0 dependencies retain their compatibility-significant minor such as `"0.12"`. The intentional exact `tree-sitter-iter = "=1.27.0"` MSRV pin is unchanged. The broader requirements resolve to the existing locked versions without additional lockfile churn.

aube v1.38.1 includes fixes for peer dependency resolution, cold project materialization, Git credential prompting, POSIX shim symlinks, update range preservation, and project-root cleanup protection.

Upstream comparison: https://github.com/jdx/aube/compare/v1.38.0...v1.38.1

## Validation
- `mise run lint-fix`
- `cargo check --locked`
- `cargo test --locked --bin mise aube` (16 passed)
- `cargo test --locked --bin mise task::workspace::node::tests` (29 passed)
- `mise run test:e2e e2e/backend/test_npm_aube`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patch bump to the in-process npm package manager affects install resolution and materialization; Cargo.toml relaxations are policy-only and should not change locked versions.
> 
> **Overview**
> **Bumps the embedded aube workspace** from **1.38.0 → 1.38.1** in `Cargo.lock` (all `aube-*` crates), picking up upstream patch fixes around peer dependency resolution, project materialization, Git credentials, POSIX shims, update ranges, and project-root cleanup.
> 
> **Relaxes `Cargo.toml` version pins** across the root crate and workspace members (`mise-interactive-config`, `vfox`) to the lowest compatibility-significant specificity (e.g. `"1.38"` → `"1"` for stable crates, `"1.0"` → `"1"` for `toml`). The intentional exact `tree-sitter-iter = "=1.27.0"` MSRV pin is unchanged.
> 
> **Documents contributor policy** in `AGENTS.md`: prefer minimal version requirements, lockfile-only routine updates when requirements already accept the version, focused lockfile churn, and a dedicated checklist for future embedded-aube bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc040ebd3d7fb579d6df940a109e93fdc9649fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version requirements across the project to allow compatible minor and patch releases.
  * Synchronized dependency requirements across related components.
  * Added contributor guidance for safe dependency updates and focused validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->