### PR TITLE
feat(deps): support templates in provider configs

### DIFF
--- a/docs/dev-tools/deps.md
+++ b/docs/dev-tools/deps.md
@@ -165,6 +165,33 @@ run = "npx prisma generate"
 | `depends`     | string[] | Other provider names that must complete before this one runs              |
 | `timeout`     | string   | Timeout for the run command, e.g., `"30s"`, `"5m"` (default: no timeout)  |
 
+### Templates and Environment Variables
+
+String values in provider configuration support Tera templates such as
+`{{ config_root }}`, `{{ env.NAME }}`, and `{{ vars.name }}`. Shell-style environment variables
+such as `$NAME` and `${NAME:-default}` are expanded after Tera templates, using the same
+`env_shell_expand` setting as `[env]` values.
+
+```toml
+[vars]
+package = "api"
+
+[deps.codegen]
+sources = ["{{ config_root }}/schemas/$SCHEMA_NAME.graphql"]
+outputs = ["{{ config_root }}/generated/${SCHEMA_NAME:-default}/"]
+dir = "{{ config_root }}"
+env = { OUTPUT_PACKAGE = "{{ vars.package }}-$BUILD_MODE" }
+run = "npm run codegen -- $OUTPUT_PACKAGE"
+```
+
+`$VAR` expressions in `run` are left for the provider's shell to expand at execution time. This
+allows `run` to use values from the provider's `env` table. Tera expressions in `run` are rendered
+when the provider configuration is loaded.
+
+Provider IDs and environment-variable names are not templated. Invalid Tera templates are reported
+as configuration errors before a provider command starts. An undefined shell-style variable is left
+unchanged with a warning; use `${NAME:-}` to explicitly default it to an empty string.
+
 ## Freshness Checking
 
 mise uses blake3 hashing to determine if sources or the effective provider command have

--- a/e2e/cli/test_deps_templates
+++ b/e2e/cli/test_deps_templates
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+export DEPS_SUFFIX=expanded
+mkdir -p work
+echo input >work/input-expanded
+
+cat >mise.toml <<'EOF'
+[vars]
+label = "rendered"
+
+[deps.setup]
+sources = ["{{ config_root }}/work/input-$DEPS_SUFFIX"]
+outputs = ["{{ config_root }}/work/output-$DEPS_SUFFIX"]
+run = 'printf "%s\n" "{{ config_root }}|$RUNTIME_VALUE|{{ vars.label }}" > output-$DEPS_SUFFIX; echo run >> runs'
+dir = "{{ config_root }}/work"
+description = "setup-$DEPS_SUFFIX"
+timeout = "${DEPS_TIMEOUT:-5s}"
+
+[deps.setup.env]
+RUNTIME_VALUE = "provider-$DEPS_SUFFIX"
+EOF
+
+assert_fail_contains "mise deps setup --explain" "Command: setup-expanded"
+assert_contains "mise prepare --dry-run --only setup 2>&1" "setup"
+mise deps --force --only setup
+assert "cat work/output-expanded" "$PWD|provider-expanded|rendered"
+assert "wc -l < work/runs | tr -d ' '" "1"
+
+# The rendered source and output paths participate in freshness checks.
+mise deps --only setup
+assert "wc -l < work/runs | tr -d ' '" "1"
+echo changed >work/input-expanded
+mise deps --only setup
+assert "wc -l < work/runs | tr -d ' '" "2"
+
+# Each monorepo provider uses the config_root of the file that defines it.
+mkdir -p monorepo/apps/a monorepo/apps/b
+cat >monorepo/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+config_roots = ["apps/*"]
+EOF
+for app in a b; do
+  cat >"monorepo/apps/$app/mise.toml" <<'EOF'
+[deps.render]
+outputs = ["{{ config_root }}/root.txt"]
+run = "printf '%s' '{{ config_root }}' > root.txt"
+dir = "{{ config_root }}"
+EOF
+done
+(
+  cd monorepo
+  mise deps --monorepo --force
+)
+assert "cat monorepo/apps/a/root.txt" "$PWD/monorepo/apps/a"
+assert "cat monorepo/apps/b/root.txt" "$PWD/monorepo/apps/b"
+
+# Invalid templates fail before the provider command starts.
+mkdir invalid
+cat >invalid/mise.toml <<'EOF'
+[deps.bad]
+auto = true
+sources = ["{{ missing }}"]
+run = "touch side-effect"
+
+[tasks.default]
+run = "touch task-side-effect"
+EOF
+assert_fail_contains "cd invalid && mise deps --force" 'deps provider "bad" field "sources[0]"'
+assert_fail "test -e invalid/side-effect"
+assert_fail_contains "cd invalid && mise run default" 'deps provider "bad" field "sources[0]"'
+assert_fail "test -e invalid/task-side-effect"
+
+# Provider env templates are rendered after the effective layered and tools env is known.
+mkdir effective-env
+cat >effective-env/mise.toml <<'EOF'
+[env]
+LAYERED_VALUE = "from-base"
+TOOLS_VALUE = { value = "from-tools", tools = true }
+EOF
+cat >effective-env/mise.local.toml <<'EOF'
+[deps.render]
+sources = ["{{ env.LAYERED_VALUE }}.source"]
+outputs = ["{{ env.LAYERED_VALUE }}.result"]
+run = "printf '%s' \"$VALUE\" > {{ env.LAYERED_VALUE }}.result; echo run >> runs"
+env = { VALUE = "{{ env.LAYERED_VALUE }}|{{ env.TOOLS_VALUE }}" }
+description = "{{ env.TOOLS_VALUE }}"
+EOF
+touch effective-env/from-base.source
+(
+  cd effective-env
+  mise deps --force
+)
+assert "cat effective-env/from-base.result" "from-base|from-tools"
+assert "wc -l < effective-env/runs | tr -d ' '" "1"
+assert_contains "cd effective-env && mise deps render --explain 2>&1" "Status: fresh"
+assert "wc -l < effective-env/runs | tr -d ' '" "1"
+sed -i.bak 's/from-tools/from-tools-changed/' effective-env/mise.toml
+assert_fail_contains "cd effective-env && mise deps render --explain" "provider command changed"
+(
+  cd effective-env
+  mise deps
+)
+assert "cat effective-env/from-base.result" "from-base|from-tools-changed"
+assert "wc -l < effective-env/runs | tr -d ' '" "2"
+
+# Invalid deps templates encountered during uv venv discovery remain configuration errors.
+mkdir invalid-uv
+touch invalid-uv/uv.lock
+cat >invalid-uv/mise.toml <<'EOF'
+[settings]
+python.uv_venv_auto = "source"
+
+[deps.uv]
+sources = ["{{ invalid("]
+EOF
+assert_fail_contains "cd invalid-uv && mise env" 'deps provider "uv" field "sources[0]"'
+
+# Disabling shell expansion leaves provider values unchanged while Tera still renders.
+mkdir no-shell-expand
+cat >no-shell-expand/mise.toml <<'EOF'
+[vars]
+prefix = "rendered"
+
+[settings]
+env_shell_expand = false
+
+[deps.literal]
+outputs = ["{{ config_root }}/result"]
+run = "printf '%s' \"$VALUE\" > result"
+env = { VALUE = "{{ vars.prefix }}-$DEPS_SUFFIX" }
+EOF
+(
+  cd no-shell-expand
+  mise deps --force
+)
+literal_deps_suffix="$(printf '\044DEPS_SUFFIX')"
+assert "cat no-shell-expand/result" "rendered-$literal_deps_suffix"
+
+# Providers excluded from this invocation are not rendered.
+mkdir filtered
+cat >filtered/mise.toml <<'EOF'
+[deps.selected]
+outputs = ["selected"]
+run = "touch selected"
+
+[deps.unselected]
+sources = ["{{ env.MISSING_VALUE }}"]
+run = "touch unselected"
+EOF
+(
+  cd filtered
+  mise deps --force --only selected
+)
+assert "test -e filtered/selected"
+assert_fail "test -e filtered/unselected"
+rm filtered/selected
+(
+  cd filtered
+  mise deps --force --skip unselected
+)
+assert "test -e filtered/selected"
+assert_fail "test -e filtered/unselected"
+
+# Non-auto providers are not rendered during automatic task dependency checks.
+mkdir manual
+cat >manual/mise.toml <<'EOF'
+[deps.manual]
+sources = ["{{ env.MISSING_VALUE }}"]
+run = "touch provider-side-effect"
+
+[tasks.default]
+run = "touch task-side-effect"
+EOF
+(
+  cd manual
+  mise run default
+)
+assert "test -e manual/task-side-effect"
+assert_fail "test -e manual/provider-side-effect"

