### PR TITLE
feat(node): apply patches to the source build

### DIFF
--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1249,6 +1249,10 @@
           "type": "object",
           "unevaluatedProperties": false,
           "properties": {
+            "apply_patches": {
+              "description": "A list of patch files or URLs to apply to node source.",
+              "type": "string"
+            },
             "cflags": {
               "description": "Additional CFLAGS options (e.g., to override -O3).",
               "type": "string"

--- a/settings.toml
+++ b/settings.toml
@@ -1654,6 +1654,21 @@ env = "MISE_NO_HOOKS"
 optional = true
 type = "Bool"
 
+[node.apply_patches]
+description = "A list of patch files or URLs to apply to node source."
+docs = """
+Newline-separated list of patch files or URLs, applied to the extracted node source before
+`./configure` runs.
+
+They only reach a source build. `node.compile = true` forces one; failing that, they still apply
+whenever no precompiled archive exists for the version and mise falls back to compiling on its own.
+When a precompiled binary is what gets installed, mise warns rather than dropping the patches
+silently.
+"""
+env = "MISE_NODE_APPLY_PATCHES"
+optional = true
+type = "String"
+
 [node.cflags]
 description = "Additional CFLAGS options (e.g., to override -O3)."
 env = "MISE_NODE_CFLAGS"

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -108,3 +108,97 @@ pub fn new_backend_arg(tool_name: &str) -> BackendArg {
         BackendResolution::new(true),
     )
 }
+
+/// Split an `apply_patches` setting into individual sources.
+///
+/// The setting is one newline-separated list mixing local paths and URLs, the shape
+/// `ruby.apply_patches` established.
+///
+/// Lines are trimmed, and `lines()` rather than `split('\n')` so a CRLF config does not leave a
+/// `\r` on the end of every URL. Neither a path nor a URL can legitimately carry surrounding
+/// whitespace, and a TOML multi-line string indented to match the surrounding block would
+/// otherwise turn every entry into a filename that starts with spaces.
+pub fn patch_sources(setting: Option<&str>) -> Vec<String> {
+    setting
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Read each patch source, fetching the ones that are URLs.
+///
+/// Returned one entry per source rather than concatenated: the `-p` strip level a patch needs is
+/// decided per patch, so a caller that runs `patch` itself has to keep them apart.
+pub async fn fetch_patch_contents(sources: &[String]) -> Result<Vec<String>> {
+    let re = xx::regex!(r#"^[Hh][Tt][Tt][Pp][Ss]?://"#);
+    let mut patches = vec![];
+    for f in sources {
+        if re.is_match(f) {
+            patches.push(crate::http::HTTP.get_text(f).await?);
+        } else {
+            patches.push(crate::file::read_to_string(f)?);
+        }
+    }
+    Ok(patches)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn patch_sources_splits_and_drops_blank_lines() {
+        assert!(patch_sources(None).is_empty());
+        assert!(patch_sources(Some("")).is_empty());
+        assert_eq!(
+            patch_sources(Some(
+                "https://example.com/a.patch\n\n./patches/b.patch\n/tmp/c.patch\n"
+            )),
+            vec![
+                "https://example.com/a.patch",
+                "./patches/b.patch",
+                "/tmp/c.patch"
+            ]
+        );
+    }
+
+    /// A TOML multi-line string indented to match its block, and a config saved with CRLF, both
+    /// used to hand back sources with whitespace baked into the path or URL.
+    #[test]
+    fn patch_sources_ignores_surrounding_whitespace() {
+        assert_eq!(
+            patch_sources(Some(
+                "\n  https://example.com/a.patch  \n   \n\t./patches/b.patch\n"
+            )),
+            vec!["https://example.com/a.patch", "./patches/b.patch"]
+        );
+        assert_eq!(
+            patch_sources(Some("https://example.com/a.patch\r\n./patches/b.patch\r\n")),
+            vec!["https://example.com/a.patch", "./patches/b.patch"]
+        );
+        assert!(patch_sources(Some("   \n\t\n  ")).is_empty());
+    }
+
+    /// Local sources only, so this stays offline. The `join("\n")` at the end is what ruby feeds
+    /// to `ruby-build --patch` on stdin — pinned here because that side is not compiled on Windows.
+    #[tokio::test]
+    async fn fetch_patch_contents_reads_every_source_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.patch");
+        let b = dir.path().join("b.patch");
+        std::fs::write(&a, "PATCH A\n").unwrap();
+        std::fs::write(&b, "PATCH B\n").unwrap();
+
+        let sources = vec![
+            a.to_string_lossy().to_string(),
+            b.to_string_lossy().to_string(),
+        ];
+        let contents = fetch_patch_contents(&sources).await.unwrap();
+
+        assert_eq!(contents, vec!["PATCH A\n", "PATCH B\n"]);
+        assert_eq!(contents.join("\n"), "PATCH A\n\nPATCH B\n");
+    }
+}

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -17,7 +17,7 @@ use crate::toolset::{ToolRequest, ToolVersion};
 use crate::ui::progress_report::SingleReport;
 use crate::{env, file, gpg, hash, http, plugins};
 use async_trait::async_trait;
-use eyre::{Result, bail, ensure};
+use eyre::{Result, WrapErr, bail, ensure};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -126,7 +126,10 @@ impl NodePlugin {
             })
             .await?
         {
-            FetchOutcome::Downloaded => Ok(()),
+            FetchOutcome::Downloaded => {
+                warn_patches_not_applied();
+                Ok(())
+            }
             FetchOutcome::NotFound => {
                 if ctx.locked {
                     if let Some(message) = node_flavor_not_found_message(opts) {
@@ -160,7 +163,10 @@ impl NodePlugin {
             .fetch_binary(ctx, tv, opts, || self.extract_zip(opts, ctx))
             .await?
         {
-            FetchOutcome::Downloaded => Ok(()),
+            FetchOutcome::Downloaded => {
+                warn_patches_not_applied();
+                Ok(())
+            }
             FetchOutcome::NotFound => bail!("precompiled node archive not found (404)"),
         }
     }
@@ -206,9 +212,49 @@ impl NodePlugin {
                 ..Default::default()
             },
         )?;
+        self.exec_patches(ctx, opts, tv).await?;
         self.exec_configure(ctx, opts, tv)?;
         self.exec_make(ctx, opts, tv)?;
         self.exec_make_install(ctx, opts, tv)?;
+        Ok(())
+    }
+
+    /// Apply `node.apply_patches` to the extracted source, before `./configure` sees it.
+    ///
+    /// Each patch is applied on its own rather than concatenated, because the `-p` strip level is
+    /// decided per patch — a git-style patch and a plain one in the same blob cannot both be right.
+    async fn exec_patches(
+        &self,
+        ctx: &InstallContext,
+        opts: &BuildOpts,
+        tv: &ToolVersion,
+    ) -> Result<()> {
+        let sources = plugins::core::patch_sources(Settings::get().node.apply_patches.as_deref());
+        if sources.is_empty() {
+            return Ok(());
+        }
+        let patches = plugins::core::fetch_patch_contents(&sources).await?;
+        file::create_dir_all(&*env::MISE_TMP_DIR)?;
+        for (source, patch) in sources.iter().zip(patches) {
+            ctx.pr.set_message(format!("patch {source}"));
+            let patch_file = env::MISE_TMP_DIR.join(format!(
+                "node-v{}-{}.patch",
+                opts.version,
+                hash::hash_to_str(source)
+            ));
+            file::write(&patch_file, &patch)?;
+            CmdLineRunner::new("patch")
+                .with_pr(ctx.pr.as_ref())
+                .prepend_path(opts.path.clone())?
+                .current_dir(&opts.build_dir)
+                .env_values(tv.install_env())
+                .arg(format!("-p{}", patch_strip_level(&patch)))
+                .arg("--force")
+                .arg("-i")
+                .arg(&patch_file)
+                .execute()
+                .wrap_err_with(|| format!("failed to apply patch {source}"))?;
+        }
         Ok(())
     }
 
@@ -801,6 +847,14 @@ impl Backend for NodePlugin {
             {
                 opts.insert("make_install_opts".to_string(), make_install_opts);
             }
+            // Patches change what the build produces, so they belong to the artifact's identity.
+            if let Some(apply_patches) = node
+                .apply_patches
+                .clone()
+                .filter(|patches| !patches.is_empty())
+            {
+                opts.insert("apply_patches".to_string(), apply_patches);
+            }
         }
 
         // Flavor affects which binary variant is downloaded.
@@ -1124,6 +1178,35 @@ fn source_tarball_name(v: &str) -> String {
     format!("node-v{v}.tar.gz")
 }
 
+/// How far to strip leading path components when applying `patch`.
+///
+/// python-build and ruby-build both default to `-p0` and bump to `-p1` when the patch looks
+/// git-generated, but they sniff for different markers — `diff --git a/` and `--- a/`
+/// respectively. Accepting either means a patch written for python or for ruby applies the same
+/// way here, rather than the user having to know which tool a patch was authored against.
+fn patch_strip_level(patch: &str) -> u8 {
+    let git_style = patch
+        .lines()
+        .any(|line| line.starts_with("diff --git a/") || line.starts_with("--- a/"));
+    if git_style { 1 } else { 0 }
+}
+
+/// `node.apply_patches` only reaches the source build, so say so rather than let the patches
+/// vanish silently when a precompiled binary is what actually got installed.
+fn warn_patches_not_applied() {
+    if Settings::get()
+        .node
+        .apply_patches
+        .as_deref()
+        .is_some_and(|s| !s.trim().is_empty())
+    {
+        warn!(
+            "node.apply_patches is set but a precompiled node was installed, so no patch was applied. \
+             Set node.compile=true to build from source."
+        );
+    }
+}
+
 fn should_compile_from_source(
     locked: bool,
     lock_platforms: &BTreeMap<String, PlatformInfo>,
@@ -1396,6 +1479,60 @@ mod tests {
                 ("make_opts".to_string(), "-s".to_string()),
             ])
         );
+    }
+
+    #[test]
+    fn test_node_lockfile_options_include_apply_patches() {
+        let opts = resolve_node_lockfile_options(|settings| {
+            settings.node.compile = Some(true);
+            settings.node.apply_patches = Some("https://example.com/node.patch".to_string());
+        });
+
+        assert_eq!(
+            opts,
+            BTreeMap::from([
+                (
+                    "apply_patches".to_string(),
+                    "https://example.com/node.patch".to_string(),
+                ),
+                ("compile".to_string(), "true".to_string()),
+            ])
+        );
+    }
+
+    /// With compilation off the patches never run, so recording them would split lockfile entries
+    /// for artifacts that are in fact identical.
+    #[test]
+    fn test_node_lockfile_options_omit_apply_patches_when_not_compiling() {
+        let opts = resolve_node_lockfile_options(|settings| {
+            settings.node.compile = Some(false);
+            settings.node.apply_patches = Some("https://example.com/node.patch".to_string());
+        });
+
+        assert_eq!(
+            opts,
+            BTreeMap::from([("compile".to_string(), "false".to_string())])
+        );
+    }
+
+    /// Mirrors what python-build and ruby-build sniff for, taking either marker so a patch written
+    /// against either tool lands the same way.
+    #[test]
+    fn test_patch_strip_level() {
+        assert_eq!(
+            patch_strip_level("diff --git a/src/node.cc b/src/node.cc\n--- a/src/node.cc\n"),
+            1
+        );
+        // ruby-build's marker on its own, with no `diff --git` header
+        assert_eq!(patch_strip_level("--- a/configure\n+++ b/configure\n"), 1);
+        // a plain `diff -u` between two trees
+        assert_eq!(
+            patch_strip_level("--- configure.orig\n+++ configure\n@@ -1 +1 @@\n"),
+            0
+        );
+        assert_eq!(patch_strip_level(""), 0);
+        // the marker only counts at the start of a line, not inside the diff body
+        assert_eq!(patch_strip_level("--- old\n+++ new\n+// --- a/nope\n"), 0);
     }
 
     #[test]

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -356,26 +356,16 @@ impl RubyPlugin {
     }
 
     fn fetch_patch_sources(&self) -> Vec<String> {
-        let settings = Settings::get();
-        let patch_sources = settings.ruby.apply_patches.clone().unwrap_or_default();
-        patch_sources
-            .split('\n')
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty())
-            .collect()
+        plugins::core::patch_sources(Settings::get().ruby.apply_patches.as_deref())
     }
 
