### PR TITLE
fix(tests): repair the workspace member tests and run them in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,11 @@ jobs:
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - uses: ./.github/actions/mise-tools
       - run: mise x -- cargo test --all-features
+      # `cargo test` above resolves to the root package, so the workspace members are built as
+      # dependencies but never tested. Run them separately rather than adding --workspace to the
+      # line above, which would extend --all-features to members whose features are exclusive.
+      - name: cargo test (workspace members)
+        run: cargo test --workspace --exclude mise
       - run: mise run test:e2e e2e/cli/test_system_install_brew_macos_slow
       - run: sccache --show-stats
         if: always()
@@ -441,6 +446,10 @@ jobs:
           retry_wait_seconds: 30
           max_attempts: 2
           command: cargo test
+      # Windows is where the members rot fastest: their tests assume POSIX paths and shells
+      # unless something runs them here.
+      - name: cargo test (workspace members)
+        run: cargo test --workspace --exclude mise
   windows-e2e:
     runs-on: windows-latest
     timeout-minutes: 40

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -2636,17 +2636,17 @@ packages:
 "#;
         let pkg = first_registry_package(yml);
 
-        for (os, arch) in [
-            ("linux", "amd64"),
-            ("darwin", "arm64"),
-            ("windows", "amd64"),
+        // What is under test is that the `envs: [all]` override supplied the URL on every
+        // platform. A raw-format URL additionally picks up the Windows executable extension,
+        // which `test_url_adds_exe_when_missing` covers on its own.
+        for (os, arch, expected) in [
+            ("linux", "amd64", "https://example.com/tool-all"),
+            ("darwin", "arm64", "https://example.com/tool-all"),
+            ("windows", "amd64", "https://example.com/tool-all.exe"),
         ] {
             let resolved = pkg.clone().with_version(&["1.0.0"], os, arch);
 
-            assert_eq!(
-                resolved.url("1.0.0", os, arch).unwrap(),
-                "https://example.com/tool-all"
-            );
+            assert_eq!(resolved.url("1.0.0", os, arch).unwrap(), expected);
         }
     }
 

--- a/crates/mise-cache-rustc/src/lib.rs
+++ b/crates/mise-cache-rustc/src/lib.rs
@@ -1323,8 +1323,15 @@ mod tests {
         );
         let second = invocation.action(second_context).unwrap();
 
+        // The descriptor is canonical JSON, so the value appears the way JSON writes it --
+        // on Windows that means escaped separators. Quote it with the same serializer instead
+        // of hand-rolling the escaping; that also pins the surrounding quotes, so this only
+        // matches a whole JSON string rather than any substring.
         let descriptor = String::from_utf8(first.bytes).unwrap();
-        assert!(descriptor.contains(&first_out_dir.display().to_string()));
+        let expected =
+            String::from_utf8(canonical_json(&first_out_dir.display().to_string()).unwrap())
+                .unwrap();
+        assert!(descriptor.contains(&expected), "{descriptor}");
         assert_ne!(first.digest, second.digest);
     }
 

