### PR TITLE
fix(http): honor system install destinations

### DIFF
--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -461,10 +461,17 @@ The HTTP backend implements an intelligent caching system to optimize disk usage
 
 ### Cache Location
 
-Downloaded and extracted files are cached in `$MISE_CACHE_DIR/http-tarballs/` instead of being stored separately for each tool installation. By default:
+For normal user installations, downloaded and extracted files are cached in
+`$MISE_DATA_DIR/http-tarballs/` instead of being stored separately for each tool
+installation. By default:
 
-- **Linux**: `~/.cache/mise/http-tarballs/`
-- **macOS**: `~/Library/Caches/mise/http-tarballs/`
+- **Linux**: `~/.local/share/mise/http-tarballs/`
+- **macOS**: `~/.local/share/mise/http-tarballs/`
+
+Explicit `mise install --system`, `mise install --shared`, and `mise
+install-into` installations are extracted directly into their destination.
+They do not use this persistent extraction cache, so the resulting installation
+is self-contained and does not link to the installing user's home directory.
 
 ### Cache Key Generation
 
@@ -476,30 +483,33 @@ Cache keys are generated based on the file content to ensure identical downloads
 Example cache directory structure:
 
 ```
-~/.cache/mise/http-tarballs/
+~/.local/share/mise/http-tarballs/
 ├── 71f774faa03daf1a58cc3339f8c73e6557348c8e0a2f3fb8148cc26e26bad83f/
-│   ├── extracted/
-│   │   └── bin/my-tool
+│   ├── bin/my-tool
 │   └── metadata.json
 └── 1c2af379bdf1fed266bc44b49271e2df5b0dafae09f1cc744b3505ec50c84719_strip_1/
-    ├── extracted/
-    │   └── my-tool
+    ├── my-tool
     └── metadata.json
 ```
 
 ### Symlinked Installations
 
-Tool installations are symlinks to the cached extracted content:
+Normal user installations are symlinks to the cached extracted content:
 
 ```bash
-~/.local/share/mise/installs/http-my-tool/1.0.0 → ~/.cache/mise/http-tarballs/71f774.../extracted
+~/.local/share/mise/installs/http-my-tool/1.0.0 → ~/.local/share/mise/http-tarballs/71f774...
 ```
 
 This approach provides several benefits:
 
-- **Space efficiency**: Multiple tools using the same tarball share a single cached copy
+- **Space efficiency**: Normal user installs share identical tarballs across tools
 - **Faster installations**: Cache hits avoid re-downloading and re-extracting files
 - **Consistency**: Identical file content always uses the same cache entry
+
+System, shared, and install-into destinations contain real files rather than
+these symlinks. This avoids leaving hidden cache entries behind after an
+uninstall and keeps shared installations independent of a specific user's data
+directory.
 
 ### Cache Metadata
 
@@ -517,9 +527,10 @@ Each cache entry includes a `metadata.json` file with information about the cach
 
 ### Cache Management
 
-The HTTP backend cache follows mise's standard cache management:
+Normal HTTP installations store their cache in
+`$MISE_DATA_DIR/http-tarballs/`. It is intentionally outside `MISE_CACHE_DIR`,
+so `mise cache clear` does not remove content that installed symlinks still
+reference.
 
-- Cache entries can be cleared with `mise cache clear`
-- The cache directory respects the `MISE_CACHE_DIR` environment variable
-- **Autopruner**: mise automatically cleans up unused cache entries after 30 days of inactivity
-- Manual cleanup is available with `mise cache clear` if needed
+System, shared, and install-into destinations do not create a persistent HTTP
+extraction cache.

