### PR TITLE
fix(release): publish cache workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,8 +116,8 @@ filetime = "0.2"
 flate2 = "1"
 futures-util = "0.3"
 mise-sigstore = { path = "crates/mise-sigstore", default-features = false }
-mise-cache-core = { path = "crates/mise-cache-core", default-features = false }
-mise-cache-rustc = { path = "crates/mise-cache-rustc" }
+mise-cache-core = { path = "crates/mise-cache-core", version = "0.1", default-features = false }
+mise-cache-rustc = { path = "crates/mise-cache-rustc", version = "0.1" }
 fslock = "0.2"
 gix = { version = "<1", features = ["worktree-mutation"] }
 glob = "0.3"

--- a/crates/mise-cache-core/Cargo.toml
+++ b/crates/mise-cache-core/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 description = "Action cache protocol, CAS, authentication, and transport primitives for mise"
 homepage = "https://github.com/jdx/mise"
 repository = "https://github.com/jdx/mise"
-publish = false
 
 [dependencies]
 base64 = "0.23"

--- a/crates/mise-cache-rustc/Cargo.toml
+++ b/crates/mise-cache-rustc/Cargo.toml
@@ -6,10 +6,9 @@ license = "MIT"
 description = "Conservative rustc action analysis and key construction for mise"
 homepage = "https://github.com/jdx/mise"
 repository = "https://github.com/jdx/mise"
-publish = false
 
 [dependencies]
-mise-cache-core = { path = "../mise-cache-core", default-features = false }
+mise-cache-core = { path = "../mise-cache-core", version = "0.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 

--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -311,6 +311,15 @@ if [[ $cur_version != "$latest_version" ]]; then
 	AQUA_REGISTRY_VERSION=""
 	INTERACTIVE_CONFIG_VERSION=""
 	MISE_SIGSTORE_VERSION=""
+	MISE_CACHE_CORE_VERSION=""
+	MISE_CACHE_RUSTC_VERSION=""
+
+	bump_and_publish_subcrate "mise-cache-core" "crates/mise-cache-core" "MISE_CACHE_CORE_VERSION"
+	cargo add -p mise "mise-cache-core@$MISE_CACHE_CORE_VERSION" --no-default-features
+	cargo add -p mise-cache-rustc "mise-cache-core@$MISE_CACHE_CORE_VERSION" --no-default-features
+
+	bump_and_publish_subcrate "mise-cache-rustc" "crates/mise-cache-rustc" "MISE_CACHE_RUSTC_VERSION"
+	cargo add -p mise "mise-cache-rustc@$MISE_CACHE_RUSTC_VERSION"
 
 	bump_and_publish_subcrate "mise-sigstore" "crates/mise-sigstore" "MISE_SIGSTORE_VERSION"
 	cargo add -p mise "mise-sigstore@$MISE_SIGSTORE_VERSION" --no-default-features


### PR DESCRIPTION
## Summary

- make `mise-cache-core` and `mise-cache-rustc` publishable workspace crates
- add compatible `0.1` version requirements to their path dependencies
- publish cache crates in dependency order before publishing `mise`
- update `mise-cache-rustc` to the freshly published core version before publishing it

## Root cause

`mise 2026.8.4` could not be packaged because both cache crates were required path dependencies with `publish = false` and no registry version requirement. Cargo rejects path-only dependencies when publishing the parent crate.

The initial `0.1.0` versions of both crates have been bootstrapped on crates.io. This change lets subsequent release runs manage them with the existing CalVer subcrate flow and crates.io trusted-publishing token.

## Validation

- published and verified `mise-cache-core 0.1.0`
- dry-ran, published, and verified `mise-cache-rustc 0.1.0` against the registry copy of `mise-cache-core`
- transformed all workspace path dependencies as the release script does and completed a `mise 2026.8.4` publish dry-run against crates.io packages
- `cargo check --locked -p mise-cache-core -p mise-cache-rustc`
- `mise run lint-fix`
- `bash -n xtasks/release-plz`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and Cargo manifest changes only; no runtime behavior changes, but incorrect publish order or version pins could break future releases.
> 
> **Overview**
> Unblocks **crates.io publishing** for `mise` by treating `mise-cache-core` and `mise-cache-rustc` like other workspace subcrates instead of path-only, non-publishable dependencies.
> 
> **Manifest changes:** `publish = false` is removed from both cache crates. Path dependencies now include a **`0.1` registry version** on the root `mise` crate and on `mise-cache-rustc`’s dependency on `mise-cache-core`, so Cargo can resolve them when packaging the parent crate.
> 
> **Release script:** `xtasks/release-plz` publishes **`mise-cache-core` first**, rewrites dependents to the published core version, then publishes **`mise-cache-rustc`**, and finally pins `mise` to those registry versions—**before** the existing `mise-sigstore` / `vfox` / `mise` publish steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 991e6a02185f6696704d171e515d3a6ece01bb75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->