### PR TITLE
feat(python): install pypy on the precompiled path

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -34,6 +34,27 @@ const ATTESTATION_HELP: &str = "To disable attestation verification, set MISE_PY
     or add `python.github_attestations = false` under [settings] in mise.toml";
 const PBS_RELEASE_DOWNLOAD_URL: &str =
     "https://github.com/astral-sh/python-build-standalone/releases/download/";
+/// PyPy's own release index. python-build-standalone ships CPython only, so this is where the
+/// precompiled path has to look for a `pypy*` version.
+const PYPY_VERSIONS_URL: &str = "https://downloads.python.org/pypy/versions.json";
+
+/// One entry of PyPy's `versions.json`. Only the fields mise uses are modeled.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct PypyRelease {
+    pypy_version: String,
+    python_version: String,
+    #[serde(default)]
+    date: Option<String>,
+    files: Vec<PypyFile>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct PypyFile {
+    filename: String,
+    arch: String,
+    platform: String,
+    download_url: String,
+}
 
 #[derive(Debug)]
 pub struct PythonPlugin {
@@ -329,11 +350,150 @@ impl PythonPlugin {
             .await
     }
 
+    async fn fetch_pypy_releases(&self) -> eyre::Result<&Vec<PypyRelease>> {
+        static PYPY_CACHE: Lazy<CacheManager<Vec<PypyRelease>>> = Lazy::new(|| {
+            CacheManagerBuilder::new(dirs::CACHE.join("python").join("pypy.msgpack.z"))
+                .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
+                .build()
+        });
+        PYPY_CACHE
+            .get_or_try_init_async(async || Ok(HTTP_FETCH.json(PYPY_VERSIONS_URL).await?))
+            .await
+    }
+
+    /// Resolve the archive a `pypy*` version would install on `target`, for `mise lock`.
+    ///
+    /// The URL is always recorded when one exists; the checksum stays unset because PyPy publishes
+    /// none in machine-readable form, and `verify_checksum` fills it in on first install. An
+    /// unresolvable target (no build published, or a version outside the index) records nothing
+    /// rather than failing the lock of the other platforms.
+    async fn resolve_pypy_lock_info(
+        &self,
+        version: &str,
+        target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        // Same split as fetch_precompiled_for_target: settings win for the platform we are on,
+        // the target's own values describe every other one.
+        let settings = Settings::get();
+        let (os, arch) = if target.is_current() {
+            // settings.os(), not std::env::consts::OS: `is_current` compares against
+            // Platform::current(), which is built from settings.os(). Reading the host OS here
+            // would let `MISE_OS=linux` on a windows host take this branch and then record a
+            // win64 archive under the linux platform key.
+            (settings.os(), settings.arch())
+        } else {
+            (target.os_name(), target.arch_name())
+        };
+        let Some((platform, arch)) = pypy_platform_arch(os, arch) else {
+            return Ok(PlatformInfo::default());
+        };
+        let releases = self.fetch_pypy_releases().await?;
+        let url = releases
+            .iter()
+            .find(|r| pypy_version_str(r).as_deref() == Some(version))
+            .and_then(|r| pypy_file_for(r, platform, arch))
+            .map(|f| f.download_url.clone());
+        Ok(PlatformInfo {
+            url,
+            ..Default::default()
+        })
+    }
+
+    /// Install a `pypy*` version from PyPy's own downloads.
+    ///
+    /// python-build-standalone publishes CPython only, so the precompiled path cannot serve these.
+    /// PyPy publishes no checksums next to its archives — they live on an HTML page — so integrity
+    /// rests on `verify_checksum`, which locks the digest on first install and enforces it after,
+    /// the same treatment every backend gives a source without upstream checksums. There is no
+    /// provenance step for the same reason: PyPy publishes no attestations.
+    async fn install_pypy(&self, ctx: &InstallContext, tv: &mut ToolVersion) -> eyre::Result<()> {
+        let platform_key = self.get_platform_key();
+        let url = if let Some(url) = tv
+            .lock_platforms
+            .get(&platform_key)
+            .and_then(|pi| pi.url.clone())
+        {
+            debug!("using lockfile URL for platform {platform_key}: {url}");
+            url
+        } else {
+            let settings = Settings::get();
+            let os = settings.os();
+            let (platform, arch) = pypy_platform_arch(os, settings.arch())
+                .ok_or_else(|| eyre!("pypy publishes no build for {os}-{}", settings.arch()))?;
+            let releases = self.fetch_pypy_releases().await?;
+            let release = releases
+                .iter()
+                .find(|r| pypy_version_str(r).as_deref() == Some(tv.version.as_str()))
+                .ok_or_else(|| eyre!("no pypy release found for {tv}"))?;
+            let file = pypy_file_for(release, platform, arch).ok_or_else(|| {
+                eyre!(
+                    "pypy {} publishes no {platform}/{arch} build",
+                    release.pypy_version
+                )
+            })?;
+            file.download_url.clone()
+        };
+        let filename = url.split('/').next_back().unwrap();
+
+        let tarball_path = tv.download_path().join(filename);
+        ctx.pr.set_message(format!("download {filename}"));
+        HTTP.download_file(&url, &tarball_path, Some(ctx.pr.as_ref()))
+            .await?;
+        tv.lock_platforms.entry(platform_key).or_default().url = Some(url.clone());
+        self.verify_checksum(ctx, tv, &tarball_path)?;
+
+        let install = tv.install_path();
+        file::remove_all(&install)?;
+        file::extract_archive(
+            &tarball_path,
+            &install,
+            ExtractionFormat::from_file_name(filename),
+            &ExtractOptions {
+                strip_components: 1,
+                pr: Some(ctx.pr.as_ref()),
+                ..Default::default()
+            },
+        )?;
+
+        // The archives already carry the interpreter entrypoints — `bin/python` on unix,
+        // `python.exe`/`python3.exe` at the root on windows — but no pip. python-build ran
+        // `ensurepip` on its pypy definitions for exactly that reason; the wheel ships inside the
+        // archive, so this needs no network. It lands `bin/pip*` on unix and `Scripts\pip.exe` on
+        // windows, both of which `list_bin_paths` already exposes.
+        ctx.pr.set_message("ensurepip".into());
+        CmdLineRunner::new(python_path(tv))
+            .with_pr(ctx.pr.as_ref())
+            .args(["-m", "ensurepip", "--upgrade", "--default-pip"])
+            .env("PIP_REQUIRE_VIRTUALENV", "false")
+            .execute()?;
+
+        // Belt and braces: current releases ship `bin/python` as a symlink already.
+        if !install.join("bin").join("python").exists() {
+            #[cfg(unix)]
+            file::make_symlink(&install.join("bin/python3"), &install.join("bin/python"))?;
+        }
+        Ok(())
+    }
+
     async fn install_precompiled(
         &self,
         ctx: &InstallContext,
         tv: &mut ToolVersion,
     ) -> eyre::Result<()> {
+        // Only where the precompiled list is actually the source of truth. With `compile` unset on
+        // unix this function is still entered, but a `pypy*` version falls through to python-build
+        // below and installs fine today — no reason to change that here.
+        if tv.version.starts_with("pypy") {
+            if cfg!(windows) || Settings::get().python.compile == Some(false) {
+                return self.install_pypy(ctx, tv).await;
+            }
+            // With `compile` unset on unix this function is still entered, but python-build owns
+            // pypy there and installs it fine today. Hand over directly rather than falling
+            // through: the CPython path below would pick up a pypy URL recorded in the lockfile
+            // and then verify it against python-build-standalone's attestations, which it is not
+            // from. It would also warn about a missing precompiled build that was never expected.
+            return self.install_compiled(ctx, tv).await;
+        }
         let platform_key = self.get_platform_key();
         let url = if let Some(url) = tv
             .lock_platforms
@@ -812,7 +972,26 @@ impl Backend for PythonPlugin {
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
         if cfg!(windows) || Settings::get().python.compile == Some(false) {
-            Ok(self
+            // python-build-standalone is CPython only, so pypy comes from its own index — and only
+            // the releases that publish an archive for this platform, the way the CPython list is
+            // already filtered. Offering the rest would list versions that cannot install: macOS
+            // arm64 is the sharp case, with builds for 43 of the 94 indexed releases.
+            let mut versions = vec![];
+            let settings = Settings::get();
+            if let Some((platform, arch)) = pypy_platform_arch(settings.os(), settings.arch()) {
+                // A failure here must not take the CPython list down with it.
+                match self.fetch_pypy_releases().await {
+                    Ok(releases) => versions = pypy_version_infos(releases, platform, arch),
+                    // warn, not debug: this list gets cached for the whole
+                    // fetch_remote_versions_cache window, so a user would see `ls-remote` lose
+                    // every pypy entry with nothing to explain it. The cpython branch below uses
+                    // `?`, so only this half can cache a partial answer.
+                    Err(err) => {
+                        warn!("failed to fetch pypy versions, listing cpython only: {err:#}")
+                    }
+                }
+            }
+            let cpython = self
                 .fetch_precompiled_remote_versions()
                 .await?
                 .iter()
@@ -821,7 +1000,8 @@ impl Backend for PythonPlugin {
                     created_at: python_precompiled_created_at(date),
                     ..Default::default()
                 })
-                .collect())
+                .collect();
+            Ok(merge_pypy_and_cpython(versions, cpython))
         } else {
             self.install_or_update_python_build(None)?;
             let python_build_bin = self.python_build_bin();
@@ -1009,6 +1189,9 @@ impl Backend for PythonPlugin {
         target: &PlatformTarget,
     ) -> Result<PlatformInfo> {
         let version = &tv.version;
+        if version.starts_with("pypy") {
+            return self.resolve_pypy_lock_info(version, target).await;
+        }
         let locked_filename = tv
             .lock_platforms
             .get(&target.to_key())
@@ -1271,6 +1454,93 @@ fn python_arch_for_target(target: &PlatformTarget) -> &'static str {
     }
 }
 
+/// Spell a PyPy release the way python-build's definitions do, e.g. `pypy3.10-7.3.17`, so the
+/// same version string resolves whichever install path is taken.
+///
+/// `None` for the `nightly` entries: they point at rolling `pypy-c-jit-latest-*` artifacts on
+/// buildbot, so the same version string would name different bytes on every install and the
+/// recorded checksum would go stale immediately. python-build ships no nightly definitions either.
+fn pypy_version_str(release: &PypyRelease) -> Option<String> {
+    if !release
+        .pypy_version
+        .starts_with(|c: char| c.is_ascii_digit())
+    {
+        return None;
+    }
+    let mut parts = release.python_version.split('.');
+    let major = parts.next()?;
+    let minor = parts.next()?;
+    if major.is_empty() || minor.is_empty() {
+        return None;
+    }
+    Some(format!("pypy{major}.{minor}-{}", release.pypy_version))
+}
+
+/// Put the two halves of the python list together: pypy first, CPython after.
+///
+/// `python@latest` takes the tail, so CPython has to end up there. Concatenation rather than a
+/// sort: each half keeps the order its own source published, and nothing here compares a pypy
+/// version string against a CPython one — the two sources make no promise those are comparable.
+fn merge_pypy_and_cpython(pypy: Vec<VersionInfo>, cpython: Vec<VersionInfo>) -> Vec<VersionInfo> {
+    pypy.into_iter().chain(cpython).collect()
+}
+
+/// The `(platform, arch)` pair `versions.json` uses for the host, or `None` where PyPy publishes
+/// no build — notably Windows on arm64.
+fn pypy_platform_arch(os: &str, arch: &str) -> Option<(&'static str, &'static str)> {
+    match (os, arch) {
+        ("linux", "x64" | "x86_64") => Some(("linux", "x64")),
+        ("linux", "arm64" | "aarch64") => Some(("linux", "aarch64")),
+        ("macos", "x64" | "x86_64") => Some(("darwin", "x64")),
+        ("macos", "arm64" | "aarch64") => Some(("darwin", "arm64")),
+        ("windows", "x64" | "x86_64") => Some(("win64", "x64")),
+        _ => None,
+    }
+}
+
+/// Turn the PyPy index into version entries for `ls-remote` on `platform`/`arch`.
+///
+/// Releases with no archive for that pair are dropped: PyPy's platform coverage is uneven — 3.6 and
+/// 3.7 have no macOS arm64 build at all — and listing one would let a bare `pypy3.7` resolve to a
+/// version that then fails at download.
+///
+/// The order is PyPy's own: `versions.json` is newest-first, so reversing it gives oldest-first,
+/// and a bare `pypy3.10` — which takes the last prefix match — lands on whatever upstream lists
+/// as its most recent 3.10 build. Nothing here parses or compares the version strings; PyPy's
+/// `7.3.4rc2` and friends are exactly the shapes a semver comparator gets wrong.
+fn pypy_version_infos(releases: &[PypyRelease], platform: &str, arch: &str) -> Vec<VersionInfo> {
+    releases
+        .iter()
+        .rev()
+        .filter(|r| pypy_file_for(r, platform, arch).is_some())
+        .filter_map(|r| {
+            Some(VersionInfo {
+                version: pypy_version_str(r)?,
+                created_at: pypy_created_at(r.date.as_deref()),
+                ..Default::default()
+            })
+        })
+        // versions.json repeats a few releases verbatim
+        .unique_by(|v| v.version.clone())
+        .collect()
+}
+
+/// `versions.json` dates are plain `YYYY-MM-DD`; `created_at` wants a timestamp.
+fn pypy_created_at(date: Option<&str>) -> Option<String> {
+    let date = date?;
+    if date.len() != 10 {
+        return None;
+    }
+    Some(format!("{date}T00:00:00Z"))
+}
+
+fn pypy_file_for<'a>(release: &'a PypyRelease, platform: &str, arch: &str) -> Option<&'a PypyFile> {
+    release
+        .files
+        .iter()
+        .find(|f| f.platform == platform && f.arch == arch)
+}
+
 fn ensure_not_windows() -> eyre::Result<()> {
     if cfg!(windows) {
         bail!(
@@ -1296,6 +1566,211 @@ mod tests {
         let mut opts = ToolVersionOptions::default();
         opts.opts.insert(key.to_string(), value);
         opts
+    }
+
+    /// Two entries in the shape `https://downloads.python.org/pypy/versions.json` publishes.
+    const PYPY_VERSIONS_FIXTURE: &str = r#"[
+      {
+        "pypy_version": "7.3.17",
+        "python_version": "3.10.14",
+        "stable": true,
+        "date": "2024-08-28",
+        "files": [
+          {"filename": "pypy3.10-v7.3.17-linux64.tar.bz2", "arch": "x64", "platform": "linux",
+           "download_url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-linux64.tar.bz2"},
+          {"filename": "pypy3.10-v7.3.17-aarch64.tar.bz2", "arch": "aarch64", "platform": "linux",
+           "download_url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-aarch64.tar.bz2"},
+          {"filename": "pypy3.10-v7.3.17-macos_arm64.tar.bz2", "arch": "arm64", "platform": "darwin",
+           "download_url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_arm64.tar.bz2"},
+          {"filename": "pypy3.10-v7.3.17-win64.zip", "arch": "x64", "platform": "win64",
+           "download_url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-win64.zip"}
+        ]
+      },
+      {
+        "pypy_version": "7.3.23",
+        "python_version": "2.7.18",
+        "stable": true,
+        "date": "2026-05-01",
+        "files": [
+          {"filename": "pypy2.7-v7.3.23-linux64.tar.bz2", "arch": "x64", "platform": "linux",
+           "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux64.tar.bz2"}
+        ]
+      },
+      {
+        "pypy_version": "nightly",
+        "python_version": "3.10",
+        "files": [
+          {"filename": "pypy-c-jit-latest-linux64.tar.bz2", "arch": "x64", "platform": "linux",
+           "download_url": "https://buildbot.pypy.org/nightly/py3.10/pypy-c-jit-latest-linux64.tar.bz2"}
+        ]
+      }
+    ]"#;
+
+    fn pypy_fixture() -> Vec<PypyRelease> {
+        serde_json::from_str(PYPY_VERSIONS_FIXTURE).unwrap()
+    }
+
+    /// The nightly entry is dropped: its `download_url` is a rolling `pypy-c-jit-latest-*`
+    /// artifact, so a pinned version + recorded checksum could never stay true.
+    #[test]
+    fn pypy_versions_are_spelled_like_python_build_definitions() {
+        let releases = pypy_fixture();
+        assert_eq!(releases.len(), 3);
+        assert_eq!(
+            releases.iter().filter_map(pypy_version_str).collect_vec(),
+            vec!["pypy3.10-7.3.17", "pypy2.7-7.3.23"]
+        );
+    }
+
+    #[test]
+    fn pypy_platform_arch_covers_what_pypy_publishes() {
+        assert_eq!(pypy_platform_arch("linux", "x64"), Some(("linux", "x64")));
+        assert_eq!(
+            pypy_platform_arch("linux", "arm64"),
+            Some(("linux", "aarch64"))
+        );
+        assert_eq!(pypy_platform_arch("macos", "x64"), Some(("darwin", "x64")));
+        assert_eq!(
+            pypy_platform_arch("macos", "arm64"),
+            Some(("darwin", "arm64"))
+        );
+        assert_eq!(pypy_platform_arch("windows", "x64"), Some(("win64", "x64")));
+        // pypy ships no windows arm64 build
+        assert_eq!(pypy_platform_arch("windows", "arm64"), None);
+    }
+
+    #[test]
+    fn pypy_file_lookup_picks_the_host_archive() {
+        let releases = pypy_fixture();
+        let release = &releases[0];
+        assert_eq!(
+            pypy_file_for(release, "win64", "x64").map(|f| f.filename.as_str()),
+            Some("pypy3.10-v7.3.17-win64.zip")
+        );
+        assert_eq!(
+            pypy_file_for(release, "darwin", "arm64").map(|f| f.filename.as_str()),
+            Some("pypy3.10-v7.3.17-macos_arm64.tar.bz2")
+        );
+        assert!(pypy_file_for(release, "win64", "aarch64").is_none());
+        // the 2.7 release publishes linux only
+        assert!(pypy_file_for(&releases[1], "win64", "x64").is_none());
+    }
+
+    #[test]
+    fn pypy_created_at_becomes_a_timestamp() {
+        assert_eq!(
+            pypy_created_at(Some("2024-08-28")).as_deref(),
+            Some("2024-08-28T00:00:00Z")
+        );
+        assert_eq!(pypy_created_at(None), None);
+        assert_eq!(pypy_created_at(Some("2024-08")), None);
+    }
+
+    /// `versions.json` repeats a handful of releases verbatim (`7.3.6rc1` appears twice for each
+    /// of 2.7/3.7/3.8), which would otherwise show up twice in `ls-remote`.
+    #[test]
+    fn pypy_version_infos_dedupes_and_dates() {
+        let mut releases = pypy_fixture();
+        let dupe = releases[0].clone();
+        releases.push(dupe);
+        let infos = pypy_version_infos(&releases, "linux", "x64");
+        // the fixture is index order, so the list is that reversed: the 3.10 release is last in
+        // the input (as the duplicate) and therefore first here
+        assert_eq!(
+            infos.iter().map(|v| v.version.as_str()).collect_vec(),
+            vec!["pypy3.10-7.3.17", "pypy2.7-7.3.23"]
+        );
+        assert_eq!(infos[0].created_at.as_deref(), Some("2024-08-28T00:00:00Z"));
+    }
+
+    /// The list is upstream's own order reversed, with nothing parsing the version strings.
+    /// `versions.json` is newest-first, and a bare `pypy3.10` takes the last prefix match, so the
+    /// newest 3.10 has to end up last among the 3.10 entries.
+    #[test]
+    fn pypy_version_infos_follow_the_index_order_reversed() {
+        let json = r#"[
+          {"pypy_version": "7.3.19", "python_version": "3.10.16", "date": "2025-02-26",
+           "files": [{"filename": "a", "arch": "x64", "platform": "linux", "download_url": "u"}]},
+          {"pypy_version": "7.3.17", "python_version": "3.10.14", "date": "2024-08-28",
+           "files": [{"filename": "b", "arch": "x64", "platform": "linux", "download_url": "u"}]},
+          {"pypy_version": "7.3.4rc2", "python_version": "2.7.18", "date": "2021-04-01",
+           "files": [{"filename": "c", "arch": "x64", "platform": "linux", "download_url": "u"}]},
+          {"pypy_version": "7.3.4", "python_version": "2.7.18", "date": "2021-04-04",
+           "files": [{"filename": "d", "arch": "x64", "platform": "linux", "download_url": "u"}]}
+        ]"#;
+        let releases: Vec<PypyRelease> = serde_json::from_str(json).unwrap();
+        let listed = pypy_version_infos(&releases, "linux", "x64")
+            .into_iter()
+            .map(|v| v.version)
+            .collect_vec();
+
+        // exactly the input read backwards — note 7.3.4 sits *before* 7.3.4rc2 upstream, and that
+        // is preserved rather than "corrected" by comparing the strings
+        assert_eq!(
+            listed,
+            vec![
+                "pypy2.7-7.3.4",
+                "pypy2.7-7.3.4rc2",
+                "pypy3.10-7.3.17",
+                "pypy3.10-7.3.19"
+            ]
+        );
+        // a bare `pypy3.10` takes the last prefix match
+        assert_eq!(
+            listed.iter().rfind(|v| v.starts_with("pypy3.10-")).unwrap(),
+            "pypy3.10-7.3.19"
+        );
+    }
+
+    /// PyPy's platform coverage is uneven, so a version listed on one host may have no archive on
+    /// another. Listing it there would let a bare `pypy2.7` resolve to something uninstallable.
+    #[test]
+    fn pypy_version_infos_drops_releases_with_no_archive_for_the_platform() {
+        let releases = pypy_fixture();
+        let listed = |platform, arch| {
+            pypy_version_infos(&releases, platform, arch)
+                .into_iter()
+                .map(|v| v.version)
+                .collect_vec()
+        };
+        // the 2.7 fixture release publishes linux/x64 only
+        assert_eq!(listed("win64", "x64"), vec!["pypy3.10-7.3.17"]);
+        assert_eq!(listed("linux", "aarch64"), vec!["pypy3.10-7.3.17"]);
+        assert_eq!(
+            listed("linux", "x64"),
+            vec!["pypy2.7-7.3.23", "pypy3.10-7.3.17"]
+        );
+        // neither fixture release publishes darwin/x64
+        assert!(listed("darwin", "x64").is_empty());
+        // and the order is the fixture's, reversed — 2.7 sits after 3.10 in the input
+        assert_eq!(
+            pypy_fixture()
+                .iter()
+                .filter_map(pypy_version_str)
+                .collect_vec(),
+            vec!["pypy3.10-7.3.17", "pypy2.7-7.3.23"]
+        );
+    }
+
+    /// `python@latest` resolves against the end of the list, so the merged list puts pypy first
+    /// and CPython after — by concatenation, without comparing any two version strings.
+    #[test]
+    fn merged_list_keeps_cpython_last() {
+        let vi = |v: &str| VersionInfo {
+            version: v.to_string(),
+            ..Default::default()
+        };
+        let pypy = vec![vi("pypy2.7-7.3.23"), vi("pypy3.10-7.3.17")];
+        let cpython = vec![vi("3.12.0"), vi("3.13.1")];
+
+        let merged = merge_pypy_and_cpython(pypy.clone(), cpython)
+            .into_iter()
+            .map(|v| v.version)
+            .collect_vec();
+
+        assert_eq!(merged.last().unwrap(), "3.13.1");
+        assert!(merged[..pypy.len()].iter().all(|v| v.starts_with("pypy")));
+        assert!(merged[pypy.len()..].iter().all(|v| !v.starts_with("pypy")));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3866.

## Problem

The precompiled path — taken when `python.compile=false`, and taken **unconditionally on Windows** ([`python.rs`](https://github.com/jdx/mise/blob/6ca9551ba5a3/src/plugins/core/python.rs#L354)) — is served entirely by `astral-sh/python-build-standalone`, which publishes **CPython only**. PyPy is distributed separately, from `downloads.python.org/pypy`, and mise had no code that read that index. So:

```
$ mise install python@pypy3.10-7.3.17                     # default (compiled) path, linux
… Installed pypy3.10-v7.3.17-linux64                      ✓

$ MISE_PYTHON_COMPILE=false mise install python@pypy3.10-7.3.17
mise ERROR no precompiled python found for core:python@pypy3.10-7.3.17
```

On Windows the second line is the only available behaviour: pypy versions never appear in `mise ls-remote python` and cannot be installed at all.

This is not an upstream limitation:

- `https://downloads.python.org/pypy/versions.json` is a machine-readable index of every release (101 entries as of this PR).
- **93 of those 101 entries publish a `win64/x64` build** — 87 of the 94 versions this PR ends up listing, once nightlies and duplicate entries are dropped. The Windows gap is on mise's side.
- mise's own Windows block, [`ensure_not_windows`](https://github.com/jdx/mise/blob/6ca9551ba5a3/src/plugins/core/python.rs#L1274), says *"python cannot currently be **compiled** on windows"* — that is about python-build (bash), and PyPy is not compiled at all here.
- python-build's own pypy definitions have **no Windows branch** either (`linux64` / `osx64` / … , everything else `err_no_binary`), so getting python-build to run on Windows would not have fixed it.

## What this changes

A pypy branch on the precompiled path only. Nothing about the existing CPython path or the default compiled path changes — this is purely additive, and the previously-failing invocations now succeed.

- `_list_remote_versions` merges the PyPy index into the precompiled list, spelled the way python-build spells it (`pypy3.10-7.3.17`) so the same version string resolves on either path.
- `install_precompiled` routes `pypy*` to a new `install_pypy`: resolve the archive from the index, download, `verify_checksum`, extract with `strip_components: 1`, then `python -m ensurepip`.

Both are gated on the same condition the precompiled list itself is gated on — `cfg!(windows) || python.compile == Some(false)`. Note that `install_precompiled` is *also* entered when `compile` is simply unset, where a `pypy*` version currently falls through to `install_compiled` and installs fine via python-build; that fall-through is deliberately left alone, so the default unix path behaves exactly as it does today.

### Integrity

PyPy publishes no machine-readable checksums — the sidecar files 404, `versions.json` has no hash field, and the digests live only in the HTML at `pypy.org/checksums.html`. So this uses mise's standard treatment for a source without upstream checksums: [`verify_checksum`](https://github.com/jdx/mise/blob/6ca9551ba5a3/src/backend/mod.rs#L3458) records a blake3 digest in the lockfile on first install and enforces it on every install after. This is exactly what `ubi:` and friends already do, and the precompiled path already called this function. Parsing `checksums.html` is a strictly additive follow-up, deliberately left out here.

There is no provenance step, because PyPy publishes no attestations. `verify_precompiled_provenance` stays CPython-only.

### `latest` is unaffected

`python@latest` resolves against the end of the list, and the two halves are **concatenated** — pypy first, CPython after — so the tail is always CPython. `merge_pypy_and_cpython` is the single place that decides this, and there is a test on it.

Nothing on this path parses or compares a version string. Sorting the merged list would mean handing PyPy's `7.3.4rc2`-shaped names to a comparator, which AGENTS.md rules out and which gets that shape wrong in practice: an earlier revision of this PR did sort, and `pypy2.7` came out `… 7.3.4, 7.3.4rc2, 7.3.4rc1 …`, leaving a bare `pypy3.6` on `pypy3.6-7.3.3rc1`.

The pypy half keeps the order its own source published instead. `versions.json` is newest-first, so `pypy_version_infos` reverses it, and a bare `pypy3.10` — which takes the last prefix match — lands on whatever upstream lists as its most recent 3.10 entry. Measured against the live index, with this branch built and run on a windows host:

```
$ mise ls-remote python                                  # win64/x64
208 entries, 87 of them pypy, last entry 3.15.0a1

$ mise ls-remote python                                  # MISE_OS=linux MISE_ARCH=x64
215 entries, 94 of them pypy, last entry 3.15.0a1

pypy2.7 -> pypy2.7-7.3.23      pypy3.9  -> pypy3.9-7.3.16
pypy3.6 -> pypy3.6-7.3.3       pypy3.10 -> pypy3.10-7.3.19
pypy3.7 -> pypy3.7-7.3.9       pypy3.11 -> pypy3.11-7.3.23
pypy3.8 -> pypy3.8-7.3.11
```

Both platforms end on CPython, and both resolve every pypy line identically — except `pypy3.6`, which publishes no `win64` build and so is not listed there at all rather than resolving to something that cannot install.

Every line above lands on its newest stable build today. The ordering is upstream's, not this code's, so an index that ever listed a release candidate ahead of a stable build would surface that instead; that is the trade for not running a comparator over these names.

### `nightly` entries are excluded

`versions.json` carries four `nightly` pseudo-releases whose files are rolling `pypy-c-jit-latest-*` artifacts on `buildbot.pypy.org`. A pinned version name pointing at bytes that change daily would make the recorded checksum go stale on every install, so these are filtered out. python-build ships no nightly definitions either.

## Verification

The archive handling was measured directly rather than inferred.

**Windows (this is the platform the change unblocks) — `pypy3.10-v7.3.17-win64.zip`:**

```
top-level entries in zip: pypy3.10-v7.3.17-win64          → strip_components: 1 is correct
directly under that root: python.exe, python3.exe, python3.10.exe,
                          pypy.exe, pypy3.exe, pypy3.10.exe, libpypy3.10-c.dll, …
```

So no `install_python3_windows` equivalent is needed — the interpreter entrypoints `python_path()` looks for are already there. Running ensurepip against the extracted tree:

```
> .\python.exe -c "import sys; print(sys.implementation.name, sys.version.split()[0])"
pypy 3.10.14
> .\python.exe -m ensurepip --upgrade --default-pip
Successfully installed pip-23.0.1 setuptools-65.5.0        (exit 0, offline — bundled wheels)
> ls Scripts
pip.exe  pip3.10.exe  pip3.exe
> .\python.exe -m pip --version
pip 23.0.1 …
```

`list_bin_paths` on Windows already returns the install root **and** `Scripts`, so both `python.exe` and `pip.exe` land on PATH with no extra work. `install_pip_wrappers_windows` is not needed here — unlike python-build-standalone, PyPy's ensurepip does produce a real `pip.exe` launcher.

**Linux — `pypy3.10-v7.3.17-linux64.tar.bz2`:**

```
top-level dirs: pypy3.10-v7.3.17-linux64
bin/ in the archive: python -> pypy3.10, python3 -> pypy3.10, python3.10 -> pypy3.10, pypy, pypy3, pypy3.10
```

The interpreter symlinks are already present, so the existing `bin/python` fallback is a no-op; what python-build added on top was pip, which is why `ensurepip` is here:

```
$ ./bin/python -m ensurepip --upgrade --default-pip
Successfully installed pip-23.0.1 setuptools-65.5.0       (exit 0, offline)
$ ls bin        # after
pip  pip3  pip3.10  pypy  pypy3  pypy3.10  python  python3  python3.10
$ ./bin/python -c 'import sys; print(sys.implementation.name)'
pypy
```

Both archives bundle `ensurepip/_bundled/pip-23.0.1-py3-none-any.whl`, so that step needs no network.

**Index shape**, checked against the live `versions.json` (101 releases / 616 file entries): every release carries `pypy_version`, `python_version` and `files`; every file entry carries `filename`, `arch`, `platform`, `download_url`; all dates are `YYYY-MM-DD`; four releases have no `date` (all `nightly`); three release names are exact duplicates (`7.3.6rc1` for 2.7/3.7/3.8 appears twice), hence the dedup. Archive extensions are `.tar.bz2`, `.tar.gz` and `.zip`, all of which `ExtractionFormat::from_file_name` already resolves.

Platform/arch pairs published: `linux/x64` (101), `linux/i686` (101), `darwin/x64` (100), `linux/aarch64` (93), `win64/x64` (93), `linux/s390x` (75), `darwin/arm64` (46), `win32/x86` (7). The mapping here covers linux x64/aarch64, darwin x64/arm64 and win64/x64; anything else (notably Windows on arm64) fails with an explicit "pypy publishes no build for …" instead of a confusing not-found.

Unit tests are pure — they parse a fixture in the shape of the real index, so no network in CI.

## Not in this PR

- The default (compiled) path on unix still installs pypy through python-build. Serving it natively would drop the pyenv clone for pypy users too, but it would change the behaviour of installs that work today; happy to do it as a follow-up.
- `checksums.html` parsing, per the integrity note above.
- PyPy publishes glibc linux builds only, so musl hosts are unchanged — python-build's pypy definitions download the same glibc tarball today.

## End-to-end check

Run on a windows host with this branch built (`2026.8.4-DEBUG windows-x64`) against a scratch `MISE_DATA_DIR`. Windows is the platform this PR unblocks, so it is the one worth checking end to end:

```
$ mise install python@pypy3.10-7.3.17
download pypy3.10-v7.3.17-win64.zip
generate checksum pypy3.10-v7.3.17-win64.zip
extract pypy3.10-v7.3.17-win64.zip
ensurepip
  Successfully installed pip-23.0.1 setuptools-65.5.0
python --version
  Python 3.10.14 (39dc8d3c85a7, Aug 27 2024, 14:33:33)
  [PyPy 7.3.17 with MSC v.1929 64 bit (AMD64)]
✓ installed

$ mise exec python@pypy3.10-7.3.17 -- python -c "import sys; print(sys.implementation.name, sys.version.split()[0])"
pypy 3.10.14

$ mise exec python@pypy3.10-7.3.17 -- pip --version
pip 23.0.1 from …\installs\python\pypy3.10-7.3.17\lib\site-packages\pip (python 3.10)
```

Before this change the first line was `mise ERROR no precompiled python found for core:python@pypy3.10-7.3.17`.

Still outstanding, because it needs a linux host:

```
MISE_PYTHON_COMPILE=false mise install python@pypy3.10-7.3.17
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for discovering and installing PyPy releases.
- PyPy versions now appear in runtime listings with normalized versions and release dates.
- Added platform-specific archive selection, checksum verification, and extraction.
- Added offline `ensurepip` setup for PyPy installations.
- Precompiled installations can use PyPy on Windows or when compilation is disabled.
- Lockfile resolution now supports PyPy archives.

## Bug Fixes
- CPython discovery continues when PyPy release information is unavailable.
- Improved release sorting, deduplication, and platform compatibility filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
