### PR TITLE
chore(settings): remove the dead aqua.cosign_extra_args setting

### DIFF
--- a/docs/dev-tools/backends/aqua.md
+++ b/docs/dev-tools/backends/aqua.md
@@ -194,9 +194,6 @@ mise natively verifies Cosign signatures without requiring the `cosign` CLI tool
 ```bash
 # Enable/disable Cosign verification (default: true)
 export MISE_AQUA_COSIGN=true
-
-# Pass extra arguments to the verification process
-export MISE_AQUA_COSIGN_EXTRA_ARGS="--key /path/to/key.pub"
 ```
 
 ### SLSA Provenance Verification

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -575,13 +575,6 @@
               "description": "Use cosign to verify aqua tool signatures.",
               "type": "boolean"
             },
-            "cosign_extra_args": {
-              "description": "Extra arguments to pass to cosign when verifying aqua tool signatures.",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
             "github_attestations": {
               "default": true,
               "description": "Enable GitHub Artifact Attestations verification for aqua tools.",

--- a/settings.toml
+++ b/settings.toml
@@ -107,14 +107,6 @@ description = "Use cosign to verify aqua tool signatures."
 env = "MISE_AQUA_COSIGN"
 type = "Bool"
 
-[aqua.cosign_extra_args]
-description = "Extra arguments to pass to cosign when verifying aqua tool signatures."
-env = "MISE_AQUA_COSIGN_EXTRA_ARGS"
-optional = true
-parse_env = "list_by_comma"
-rust_type = "Vec<String>"
-type = "ListString"
-
 [aqua.github_attestations]
 default = true
 description = "Enable GitHub Artifact Attestations verification for aqua tools."


### PR DESCRIPTION
`aqua.cosign_extra_args` / `MISE_AQUA_COSIGN_EXTRA_ARGS` does nothing. Setting it has had no
effect for about eleven months, and the docs still showed people how to use it.

## When it died

[#4148](https://github.com/jdx/mise/pull/4148) added it when mise shelled out to the `cosign` CLI.
[#6332](https://github.com/jdx/mise/pull/6332) — "integrate native sigstore-verification for
security verification", merged 2025-09-18 — replaced the external cosign, slsa-verifier and
`gh attestation verify` calls with a native Rust implementation, and the setting lost its last
reader there. Bisecting `src/backend/aqua.rs` puts it exactly on that commit:

```
7e4dfff5c1f1  2025-09-13  reads aqua.cosign_extra_args
92990728046f  2025-09-18  does not                       <- #6332
```

Today nothing in `src/`, `crates/`, `xtasks/`, `e2e/`, `e2e-win/` or `registry/` reads it, and mise
never spawns the `cosign` binary — verification runs in-process via `src/github/sigstore.rs`.

Until very recently the documented form was not even a silent no-op — it was a crash, because this
was one of four list settings missing `parse_env`:

```console
$ export MISE_AQUA_COSIGN_EXTRA_ARGS="--key /path/to/key.pub"   # straight from the docs
The application panicked (crashed).
   0: failed to deserialize value `SettingsAqua::cosign_extra_args` from environment variable
      `MISE_AQUA_COSIGN_EXTRA_ARGS`: invalid type: string "...", expected a sequence
```

That panic was fixed separately in #11835, which added `parse_env` to the same block. It merged on
2026-08-11 and this branch is rebased on top of it, so the conflict those two PRs had is resolved:
the block being deleted here is the one #11835 edited, `parse_env` line included. Setting the
variable no longer panics — it is now a plain no-op, which is the same reason to remove it.

## Checked before removing

- **Every open pull request** was scanned for `cosign_extra_args` / `COSIGN_EXTRA_ARGS` — twenty of
  them when this was written.
  The only hit is #11835 above. Nothing else uses it or is preparing to.
- Issue and discussion search: `cosign_extra_args` returns nothing; `MISE_AQUA_COSIGN_EXTRA_ARGS`
  returns only #11835.
- `CHANGELOG.md` still records #4148 and is deliberately left alone — that is history, not current
  behaviour.

## What a user with it in their config will see

Worth being explicit, because it is sharper than a warning. An unknown key does not just get
ignored: the `[settings]` table from that file stops loading. Measured on v2026.8.2 with a name
that is already unknown, standing in for the removed one:

```console
# today, with the real setting
$ mise settings get aqua.cosign
true

# with an unknown key in [settings.aqua]
$ mise settings get aqua.cosign
Error loading settings file: unknown field `...`, expected one of `baked_registry`, `cosign`, ...
in `settings.aqua`
```

Exit status stays 0, but the value is gone. So anyone carrying this setting has to delete the line,
and until they do, their other `aqua` settings in that file are dropped.

**If you would rather avoid that edge**, the alternative is the deprecation path this repo already
uses for `dotnet.package_flags` — `deprecated` plus `deprecated_warn_at` / `deprecated_remove_at`.
It keeps the key valid while warning. I did not take it here because that mechanism is for
replacing a setting that still works, and there is no replacement to point at: this one has done
nothing since 2025. Happy to switch it to a deprecation if you prefer.

## Files

`settings.toml` (the definition), `docs/dev-tools/backends/aqua.md` (the example), and
`schema/mise.json`, regenerated with `bun xtasks/render/schema.ts`. The schema diff is the removal
and nothing else — no reformatting churn. 18 deletions, no insertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for configuring additional Cosign verification arguments for Aqua tools.
  * The related environment variable and configuration setting are no longer available.
  * Aqua Cosign verification remains configurable through the existing `cosign` setting.
  * Update existing configurations that use the removed option to rely on the supported setting instead.
* **Documentation**
  * Removed references to the retired configuration option from the Aqua documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

