### PR TITLE
test(aqua): expect the Windows executable extension in the envs override test

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -2636,17 +2636,17 @@ packages:
 "#;
         let pkg = first_registry_package(yml);
 
-        for (os, arch) in [
-            ("linux", "amd64"),
-            ("darwin", "arm64"),
-            ("windows", "amd64"),
+        // What is under test is that the `envs: [all]` override supplied the URL on every
+        // platform. A raw-format URL additionally picks up the Windows executable extension,
+        // which `test_url_adds_exe_when_missing` covers on its own.
+        for (os, arch, expected) in [
+            ("linux", "amd64", "https://example.com/tool-all"),
+            ("darwin", "arm64", "https://example.com/tool-all"),
+            ("windows", "amd64", "https://example.com/tool-all.exe"),
         ] {
             let resolved = pkg.clone().with_version(&["1.0.0"], os, arch);
 
-            assert_eq!(
-                resolved.url("1.0.0", os, arch).unwrap(),
-                "https://example.com/tool-all"
-            );
+            assert_eq!(resolved.url("1.0.0", os, arch).unwrap(), expected);
         }
     }
 


### PR DESCRIPTION
`test_override_envs_all_matches_any_platform` has always failed. On `main`, with nothing else
changed:

```
---- types::tests::test_override_envs_all_matches_any_platform stdout ----
assertion `left == right` failed
  left:  "https://example.com/tool-all.exe"
 right: "https://example.com/tool-all"
```

## Not a platform-specific failure

The test loops over `linux`, `darwin` and `windows` and asserts one URL for all three. The
platform is an *argument*, not the host: `url()` calls `complete_windows_ext_to_asset(s, v, os)`,
which returns early unless `os == "windows"` and otherwise appends the extension for a raw-format
URL. Neither it nor `append_str_ext` looks at `cfg!(windows)` or `std::env::consts::OS`, so the
windows iteration appends `.exe` wherever the test runs.

## The expectation was wrong, not the code

Appending `.exe` there is the intended behaviour. `complete_windows_ext_to_asset` is documented as
mirroring upstream aqua's `completeWindowsExtToAsset`, and `test_url_adds_exe_when_missing` already
pins the same result for the same inputs — `format: raw`, `os = "windows"`, no extension on the
URL. `test_url_no_double_exe_extension` and `test_url_preserves_jar_when_completing_windows_ext`
cover the neighbouring cases.

What this test is actually for is that an `envs: [all]` override supplies the URL on every
platform, which the `.exe` suffix does not affect. So the windows row now expects
`tool-all.exe`, with a comment saying why it differs.

## Why nobody saw it

CI never runs this crate. Every test invocation in `.github/workflows/test.yml` is a bare
`cargo test` from the workspace root:

| line | job | command |
| --- | --- | --- |
| 169 | `unit` (macOS, gating) | `cargo test --all-features` |
| 205 | `nightly` (`continue-on-error`) | `cargo test --all-features` |
| 443 | `windows-unit` (gating) | `cargo test` |

With a root package and no `default-members`, that is the `mise` package only. Member crates are
built as dependencies, but their unit tests never run.

## Why this PR does not also add `--workspace`

Because it would turn CI red immediately. Running every member crate against `main` locally:

| crate | result on `main` |
| --- | --- |
| `aqua-registry` | 116 passed, **1 failed** ← fixed here |
| `vfox` | 108 passed, **2 failed**, 2 ignored |
| `mise-interactive-config` | 35 passed, **2 failed** |
| `mise-sigstore` | 26 passed |
| `mise-cache-rustc` | 22 passed, **1 failed** |
| `mise-cache-core` | 22 passed |
| `mise-shim` | no tests |

337 tests that CI does not run, and six failures among them. The other five:

```
vfox                      2 failures
mise-interactive-config   schema::tests::test_valid_settings
                              assertion failed: is_valid_setting("aqua.baked_registry")
                          schema::tests::test_setting_types
                              left: Some(Integer)
mise-cache-rustc          tests::absolute_environment_values_remain_literal_action_inputs
                              assertion failed: descriptor.contains(&first_out_dir.display().to_string())
```

Those are separate problems in separate crates, and bundling them into a one-line test fix would
make this unreviewable. Widening CI coverage looks worth doing, but it wants its own change once
those are dealt with — happy to follow up if that is wanted.

## Verified

`cargo test -p aqua-registry` → 117 passed, 0 failed (was 116 passed, 1 failed).
`cargo fmt --all` and `cargo clippy -p aqua-registry --all-targets -- -D warnings` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected environment override validation across platforms.
  * Windows URLs now correctly include the `.exe` suffix, while Linux and macOS URLs remain extensionless.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->