### PR TITLE
fix(core): honor forced colors in tables

### DIFF
--- a/e2e/cli/test_color_output
+++ b/e2e/cli/test_color_output
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+cat >mise.toml <<'EOF'
+[tools]
+dummy = "1.0.0"
+EOF
+
+assert_colored() {
+  local output="$1"
+  if [[ $output != *$'\033['* ]]; then
+    fail "expected ANSI colors in output: $output"
+  fi
+}
+
+assert_uncolored() {
+  local output="$1"
+  if [[ $output == *$'\033['* ]]; then
+    fail "expected no ANSI colors in output: $output"
+  fi
+}
+
+forced_pipe="$TMPDIR/mise-ls-forced-pipe"
+forced_file="$TMPDIR/mise-ls-forced-file"
+plain_pipe="$TMPDIR/mise-ls-plain-pipe"
+force_zero="$TMPDIR/mise-ls-force-zero"
+mise_color_zero="$TMPDIR/mise-ls-mise-color-zero"
+no_color="$TMPDIR/mise-ls-no-color"
+clicolor_zero="$TMPDIR/mise-ls-clicolor-zero"
+force_overrides_clicolor="$TMPDIR/mise-ls-force-overrides-clicolor"
+
+# These independent invocations run concurrently to keep the regression test fast.
+CLICOLOR_FORCE=1 mise ls dummy | cat >"$forced_pipe" &
+pids=("$!")
+CLICOLOR_FORCE=1 mise ls dummy >"$forced_file" &
+pids+=("$!")
+mise ls dummy | cat >"$plain_pipe" &
+pids+=("$!")
+CLICOLOR_FORCE=0 mise ls dummy | cat >"$force_zero" &
+pids+=("$!")
+MISE_COLOR=0 mise ls dummy | cat >"$mise_color_zero" &
+pids+=("$!")
+NO_COLOR=1 mise ls dummy | cat >"$no_color" &
+pids+=("$!")
+CLICOLOR=0 mise ls dummy | cat >"$clicolor_zero" &
+pids+=("$!")
+CLICOLOR=0 CLICOLOR_FORCE=1 mise ls dummy | cat >"$force_overrides_clicolor" &
+pids+=("$!")
+
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+
+assert_colored "$(cat "$forced_pipe")"
+assert_colored "$(cat "$forced_file")"
+assert_uncolored "$(cat "$plain_pipe")"
+assert_uncolored "$(cat "$force_zero")"
+assert_uncolored "$(cat "$mise_color_zero")"
+assert_uncolored "$(cat "$no_color")"
+assert_uncolored "$(cat "$clicolor_zero")"
+
+# CLICOLOR_FORCE takes precedence over CLICOLOR=0.
+assert_colored "$(cat "$force_overrides_clicolor")"
+
+forced_output="$(cat "$forced_pipe")"
+[[ $forced_output == *"dummy"* ]] || fail "forced color output omitted table content"

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -58,7 +58,9 @@ impl MiseTable {
         if let Some(w) = *crate::env::TERM_WIDTH_OVERRIDE {
             table.set_width(w.min(u16::MAX as usize) as u16);
         }
-        if !console::colors_enabled() {
+        if console::colors_enabled() {
+            table.enforce_styling();
+        } else {
             table.force_no_tty();
         }
         if !no_header && console::user_attended() {


### PR DESCRIPTION
## Summary

- propagate mise's final color decision to the shared `MiseTable` renderer
- preserve ANSI styling in piped or redirected table output when `CLICOLOR_FORCE=1`
- continue suppressing colors for `MISE_COLOR=0`, `NO_COLOR`, and `CLICOLOR=0` without changing non-TTY layout behavior

## Details

Mise already enables colors through `console::colors_enabled()` when `CLICOLOR_FORCE` is set, but `comfy-table` performs its own stdout TTY check and strips styling from redirected output. PR #3607 previously called `enforce_styling()` for the enabled case; PR #5322 replaced that branch while adding reliable no-color handling, leaving only `force_no_tty()` for the disabled case.

The shared table constructor now explicitly handles both outcomes: it enforces styling when mise's final color decision is enabled and forces no styling when it is disabled. Because this is applied in `MiseTable`, all commands using the common renderer receive consistent behavior. Header omission and terminal-width handling remain based on the existing TTY checks, so `CLICOLOR_FORCE` changes color only.

## Verification

- `mise run test:e2e e2e/cli/test_color_output`
- `mise run test:e2e e2e/tasks/test_task_ls`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d e2e/cli/test_color_output`
- `mise exec -- shellcheck e2e/cli/test_color_output`

`mise run format` and `mise run lint` could not complete because hk does not recognize this Sapling working copy as a Git repository; the relevant Rustfmt, shfmt, ShellCheck, Cargo check, and Clippy checks passed individually. The broader `e2e/cli/test_ls` fixture was also attempted but could not clone `https://github.com/jdx/vfox-tiny.git` in the isolated test environment; the new fully offline regression test and the shared task-table regression suite passed.

Addresses https://github.com/jdx/mise/discussions/7800

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color handling for `mise ls` output based on terminal color settings.
  * Ensured forced color output takes precedence when color is otherwise disabled.
  * Preserved readable table output when colors are unavailable.

* **Tests**
  * Added end-to-end coverage for colored and non-colored command output scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->