### PR TITLE
fix(rust): reuse external rustup installations

### DIFF
--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -16,6 +16,11 @@ MISE_CARGO_HOME = "{{env.HOME}}/.local/share/cargo"
 
 Explicit `RUSTUP_HOME` and `CARGO_HOME` values in `[env]` take precedence over their corresponding `MISE_` variables.
 
+When the standard Rust homes have not been initialized and no home override is configured, mise can also reuse a
+package-manager installation of rustup. The original `PATH` must contain a directory with the `rustup`, `cargo`, and
+`rustc` proxies, as provided by package managers such as Homebrew, APT, and pacman. An explicit Rust or Cargo home
+continues to use mise's managed rustup initialization instead of an external proxy directory.
+
 Unlike most tools, these won't exist inside of `~/.local/share/mise/installs` because they are managed by rustup.
 mise keeps a symlink there for install tracking, sets the `RUSTUP_TOOLCHAIN` environment variable to the requested
 version, and asks rustup to install any configured components or targets when you run `mise install`.

--- a/e2e/core/test_rust_external_provider
+++ b/e2e/core/test_rust_external_provider
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+unset CARGO_HOME RUSTUP_HOME MISE_CARGO_HOME MISE_RUSTUP_HOME
+
+ROOT=$PWD
+ORIGINAL_PATH=$PATH
+
+write_proxy() {
+  local path=$1
+  cat >"$path" <<'PROXY'
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+PREFIX=${TEST_RUST_PROVIDER_PREFIX:-$(cd "$BIN_DIR/.." && pwd -P)}
+STATE="$PREFIX/state"
+mkdir -p "$STATE"
+
+	case "$(basename "$0")" in
+	rustup)
+		echo "$*" >>"$STATE/rustup.log"
+		case "${1:-} ${2:-}" in
+			"--version ")
+				echo "rustup 1.0.0 (external provider)"
+				;;
+			"toolchain install")
+				version=$3
+				mkdir -p "$STATE/toolchains/$version"
+				shift 3
+				while [[ $# -gt 0 ]]; do
+					case "$1" in
+						--component)
+							echo "$2-x86_64-unknown-linux-gnu" >>"$STATE/components"
+							shift 2
+							;;
+						--target)
+							echo "$2" >>"$STATE/targets"
+							shift 2
+							;;
+						--profile)
+							shift 2
+							;;
+						*)
+							shift
+							;;
+					esac
+				done
+				;;
+			"toolchain uninstall")
+				rm -rf "$STATE/toolchains/$3"
+				;;
+			"component list")
+				cat "$STATE/components" 2>/dev/null || true
+				;;
+			"target list")
+				cat "$STATE/targets" 2>/dev/null || true
+				;;
+			"check ")
+				;;
+			*)
+				echo "unexpected rustup args: $*" >&2
+				exit 1
+				;;
+		esac
+		;;
+	rustc)
+		if [[ ! -d "$STATE/toolchains/$RUSTUP_TOOLCHAIN" ]]; then
+			echo "error: toolchain '$RUSTUP_TOOLCHAIN' is not installed" >&2
+			exit 1
+		fi
+		echo "rustc $RUSTUP_TOOLCHAIN (external provider)"
+		;;
+	cargo)
+		if [[ ! -d "$STATE/toolchains/$RUSTUP_TOOLCHAIN" ]]; then
+			echo "error: toolchain '$RUSTUP_TOOLCHAIN' is not installed" >&2
+			exit 1
+		fi
+		echo "cargo $RUSTUP_TOOLCHAIN (external provider)"
+		;;
+	rustup-init)
+		echo invoked >>"$STATE/rustup-init.log"
+		exit 99
+		;;
+esac
+PROXY
+  chmod +x "$path"
+}
+
+run_case() {
+  local mode=$1
+  local version=$2
+  local case_root="$ROOT/$mode"
+  local prefix="$case_root/prefix"
+  local bin="$prefix/bin"
+  local home="$case_root/home"
+  local project="$case_root/project"
+  local shims="$case_root/data/shims"
+  local direct="$case_root/direct/bin"
+  local alternate="$case_root/alternate"
+  local alternate_bin="$alternate/bin"
+  local explicit="$case_root/explicit"
+  local explicit_cargo="$explicit/cargo"
+  local explicit_rustup="$explicit/rustup"
+  local explicit_bin="$explicit_cargo/bin"
+
+  mkdir -p "$bin" "$home" "$project" "$shims" "$direct" "$alternate_bin" "$explicit_bin" "$explicit_rustup"
+  for command in rustup cargo rustc; do
+    cat >"$shims/$command" <<'SHIM'
+#!/usr/bin/env bash
+echo "mise shim must not be selected as an external Rust provider" >&2
+exit 77
+SHIM
+    chmod +x "$shims/$command"
+  done
+  for command in rustup cargo rustc; do
+    cat >"$direct/$command" <<DIRECT
+#!/usr/bin/env bash
+echo "$command 1.0.0 (direct package binary)"
+DIRECT
+    chmod +x "$direct/$command"
+  done
+  if [[ $mode == current ]]; then
+    mkdir -p "$prefix/libexec/bin" "$prefix/etc/rustup"
+    echo 'default_toolchain = "stable"' >"$prefix/etc/rustup/settings.toml"
+    for command in rustup cargo rustc; do
+      write_proxy "$prefix/libexec/bin/$command"
+      cat >"$bin/$command" <<WRAPPER
+#!/usr/bin/env bash
+export RUSTUP_OVERRIDE_UNIX_FALLBACK_SETTINGS="$prefix/etc/rustup/settings.toml"
+export TEST_RUST_PROVIDER_PREFIX="$prefix"
+exec "$prefix/libexec/bin/$command" "\$@"
+WRAPPER
+      chmod +x "$bin/$command"
+    done
+  else
+    write_proxy "$bin/rustup-init"
+    ln -s rustup-init "$bin/rustup"
+    ln -s rustup-init "$bin/cargo"
+    ln -s rustup-init "$bin/rustc"
+  fi
+
+  cat >"$project/mise.toml" <<EOF
+[tools]
+rust = { version = "$version", components = ["rustfmt"], targets = ["wasm32-unknown-unknown"] }
+EOF
+
+  (
+    cd "$project"
+    export HOME="$home"
+    export PATH="$shims:$direct:$bin:$ORIGINAL_PATH"
+    export MISE_DATA_DIR="$case_root/data"
+    export MISE_CACHE_DIR="$case_root/cache"
+    export MISE_STATE_DIR="$case_root/state"
+    export MISE_OFFLINE=1
+
+    mise install
+    assert_contains "mise exec -- rustc -V" "rustc $version (external provider)"
+    assert_contains "mise exec -- cargo -V" "cargo $version (external provider)"
+    assert_contains "readlink '$case_root/data/installs/rust/$version'" "$bin"
+    assert_contains "grep -c '^toolchain install' '$prefix/state/rustup.log'" "1"
+
+    # Initializing the default Rust homes later must not take ownership away
+    # from the external provider recorded by the mise install symlink.
+    mkdir -p "$home/.cargo/bin" "$home/.rustup"
+    touch "$home/.cargo/bin/cargo" "$home/.rustup/settings.toml"
+    mise install
+    assert_contains "grep -c '^toolchain install' '$prefix/state/rustup.log'" "1"
+    assert_contains "mise exec -- sh -c 'command -v rustc'" "$bin/rustc"
+    assert_contains "mise exec -- rustc -V" "rustc $version (external provider)"
+
+    for command in rustup cargo rustc; do
+      write_proxy "$alternate_bin/$command"
+    done
+    export PATH="$alternate_bin:$PATH"
+
+    mise install
+    assert_contains "grep -c '^toolchain install' '$prefix/state/rustup.log'" "1"
+    assert "test ! -e '$alternate/state/toolchains/$version'"
+
+    # Explicit Rust homes take ownership consistently, including execution
+    # and uninstall after an earlier external-provider installation.
+    export PATH="$shims:$direct:$bin:$ORIGINAL_PATH"
+    for command in rustup cargo rustc; do
+      write_proxy "$explicit_bin/$command"
+    done
+    touch "$explicit_rustup/settings.toml"
+    cat >mise.toml <<EOF
+[env]
+CARGO_HOME = "$explicit_cargo"
+RUSTUP_HOME = "$explicit_rustup"
+
+[tools]
+rust = { version = "$version", components = ["rustfmt"], targets = ["wasm32-unknown-unknown"] }
+EOF
+
+    mise install
+    assert_contains "readlink '$case_root/data/installs/rust/$version'" "$explicit_bin"
+    assert_contains "grep -c '^toolchain install' '$explicit_cargo/state/rustup.log'" "1"
+    assert_contains "mise exec -- sh -c 'command -v rustc'" "$explicit_bin/rustc"
+    assert_contains "mise exec -- rustc -V" "rustc $version (external provider)"
+
+    mise uninstall --yes "rust@$version"
+    assert_contains "tail -1 '$explicit_cargo/state/rustup.log'" "toolchain uninstall $version"
+    assert "! grep -q '^toolchain uninstall' '$prefix/state/rustup.log'"
+    assert "test ! -f '$alternate/state/rustup.log' || ! grep -q '^toolchain uninstall' '$alternate/state/rustup.log'"
+  )
+
+  assert "test ! -e '$prefix/state/rustup-init.log'"
+}
+
+run_case current 1.80.0
+run_case legacy 1.81.0

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::{collections::BTreeMap, collections::BTreeSet, ffi::OsString, sync::Arc};
 
 use crate::backend::VersionInfo;
