### PR TITLE
feat(http): resume interrupted downloads

### DIFF
--- a/e2e/backend/test_aqua_resume_download
+++ b/e2e/backend/test_aqua_resume_download
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+export MISE_AQUA_BAKED_REGISTRY=0
+export MISE_HTTP_RETRIES=0
+
+detect_platform
+
+mkdir -p fixture/resume-tool/bin registry
+cat <<'EOF_TOOL' >fixture/resume-tool/bin/resume-tool
+#!/usr/bin/env sh
+echo resumed download
+EOF_TOOL
+chmod +x fixture/resume-tool/bin/resume-tool
+tar -czf artifact.tar.gz -C fixture resume-tool
+
+cat <<'EOF_SERVER' >server.py
+import http.server
+import pathlib
+import socket
+
+artifact = pathlib.Path("artifact.tar.gz").read_bytes()
+request_count = 0
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        global request_count
+        request_count += 1
+        range_header = self.headers.get("Range", "")
+        if_range = self.headers.get("If-Range", "")
+        with open("requests.log", "a", encoding="utf-8") as log:
+            log.write(f"{request_count} range={range_header} if-range={if_range}\n")
+
+        if request_count == 1:
+            midpoint = len(artifact) // 2
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(artifact)))
+            self.send_header("ETag", '"resume-v1"')
+            self.end_headers()
+            self.wfile.write(artifact[:midpoint])
+            self.wfile.flush()
+            self.connection.shutdown(socket.SHUT_RDWR)
+            self.connection.close()
+            return
+
+        if range_header.startswith("bytes="):
+            offset = int(range_header.removeprefix("bytes=").removesuffix("-"))
+            body = artifact[offset:]
+            self.send_response(206)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Content-Range", f"bytes {offset}-{len(artifact) - 1}/{len(artifact)}")
+            self.send_header("ETag", '"resume-v1"')
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(artifact)))
+        self.send_header("ETag", '"resume-v1"')
+        self.end_headers()
+        self.wfile.write(artifact)
+
+    def log_message(self, *_args):
+        pass
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+pathlib.Path("server.port").write_text(str(server.server_port), encoding="utf-8")
+server.serve_forever()
+EOF_SERVER
+
+python3 server.py &
+server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+wait_for_file server.port "HTTP server port"
+port="$(cat server.port)"
+
+cat >registry/registry.yml <<EOF_REGISTRY
+packages:
+  - type: http
+    name: example/resume-tool
+    supported_envs:
+      - darwin
+      - linux
+    url: http://127.0.0.1:$port/artifact.tar.gz
+    files:
+      - name: resume-tool
+        src: resume-tool/bin/resume-tool
+EOF_REGISTRY
+
+export MISE_AQUA_REGISTRY_URL="file://$PWD/registry"
+
+assert_fail "mise install aqua:example/resume-tool@1.0.0"
+assert_succeed "find '$MISE_DATA_DIR/downloads' -name '*.mise-part' -type f | grep -q ."
+assert_succeed "find '$MISE_DATA_DIR/downloads' -name '*.mise-part.json' -type f | grep -q ."
+
+mise install aqua:example/resume-tool@1.0.0
+assert "mise exec aqua:example/resume-tool@1.0.0 -- resume-tool" "resumed download"
+assert_contains "sed -n '1p' requests.log" 'range= if-range='
+assert_contains "cat requests.log" 'range=bytes='
+assert_contains "cat requests.log" 'if-range="resume-v1"'
+assert_fail "find '$MISE_DATA_DIR/downloads' -name '*.mise-part' -type f | grep -q ."
+assert_fail "find '$MISE_DATA_DIR/downloads' -name '*.mise-part.json' -type f | grep -q ."

--- a/settings.toml
+++ b/settings.toml
@@ -1213,7 +1213,9 @@ all retry attempts and backoff delays. This is separate from `http_timeout`,
 which detects stalled connections by timing out individual reads.
 
 When this budget is exhausted, mise reports the URL, active attempt, bytes
