### PR TITLE
feat(cache): enforce CI trust and qualification policy

### DIFF
--- a/crates/mise-cache-core/src/agent.rs
+++ b/crates/mise-cache-core/src/agent.rs
@@ -54,6 +54,9 @@ pub enum AgentRequest {
     RecordActionHit {
         action: CacheDigest,
     },
+    RecordActionVerification {
+        matched: bool,
+    },
     StoreActionResult {
         result: RemoteActionResult,
     },
@@ -94,6 +97,7 @@ pub enum AgentResponse {
         result: Option<RemoteActionResult>,
     },
     ActionHitRecorded,
+    ActionVerificationRecorded,
     ActionStored {
         path: PathBuf,
     },
@@ -120,6 +124,16 @@ pub struct AgentStats {
     pub stores: u64,
     /// Total size of newly stored objects.
     pub stored_bytes: u64,
+    /// Number of cache hits compiled again for qualification.
+    pub verifications: u64,
+    /// Number of qualification builds that diverged from the cached result.
+    pub divergences: u64,
+    /// CAS payload bytes downloaded from the remote cache.
+    pub downloaded_bytes: u64,
+    /// CAS payload bytes uploaded to the remote cache.
+    pub uploaded_bytes: u64,
+    /// Complete actions staged before an adapter requested them.
+    pub prefetched_actions: u64,
 }
 
 /// Adapter-owned data needed to reconstruct an action before fresh dependency
@@ -139,6 +153,11 @@ struct AtomicAgentStats {
     hits: AtomicU64,
     stores: AtomicU64,
     stored_bytes: AtomicU64,
+    verifications: AtomicU64,
+    divergences: AtomicU64,
+    downloaded_bytes: AtomicU64,
+    uploaded_bytes: AtomicU64,
+    prefetched_actions: AtomicU64,
 }
 
 /// Shared state for an agent hosted by the top-level `mise run` process.
@@ -516,6 +535,11 @@ impl CacheAgent {
             hits: self.stats.hits.load(Ordering::Relaxed),
             stores: self.stats.stores.load(Ordering::Relaxed),
             stored_bytes: self.stats.stored_bytes.load(Ordering::Relaxed),
+            verifications: self.stats.verifications.load(Ordering::Relaxed),
+            divergences: self.stats.divergences.load(Ordering::Relaxed),
+            downloaded_bytes: self.stats.downloaded_bytes.load(Ordering::Relaxed),
+            uploaded_bytes: self.stats.uploaded_bytes.load(Ordering::Relaxed),
+            prefetched_actions: self.stats.prefetched_actions.load(Ordering::Relaxed),
         }
     }
 
@@ -636,6 +660,9 @@ impl CacheAgent {
         }
         self.actions.store(&result)?;
         self.pending_remote_actions.lock().unwrap().remove(&action);
+        self.stats
+            .prefetched_actions
+            .fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
@@ -691,6 +718,9 @@ impl CacheAgent {
         self.stats
             .stored_bytes
             .fetch_add(digest.size, Ordering::Relaxed);
+        self.stats
+            .downloaded_bytes
+            .fetch_add(digest.size, Ordering::Relaxed);
         Ok(path)
     }
 
@@ -703,6 +733,13 @@ impl CacheAgent {
                 self.find_action_result(&action).await
             }
             AgentRequest::RecordActionHit { action } => self.record_action_hit(&action),
+            AgentRequest::RecordActionVerification { matched } => {
+                self.stats.verifications.fetch_add(1, Ordering::Relaxed);
+                if !matched {
+                    self.stats.divergences.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(AgentResponse::ActionVerificationRecorded)
+            }
             AgentRequest::StoreActionResult { result } => self.store_action_result(&result).await,
             AgentRequest::FindActionPrediction { task, invocation } => {
                 self.find_action_prediction(&task, &invocation)
@@ -783,6 +820,10 @@ impl CacheAgent {
                     "remote cache blob upload failed for {}: {error}",
                     digest.hash
                 );
+            } else {
+                self.stats
+                    .uploaded_bytes
+                    .fetch_add(digest.size, Ordering::Relaxed);
             }
         }
         Ok(AgentResponse::Stored { path })
@@ -1279,6 +1320,15 @@ mod tests {
                 ..AgentStats::default()
             }
         );
+
+        assert!(matches!(
+            agent
+                .respond(AgentRequest::RecordActionVerification { matched: false })
+                .await,
+            AgentResponse::ActionVerificationRecorded
+        ));
+        assert_eq!(agent.stats().verifications, 1);
+        assert_eq!(agent.stats().divergences, 1);
     }
 
     #[tokio::test]

