### PR TITLE
feat(tasks): warn when a task_config.includes path does not exist

### DIFF
--- a/docs/cli/tasks/validate.md
+++ b/docs/cli/tasks/validate.md
@@ -54,3 +54,4 @@ The validate command performs the following checks:
   • Shell Commands: Checks shell executables exist
   • Glob Patterns: Validates source and output patterns
   • Run Entries: Ensures tasks reference valid dependencies
+  • Task Includes: Flags task_config.includes paths that do not exist

--- a/e2e/tasks/test_task_broken_include
+++ b/e2e/tasks/test_task_broken_include
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# A task_config.includes entry that points at nothing used to be dropped in silence, so a typo or a
+# moved file made tasks disappear with nothing to say why.
+# See: https://github.com/jdx/mise/discussions/4792
+
+cat <<EOF >tasks.toml
+[hello]
+run = 'echo "hi"'
+EOF
+
+cat <<EOF >mise.toml
+[task_config]
+includes = ["gone.toml", "tasks.toml"]
+EOF
+
+# the surviving include still loads, and the dead one is now named
+assert_contains "mise tasks 2>&1" "hello"
+assert_contains "mise tasks 2>&1" "gone.toml"
+assert_contains "mise tasks 2>&1" "does not exist"
+
+# mise tasks validate reports it too, and says which include.
+# These also pin the severity: assert_contains fails the test on a non-zero exit, and `validate`
+# only exits non-zero when it found an *error*, so a passing assertion here is the warning-not-error
+# check as well.
+assert_contains "mise tasks validate 2>&1" "missing-include"
+assert_contains "mise tasks validate --json 2>&1" "missing-include"
+
+# a directory include is satisfied by the directory existing
+mkdir -p mytasks
+cat <<EOF >mytasks/fromdir
+#!/usr/bin/env bash
+echo "from dir"
+EOF
+chmod +x mytasks/fromdir
+
+cat <<EOF >mise.toml
+[task_config]
+includes = ["mytasks", "tasks.toml"]
+EOF
+
+assert_contains "mise tasks 2>&1" "fromdir"
+assert_not_contains "mise tasks 2>&1" "does not exist"
+
+# The built-in default includes must never warn. Only one of the five default task directories
+# usually exists, so warning on the rest would fire on nearly every mise invocation.
+rm -f mise.toml
+mkdir -p mise-tasks
+cat <<EOF >mise-tasks/fromdefault
+#!/usr/bin/env bash
+echo "from default"
+EOF
+chmod +x mise-tasks/fromdefault
+
+assert_contains "mise tasks 2>&1" "fromdefault"
+assert_not_contains "mise tasks 2>&1" "does not exist"
+
+# A glob matching nothing is the normal state of a directory whose task files are not written yet.
+cat <<EOF >mise.toml
+[task_config]
+includes = ["empty/*.toml", "tasks.toml"]
+EOF
+
+assert_contains "mise tasks 2>&1" "hello"
+assert_not_contains "mise tasks 2>&1" "does not exist"

--- a/e2e/tasks/test_task_edit_nested_names
+++ b/e2e/tasks/test_task_edit_nested_names
@@ -110,7 +110,9 @@ cat <<'EOF' >mise.toml
 includes = ["tasks.d", "existing-tasks"]
 EOF
 
-TASK_PATH5=$(mise tasks edit dotted --path 2>&1)
+# stdout only: `tasks.d` is deliberately absent here, so loading the tasks now warns about it, and
+# folding stderr into a path capture would compare the warning against the path.
+TASK_PATH5=$(mise tasks edit dotted --path)
 assert "printf '%s' \"$TASK_PATH5\"" "$PWD/existing-tasks/dotted"
 assert "test -f \"$TASK_PATH5\""
 

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4251,6 +4251,7 @@ The validate command performs the following checks:
   • Shell Commands: Checks shell executables exist
   • Glob Patterns: Validates source and output patterns
   • Run Entries: Ensures tasks reference valid dependencies