-received during that attempt, and this setting name.
+received during that attempt, and this setting name. If the server supplies a
+strong ETag or Last-Modified validator, the validated partial download is kept
+for the next attempt or mise invocation.
 """
 env = "MISE_HTTP_DOWNLOAD_TIMEOUT"
 type = "Duration"
@@ -1236,6 +1238,11 @@ cached data is insufficient, then fail or fall back immediately.
 
 When a retry rescues a request, a warning is logged with the original error so
 flaky infrastructure doesn't silently mask itself.
+
+Artifact downloads resume from validated partial files when the server supports
+byte ranges and supplies a strong ETag or Last-Modified value. Servers without
+a safe validator restart downloads from the beginning. Changing the request URL
+or request headers also discards the previous partial download.
 """
 env = "MISE_HTTP_RETRIES"
 type = "Integer"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3065,7 +3065,13 @@ pub trait Backend: Debug + Send + Sync {
     fn create_install_dirs(&self, tv: &ToolVersion) -> eyre::Result<()> {
         let _ = remove_all_with_warning(tv.install_path());
         if !Settings::get().always_keep_download {
-            let _ = remove_all_with_warning(tv.download_path());
+            let download_path = tv.download_path();
+            if let Err(err) = crate::http::cleanup_download_dir(&download_path) {
+                debug!(
+                    "failed to clean download directory {}: {err:#}",
+                    display_path(&download_path)
+                );
+            }
         }
         let _ = remove_all_with_warning(tv.cache_path());
         let _ = file::remove_file(tv.install_path()); // removes if it is a symlink
@@ -3102,7 +3108,13 @@ pub trait Backend: Debug + Send + Sync {
     }
     fn cleanup_install_dirs(&self, tv: &ToolVersion) {
         if !Settings::get().always_keep_download {
-            let _ = remove_all_with_warning(tv.download_path());
+            let download_path = tv.download_path();
+            if let Err(err) = crate::http::cleanup_download_dir(&download_path) {
+                debug!(
+                    "failed to clean download directory {}: {err:#}",
+                    display_path(&download_path)
+                );
+            }
         }
     }
     fn cleanup_empty_installs_dir(&self) {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,16 +1,20 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use eyre::{Report, Result, WrapErr, bail, ensure, eyre};
 use regex::Regex;
 use reqwest::StatusCode;
-use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use reqwest::header::{
+    ACCEPT_ENCODING, AUTHORIZATION, CONTENT_RANGE, CONTENT_TYPE, DATE, ETAG, HeaderMap,
+    HeaderValue, IF_RANGE, LAST_MODIFIED, RANGE,
+};
 use reqwest::{ClientBuilder, IntoUrl, Method, Response};
+use serde::{Deserialize, Serialize};
 use std::sync::LazyLock as Lazy;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::OnceCell;
@@ -76,6 +80,7 @@ struct SendOnceOptions {
     use_netrc: bool,
     retry_github_oauth_401: bool,
     error_for_status: bool,
+    allow_range_not_satisfiable: bool,
     retry_state: Option<RetryStateHandle>,
 }
 
@@ -85,6 +90,7 @@ impl SendOnceOptions {
             use_netrc,
             retry_github_oauth_401: true,
             error_for_status: true,
+            allow_range_not_satisfiable: false,
             retry_state,
         }
     }
@@ -94,14 +100,331 @@ impl SendOnceOptions {
         self
     }
 
+    fn allow_range_not_satisfiable(mut self) -> Self {
+        self.allow_range_not_satisfiable = true;
+        self
+    }
+
     fn recursive_retry(&self) -> Self {
         Self {
             use_netrc: false,
             retry_github_oauth_401: false,
             error_for_status: self.error_for_status,
+            allow_range_not_satisfiable: self.allow_range_not_satisfiable,
             retry_state: self.retry_state.clone(),
         }
     }
+}
+
+const PARTIAL_DOWNLOAD_STATE_VERSION: u8 = 2;
+const PARTIAL_DOWNLOAD_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+enum DownloadValidator {
+    Etag(String),
+    LastModified {
+        value: String,
+        response_date: String,
+    },
+}
+
+impl DownloadValidator {
+    fn as_header_value(&self) -> &str {
+        match self {
+            Self::Etag(value) | Self::LastModified { value, .. } => value,
+        }
+    }
+
+    fn matches(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Etag(a), Self::Etag(b)) => a == b,
+            (Self::LastModified { value: a, .. }, Self::LastModified { value: b, .. }) => a == b,
+            _ => false,
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        match self {
+            Self::Etag(value) => !value.is_empty() && !value.starts_with("W/"),
+            Self::LastModified {
+                value,
+                response_date,
+            } => is_strong_last_modified(value, response_date),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DownloadSizeMismatch {
+    expected: u64,
+    actual: u64,
+}
+
+impl std::fmt::Display for DownloadSizeMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "downloaded file size mismatch: expected {} bytes, got {}",
+            self.expected, self.actual
+        )
+    }
+}
+
+impl std::error::Error for DownloadSizeMismatch {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PartialDownloadState {
+    version: u8,
+    request_hash: String,
+    validator: DownloadValidator,
+    total_size: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct PartialDownload {
+    path: PathBuf,
+    state_path: PathBuf,
+    request_hash: String,
+}
+
+impl PartialDownload {
+    fn new(destination: &Path, request_hash: String) -> Result<Self> {
+        let parent = destination.parent().ok_or_else(|| {
+            eyre!(
+                "download destination has no parent: {}",
+                destination.display()
+            )
+        })?;
+        let filename = destination
+            .file_name()
+            .ok_or_else(|| {
+                eyre!(
+                    "download destination has no filename: {}",
+                    destination.display()
+                )
+            })?
+            .to_string_lossy();
+        let partial_name = format!(".{filename}.mise-part");
+        Ok(Self {
+            path: parent.join(&partial_name),
+            state_path: parent.join(format!("{partial_name}.json")),
+            request_hash,
+        })
+    }
+
+    fn load(&self) -> Result<Option<(PartialDownloadState, u64)>> {
+        let state_bytes = match std::fs::read(&self.state_path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                self.remove_partial_if_exists()?;
+                return Ok(None);
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let state: PartialDownloadState = match serde_json::from_slice(&state_bytes) {
+            Ok(state) => state,
+            Err(_) => {
+                self.clear()?;
+                return Ok(None);
+            }
+        };
+        let partial_size = match std::fs::metadata(&self.path) {
+            Ok(metadata) => metadata.len(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                self.remove_state_if_exists()?;
+                return Ok(None);
+            }
+            Err(err) => return Err(err.into()),
+        };
+        if state.version != PARTIAL_DOWNLOAD_STATE_VERSION
+            || state.request_hash != self.request_hash
+            || !state.validator.is_valid()
+            || partial_size == 0
+            || state.total_size.is_some_and(|total| partial_size > total)
+        {
+            self.clear()?;
+            return Ok(None);
+        }
+        Ok(Some((state, partial_size)))
+    }
+
+    fn write_state(&self, state: &PartialDownloadState) -> Result<()> {
+        let parent = self.state_path.parent().unwrap();
+        let mut temp = tempfile::NamedTempFile::with_prefix_in(".mise-download-state.", parent)?;
+        serde_json::to_writer(&mut temp, state)?;
+        temp.as_file_mut().sync_all()?;
+        temp.persist(&self.state_path).map_err(|err| err.error)?;
+        Ok(())
+    }
+
+    fn clear(&self) -> Result<()> {
+        self.remove_partial_if_exists()?;
+        self.remove_state_if_exists()?;
+        Ok(())
+    }
+
+    fn remove_partial_if_exists(&self) -> Result<()> {
+        remove_file_if_exists(&self.path)
+    }
+
+    fn remove_state_if_exists(&self) -> Result<()> {
+        remove_file_if_exists(&self.state_path)
+    }
+
+    fn persist(&self, destination: &Path) -> Result<()> {
+        let temp_path = tempfile::TempPath::try_from_path(&self.path)?;
+        if let Err(err) = temp_path.persist(destination) {
+            let error = err.error;
+            let _ = err.path.keep();
+            return Err(error.into());
+        }
+        self.remove_state_if_exists()?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParsedContentRange {
+    Bytes { start: u64, end: u64, total: u64 },
+    Unsatisfied { total: u64 },
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Removes completed download artifacts while retaining partial download pairs
+/// for validation by a later invocation. Explicit backend purges still remove
+/// the entire downloads directory.
+pub(crate) fn cleanup_download_dir(path: &Path) -> Result<()> {
+    let entries = match std::fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let pair_path = name
+            .strip_suffix(".mise-part.json")
+            .map(|stem| path.join(format!("{stem}.mise-part")))
+            .or_else(|| {
+                name.strip_suffix(".mise-part")
+                    .map(|_| path.join(format!("{name}.json")))
+            });
+        if name.starts_with('.')
+            && pair_path.is_some_and(|pair_path| {
+                pair_path.is_file()
+                    && partial_file_is_recent(&entry.path())
+                    && partial_file_is_recent(&pair_path)
+            })
+        {
+            continue;
+        }
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            file::remove_all(&path)?;
+        } else {
+            remove_file_if_exists(&path)?;
+        }
+    }
+    if std::fs::read_dir(path)?.next().is_none() {
+        std::fs::remove_dir(path)?;
+    }
+    Ok(())
+}
+
+fn partial_file_is_recent(path: &Path) -> bool {
+    let Ok(modified) = std::fs::metadata(path).and_then(|metadata| metadata.modified()) else {
+        return false;
+    };
+    SystemTime::now()
+        .duration_since(modified)
+        .map_or(true, |age| age <= PARTIAL_DOWNLOAD_MAX_AGE)
+}
+
+fn update_download_hash(hasher: &mut blake3::Hasher, value: &[u8]) {
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn download_request_hash(url: &Url, headers: &HeaderMap) -> String {
+    let mut hasher = blake3::Hasher::new();
+    update_download_hash(&mut hasher, url.as_str().as_bytes());
+
+    let mut header_values = headers
+        .keys()
+        .flat_map(|name| {
+            headers
+                .get_all(name)
+                .iter()
+                .map(move |value| (name.as_str().as_bytes(), value.as_bytes()))
+        })
+        .collect::<Vec<_>>();
+    header_values.sort_unstable();
+    for (name, value) in header_values {
+        update_download_hash(&mut hasher, name);
+        update_download_hash(&mut hasher, value);
+    }
+
+    if let Some(replacements) = &Settings::get().url_replacements {
+        for (pattern, replacement) in replacements {
+            update_download_hash(&mut hasher, pattern.as_bytes());
+            update_download_hash(&mut hasher, replacement.as_bytes());
+        }
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+fn response_validator(headers: &HeaderMap) -> Option<DownloadValidator> {
+    headers
+        .get(ETAG)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty() && !value.starts_with("W/"))
+        .map(|value| DownloadValidator::Etag(value.to_string()))
+        .or_else(|| {
+            let value = headers
+                .get(LAST_MODIFIED)
+                .and_then(|value| value.to_str().ok())
+                .filter(|value| !value.is_empty())?;
+            let response_date = headers.get(DATE)?.to_str().ok()?;
+            is_strong_last_modified(value, response_date).then(|| DownloadValidator::LastModified {
+                value: value.to_string(),
+                response_date: response_date.to_string(),
+            })
+        })
+}
+
+fn is_strong_last_modified(value: &str, response_date: &str) -> bool {
+    let Ok(last_modified) = chrono::DateTime::parse_from_rfc2822(value) else {
+        return false;
+    };
+    let Ok(response_date) = chrono::DateTime::parse_from_rfc2822(response_date) else {
+        return false;
+    };
+    response_date.signed_duration_since(last_modified) >= chrono::Duration::seconds(60)
+}
+
+fn parse_content_range(value: &str) -> Option<ParsedContentRange> {
+    let value = value.strip_prefix("bytes ")?;
+    let (range, total) = value.split_once('/')?;
+    let total = total.parse::<u64>().ok()?;
+    if range == "*" {
+        return Some(ParsedContentRange::Unsatisfied { total });
+    }
+    let (start, end) = range.split_once('-')?;
+    let start = start.parse::<u64>().ok()?;
+    let end = end.parse::<u64>().ok()?;
+    if start > end || end >= total {
+        return None;
+    }
+    Some(ParsedContentRange::Bytes { start, end, total })
 }
 
 #[derive(Debug)]
@@ -435,39 +758,203 @@ impl Client {
         debug!("GET Downloading {} to {}", &url, display_path(path));
         let parent = path.parent().unwrap();
         file::create_dir_all(parent)?;
+        let partial = PartialDownload::new(path, download_request_hash(&url, headers))?;
+        // Backends may already hold a lock for the destination while they
+        // download it (for example rustup-init). Lock the downloader-owned
+        // partial path instead so concurrent transfers are serialized without
+        // recursively acquiring the caller's destination lock.
+        let lock_path = partial.path.clone();
+        let _download_lock =
+            tokio::task::spawn_blocking(move || crate::lock_file::LockFile::new(&lock_path).lock())
+                .await??;
         let attempt = Arc::new(AtomicUsize::new(0));
         let bytes_received = Arc::new(AtomicU64::new(0));
 
-        // Retry the whole download so a mid-stream chunk failure restarts from
-        // byte 0 instead of failing the install. send_once_with_https_fallback
-        // (not send_with_https_fallback) is used inside to avoid retry-on-retry.
+        // Retry the whole transfer, resuming a validated partial response when
+        // possible. send_once_with_https_fallback_allow_416 (not
+        // send_with_https_fallback) is used inside to avoid retry-on-retry.
         let download = retry_async("GET", &url, || {
             let attempt = attempt.clone();
             let bytes_received = bytes_received.clone();
             let request_url = url.clone();
+            let partial = partial.clone();
             async move {
                 attempt.fetch_add(1, Ordering::Relaxed);
                 bytes_received.store(0, Ordering::Relaxed);
-                let mut resp = self
-                    .send_once_with_https_fallback(Method::GET, request_url, headers, "GET")
-                    .await?;
-                if let Some(pr) = pr {
-                    if let Some(length) = resp.content_length() {
-                        pr.set_length(length);
-                    }
-                    pr.set_position(0);
+                self.download_file_attempt(request_url, headers, &partial, pr, &bytes_received)
+                    .await
+            }
+        });
+
+        match tokio::time::timeout(total_timeout, download).await {
+            Ok(result) => result?,
+            Err(_) => {
+                // A timeout cancels the transfer future before its normal cleanup
+                // runs. Loading the sidecar removes an unvalidated partial while
+                // preserving a resumable one.
+                if let Err(err) = partial.load() {
+                    debug!("failed to validate partial download after timeout: {err:#}");
                 }
-                let (temp_file, file) = {
-                    let path = path.to_path_buf();
-                    let parent = parent.to_path_buf();
-                    tokio::task::spawn_blocking(move || {
-                        let temp_file = tempfile::NamedTempFile::with_prefix_in(path, parent)?;
-                        let file = temp_file.reopen()?;
-                        Ok::<_, std::io::Error>((temp_file, file))
-                    })
-                    .await??
+                bail!(
+                    "HTTP download timed out after {} for {} (attempt {}, {} bytes received; change with `http_download_timeout` or env `MISE_HTTP_DOWNLOAD_TIMEOUT`)",
+                    format_duration(total_timeout),
+                    url,
+                    attempt.load(Ordering::Relaxed),
+                    bytes_received.load(Ordering::Relaxed),
+                )
+            }
+        }
+
+        // Complete the atomic rename after the cancellable transfer budget. A
+        // blocking task cannot be cancelled once it starts, so keeping it out
+        // of `timeout` prevents us from returning an error while it can still
+        // install the destination in the background.
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || partial.persist(&path)).await??;
+        Ok(())
+    }
+
+    async fn download_file_attempt(
+        &self,
+        url: Url,
+        headers: &HeaderMap,
+        partial: &PartialDownload,
+        pr: Option<&dyn SingleReport>,
+        bytes_received: &AtomicU64,
+    ) -> Result<()> {
+        let mut restarted_without_resume = false;
+        loop {
+            let resume = if restarted_without_resume {
+                None
+            } else {
+                partial.load()?
+            };
+            if let Some((state, partial_size)) = &resume
+                && state.total_size == Some(*partial_size)
+            {
+                if let Some(pr) = pr {
+                    pr.set_length(*partial_size);
+                    pr.set_position(*partial_size);
+                }
+                return Ok(());
+            }
+
+            let offset = resume.as_ref().map(|(_, size)| *size).unwrap_or(0);
+            let mut request_headers = headers.clone();
+            request_headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
+            if let Some((state, _)) = &resume {
+                request_headers.insert(RANGE, HeaderValue::from_str(&format!("bytes={offset}-"))?);
+                request_headers.insert(
+                    IF_RANGE,
+                    HeaderValue::from_str(state.validator.as_header_value())?,
+                );
+            }
+
+            let mut resp = self
+                .send_once_with_https_fallback_allow_416(
+                    Method::GET,
+                    url.clone(),
+                    &request_headers,
+                    "GET",
+                )
+                .await?;
+
+            if resp.status() == StatusCode::RANGE_NOT_SATISFIABLE {
+                if let Some(ParsedContentRange::Unsatisfied { total }) = resp
+                    .headers()
+                    .get(CONTENT_RANGE)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(parse_content_range)
+                {
+                    debug!("range request at offset {offset} was unsatisfied for {total} bytes");
+                }
+                partial.clear()?;
+                if offset > 0 && !restarted_without_resume {
+                    restarted_without_resume = true;
+                    continue;
+                }
+                resp.error_for_status_ref()?;
+            }
+
+            let (write_offset, total_size, validator, resumable) = if resp.status()
+                == StatusCode::PARTIAL_CONTENT
+            {
+                let Some((state, _)) = resume else {
+                    partial.clear()?;
+                    if !restarted_without_resume {
+                        restarted_without_resume = true;
+                        continue;
+                    }
+                    bail!("server returned partial content without a resumable request");
                 };
-                let mut file = tokio::fs::File::from_std(file);
+                let content_range = resp
+                    .headers()
+                    .get(CONTENT_RANGE)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(parse_content_range);
+                let Some(ParsedContentRange::Bytes { start, end, total }) = content_range else {
+                    partial.clear()?;
+                    if restarted_without_resume {
+                        bail!("server returned an invalid Content-Range response");
+                    }
+                    restarted_without_resume = true;
+                    continue;
+                };
+                let validator = response_validator(resp.headers());
+                let response_length_matches = resp
+                    .content_length()
+                    .is_none_or(|length| length == end - start + 1);
+                if start != offset
+                    || end + 1 != total
+                    || !response_length_matches
+                    || state.total_size.is_some_and(|expected| expected != total)
+                    || validator
+                        .as_ref()
+                        .is_some_and(|value| !value.matches(&state.validator))
+                {
+                    partial.clear()?;
+                    if restarted_without_resume {
+                        bail!("server returned inconsistent partial content");
+                    }
+                    restarted_without_resume = true;
+                    continue;
+                }
+                let validator = validator.unwrap_or(state.validator);
+                (offset, Some(total), Some(validator), true)
+            } else {
+                partial.clear()?;
+                let total_size = resp.content_length();
+                let validator = response_validator(resp.headers());
+                let resumable = total_size.is_some() && validator.is_some();
+                (0, total_size, validator.filter(|_| resumable), resumable)
+            };
+
+            let state = validator.map(|validator| PartialDownloadState {
+                version: PARTIAL_DOWNLOAD_STATE_VERSION,
+                request_hash: partial.request_hash.clone(),
+                validator,
+                total_size,
+            });
+            if let Some(state) = &state {
+                partial.write_state(state)?;
+            } else {
+                partial.remove_state_if_exists()?;
+            }
+
+            if let Some(pr) = pr {
+                if let Some(total_size) = total_size {
+                    pr.set_length(total_size);
+                }
+                pr.set_position(write_offset);
+            }
+            let mut file = tokio::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .append(write_offset > 0)
+                .truncate(write_offset == 0)
+                .open(&partial.path)
+                .await?;
+            let transfer = async {
                 while let Some(chunk) = resp.chunk().await? {
                     if crate::ui::ctrlc::is_cancelled() {
                         bail!("download cancelled by user");
@@ -479,29 +966,30 @@ impl Client {
                     }
                 }
                 file.shutdown().await?;
-                drop(file);
-                Ok(temp_file)
+                file.sync_all().await?;
+                Ok::<_, Report>(())
             }
-        });
+            .await;
+            if transfer.is_err()
+                && !resumable
+                && let Err(err) = partial.clear()
+            {
+                debug!("failed to remove unvalidated partial download: {err:#}");
+            }
+            transfer?;
 
-        let temp_file = match tokio::time::timeout(total_timeout, download).await {
-            Ok(result) => result?,
-            Err(_) => bail!(
-                "HTTP download timed out after {} for {} (attempt {}, {} bytes received; change with `http_download_timeout` or env `MISE_HTTP_DOWNLOAD_TIMEOUT`)",
-                format_duration(total_timeout),
-                url,
-                attempt.load(Ordering::Relaxed),
-                bytes_received.load(Ordering::Relaxed),
-            ),
-        };
-
-        // Complete the atomic rename after the cancellable transfer budget. A
-        // blocking task cannot be cancelled once it starts, so keeping it out
-        // of `timeout` prevents us from returning an error while it can still
-        // install the destination in the background.
-        let path = path.to_path_buf();
-        tokio::task::spawn_blocking(move || temp_file.persist(path)).await??;
-        Ok(())
+            if let Some(total_size) = total_size {
+                let actual_size = tokio::fs::metadata(&partial.path).await?.len();
+                if actual_size != total_size {
+                    return Err(DownloadSizeMismatch {
+                        expected: total_size,
+                        actual: actual_size,
+                    }
+                    .into());
+                }
+            }
+            return Ok(());
+        }
     }
 
     async fn send_with_https_fallback(
@@ -583,7 +1071,7 @@ impl Client {
     /// The fallback only fires on connection-level errors (corporate proxy
     /// blocking plain http), not on HTTP status errors — falling back to https
     /// after the server already returned a 4xx/5xx makes no sense.
-    async fn send_once_with_https_fallback(
+    async fn send_once_with_https_fallback_allow_416(
         &self,
         method: Method,
         url: Url,
@@ -595,7 +1083,7 @@ impl Client {
             url,
             headers,
             verb_label,
-            SendOnceOptions::new(None, true),
+            SendOnceOptions::new(None, true).allow_range_not_satisfiable(),
         )
         .await
     }
@@ -838,7 +1326,10 @@ impl Client {
                 &body,
             ));
         }
-        if options.error_for_status {
+        if options.error_for_status
+            && !(options.allow_range_not_satisfiable
+                && resp.status() == StatusCode::RANGE_NOT_SATISFIABLE)
+        {
             resp.error_for_status_ref()?;
         }
         Ok(resp)
@@ -1318,6 +1809,9 @@ pub(crate) fn is_transient(err: &Report) -> bool {
         return false;
     }
     err.chain().any(|e| {
+        if e.downcast_ref::<DownloadSizeMismatch>().is_some() {
+            return true;
+        }
         let Some(reqwest_err) = e.downcast_ref::<reqwest::Error>() else {
             return false;
         };
@@ -1734,6 +2228,111 @@ mod tests {
 
     fn ok_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+    }
+    fn truncated_download_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 10\r\n",
+            "ETag: \"artifact-v1\"\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "hello"
+        )
+    }
+    fn resumed_download_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 206 Partial Content\r\n",
+            "Content-Length: 5\r\n",
+            "Content-Range: bytes 5-9/10\r\n",
+            "ETag: \"artifact-v1\"\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "world"
+        )
+    }
+    fn truncated_last_modified_download_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 10\r\n",
+            "Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT\r\n",
+            "Date: Wed, 21 Oct 2015 07:29:00 GMT\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "hello"
+        )
+    }
+    fn resumed_last_modified_download_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 206 Partial Content\r\n",
+            "Content-Length: 5\r\n",
+            "Content-Range: bytes 5-9/10\r\n",
+            "Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT\r\n",
+            "Date: Wed, 21 Oct 2015 07:30:00 GMT\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "world"
+        )
+    }
+    fn invalid_resumed_download_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 206 Partial Content\r\n",
+            "Content-Length: 6\r\n",
+            "Content-Range: bytes 4-9/10\r\n",
+            "ETag: \"artifact-v1\"\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "oworld"
+        )
+    }
+    fn changed_validator_download_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 206 Partial Content\r\n",
+            "Content-Length: 5\r\n",
+            "Content-Range: bytes 5-9/10\r\n",
+            "ETag: \"artifact-v2\"\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "world"
+        )
+    }
+    fn full_download_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 10\r\n",
+            "ETag: \"artifact-v1\"\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "helloworld"
+        )
+    }
+    fn truncated_download_without_validator_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 10\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "hello"
+        )
+    }
+    fn truncated_encoded_download_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: 10\r\n",
+            "Content-Encoding: gzip\r\n",
+            "ETag: \"artifact-v1\"\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "hello"
+        )
+    }
+    fn range_not_satisfiable_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 416 Range Not Satisfiable\r\n",
+            "Content-Range: bytes */4\r\n",
+            "Content-Length: 0\r\n",
+            "Connection: close\r\n",
+            "\r\n"
+        )
     }
     fn bad_gateway_response() -> &'static str {
         "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