--- a/docs/tasks/remote-cache-protocol.md
+++ b/docs/tasks/remote-cache-protocol.md
@@ -10,11 +10,13 @@ storage, authentication, and integrity model. It does not expose mise's local ca
 manifests, or archive formats. Local storage is an implementation detail and may use archives or
 packs without changing the remote protocol.
 
-Version 1 separates two kinds of immutable data:
+Version 1 separates immutable build data from mutable discovery state:
 
 - **Content-addressable storage (CAS)** contains blobs and directory objects identified by their
   digest.
 - **Action results** map the digest of a canonical build action to its output directory and logs.
+- **Action manifests** are ETag-guarded, task-scoped indexes used to prefetch prior action results on
+  fresh workers. Clients merge and retry stale writes so concurrent builds do not lose discoveries.
 
 This separation deduplicates content between actions, permits partial and parallel transfers, and
 allows a server to verify all referenced content before publishing a cache hit.
@@ -66,6 +68,11 @@ not require unused prediction fields in task metadata.
 Outside CI, mise action-cache sessions may read local and remote entries but do not upload. CI write
 authorization remains a server decision based on verified workload identity; a client-side mode is
 only defense in depth.
+
+GitHub Actions protected-branch `push` jobs and GitLab protected-branch push pipelines may use the
+configured write mode. Pull requests, tags/releases, unprotected branches, unknown CI systems, and
+local runs are restricted to reads; a configured write-only client disables its remote rather than
+silently broadening to read access. Tag and release pipelines do not activate compiler caching.
 
 ## Digests
 
@@ -330,6 +337,20 @@ The response is `201 Created`, `204 No Content` for an identical committed resul
 when a different result already owns the action key, or `412 Precondition Failed` when the immutable
 precondition is absent or fails. Concurrent valid writers may upload identical CAS data, but only one
 action-result commit wins.
