### PR TITLE
fix(e2e): show what a failing command printed

### DIFF
--- a/e2e/assert.sh
+++ b/e2e/assert.sh
@@ -116,13 +116,30 @@ wait_for_file() {
 # Safeguard against running the test directly, which would execute in the actual user home
 [[ -n ${TEST_NAME:-} ]] || fail "tests should be called using run_test"
 
+# Capture stdout so a failure can show what the command actually said. Only stdout:
+# every caller but assert_succeed reads the return value back through `$(...)` and
+# compares it, so folding stderr in would break any assertion against a command that
+# warns. stderr still goes straight to the test's stderr, as before.
+#
+# The trailing `printf x` is what keeps trailing newlines: command substitution strips
+# them, so without it assert_succeed — the one caller that prints this straight through
+# rather than capturing it — would run the command's last line into the ok message.
+# Deliberately no temp file: tests are free to shadow commands on PATH, and
+# cli/test_bootstrap_remote stubs `mktemp` with one that hands back a directory.
 quiet_assert_succeed() {
-  local status=0
+  local status=0 output
   debug "$ $1"
-  bash -c "$1" || status=$?
+  output="$(
+    bash -c "$1"
+    s=$?
+    printf x
+    exit "$s"
+  )" || status=$?
+  output="${output%x}"
   if [[ $status -ne 0 ]]; then
-    fail "[$1] command failed with status $status"
+    fail "[$1] command failed with status $status"$'\n'"$output"
   fi
+  printf '%s' "$output"
 }
 quiet_assert_fail() {
   local status=0

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -121,6 +121,9 @@ pub struct CmdLineRunner<'a> {
     observe_stderr: Option<OutputObserver<'a>>,
     timeout: Option<Duration>,
     sandbox: Option<crate::sandbox::SandboxConfig>,
+    /// Whether a sandbox was actually installed on this command. Outlives `sandbox`, which
+    /// `apply_sandbox` consumes, so a spawn failure can still say what it was.
+    sandbox_requested: bool,
 }
 
 const GUARD_RUNNING: u8 = 0;
@@ -550,6 +553,7 @@ impl<'a> CmdLineRunner<'a> {
             observe_stderr: None,
             timeout: None,
             sandbox: None,
+            sandbox_requested: false,
         }
     }
 