--- a/src/cli/deps/install.rs
+++ b/src/cli/deps/install.rs
@@ -64,13 +64,8 @@ impl DepsInstall {
             return Ok(());
         }
 
-        if self.explain {
-            let Some(ref provider_id) = self.provider else {
-                bail!(
-                    "--explain requires a provider argument, e.g.: mise deps install npm --explain"
-                );
-            };
-            return self.explain_provider(&engine, provider_id);
+        if self.explain && self.provider.is_none() {
+            bail!("--explain requires a provider argument, e.g.: mise deps install npm --explain");
         }
 
         // If a provider is specified as a positional arg, treat it like --only.
@@ -110,6 +105,15 @@ impl DepsInstall {
                     .await?
             }
         };
+
+        if self.explain {
+            let env = ts.env_with_path(&install_config).await?;
+            return Self::explain_provider(
+                &engine,
+                self.provider.as_deref().expect("provider checked above"),
+                &env,
+            );
+        }
 
         let install_opts = InstallOptions {
             missing_args_only: false,
@@ -161,7 +165,11 @@ impl DepsInstall {
         Ok(())
     }
 
-    fn explain_provider(&self, engine: &DepsEngine, provider_id: &str) -> Result<()> {
+    fn explain_provider(
+        engine: &DepsEngine,
+        provider_id: &str,
+        effective_env: &std::collections::BTreeMap<String, String>,
+    ) -> Result<()> {
         let Some(provider) = engine.find_provider(provider_id) else {
             let available = engine
                 .list_providers()
@@ -208,7 +216,7 @@ impl DepsInstall {
         }
 
         // Command
-        if let Ok(cmd) = provider.install_command() {
+        if let Ok(cmd) = provider.install_command_with_env(effective_env) {
             miseprintln!("Command: {}", cmd.description);
         }
 
@@ -219,7 +227,7 @@ impl DepsInstall {
             bail!("provider '{}' is inactive: {reason}", provider.id());
         }
 
-        let freshness = engine.check_provider_freshness(provider)?;
+        let freshness = engine.check_provider_freshness(provider, effective_env)?;
         if freshness.is_fresh() {
             miseprintln!("Status: fresh ({})", freshness.reason());
         } else {

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -272,7 +272,7 @@ impl HookEnv {
             }
         }
         ts.notify_if_versions_missing(config).await;
-        crate::deps::notify_if_stale(config);
+        crate::deps::notify_if_stale(config, cur_env);
         Ok(())
     }
 

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -28,7 +28,7 @@ use crate::config::env_directive::{
 };
 use crate::config::settings::SettingsPartial;
 use crate::config::{Alias, AliasMap, Config, Settings};
-use crate::deps::DepsConfig;
+use crate::deps::{DepsConfig, DepsTemplateContext};
 use crate::env_diff::EnvMap;
 use crate::file::{create_dir_all, display_path};
 use crate::hooks::{Hook, HookDef, Hooks};
@@ -1665,8 +1665,20 @@ impl ConfigFile for MiseToml {
             .collect())
     }
 
-    fn deps_config(&self) -> Option<DepsConfig> {
-        self.deps.clone()
+    fn deps_config(&self) -> eyre::Result<Option<DepsConfig>> {
+        let Some(mut deps) = self.deps.clone() else {
+            return Ok(None);
+        };
+        let context = self.template_context();
+        for (provider_id, provider) in &mut deps.providers {
+            provider.template_context = Some(DepsTemplateContext {
+                config_path: self.path.clone(),
+                provider_id: provider_id.clone(),
+                context: context.clone(),
+            });
+            provider.validate_template_syntax()?;
+        }
+        Ok(Some(deps))
     }
 
     fn oci_config(&self) -> Option<OciConfig> {
@@ -4454,6 +4466,63 @@ run = 'echo "template"'
         foo5=5
         foo6=6
         "#);
+    }
+
+    #[test]
+    fn test_deps_config_renders_templates_and_shell_env() {
+        let config = parse(
+            indoc! {r#"
+            [env]
+            DEPS_SUFFIX = "expanded"
+
+            [deps.setup]
+            run = "echo {{ config_root }} $DEPS_SUFFIX"
+            sources = ["{{ config_root }}/input-$DEPS_SUFFIX"]
+            outputs = ["$DEPS_SUFFIX/output"]
+            env = { ROOT = "{{ config_root }}", SUFFIX = "$DEPS_SUFFIX" }
+            dir = "{{ config_root }}/$DEPS_SUFFIX"
+            description = "setup-$DEPS_SUFFIX"
+            depends = ["dependency-$DEPS_SUFFIX"]
+            timeout = "{{ 2 + 3 }}s"
+        "#}
+            .to_string(),
+        );
+
+        let deps = config.deps_config().unwrap().unwrap();
+        let provider = deps.providers["setup"].rendered(&BTreeMap::new()).unwrap();
+        let config_root = CWD.as_ref().unwrap().to_string_lossy();
+        assert_eq!(
+            provider.run.as_deref(),
+            Some(format!("echo {config_root} $DEPS_SUFFIX").as_str())
+        );
+        assert_eq!(provider.sources, [format!("{config_root}/input-expanded")]);
+        assert_eq!(provider.outputs, ["expanded/output"]);
+        assert_eq!(provider.env["ROOT"], config_root);
+        assert_eq!(provider.env["SUFFIX"], "expanded");
+        assert_eq!(
+            provider.dir.as_deref(),
+            Some(format!("{config_root}/expanded").as_str())
+        );
+        assert_eq!(provider.description.as_deref(), Some("setup-expanded"));
+        assert_eq!(provider.depends, ["dependency-expanded"]);
+        assert_eq!(provider.timeout.as_deref(), Some("5s"));
+    }
+
+    #[test]
+    fn test_deps_config_reports_template_errors_with_field_context() {
+        let config = parse(
+            indoc! {r#"
+            [deps.setup]
+            run = "echo ok"
+            sources = ["{{ invalid("]
+        "#}
+            .to_string(),
+        );
+
+        let err = config.deps_config().unwrap_err().to_string();
+        assert!(err.contains("deps provider \"setup\""), "{err}");
+        assert!(err.contains("field \"sources[0]\""), "{err}");
+        assert!(err.contains(".test.mise.toml"), "{err}");
     }
 
     fn parse(s: String) -> MiseToml {

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -150,8 +150,8 @@ pub trait ConfigFile: Debug + Send + Sync {
         Ok(Default::default())
     }
 
-    fn deps_config(&self) -> Option<DepsConfig> {
-        None
+    fn deps_config(&self) -> Result<Option<DepsConfig>> {
+        Ok(None)
     }
 
     fn oci_config(&self) -> Option<crate::oci::OciConfig> {

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -10,7 +10,6 @@ use crate::cmd::CmdLineRunner;
 use crate::config::config_file::ConfigFile;
 use crate::config::{Config, Settings};
 use crate::task::monorepo_scope;
-use crate::tera::{BASE_CONTEXT, contains_template_syntax, get_tera, render_str};
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use crate::ui::style;
@@ -23,6 +22,10 @@ struct ScopedDepsProvider {
     inner: Box<dyn DepsProvider>,
     id: String,
     depends: Vec<String>,
+    scope: String,
+    scoped_ids: HashSet<String>,
+    fallback_ids: HashSet<String>,
+    qualified_fallback_ids: HashMap<String, String>,
 }
 
 impl ScopedDepsProvider {
@@ -56,13 +59,32 @@ impl ScopedDepsProvider {
                 }
             })
             .collect();
-        Self { inner, id, depends }
+        Self {
+            inner,
+            id,
+            depends,
+            scope: scope.to_string(),
+            scoped_ids: scoped_ids.clone(),
+            fallback_ids: fallback_ids.clone(),
+            qualified_fallback_ids: qualified_fallback_ids.clone(),
+        }
     }
 }
 
 impl DepsProvider for ScopedDepsProvider {
     fn base(&self) -> &super::providers::ProviderBase {
         self.inner.base()
+    }
+
+    fn rendered(&self, effective_env: &BTreeMap<String, String>) -> Result<Box<dyn DepsProvider>> {
+        Ok(Box::new(Self::new(
+            self.inner.rendered(effective_env)?,
+            self.id.clone(),
+            &self.scope,
+            &self.scoped_ids,
+            &self.fallback_ids,
+            &self.qualified_fallback_ids,
+        )))
     }
 
     fn id(&self) -> &str {
@@ -160,6 +182,7 @@ pub struct DepsResult {
 struct DepsJob {
     id: String,
     cmd: super::DepsCommand,
+    command_hash: String,
     outputs: Vec<PathBuf>,
     depends: Vec<String>,
     timeout: Option<std::time::Duration>,
@@ -215,19 +238,25 @@ impl DepsEngine {
             .ok_or_else(|| eyre::eyre!("no config file in scope sets monorepo_root = true"))?;
         let mut scoped_providers: Vec<(Box<dyn DepsProvider>, String, String)> = vec![];
         let mut provider_indices: HashMap<String, usize> = HashMap::new();
-        let config_files: Vec<_> = config_files.into_iter().collect();
+        let config_files: Vec<_> = config_files
+            .into_iter()
+            .map(|cf| {
+                let deps_config = cf.deps_config()?;
+                Ok((cf, deps_config))
+            })
+            .collect::<Result<_>>()?;
         let mut disabled_by_root: HashMap<PathBuf, HashSet<String>> = HashMap::new();
 
         // Layered config files share one provider namespace at each config root.
         // Collect disables first so their behavior does not depend on file order.
-        for cf in &config_files {
+        for (cf, deps_config) in &config_files {
             let Some(config_project_root) = cf.project_root() else {
                 continue;
             };
             if !config_project_root.starts_with(&monorepo_root) {
                 continue;
             }
-            if let Some(deps_config) = cf.deps_config() {
+            if let Some(deps_config) = deps_config {
                 disabled_by_root
                     .entry(cf.config_root())
                     .or_default()
@@ -235,14 +264,14 @@ impl DepsEngine {
             }
         }
 
-        for cf in config_files {
+        for (cf, deps_config) in config_files {
             let Some(config_project_root) = cf.project_root() else {
                 continue;
             };
             if !config_project_root.starts_with(&monorepo_root) {
                 continue;
             }
-            let Some(deps_config) = cf.deps_config() else {
+            let Some(deps_config) = deps_config else {
                 continue;
             };
 
@@ -379,7 +408,7 @@ impl DepsEngine {
         // Only include config files that belong to the current project root
         // (skip config files outside the current project root, e.g. from parent directories).
         for cf in config.config_files.values() {
-            let Some(deps_config) = cf.deps_config() else {
+            let Some(deps_config) = cf.deps_config()? else {
                 continue;
             };
 
@@ -497,19 +526,28 @@ impl DepsEngine {
     }
 
     /// Check freshness for a specific provider (public API for --explain)
-    pub fn check_provider_freshness(&self, provider: &dyn DepsProvider) -> Result<FreshnessResult> {
-        self.check_freshness(provider)
+    pub fn check_provider_freshness(
+        &self,
+        provider: &dyn DepsProvider,
+        effective_env: &BTreeMap<String, String>,
+    ) -> Result<FreshnessResult> {
+        let provider = provider.rendered(effective_env)?;
+        let command_hash = provider.install_command()?.freshness_hash();
+        self.check_freshness(provider.as_ref(), &command_hash)
     }
 
     /// Check if any auto-enabled provider has stale outputs (without running)
     /// Returns the IDs and reasons of stale providers
-    pub fn check_staleness(&self) -> Vec<(&str, String)> {
+    pub fn check_staleness(&self, effective_env: &BTreeMap<String, String>) -> Vec<(&str, String)> {
         self.providers
             .iter()
             .filter(|p| p.is_auto())
             .filter(|p| matches!(p.applicability(), Applicable))
             .filter_map(|p| {
-                let result = self.check_freshness(p.as_ref());
+                let result = p.rendered(effective_env).and_then(|rendered| {
+                    let command_hash = rendered.install_command()?.freshness_hash();
+                    self.check_freshness(rendered.as_ref(), &command_hash)
+                });
                 match result {
                     Ok(r) if !r.is_fresh() => Some((p.id(), r.reason().to_string())),
                     _ => None,
@@ -520,6 +558,14 @@ impl DepsEngine {
 
     /// Reject explicitly selected providers that cannot run.
     pub fn validate_selection(&self, only: Option<&[String]>, skip: &[String]) -> Result<()> {
+        Self::validate_provider_selection(&self.providers, only, skip)
+    }
+
+    fn validate_provider_selection(
+        providers: &[Box<dyn DepsProvider>],
+        only: Option<&[String]>,
+        skip: &[String],
+    ) -> Result<()> {
         let Some(only) = only else {
             return Ok(());
         };
@@ -527,7 +573,7 @@ impl DepsEngine {
             if skip.contains(id) {
                 continue;
             }
-            let Some(provider) = self.providers.iter().find(|provider| provider.id() == id) else {
+            let Some(provider) = providers.iter().find(|provider| provider.id() == id) else {
                 continue;
             };
             if let DepsProviderApplicability::Inactive(reason) = provider.applicability() {
@@ -541,7 +587,7 @@ impl DepsEngine {
     pub async fn run(&self, opts: DepsOptions) -> Result<DepsResult> {
         let mut results = vec![];
 
-        self.validate_selection(opts.only.as_deref(), &opts.skip)?;
+        Self::validate_provider_selection(&self.providers, opts.only.as_deref(), &opts.skip)?;
 
         let is_selected = |provider: &dyn DepsProvider| {
             (!opts.auto_only || provider.is_auto())
@@ -568,6 +614,7 @@ impl DepsEngine {
         let mut candidates: Vec<(DepsJob, String)> = vec![];
         // Track IDs of providers that are fresh/skipped (treated as already satisfied for deps)
         let mut satisfied_ids: HashSet<String> = HashSet::new();
+        let mut providers: Vec<Box<dyn DepsProvider>> = vec![];
 
         for provider in &self.providers {
             let id = provider.id().to_string();
@@ -602,14 +649,16 @@ impl DepsEngine {
                 continue;
             }
 
+            let provider = provider.rendered(&opts.env)?;
+            let cmd = provider.install_command()?;
+            let command_hash = cmd.freshness_hash();
             let freshness = if opts.force {
                 FreshnessResult::Forced
             } else {
-                self.check_freshness(provider.as_ref())?
+                self.check_freshness(provider.as_ref(), &command_hash)?
             };
 
             if !freshness.is_fresh() {
-                let cmd = provider.install_command()?;
                 // Carry both required and optional outputs so session-staleness
                 // can be cleared on whichever paths actually exist after the run.
                 let outputs: Vec<PathBuf> = provider
@@ -625,6 +674,7 @@ impl DepsEngine {
                     DepsJob {
                         id,
                         cmd,
+                        command_hash,
                         outputs,
                         depends,
                         timeout,
@@ -636,6 +686,7 @@ impl DepsEngine {
                 results.push(DepsStepResult::Fresh(id.clone()));
                 satisfied_ids.insert(id);
             }
+            providers.push(provider);
         }
 
         let mut inactive_blocked_ids: HashSet<String> = inactive_ids.keys().cloned().collect();
@@ -687,7 +738,7 @@ impl DepsEngine {
             // commands after execution could observe a concurrently changed config.
             let command_hashes: HashMap<String, String> = to_run
                 .iter()
-                .map(|job| (job.id.clone(), job.cmd.freshness_hash()))
+                .map(|job| (job.id.clone(), job.command_hash.clone()))
                 .collect();
             let has_deps = to_run.iter().any(|j| !j.depends.is_empty());
 
@@ -716,7 +767,7 @@ impl DepsEngine {
             // successfully ran provider.
             for step in &results {
                 if let DepsStepResult::Ran(id) = step
-                    && let Some(provider) = self.providers.iter().find(|p| p.id() == id)
+                    && let Some(provider) = providers.iter().find(|p| p.id() == id)
                 {
                     let project_root = &provider.base().project_root;
                     let sources = provider.sources();
@@ -995,7 +1046,11 @@ impl DepsEngine {
     ///
     /// Uses blake3 content hashing with persistent state. On first run (no
     /// stored hashes), the provider is always considered stale.
-    pub fn check_freshness(&self, provider: &dyn DepsProvider) -> Result<FreshnessResult> {
+    pub fn check_freshness(
+        &self,
+        provider: &dyn DepsProvider,
+        command_hash: &str,
+    ) -> Result<FreshnessResult> {
         if let DepsProviderApplicability::Inactive(reason) = provider.applicability() {
             return Err(eyre::eyre!(
                 "deps provider '{}' is inactive: {reason}",
@@ -1055,7 +1110,6 @@ impl DepsEngine {
             return Ok(FreshnessResult::NoSources);
         }
 
-        let command_hash = provider.install_command()?.freshness_hash();
         match st.get_command_hash(provider_id) {
             Some(stored_hash) if stored_hash != command_hash => {
                 return Ok(FreshnessResult::Stale(
@@ -1141,33 +1195,11 @@ impl DepsEngine {
             runner = runner.env(k, v);
         }
 
-        // Apply command-specific environment (can override toolset env)
-        // Render tera templates in env values (e.g., "{{env.baz}}")
-        let has_template_env = cmd.env.values().any(|v| contains_template_syntax(v));
-        let mut tera_state = if has_template_env {
-            let mut tera_ctx = BASE_CONTEXT.clone();
-            // Merge toolset env (which includes [env] directives) into tera context
-            // so templates like "{{env.MY_VAR}}" can resolve config-defined vars
-            let mut env_map = crate::env::PRISTINE_ENV.clone();
-            env_map.extend(toolset_env.iter().map(|(k, v)| (k.clone(), v.clone())));
-            tera_ctx.insert("env", &env_map);
-            Some((get_tera(cmd.cwd.as_deref()), tera_ctx))
-        } else {
-            None
-        };
+        // Apply command-specific environment (can override toolset env).
+        // Config-file templates have already been rendered with that file's
+        // config_root and environment context during provider discovery.
         for (k, v) in &cmd.env {
-            let rendered = if contains_template_syntax(v) {
-                let (tera, tera_ctx) = tera_state
-                    .as_mut()
-                    .expect("tera state should exist for template env values");
-                render_str(tera, v, tera_ctx).unwrap_or_else(|e| {
-                    warn!("failed to render template for deps env {k}: {e}");
-                    v.clone()
-                })
-            } else {
-                v.clone()
-            };
-            runner = runner.env(k, &rendered);
+            runner = runner.env(k, v);
         }
 
         // Use raw output for better UX during dependency installation

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -11,6 +11,7 @@ use crate::file::display_filename;
 
 pub use engine::{DepsEngine, DepsOptions, DepsStepResult};
 pub use rule::DepsConfig;
+pub(crate) use rule::DepsTemplateContext;
 
 pub(crate) mod deps_ordering;
 mod engine;
@@ -196,6 +197,15 @@ pub trait DepsProvider: Debug + Send + Sync {
     /// Access the shared base (project root + config)
     fn base(&self) -> &providers::ProviderBase;
 
+    /// Rebuild this provider after rendering all config fields against the
+    /// effective environment available at execution time.
+    fn rendered(&self, effective_env: &BTreeMap<String, String>) -> Result<Box<dyn DepsProvider>> {
+        let base = self.base();
+        let config = base.config.rendered(effective_env)?;
+        crate::deps::DepsEngine::build_provider(&base.id, &base.project_root, config)
+            .ok_or_else(|| eyre::eyre!("unknown deps provider '{}'", base.id))
+    }
+
     /// Unique identifier for this provider (e.g., "npm", "cargo", "codegen")
     fn id(&self) -> &str {
         &self.base().id
@@ -229,6 +239,13 @@ pub trait DepsProvider: Debug + Send + Sync {
 
     /// The command to run when outputs are stale relative to sources
     fn install_command(&self) -> Result<DepsCommand>;
+
+    fn install_command_with_env(
+        &self,
+        effective_env: &BTreeMap<String, String>,
+    ) -> Result<DepsCommand> {
+        self.rendered(effective_env)?.install_command()
+    }
 
     /// Whether this provider is applicable, with an actionable reason if not.
     fn applicability(&self) -> DepsProviderApplicability;
@@ -271,7 +288,7 @@ pub trait DepsProvider: Debug + Send + Sync {
 }
 
 /// Warn if any auto-enabled deps providers are stale
-pub fn notify_if_stale(config: &Arc<Config>) {
+pub fn notify_if_stale(config: &Arc<Config>, effective_env: &BTreeMap<String, String>) {
     // Skip in shims or quiet mode
     if *env::__MISE_SHIM || Settings::get().quiet {
         return;
@@ -286,7 +303,7 @@ pub fn notify_if_stale(config: &Arc<Config>) {
         return;
     };
 
-    let stale = engine.check_staleness();
+    let stale = engine.check_staleness(effective_env);
     if !stale.is_empty() {
         let providers: Vec<String> = stale
             .iter()
@@ -422,20 +439,23 @@ pub fn create_provider(
     project_root: &Path,
     config: Option<&crate::config::Config>,
 ) -> Result<Box<dyn DepsProvider>> {
-    let (provider_root, provider_config) = config
-        .and_then(|c| {
-            c.config_files.values().find_map(|cf| {
-                cf.deps_config()
-                    .and_then(|dc| dc.providers.get(ecosystem).cloned())
-                    .map(|provider_config| (cf.config_root(), provider_config))
-            })
-        })
-        .unwrap_or_else(|| {
-            (
-                project_root.to_path_buf(),
-                rule::DepsProviderConfig::default(),
-            )
-        });
+    let mut configured = None;
+    if let Some(config) = config {
+        for cf in config.config_files.values() {
+            if let Some(deps_config) = cf.deps_config()?
+                && let Some(provider_config) = deps_config.providers.get(ecosystem)
+            {
+                configured = Some((cf.config_root(), provider_config.clone()));
+                break;
+            }
+        }
+    }
+    let (provider_root, provider_config) = configured.unwrap_or_else(|| {
+        (
+            project_root.to_path_buf(),
+            rule::DepsProviderConfig::default(),
+        )
+    });
 
     DepsEngine::build_provider(ecosystem, &provider_root, provider_config)
         .ok_or_else(|| eyre::eyre!("unknown deps provider '{ecosystem}'"))

--- a/src/deps/rule.rs
+++ b/src/deps/rule.rs
@@ -1,6 +1,21 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
+use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
+use tera::Context as TeraContext;
+
+use crate::config::Settings;
+use crate::config::env_directive::shell_expand_env;
+use crate::file::display_path;
+use crate::tera::{contains_template_syntax, get_tera, render_str};
+
+#[derive(Debug, Clone)]
+pub(crate) struct DepsTemplateContext {
+    pub(crate) config_path: PathBuf,
+    pub(crate) provider_id: String,
+    pub(crate) context: TeraContext,
+}
 
 /// List of built-in provider names that have specialized implementations
 pub const BUILTIN_PROVIDERS: &[&str] = &[
@@ -51,6 +66,165 @@ pub struct DepsProviderConfig {
     pub depends: Vec<String>,
     /// Timeout for the run command (e.g., "30s", "5m", "1h")
     pub timeout: Option<String>,
+    /// Context retained for rendering env values after the toolset environment is known.
+    #[serde(skip)]
+    pub(crate) template_context: Option<DepsTemplateContext>,
+}
+
+impl DepsProviderConfig {
+    pub(crate) fn rendered(&self, effective_env: &BTreeMap<String, String>) -> Result<Self> {
+        let Some(template) = &self.template_context else {
+            return Ok(self.clone());
+        };
+        let mut rendered = self.clone();
+        let mut context = template.context.clone();
+        let mut env_vars: BTreeMap<String, String> = context
+            .get("env")
+            .and_then(|value| Deserialize::deserialize(value.clone()).ok())
+            .unwrap_or_default();
+        env_vars.extend(effective_env.clone());
+        context.insert("env", &env_vars);
+
+        rendered.render_strings(|field, input, shell_expand| {
+            let mut output = render_template_field(template, field, input, &context)?;
+            if shell_expand && output.contains('$') && Settings::get().env_shell_expand {
+                output = expand_shell_vars(&output, &env_vars);
+            }
+            Ok(output)
+        })?;
+        rendered.env = self.render_env(effective_env)?;
+        Ok(rendered)
+    }
+
+    pub(crate) fn validate_template_syntax(&self) -> Result<()> {
+        let Some(template) = &self.template_context else {
+            return Ok(());
+        };
+        let validate = |field: &str, input: &str| -> Result<()> {
+            if contains_template_syntax(input) {
+                let mut tera = get_tera(template.config_path.parent());
+                tera.validate_template_syntax("__deps_validation", input)
+                    .wrap_err_with(|| template_error_context(template, field))?;
+            }
+            Ok(())
+        };
+        if let Some(run) = &self.run {
+            validate("run", run)?;
+        }
+        for (index, source) in self.sources.iter().enumerate() {
+            validate(&format!("sources[{index}]"), source)?;
+        }
+        for (index, output) in self.outputs.iter().enumerate() {
+            validate(&format!("outputs[{index}]"), output)?;
+        }
+        for (key, value) in &self.env {
+            validate(&format!("env.{key}"), value)?;
+        }
+        if let Some(dir) = &self.dir {
+            validate("dir", dir)?;
+        }
+        if let Some(description) = &self.description {
+            validate("description", description)?;
+        }
+        for (index, dependency) in self.depends.iter().enumerate() {
+            validate(&format!("depends[{index}]"), dependency)?;
+        }
+        if let Some(timeout) = &self.timeout {
+            validate("timeout", timeout)?;
+        }
+        Ok(())
+    }
+
+    pub fn render_strings(
+        &mut self,
+        mut render: impl FnMut(&str, &str, bool) -> Result<String>,
+    ) -> Result<()> {
+        if let Some(run) = &mut self.run {
+            *run = render("run", run, false)?;
+        }
+        for (index, source) in self.sources.iter_mut().enumerate() {
+            *source = render(&format!("sources[{index}]"), source, true)?;
+        }
+        for (index, output) in self.outputs.iter_mut().enumerate() {
+            *output = render(&format!("outputs[{index}]"), output, true)?;
+        }
+        if let Some(dir) = &mut self.dir {
+            *dir = render("dir", dir, true)?;
+        }
+        if let Some(description) = &mut self.description {
+            *description = render("description", description, true)?;
+        }
+        for (index, dependency) in self.depends.iter_mut().enumerate() {
+            *dependency = render(&format!("depends[{index}]"), dependency, true)?;
+        }
+        if let Some(timeout) = &mut self.timeout {
+            *timeout = render("timeout", timeout, true)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn render_env(
+        &self,
+        effective_env: &BTreeMap<String, String>,
+    ) -> Result<BTreeMap<String, String>> {
+        let Some(template) = &self.template_context else {
+            return Ok(self.env.clone());
+        };
+        let mut context = template.context.clone();
+        let mut env_vars: BTreeMap<String, String> = context
+            .get("env")
+            .and_then(|value| Deserialize::deserialize(value.clone()).ok())
+            .unwrap_or_default();
+        env_vars.extend(effective_env.clone());
+        context.insert("env", &env_vars);
+
+        self.env
+            .iter()
+            .map(|(key, input)| {
+                let field = format!("env.{key}");
+                let mut output = render_template_field(template, &field, input, &context)?;
+                if output.contains('$') && Settings::get().env_shell_expand {
+                    output = expand_shell_vars(&output, &env_vars);
+                }
+                Ok((key.clone(), output))
+            })
+            .collect()
+    }
+}
+
+fn render_template_field(
+    template: &DepsTemplateContext,
+    field: &str,
+    input: &str,
+    context: &TeraContext,
+) -> Result<String> {
+    if !contains_template_syntax(input) {
+        return Ok(input.to_string());
+    }
+    let mut tera = get_tera(template.config_path.parent());
+    render_str(&mut tera, input, context).wrap_err_with(|| template_error_context(template, field))
+}
+
+fn template_error_context(template: &DepsTemplateContext, field: &str) -> String {
+    format!(
+        "failed to render deps provider {:?} field {:?} in {}",
+        template.provider_id,
+        field,
+        display_path(&template.config_path)
+    )
+}
+
+fn expand_shell_vars(input: &str, env_vars: &BTreeMap<String, String>) -> String {
+    let mut missing_vars = Vec::new();
+    let output = shell_expand_env(input, env_vars, &mut missing_vars);
+    for var in missing_vars {
+        warn_once!(
+            "env var '{var}' is not defined and will be left unexpanded. \
+             Use ${{{var}:-}} to default to an empty string and suppress \
+             this warning."
+        );
+    }
+    output
 }
 
 /// Top-level [deps] configuration section
@@ -66,4 +240,110 @@ pub struct DepsConfig {
     /// All provider configurations (both built-in and custom)
     #[serde(flatten)]
     pub providers: BTreeMap<String, DepsProviderConfig>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_strings_covers_all_provider_values() {
+        let mut context = TeraContext::new();
+        context.insert("env", &BTreeMap::<String, String>::new());
+        let mut config = DepsProviderConfig {
+            run: Some("run".into()),
+            sources: vec!["source".into()],
+            outputs: vec!["output".into()],
+            env: BTreeMap::from([("KEY".into(), "{{ env.EFFECTIVE }}".into())]),
+            dir: Some("dir".into()),
+            description: Some("description".into()),
+            depends: vec!["dependency".into()],
+            timeout: Some("timeout".into()),
+            template_context: Some(DepsTemplateContext {
+                config_path: PathBuf::from("mise.toml"),
+                provider_id: "test".into(),
+                context,
+            }),
+            ..Default::default()
+        };
+        let mut fields = Vec::new();
+
+        config
+            .render_strings(|field, value, shell_expand| {
+                fields.push((field.to_string(), shell_expand));
+                Ok(format!("rendered-{value}"))
+            })
+            .unwrap();
+
+        assert_eq!(config.run.as_deref(), Some("rendered-run"));
+        assert_eq!(config.sources, ["rendered-source"]);
+        assert_eq!(config.outputs, ["rendered-output"]);
+        assert_eq!(config.env["KEY"], "{{ env.EFFECTIVE }}");
+        assert_eq!(
+            config
+                .render_env(&BTreeMap::from([(
+                    "EFFECTIVE".into(),
+                    "effective-value".into()
+                )]))
+                .unwrap()["KEY"],
+            "effective-value"
+        );
+        assert_eq!(config.dir.as_deref(), Some("rendered-dir"));
+        assert_eq!(config.description.as_deref(), Some("rendered-description"));
+        assert_eq!(config.depends, ["rendered-dependency"]);
+        assert_eq!(config.timeout.as_deref(), Some("rendered-timeout"));
+        assert_eq!(
+            fields,
+            [
+                ("run".into(), false),
+                ("sources[0]".into(), true),
+                ("outputs[0]".into(), true),
+                ("dir".into(), true),
+                ("description".into(), true),
+                ("depends[0]".into(), true),
+                ("timeout".into(), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_rendered_uses_effective_env_for_all_provider_values() {
+        let mut context = TeraContext::new();
+        context.insert("env", &BTreeMap::<String, String>::new());
+        let config = DepsProviderConfig {
+            run: Some("echo {{ env.EFFECTIVE }}".into()),
+            sources: vec!["{{ env.EFFECTIVE }}/source".into()],
+            outputs: vec!["{{ env.EFFECTIVE }}/output".into()],
+            env: BTreeMap::from([("KEY".into(), "{{ env.EFFECTIVE }}".into())]),
+            dir: Some("{{ env.EFFECTIVE }}".into()),
+            description: Some("{{ env.EFFECTIVE }} description".into()),
+            depends: vec!["{{ env.EFFECTIVE }}".into()],
+            timeout: Some("{{ env.TIMEOUT }}s".into()),
+            template_context: Some(DepsTemplateContext {
+                config_path: PathBuf::from("mise.toml"),
+                provider_id: "test".into(),
+                context,
+            }),
+            ..Default::default()
+        };
+
+        let rendered = config
+            .rendered(&BTreeMap::from([
+                ("EFFECTIVE".into(), "effective".into()),
+                ("TIMEOUT".into(), "5".into()),
+            ]))
+            .unwrap();
+
+        assert_eq!(rendered.run.as_deref(), Some("echo effective"));
+        assert_eq!(rendered.sources, ["effective/source"]);
+        assert_eq!(rendered.outputs, ["effective/output"]);
+        assert_eq!(rendered.env["KEY"], "effective");
+        assert_eq!(rendered.dir.as_deref(), Some("effective"));
+        assert_eq!(
+            rendered.description.as_deref(),
+            Some("effective description")
+        );
+        assert_eq!(rendered.depends, ["effective"]);
+        assert_eq!(rendered.timeout.as_deref(), Some("5s"));
+    }
 }

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -364,7 +364,7 @@ impl Toolset {
             .collect();
 
         env.extend(config.env().await?.clone());
-        if let Some(venv) = uv::uv_venv(config, self).await {
+        if let Some(venv) = uv::uv_venv(config, self).await? {
             for (k, v) in venv.env.clone() {
                 env.insert(k, v);
             }

--- a/src/toolset/toolset_paths.rs
+++ b/src/toolset/toolset_paths.rs
@@ -76,7 +76,7 @@ impl Toolset {
         paths.extend(config.path_dirs().await?.clone());
 
         // 3. UV venv path (if any) - ensure project venv takes precedence over tool and tool_add_paths
-        if let Some(venv) = uv::uv_venv(config, self).await {
+        if let Some(venv) = uv::uv_venv(config, self).await? {
             paths.push(venv.venv_path.clone());
         }
 
@@ -111,7 +111,7 @@ impl Toolset {
         let mut tool_paths = Vec::new();
 
         // UV venv path (if any) - these are tool-managed paths
-        if let Some(venv) = uv::uv_venv(config, self).await {
+        if let Some(venv) = uv::uv_venv(config, self).await? {
             tool_paths.push(venv.venv_path.clone());
         }
 

--- a/src/uv.rs
+++ b/src/uv.rs
@@ -5,6 +5,7 @@ use crate::env_diff::EnvMap;
 use crate::file::display_path;
 use crate::toolset::Toolset;
 use crate::{dirs, env, file};
+use eyre::Result;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock as Lazy;
 use std::{collections::HashMap, sync::Arc};
@@ -15,15 +16,17 @@ use tokio::sync::OnceCell;
 static UV_VENV: Lazy<OnceCell<Option<Venv>>> = Lazy::new(Default::default);
 const UV_PROJECT_ENVIRONMENT: &str = "UV_PROJECT_ENVIRONMENT";
 
-pub async fn uv_venv(config: &Arc<Config>, ts: &Toolset) -> &'static Option<Venv> {
+pub async fn uv_venv(config: &Arc<Config>, ts: &Toolset) -> Result<&'static Option<Venv>> {
     UV_VENV
-        .get_or_init(async || {
+        .get_or_try_init(async || {
             let settings = Settings::get();
             let uv_auto = settings.python.uv_venv_auto;
             if !uv_auto.should_source() {
-                return None;
+                return Ok(None);
             }
-            let uv_root = uv_root()?;
+            let Some(uv_root) = uv_root() else {
+                return Ok(None);
+            };
             let venv_path = uv_venv_path(config, &uv_root);
             if !venv_path.exists() {
                 if uv_auto.should_create() {
@@ -39,18 +42,18 @@ pub async fn uv_venv(config: &Arc<Config>, ts: &Toolset) -> &'static Option<Venv
                     )
                     .await
                     {
-                        Ok(true) => {}            // venv created successfully, fall through to load it
-                        Ok(false) => return None, // uv not available, venv not created
+                        Ok(true) => {}                // venv created successfully, fall through to load it
+                        Ok(false) => return Ok(None), // uv not available, venv not created
                         Err(err) => {
                             warn_once!(
                                 "uv venv creation failed at: {p}\n\n{err}",
                                 p = display_path(&venv_path)
                             );
-                            return None;
+                            return Ok(None);
                         }
                     }
                 } else {
-                    if !deps_uv_enabled(config, &uv_root) {
+                    if !deps_uv_enabled(config, &uv_root)? {
                         warn_once!(
                             "uv venv not found at: {p}\n\n\
                             To create it, run a `uv` command like `uv sync` or `uv venv`. \
@@ -58,7 +61,7 @@ pub async fn uv_venv(config: &Arc<Config>, ts: &Toolset) -> &'static Option<Venv
                             p = display_path(&venv_path)
                         );
                     }
-                    return None;
+                    return Ok(None);
                 }
             }
 
@@ -70,7 +73,7 @@ pub async fn uv_venv(config: &Arc<Config>, ts: &Toolset) -> &'static Option<Venv
             {
                 extra_env.insert("UV_PYTHON".to_string(), tv.version.to_string());
             }
-            Some(load_venv(&venv_path, extra_env))
+            Ok(Some(load_venv(&venv_path, extra_env)))
         })
         .await
 }
@@ -111,14 +114,19 @@ fn resolve_uv_venv_path(uv_root: &Path, project_environment: Option<&str>) -> Pa
     }
 }
 
-fn deps_uv_enabled(config: &Config, uv_root: &Path) -> bool {
-    config.config_files.values().any(|cf| {
+fn deps_uv_enabled(config: &Config, uv_root: &Path) -> Result<bool> {
+    for cf in config.config_files.values() {
         if cf.config_root() != uv_root {
-            return false;
+            continue;
         }
-        cf.deps_config()
+        if cf
+            .deps_config()?
             .is_some_and(|deps| deps.providers.contains_key("uv"))
-    })
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- render Tera templates in deps provider fields using the defining config file's context
- defer provider `env` rendering until the effective layered and toolset environment is available
- expand shell-style environment references after Tera rendering while preserving `$VAR` expressions in `run` for the provider shell
- propagate template failures as contextual configuration errors instead of warnings or unrelated UV-venv diagnostics
- include rendered provider env values in freshness identity across execution, `--explain`, and hook-env status

## Cause

Deps provider values were kept raw until execution, where only `env` values received a best-effort Tera pass. That late path did not provide the defining file's `config_root`, ignored rendering failures with a warning, and left freshness inputs such as `sources`, `outputs`, and `dir` inconsistent with the command environment.

Most provider configuration is now rendered while it is read from each config file. Provider `env` values retain that file's template context and are rendered once the effective layered and toolset environment is known, preserving configurations that depend on `tools = true` values. Execution, `--explain`, and hook-env status use the same rendered environment when computing command freshness, so changing an effective provider env value invalidates the previous output. Provider IDs, environment-variable names, and disabled-provider IDs remain literal. Tera errors include the provider, field, and config path. Shell-style expansion follows the existing `env_shell_expand` behavior, except in `run`, where shell variables remain available to the provider's runtime environment.

UV virtual-environment discovery now propagates deps configuration failures rather than converting them into a misleading missing-venv warning.

## Verification

- `mise exec -- cargo test --all-features config::config_file::mise_toml::tests::test_deps_config -- --nocapture`
- `mise run test:e2e e2e/cli/test_deps_templates` (including layered env, `tools = true`, env-change invalidation, disabled shell expansion, and UV error propagation)
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`

`mise run format` cannot start its hk task in this Sapling working copy because hk reports `failed to find git repository`; the applicable Rustfmt and Clippy checks above pass.

Addresses https://github.com/jdx/mise/discussions/8765

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tera template rendering for dependency provider paths, commands, environment values, descriptions, and timeouts.
  * Added optional shell-style environment-variable expansion with explicit default values.
  * Added monorepo- and `config_root`-aware rendering, including effective tool environment access.
  * Dependency freshness checks now account for the associated command.

* **Bug Fixes**
  * Invalid templates now produce configuration errors before commands run.
  * Undefined shell variables remain unchanged with warnings.
  * Dependency and virtual-environment configuration errors are now surfaced instead of silently ignored.

* **Documentation**
  * Documented dependency templates and shell environment-variable expansion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