--- a/crates/mise-interactive-config/build.rs
+++ b/crates/mise-interactive-config/build.rs
@@ -318,14 +318,18 @@ fn extract_settings_keys(
                 .and_then(|d| d.as_str())
                 .unwrap_or("");
 
-            // Check if this is a nested object with properties (like aqua, cargo, etc.)
+            // Check if this is a nested object with properties (like aqua, cargo, etc.).
+            //
+            // The presence of `properties` is what separates the two shapes the schema emits
+            // for `type: "object"`: a group of nested settings has them, while a map-valued
+            // setting such as `url_replacements` instead carries an object-valued
+            // `additionalProperties` and no `properties`. Do not key this on how the object is
+            // closed -- the schema has used `additionalProperties: false` and
+            // `unevaluatedProperties: false` at different times, and matching on one of them
+            // silently drops every nested setting.
             let is_nested_object = prop_value.get("type").and_then(|t| t.as_str())
                 == Some("object")
-                && prop_value.get("properties").is_some()
-                && prop_value
-                    .get("additionalProperties")
-                    .and_then(|a| a.as_bool())
-                    == Some(false);
+                && prop_value.get("properties").is_some();
 
             if is_nested_object {
                 // Recurse into nested settings

--- a/crates/mise-interactive-config/src/schema.rs
+++ b/crates/mise-interactive-config/src/schema.rs
@@ -161,8 +161,13 @@ mod tests {
         // Common settings should be valid
         assert!(is_valid_setting("experimental"));
         assert!(is_valid_setting("color"));
-        // Nested settings should use dot notation
+        // Nested settings should use dot notation. More than one group, and one nested two
+        // levels deep, so a partial extraction cannot pass this.
         assert!(is_valid_setting("aqua.baked_registry"));
+        assert!(is_valid_setting("python.compile"));
+        assert!(is_valid_setting("task.cache.remote_url"));
+        // A group is not a setting on its own
+        assert!(!is_valid_setting("aqua"));
         // Invalid settings
         assert!(!is_valid_setting("invalid_setting"));
     }
@@ -177,8 +182,9 @@ mod tests {
     fn test_setting_types() {
         // quiet is a boolean
         assert_eq!(setting_type("quiet"), Some(SchemaType::Boolean));
-        // jobs is a number
-        assert_eq!(setting_type("jobs"), Some(SchemaType::Number));
+        // jobs is an integer: the schema started distinguishing integers from numbers in
+        // jdx/mise#11037. Both land in the same arm where the editor consumes the type.
+        assert_eq!(setting_type("jobs"), Some(SchemaType::Integer));
     }
 
     #[test]

--- a/crates/vfox/plugins/dummy/hooks/post_install.lua
+++ b/crates/vfox/plugins/dummy/hooks/post_install.lua
@@ -1,21 +1,49 @@
+local file = require("file")
+
+local windows = package.config:sub(1, 1) == "\\"
+
+--- Single-quote `s` for a POSIX shell, including any apostrophe it contains.
+local function sh_quote(s)
+	return "'" .. s:gsub("'", "'\\''") .. "'"
+end
+
+--- Create the directory `path`, including any missing parents.
+--- Lua has no mkdir, so this shells out; cmd.exe has no `-p` and wants backslashes.
+--- The exit status is not a usable signal here -- this runs on Lua 5.1, where os.execute returns
+--- system()'s raw status, and cmd.exe's mkdir fails when the directory already exists -- so the
+--- result is checked against the filesystem instead.
+local function mkdirp(path)
+	if windows then
+		os.execute('mkdir "' .. path:gsub("/", "\\") .. '" 2>nul')
+	else
+		os.execute("mkdir -p " .. sh_quote(path))
+	end
+	if not file.exists(path) then
+		error("post_install: could not create " .. path)
+	end
+end
+
 function PLUGIN:PostInstall(ctx)
 	--- SDK installation root path
 	local rootPath = ctx.rootPath
 	local runtimeVersion = ctx.runtimeVersion
 
 	-- Create the installation directory structure for dummy plugin
-	os.execute("mkdir -p " .. rootPath .. "/bin")
-	local version_file = io.open(rootPath .. "/VERSION", "w")
-	if version_file then
-		version_file:write(runtimeVersion)
-		version_file:close()
-	end
+	mkdirp(rootPath .. "/bin")
+
+	local version_file = assert(io.open(rootPath .. "/VERSION", "w"))
+	assert(version_file:write(runtimeVersion))
+	assert(version_file:close())
 
 	-- Create a dummy executable
-	local dummy_file = io.open(rootPath .. "/bin/dummy", "w")
-	if dummy_file then
-		dummy_file:write("#!/bin/sh\necho 'dummy version 1.0.0'\n")
-		dummy_file:close()
-		os.execute("chmod +x " .. rootPath .. "/bin/dummy")
+	local dummy_path = rootPath .. "/bin/dummy"
+	local dummy_file = assert(io.open(dummy_path, "w"))
+	assert(dummy_file:write("#!/bin/sh\necho 'dummy version 1.0.0'\n"))
+	assert(dummy_file:close())
+	if not windows then
+		-- On Lua 5.1 os.execute returns system()'s status, so 0 is the success case.
+		if os.execute("chmod +x " .. sh_quote(dummy_path)) ~= 0 then
+			error("post_install: could not chmod " .. dummy_path)
+		end
 	end
 end

--- a/crates/vfox/src/hooks/post_install.rs
+++ b/crates/vfox/src/hooks/post_install.rs
@@ -41,12 +41,24 @@ mod tests {
 
     #[test]
     async fn dummy() {
+        // A temp dir, not a relative path: the dummy plugin's PostInstall writes a VERSION file
+        // and a bin/ directory under rootPath, which would otherwise land in the crate directory.
+        //
+        // The apostrophe is deliberate. PostInstall builds a shell command to create the
+        // directory, so a path like this is what breaks naive quoting.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("O'Brien");
         let p = Plugin::test("dummy");
         let ctx = PostInstallContext {
-            root_path: PathBuf::from("root_path"),
+            root_path: root.clone(),
             runtime_version: "runtime_version".to_string(),
             sdk_info: BTreeMap::new(),
         };
         p.post_install(ctx).await.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(root.join("VERSION")).unwrap(),
+            "runtime_version"
+        );
+        assert!(root.join("bin").join("dummy").exists());
     }
 }

--- a/crates/vfox/src/snapshots/vfox__vfox__tests__env_keys.snap
+++ b/crates/vfox/src/snapshots/vfox__vfox__tests__env_keys.snap
@@ -1,5 +1,0 @@
----
-source: crates/vfox/src/vfox.rs
-expression: output
----
-[EnvKey { key: "PATH", value: "<INSTALL_DIR>/dummy/1.0.0/bin" }]

--- a/crates/vfox/src/vfox.rs
+++ b/crates/vfox/src/vfox.rs
@@ -912,11 +912,18 @@ mod tests {
             )
             .await
             .unwrap();
-        let output = format!("{keys:?}").replace(
-            &vfox.install_dir.to_string_lossy().to_string(),
-            "<INSTALL_DIR>",
-        );
-        assert_snapshot!(output);
+        // Asserted rather than snapshotted: the dummy plugin reports the install dir itself on
+        // Windows and its `bin` subdirectory elsewhere (see test_env_keys_for_install_dir), and
+        // the separators differ too, so one snapshot cannot describe both.
+        let install_dir = vfox.install_dir.join("dummy").join("1.0.0");
+        let expected = if cfg!(windows) {
+            install_dir
+        } else {
+            install_dir.join("bin")
+        };
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].key, "PATH");
+        assert_eq!(keys[0].value, expected.to_string_lossy().into_owned());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Every `cargo test` in `.github/workflows/test.yml` is invoked from the workspace root, and with a
root package and no `default-members` that selects `mise` alone. The six member crates are built as
dependencies but their tests never run — so they rotted. Six fail against `main`:

