### PR TITLE
fix(aqua): accept version bounds with four components and the != operator

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -836,7 +836,7 @@ impl AquaPackage {
                 .unwrap()
                 .replace(' ', "")
                 .split(',')
-                .map(versions::Requirement::new)
+                .map(AquaRequirement::parse)
                 .collect::<Vec<_>>();
             if requirements.iter().any(|r| r.is_none()) {
                 return Err("invalid semver requirement".to_string().into());
@@ -844,7 +844,7 @@ impl AquaPackage {
             if let Some(ver) = &ver {
                 Ok(requirements
                     .iter()
-                    .all(|r| r.clone().is_some_and(|r| r.matches(ver)))
+                    .all(|r| r.as_ref().is_some_and(|r| r.matches(ver)))
                     .into())
             } else {
                 Err("invalid version".to_string().into())
@@ -857,6 +857,64 @@ impl AquaPackage {
         let mut ctx = Context::default();
         ctx.insert("Version", v);
         ctx
+    }
+}
+
+/// One comma-separated term of an aqua `semver()` constraint, e.g. `<=5.34.1.0` or `!=0.0.45`.
+///
+/// `versions::Requirement::new` cannot express these. It requires the whole string to parse,
+/// and the `Versioning::parse` inside it tries `SemVer` first — so a bound like `5.34.1.0` is
+/// consumed as `5.34.1` with `.0` left over and the requirement is rejected outright. It also
+/// has no operator for `!=`. Either way the caller only sees `None`, which
+/// `AquaPackage::version_override` turns into a silently false constraint.
+///
+/// aqua evaluates these with `hashicorp/go-version`, which accepts any number of components and
+/// supports `!=`, so the operator is split off here and the bound read with `Versioning::new`,
+/// which does fall back to `Version` for such strings. The comparison itself is still
+/// `versions::Requirement::matches`, so ordering, tilde and caret semantics are unchanged.
+struct AquaRequirement {
+    inner: versions::Requirement,
+    /// `!=` has no `versions::Op`, so it is `Exact` read backwards.
+    negated: bool,
+}
+
+impl AquaRequirement {
+    fn parse(s: &str) -> Option<Self> {
+        if s == "*" {
+            return Some(Self {
+                inner: versions::Requirement {
+                    op: versions::Op::Wildcard,
+                    version: None,
+                },
+                negated: false,
+            });
+        }
+        // Longest operators first, or `>=` would be read as `>` with a leading `=` on the bound.
+        let (op, negated, bound) = [
+            (">=", versions::Op::GreaterEq, false),
+            ("<=", versions::Op::LessEq, false),
+            ("!=", versions::Op::Exact, true),
+            (">", versions::Op::Greater, false),
+            ("<", versions::Op::Less, false),
+            ("=", versions::Op::Exact, false),
+            ("~", versions::Op::Tilde, false),
+            ("^", versions::Op::Caret, false),
+        ]
+        .into_iter()
+        .find_map(|(prefix, op, negated)| {
+            s.strip_prefix(prefix).map(|bound| (op, negated, bound))
+        })?;
+        Some(Self {
+            inner: versions::Requirement {
+                op,
+                version: Some(Versioning::new(bound)?),
+            },
+            negated,
+        })
+    }
+
+    fn matches(&self, v: &Versioning) -> bool {
+        self.inner.matches(v) != self.negated
     }
 }
 
@@ -1936,6 +1994,82 @@ packages:
         // which sorts before numeric versions.
         assert!(result.error_message.is_some());
         assert!(result.asset.is_empty());
+    }
+
+    /// Two overrides that differ only in which branch is picked, so `version_override`
+    /// reports the answer: `Some("first")` when the constraint held, `Some("fallback")` otherwise.
+    fn constraint_probe(constraint: &str) -> AquaPackage {
+        AquaPackage {
+            version_constraint: "false".to_string(),
+            version_overrides: vec![
+                AquaPackage {
+                    version_constraint: constraint.to_string(),
+                    asset: "first".to_string(),
+                    ..Default::default()
+                },
+                AquaPackage {
+                    version_constraint: "true".to_string(),
+                    asset: "fallback".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    fn constraint_holds(constraint: &str, version: &str) -> bool {
+        constraint_probe(constraint)
+            .version_override(&[version])
+            .map(|pkg| pkg.asset == "first")
+            .expect("a version_override always matches, since the last one is unconditional")
+    }
+
+    #[test]
+    fn test_semver_constraint_accepts_four_component_bounds() {
+        // https://github.com/jdx/mise/discussions/4813: relocatable-perl selects the linux asset
+        // name for old releases with semver("<= 5.34.1.0"). Rejecting that bound sent 5.32.1.0
+        // to the fallback branch, which asks for an asset the release does not have.
+        assert!(constraint_holds("semver(\"<= 5.34.1.0\")", "5.32.1.0"));
+        assert!(constraint_holds("semver(\"<= 5.34.1.0\")", "5.34.1.0"));
+        assert!(!constraint_holds("semver(\"<= 5.34.1.0\")", "5.36.0.0"));
+
+        // Both directions, so "the bound is rejected and everything is false" cannot pass.
+        assert!(constraint_holds("semver(\">= 1.0.0.0\")", "5.32.1.0"));
+        assert!(!constraint_holds("semver(\"< 1.0.0.0\")", "5.32.1.0"));
+    }
+
+    #[test]
+    fn test_semver_constraint_compares_bounds_against_shorter_versions() {
+        // haskell/cabal pins 4-component bounds while its releases are 3-component.
+        assert!(constraint_holds("semver(\"<= 3.16.1.0\")", "3.16.1"));
+        assert!(!constraint_holds("semver(\"<= 3.16.1.0\")", "3.17.0"));
+    }
+
+    #[test]
+    fn test_semver_constraint_supports_not_equal() {
+        // mattn/efm-langserver and sheepla/qiitaz exclude a single bad release this way.
+        assert!(constraint_holds("semver(\"!= 0.0.45\")", "0.0.46"));
+        assert!(!constraint_holds("semver(\"!= 0.0.45\")", "0.0.45"));
+    }
+
+    #[test]
+    fn test_semver_constraint_still_ands_comma_separated_terms() {
+        assert!(constraint_holds(
+            "semver(\">= 1.0.0, <= 9.0.0\")",
+            "5.32.1.0"
+        ));
+        assert!(!constraint_holds(
+            "semver(\">= 1.0.0, <= 5.0.0\")",
+            "5.32.1.0"
+        ));
+    }
+
+    #[test]
+    fn test_semver_constraint_without_an_operator_is_not_satisfied() {
+        // aqua requires an operator; an unparseable term errors, and the caller reads that
+        // as "does not apply" rather than propagating it.
+        assert!(!constraint_holds("semver(\"5.32.1.0\")", "5.32.1.0"));
+        assert!(!constraint_holds("semver(\"<= \")", "5.32.1.0"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the root cause of https://github.com/jdx/mise/discussions/4813.

## The symptom

```console
$ mise install perl@5.32.1.0
mise ERROR Failed to install aqua:skaji/relocatable-perl@5.32.1.0: no asset found: perl-linux-amd64.tar.gz
Available assets:
perl-darwin-2level.tar.gz
perl-darwin-2level.tar.xz
perl-x86_64-linux.tar.gz
perl-x86_64-linux.tar.xz
```

The registry entry is right: `semver("<= 5.34.1.0")` selects `perl-{{.Arch}}-{{.OS}}` with
`amd64 → x86_64` for linux, which is exactly `perl-x86_64-linux.tar.gz`. mise was not choosing that
branch.

## Isolating it

A local registry (`MISE_AQUA_REGISTRIES=file://…`) where every branch fails with a
self-identifying asset name makes the chosen branch visible without downloading anything:

```
constraint on the first override    version     branch taken
"true"                              5.32.1.0    under test      mechanism is fine
semver("<= 5.99.0")                 5.32.1.0    under test      4-component VERSION is fine
semver("<= 1.0.0")                  5.32.1.0    fallback        correctly false
semver("<= 6.0.0.0")                5.32.1.0    fallback        wrong
semver("<= 5.34.1.0")               5.32.1.0    fallback        wrong
semver(">= 1.0.0.0")                5.32.1.0    fallback        wrong
semver("<  1.0.0.0")                5.32.1.0    fallback        right answer, wrong reason
semver("<= 3.11.0.0")               3.11.0      fallback        wrong — bound side only
semver("!= 1.0.0")                  3.11.0      fallback        wrong — operator unsupported
```

`>= 1.0.0.0` and `< 1.0.0.0` both being false rules out a comparison error: the bound is rejected
before any comparison happens. `<= 3.11.0.0` failing against a 3-component version pins it to the
bound rather than the version.

## Cause

`semver()` was built on `versions::Requirement::new`, which requires the whole string to parse
(`Ok(("", r))` or nothing) and whose `Versioning::parse` tries `SemVer` first. `5.34.1.0` is
consumed as `5.34.1` with `.0` left over, so the requirement is `None`. `versions::Op` also has no
variant for `!=`, so those never parse either.

`AquaPackage::version_override` turns that `None` into a false constraint —
`.unwrap_or(false.into())`, with the error going to `log::debug!` — which is why this was silent
rather than an error.

`Versioning::new` does read these strings, because it falls back to `Version` after `SemVer`. That
is why the version side always worked while the bound side never did.

aqua evaluates the same constraints with `hashicorp/go-version` (`pkg/expr/version_compare.go`),
which takes any number of components and supports `!=`, so the registry is written expecting both.
This is a mise-side divergence, not a registry bug.

## Impact

21 `version_overrides` in the baked registry were dead — 19 with a 4-component bound, 2 with `!=`:

| aqua package | mise registry name | constraints |
| --- | --- | --- |
| `haskell/cabal` | `cabal` | 7, e.g. `<= 2.4.1.0`, `<= 3.16.1.0` |
| `commercialhaskell/stack` | `stack` | 4, e.g. `<= 0.1.1.0`, `<= 2.1.0.3` |
| `skaji/relocatable-perl` | `perl` | 3, `<= 5.34.1.0`, `<= 5.36.0.0`, `<= 5.42.2.0` |
| `SonarSource/sonarqube-cli` | `sonarqube-cli` | 3, e.g. `< 0.10.0.1266` |
| `kubevela/kubevela` | `kubevela` | `<= 0.0.1.1` |
| `so-dang-cool/fib` | — | `<= 1.1.2.3` |
| `mattn/efm-langserver` | — | `!= 0.0.45` |
| `sheepla/qiitaz` | — | `!= 0.0.5` |

## The change

Split the operator off (longest first, so `>=` is not read as `>`), read the bound with
`Versioning::new`, and hand the comparison to `versions::Requirement::matches` by constructing the
`Requirement` directly — its fields and every `Op` variant are public. Ordering, tilde and caret
semantics therefore stay the crate's. `!=` is `Exact` read backwards, and `*` keeps its
no-bound form.

Everything else is unchanged: comma-separated terms are still ANDed, and an unparseable term still
errors, which the caller still reads as "this branch does not apply".

## Not included

`src/tera.rs` uses `Requirement::new` in the `semver_matching` filter and shares the underlying
limitation, but it reports the failure (`semver_matching requirement is invalid: …`) instead of
swallowing it, and that filter is mise's own — being strict about semver there is a defensible
contract. Only aqua's `semver()` has to mirror aqua.

## Verified

`cargo test -p aqua-registry` and `cargo clippy -p aqua-registry --all-targets -- -D warnings` run
locally, plus `cargo fmt --all`. The new tests cover the 4-component bound in both directions, a
4-component bound against a shorter version, `!=` both ways, comma-separated terms, and an
operator-less term still being rejected. `test_version_override_non_version_string_matches_semver`,
which pins the unrelated "`brew` parses as a General version" quirk, still passes.

One pre-existing failure shows up on Windows in this crate,
`test_override_envs_all_matches_any_platform` (expects `tool-all`, gets `tool-all.exe`). It fails
identically on `main` with this branch's changes reverted, so it is not from here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Aqua version constraint parsing.
  - Added support for four-component version bounds and not-equal (`!=`) constraints.
  - Preserved comma-separated constraint combinations and existing comparison behavior.
  - Correctly handles comparisons with shorter version numbers.
  - Invalid or operator-less constraints remain unsatisfied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->