### PR TITLE
fix(activate): forward --silent and --log-level into the generated hook

### DIFF
--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -127,11 +127,12 @@ impl Activate {
         let exe_dir = mise_bin.parent().unwrap();
         let mut flags = vec![];
         if self.quiet {
-            flags.push(" --quiet");
+            flags.push(" --quiet".to_string());
         }
         if self.status {
-            flags.push(" --status");
+            flags.push(" --status".to_string());
         }
+        flags.extend(forwarded_logging_flags(&env::ARGS.read().unwrap()));
         if let Some(prepend_path) = self.prepend_path(exe_dir) {
             prelude.push(prepend_path);
         }
@@ -191,6 +192,37 @@ impl Activate {
     }
 }
 
+/// Logging flags given to `mise activate` that have to keep applying to every later
+/// `hook-env`, since that — not `activate` — is what prints the per-directory output.
+///
+/// Only `--quiet` reaches [`Activate`] as a field; `--silent` and `--log-level` are global
+/// flags on [`crate::cli::Cli`], so they are read back from the argv `Cli::run` recorded.
+/// `--quiet` is left to `Activate::quiet` to avoid emitting it twice, and the verbosity
+/// flags (`-v`, `--debug`, `--trace`) are deliberately not forwarded — the same split
+/// `hook_env::has_preclap_logging_flag` draws between flags that suppress warnings and
+/// flags that do not.
+///
+/// Flags are forwarded in the order they were given, so `hook-env`'s own
+/// `overrides_with_all` resolves them exactly as this invocation did.
+/// `--log-level <LEVEL>` is normalized to `--log-level=<LEVEL>` so the flag survives as a
+/// single word when the shell templates split the flag string.
+fn forwarded_logging_flags(args: &[String]) -> Vec<String> {
+    let mut flags = vec![];
+    let mut remaining = args.iter();
+    while let Some(arg) = remaining.next() {
+        if arg == "--silent" {
+            flags.push(" --silent".to_string());
+        } else if let Some(level) = arg.strip_prefix("--log-level=") {
+            flags.push(format!(" --log-level={level}"));
+        } else if arg == "--log-level"
+            && let Some(level) = remaining.next()
+        {
+            flags.push(format!(" --log-level={level}"));
+        }
+    }
+    flags
+}
+
 fn remove_shims() -> std::io::Result<Option<ActivatePrelude>> {
     // When not_found_auto_install is enabled, preserve shims in PATH so they can
     // trigger auto-install for tools that aren't installed yet
@@ -237,3 +269,76 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
     $ <bold>(&mise activate pwsh) | Out-String | Invoke-Expression</bold>
 "#
 );
+
+#[cfg(test)]
+mod tests {
+    use super::forwarded_logging_flags;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn forwards_silent_so_it_reaches_hook_env() {
+        assert_eq!(
+            forwarded_logging_flags(&args(&["mise", "activate", "bash", "--silent"])),
+            vec![" --silent".to_string()]
+        );
+    }
+
+    #[test]
+    fn forwards_a_flag_given_before_the_subcommand_too() {
+        assert_eq!(
+            forwarded_logging_flags(&args(&["mise", "--silent", "activate", "bash"])),
+            vec![" --silent".to_string()]
+        );
+    }
+
+    #[test]
+    fn normalizes_both_log_level_spellings_to_one_word() {
+        let separate =
+            forwarded_logging_flags(&args(&["mise", "activate", "bash", "--log-level", "error"]));
+        let joined =
+            forwarded_logging_flags(&args(&["mise", "activate", "bash", "--log-level=error"]));
+        assert_eq!(separate, vec![" --log-level=error".to_string()]);
+        assert_eq!(separate, joined);
+    }
+
+    #[test]
+    fn keeps_the_order_so_hook_env_resolves_overrides_the_same_way() {
+        assert_eq!(
+            forwarded_logging_flags(&args(&[
+                "mise",
+                "activate",
+                "bash",
+                "--silent",
+                "--log-level=error"
+            ])),
+            vec![" --silent".to_string(), " --log-level=error".to_string()]
+        );
+    }
+
+    #[test]
+    fn leaves_quiet_to_the_activate_flag_and_skips_verbosity() {
+        // `--quiet` is carried by `Activate::quiet`; forwarding it here would duplicate it.
+        // `-v`/`--debug`/`--trace` raise the level rather than suppressing warnings.
+        for arg in ["-q", "--quiet", "-v", "--debug", "--trace"] {
+            assert!(
+                forwarded_logging_flags(&args(&["mise", "activate", "bash", arg])).is_empty(),
+                "{arg} should not be forwarded"
+            );
+        }
+    }
+
+    #[test]
+    fn a_trailing_log_level_without_a_value_is_dropped() {
+        assert!(
+            forwarded_logging_flags(&args(&["mise", "activate", "bash", "--log-level"])).is_empty()
+        );
+    }
+
+    #[test]
+    fn nothing_is_forwarded_without_a_logging_flag() {
+        assert!(forwarded_logging_flags(&args(&["mise", "activate", "bash"])).is_empty());
+    }
+}


