### PR TITLE
feat(ls): match a tool name across backends

### DIFF
--- a/e2e/cli/test_ls
+++ b/e2e/cli/test_ls
@@ -38,3 +38,16 @@ assert_contains "mise ls" "cargo:usage-cli"
 assert_not_contains "mise ls" "cargo-usage-cli" # if the backend meta file isn't working right these will be displayed
 
 assert_contains "mise ls --prunable" "cargo:usage-cli"
+
+# The same tool from two backends should both answer to its name. `mise ls` with no
+# filter already listed both; `mise ls jq` used to show only the registry one, which is
+# what made a second install look like it had vanished.
+# See https://github.com/jdx/mise/discussions/4491
+mise use jq@1.7.1
+mise use "ubi:jqlang/jq@jq-1.8.1"
+assert_contains "mise ls jq" "ubi:jqlang/jq"
+assert_contains "mise ls jq" "jq-1.8.1"
+assert_contains "mise ls jq" "1.7.1"
+# Spelling a backend out is a narrowing request, so it must not pull the other one in.
+assert_contains "mise ls ubi:jqlang/jq" "jq-1.8.1"
+assert_not_contains "mise ls ubi:jqlang/jq" "1.7.1"

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -169,7 +169,7 @@ impl Ls {
             // only runtimes for 1 plugin
             let runtimes: Vec<RuntimeRow<'_>> = runtimes
                 .into_iter()
-                .filter(|(_, p, _, _)| plugins.contains(p.ba()))
+                .filter(|(_, p, _, _)| matches_requested_tool(plugins, p.ba()))
                 .collect();
             let mut r = vec![];
             for row in runtimes {
@@ -267,6 +267,14 @@ impl Ls {
         table.truncate(true).print()
     }
 
+    /// Deliberately does *not* widen the tool filter the way the other listings do.
+    ///
+    /// `--prunable` previews `mise prune`, and both share `prune::prunable_tools`, which
+    /// matches on `BackendArg` equality. Accepting a name from another backend here would
+    /// either disagree with what `mise prune <name>` then deletes, or — if the widening
+    /// were pushed down into `prunable_tools` — make a destructive command act on an
+    /// install the user did not name. Agreeing with `prune` is the more useful of the two
+    /// consistencies.
     async fn get_prunable_runtime_list(&self, config: &Arc<Config>) -> Result<Vec<RuntimeRow<'_>>> {
         let installed_tool = self.installed_tool.clone().unwrap_or_default();
         Ok(
@@ -317,7 +325,7 @@ impl Ls {
             .into_iter()
             .map(|(b, tv)| ((b, tv.version.clone()), tv))
             .filter(|((b, _), _)| match &self.installed_tool {
-                Some(p) => p.contains(b.ba()),
+                Some(p) => matches_requested_tool(p, b.ba()),
                 None => true,
             })
             .sorted_by_cached_key(|((plugin_name, version), _)| {
@@ -333,7 +341,7 @@ impl Ls {
                 !source.is_unknown() || p.is_version_installed(config, tv, true)
             })
             .filter(|(_ls, p, _, _)| match &self.installed_tool {
-                Some(backend) => backend.contains(p.ba()),
+                Some(backend) => matches_requested_tool(backend, p.ba()),
                 None => true,
             })
             .collect();
@@ -364,7 +372,7 @@ impl Ls {
             .into_iter()
             .map(|(b, tv)| ((b, tv.version.clone()), tv))
             .filter(|((b, _), _)| match &self.installed_tool {
-                Some(p) => p.contains(b.ba()),
+                Some(p) => matches_requested_tool(p, b.ba()),
                 None => true,
             })
             .sorted_by_cached_key(|((plugin_name, version), _)| {
@@ -381,13 +389,27 @@ impl Ls {
                 !source.is_unknown() || p.is_version_installed(config, tv, true)
             })
             .filter(|(_ls, p, _, _)| match &self.installed_tool {
-                Some(backend) => backend.contains(p.ba()),
+                Some(backend) => matches_requested_tool(backend, p.ba()),
                 None => true,
             })
             .collect();
 
         Ok((rvs, sources_map))
     }
+}
+
+/// Whether `ba` is one of the tools named on the command line.
+///
+/// A bare name also matches an entry from another backend that installs the same binary,
+/// so `mise ls navi` shows `cargo:.../navi` next to the registry one rather than hiding
+/// it — `mise ls` with no filter already lists both (discussion #4491).
+///
+/// Spelling a backend out keeps matching only itself: `mise ls ubi:jqlang/jq` passes the
+/// whole string as the bin name, which cannot match a trailing segment.
+fn matches_requested_tool(requested: &[BackendArg], ba: &BackendArg) -> bool {
+    requested
+        .iter()
+        .any(|req| req == ba || ba.matches_bin_name(&req.short))
 }
 
 type JSONOutput = IndexMap<String, Vec<JSONToolVersion>>;
@@ -658,3 +680,58 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
                     ~/.config/mise/config.toml  latest
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ba(short: &str) -> BackendArg {
+        BackendArg::from(short.to_string())
+    }
+
+    /// The case from discussion #4491: the same tool installed twice, once from the
+    /// registry and once straight from a backend, should both answer to its name.
+    #[test]
+    fn bare_name_matches_another_backend() {
+        let requested = vec![ba("navi")];
+        assert!(matches_requested_tool(
+            &requested,
+            &ba("cargo:https://github.com/denisidoro/navi")
+        ));
+        assert!(matches_requested_tool(&requested, &ba("navi")));
+        assert!(matches_requested_tool(
+            &requested,
+            &ba("ubi:denisidoro/navi")
+        ));
+    }
+
+    /// Naming a backend is a narrowing request, so it must not pull in the others.
+    #[test]
+    fn explicit_backend_matches_only_itself() {
+        let requested = vec![ba("ubi:jqlang/jq")];
+        assert!(matches_requested_tool(&requested, &ba("ubi:jqlang/jq")));
+        assert!(!matches_requested_tool(&requested, &ba("jq")));
+    }
+
+    /// Matching is on the whole trailing segment, not a prefix, so neighbouring tool
+    /// names stay separate.
+    #[test]
+    fn unrelated_tool_does_not_match() {
+        let requested = vec![ba("node")];
+        assert!(!matches_requested_tool(&requested, &ba("npm:node-gyp")));
+        assert!(!matches_requested_tool(&requested, &ba("nodemon")));
+    }
+
+    /// A registry alias resolves before any of this, so the two spellings are already the
+    /// same `BackendArg` and match on plain equality rather than by name.
+    #[test]
+    fn registry_aliases_still_match() {
+        assert!(matches_requested_tool(&[ba("node")], &ba("nodejs")));
+        assert!(matches_requested_tool(&[ba("nodejs")], &ba("node")));
+    }
+
+    #[test]
+    fn no_filter_entries_match_nothing() {
+        assert!(!matches_requested_tool(&[], &ba("node")));
+    }
+}


### PR DESCRIPTION
Closes #4491.

## The problem

Installing a tool from two backends — the registry one plus, say, a `cargo:` build of an unreleased revision — leaves `mise ls <name>` showing only one of them, while `mise ls` with no filter shows both. The second install looks like it vanished.

Reproduced on **v2026.8.3**. The reporter used `cargo:`; this is the same shape with `ubi:`, which installs faster:

```console
$ mise ls
jq             1.7.1   .../mise.toml  1.7.1
ubi:jqlang/jq  jq-1.7  .../mise.toml  jq-1.7

$ mise ls jq
jq  1.7.1  .../mise.toml  1.7.1              # the ubi one is missing

$ mise bin-paths | grep jq
.../installs/jq/1.7.1
.../installs/ubi-jqlang-jq/jq-1.7            # but both are on PATH
```

The filter compares `BackendArg`s, and `PartialEq for BackendArg` is a `short` string comparison, so `jq` and `ubi:jqlang/jq` are simply unrelated values.

## The change

The five filter sites in `ls.rs` all went through `plugins.contains(ba)`. They now share one helper that additionally accepts an entry whose trailing name segment matches:

```rust
fn matches_requested_tool(requested: &[BackendArg], ba: &BackendArg) -> bool {
    requested
        .iter()
        .any(|req| req == ba || ba.matches_bin_name(&req.short))
}
```

`BackendArg::matches_bin_name` already existed and is the cross-backend identity this needs — it compares the last segment after `:` or `/`, case-insensitively on Windows and with `.exe` stripped. #11803 uses it to name installed-but-inactive tools, so this is a second caller rather than a new concept.

Spelling a backend out stays a narrowing request: `mise ls ubi:jqlang/jq` passes the whole string as the bin name, which cannot match a trailing segment, so it still lists only that backend.

`--prunable` is deliberately left exact. It shares `prune::prunable_tools` with `mise prune`, so widening it would either disagree with what `mise prune <name>` then deletes, or — if the widening were pushed down into `prunable_tools` — make a destructive command act on an install the user did not name. `--prunable` exists to preview `prune`, so agreeing with `prune` is the more useful of the two consistencies. There is a comment on `get_prunable_runtime_list` saying so, since the omission otherwise reads as an oversight.

## Scope: display only

PATH and version resolution are untouched. The title of the discussion asks to treat the two as one tool, but the reporter installed the second copy deliberately to get an unreleased revision — collapsing them would remove the thing they set up. What is actually inconsistent is that `mise ls` and `mise ls <name>` disagree, and that is what this fixes.

## Known limit

Matching is on the name, so a package whose crate name differs from its binary does not merge. The `cargo:usage-cli` already installed by `e2e/cli/test_ls` provides a `usage` binary and will not appear under `mise ls usage`. Being exact would mean scanning the installed binaries, which does not work for a version that is listed but not installed and adds I/O to every `ls`. The approximation covers the reported case and cannot over-match, since the comparison is on the whole trailing segment — `mise ls node` does not pick up `npm:node-gyp`.

## Default rather than a flag

Extra rows only appear when the same tool really is installed from two backends, and in that situation seeing both is the point. If you would rather have it behind something like `--all-backends`, that is a small change — say the word.

## Tests

Four unit tests in a new `mod tests` (the file had none):

- a bare name matches `cargo:https://github.com/denisidoro/navi` and `ubi:denisidoro/navi`
- `ubi:jqlang/jq` matches itself but not `jq`
- `node` matches neither `npm:node-gyp` nor `nodejs`
- an empty request list matches nothing

And an e2e block appended to `e2e/cli/test_ls`, using versions that differ between the two backends so the assertions can tell them apart: `mise ls jq` shows both, `mise ls ubi:jqlang/jq` shows only the ubi one.

The existing assertion that `mise ls missing-tool` fails with *"not found in mise tool registry"* is unaffected — that happens while resolving the `BackendArg`, before any of this filtering.

No CLI arguments were added, so the generated `mise.usage.kdl` / `docs/cli` / `man` files are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool filtering in listings to match equivalent installations when using a bare tool name.
  * Explicit backend filters now show only tools from the selected backend.
  * Applied consistent filtering across standard, JSON, and all-source listings.
  * Prevented similarly prefixed tool names from being incorrectly matched.
  * Preserved precise filtering for prunable tool listings.
  * Added coverage for registry and UBI installations, aliases, empty filters, and backend-specific searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->