### PR TITLE
test(task): isolate cargo writes in cache session e2e

### DIFF
--- a/e2e/tasks/test_task_action_cache_session
+++ b/e2e/tasks/test_task_action_cache_session
@@ -33,7 +33,9 @@ rust_cache = true
 deny_write = true
 allow_write = ["target"]
 run = '''
-cargo build
+# Cargo creates lock files in CARGO_HOME even for a dependency-free crate. Keep
+# those writes inside the path permitted by this task's deny_write sandbox.
+CARGO_HOME=target/cargo-home CARGO_TARGET_DIR=target cargo build
 test -f target/debug/libcache_e2e.rlib
 '''
 EOF


### PR DESCRIPTION
## Summary
- keep the cache-session fixture’s Cargo home and target directory inside its permitted `target/` sandbox path
- prevent fresh CI containers from failing when Cargo creates its global cache lock files

## Context
The E2E failure seen on #11857 was unrelated to the install-hook change. `cargo build` creates `.global-cache`, `.package-cache`, and `.package-cache-mutate` in `CARGO_HOME` even for the dependency-free fixture. On fresh CI containers, those files do not exist yet and the task’s `deny_write = true` sandbox rejects their creation outside `allow_write = ["target"]`.

## Testing
- `mise run lint-fix`
- `e2e/run_test tasks/test_task_action_cache_session`
- repeated the focused test with a fresh external `CARGO_HOME`; the fixture now succeeds because it scopes Cargo writes to `target/`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E fixture-only change; no production task-cache or sandbox behavior is modified.
> 
> **Overview**
> Fixes the **cache-session** E2E `compile` task so `cargo build` no longer writes outside the sandbox.
> 
> The task uses `deny_write = true` with `allow_write = ["target"]`, but plain `cargo build` still creates lock/cache files under the default **`CARGO_HOME`**, which fails on fresh CI. The run script now sets **`CARGO_HOME=target/cargo-home`** and **`CARGO_TARGET_DIR=target`** so all Cargo writes stay under the permitted `target/` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc941c18bd9e39b728424f6a26e70a764a9abf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compile task caching by storing Cargo build data within the project’s target directory.
  * Preserved existing build verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->