### PR TITLE
docs(task): fix boolean flag usage examples

### DIFF
--- a/docs/tasks/task-arguments.md
+++ b/docs/tasks/task-arguments.md
@@ -25,7 +25,7 @@ flag "--region <region>" help="AWS region" default="us-east-1" env="AWS_REGION"
 
 run = '''
 echo "Deploying to ${usage_environment?} in ${usage_region?}"
-[[ "${usage_verbose?}" == "true" ]] && set -x
+[[ "${usage_verbose:-false}" == "true" ]] && set -x
 ./deploy.sh "${usage_environment?}" "${usage_region?}"
 '''
 ```
@@ -659,7 +659,7 @@ flag "-v --verbose"
 '''
 run = [
   'cargo build ${usage_target?}',
-  './package.sh ${usage_verbose?}'
+  './package.sh ${usage_verbose:-false}'
 ]
 ```
 
@@ -699,7 +699,7 @@ flag "--env <env>" {
 }
 flag "--force"
 '''
-run = 'deploy --env ${usage_env?} ${usage_force?}'
+run = 'deploy --env ${usage_env?} ${usage_force:+--force}'
 ```
 
 </div>


### PR DESCRIPTION
## Summary

- use a safe `false` fallback when documentation examples read optional boolean usage flags
- use conditional parameter expansion when an enabled boolean should forward a CLI flag
- keep the documented `flag "-f --fast"` syntax unchanged because both aliases work on current main

## Context

The short-form parsing failure reported in the discussion is no longer reproducible: `-f` and `--fast` both set the same usage value, and existing E2E coverage exercises short aliases. However, several examples still used `${usage_flag?}` for boolean flags without defaults. Those variables are intentionally unset when omitted, so the examples contradicted the page's later recommendation and could fail under normal optional usage.

The examples now use `${usage_flag:-false}` when consuming a boolean value and `${usage_flag:+--flag}` when conditionally forwarding a command-line option. This is a documentation-only change; the usage syntax, help rendering, and parser behavior are unchanged.

## Verification

- manually verified an omitted flag, `-f`, and `--fast` produce `false`, `true`, and `true` with the corrected example
- manually verified `${usage_force:+--force}` emits the option only when enabled
- `mise run test:e2e e2e/tasks/test_task_usage_env_toml e2e/tasks/test_task_usage_env`
- `mise exec -- prettier --check docs/tasks/task-arguments.md`
- `mise exec -- markdownlint docs/tasks/task-arguments.md`
- `mise run docs:build`

Addresses https://github.com/jdx/mise/discussions/6911

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated task argument examples to handle optional boolean flags safely.
  * Added clearer defaults for verbose and force options when values are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->