| crate | on `main` |
| --- | --- |
| `aqua-registry` | 116 passed, **1 failed** |
| `vfox` | 108 passed, **2 failed**, 2 ignored |
| `mise-interactive-config` | 35 passed, **2 failed** |
| `mise-cache-rustc` | 22 passed, **1 failed** |
| `mise-sigstore` | 26 passed |
| `mise-cache-core` | 22 passed |

This fixes all six and puts the members on both gating unit jobs, so the fix proves itself rather
than resting on a local run.

## A real bug: nested settings were invisible to the interactive editor

`crates/mise-interactive-config/build.rs` decided whether a schema node was a group of nested
settings by looking for `additionalProperties: false`. The schema emits `unevaluatedProperties:
false` for those objects, so it stopped recursing and **every nested setting disappeared from
`SCHEMA_SETTINGS`** — the editor did not know `aqua.*`, `python.*`, `task.cache.*` or any of the
other 30 groups existed.

Keying on the presence of `properties` fixes it and does not depend on how the object is closed.
That is also the honest discriminator: a group has `properties`; a map-valued setting such as
`url_replacements` has an object-valued `additionalProperties` and no `properties`. Checked against
the current schema — 30 groups recurse, `url_replacements` stays a leaf, nothing carries both.

The generated table goes from **0 dotted entries to 147**, six of them two levels deep
(`task.cache.remote_url` and friends).

