### PR TITLE
fix(deps): invalidate state when commands change

### DIFF
--- a/docs/dev-tools/deps.md
+++ b/docs/dev-tools/deps.md
@@ -167,13 +167,16 @@ run = "npx prisma generate"
 
 ## Freshness Checking
 
-mise uses blake3 content hashing to determine if sources have changed since the last
-successful run. Hashes are stored in `$MISE_STATE_DIR/deps/<hash>.toml`, keyed by
-project root (so nothing is written inside the project directory).
+mise uses blake3 hashing to determine if sources or the effective provider command have
+changed since the last successful run. Hashes are stored in
+`$MISE_STATE_DIR/deps/<hash>.toml`, keyed by project root (so nothing is written inside
+the project directory). Command hashes include the run command, shell, provider `env`,
+and working directory; raw command and environment values are not stored in state.
 
 1. Compute blake3 hashes of all source files
-2. Compare against stored hashes from the last successful run
-3. If any file was added, removed, or changed, the provider is stale
+2. Compute a blake3 hash of the effective provider command
+3. Compare against stored hashes from the last successful run
+4. If a source or the effective command was added, removed, or changed, the provider is stale
 
 This means:
 
@@ -181,6 +184,7 @@ This means:
 - If `node_modules/` doesn't exist, the provider is always stale
 - If sources don't exist, the provider is considered fresh (nothing to do)
 - On first run (no stored state), the provider is always considered stale
+- State created before command hashing is migrated by running each provider once
 
 ## Auto-Install
 