@@ -1498,6 +1502,7 @@ impl<'a> CmdLineRunner<'a> {
     /// as the file descriptor may not be fully closed yet.
     fn spawn_with_etxtbsy_retry(&mut self) -> std::io::Result<std::process::Child> {
         let mut attempt = 0;
+        let sandboxed = self.sandbox_requested;
         loop {
             match self.cmd.as_std_mut().spawn() {
                 Ok(child) => return Ok(child),
@@ -1507,13 +1512,14 @@ impl<'a> CmdLineRunner<'a> {
                     // Exponential backoff: 50ms, 100ms, 200ms
                     std::thread::sleep(std::time::Duration::from_millis(50 * (1 << (attempt - 1))));
                 }
-                Err(err) => return Err(err),
+                Err(err) => return Err(Self::explain_spawn_failure(sandboxed, err)),
             }
         }
     }
 
     async fn spawn_async_with_etxtbsy_retry(&mut self) -> std::io::Result<tokio::process::Child> {
         let mut attempt = 0;
+        let sandboxed = self.sandbox_requested;
         loop {
             match self.cmd.spawn() {
                 Ok(child) => return Ok(child),
@@ -1523,9 +1529,30 @@ impl<'a> CmdLineRunner<'a> {
                     tokio::time::sleep(std::time::Duration::from_millis(50 * (1 << (attempt - 1))))
                         .await;
                 }
-                Err(err) => return Err(err),
+                Err(err) => return Err(Self::explain_spawn_failure(sandboxed, err)),
             }
         }
+    }
+
+    /// Say that a spawn failure may be the sandbox, since the hook itself cannot.
+    ///
+    /// The `pre_exec` hook runs post-fork, where it must stay async-signal-safe: it can return
+    /// an errno and nothing else. std has no channel for a message, and building one there
+    /// would allocate — an `io::Error::other` even arrives as a bare `EINVAL`, losing both the
+    /// text and the code. So the hook returns errnos and the explaining happens here, in the
+    /// parent, where formatting is free.
+    ///
+    /// Takes the flag by value rather than `&self`: the callers hold a `&mut` borrow of
+    /// `self.cmd` for the whole `match`, so reading a field there would not borrow-check.
+    ///
+    /// The original error becomes the source rather than text inside the message. See
+    /// [`SandboxSpawnFailure`] for why folding it into a string would be a behaviour change.
+    fn explain_spawn_failure(sandbox_requested: bool, err: std::io::Error) -> std::io::Error {
+        if !sandbox_requested {
+            return err;
+        }
+        let kind = err.kind();
+        std::io::Error::new(kind, SandboxSpawnFailure(err))
     }
 
     /// Prepare sandbox restrictions on the command. Must be called before execute()
@@ -1549,6 +1576,17 @@ impl<'a> CmdLineRunner<'a> {
 
         #[cfg(target_os = "linux")]
         {
+            self.sandbox_requested = true;
+            // Landlock needs every allowed path to exist, and the hook cannot say so from
+            // post-fork — warn here, where stderr is safe to touch and someone is reading it.
+            for path in sandbox.allow_read.iter().chain(sandbox.allow_write.iter()) {
+                if !path.exists() {
+                    warn!(
+                        "sandbox: {} does not exist, so its rule will not apply",
+                        display_path(path)
+                    );
+                }
+            }
             // On Linux, clear inherited env before pre_exec so child only sees filtered vars.
             // env_clear() also wipes envs explicitly set via .envs(), so save and restore them.
             if sandbox.effective_deny_env() {
@@ -1568,13 +1606,15 @@ impl<'a> CmdLineRunner<'a> {
             let sandbox = sandbox.clone();
             unsafe {
                 self.cmd.as_std_mut().pre_exec(move || {
+                    // Post-fork: no allocation, no I/O, no formatting. Return a bare errno and
+                    // let the parent explain — see explain_spawn_failure.
+                    let sandbox_failed =
+                        || std::io::Error::from_raw_os_error(nix::errno::Errno::EPERM as i32);
                     if sandbox.effective_deny_read() || sandbox.effective_deny_write() {
-                        crate::sandbox::landlock_apply(&sandbox)
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
+                        crate::sandbox::landlock_apply(&sandbox).map_err(|_| sandbox_failed())?;
                     }
                     if sandbox.effective_deny_net() {
-                        crate::sandbox::seccomp_apply()
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
+                        crate::sandbox::seccomp_apply().map_err(|_| sandbox_failed())?;
                     }
                     Ok(())
                 });
@@ -1583,6 +1623,7 @@ impl<'a> CmdLineRunner<'a> {
 
         #[cfg(target_os = "macos")]
         {
+            self.sandbox_requested = true;
             // On macOS, rewrite the command to go through sandbox-exec.
             // Build a new Command that wraps the original through sandbox-exec,
             // preserving stdio, cwd, and env from the original.
@@ -1741,6 +1782,40 @@ impl<'a> CmdLineRunner<'a> {
             .get_args()
             .map(|s| s.to_string_lossy().to_string())
             .collect::<Vec<_>>()
+    }
+}
+
+/// A spawn failure with the sandbox named as a likely cause.
+///
+/// Holds the original error as [`std::error::Error::source`] instead of formatting it into the
+/// message. `TaskExecutor::is_text_file_busy` looks for ETXTBSY by walking the error chain for an
+/// `io::Error` that carries an errno, and `io::Error::new(kind, String)` reports
+/// `raw_os_error() == None` — flattening the cause into text would silently switch off the outer
+/// ETXTBSY retry for every sandboxed task. Keeping it as the source leaves the errno reachable,
+/// and mise's error rendering joins the chain either way.
+#[derive(Debug)]
+struct SandboxSpawnFailure(std::io::Error);
+
+impl Display for SandboxSpawnFailure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Only set where a sandbox is actually installed, so the hint can name the mechanism.
+        #[cfg(target_os = "linux")]
+        const HOW: &str = "deny_read/deny_write need Landlock and deny_net needs seccomp, and a \
+                           kernel or container without Landlock cannot run them";
+        #[cfg(target_os = "macos")]
+        const HOW: &str = "the command is rewritten to run under sandbox-exec";
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        const HOW: &str = "no sandbox mechanism is available on this platform";
+        write!(
+            f,
+            "this command was sandboxed, so applying the sandbox is a likely cause: {HOW}"
+        )
+    }
+}
+
+impl std::error::Error for SandboxSpawnFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
     }
 }
 
@@ -2286,6 +2361,42 @@ mod tests {
         // non-regression contract shared by every CmdLineRunner call site.
         let r = super::CmdLineRunner::new("bash").cmd_body_args(&["-c".to_string()], "echo hi");
         assert_eq!(r.get_args(), vec!["-c".to_string(), "echo hi".to_string()]);
+    }
+
+    #[test]
+    fn test_explain_spawn_failure_keeps_errno_reachable() {
+        let etxtbsy = nix::errno::Errno::ETXTBSY as i32;
+        let annotated = super::CmdLineRunner::explain_spawn_failure(
+            true,
+            std::io::Error::from_raw_os_error(etxtbsy),
+        );
+
+        assert!(annotated.to_string().contains("sandboxed"));
+
+        // Mirrors TaskExecutor::is_text_file_busy. That retry finds ETXTBSY by walking the chain
+        // for an io::Error carrying an errno, so annotating must leave one in place — formatting
+        // the cause into the message would drop the errno and disable the retry.
+        let report = eyre::Report::new(annotated);
+        assert!(report.chain().any(|cause| {
+            cause
+                .downcast_ref::<std::io::Error>()
+                .and_then(|err| err.raw_os_error())
+                == Some(etxtbsy)
+        }));
+    }
+
+    #[test]
+    fn test_explain_spawn_failure_passes_through_unsandboxed() {
+        // Control: without a sandbox the error must come back untouched, so the assertion above
+        // is about the annotation and not about io::Error in general.
+        let etxtbsy = nix::errno::Errno::ETXTBSY as i32;
+        let untouched = super::CmdLineRunner::explain_spawn_failure(
+            false,
+            std::io::Error::from_raw_os_error(etxtbsy),
+        );
+
+        assert_eq!(untouched.raw_os_error(), Some(etxtbsy));
+        assert!(!untouched.to_string().contains("sandboxed"));
     }
 }
 

--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -54,11 +54,10 @@ fn add_path_rule(
         Err(_) => {
             // Path doesn't exist — on Linux, Landlock requires existing paths.
             // This affects cases like --allow-write=./dist where the dir doesn't exist yet.
-            // We warn rather than silently skipping or granting broader ancestor access.
-            eprintln!(
-                "mise sandbox: path '{}' does not exist, sandbox rule may not apply as expected",
-                path.display()
-            );
+            // Skipped silently here on purpose: this runs inside a post-fork `pre_exec` hook,
+            // where taking the stderr lock can deadlock if another thread held it across the
+            // fork. `CmdLineRunner::apply_sandbox` warns about missing paths from the parent
+            // instead, before the fork.
             Ok(ruleset)
         }
     }
@@ -106,7 +105,12 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<()> {
         if installs_dir.exists() {
             ruleset = add_path_rule(ruleset, installs_dir, read_access)?;
         }
-        ruleset = add_path_rule(ruleset, &crate::env::MISE_DATA_DIR, read_access)?;
+        // Guarded like installs_dir above: mise's own directories are created lazily, and a
+        // rule granting access to a directory that does not exist grants nothing.
+        let data_dir: &std::path::Path = &crate::env::MISE_DATA_DIR;
+        if data_dir.exists() {
+            ruleset = add_path_rule(ruleset, data_dir, read_access)?;
+        }
         for path in &config.allow_read {
             ruleset = add_path_rule(ruleset, path, read_access)?;
         }
@@ -128,7 +132,12 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<()> {
         if installs_dir.exists() {
             ruleset = add_path_rule(ruleset, installs_dir, read_access)?;
         }
-        ruleset = add_path_rule(ruleset, &crate::env::MISE_DATA_DIR, read_access)?;
+        // Guarded like installs_dir above: mise's own directories are created lazily, and a
+        // rule granting access to a directory that does not exist grants nothing.
+        let data_dir: &std::path::Path = &crate::env::MISE_DATA_DIR;
+        if data_dir.exists() {
+            ruleset = add_path_rule(ruleset, data_dir, read_access)?;
+        }
         for path in &config.allow_read {
             ruleset = add_path_rule(ruleset, path, read_access)?;
         }


### PR DESCRIPTION
## What this is now

**The tranche half of this PR is gone** — #12033 landed the same fix first (collect both statuses instead of returning only the second line's). This PR is rebased onto that and no longer touches `.github/workflows/test.yml`. What remains is the other half of the same investigation, which #12033 does not cover.

## A failing assertion said nothing about why

`quiet_assert_succeed` reported an exit status and no output. That is why the CI logs for `tasks/test_task_action_cache_session` contain no trace of why `mise run compile` exits 1 — nothing ever captured it. Now a failure prints what the command said.

Stdout only, deliberately: every caller except `assert_succeed` reads the value back through `$(...)` and compares it, so folding stderr in would break every assertion against a command that also warns. stderr still goes straight to the test's stderr, as before.

Two details that are not obvious:

- The trailing `printf x` keeps trailing newlines. Command substitution strips them, and `assert_succeed` prints this value through rather than capturing it, so without that its `ok` line would run into the command's last line of output.
- No temp file. Tests are free to shadow commands on PATH, and `cli/test_bootstrap_remote` stubs `mktemp` with one that hands back a directory.

## A spawn failure did not say the sandbox might be the cause

The `pre_exec` hook runs post-fork, where it has to stay async-signal-safe: it can return an errno and nothing else. Even `io::Error::other` arrives in the parent as a bare `EINVAL`, losing both the text and the code. So the hook keeps returning errnos and the parent does the explaining, where formatting costs nothing.

`sandbox_requested` is a separate flag because `apply_sandbox` consumes `sandbox`, so the config is gone by the time the spawn fails. It is passed by value rather than read off `&self` because the callers hold a `&mut` borrow of `self.cmd` across the whole `match`.

The original error becomes the `source` rather than text folded into a message, so anything matching on `ErrorKind` still sees what it saw before.
