### PR TITLE
fix(task): normalize variadic usage env values

### DIFF
--- a/e2e/tasks/test_task_usage_map_tera
+++ b/e2e/tasks/test_task_usage_map_tera
@@ -51,6 +51,33 @@ tag_count=2
 tag=foo
 tag=bar"
 
+# Variadic args backed by an environment variable remain arrays in the usage map
+cat <<'EOF' >mise.toml
+[tasks.usage-tera-var-env]
+description = "Test variadic args from env in usage map"
+usage = '''
+arg "<nodenames>" var=#true env="NODENAMES"
+'''
+run = '''
+echo "node_count={{ usage.nodenames | length }}"
+echo "nodes={{ usage.nodenames | join(sep='::') }}"
+{% for node in usage.nodenames %}
+echo "node={{ node }}"
+{% endfor %}
+'''
+EOF
+
+assert "NODENAMES='foo bar baz' mise run usage-tera-var-env" "\
+node_count=1
+nodes=foo bar baz
+node=foo bar baz"
+
+assert "NODENAMES='from env' mise run usage-tera-var-env one two" "\
+node_count=2
+nodes=one::two
+node=one
+node=two"
+
 # Hyphenated flag names become snake_case keys on the usage map (e.g. --foo-bar -> usage.foo_bar)
 cat <<'EOF' >mise.toml
 [tasks.usage-tera-hyphen]

--- a/src/task/task_script_parser.rs
+++ b/src/task/task_script_parser.rs
@@ -842,25 +842,29 @@ impl TaskScriptParser {
         let mut usage_ctx: HashMap<String, tera::Value> = HashMap::new();
 
         // These values are not escaped or shell-quoted.
-        let to_tera_value = |val: &usage::parse::ParseValue| -> tera::Value {
-            use tera::Value;
-            use usage::parse::ParseValue::*;
-            match val {
-                MultiBool(v) => Value::from(v.len()),
-                MultiString(v) => Value::from(v.to_vec()),
-                Bool(v) => Value::from(*v),
-                String(v) => Value::from(v.clone()),
-            }
-        };
+        let to_tera_value =
+            |val: &usage::parse::ParseValue, variadic_string: bool| -> tera::Value {
+                use tera::Value;
+                use usage::parse::ParseValue::*;
+                match val {
+                    MultiBool(v) => Value::from(v.len()),
+                    MultiString(v) => Value::from(v.to_vec()),
+                    Bool(v) => Value::from(*v),
+                    // usage-lib returns env-backed variadic values as String. Keep the
+                    // structured usage map consistent with CLI and default values.
+                    String(v) if variadic_string => Value::from(vec![v.clone()]),
+                    String(v) => Value::from(v.clone()),
+                }
+            };
 
         // The names are converted to snake_case (hyphens become underscores).
         // For example, a flag like "--dry-run" becomes accessible as {{ usage.dry_run }}.
         for (arg, val) in &usage.args {
-            let tera_val = to_tera_value(val);
+            let tera_val = to_tera_value(val, arg.var);
             usage_ctx.insert(arg.name.to_snake_case(), tera_val);
         }
         for (flag, val) in &usage.flags {
-            let tera_val = to_tera_value(val);
+            let tera_val = to_tera_value(val, flag.var && flag.arg.is_some());
             usage_ctx.insert(flag.name.to_snake_case(), tera_val);
         }
 
@@ -1723,6 +1727,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_usage_variadic_arg_env() {
+        let env = EnvMap::from_iter(vec![("NODENAMES".to_string(), "foo bar baz".to_string())]);
+        let usage = r#"arg "<nodenames>" var=#true env="NODENAMES""#;
+        let template = "echo {{ usage.nodenames | length }}:{{ usage.nodenames | join(sep='::') }}";
+
+        assert_eq!(
+            render_usage_with_env(usage, template, &[], &env).await,
+            "echo 1:foo bar baz"
+        );
+        assert_eq!(
+            render_usage_with_env(usage, template, &["one", "two"], &env).await,
+            "echo 2:one::two"
+        );
+
+        let spec: usage::Spec = usage.parse().unwrap();
+        let env_map = HashMap::from_iter(env);
+        let parsed = usage::Parser::new(&spec)
+            .with_env(env_map)
+            .parse(&[String::new()])
+            .unwrap();
+        let usage_ctx = TaskScriptParser::make_usage_ctx(&parsed);
+        assert_eq!(
+            usage_ctx["nodenames"].as_array().unwrap()[0],
+            tera::Value::from("foo bar baz")
+        );
+    }
+
+    #[tokio::test]
     async fn test_usage_flag_renders() {
         // Short + long with value
         assert_eq!(
@@ -1811,6 +1843,21 @@ mod tests {
             )
             .await,
             "echo true"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_usage_variadic_flag_env() {
+        let env = EnvMap::from_iter(vec![("TAGS".to_string(), "foo bar".to_string())]);
+        assert_eq!(
+            render_usage_with_env(
+                r#"flag "--tag <tag>" var=#true env="TAGS""#,
+                "echo {{ usage.tag | length }}:{{ usage.tag | join(sep='::') }}",
+                &[],
+                &env,
+            )
+            .await,
+            "echo 1:foo bar"
         );
     }
 


### PR DESCRIPTION
## Summary
- normalize environment-backed variadic usage arguments and value-taking flags to arrays in the structured Tera `usage` map
- preserve each environment variable as one array element instead of splitting on whitespace
- add unit and offline E2E coverage for env values, CLI precedence, joining, indexing, and iteration

## Root cause

`usage-lib` returns CLI and default values for `var=#true` as `MultiString`, but returns an `env=` value as a scalar `String`. mise copied that parser type directly into the Tera context, so filters such as `join` rejected environment-backed variadic values even though the documented `usage` map contract says they are arrays.

This change normalizes the value at mise's structured Tera boundary. It intentionally leaves the shell-facing `$usage_*` serialization and deprecated template helpers unchanged. A single environment variable remains one logical value, preserving embedded whitespace and matching the existing single-string default behavior.

## Verification
- `mise exec -- cargo test --all-features task::task_script_parser::tests`
- `mise run test:e2e e2e/tasks/test_task_usage_map_tera e2e/tasks/test_task_usage_env_tera`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shellcheck e2e/tasks/test_task_usage_map_tera`
- `mise exec -- shfmt -d e2e/tasks/test_task_usage_map_tera`

`mise run format` and `mise run lint` reach the repository-wide `hk` wrapper, which exits before running checks because this checkout is managed by Sapling and `hk` requires a Git worktree. The relevant formatting, shell, Cargo, and Clippy checks above pass when run directly.

Addresses https://github.com/jdx/mise/discussions/7550

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*