--- a/e2e/cli/test_deps_command_freshness_slow
+++ b/e2e/cli/test_deps_command_freshness_slow
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+printf 'input\n' >input.txt
+
+cat >mise.toml <<'EOF'
+[deps.command]
+sources = ["input.txt"]
+outputs = ["output.txt"]
+run = "printf 'first\\n' >> runs.txt; cp input.txt output.txt"
+EOF
+
+assert_contains "mise deps --only command 2>&1" "Installed: command"
+assert "cat runs.txt" "first"
+assert_contains "mise deps --only command 2>&1" "up to date"
+
+cat >mise.toml <<'EOF'
+[deps.command]
+sources = ["input.txt"]
+outputs = ["output.txt"]
+run = "printf 'second\\n' >> runs.txt; cp input.txt output.txt"
+EOF
+
+assert_contains "mise deps --dry-run --only command 2>&1" "provider command changed"
+assert_contains "mise deps command --explain 2>&1 || true" "provider command changed"
+assert_contains "mise deps --only command 2>&1" "Installed: command"
+assert "cat runs.txt" $'first\nsecond'
+assert_contains "mise deps --only command 2>&1" "up to date"
+
+mkdir -p "$HOME/.config/mise"
+cat >"$HOME/.config/mise/config.toml" <<'EOF'
+[settings]
+unix_default_inline_shell_args = "sh -c -o errexit"
+EOF
+
+cat >mise.toml <<'EOF'
+[deps.shell]
+sources = ["input.txt"]
+outputs = ["shell-output.txt"]
+run = "printf 'run\\n' >> shell-runs.txt; cp input.txt shell-output.txt"
+EOF
+
+mise deps --only shell >/dev/null
+assert "cat shell-runs.txt" "run"
+assert_contains "mise deps --only shell 2>&1" "up to date"
+
+cat >"$HOME/.config/mise/config.toml" <<'EOF'
+[settings]
+unix_default_inline_shell_args = "sh -c"
+EOF
+
+cat >mise.toml <<'EOF'
+[deps.shell]
+sources = ["input.txt"]
+outputs = ["shell-output.txt"]
+run = "printf 'run\\n' >> shell-runs.txt; cp input.txt shell-output.txt"
+EOF
+
+assert_contains "mise deps --dry-run --only shell 2>&1" "provider command changed"
+assert_contains "mise deps --only shell 2>&1" "Installed: shell"
+assert "wc -l < shell-runs.txt | tr -d ' '" "2"
+assert_contains "mise deps --only shell 2>&1" "up to date"
+
+cat >mise.toml <<'EOF'
+[deps.environment]
+sources = ["input.txt"]
+outputs = ["env-output.txt"]
+run = "printf '%s\\n' \"$MODE\" >> env-runs.txt; cp input.txt env-output.txt"
+env = { MODE = "one" }
+EOF
+
+mise deps --only environment >/dev/null
+assert "cat env-runs.txt" "one"
+
+cat >mise.toml <<'EOF'
+[deps.environment]
+sources = ["input.txt"]
+outputs = ["env-output.txt"]
+run = "printf '%s\\n' \"$MODE\" >> env-runs.txt; cp input.txt env-output.txt"
+env = { MODE = "two" }
+EOF
+
+assert_contains "mise deps --dry-run --only environment 2>&1" "provider command changed"
+mise deps --only environment >/dev/null
+assert "cat env-runs.txt" $'one\ntwo'
+
+mkdir -p dir-a dir-b
+printf 'input\n' >dir-a/input.txt
+printf 'input\n' >dir-b/input.txt
+printf 'input\n' >dir-b/output.txt
+
+cat >mise.toml <<'EOF'
+[deps.directory]
+sources = ["input.txt"]
+outputs = ["output.txt"]
+run = "cp input.txt output.txt; pwd >> ../dir-runs.txt"
+dir = "dir-a"
+EOF
+
+mise deps --only directory >/dev/null
+
+cat >mise.toml <<'EOF'
+[deps.directory]
+sources = ["input.txt"]
+outputs = ["output.txt"]
+run = "cp input.txt output.txt; pwd >> ../dir-runs.txt"
+dir = "dir-b"
+EOF
+
+assert_contains "mise deps --dry-run --only directory 2>&1" "provider command changed"
+mise deps --only directory >/dev/null
+assert_contains "tail -n 1 dir-runs.txt" "/dir-b"
+
+cat >mise.toml <<'EOF'
+[deps.failure]
+sources = ["input.txt"]
+outputs = ["failure-output.txt"]
+run = "cp input.txt failure-output.txt"
+EOF
+
+mise deps --only failure >/dev/null
+
+cat >mise.toml <<'EOF'
+[deps.failure]
+sources = ["input.txt"]
+outputs = ["failure-output.txt"]
+run = "exit 7"
+EOF
+
+assert_fail "mise deps --only failure 2>&1" "exit code 7"
+assert_contains "mise deps --dry-run --only failure 2>&1" "provider command changed"
+
+cat >mise.toml <<'EOF'
+[deps.legacy]
+sources = ["input.txt"]
+outputs = ["legacy-output.txt"]
+run = "printf 'run\\n' >> legacy-runs.txt; cp input.txt legacy-output.txt"
+EOF
+
+mise deps --only legacy >/dev/null
+state_file="$(find "$MISE_STATE_DIR/deps" -type f -name '*.toml')"
+sed -i.bak '/^\[command_hashes\]/,$d' "$state_file"
+assert_contains "mise deps --dry-run --only legacy 2>&1" "provider command changed"
+mise deps --only legacy >/dev/null
+assert "wc -l < legacy-runs.txt | tr -d ' '" "2"
+assert_contains "mise deps --only legacy 2>&1" "up to date"
+
+printf 'existing\n' >no-sources-output.txt
+cat >mise.toml <<'EOF'
+[deps.no_sources]
+outputs = ["no-sources-output.txt"]
+run = "printf 'unexpected\\n' >> no-sources-runs.txt"
+EOF
+
+assert_contains "mise deps --only no_sources 2>&1" "up to date"
+assert "test ! -e no-sources-runs.txt && echo skipped" "skipped"
+
+cat >mise.toml <<'EOF'
+[deps.no_sources]
+outputs = ["no-sources-output.txt"]
+run = "printf 'still unexpected\\n' >> no-sources-runs.txt"
+EOF
+
+assert "mise deps --dry-run --only no_sources 2>&1" ""
+assert "test ! -e no-sources-runs.txt && echo skipped" "skipped"

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -683,6 +683,12 @@ impl DepsEngine {
 
         // Run stale providers with dependency ordering
         if !to_run.is_empty() {
+            // Retain the fingerprint of the exact command that will run. Rebuilding
+            // commands after execution could observe a concurrently changed config.
+            let command_hashes: HashMap<String, String> = to_run
+                .iter()
+                .map(|job| (job.id.clone(), job.cmd.freshness_hash()))
+                .collect();
             let has_deps = to_run.iter().any(|j| !j.depends.is_empty());
 
             if has_deps {
@@ -725,6 +731,9 @@ impl DepsEngine {
                         let provider_id = provider.base().id.as_str();
                         st.set_hashes(provider_id, hashes);
                         st.set_seen_outputs(provider_id, seen);
+                        if let Some(command_hash) = command_hashes.get(id) {
+                            st.set_command_hash(provider_id, command_hash.clone());
+                        }
                         if let Err(e) = st.save(project_root) {
                             warn!("failed to save deps state: {e}");
                         }
@@ -1040,8 +1049,32 @@ impl DepsEngine {
             ));
         }
 
+        // Existing outputs without sources are fresh by definition. Command fingerprints only
+        // invalidate providers whose source state can otherwise be compared across runs.
         if sources.is_empty() {
             return Ok(FreshnessResult::NoSources);
+        }
+
+        let command_hash = provider.install_command()?.freshness_hash();
+        match st.get_command_hash(provider_id) {
+            Some(stored_hash) if stored_hash != command_hash => {
+                return Ok(FreshnessResult::Stale(
+                    "provider command changed".to_string(),
+                ));
+            }
+            Some(_) => {}
+            None if st.get_hashes(provider_id).is_some()
+                || st.get_seen_outputs(provider_id).is_some() =>
+            {
+                // State written by mise versions before command hashing cannot prove
+                // that the provider definition is unchanged. Re-run it once to migrate.
+                return Ok(FreshnessResult::Stale(
+                    "provider command changed".to_string(),
+                ));
+            }
+            None => {
+                return Ok(FreshnessResult::Stale("no previous state".to_string()));
+            }
         }
 
         let current_hashes = state::hash_sources(&sources, project_root)?;

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -158,6 +158,37 @@ impl DepsCommand {
                 .unwrap_or_else(|| run.to_string()),
         })
     }
