### PR TITLE
registry: add zk (aqua:zk-org/zk)

### DIFF
--- a/registry/zk.toml
+++ b/registry/zk.toml
@@ -1,0 +1,9 @@
+backends = ["aqua:zk-org/zk"]
+
+bins = ["zk"]
+
+description = "A plain text note-taking assistant"
+
+test = { cmd = "zk --version", expected = "zk {{version}}" }
+
+version_order = "semver"


### PR DESCRIPTION
## Summary

Add `zk` to the mise registry using the existing Aqua Registry package `aqua:zk-org/zk`.

`zk` is a plain text note-taking assistant.

## Popularity

- GitHub: 2,752 stars, 186 forks
- Aqua Registry: `zk-org/zk` is already registered

## Testing

- `cargo run -- test-tool zk --raw`
- `mise run pre-commit`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `zk` backend.
  * Enabled reliable version detection using semantic version ordering.
  * Added automated version validation to improve compatibility and backend discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->