### PR TITLE
fix(release): update workspace dependency across calver years

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -139,6 +139,17 @@ set_package_version() {
 	sed -i.bak "s/^version = \"$old_pattern\"$/version = \"$new_version\"/" "$manifest"
 	rm -f "$manifest.bak"
 
+	# Keep the workspace path dependency compatible when the calver year changes.
+	if [[ $crate_name == mise-interactive-config ]]; then
+		sed -i.bak -E \
+			"/^mise-interactive-config = /s/version = \"[^\"]+\"/version = \"$new_version\"/" \
+			Cargo.toml
+		rm -f Cargo.toml.bak
+		grep -Fqx \
+			"mise-interactive-config = { path = \"crates/mise-interactive-config\", version = \"$new_version\" }" \
+			Cargo.toml
+	fi
+
 	cargo update --offline -p "$crate_name" --precise "$new_version"
 }
 


### PR DESCRIPTION
## Summary

- update the root `mise-interactive-config` path dependency whenever its package version is bumped
- accept either broad requirements such as `2026` or concrete requirements such as `2026.8.0`
- verify that the dependency line was rewritten before updating the lockfile

## Root cause

The immediate release fix preserved the broad `version = "2026"` requirement. That unblocks releases during 2026, but Cargo would reject the first `mise-interactive-config` bump to `2027.x` because the workspace dependency would no longer match the local package version.

## Validation

- simulated `mise-interactive-config` advancing from `2026.1.12` to `2027.1.0` in a disposable worktree
- verified the package manifest, root dependency, lockfile, and offline Cargo metadata all update successfully
- `mise run lint-fix`
- `bash -n xtasks/release-plz`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the CI-only release bash script; no runtime auth, data, or app logic.
> 
> **Overview**
> Extends **`set_package_version`** in `xtasks/release-plz` so bumping **`mise-interactive-config`** also rewrites the root **`Cargo.toml`** path dependency `version` to the new package version (regex replaces any prior requirement, e.g. `2026` or `2026.8.0`).
> 
> A **`grep -Fqx`** check confirms the dependency line matches the expected path + version before **`cargo update`** runs, avoiding lockfile updates when the workspace requirement would still disagree with the crate after a calver year rollover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c282c44fe5c24c73f8bae3a2abd723af224ef92d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release version consistency for the interactive configuration component.
  * Added validation to ensure package references remain aligned during version updates.
* **User Impact**
  * No new user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->