### PR TITLE
fix(python): honor disable_tools for the venv directive

### DIFF
--- a/e2e/core/test_python_venv_disable_tools
+++ b/e2e/core/test_python_venv_disable_tools
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# `disable_tools = ["python"]` turned the tool off but left its venv activated: VIRTUAL_ENV and the
+# venv's bin directory stayed on PATH while `mise which python` reported the tool as absent.
+# See: https://github.com/jdx/mise/discussions/4690
+
+export MISE_PYTHON_GITHUB_ATTESTATIONS=0
+
+cat >.mise.toml <<EOF
+[env._.python]
+venv = {path = "{{config_root}}/.venv", create=true}
+[tools]
+python = "3.12.3"
+EOF
+
+mise i
+
+# Control first, and it has to come first: the venv must exist on disk before the suppression means
+# anything. With no .venv yet, "no VIRTUAL_ENV" is just the tool being unavailable to create one.
+assert_contains "mise env -s bash" "VIRTUAL_ENV"
+assert "mise x -- which python" "$PWD/.venv/bin/python"
+assert "test -d .venv && echo yes" "yes"
+
+# Now disable the tool from a local config, which is how the reporter drives it.
+cat >mise.local.toml <<EOF
+[settings]
+disable_tools = ["python"]
+EOF
+
+# The venv is still on disk, so this is the case that used to leak.
+assert "test -d .venv && echo yes" "yes"
+assert_not_contains "mise env -s bash" "VIRTUAL_ENV"
+assert_not_contains "mise env -s bash" ".venv/bin"
+
+# enable_tools is an allowlist, so one that leaves python out disables the venv the same way.
+cat >mise.local.toml <<EOF
+[settings]
+enable_tools = ["node"]
+EOF
+
+assert_not_contains "mise env -s bash" "VIRTUAL_ENV"
+
+# ...and naming python in the allowlist brings it back, which pins that this is the tool gate
+# rather than the local config merely displacing the env directive.
+cat >mise.local.toml <<EOF
+[settings]
+enable_tools = ["python"]
+EOF
+
+# All three, not just VIRTUAL_ENV: the reported symptom was `which python` resolving into the
+# venv's bin directory, so a restore that only put VIRTUAL_ENV back would still be broken.
+assert_contains "mise env -s bash" "VIRTUAL_ENV"
+assert_contains "mise env -s bash" ".venv/bin"
+assert "mise x -- which python" "$PWD/.venv/bin/python"

--- a/src/config/env_directive/venv.rs
+++ b/src/config/env_directive/venv.rs
@@ -7,10 +7,11 @@ use crate::config::{Config, Settings};
 use crate::env_diff::EnvMap;
 use crate::file::{display_path, which_no_shims};
 use crate::lock_file::LockFile;
