### PR TITLE
feat(task): support arguments in sources and outputs

### DIFF
--- a/docs/tasks/task-arguments.md
+++ b/docs/tasks/task-arguments.md
@@ -86,7 +86,9 @@ used with Tera's `for` loops and filters like `length`. The `usage` map is
 the same task.
 
 <span v-pre>`{{usage.*}}`</span> templates can also be used in `depends`, `depends_post`, and
-`wait_for` to forward arguments to dependency tasks. See
+`wait_for` to forward arguments to dependency tasks. They are also available in task
+`sources` and `outputs`, allowing freshness checks, artifact caching, `task_source_files()`,
+and `mise watch` to use the files selected by the current invocation. See
 [Passing parent task arguments to dependencies](/tasks/task-configuration#passing-parent-task-arguments-to-dependencies)
 for details.
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -406,6 +406,36 @@ outputs = ["target/debug/mycli"]
 Running the above will only execute `cargo build` if `mise.toml`, `Cargo.toml`, or any ".rs" file in the `src` directory
 has changed since the last build.
 
+Sources and outputs may use parsed task arguments. This keeps freshness checks and
+`mise watch` aligned with the files selected by the invocation:
+
+```mise-toml
+[tasks.validate]
+usage = 'arg "<input>"'
+sources = ["{{usage.input}}"]
+outputs = ["{{usage.input}}.validated"]
+run = "validate {{usage.input}} > {{usage.input}}.validated"
+```
+
+Flags can select different artifacts in the same way:
+
+```mise-toml
+[tasks.build]
+usage = 'flag "--release"'
+outputs = ["{% if usage.release %}dist/release{% else %}dist/debug{% endif %}/app"]
+run = "build {% if usage.release %}--release{% endif %}"
+```
+
+The deprecated `arg()`, `option()`, and `flag()` template functions are also
+supported for compatibility, but new tasks should define a `usage` spec and use
+the typed <span v-pre>`{{usage.*}}`</span> map.
+
+Argument templates in `sources` and `outputs` require mise to parse the task
+arguments. They cannot be used with `raw_args = true` or when task arguments are
+passed after `--` (for example, `mise run task -- --help`), because both forms
+bypass usage parsing. In those cases, mise reports an error before starting the
+task; use static patterns or invoke the task through the usage parser instead.
+
 The [`task_source_files`](../templates.md#task-source-files) function can be used to iterate over a task's
 `sources` within its template context.
 

--- a/e2e/tasks/test_task_usage_sources_outputs
+++ b/e2e/tasks/test_task_usage_sources_outputs
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+mkdir argument-patterns
+cd argument-patterns || exit 1
+
+cat <<'EOF' >mise.toml
+[settings]
+experimental = true
+
+[tasks.build]
+usage = '''
+arg "<name>"
+flag "--release"
+'''
+sources = ["{% if usage.release %}release{% else %}debug{% endif %}/{{usage.name}}.in"]
+outputs = ["{% if usage.release %}release{% else %}debug{% endif %}/{{usage.name}}.out"]
+run = '''
+mkdir -p {% if usage.release %}release{% else %}debug{% endif %}
+cp {% if usage.release %}release{% else %}debug{% endif %}/{{usage.name}}.in {% if usage.release %}release{% else %}debug{% endif %}/{{usage.name}}.out
+echo "{{ task_source_files() | join(sep=' ') }}"
+'''
+
+[tasks.legacy]
+sources = ["{{arg(name='input')}}"]
+outputs = ["{{arg(name='output')}}"]
+run = "cp {{arg(name='input')}} {{arg(name='output')}}"
+
+[tasks.side-effect]
+run = "touch side-effect"
+
+[tasks.invalid]
+usage = 'arg "<required>"'
+depends = ["side-effect"]
+sources = ["{{usage.required}}.in"]
+outputs = ["{{usage.required}}.out"]
+run = "touch {{usage.required}}.out"
+
+[tasks.cached]
+usage = 'arg "<profile>"'
+sources = ["cache-input.txt"]
+outputs = ["cache/{{usage.profile}}.txt"]
+cache = { enabled = true }
+run = '''
+mkdir -p cache
+printf '%s\n' "{{usage.profile}}" > "cache/{{usage.profile}}.txt"
+printf '%s\n' "{{usage.profile}}" >> cache-runs
+'''
+
+[tasks.raw-pattern]
+raw_args = true
+sources = ["{{arg(name='input')}}"]
+run = "true"
+
+[tasks.help-pattern]
+usage = 'arg "<input>"'
+sources = ["{{usage.input}}"]
+run = "true"
+
+[tasks.metadata]
+usage = 'arg "<name>"'
+sources = ["{{env.MISE_TASK_NAME}}/{{usage.name}}.in"]
+outputs = ["{{env.MISE_TASK_NAME}}/{{usage.name}}.out"]
+run = "cp {{env.MISE_TASK_NAME}}/{{usage.name}}.in {{env.MISE_TASK_NAME}}/{{usage.name}}.out"
+EOF
+
+mkdir debug release
+touch debug/app.in release/app.in
+
+assert "mise run -q build app" "debug/app.in"
+assert_empty "mise run -q build app"
+assert "mise run -q build app --release" "release/app.in"
+[[ -f debug/app.out ]] || fail "debug output was not created"
+[[ -f release/app.out ]] || fail "release output was not created"
+
+sleep 1
+touch debug/app.in
+assert "mise run -q build app" "debug/app.in"
+
+echo legacy >"input file.txt"
+assert "mise run -q legacy 'input file.txt' 'output file.txt'"
+cmp "input file.txt" "output file.txt" || fail "legacy helper paths were shell-quoted"
+help=$(mise run legacy --help 2>&1)
+[[ $(grep -c '^  <input>' <<<"$help") == 1 ]] || fail "input argument was duplicated"
+[[ $(grep -c '^  <output>' <<<"$help") == 1 ]] || fail "output argument was duplicated"
+
+assert_fail_contains "mise run invalid" "Missing required arg: <required>"
+[[ ! -e side-effect ]] || fail "dependency ran before usage validation"
+
+touch cache-input.txt
+mise run cached debug
+mise run cached release
+rm cache/debug.txt cache/release.txt
+assert_contains "mise run cached debug 2>&1" "restored outputs from cache"
+assert_contains "mise run cached release 2>&1" "restored outputs from cache"
+assert "cat cache/debug.txt" "debug"
+assert "cat cache/release.txt" "release"
+assert "wc -l < cache-runs | tr -d ' '" "2"
+
+assert_fail_contains \
+  "mise run raw-pattern input.txt" \
+  "cannot use argument templates in sources or outputs when usage parsing is disabled"
+assert_fail_contains \
+  "mise run help-pattern -- --help" \
+  "cannot use argument templates in sources or outputs when usage parsing is disabled"
+
+mkdir metadata
+echo metadata >metadata/context.in
+mise run metadata context
+assert "cat metadata/context.out" "metadata"

--- a/e2e/tasks/test_task_usage_sources_outputs_deps
+++ b/e2e/tasks/test_task_usage_sources_outputs_deps
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+cat <<'EOF' >mise.toml
+[tasks.prepare]
+usage = 'arg "<name>"'
+sources = ["{{env.SELECTOR}}/{{usage.name}}.in"]
+outputs = ["{{env.SELECTOR}}/{{usage.name}}.prepared"]
+run = "cp {{env.SELECTOR}}/{{usage.name}}.in {{env.SELECTOR}}/{{usage.name}}.prepared"
+
+[tasks.cleanup]
+usage = 'arg "<name>"'
+sources = ["{{env.SELECTOR}}/{{usage.name}}.prepared"]
+outputs = ["{{env.SELECTOR}}/{{usage.name}}.cleaned"]
+run = "cp {{env.SELECTOR}}/{{usage.name}}.prepared {{env.SELECTOR}}/{{usage.name}}.cleaned"
+
+[tasks.pipeline]
+usage = 'arg "<name>"'
+depends = [{ task = "prepare", args = ["{{usage.name}}"], env = { SELECTOR = "selected" } }]
+depends_post = [{ task = "cleanup", args = ["{{usage.name}}"], env = { SELECTOR = "selected" } }]
+run = "test -f selected/{{usage.name}}.prepared"
+
+[tasks.generate-selector]
+run = '''
+mkdir -p generated
+printf 'SELECTOR=generated\n' > selector.env
+printf 'dependency\n' > generated/item.in
+'''
+
+[tasks.from-generated-env]
+usage = 'arg "<name>"'
+depends = ["generate-selector"]
+sources = ["{{env.SELECTOR}}/{{usage.name}}.in"]
+outputs = ["{{env.SELECTOR}}/{{usage.name}}.out"]
+run = "cp {{env.SELECTOR}}/{{usage.name}}.in {{env.SELECTOR}}/{{usage.name}}.out"
+
+[tasks.from-generated-env.env]
+_.file = "selector.env"
+EOF
+
+mkdir selected
+echo selected >selected/artifact.in
+assert_succeed "mise run pipeline artifact"
+assert "cat selected/artifact.prepared" "selected"
+assert "cat selected/artifact.cleaned" "selected"
+
+assert_succeed "mise run from-generated-env item"
+assert "cat generated/item.out" "dependency"

--- a/e2e/tasks/test_task_watch_usage_sources
+++ b/e2e/tasks/test_task_watch_usage_sources
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+mise use -g watchexec@latest
+
+cat <<'EOF' >mise.toml
+[tasks.watched]
+usage = 'arg "<source>"'
+sources = ["{{usage.source}}"]
+run = "echo watched"
+EOF
+touch selected.txt
+
+assert_fail_contains "mise watch --postpone watched" "Missing required arg: <source>"
+
+wait_for_watchexec() {
+  local log_file="$1"
+  for _ in $(seq 1 150); do
+    grep -Fq '$ watchexec ' "$log_file" && return 0
+    sleep 0.1
+  done
+  fail "timed out waiting for watchexec command in $log_file"
+}
+
+MISE_DEBUG=1 mise watch --postpone watched selected.txt >watch.log 2>&1 &
+watch_pid=$!
+trap 'kill "$watch_pid" 2>/dev/null || true' EXIT
+wait_for_watchexec watch.log
+kill "$watch_pid"
+wait "$watch_pid" 2>/dev/null || true
+assert_contains "grep -F '\$ watchexec ' watch.log" "-f selected.txt"
+
+MISE_DEBUG=1 mise watch --skip-deps --postpone watched selected.txt >skip.log 2>&1 &
+watch_pid=$!
+wait_for_watchexec skip.log
+kill "$watch_pid"
+wait "$watch_pid" 2>/dev/null || true
+assert_contains "grep -F '\$ watchexec ' skip.log" "-f selected.txt"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -875,12 +875,11 @@ impl Run {
 
         // Validate every scheduled invocation before starting the scheduler so
         // an invalid parent or dependency cannot run any task commands first.
-        let executor = self.executor.as_ref().expect("task executor initialized");
         for task in tasks.all() {
-            if let Err(err) = executor
-                .preflight_task_usage(&config, task)
-                .await
-                .wrap_err_with(|| format!("failed to validate task {}", task.name))
+            if let Err(err) =
+                crate::task::task_executor::TaskExecutor::preflight_task_usage(&config, task)
+                    .await
+                    .wrap_err_with(|| format!("failed to validate task {}", task.name))
             {
                 if let Some(session) = &self.cache_session
                     && let Err(finish_err) = session.finish().await

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -6,12 +6,13 @@ use crate::config::Config;
 use crate::dirs;
 use crate::env;
 use crate::request_exit;
+use crate::task::task_context_builder::TaskContextBuilder;
 use crate::task::task_source_checker::task_cwd;
 use crate::task::{Deps, Task};
 use crate::toolset::ToolsetBuilder;
 use clap::{CommandFactory, ValueEnum, ValueHint};
 use console::style;
-use eyre::bail;
+use eyre::{Context, bail};
 use itertools::Itertools;
 use std::cmp::PartialEq;
 use std::iter::once;
@@ -85,11 +86,32 @@ impl Watch {
         if args.is_empty() {
             bail!("No tasks specified");
         }
-        let tasks = crate::task::task_list::get_task_lists(&config, &args, false, false).await?;
+        let mut tasks =
+            crate::task::task_list::get_task_lists(&config, &args, false, false).await?;
+        let context_builder = TaskContextBuilder::new();
         let watched_tasks = if self.skip_deps {
+            for task in &mut tasks {
+                crate::task::task_executor::TaskExecutor::preflight_task_usage(&config, task)
+                    .await
+                    .wrap_err_with(|| format!("failed to validate task {}", task.name))?;
+                context_builder
+                    .render_task_file_templates(&config, task, &[])
+                    .await?;
+            }
             tasks.to_vec()
         } else {
-            let deps = Deps::new(&config, tasks.clone()).await?;
+            let mut deps = Deps::new(&config, tasks.clone()).await?;
+            let node_indices = deps.graph.node_indices().collect_vec();
+            for idx in node_indices {
+                let mut task = deps.graph[idx].clone();
+                crate::task::task_executor::TaskExecutor::preflight_task_usage(&config, &task)
+                    .await
+                    .wrap_err_with(|| format!("failed to validate task {}", task.name))?;
+                context_builder
+                    .render_task_file_templates(&config, &mut task, &[])
+                    .await?;
+                deps.graph[idx] = task;
+            }
             deps.all().cloned().collect()
         };
         let mut args = vec![];

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -708,6 +708,16 @@ pub struct Task {
     pub interactive: bool,
     #[serde(default)]
     pub sources: Vec<String>,
+    /// Unrendered source templates retained for per-invocation argument rendering.
+    #[serde(skip)]
+    pub raw_sources: Vec<String>,
+    /// Config environment captured during the ordinary task render. Reusing it
+    /// for pre-scheduler file-template rendering avoids executing env hooks a
+    /// second time before dependencies have run.
+    #[serde(skip)]
+    pub(crate) file_template_env: EnvMap,
+    #[serde(skip)]
+    pub(crate) file_template_vars: Option<IndexMap<String, String>>,
     #[serde(default)]
     pub watch: Option<TaskWatchOptions>,
     #[serde(default)]
@@ -1934,7 +1944,7 @@ impl Task {
             clear_usage_env(&mut env);
         }
         let (mut spec, scripts) = if let Some(file) = self.file_path(config).await? {
-            let spec = parse_task_script_usage(&file)
+            let file_spec = parse_task_script_usage(&file)
                 .inspect_err(|e| {
                     warn!(
                         "failed to parse task file {} with usage: {e:?}",
@@ -1942,21 +1952,98 @@ impl Task {
                     )
                 })
                 .unwrap_or_default();
+            let file_templates = self.usage_file_templates();
+            let parser = Self::make_script_parser(self.config_root.clone(), extra_vars);
+            let (_, mut spec) = parser
+                .parse_run_scripts_with_spec_templates(config, self, &[], &file_templates, &env)
+                .await?;
+            spec.merge(file_spec);
             (spec, vec![])
         } else {
             let scripts_only = self.run_script_strings();
+            let file_templates = self.usage_file_templates();
             let parser_dir = match cwd {
                 Some(cwd) => Some(cwd),
                 None => self.dir(config).await?,
             };
             let (scripts, spec) = Self::make_script_parser(parser_dir, extra_vars)
-                .parse_run_scripts(config, self, &scripts_only, &env)
+                .parse_run_scripts_with_spec_templates(
+                    config,
+                    self,
+                    &scripts_only,
+                    &file_templates,
+                    &env,
+                )
                 .await?;
             (spec, scripts)
         };
         self.populate_spec_metadata(&mut spec);
         self.populate_usage_about(&mut spec);
         Ok((spec, scripts))
+    }
+
+    pub(crate) fn usage_file_templates(&self) -> Vec<String> {
+        let sources = if self.raw_sources.is_empty() {
+            &self.sources
+        } else {
+            &self.raw_sources
+        };
+        sources
+            .iter()
+            .chain(
+                self.raw_outputs
+                    .templates
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter(),
+            )
+            .filter(|template| template_has_usage_input(template))
+            .cloned()
+            .collect()
+    }
+
+    pub fn has_usage_file_templates(&self) -> bool {
+        !self.usage_file_templates().is_empty()
+    }
+
+    pub async fn render_file_templates_with_args(
+        &mut self,
+        config: &Arc<Config>,
+        env: &EnvMap,
+        extra_vars: Option<IndexMap<String, String>>,
+    ) -> Result<()> {
+        if !self.has_usage_file_templates() {
+            return Ok(());
+        }
+        if self.should_bypass_usage_parser() {
+            bail!(
+                "task '{}' cannot use argument templates in sources or outputs when usage parsing is disabled",
+                self.name
+            );
+        }
+
+        let (spec, _) = self
+            .parse_usage_spec_with_vars(config, None, env, extra_vars.clone())
+            .await?;
+        let parser = Self::make_script_parser(self.config_root.clone(), extra_vars);
+        let raw_sources = if self.raw_sources.is_empty() {
+            self.sources.clone()
+        } else {
+            self.raw_sources.clone()
+        };
+        self.sources = parser
+            .render_file_templates_with_args(config, self, &raw_sources, env, &self.args, &spec)
+            .await?;
+
+        if let Some(raw_outputs) = self.raw_outputs.templates.clone() {
+            let rendered_outputs = parser
+                .render_file_templates_with_args(config, self, &raw_outputs, env, &self.args, &spec)
+                .await?;
+            if let TaskOutputs::Files(files) = &mut self.outputs {
+                *files = rendered_outputs;
+            }
+        }
+        Ok(())
     }
 
     fn make_script_parser(
@@ -1974,18 +2061,30 @@ impl Task {
     pub async fn parse_usage_spec_for_display(&self, config: &Arc<Config>) -> Result<usage::Spec> {
         let dir = self.dir(config).await?;
         let mut spec = if let Some(file) = self.file_path(config).await? {
-            parse_task_script_usage(&file)
+            let file_spec = parse_task_script_usage(&file)
                 .inspect_err(|e| {
                     warn!(
                         "failed to parse task file {} with usage: {e:?}",
                         file::display_path(&file)
                     )
                 })
-                .unwrap_or_default()
+                .unwrap_or_default();
+            let file_templates = self.usage_file_templates();
+            let mut spec = TaskScriptParser::new(dir)
+                .parse_run_scripts_for_spec_only_with_templates(config, self, &[], &file_templates)
+                .await?;
+            spec.merge(file_spec);
+            spec
         } else {
             let scripts_only = self.run_script_strings();
+            let file_templates = self.usage_file_templates();
             TaskScriptParser::new(dir)
-                .parse_run_scripts_for_spec_only(config, self, &scripts_only)
+                .parse_run_scripts_for_spec_only_with_templates(
+                    config,
+                    self,
+                    &scripts_only,
+                    &file_templates,
+                )
                 .await?
         };
         self.populate_spec_metadata(&mut spec);
@@ -2001,18 +2100,30 @@ impl Task {
         config: &Arc<Config>,
     ) -> Result<usage::Spec> {
         let mut spec = if let Some(file) = self.file_path_raw() {
-            parse_task_script_usage(&file)
+            let file_spec = parse_task_script_usage(&file)
                 .inspect_err(|e| {
                     warn!(
                         "failed to parse task file {} with usage: {e:?}",
                         file::display_path(&file)
                     )
                 })
-                .unwrap_or_default()
+                .unwrap_or_default();
+            let file_templates = self.usage_file_templates();
+            let mut spec = TaskScriptParser::new(self.config_root.clone())
+                .parse_run_scripts_for_preflight_with_templates(config, self, &[], &file_templates)
+                .await?;
+            spec.merge(file_spec);
+            spec
         } else {
             let scripts_only = self.run_script_strings();
+            let file_templates = self.usage_file_templates();
             TaskScriptParser::new(self.config_root.clone())
-                .parse_run_scripts_for_preflight(config, self, &scripts_only)
+                .parse_run_scripts_for_preflight_with_templates(
+                    config,
+                    self,
+                    &scripts_only,
+                    &file_templates,
+                )
                 .await?
         };
         self.populate_spec_metadata(&mut spec);
@@ -2522,7 +2633,13 @@ impl Task {
         if other.output.is_some() {
             self.output = other.output;
         }
+        let other_raw_sources = if other.raw_sources.is_empty() {
+            other.sources.clone()
+        } else {
+            other.raw_sources.clone()
+        };
         self.sources.extend(other.sources);
+        self.raw_sources.extend(other_raw_sources);
         if other.watch.is_some() {
             self.watch = other.watch;
         }
@@ -2611,6 +2728,7 @@ impl Task {
         if !self.sources.is_empty() && self.outputs.is_empty() {
             self.outputs = TaskOutputs::Auto;
         }
+        self.raw_sources = self.sources.clone();
         self.raw_outputs = self.outputs.raw_templates_without_env();
         // Save unrendered dependency templates so they can be re-rendered later
         // with parent task args available (for passing args to dependencies).
@@ -2641,6 +2759,13 @@ impl Task {
 
         let mut tera = get_tera(Some(config_root));
         let tera_ctx = self.tera_ctx(config).await?;
+        self.file_template_env = tera_ctx
+            .get("env")
+            .and_then(|value| serde::Deserialize::deserialize(value.clone()).ok())
+            .unwrap_or_default();
+        self.file_template_vars = tera_ctx
+            .get("vars")
+            .and_then(|value| serde::Deserialize::deserialize(value.clone()).ok());
         for a in &mut self.aliases {
             if contains_template_syntax(a) {
                 *a = render_str(&mut tera, a, &tera_ctx)?;
@@ -2650,12 +2775,16 @@ impl Task {
         if contains_template_syntax(&self.description) {
             self.description = render_str(&mut tera, &self.description, &tera_ctx)?;
         }
+        let raw_sources = self.sources.clone();
         for s in &mut self.sources {
-            if contains_template_syntax(s) {
+            if contains_template_syntax(s) && !template_has_usage_input(s) {
                 *s = render_str(&mut tera, s, &tera_ctx)?;
             }
         }
+        // Preserve the raw source templates captured before ordinary config
+        // rendering so usage-dependent patterns can be rendered per invocation.
         self.store_raw_render_inputs();
+        self.raw_sources = raw_sources;
         self.raw_outputs = self.outputs.render(&mut tera, &tera_ctx)?;
         // Render deps that don't contain {{usage.*}} references. Deps with usage
         // references are deferred until render_depends_with_usage() is called with
@@ -3096,6 +3225,9 @@ impl Default for Task {
             trailing_args: vec![],
             interactive: false,
             sources: vec![],
+            raw_sources: vec![],
+            file_template_env: Default::default(),
+            file_template_vars: None,
             watch: None,
             outputs: Default::default(),
             cache: Default::default(),
@@ -3505,6 +3637,38 @@ fn tera_template_has_usage_ref(s: &str) -> bool {
     false
 }
 
+/// Whether a template needs the invocation's parsed usage values. In addition
+/// to the preferred `usage.*` map, keep the deprecated helper functions working
+/// in file patterns for backwards compatibility with task run templates.
+pub(crate) fn template_has_usage_input(s: &str) -> bool {
+    if tera_template_has_usage_ref(s) {
+        return true;
+    }
+    const TAGS: [(&str, &str); 2] = [("{{", "}}"), ("{%", "%}")];
+    TAGS.into_iter().any(|(open, close)| {
+        let mut rest = s;
+        while let Some(start) = rest.find(open) {
+            rest = &rest[start + open.len()..];
+            let Some(end) = rest.find(close) else {
+                break;
+            };
+            let tag = &rest[..end];
+            if ["arg", "option", "flag"].into_iter().any(|name| {
+                tag.match_indices(name).any(|(idx, _)| {
+                    let before = tag[..idx].chars().next_back();
+                    let after = tag[idx + name.len()..].trim_start().chars().next();
+                    before.is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_')
+                        && after == Some('(')
+                })
+            }) {
+                return true;
+            }
+            rest = &rest[end + close.len()..];
+        }
+        false
+    })
+}
+
 fn tera_tag_has_usage_ref(tag: &str) -> bool {
     ["usage.", "usage["].iter().any(|needle| {
         tag.match_indices(needle).any(|(idx, _)| {
@@ -3572,9 +3736,22 @@ mod tests {
     #[cfg(unix)]
     use super::{TaskCacheConfig, TaskOutput};
     use super::{
-        clear_usage_env, env_contains_key, name_from_path, tera_tag_has_usage_ref,
-        tera_template_has_usage_ref,
+        clear_usage_env, env_contains_key, name_from_path, template_has_usage_input,
+        tera_tag_has_usage_ref, tera_template_has_usage_ref,
     };
+
+    #[test]
+    fn test_template_has_usage_input() {
+        assert!(template_has_usage_input("{{ usage.target }}"));
+        assert!(template_has_usage_input("{{usage['target']}}"));
+        assert!(template_has_usage_input("{{ arg(name='target') }}"));
+        assert!(template_has_usage_input(
+            "{% if flag(name='release') %}x{% endif %}"
+        ));
+        assert!(template_has_usage_input("{{ option(name='profile') }}"));
+        assert!(!template_has_usage_input("{{ vars.target }}"));
+        assert!(!template_has_usage_input("{{ target_flag(value='x') }}"));
+    }
 
     #[derive(Debug)]
     struct BrokenWorkspaceProvider;

--- a/src/task/task_context_builder.rs
+++ b/src/task/task_context_builder.rs
@@ -18,6 +18,29 @@ type EnvResolutionResult = (
     Option<IndexMap<String, String>>,
 );
 
+pub(crate) struct ResolvedTaskContext {
+    pub(crate) toolset: Toolset,
+    pub(crate) env: BTreeMap<String, String>,
+    pub(crate) task_env: Vec<(String, String)>,
+    pub(crate) extra_vars: Option<IndexMap<String, String>>,
+}
+
+const MISE_PROJECT_ROOT_KEY: &str = "MISE_PROJECT_ROOT";
+const MISE_MONOREPO_ROOT_KEY: &str = "MISE_MONOREPO_ROOT";
+const MISE_TASK_NAME_KEY: &str = "MISE_TASK_NAME";
+const MISE_TASK_FILE_KEY: &str = "MISE_TASK_FILE";
+const MISE_TASK_DIR_KEY: &str = "MISE_TASK_DIR";
+const MISE_CONFIG_ROOT_KEY: &str = "MISE_CONFIG_ROOT";
+
+pub(crate) const TASK_METADATA_ENV_KEYS: &[&str] = &[
+    MISE_PROJECT_ROOT_KEY,
+    MISE_MONOREPO_ROOT_KEY,
+    MISE_TASK_NAME_KEY,
+    MISE_TASK_FILE_KEY,
+    MISE_TASK_DIR_KEY,
+    MISE_CONFIG_ROOT_KEY,
+];
+
 /// Builds toolset and environment context for task execution
 ///
 /// Handles:
@@ -50,6 +73,127 @@ impl TaskContextBuilder {
             tool_request_set_cache: RwLock::new(IndexMap::new()),
             env_resolution_cache: RwLock::new(IndexMap::new()),
         }
+    }
+
+    /// Resolve the same task-local toolset, environment, and vars used during
+    /// execution, then render argument-dependent source/output patterns before
+    /// freshness checks or watch filter construction.
+    pub async fn render_task_file_templates(
+        &self,
+        config: &Arc<Config>,
+        task: &mut Task,
+        _cli_tools: &[ToolArg],
+    ) -> Result<()> {
+        if !task.has_usage_file_templates() {
+            return Ok(());
+        }
+        // The full task environment may execute source/plugin hooks whose
+        // inputs are produced by dependencies. Use the config context captured
+        // during normal task loading plus literal task/dependency overrides;
+        // execution re-renders with the full environment after dependencies.
+        let mut env = if task.file_template_env.is_empty() {
+            crate::env::PRISTINE_ENV.clone()
+        } else {
+            task.file_template_env.clone()
+        };
+        for directive in task.inherited_env.0.iter().chain(task.env.0.iter()) {
+            Self::apply_literal_env(&mut env, directive);
+        }
+        for (directive, _) in &task.overlay_env {
+            Self::apply_literal_env(&mut env, directive);
+        }
+        Self::inject_task_metadata(config, task, &mut env).await?;
+        task.render_file_templates_with_args(config, &env, task.file_template_vars.clone())
+            .await
+    }
+
+    fn apply_literal_env(env: &mut BTreeMap<String, String>, directive: &EnvDirective) {
+        match directive {
+            EnvDirective::Val(key, value, _) if !crate::tera::contains_template_syntax(value) => {
+                env.insert(key.clone(), value.clone());
+            }
+            EnvDirective::Default(key, value, _)
+                if !crate::tera::contains_template_syntax(value)
+                    && env.get(key).is_none_or(|current| current.is_empty()) =>
+            {
+                env.insert(key.clone(), value.clone());
+            }
+            EnvDirective::Rm(key, _) => {
+                env.remove(key);
+            }
+            _ => {}
+        }
+    }
+
+    /// Resolve the task-local toolset and environment shared by file-template
+    /// rendering and task execution.
+    pub(crate) async fn resolve_task_context(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+        cli_tools: &[ToolArg],
+    ) -> Result<ResolvedTaskContext> {
+        let mut tools = cli_tools.to_vec();
+        tools.extend(task.tool_args()?);
+        let task_cf = if task.is_remote() {
+            None
+        } else {
+            task.cf(config).cloned()
+        };
+        let toolset = self
+            .build_toolset_for_task(config, task, task_cf.as_ref(), &tools)
+            .await?;
+        let (mut env, task_env, extra_vars) = if let Some(task_cf) = task_cf.as_ref() {
+            self.resolve_task_env_with_config(config, task, task_cf, &toolset)
+                .await?
+        } else {
+            let (env, task_env) = task.render_env(config, &toolset).await?;
+            (env, task_env, None)
+        };
+        Self::inject_task_metadata(config, task, &mut env).await?;
+        Ok(ResolvedTaskContext {
+            toolset,
+            env,
+            task_env,
+            extra_vars,
+        })
+    }
+
+    async fn inject_task_metadata(
+        config: &Arc<Config>,
+        task: &Task,
+        env: &mut BTreeMap<String, String>,
+    ) -> Result<()> {
+        let project_root = if task.global || task.is_remote() {
+            config.project_root.clone().or(task.config_root.clone())
+        } else {
+            task.config_root.clone().or(config.project_root.clone())
+        };
+        if let Some(root) = project_root {
+            env.insert(MISE_PROJECT_ROOT_KEY.into(), root.display().to_string());
+        }
+        if let Some(monorepo_root) = config.monorepo_root() {
+            env.insert(
+                MISE_MONOREPO_ROOT_KEY.into(),
+                monorepo_root.display().to_string(),
+            );
+        }
+        env.insert(MISE_TASK_NAME_KEY.into(), task.name.clone());
+        let task_file = task
+            .file_path(config)
+            .await?
+            .unwrap_or(task.config_source.clone());
+        env.insert(MISE_TASK_FILE_KEY.into(), task_file.display().to_string());
+        if let Some(dir) = task_file.parent() {
+            env.insert(MISE_TASK_DIR_KEY.into(), dir.display().to_string());
+        }
+        if let Some(config_root) = &task.config_root {
+            env.insert(
+                MISE_CONFIG_ROOT_KEY.into(),
+                config_root.display().to_string(),
+            );
+        }
+        Ok(())
     }
 
     /// Build toolset for a task, with caching for monorepo tasks

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -9,7 +9,9 @@ use crate::task::TaskArtifactCache;
 use crate::task::task_cache::{
     CommandInput, TaskCacheContext, TaskCacheMissReason, TaskCacheRestore,
 };
-use crate::task::task_context_builder::TaskContextBuilder;
+use crate::task::task_context_builder::{
+    ResolvedTaskContext, TASK_METADATA_ENV_KEYS, TaskContextBuilder,
+};
 use crate::task::task_list::split_task_spec;
 use crate::task::task_output::{TaskOutput, trunc};
 use crate::task::task_output_handler::OutputHandler;
@@ -456,15 +458,29 @@ impl TaskExecutor {
             permit,
             allow_during_interruption,
         } = ctx;
-        let prefix = task.estyled_prefix();
         let total_start = std::time::Instant::now();
         Self::check_interruption(allow_during_interruption)?;
+        let mut task = task.clone();
+        let prefix = task.estyled_prefix();
         if Settings::get().task.skip.contains(&task.name) {
-            if !self.quiet(Some(task)) {
-                self.eprint(task, &prefix, "skipping task");
+            if !self.quiet(Some(&task)) {
+                self.eprint(&task, &prefix, "skipping task");
             }
             return Ok(TaskRunOutcome::default());
         }
+        let mut prepared_context = None;
+        let mut prepared_task_file = None;
+        if task.has_usage_file_templates() {
+            let mut context = self.prepare_task_context(config, &task).await?;
+            task.render_file_templates_with_args(config, &context.env, context.extra_vars.clone())
+                .await?;
+            prepared_task_file = Some(
+                self.parse_task_usage(config, &task, &mut context.env, context.extra_vars.clone())
+                    .await?,
+            );
+            prepared_context = Some(context);
+        }
+        let task = &task;
         // If any dependency executed or restored, skip the source freshness check
         // so that downstream tasks are invalidated by upstream changes.
         let artifact_cache_enabled =
@@ -485,10 +501,17 @@ impl TaskExecutor {
             mut env,
             task_env,
             extra_vars,
-        } = self.prepare_task_context(config, task).await?;
-        let task_file = self
-            .parse_task_usage(config, task, &mut env, extra_vars.clone())
-            .await?;
+        } = match prepared_context {
+            Some(context) => context,
+            None => self.prepare_task_context(config, task).await?,
+        };
+        let task_file = match prepared_task_file {
+            Some(task_file) => task_file,
+            None => {
+                self.parse_task_usage(config, task, &mut env, extra_vars.clone())
+                    .await?
+            }
+        };
 
         // Confirmation must happen before a cache restore because restoring
         // outputs mutates the working tree just like executing the task.
@@ -994,6 +1017,11 @@ impl TaskExecutor {
                 }
                 to_run.push(t);
             }
+        }
+        for task in &to_run {
+            Self::preflight_task_usage(config, task)
+                .await
+                .wrap_err_with(|| format!("failed to validate task {}", task.name))?;
         }
         let sub_deps = Deps::new_pruned(config, to_run, completion_state).await?;
         let sub_deps = Arc::new(Mutex::new(sub_deps));
@@ -1771,7 +1799,7 @@ impl TaskExecutor {
     /// Validate a task invocation before the scheduler starts any task commands.
     /// Runtime execution repeats this work so configuration changes made while
     /// dependencies run are still detected.
-    pub async fn preflight_task_usage(&self, config: &Arc<Config>, task: &Task) -> Result<()> {
+    pub(crate) async fn preflight_task_usage(config: &Arc<Config>, task: &Task) -> Result<()> {
         if task.should_bypass_usage_parser() {
             return Ok(());
         }
@@ -1801,6 +1829,12 @@ impl TaskExecutor {
                         format!("invalid task script template for task {}", task.name)
                     })?;
             }
+        }
+        for template in task.usage_file_templates() {
+            task.validate_template_syntax_for_preflight(&template)
+                .wrap_err_with(|| {
+                    format!("invalid source/output template for task {}", task.name)
+                })?;
         }
         if dynamic_usage {
             // The side-effect-free context intentionally omits task/subproject
@@ -1833,12 +1867,12 @@ impl TaskExecutor {
                 .chain(task.args.iter().cloned())
                 .collect()
         };
-        match self.parse_usage_spec_and_init_env_from_spec(task, &mut env, &usage_args, &spec) {
+        match Self::parse_usage_spec_and_init_env_from_spec(task, &mut env, &usage_args, &spec) {
             Ok(()) => Ok(()),
             Err(_) if Self::has_unavailable_required_env_input(&spec.cmd, &env) => {
                 let mut probe_env = env.clone();
                 Self::fill_unavailable_required_env_inputs(&spec.cmd, &mut probe_env);
-                match self.parse_usage_spec_and_init_env_from_spec(
+                match Self::parse_usage_spec_and_init_env_from_spec(
                     task,
                     &mut probe_env,
                     &usage_args,
@@ -1921,41 +1955,20 @@ impl TaskExecutor {
         config: &Arc<Config>,
         task: &Task,
     ) -> Result<PreparedTaskContext> {
-        let mut tools = self.tool.clone();
-        tools.extend(task.tool_args()?);
         let ts_build_start = std::time::Instant::now();
-
-        // Remote tasks need tools from the full config hierarchy rather than a
-        // config file rooted at their downloaded source.
-        let task_cf = if task.is_remote() {
-            None
-        } else {
-            task.cf(config)
-        };
-        let toolset = self
+        let ResolvedTaskContext {
+            toolset,
+            mut env,
+            task_env,
+            extra_vars,
+        } = self
             .context_builder
-            .build_toolset_for_task(config, task, task_cf, &tools)
+            .resolve_task_context(config, task, &self.tool)
             .await?;
         trace!(
-            "task {} ToolsetBuilder::build took {}ms",
+            "task {} context resolution took {}ms",
             task.name,
             ts_build_start.elapsed().as_millis()
-        );
-
-        let env_render_start = std::time::Instant::now();
-        // extra_vars contains resolved vars from the task's config hierarchy.
-        let (mut env, task_env, extra_vars) = if let Some(task_cf) = task_cf {
-            self.context_builder
-                .resolve_task_env_with_config(config, task, task_cf, &toolset)
-                .await?
-        } else {
-            let (env, task_env) = task.render_env(config, &toolset).await?;
-            (env, task_env, None)
-        };
-        trace!(
-            "task {} render_env took {}ms",
-            task.name,
-            env_render_start.elapsed().as_millis()
         );
 
         let mut nested_mise_diff_exclude_keys: HashSet<String> = task_env
@@ -1963,6 +1976,7 @@ impl TaskExecutor {
             .map(|(key, _)| key.clone())
             .filter(|key| key.as_str() != crate::env::PATH_KEY.as_str())
             .chain(once("__MISE_DIFF".to_string()))
+            .chain(TASK_METADATA_ENV_KEYS.iter().copied().map(str::to_string))
             .collect();
         if !self.timings {
             Self::insert_env_excluded_from_nested_mise_diff(
@@ -1989,61 +2003,6 @@ impl TaskExecutor {
             );
         }
 
-        // Prefer the task's own config root for project tasks. Global and
-        // remote tasks retain the invoking project's root.
-        let project_root = if task.global || task.is_remote() {
-            config.project_root.clone().or(task.config_root.clone())
-        } else {
-            task.config_root.clone().or(config.project_root.clone())
-        };
-        if let Some(root) = project_root {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_PROJECT_ROOT",
-                root.display().to_string(),
-            );
-        }
-        if let Some(monorepo_root) = config.monorepo_root() {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_MONOREPO_ROOT",
-                monorepo_root.display().to_string(),
-            );
-        }
-        Self::insert_env_excluded_from_nested_mise_diff(
-            &mut env,
-            &mut nested_mise_diff_exclude_keys,
-            "MISE_TASK_NAME",
-            task.name.clone(),
-        );
-        let task_file = task
-            .file_path(config)
-            .await?
-            .unwrap_or(task.config_source.clone());
-        Self::insert_env_excluded_from_nested_mise_diff(
-            &mut env,
-            &mut nested_mise_diff_exclude_keys,
-            "MISE_TASK_FILE",
-            task_file.display().to_string(),
-        );
-        if let Some(dir) = task_file.parent() {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_TASK_DIR",
-                dir.display().to_string(),
-            );
-        }
-        if let Some(config_root) = &task.config_root {
-            Self::insert_env_excluded_from_nested_mise_diff(
-                &mut env,
-                &mut nested_mise_diff_exclude_keys,
-                "MISE_CONFIG_ROOT",
-                config_root.display().to_string(),
-            );
-        }
         if Settings::get().env_cache {
             let key = CachedEnv::ensure_encryption_key();
             Self::insert_env_excluded_from_nested_mise_diff(
@@ -2115,11 +2074,10 @@ impl TaskExecutor {
             return Ok(());
         }
         let args = get_args();
-        self.parse_usage_spec_and_init_env_from_spec(task, env, &args, &spec)
+        Self::parse_usage_spec_and_init_env_from_spec(task, env, &args, &spec)
     }
 
     fn parse_usage_spec_and_init_env_from_spec(
-        &self,
         task: &Task,
         env: &mut BTreeMap<String, String>,
         args: &[String],

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -23,6 +23,7 @@ type TeraSpecParsingResult = (
 );
 
 type TaskTemplateResult = std::result::Result<JsonValue, String>;
+const CONFLICTING_DEFINITION_PREFIX: &str = "conflicting definitions for task";
 
 pub struct TaskScriptParser {
     dir: Option<PathBuf>,
@@ -82,6 +83,19 @@ impl TaskScriptParser {
         }
     }
 
+    fn collect_spec_template(
+        tera: &mut TeraEngine,
+        template: &str,
+        ctx: &tera::Context,
+    ) -> Result<()> {
+        if let Err(err) = Self::render_script_with_context(tera, template, ctx)
+            && format!("{err:#}").contains(CONFLICTING_DEFINITION_PREFIX)
+        {
+            return Err(err);
+        }
+        Ok(())
+    }
+
     fn render_usage_with_context(
         tera: &mut TeraEngine,
         usage: &str,
@@ -105,7 +119,7 @@ impl TaskScriptParser {
             "2026.5.0",
             "2027.5.0",
             "tera_template_task_args",
-            "Task '{}' uses deprecated Tera template functions (arg(), option(), flag()) in run scripts. \
+            "Task '{}' uses deprecated Tera template functions (arg(), option(), flag()). \
              Use the 'usage' field instead. See https://mise.jdx.dev/tasks/task-arguments.html",
             task_name
         );
@@ -292,8 +306,8 @@ impl TaskScriptParser {
     fn setup_tera_for_spec_parsing(&self, task: &Task) -> TeraSpecParsingResult {
         let mut tera = self.get_tera();
         let arg_order = Arc::new(Mutex::new(HashMap::new()));
-        let input_args = Arc::new(Mutex::new(vec![]));
-        let input_flags = Arc::new(Mutex::new(vec![]));
+        let input_args: Arc<Mutex<Vec<usage::SpecArg>>> = Arc::new(Mutex::new(vec![]));
+        let input_flags: Arc<Mutex<Vec<usage::SpecFlag>>> = Arc::new(Mutex::new(vec![]));
         // override throw function to do nothing
         Self::register_template_function(&mut tera, "throw", move |_| Ok(JsonValue::Null));
         // render args, options, and flags as null
@@ -309,14 +323,6 @@ impl TaskScriptParser {
                 let required = Self::template_arg::<bool>(args, "required")?.unwrap_or(true);
                 let var = Self::template_arg::<bool>(args, "var")?.unwrap_or(false);
                 let name = Self::template_arg::<String>(args, "name")?.unwrap_or(i.to_string());
-
-                let mut arg_order = arg_order.lock().map_err(Self::lock_error)?;
-
-                if arg_order.contains_key(&name) {
-                    trace!("already seen {name}");
-                    return Ok(json!(""));
-                }
-                arg_order.insert(name.clone(), i);
 
                 let usage = Self::template_arg::<String>(args, "usage")?.unwrap_or_default();
                 let help = Self::template_arg::<String>(args, "help")?;
@@ -364,7 +370,21 @@ impl TaskScriptParser {
                 arg.env = env;
                 arg.usage = arg.usage();
 
-                input_args.lock().map_err(Self::lock_error)?.push(arg);
+                {
+                    let mut input_args = input_args.lock().map_err(Self::lock_error)?;
+                    if let Some(existing) = input_args.iter().find(|existing| existing.name == name)
+                    {
+                        if format!("{existing:?}") != format!("{arg:?}") {
+                            return Err(format!(
+                                "{CONFLICTING_DEFINITION_PREFIX} argument '{name}'"
+                            ));
+                        }
+                        trace!("already seen {name}");
+                        return Ok(json!(""));
+                    }
+                    input_args.push(arg);
+                }
+                arg_order.lock().map_err(Self::lock_error)?.insert(name, i);
                 Ok(json!(""))
             }
         });
@@ -448,7 +468,15 @@ impl TaskScriptParser {
                 flag.arg = Some(value_arg);
                 flag.usage = flag.usage();
 
-                input_flags.lock().map_err(Self::lock_error)?.push(flag);
+                let mut input_flags = input_flags.lock().map_err(Self::lock_error)?;
+                if let Some(existing) = input_flags.iter().find(|existing| existing.name == name) {
+                    if format!("{existing:?}") != format!("{flag:?}") {
+                        return Err(format!("{CONFLICTING_DEFINITION_PREFIX} option '{name}'"));
+                    }
+                    trace!("already seen {name}");
+                    return Ok(json!(""));
+                }
+                input_flags.push(flag);
 
                 Ok(json!(""))
             }
@@ -543,7 +571,15 @@ impl TaskScriptParser {
                 flag.arg = arg;
                 flag.usage = flag.usage();
 
-                input_flags.lock().map_err(Self::lock_error)?.push(flag);
+                let mut input_flags = input_flags.lock().map_err(Self::lock_error)?;
+                if let Some(existing) = input_flags.iter().find(|existing| existing.name == name) {
+                    if format!("{existing:?}") != format!("{flag:?}") {
+                        return Err(format!("{CONFLICTING_DEFINITION_PREFIX} flag '{name}'"));
+                    }
+                    trace!("already seen {name}");
+                    return Ok(json!(""));
+                }
+                input_flags.push(flag);
 
                 Ok(json!(""))
             }
@@ -554,23 +590,36 @@ impl TaskScriptParser {
         (tera, arg_order, input_args, input_flags)
     }
 
+    #[cfg(test)]
     pub async fn parse_run_scripts_for_spec_only(
         &self,
         config: &Arc<Config>,
         task: &Task,
         scripts: &[String],
     ) -> Result<usage::Spec> {
-        self.parse_run_scripts_for_spec_only_inner(config, task, scripts, false)
+        self.parse_run_scripts_for_spec_only_with_templates(config, task, scripts, &[])
             .await
     }
 
-    pub async fn parse_run_scripts_for_preflight(
+    pub async fn parse_run_scripts_for_spec_only_with_templates(
         &self,
         config: &Arc<Config>,
         task: &Task,
         scripts: &[String],
+        spec_templates: &[String],
     ) -> Result<usage::Spec> {
-        self.parse_run_scripts_for_spec_only_inner(config, task, scripts, true)
+        self.parse_run_scripts_for_spec_only_inner(config, task, scripts, spec_templates, false)
+            .await
+    }
+
+    pub async fn parse_run_scripts_for_preflight_with_templates(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+        scripts: &[String],
+        spec_templates: &[String],
+    ) -> Result<usage::Spec> {
+        self.parse_run_scripts_for_spec_only_inner(config, task, scripts, spec_templates, true)
             .await
     }
 
@@ -585,14 +634,19 @@ impl TaskScriptParser {
         config: &Arc<Config>,
         task: &Task,
         scripts: &[String],
+        spec_templates: &[String],
         preflight: bool,
     ) -> Result<usage::Spec> {
         let usage_has_template = contains_template_syntax(&task.usage);
         let scripts_have_template = scripts
             .iter()
             .any(|script| contains_template_syntax(script));
+        let spec_templates_have_template = spec_templates
+            .iter()
+            .any(|template| contains_template_syntax(template));
         if !usage_has_template
-            && (!scripts_have_template || Settings::get().task.disable_spec_from_run_scripts)
+            && (!(scripts_have_template || spec_templates_have_template)
+                || Settings::get().task.disable_spec_from_run_scripts)
         {
             return task.usage.trim().parse().map_err(Into::into);
         }
@@ -627,7 +681,14 @@ impl TaskScriptParser {
         if scripts_have_template {
             for script in scripts {
                 if contains_template_syntax(script) {
-                    let _ = Self::render_script_with_context(&mut tera, script, &tera_ctx);
+                    Self::collect_spec_template(&mut tera, script, &tera_ctx)?;
+                }
+            }
+        }
+        if spec_templates_have_template {
+            for template in spec_templates {
+                if contains_template_syntax(template) {
+                    Self::collect_spec_template(&mut tera, template, &tera_ctx)?;
                 }
             }
         }
@@ -657,6 +718,7 @@ impl TaskScriptParser {
         Ok(spec)
     }
 
+    #[cfg(test)]
     pub async fn parse_run_scripts(
         &self,
         config: &Arc<Config>,
@@ -664,11 +726,26 @@ impl TaskScriptParser {
         scripts: &[String],
         env: &EnvMap,
     ) -> Result<(Vec<String>, usage::Spec)> {
+        self.parse_run_scripts_with_spec_templates(config, task, scripts, &[], env)
+            .await
+    }
+
+    pub async fn parse_run_scripts_with_spec_templates(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+        scripts: &[String],
+        spec_templates: &[String],
+        env: &EnvMap,
+    ) -> Result<(Vec<String>, usage::Spec)> {
         let usage_has_template = contains_template_syntax(&task.usage);
         let scripts_have_template = scripts
             .iter()
             .any(|script| contains_template_syntax(script));
-        if !usage_has_template && !scripts_have_template {
+        let spec_templates_have_template = spec_templates
+            .iter()
+            .any(|template| contains_template_syntax(template));
+        if !usage_has_template && !scripts_have_template && !spec_templates_have_template {
             let scripts = scripts.iter().map(|s| s.trim().to_string()).collect();
             return Ok((scripts, task.usage.trim().parse()?));
         }
@@ -703,6 +780,13 @@ impl TaskScriptParser {
         } else {
             scripts.iter().map(|s| s.trim().to_string()).collect()
         };
+        if spec_templates_have_template {
+            for template in spec_templates {
+                if contains_template_syntax(template) {
+                    Self::collect_spec_template(&mut tera, template, &tera_ctx)?;
+                }
+            }
+        }
         let mut cmd = usage::SpecCommand::default();
         // TODO: ensure no gaps in args, e.g.: 1,2,3,4,5
         let arg_order = arg_order.lock().unwrap();
@@ -834,6 +918,90 @@ impl TaskScriptParser {
             )?);
         }
         Ok(out)
+    }
+
+    /// Render source/output templates with parsed task arguments. Unlike run
+    /// scripts, values are not shell-quoted because the result is a filesystem
+    /// pattern rather than shell source code.
+    pub async fn render_file_templates_with_args(
+        &self,
+        config: &Arc<Config>,
+        task: &Task,
+        templates: &[String],
+        env: &EnvMap,
+        args: &[String],
+        spec: &usage::Spec,
+    ) -> Result<Vec<String>> {
+        let parser_args = once(String::new())
+            .chain(task.args_for_usage_parser(spec, args))
+            .collect::<Vec<_>>();
+        let env_map: HashMap<String, String> =
+            env.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        let parsed = match usage::Parser::new(spec)
+            .with_env(env_map)
+            .parse(&parser_args)
+        {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                // Match run-script usage failures: print usage's output directly so help and
+                // parse errors are not wrapped as source/output rendering failures.
+                eprintln!("{}", format!("{err}").trim_end());
+                return Err(request_exit(1));
+            }
+        };
+
+        let mut tera = self.get_tera();
+        self.register_task_source_files_function(&mut tera, task);
+        Self::register_template_function(&mut tera, "arg", {
+            let usage_args = parsed.args.clone();
+            move |args| {
+                let i = Self::template_arg::<i64>(args, "i")?
+                    .map(|i| i as usize)
+                    .unwrap_or_default();
+                let name =
+                    Self::template_arg::<String>(args, "name")?.unwrap_or_else(|| i.to_string());
+                Ok(json!(
+                    usage_args
+                        .iter()
+                        .find(|(arg, _)| arg.name == name)
+                        .map(|(_, value)| value.to_string())
+                        .unwrap_or_default()
+                ))
+            }
+        });
+        let flag_func = |default_value: String| {
+            let usage_flags = parsed.flags.clone();
+            move |args: &HashMap<String, JsonValue>| {
+                let name = Self::string_arg(args, "name")?;
+                Ok(json!(
+                    usage_flags
+                        .iter()
+                        .find(|(flag, _)| flag.name == name)
+                        .map(|(_, value)| value.to_string())
+                        .unwrap_or(default_value.clone())
+                ))
+            }
+        };
+        Self::register_template_function(&mut tera, "option", flag_func(String::new()));
+        Self::register_template_function(&mut tera, "flag", flag_func(false.to_string()));
+
+        let mut tera_ctx = task.tera_ctx_for_usage(config).await?;
+        self.inject_extra_vars(&mut tera_ctx);
+        tera_ctx.insert("env", env);
+        let mut usage_map = Self::make_usage_ctx_from_spec_defaults(spec);
+        usage_map.extend(Self::make_usage_ctx(&parsed));
+        tera_ctx.insert("usage", &usage_map);
+
+        templates
+            .iter()
+            .map(|template| {
+                if contains_template_syntax(template) {
+                    Self::render_script_with_context(&mut tera, template, &tera_ctx)
+                } else {
+                    Ok(template.clone())
+                }
+            })
+            .collect()
     }
 
     pub(crate) fn make_usage_ctx(
@@ -1027,6 +1195,39 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(parsed_scripts, vec!["echo abc"]);
+    }
+
+    #[tokio::test]
+    async fn test_spec_templates_deduplicate_identical_flags() {
+        let config = Config::get().await.unwrap();
+        let task = Task::default();
+        let parser = TaskScriptParser::new(None);
+        let templates = vec![
+            "{{ flag(name='release') }}".to_string(),
+            "{% if flag(name='release') %}release{% endif %}".to_string(),
+        ];
+        let spec = parser
+            .parse_run_scripts_for_spec_only_with_templates(&config, &task, &[], &templates)
+            .await
+            .unwrap();
+        assert_eq!(spec.cmd.flags.len(), 1);
+        assert_eq!(spec.cmd.flags[0].name, "release");
+    }
+
+    #[tokio::test]
+    async fn test_spec_templates_reject_conflicting_flags() {
+        let config = Config::get().await.unwrap();
+        let task = Task::default();
+        let parser = TaskScriptParser::new(None);
+        let templates = vec![
+            "{{ flag(name='release') }}".to_string(),
+            "{{ flag(name='release', required=true) }}".to_string(),
+        ];
+        let err = parser
+            .parse_run_scripts_for_spec_only_with_templates(&config, &task, &[], &templates)
+            .await
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("conflicting definitions for task flag 'release'"));
     }
 
     #[tokio::test]

--- a/src/task/task_sources.rs
+++ b/src/task/task_sources.rs
@@ -92,7 +92,9 @@ impl TaskOutputs {
                     .get("env")
                     .and_then(|v| serde::Deserialize::deserialize(v.clone()).ok());
                 for file in files.iter_mut() {
-                    if contains_template_syntax(file) {
+                    if contains_template_syntax(file)
+                        && !crate::task::template_has_usage_input(file)
+                    {
                         *file = render_str(tera, file, ctx)?;
                     }
                 }
@@ -132,7 +134,9 @@ impl TaskOutputs {
                 *files = raw_templates
                     .iter()
                     .map(|tmpl| {
-                        if contains_template_syntax(tmpl) {
+                        if contains_template_syntax(tmpl)
+                            && !crate::task::template_has_usage_input(tmpl)
+                        {
                             render_str(&mut tera, tmpl, &ctx)
                         } else {
                             Ok(tmpl.clone())


### PR DESCRIPTION
## Summary

- defer task source and output template expansion until each scheduled task occurrence has parsed its arguments
- support the recommended `{{usage.*}}` values and the deprecated `arg()`, `option()`, and `flag()` helpers in file patterns
- use the same rendered patterns for freshness, artifact caching, `task_source_files()`, and `mise watch`
- discover usage declarations that appear only in source/output templates, deduplicate identical declarations, and reject conflicting definitions

## Details

Previously, sources and outputs were rendered while loading configuration, before task arguments and dependency environments were available. This left `{{usage.*}}` without invocation values and made the legacy helpers unknown. The new flow preserves raw patterns, validates every scheduled occurrence before the scheduler starts, then renders filesystem patterns with the complete task-local toolset, environment, and vars after that occurrence's dependencies finish and before its freshness/cache checks.

This ordering keeps preflight side-effect free: it does not run `_.source` or plugin environment hooks before a dependency can produce their inputs. `mise watch`, which must determine filters before starting watchexec, renders from the already-loaded config context plus literal task/dependency overrides and performs the same argument preflight first. Filesystem values remain unquoted, while existing shell escaping for run scripts is unchanged. Normal dependencies, post dependencies, injected tasks, and watch targets receive their own arguments and dependency environment. Task file rendering and execution share the standard `MISE_TASK_*` metadata keys. Tasks that bypass usage parsing through `raw_args` or double-dash help passthrough fail before scheduling when they contain argument-dependent patterns. This restriction is documented, and argument parse failures use the same unwrapped usage error output as run scripts.

## Testing

Passed:

- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d` for the three new E2E files
- `mise exec -- shellcheck` for the three new E2E files
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo test --all-features task_script_parser`
- `mise exec -- cargo test --all-features test_template_has_usage_input`
- `mise run test:e2e e2e/tasks/test_task_usage_sources_outputs`
- `mise run test:e2e e2e/tasks/test_task_usage_sources_outputs_deps`
- `mise run test:e2e e2e/tasks/test_task_watch_usage_sources`
- `mise run test:e2e e2e/tasks/test_task_run_sources`
- `mise run test:e2e e2e/tasks/test_task_usage_preflight`
- `mise run test:e2e e2e/tasks/test_task_watch_skip_deps`

The CodeRabbit follow-ups were additionally verified with the affected E2Es, the task script parser unit suite, Rustfmt, shfmt, ShellCheck, Cargo check, and Clippy. Regression coverage now verifies watch preflight, distinct Debug/Release output paths, and a task whose dependency generates the env file used by its argument-dependent source/output patterns. The watch assertion checks the rendered `-f` filter rather than the task argument portion of the watchexec command.

`mise run format` and `mise run lint` could not run their hk wrapper in this Sapling working copy because hk reported `failed to find git repository`; the underlying Rustfmt, shfmt, ShellCheck, Cargo check, and Clippy checks above passed individually.

Addresses https://github.com/jdx/mise/discussions/5229

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Task `sources` and `outputs` can now use parsed arguments and flags through `usage.*` templates.
  - Usage-derived paths work with dependencies, caching, freshness checks, file selection, and watch mode.
  - Added validation for unsupported raw-argument and post-`--` usage-template scenarios.
  - Legacy `arg()`, `option()`, and `flag()` templates remain supported with compatibility guidance.

- **Bug Fixes**
  - Improved task usage validation and template rendering, including dependency-specific environments and clearer task-specific errors.
  - Prevented usage-dependent paths from rendering before required arguments are available.

- **Documentation**
  - Expanded configuration and argument-template documentation with examples and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->