--- a/e2e/backend/test_http_system_install
+++ b/e2e/backend/test_http_system_install
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURES="$TMPDIR/http-system-install-fixtures"
+PORT_FILE="$TMPDIR/http-system-install-port"
+SYSTEM_DATA="$HOME/.local/share/mise-system-http"
+SYSTEM_INSTALLS="$SYSTEM_DATA/installs"
+SHARED_INSTALLS="$HOME/.local/share/mise-shared-http"
+USER_INSTALLS="$MISE_DATA_DIR/installs"
+
+mkdir -p "$FIXTURES/archive/bin"
+cat >"$FIXTURES/archive/bin/system-archive" <<'EOF'
+#!/usr/bin/env bash
+echo system-archive-ok
+EOF
+chmod +x "$FIXTURES/archive/bin/system-archive"
+tar czf "$FIXTURES/system-archive.tar.gz" -C "$FIXTURES" archive
+
+mkdir -p "$FIXTURES/install-into-exact/bin"
+cat >"$FIXTURES/install-into-exact/bin/system-archive" <<'EOF'
+#!/usr/bin/env bash
+echo install-into-exact-ok
+EOF
+chmod +x "$FIXTURES/install-into-exact/bin/system-archive"
+tar czf "$FIXTURES/install-into-exact.tar.gz" -C "$FIXTURES" install-into-exact
+
+mkdir -p "$FIXTURES/shared-archive/bin"
+cat >"$FIXTURES/shared-archive/bin/shared-archive" <<'EOF'
+#!/usr/bin/env bash
+echo shared-archive-ok
+EOF
+chmod +x "$FIXTURES/shared-archive/bin/shared-archive"
+tar czf "$FIXTURES/shared-archive.tar.gz" -C "$FIXTURES" shared-archive
+
+cat >"$FIXTURES/system-raw" <<'EOF'
+#!/usr/bin/env bash
+echo system-raw-ok
+EOF
+chmod +x "$FIXTURES/system-raw"
+printf 'latest\n' >"$FIXTURES/versions.txt"
+printf '1.0.0\n' >"$FIXTURES/exact-versions.txt"
+
+python3 -u - "$FIXTURES" "$PORT_FILE" <<'PY' >/dev/null 2>&1 &
+import functools
+import http.server
+import socketserver
+import sys
+from pathlib import Path
+
+root = sys.argv[1]
+port_file = Path(sys.argv[2])
+handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=root)
+with socketserver.TCPServer(("127.0.0.1", 0), handler) as httpd:
+    port_file.write_text(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+wait_for_file "$PORT_FILE" "HTTP system install test server port file" 30 "$SERVER_PID"
+PORT=$(cat "$PORT_FILE")
+
+export MISE_SYSTEM_DATA_DIR="$SYSTEM_DATA"
+export MISE_SHARED_INSTALL_DIRS="$SHARED_INSTALLS"
+
+cat >mise.toml <<EOF
+[tools."http:system-archive"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/system-archive.tar.gz"
+bin_path = "archive/bin"
+EOF
+
+mise install --system
+
+SYSTEM_ARCHIVE="$SYSTEM_INSTALLS/http-system-archive/1.0.0"
+assert_directory_exists "$SYSTEM_ARCHIVE"
+assert "test ! -L '$SYSTEM_ARCHIVE' && echo directory" directory
+assert "test ! -e '$USER_INSTALLS/http-system-archive/1.0.0' && test ! -L '$USER_INSTALLS/http-system-archive/1.0.0' && echo missing" missing
+assert_contains "mise x -- system-archive" system-archive-ok
+assert "mise ls --json http:system-archive | jq -r '.[0].install_path'" "$SYSTEM_ARCHIVE"
+
+# Explicit destinations contain the real installation and leave no hidden cache.
+assert "test ! -e '$SYSTEM_INSTALLS/http-system-archive/.http-tarballs' && echo missing" missing
+rm -rf "$MISE_DATA_DIR/http-tarballs"
+assert_contains "mise x -- system-archive" system-archive-ok
+
+cat >mise.toml <<EOF
+[tools."http:system-raw"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/system-raw"
+bin = "system-raw"
+bin_path = "bin"
+EOF
+
+mise install --system
+
+SYSTEM_RAW="$SYSTEM_INSTALLS/http-system-raw/1.0.0/bin/system-raw"
+assert "test -f '$SYSTEM_RAW' && test ! -L '$SYSTEM_RAW' && echo file" file
+assert_contains "mise x -- system-raw" system-raw-ok
+
+cat >mise.toml <<EOF
+[tools."http:shared-archive"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/shared-archive.tar.gz"
+bin_path = "shared-archive/bin"
+EOF
+
+mise install --shared "$SHARED_INSTALLS"
+
+SHARED_ARCHIVE="$SHARED_INSTALLS/http-shared-archive/1.0.0"
+assert_directory_exists "$SHARED_ARCHIVE"
+assert "test ! -L '$SHARED_ARCHIVE' && echo directory" directory
+assert "test ! -e '$USER_INSTALLS/http-shared-archive/1.0.0' && test ! -L '$USER_INSTALLS/http-shared-archive/1.0.0' && echo missing" missing
+assert_contains "mise x -- shared-archive" shared-archive-ok
+assert "mise ls --json http:shared-archive | jq -r '.[0].install_path'" "$SHARED_ARCHIVE"
+assert "test ! -e '$SHARED_INSTALLS/http-shared-archive/.http-tarballs' && echo missing" missing
+
+# Discovering an existing shared install must not redirect a normal forced
+# reinstall into the shared destination, or remove the shared installation.
+rm -rf "$MISE_DATA_DIR/http-tarballs"
+mise install --force
+
+USER_ARCHIVE="$USER_INSTALLS/http-shared-archive/1.0.0"
+assert "test -L '$USER_ARCHIVE' && echo symlink" symlink
+assert_directory_exists "$MISE_DATA_DIR/http-tarballs"
+assert_contains "'$SHARED_ARCHIVE/shared-archive/bin/shared-archive'" shared-archive-ok
+
+# Relative shared destinations are resolved before installation, so their
+# contents never depend on the symlink's working directory.
+RELATIVE_SHARED="$PWD/relative-shared"
+mise install --shared relative-shared --force
+assert_contains "'$RELATIVE_SHARED/http-shared-archive/1.0.0/shared-archive/bin/shared-archive'" shared-archive-ok
+
+# latest keeps a content-derived real directory and an alias inside the system tree.
+cat >mise.toml <<EOF
+[tools."http:system-latest"]
+version = "latest"
+url = "http://127.0.0.1:$PORT/system-archive.tar.gz"
+version_list_url = "http://127.0.0.1:$PORT/versions.txt"
+bin_path = "archive/bin"
+EOF
+
+# A primary latest installation and runtime alias must not redirect discovery
+# or validation away from an explicitly requested system destination.
+mise install
+USER_LATEST="$USER_INSTALLS/http-system-latest/latest"
+assert "test -L '$USER_LATEST' && echo symlink" symlink
+
+mise install --system --force
+SYSTEM_LATEST="$SYSTEM_INSTALLS/http-system-latest/latest"
+assert "test -L '$SYSTEM_LATEST' && echo symlink" symlink
+assert "test -d '$SYSTEM_LATEST' && echo directory" directory
+assert_contains "'$SYSTEM_LATEST/archive/bin/system-archive'" system-archive-ok
+
+# Install the same tool normally first and create a fuzzy runtime alias. Exact
+# install-into binary discovery must not remap through this existing install.
+mise install \
+  "http:install-into[url=http://127.0.0.1:$PORT/system-archive.tar.gz,bin_path=archive/bin,version_list_url=http://127.0.0.1:$PORT/exact-versions.txt]@1.0.0"
+
+# install-into is also self-contained and does not link into the user's cache.
+INSTALL_INTO="$HOME/http-install-into"
+mise install-into \
+  "http:install-into[url=http://127.0.0.1:$PORT/install-into-exact.tar.gz,bin_path=install-into-exact/bin,version_list_url=http://127.0.0.1:$PORT/exact-versions.txt]@1" \
+  "$INSTALL_INTO"
+assert_directory_exists "$INSTALL_INTO"
+assert "test ! -L '$INSTALL_INTO' && echo directory" directory
+assert "test ! -e '$HOME/1.0.0' && test ! -L '$HOME/1.0.0' && echo missing" missing
+rm -rf "$MISE_DATA_DIR/http-tarballs"
+assert_contains "'$INSTALL_INTO/install-into-exact/bin/system-archive'" install-into-exact-ok

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -22,7 +22,7 @@ use crate::toolset::ToolRequest;
 use crate::toolset::ToolVersion;
 use crate::toolset::ToolVersionOptions;
 use crate::ui::progress_report::SingleReport;
-use crate::{dirs, file, hash};
+use crate::{dirs, env, file, hash};
 use async_trait::async_trait;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
@@ -71,6 +71,11 @@ struct CachePlan {
     key: String,
     file_info: FileInfo,
     strip_components: usize,
+}
+
+struct CacheTarget<'a> {
+    dir: &'a Path,
+    plan: &'a CachePlan,
 }
 
 impl FileInfo {
@@ -240,24 +245,40 @@ impl HttpBackend {
     // Cache path helpers
     // -------------------------------------------------------------------------
 
-    /// Get the http-tarballs directory in DATA (survives `mise cache clear`)
+    /// Get the shared extraction cache used by normal user installs.
     fn tarballs_dir() -> PathBuf {
         dirs::DATA.join(HTTP_TARBALLS_DIR)
     }
 
     /// Get the path to a specific cache entry
-    fn cache_path(&self, cache_key: &str) -> PathBuf {
-        Self::tarballs_dir().join(cache_key)
+    fn cache_path(cache_dir: &Path, cache_key: &str) -> PathBuf {
+        cache_dir.join(cache_key)
+    }
+
+    /// Remove an install entry without following an existing symlink. This is
+    /// needed when migrating a system/shared install created by an older mise
+    /// version from a cache symlink to a real directory.
+    fn remove_install_path(path: &Path) -> Result<()> {
+        if path
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            std::fs::remove_file(path)?;
+        } else {
+            file::remove_all(path)?;
+        }
+        Ok(())
     }
 
     /// Get the path to the metadata file for a cache entry
-    fn metadata_path(&self, cache_key: &str) -> PathBuf {
-        self.cache_path(cache_key).join(METADATA_FILE)
+    fn metadata_path(cache_dir: &Path, cache_key: &str) -> PathBuf {
+        Self::cache_path(cache_dir, cache_key).join(METADATA_FILE)
     }
 
     /// Check if a cache entry exists and is valid
-    fn is_cached(&self, cache_key: &str) -> bool {
-        self.cache_path(cache_key).exists() && self.metadata_path(cache_key).exists()
+    fn is_cached(cache_dir: &Path, cache_key: &str) -> bool {
+        Self::cache_path(cache_dir, cache_key).exists()
+            && Self::metadata_path(cache_dir, cache_key).exists()
     }
 
     // -------------------------------------------------------------------------
@@ -388,14 +409,19 @@ impl HttpBackend {
     /// Detect extraction type from an existing cache directory
     /// This handles the case where a cache hit occurs but the original extraction
     /// used different options (e.g., different `bin` name)
-    fn extraction_type_from_cache(&self, cache_key: &str, file_info: &FileInfo) -> ExtractionType {
+    fn extraction_type_from_cache(
+        &self,
+        cache_dir: &Path,
+        cache_key: &str,
+        file_info: &FileInfo,
+    ) -> ExtractionType {
         // For archives, we don't need to detect the filename
         if !file_info.is_compressed_binary && file_info.format != file::ExtractionFormat::Raw {
             return ExtractionType::Archive;
         }
 
         // For raw files, find the actual filename in the cache directory
-        let cache_path = self.cache_path(cache_key);
+        let cache_path = Self::cache_path(cache_dir, cache_key);
         for entry in xx::file::ls(&cache_path).unwrap_or_default() {
             if let Some(name) = entry.file_name().map(|n| n.to_string_lossy().to_string()) {
                 // Skip metadata file
@@ -419,21 +445,21 @@ impl HttpBackend {
     fn extract_to_cache(
         &self,
         tv: &ToolVersion,
+        cache: CacheTarget<'_>,
         file_path: &Path,
-        cache_plan: &CachePlan,
         url: &str,
         opts: &HttpOptions<'_>,
         pr: Option<&dyn SingleReport>,
     ) -> Result<ExtractionType> {
-        let cache_path = self.cache_path(&cache_plan.key);
+        let cache_path = Self::cache_path(cache.dir, &cache.plan.key);
 
         // Ensure parent directory exists
-        file::create_dir_all(Self::tarballs_dir())?;
+        file::create_dir_all(cache.dir)?;
 
         // Create unique temp directory for atomic extraction
-        let tmp_path = Self::tarballs_dir().join(format!(
+        let tmp_path = cache.dir.join(format!(
             "{}.tmp-{}-{}",
-            cache_plan.key,
+            cache.plan.key,
             std::process::id(),
             SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis()
         ));
@@ -445,7 +471,7 @@ impl HttpBackend {
 
         // Perform extraction
         let extraction_type =
-            self.extract_artifact(tv, &tmp_path, file_path, cache_plan, opts, pr)?;
+            self.extract_artifact(tv, &tmp_path, file_path, cache.plan, opts, pr)?;
 
         // Atomic replace
         if cache_path.exists() {
@@ -454,9 +480,57 @@ impl HttpBackend {
         std::fs::rename(&tmp_path, &cache_path)?;
 
         // Write metadata
-        self.write_metadata(&cache_plan.key, url, file_path, opts)?;
+        self.write_metadata(cache.dir, &cache.plan.key, url, file_path, opts)?;
 
         Ok(extraction_type)
+    }
+
+    /// Extract directly into an explicit system/shared/install-into destination.
+    /// The temporary directory lives next to the destination so the final rename
+    /// is atomic and the resulting installation has no dependency on user data.
+    fn extract_to_install_path(
+        &self,
+        tv: &ToolVersion,
+        file_path: &Path,
+        cache_plan: &CachePlan,
+        opts: &HttpOptions<'_>,
+        pr: Option<&dyn SingleReport>,
+    ) -> Result<()> {
+        let install_path = Self::install_path_for(tv, &cache_plan.key);
+        let parent = install_path
+            .parent()
+            .ok_or_else(|| eyre::eyre!("HTTP install path must have a parent"))?;
+        file::create_dir_all(parent)?;
+        let tmp_path = parent.join(format!(
+            ".mise-tmp-{}-{}-{}",
+            cache_plan.key,
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis()
+        ));
+        file::remove_all(&tmp_path)?;
+
+        let extract_path = if matches!(cache_plan.file_info.format, file::ExtractionFormat::Raw)
+            || cache_plan.file_info.is_compressed_binary
+        {
+            opts.bin_path()
+                .map(|path| tmp_path.join(template_string(&path, tv)))
+                .unwrap_or_else(|| tmp_path.clone())
+        } else {
+            tmp_path.clone()
+        };
+
+        if let Err(err) = self.extract_artifact(tv, &extract_path, file_path, cache_plan, opts, pr)
+        {
+            let _ = file::remove_all(&tmp_path);
+            return Err(err);
+        }
+
+        Self::remove_install_path(&install_path)?;
+        if let Err(err) = std::fs::rename(&tmp_path, &install_path) {
+            let _ = file::remove_all(&tmp_path);
+            return Err(err.into());
+        }
+        Ok(())
     }
 
     /// Extract a single artifact to the given directory
@@ -570,6 +644,7 @@ impl HttpBackend {
     /// Write cache metadata file
     fn write_metadata(
         &self,
+        cache_dir: &Path,
         cache_key: &str,
         url: &str,
         file_path: &Path,
@@ -584,7 +659,7 @@ impl HttpBackend {
         };
 
         let json = serde_json::to_string_pretty(&metadata)?;
-        file::write(self.metadata_path(cache_key), json)?;
+        file::write(Self::metadata_path(cache_dir, cache_key), json)?;
         Ok(())
     }
 
@@ -605,9 +680,17 @@ impl HttpBackend {
 
     /// Return the absolute path where the HTTP install symlink should live.
     fn install_path_for(tv: &ToolVersion, cache_key: &str) -> PathBuf {
-        tv.ba()
-            .installs_path
-            .join(Self::install_version_name(tv, cache_key))
+        if tv.install_path_is_exact
+            && let Some(install_path) = &tv.install_path
+        {
+            return install_path.clone();
+        }
+        let tool_dir = tv
+            .install_path
+            .as_ref()
+            .and_then(|path| path.parent())
+            .unwrap_or(&tv.ba().installs_path);
+        tool_dir.join(Self::install_version_name(tv, cache_key))
     }
 
     /// Return the install path later lookups should check for this HTTP tool.
@@ -618,9 +701,12 @@ impl HttpBackend {
         if tv.version == "latest" {
             tv.install_path()
         } else {
-            tv.ba()
-                .installs_path
-                .join(Self::install_version_name(tv, ""))
+            let pathname = Self::install_version_name(tv, "");
+            env::find_in_shared_installs(
+                tv.ba().installs_path.join(&pathname),
+                &tv.ba().tool_dir_name(),
+                &pathname,
+            )
         }
     }
 
@@ -653,19 +739,18 @@ impl HttpBackend {
     fn create_install_symlink(
         &self,
         tv: &ToolVersion,
+        cache_dir: &Path,
         cache_key: &str,
         extraction_type: &ExtractionType,
         opts: &HttpOptions<'_>,
     ) -> Result<()> {
-        let cache_path = self.cache_path(cache_key);
+        let cache_path = Self::cache_path(cache_dir, cache_key);
 
         // Determine version name for install path
         let install_path = Self::install_path_for(tv, cache_key);
 
         // Clean up existing install
-        if install_path.exists() {
-            file::remove_all(&install_path)?;
-        }
+        Self::remove_install_path(&install_path)?;
         if let Some(parent) = install_path.parent() {
             file::create_dir_all(parent)?;
         }
@@ -691,17 +776,17 @@ impl HttpBackend {
 
     /// Create additional symlink for latest versions
     fn create_version_alias_symlink(&self, tv: &ToolVersion, cache_key: &str) -> Result<()> {
-        if tv.version != "latest" {
+        if tv.version != "latest" || tv.install_path_is_exact {
             return Ok(());
         }
 
-        let content_version = Self::content_version_name(cache_key);
-        let original_path = tv.ba().installs_path.join(&tv.version);
-        let content_path = tv.ba().installs_path.join(&content_version);
+        let content_path = Self::install_path_for(tv, cache_key);
+        let tool_dir = content_path
+            .parent()
+            .ok_or_else(|| eyre::eyre!("HTTP install path must have a parent"))?;
+        let original_path = tool_dir.join(&tv.version);
 
-        if original_path.exists() {
-            file::remove_all(&original_path)?;
-        }
+        Self::remove_install_path(&original_path)?;
         if let Some(parent) = original_path.parent() {
             file::create_dir_all(parent)?;
         }
@@ -1045,35 +1130,41 @@ impl Backend for HttpBackend {
 
         // Generate cache key
         let cache_plan = self.cache_plan(&file_path, &opts)?;
-
-        // Acquire lock and extract or reuse cache
-        let cache_path = self.cache_path(&cache_plan.key);
-        let _lock = crate::lock_file::get(&cache_path, ctx.force)?;
-
-        // Determine extraction type based on whether we're using cache or extracting fresh
-        // On cache hit, we need to detect the actual filename from the cache (which may differ
-        // from current options if a previous extraction used different `bin` name)
         ctx.pr.next_operation();
-        let extraction_type = if self.is_cached(&cache_plan.key) {
-            ctx.pr.set_message("using cached tarball".into());
-            // Report extraction operation as complete (instant since we're using cache)
-            ctx.pr.set_length(1);
-            ctx.pr.set_position(1);
-            self.extraction_type_from_cache(&cache_plan.key, &cache_plan.file_info)
-        } else {
-            ctx.pr.set_message("extracting to cache".into());
-            self.extract_to_cache(
+        if tv.install_path_is_explicit {
+            ctx.pr.set_message("extracting to install path".into());
+            self.extract_to_install_path(
                 &tv,
                 &file_path,
                 &cache_plan,
-                &url,
                 &opts,
                 Some(ctx.pr.as_ref()),
-            )?
-        };
-
-        // Create symlinks
-        self.create_install_symlink(&tv, &cache_plan.key, &extraction_type, &opts)?;
+            )?;
+        } else {
+            let cache_dir = Self::tarballs_dir();
+            let cache_path = Self::cache_path(&cache_dir, &cache_plan.key);
+            let _lock = crate::lock_file::get(&cache_path, ctx.force)?;
+            let extraction_type = if Self::is_cached(&cache_dir, &cache_plan.key) {
+                ctx.pr.set_message("using cached tarball".into());
+                ctx.pr.set_length(1);
+                ctx.pr.set_position(1);
+                self.extraction_type_from_cache(&cache_dir, &cache_plan.key, &cache_plan.file_info)
+            } else {
+                ctx.pr.set_message("extracting to cache".into());
+                self.extract_to_cache(
+                    &tv,
+                    CacheTarget {
+                        dir: &cache_dir,
+                        plan: &cache_plan,
+                    },
+                    &file_path,
+                    &url,
+                    &opts,
+                    Some(ctx.pr.as_ref()),
+                )?
+            };
+            self.create_install_symlink(&tv, &cache_dir, &cache_plan.key, &extraction_type, &opts)?;
+        }
         self.create_version_alias_symlink(&tv, &cache_plan.key)?;
         tv.install_path = Some(Self::install_path_for(&tv, &cache_plan.key));
 
@@ -1175,13 +1266,21 @@ mod tests {
     use crate::toolset::{ToolRequest, ToolSource};
 
     fn http_test_tv(version: &str) -> ToolVersion {
-        let backend = Arc::new(BackendArg::new_raw(
+        http_test_tv_with_installs(version, None)
+    }
+
+    fn http_test_tv_with_installs(version: &str, installs_path: Option<PathBuf>) -> ToolVersion {
+        let mut backend = BackendArg::new_raw(
             "http-absolute-version".to_string(),
             Some("http:absolute-version".to_string()),
             "absolute-version".to_string(),
             None,
             BackendResolution::new(true),
-        ));
+        );
+        if let Some(installs_path) = installs_path {
+            backend.installs_path = installs_path;
+        }
+        let backend = Arc::new(backend);
         let request = ToolRequest::Version {
             backend,
             version: version.to_string(),
@@ -1320,6 +1419,62 @@ mod tests {
         let lookup_path = HttpBackend::lookup_install_path(&tv);
 
         assert_eq!(lookup_path, install_path);
+    }
+
+    #[test]
+    fn explicit_install_path_uses_destination_tool_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let primary_tool_dir = temp.path().join("user/installs/http-absolute-version");
+        let destination_tool_dir = temp.path().join("shared/http-absolute-version");
+        let mut tv = http_test_tv_with_installs("1.0.0", Some(primary_tool_dir));
+        tv.install_path = Some(destination_tool_dir.join("1.0.0"));
+
+        assert_eq!(
+            HttpBackend::install_path_for(&tv, "abcdef123456"),
+            destination_tool_dir.join("1.0.0")
+        );
+    }
+
+    #[test]
+    fn explicit_latest_install_stays_in_destination_tool_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let primary_tool_dir = temp.path().join("user/installs/http-absolute-version");
+        let destination_tool_dir = temp.path().join("system/http-absolute-version");
+        let mut tv = http_test_tv_with_installs("latest", Some(primary_tool_dir));
+        tv.install_path = Some(destination_tool_dir.join("latest"));
+
+        assert_eq!(
+            HttpBackend::install_path_for(&tv, "abcdef123456"),
+            destination_tool_dir.join("abcdef1")
+        );
+    }
+
+    #[test]
+    fn primary_install_keeps_shared_data_cache() {
+        let temp = tempfile::tempdir().unwrap();
+        let primary_tool_dir = temp.path().join("user/installs/http-absolute-version");
+        let mut tv = http_test_tv_with_installs("1.0.0", Some(primary_tool_dir.clone()));
+        tv.install_path = Some(primary_tool_dir.join("1.0.0"));
+
+        assert_eq!(
+            HttpBackend::tarballs_dir(),
+            dirs::DATA.join(HTTP_TARBALLS_DIR)
+        );
+    }
+
+    #[test]
+    fn exact_install_path_is_not_rewritten() {
+        let temp = tempfile::tempdir().unwrap();
+        let primary_tool_dir = temp.path().join("user/installs/http-absolute-version");
+        let destination = temp.path().join("install-into/destination");
+        let mut tv = http_test_tv_with_installs("1.0.0", Some(primary_tool_dir));
+        tv.install_path = Some(destination.clone());
+        tv.install_path_is_exact = true;
+
+        assert_eq!(
+            HttpBackend::install_path_for(&tv, "abcdef123456"),
+            destination
+        );
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -224,11 +224,25 @@ fn has_local_version_listing_option_override(
 ///
 /// For fuzzy requests like `latest` or `1.46`, backends may discover bins under
 /// the resolved version dir, but PATH-facing callers should use `runtime_path()`
-/// for the same version. Paths outside the install dir are returned unchanged.
+/// for the same version. Remapping is limited to aliases in the same tool root;
+/// paths outside the install dir or aliases in another install root are returned
+/// unchanged.
 pub(crate) fn runtime_path_for_install_path(tv: &ToolVersion, path: PathBuf) -> PathBuf {
+    // install-into, system, and shared installs give the backend an explicit
+    // destination. Remapping a path below it through a fuzzy runtime alias can
+    // select an unrelated normal installation of the same requested version.
+    if tv.install_path_is_exact || tv.install_path_is_explicit {
+        return path;
+    }
     let install_path = tv.install_path();
+    let runtime_path = tv.runtime_path();
+    // A re-resolved ToolVersion does not retain the transient destination flags
+    // used by install-into/system/shared installs. Never cross from a discovered
+    // shared/system install into a fuzzy alias in the primary user install root.
+    if install_path.parent() != runtime_path.parent() {
+        return path;
+    }
     if let Ok(relative_path) = path.strip_prefix(&install_path) {
-        let runtime_path = tv.runtime_path();
         if relative_path.as_os_str().is_empty() {
             runtime_path
         } else {
@@ -1264,6 +1278,145 @@ mod tests {
         assert_eq!(
             runtime_path_for_install_path(&tv, install_path.join("bin")),
             install_path.join("bin")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_runtime_path_for_exact_install_path_skips_runtime_alias() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let short = format!(
+            "runtime-remap-exact-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short.clone(),
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = temp_dir.path().join("installs").join(&short);
+        fs::create_dir_all(&backend.installs_path)?;
+
+        let normal_install = backend.installs_path.join("1.0.1");
+        fs::create_dir_all(normal_install.join("bin"))?;
+        file::make_symlink_or_file(Path::new("./1.0.1"), &backend.installs_path.join("latest"))?;
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "latest".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let exact_install = temp_dir.path().join("install-into");
+        let mut tv = ToolVersion::new(request, "1.0.1".into());
+        tv.install_path = Some(exact_install.clone());
+        tv.install_path_is_exact = true;
+
+        assert_eq!(
+            runtime_path_for_install_path(&tv, exact_install.join("bin")),
+            exact_install.join("bin")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_runtime_path_for_explicit_install_path_skips_primary_runtime_alias() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let short = format!(
+            "runtime-remap-explicit-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short.clone(),
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = temp_dir.path().join("user/installs").join(&short);
+        fs::create_dir_all(&backend.installs_path)?;
+
+        let normal_install = backend.installs_path.join("1.0.1");
+        fs::create_dir_all(normal_install.join("bin"))?;
+        file::make_symlink_or_file(Path::new("./1.0.1"), &backend.installs_path.join("latest"))?;
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "latest".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let explicit_install = temp_dir
+            .path()
+            .join("system/installs")
+            .join(&short)
+            .join("content-version");
+        let mut tv = ToolVersion::new(request, "1.0.1".into());
+        tv.install_path = Some(explicit_install.clone());
+        tv.install_path_is_explicit = true;
+
+        assert_eq!(
+            runtime_path_for_install_path(&tv, explicit_install.join("bin")),
+            explicit_install.join("bin")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_runtime_path_for_reresolved_shared_install_skips_primary_runtime_alias() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let short = format!(
+            "runtime-remap-reresolved-shared-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let mut backend = BackendArg::new_raw(
+            short.clone(),
+            None,
+            short.clone(),
+            None,
+            BackendResolution::new(false),
+        );
+        backend.installs_path = temp_dir.path().join("user/installs").join(&short);
+        fs::create_dir_all(&backend.installs_path)?;
+
+        let normal_install = backend.installs_path.join("1.0.0");
+        fs::create_dir_all(normal_install.join("bin"))?;
+        file::make_symlink_or_file(Path::new("./1.0.0"), &backend.installs_path.join("latest"))?;
+
+        let request = ToolRequest::Version {
+            backend: Arc::new(backend),
+            version: "latest".into(),
+            options: ToolVersionOptions::default(),
+            source: ToolSource::Argument,
+        };
+        let shared_install = temp_dir
+            .path()
+            .join("shared/installs")
+            .join(&short)
+            .join("1.0.1");
+        fs::create_dir_all(shared_install.join("bin"))?;
+        let mut tv = ToolVersion::new(request, "1.0.1".into());
+        // Re-resolution preserves the discovered path, but not the transient
+        // install_path_is_explicit flag from the original install command.
+        tv.install_path = Some(shared_install.clone());
+
+        assert_eq!(
+            runtime_path_for_install_path(&tv, shared_install.join("bin")),
+            shared_install.join("bin")
         );
 
         Ok(())

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -16,6 +16,7 @@ use clap::ValueHint;
 use eyre::Result;
 use itertools::Itertools;
 use jiff::Timestamp;
+use path_absolutize::Absolutize;
 use std::path::PathBuf;
 
 /// Install a tool version
@@ -388,7 +389,9 @@ impl Install {
             Some(env::MISE_SYSTEM_INSTALLS_DIR.clone())
         } else {
             self.shared.clone()
-        };
+        }
+        .map(|path| path.absolutize().map(|path| path.into_owned()))
+        .transpose()?;
         Ok(InstallOptions {
             force: self.force,
             jobs: self.jobs,

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -8,6 +8,7 @@ use crate::ui::prompt;
 use clap::ValueHint;
 use console::style;
 use eyre::{Result, bail, eyre};
+use path_absolutize::Absolutize;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -31,6 +32,7 @@ pub struct InstallInto {
 
 impl InstallInto {
     pub async fn run(self) -> Result<()> {
+        let install_path = self.path.absolutize()?.into_owned();
         let config = Config::get().await?;
         let ts = Arc::new(
             ToolsetBuilder::new()
@@ -58,7 +60,9 @@ impl InstallInto {
             locked: false, // install-into doesn't support locked mode
             before_date,
         };
-        tv.install_path = Some(self.path.clone());
+        tv.install_path = Some(install_path.clone());
+        tv.install_path_is_exact = true;
+        tv.install_path_is_explicit = true;
         // install-into force-reinstalls, which uninstalls (rm -rf) whatever
         // already exists at the install path. Check immediately before the
         // install performs that deletion (rather than at the start of `run`) so
@@ -67,19 +71,19 @@ impl InstallInto {
         // directory (e.g. `.`) unless the user passes -y/--yes or confirms
         // interactively; the prompt defaults to "no" since it is destructive.
         // (#8115)
-        if path_has_contents(&self.path) {
+        if path_has_contents(&install_path) {
             let proceed = Settings::get().yes
                 || prompt::confirm_with_default(
                     format!(
                         "{} is not empty; install-into will delete its contents. Continue?",
-                        display_path(&self.path)
+                        display_path(&install_path)
                     ),
                     false,
                 )?;
             if !proceed {
                 bail!(
                     "refusing to overwrite non-empty directory {}; pass {} or choose an empty/new path",
-                    display_path(&self.path),
+                    display_path(&install_path),
                     style("--yes").yellow().for_stderr()
                 );
             }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -44,6 +44,13 @@ pub struct ToolVersion {
     resolved_from_lockfile: bool,
     pub lock_platforms: BTreeMap<String, PlatformInfo>,
     pub install_path: Option<PathBuf>,
+    /// The HTTP backend should treat `install_path` as the final destination
+    /// rather than a `<tool>/<version>` path. Used by install-into.
+    pub(crate) install_path_is_exact: bool,
+    /// The HTTP backend should place files directly in `install_path` instead
+    /// of linking to its shared extraction cache. Set for system, shared, and
+    /// install-into destinations.
+    pub(crate) install_path_is_explicit: bool,
     /// Conda packages resolved during installation: (platform, basename) -> CondaPackageInfo
     pub conda_packages: BTreeMap<(String, String), CondaPackageInfo>,
     /// pkgx packages resolved during installation: (platform, package@version) -> PkgxPackageInfo
@@ -78,6 +85,8 @@ impl ToolVersion {
             resolved_from_lockfile: false,
             lock_platforms: Default::default(),
             install_path: None,
+            install_path_is_exact: false,
+            install_path_is_explicit: false,
             conda_packages: Default::default(),
             pkgx_packages: Default::default(),
             install_satisfied: None,

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -557,6 +557,7 @@ impl Toolset {
         if let Some(dir) = &opts.install_dir {
             let tool_dir_name = tv.ba().tool_dir_name();
             tv.install_path = Some(dir.join(tool_dir_name).join(tv.tv_pathname()));
+            tv.install_path_is_explicit = true;
         }
         let before_date = transitive_dependency_before_date(tr, &tv);
 


### PR DESCRIPTION
## Summary

- honor the destination selected by `mise install --system` and `mise install --shared` in the HTTP backend
- extract explicit system, shared, and `install-into` destinations directly instead of linking them to a persistent cache
- preserve normal user installs' existing cross-tool cache and symlink behavior
- resolve relative shared paths before installation and keep content-derived `latest` aliases inside the selected destination

## Root cause

The shared install pipeline supplied the requested destination through `ToolVersion.install_path`, but the HTTP backend rebuilt its install path from the primary user directory. It therefore left the pre-created system version directory empty and created the actual cache symlink under the user's install tree.

The initial destination-aware fix moved that cache beside each destination tool. Review identified that this still left three problems: relative `--shared` paths produced relative symlink targets, uninstalling a version left the hidden extraction cache behind, and `install-into` still depended on the invoking user's data directory.

## Behavior

Explicit system, shared, and `install-into` destinations now contain real extracted files. Extraction uses a temporary sibling directory followed by an atomic rename, so failed installs do not expose partial destinations. This removes the destination-local cache leak and makes those installations independent of the installing user's home directory.

Normal user installs retain the existing shared cache in `$MISE_DATA_DIR/http-tarballs` and continue to use symlinks for cross-tool deduplication. A normal forced install remains a user install even when an existing shared copy is discoverable, and it does not alter that shared copy.

Relative `--shared` paths are absolutized before they are assigned to tool versions. `latest` system installs keep a real content-derived directory plus the normal `latest` alias within the system tree. Concrete-version lookup continues to use the common shared/system discovery path.

Exact `install-into` destinations also bypass fuzzy runtime-path remapping during binary discovery. An existing normal installation and its runtime alias therefore cannot redirect validation or execution away from the newly populated destination.

## Verification

- `mise exec -- cargo test --all-features backend::http::tests` — 17 passed
- `mise exec -- cargo test --all-features test_runtime_path_for_exact_install_path_skips_runtime_alias` — passed
- `mise run test:e2e e2e/backend/test_http_system_install` — passed
  - covers archive and raw-file system installs, shared installs, relative `--shared`, normal force with an existing shared install, `latest --system`, and self-contained `install-into` in the presence of an existing fuzzy runtime alias
  - asserts exact JSON `install_path` values rather than matching tool names
- `mise exec -- cargo check --all-features` — passed
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings` — passed
- Rustfmt, shfmt, and ShellCheck passed individually

`mise run format` and `mise run lint` cannot run their hk wrapper in this Sapling working copy because hk requires a Git worktree. The relevant format and lint checks above were run directly.

Addresses https://github.com/jdx/mise/discussions/9475

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*