+
+    /// Hash the parts of this command that can affect its outputs.
+    ///
+    /// Length-prefixing every field keeps the encoding unambiguous, while the
+    /// persisted state contains only the digest and never the command or env values.
+    pub(crate) fn freshness_hash(&self) -> String {
+        fn update(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+            hasher.update(&(bytes.len() as u64).to_le_bytes());
+            hasher.update(bytes);
+        }
+
+        let mut hasher = blake3::Hasher::new();
+        update(&mut hasher, self.program.as_bytes());
+        update(&mut hasher, &(self.args.len() as u64).to_le_bytes());
+        for arg in &self.args {
+            update(&mut hasher, arg.as_bytes());
+        }
+        update(&mut hasher, &(self.env.len() as u64).to_le_bytes());
+        for (key, value) in &self.env {
+            update(&mut hasher, key.as_bytes());
+            update(&mut hasher, value.as_bytes());
+        }
+        match &self.cwd {
+            Some(cwd) => {
+                update(&mut hasher, &[1]);
+                update(&mut hasher, cwd.as_os_str().as_encoded_bytes());
+            }
+            None => update(&mut hasher, &[0]),
+        }
+        hasher.finalize().to_hex().to_string()
+    }
 }
 
 /// Trait for deps providers that can check and install dependencies