### PR DESCRIPTION
## The problem

The per-directory output people want to silence is printed by `hook-env`, not by `activate` —
`activate` only emits the script that calls it, on every prompt and every `cd`. That script carries
`--quiet` and `--status`, because both are fields on the `Activate` command. `--silent` and
`--log-level` are global flags on `Cli`, so they applied to the single `activate` run — which prints
nothing but the script — and were then lost.

What the generated script ends up carrying, measured on **v2026.8.2**:

```console
$ mise activate bash                     ->  __MISE_FLAGS=()
$ mise activate bash --quiet             ->  __MISE_FLAGS=(--quiet)
$ mise activate bash --silent            ->  __MISE_FLAGS=()
$ mise activate bash --log-level=error   ->  __MISE_FLAGS=()
```

Nothing is wrong on the receiving side — `hook-env` honours both flags as soon as it is given them.
Same version, with `status.missing_tools = "always"` and two tools configured but not installed:

```console
$ mise hook-env -s bash                    ->  mise WARN  missing: node@22.14.0 erlang@27.3.1
$ mise hook-env -s bash --silent           ->  (nothing)
$ mise hook-env -s bash --log-level=error  ->  (nothing)
```

`--quiet` works, the other two do not, which is what makes it look like a logging bug rather than a
plumbing one. Reported in https://github.com/jdx/mise/discussions/4789 against v2025.4.0; it still
reproduces.

## The change

Read the flags back from the argv that `Cli::run` already records — the same source
`hook_env::has_preclap_logging_flag` reads. That function has enumerated
`-q` / `--quiet` / `--silent` / `--log-level` as the flags `hook-env` must honour (it gives up the
fast path for them) all along, so the receiving side was already prepared; only the generating side
was missing.

Two deliberate limits, both matching the split that `has_preclap_logging_flag` already draws and
that `ignores_logging_flags_that_do_not_suppress_warnings` pins:

- `--quiet` is left to `Activate::quiet`, so it is not emitted twice.
- `-v` / `--debug` / `--trace` are not forwarded. They raise the level rather than suppress
  warnings, and `MISE_LOG_LEVEL` already covers wanting a verbose hook permanently.

Flags keep the order they were given, so `hook-env`'s own `overrides_with_all` resolves
`--silent --log-level=error` exactly as this invocation did. `--log-level <LEVEL>` is normalized to
`--log-level=<LEVEL>` so it survives as a single word when the shell templates run the flag string
through `shell_words::split`.

Reading argv rather than adding clap fields is what makes this work for `mise --silent activate bash`
as well as `mise activate bash --silent`; a subcommand-level field only accepts the second form. It
also leaves the CLI surface untouched, so `docs/cli/activate.md` — which is generated from the clap
definitions — does not change, and neither do the shell snapshots, which construct
`ActivateOptions { flags: … }` directly instead of going through `Activate`.

## Not included

`mise --quiet activate bash` (the global position for `--quiet`) is unchanged here, since
`Activate::quiet` still owns that flag. It is a pre-existing gap, not one this introduces.

## Verified

`cargo fmt --all`. The new unit tests cover both `--log-level` spellings normalizing to one word,
the global position, order preservation, `--quiet` and the verbosity flags staying out, and a
trailing `--log-level` with no value being dropped rather than panicking. They are pure functions
over an argv slice — no filesystem, no network.

The same measurement as above, against a binary built from this branch, so the flags now reach the
script that `hook-env` is actually invoked from:

```console
$ mise activate bash                                -> __MISE_FLAGS=()
$ mise activate bash --quiet                        -> __MISE_FLAGS=(--quiet)
$ mise activate bash --silent                       -> __MISE_FLAGS=(--silent)
$ mise activate bash --log-level=error              -> __MISE_FLAGS=(--log-level=error)
$ mise activate bash --log-level error              -> __MISE_FLAGS=(--log-level=error)
$ mise --silent activate bash                       -> __MISE_FLAGS=(--silent)
$ mise activate bash --silent --log-level=error     -> __MISE_FLAGS=(--silent --log-level=error)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * The `activate` command now carries selected logging options into subsequent `hook-env` invocations.
  * Silent mode and explicit log-level settings are preserved and normalized consistently.
  * Logging options remain in their original order, while quiet and verbosity flags are excluded.
* **Bug Fixes**
  * Improved handling of missing or incomplete log-level values.
* **Tests**
  * Added coverage for logging-option forwarding, filtering, normalization, ordering, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
