### PR TITLE
fix(vfox): expose tool options to hooks

### DIFF
--- a/docs/dev-tools/backends/vfox.md
+++ b/docs/dev-tools/backends/vfox.md
@@ -114,6 +114,23 @@ includes `http.get`, `http.head`, `http.download_file`, and their `try_*` varian
 The following [tool-options](/dev-tools/#tool-options) are available for the `vfox` backend—these
 go in `[tools]` in `mise.toml`.
 
+Traditional vfox lifecycle hooks for a selected tool version can read custom options from their
+hook environment. Option names are uppercased and exposed with both the current and legacy-compatible
+prefixes:
+
+```toml
+[tools]
+"vfox:example/plugin" = { version = "1.0.0", extensions = "opentelemetry,swoole" }
+```
+
+```lua
+local extensions = os.getenv("MISE_TOOL_OPTS__EXTENSIONS")
+-- RTX_TOOL_OPTS__EXTENSIONS contains the same value for legacy compatibility.
+```
+
+These variables are available only while mise runs the plugin hook and are not exported to the
+user's shell. Backend plugins should use the structured `ctx.options` value instead.
+
 ### `install_env`
 
 Set environment variables for commands that a vfox plugin starts with `cmd.exec`

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -131,8 +131,11 @@ The python `virtualenv` tool option is deprecated and will be removed in a futur
 Use [`_.python.venv`](/lang/python.html#automatic-virtualenv-activation) in the `[env]` section instead.
 :::
 
-This will be passed to all plugin scripts as `MISE_TOOL_OPTS__VIRTUALENV=.venv`. The user can specify
-any option, and it will be passed to the plugin in that format.
+For asdf plugins and version-specific vfox lifecycle hooks, this is passed as
+`MISE_TOOL_OPTS__VIRTUALENV=.venv` and the legacy-compatible
+`RTX_TOOL_OPTS__VIRTUALENV=.venv`. These variables are scoped to the plugin hook environment; mise
+does not export them to the user's shell. Custom backend options are passed to the plugin in that
+format; mise-managed fields such as `depends`, `install_env`, and `os` are not exported.
 
 Currently, this only supports simple strings, but we can make it compatible with more complex types
 (arrays, tables) fairly easily if there is a need for it.

--- a/e2e/backend/test_vfox_tool_options
+++ b/e2e/backend/test_vfox_tool_options
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+PLUGIN_DIR="$PWD/vfox-tool-options"
+PRE_MARKER="$MISE_DATA_DIR/vfox-tool-options-pre"
+POST_MARKER="$MISE_DATA_DIR/vfox-tool-options-post"
+OS_MARKER="$MISE_DATA_DIR/vfox-tool-options-os-execute"
+UNINSTALL_MARKER="$MISE_DATA_DIR/vfox-tool-options-uninstall"
+
+mkdir -p "$PLUGIN_DIR/hooks"
+
+cat >"$PLUGIN_DIR/metadata.lua" <<'LUA'
+PLUGIN = {}
+PLUGIN.name = "tool-options"
+PLUGIN.version = "0.1.0"
+PLUGIN.homepage = "https://example.com/tool-options"
+PLUGIN.license = "MIT"
+PLUGIN.description = "tool option environment test plugin"
+LUA
+
+cat >"$PLUGIN_DIR/hooks/available.lua" <<'LUA'
+function PLUGIN:Available(ctx)
+	return {
+		{ version = "1.0.0" },
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/pre_install.lua" <<LUA
+function PLUGIN:PreInstall(ctx)
+	local marker = io.open([[$PRE_MARKER]], "w")
+	marker:write(table.concat({
+		os.getenv("MISE_TOOL_OPTS__EXTENSIONS") or "missing",
+		os.getenv("RTX_TOOL_OPTS__EXTENSIONS") or "missing",
+		os.getenv("MISE_TOOL_OPTS__CONFIG_OVERRIDE") or "missing",
+		os.getenv("RTX_TOOL_OPTS__CONFIG_OVERRIDE") or "missing",
+		os.getenv("MISE_TOOL_OPTS__INSTALL_OVERRIDE") or "missing",
+		os.getenv("RTX_TOOL_OPTS__INSTALL_OVERRIDE") or "missing",
+		os.getenv("MISE_TOOL_OPTS__RETRIES") or "missing",
+	}, "|"))
+	marker:close()
+	return { version = ctx.version }
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/post_install.lua" <<LUA
+function PLUGIN:PostInstall(ctx)
+	local cmd = require("cmd")
+	local cmd_value = cmd.exec("printf '%s' \"\$MISE_TOOL_OPTS__EXTENSIONS\"")
+	os.execute("printf '%s' \"\$RTX_TOOL_OPTS__EXTENSIONS\" > \"\$MISE_TEST_OPTION_OS_MARKER\"")
+
+	local marker = io.open([[$POST_MARKER]], "w")
+	marker:write(table.concat({
+		cmd_value,
+		os.getenv("RTX_TOOL_OPTS__EXTENSIONS") or "missing",
+		os.getenv("MISE_TOOL_OPTS__CONFIG_OVERRIDE") or "missing",
+		os.getenv("RTX_TOOL_OPTS__CONFIG_OVERRIDE") or "missing",
+		os.getenv("MISE_TOOL_OPTS__INSTALL_OVERRIDE") or "missing",
+		os.getenv("RTX_TOOL_OPTS__INSTALL_OVERRIDE") or "missing",
+	}, "|"))
+	marker:close()
+
+	os.execute("mkdir -p \"" .. ctx.rootPath .. "/bin\"")
+	local bin = io.open(ctx.rootPath .. "/bin/tool-options", "w")
+	bin:write("#!/bin/sh\necho tool-options\n")
+	bin:close()
+	os.execute("chmod +x \"" .. ctx.rootPath .. "/bin/tool-options\"")
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/env_keys.lua" <<'LUA'
+function PLUGIN:EnvKeys(ctx)
+	return {
+		{ key = "PATH", value = ctx.path .. "/bin" },
+		{ key = "VFOX_TOOL_OPTION", value = os.getenv("MISE_TOOL_OPTS__EXTENSIONS") },
+	}
+end
+LUA
+
+cat >"$PLUGIN_DIR/hooks/pre_uninstall.lua" <<LUA
+function PLUGIN:PreUninstall(ctx)
+	local marker = io.open([[$UNINSTALL_MARKER]], "w")
+	marker:write(table.concat({
+		os.getenv("MISE_TOOL_OPTS__EXTENSIONS") or "missing",
+		os.getenv("RTX_TOOL_OPTS__EXTENSIONS") or "missing",
+	}, "|"))
+	marker:close()
+end
+LUA
+
+git -C "$PLUGIN_DIR" init -q
+git -C "$PLUGIN_DIR" add .
+git -C "$PLUGIN_DIR" -c user.name=mise -c user.email=mise@example.com commit -qm "test(e2e): initialize plugin fixture"
+
+cat >mise.toml <<EOF
+[env]
+MISE_TOOL_OPTS__CONFIG_OVERRIDE = "from-config"
+RTX_TOOL_OPTS__CONFIG_OVERRIDE = "from-config"
+MISE_TEST_OPTION_OS_MARKER = "$OS_MARKER"
+
+[tools]
+"vfox:file://$PLUGIN_DIR" = { version = "1.0.0", extensions = "opentelemetry,swoole", config_override = "from-option", install_override = "from-option", retries = 2, install_env = { MISE_TOOL_OPTS__INSTALL_OVERRIDE = "from-install-env", RTX_TOOL_OPTS__INSTALL_OVERRIDE = "from-install-env" } }
+EOF
+
+export MISE_LOCKFILE=1
+detect_platform
+
+MISE_TOOL_OPTS__EXTENSIONS=ambient RTX_TOOL_OPTS__EXTENSIONS=ambient mise lock --platform "$MISE_PLATFORM"
+assert \
+  "cat '$PRE_MARKER'" \
+  "opentelemetry,swoole|opentelemetry,swoole|from-config|from-config|from-option|from-option|2"
+
+MISE_TOOL_OPTS__EXTENSIONS=ambient RTX_TOOL_OPTS__EXTENSIONS=ambient mise install
+assert \
+  "cat '$PRE_MARKER'" \
+  "opentelemetry,swoole|opentelemetry,swoole|from-config|from-config|from-option|from-option|2"
+assert \
+  "cat '$POST_MARKER'" \
+  "opentelemetry,swoole|opentelemetry,swoole|from-config|from-config|from-install-env|from-install-env"
+assert "cat '$OS_MARKER'" "opentelemetry,swoole"
+assert "mise exec -- tool-options" "tool-options"
+assert_contains "mise env" "VFOX_TOOL_OPTION=opentelemetry,swoole"
+assert_not_contains "mise env" "MISE_TOOL_OPTS__EXTENSIONS"
+
+mise uninstall "vfox:file://$PLUGIN_DIR@1.0.0"
+assert \
+  "cat '$UNINSTALL_MARKER'" \
+  "opentelemetry,swoole|opentelemetry,swoole"

--- a/src/backend/vfox.rs
+++ b/src/backend/vfox.rs
@@ -22,7 +22,7 @@ use crate::install_context::InstallContext;
 use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::plugins::Plugin;
 use crate::plugins::vfox_plugin::VfoxPlugin;
-use crate::toolset::{ToolVersion, Toolset, install_state};
+use crate::toolset::{ToolOptions, ToolVersion, Toolset, install_state};
 use crate::ui::multi_progress_report::MultiProgressReport;
 
 #[derive(Debug)]
@@ -50,6 +50,45 @@ fn remove_env_var(env: &mut indexmap::IndexMap<String, String>, key: &str) {
     }
     #[cfg(not(windows))]
     env.shift_remove(key);
+}
+
+fn set_env_var(
+    env: &mut indexmap::IndexMap<String, String>,
+    key: impl Into<String>,
+    value: impl Into<String>,
+) {
+    let key = key.into();
+    remove_env_var(env, &key);
+    env.insert(key, value.into());
+}
+
+fn add_tool_option_env(env: &mut indexmap::IndexMap<String, String>, options: &ToolOptions) {
+    for (key, value) in options.opts_as_strings() {
+        let key = key.to_uppercase();
+        set_env_var(env, format!("RTX_TOOL_OPTS__{key}"), value.clone());
+        set_env_var(env, format!("MISE_TOOL_OPTS__{key}"), value);
+    }
+}
+
+fn is_tool_option_env_key(key: &str) -> bool {
+    let matches =
+        |key: &str| key.starts_with("MISE_TOOL_OPTS__") || key.starts_with("RTX_TOOL_OPTS__");
+    if cfg!(windows) {
+        matches(&key.to_uppercase())
+    } else {
+        matches(key)
+    }
+}
+
+fn restore_config_tool_option_env(
+    env: &mut indexmap::IndexMap<String, String>,
+    config_env: &indexmap::IndexMap<String, String>,
+) {
+    for (key, value) in config_env {
+        if is_tool_option_env_key(key) {
+            set_env_var(env, key.clone(), value.clone());
+        }
+    }
 }
 
 #[async_trait]
@@ -176,11 +215,13 @@ impl Backend for VfoxBackend {
             .unwrap_or_default()
             .into_iter()
             .collect();
+        let tool_options = self.tool_options_for_tv(&ctx.config, &tv).await;
+        add_tool_option_env(&mut cmd_env, &tool_options);
         let mut install_env_removals = Vec::new();
         for (key, value) in tv.install_env() {
             match value.into_string() {
                 Some(value) => {
-                    cmd_env.insert(key, value);
+                    set_env_var(&mut cmd_env, key, value);
                 }
                 None => {
                     remove_env_var(&mut cmd_env, &key);
@@ -223,7 +264,7 @@ impl Backend for VfoxBackend {
                             k.as_str() == crate::env::PATH_KEY.as_str()
                         };
                         if !is_path {
-                            cmd_env.insert(k, v);
+                            set_env_var(&mut cmd_env, k, v);
                         }
                     }
                 }
@@ -233,6 +274,9 @@ impl Backend for VfoxBackend {
         for key in install_env_removals {
             remove_env_var(&mut cmd_env, &key);
         }
+        if let Ok(config_env) = ctx.config.env().await {
+            restore_config_tool_option_env(&mut cmd_env, &config_env);
+        }
         if !cmd_env.is_empty() {
             vfox.cmd_env = Some(cmd_env);
         }
@@ -240,14 +284,13 @@ impl Backend for VfoxBackend {
         // Use backend methods if the plugin supports them
         if self.is_backend_plugin() {
             let tool_name = self.get_tool_name()?;
-            let tool_opts = tv.request.options();
             vfox.backend_install(
                 &self.pathname,
                 tool_name,
                 &tv.version,
                 tv.install_path(),
                 tv.download_path(),
-                tool_opts.into_backend_options().into_map(),
+                tool_options.into_backend_options().into_map(),
             )
             .await
             .wrap_err("Backend install method failed")?;
@@ -380,9 +423,7 @@ impl Backend for VfoxBackend {
 
         let (mut vfox, log_rx) = self.plugin.vfox()?;
         Self::forward_plugin_logs(log_rx);
-        if let Ok(dep_env) = self.dependency_env(config).await {
-            vfox.cmd_env = Some(dep_env.into_iter().collect());
-        }
+        vfox.cmd_env = Some(self.cmd_env_for_tv(config, tv).await);
         vfox.pre_uninstall(&self.pathname, &tv.version, tv.install_path())
             .await?;
         Ok(())
@@ -414,7 +455,8 @@ impl Backend for VfoxBackend {
 
         let (os, arch) = Self::to_vfox_platform(target);
 
-        let (vfox, _log_rx) = self.plugin.vfox()?;
+        let (mut vfox, _log_rx) = self.plugin.vfox()?;
+        vfox.cmd_env = Some(self.cmd_env_for_tv(&config, tv).await);
         let pre_install = vfox
             .pre_install_for_platform(&self.pathname, &tv.version, os, arch)
             .await?;
@@ -438,7 +480,8 @@ impl Backend for VfoxBackend {
 
         let (os, arch) = Self::to_vfox_platform(target);
 
-        let (vfox, _log_rx) = self.plugin.vfox()?;
+        let (mut vfox, _log_rx) = self.plugin.vfox()?;
+        vfox.cmd_env = Some(self.cmd_env_for_tv(&config, tv).await);
         let (url, att) = vfox
             .pre_install_provenance_for_platform(&self.pathname, &tv.version, os, arch)
             .await?;
@@ -484,6 +527,33 @@ impl VfoxBackend {
         self.tool_name
             .as_deref()
             .ok_or_else(|| eyre::eyre!("VfoxBackend requires a tool name (plugin:tool format)"))
+    }
+
+    async fn cmd_env_for_tv(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+    ) -> indexmap::IndexMap<String, String> {
+        let mut cmd_env = self
+            .dependency_env(config)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        add_tool_option_env(&mut cmd_env, &self.tool_options_for_tv(config, tv).await);
+        if let Ok(config_env) = config.env().await {
+            restore_config_tool_option_env(&mut cmd_env, &config_env);
+        }
+        cmd_env
+    }
+
+    async fn tool_options_for_tv(&self, config: &Arc<Config>, tv: &ToolVersion) -> ToolOptions {
+        let mut options = config
+            .get_tool_opts_with_overrides(&self.ba)
+            .await
+            .unwrap_or_default();
+        options.apply_overrides(&tv.request.options());
+        options
     }
 
     pub fn from_arg(ba: BackendArg, backend_plugin_name: Option<String>) -> Self {
@@ -551,7 +621,7 @@ impl VfoxBackend {
         config: &Arc<Config>,
         tv: &ToolVersion,
     ) -> eyre::Result<BTreeMap<String, String>> {
-        let opts = tv.request.options();
+        let opts = self.tool_options_for_tv(config, tv).await;
         let install_path = tv.install_path();
         let opts_hash = {
             use std::hash::{Hash, Hasher};
@@ -579,9 +649,7 @@ impl VfoxBackend {
             .get_or_try_init_async(async || {
                 self.ensure_plugin_installed(config).await?;
                 let (mut vfox, _log_rx) = self.plugin.vfox()?;
-                if let Ok(dep_env) = self.dependency_env(config).await {
-                    vfox.cmd_env = Some(dep_env.into_iter().collect());
-                }
+                vfox.cmd_env = Some(self.cmd_env_for_tv(config, tv).await);
 
                 // Use backend methods if the plugin supports them
                 let env_keys = if self.is_backend_plugin() {
@@ -651,6 +719,84 @@ fn verified_attestation_to_provenance(att: vfox::VerifiedAttestation) -> Provena
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_add_tool_option_env() {
+        let mut options = ToolOptions::default();
+        options
+            .insert_option(
+                "extensions".to_string(),
+                toml::Value::String("opentelemetry\nswoole".to_string()),
+            )
+            .unwrap();
+        options
+            .insert_option("retries".to_string(), toml::Value::Integer(2))
+            .unwrap();
+        options.depends = Some(vec!["dependency".to_string()]);
+        options.install_env.insert(
+            "PRIVATE".to_string(),
+            crate::config::env_directive::EnvValue::String("value".to_string()),
+        );
+
+        let mut env = indexmap::indexmap! {
+            "MISE_TOOL_OPTS__EXTENSIONS".to_string() => "ambient".to_string(),
+            "RTX_TOOL_OPTS__EXTENSIONS".to_string() => "ambient".to_string(),
+        };
+        add_tool_option_env(&mut env, &options);
+
+        assert_eq!(
+            env.get("MISE_TOOL_OPTS__EXTENSIONS").unwrap(),
+            "opentelemetry\nswoole"
+        );
+        assert_eq!(
+            env.get("RTX_TOOL_OPTS__EXTENSIONS").unwrap(),
+            "opentelemetry\nswoole"
+        );
+        assert_eq!(env.get("MISE_TOOL_OPTS__RETRIES").unwrap(), "2");
+        assert_eq!(env.get("RTX_TOOL_OPTS__RETRIES").unwrap(), "2");
+        assert!(!env.contains_key("MISE_TOOL_OPTS__DEPENDS"));
+        assert!(!env.contains_key("MISE_TOOL_OPTS__INSTALL_ENV"));
+    }
+
+    #[test]
+    fn test_restore_config_tool_option_env() {
+        let mut env = indexmap::indexmap! {
+            "MISE_TOOL_OPTS__EXTENSIONS".to_string() => "generated".to_string(),
+            "RTX_TOOL_OPTS__EXTENSIONS".to_string() => "generated".to_string(),
+        };
+        let config_env = indexmap::indexmap! {
+            "MISE_TOOL_OPTS__EXTENSIONS".to_string() => "configured".to_string(),
+            "RTX_TOOL_OPTS__EXTENSIONS".to_string() => "configured".to_string(),
+            "UNRELATED".to_string() => "ignored".to_string(),
+        };
+
+        restore_config_tool_option_env(&mut env, &config_env);
+
+        assert_eq!(env["MISE_TOOL_OPTS__EXTENSIONS"], "configured");
+        assert_eq!(env["RTX_TOOL_OPTS__EXTENSIONS"], "configured");
+        assert!(!env.contains_key("UNRELATED"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_tool_option_env_names_are_case_insensitive_on_windows() {
+        let mut env = indexmap::indexmap! {
+            "mise_tool_opts__extensions".to_string() => "ambient".to_string(),
+        };
+        let mut options = ToolOptions::default();
+        options
+            .insert_option(
+                "extensions".to_string(),
+                toml::Value::String("configured".to_string()),
+            )
+            .unwrap();
+
+        add_tool_option_env(&mut env, &options);
+
+        assert_eq!(env.len(), 2);
+        assert_eq!(env["MISE_TOOL_OPTS__EXTENSIONS"], "configured");
+        assert_eq!(env["RTX_TOOL_OPTS__EXTENSIONS"], "configured");
+    }
 
     #[tokio::test]
     async fn test_vfox_props() {


### PR DESCRIPTION
## Summary

- expose configured vfox tool options to version-specific plugin hooks through `MISE_TOOL_OPTS__*` and legacy-compatible `RTX_TOOL_OPTS__*`
- preserve the existing environment precedence so ambient values are replaced by tool options while explicit `[env]` and `install_env` values can override them
- apply the same scoped environment to install, lock/provenance, exec-env, and uninstall hook paths without exporting it to the user shell

## Root cause

mise already parsed vfox tool options and supplied structured `ctx.options` to backend hooks, but traditional vfox hooks execute against a sanitized Lua environment that never received the plugin option variables documented for plugin scripts. As a result, calls such as `os.getenv("MISE_TOOL_OPTS__EXTENSIONS")` returned nil even though the option was present in the resolved tool request.

## Implementation

The vfox backend now builds the same option variable names and string values as the asdf backend, merges them into the hook-only command environment, and restores explicitly configured option variables afterward. Core mise options such as `depends`, `os`, and `install_env` are excluded. Version discovery and legacy-file parsing remain unchanged because they do not have a concrete tool occurrence.

A local traditional vfox plugin regression test covers `PreInstall`, `PostInstall`, `cmd.exec`, `os.execute`, `EnvKeys`, `PreUninstall`, lock resolution, ambient collisions, explicit overrides, and shell-environment isolation.

## Verification

Passed:

- `mise exec -- cargo test --all-features backend::vfox::test --no-fail-fast`
- `mise run test:e2e e2e/backend/test_vfox_tool_options e2e/backend/test_vfox_install_env e2e/backend/test_vfox_pre_uninstall`
- `mise run test:e2e e2e/backend/test_vfox_backend_npm`
- `mise --cd crates/vfox run test`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- Rustfmt, ShellCheck, shfmt, Markdownlint, and Prettier checks for the changed files

Local full `mise run lint` could not start because hk does not recognize this Sapling working copy as a Git repository. The existing network-backed `e2e/lockfile/test_lockfile_vfox_provenance` also currently receives no URL from upstream vfox-cmake; the new offline lock-path regression passes independently.

Addresses https://github.com/jdx/mise/discussions/6153

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom options in vfox tool lifecycle hooks.
  * Options are available through `MISE_TOOL_OPTS__*` variables, with legacy `RTX_TOOL_OPTS__*` aliases.
  * Tool options now apply consistently during installation, uninstallation, environment setup, locking, and command execution.
  * Added documentation covering option behavior for vfox and asdf plugins.

* **Bug Fixes**
  * Improved handling of option names on Windows.
  * Ensured configured options are preserved across tool operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->