### PR TITLE
fix(conda): keep dependency DLLs beside the binaries on Windows

### DIFF
--- a/e2e-win/conda.Tests.ps1
+++ b/e2e-win/conda.Tests.ps1
@@ -2,4 +2,12 @@ Describe 'conda' {
     It 'executes ripgrep via conda backend' {
         mise x conda:ripgrep@14.1.0 -- rg --version | Out-String | Should -Match "ripgrep 14"
     }
+
+    # Entries in .mise-bins are copies on Windows, and a copied executable looks for its
+    # imports beside itself. zstd links against DLLs that belong to dependency packages,
+    # so before those were brought along too this exited with STATUS_DLL_NOT_FOUND
+    # (0xC0000135) and printed nothing.
+    It 'runs a binary that links DLLs from dependency packages' {
+        mise x conda:zstd@1.5.7 -- zstd --version | Out-String | Should -Match "Zstandard CLI"
+    }
 }

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -596,6 +596,82 @@ impl CondaBackend {
                 file::make_symlink_or_copy(&src, &dst)?;
             }
         }
+
+        // On Windows the entries above are copies, and a copied executable resolves its
+        // imports from its own directory before anything on PATH. The DLLs it needs sit
+        // next to the original and mostly belong to dependency packages, so the
+        // main-package filter leaves them behind and the copy dies with
+        // STATUS_DLL_NOT_FOUND (`conda:postgresql` needs 91 of them). Bring every DLL
+        // along: they are libraries, not commands, so this does not put dependency
+        // executables on PATH, which is what this directory exists to prevent.
+        //
+        // unix does not need it — the entries there are symlinks, and `$ORIGIN` in an
+        // ELF RPATH resolves against the *target's* directory, so `../lib` still lands
+        // inside the install.
+        if cfg!(windows) {
+            for dir in bin_dirs {
+                let bin_dir = install_path.join(dir);
+                // Only some of these exist in any given package. Anything other than a
+                // missing directory has to surface: swallowing it would drop a DLL and
+                // still report the install as a success, which lands the user right back
+                // on the STATUS_DLL_NOT_FOUND this is meant to prevent.
+                let entries = match std::fs::read_dir(&bin_dir) {
+                    Ok(entries) => entries,
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(err) => {
+                        return Err(err).wrap_err_with(|| {
+                            format!("failed to read {}", file::display_path(&bin_dir))
+                        });
+                    }
+                };
+                for entry in entries {
+                    let entry = entry.wrap_err_with(|| {
+                        format!(
+                            "failed to read an entry in {}",
+                            file::display_path(&bin_dir)
+                        )
+                    })?;
+                    let src = entry.path();
+                    if !src
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("dll"))
+                    {
+                        continue;
+                    }
+                    // Asked of the `DirEntry` rather than the path: `Path::is_file`
+                    // reports a metadata failure as "not a file", which would skip a DLL
+                    // that antivirus or a permission problem merely made unreadable for a
+                    // moment. Anything not a directory is fair game, including a symlink.
+                    let file_type = entry.file_type().wrap_err_with(|| {
+                        format!(
+                            "failed to stat {} in {}",
+                            entry.file_name().to_string_lossy(),
+                            file::display_path(&bin_dir)
+                        )
+                    })?;
+                    if file_type.is_dir() {
+                        continue;
+                    }
+                    let Some(name) = src.file_name() else {
+                        continue;
+                    };
+                    let dst = symlink_dir.join(name);
+                    if dst.exists() {
+                        // First writer wins, and the order is deliberate: the main
+                        // package's own DLLs are placed above, then `Library/bin` before
+                        // `Scripts` and `bin`. A name reaching here twice means two bin
+                        // directories disagree, which is worth seeing under --verbose.
+                        trace!(
+                            "conda: {} already present in {}, keeping the earlier one",
+                            name.to_string_lossy(),
+                            file::display_path(&symlink_dir)
+                        );
+                        continue;
+                    }
+                    file::hard_link_or_copy(&src, &dst)?;
+                }
+            }
+        }
         Ok(())
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -278,6 +278,30 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
         .map(|_| ())
 }
 
+/// Give `from`'s content a second name at `to` without duplicating it, falling back to a
+/// copy.
+///
+/// A hard link needs both paths on one volume and a filesystem that supports them, so
+/// failing is an ordinary outcome rather than an error worth surfacing.
+pub fn hard_link_or_copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    match fs::hard_link(from, to) {
+        Ok(()) => {
+            trace!("ln {} {}", from.display(), to.display());
+            Ok(())
+        }
+        Err(err) => {
+            trace!(
+                "ln {} {} failed ({err}), copying instead",
+                from.display(),
+                to.display()
+            );
+            copy(from, to)
+        }
+    }
+}
+
 pub fn copy_dir_all<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
