### PR TITLE
fix(aqua): look up package metadata by aqua package name

### DIFF
--- a/e2e/cli/test_tool
+++ b/e2e/cli/test_tool
@@ -28,6 +28,15 @@ mise tool aqua:cli/cli --json | jq -e '.security | type == "array"' || fail "sec
 # Test that security features have type field when present
 mise tool aqua:cli/cli --json | jq -e '.security | if length > 0 then .[0].type else true end' || fail "security feature missing type field"
 
+# Naming an aqua tool by its registry short name must reach the same package as spelling
+# the backend out. Both are cli/cli; only the second form used to resolve, because the
+# lookup went through the short name rather than the aqua package name.
+# See https://github.com/jdx/mise/discussions/4917
+short_desc=$(mise tool github-cli --description)
+[[ -n $short_desc && $short_desc != "[none]" ]] || fail "short name should carry a description"
+[[ $short_desc == "$(mise tool aqua:cli/cli --description)" ]] || fail "description differs by spelling"
+[[ $(mise tool github-cli --json | jq -c '.security') == "$(mise tool aqua:cli/cli --json | jq -c '.security')" ]] || fail "security differs by spelling"
+
 # Test core plugin security features
 # Node has checksum + gpg
 mise tool node --json | jq -e '.security | length >= 1' || fail "node should have security features"

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -168,8 +168,11 @@ impl Backend for AquaBackend {
     }
 
     async fn description(&self) -> Option<String> {
+        // `self.id`, not `ba.tool_name`: the registry is keyed by aqua package name, and
+        // `from_arg` is what turns a bare `jq` into `jqlang/jq`. Looking it up by the
+        // short name misses every tool named the usual way, and `.ok()` hides that.
         AQUA_REGISTRY
-            .package(&self.ba.tool_name)
+            .package(&self.id)
             .await
             .ok()
             .and_then(|p| p.description.clone())
@@ -199,7 +202,8 @@ impl Backend for AquaBackend {
     async fn security_info(&self) -> Vec<crate::backend::SecurityFeature> {
         use crate::backend::SecurityFeature;
 
-        let pkg = match AQUA_REGISTRY.package(&self.ba.tool_name).await {
+        // Keyed by aqua package name, same as `description` above.
+        let pkg = match AQUA_REGISTRY.package(&self.id).await {
             Ok(pkg) => pkg,
             Err(_) => return vec![],
         };


### PR DESCRIPTION
Closes #4917.

## The problem

`mise tool <name>` shows no description and no security features for aqua tools — but only when the tool is named the ordinary way. Spell the backend out and both appear.

Measured on **v2026.8.2**, same underlying package (`registry/github-cli.toml` → `aqua:cli/cli`) reached two ways:

```console
$ mise tool github-cli --description
[none]
$ mise tool github-cli --json
  "security": []

$ mise tool aqua:cli/cli --description
GitHub's official command line tool
$ mise tool aqua:cli/cli --json
  "security": [ … ]
```

#4917 read this as a missing feature — "add descriptions to `mise tool`". The display side was never missing: there is a `--description` flag and a `description` field in `--json`. They were being fed nothing.

## Cause

`AquaBackend` carries two identifiers. `from_arg` builds `self.id` by resolving a bare name through mise's registry into the aqua package name:

```rust
let mut id = full.split_once(":").unwrap_or(("", &full)).1;
if !id.contains("/") {
    id = REGISTRY.get(id).and_then(|t| … strip_prefix("aqua:")) …
}
```

Version listing and installation use that. `description()` and `security_info()` used `ba.tool_name` instead, which for a tool named `jq` is `jq` — not an aqua package name. `AQUA_REGISTRY.package("jq")` errors, and the error is discarded: `.ok()` in one, `Err(_) => return vec![]` in the other. Nothing warns, so it reads as "this tool has no description" rather than "the lookup failed".

That covers every aqua tool referenced by its registry short name, which is how nearly everyone refers to them.

## The change

Two lines: `&self.ba.tool_name` → `&self.id`, matching what the rest of the file already does.

The third `tool_name` use in this file, in `has_legacy_root_bin`, is left alone — it takes the trailing segment of `short`/`tool_name` as a *binary name* guess, which is a different question.

No other backend implements either method; both fall through to the `Backend` trait defaults, so the blast radius is this file.

## Why it survived

`e2e/cli/test_tool` asserts the security field on `aqua:cli/cli` — the full spec, the spelling that resolves. The short-name path was never covered.

The added assertions pair the two spellings of the same package: the short name must produce a non-empty description, and both spellings must agree on description and on `security`. They compare the two forms rather than pinning aqua's wording, so a copy change upstream will not break them. Before this change the short-name side is `[none]` and `[]` while the full-spec side is populated, so all three fail.

## Not included

The homepage half of #4917 is a separate matter and stays open: mise's registry has no homepage field, and the only `url` keys are download URLs for the `http` backend. Deriving one from the backend works for `aqua:`/`ubi:` but not for `conda:`, `npm:` or `http:`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aqua registry lookups now return consistent descriptions and security information when tools are referenced by either their short name or fully qualified name.
  * Added end-to-end coverage to verify equivalent results for both naming formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->