### PR TITLE
docs(env): clarify _.source PATH handling

### DIFF
--- a/docs/environments/index.md
+++ b/docs/environments/index.md
@@ -496,6 +496,19 @@ The `env._.source` directive supports:
 - Using relative or absolute paths
 - The `redact` and `tools` options
 
+For `PATH`, sourced scripts may prepend entries by preserving the original value as an exact
+suffix:
+
+```sh
+export PATH="/new/bin:$PATH"
+```
+
+Appending, removing, reordering, or replacing existing `PATH` entries is not supported. Those
+changes are ignored because mise tracks path additions separately so it can preserve activation
+ordering and remove them cleanly when the environment changes. Relative prepended entries are
+resolved against <span v-pre>`{{config_root}}`</span>, and empty entries are ignored rather than
+adding the current directory to `PATH`.
+
 ```toml
 [env]
 _.source = 'source.sh'

--- a/e2e/env/test_env_source
+++ b/e2e/env/test_env_source
@@ -27,6 +27,15 @@ EOF
 path_output=$(mise env -s bash | grep PATH)
 assert_not_contains "$path_output" "$MISE_CONFIG_DIR"
 
+# PATH changes other than prepends are intentionally unsupported. Appending must not be
+# misinterpreted as a prepend or leak into the activated environment.
+cat >"$MISE_CONFIG_DIR/source.sh" <<EOF
+export PATH="\$PATH:/unsupported-append-test-dir"
+EOF
+
+path_output=$(mise env -s bash | grep PATH)
+assert_not_contains "$path_output" "/unsupported-append-test-dir"
+
 # Env vars exported by `_.source` are visible to a later `_.path` template.
 # Directives inside `[env]._` now resolve in the order they are written, so
 # `_.source` (written first) runs before `_.path`. Regression test for

--- a/e2e/env/test_env_source
+++ b/e2e/env/test_env_source
@@ -24,8 +24,7 @@ cat >"$MISE_CONFIG_DIR/source.sh" <<EOF
 export PATH="/custom-test-dir:\$PATH"
 EOF
 
-path_output=$(mise env -s bash | grep PATH)
-assert_not_contains "$path_output" "$MISE_CONFIG_DIR"
+assert_not_contains "mise env -s bash | grep PATH" "$MISE_CONFIG_DIR"
 
 # PATH changes other than prepends are intentionally unsupported. Appending must not be
 # misinterpreted as a prepend or leak into the activated environment.
@@ -33,8 +32,7 @@ cat >"$MISE_CONFIG_DIR/source.sh" <<EOF
 export PATH="\$PATH:/unsupported-append-test-dir"
 EOF
 
-path_output=$(mise env -s bash | grep PATH)
-assert_not_contains "$path_output" "/unsupported-append-test-dir"
+assert_not_contains "mise env -s bash | grep PATH" "/unsupported-append-test-dir"
 
 # Env vars exported by `_.source` are visible to a later `_.path` template.
 # Directives inside `[env]._` now resolve in the order they are written, so

--- a/src/config/env_directive/source.rs
+++ b/src/config/env_directive/source.rs
@@ -37,7 +37,10 @@ impl EnvResults {
                 match p {
                     EnvDiffOperation::Add(k, v) | EnvDiffOperation::Change(k, v) => {
                         if k == *env::PATH_KEY {
-                            // TODO: perhaps deal with path removals as well
+                            // `_.source` intentionally supports PATH prepends only. Preserving the
+                            // original PATH as an exact suffix lets mise represent the additions in
+                            // env_paths, where activation ordering and cleanup are managed. General
+                            // PATH edits cannot be reproduced safely by that model.
                             if let Some(new_path) = v.strip_suffix(&orig_path) {
                                 for p in env::split_paths(new_path) {
                                     if p.as_os_str().is_empty() {


### PR DESCRIPTION
## Summary

- document that `env._.source` supports PATH prepends only
- explain why appends, removals, reordering, replacements, and empty entries are ignored
- add e2e coverage that an appended PATH entry is not applied
- replace the stale PATH-removal TODO with the intended prepend-only contract

## Why

mise tracks PATH additions separately so activation order and cleanup remain deterministic. Supporting arbitrary PATH transformations from a sourced shell would not fit that model reliably.

Closes the design question raised in https://github.com/jdx/mise/discussions/8931.

## Validation

- `mise run test:e2e e2e/env/test_env_source`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, tests, and comment-only code changes; PATH handling behavior is unchanged.
> 
> **Overview**
> **Documents and locks in the `env._.source` PATH contract:** only prepends of the form `export PATH="/new/bin:$PATH"` are honored; appends, removals, reordering, replacements, and empty segments are ignored because mise records additions via `env_paths` for activation order and teardown.
> 
> Adds user-facing docs (prepend example, `config_root` resolution for relative entries, empty-entry behavior) and an e2e check that `PATH="$PATH:/dir"` does not appear in `mise env` output. Replaces the old “PATH removals” TODO in `source.rs` with comments stating the prepend-only design—**no change to runtime logic** beyond that clarification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2adb55960c924773b4b3886bd0d7ff869c8ccd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that sourced environment scripts support only prepending entries to `PATH`, preserving the original `PATH` as an exact suffix.
  * Documented that relative entries resolve from the configuration root and empty entries are ignored.
  * Clarified that other `PATH` changes, including appended entries, are disregarded.

* **Tests**
  * Added regression coverage confirming unsupported appended entries and configuration-directory paths do not carry into activated environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->