@@ -2269,6 +2868,20 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         );
     }
 
+    #[test]
+    fn test_only_download_size_mismatches_are_transient_eof_errors() {
+        let mismatch: Report = DownloadSizeMismatch {
+            expected: 10,
+            actual: 5,
+        }
+        .into();
+        assert!(is_transient(&mismatch));
+
+        let unrelated: Report =
+            std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "local file truncated").into();
+        assert!(!is_transient(&unrelated));
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn test_circuit_broken_http_origin_falls_back_to_https() {
         let _settings_guard = set_test_prefer_offline(3);
@@ -2330,6 +2943,459 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
 
         assert!(resp.status().is_success());
         assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingReport {
+        positions: Mutex<Vec<u64>>,
+        lengths: Mutex<Vec<u64>>,
+    }
+
+    impl SingleReport for RecordingReport {
+        fn set_position(&self, position: u64) {
+            self.positions.lock().unwrap().push(position);
+        }
+
+        fn set_length(&self, length: u64) {
+            self.lengths.lock().unwrap().push(length);
+        }
+    }
+
+    #[test]
+    fn test_parse_content_range() {
+        assert_eq!(
+            parse_content_range("bytes 5-9/10"),
+            Some(ParsedContentRange::Bytes {
+                start: 5,
+                end: 9,
+                total: 10
+            })
+        );
+        assert_eq!(
+            parse_content_range("bytes */10"),
+            Some(ParsedContentRange::Unsatisfied { total: 10 })
+        );
+        assert_eq!(parse_content_range("bytes 5-10/10"), None);
+        assert_eq!(parse_content_range("items 5-9/10"), None);
+    }
+
+    #[test]
+    fn test_response_validator_requires_strong_etag_or_last_modified() {
+        let mut headers = HeaderMap::new();
+        headers.insert(ETAG, HeaderValue::from_static("W/\"weak\""));
+        assert_eq!(response_validator(&headers), None);
+
+        headers.insert(
+            LAST_MODIFIED,
+            HeaderValue::from_static("Wed, 21 Oct 2015 07:28:00 GMT"),
+        );
+        assert_eq!(response_validator(&headers), None);
+
+        headers.insert(
+            DATE,
+            HeaderValue::from_static("Wed, 21 Oct 2015 07:28:59 GMT"),
+        );
+        assert_eq!(response_validator(&headers), None);
+
+        headers.insert(
+            DATE,
+            HeaderValue::from_static("Wed, 21 Oct 2015 07:29:00 GMT"),
+        );
+        assert_eq!(
+            response_validator(&headers),
+            Some(DownloadValidator::LastModified {
+                value: "Wed, 21 Oct 2015 07:28:00 GMT".to_string(),
+                response_date: "Wed, 21 Oct 2015 07:29:00 GMT".to_string(),
+            })
+        );
+
+        headers.insert(ETAG, HeaderValue::from_static("\"strong\""));
+        assert_eq!(
+            response_validator(&headers),
+            Some(DownloadValidator::Etag("\"strong\"".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_cleanup_download_dir_preserves_only_partial_pairs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("artifact.tar.gz"), b"complete").unwrap();
+        std::fs::write(dir.path().join(".artifact.tar.gz.mise-part"), b"partial").unwrap();
+        std::fs::write(
+            dir.path().join(".artifact.tar.gz.mise-part.json"),
+            b"metadata",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join(".orphan.mise-part"), b"orphan").unwrap();
+        let expired_partial = dir.path().join(".expired.mise-part");
+        let expired_state = dir.path().join(".expired.mise-part.json");
+        std::fs::write(&expired_partial, b"expired partial").unwrap();
+        std::fs::write(&expired_state, b"expired metadata").unwrap();
+        let expired_time = filetime::FileTime::from_system_time(
+            SystemTime::now() - PARTIAL_DOWNLOAD_MAX_AGE - Duration::from_secs(1),
+        );
+        filetime::set_file_mtime(&expired_partial, expired_time).unwrap();
+        filetime::set_file_mtime(&expired_state, expired_time).unwrap();
+        std::fs::create_dir(dir.path().join("extracted")).unwrap();
+
+        cleanup_download_dir(dir.path()).unwrap();
+
+        assert!(!dir.path().join("artifact.tar.gz").exists());
+        assert!(!dir.path().join("extracted").exists());
+        assert!(dir.path().join(".artifact.tar.gz.mise-part").exists());
+        assert!(dir.path().join(".artifact.tar.gz.mise-part.json").exists());
+        assert!(!dir.path().join(".orphan.mise-part").exists());
+        assert!(!expired_partial.exists());
+        assert!(!expired_state.exists());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_retry_resumes_validated_partial() {
+        let _guard = set_test_http_retries(1);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_response(),
+            resumed_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let report = RecordingReport::default();
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        client
+            .download_file_with_headers(&url, &destination, &HeaderMap::new(), Some(&report))
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        let requests = requests.lock().unwrap();
+        let resumed = requests[1].to_ascii_lowercase();
+        assert!(resumed.contains("range: bytes=5-"));
+        assert!(resumed.contains("if-range: \"artifact-v1\""));
+        assert!(resumed.contains("accept-encoding: identity"));
+        assert!(report.positions.lock().unwrap().contains(&5));
+        assert!(
+            report
+                .lengths
+                .lock()
+                .unwrap()
+                .iter()
+                .all(|length| *length == 10)
+        );
+
+        let partial = PartialDownload::new(
+            &destination,
+            download_request_hash(&url.parse().unwrap(), &HeaderMap::new()),
+        )
+        .unwrap();
+        assert!(!partial.path.exists());
+        assert!(!partial.state_path.exists());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_does_not_reacquire_destination_lock() {
+        let (port, count) = spawn_canned_server(vec![ok_response()]).await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let _destination_lock = crate::lock_file::LockFile::new(&destination)
+            .lock()
+            .unwrap();
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            client.download_file(&url, &destination, None),
+        )
+        .await
+        .expect("download deadlocked on a lock already held by its caller")
+        .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"OK");
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_retry_resumes_with_last_modified_validator() {
+        let _guard = set_test_http_retries(1);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_last_modified_download_response(),
+            resumed_last_modified_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        let resumed = requests.lock().unwrap()[1].to_ascii_lowercase();
+        assert!(resumed.contains("range: bytes=5-"));
+        assert!(resumed.contains("if-range: wed, 21 oct 2015 07:28:00 gmt"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_resumes_across_calls_without_storing_secrets() {
+        let _guard = set_test_http_retries(0);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_response(),
+            resumed_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/private?token=url-secret");
+        let parsed_url: Url = url.parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer header-secret"),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        std::fs::write(&destination, b"existing destination").unwrap();
+        let partial =
+            PartialDownload::new(&destination, download_request_hash(&parsed_url, &headers))
+                .unwrap();
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let _err = client
+            .download_file_with_headers(&url, &destination, &headers, None)
+            .await
+            .unwrap_err();
+        assert_eq!(std::fs::read(&partial.path).unwrap(), b"hello");
+        let state = std::fs::read_to_string(&partial.state_path).unwrap();
+        assert!(!state.contains("url-secret"));
+        assert!(!state.contains("header-secret"));
+        assert_eq!(
+            std::fs::read(&destination).unwrap(),
+            b"existing destination"
+        );
+
+        client
+            .download_file_with_headers(&url, &destination, &headers, None)
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        assert!(
+            requests.lock().unwrap()[1]
+                .to_ascii_lowercase()
+                .contains("range: bytes=5-")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_without_validator_restarts_from_zero() {
+        let _guard = set_test_http_retries(1);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_without_validator_response(),
+            full_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        assert!(
+            !requests.lock().unwrap()[1]
+                .to_ascii_lowercase()
+                .contains("range:")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_does_not_resume_automatically_decoded_response() {
+        let _guard = set_test_http_retries(0);
+        let (port, count) = spawn_canned_server(vec![truncated_encoded_download_response()]).await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let partial = PartialDownload::new(
+            &destination,
+            download_request_hash(&url.parse().unwrap(), &HeaderMap::new()),
+        )
+        .unwrap();
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let _err = client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+        assert!(!partial.path.exists());
+        assert!(!partial.state_path.exists());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_restarts_when_server_ignores_range() {
+        let _guard = set_test_http_retries(0);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_response(),
+            full_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let _err = client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap_err();
+        client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        assert!(
+            requests.lock().unwrap()[1]
+                .to_ascii_lowercase()
+                .contains("range: bytes=5-")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_restarts_after_invalid_content_range() {
+        let _guard = set_test_http_retries(0);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_response(),
+            invalid_resumed_download_response(),
+            full_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let _err = client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap_err();
+        client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 3);
+        let requests = requests.lock().unwrap();
+        assert!(requests[1].to_ascii_lowercase().contains("range: bytes=5-"));
+        assert!(!requests[2].to_ascii_lowercase().contains("range:"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_restarts_when_validator_changes() {
+        let _guard = set_test_http_retries(0);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_response(),
+            changed_validator_download_response(),
+            full_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let _err = client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap_err();
+        client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 3);
+        let requests = requests.lock().unwrap();
+        assert!(requests[1].to_ascii_lowercase().contains("range: bytes=5-"));
+        assert!(!requests[2].to_ascii_lowercase().contains("range:"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_discards_partial_when_request_headers_change() {
+        let _guard = set_test_http_retries(0);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_response(),
+            full_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+        let mut original_headers = HeaderMap::new();
+        original_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer old"));
+        let mut changed_headers = HeaderMap::new();
+        changed_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer new"));
+
+        let _err = client
+            .download_file_with_headers(&url, &destination, &original_headers, None)
+            .await
+            .unwrap_err();
+        client
+            .download_file_with_headers(&url, &destination, &changed_headers, None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+        assert!(
+            !requests.lock().unwrap()[1]
+                .to_ascii_lowercase()
+                .contains("range:")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_download_recovers_from_unsatisfied_range() {
+        let _guard = set_test_http_retries(0);
+        let (port, count, requests) = spawn_recording_server(vec![
+            truncated_download_response(),
+            range_not_satisfiable_response(),
+            full_download_response(),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let _err = client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap_err();
+        client
+            .download_file(&url, &destination, None)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"helloworld");
+        assert_eq!(count.load(Ordering::SeqCst), 3);
+        let requests = requests.lock().unwrap();
+        assert!(requests[1].to_ascii_lowercase().contains("range: bytes=5-"));
+        assert!(!requests[2].to_ascii_lowercase().contains("range:"));
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

- resume interrupted artifact downloads with HTTP Range requests when a strong ETag or Last-Modified validator is available
- keep validated partial files across retries and mise invocations while hashing request identity without persisting URLs, credentials, or tokens
- safely restart from byte zero when validators, request identity, Content-Range, or Range support do not match
- preserve resumable partials through normal install cleanup while retaining full deletion for explicit backend purge

## Details

The shared downloader previously created a new NamedTempFile for every retry, so any bytes received before a disconnect or timeout were discarded. This change stores a hidden partial file and versioned metadata beside the destination, protects them with a downloader-owned partial-file lock and request-identity hashing, and uses Range plus If-Range only with a safe validator. Last-Modified is accepted only when the response Date proves it is strong under the RFC 9110 60-second rule; subsequent responses compare the Last-Modified identity without treating their changing Date headers as a new artifact. Abandoned partials expire after 30 days.

The downloader lock deliberately uses the partial path rather than the destination path. Some backends, including Rust's rustup bootstrap, already lock the destination while downloading it; reusing that identity caused a recursive lock and stalled Linux and Windows E2E until timeout.

A real GitHub release asset was verified to return 206 Partial Content with byte ranges, a strong ETag, and Last-Modified, matching the original aqua/GitHub release use case.

## Testing

- `mise exec -- cargo test --all-features http::tests` (78 passed)
- `mise run test:e2e e2e/backend/test_aqua_resume_download`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run render:schema` (no generated schema diff)
- cargo fmt, shfmt, ShellCheck, and Taplo checks passed individually
- `mise run format` and `mise run lint` wrappers could not start because hk does not recognize this Sapling working copy as a Git repository; their relevant underlying checks above passed

Addresses https://github.com/jdx/mise/discussions/5988

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads can now resume interrupted transfers when safe validation information is available.
  * Partial downloads are preserved across retries and application invocations, reducing redundant data transfer.
  * Invalid or changed download data is detected and safely restarted.

* **Bug Fixes**
  * Improved handling of interrupted, incomplete, or mismatched downloads.
  * Completed and obsolete temporary files are cleaned up automatically.

* **Documentation**
  * Added guidance on resumable downloads, retry behavior, and when downloads restart from the beginning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
