### PR TITLE
feat(cache): persist task rust action manifests

### DIFF
--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -2,6 +2,7 @@ use crate::{CacheDigest, LocalActionCache, LocalCas, RemoteActionResult};
 use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
@@ -10,6 +11,9 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader
 const MAX_EXECUTABLE_IDENTITIES: usize = 64;
 const MAX_EXECUTABLE_IDENTITY_SIZE: usize = 64 * 1024;
 const MAX_EXECUTABLE_IDENTITY_BYTES: usize = 256 * 1024;
+const TASK_ACTION_MANIFEST_VERSION: u8 = 1;
+const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
+const MAX_ACTION_PREDICTION_PAYLOAD: usize = 256 * 1024;
 
 /// Wire protocol version used between an in-process cache agent and its shims.
 pub const AGENT_PROTOCOL_VERSION: u8 = 1;
@@ -38,6 +42,14 @@ pub enum AgentRequest {
     StoreActionResult {
         result: RemoteActionResult,
     },
+    FindActionPrediction {
+        task: String,
+        invocation: CacheDigest,
+    },
+    RecordActionPrediction {
+        task: String,
+        prediction: ActionPrediction,
+    },
     FindExecutableIdentity {
         executable: PathBuf,
         environment: BTreeMap<String, Option<String>>,
@@ -53,14 +65,33 @@ pub enum AgentRequest {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentResponse {
-    Hello { protocol: u8, agent_version: String },
-    Blob { path: Option<PathBuf> },
-    Stored { path: PathBuf },
-    ActionResult { result: Option<RemoteActionResult> },
+    Hello {
+        protocol: u8,
+        agent_version: String,
+    },
+    Blob {
+        path: Option<PathBuf>,
+    },
+    Stored {
+        path: PathBuf,
+    },
+    ActionResult {
+        result: Option<RemoteActionResult>,
+    },
     ActionHitRecorded,
-    ActionStored { path: PathBuf },
-    ExecutableIdentity { stdout: Option<Vec<u8>> },
-    Error { message: String },
+    ActionStored {
+        path: PathBuf,
+    },
+    ActionPrediction {
+        prediction: Option<ActionPrediction>,
+    },
+    ActionPredictionRecorded,
+    ExecutableIdentity {
+        stdout: Option<Vec<u8>>,
+    },
+    Error {
+        message: String,
+    },
 }
 
 /// Aggregate cache activity for one task session.
@@ -74,6 +105,17 @@ pub struct AgentStats {
     pub stores: u64,
     /// Total size of newly stored objects.
     pub stored_bytes: u64,
+}
+
+/// Adapter-owned data needed to reconstruct an action before fresh dependency
+/// discovery is available.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionPrediction {
+    pub invocation: CacheDigest,
+    pub action: CacheDigest,
+    pub adapter: String,
+    pub payload: String,
 }
 
 #[derive(Default)]
@@ -96,6 +138,25 @@ pub struct CacheAgent {
     write_locks: Arc<Mutex<BTreeMap<CacheDigest, Weak<tokio::sync::Mutex<()>>>>>,
     stats: Arc<AtomicAgentStats>,
     executable_identities: Arc<Mutex<BTreeMap<ExecutableIdentityKey, Vec<u8>>>>,
+    manifest_dir: Arc<PathBuf>,
+    task_actions: Arc<Mutex<BTreeMap<String, TaskActionState>>>,
+    next_task_run: Arc<AtomicU64>,
+    manifest_write_lock: Arc<Mutex<()>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskActionManifest {
+    version: u8,
+    task: String,
+    predictions: Vec<ActionPrediction>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct TaskActionState {
+    manifest: String,
+    baseline_loaded: bool,
+    predictions: BTreeMap<CacheDigest, ActionPrediction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -110,12 +171,100 @@ impl CacheAgent {
         let cache_dir = cache_dir.into();
         Self {
             cas: LocalCas::new(cache_dir.clone()),
-            actions: LocalActionCache::new(cache_dir),
+            actions: LocalActionCache::new(cache_dir.clone()),
             version: version.into(),
             write_locks: Arc::new(Mutex::new(BTreeMap::new())),
             stats: Arc::new(AtomicAgentStats::default()),
             executable_identities: Arc::new(Mutex::new(BTreeMap::new())),
+            manifest_dir: Arc::new(cache_dir.join("task-manifests").join("v1")),
+            task_actions: Arc::new(Mutex::new(BTreeMap::new())),
+            next_task_run: Arc::new(AtomicU64::new(0)),
+            manifest_write_lock: Arc::new(Mutex::new(())),
         }
+    }
+
+    /// Load the last successful action manifest for a task into this session.
+    pub fn begin_task(&self, task: &str) -> Result<String> {
+        validate_task_identity(task)?;
+        let path = self.task_manifest_path(task);
+        let state = match fs::read(&path) {
+            Ok(contents) => {
+                let manifest: TaskActionManifest = serde_json::from_slice(&contents)?;
+                validate_task_manifest(&manifest, task)?;
+                TaskActionState {
+                    manifest: task.to_string(),
+                    baseline_loaded: true,
+                    predictions: manifest
+                        .predictions
+                        .into_iter()
+                        .map(|prediction| (prediction.invocation.clone(), prediction))
+                        .collect(),
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => TaskActionState {
+                manifest: task.to_string(),
+                baseline_loaded: true,
+                ..TaskActionState::default()
+            },
+            Err(error) => return Err(error.into()),
+        };
+        let sequence = self.next_task_run.fetch_add(1, Ordering::Relaxed);
+        let run =
+            CacheDigest::blake3(format!("{task}\0{}\0{sequence}", std::process::id()).as_bytes())
+                .hash;
+        self.task_actions.lock().unwrap().insert(run.clone(), state);
+        Ok(run)
+    }
+
+    /// Atomically publish the candidate manifest collected by a successful task.
+    pub fn commit_task(&self, run: &str) -> Result<()> {
+        validate_task_identity(run)?;
+        let state = self
+            .task_actions
+            .lock()
+            .unwrap()
+            .get(run)
+            .cloned()
+            .ok_or_else(|| eyre::eyre!("task action manifest baseline was not loaded"))?;
+        if !state.baseline_loaded {
+            bail!("task action manifest baseline was not loaded");
+        }
+        let task = state.manifest;
+        validate_task_identity(&task)?;
+        let _write_guard = self.manifest_write_lock.lock().unwrap();
+        let mut predictions = match fs::read(self.task_manifest_path(&task)) {
+            Ok(contents) => {
+                let current: TaskActionManifest = serde_json::from_slice(&contents)?;
+                validate_task_manifest(&current, &task)?;
+                current
+                    .predictions
+                    .into_iter()
+                    .map(|prediction| (prediction.invocation.clone(), prediction))
+                    .collect::<BTreeMap<_, _>>()
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => BTreeMap::new(),
+            Err(error) => return Err(error.into()),
+        };
+        predictions.extend(state.predictions);
+        let manifest = TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: predictions.into_values().collect(),
+        };
+        validate_task_manifest(&manifest, &task)?;
+        fs::create_dir_all(self.manifest_dir.as_path())?;
+        let mut temporary = tempfile::NamedTempFile::new_in(self.manifest_dir.as_path())?;
+        serde_json::to_writer(temporary.as_file_mut(), &manifest)?;
+        temporary.as_file_mut().sync_all()?;
+        temporary
+            .persist(self.task_manifest_path(&task))
+            .map_err(|error| error.error)?;
+        self.task_actions.lock().unwrap().remove(run);
+        Ok(())
+    }
+
+    fn task_manifest_path(&self, task: &str) -> PathBuf {
+        self.manifest_dir.join(format!("{task}.json"))
     }
 
     /// Return a snapshot of this session's cache activity.
@@ -170,6 +319,12 @@ impl CacheAgent {
                 .actions
                 .store(&result)
                 .map(|path| AgentResponse::ActionStored { path }),
+            AgentRequest::FindActionPrediction { task, invocation } => {
+                self.find_action_prediction(&task, &invocation)
+            }
+            AgentRequest::RecordActionPrediction { task, prediction } => {
+                self.record_action_prediction(&task, prediction)
+            }
             AgentRequest::FindExecutableIdentity {
                 executable,
                 environment,
@@ -194,6 +349,43 @@ impl CacheAgent {
         }
         self.stats.hits.fetch_add(1, Ordering::Relaxed);
         Ok(AgentResponse::ActionHitRecorded)
+    }
+
+    fn find_action_prediction(
+        &self,
+        task: &str,
+        invocation: &CacheDigest,
+    ) -> Result<AgentResponse> {
+        validate_task_identity(task)?;
+        invocation.validate()?;
+        let prediction = self
+            .task_actions
+            .lock()
+            .unwrap()
+            .get(task)
+            .and_then(|state| state.predictions.get(invocation))
+            .cloned();
+        Ok(AgentResponse::ActionPrediction { prediction })
+    }
+
+    fn record_action_prediction(
+        &self,
+        task: &str,
+        prediction: ActionPrediction,
+    ) -> Result<AgentResponse> {
+        validate_task_identity(task)?;
+        validate_action_prediction(&prediction)?;
+        let mut tasks = self.task_actions.lock().unwrap();
+        let state = tasks.entry(task.to_string()).or_default();
+        if !state.predictions.contains_key(&prediction.invocation)
+            && state.predictions.len() >= MAX_TASK_ACTION_PREDICTIONS
+        {
+            bail!("task action manifest contains too many predictions");
+        }
+        state
+            .predictions
+            .insert(prediction.invocation.clone(), prediction);
+        Ok(AgentResponse::ActionPredictionRecorded)
     }
 
     fn executable_identity_key(
@@ -318,6 +510,52 @@ impl CacheAgent {
         }
         Ok(())
     }
+}
+
+fn validate_task_identity(task: &str) -> Result<()> {
+    if task.len() != 64
+        || !task
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("invalid task action identity");
+    }
+    Ok(())
+}
+
+fn validate_action_prediction(prediction: &ActionPrediction) -> Result<()> {
+    prediction.invocation.validate()?;
+    prediction.action.validate()?;
+    if prediction.adapter.is_empty()
+        || !prediction
+            .adapter
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        bail!("invalid action prediction adapter");
+    }
+    if prediction.payload.len() > MAX_ACTION_PREDICTION_PAYLOAD {
+        bail!("action prediction payload is too large");
+    }
+    serde_json::from_str::<serde_json::Value>(&prediction.payload)?;
+    Ok(())
+}
+
+fn validate_task_manifest(manifest: &TaskActionManifest, task: &str) -> Result<()> {
+    if manifest.version != TASK_ACTION_MANIFEST_VERSION || manifest.task != task {
+        bail!("task action manifest has an invalid identity");
+    }
+    if manifest.predictions.len() > MAX_TASK_ACTION_PREDICTIONS {
+        bail!("task action manifest contains too many predictions");
+    }
+    let mut invocations = BTreeMap::new();
+    for prediction in &manifest.predictions {
+        validate_action_prediction(prediction)?;
+        if invocations.insert(&prediction.invocation, ()).is_some() {
+            bail!("task action manifest contains duplicate predictions");
+        }
+    }
+    Ok(())
 }
 
 async fn send_response(
@@ -477,6 +715,150 @@ mod tests {
                 ..AgentStats::default()
             }
         );
+    }
+
+    #[tokio::test]
+    async fn publishes_only_successfully_committed_task_action_manifests() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path().join("cache");
+        let task = "a".repeat(64);
+        let first_invocation = CacheDigest::blake3(b"first invocation");
+        let first = ActionPrediction {
+            invocation: first_invocation.clone(),
+            action: CacheDigest::blake3(b"first action"),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        };
+
+        let agent = CacheAgent::new(&cache, "test-version");
+        let first_run = agent.begin_task(&task).unwrap();
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: first_run.clone(),
+                    prediction: first.clone(),
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+        agent.commit_task(&first_run).unwrap();
+
+        let uncommitted = CacheAgent::new(&cache, "test-version");
+        let uncommitted_run = uncommitted.begin_task(&task).unwrap();
+        let second_invocation = CacheDigest::blake3(b"second invocation");
+        assert!(matches!(
+            uncommitted
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: uncommitted_run,
+                    prediction: ActionPrediction {
+                        invocation: second_invocation.clone(),
+                        action: CacheDigest::blake3(b"second action"),
+                        adapter: "rustc".into(),
+                        payload: "{}".into(),
+                    },
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+
+        let next_session = CacheAgent::new(&cache, "test-version");
+        let next_run = next_session.begin_task(&task).unwrap();
+        assert!(matches!(
+            next_session
+                .respond(AgentRequest::FindActionPrediction {
+                    task: next_run.clone(),
+                    invocation: first_invocation,
+                })
+                .await,
+            AgentResponse::ActionPrediction {
+                prediction: Some(prediction)
+            } if prediction == first
+        ));
+        assert!(matches!(
+            next_session
+                .respond(AgentRequest::FindActionPrediction {
+                    task: next_run,
+                    invocation: second_invocation,
+                })
+                .await,
+            AgentResponse::ActionPrediction { prediction: None }
+        ));
+
+        let corrupt_task = "b".repeat(64);
+        fs::create_dir_all(next_session.manifest_dir.as_path()).unwrap();
+        fs::write(next_session.task_manifest_path(&corrupt_task), b"not json").unwrap();
+        assert!(next_session.begin_task(&corrupt_task).is_err());
+        let corrupt_run = "c".repeat(64);
+        next_session.task_actions.lock().unwrap().insert(
+            corrupt_run.clone(),
+            TaskActionState {
+                manifest: corrupt_task.clone(),
+                ..TaskActionState::default()
+            },
+        );
+        assert!(matches!(
+            next_session
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: corrupt_run.clone(),
+                    prediction: first,
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+        assert!(next_session.commit_task(&corrupt_run).is_err());
+        assert_eq!(
+            fs::read(next_session.task_manifest_path(&corrupt_task)).unwrap(),
+            b"not json"
+        );
+    }
+
+    #[tokio::test]
+    async fn merges_overlapping_runs_into_one_task_manifest() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path().join("cache");
+        let task = "d".repeat(64);
+        let agent = CacheAgent::new(&cache, "test-version");
+        let first_run = agent.begin_task(&task).unwrap();
+        let second_run = agent.begin_task(&task).unwrap();
+        assert_ne!(first_run, second_run);
+        let first_invocation = CacheDigest::blake3(b"overlap one");
+        let second_invocation = CacheDigest::blake3(b"overlap two");
+        for (run, invocation) in [
+            (&first_run, &first_invocation),
+            (&second_run, &second_invocation),
+        ] {
+            assert!(matches!(
+                agent
+                    .respond(AgentRequest::RecordActionPrediction {
+                        task: run.clone(),
+                        prediction: ActionPrediction {
+                            invocation: invocation.clone(),
+                            action: CacheDigest::blake3(invocation.hash.as_bytes()),
+                            adapter: "rustc".into(),
+                            payload: "{}".into(),
+                        },
+                    })
+                    .await,
+                AgentResponse::ActionPredictionRecorded
+            ));
+        }
+        agent.commit_task(&first_run).unwrap();
+        agent.commit_task(&second_run).unwrap();
+
+        let next = CacheAgent::new(cache, "test-version");
+        let run = next.begin_task(&task).unwrap();
+        for invocation in [first_invocation, second_invocation] {
+            assert!(matches!(
+                next.respond(AgentRequest::FindActionPrediction {
+                    task: run.clone(),
+                    invocation,
+                })
+                .await,
+                AgentResponse::ActionPrediction {
+                    prediction: Some(_)
+                }
+            ));
+        }
     }
 
     #[tokio::test]

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -18,7 +18,9 @@ use url::{Host, Url};
 mod agent;
 mod local;
 
-pub use agent::{AGENT_PROTOCOL_VERSION, AgentRequest, AgentResponse, AgentStats, CacheAgent};
+pub use agent::{
+    AGENT_PROTOCOL_VERSION, ActionPrediction, AgentRequest, AgentResponse, AgentStats, CacheAgent,
+};
 pub use local::{LocalActionCache, LocalCas};
 
 pub const PROTOCOL_VERSION: u8 = 1;

--- a/crates/mise-cache-rustc/src/dep_info.rs
+++ b/crates/mise-cache-rustc/src/dep_info.rs
@@ -132,6 +132,43 @@ pub struct DiscoveredInputs {
 }
 
 impl DiscoveredInputs {
+    pub(crate) fn from_paths(
+        working_dir: &Path,
+        paths: BTreeSet<PathBuf>,
+        environment: BTreeMap<String, Option<String>>,
+    ) -> Result<Self, BypassReason> {
+        if !working_dir.is_absolute() {
+            return Err(BypassReason::RelativeWorkingDirectory(
+                working_dir.to_path_buf(),
+            ));
+        }
+        let working_dir = normalize_components(working_dir);
+        let mut inputs = Vec::with_capacity(paths.len());
+        for path in paths {
+            let metadata = std::fs::metadata(&path).map_err(|error| BypassReason::InputRead {
+                path: path.clone(),
+                message: error.to_string(),
+            })?;
+            if !metadata.is_file() {
+                return Err(BypassReason::InputRead {
+                    path,
+                    message: "input is not a regular file".into(),
+                });
+            }
+            let digest =
+                CacheDigest::blake3_file(&path).map_err(|error| BypassReason::InputRead {
+                    path: path.clone(),
+                    message: error.to_string(),
+                })?;
+            inputs.push(ActionInput { path, digest });
+        }
+        Ok(Self {
+            working_dir,
+            inputs,
+            environment,
+        })
+    }
+
     /// Reject inputs whose modification time overlaps the compiler invocation.
     ///
     /// Input contents are first hashed after rustc reports their paths. This
@@ -249,30 +286,7 @@ impl RustcInvocation {
                 normalize_components(&absolute)
             })
             .collect::<BTreeSet<_>>();
-        let mut inputs = Vec::with_capacity(paths.len());
-        for path in paths {
-            let metadata = std::fs::metadata(&path).map_err(|error| BypassReason::InputRead {
-                path: path.clone(),
-                message: error.to_string(),
-            })?;
-            if !metadata.is_file() {
-                return Err(BypassReason::InputRead {
-                    path,
-                    message: "input is not a regular file".into(),
-                });
-            }
-            let digest =
-                CacheDigest::blake3_file(&path).map_err(|error| BypassReason::InputRead {
-                    path: path.clone(),
-                    message: error.to_string(),
-                })?;
-            inputs.push(ActionInput { path, digest });
-        }
-        Ok(DiscoveredInputs {
-            working_dir,
-            inputs,
-            environment: dep_info.environment.clone(),
-        })
+        DiscoveredInputs::from_paths(&working_dir, paths, dep_info.environment.clone())
     }
 }
 

--- a/crates/mise-cache-rustc/src/lib.rs
+++ b/crates/mise-cache-rustc/src/lib.rs
@@ -1,5 +1,5 @@
 use mise_cache_core::{CacheDigest, canonical_json};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
@@ -121,6 +121,10 @@ pub enum BypassReason {
     ConflictingEnvironment(String),
     #[error("failed to serialize the rustc action: {0}")]
     Serialization(String),
+    #[error("rustc action prediction is unsupported")]
+    UnsupportedPrediction,
+    #[error("rustc action prediction contains an invalid input path: {0}")]
+    InvalidPredictedInput(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -242,10 +246,14 @@ impl RustcInvocation {
             }
             files.insert(path);
         }
+        let dep_info = dep_info.ok_or(BypassReason::NoDepInfo)?;
+        if dep_info.parent() != Some(output_directory.as_path()) {
+            return Err(BypassReason::SplitOutputDirectories);
+        }
         Ok(RustcOutputs {
             directory: output_directory,
             files: files.into_iter().collect(),
-            dep_info: dep_info.ok_or(BypassReason::NoDepInfo)?,
+            dep_info,
         })
     }
 
@@ -256,6 +264,37 @@ impl RustcInvocation {
     /// dep-info.
     pub fn action(&self, context: ActionContext) -> Result<RustcAction, BypassReason> {
         ActionBuilder::new(self, context).build()
+    }
+
+    /// Fingerprint the modeled invocation before dependency contents are known.
+    pub fn invocation_digest(&self, context: &ActionContext) -> Result<CacheDigest, BypassReason> {
+        let descriptor = ActionBuilder::new(self, context.clone()).invocation_descriptor()?;
+        let bytes = canonical_json(&descriptor)
+            .map_err(|error| BypassReason::Serialization(error.to_string()))?;
+        Ok(CacheDigest::blake3(&bytes))
+    }
+
+    /// Capture normalized dependency paths for a future invocation that has no
+    /// dep-info file yet.
+    pub fn prediction(
+        &self,
+        context: &ActionContext,
+        discovered: &DiscoveredInputs,
+    ) -> Result<RustcInputPrediction, BypassReason> {
+        let builder = ActionBuilder::new(self, context.clone());
+        builder.validate_mappings()?;
+        let inputs = discovered
+            .inputs
+            .iter()
+            .map(|input| builder.normalize_path(&input.path))
+            .collect::<Result<BTreeSet<_>, _>>()?
+            .into_iter()
+            .collect();
+        Ok(RustcInputPrediction {
+            version: 1,
+            inputs,
+            environment: discovered.environment.keys().cloned().collect(),
+        })
     }
 }
 
@@ -303,6 +342,56 @@ pub struct RustcAction {
     pub bytes: Vec<u8>,
 }
 
+/// Normalized input names from the last successful execution of one modeled
+/// rustc invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcInputPrediction {
+    pub version: u8,
+    pub inputs: Vec<String>,
+    pub environment: Vec<String>,
+}
+
+impl RustcInputPrediction {
+    /// Rehash the predicted paths and read the current environment. The caller
+    /// still recomputes the full action digest, so changed inputs are misses.
+    pub fn discover(
+        &self,
+        working_dir: &Path,
+        path_mappings: &[PathMapping],
+    ) -> Result<DiscoveredInputs, BypassReason> {
+        if self.version != 1 {
+            return Err(BypassReason::UnsupportedPrediction);
+        }
+        if self.inputs.len() > 16 * 1024 || self.environment.len() > 4 * 1024 {
+            return Err(BypassReason::UnsupportedPrediction);
+        }
+        let paths = self
+            .inputs
+            .iter()
+            .map(|path| denormalize_path(path, path_mappings))
+            .collect::<Result<BTreeSet<_>, _>>()?;
+        let environment = self
+            .environment
+            .iter()
+            .map(|name| {
+                if name.is_empty() || name.contains(['=', '\0']) {
+                    return Err(BypassReason::UnsupportedPrediction);
+                }
+                let value = std::env::var_os(name)
+                    .map(|value| {
+                        value
+                            .into_string()
+                            .map_err(|_| BypassReason::UnsupportedPrediction)
+                    })
+                    .transpose()?;
+                Ok((name.clone(), value))
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        DiscoveredInputs::from_paths(working_dir, paths, environment)
+    }
+}
+
 #[derive(Serialize)]
 struct ActionDescriptor {
     version: u8,
@@ -312,6 +401,16 @@ struct ActionDescriptor {
     arguments: Vec<String>,
     environment: BTreeMap<String, Option<String>>,
     inputs: Vec<InputDescriptor>,
+}
+
+#[derive(Serialize)]
+struct InvocationDescriptor {
+    version: u8,
+    kind: &'static str,
+    adapter_version: u8,
+    compiler: CompilerDescriptor,
+    arguments: Vec<String>,
+    required_inputs: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -690,12 +789,7 @@ impl<'a> ActionBuilder<'a> {
 
     fn build(self) -> Result<RustcAction, BypassReason> {
         self.validate_mappings()?;
-        let arguments = self
-            .invocation
-            .arguments
-            .iter()
-            .map(|argument| self.normalize_argument(argument))
-            .collect::<Result<Vec<_>, _>>()?;
+        let invocation = self.invocation_descriptor()?;
         // rustc may embed these values verbatim through `env!`; unlike paths
         // used to locate inputs and outputs, changing them changes the artifact.
         let environment = self.context.environment.clone();
@@ -731,12 +825,8 @@ impl<'a> ActionBuilder<'a> {
             version: ACTION_SCHEMA_VERSION,
             kind: "rustc",
             adapter_version: ADAPTER_VERSION,
-            compiler: CompilerDescriptor {
-                toolchain: self.context.compiler.toolchain,
-                rustc_version: self.context.compiler.rustc_version,
-                host: self.context.compiler.host,
-            },
-            arguments,
+            compiler: invocation.compiler,
+            arguments: invocation.arguments,
             environment,
             inputs,
         };
@@ -744,6 +834,36 @@ impl<'a> ActionBuilder<'a> {
             .map_err(|error| BypassReason::Serialization(error.to_string()))?;
         let digest = CacheDigest::blake3(&bytes);
         Ok(RustcAction { digest, bytes })
+    }
+
+    fn invocation_descriptor(&self) -> Result<InvocationDescriptor, BypassReason> {
+        self.validate_mappings()?;
+        let arguments = self
+            .invocation
+            .arguments
+            .iter()
+            .map(|argument| self.normalize_argument(argument))
+            .collect::<Result<Vec<_>, _>>()?;
+        let required_inputs = self
+            .invocation
+            .required_inputs
+            .iter()
+            .map(|path| self.normalize_path(path))
+            .collect::<Result<BTreeSet<_>, _>>()?
+            .into_iter()
+            .collect();
+        Ok(InvocationDescriptor {
+            version: ACTION_SCHEMA_VERSION,
+            kind: "rustc",
+            adapter_version: ADAPTER_VERSION,
+            compiler: CompilerDescriptor {
+                toolchain: self.context.compiler.toolchain.clone(),
+                rustc_version: self.context.compiler.rustc_version.clone(),
+                host: self.context.compiler.host.clone(),
+            },
+            arguments,
+            required_inputs,
+        })
     }
 
     fn validate_mappings(&self) -> Result<(), BypassReason> {
@@ -825,6 +945,33 @@ impl<'a> ActionBuilder<'a> {
         }
         Err(BypassReason::UnmappedAbsolutePath(absolute))
     }
+}
+
+fn denormalize_path(value: &str, mappings: &[PathMapping]) -> Result<PathBuf, BypassReason> {
+    for mapping in mappings {
+        let prefix = format!("${{{}}}", mapping.placeholder);
+        let suffix = if value == prefix {
+            ""
+        } else if let Some(suffix) = value.strip_prefix(&format!("{prefix}/")) {
+            suffix
+        } else {
+            continue;
+        };
+        if !mapping.root.is_absolute()
+            || (!suffix.is_empty()
+                && suffix.split('/').any(|component| {
+                    component.is_empty()
+                        || matches!(component, "." | "..")
+                        || component.contains('\\')
+                }))
+        {
+            return Err(BypassReason::InvalidPredictedInput(value.into()));
+        }
+        let mut path = normalize_components(&mapping.root);
+        path.extend(suffix.split('/').filter(|component| !component.is_empty()));
+        return Ok(path);
+    }
+    Err(BypassReason::InvalidPredictedInput(value.into()))
 }
 
 fn normalize_components(path: &Path) -> PathBuf {
@@ -1029,6 +1176,24 @@ mod tests {
     }
 
     #[test]
+    fn dep_info_must_share_the_artifact_output_directory() {
+        let working_dir = absolute(&["workspace"]);
+        let invocation = RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info=target/dep-info/widget.d,metadata,link",
+            "--out-dir=target/debug/deps",
+            "src/lib.rs",
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            invocation.outputs(&working_dir),
+            Err(BypassReason::SplitOutputDirectories)
+        );
+    }
+
+    #[test]
     fn equivalent_worktrees_produce_the_same_action_key() {
         let first_context = context(&[
             ("src/lib.rs", "source"),
@@ -1068,6 +1233,71 @@ mod tests {
         ];
         let second = invocation.action(second_context).unwrap();
         assert_eq!(first.digest, second.digest);
+    }
+
+    #[test]
+    fn predicts_inputs_without_reusing_stale_contents() {
+        let directory = tempfile::tempdir().unwrap();
+        let workspace = directory.path().canonicalize().unwrap();
+        std::fs::create_dir(workspace.join("src")).unwrap();
+        std::fs::write(workspace.join("src/lib.rs"), "pub fn value() -> u8 { 1 }").unwrap();
+        let invocation = RustcInvocation::parse(&args(&[
+            "--crate-name=widget",
+            "--crate-type=lib",
+            "--emit=dep-info,metadata,link",
+            "--out-dir=target/debug/deps",
+            "src/lib.rs",
+        ]))
+        .unwrap();
+        let compiler = CompilerIdentity {
+            toolchain: "stable".into(),
+            rustc_version: "rustc test".into(),
+            host: "test-host".into(),
+        };
+        let context = ActionContext {
+            compiler,
+            working_dir: workspace.clone(),
+            path_mappings: vec![PathMapping::new(&workspace, "workspace")],
+            environment: BTreeMap::new(),
+            inputs: Vec::new(),
+        };
+        let dep_info = RustcDepInfo {
+            files: vec!["src/lib.rs".into()],
+            environment: BTreeMap::new(),
+        };
+        let discovered = invocation.discover_inputs(&dep_info, &workspace).unwrap();
+        let mut initial_context = context.clone();
+        discovered.clone().apply_to(&mut initial_context).unwrap();
+        let initial = invocation.action(initial_context).unwrap();
+        let prediction = invocation.prediction(&context, &discovered).unwrap();
+        assert_eq!(prediction.inputs, ["${workspace}/src/lib.rs"]);
+
+        let predicted = prediction
+            .discover(&workspace, &context.path_mappings)
+            .unwrap();
+        let mut predicted_context = context.clone();
+        predicted.apply_to(&mut predicted_context).unwrap();
+        assert_eq!(invocation.action(predicted_context).unwrap(), initial);
+
+        std::fs::write(workspace.join("src/lib.rs"), "pub fn value() -> u8 { 2 }").unwrap();
+        let changed = prediction
+            .discover(&workspace, &context.path_mappings)
+            .unwrap();
+        let mut changed_context = context;
+        changed.apply_to(&mut changed_context).unwrap();
+        assert_ne!(
+            invocation.action(changed_context).unwrap().digest,
+            initial.digest
+        );
+    }
+
+    #[test]
+    fn predicted_mapping_root_round_trips() {
+        let workspace = workspace();
+        assert_eq!(
+            denormalize_path("${workspace}", &[PathMapping::new(&workspace, "workspace")]).unwrap(),
+            workspace
+        );
     }
 
     #[test]

--- a/e2e/tasks/test_task_action_cache_session
+++ b/e2e/tasks/test_task_action_cache_session
@@ -23,6 +23,7 @@ deny_env = true
 run = '''
 test -n "$MISE_CACHE_SOCKET"
 test -n "$MISE_CACHE_STAGING_DIR"
+test -n "$MISE_CACHE_TASK"
 test "$CARGO_INCREMENTAL" = 0
 "$RUSTC_WRAPPER" true
 '''

--- a/e2e/tasks/test_task_rust_cache_restore
+++ b/e2e/tasks/test_task_rust_cache_restore
@@ -17,6 +17,16 @@ invoke() {
 }
 
 export CACHE_TEST_ENV=first
+if test -f cold-run; then
+  export CACHE_TEST_ENV=second
+  cold="$(invoke 2>&1)"
+  test "$cold" = "$(printf 'cached stdout\ncached stderr')"
+  test "$(cat compile-count)" = 3
+  test "$(cat out/libdemo.rlib)" = 'cached artifact second'
+  test -f out/demo.d
+  exit 0
+fi
+
 first="$(invoke 2>&1)"
 test "$first" = "$(printf 'cached stdout\ncached stderr')"
 test "$(cat compile-count)" = 1
@@ -60,6 +70,7 @@ case "$fourth" in
 esac
 test "$(cat compile-count)" = 3
 test "$(cat out/libdemo.rlib)" = 'cached artifact second'
+touch cold-run
 '''
 EOF
 
@@ -98,4 +109,6 @@ printf 'cached stderr\n' >&2
 EOF
 chmod +x fake-rustc
 
-assert_contains "mise run restore 2>&1" "Action cache: 1/2 hits"
+assert_contains "mise run restore 2>&1" "Action cache: 1/3 hits"
+rm -rf out
+assert_contains "mise run restore 2>&1" "Action cache: 1/1 hits"

--- a/src/cache/rustc.rs
+++ b/src/cache/rustc.rs
@@ -1,12 +1,12 @@
 use super::session;
 use eyre::{Context, Result, bail};
 use mise_cache_core::{
-    AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode, RemoteActionResult,
-    RustcMetadata, canonical_json,
+    ActionPrediction, AgentRequest, AgentResponse, CacheDigest, CacheDirectory, CacheFileNode,
+    RemoteActionResult, RustcMetadata, canonical_json,
 };
 use mise_cache_rustc::{
     ActionContext, CompilerIdentity, DiscoveredInputs, PathMapping, RustcAction, RustcDepInfo,
-    RustcInvocation, RustcOutputs,
+    RustcInputPrediction, RustcInvocation, RustcOutputs,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -22,18 +22,33 @@ pub(super) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
     let working_dir = std::env::current_dir()?;
     let outputs = invocation.outputs(&working_dir)?;
 
+    let mut action_lookup_attempted = false;
     if outputs.dep_info.is_file()
         && let Ok((action, discovered)) =
             action_from_current_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)
     {
+        action_lookup_attempted = true;
         match restore_result(&action, &outputs, &discovered) {
             Ok(Some((stdout, stderr))) => {
+                record_prediction(rustc, &invocation, &action, &discovered, &working_dir);
                 let _ = replay_bytes(&stdout, &stderr);
                 return Ok(ExitCode::SUCCESS);
             }
             Ok(None) => {}
             Err(error) => {
                 eprintln!("mise rustc cache warning: result was not restored: {error:#}");
+            }
+        }
+    }
+    if !action_lookup_attempted {
+        match restore_predicted_result(rustc, &invocation, &outputs, &working_dir) {
+            Ok(Some((stdout, stderr))) => {
+                let _ = replay_bytes(&stdout, &stderr);
+                return Ok(ExitCode::SUCCESS);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!("mise rustc cache warning: prediction was not restored: {error:#}");
             }
         }
     }
@@ -46,18 +61,64 @@ pub(super) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
         .wrap_err("failed to execute rustc")?;
     let _ = replay_output(&output);
     if output.status.success() {
-        let publication = (|| {
+        let publication: Result<()> = (|| {
             let (action, discovered) =
                 action_from_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)?;
             discovered.verify_not_modified_since(compilation_started)?;
             discovered.verify()?;
-            publish_result(&action.digest, &action.bytes, &outputs.files, &output)
+            let mut cacheable_outputs = outputs.files.clone();
+            cacheable_outputs.push(outputs.dep_info.clone());
+            publish_result(&action.digest, &action.bytes, &cacheable_outputs, &output)?;
+            record_prediction(rustc, &invocation, &action, &discovered, &working_dir);
+            Ok(())
         })();
         if let Err(error) = publication {
             eprintln!("mise rustc cache warning: result was not stored: {error:#}");
         }
     }
     Ok(exit_code(output.status))
+}
+
+fn restore_predicted_result(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    outputs: &RustcOutputs,
+    working_dir: &Path,
+) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+    let task = std::env::var(session::TASK_ENV)
+        .wrap_err_with(|| format!("{} is not set", session::TASK_ENV))?;
+    let mut context = base_action_context(rustc, working_dir)?;
+    let invocation_digest = invocation.invocation_digest(&context)?;
+    let responses = session::request_agent(&[AgentRequest::FindActionPrediction {
+        task,
+        invocation: invocation_digest.clone(),
+    }])?;
+    let Some(response) = responses.into_iter().next() else {
+        bail!("cache agent did not return an action prediction response");
+    };
+    let prediction = match response {
+        AgentResponse::ActionPrediction {
+            prediction: Some(prediction),
+        } => prediction,
+        AgentResponse::ActionPrediction { prediction: None } => return Ok(None),
+        AgentResponse::Error { message } => bail!(message),
+        _ => bail!("cache agent returned an unexpected action prediction response"),
+    };
+    if prediction.adapter != "rustc" || prediction.invocation != invocation_digest {
+        bail!("cache agent returned an incompatible rustc action prediction");
+    }
+    let input_prediction: RustcInputPrediction = serde_json::from_str(&prediction.payload)?;
+    if String::from_utf8(canonical_json(&input_prediction)?)? != prediction.payload {
+        bail!("cache agent returned a non-canonical rustc action prediction");
+    }
+    let discovered = input_prediction.discover(working_dir, &context.path_mappings)?;
+    discovered.clone().apply_to(&mut context)?;
+    let action = invocation.action(context)?;
+    let restored = restore_result(&action, outputs, &discovered)?;
+    if restored.is_some() {
+        record_prediction_value(invocation_digest, action.digest.clone(), prediction.payload);
+    }
+    Ok(restored)
 }
 
 fn action_from_dep_info(
@@ -88,16 +149,64 @@ fn action_from_parsed_dep_info(
     working_dir: &Path,
 ) -> Result<(RustcAction, DiscoveredInputs)> {
     let discovered = invocation.discover_inputs(dep_info, working_dir)?;
-    let mut context = ActionContext {
+    let mut context = base_action_context(rustc, working_dir)?;
+    discovered.clone().apply_to(&mut context)?;
+    let action = invocation.action(context)?;
+    Ok((action, discovered))
+}
+
+fn base_action_context(rustc: &OsStr, working_dir: &Path) -> Result<ActionContext> {
+    Ok(ActionContext {
         compiler: compiler_identity(rustc)?,
         working_dir: working_dir.to_path_buf(),
         path_mappings: path_mappings(working_dir),
         environment: BTreeMap::new(),
         inputs: Vec::new(),
-    };
-    discovered.clone().apply_to(&mut context)?;
-    let action = invocation.action(context)?;
-    Ok((action, discovered))
+    })
+}
+
+fn record_prediction(
+    rustc: &OsStr,
+    invocation: &RustcInvocation,
+    action: &RustcAction,
+    discovered: &DiscoveredInputs,
+    working_dir: &Path,
+) {
+    let result = (|| {
+        let context = base_action_context(rustc, working_dir)?;
+        let invocation_digest = invocation.invocation_digest(&context)?;
+        let prediction = invocation.prediction(&context, discovered)?;
+        let payload = String::from_utf8(canonical_json(&prediction)?)?;
+        record_prediction_value(invocation_digest, action.digest.clone(), payload);
+        Result::<()>::Ok(())
+    })();
+    if let Err(error) = result {
+        eprintln!("mise rustc cache warning: action prediction was not recorded: {error:#}");
+    }
+}
+
+fn record_prediction_value(invocation: CacheDigest, action: CacheDigest, payload: String) {
+    let result = (|| {
+        let task = std::env::var(session::TASK_ENV)
+            .wrap_err_with(|| format!("{} is not set", session::TASK_ENV))?;
+        let responses = session::request_agent(&[AgentRequest::RecordActionPrediction {
+            task,
+            prediction: ActionPrediction {
+                invocation,
+                action,
+                adapter: "rustc".into(),
+                payload,
+            },
+        }])?;
+        match responses.into_iter().next() {
+            Some(AgentResponse::ActionPredictionRecorded) => Ok(()),
+            Some(AgentResponse::Error { message }) => bail!(message),
+            _ => bail!("cache agent returned an unexpected prediction response"),
+        }
+    })();
+    if let Err(error) = result {
+        eprintln!("mise rustc cache warning: action prediction was not recorded: {error:#}");
+    }
 }
 
 fn verify_environment(environment: &BTreeMap<String, Option<String>>) -> Result<()> {
@@ -293,6 +402,7 @@ fn validated_outputs(
     let mut expected = outputs
         .files
         .iter()
+        .chain(std::iter::once(&outputs.dep_info))
         .map(|path| {
             let name = path
                 .file_name()
@@ -654,6 +764,10 @@ mod tests {
         }
     }
 
+    fn test_output_directory(file: CacheFileNode) -> CacheDirectory {
+        test_directory(vec![file, test_file("demo.d")])
+    }
+
     #[test]
     fn parses_verbose_rustc_identity() {
         let verbose = "rustc 1.97.0 (abc 2026-08-01)\n\
@@ -686,10 +800,11 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let outputs = test_outputs(root.path());
         let files =
-            validated_outputs(test_directory(vec![test_file("libdemo.rlib")]), &outputs).unwrap();
+            validated_outputs(test_output_directory(test_file("libdemo.rlib")), &outputs).unwrap();
 
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].1, outputs.files[0]);
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().any(|(_, path)| path == &outputs.files[0]));
+        assert!(files.iter().any(|(_, path)| path == &outputs.dep_info));
     }
 
     #[test]
@@ -697,8 +812,11 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let outputs = test_outputs(root.path());
         assert!(
-            validated_outputs(test_directory(vec![test_file("../libdemo.rlib")]), &outputs,)
-                .is_err()
+            validated_outputs(
+                test_output_directory(test_file("../libdemo.rlib")),
+                &outputs,
+            )
+            .is_err()
         );
     }
 
@@ -708,7 +826,7 @@ mod tests {
         let outputs = test_outputs(root.path());
         let mut file = test_file("libdemo.rlib");
         file.executable = true;
-        assert!(validated_outputs(test_directory(vec![file]), &outputs).is_err());
+        assert!(validated_outputs(test_output_directory(file), &outputs).is_err());
     }
 
     #[test]
@@ -717,7 +835,7 @@ mod tests {
         let outputs = test_outputs(root.path());
         let mut file = test_file("libdemo.rlib");
         file.mode = 0o666;
-        assert!(validated_outputs(test_directory(vec![file]), &outputs).is_err());
+        assert!(validated_outputs(test_output_directory(file), &outputs).is_err());
     }
 
     #[cfg(unix)]

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -4,8 +4,10 @@ use crate::task::TaskRustCacheConfig;
 use bytesize::ByteSize;
 use eyre::{Context, Result, bail};
 use mise_cache_core::{
-    AGENT_PROTOCOL_VERSION, AgentRequest, AgentResponse, AgentStats, CacheAgent,
+    AGENT_PROTOCOL_VERSION, AgentRequest, AgentResponse, AgentStats, CacheAgent, CacheDigest,
+    canonical_json,
 };
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
@@ -19,29 +21,51 @@ use tokio::task::JoinHandle;
 const RUSTC_SHIM_STEM: &str = "mise-cache-rustc";
 const SOCKET_ENV: &str = "MISE_CACHE_SOCKET";
 pub(super) const STAGING_ENV: &str = "MISE_CACHE_STAGING_DIR";
+pub(super) const TASK_ENV: &str = "MISE_CACHE_TASK";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct CacheSessionEnvironment {
     socket: String,
     rustc_shim: String,
     staging: String,
+    agent: CacheAgent,
 }
 
 impl CacheSessionEnvironment {
-    pub(crate) fn apply(&self, task: &Task, environment: &mut BTreeMap<String, String>) {
+    pub(crate) fn apply(
+        &self,
+        task: &Task,
+        environment: &mut BTreeMap<String, String>,
+    ) -> Option<TaskActionRun> {
         if !task.rust_cache.as_ref().is_some_and(|cache| cache.enabled) {
-            return;
+            return None;
         }
+        let task_identity = task_action_identity(task);
+        let (protocol_task, action_run) = match self.agent.begin_task(&task_identity) {
+            Ok(run) => (
+                run.clone(),
+                Some(TaskActionRun {
+                    run,
+                    agent: self.agent.clone(),
+                }),
+            ),
+            Err(error) => {
+                warn!("task {} action manifest was not loaded: {error}", task.name);
+                (task_identity, None)
+            }
+        };
         environment.insert(SOCKET_ENV.into(), self.socket.clone());
         environment.insert(STAGING_ENV.into(), self.staging.clone());
+        environment.insert(TASK_ENV.into(), protocol_task);
         if let Some(previous) = environment.insert("RUSTC_WRAPPER".into(), self.rustc_shim.clone())
             && previous != self.rustc_shim
         {
             environment.insert(PREVIOUS_RUSTC_WRAPPER_ENV.into(), previous);
         }
         environment.insert("CARGO_INCREMENTAL".into(), "0".into());
+        action_run
     }
 
     pub(crate) fn sandbox_paths(&self) -> [PathBuf; 3] {
@@ -51,6 +75,53 @@ impl CacheSessionEnvironment {
             PathBuf::from(&self.staging),
         ]
     }
+}
+
+pub(crate) struct TaskActionRun {
+    run: String,
+    agent: CacheAgent,
+}
+
+impl TaskActionRun {
+    pub(crate) fn commit(self) -> Result<()> {
+        self.agent.commit_task(&self.run)
+    }
+}
+
+#[derive(Serialize)]
+struct TaskActionIdentity<'a> {
+    version: u8,
+    name: &'a str,
+    phase: crate::task::TaskRunPhase,
+    run: &'a [crate::task::RunEntry],
+    args: &'a [String],
+    shell: &'a Option<String>,
+    dir: &'a Option<String>,
+    source: String,
+}
+
+fn task_action_identity(task: &Task) -> String {
+    let source = task
+        .config_root
+        .as_deref()
+        .and_then(|root| task.config_source.strip_prefix(root).ok())
+        .map(Path::to_path_buf)
+        .or_else(|| task.config_source.file_name().map(PathBuf::from))
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned();
+    let material = TaskActionIdentity {
+        version: 1,
+        name: &task.name,
+        phase: task.run_phase,
+        run: task.run(),
+        args: &task.args,
+        shell: &task.shell,
+        dir: &task.dir,
+        source,
+    };
+    let bytes = canonical_json(&material).expect("task action identity must serialize");
+    CacheDigest::blake3(&bytes).hash
 }
 
 pub(crate) struct CacheSession {
@@ -73,6 +144,7 @@ impl CacheSession {
                 socket,
                 rustc_shim: shim.to_string_lossy().into_owned(),
                 staging: staging.to_string_lossy().into_owned(),
+                agent: agent.clone(),
             },
             agent,
             shutdown: Mutex::new(Some(shutdown_tx)),
@@ -573,24 +645,30 @@ mod tests {
 
     #[test]
     fn session_environment_is_scoped_to_selected_adapters() {
+        let cache = tempfile::tempdir().unwrap();
         let environment = CacheSessionEnvironment {
             socket: "socket".into(),
             rustc_shim: "shim".into(),
             staging: "staging".into(),
+            agent: CacheAgent::new(cache.path(), VERSION),
         };
         let mut task = Task::default();
         let mut values = BTreeMap::from([("RUSTC_WRAPPER".into(), "existing".into())]);
-        environment.apply(&task, &mut values);
+        let run = environment.apply(&task, &mut values);
+        assert!(run.is_none());
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
 
         task.rust_cache = Some(TaskRustCacheConfig { enabled: false });
-        environment.apply(&task, &mut values);
+        let run = environment.apply(&task, &mut values);
+        assert!(run.is_none());
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
 
         task.rust_cache = Some(TaskRustCacheConfig { enabled: true });
-        environment.apply(&task, &mut values);
+        let run = environment.apply(&task, &mut values);
+        assert!(run.is_some());
         assert_eq!(values.get(SOCKET_ENV).unwrap(), "socket");
         assert_eq!(values.get(STAGING_ENV).unwrap(), "staging");
+        assert_eq!(values.get(TASK_ENV).unwrap().len(), 64);
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "shim");
         assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
         assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -417,6 +417,7 @@ impl TaskExecutor {
                 sandbox.pass_through_env.extend([
                     "MISE_CACHE_SOCKET".into(),
                     "MISE_CACHE_STAGING_DIR".into(),
+                    "MISE_CACHE_TASK".into(),
                     "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER".into(),
                     "RUSTC_WRAPPER".into(),
                     "CARGO_INCREMENTAL".into(),
@@ -647,9 +648,10 @@ impl TaskExecutor {
             .as_ref()
             .filter(|_| self.task_cache.writes())
             .map(|_| Arc::new(StdMutex::new(Vec::new())));
-        if let Some(session) = &self.cache_session {
-            session.apply(task, &mut env);
-        }
+        let action_cache_run = self
+            .cache_session
+            .as_ref()
+            .and_then(|session| session.apply(task, &mut env));
         let exec_ctx = TaskExecContext {
             task,
             env: &env,
@@ -745,6 +747,11 @@ impl TaskExecutor {
         } else {
             None
         };
+        if let Some(run) = action_cache_run
+            && let Err(err) = run.commit()
+        {
+            warn!("task {} action manifest write failed: {err}", task.name);
+        }
 
         Ok(TaskRunOutcome {
             did_work: true,


### PR DESCRIPTION
## Summary
- persist adapter-neutral action predictions in a task-scoped manifest after successful task completion
- let the rustc shim reconstruct and hash previously discovered inputs when Cargo dep-info is absent
- restore compiler artifacts and dep-info on clean-target local hits while changed files or environment values safely miss
- retain the previous successful manifest when a task fails

This remains local-only; remote manifest lookup and batch prefetch are follow-up work.

## Testing
- `cargo test -p mise-cache-core -p mise-cache-rustc`
- `cargo test --bin mise cache::`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run test:e2e e2e/tasks/test_task_rust_cache_restore e2e/tasks/test_task_action_cache_session`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added task-scoped action prediction for Rust compilation caching.
  - Rust cache sessions now track task activity and commit successful predictions for future runs.
  - Cache restoration can reuse predictions when dependency information is unavailable.
- **Bug Fixes**
  - Improved validation of predicted inputs, paths, manifests, and cache outputs.
  - Published cache results now include dependency metadata required for reliable restoration.
- **Tests**
  - Expanded coverage for unchanged and modified inputs, committed predictions, restored outputs, and repeated task executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rustc action-cache hit/miss semantics and on-disk manifest state; mitigated by input rehashing, validation, and commit-only-on-success, but incorrect predictions could still cause wrong restores if safeguards fail.
> 
> **Overview**
> **Task-scoped action predictions** are persisted under the cache agent as versioned JSON manifests. Each `rust_cache` task run gets a session id via `MISE_CACHE_TASK`; the shim can **find/record** predictions keyed by invocation digest, and manifests are **merged and atomically published** only when the task finishes successfully (failed runs leave the prior manifest unchanged).
> 
> The **rustc adapter** gains an invocation fingerprint before inputs are hashed, plus `RustcInputPrediction` to store normalized paths/env from a prior success. On restore, when dep-info is not used for the initial lookup, the shim **loads a prediction**, re-discovers and rehashes inputs (so content/env changes still miss), then restores artifacts. Cached publications now include **dep-info** alongside rlib/rmeta, and dep-info must live in the same output directory as artifacts.
> 
> **E2E** coverage adds cold-target restore via predictions and asserts `MISE_CACHE_TASK` in sandboxed rust cache sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc6cee76414d679889fc81a387379c9d4155380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->