## Two stale expectations

- `setting_type("jobs")` — the schema started distinguishing integers from numbers in #11037, so
  this is `Integer` now. `Integer` and `Number` land in the same arm where the editor consumes the
  type (`editor/actions.rs`), so nothing behaves differently.
- `test_override_envs_all_matches_any_platform` asserted one URL for all three platforms it loops
  over, but the windows iteration goes through `complete_windows_ext_to_asset`, which appends
  `.exe` to a raw-format URL — exactly what `test_url_adds_exe_when_missing` already pins. The
  platform is an argument, not the host, so this failed everywhere. (Also open on its own as
  #11833; whichever lands first, the other rebases away.)

## Two POSIX assumptions

- `mise-cache-rustc` compared the descriptor against a raw path, but the descriptor is canonical
  JSON, where a Windows separator is escaped. The expected value is now built with the same
  serializer, which also pins the surrounding quotes — so it matches a whole JSON string instead of
  any substring.
- The dummy vfox plugin built its layout with `mkdir -p` and `chmod`. Neither does anything on
  Windows, and since a plugin with no download URL is the only thing that creates the install
  directory, `test_install` found nothing there. Its `env_keys` snapshot was Unix-only too, and the
  plugin deliberately reports the install dir itself on Windows rather than `bin` — one snapshot
  cannot describe both, so it is asserted the way its sibling `test_env_keys_for_install_dir`
  already does.

While fixing the plugin: `post_install.rs`'s `dummy` test passed a *relative* `rootPath`, so the
hook wrote `root_path/VERSION` and `root_path/bin/dummy` into the crate directory. On Windows that
used to fail silently; with the plugin fixed it would start littering. It gets a temp dir, and now
also checks what the hook wrote.

## CI

A separate step rather than `--workspace` on the existing line:

```yaml
- name: cargo test (workspace members)
  run: cargo test --workspace --exclude mise
```

Adding `--workspace` to `cargo test --all-features` would extend `--all-features` to members whose
features are mutually exclusive (`mise-cache-rustc` has `native-tls`, `rustls` and
`rustls-native-roots`). Default features, matching how these were verified.

It goes on both `unit` and `windows-unit`: two of these six failures were Windows-only, so Windows
is where the members rot fastest.

## Verified

The exact command CI will run, locally — it excludes the root package, so it does not need cmake:

```
cargo test --workspace --exclude mise
```

```
aqua-registry            117 passed
mise-cache-core           22 passed
mise-cache-rustc          23 passed
mise-interactive-config   37 passed
mise-shim                  0 tests
mise-sigstore             26 passed
vfox                     110 passed, 2 ignored
```

Plus `cargo fmt --all` and `cargo clippy -p <crate> --all-targets -- -D warnings` clean for each
touched crate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility for plugin installation, executable setup, PATH handling, and generated files.
  * Corrected environment value handling to preserve exact serialized inputs.
  * Improved recognition and validation of nested configuration settings.
  * Fixed platform-specific executable path and URL handling across macOS, Linux, and Windows.

* **Tests**
  * Expanded cross-platform coverage for workspace tests, nested settings, plugin installation, and environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->