@@ -408,4 +439,47 @@ pub fn create_provider(
 
     DepsEngine::build_provider(ecosystem, &provider_root, provider_config)
         .ok_or_else(|| eyre::eyre!("unknown deps provider '{ecosystem}'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command() -> DepsCommand {
+        DepsCommand {
+            program: "sh".to_string(),
+            args: vec!["-c".to_string(), "echo first".to_string()],
+            env: BTreeMap::from([("MODE".to_string(), "debug".to_string())]),
+            cwd: Some(PathBuf::from("project")),
+            description: "first description".to_string(),
+        }
+    }
+
+    #[test]
+    fn deps_command_freshness_hash_tracks_execution_inputs() {
+        let original = command();
+        assert_eq!(original.freshness_hash(), command().freshness_hash());
+
+        let mut changed = command();
+        changed.program = "bash".to_string();
+        assert_ne!(original.freshness_hash(), changed.freshness_hash());
+
+        let mut changed = command();
+        changed.args.push("extra".to_string());
+        assert_ne!(original.freshness_hash(), changed.freshness_hash());
+
+        let mut changed = command();
+        changed
+            .env
+            .insert("MODE".to_string(), "release".to_string());
+        assert_ne!(original.freshness_hash(), changed.freshness_hash());
+
+        let mut changed = command();
+        changed.cwd = Some(PathBuf::from("other-project"));
+        assert_ne!(original.freshness_hash(), changed.freshness_hash());
+
+        let mut changed = command();
+        changed.description = "cosmetic change".to_string();
+        assert_eq!(original.freshness_hash(), changed.freshness_hash());
+    }
 }

--- a/src/deps/state.rs
+++ b/src/deps/state.rs
@@ -9,8 +9,9 @@ use crate::hash::{file_hash_blake3, hash_to_str};
 
 /// Persistent state for deps freshness checking.
 ///
-/// Stores blake3 content hashes of source files keyed by provider ID, plus the
-/// set of optional output paths that existed at the last successful run.
+/// Stores blake3 content hashes of source files and effective commands keyed by
+/// provider ID, plus the set of optional output paths that existed at the last
+/// successful run.
 /// Persisted to `$MISE_STATE_DIR/deps/<hash>.toml`, keyed by project root.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct DepsState {
@@ -22,6 +23,9 @@ pub struct DepsState {
     /// output that was previously present has been deleted.
     #[serde(default)]
     pub seen_outputs: BTreeMap<String, Vec<String>>,
+    /// provider_id → blake3 hash of the effective command
+    #[serde(default)]
+    pub command_hashes: BTreeMap<String, String>,
 }
 
 impl DepsState {
@@ -74,6 +78,16 @@ impl DepsState {
     /// Record optional outputs that exist after a successful run.
     pub fn set_seen_outputs(&mut self, provider_id: &str, outputs: Vec<String>) {
         self.seen_outputs.insert(provider_id.to_string(), outputs);
+    }
+
+    /// Get the effective command hash recorded after the last successful run.
+    pub fn get_command_hash(&self, provider_id: &str) -> Option<&str> {
+        self.command_hashes.get(provider_id).map(String::as_str)
+    }
+
+    /// Record the effective command hash after a successful run.
+    pub fn set_command_hash(&mut self, provider_id: &str, hash: String) {
+        self.command_hashes.insert(provider_id.to_string(), hash);
     }
 }
 
@@ -143,4 +157,38 @@ fn state_path(project_root: &Path) -> PathBuf {
     dirs::STATE
         .join("deps")
         .join(format!("{}.toml", hash_to_str(&project_root)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_state_without_command_hashes_is_supported() {
+        let state: DepsState = toml::from_str(
+            r#"
+                [providers.example]
+                input = "hash"
+
+                [seen_outputs]
+                example = ["output"]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(state.get_hashes("example").unwrap()["input"], "hash");
+        assert_eq!(state.get_seen_outputs("example").unwrap(), &["output"]);
+        assert_eq!(state.get_command_hash("example"), None);
+    }
+
+    #[test]
+    fn command_hashes_round_trip() {
+        let mut state = DepsState::default();
+        state.set_command_hash("example", "digest".to_string());
+
+        let serialized = toml::to_string(&state).unwrap();
+        assert!(!serialized.contains("run command"));
+        let restored: DepsState = toml::from_str(&serialized).unwrap();
+        assert_eq!(restored.get_command_hash("example"), Some("digest"));
+    }
 }


### PR DESCRIPTION
## Summary

- include each deps provider's effective command in freshness tracking
- invalidate otherwise-fresh providers when their command, declared environment, working directory, or execution shell changes
- migrate legacy deps state conservatively by rerunning each affected provider once
- preserve the existing no-sources freshness behavior for providers whose outputs already exist

## Root cause

Deps state previously stored only source hashes and observed outputs. Once those signals were fresh, editing a provider's `run` command did not invalidate the state, so the updated command was skipped.

This change fingerprints the exact `DepsCommand` selected for execution: program, arguments, provider-declared environment, and working directory. The state stores only the BLAKE3 digest, never raw commands or environment values. Cosmetic metadata and ambient/toolset environment are intentionally excluded.

The initial implementation evaluated the command fingerprint before the existing `NoSources` result. That caused a provider with outputs but no sources to run once despite its outputs already existing. The no-sources check now precedes command hashing, while missing required outputs continue to take priority.

## Behavior

- output/session freshness checks keep their existing priority
- providers with existing outputs but no sources remain fresh and do not track command changes
- a changed command reports `provider command changed` in dry-run and explain output for source-tracked providers
- state is updated only after a successful provider execution; failed commands remain stale for the next attempt
- state written by older mise versions has no command fingerprint, so providers with existing source freshness state run once and then become fresh normally
- `mise deps`, `mise prepare`, auto deps, and monorepo providers share this engine behavior

## Verification

- `mise run test:e2e e2e/cli/test_deps_command_freshness_slow`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d e2e/cli/test_deps_command_freshness_slow`
- `mise exec -- shellcheck e2e/cli/test_deps_command_freshness_slow`

Addresses https://github.com/jdx/mise/discussions/8775

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependency freshness now detects changes to provider commands, shell settings, environment variables, and working directories.
  * Legacy dependency state is supported and automatically updated during the next provider run.
  * Dependencies without source inputs can reuse existing outputs without unnecessary reruns.

* **Bug Fixes**
  * Improved reporting for failed commands and dry-run changes.

* **Tests**
  * Added coverage for command, environment, directory, failure, dry-run, and legacy-state scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->