### PR TITLE
fix(install): run install hooks from project root

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -34,6 +34,8 @@ leave = "echo 'I left the project'"
 ## Preinstall/postinstall hook
 
 These hooks are run before and after tools are installed (respectively). Unlike other hooks, these hooks do not require `mise activate`.
+They run with the project root as their working directory, even when `mise install` is invoked from
+a subdirectory. The invocation directory remains available in `MISE_ORIGINAL_CWD`.
 
 ```toml
 [hooks]

--- a/e2e/config/test_hooks
+++ b/e2e/config/test_hooks
@@ -8,8 +8,8 @@ dummy = 'latest'
 enter = { run = 'echo HOOK-ENTER' }
 leave = { run = 'echo HOOK-LEAVE' }
 cd = { run = 'echo HOOK-CD' }
-preinstall = { run = 'echo PREINSTALL' }
-postinstall = { run = 'echo POSTINSTALL' }
+preinstall = { run = 'echo PREINSTALL:\$(pwd)' }
+postinstall = { run = 'echo POSTINSTALL:\$(pwd)' }
 EOF
 
 # preinstall + postinstall hooks fire when installing
@@ -18,6 +18,11 @@ assert_contains "mise i dummy@1 2>&1" "POSTINSTALL"
 # `mise i` with nothing missing still runs postinstall (MISE_INSTALLED_TOOLS=[], #10574)
 assert_contains "mise i 2>&1" "POSTINSTALL"
 assert_contains "mise i dummy@1 2>&1" "POSTINSTALL"
+
+# install hooks run from the project root even when mise is invoked in a subdirectory (#11854)
+project_root="$PWD"
+assert_contains "cd foo && mise i dummy@2 2>&1" "PREINSTALL:$project_root"
+assert_contains "cd foo && mise i dummy@2 2>&1" "POSTINSTALL:$project_root"
 eval "$(mise hook-env)"
 
 cd ~/workdir || exit 1

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -692,6 +692,9 @@ async fn execute(
             }
             c.env_clear();
             c.envs(env.iter());
+            if matches!(hook.hook, Hooks::Preinstall | Hooks::Postinstall) {
+                c.current_dir(root);
+            }
             // Send the hook's stdout to mise's stderr (matching the duct
             // `stdout_to_stderr()` the non-cmd path uses) by handing the child a
             // clone of our stderr handle. Redirecting the descriptor directly —
@@ -707,11 +710,13 @@ async fn execute(
         }
     }
 
-    cmd(&shell[0], args)
-        .stdout_to_stderr()
-        // .dir(root)
-        .full_env(env)
-        .run()?;
+    let command = cmd(&shell[0], args).stdout_to_stderr().full_env(env);
+    let command = if matches!(hook.hook, Hooks::Preinstall | Hooks::Postinstall) {
+        command.dir(root)
+    } else {
+        command
+    };
+    command.run()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- run inline `preinstall` and `postinstall` hooks from the owning project root
- preserve invocation-directory access through `MISE_ORIGINAL_CWD`
- apply the behavior to the Windows `cmd.exe` execution path
- document the working-directory contract and add nested-directory regression coverage

## Root cause

Inline install hooks spawned their shell without setting a working directory, so they inherited the directory where `mise install` was invoked. Task-backed hooks already used `mise --cd <project-root> run`, which made equivalent hook forms behave differently.

## Impact

Relative paths in inline install hooks now resolve consistently from the project root. Hooks that need the invocation directory can continue to use `MISE_ORIGINAL_CWD`. Directory-change hooks retain their existing working-directory behavior.

## Validation

- `mise run test:e2e e2e/config/test_hooks`
- `mise run lint-fix`

Closes discussion #11854.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavior fix for install hooks only; hooks that depended on invocation cwd must use `MISE_ORIGINAL_CWD`, which is documented.
> 
> **Overview**
> **Inline `preinstall` and `postinstall` hooks now run with the project root as their working directory**, including when `mise install` is started from a subdirectory. The invocation directory is still exposed via `MISE_ORIGINAL_CWD`.
> 
> In `hooks.rs`, install hooks set the child process cwd to the config `root` on both the normal duct path and the Windows `cmd.exe` verbatim path (replacing the previously commented `.dir(root)`). **Enter/leave/cd hooks are unchanged.**
> 
> Docs describe this contract; e2e coverage asserts `pwd` in install hooks matches the project root when installing from `foo/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc0f8072cdce24f083b360c86d8b4fd42cdfff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Preinstall and postinstall hooks now run from the project root, even when installation starts in a subdirectory.
  * The original invocation directory remains available through `MISE_ORIGINAL_CWD`.
* **Documentation**
  * Added documentation covering the updated hook behavior.
* **Tests**
  * Added coverage confirming hook execution from the project root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->