### PR TITLE
fix(task): invalidate tasks when templates change

### DIFF
--- a/e2e/tasks/test_task_templates
+++ b/e2e/tasks/test_task_templates
@@ -170,4 +170,35 @@ EOF
 
 assert_fail "mise run failing-task" "from template"
 
+# A template's config file contributes to the resolved task definition and
+# must invalidate source freshness when it changes.
+mkdir -p pkgs/a
+cat <<'EOF' >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["pkgs/*"]
+
+[task_templates.demo]
+run = "printf v1 > out.txt"
+sources = ["in.txt"]
+outputs = ["out.txt"]
+EOF
+cat <<'EOF' >pkgs/a/mise.toml
+[tasks.demo]
+extends = "demo"
+EOF
+touch pkgs/a/in.txt
+
+mise run '//...:demo'
+assert "cat pkgs/a/out.txt" "v1"
+assert_contains "mise run '//...:demo' 2>&1" "sources up-to-date, skipping"
+assert_contains "mise task info '//pkgs/a:demo' --json" "$PWD/mise.toml"
+assert_contains "mise task info '//pkgs/a:demo' --json" "$PWD/pkgs/a/mise.toml"
+
+sleep 1
+sed -i.bak 's/printf v1/printf v2/' mise.toml
+mise run '//...:demo'
+assert "cat pkgs/a/out.txt" "v2"
+
 echo '' >mise.toml

--- a/src/cli/generate/task_docs.rs
+++ b/src/cli/generate/task_docs.rs
@@ -47,14 +47,7 @@ impl TaskDocs {
     pub async fn run(self) -> eyre::Result<()> {
         let config = Config::get().await?;
         let dir = dirs::CWD.as_ref().unwrap();
-        let templates = config
-            .config_files
-            .values()
-            .rev()
-            .flat_map(|cf| cf.task_templates())
-            .collect();
-        let tasks =
-            config::load_tasks_in_dir(&config, dir, &config.config_files, &templates).await?;
+        let tasks = config::load_tasks_in_dir(&config, dir, &config.config_files).await?;
         let visible_tasks: Vec<_> = tasks.iter().filter(|t| !t.hide).collect();
         if let Some(output) = &self.output {
             if self.multi {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2618,14 +2618,21 @@ impl Debug for Config {
 
 #[derive(Clone, Debug, Default)]
 struct TaskDefinitions {
-    templates: IndexMap<String, TaskTemplate>,
+    templates: IndexMap<String, SourcedTaskTemplate>,
     workspace_defaults: Option<WorkspaceTaskDefaults>,
+}
+
+#[derive(Clone, Debug)]
+struct SourcedTaskTemplate {
+    template: TaskTemplate,
+    source: PathBuf,
 }
 
 #[derive(Clone, Debug)]
 struct WorkspaceTaskDefaults {
     project_roots: BTreeSet<PathBuf>,
     tasks: IndexMap<String, TaskTemplate>,
+    source: PathBuf,
 }
 
 /// Collect all task templates from the config file hierarchy and task-name defaults from the
@@ -2635,12 +2642,18 @@ fn collect_task_definitions(
     config_files: &ConfigMap,
     workspace_graph: Option<&crate::task::workspace::WorkspaceProjectGraph>,
 ) -> TaskDefinitions {
-    let mut templates = IndexMap::new();
+    let mut definitions = TaskDefinitions::default();
 
     // Iterate in reverse order (global -> local) so child directories override parent configs
     for cf in config_files.values().rev() {
         for (name, template) in cf.task_templates() {
-            templates.insert(name, template);
+            definitions.templates.insert(
+                name,
+                SourcedTaskTemplate {
+                    template,
+                    source: cf.get_path().to_path_buf(),
+                },
+            );
         }
     }
 
@@ -2674,14 +2687,13 @@ fn collect_task_definitions(
             (!tasks.is_empty()).then_some(WorkspaceTaskDefaults {
                 project_roots,
                 tasks,
+                source: cf.get_path().to_path_buf(),
             })
         })
         .flatten();
 
-    TaskDefinitions {
-        templates,
-        workspace_defaults,
-    }
+    definitions.workspace_defaults = workspace_defaults;
+    definitions
 }
 
 /// Resolve task definition layers from highest to lowest precedence.
@@ -2707,7 +2719,8 @@ fn resolve_task_template(task: &mut Task, definitions: &TaskDefinitions) -> Resu
             )
         })?;
 
-        task.merge_template(template);
+        task.merge_template(&template.template);
+        task.add_config_source(&template.source);
     }
     if let Some(defaults) = &definitions.workspace_defaults
         && !task.global
@@ -2724,6 +2737,7 @@ fn resolve_task_template(task: &mut Task, definitions: &TaskDefinitions) -> Resu
             .map_or(task.name.as_str(), |(_, name)| name);
         if let Some(default) = defaults.tasks.get(task_name) {
             task.merge_template(default);
+            task.add_config_source(&defaults.source);
         }
     }
     Ok(())
