### PR TITLE
docs(env): explain what `tools = true` costs you

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -131,6 +131,37 @@ _.path = { path = ["{{env.GEM_HOME}}/bin"], tools = true } # directives may also
 NODE_VERSION = { value = "{{ tools.node.version }}", tools = true }
 ```
 
+These are resolved in a second pass, once tools are available. Two things follow from that.
+
+A value can only be referenced by values declared after it. This holds in either pass:
+
+```toml
+[env]
+SOME_REF = "/default/{{ env.SERVICE_NAME }}" # error: Field `SERVICE_NAME` is not defined
+SERVICE_NAME = "api"
+```
+
+And the two passes are separate, so an ordinary value cannot see a `tools = true` one no matter
+where it is declared — the second pass has not run yet:
+
+```toml
+[env]
+SERVICE_NAME = { value = "api", tools = true }
+SOME_REF = "/default/{{ env.SERVICE_NAME }}" # error: Field `SERVICE_NAME` is not defined
+```
+
+Mark the value doing the referencing `tools = true` as well, keeping it after the one it
+references, and both are resolved together:
+
+```toml
+[env]
+SERVICE_NAME = { value = "api", tools = true }
+SOME_REF = { value = "/default/{{ env.SERVICE_NAME }}", tools = true }
+```
+
+The other direction needs nothing: a `tools = true` value can reference a plain one, because the
+first pass has already finished by the time it runs.
+
 ## Redactions
 
 Variables can be redacted from the output by setting `redact = true`:


### PR DESCRIPTION
Closes #4520.

## What the reporter hit

```toml
[env]
SERVICE_NAME = { value = "{{ exec(command='dasel …') }}", tools = true }
SOME_REF = "/default/{{ env.SERVICE_NAME }}"
```
```
mise ERROR Variable `env.SERVICE_NAME` not found in context
```

They read it as "a value containing an `exec` block cannot be referenced". That is not what is happening — `exec` is incidental. Measured on **v2026.8.2**, keeping the `exec` and dropping only `tools = true`:

```console
$ mise env
export SERVICE_NAME=hello
export SOME_REF=/default/hello
```

The three cases that isolate it:

```console
tools = true alone                        -> export SERVICE_NAME=hello         ok
plain value references a tools = true one -> ERROR: SERVICE_NAME is not defined
tools = true references a tools = true    -> export SOME_REF=/default/hello    ok
```

## Why it behaves that way

This is the design, not an accident of ordering. `[env]` resolves in two passes and `ToolsFilter` partitions the directives between them — `NonToolsOnly` first, from `PRISTINE_ENV`, then `ToolsOnly` once tools exist. The first pass drops `tools = true` directives from its input *before* templating, so nothing in that pass can see them. The second pass extends its tera `env` with the first pass's results, which is why a `tools = true` value can reference a plain one, and why two `tools = true` values can reference each other.

One-way is the point: `tools = true` exists for values that are not knowable until tools are installed, so making them visible beforehand would be contradictory.

So the behaviour stays. What was missing is that the docs say how to opt into the second pass without mentioning what it costs you.

## The change

Three paragraphs and two examples in the "Lazy eval" section, right after the existing `tools = true` block: the failure, the fix (mark the referencing value too), and the note that the reverse direction needs nothing.

The examples use a plain string rather than `exec`, so the cause reads as `tools = true` rather than leaving the same wrong inference available.

Docs only — one hand-written page, no generated files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on lazy evaluation for environment variables that depend on tools.
  * Clarified when tool-dependent values can reference ordinary values and when references require both values to enable tool support.
  * Documented evaluation behavior and related reference limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->