### PR TITLE
fix(hook-env): preserve path order with duplicates

### DIFF
--- a/e2e/env/test_path_duplicate_original
+++ b/e2e/env/test_path_duplicate_original
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Regression test for https://github.com/jdx/mise/discussions/8028.
+# A path prepended after activation can duplicate an entry captured in
+# __MISE_ORIG_PATH. That duplicate must not move the neighboring prepends, and
+# repeated hook-env runs must leave the reconstructed PATH unchanged.
+
+MISE_BIN=$(command -v mise)
+
+mkdir -p homebrew/bin homebrew/sbin custom-a custom-b managed
+cat >mise.toml <<EOF
+[env]
+_.path = ["$PWD/managed"]
+EOF
+
+MANAGED_PATH="$PWD/managed"
+BREW_BIN="$PWD/homebrew/bin"
+BREW_SBIN="$PWD/homebrew/sbin"
+CUSTOM_A="$PWD/custom-a"
+CUSTOM_B="$PWD/custom-b"
+
+export __MISE_ORIG_PATH="$BREW_BIN:$BREW_SBIN:/usr/bin:/bin"
+export PATH="$CUSTOM_B:$BREW_SBIN:$CUSTOM_A:$BREW_BIN:$BREW_SBIN:/usr/bin:/bin"
+
+eval "$("$MISE_BIN" hook-env -s bash)"
+
+EXPECTED="$CUSTOM_B:$BREW_SBIN:$CUSTOM_A:$MANAGED_PATH:$BREW_BIN:$BREW_SBIN:/usr/bin:/bin"
+assert "printf '%s\n' \"\$PATH\"" "$EXPECTED"
+
+FIRST_PATH=$PATH
+eval "$("$MISE_BIN" hook-env -s bash)"
+assert "printf '%s\n' \"\$PATH\"" "$FIRST_PATH"

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -13,9 +13,9 @@ use console::truncate_str;
 use eyre::Result;
 use indexmap::IndexSet;
 use itertools::Itertools;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{borrow::Cow, sync::Arc};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -291,65 +291,12 @@ impl HookEnv {
         let (pre, post, post_user) = match &*env::__MISE_ORIG_PATH {
             Some(orig_path) if !Settings::get().activate_aggressive => {
                 let orig_paths: Vec<PathBuf> = split_paths(orig_path).collect();
-                let orig_set: HashSet<_> = orig_paths.iter().collect();
-
-                // Get all mise-managed paths from the previous session
-                // to_remove contains ALL paths that mise added (tool installs, config paths, etc.)
-                let mise_paths_set: HashSet<_> = to_remove.iter().collect();
-
-                // Find paths in current that are not in original and not mise-managed.
-                // Split them into "pre" (before the original PATH entries) and "post_user"
-                // (after the original PATH entries) to preserve their intended position.
-                // This prevents paths appended after `mise activate` in shell rc from
-                // being moved to the front of PATH.
-                //
-                // Also collect orig paths in their current order to preserve any
-                // reordering done after activation (e.g., by ~/.zlogin which runs
-                // after ~/.zshrc where mise activate is typically placed).
-                let mut pre = Vec::new();
-                let mut post_user = Vec::new();
-                let mut orig_reordered = Vec::new();
-                let mut seen_orig = false;
-                let mut seen_in_current: HashSet<&PathBuf> = HashSet::new();
+                let mise_paths_set: HashSet<_> = to_remove.iter().map(PathBuf::as_path).collect();
                 let mise_install_dirs = crate::path_env::mise_install_dirs();
-                for path in &current_paths {
-                    if orig_set.contains(path) {
-                        seen_orig = true;
-                        orig_reordered.push(path.clone());
-                        seen_in_current.insert(path);
-                        continue;
-                    }
-
-                    // Skip if it's a mise-managed path from previous session
-                    if mise_paths_set.contains(path) {
-                        continue;
-                    }
-
-                    // Paths under mise's installs dir are mise-managed even if
-                    // the previous session diff did not claim them. Preserving a
-                    // stale install path as a user prefix can shadow the active
-                    // version selected by the current toolset.
-                    if crate::path_env::is_mise_install_path(path, &mise_install_dirs) {
-                        continue;
-                    }
-
-                    // Place in pre or post_user based on position relative to original PATH
-                    if seen_orig {
-                        post_user.push(path.clone());
-                    } else {
-                        pre.push(path.clone());
-                    }
-                }
-
-                // Append any orig paths that are no longer in current PATH
-                // (to avoid losing paths that may have been temporarily removed)
-                for path in &orig_paths {
-                    if !seen_in_current.contains(path) {
-                        orig_reordered.push(path.clone());
-                    }
-                }
-
-                (pre, orig_reordered, post_user)
+                partition_path_entries(&current_paths, &orig_paths, |path| {
+                    mise_paths_set.contains(path)
+                        || crate::path_env::is_mise_install_path(path, &mise_install_dirs)
+                })
             }
             _ => (vec![], current_paths, vec![]),
         };
@@ -547,6 +494,60 @@ impl HookEnv {
     }
 }
 