@@ -2072,6 +2096,32 @@ mod tests {
     fn test_run_blocking_outside_runtime() {
         // no tokio runtime at all — must run the closure inline, not panic
         assert_eq!(run_blocking(|| 42), 42);
+    }
+
+    #[test]
+    fn hard_link_or_copy_reproduces_the_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let from = tmp.path().join("libexample.dll");
+        let to = tmp.path().join("copy.dll");
+        fs::write(&from, b"payload").unwrap();
+
+        hard_link_or_copy(&from, &to).unwrap();
+        assert_eq!(fs::read(&to).unwrap(), b"payload");
+    }
+
+    /// The fallback has to be reachable, not just present: linking onto a name that is
+    /// already taken fails, and callers still expect the destination to be usable.
+    #[test]
+    fn hard_link_or_copy_falls_back_when_linking_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let from = tmp.path().join("libexample.dll");
+        let to = tmp.path().join("existing.dll");
+        fs::write(&from, b"new").unwrap();
+        fs::write(&to, b"old").unwrap();
+
+        // `fs::hard_link` refuses an existing destination, so this exercises the copy arm.
+        hard_link_or_copy(&from, &to).unwrap();
+        assert_eq!(fs::read(&to).unwrap(), b"new");
     }
 
     fn utf16le(s: &str) -> Vec<u8> {


### PR DESCRIPTION
## The problem

On Windows a conda package whose binaries link against DLLs from *dependency* packages installs successfully and then cannot run. Found while checking whether `conda:postgresql` is a workable answer for #4098.

Measured on **v2026.8.3** (windows-x64):

```console
$ mise use conda:postgresql@18.4
mise conda:postgresql@18.4 ✓ installed          # 41s

$ .mise-bins\postgres.exe --version
(no output)
exit = -1073741515                              # 0xC0000135 STATUS_DLL_NOT_FOUND

$ Library\bin\postgres.exe --version            # the same binary, where conda unpacked it
postgres (PostgreSQL) 18.4
exit = 0
```

## Cause

`create_symlink_bin_dir` materialises only the main package's files into `.mise-bins`, using the `PathsEntry` list rattler returns. That is deliberate and worth keeping — for postgres it holds back 37 dependency executables that would otherwise land on PATH just because you installed a database:

```
Library\bin  .exe: 74   .dll: 94
.mise-bins   .exe: 37   .dll:  3

only in Library\bin: openssl.exe, xmllint.exe, kinit.exe, klist.exe, zstd.exe,
                     lz4.exe, xsltproc.exe, pg_config.exe, icu tools, …
```

The DLLs get held back by the same filter. On Windows `make_symlink_or_copy` is a plain `copy`, and a copied executable resolves its imports from its own directory before anything on PATH — so the 91 dependency DLLs sitting in `Library\bin` are unreachable.

unix does not hit this: those entries are symlinks, and `$ORIGIN` in an ELF RPATH resolves against the *target's* directory, so `../lib` still lands inside the install. Confirmed — the same package on linux-x64 installs in 6s and runs:

```console
$ mise exec -- postgres --version
postgres (PostgreSQL) 18.4
$ mise exec -- psql --version
psql (PostgreSQL) 18.4
```

## The change

Bring every DLL in the bin directories into `.mise-bins`, regardless of which package owns it. DLLs are libraries, not commands, so the property this directory exists to protect is untouched — the 37 dependency executables above stay out.

Hard link rather than copy where the filesystem allows it, falling back to a copy. Postgres alone carries **67MB of DLLs against a 174MB install**, so copying would inflate every such package by roughly half. A hard link needs the same volume and does not need elevation on Windows.

Validated by reconstructing `.mise-bins` and adding just the DLLs:

```console
=== replica of .mise-bins ===
exit = -1073741515

=== after hard-linking the 91 dependency DLLs ===
postgres (PostgreSQL) 18.4      exit = 0
psql (PostgreSQL) 18.4          exit = 0
```

## Blast radius

Only packages that link DLLs owned by their dependencies. Packages whose binaries are self-contained were already fine and stay fine — checked on Windows:

| | result |
|---|---|
| `conda:make@4.4.1` | `GNU Make 4.4.1`, exit 0 |
| `conda:luajit@2.1.1744318430` | `LuaJIT 2.1.1744318430 …`, exit 0 |
| `conda:zstd@1.5.7` | **broken** before this change |
| `conda:libxml2` | **broken** before this change |

## Tests

**e2e (`e2e-win/conda.Tests.ps1`)** — a Windows-only defect belongs in the suite that runs on Windows, so this goes next to the existing ripgrep case. `conda:zstd@1.5.7` is the smallest reproducer I found at 13MB, with a single executable and 61 DLLs in `Library\bin` against 2 in `.mise-bins`. Before this change it exits `0xC0000135` and prints nothing; after, it prints `*** Zstandard CLI (64-bit) v1.5.7, by Yann Collet ***`.

**Unit (`src/file.rs`)** — two tests for the new `hard_link_or_copy`: that the destination has the source's content, and that the copy fallback is actually reachable (linking onto an existing name fails, and the destination must still end up correct).

No settings or CLI arguments were added, so the generated files are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Conda tool setup by making required dependency files available alongside executables.
  * Preserved existing files, skipped unsupported entries, and handled missing directories safely during binary setup.

* **Reliability**
  * Improved file handling by falling back to copying when creating a hard link is not possible.

* **Tests**
  * Added Windows end-to-end coverage verifying that Conda-provided tools run successfully with their dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->