### PR TITLE
fix(settings): stop list settings from panicking when set from the environment

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -33,6 +33,7 @@ type = "Bool"
 description = "[experimental] List of age identity files to use for decryption."
 env = "MISE_AGE_IDENTITY_FILES"
 optional = true
+parse_env = "list_by_os_path_separator"
 rust_type = "Vec<PathBuf>"
 type = "ListPath"
 
@@ -47,6 +48,7 @@ type = "Path"
 description = "[experimental] List of SSH identity files to use for age decryption."
 env = "MISE_AGE_SSH_IDENTITY_FILES"
 optional = true
+parse_env = "list_by_os_path_separator"
 rust_type = "Vec<PathBuf>"
 type = "ListPath"
 
@@ -105,6 +107,7 @@ type = "Bool"
 description = "Extra arguments to pass to cosign when verifying aqua tool signatures."
 env = "MISE_AQUA_COSIGN_EXTRA_ARGS"
 optional = true
+parse_env = "list_by_comma"
 rust_type = "Vec<String>"
 type = "ListString"
 
@@ -1919,6 +1922,7 @@ insecure_registries = ["registry.lan:5000", "10.0.0.8:5000"]
 """
 env = "MISE_OCI_INSECURE_REGISTRIES"
 optional = true
+parse_env = "list_by_comma"
 rust_type = "Vec<String>"
 type = "ListString"
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -2365,6 +2365,133 @@ mod tests {
         }
     }
 
+    /// Every scalar setting type in settings.toml. Anything else is a collection.
+    ///
+    /// Spelled as "not a scalar" rather than by listing the collections on purpose. A new
+    /// collection type — `SetPath`, say — has the same failure mode and is caught here
+    /// automatically, whereas enumerating `List*`/`SetString`/`IndexMap<…>` would let it through
+    /// silently, which is the exact failure this guard exists to prevent. A new *scalar* type
+    /// instead fails this test loudly and is fixed by adding one entry here, which is the cheaper
+    /// mistake to make.
+    const SCALAR_SETTING_TYPES: &[&str] = &[
+        "Bool",
+        "BoolOrString",
+        "Duration",
+        "Integer",
+        "Path",
+        "String",
+        "Url",
+    ];
+
+    /// Collect settings that are readable from the environment, hold a collection, and declare no
+    /// `parse_env`.
+    fn collect_settings_missing_parse_env(
+        table: &toml::Table,
+        prefix: &str,
+        missing: &mut Vec<String>,
+    ) {
+        for (key, value) in table {
+            let toml::Value::Table(setting) = value else {
+                continue;
+            };
+            let full_key = if prefix.is_empty() {
+                key.clone()
+            } else {
+                format!("{prefix}.{key}")
+            };
+            // A nested table that has no "type" or "description" is a grouping table
+            // (e.g., [aqua], [node]), not a setting itself.
+            if !setting.contains_key("type") && !setting.contains_key("description") {
+                collect_settings_missing_parse_env(setting, &full_key, missing);
+                continue;
+            }
+            let is_collection = setting
+                .get("type")
+                .and_then(|type_| type_.as_str())
+                .is_some_and(|type_| !SCALAR_SETTING_TYPES.contains(&type_));
+            if is_collection && setting.contains_key("env") && !setting.contains_key("parse_env") {
+                missing.push(full_key);
+            }
+        }
+    }
+
+    #[test]
+    fn test_settings_toml_collection_settings_declare_parse_env() {
+        // A collection setting that can be set from the environment needs `parse_env`. Without it
+        // confique hands the raw string to a `Vec`, set or map deserializer and mise aborts before
+        // doing anything: "failed to deserialize value `SettingsAge::identity_files` from
+        // environment variable `MISE_AGE_IDENTITY_FILES`: invalid type: string "...", expected a
+        // sequence".
+        let content =
+            std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/settings.toml"))
+                .expect("failed to read settings.toml");
+        let table: toml::Table = content.parse().expect("failed to parse settings.toml");
+
+        let mut missing = vec![];
+        collect_settings_missing_parse_env(&table, "", &mut missing);
+
+        assert!(
+            missing.is_empty(),
+            "these collection settings are readable from the environment but declare no \
+             parse_env, so mise panics as soon as one is set: {missing:?}"
+        );
+    }
+
+    /// The guard above only earns its place if it catches every collection type, not just `List*`.
+    /// settings.toml also carries `SetString` and `IndexMap<String, String>`, which fail the same
+    /// way, so a violation of each is checked against a fixture here rather than waiting for one
+    /// to be committed.
+    #[test]
+    fn test_parse_env_guard_covers_sets_and_maps_too() {
+        let table: toml::Table = r#"
+            [bad_list]
+            description = "x"
+            type = "ListString"
+            env = "MISE_BAD_LIST"
+
+            [bad_set]
+            description = "x"
+            type = "SetString"
+            env = "MISE_BAD_SET"
+
+            [bad_map]
+            description = "x"
+            type = "IndexMap<String, String>"
+            env = "MISE_BAD_MAP"
+
+            [group.bad_nested]
+            description = "x"
+            type = "ListPath"
+            env = "MISE_BAD_NESTED"
+
+            [ok_has_parse_env]
+            description = "x"
+            type = "SetString"
+            env = "MISE_OK_PARSE"
+            parse_env = "set_by_comma"
+
+            [ok_no_env]
+            description = "x"
+            type = "SetString"
+
+            [ok_scalar]
+            description = "x"
+            type = "String"
+            env = "MISE_OK_SCALAR"
+        "#
+        .parse()
+        .expect("fixture parses");
+
+        let mut missing = vec![];
+        collect_settings_missing_parse_env(&table, "", &mut missing);
+        missing.sort();
+
+        assert_eq!(
+            missing,
+            vec!["bad_list", "bad_map", "bad_set", "group.bad_nested"]
+        );
+    }
+
     #[test]
     fn test_settings_node_build_cmds() {
         let node = SettingsNode::default();


### PR DESCRIPTION
## The problem

A `List*` setting needs `parse_env` for confique to split the environment variable into elements.
Four settings do not declare one, so setting any of them aborts mise before it does anything.

Measured on **v2026.8.2 windows-x64**, with two settings that *do* declare `parse_env` as controls:

```
MISE_AGE_IDENTITY_FILES=/tmp/id.txt          rc=101  panic
MISE_AGE_SSH_IDENTITY_FILES=/tmp/id_ed25519  rc=101  panic
MISE_OCI_INSECURE_REGISTRIES=registry:5000   rc=101  panic
MISE_AQUA_COSIGN_EXTRA_ARGS=--key /k.pub     rc=101  panic

MISE_DISABLE_TOOLS=node                      rc=0    -> ["node"]
MISE_TRUSTED_CONFIG_PATHS=/tmp               rc=0    -> ["/tmp"]
```

```
The application panicked (crashed).
Message: called `Result::unwrap()` on an `Err` value:
   0: failed to deserialize value `SettingsAge::identity_files` from environment variable
      `MISE_AGE_IDENTITY_FILES`: invalid type: string "/tmp/id.txt", expected a sequence
Location: src\config\settings.rs:488
```

Three of the four are live settings, and the fourth is documented with the exact string that
crashes:

| setting | env var | read by |
| --- | --- | --- |
| `age.identity_files` | `MISE_AGE_IDENTITY_FILES` | `src/agecrypt.rs:356` |
| `age.ssh_identity_files` | `MISE_AGE_SSH_IDENTITY_FILES` | `src/agecrypt.rs:378` |
| `oci.insecure_registries` | `MISE_OCI_INSECURE_REGISTRIES` | `src/oci/registry.rs:114` |
| `aqua.cosign_extra_args` | `MISE_AQUA_COSIGN_EXTRA_ARGS` | — (see below) |

`docs/dev-tools/backends/aqua.md` shows `export MISE_AQUA_COSIGN_EXTRA_ARGS="--key /path/to/key.pub"`,
which is exactly the shape that panics.

## Separators

Following what the other twenty list settings already do:

| setting | value | why |
| --- | --- | --- |
| `age.identity_files` | `list_by_os_path_separator` | all five `ListPath` settings with an env var use it |
| `age.ssh_identity_files` | `list_by_os_path_separator` | same |
| `oci.insecure_registries` | `list_by_comma` | **must not be colon** — its values are `host` or `host:port`, which colon would cut in half |
| `aqua.cosign_extra_args` | `list_by_comma` | matches the other flag list, `dotnet.package_flags`; comma also survives a Windows path inside an argument |

## The test

Rather than pin the four instances, the new test walks `settings.toml` and fails if any `List*`
setting with an `env` key lacks `parse_env`, so a new list setting cannot ship without a separator.
It follows `test_settings_toml_is_sorted`, which already reads the file at test time and skips
grouping tables. `task_disable_paths` — the deprecated alias that has no env var — falls out
naturally.

## No render round-trip

`parse_env` is consumed by `codegen_settings` in `build.rs` at compile time and reaches no
checked-in generated file: `xtasks/render/schema.ts` reads only `description`/`type`/`default`/
`deprecated`/`enum`, and `docs/settings.data.ts` reads `settings.toml` directly at VitePress build
time — so the docs pages pick up the separator automatically.

## Worth a separate look

`aqua.cosign_extra_args` is dead: nothing in `src/`, `crates/` or `xtasks/` reads it, and mise no
longer shells out to the `cosign` binary at all — verification is in-process via
`src/github/sigstore.rs`. It is fixed here along with the others because excluding it would mean
carrying an exception list in the test, and not crashing is an improvement either way. Removing it
touches `schema/mise.json` and a released setting name, so it seems better as its own change. Happy
to open that if wanted.

## Verified

`cargo fmt --all`. The root package cannot be built on this machine (`libz-ng-sys` wants cmake), so
the walker was exercised separately against this repo's `settings.toml`: it reports no offenders
after the change, and — with two planted offenders, one nested, plus decoys that must not fire — it
does detect, so it is not passing vacuously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved environment-variable parsing for identity file paths using platform-specific path separators.
  - Added comma-separated parsing for cosign arguments and insecure registry lists.

- **Bug Fixes**
  - Improved handling of collection-based settings configured through environment variables.

- **Tests**
  - Added validation to ensure environment-configurable collection settings declare an appropriate parsing method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->