### PR TITLE
fix(conda): activate package commands

### DIFF
--- a/docs/dev-tools/backends/conda.md
+++ b/docs/dev-tools/backends/conda.md
@@ -6,6 +6,11 @@ Anaconda channels without needing conda or mamba installed.
 This backend fetches pre-built packages from the anaconda.org API and extracts them directly,
 making it a lightweight way to install conda packages as standalone CLI tools.
 
+Commands from the selected package run inside that package's isolated conda prefix. mise sets
+`CONDA_PREFIX`, adds the prefix's executable directories for the command process, and applies
+`etc/conda/activate.d` scripts before starting it. This lets a command use its packaged runtime
+dependencies without adding dependency commands to your interactive shell's `PATH`.
+
 The code for this is inside the mise repository at [`./src/backend/conda.rs`](https://github.com/jdx/mise/blob/main/src/backend/conda.rs).
 
 ## Dependencies

--- a/e2e-win/conda.Tests.ps1
+++ b/e2e-win/conda.Tests.ps1
@@ -9,5 +9,21 @@ Describe 'conda' {
     # (0xC0000135) and printed nothing.
     It 'runs a binary that links DLLs from dependency packages' {
         mise x conda:zstd@1.5.7 -- zstd --version | Out-String | Should -Match "Zstandard CLI"
+
+        $installPath = (mise where conda:zstd@1.5.7).Trim()
+        $launcherPath = Join-Path $installPath '.mise-bins\zstd.cmd'
+        $directExePath = Join-Path $installPath '.mise-bins\zstd.exe'
+        $activateDir = Join-Path $installPath 'etc\conda\activate.d'
+        $activationMarker = Join-Path $installPath 'native-activation-marker'
+        New-Item -ItemType Directory -Path $activateDir -Force | Out-Null
+        "@echo activated>`"$activationMarker`"" |
+            Out-File -FilePath (Join-Path $activateDir 'mise-test.cmd') -Encoding ascii
+
+        $launcherPath | Should -Exist
+        $directExePath | Should -Not -Exist
+        Remove-Item -LiteralPath $activationMarker -ErrorAction SilentlyContinue
+        $activationMarker | Should -Not -Exist
+        mise x conda:zstd@1.5.7 -- zstd --version | Out-String | Should -Match "Zstandard CLI"
+        (Get-Content $activationMarker).Trim() | Should -Be 'activated'
     }
 }

--- a/e2e/backend/test_conda_activation
+++ b/e2e/backend/test_conda_activation
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+CHANNEL_ROOT="$TMPDIR/conda-channel"
+PORT_FILE="$TMPDIR/conda-channel-port"
+mkdir -p "$CHANNEL_ROOT"
+
+python3 - "$CHANNEL_ROOT" "$PORT_FILE" <<'PY' &
+import hashlib
+import http.server
+import io
+import json
+import socketserver
+import sys
+import tarfile
+from pathlib import Path
+
+root = Path(sys.argv[1])
+port_file = Path(sys.argv[2])
+subdir = root / "noarch"
+subdir.mkdir(parents=True)
+
+
+def package(name, files, depends=None):
+    depends = depends or []
+    paths = []
+    for path, content in files.items():
+        paths.append({
+            "_path": path,
+            "path_type": "hardlink",
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "size_in_bytes": len(content),
+        })
+
+    index = {
+        "name": name,
+        "version": "1.0.0",
+        "build": "0",
+        "build_number": 0,
+        "depends": depends,
+        "subdir": "noarch",
+    }
+    metadata = {
+        "info/index.json": json.dumps(index).encode(),
+        "info/paths.json": json.dumps({"paths_version": 1, "paths": paths}).encode(),
+        "info/files": ("\n".join(files) + "\n").encode(),
+    }
+    archive_name = f"{name}-1.0.0-0.tar.bz2"
+    archive_path = subdir / archive_name
+    with tarfile.open(archive_path, "w:bz2") as archive:
+        for path, content in {**files, **metadata}.items():
+            info = tarfile.TarInfo(path)
+            info.size = len(content)
+            info.mode = 0o755 if path.startswith("bin/") else 0o644
+            archive.addfile(info, io.BytesIO(content))
+
+    data = archive_path.read_bytes()
+    return archive_name, {
+        **index,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "size": len(data),
+    }
+
+
+def tool_package(name, marker):
+    return package(name, {
+        f"bin/{name}": (
+            "#!/bin/sh\n"
+            "printf '%s|%s|%s|%s\\n' "
+            f"'{marker}' \"$CONDA_PREFIX\" \"$CONDA_TEST_ACTIVATED\" "
+            "\"$(dependency-command)\"\n"
+        ).encode(),
+        "etc/conda/activate.d/fixture.sh": b"export CONDA_TEST_ACTIVATED=activated\n",
+    }, ["fixture-dependency >=1.0.0"])
+
+
+packages = dict([
+    package("fixture-dependency", {
+        "bin/dependency-command": b"#!/bin/sh\nprintf dependency-output\n",
+    }),
+    tool_package("fixture-one", "one"),
+    tool_package("fixture-two", "two"),
+])
+(subdir / "repodata.json").write_text(json.dumps({
+    "info": {"subdir": "noarch"},
+    "packages": packages,
+    "packages.conda": {},
+    "removed": [],
+    "repodata_version": 1,
+}))
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=root, **kwargs)
+
+    def log_message(self, *_args):
+        pass
+
+
+with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+    port_file.write_text(str(server.server_address[1]))
+    server.serve_forever()
+PY
+SERVER_PID=$!
+cleanup() {
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_file "$PORT_FILE" "conda channel port" 30 "$SERVER_PID"
+SERVER_PORT="$(cat "$PORT_FILE")"
+
+cat >mise.toml <<EOF
+[settings]
+lockfile = true
+
+[tools]
+"conda:fixture-one" = { version = "1.0.0", channel = "http://127.0.0.1:$SERVER_PORT" }
+"conda:fixture-two" = { version = "1.0.0", channel = "http://127.0.0.1:$SERVER_PORT" }
+EOF
+
+mise install
+
+one_prefix="$MISE_DATA_DIR/installs/conda-fixture-one/1.0.0"
+two_prefix="$MISE_DATA_DIR/installs/conda-fixture-two/1.0.0"
+assert "mise exec -- fixture-one" "one|$one_prefix|activated|dependency-output"
+assert "mise exec -- fixture-two" "two|$two_prefix|activated|dependency-output"
+assert_fail "mise exec -- sh -c 'command -v dependency-command'"
+assert_succeed "test ! -e '$one_prefix/.mise-bins/dependency-command'"
+assert_succeed "test ! -e '$two_prefix/.mise-bins/dependency-command'"
+
+# Locked installs use the same launcher generation path.
+mise uninstall -a conda:fixture-one
+mise install
+assert "mise exec -- fixture-one" "one|$one_prefix|activated|dependency-output"

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -30,7 +30,7 @@ use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use versions::Versioning;
@@ -433,7 +433,7 @@ impl CondaBackend {
         }
 
         Self::make_bins_executable(&install_path)?;
-        self.create_symlink_bin_dir(tv, &main_paths)?;
+        self.create_bin_launcher_dir(tv, &main_paths)?;
 
         // Store lockfile info
         let n_deps = all_records.len() - 1; // all except main
@@ -529,7 +529,7 @@ impl CondaBackend {
         }
 
         Self::make_bins_executable(&install_path)?;
-        self.create_symlink_bin_dir(tv, &main_paths)?;
+        self.create_bin_launcher_dir(tv, &main_paths)?;
 
         // Repopulate tv.conda_packages from lockfile so downstream lockfile update preserves entries
         for basename in &dep_basenames {
@@ -562,10 +562,12 @@ impl CondaBackend {
         Ok(())
     }
 
-    /// Creates a `.mise-bins` directory with symlinks only to binaries from the main package.
+    /// Creates a `.mise-bins` directory with launchers only for binaries from the main package.
     /// Uses the PathsEntry list returned by rattler's link_package to identify which files
-    /// belong to the main package (excluding transitive dependency binaries).
-    fn create_symlink_bin_dir(&self, tv: &ToolVersion, main_paths: &[PathsEntry]) -> Result<()> {
+    /// belong to the main package (excluding transitive dependency binaries). The launchers
+    /// activate the package prefix only for the command they start, so dependencies are
+    /// available to that command without exposing their binaries on the user's PATH.
+    fn create_bin_launcher_dir(&self, tv: &ToolVersion, main_paths: &[PathsEntry]) -> Result<()> {
         let symlink_dir = tv.install_path().join(MISE_BINS_DIR);
         file::create_dir_all(&symlink_dir)?;
 
@@ -591,9 +593,9 @@ impl CondaBackend {
                 continue;
             };
             let src = install_path.join(&entry.relative_path);
-            let dst = symlink_dir.join(bin_name);
+            let dst = Self::bin_launcher_path(&symlink_dir, bin_name, cfg!(windows));
             if src.exists() && !dst.exists() {
-                file::make_symlink_or_copy(&src, &dst)?;
+                Self::create_bin_launcher(&install_path, &src, &dst)?;
             }
         }
 
@@ -673,6 +675,91 @@ impl CondaBackend {
             }
         }
         Ok(())
+    }
+
+    fn bin_launcher_path(
+        launcher_dir: &Path,
+        bin_name: &std::ffi::OsStr,
+        windows: bool,
+    ) -> PathBuf {
+        let launcher = launcher_dir.join(bin_name);
+        if windows
+            && launcher
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"))
+        {
+            launcher.with_extension("cmd")
+        } else {
+            launcher
+        }
+    }
+
+    fn create_bin_launcher(prefix: &Path, target: &Path, launcher: &Path) -> Result<()> {
+        #[cfg(unix)]
+        {
+            file::write(launcher, Self::render_unix_launcher(prefix, target))?;
+            file::make_executable(launcher)?;
+        }
+
+        #[cfg(windows)]
+        {
+            let needs_activation_launcher = target
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| {
+                    ext.eq_ignore_ascii_case("exe")
+                        || ext.eq_ignore_ascii_case("cmd")
+                        || ext.eq_ignore_ascii_case("bat")
+                });
+            if needs_activation_launcher {
+                file::write(launcher, Self::render_windows_launcher(prefix, target))?;
+            } else {
+                // Preserve the existing fallback for uncommon executable formats. Native
+                // .exe files remain at their original path and are invoked by a .cmd launcher
+                // so their adjacent dependency DLLs and prefix activation are both available.
+                file::make_symlink_or_copy(target, launcher)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(any(unix, test))]
+    fn render_unix_launcher(prefix: &Path, target: &Path) -> String {
+        let prefix = shell_quote(&prefix.to_string_lossy());
+        let target = shell_quote(&target.to_string_lossy());
+        format!(
+            "#!/bin/sh\n\
+             export CONDA_PREFIX={prefix}\n\
+             export CONDA_DEFAULT_ENV={prefix}\n\
+             export CONDA_SHLVL=1\n\
+             export PATH=\"$CONDA_PREFIX/bin${{PATH:+:$PATH}}\"\n\
+             for _mise_conda_script in \"$CONDA_PREFIX\"/etc/conda/activate.d/*.sh; do\n\
+             \tif [ -f \"$_mise_conda_script\" ]; then\n\
+             \t\t. \"$_mise_conda_script\" || exit $?\n\
+             \tfi\n\
+             done\n\
+             unset _mise_conda_script\n\
+             exec {target} \"$@\"\n"
+        )
+    }
+
+    #[cfg(any(windows, test))]
+    fn render_windows_launcher(prefix: &Path, target: &Path) -> String {
+        let prefix = cmd_escape_value(&prefix.to_string_lossy());
+        let target = cmd_escape_value(&target.to_string_lossy());
+        format!(
+            "@echo off\r\n\
+             setlocal\r\n\
+             set \"CONDA_PREFIX={prefix}\"\r\n\
+             set \"CONDA_DEFAULT_ENV={prefix}\"\r\n\
+             set \"CONDA_SHLVL=1\"\r\n\
+             set \"PATH={prefix};{prefix}\\Library\\mingw-w64\\bin;{prefix}\\Library\\usr\\bin;{prefix}\\Library\\bin;{prefix}\\Scripts;{prefix}\\bin;%PATH%\"\r\n\
+             for %%F in (\"{prefix}\\etc\\conda\\activate.d\\*.bat\") do if exist \"%%~fF\" call \"%%~fF\"\r\n\
+             for %%F in (\"{prefix}\\etc\\conda\\activate.d\\*.cmd\") do if exist \"%%~fF\" call \"%%~fF\"\r\n\
+             call \"{target}\" %*\r\n\
+             exit /b %ERRORLEVEL%\r\n"
+        )
     }
 
     /// Resolve conda packages for lockfile's shared conda-packages section.
@@ -908,15 +995,37 @@ impl Backend for CondaBackend {
     }
 }
 
+#[cfg(any(unix, test))]
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(any(windows, test))]
+fn cmd_escape_value(value: &str) -> String {
+    value
+        .replace('^', "^^")
+        .replace('%', "%%")
+        .replace('&', "^&")
+        .replace('|', "^|")
+        .replace('<', "^<")
+        .replace('>', "^>")
+        .replace('"', "^\"")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{CondaBackend, CondaOptions};
+    #[cfg(unix)]
+    use crate::file;
     use crate::toolset::ToolVersionOptions;
     use rattler_conda_types::package::{ArchiveIdentifier, CondaArchiveType, DistArchiveType};
     use rattler_conda_types::{
         PackageName, PackageRecord, RepoDataRecord, Version, package::DistArchiveIdentifier,
     };
     use std::collections::BTreeMap;
+    use std::path::Path;
+    #[cfg(unix)]
+    use std::process::Command;
     use std::str::FromStr;
     use url::Url;
 
@@ -979,6 +1088,91 @@ mod tests {
         assert_ne!(first, second);
         assert_eq!(first.parent(), dest.parent());
         assert_eq!(second.parent(), dest.parent());
+    }
+
+    #[test]
+    fn unix_launcher_quotes_prefix_and_target() {
+        let launcher = CondaBackend::render_unix_launcher(
+            Path::new("/tmp/prefix with ' quote"),
+            Path::new("/tmp/prefix with ' quote/bin/tool"),
+        );
+
+        assert!(launcher.contains("export CONDA_PREFIX='/tmp/prefix with '\\'' quote'"));
+        assert!(launcher.contains("exec '/tmp/prefix with '\\'' quote/bin/tool' \"$@\""));
+    }
+
+    #[test]
+    fn windows_launcher_escapes_cmd_metacharacters() {
+        let launcher = CondaBackend::render_windows_launcher(
+            Path::new(r"C:\prefix&tools%name%"),
+            Path::new(r"C:\prefix&tools%name%\Scripts\tool.cmd"),
+        );
+
+        assert!(launcher.contains(r#"set "CONDA_PREFIX=C:\prefix^&tools%%name%%""#));
+        assert!(launcher.contains(r#"call "C:\prefix^&tools%%name%%\Scripts\tool.cmd" %*"#));
+    }
+
+    #[test]
+    fn windows_native_executable_uses_cmd_launcher_path() {
+        let launcher = CondaBackend::bin_launcher_path(
+            Path::new("/prefix/.mise-bins"),
+            std::ffi::OsStr::new("tool.exe"),
+            true,
+        );
+
+        assert_eq!(launcher, Path::new("/prefix/.mise-bins/tool.cmd"));
+        assert_eq!(
+            CondaBackend::bin_launcher_path(
+                Path::new("/prefix/.mise-bins"),
+                std::ffi::OsStr::new("tool.cmd"),
+                true,
+            ),
+            Path::new("/prefix/.mise-bins/tool.cmd")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_launcher_activates_only_its_own_prefix() {
+        let temp = tempfile::tempdir().unwrap();
+        let prefix = temp.path().join("prefix with ' quote");
+        let bin_dir = prefix.join("bin");
+        let activate_dir = prefix.join("etc/conda/activate.d");
+        let target = bin_dir.join("tool");
+        let dependency = bin_dir.join("dependency-command");
+        let launcher = temp.path().join("launcher");
+        file::create_dir_all(&bin_dir).unwrap();
+        file::create_dir_all(&activate_dir).unwrap();
+        file::write(
+            &target,
+            "#!/bin/sh\nprintf '%s\\n' \"$CONDA_PREFIX\" \"$CONDA_DEFAULT_ENV\" \"$CONDA_SHLVL\" \"$CONDA_TEST_ACTIVATED\" \"$(dependency-command)\" \"$1\"\nexit 23\n",
+        )
+        .unwrap();
+        file::make_executable(&target).unwrap();
+        file::write(&dependency, "#!/bin/sh\nprintf dependency-output\n").unwrap();
+        file::make_executable(&dependency).unwrap();
+        file::write(
+            activate_dir.join("test.sh"),
+            "export CONDA_TEST_ACTIVATED=activated\n",
+        )
+        .unwrap();
+        CondaBackend::create_bin_launcher(&prefix, &target, &launcher).unwrap();
+
+        let output = Command::new(&launcher)
+            .arg("forwarded argument")
+            .env("CONDA_PREFIX", "/wrong/prefix")
+            .env("PATH", "/usr/bin:/bin")
+            .output()
+            .unwrap();
+
+        assert_eq!(output.status.code(), Some(23));
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            format!(
+                "{0}\n{0}\n1\nactivated\ndependency-output\nforwarded argument\n",
+                prefix.display()
+            )
+        );
     }
 
     /// Regression test for https://github.com/jdx/mise/discussions/9829:


### PR DESCRIPTION
## Summary

- run conda package commands through prefix-aware launchers instead of direct symlinks
- activate each command's own conda prefix without exposing dependency binaries on the user's shell `PATH`
- route Windows native executables through activation-aware `.cmd` launchers while keeping the executable at its original prefix path

## Problem

The conda backend exposes only binaries from the main package through `.mise-bins`, but those entries were direct symlinks or copies. That skipped conda activation entirely. Packages such as `jdtls` ship a launcher that expands `${CONDA_PREFIX}` and also rely on dependency executables and `etc/conda/activate.d` variables, so the launcher resolved `/libexec/jdtls/...` and failed.

Setting one global `CONDA_PREFIX` is not safe because multiple independently installed conda tools can be active at the same time. Each command therefore receives its own isolated prefix environment in its launcher process.

## Solution

On Unix, `.mise-bins` entries now set `CONDA_PREFIX`, `CONDA_DEFAULT_ENV`, `CONDA_SHLVL`, prepend the package prefix's `bin` directory, source its activation scripts, and then `exec` the original main-package command. On Windows, native `.exe` files stay in their original prefix directory beside their dependency DLLs, while `.mise-bins` exposes an activation-aware `.cmd` launcher. Existing `.cmd` and `.bat` targets use the same scoped activation environment.

Dependency commands remain unavailable from the user's normal `PATH`; they are available only to the package command and its children. Fresh and lockfile-based installs share the same launcher generation path.

## Verification

- `mise exec -- cargo test --all-features backend::conda::tests`
- `mise run test:e2e e2e/backend/test_conda_activation`
- Windows E2E verifies a native `zstd.exe` runs through its `.cmd` launcher and executes an `activate.d` script
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d -s e2e/backend/test_conda_activation`
- `mise exec -- shellcheck -x e2e/backend/test_conda_activation`

The local HTTP fixture initially could not bind inside the sandbox; rerunning the E2E with host permissions succeeded.

Addresses https://github.com/jdx/mise/discussions/8576

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conda-installed tools now use launchers that automatically activate their environments.
  * Dependency executables remain isolated from the interactive shell’s command path.
  * Windows support includes command launchers and required dependency handling.

* **Bug Fixes**
  * Improved argument forwarding, quoting, exit-code preservation, and activation behavior across platforms.

* **Documentation**
  * Documented Conda environment activation and executable path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->