### PR TITLE
feat(cache): sync rust actions with remote cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6443,6 +6443,7 @@ dependencies = [
  "base64 0.23.0",
  "blake3",
  "eyre",
+ "fslock",
  "hex",
  "log",
  "mockito",

--- a/crates/mise-cache-core/Cargo.toml
+++ b/crates/mise-cache-core/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 base64 = "0.23"
 blake3 = "1"
 eyre = "0.6"
+fslock = "0.2"
 hex = "0.4"
 log = "0.4"
 rand = "0.10"

--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -1,9 +1,13 @@
-use crate::{CacheDigest, LocalActionCache, LocalCas, RemoteActionResult};
+use crate::{
+    BlobSource, BlobUpload, CacheDigest, LocalActionCache, LocalCas, ManifestPutOutcome,
+    RemoteActionResult, RemoteCacheClient, RemoteCacheMode, canonical_json,
+};
 use eyre::{Result, bail};
+use log::warn;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
@@ -14,6 +18,13 @@ const MAX_EXECUTABLE_IDENTITY_BYTES: usize = 256 * 1024;
 const TASK_ACTION_MANIFEST_VERSION: u8 = 1;
 const MAX_TASK_ACTION_PREDICTIONS: usize = 16 * 1024;
 const MAX_ACTION_PREDICTION_PAYLOAD: usize = 256 * 1024;
+
+/// Remote action-cache access owned by one task session.
+pub struct AgentRemoteCache {
+    pub client: RemoteCacheClient,
+    pub mode: RemoteCacheMode,
+    pub staging_dir: PathBuf,
+}
 
 /// Wire protocol version used between an in-process cache agent and its shims.
 pub const AGENT_PROTOCOL_VERSION: u8 = 1;
@@ -142,6 +153,10 @@ pub struct CacheAgent {
     task_actions: Arc<Mutex<BTreeMap<String, TaskActionState>>>,
     next_task_run: Arc<AtomicU64>,
     manifest_write_lock: Arc<Mutex<()>>,
+    remote: Option<Arc<RemoteCacheClient>>,
+    remote_mode: RemoteCacheMode,
+    remote_staging_dir: Arc<PathBuf>,
+    pending_remote_actions: Arc<Mutex<BTreeMap<CacheDigest, RemoteActionResult>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -152,11 +167,19 @@ struct TaskActionManifest {
     predictions: Vec<ActionPrediction>,
 }
 
+#[derive(Serialize)]
+struct TaskActionManifestSelector<'a> {
+    version: u8,
+    kind: &'static str,
+    task: &'a str,
+}
+
 #[derive(Debug, Clone, Default)]
 struct TaskActionState {
     manifest: String,
     baseline_loaded: bool,
     predictions: BTreeMap<CacheDigest, ActionPrediction>,
+    remote_etag: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -168,11 +191,31 @@ struct ExecutableIdentityKey {
 impl CacheAgent {
     /// Create an agent backed by the cache rooted at `cache_dir`.
     pub fn new(cache_dir: impl Into<PathBuf>, version: impl Into<Arc<str>>) -> Self {
-        let cache_dir = cache_dir.into();
+        Self::build(cache_dir.into(), version.into(), None)
+    }
+
+    /// Create an agent with local-first access to a remote action cache.
+    pub fn new_remote(
+        cache_dir: impl Into<PathBuf>,
+        version: impl Into<Arc<str>>,
+        remote: AgentRemoteCache,
+    ) -> Self {
+        Self::build(cache_dir.into(), version.into(), Some(remote))
+    }
+
+    fn build(cache_dir: PathBuf, version: Arc<str>, remote: Option<AgentRemoteCache>) -> Self {
+        let remote_mode = remote
+            .as_ref()
+            .map_or(RemoteCacheMode::ReadOnly, |remote| remote.mode);
+        let remote_staging_dir = remote.as_ref().map_or_else(
+            || cache_dir.join("remote"),
+            |remote| remote.staging_dir.clone(),
+        );
+        let remote = remote.map(|remote| Arc::new(remote.client));
         Self {
             cas: LocalCas::new(cache_dir.clone()),
             actions: LocalActionCache::new(cache_dir.clone()),
-            version: version.into(),
+            version,
             write_locks: Arc::new(Mutex::new(BTreeMap::new())),
             stats: Arc::new(AtomicAgentStats::default()),
             executable_identities: Arc::new(Mutex::new(BTreeMap::new())),
@@ -180,33 +223,66 @@ impl CacheAgent {
             task_actions: Arc::new(Mutex::new(BTreeMap::new())),
             next_task_run: Arc::new(AtomicU64::new(0)),
             manifest_write_lock: Arc::new(Mutex::new(())),
+            remote,
+            remote_mode,
+            remote_staging_dir: Arc::new(remote_staging_dir),
+            pending_remote_actions: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
     /// Load the last successful action manifest for a task into this session.
-    pub fn begin_task(&self, task: &str) -> Result<String> {
+    pub async fn begin_task(&self, task: &str) -> Result<String> {
         validate_task_identity(task)?;
-        let path = self.task_manifest_path(task);
-        let state = match fs::read(&path) {
-            Ok(contents) => {
-                let manifest: TaskActionManifest = serde_json::from_slice(&contents)?;
-                validate_task_manifest(&manifest, task)?;
-                TaskActionState {
-                    manifest: task.to_string(),
-                    baseline_loaded: true,
-                    predictions: manifest
-                        .predictions
-                        .into_iter()
-                        .map(|prediction| (prediction.invocation.clone(), prediction))
-                        .collect(),
+        let (remote_manifest, mut remote_etag) = if self.remote_mode.reads() {
+            match self.get_remote_task_manifest(task).await {
+                Ok(Some((manifest, etag))) => (Some(manifest), Some(etag)),
+                Ok(None) => (None, None),
+                Err(error) => {
+                    warn!("remote task action manifest lookup failed for {task}: {error}");
+                    (None, None)
                 }
             }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => TaskActionState {
+        } else {
+            (None, None)
+        };
+        let manifest = {
+            let _write_guard = self.manifest_write_lock.lock().unwrap();
+            let _file_guard = self.lock_task_manifest(task)?;
+            let local_manifest = self.load_task_manifest(task)?;
+            let manifest = match (remote_manifest, local_manifest) {
+                (Some(remote), Some(local)) => {
+                    let (manifest, merged) = merge_remote_task_manifest(task, remote, local);
+                    if !merged {
+                        remote_etag = None;
+                    }
+                    Some(manifest)
+                }
+                (Some(remote), None) => Some(remote),
+                (None, local) => local,
+            };
+            if let Some(manifest) = &manifest {
+                self.persist_task_manifest(manifest)?;
+            }
+            manifest
+        };
+        let state = if let Some(manifest) = manifest {
+            TaskActionState {
                 manifest: task.to_string(),
                 baseline_loaded: true,
+                predictions: manifest
+                    .predictions
+                    .into_iter()
+                    .map(|prediction| (prediction.invocation.clone(), prediction))
+                    .collect(),
+                remote_etag,
+            }
+        } else {
+            TaskActionState {
+                manifest: task.to_string(),
+                baseline_loaded: true,
+                remote_etag,
                 ..TaskActionState::default()
-            },
-            Err(error) => return Err(error.into()),
+            }
         };
         let sequence = self.next_task_run.fetch_add(1, Ordering::Relaxed);
         let run =
@@ -217,7 +293,7 @@ impl CacheAgent {
     }
 
     /// Atomically publish the candidate manifest collected by a successful task.
-    pub fn commit_task(&self, run: &str) -> Result<()> {
+    pub async fn commit_task(&self, run: &str) -> Result<()> {
         validate_task_identity(run)?;
         let state = self
             .task_actions
@@ -231,40 +307,165 @@ impl CacheAgent {
         }
         let task = state.manifest;
         validate_task_identity(&task)?;
-        let _write_guard = self.manifest_write_lock.lock().unwrap();
-        let mut predictions = match fs::read(self.task_manifest_path(&task)) {
-            Ok(contents) => {
-                let current: TaskActionManifest = serde_json::from_slice(&contents)?;
-                validate_task_manifest(&current, &task)?;
-                current
-                    .predictions
-                    .into_iter()
-                    .map(|prediction| (prediction.invocation.clone(), prediction))
-                    .collect::<BTreeMap<_, _>>()
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => BTreeMap::new(),
-            Err(error) => return Err(error.into()),
+        let manifest = {
+            let _write_guard = self.manifest_write_lock.lock().unwrap();
+            let _file_guard = self.lock_task_manifest(&task)?;
+            let mut predictions = self
+                .load_task_manifest(&task)?
+                .map(|manifest| {
+                    manifest
+                        .predictions
+                        .into_iter()
+                        .map(|prediction| (prediction.invocation.clone(), prediction))
+                        .collect::<BTreeMap<_, _>>()
+                })
+                .unwrap_or_default();
+            predictions.extend(state.predictions);
+            let manifest = TaskActionManifest {
+                version: TASK_ACTION_MANIFEST_VERSION,
+                task: task.clone(),
+                predictions: predictions.into_values().collect(),
+            };
+            validate_task_manifest(&manifest, &task)?;
+            self.persist_task_manifest(&manifest)?;
+            manifest
         };
-        predictions.extend(state.predictions);
-        let manifest = TaskActionManifest {
-            version: TASK_ACTION_MANIFEST_VERSION,
-            task: task.clone(),
-            predictions: predictions.into_values().collect(),
-        };
-        validate_task_manifest(&manifest, &task)?;
-        fs::create_dir_all(self.manifest_dir.as_path())?;
-        let mut temporary = tempfile::NamedTempFile::new_in(self.manifest_dir.as_path())?;
-        serde_json::to_writer(temporary.as_file_mut(), &manifest)?;
-        temporary.as_file_mut().sync_all()?;
-        temporary
-            .persist(self.task_manifest_path(&task))
-            .map_err(|error| error.error)?;
         self.task_actions.lock().unwrap().remove(run);
+        if self.remote_mode.writes() {
+            match self
+                .put_remote_task_manifest(&task, manifest, state.remote_etag)
+                .await
+            {
+                Ok(remote_manifest) => {
+                    let _write_guard = self.manifest_write_lock.lock().unwrap();
+                    let reconciliation = (|| {
+                        let _file_guard = self.lock_task_manifest(&task)?;
+                        let manifest = match self.load_task_manifest(&task)? {
+                            Some(local) => {
+                                merge_remote_task_manifest(&task, remote_manifest, local).0
+                            }
+                            None => remote_manifest,
+                        };
+                        self.persist_task_manifest(&manifest)
+                    })();
+                    if let Err(error) = reconciliation {
+                        warn!(
+                            "remote task action manifest reconciliation failed for {task}: {error}"
+                        );
+                    }
+                }
+                Err(error) => {
+                    warn!("remote task action manifest upload failed for {task}: {error}");
+                }
+            }
+        }
         Ok(())
     }
 
     fn task_manifest_path(&self, task: &str) -> PathBuf {
         self.manifest_dir.join(format!("{task}.json"))
+    }
+
+    fn task_manifest_lock_path(&self, task: &str) -> PathBuf {
+        self.manifest_dir.join("locks").join(format!("{task}.lock"))
+    }
+
+    fn lock_task_manifest(&self, task: &str) -> Result<fslock::LockFile> {
+        let path = self.task_manifest_lock_path(task);
+        fs::create_dir_all(path.parent().expect("task manifest lock has a parent"))?;
+        let mut lock = fslock::LockFile::open(&path)?;
+        lock.lock()?;
+        Ok(lock)
+    }
+
+    fn load_task_manifest(&self, task: &str) -> Result<Option<TaskActionManifest>> {
+        match fs::read(self.task_manifest_path(task)) {
+            Ok(contents) => Ok(Some(self.parse_task_manifest(task, &contents, false)?)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn parse_task_manifest(
+        &self,
+        task: &str,
+        contents: &[u8],
+        require_canonical: bool,
+    ) -> Result<TaskActionManifest> {
+        let manifest: TaskActionManifest = serde_json::from_slice(contents)?;
+        validate_task_manifest(&manifest, task)?;
+        if require_canonical && canonical_json(&manifest)? != contents {
+            bail!("task action manifest is not canonical JSON");
+        }
+        Ok(manifest)
+    }
+
+    fn task_manifest_selector(task: &str) -> Result<(Vec<u8>, CacheDigest)> {
+        let bytes = canonical_json(&TaskActionManifestSelector {
+            version: 1,
+            kind: "task_action_manifest",
+            task,
+        })?;
+        let digest = CacheDigest::blake3(&bytes);
+        Ok((bytes, digest))
+    }
+
+    fn persist_task_manifest(&self, manifest: &TaskActionManifest) -> Result<()> {
+        let bytes = canonical_json(manifest)?;
+        fs::create_dir_all(self.manifest_dir.as_path())?;
+        let mut temporary = tempfile::NamedTempFile::new_in(self.manifest_dir.as_path())?;
+        std::io::Write::write_all(temporary.as_file_mut(), &bytes)?;
+        temporary.as_file_mut().sync_all()?;
+        temporary
+            .persist(self.task_manifest_path(&manifest.task))
+            .map_err(|error| error.error)?;
+        Ok(())
+    }
+
+    async fn get_remote_task_manifest(
+        &self,
+        task: &str,
+    ) -> Result<Option<(TaskActionManifest, String)>> {
+        let Some(remote) = &self.remote else {
+            return Ok(None);
+        };
+        let (_, selector) = Self::task_manifest_selector(task)?;
+        let Some(remote_manifest) = remote.get_action_manifest(&selector).await? else {
+            return Ok(None);
+        };
+        let manifest = self.parse_task_manifest(task, &remote_manifest.bytes, true)?;
+        Ok(Some((manifest, remote_manifest.etag)))
+    }
+
+    async fn put_remote_task_manifest(
+        &self,
+        task: &str,
+        mut manifest: TaskActionManifest,
+        mut expected_etag: Option<String>,
+    ) -> Result<TaskActionManifest> {
+        let Some(remote) = &self.remote else {
+            return Ok(manifest);
+        };
+        let (_, selector) = Self::task_manifest_selector(task)?;
+        for _ in 0..4 {
+            let bytes = canonical_json(&manifest)?;
+            match remote
+                .put_action_manifest(&selector, &bytes, expected_etag.as_deref())
+                .await?
+            {
+                ManifestPutOutcome::Stored => return Ok(manifest),
+                ManifestPutOutcome::PreconditionFailed => {
+                    let Some((remote_manifest, etag)) = self.get_remote_task_manifest(task).await?
+                    else {
+                        expected_etag = None;
+                        continue;
+                    };
+                    manifest = merge_task_manifests(task, Some(remote_manifest), manifest)?;
+                    expected_etag = Some(etag);
+                }
+            }
+        }
+        bail!("remote task action manifest changed too frequently")
     }
 
     /// Return a snapshot of this session's cache activity.
@@ -290,35 +491,14 @@ impl CacheAgent {
 
     async fn respond(&self, request: AgentRequest) -> AgentResponse {
         let result = match request {
-            AgentRequest::FindBlob { digest } => self
-                .cas
-                .find(&digest)
-                .map(|path| AgentResponse::Blob { path }),
-            AgentRequest::StoreBlob { digest, source } => {
-                let lock = self.write_lock(&digest);
-                let _guard = lock.lock().await;
-                if let Ok(Some(path)) = self.cas.find(&digest) {
-                    return AgentResponse::Stored { path };
-                }
-                self.cas.store_file(&digest, &source).map(|path| {
-                    self.stats.stores.fetch_add(1, Ordering::Relaxed);
-                    self.stats
-                        .stored_bytes
-                        .fetch_add(digest.size, Ordering::Relaxed);
-                    AgentResponse::Stored { path }
-                })
-            }
+            AgentRequest::FindBlob { digest } => self.find_blob(&digest).await,
+            AgentRequest::StoreBlob { digest, source } => self.store_blob(&digest, &source).await,
             AgentRequest::FindActionResult { action } => {
                 self.stats.lookups.fetch_add(1, Ordering::Relaxed);
-                self.actions
-                    .find(&action)
-                    .map(|result| AgentResponse::ActionResult { result })
+                self.find_action_result(&action).await
             }
             AgentRequest::RecordActionHit { action } => self.record_action_hit(&action),
-            AgentRequest::StoreActionResult { result } => self
-                .actions
-                .store(&result)
-                .map(|path| AgentResponse::ActionStored { path }),
+            AgentRequest::StoreActionResult { result } => self.store_action_result(&result).await,
             AgentRequest::FindActionPrediction { task, invocation } => {
                 self.find_action_prediction(&task, &invocation)
             }
@@ -343,9 +523,128 @@ impl CacheAgent {
         })
     }
 
+    async fn find_blob(&self, digest: &CacheDigest) -> Result<AgentResponse> {
+        if let Some(path) = self.cas.find(digest)? {
+            return Ok(AgentResponse::Blob { path: Some(path) });
+        }
+        if !self.remote_mode.reads() {
+            return Ok(AgentResponse::Blob { path: None });
+        }
+        let Some(remote) = &self.remote else {
+            return Ok(AgentResponse::Blob { path: None });
+        };
+        let lock = self.write_lock(digest);
+        let _guard = lock.lock().await;
+        if let Some(path) = self.cas.find(digest)? {
+            return Ok(AgentResponse::Blob { path: Some(path) });
+        }
+        match remote
+            .get_blob_file(digest, self.remote_staging_dir.as_path())
+            .await
+        {
+            Ok(temporary) => {
+                let path = self.cas.store_file(digest, temporary.path())?;
+                self.stats.stores.fetch_add(1, Ordering::Relaxed);
+                self.stats
+                    .stored_bytes
+                    .fetch_add(digest.size, Ordering::Relaxed);
+                Ok(AgentResponse::Blob { path: Some(path) })
+            }
+            Err(error) => {
+                warn!(
+                    "remote cache blob lookup failed for {}: {error}",
+                    digest.hash
+                );
+                Ok(AgentResponse::Blob { path: None })
+            }
+        }
+    }
+
+    async fn store_blob(&self, digest: &CacheDigest, source: &Path) -> Result<AgentResponse> {
+        let lock = self.write_lock(digest);
+        let _guard = lock.lock().await;
+        let path = if let Some(path) = self.cas.find(digest)? {
+            path
+        } else {
+            let path = self.cas.store_file(digest, source)?;
+            self.stats.stores.fetch_add(1, Ordering::Relaxed);
+            self.stats
+                .stored_bytes
+                .fetch_add(digest.size, Ordering::Relaxed);
+            path
+        };
+        if self.remote_mode.writes()
+            && let Some(remote) = &self.remote
+            && let Err(error) = remote
+                .put_blob(&BlobUpload {
+                    digest: digest.clone(),
+                    source: BlobSource::Path(path.clone()),
+                })
+                .await
+        {
+            warn!(
+                "remote cache blob upload failed for {}: {error}",
+                digest.hash
+            );
+        }
+        Ok(AgentResponse::Stored { path })
+    }
+
+    async fn find_action_result(&self, action: &CacheDigest) -> Result<AgentResponse> {
+        if let Some(result) = self.actions.find(action)? {
+            return Ok(AgentResponse::ActionResult {
+                result: Some(result),
+            });
+        }
+        if !self.remote_mode.reads() {
+            return Ok(AgentResponse::ActionResult { result: None });
+        }
+        let Some(remote) = &self.remote else {
+            return Ok(AgentResponse::ActionResult { result: None });
+        };
+        match remote.get_action_result(action).await {
+            Ok(Some(result)) => {
+                self.pending_remote_actions
+                    .lock()
+                    .unwrap()
+                    .insert(action.clone(), result.clone());
+                Ok(AgentResponse::ActionResult {
+                    result: Some(result),
+                })
+            }
+            Ok(None) => Ok(AgentResponse::ActionResult { result: None }),
+            Err(error) => {
+                warn!(
+                    "remote cache action lookup failed for {}: {error}",
+                    action.hash
+                );
+                Ok(AgentResponse::ActionResult { result: None })
+            }
+        }
+    }
+
+    async fn store_action_result(&self, result: &RemoteActionResult) -> Result<AgentResponse> {
+        let path = self.actions.store(result)?;
+        if self.remote_mode.writes()
+            && let Some(remote) = &self.remote
+            && let Err(error) = remote.put_action_result(result).await
+        {
+            warn!(
+                "remote cache action upload failed for {}: {error}",
+                result.action.hash
+            );
+        }
+        Ok(AgentResponse::ActionStored { path })
+    }
+
     fn record_action_hit(&self, action: &CacheDigest) -> Result<AgentResponse> {
         if self.actions.find(action)?.is_none() {
-            bail!("cannot record a hit for a missing action result");
+            let pending = self.pending_remote_actions.lock().unwrap().remove(action);
+            if let Some(result) = pending {
+                self.actions.store(&result)?;
+            } else {
+                bail!("cannot record a hit for a missing action result");
+            }
         }
         self.stats.hits.fetch_add(1, Ordering::Relaxed);
         Ok(AgentResponse::ActionHitRecorded)
@@ -558,6 +857,50 @@ fn validate_task_manifest(manifest: &TaskActionManifest, task: &str) -> Result<(
     Ok(())
 }
 
+fn merge_task_manifests(
+    task: &str,
+    base: Option<TaskActionManifest>,
+    update: TaskActionManifest,
+) -> Result<TaskActionManifest> {
+    validate_task_manifest(&update, task)?;
+    let mut predictions = BTreeMap::new();
+    if let Some(base) = base {
+        validate_task_manifest(&base, task)?;
+        predictions.extend(
+            base.predictions
+                .into_iter()
+                .map(|prediction| (prediction.invocation.clone(), prediction)),
+        );
+    }
+    predictions.extend(
+        update
+            .predictions
+            .into_iter()
+            .map(|prediction| (prediction.invocation.clone(), prediction)),
+    );
+    let manifest = TaskActionManifest {
+        version: TASK_ACTION_MANIFEST_VERSION,
+        task: task.to_owned(),
+        predictions: predictions.into_values().collect(),
+    };
+    validate_task_manifest(&manifest, task)?;
+    Ok(manifest)
+}
+
+fn merge_remote_task_manifest(
+    task: &str,
+    remote: TaskActionManifest,
+    local: TaskActionManifest,
+) -> (TaskActionManifest, bool) {
+    match merge_task_manifests(task, Some(remote), local.clone()) {
+        Ok(manifest) => (manifest, true),
+        Err(error) => {
+            warn!("remote task action manifest merge failed for {task}: {error}");
+            (local, false)
+        }
+    }
+}
+
 async fn send_response(
     writer: &mut (impl AsyncWrite + Unpin),
     response: &AgentResponse,
@@ -572,6 +915,8 @@ async fn send_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ACTION_RESULT_MEDIA_TYPE;
+    use std::time::Duration;
 
     async fn handshake(stream: &mut (impl AsyncRead + AsyncWrite + Unpin), version: &str) {
         let request = AgentRequest::Hello {
@@ -731,7 +1076,7 @@ mod tests {
         };
 
         let agent = CacheAgent::new(&cache, "test-version");
-        let first_run = agent.begin_task(&task).unwrap();
+        let first_run = agent.begin_task(&task).await.unwrap();
         assert!(matches!(
             agent
                 .respond(AgentRequest::RecordActionPrediction {
@@ -741,10 +1086,10 @@ mod tests {
                 .await,
             AgentResponse::ActionPredictionRecorded
         ));
-        agent.commit_task(&first_run).unwrap();
+        agent.commit_task(&first_run).await.unwrap();
 
         let uncommitted = CacheAgent::new(&cache, "test-version");
-        let uncommitted_run = uncommitted.begin_task(&task).unwrap();
+        let uncommitted_run = uncommitted.begin_task(&task).await.unwrap();
         let second_invocation = CacheDigest::blake3(b"second invocation");
         assert!(matches!(
             uncommitted
@@ -762,7 +1107,7 @@ mod tests {
         ));
 
         let next_session = CacheAgent::new(&cache, "test-version");
-        let next_run = next_session.begin_task(&task).unwrap();
+        let next_run = next_session.begin_task(&task).await.unwrap();
         assert!(matches!(
             next_session
                 .respond(AgentRequest::FindActionPrediction {
@@ -787,7 +1132,7 @@ mod tests {
         let corrupt_task = "b".repeat(64);
         fs::create_dir_all(next_session.manifest_dir.as_path()).unwrap();
         fs::write(next_session.task_manifest_path(&corrupt_task), b"not json").unwrap();
-        assert!(next_session.begin_task(&corrupt_task).is_err());
+        assert!(next_session.begin_task(&corrupt_task).await.is_err());
         let corrupt_run = "c".repeat(64);
         next_session.task_actions.lock().unwrap().insert(
             corrupt_run.clone(),
@@ -805,11 +1150,324 @@ mod tests {
                 .await,
             AgentResponse::ActionPredictionRecorded
         ));
-        assert!(next_session.commit_task(&corrupt_run).is_err());
+        assert!(next_session.commit_task(&corrupt_run).await.is_err());
         assert_eq!(
             fs::read(next_session.task_manifest_path(&corrupt_task)).unwrap(),
             b"not json"
         );
+    }
+
+    #[tokio::test]
+    async fn round_trips_task_actions_between_fresh_local_caches() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let task = "e".repeat(64);
+        let invocation = CacheDigest::blake3(b"remote invocation");
+        let action_bytes = canonical_json(&serde_json::json!({"kind":"rustc"})).unwrap();
+        let metadata_bytes = canonical_json(&serde_json::json!({"kind":"metadata"})).unwrap();
+        let directory_bytes = canonical_json(&serde_json::json!({"kind":"directory"})).unwrap();
+        let action = CacheDigest::blake3(&action_bytes);
+        let metadata = CacheDigest::blake3(&metadata_bytes);
+        let output_root = CacheDigest::blake3(&directory_bytes);
+        let result = RemoteActionResult {
+            action: action.clone(),
+            metadata: Some(metadata.clone()),
+            output_root: Some(output_root.clone()),
+            version: 1,
+        };
+        let prediction = ActionPrediction {
+            invocation: invocation.clone(),
+            action: action.clone(),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        };
+        let manifest_bytes = canonical_json(&TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: vec![prediction.clone()],
+        })
+        .unwrap();
+        let manifest_etag = blake3::hash(&manifest_bytes).to_hex().to_string();
+        let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+
+        let mut mocks = Vec::new();
+        for (digest, bytes) in [
+            (&action, action_bytes.as_slice()),
+            (&metadata, metadata_bytes.as_slice()),
+            (&output_root, directory_bytes.as_slice()),
+        ] {
+            mocks.push(
+                server
+                    .mock("PUT", blob_path(digest).as_str())
+                    .match_header("mise-cache-namespace", "test")
+                    .match_body(bytes.to_vec())
+                    .with_status(200)
+                    .expect(1)
+                    .create_async()
+                    .await,
+            );
+        }
+        mocks.push(
+            server
+                .mock("PUT", action_path(&result.action).as_str())
+                .match_header("mise-cache-namespace", "test")
+                .with_status(200)
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        mocks.push(
+            server
+                .mock("PUT", action_manifest_path(&selector).as_str())
+                .match_header("mise-cache-namespace", "test")
+                .match_header("if-none-match", "*")
+                .match_body(manifest_bytes.clone())
+                .with_status(201)
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        mocks.push(
+            server
+                .mock("GET", action_manifest_path(&selector).as_str())
+                .with_status(200)
+                .with_header("etag", &format!("\"{manifest_etag}\""))
+                .with_body(manifest_bytes.clone())
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        mocks.push(
+            server
+                .mock("GET", action_path(&action).as_str())
+                .with_status(200)
+                .with_header("content-type", ACTION_RESULT_MEDIA_TYPE)
+                .with_body(serde_json::to_vec(&result).unwrap())
+                .expect(1)
+                .create_async()
+                .await,
+        );
+        for (digest, bytes) in [
+            (&action, action_bytes.as_slice()),
+            (&metadata, metadata_bytes.as_slice()),
+            (&output_root, directory_bytes.as_slice()),
+        ] {
+            mocks.push(
+                server
+                    .mock("GET", blob_path(digest).as_str())
+                    .with_status(200)
+                    .with_body(bytes)
+                    .expect(1)
+                    .create_async()
+                    .await,
+            );
+        }
+
+        let writer = remote_agent(
+            &server,
+            directory.path().join("writer"),
+            RemoteCacheMode::WriteOnly,
+        );
+        for (index, (digest, bytes)) in [
+            (&action, action_bytes.as_slice()),
+            (&metadata, metadata_bytes.as_slice()),
+            (&output_root, directory_bytes.as_slice()),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let source = directory.path().join(format!("source-{index}"));
+            fs::write(&source, bytes).unwrap();
+            assert!(matches!(
+                writer
+                    .respond(AgentRequest::StoreBlob {
+                        digest: digest.clone(),
+                        source,
+                    })
+                    .await,
+                AgentResponse::Stored { .. }
+            ));
+        }
+        assert!(matches!(
+            writer
+                .respond(AgentRequest::StoreActionResult {
+                    result: result.clone(),
+                })
+                .await,
+            AgentResponse::ActionStored { .. }
+        ));
+        let run = writer.begin_task(&task).await.unwrap();
+        assert!(matches!(
+            writer
+                .respond(AgentRequest::RecordActionPrediction {
+                    task: run.clone(),
+                    prediction: prediction.clone(),
+                })
+                .await,
+            AgentResponse::ActionPredictionRecorded
+        ));
+        writer.commit_task(&run).await.unwrap();
+
+        let reader = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        let run = reader.begin_task(&task).await.unwrap();
+        assert!(matches!(
+            reader
+                .respond(AgentRequest::FindActionPrediction {
+                    task: run,
+                    invocation,
+                })
+                .await,
+            AgentResponse::ActionPrediction {
+                prediction: Some(found)
+            } if found == prediction
+        ));
+        assert!(matches!(
+            reader
+                .respond(AgentRequest::FindActionResult {
+                    action: action.clone(),
+                })
+                .await,
+            AgentResponse::ActionResult {
+                result: Some(found)
+            } if found == result
+        ));
+        for digest in [&action, &metadata, &output_root] {
+            assert!(matches!(
+                reader
+                    .respond(AgentRequest::FindBlob {
+                        digest: digest.clone(),
+                    })
+                    .await,
+                AgentResponse::Blob { path: Some(_) }
+            ));
+        }
+        assert!(matches!(
+            reader
+                .respond(AgentRequest::RecordActionHit { action })
+                .await,
+            AgentResponse::ActionHitRecorded
+        ));
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn keeps_newer_local_predictions_when_remote_manifest_is_stale() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let task = "f".repeat(64);
+        let invocation = CacheDigest::blake3(b"shared invocation");
+        let local_prediction = ActionPrediction {
+            invocation: invocation.clone(),
+            action: CacheDigest::blake3(b"new local action"),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        };
+        let remote_prediction = ActionPrediction {
+            invocation: invocation.clone(),
+            action: CacheDigest::blake3(b"stale remote action"),
+            adapter: "rustc".into(),
+            payload: "{}".into(),
+        };
+        let remote_manifest = TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: vec![remote_prediction],
+        };
+        let remote_bytes = canonical_json(&remote_manifest).unwrap();
+        let remote_etag = blake3::hash(&remote_bytes).to_hex().to_string();
+        let (_, selector) = CacheAgent::task_manifest_selector(&task).unwrap();
+        let remote = server
+            .mock("GET", action_manifest_path(&selector).as_str())
+            .with_status(200)
+            .with_header("etag", &format!("\"{remote_etag}\""))
+            .with_body(remote_bytes)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let agent = remote_agent(
+            &server,
+            directory.path().join("reader"),
+            RemoteCacheMode::ReadOnly,
+        );
+        agent
+            .persist_task_manifest(&TaskActionManifest {
+                version: TASK_ACTION_MANIFEST_VERSION,
+                task: task.clone(),
+                predictions: vec![local_prediction.clone()],
+            })
+            .unwrap();
+
+        let run = agent.begin_task(&task).await.unwrap();
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::FindActionPrediction {
+                    task: run,
+                    invocation,
+                })
+                .await,
+            AgentResponse::ActionPrediction {
+                prediction: Some(found)
+            } if found == local_prediction
+        ));
+        let persisted = agent.load_task_manifest(&task).unwrap().unwrap();
+        assert_eq!(persisted.predictions, vec![local_prediction]);
+        remote.assert_async().await;
+    }
+
+    fn remote_agent(
+        server: &mockito::ServerGuard,
+        cache_dir: PathBuf,
+        mode: RemoteCacheMode,
+    ) -> CacheAgent {
+        let client = RemoteCacheClient::new(crate::RemoteCacheConfig {
+            base_url: server.url().parse().unwrap(),
+            namespace: "test".into(),
+            token: None,
+            token_file: None,
+            oidc_audience: None,
+            connect_timeout: Duration::from_secs(1),
+            read_timeout: Duration::from_secs(1),
+            download_timeout: Duration::from_secs(1),
+            retries: 0,
+        })
+        .unwrap();
+        CacheAgent::new_remote(
+            &cache_dir,
+            "test-version",
+            AgentRemoteCache {
+                client,
+                mode,
+                staging_dir: cache_dir.join("remote"),
+            },
+        )
+    }
+
+    fn blob_path(digest: &CacheDigest) -> String {
+        format!(
+            "/v1/blobs/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        )
+    }
+
+    fn action_path(digest: &CacheDigest) -> String {
+        format!(
+            "/v1/action-results/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        )
+    }
+
+    fn action_manifest_path(digest: &CacheDigest) -> String {
+        format!(
+            "/v1/action-manifests/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        )
     }
 
     #[tokio::test]
@@ -818,8 +1476,8 @@ mod tests {
         let cache = directory.path().join("cache");
         let task = "d".repeat(64);
         let agent = CacheAgent::new(&cache, "test-version");
-        let first_run = agent.begin_task(&task).unwrap();
-        let second_run = agent.begin_task(&task).unwrap();
+        let first_run = agent.begin_task(&task).await.unwrap();
+        let second_run = agent.begin_task(&task).await.unwrap();
         assert_ne!(first_run, second_run);
         let first_invocation = CacheDigest::blake3(b"overlap one");
         let second_invocation = CacheDigest::blake3(b"overlap two");
@@ -842,11 +1500,11 @@ mod tests {
                 AgentResponse::ActionPredictionRecorded
             ));
         }
-        agent.commit_task(&first_run).unwrap();
-        agent.commit_task(&second_run).unwrap();
+        agent.commit_task(&first_run).await.unwrap();
+        agent.commit_task(&second_run).await.unwrap();
 
         let next = CacheAgent::new(cache, "test-version");
-        let run = next.begin_task(&task).unwrap();
+        let run = next.begin_task(&task).await.unwrap();
         for invocation in [first_invocation, second_invocation] {
             assert!(matches!(
                 next.respond(AgentRequest::FindActionPrediction {
@@ -859,6 +1517,51 @@ mod tests {
                 }
             ));
         }
+    }
+
+    #[test]
+    fn keeps_local_manifest_when_remote_merge_exceeds_prediction_limit() {
+        let task = "7".repeat(64);
+        let prediction = |index: usize| {
+            let digest = CacheDigest::blake3(&index.to_le_bytes());
+            ActionPrediction {
+                invocation: digest.clone(),
+                action: digest,
+                adapter: "rustc".into(),
+                payload: "{}".into(),
+            }
+        };
+        let local = TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: (0..MAX_TASK_ACTION_PREDICTIONS).map(prediction).collect(),
+        };
+        let expected_first = local.predictions[0].clone();
+        let remote = TaskActionManifest {
+            version: TASK_ACTION_MANIFEST_VERSION,
+            task: task.clone(),
+            predictions: vec![prediction(MAX_TASK_ACTION_PREDICTIONS)],
+        };
+
+        let (manifest, merged) = merge_remote_task_manifest(&task, remote, local);
+        assert!(!merged);
+        assert_eq!(manifest.predictions.len(), MAX_TASK_ACTION_PREDICTIONS);
+        assert_eq!(manifest.predictions[0], expected_first);
+    }
+
+    #[test]
+    fn task_manifest_lock_is_shared_across_agents() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path().join("cache");
+        let first = CacheAgent::new(&cache, "test-version");
+        let second = CacheAgent::new(&cache, "test-version");
+        let task = "8".repeat(64);
+
+        let first_lock = first.lock_task_manifest(&task).unwrap();
+        let mut contender = fslock::LockFile::open(&second.task_manifest_lock_path(&task)).unwrap();
+        assert!(!contender.try_lock().unwrap());
+        drop(first_lock);
+        assert!(contender.try_lock().unwrap());
     }
 
     #[tokio::test]

--- a/crates/mise-cache-core/src/lib.rs
+++ b/crates/mise-cache-core/src/lib.rs
@@ -3,7 +3,7 @@ use eyre::{Result, bail, eyre};
 use log::warn;
 use reqwest::StatusCode;
 use reqwest::header::{
-    ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, IF_NONE_MATCH,
+    ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, ETAG, HeaderValue, IF_MATCH, IF_NONE_MATCH,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
@@ -19,7 +19,8 @@ mod agent;
 mod local;
 
 pub use agent::{
-    AGENT_PROTOCOL_VERSION, ActionPrediction, AgentRequest, AgentResponse, AgentStats, CacheAgent,
+    AGENT_PROTOCOL_VERSION, ActionPrediction, AgentRemoteCache, AgentRequest, AgentResponse,
+    AgentStats, CacheAgent,
 };
 pub use local::{LocalActionCache, LocalCas};
 
@@ -29,6 +30,8 @@ const NAMESPACE_HEADER: &str = "mise-cache-namespace";
 pub const ACTION_RESULT_MEDIA_TYPE: &str = "application/vnd.mise.cache-action-result.v1+json";
 pub const DIRECTORY_MEDIA_TYPE: &str = "application/vnd.mise.cache-directory.v1+json";
 pub const CLIENT_METADATA_MEDIA_TYPE: &str = "application/vnd.mise.cache-client-metadata.v1+json";
+pub const TASK_ACTION_MANIFEST_MEDIA_TYPE: &str =
+    "application/vnd.mise.cache-task-action-manifest.v1+json";
 pub const BLOB_MEDIA_TYPE: &str = "application/octet-stream";
 
 /// Serialize a protocol object using the JSON Canonicalization Scheme.
@@ -242,11 +245,23 @@ pub struct RustcMetadata {
 pub enum BlobSource {
     Bytes(Vec<u8>),
     File(tempfile::NamedTempFile),
+    Path(PathBuf),
 }
 
 pub struct BlobUpload {
     pub digest: CacheDigest,
     pub source: BlobSource,
+}
+
+pub struct RemoteActionManifest {
+    pub bytes: Vec<u8>,
+    pub etag: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestPutOutcome {
+    Stored,
+    PreconditionFailed,
 }
 
 pub struct RemoteCacheClient {
@@ -302,6 +317,17 @@ impl RemoteCacheClient {
         Ok(self.base_url.join(&format!(
             "v{PROTOCOL_VERSION}/blobs/{}/{}/{}",
             digest.algorithm, digest.hash, digest.size
+        ))?)
+    }
+
+    fn action_manifest_endpoint(&self, key: &CacheDigest) -> Result<Url> {
+        key.validate()?;
+        if key.algorithm != "blake3" {
+            bail!("remote action manifest keys must use blake3");
+        }
+        Ok(self.base_url.join(&format!(
+            "v{PROTOCOL_VERSION}/action-manifests/{}/{}/{}",
+            key.algorithm, key.hash, key.size
         ))?)
     }
 
@@ -374,6 +400,69 @@ impl RemoteCacheClient {
         .await
     }
 
+    pub async fn get_action_manifest(
+        &self,
+        key: &CacheDigest,
+    ) -> Result<Option<RemoteActionManifest>> {
+        let url = self.action_manifest_endpoint(key)?;
+        retry_async("GET", &url, self.retries, || async {
+            let response = self
+                .request(
+                    reqwest::Method::GET,
+                    url.clone(),
+                    TASK_ACTION_MANIFEST_MEDIA_TYPE,
+                )
+                .await?
+                .send()
+                .await?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            let response = response.error_for_status()?;
+            let etag = parse_strong_etag(response.headers().get(ETAG))?;
+            let bytes = response.bytes().await?.to_vec();
+            if blake3::hash(&bytes).to_hex().as_str() != etag {
+                bail!("remote action manifest ETag does not match its body");
+            }
+            Ok(Some(RemoteActionManifest { bytes, etag }))
+        })
+        .await
+    }
+
+    pub async fn put_action_manifest(
+        &self,
+        key: &CacheDigest,
+        bytes: &[u8],
+        expected_etag: Option<&str>,
+    ) -> Result<ManifestPutOutcome> {
+        let url = self.action_manifest_endpoint(key)?;
+        let body = bytes.to_vec();
+        let expected_etag = expected_etag.map(quoted_etag).transpose()?;
+        retry_async("PUT", &url, self.retries, || async {
+            let mut request = self
+                .request(
+                    reqwest::Method::PUT,
+                    url.clone(),
+                    TASK_ACTION_MANIFEST_MEDIA_TYPE,
+                )
+                .await?
+                .header(CONTENT_TYPE, TASK_ACTION_MANIFEST_MEDIA_TYPE)
+                .body(body.clone());
+            request = if let Some(etag) = &expected_etag {
+                request.header(IF_MATCH, etag)
+            } else {
+                request.header(IF_NONE_MATCH, "*")
+            };
+            let response = request.send().await?;
+            if response.status() == StatusCode::PRECONDITION_FAILED {
+                return Ok(ManifestPutOutcome::PreconditionFailed);
+            }
+            response.error_for_status()?;
+            Ok(ManifestPutOutcome::Stored)
+        })
+        .await
+    }
+
     pub async fn get_blob(
         &self,
         digest: &CacheDigest,
@@ -441,6 +530,12 @@ impl RemoteCacheClient {
                     let stream = tokio_util::io::ReaderStream::new(file);
                     (length, reqwest::Body::wrap_stream(stream))
                 }
+                BlobSource::Path(path) => {
+                    let file = tokio::fs::File::open(path).await?;
+                    let length = file.metadata().await?.len();
+                    let stream = tokio_util::io::ReaderStream::new(file);
+                    (length, reqwest::Body::wrap_stream(stream))
+                }
             };
             let response = self
                 .request(reqwest::Method::PUT, url.clone(), BLOB_MEDIA_TYPE)
@@ -458,6 +553,32 @@ impl RemoteCacheClient {
         })
         .await
     }
+}
+
+fn parse_strong_etag(value: Option<&HeaderValue>) -> Result<String> {
+    let value = value
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| eyre!("remote action manifest response is missing an ETag"))?;
+    let etag = value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .filter(|value| is_lower_hex_digest(value))
+        .ok_or_else(|| eyre!("remote action manifest response has an invalid ETag"))?;
+    Ok(etag.to_owned())
+}
+
+fn quoted_etag(etag: &str) -> Result<HeaderValue> {
+    if !is_lower_hex_digest(etag) {
+        bail!("invalid remote action manifest ETag");
+    }
+    Ok(HeaderValue::from_str(&format!("\"{etag}\""))?)
+}
+
+fn is_lower_hex_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 #[derive(Clone)]

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -1,11 +1,12 @@
+use crate::config::Settings;
 use crate::task::Task;
 #[cfg(test)]
 use crate::task::TaskRustCacheConfig;
 use bytesize::ByteSize;
 use eyre::{Context, Result, bail};
 use mise_cache_core::{
-    AGENT_PROTOCOL_VERSION, AgentRequest, AgentResponse, AgentStats, CacheAgent, CacheDigest,
-    canonical_json,
+    AGENT_PROTOCOL_VERSION, AgentRemoteCache, AgentRequest, AgentResponse, AgentStats, CacheAgent,
+    CacheDigest, RemoteCacheClient, RemoteCacheConfig, canonical_json,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -34,7 +35,7 @@ pub(crate) struct CacheSessionEnvironment {
 }
 
 impl CacheSessionEnvironment {
-    pub(crate) fn apply(
+    pub(crate) async fn apply(
         &self,
         task: &Task,
         environment: &mut BTreeMap<String, String>,
@@ -43,7 +44,7 @@ impl CacheSessionEnvironment {
             return None;
         }
         let task_identity = task_action_identity(task);
-        let (protocol_task, action_run) = match self.agent.begin_task(&task_identity) {
+        let (protocol_task, action_run) = match self.agent.begin_task(&task_identity).await {
             Ok(run) => (
                 run.clone(),
                 Some(TaskActionRun {
@@ -83,8 +84,8 @@ pub(crate) struct TaskActionRun {
 }
 
 impl TaskActionRun {
-    pub(crate) fn commit(self) -> Result<()> {
-        self.agent.commit_task(&self.run)
+    pub(crate) async fn commit(self) -> Result<()> {
+        self.agent.commit_task(&self.run).await
     }
 }
 
@@ -136,7 +137,11 @@ impl CacheSession {
         let shim = install_session_shim(session_dir)?;
         let staging = session_dir.join("staging");
         std::fs::create_dir(&staging)?;
-        let agent = CacheAgent::new(cache_dir, VERSION);
+        let agent = if let Some(remote) = action_remote_cache(&cache_dir)? {
+            CacheAgent::new_remote(cache_dir, VERSION, remote)
+        } else {
+            CacheAgent::new(cache_dir, VERSION)
+        };
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (socket, server) = spawn_server(session_dir, agent.clone(), shutdown_rx).await?;
         Ok(Self {
@@ -166,6 +171,40 @@ impl CacheSession {
         }
         Ok(self.agent.stats())
     }
+}
+
+fn action_remote_cache(cache_dir: &Path) -> Result<Option<AgentRemoteCache>> {
+    let settings = Settings::get();
+    let Some(base_url) = settings.task.cache.remote_url.clone() else {
+        return Ok(None);
+    };
+    let namespace = settings
+        .task
+        .cache
+        .remote_namespace
+        .as_deref()
+        .map(str::trim)
+        .filter(|namespace| !namespace.is_empty())
+        .ok_or_else(|| {
+            eyre::eyre!("task.cache.remote_namespace is required when task.cache.remote_url is set")
+        })?
+        .to_string();
+    let client = RemoteCacheClient::new(RemoteCacheConfig {
+        base_url: base_url.parse().wrap_err("invalid task.cache.remote_url")?,
+        namespace,
+        token: settings.task.cache.remote_token.clone(),
+        token_file: settings.task.cache.remote_token_file.clone(),
+        oidc_audience: settings.task.cache.remote_oidc_audience.clone(),
+        connect_timeout: settings.http_timeout(),
+        read_timeout: settings.http_timeout(),
+        download_timeout: settings.http_download_timeout(),
+        retries: settings.http_retries(),
+    })?;
+    Ok(Some(AgentRemoteCache {
+        client,
+        mode: settings.task.cache.remote_mode,
+        staging_dir: cache_dir.join("remote"),
+    }))
 }
 
 impl Drop for CacheSession {
@@ -643,8 +682,8 @@ fn validate_handshake_response(response: &str) -> Result<()> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn session_environment_is_scoped_to_selected_adapters() {
+    #[tokio::test]
+    async fn session_environment_is_scoped_to_selected_adapters() {
         let cache = tempfile::tempdir().unwrap();
         let environment = CacheSessionEnvironment {
             socket: "socket".into(),
@@ -654,17 +693,17 @@ mod tests {
         };
         let mut task = Task::default();
         let mut values = BTreeMap::from([("RUSTC_WRAPPER".into(), "existing".into())]);
-        let run = environment.apply(&task, &mut values);
+        let run = environment.apply(&task, &mut values).await;
         assert!(run.is_none());
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
 
         task.rust_cache = Some(TaskRustCacheConfig { enabled: false });
-        let run = environment.apply(&task, &mut values);
+        let run = environment.apply(&task, &mut values).await;
         assert!(run.is_none());
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
 
         task.rust_cache = Some(TaskRustCacheConfig { enabled: true });
-        let run = environment.apply(&task, &mut values);
+        let run = environment.apply(&task, &mut values).await;
         assert!(run.is_some());
         assert_eq!(values.get(SOCKET_ENV).unwrap(), "socket");
         assert_eq!(values.get(STAGING_ENV).unwrap(), "staging");

--- a/src/task/task_cache_store.rs
+++ b/src/task/task_cache_store.rs
@@ -1157,7 +1157,9 @@ mod tests {
             .find_map(|upload| {
                 (upload.digest == root).then(|| match &upload.source {
                     BlobSource::Bytes(bytes) => bytes.as_slice(),
-                    BlobSource::File(_) => panic!("directory object must be in memory"),
+                    BlobSource::File(_) | BlobSource::Path(_) => {
+                        panic!("directory object must be in memory")
+                    }
                 })
             })
             .unwrap();
@@ -1170,7 +1172,9 @@ mod tests {
             .find_map(|upload| {
                 (&upload.digest == dist_digest).then(|| match &upload.source {
                     BlobSource::Bytes(bytes) => bytes.as_slice(),
-                    BlobSource::File(_) => panic!("directory object must be in memory"),
+                    BlobSource::File(_) | BlobSource::Path(_) => {
+                        panic!("directory object must be in memory")
+                    }
                 })
             })
             .unwrap();

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -648,10 +648,11 @@ impl TaskExecutor {
             .as_ref()
             .filter(|_| self.task_cache.writes())
             .map(|_| Arc::new(StdMutex::new(Vec::new())));
-        let action_cache_run = self
-            .cache_session
-            .as_ref()
-            .and_then(|session| session.apply(task, &mut env));
+        let action_cache_run = if let Some(session) = self.cache_session.as_ref() {
+            session.apply(task, &mut env).await
+        } else {
+            None
+        };
         let exec_ctx = TaskExecContext {
             task,
             env: &env,
@@ -748,7 +749,7 @@ impl TaskExecutor {
             None
         };
         if let Some(run) = action_cache_run
-            && let Err(err) = run.commit()
+            && let Err(err) = run.commit().await
         {
             warn!("task {} action manifest write failed: {err}", task.name);
         }


### PR DESCRIPTION
## Summary
- connect the in-process Rust action-cache session to the configured remote cache
- download remote action results and referenced blobs into the verified local CAS
- upload committed action results, blobs, and task action manifests at session shutdown
- merge local and remote task manifests under process and per-task filesystem locks, preserving newer local predictions across concurrent `mise run` processes
- degrade safely when a remote merge exceeds the prediction bound or optional post-upload reconciliation fails
- preserve local-only behavior when no remote cache is configured

## Validation
- `cargo fmt --check`
- `cargo test -p mise-cache-core` (26 passed at this layer)
- `cargo clippy -p mise-cache-core --all-features --all-targets -- -D warnings`
- cache-focused unit and end-to-end tests run on the top of the stack

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed cache consistency (manifest merge, ETag races, remote/local prediction conflicts) and expands the task-run async path; remote failures are mostly logged and degraded rather than failing tasks.
> 
> **Overview**
> Wires the in-process **Rust action-cache agent** to an optional remote cache when `task.cache.remote_url` is set, while keeping purely local behavior when it is not.
> 
> **`CacheAgent`** gains `new_remote` and local-first remote paths: blob and action-result lookups fall back to the remote (then into the verified local CAS), stores optionally upload blobs and action results, and remote hits can be promoted into the local action cache on `RecordActionHit`. **Task action manifests** are fetched at `begin_task`, merged with local state under per-task `fslock` locks and canonical JSON persistence, and uploaded on `commit_task` with ETag-based conditional writes and retry/reconcile on conflicts; merge failures (e.g. prediction limit) keep local data and log warnings.
> 
> **`RemoteCacheClient`** adds action-manifest GET/PUT (`/v1/action-manifests/...`), ETag validation, and **`BlobSource::Path`** for streaming uploads from on-disk CAS paths.
> 
> **`CacheSession`** builds the remote client from settings (namespace required with URL, mode, auth/timeouts) and propagates async `begin_task` / `commit_task` through task execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b452d8e4f5e5e56a0ca686f21168d3150a7a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added remote caching for task data and action results.
  - Added task action manifest synchronization with remote storage.
  - Added configurable authentication, retries, timeouts, operating modes, and staging.
  - Added support for streaming file-based blob uploads.

- **Improvements**
  - Task execution now asynchronously records and retrieves cached actions.
  - Cache hits can promote pending remote action results.
  - Concurrent cache updates safely detect conflicts and merge changes.
  - Remote cache configuration validates required connection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->