+    /// ruby-build takes every patch as one blob on stdin, so they are concatenated here.
     async fn fetch_patches(&self) -> Result<String> {
-        let mut patches = vec![];
-        let re = regex!(r#"^[Hh][Tt][Tt][Pp][Ss]?://"#);
-        for f in &self.fetch_patch_sources() {
-            if re.is_match(f) {
-                patches.push(HTTP.get_text(f).await?);
-            } else {
-                patches.push(file::read_to_string(f)?);
-            }
-        }
-        Ok(patches.join("\n"))
+        Ok(
+            plugins::core::fetch_patch_contents(&self.fetch_patch_sources())
+                .await?
+                .join("\n"),
+        )
     }
 
     /// Fetch Ruby source tarball info from cache.ruby-lang.org index


### PR DESCRIPTION
Addresses the implementable part of #4894.

## Why only node

#4894 asks for patching "for any language from the core". Going through the core tools, that turns out not to be one feature — for most of them there is nothing to patch:

| how it installs | tools | patching |
|---|---|---|
| source build via an external build script | python (`python-build`), ruby (`ruby-build` / `ruby-install`) | already supported |
| **source build in mise's own code** | **node** (`install_compiling`) | **this PR** |
| source build via an external tool | erlang (`kerl`) | no hook upstream |
| downloads an official prebuilt archive | bun, deno, dotnet, elixir, go, java, rust, swift, zig | nothing to patch |

The existing support isn't really a mise feature: `python.patch_url` and `ruby.apply_patches` fetch the patch text and hand it to `python-build --patch` / `ruby-build --patch`, and those scripts own the "fetch source → apply → configure → make" pipeline.

node is the one core tool where mise runs that pipeline itself — `install_compiling` downloads the source tarball, extracts it, then shells out to `./configure`, `make`, `make install`. The seam between extract and configure is exactly where a patch belongs, so this is a small change.

erlang is a dead end for now, not an oversight: kerl 4.4.0 has a `maybe_patch()`, but it is an empty stub —

```sh
maybe_patch() {
    # $1 = OS platform e.g., Darwin, etc
    # $2 = OTP release
    release=$(get_otp_version "$2")
    case "$1" in
    Darwin) ;;
    SunOS) ;;
    *) ;;
    esac
}
```

— and no `KERL_*` variable takes a user patch. That one needs upstream kerl.

## What this adds

`node.apply_patches` (`MISE_NODE_APPLY_PATCHES`), the same shape as `ruby.apply_patches`: a newline-separated list of patch files or URLs. They are applied to the extracted source before `./configure` runs.

```toml
[settings.node]
compile = true
apply_patches = """
https://example.com/node-openssl.patch
./patches/local.patch
"""
```

### Strip level

python-build and ruby-build both default to `-p0` and bump to `-p1` when the patch looks git-generated, but they sniff for different markers:

```sh
grep -q '^diff --git a/' "$patchfile" && striplevel=1   # python-build
grep -q '^--- a/'        "$patchfile" && striplevel=1   # ruby-build
patch -p$striplevel --force -i "$patchfile"
```

`patch_strip_level` accepts either marker, so a patch authored against python-build or against ruby-build lands the same way here and users don't have to know which tool a given patch was written for.

### One patch at a time

ruby concatenates every patch into one blob because `ruby-build --patch` reads a single patch from stdin. mise runs `patch` itself here, so each patch is applied separately — the strip level is a per-patch property, and a git-style patch concatenated with a plain one cannot both be right.

### Precompiled installs warn

`node.apply_patches` only reaches the source build. If it is set and a precompiled binary is what actually got installed, mise now says so rather than letting the patches vanish silently:

> node.apply_patches is set but a precompiled node was installed, so no patch was applied. Set node.compile=true to build from source.

This is deliberately asymmetric with python and ruby, which ignore their patch settings on the precompiled path without comment. It fires only where the outcome is known — the `FetchOutcome::Downloaded` arms — so the 404 fallback from precompiled into `install_compiling`, which *does* apply the patches, stays quiet.

### Lockfile

`apply_patches` joins `cflags` / `configure_opts` / `make_opts` in `resolve_lockfile_options`, gated the same way on `compile != Some(false)`. Patches change what the build produces, so they belong to the artifact's identity; recording them when compilation is off would split lockfile entries for artifacts that are in fact identical. Same treatment ruby gives it.

### Shared with ruby

`fetch_patch_sources` / `fetch_patches` in `ruby.rs` were "split on newlines" plus "fetch if it looks like a URL, otherwise read the file", which node needs verbatim. Those moved to `plugins::core` as `patch_sources` and `fetch_patch_contents`. ruby's `fetch_patches` is now a wrapper that joins the results with `\n`, exactly as before, and a test pins the joined output.

Because the splitter is now shared, one behaviour does change for ruby: entries are trimmed and read with `lines()` rather than `split('\n')`, so an indented multi-line TOML string and a config saved with CRLF both work where they previously handed back paths with leading spaces or a trailing `\r`. That is a widening — nothing that parsed before stops parsing.

## Verification

`cargo check -p mise --all-targets` (clean), `cargo fmt --all`, `cargo clippy -p mise --all-targets` (nothing on the touched files), and `cargo test -p mise --bin mise plugins::core` — 80 passed, 0 failed, including the new tests. `schema/mise.json` regenerated; the diff is the one new property.

**`patch` behaviour was measured against a real `patch(1)`, with a control**, since the heuristic is the part that can silently do the wrong thing. Two patches were generated over the same one-line file — one with `git diff`, one with `diff -u` — and applied in a source root laid out the way mise extracts node:

```console
git-style.patch -> -p1   patching file configure   exit: 0   -> PATCHED_BY_GIT_STYLE
plain.patch     -> -p0   patching file configure   exit: 0   -> PATCHED_BY_PLAIN

control: the git-style patch forced through -p0
                         exit: 1                   -> ORIGINAL   (unchanged)
```

The control failing is the point: the strip level is load-bearing, not cosmetic, and `patch` exits non-zero when it is wrong, so a bad patch fails the install instead of producing a quietly-unpatched build.

### Not run

- **An end-to-end `node.compile = true` install with a patch.** Compiling node takes well over half an hour and is unix-only; there is no node source-build job in CI either.
- **`ruby.rs` was not compiled locally.** `plugins/core/mod.rs` routes `mod ruby` to `ruby_windows.rs` under `#[cfg_attr(windows, ...)]`, and this was developed on Windows, so the ruby change is covered by the `unit` and `unit-macos` jobs only. To keep that gap small, the one ruby-specific behaviour — the `\n` join for `ruby-build`'s stdin — is pinned by a test in `plugins/core/mod.rs`, which does compile on Windows.

## Not in this PR

- python and ruby keep delegating to their build scripts; nothing there changes.
- erlang, pending a patch hook in kerl.
- The download-only tools, which have no source to patch.

So this does **not** close #4894 as literally worded — "all core tools" is not achievable — but it covers the one remaining tool where patching is meaningful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Node.js source patches using local files or URLs.
  * Multiple patches can be listed on separate lines and applied in order during source builds.
  * Patch configuration is available through settings or the `MISE_NODE_APPLY_PATCHES` environment variable.
  * Patches automatically detect the appropriate path-stripping level.

* **Bug Fixes**
  * Added warnings when patches are configured for precompiled installations, where they cannot be applied.
  * Improved patch loading, ordering, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
