### PR TITLE
fix(watch): run default task when omitted

### DIFF
--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -20,6 +20,7 @@ cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 Tasks to run
 Can specify multiple tasks by separating with `:::`
 e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
+Defaults to `default`
 
 ### `[ARGS]…`
 

--- a/e2e/cli/test_watch_default_task
+++ b/e2e/cli/test_watch_default_task
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+mkdir -p "$HOME/bin"
+cat >"$HOME/bin/watchexec" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$HOME/watchexec-args"
+EOF
+chmod +x "$HOME/bin/watchexec"
+export PATH="$HOME/bin:$PATH"
+
+cat >mise.toml <<'EOF'
+[tasks.default]
+run = "echo default"
+sources = ["src/**/*.rs"]
+
+[tasks.named]
+run = "echo named"
+sources = ["named/**/*.rs"]
+EOF
+
+# Omitting a task watches the default task through the same path as an explicit task.
+mise watch --skip-deps
+assert_contains "cat \"$HOME/watchexec-args\"" "src/**/*.rs"
+assert_contains "cat \"$HOME/watchexec-args\"" "--skip-deps"
+assert "tail -1 \"$HOME/watchexec-args\"" "default"
+
+# Explicit positional and legacy flag task selections must not gain the default task.
+mise watch named
+assert_contains "cat \"$HOME/watchexec-args\"" "named/**/*.rs"
+assert_not_contains "cat \"$HOME/watchexec-args\"" "src/**/*.rs"
+assert "tail -1 \"$HOME/watchexec-args\"" "named"
+
+mise watch -t named
+assert "tail -1 \"$HOME/watchexec-args\"" "named"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -5423,6 +5423,7 @@ This shows the manual page for Watchexec, if the output is a terminal and the 'm
 Tasks to run
 Can specify multiple tasks by separating with `:::`
 e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
+Defaults to `default`
 .TP
 \fB<ARGS>\fR
 Task and arguments to run

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -5465,6 +5465,7 @@ This shows the manual page for Watchexec, if the output is a terminal and the 'm
 Tasks to run
 Can specify multiple tasks by separating with `:::`
 e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
+Defaults to `default`
 """# required=#false
     arg "[ARGS]…" help="Task and arguments to run" required=#false double_dash=automatic var=#true
 }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -11,7 +11,6 @@ use crate::task::{Deps, Task};
 use crate::toolset::ToolsetBuilder;
 use clap::{CommandFactory, ValueEnum, ValueHint};
 use console::style;
-use eyre::bail;
 use itertools::Itertools;
 use std::cmp::PartialEq;
 use std::iter::once;
@@ -30,6 +29,7 @@ pub struct Watch {
     /// Tasks to run
     /// Can specify multiple tasks by separating with `:::`
     /// e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
+    /// Defaults to `default`
     #[clap(allow_hyphen_values = true, verbatim_doc_comment)]
     task: Option<String>,
 
@@ -77,13 +77,13 @@ impl Watch {
                 return Err(request_exit(1));
             }
         }
-        let args = once(self.task)
+        let mut args = once(self.task)
             .flatten()
             .chain(self.task_flag.iter().cloned())
             .chain(self.args.iter().cloned())
             .collect::<Vec<_>>();
         if args.is_empty() {
-            bail!("No tasks specified");
+            args.push("default".to_string());
         }
         let tasks = crate::task::task_list::get_task_lists(&config, &args, false, false).await?;
         let watched_tasks = if self.skip_deps {


### PR DESCRIPTION
## Summary

- run the `default` task when `mise watch` is invoked without a task name
- preserve explicit positional, multiple-task, and legacy `-t/--task` selections
- document the default task behavior in the generated CLI reference and man page

## Problem

`mise run` defaults to `tasks.default`, but `mise watch` collected its optional task arguments and returned `No tasks specified` when none were present. This prevented a configured default task from using the otherwise normal watch path.

The watch command now adds `default` only after all explicit positional and legacy task inputs have been collected and found to be empty. Keeping this as a runtime fallback instead of a Clap positional default avoids injecting `default` alongside an explicit `-t/--task` selection. The resulting task is resolved through the same dependency, source, watch-option, and `--skip-deps` paths as `mise watch default`.

## Verification

- `mise run test:e2e e2e/cli/test_watch_default_task`
- `mise run test:e2e e2e/cli/test_watch_ignore e2e/cli/test_watch_task_no_vcs_ignore e2e/tasks/test_task_watch_skip_deps e2e/tasks/test_task_default`
- `mise exec -- cargo test --all-features cli::watch::tests`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run render`
- Rustfmt, ShellCheck, shfmt, and Prettier checks passed individually

`mise run format` and `mise run lint` could not run their hk wrapper because hk does not recognize this Sapling working copy as a Git repository; the relevant checks above were run directly instead.

Addresses https://github.com/jdx/mise/discussions/7090

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `mise watch` now runs the `default` task when no task is specified.
  * Task selection remains available through positional arguments and the legacy `-t` option.
* **Documentation**
  * Updated CLI help, manual pages, and watch documentation to clarify that omitted task arguments default to `default`.
* **Tests**
  * Added end-to-end coverage for default and explicitly selected watch tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->