### PR TITLE
fix(e2e): drop the write sandbox the CI runners cannot provide

### DIFF
--- a/e2e/tasks/test_task_action_cache_session
+++ b/e2e/tasks/test_task_action_cache_session
@@ -28,10 +28,13 @@ test "$CARGO_INCREMENTAL" = 0
 "$RUSTC_WRAPPER" true
 '''
 
+# No deny_write here: it needs Landlock, and the CI runners do not have it —
+# `landlock: NotEnabled` in RestrictionStatus — so mise correctly refuses to run a task
+# it cannot sandbox and this task failed on every run. The write sandbox is not what
+# this test is asserting; `stored` and the action-results file below are. `sandboxed`
+# above still covers rust_cache under a sandbox, via deny_env, which needs no Landlock.
 [tasks.compile]
 rust_cache = true
-deny_write = true
-allow_write = ["target"]
 run = '''
 cargo build
 test -f target/debug/libcache_e2e.rlib


### PR DESCRIPTION
`tasks/test_task_action_cache_session` is failing on every PR right now. It has been broken since #11812; it only became visible today.

## Why it fails

The `compile` task asks for `deny_write`, which on Linux means Landlock, and the runners do not have it:

```
mise sandbox: failed to apply landlock restrictions: RestrictionStatus {
  ruleset: NotEnforced, no_new_privs: true, landlock: NotEnabled,
  log_same_exec: true, log_new_exec: false, log_subdomains: true, all_threads: false }
```

mise is right to refuse a task it cannot sandbox, so the fix belongs in the test.

That message is not visible on `main` — `pre_exec` can only hand an errno back to the parent, so `spawn` reports a bare `Invalid argument (os error 22)` and the reason is dropped. It is quoted above from a run with jdx/mise#11853 applied, which prints it. That is why this has been hard to place.

## What this changes

Drops `deny_write` / `allow_write` from the `compile` task, with a comment recording why.

The write sandbox is not what the test asserts — `stored` and the action-results file are. And `rust_cache` under a sandbox is still covered by the `sandboxed` task just above, which uses `deny_env` and needs no Landlock. So the only coverage given up is "the write sandbox specifically", which the runners cannot execute at all.

## Why it surfaced today

Tranches come from a test's index in a sorted list, `index % TEST_TRANCHE_COUNT`. Each workflow branch runs two of them as two lines of one `command:`, and without `set -e` only the second line's status survives — so tranches 0-3 could fail without failing CI. This test sat in tranche 3.

A test file added to main shifted every later index by one, moving it to tranche 4 — the second line — where the failure does propagate. Nothing about the test changed; its position did.

jdx/mise#11853 fixes that swallowing separately. This PR is the test fix on its own so the current breakage clears without waiting on that discussion.

## Verified

Run in `ghcr.io/jdx/mise:e2e` with the three `landlock_*` syscalls blocked by a seccomp profile, which reproduces what the runners do:

```
before:  [compile] ERROR failed to execute command: sh -c -o errexit cargo build
         [compile] ERROR Invalid argument (os error 22)
         exit: 1

after:   [mise run compile 2>&1] 'stored' is in output
         [find …/action-results -type f -name '*.json' -print -quit] output is not empty
         [MISE_EXPERIMENTAL=0 mise run rust] 'Rust action caching is experimental' is in failure output
         exit: 0
```

It also passes locally with Landlock available, so this does not depend on the sandbox being absent.

## Worth a follow-up, not in this PR

- Landlock is not available everywhere, and `deny_write` is currently an all-or-nothing hard error. Whether e2e should be able to assert sandbox behaviour conditionally, rather than not at all, is a separate design question.
- The lost error message is jdx/mise#11853's territory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compile task behavior to avoid unsupported write restrictions.
  * Continued validating task caching and action-result artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->