+use crate::registry::tool_enabled;
 use crate::toolset::Toolset;
 use crate::{backend, plugins};
 use indexmap::IndexMap;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -34,6 +35,22 @@ pub(crate) struct PythonVenvOptions {
     pub(crate) uv_create_args: Option<Vec<String>>,
     pub(crate) python_create_args: Option<Vec<String>>,
     pub(crate) require_uv: bool,
+}
+
+/// Whether `_.python.venv` should do anything, given the tool allow/deny settings.
+///
+/// The directive exists to put a python on PATH, so turning python off has to turn it off too —
+/// otherwise `mise which python` reports the tool as absent while `VIRTUAL_ENV` and the venv's
+/// bin directory are still exported, which is the state #4690 reported.
+///
+/// Goes through the same [`tool_enabled`] every other consumer of these settings uses, so the
+/// allowlist form is covered as well: `enable_tools = ["node"]` leaves python out, and the venv
+/// stops with it.
+fn python_venv_enabled(
+    enable_tools: Option<&BTreeSet<String>>,
+    disable_tools: &BTreeSet<String>,
+) -> bool {
+    tool_enabled(enable_tools, disable_tools, &"python".to_string())
 }
 
 pub(crate) fn load_venv(
@@ -219,6 +236,14 @@ impl EnvResults {
         mut options: PythonVenvOptions,
     ) -> Result<()> {
         trace!("python venv: {} create={create}", display_path(&path));
+        let settings = Settings::get();
+        if !python_venv_enabled(settings.enable_tools().as_ref(), &settings.disable_tools()) {
+            // Before the creation branch as well as the activation one: with python turned off the
+            // venv would fail to build anyway, and "declined to run" is a different thing from
+            // "tried and could not".
+            debug!("python venv skipped: the python tool is disabled");
+            return Ok(());
+        }
         trust_check(ctx.source)?;
         let venv = ctx.parse_template(&path)?;
         let venv = ctx.normalize_path(venv.into());
@@ -342,5 +367,34 @@ mod tests {
         ]
         "#
         );
+    }
+}
+
+// Separate from `tests` above because that module is unix-only and these are not: the gate is
+// plain set arithmetic, and it is worth running everywhere the gate runs.
+#[cfg(test)]
+mod venv_enabled_tests {
+    use super::*;
+
+    fn set(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn disable_tools_turns_the_venv_off() {
+        assert!(!python_venv_enabled(None, &set(&["python"])));
+        // an unrelated tool being disabled changes nothing
+        assert!(python_venv_enabled(None, &set(&["node"])));
+        assert!(python_venv_enabled(None, &set(&[])));
+    }
+
+    #[test]
+    fn enable_tools_is_an_allowlist_and_covers_the_venv_too() {
+        // the non-obvious half: an allowlist that omits python disables the venv, even though
+        // nothing named python appears in `disable_tools`
+        assert!(!python_venv_enabled(Some(&set(&["node"])), &set(&[])));
+        assert!(python_venv_enabled(Some(&set(&["python"])), &set(&[])));
+        // an empty allowlist is "no tools at all", not "no opinion"
+        assert!(!python_venv_enabled(Some(&set(&[])), &set(&[])));
     }
 }


### PR DESCRIPTION
Closes #4690.

## Problem

`disable_tools = ["python"]` turns the tool off but leaves its virtualenv activated. Measured on **v2026.8.2**, with `[env] _.python.venv = { path = "{{config_root}}/.venv", create = true }` in `mise.toml` and `[settings] disable_tools = ["python"]` in `mise.local.toml`:

```console
$ mise which python
mise ERROR python is not a mise bin. Perhaps you need to install it first.

$ mise ls --current
(nothing)

$ mise env
export PATH='…/proj/.venv/Scripts;C:\Program Files\PowerShell\7;…'
export VIRTUAL_ENV='…/proj/.venv'
```

The tool is gone and the venv it belongs to is still on PATH. That is the state @dahpgjgamgan reported: `which python3` resolves into `.venv/bin/`, and the only way out is editing the non-local config — which defeats the point of keeping the override in `mise.local.toml`.

**Whether it reproduces depends on the venv already existing**, which is worth stating because it is easy to measure the wrong thing:

| | `mise ls --current` | `VIRTUAL_ENV` |
|---|---|---|
| no `disable_tools` (control) | `python 3.12.13` | exported |
| `disable_tools`, no `.venv` yet | empty | not exported |
| **`disable_tools`, `.venv` on disk** | **empty** | **exported** |

The middle row looks like the bug is already fixed. It is not — creation needs the tool, so it fails for an unrelated reason. Only the third row shows the actual behaviour.

The cause is what the reporter worked out from the source in 2025-03 and never got an answer on: `src/config/env_directive/venv.rs` contains no reference to `disable_tools` at all. The directive is resolved independently of the toolset.

## What this changes

An early return at the top of `EnvResults::venv`, through the same `tool_enabled` helper that `backend/mod.rs`, `cli/registry.rs`, `cli/search.rs`, `toolset/tool_request_set.rs` and `toolset/mod.rs` already use:

```rust
let settings = Settings::get();
if !python_venv_enabled(settings.enable_tools().as_ref(), &settings.disable_tools()) {
    debug!("python venv skipped: the python tool is disabled");
    return Ok(());
}
```

It sits before the creation branch as well as the activation one — with python off the venv could not be built anyway, and "declined to run" is a different thing from "tried and could not".

Because it goes through `tool_enabled`, the allowlist form is covered too: `enable_tools = ["node"]` leaves python out, so the venv stops with it. That is the half most likely to surprise, so it has its own unit test and its own e2e assertion.

## This is a behaviour change

Anyone relying today on `disable_tools = ["python"]` *plus* an activated venv loses the activation. That is the defect being fixed rather than a side effect, but it is a real change and worth calling out in the release notes.

**The counter-argument I would expect** is that `_.python.venv` is an env directive, not a tool, so the tool settings should not reach it. What makes me think otherwise is that the current state is not neutral — it is self-contradictory. `mise which python` already answers "not a mise bin" in the same invocation that exports `VIRTUAL_ENV` and prepends the venv's bin directory. Whichever way it is resolved, those two should agree. Happy to close this if you would rather they agree the other way.

## Verification

- Unit tests for `python_venv_enabled` cover `disable_tools` hit/miss/empty and all three allowlist shapes, including the empty allowlist meaning "no tools at all". They live in their own module rather than the file's existing `#[cfg(unix)]` one, so they compile and **run on every platform** — including the box this was developed on.
- New e2e `e2e/core/test_python_venv_disable_tools`, modelled on `e2e/core/test_python_venv`. It takes the control first and asserts `.venv` is on disk before checking that the suppression holds, so it cannot pass for the wrong reason. It also pins the allowlist behaviour in both directions — `enable_tools = ["node"]` suppresses, `enable_tools = ["python"]` restores — which rules out the local config merely displacing the env directive.
- `cargo fmt --all`, `cargo clippy --all-targets` clean on the touched file.

## Not in this PR

- The `activate` option the reporter prototyped on the directive itself. `disable_tools` is the mechanism they already use for every other tool, and if that carries the use case then a new directive option is a separate design question.
- Other env directives. `_.python.venv` is the only one tied to a specific tool; `Module`, `Source`, `File` and `Path` are not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python virtual environments now respect configured tool enable/disable settings.
  * Disabling or excluding Python prevents virtual-environment activation and avoids creating a new environment.
  * Existing virtual environments remain available on disk and are restored automatically when Python is enabled.

* **Bug Fixes**
  * Improved consistency of Python virtual-environment behavior across supported platforms and configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->