@@ -109,8 +110,12 @@ impl RustPlugin {
         &self,
         ctx: &InstallContext,
         tv: &ToolVersion,
-        homes: &RustHomes,
+        runtime: &RustRuntime,
     ) -> Result<()> {
+        if runtime.is_external() {
+            return Ok(());
+        }
+        let homes = &runtime.homes;
         let settings = Settings::get();
         if rustup_is_initialized(homes) {
             return Ok(());
@@ -153,15 +158,15 @@ impl RustPlugin {
         &self,
         ctx: &InstallContext,
         tv: &ToolVersion,
-        homes: &RustHomes,
+        runtime: &RustRuntime,
     ) -> Result<()> {
         ctx.pr.set_message(format!("{RUSTC_BIN} -V"));
-        CmdLineRunner::new(RUSTC_BIN)
+        CmdLineRunner::new(runtime.bin_dir.join(RUSTC_BIN))
             .with_pr(ctx.pr.as_ref())
             .arg("-V")
             .env_values(tv.install_env())
-            .envs(rustup_env(homes, &tv.version))
-            .prepend_path(vec![homes.cargo_bindir()])?
+            .envs(rustup_env(&runtime.homes, &tv.version))
+            .prepend_path(vec![runtime.bin_dir.clone()])?
             .execute()
     }
 
@@ -173,7 +178,7 @@ impl RustPlugin {
         &self,
         tv: &ToolVersion,
         subcommand: &str,
-        homes: &RustHomes,
+        runtime: &RustRuntime,
     ) -> Result<Option<BTreeSet<String>>> {
         let args = vec![
             subcommand.to_string(),
@@ -182,12 +187,12 @@ impl RustPlugin {
             "--toolchain".to_string(),
             tv.version.clone(),
         ];
-        let mut cmd = cmd(RUSTUP_BIN, args)
-            .env("PATH", rustup_path_env(homes)?)
+        let mut cmd = cmd(runtime.bin_dir.join(RUSTUP_BIN), args)
+            .env("PATH", rustup_path_env(runtime)?)
             .stdout_capture()
             .stderr_capture()
             .unchecked();
-        for (key, value) in rustup_env(homes, &tv.version) {
+        for (key, value) in rustup_env(&runtime.homes, &tv.version) {
             cmd = cmd.env(key, value);
         }
         let output = match cmd.run() {
@@ -264,10 +269,10 @@ impl Backend for RustPlugin {
             return Ok(false);
         }
 
-        let homes = RustHomes::resolve(config).await?;
-        if !file::is_symlink_to(&tv.install_path(), &homes.cargo_bindir()) {
+        let runtime = RustRuntime::resolve_for_tool_version(config, tv).await?;
+        if !file::is_symlink_to(&tv.install_path(), &runtime.bin_dir) {
             debug!(
-                "{} points outside the configured Cargo home",
+                "{} points outside the selected Rust proxy directory",
                 tv.install_path().display()
             );
             return Ok(false);
@@ -279,7 +284,7 @@ impl Backend for RustPlugin {
         if let Some(components) = components
             && !components.is_empty()
         {
-            let Some(installed) = self.rustup_installed_items(tv, "component", &homes)? else {
+            let Some(installed) = self.rustup_installed_items(tv, "component", &runtime)? else {
                 return Ok(false);
             };
             let missing = self.missing_components(&components, &installed);
@@ -296,7 +301,7 @@ impl Backend for RustPlugin {
         if let Some(targets) = targets
             && !targets.is_empty()
         {
-            let Some(installed) = self.rustup_installed_items(tv, "target", &homes)? else {
+            let Some(installed) = self.rustup_installed_items(tv, "target", &runtime)? else {
                 return Ok(false);
             };
             let missing = self.missing_targets(&targets, &installed);
@@ -383,32 +388,32 @@ impl Backend for RustPlugin {
     }
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
-        let homes = RustHomes::resolve(&ctx.config).await?;
-        let _state_locks = lock_rust_state(&homes).await?;
-        self.setup_rustup(ctx, &tv, &homes).await?;
+        let runtime = RustRuntime::resolve_for_tool_version(&ctx.config, &tv).await?;
+        let _state_locks = lock_rust_state(&runtime.homes).await?;
+        self.setup_rustup(ctx, &tv, &runtime).await?;
 
         let raw_opts = tv.request.options();
         let (profile, components, targets) = RustOptions::new(&raw_opts).install_args();
 
-        let mut cmd = CmdLineRunner::new(RUSTUP_BIN)
+        let mut cmd = CmdLineRunner::new(runtime.bin_dir.join(RUSTUP_BIN))
             .with_pr(ctx.pr.as_ref())
             .arg("toolchain")
             .arg("install")
             .arg(&tv.version)
             .opt_args("--component", components)
             .opt_args("--target", targets)
-            .prepend_path(vec![homes.cargo_bindir()])?
+            .prepend_path(vec![runtime.bin_dir.clone()])?
             .env_values(tv.install_env())
-            .envs(rustup_env(&homes, &tv.version));
+            .envs(rustup_env(&runtime.homes, &tv.version));
         if let Some(profile) = profile.as_ref() {
             cmd = cmd.arg("--profile").arg(profile);
         }
         cmd.execute()?;
 
         file::remove_all(tv.install_path())?;
-        file::make_symlink(&homes.cargo_bindir(), &tv.install_path())?;
+        file::make_symlink(&runtime.bin_dir, &tv.install_path())?;
 
-        self.test_rust(ctx, &tv, &homes).await?;
+        self.test_rust(ctx, &tv, &runtime).await?;
 
         Ok(tv)
     }
@@ -419,25 +424,25 @@ impl Backend for RustPlugin {
         pr: &dyn SingleReport,
         tv: &ToolVersion,
     ) -> Result<()> {
-        let homes = RustHomes::resolve(config).await?;
-        let mut env = rustup_env(&homes, &tv.version);
+        let runtime = RustRuntime::resolve_recorded_for_tool_version(config, tv).await?;
+        let mut env = rustup_env(&runtime.homes, &tv.version);
         env.remove("RUSTUP_TOOLCHAIN");
-        CmdLineRunner::new(RUSTUP_BIN)
+        CmdLineRunner::new(runtime.bin_dir.join(RUSTUP_BIN))
             .with_pr(pr)
             .arg("toolchain")
             .arg("uninstall")
             .arg(&tv.version)
-            .prepend_path(vec![homes.cargo_bindir()])?
+            .prepend_path(vec![runtime.bin_dir])?
             .envs(env)
             .execute()
     }
 
-    async fn list_bin_paths(
-        &self,
-        config: &Arc<Config>,
-        _tv: &ToolVersion,
-    ) -> Result<Vec<PathBuf>> {
-        Ok(vec![RustHomes::resolve(config).await?.cargo_bindir()])
+    async fn list_bin_paths(&self, config: &Arc<Config>, tv: &ToolVersion) -> Result<Vec<PathBuf>> {
+        Ok(vec![
+            RustRuntime::resolve_recorded_for_tool_version(config, tv)
+                .await?
+                .bin_dir,
+        ])
     }
 
     async fn exec_env(
@@ -462,8 +467,9 @@ impl Backend for RustPlugin {
             Ok(oi)
         } else {
             let ts = config.get_toolset().await?;
-            let mut cmd =
-                cmd!(RUSTUP_BIN, "check").env("PATH", self.path_env_for_cmd(config, tv).await?);
+            let runtime = RustRuntime::resolve_recorded_for_tool_version(config, tv).await?;
+            let mut cmd = cmd(runtime.bin_dir.join(RUSTUP_BIN), ["check"])
+                .env("PATH", self.path_env_for_cmd(config, tv).await?);
             for (k, v) in self.exec_env(config, ts, tv).await? {
                 cmd = cmd.env(k, v);
             }
@@ -645,6 +651,7 @@ async fn lock_rust_state(homes: &RustHomes) -> Result<Vec<fslock::LockFile>> {
 struct RustHomes {
     cargo: PathBuf,
     rustup: PathBuf,
+    explicit: bool,
 }
 
 impl RustHomes {
@@ -667,6 +674,14 @@ impl RustHomes {
         configured_rustup: Option<PathBuf>,
         ambient_rustup: Option<PathBuf>,
     ) -> Self {
+        let cargo_explicit = config_env.contains_key("CARGO_HOME")
+            || config_env.contains_key("MISE_CARGO_HOME")
+            || configured_cargo.is_some()
+            || ambient_cargo.is_some();
+        let rustup_explicit = config_env.contains_key("RUSTUP_HOME")
+            || config_env.contains_key("MISE_RUSTUP_HOME")
+            || configured_rustup.is_some()
+            || ambient_rustup.is_some();
         Self {
             cargo: select_rust_home(
                 config_env,
@@ -684,6 +699,7 @@ impl RustHomes {
                 ambient_rustup,
                 dirs::HOME.join(".rustup"),
             ),
+            explicit: cargo_explicit || rustup_explicit,
         }
     }
 
@@ -694,6 +710,157 @@ impl RustHomes {
     fn cargo_bin(&self) -> PathBuf {
         self.cargo_bindir().join(CARGO_BIN)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RustProvider {
+    Managed,
+    External,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RustRuntime {
+    homes: RustHomes,
+    bin_dir: PathBuf,
+    provider: RustProvider,
+}
+
+impl RustRuntime {
+    async fn resolve_for_tool_version(config: &Arc<Config>, tv: &ToolVersion) -> Result<Self> {
+        let homes = RustHomes::resolve(config).await?;
+        Ok(Self::from_paths_with_install(
+            homes,
+            &env::PATH,
+            &tv.install_path(),
+            rustup_proxy_dir_is_usable,
+        ))
+    }
+
+    async fn resolve_recorded_for_tool_version(
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+    ) -> Result<Self> {
+        let homes = RustHomes::resolve(config).await?;
+        Ok(Self::from_paths_with_install(
+            homes,
+            &env::PATH,
+            &tv.install_path(),
+            rustup_proxy_dir_is_usable,
+        ))
+    }
+
+    fn from_paths_with(
+        homes: RustHomes,
+        paths: &[PathBuf],
+        provider_is_usable: impl Fn(&Path) -> bool,
+    ) -> Self {
+        if !rustup_is_initialized(&homes)
+            && !homes.explicit
+            && let Some(bin_dir) = external_rustup_bin_dir(paths, provider_is_usable)
+        {
+            debug!(
+                "using external rustup proxies from {}",
+                file::display_path(&bin_dir)
+            );
+            return Self {
+                homes,
+                bin_dir,
+                provider: RustProvider::External,
+            };
+        }
+        let bin_dir = homes.cargo_bindir();
+        Self {
+            homes,
+            bin_dir,
+            provider: RustProvider::Managed,
+        }
+    }
+
+    fn from_paths_with_install(
+        homes: RustHomes,
+        paths: &[PathBuf],
+        install_path: &Path,
+        provider_is_usable: impl Fn(&Path) -> bool,
+    ) -> Self {
+        if !homes.explicit
+            && let Some(bin_dir) =
+                recorded_external_rustup_bin_dir(&homes, install_path, &provider_is_usable)
+        {
+            debug!(
+                "using recorded external rustup proxies from {}",
+                file::display_path(&bin_dir)
+            );
+            return Self {
+                homes,
+                bin_dir,
+                provider: RustProvider::External,
+            };
+        }
+        Self::from_paths_with(homes, paths, provider_is_usable)
+    }
+
+    fn is_external(&self) -> bool {
+        self.provider == RustProvider::External
+    }
+}
+
+fn recorded_external_rustup_bin_dir(
+    homes: &RustHomes,
+    install_path: &Path,
+    provider_is_usable: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    file::resolve_symlink(install_path)
+        .ok()
+        .flatten()
+        .map(|target| {
+            if target.is_absolute() {
+                target
+            } else {
+                install_path.parent().unwrap_or(Path::new(".")).join(target)
+            }
+        })
+        .filter(|target| target != &homes.cargo_bindir())
+        .filter(|target| provider_is_usable(target))
+}
+
+fn external_rustup_bin_dir(
+    paths: &[PathBuf],
+    provider_is_usable: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    paths
+        .iter()
+        .filter(|path| !file::is_mise_shims_dir(path))
+        .find(|path| {
+            [RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]
+                .iter()
+                .all(|bin| file::is_executable(&path.join(bin)))
+                && provider_is_usable(path)
+        })
+        .cloned()
+}
+
+fn rustup_proxy_dir_is_usable(bin_dir: &Path) -> bool {
+    if !Command::new(bin_dir.join(RUSTUP_BIN))
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+    {
+        return false;
+    }
+
+    const PROBE_TOOLCHAIN: &str = "mise-proxy-probe:invalid";
+    [CARGO_BIN, RUSTC_BIN].iter().all(|bin| {
+        Command::new(bin_dir.join(bin))
+            .arg("--version")
+            .env("RUSTUP_TOOLCHAIN", PROBE_TOOLCHAIN)
+            .env("RUSTUP_AUTO_INSTALL", "0")
+            .output()
+            .is_ok_and(|output| {
+                !output.status.success()
+                    && (String::from_utf8_lossy(&output.stdout).contains(PROBE_TOOLCHAIN)
+                        || String::from_utf8_lossy(&output.stderr).contains(PROBE_TOOLCHAIN))
+            })
+    })
 }
 
 fn rustup_is_initialized(homes: &RustHomes) -> bool {
@@ -744,9 +911,9 @@ fn rustup_env(homes: &RustHomes, toolchain: &str) -> BTreeMap<String, String> {
     .into()
 }
 
-fn rustup_path_env(homes: &RustHomes) -> Result<OsString> {
+fn rustup_path_env(runtime: &RustRuntime) -> Result<OsString> {
     Ok(env::join_paths(
-        std::iter::once(homes.cargo_bindir()).chain(env::PATH.clone()),
+        std::iter::once(runtime.bin_dir.clone()).chain(env::PATH.clone()),
     )?)
 }
 
@@ -818,6 +985,23 @@ const RUST_TARGET_ARCHES: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rust_homes_at(root: &Path, explicit: bool) -> RustHomes {
+        RustHomes {
+            cargo: root.join("cargo"),
+            rustup: root.join("rustup"),
+            explicit,
+        }
+    }
+
+    fn create_proxy_dir(path: &Path, bins: &[&str]) {
+        std::fs::create_dir_all(path).unwrap();
+        for bin in bins {
+            let path = path.join(bin);
+            std::fs::write(&path, b"proxy").unwrap();
+            file::make_executable(path).unwrap();
+        }
+    }
 
     fn opts_with(key: &str, value: &str) -> ToolVersionOptions {
         let mut opts = ToolVersionOptions::default();
@@ -1050,6 +1234,7 @@ targets = ["wasm32-wasip1", " wasm32-wasip1 "]
 
         assert_eq!(homes.cargo, dirs::HOME.join(".cargo"));
         assert_eq!(homes.rustup, dirs::HOME.join(".rustup"));
+        assert!(!homes.explicit);
     }
 
     #[test]
@@ -1083,6 +1268,7 @@ targets = ["wasm32-wasip1", " wasm32-wasip1 "]
             homes.rustup,
             resolve_rust_home(PathBuf::from("/config/rustup"))
         );
+        assert!(homes.explicit);
     }
 
     #[test]
@@ -1108,5 +1294,131 @@ targets = ["wasm32-wasip1", " wasm32-wasip1 "]
             homes.rustup,
             resolve_rust_home(PathBuf::from("/settings/rustup"))
         );
+        assert!(homes.explicit);
+    }
+
+    #[test]
+    fn rust_runtime_prefers_initialized_homes() {
+        let root = tempfile::tempdir().unwrap();
+        let homes = rust_homes_at(root.path(), false);
+        create_proxy_dir(&homes.cargo_bindir(), &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+        std::fs::create_dir_all(&homes.rustup).unwrap();
+        std::fs::write(homes.rustup.join("settings.toml"), b"").unwrap();
+        let external = root.path().join("external/bin");
+        create_proxy_dir(&external, &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+
+        let runtime = RustRuntime::from_paths_with(homes.clone(), &[external], |_| true);
+
+        assert_eq!(runtime.provider, RustProvider::Managed);
+        assert_eq!(runtime.bin_dir, homes.cargo_bindir());
+    }
+
+    #[test]
+    fn rust_runtime_uses_complete_external_provider() {
+        let root = tempfile::tempdir().unwrap();
+        let homes = rust_homes_at(root.path(), false);
+        let external = root.path().join("external/bin");
+        create_proxy_dir(&external, &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+
+        let runtime =
+            RustRuntime::from_paths_with(homes, std::slice::from_ref(&external), |_| true);
+
+        assert_eq!(runtime.provider, RustProvider::External);
+        assert_eq!(runtime.bin_dir, external);
+    }
+
+    #[test]
+    fn rust_runtime_prefers_recorded_external_provider() {
+        let root = tempfile::tempdir().unwrap();
+        let homes = rust_homes_at(root.path(), false);
+        let recorded = root.path().join("recorded/bin");
+        let earlier_on_path = root.path().join("earlier/bin");
+        create_proxy_dir(&recorded, &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+        create_proxy_dir(&earlier_on_path, &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+        let install_path = root.path().join("installs/rust/1.80.0");
+        std::fs::create_dir_all(install_path.parent().unwrap()).unwrap();
+        file::make_symlink(&recorded, &install_path).unwrap();
+
+        let runtime =
+            RustRuntime::from_paths_with_install(homes, &[earlier_on_path], &install_path, |_| {
+                true
+            });
+
+        assert_eq!(runtime.provider, RustProvider::External);
+        assert_eq!(runtime.bin_dir, recorded);
+    }
+
+    #[test]
+    fn rust_runtime_keeps_recorded_external_provider_after_default_home_initialization() {
+        let root = tempfile::tempdir().unwrap();
+        let homes = rust_homes_at(root.path(), false);
+        create_proxy_dir(&homes.cargo_bindir(), &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+        std::fs::create_dir_all(&homes.rustup).unwrap();
+        std::fs::write(homes.rustup.join("settings.toml"), b"").unwrap();
+        let recorded = root.path().join("recorded/bin");
+        create_proxy_dir(&recorded, &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+        let install_path = root.path().join("installs/rust/1.80.0");
+        std::fs::create_dir_all(install_path.parent().unwrap()).unwrap();
+        file::make_symlink(&recorded, &install_path).unwrap();
+
+        let runtime = RustRuntime::from_paths_with_install(
+            homes,
+            std::slice::from_ref(&recorded),
+            &install_path,
+            |_| true,
+        );
+
+        assert_eq!(runtime.provider, RustProvider::External);
+        assert_eq!(runtime.bin_dir, recorded);
+    }
+
+    #[test]
+    fn rust_runtime_explicit_homes_override_recorded_external_provider() {
+        let root = tempfile::tempdir().unwrap();
+        let homes = rust_homes_at(root.path(), true);
+        create_proxy_dir(&homes.cargo_bindir(), &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+        std::fs::create_dir_all(&homes.rustup).unwrap();
+        std::fs::write(homes.rustup.join("settings.toml"), b"").unwrap();
+        let recorded = root.path().join("recorded/bin");
+        create_proxy_dir(&recorded, &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+        let install_path = root.path().join("installs/rust/1.80.0");
+        std::fs::create_dir_all(install_path.parent().unwrap()).unwrap();
+        file::make_symlink(&recorded, &install_path).unwrap();
+
+        let runtime = RustRuntime::from_paths_with_install(
+            homes.clone(),
+            std::slice::from_ref(&recorded),
+            &install_path,
+            |_| true,
+        );
+
+        assert_eq!(runtime.provider, RustProvider::Managed);
+        assert_eq!(runtime.bin_dir, homes.cargo_bindir());
+    }
+
+    #[test]
+    fn rust_runtime_rejects_incomplete_external_provider() {
+        let root = tempfile::tempdir().unwrap();
+        let homes = rust_homes_at(root.path(), false);
+        let external = root.path().join("external/bin");
+        create_proxy_dir(&external, &[RUSTUP_BIN, CARGO_BIN]);
+
+        let runtime = RustRuntime::from_paths_with(homes.clone(), &[external], |_| true);
+
+        assert_eq!(runtime.provider, RustProvider::Managed);
+        assert_eq!(runtime.bin_dir, homes.cargo_bindir());
+    }
+
+    #[test]
+    fn rust_runtime_does_not_replace_explicit_homes() {
+        let root = tempfile::tempdir().unwrap();
+        let homes = rust_homes_at(root.path(), true);
+        let external = root.path().join("external/bin");
+        create_proxy_dir(&external, &[RUSTUP_BIN, CARGO_BIN, RUSTC_BIN]);
+
+        let runtime = RustRuntime::from_paths_with(homes.clone(), &[external], |_| true);
+
+        assert_eq!(runtime.provider, RustProvider::Managed);
+        assert_eq!(runtime.bin_dir, homes.cargo_bindir());
     }
 }


### PR DESCRIPTION
## Summary

- reuse complete external Rustup proxy directories when the default Rust homes are not initialized
- keep initialized or explicitly configured Cargo and Rustup homes on the existing mise-managed path
- use the selected proxy provider consistently for install, validation, component and target checks, execution, outdated checks, and uninstall

## Root cause

The Rust backend treated `RUSTUP_HOME/settings.toml` plus `CARGO_HOME/bin` as the only reusable Rustup layout. Package managers such as Homebrew install `rustup`, `cargo`, and `rustc` proxies in their own bin directory, so mise downloaded and initialized another Rustup installation even when a complete external provider was already available.

The new provider selection is capability based rather than Homebrew specific. It checks the original PATH, excludes mise shim directories, and accepts a directory only when `rustup` is runnable and both `cargo` and `rustc` demonstrate Rustup proxy behavior for a selected toolchain. This prevents an unrelated package-manager `rustup` plus direct `cargo`/`rustc` binaries from being combined as a provider. Explicit Rust home settings continue to opt into the managed initialization path.

Wrappers and symlinks are retained as selected instead of being canonicalized, preserving package-manager environment setup. This supports both the current Homebrew wrapper layout and the older proxy plus `rustup-init` layout without changing package-manager-owned files.

## Verification

- `mise exec -- cargo test --all-features plugins::core::rust::tests`
- `mise run test:e2e e2e/core/test_rust_external_provider` (current and legacy proxy layouts, mise shim exclusion, and direct non-proxy binary rejection)
- `mise run test:e2e e2e/core/test_rust_components_reconcile e2e/core/test_rust_config_env_homes e2e/core/test_rust_parallel_install`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d e2e/core/test_rust_external_provider`
- `mise exec -- shellcheck e2e/core/test_rust_external_provider`
- macOS arm64: poured the real `brew:rustup` 1.29.0_2 bottle into a disposable `/tmp` prefix via `MISE_SYSTEM_BREW_PREFIX`; installed Rust 1.85.0 without creating a managed Cargo proxy, verified `rustc 1.85.0` and `cargo 1.85.0`, confirmed the mise install symlink targeted the external wrapper directory, and uninstalled the toolchain successfully
- Linux validation is delegated to this Draft PR's GitHub Actions because compiling the full workspace in local Docker emulation exceeded the available workstation resources

`mise run format` and `mise run lint` could not use the repository hk wrapper because it reports `failed to find git repository` in this Sapling working copy; the relevant Rustfmt, shfmt, ShellCheck, Cargo check, and Clippy commands above pass individually.

Addresses https://github.com/jdx/mise/discussions/8006

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rust installations can reuse compatible system-provided rustup and Cargo tools when no explicit Rust home is configured.
  * External Rust toolchains support component and target management, reuse, validation, and removal.
  * Explicit Rust or Cargo home settings continue using mise-managed Rust tooling.

* **Documentation**
  * Clarified supported external rustup layouts, required tools, and configuration behavior.

* **Tests**
  * Added coverage for current and legacy external-provider setups, offline operation, and command resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->