### PR TITLE
docs: correct what the not-found handler can install

### DIFF
--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -428,7 +428,7 @@ If you type a command in your shell (e.g., `node`) and it is not found, mise can
 - **When it triggers:** When a command is not found in the shell and the handler is enabled.
 - **How to control:**
   - Setting: [`not_found_auto_install`](/configuration/settings.html#not_found_auto_install) (default: true)
-- **Limitation:** Only works for tools that already have at least one version installed, since mise cannot know which tool provides a binary otherwise.
+- **Limitation:** mise identifies the provider from the registry's bin metadata, so this covers configured tools even if they have never been installed — but not tools configured by a raw backend spec (e.g. `cargo:some-crate`), which carry no such metadata. Install those explicitly with `mise install`, or `mise x` to install and run in one step. See [troubleshooting](/troubleshooting.html#auto-install-on-command-not-found-does-not-trigger).
 
 ::: tip
 Disable auto_install for specific tools by setting [`auto_install_disable_tools`](/configuration/settings.html#auto_install_disable_tools) to a list of tool names.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -376,15 +376,18 @@ eval "$(mise hook-env)"
 
 See also the [CI/CD section](/tips-and-tricks.html#ci-cd) in Tips & Tricks.
 
-## Auto-install on command not found handler does not work for new tools
+## Auto-install on command not found does not trigger
 
-If you are expecting mise to automatically install a tool when you run a command that is not found (using the [`not_found_auto_install`](/configuration/settings.html#not_found_auto_install) feature), be aware of an important limitation:
+When you run a command that is not found, mise can install the tool that provides it (the [`not_found_auto_install`](/configuration/settings.html#not_found_auto_install) feature). It maps the command back to a tool using the `bins` metadata in mise's registry, which means a tool that is configured but has never been installed is handled too — not only a missing version of a tool you already have.
 
-**mise can only auto-install missing versions of tools that already have at least one version installed.**
+If nothing happens, it is usually one of these:
 
-This is because mise does not have a way of knowing which binaries a tool provides unless there is already an installed (even inactive) version of that tool. If you have never installed any version of a tool, mise cannot determine which tool is responsible for a given binary name, and so it cannot auto-install it on demand.
+- **The tool is configured by a raw backend spec.** `"cargo:some-crate" = "1.0.0"` or `"ubi:owner/repo" = "1.0.0"` is not a registry entry, so it carries no bin metadata and nothing connects the command you typed to it.
+- **The tool is not configured at all.** The handler only installs tools your config already asks for in the current directory; it will not pick a tool for a command you have never declared.
+- **The feature is off for that tool** — either [`not_found_auto_install`](/configuration/settings.html#not_found_auto_install) is `false`, or the tool is listed in [`auto_install_disable_tools`](/configuration/settings.html#auto_install_disable_tools).
 
 **Workarounds:**
 
-- Manually install at least one version of the tool you want to be auto-installed in the future. After that, the auto-install feature will work for missing versions of that tool.
-- Use [`mise x|exec`](/cli/exec) or [`mise r|run`](/cli/run) to trigger auto-install for missing tools, even if no version is currently installed. These commands will attempt to install the required tool versions automatically.
+- Where a registry entry exists, refer to the tool by its registry name (`ripgrep`) rather than by a raw backend spec (`ubi:BurntSushi/ripgrep`), so the handler can map the command to it.
+- Otherwise install it explicitly instead of on demand: `mise install`, or [`mise x|exec`](/cli/exec) to install and then run something in one step. Both materialise the whole configured toolset, so the backend does not matter. [`mise r|run`](/cli/run) does the same, but only as part of running a task.
+- Installing once by hand is enough to make the handler work from then on: with a version present, mise can also discover the mapping from the installed executables.

--- a/settings.toml
+++ b/settings.toml
@@ -1785,11 +1785,18 @@ docs = """
 Set to false to disable the "command not found" handler to autoinstall missing tool versions.
 Disable this if experiencing strange behavior in your shell when a command is not found.
 
-**Important limitation**: This handler only installs missing versions of tools that already have
-at least one version installed. mise cannot determine which tool provides a binary without having
-the tool installed first, so it cannot auto-install completely new tools.
+The handler works out which tool provides a command from the `bins` metadata in mise's registry, so
+it can install a tool that is configured but has never been installed — not only a missing version
+of a tool you already have.
 
-This also runs in shims if the terminal is interactive.
+**Limitation**: this only covers tools mise's registry knows. A tool configured by a raw backend
+spec (`ubi:owner/repo`, `cargo:…`, `npm:…`) carries no bin metadata, so a command name cannot be
+traced back to it. Install those explicitly instead — `mise install`, or [`mise x`](/cli/exec) to
+install and run in one step — since both materialise the whole configured toolset whatever the
+backend. The tool also has to be configured in a config file that applies to the current directory:
+mise will not install something you have not asked for.
+
+This also runs in shims.
 """
 env = "MISE_NOT_FOUND_AUTO_INSTALL"
 type = "Bool"


### PR DESCRIPTION
## The problem

`not_found_auto_install` is documented as only able to install a *missing version* of a tool that
already has one installed. That stopped being true when the registry gained `bins` metadata in
#11666 and #11675–#11678.

Measured on **v2026.8.3**, from an empty data directory, PATH-based (`eval "$(mise activate bash)"`),
with neither binary present on the system:

```console
$ mise ls --current
ripgrep  14.1.1 (missing)  .../mise.toml  14.1.1
shfmt    3.10.0 (missing)  .../mise.toml  3.10.0

$ shfmt --version
v3.10.0
$ rg --version
ripgrep 14.1.1 (rev 4649aa9700)
```

Both were installed on first use, and neither had ever been installed. The second case also rules
out name matching: the binary is `rg` while the tool is `ripgrep`.

Control — a tool with no registry entry, so no `bins`:

```console
# "ubi:sharkdp/fd" = "10.2.0", declared and never installed
$ fd --version
bash: command not found: fd     # exit 127, installs dir still absent
```

So the limitation still exists, but it is a different one: *tools mise's registry does not know*,
rather than *tools never installed*. 914 of 956 `registry/*.toml` files carry `bins`.

## What the code does

`install_missing_bin` filters `list_missing_versions` through
`REGISTRY.get(short).provides_bin(bin_name)` and applies registry override order **before** falling
back to executable discovery from installed versions — the comment there says so explicitly:
"Registry bin metadata is the only provider signal available before a tool has ever been installed."
`src/shims.rs` goes through the same function.

## The change

Prose only, in the three places that state the old limitation:

- `settings.toml` — the `docs` block for `not_found_auto_install`
- `docs/troubleshooting.md` — the section, including its heading. It previously led with a
  workaround ("install one version by hand first") that is no longer needed; it is now a short list
  of the reasons the handler genuinely does not fire, with `mise x` / `mise r` as the answer for raw
  backend specs.
- `docs/dev-tools/index.md` — the Limitation bullet

Two claims in that text were checked rather than assumed:

- `mise x` does install a raw backend spec on demand — `mise x -- fd --version` with only
  `"ubi:sharkdp/fd" = "10.2.0"` configured prints `ubi:sharkdp/fd@10.2.0 ✓ installed` then `fd 10.2.0`.
- The shim path does **not** require an interactive terminal, so `if the terminal is interactive` is
  dropped from that sentence. With stdin and stdout both piped, a shim for a configured-but-missing
  version installs it. `src/shims.rs` has no interactivity check; the only extra gate is offline
  `usage complete-word` completion.

## No render round-trip

The `docs = """…"""` field feeds no generated artifact, so `mise run render` produces no diff:
`codegen_settings` in `build.rs` reads only `description`/`env`/`default`/`parse_env`/
`deserialize_with`; `xtasks/render/schema.ts` reads only `description`; and `docs/settings.data.ts`
renders `props.docs ?? props.description` from `settings.toml` at VitePress build time.

No behaviour changes and no Rust is touched.

## Context

Raised while answering https://github.com/jdx/mise/discussions/4805, where a user asked whether a
PATH-based setup can install tools on first use. It can — the documentation said otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified automatic installation for missing commands, including configured tools that have never been installed.
  * Documented registry binary metadata requirements and limitations for raw backend specifications.
  * Added guidance for directory-specific configuration, shim behavior, and using `mise x` or `mise r` as alternatives.
  * Updated troubleshooting guidance and related settings documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->