+  • Task Includes: Flags task_config.includes paths that do not exist
 
 """#
         flag --errors-only help="Only show errors (skip warnings)"

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::config::Config;
+use crate::dirs;
 use crate::duration;
 use crate::file;
 use crate::task::task_fetcher::TaskFetcher;
@@ -110,6 +111,7 @@ impl TasksValidate {
         for task in &tasks {
             issues.extend(self.validate_task(task, &all_tasks, &config).await);
         }
+        issues.extend(self.validate_task_includes(&config)?);
 
         // Filter by severity if needed
         if self.errors_only {
@@ -142,6 +144,32 @@ impl TasksValidate {
         }
 
         Ok(())
+    }
+
+    /// Report `task_config.includes` entries that point at nothing.
+    ///
+    /// Not attached to any task — a dead include is why a task is *missing*, so there is nothing to
+    /// hang it off. Uses the same pseudo-task convention as `graph_error_issue`.
+    fn validate_task_includes(&self, config: &Arc<Config>) -> Result<Vec<ValidationIssue>> {
+        let Some(cwd) = &*dirs::CWD else {
+            return Ok(vec![]);
+        };
+        Ok(
+            crate::config::missing_task_includes_for_dir(cwd, &config.config_files)?
+                .into_iter()
+                .map(|path| ValidationIssue {
+                    task: "task_config.includes".to_string(),
+                    severity: Severity::Warning,
+                    category: "missing-include".to_string(),
+                    message: format!("Include path does not exist: {}", file::display_path(&path)),
+                    details: Some(
+                        "Tasks from this include are silently absent. Remove it from \
+                         task_config.includes or create the path."
+                            .to_string(),
+                    ),
+                })
+                .collect(),
+        )
     }
 
     async fn find_additional_graph_issues(
@@ -837,6 +865,7 @@ The validate command performs the following checks:
   • <bold>Shell Commands</bold>: Checks shell executables exist
   • <bold>Glob Patterns</bold>: Validates source and output patterns
   • <bold>Run Entries</bold>: Ensures tasks reference valid dependencies
+  • <bold>Task Includes</bold>: Flags task_config.includes paths that do not exist
 "#
 );
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4184,6 +4184,101 @@ fn expand_task_include(dir: &Path, pattern: &str) -> Vec<PathBuf> {
     }
 }
 
+/// The path a literal task include resolves to, when nothing exists there.
+///
+/// Globs are deliberately excluded: a glob matching nothing is the normal state of a directory
+/// whose task files have not been written yet, so reporting it would be noise. `git::` entries
+/// never reach here — callers branch on them before expanding.
+///
+/// Only ever called for *explicit* `task_config.includes`. The built-in defaults
+/// (`default_task_includes`) are mostly absent on any given project, so running this over them
+/// would warn on every mise invocation.
+fn missing_literal_include(dir: &Path, pattern: &str) -> Option<PathBuf> {
+    let pattern = file::replace_path(pattern);
+    let pattern = pattern.to_string_lossy();
+    if is_glob_pattern(&pattern) {
+        return None;
+    }
+    let path = PathBuf::from(&*pattern);
+    let resolved = if path.is_absolute() {
+        path
+    } else {
+        dir.join(path)
+    };
+    if resolved.exists() {
+        return None;
+    }
+    // `dir.join("./tasks.toml")` keeps the `.` component, and `<root>/./tasks.toml` in a warning
+    // reads like mise mangled the path. Only the displayed form changes; both spellings name the
+    // same file, and the existence check above already ran.
+    Some(
+        resolved
+            .components()
+            .filter(|c| !matches!(c, std::path::Component::CurDir))
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod task_include_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn missing_literal_include_only_flags_absent_literal_paths() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let dir = tmp.path();
+        fs::write(dir.join("tasks.toml"), "")?;
+        fs::create_dir(dir.join("mytasks"))?;
+
+        // an include that resolves to something is fine, file or directory alike
+        assert_eq!(missing_literal_include(dir, "tasks.toml"), None);
+        assert_eq!(missing_literal_include(dir, "mytasks"), None);
+
+        // an include that resolves to nothing is reported, resolved against the include root
+        assert_eq!(
+            missing_literal_include(dir, "gone.toml"),
+            Some(dir.join("gone.toml"))
+        );
+
+        // a `./` prefix resolves to the same file, and must not survive into the message
+        assert_eq!(missing_literal_include(dir, "./tasks.toml"), None);
+        assert_eq!(
+            missing_literal_include(dir, "./gone.toml"),
+            Some(dir.join("gone.toml"))
+        );
+
+        // globs are never reported: matching nothing is the normal state of a directory whose
+        // task files have not been written yet
+        assert_eq!(missing_literal_include(dir, "nope/*.toml"), None);
+        assert_eq!(missing_literal_include(dir, "*.toml"), None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn missing_literal_include_keeps_absolute_paths_absolute() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let other = TempDir::new()?;
+        let absent = other.path().join("gone.toml");
+
+        // an absolute include must not be joined onto the include root
+        assert_eq!(
+            missing_literal_include(tmp.path(), &absent.to_string_lossy()),
+            Some(absent.clone())
+        );
+
+        fs::write(&absent, "")?;
+        assert_eq!(
+            missing_literal_include(tmp.path(), &absent.to_string_lossy()),
+            None
+        );
+
+        Ok(())
+    }
+}
+
 fn task_include_patterns_for_dir(
     dir: &Path,
     config_files: &ConfigMap,
@@ -4236,6 +4331,24 @@ pub fn task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec
         })
         .unique()
         .collect::<Vec<_>>())
+}
+
+/// Explicit `task_config.includes` entries that point at nothing.
+///
+/// Returns the resolved paths, in the order they are declared. Empty when the config does not set
+/// `includes` at all — the built-in defaults are not reported, because they are absent on almost
+/// every project and are not something the user asked for.
+pub fn missing_task_includes_for_dir(dir: &Path, config_files: &ConfigMap) -> Result<Vec<PathBuf>> {
+    let (includes, resolve_dir, uses_defaults) = task_include_patterns_for_dir(dir, config_files)?;
+    if uses_defaults {
+        return Ok(vec![]);
+    }
+    Ok(includes
+        .iter()
+        .filter(|include| !include.starts_with("git::"))
+        .filter_map(|include| missing_literal_include(&resolve_dir, include))
+        .unique()
+        .collect())
 }
 
 /// Returns the directory where a new file task should be created.
@@ -4490,7 +4603,7 @@ async fn load_task_sources_from_configs(
     // a config can only vouch for task include files when it was actually
     // trusted — safe configs load without trust and cannot vouch for anything
     let require_task_include_trust = !configs.iter().any(|cf| is_path_trusted(cf.get_path()));
-    let (includes, resolve_dir, include_config_precedence) = configs
+    let explicit_includes = configs
         .iter()
         .enumerate()
         .find_map(|(precedence, cf)| match cf.task_config_includes() {
@@ -4506,7 +4619,11 @@ async fn load_task_sources_from_configs(
                     .clone()
                     .map(|includes| (includes, tc.includes_root.clone(), configs.len()))
             })
-        })
+        });
+    // Only an include the user wrote is worth complaining about; the built-in defaults are absent
+    // on nearly every project.
+    let uses_default_includes = explicit_includes.is_none();
+    let (includes, resolve_dir, include_config_precedence) = explicit_includes
         .unwrap_or_else(|| (default_task_includes(), dir.to_path_buf(), configs.len()));
 
     // Resolve task defaults once for the config root so inline tasks from
@@ -4564,6 +4681,24 @@ async fn load_task_sources_from_configs(
         let paths = if include.starts_with("git::") {
             vec![resolve_git_url_to_path(include).await?]
         } else {
+            if !uses_default_includes
+                && let Some(missing) = missing_literal_include(&resolve_dir, include)
+            {
+                // The message carries both halves on purpose, which also makes it the right
+                // dedup key for `warn_once!`: one line per (entry, resolved path) pair, i.e. one
+                // per distinct broken thing.
+                //
+                // - the entry, because it can look nothing like the path it resolves to — a
+                //   `~/tasks.toml` entry resolves to `$HOME/tasks.toml`, and the path alone
+                //   leaves the reader hunting for the config line to delete
+                // - the resolved path, because the same config is loaded once per directory and
+                //   every one of them resolves the entry identically, so including it collapses a
+                //   monorepo's worth of repeats into a single line
+                warn_once!(
+                    "task_config.includes entry '{include}' does not exist: {}",
+                    display_path(&missing)
+                );
+            }
             expand_task_include(&resolve_dir, include)
         };
         for p in paths {


### PR DESCRIPTION
From https://github.com/jdx/mise/discussions/4792. Not `Closes` — that thread asks for three things and this is one of them (see "Not in this PR").

## Problem

A `task_config.includes` entry that points at nothing is dropped in silence. Measured on **v2026.8.2**:

```console
$ cat mise.toml
[task_config]
includes = ["./does-not-exist.toml", "./real-tasks.toml"]

$ mise tasks ls
hello

$ echo $?
0
```

Nothing on stderr, and **nothing at `--verbose` either** — grepping the verbose output for the missing filename returns zero lines. `mise tasks validate` is just as quiet:

```console
$ mise tasks validate
✓ All 1 task(s) validated successfully
```

So a typo, a renamed file, or a moved directory makes tasks disappear with no way to find out why. The failure mode is silent absence: the tasks that *did* load look completely normal.

The site is [`expand_task_include`](https://github.com/jdx/mise/blob/566f8074/src/config/mod.rs#L4134), whose literal-path branch is:

```rust
if resolved.exists() {
    vec![resolved]
} else {
    vec![]
}
```

The glob branch immediately above it already `warn!`s when expansion fails, so the silence is specific to literal paths.

## What this changes

`warn_once!` at load time, and a `missing-include` issue in `mise tasks validate`:

```console
$ mise tasks
mise WARN  task_config.includes entry 'gone.toml' does not exist: ~/proj/gone.toml
hello

$ mise tasks validate
1 task(s) validated with 1 issue(s):

  ⚠ 1 warning(s)

Task: task_config.includes
  ⚠ Include path does not exist: ~/proj/gone.toml [missing-include]
      Tasks from this include are silently absent. Remove it from task_config.includes or create the path.
```

Both go through one new pure function, `missing_literal_include`, so the two paths cannot drift.

### The built-in defaults must not warn — this is the whole risk of the change

When `includes` is unset, [`default_task_includes()`](https://github.com/jdx/mise/blob/566f8074/src/config/mod.rs#L2996) supplies five directories — `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `.config/mise/tasks`, `mise/tasks` — and they go through the same expansion. A project has at most one of them, so warning unconditionally would print four or five lines on essentially every mise invocation.

`task_include_patterns_for_dir` already returns a "used the defaults" flag; `load_tasks_from_configs` did not, so this adds one there (`uses_default_includes`) and gates the warning on it. **There is an e2e assertion for exactly this**, because without it the regression is invisible in review: a project with a real `mise-tasks/` and no `[task_config]` must produce no warning.

### Globs are deliberately excluded

`includes = ["tasks/*.toml"]` matching nothing is the normal state of a directory whose task files have not been written yet, so a glob is never reported. Only literal paths are.

### `git::` includes are untouched

They branch to `resolve_git_url_to_path` before expansion ([`config/mod.rs`](https://github.com/jdx/mise/blob/566f8074/src/config/mod.rs#L4521)), so an include that has not been fetched yet cannot be mistaken for a missing local path.

### Noise

`mise hook-env` and `mise env` do not load tasks, so this cannot reach the prompt. Within a run, the same config is loaded once per directory and each resolves the include to the same absolute path, so keying `warn_once!` on the rendered message collapses a monorepo's worth of repeats to one line.

## Severity is `Warning`, and that is a judgement call

`mise tasks validate` exits non-zero only on `Error`, so this does not fail CI. That matches the existing granularity — `missing-directory` and `not-executable` are warnings, `missing-file` is an error — and an include may legitimately be optional in a shared config.

**If you would rather this fail CI, it is a one-line change** (`Severity::Warning` → `Severity::Error` in `validate_task_includes`). I have no strong view; the reporter's use case is automation, which argues for `Error`, but silently breaking someone's `mise tasks validate` in CI argues against.

## Verification

- Unit tests for `missing_literal_include` cover: existing file, existing directory, absent path, glob (never reported), and an absolute include not being joined onto the include root. They live in `config`'s existing `#[cfg(unix)]` test module, so **they run in CI, not on my box** (Windows).
- New e2e `e2e/tasks/test_task_broken_include` covers the warning, the `validate` issue in both human and `--json` output, a directory include being satisfied, **the defaults not warning**, and a zero-match glob not warning.
- `cargo fmt --all`, `cargo clippy --all-targets` clean on the touched files.

## One existing test needed a change, and it is worth a look

`e2e/tasks/test_task_edit_nested_names` captured a path with `2>&1`:

```bash
includes = ["tasks.d", "existing-tasks"]     # tasks.d deliberately absent
TASK_PATH5=$(mise tasks edit dotted --path 2>&1)
assert "printf '%s' \"$TASK_PATH5\"" "$PWD/existing-tasks/dotted"
```

The new warning landed in the capture and broke the equality. I changed it to take stdout only, which is what a path capture wants anyway — but the reason it fired is worth your judgement rather than mine.

That block tests a real pattern: *"select the first existing directory in include order"*, which `task_creation_dir_for_dir` supports deliberately. Under that reading a missing entry is a **candidate that lost**, not a mistake, and warning about it is noise. Under the reading this PR takes — a missing include means tasks are silently absent — it is exactly what the user should hear.

I went with the second because `task_config.includes` is documented as "files and directories mise should search", not as a candidate list, and the candidate behaviour is specific to where `mise tasks add` puts a *new* task. But if you would rather the loader stay quiet when some other include in the same list did resolve, that is a small change and I am happy to make it.

The other three blocks in that file with missing includes are unaffected: they assert with `assert_fail_contains`, which tolerates extra stderr.

## Not in this PR

- **`mise tasks include <path>`**, the command #4792 actually asks for. Worth knowing before anyone builds it: setting `includes` *replaces* the five default directories rather than adding to them, so a naive append command silently drops the user's existing tasks. Measured — a project whose only task lives in `mise-tasks/` loses it the moment one `includes` entry is written. Any such command has to seed the defaults on first write, or refuse. That is a design decision, not a mechanical addition.
- **Removing** dead includes (#4792's third ask). Easier to shape once detection exists.
- `git::` includes whose fetch fails. Different code path, different problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task validation now detects and reports missing task include paths.
  * Validation output includes missing-include issues in standard and JSON formats.
  * Missing explicit includes generate warnings, while glob patterns, built-in directories, and empty matches remain quiet.

* **Documentation**
  * Updated task validation documentation to describe checks for nonexistent include paths.

* **Bug Fixes**
  * Improved handling and diagnostics for relative and absolute task include paths.
  * Refined task editing output to avoid including unrelated warnings in reported paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->