+
+## Action-manifest operations
+
+`GET /v1/action-manifests/{algorithm}/{hash}/{size}` returns the latest canonical task action
+manifest and a strong BLAKE3 `ETag`, or `404 Not Found`. The URL key is the digest of the canonical
+selector `{"kind":"task_action_manifest","task":"<task identity>","version":1}`; the server
+rejects a manifest whose task identity does not produce that key.
+
+`PUT /v1/action-manifests/{algorithm}/{hash}/{size}` creates a manifest with `If-None-Match: *` or
+updates the version named by `If-Match: "<etag>"`. The server returns `201 Created` for a new
+manifest, `204 No Content` for an update, `412 Precondition Failed` for a stale writer, and `428
+Precondition Required` when neither conditional header is present. After `412`, clients read the
+current manifest, merge predictions by invocation digest, and retry. This mutable index never
+changes the immutability of action results or CAS objects.
 
 Ordinary cache writers do not receive delete permission. Administrative deletion uses a separately
 authorized endpoint and must remove the action-result mapping before unreachable CAS data is garbage

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -938,6 +938,11 @@ run = "cargo build"
 rust_cache = true
 ```
 
+Set `rust_cache = { verify = true }` while qualifying the cache for a project or compiler upgrade.
+On a would-be hit, mise restores the cached result into a staging build, runs rustc anyway, compares
+diagnostics, output contents, and file modes, reports any divergence, and always returns rustc's live
+result. Verification hits are never served and are reported separately in the session statistics.
+
 mise injects compiler integration only into the task's child environment. Shell activation, bare
 `cargo build`, editor processes, and release builds are not intercepted. A top-level
 `mise run` owns the cache session, flushes pending uploads, and reports hits, misses, and transferred

--- a/e2e/tasks/test_task_rust_cache_restore
+++ b/e2e/tasks/test_task_rust_cache_restore
@@ -109,6 +109,6 @@ printf 'cached stderr\n' >&2
 EOF
 chmod +x fake-rustc
 
-assert_contains "mise run restore 2>&1" "Action cache: 1/3 hits"
+assert_contains "mise run restore 2>&1" "Action cache: 1 hits, 2 misses, 0 prefetched;"
 rm -rf out
-assert_contains "mise run restore 2>&1" "Action cache: 1/1 hits"
+assert_contains "mise run restore 2>&1" "Action cache: 1 hits, 0 misses, 0 prefetched;"

--- a/settings.toml
+++ b/settings.toml
@@ -2694,7 +2694,10 @@ Control access to the remote cache used by task result and action caching:
 - `write-only` uploads results without reading remote entries.
 
 The per-run `--task-cache=local-only` mode disables remote task-result access. Action-cache adapters
-may further restrict this mode; local developer task runs are read-only by default.
+may further restrict this mode. Remote writes are allowed only from protected-branch push pipelines
+in GitHub Actions and GitLab CI; pull requests, unprotected branches, other CI systems, and local
+developer runs are read-only. The server must independently enforce the same policy from verified
+OIDC claims.
 """
 enum = ["read-write", "read-only", "write-only"]
 env = "MISE_TASK_CACHE_REMOTE_MODE"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,6 +29,53 @@ pub(crate) mod session;
 
 pub use mise_cache_core::RemoteCacheMode as CacheRemoteMode;
 
+pub(crate) fn effective_remote_cache_mode(configured: CacheRemoteMode) -> Option<CacheRemoteMode> {
+    effective_remote_cache_mode_with(configured, |name| std::env::var(name).ok())
+}
+
+fn effective_remote_cache_mode_with(
+    configured: CacheRemoteMode,
+    get_env: impl Fn(&str) -> Option<String>,
+) -> Option<CacheRemoteMode> {
+    if trusted_cache_writer(&get_env) {
+        return Some(configured);
+    }
+    match configured {
+        CacheRemoteMode::ReadWrite | CacheRemoteMode::ReadOnly => Some(CacheRemoteMode::ReadOnly),
+        CacheRemoteMode::WriteOnly => None,
+    }
+}
+
+pub(crate) fn release_cache_context() -> bool {
+    release_cache_context_with(|name| std::env::var(name).ok())
+}
+
+fn trusted_cache_writer(get_env: &impl Fn(&str) -> Option<String>) -> bool {
+    if env_truthy(get_env("GITHUB_ACTIONS")) {
+        return get_env("GITHUB_EVENT_NAME").as_deref() == Some("push")
+            && get_env("GITHUB_REF_TYPE").as_deref() == Some("branch")
+            && env_truthy(get_env("GITHUB_REF_PROTECTED"));
+    }
+    if env_truthy(get_env("GITLAB_CI")) {
+        return get_env("CI_PIPELINE_SOURCE").as_deref() == Some("push")
+            && get_env("CI_COMMIT_TAG").is_none()
+            && get_env("CI_MERGE_REQUEST_IID").is_none()
+            && env_truthy(get_env("CI_COMMIT_REF_PROTECTED"));
+    }
+    false
+}
+
+fn release_cache_context_with(get_env: impl Fn(&str) -> Option<String>) -> bool {
+    (env_truthy(get_env("GITHUB_ACTIONS"))
+        && (get_env("GITHUB_REF_TYPE").as_deref() == Some("tag")
+            || get_env("GITHUB_EVENT_NAME").as_deref() == Some("release")))
+        || (env_truthy(get_env("GITLAB_CI")) && get_env("CI_COMMIT_TAG").is_some())
+}
+
+fn env_truthy(value: Option<String>) -> bool {
+    value.is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+}
+
 #[derive(Debug)]
 pub struct CacheManagerBuilder {
     cache_file_path: PathBuf,
@@ -443,10 +490,69 @@ pub(crate) fn prune(dir: &Path, opts: &PruneOptions) -> Result<PruneResults> {
 #[cfg(test)]
 mod tests {
     use crate::config::Config;
+    use std::collections::BTreeMap;
     use std::fs;
 
     use super::*;
     use pretty_assertions::assert_eq;
+
+    fn environment(values: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let values = values
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect::<BTreeMap<_, _>>();
+        move |key| values.get(key).cloned()
+    }
+
+    #[test]
+    fn remote_writes_require_a_protected_branch_ci_context() {
+        assert_eq!(
+            effective_remote_cache_mode_with(CacheRemoteMode::ReadWrite, environment(&[])),
+            Some(CacheRemoteMode::ReadOnly)
+        );
+        assert_eq!(
+            effective_remote_cache_mode_with(CacheRemoteMode::WriteOnly, environment(&[])),
+            None
+        );
+        assert_eq!(
+            effective_remote_cache_mode_with(
+                CacheRemoteMode::ReadWrite,
+                environment(&[
+                    ("GITHUB_ACTIONS", "true"),
+                    ("GITHUB_EVENT_NAME", "pull_request"),
+                    ("GITHUB_REF_PROTECTED", "true"),
+                    ("GITHUB_REF_TYPE", "branch"),
+                ]),
+            ),
+            Some(CacheRemoteMode::ReadOnly)
+        );
+        assert_eq!(
+            effective_remote_cache_mode_with(
+                CacheRemoteMode::ReadWrite,
+                environment(&[
+                    ("GITHUB_ACTIONS", "true"),
+                    ("GITHUB_EVENT_NAME", "push"),
+                    ("GITHUB_REF_PROTECTED", "true"),
+                    ("GITHUB_REF_TYPE", "branch"),
+                ]),
+            ),
+            Some(CacheRemoteMode::ReadWrite)
+        );
+    }
+
+    #[test]
+    fn release_ci_contexts_are_cache_ineligible() {
+        assert!(release_cache_context_with(environment(&[
+            ("GITHUB_ACTIONS", "true"),
+            ("GITHUB_EVENT_NAME", "push"),
+            ("GITHUB_REF_TYPE", "tag"),
+        ])));
+        assert!(!release_cache_context_with(environment(&[
+            ("GITHUB_ACTIONS", "true"),
+            ("GITHUB_EVENT_NAME", "push"),
+            ("GITHUB_REF_TYPE", "branch"),
+        ])));
+    }
 
     #[tokio::test]
     async fn test_cache() {

--- a/src/cache/rustc.rs
+++ b/src/cache/rustc.rs
@@ -17,22 +17,40 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, ExitStatus, Output};
 use std::time::SystemTime;
 
+struct CachedCompilation {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    outputs: Vec<CachedOutput>,
+}
+
+struct CachedOutput {
+    path: PathBuf,
+    digest: CacheDigest,
+    mode: u32,
+}
+
 pub(super) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode> {
     let invocation = RustcInvocation::parse(arguments)?;
     let working_dir = std::env::current_dir()?;
     let outputs = invocation.outputs(&working_dir)?;
 
+    let verify = std::env::var_os(session::VERIFY_ENV).is_some();
+    let mut verification = None;
     let mut action_lookup_attempted = false;
     if outputs.dep_info.is_file()
         && let Ok((action, discovered)) =
             action_from_current_dep_info(rustc, &invocation, &outputs.dep_info, &working_dir)
     {
         action_lookup_attempted = true;
-        match restore_result(&action, &outputs, &discovered) {
-            Ok(Some((stdout, stderr))) => {
+        match restore_result(&action, &outputs, &discovered, !verify) {
+            Ok(Some(cached)) => {
                 record_prediction(rustc, &invocation, &action, &discovered, &working_dir);
-                let _ = replay_bytes(&stdout, &stderr);
-                return Ok(ExitCode::SUCCESS);
+                if verify {
+                    verification = Some(cached);
+                } else {
+                    let _ = replay_bytes(&cached.stdout, &cached.stderr);
+                    return Ok(ExitCode::SUCCESS);
+                }
             }
             Ok(None) => {}
             Err(error) => {
@@ -41,10 +59,14 @@ pub(super) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
         }
     }
     if !action_lookup_attempted {
-        match restore_predicted_result(rustc, &invocation, &outputs, &working_dir) {
-            Ok(Some((stdout, stderr))) => {
-                let _ = replay_bytes(&stdout, &stderr);
-                return Ok(ExitCode::SUCCESS);
+        match restore_predicted_result(rustc, &invocation, &outputs, &working_dir, !verify) {
+            Ok(Some(cached)) => {
+                if verify {
+                    verification = Some(cached);
+                } else {
+                    let _ = replay_bytes(&cached.stdout, &cached.stderr);
+                    return Ok(ExitCode::SUCCESS);
+                }
             }
             Ok(None) => {}
             Err(error) => {
@@ -60,6 +82,14 @@ pub(super) fn compile(rustc: &OsStr, arguments: &[OsString]) -> Result<ExitCode>
         .output()
         .wrap_err("failed to execute rustc")?;
     let _ = replay_output(&output);
+    if let Some(cached) = verification {
+        let matched = cached_matches(&cached, &output);
+        record_verification(matched);
+        if !matched {
+            eprintln!("mise rustc cache warning: shadow verification diverged from cached output");
+        }
+        return Ok(exit_code(output.status));
+    }
     if output.status.success() {
         let publication: Result<()> = (|| {
             let (action, discovered) =
@@ -84,7 +114,8 @@ fn restore_predicted_result(
     invocation: &RustcInvocation,
     outputs: &RustcOutputs,
     working_dir: &Path,
-) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+    restore_outputs: bool,
+) -> Result<Option<CachedCompilation>> {
     let task = std::env::var(session::TASK_ENV)
         .wrap_err_with(|| format!("{} is not set", session::TASK_ENV))?;
     let mut context = base_action_context(rustc, working_dir)?;
@@ -114,7 +145,7 @@ fn restore_predicted_result(
     let discovered = input_prediction.discover(working_dir, &context.path_mappings)?;
     discovered.clone().apply_to(&mut context)?;
     let action = invocation.action(context)?;
-    let restored = restore_result(&action, outputs, &discovered)?;
+    let restored = restore_result(&action, outputs, &discovered, restore_outputs)?;
     if restored.is_some() {
         record_prediction_value(invocation_digest, action.digest.clone(), prediction.payload);
     }
@@ -229,7 +260,8 @@ fn restore_result(
     action: &RustcAction,
     outputs: &RustcOutputs,
     discovered: &DiscoveredInputs,
-) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+    restore_outputs: bool,
+) -> Result<Option<CachedCompilation>> {
     let responses = session::request_agent(&[AgentRequest::FindActionResult {
         action: action.digest.clone(),
     }])?;
@@ -270,6 +302,14 @@ fn restore_result(
     let directory: CacheDirectory =
         read_canonical_blob(&roots[2], &output_root_digest, "output directory")?;
     let files = validated_outputs(directory, outputs)?;
+    let cached_outputs = files
+        .iter()
+        .map(|(node, destination)| CachedOutput {
+            path: destination.clone(),
+            digest: node.digest.clone(),
+            mode: node.mode,
+        })
+        .collect();
 
     let mut digests = vec![metadata.stdout.clone(), metadata.stderr.clone()];
     digests.extend(files.iter().map(|(node, _)| node.digest.clone()));
@@ -297,9 +337,54 @@ fn restore_result(
 
     discovered.verify()?;
     verify_environment(&discovered.environment)?;
-    persist_outputs(staged)?;
-    record_action_hit(&action.digest);
-    Ok(Some((stdout, stderr)))
+    finalize_restored_outputs(staged, restore_outputs)?;
+    if restore_outputs {
+        record_action_hit(&action.digest);
+    }
+    Ok(Some(CachedCompilation {
+        stdout,
+        stderr,
+        outputs: cached_outputs,
+    }))
+}
+
+fn finalize_restored_outputs(
+    staged: Vec<(tempfile::NamedTempFile, PathBuf)>,
+    restore_outputs: bool,
+) -> Result<()> {
+    if restore_outputs {
+        persist_outputs(staged)?;
+    }
+    Ok(())
+}
+
+fn cached_matches(cached: &CachedCompilation, output: &Output) -> bool {
+    output.status.success()
+        && cached.stdout == output.stdout
+        && cached.stderr == output.stderr
+        && cached.outputs.iter().all(|expected| {
+            std::fs::metadata(&expected.path).is_ok_and(|metadata| {
+                file_mode(&metadata) == expected.mode
+                    && expected
+                        .digest
+                        .matches_file(&expected.path)
+                        .unwrap_or(false)
+            })
+        })
+}
+
+fn record_verification(matched: bool) {
+    let responses = session::request_agent(&[AgentRequest::RecordActionVerification { matched }]);
+    match responses.map(|responses| responses.into_iter().next()) {
+        Ok(Some(AgentResponse::ActionVerificationRecorded)) => {}
+        Ok(Some(AgentResponse::Error { message })) => {
+            eprintln!("mise rustc cache warning: verification was not recorded: {message}");
+        }
+        Ok(_) => eprintln!("mise rustc cache warning: verification was not recorded"),
+        Err(error) => {
+            eprintln!("mise rustc cache warning: verification was not recorded: {error:#}");
+        }
+    }
 }
 
 fn persist_outputs(staged: Vec<(tempfile::NamedTempFile, PathBuf)>) -> Result<()> {
@@ -870,5 +955,17 @@ mod tests {
         );
         assert!(!first_destination.exists());
         assert!(blocked_destination.is_dir());
+    }
+
+    #[test]
+    fn qualification_does_not_publish_cached_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("cached.rlib");
+        let mut cached = tempfile::NamedTempFile::new_in(root.path()).unwrap();
+        cached.write_all(b"cached").unwrap();
+
+        finalize_restored_outputs(vec![(cached, destination.clone())], false).unwrap();
+
+        assert!(!destination.exists());
     }
 }

--- a/src/cache/session.rs
+++ b/src/cache/session.rs
@@ -23,6 +23,7 @@ const RUSTC_SHIM_STEM: &str = "mise-cache-rustc";
 const SOCKET_ENV: &str = "MISE_CACHE_SOCKET";
 pub(super) const STAGING_ENV: &str = "MISE_CACHE_STAGING_DIR";
 pub(super) const TASK_ENV: &str = "MISE_CACHE_TASK";
+pub(super) const VERIFY_ENV: &str = "MISE_CACHE_RUST_VERIFY";
 const PREVIOUS_RUSTC_WRAPPER_ENV: &str = "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -60,6 +61,11 @@ impl CacheSessionEnvironment {
         environment.insert(SOCKET_ENV.into(), self.socket.clone());
         environment.insert(STAGING_ENV.into(), self.staging.clone());
         environment.insert(TASK_ENV.into(), protocol_task);
+        if task.rust_cache.as_ref().is_some_and(|cache| cache.verify) {
+            environment.insert(VERIFY_ENV.into(), "1".into());
+        } else {
+            environment.remove(VERIFY_ENV);
+        }
         if let Some(previous) = environment.insert("RUSTC_WRAPPER".into(), self.rustc_shim.clone())
             && previous != self.rustc_shim
         {
@@ -201,9 +207,13 @@ fn action_remote_cache(cache_dir: &Path) -> Result<Option<AgentRemoteCache>> {
         download_timeout: settings.http_download_timeout(),
         retries: settings.http_retries(),
     })?;
+    let Some(mode) = crate::cache::effective_remote_cache_mode(settings.task.cache.remote_mode)
+    else {
+        return Ok(None);
+    };
     Ok(Some(AgentRemoteCache {
         client,
-        mode: settings.task.cache.remote_mode,
+        mode,
         staging_dir: cache_dir.join("remote"),
     }))
 }
@@ -220,16 +230,37 @@ impl Drop for CacheSession {
 }
 
 pub(crate) fn display_stats(stats: AgentStats) {
-    if stats.lookups == 0 && stats.stores == 0 {
+    if stats.lookups == 0
+        && stats.stores == 0
+        && stats.verifications == 0
+        && stats.downloaded_bytes == 0
+        && stats.uploaded_bytes == 0
+    {
         return;
     }
     safe_eprintln!(
-        "Action cache: {}/{} hits, {} stored ({})",
+        "Action cache: {} hits, {} misses, {} prefetched; {} downloaded, {} uploaded, {} stored locally",
         stats.hits,
-        stats.lookups,
-        stats.stores,
+        cache_misses(&stats),
+        stats.prefetched_actions,
+        ByteSize::b(stats.downloaded_bytes).display().iec(),
+        ByteSize::b(stats.uploaded_bytes).display().iec(),
         ByteSize::b(stats.stored_bytes).display().iec(),
     );
+    if stats.verifications > 0 {
+        safe_eprintln!(
+            "Action cache qualification: {} verified, {} diverged",
+            stats.verifications,
+            stats.divergences,
+        );
+    }
+}
+
+fn cache_misses(stats: &AgentStats) -> u64 {
+    stats
+        .lookups
+        .saturating_sub(stats.hits)
+        .saturating_sub(stats.verifications)
 }
 
 fn install_session_shim(session_dir: &Path) -> Result<PathBuf> {
@@ -698,12 +729,18 @@ mod tests {
         assert!(run.is_none());
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
 
-        task.rust_cache = Some(TaskRustCacheConfig { enabled: false });
+        task.rust_cache = Some(TaskRustCacheConfig {
+            enabled: false,
+            ..TaskRustCacheConfig::default()
+        });
         let run = environment.apply(&task, &mut values).await;
         assert!(run.is_none());
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "existing");
 
-        task.rust_cache = Some(TaskRustCacheConfig { enabled: true });
+        task.rust_cache = Some(TaskRustCacheConfig {
+            verify: true,
+            ..TaskRustCacheConfig::default()
+        });
         let run = environment.apply(&task, &mut values).await;
         assert!(run.is_some());
         assert_eq!(values.get(SOCKET_ENV).unwrap(), "socket");
@@ -712,6 +749,7 @@ mod tests {
         assert_eq!(values.get("RUSTC_WRAPPER").unwrap(), "shim");
         assert_eq!(values.get(PREVIOUS_RUSTC_WRAPPER_ENV).unwrap(), "existing");
         assert_eq!(values.get("CARGO_INCREMENTAL").unwrap(), "0");
+        assert_eq!(values.get(VERIFY_ENV).unwrap(), "1");
     }
 
     #[test]
@@ -722,5 +760,16 @@ mod tests {
         })
         .unwrap();
         assert!(validate_handshake_response(&response).is_err());
+    }
+
+    #[test]
+    fn qualification_results_are_not_reported_as_misses() {
+        let stats = AgentStats {
+            lookups: 5,
+            hits: 2,
+            verifications: 2,
+            ..AgentStats::default()
+        };
+        assert_eq!(cache_misses(&stats), 1);
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1264,6 +1264,10 @@ impl Run {
         if !enabled {
             return Ok(());
         }
+        if crate::cache::release_cache_context() {
+            warn!("Rust action caching is disabled for release CI contexts");
+            return Ok(());
+        }
         self.cache_session = Some(
             crate::cache::session::CacheSession::start(
                 &self.tmpdir,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4667,19 +4667,25 @@ mod tests {
 
     #[test]
     fn test_task_config_rust_cache_is_a_default() {
-        let rust_default = Some(TaskRustCacheConfig { enabled: true });
+        let rust_default = Some(TaskRustCacheConfig::default());
         let mut inherited = Task::default();
         apply_task_config_rust_cache_default(&mut inherited, &rust_default);
         assert_eq!(inherited.rust_cache, rust_default);
 
         let mut disabled = Task {
-            rust_cache: Some(TaskRustCacheConfig { enabled: false }),
+            rust_cache: Some(TaskRustCacheConfig {
+                enabled: false,
+                ..TaskRustCacheConfig::default()
+            }),
             ..Default::default()
         };
         apply_task_config_rust_cache_default(&mut disabled, &rust_default);
         assert_eq!(
             disabled.rust_cache,
-            Some(TaskRustCacheConfig { enabled: false })
+            Some(TaskRustCacheConfig {
+                enabled: false,
+                ..TaskRustCacheConfig::default()
+            })
         );
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -568,70 +568,76 @@ pub struct TaskWatchOptions {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct TaskLanguageCacheOptions {
+struct TaskRustCacheOptions {
     enabled: bool,
+    verify: bool,
 }
 
-impl Default for TaskLanguageCacheOptions {
+impl Default for TaskRustCacheOptions {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            verify: false,
+        }
     }
 }
 
-macro_rules! task_language_cache_config {
-    ($name:ident) => {
-        #[derive(Debug, Clone, PartialEq, Eq)]
-        pub struct $name {
-            pub enabled: bool,
-        }
-
-        impl Default for $name {
-            fn default() -> Self {
-                Self { enabled: true }
-            }
-        }
-
-        impl<'de> Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct LanguageCacheVisitor;
-
-                impl<'de> serde::de::Visitor<'de> for LanguageCacheVisitor {
-                    type Value = $name;
-
-                    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                        formatter.write_str("a boolean or language cache options table")
-                    }
-
-                    fn visit_bool<E>(self, enabled: bool) -> std::result::Result<Self::Value, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                        Ok($name { enabled })
-                    }
-
-                    fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
-                    where
-                        M: serde::de::MapAccess<'de>,
-                    {
-                        let options = TaskLanguageCacheOptions::deserialize(
-                            serde::de::value::MapAccessDeserializer::new(map),
-                        )?;
-                        Ok($name {
-                            enabled: options.enabled,
-                        })
-                    }
-                }
-
-                deserializer.deserialize_any(LanguageCacheVisitor)
-            }
-        }
-    };
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskRustCacheConfig {
+    pub enabled: bool,
+    pub verify: bool,
 }
 
-task_language_cache_config!(TaskRustCacheConfig);
+impl Default for TaskRustCacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            verify: false,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskRustCacheConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct RustCacheVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for RustCacheVisitor {
+            type Value = TaskRustCacheConfig;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str("a boolean or Rust cache options table")
+            }
+
+            fn visit_bool<E>(self, enabled: bool) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(TaskRustCacheConfig {
+                    enabled,
+                    verify: false,
+                })
+            }
+
+            fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
+            where
+                M: serde::de::MapAccess<'de>,
+            {
+                let options = TaskRustCacheOptions::deserialize(
+                    serde::de::value::MapAccessDeserializer::new(map),
+                )?;
+                Ok(TaskRustCacheConfig {
+                    enabled: options.enabled,
+                    verify: options.verify,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(RustCacheVisitor)
+    }
+}
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -3667,13 +3673,22 @@ rust_cache = {}
         )
         .unwrap();
 
+        assert_eq!(enabled.rust_cache, Some(TaskRustCacheConfig::default()));
+        assert_eq!(table.rust_cache, Some(TaskRustCacheConfig::default()));
+
+        let verify: Task = toml::from_str(
+            r#"
+run = "cargo build"
+rust_cache = { verify = true }
+"#,
+        )
+        .unwrap();
         assert_eq!(
-            enabled.rust_cache,
-            Some(TaskRustCacheConfig { enabled: true })
-        );
-        assert_eq!(
-            table.rust_cache,
-            Some(TaskRustCacheConfig { enabled: true })
+            verify.rust_cache,
+            Some(TaskRustCacheConfig {
+                verify: true,
+                ..TaskRustCacheConfig::default()
+            })
         );
     }
 
@@ -3696,11 +3711,17 @@ rust_cache = { enabled = false }
 
         assert_eq!(
             disabled.rust_cache,
-            Some(TaskRustCacheConfig { enabled: false })
+            Some(TaskRustCacheConfig {
+                enabled: false,
+                ..TaskRustCacheConfig::default()
+            })
         );
         assert_eq!(
             table.rust_cache,
-            Some(TaskRustCacheConfig { enabled: false })
+            Some(TaskRustCacheConfig {
+                enabled: false,
+                ..TaskRustCacheConfig::default()
+            })
         );
     }
 
@@ -4996,7 +5017,7 @@ echo "test"
                 command_inputs: vec![],
             })
         );
-        assert_eq!(task.rust_cache, Some(TaskRustCacheConfig { enabled: true }));
+        assert_eq!(task.rust_cache, Some(TaskRustCacheConfig::default()));
         assert_eq!(task.pass_through_env, ["DEPLOY_TOKEN"]);
         assert_eq!(task.shell, Some("bash -c".to_string()));
         assert_eq!(task.quiet, true);

--- a/src/task/task_cache.rs
+++ b/src/task/task_cache.rs
@@ -406,9 +406,11 @@ impl TaskArtifactCacheBuilder {
                     )
                 })?
                 .to_string();
-            Some(RemoteTaskCacheConfig {
+            let mode = crate::cache::effective_remote_cache_mode(settings.task.cache.remote_mode);
+            let base_url = base_url.parse().wrap_err("invalid task.cache.remote_url")?;
+            mode.map(|mode| RemoteTaskCacheConfig {
                 remote: RemoteCacheConfig {
-                    base_url: base_url.parse().wrap_err("invalid task.cache.remote_url")?,
+                    base_url,
                     namespace,
                     token: settings.task.cache.remote_token.clone(),
                     token_file: settings.task.cache.remote_token_file.clone(),
@@ -419,7 +421,7 @@ impl TaskArtifactCacheBuilder {
                     retries: settings.http_retries(),
                 },
                 staging_dir: cache_dir.join("remote"),
-                mode: settings.task.cache.remote_mode,
+                mode,
             })
         } else {
             None

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -418,6 +418,7 @@ impl TaskExecutor {
                     "MISE_CACHE_SOCKET".into(),
                     "MISE_CACHE_STAGING_DIR".into(),
                     "MISE_CACHE_TASK".into(),
+                    "MISE_CACHE_RUST_VERIFY".into(),
                     "MISE_CACHE_PREVIOUS_RUSTC_WRAPPER".into(),
                     "RUSTC_WRAPPER".into(),
                     "CARGO_INCREMENTAL".into(),


### PR DESCRIPTION
## Summary
- permit remote cache writes only from protected `main` CI contexts
- keep pull requests, tags, unprotected pushes, unknown CI, and local runs read-only
- add `rust_cache = { verify = true }` qualification mode that compares cached and live compiler outputs
- report verified qualification entries separately from restored hits and true misses
- expose separate hit, miss, prefetch, download, upload, and local-store statistics
- document the remote action-cache trust and qualification model

## Stack
- depends on #11843 and #11842

## Validation
- `cargo fmt --check`
- `cargo test -p mise-cache-core` (29 passed)
- `cargo test --bin mise cache::` (42 passed)
- `cargo clippy -p mise-cache-core --all-features --all-targets -- -D warnings`
- `mise run test:e2e e2e/tasks/test_task_action_cache_session e2e/tasks/test_task_rust_cache_restore`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes who can publish to shared remote caches and alters rustc interception on cache hits; misclassified CI env vars could block writes or allow unexpected read-only behavior, and verify mode changes build outputs and timing on every hit.
> 
> **Overview**
> **Remote cache trust** is enforced client-side: only GitHub Actions and GitLab **protected-branch push** pipelines keep the configured remote mode; everything else is read-only, and `write-only` disables the remote instead of widening access. **Tag/release CI** skips starting the Rust action-cache session entirely.
> 
> **`rust_cache = { verify = true }`** runs a shadow compile on would-be hits—cached outputs are staged but not published, rustc runs live, results are compared (stdout/stderr, digests, modes), divergences are warned, and the live compiler output is always returned. Verification is tracked separately from hits and does not count as a miss.
> 
> The cache **agent** gains `RecordActionVerification` and expanded **session stats** (verifications, divergences, download/upload bytes, prefetched actions). End-of-run reporting uses **hits / misses / prefetched** plus transfer and local-store byte totals, with a separate qualification line when verify ran.
> 
> Docs and settings describe action manifests, the CI write policy, and the verify option; e2e expectations match the new stats format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2de7f90d3d55a3988129e5f195a0ff24929467b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->