### PR TITLE
fix(release): update cache dependencies before version resolution

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -121,6 +121,23 @@ version_relation() {
 	'
 }
 
+set_path_dependency_version() {
+	local manifest="$1"
+	local dependency="$2"
+	local new_version="$3"
+
+	sed -i.bak -E \
+		"/^$dependency = /s/version = \"[^\"]+\"/version = \"$new_version\"/" \
+		"$manifest"
+	rm -f "$manifest.bak"
+	awk -v dependency="$dependency" -v version="$new_version" '
+		index($0, dependency " = {") == 1 &&
+			index($0, "path = \"") &&
+			index($0, "version = \"" version "\"") { found = 1 }
+		END { exit !found }
+	' "$manifest"
+}
+
 set_package_version() {
 	local crate_name="$1"
 	local manifest="$2"
@@ -139,16 +156,19 @@ set_package_version() {
 	sed -i.bak "s/^version = \"$old_pattern\"$/version = \"$new_version\"/" "$manifest"
 	rm -f "$manifest.bak"
 
-	# Keep the workspace path dependency compatible when the calver year changes.
-	if [[ $crate_name == mise-interactive-config ]]; then
-		sed -i.bak -E \
-			"/^mise-interactive-config = /s/version = \"[^\"]+\"/version = \"$new_version\"/" \
-			Cargo.toml
-		rm -f Cargo.toml.bak
-		grep -Fqx \
-			"mise-interactive-config = { path = \"crates/mise-interactive-config\", version = \"$new_version\" }" \
-			Cargo.toml
-	fi
+	# Keep workspace path dependencies compatible before Cargo resolves the bump.
+	case "$crate_name" in
+	mise-cache-core)
+		set_path_dependency_version Cargo.toml mise-cache-core "$new_version"
+		set_path_dependency_version crates/mise-cache-rustc/Cargo.toml mise-cache-core "$new_version"
+		;;
+	mise-cache-rustc)
+		set_path_dependency_version Cargo.toml mise-cache-rustc "$new_version"
+		;;
+	mise-interactive-config)
+		set_path_dependency_version Cargo.toml mise-interactive-config "$new_version"
+		;;
+	esac
 
 	cargo update --offline -p "$crate_name" --precise "$new_version"
 }


### PR DESCRIPTION
## Summary
- update workspace path dependency versions before Cargo resolves release bumps
- keep `mise-cache-rustc` compatible when `mise-cache-core` is bumped
- apply the same checked helper to the root cache and interactive-config dependencies

## Root cause
Release run 31449959861 bumped `mise-cache-core` from 0.1.0 to 2026.8.0, then `cargo update --offline` failed because `mise-cache-rustc` still required `mise-cache-core = "^0.1"`.

## Validation
- exercised the complete core 0.1.0 → 2026.8.0 and rustc 0.1.0 → 2026.8.0 transition in a disposable worktree
- verified both offline Cargo updates and workspace metadata
- `bash -n xtasks/release-plz`
- `mise run lint-fix`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the CI release script with validation noted in the PR; no runtime product code paths.
> 
> **Overview**
> Release bumps now refresh **workspace path dependency `version` fields** in the right manifests **before** `cargo update --offline`, so Cargo can resolve calver jumps without stale semver constraints.
> 
> A new **`set_path_dependency_version`** helper (sed + awk verification) replaces the ad hoc `mise-interactive-config`-only logic. **`set_package_version`** uses a **`case`** on the bumped crate: **`mise-cache-core`** updates root `Cargo.toml` and `crates/mise-cache-rustc/Cargo.toml`; **`mise-cache-rustc`** and **`mise-interactive-config`** update the root workspace entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfaf5b2aad8963ca991571ed74928ba8a28d07cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version updates for workspace path dependencies.
  * Ensured dependency declarations are correctly updated and validated during package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->