### PR TITLE
fix(sops): invoke cli without age keys

### DIFF
--- a/docs/environments/secrets/sops.md
+++ b/docs/environments/secrets/sops.md
@@ -3,7 +3,7 @@
 mise reads encrypted secret files and makes values available as environment variables via `env._.file`.
 
 - **Formats**: `.env.json`, `.env.yaml`, `.env.toml`
-- **Encryption**: [sops](https://getsops.io) backed by [age](https://github.com/FiloSottile/age)
+- **Encryption**: [sops](https://getsops.io), using the built-in age support or the external `sops` CLI
 
 ## Example
 
@@ -24,7 +24,10 @@ mise will automatically decrypt the file if it is sops-encrypted.
 ## Encrypt with sops
 
 :::: info
-Currently age is the only sops encryption method supported.
+The default `sops.rops = true` implementation supports age-encrypted files. Set
+`sops.rops = false` to use the external `sops` CLI for other key services and
+methods supported by SOPS, such as AWS KMS, GCP KMS, Azure Key Vault, Vault,
+and PGP.
 ::::
 
 :::: warning

--- a/e2e/secrets/test_sops_cli_without_age
+++ b/e2e/secrets/test_sops_cli_without_age
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -x
+
+cat >"$HOME/bin/sops" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$HOME/sops-invocations"
+cat >/dev/null
+
+if [[ ${FAKE_SOPS_FAIL:-0} == 1 ]]; then
+  exit 42
+fi
+
+cat <<'YAML'
+SECRET: kms-secret
+YAML
+EOF
+chmod +x "$HOME/bin/sops"
+
+cat >.env.yaml <<'YAML'
+SECRET: ENC[AES256_GCM,data:ZmFrZQ==,iv:ZmFrZQ==,tag:ZmFrZQ==,type:str]
+sops:
+  kms:
+    - arn: arn:aws:kms:us-east-1:123456789012:key/example
+      enc: fake
+  version: 3.9.4
+YAML
+
+cat >mise.toml <<'TOML'
+[env]
+_.file = ".env.yaml"
+TOML
+
+export MISE_SOPS_ROPS=0
+export MISE_SOPS_STRICT=0
+unset MISE_SOPS_AGE_KEY MISE_SOPS_AGE_KEY_FILE SOPS_AGE_KEY SOPS_AGE_KEY_FILE
+
+# The external CLI decides how to decrypt the file, even when no age key exists.
+assert_contains "mise env" "export SECRET=kms-secret"
+assert_contains "cat \"$HOME/sops-invocations\"" "decrypt --input-type yaml --output-type yaml"
+assert_not_contains "cat \"$HOME/sops-invocations\"" "/dev/stdin"
+
+# Non-strict mode still skips a file when the external CLI actually fails.
+export FAKE_SOPS_FAIL=1
+assert_not_contains "mise env" "SECRET"
+
+# Strict mode still propagates the external CLI failure.
+export MISE_SOPS_STRICT=1
+assert_fail "mise env"
+
+# The built-in rops path still skips files without an age key in non-strict mode.
+export FAKE_SOPS_FAIL=0
+export MISE_SOPS_ROPS=1
+export MISE_SOPS_STRICT=0
+before="$(wc -l <"$HOME/sops-invocations")"
+assert_not_contains "mise env" "SECRET"
+after="$(wc -l <"$HOME/sops-invocations")"
+assert "test \"$before\" = \"$after\""

--- a/src/sops.rs
+++ b/src/sops.rs
@@ -35,7 +35,7 @@ where
 
     let (age, age_key_file) = resolve_age_key(exec_env, &mut parse_template);
 
-    if age.is_none() && !Settings::get().sops.strict {
+    if use_rops && age.is_none() && !Settings::get().sops.strict {
         debug!("age key not found, skipping decryption in non-strict mode");
         return Ok(String::new());
     }
@@ -110,15 +110,14 @@ where
             }
             Some(sops_path) => {
                 let sops = sops_path.to_string_lossy().to_string();
-                // TODO: this obviously won't work on windows
+                // sops reads stdin when no input filename is provided.
                 match cmd!(
                     sops,
+                    "decrypt",
                     "--input-type",
                     format,
                     "--output-type",
-                    format,
-                    "-d",
-                    "/dev/stdin"
+                    format
                 )
                 .stdin_bytes(input.as_bytes())
                 .read()


### PR DESCRIPTION
## Summary

- invoke the external `sops` CLI without requiring an age key when `sops.rops = false`
- use the cross-platform `sops decrypt` stdin mode instead of the Unix-only `/dev/stdin` path
- preserve non-strict skipping for actual CLI lookup or decryption failures
- document the external CLI path as the option for KMS and other SOPS key services

## Problem

The missing-age-key check ran before mise selected the built-in rops implementation or the external SOPS CLI. In non-strict mode, that caused KMS-only SOPS files to be skipped before SOPS had a chance to use AWS KMS, GCP KMS, Azure Key Vault, Vault, PGP, or another supported key service.

The age-key early return now applies only to the built-in rops path. The external CLI is always allowed to determine how to decrypt the file; if it is unavailable or decryption fails, the existing strict/non-strict behavior is unchanged.

## Verification

- `mise run test:e2e e2e/secrets/test_sops_cli_without_age`
- `mise run test:e2e e2e/secrets/test_secrets e2e/secrets/test_secrets_non_strict`
- `mise exec -- cargo test --all-features sops`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- Rustfmt, ShellCheck, shfmt, Prettier, and Markdownlint checks passed individually

`mise run format` and `mise run lint` could not run their hk wrapper because hk does not recognize this Sapling working copy as a Git repository; the relevant checks above were run directly instead.

Addresses https://github.com/jdx/mise/discussions/9363

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*