@@ -4226,18 +4240,16 @@ pub async fn load_tasks_in_dir(
     config: &Arc<Config>,
     dir: &Path,
     config_files: &ConfigMap,
-    templates: &IndexMap<String, TaskTemplate>,
 ) -> Result<Vec<Task>> {
     let workspace_graph = (Settings::get().experimental && config.monorepo_root().is_some())
         .then(|| config.workspace_project_graph_for_task_loading());
-    let mut definitions = collect_task_definitions(
+    let definitions = collect_task_definitions(
         config_files,
         workspace_graph
             .as_ref()
             .and_then(|graph| graph.as_ref().ok())
             .map(Arc::as_ref),
     );
-    definitions.templates = templates.clone();
     load_tasks_in_dir_with_definitions(config, dir, config_files, &definitions).await
 }
 
@@ -4664,6 +4676,55 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    #[test]
+    fn test_resolve_task_template_tracks_definition_sources() -> Result<()> {
+        let project_root = PathBuf::from("/workspace/packages/app");
+        let template_source = PathBuf::from("/workspace/mise.toml");
+        let defaults_source = PathBuf::from("/workspace/mise.local.toml");
+        let mut definitions = TaskDefinitions::default();
+        definitions.templates.insert(
+            "build-template".to_string(),
+            SourcedTaskTemplate {
+                template: TaskTemplate {
+                    run: vec![RunEntry::Script("echo build".to_string())],
+                    ..Default::default()
+                },
+                source: template_source.clone(),
+            },
+        );
+        definitions.workspace_defaults = Some(WorkspaceTaskDefaults {
+            project_roots: BTreeSet::from([project_root.clone()]),
+            tasks: IndexMap::from([(
+                "build".to_string(),
+                TaskTemplate {
+                    description: "default description".to_string(),
+                    ..Default::default()
+                },
+            )]),
+            source: defaults_source.clone(),
+        });
+        let primary_source = project_root.join("mise.toml");
+        let mut task = Task {
+            name: "build".to_string(),
+            extends: Some("build-template".to_string()),
+            config_source: primary_source.clone(),
+            config_root: Some(project_root),
+            ..Default::default()
+        };
+
+        resolve_task_template(&mut task, &definitions)?;
+
+        assert_eq!(
+            task.config_sources(),
+            vec![
+                primary_source.as_path(),
+                template_source.as_path(),
+                defaults_source.as_path(),
+            ]
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_task_config_rust_cache_is_a_default() {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -658,8 +658,8 @@ pub struct Task {
     pub config_source: PathBuf,
     /// Additional files that contributed to this task's definition.
     ///
-    /// The primary definition remains in `config_source`; this contains
-    /// metadata overlays merged from same-named `[tasks.<name>]` blocks.
+    /// The primary definition remains in `config_source`; this contains task
+    /// templates, workspace defaults, and metadata overlays merged into it.
     #[serde(skip)]
     pub additional_config_sources: Vec<PathBuf>,
     #[serde(skip)]
@@ -1266,6 +1266,17 @@ fn usage_flag_takes_value(cmd: &usage::SpecCommand, flag: &str) -> bool {
 }
 
 impl Task {
+    pub fn add_config_source(&mut self, source: &Path) {
+        if source != self.config_source
+            && !self
+                .additional_config_sources
+                .iter()
+                .any(|existing| existing == source)
+        {
+            self.additional_config_sources.push(source.to_path_buf());
+        }
+    }
+
     pub fn config_sources(&self) -> Vec<&Path> {
         once(self.config_source.as_path())
             .chain(self.additional_config_sources.iter().map(PathBuf::as_path))
@@ -2443,14 +2454,7 @@ impl Task {
     /// TOML file they were written in rather than the file task's script path.
     pub fn merge_toml_overlay(&mut self, other: Task) {
         for source in other.config_sources() {
-            if source != self.config_source
-                && !self
-                    .additional_config_sources
-                    .iter()
-                    .any(|existing| existing == source)
-            {
-                self.additional_config_sources.push(source.to_path_buf());
-            }
+            self.add_config_source(source);
         }
 
         fn merge_bool(base: &mut bool, overlay: bool, explicit: bool) {


### PR DESCRIPTION
## Summary

- retain the config source alongside each collected task template
- record selected templates and monorepo task defaults as contributing task definition sources
- report those sources through existing task metadata and include them in source freshness checks
- add regression coverage for template provenance and freshness invalidation

## Root cause

Template fields were merged into the resolved task after their defining config path had been discarded. As a result, source freshness only considered the package-local task config, so editing a root `[task_templates.*]` definition could leave stale outputs marked up to date.

This uses the existing `additional_config_sources` mechanism, which already drives freshness, watch, cache identity, auditing, and task metadata. Only the selected template/default config is retained.

Fixes the bug reported in https://github.com/jdx/mise/discussions/11852.

## Validation

- `cargo test --bin mise test_resolve_task_template_tracks_definition_sources`
- `mise run test:e2e e2e/tasks/test_task_templates`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task resolution and cache skip logic for template-extended tasks; behavior should improve correctness but any task using extends/workspace defaults may rerun when parent configs change.
> 
> **Overview**
> Fixes stale task runs when only a **root `[task_templates.*]`** (or monorepo task default) changes: template and default definitions now keep their **defining config path**, and that path is recorded on the resolved task via **`additional_config_sources`** so existing source freshness, metadata, and related behavior treat those files as part of the definition.
> 
> **`collect_task_definitions`** wraps templates in **`SourcedTaskTemplate`** and stores a **`source`** on **`WorkspaceTaskDefaults`**; **`resolve_task_template`** calls **`add_config_source`** after merging a named template or workspace default. **`Task::add_config_source`** centralizes deduped tracking (also used from **`merge_toml_overlay`**). **`load_tasks_in_dir`** no longer accepts an external template map—templates always come from the config hierarchy ( **`task_docs`** updated accordingly).
> 
> Regression coverage: unit test for provenance ordering and an e2e monorepo case where editing the root template reruns **`//...:demo`** and updates output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b534b0cc9075a19abf249ad88a0f6ebb777d584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Task documentation now shows all configuration sources contributing to a task, including templates, workspace defaults, and metadata overlays.
  - Configuration changes in task templates and workspace defaults are tracked more accurately, improving task freshness detection and reruns when configuration changes.
  - Task loading and configuration resolution are now more consistent across monorepo package setups.

- **Tests**
  - Added coverage for template-based tasks, source freshness, configuration metadata, and reruns after template changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->