+/// Partition PATH entries into user prepends, captured originals, and user appends.
+///
+/// The rightmost available occurrence of each captured original establishes the
+/// start of the original PATH block. Entries before that boundary are user
+/// prepends; original-valued entries at or after it remain in the original block;
+/// and other entries after it are user appends. This makes the assembled result a
+/// fixed point while preserving duplicate entries the user added or retained.
+/// Missing captured occurrences are not restored. Mise-managed entries are only
+/// retained when they belong to the original block.
+fn partition_path_entries(
+    current_paths: &[PathBuf],
+    orig_paths: &[PathBuf],
+    is_mise_managed: impl Fn(&Path) -> bool,
+) -> (Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>) {
+    let mut remaining: HashMap<&Path, usize> = HashMap::new();
+    for path in orig_paths {
+        *remaining.entry(path.as_path()).or_default() += 1;
+    }
+
+    // Prefer later occurrences as the captured originals. A duplicate prepended
+    // after activation therefore remains a user prepend, while the later copy
+    // anchors the original block. Original entries may be reordered, so this is
+    // deliberately occurrence-counted rather than an ordered subsequence match.
+    let mut first_original = None;
+    for (idx, path) in current_paths.iter().enumerate().rev() {
+        if let Some(count) = remaining.get_mut(path.as_path())
+            && *count > 0
+        {
+            *count -= 1;
+            first_original = Some(idx);
+        }
+    }
+
+    let original_values: HashSet<&Path> = orig_paths.iter().map(PathBuf::as_path).collect();
+    let mut pre = Vec::new();
+    let mut post = Vec::new();
+    let mut post_user = Vec::new();
+    for (idx, path) in current_paths.iter().enumerate() {
+        if first_original.is_some_and(|first| idx >= first)
+            && original_values.contains(path.as_path())
+        {
+            post.push(path.clone());
+        } else if is_mise_managed(path) {
+            continue;
+        } else if first_original.is_some_and(|first| idx > first) {
+            post_user.push(path.clone());
+        } else {
+            pre.push(path.clone());
+        }
+    }
+
+    (pre, post, post_user)
+}
+
 fn patch_to_status(patch: EnvDiffOperation) -> String {
     match patch {
         EnvDiffOperation::Add(k, _) => format!("+{k}"),
@@ -560,5 +561,214 @@ fn format_status(status: &str) -> Cow<'_, str> {
         truncate_str(status, TERM_WIDTH.max(60) - 5, "…")
     } else {
         status.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(values: &[&str]) -> Vec<PathBuf> {
+        values.iter().map(PathBuf::from).collect()
+    }
+
+    fn partition(
+        current: &[&str],
+        original: &[&str],
+    ) -> (Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>) {
+        partition_path_entries(&paths(current), &paths(original), |_| false)
+    }
+
+    fn assemble_partition(partition: &(Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>)) -> Vec<PathBuf> {
+        partition
+            .0
+            .iter()
+            .chain(&partition.1)
+            .chain(&partition.2)
+            .cloned()
+            .collect()
+    }
+
+    fn sequences(alphabet: &[&str], max_len: usize) -> Vec<Vec<PathBuf>> {
+        fn extend(
+            sequences: &mut Vec<Vec<PathBuf>>,
+            current: &mut Vec<PathBuf>,
+            alphabet: &[&str],
+            remaining: usize,
+        ) {
+            sequences.push(current.clone());
+            if remaining == 0 {
+                return;
+            }
+            for value in alphabet {
+                current.push(PathBuf::from(value));
+                extend(sequences, current, alphabet, remaining - 1);
+                current.pop();
+            }
+        }
+
+        let mut sequences = Vec::new();
+        extend(&mut sequences, &mut Vec::new(), alphabet, max_len);
+        sequences
+    }
+
+    #[test]
+    fn path_partition_preserves_prepended_original_duplicate() {
+        let current = paths(&["B", "original", "A", "managed", "original", "system"]);
+        let captured = paths(&["original", "system"]);
+        let (pre, original, post_user) =
+            partition_path_entries(&current, &captured, |path| path == Path::new("managed"));
+
+        assert_eq!(pre, paths(&["B", "original", "A"]));
+        assert_eq!(original, paths(&["original", "system"]));
+        assert!(post_user.is_empty());
+    }
+
+    #[test]
+    fn path_partition_keeps_duplicate_free_order() {
+        let (pre, original, post_user) =
+            partition(&["B", "A", "original", "system"], &["original", "system"]);
+
+        assert_eq!(pre, paths(&["B", "A"]));
+        assert_eq!(original, paths(&["original", "system"]));
+        assert!(post_user.is_empty());
+    }
+
+    #[test]
+    fn path_partition_preserves_original_duplicates() {
+        let (pre, original, post_user) = partition(
+            &["B", "original", "original", "system"],
+            &["original", "original", "system"],
+        );
+
+        assert_eq!(pre, paths(&["B"]));
+        assert_eq!(original, paths(&["original", "original", "system"]));
+        assert!(post_user.is_empty());
+    }
+
+    #[test]
+    fn path_partition_preserves_appended_original_duplicate() {
+        let (pre, original, post_user) = partition(
+            &["original", "system", "original", "appended"],
+            &["original", "system"],
+        );
+
+        assert_eq!(pre, paths(&["original"]));
+        assert_eq!(original, paths(&["system", "original"]));
+        assert_eq!(post_user, paths(&["appended"]));
+    }
+
+    #[test]
+    fn path_partition_preserves_reordered_original_entries() {
+        let (pre, original, post_user) = partition(
+            &["system", "original", "other"],
+            &["original", "other", "system"],
+        );
+
+        assert!(pre.is_empty());
+        assert_eq!(original, paths(&["system", "original", "other"]));
+        assert!(post_user.is_empty());
+    }
+
+    #[test]
+    fn path_partition_does_not_restore_missing_original_entries() {
+        let (pre, original, post_user) = partition(&["B", "original"], &["original", "missing"]);
+
+        assert_eq!(pre, paths(&["B"]));
+        assert_eq!(original, paths(&["original"]));
+        assert!(post_user.is_empty());
+    }
+
+    #[test]
+    fn path_partition_is_a_fixed_point_and_never_restores_removed_entries() {
+        let alphabet = ["A", "B", "C"];
+        let current_paths = sequences(&alphabet, 5);
+        let original_paths = sequences(&alphabet, 3);
+
+        for managed_mask in 0_u8..(1 << alphabet.len()) {
+            for current in &current_paths {
+                for original in &original_paths {
+                    let is_managed = |path: &Path| {
+                        alphabet.iter().enumerate().any(|(idx, value)| {
+                            managed_mask & (1 << idx) != 0 && path == Path::new(value)
+                        })
+                    };
+                    let first = partition_path_entries(current, original, is_managed);
+                    let assembled = assemble_partition(&first);
+                    let second = partition_path_entries(&assembled, original, is_managed);
+
+                    assert_eq!(
+                        second, first,
+                        "partition was not stable for current={current:?}, original={original:?}, managed_mask={managed_mask:#05b}"
+                    );
+                    for value in alphabet {
+                        let before = current
+                            .iter()
+                            .filter(|path| *path == Path::new(value))
+                            .count();
+                        let after = assembled
+                            .iter()
+                            .filter(|path| *path == Path::new(value))
+                            .count();
+                        assert!(
+                            after <= before,
+                            "partition restored {value:?} for current={current:?}, original={original:?}, managed_mask={managed_mask:#05b}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn path_partition_handles_reported_oscillation_case() {
+        let current = paths(&["B", "C", "D", "A", "A", "D"]);
+        let original = paths(&["A", "B", "C", "D"]);
+        let first = partition_path_entries(&current, &original, |_| false);
+        let assembled = assemble_partition(&first);
+        let second = partition_path_entries(&assembled, &original, |_| false);
+
+        assert_eq!(assembled, current);
+        assert_eq!(second, first);
+    }
+
+    #[test]
+    fn path_partition_ignores_mise_managed_entries() {
+        let current = paths(&["B", "managed", "original", "system"]);
+        let captured = paths(&["original", "system"]);
+        let (pre, original, post_user) =
+            partition_path_entries(&current, &captured, |path| path == Path::new("managed"));
+
+        assert_eq!(pre, paths(&["B"]));
+        assert_eq!(original, paths(&["original", "system"]));
+        assert!(post_user.is_empty());
+    }
+
+    #[test]
+    fn path_partition_preserves_mise_managed_original_entries() {
+        let current = paths(&["managed", "B", "managed", "system"]);
+        let captured = paths(&["managed", "system"]);
+        let (pre, original, post_user) =
+            partition_path_entries(&current, &captured, |path| path == Path::new("managed"));
+
+        assert_eq!(pre, paths(&["B"]));
+        assert_eq!(original, paths(&["managed", "system"]));
+        assert!(post_user.is_empty());
+    }
+
+    #[test]
+    fn path_partition_handles_large_sparse_paths() {
+        let original = (0..2_000)
+            .map(|idx| PathBuf::from(format!("original-{idx}")))
+            .collect_vec();
+        let mut current = paths(&["prepend-a", "prepend-b"]);
+        current.extend(original.iter().cloned());
+        current.push(PathBuf::from("append"));
+
+        let (pre, post, post_user) = partition_path_entries(&current, &original, |_| false);
+
+        assert_eq!(pre, paths(&["prepend-a", "prepend-b"]));
+        assert_eq!(post, original);
+        assert_eq!(post_user, paths(&["append"]));
     }
 }


### PR DESCRIPTION
## Summary

- distinguish captured PATH occurrences from duplicate entries added after activation
- preserve user-added duplicates without allowing PATH to oscillate across hook runs
- never restore original PATH occurrences that the user removed
- retain original PATH entries even when mise also manages the same directory

## Root cause

PATH reconstruction used a `HashSet` membership check and flipped `seen_orig` at the first current entry whose value appeared in `__MISE_ORIG_PATH`. If shell configuration prepended a duplicate such as `/opt/homebrew/sbin`, that extra occurrence was mistaken for the captured original and neighboring user prepends were moved to the end.

The previous revision replaced that membership check with a two-pass LCS recovery algorithm. Although it fixed the reported ordering case, the order-aware first pass and order-blind recovery pass could classify the same PATH differently after reconstruction. Repeated `hook-env` calls could therefore oscillate PATH order, and the fallback also restored duplicate occurrences that users had intentionally removed.

The partitioning helper now uses a linear reverse scan with captured multiplicity only to establish the start of the original PATH block. The rightmost available occurrences act as anchors, so an earlier duplicate remains a user prepend. From that boundary onward, original-valued occurrences stay in current order and other entries remain user appends. Missing captured occurrences are not recreated, and unselected mise-managed entries are removed.

This produces a fixed point after one reconstruction while retaining the #8028 behavior and the existing post-activation reorder behavior.

## Verification

- reproduced the original #8028 behavior on main and verified the neighboring prepend remains in place
- added a deterministic property test covering all current PATH sequences up to length 5, original PATH sequences up to length 3, and every managed-value mask over a three-value alphabet
  - asserts `partition(assemble(partition(x))) == partition(x)`
  - asserts reconstruction never increases the occurrence count of any original value
- added the reported oscillation sequence as a focused regression test
- `mise exec -- cargo test --all-features cli::hook_env::tests` (11 passed)
- `mise run test:e2e e2e/env/test_path_duplicate_original`
- `mise run test:e2e e2e/env/test_path_reorder_after_activate e2e/config/test_path_post_activate_append e2e/env/test_path_interleaved_regression e2e/env/test_zsh_reactivate_drops_stale_install_path e2e/env/test_bash_reactivate_computed_env_dedups_stale_user_path e2e/env/test_hook_env_managed_drift e2e/env/test_fish_path_move_bug`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d e2e/env/test_path_duplicate_original`
- `mise exec -- shellcheck e2e/env/test_path_duplicate_original`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`

The aggregate `mise run format` and `mise run lint` commands still cannot invoke hk in this Sapling-native working copy because hk reports `failed to find git repository`. The underlying Rust, shell formatting, ShellCheck, Cargo check, and Clippy commands listed above pass directly; CI will run the aggregate checks in a Git checkout.

Addresses https://github.com/jdx/mise/discussions/8028

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PATH reconstruction when activation involves duplicate, reordered, missing, or managed entries.
  * Prevented repeated environment updates from changing PATH unexpectedly.
  * Ensured PATH handling remains stable across repeated hook executions.

* **Tests**
  * Added regression coverage for duplicate PATH entries and repeated activation scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->