### PR TITLE
fix(deps): honor source and output overrides

### DIFF
--- a/docs/dev-tools/deps.md
+++ b/docs/dev-tools/deps.md
@@ -165,6 +165,23 @@ run = "npx prisma generate"
 | `depends`     | string[] | Other provider names that must complete before this one runs              |
 | `timeout`     | string   | Timeout for the run command, e.g., `"30s"`, `"5m"` (default: no timeout)  |
 
+Built-in providers use their documented sources and outputs when these options are
+omitted. Setting `sources` or `outputs` replaces that provider's defaults rather
+than adding to them. An empty array, such as `outputs = []`, explicitly disables
+that kind of path tracking; it also disables any optional outputs supplied by the
+built-in provider.
+
+Relative paths and glob patterns are resolved from the provider's config root after
+applying `dir`. Absolute paths are used as written. For example, a pnpm workspace
+that keeps installed packages below an application directory can override the
+root-level defaults:
+
+```toml
+[deps.pnpm]
+sources = ["pnpm-lock.yaml", "packages/app/package.json"]
+outputs = ["packages/app/node_modules"]
+```
+
 ### Templates and Environment Variables
 
 String values in provider configuration support Tera templates such as

--- a/e2e/cli/test_deps_builtin_path_overrides
+++ b/e2e/cli/test_deps_builtin_path_overrides
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Built-in providers use explicitly configured paths instead of their defaults.
+mkdir -p pnpm-project/inputs pnpm-project/packages/app
+cat >pnpm-project/pnpm-lock.yaml <<'EOF'
+lockfileVersion: '9.0'
+EOF
+echo initial >pnpm-project/inputs/app.lock
+cat >pnpm-project/mise.toml <<'EOF'
+[deps.pnpm]
+sources = ["inputs/*.lock"]
+outputs = ["packages/app/node_modules/*"]
+run = "mkdir -p packages/app/node_modules; touch packages/app/node_modules/installed-marker packages/app/node_modules/extra-marker; echo run >> .runs"
+EOF
+
+assert_contains "cd pnpm-project && mise deps --list" "inputs/app.lock"
+assert_contains "cd pnpm-project && mise deps --list" "packages/app/node_modules/*"
+assert_not_contains "cd pnpm-project && mise deps --list" "$PWD/pnpm-project/node_modules"
+
+assert "cd pnpm-project && mise deps --only pnpm"
+assert "awk 'END { print NR }' pnpm-project/.runs" "1"
+assert "cd pnpm-project && mise deps --only pnpm"
+assert "awk 'END { print NR }' pnpm-project/.runs" "1"
+
+rm pnpm-project/packages/app/node_modules/installed-marker
+assert "cd pnpm-project && mise deps --only pnpm"
+assert "awk 'END { print NR }' pnpm-project/.runs" "2"
+
+echo changed >pnpm-project/inputs/app.lock
+assert "cd pnpm-project && mise deps --only pnpm"
+assert "awk 'END { print NR }' pnpm-project/.runs" "3"
+
+rm -rf pnpm-project/packages/app/node_modules
+assert "cd pnpm-project && mise deps --only pnpm"
+assert "awk 'END { print NR }' pnpm-project/.runs" "4"
+
+# An explicit empty output list suppresses a built-in provider's optional outputs.
+mkdir uv-project
+touch uv-project/uv.lock
+cat >uv-project/mise.toml <<'EOF'
+[deps.uv]
+sources = ["uv.lock"]
+outputs = []
+run = "mkdir -p .venv; echo run >> .runs"
+EOF
+
+assert "cd uv-project && mise deps --only uv"
+assert "cd uv-project && mise deps --only uv"
+assert "awk 'END { print NR }' uv-project/.runs" "1"
+rm -rf uv-project/.venv
+assert "cd uv-project && mise deps --only uv"
+assert "awk 'END { print NR }' uv-project/.runs" "1"
+
+# Changing from default output tracking to an explicit empty list ignores paths
+# recorded under the old rules.
+mkdir uv-output-change
+touch uv-output-change/uv.lock
+cat >uv-output-change/mise.toml <<'EOF'
+[deps.uv]
+run = "mkdir -p .venv; echo run >> .runs"
+EOF
+assert "cd uv-output-change && mise deps --only uv"
+assert "awk 'END { print NR }' uv-output-change/.runs" "1"
+rm -rf uv-output-change/.venv
+cat >uv-output-change/mise.toml <<'EOF'
+[deps.uv]
+outputs = []
+run = "mkdir -p .venv; echo run >> .runs"
+EOF
+assert "cd uv-output-change && mise deps --only uv"
+assert "awk 'END { print NR }' uv-output-change/.runs" "1"
+
+# Replacing one explicit output rule with another does not enforce paths
+# recorded under the previous rule.
+mkdir output-replacement
+touch output-replacement/uv.lock
+cat >output-replacement/mise.toml <<'EOF'
+[deps.uv]
+outputs = ["old-output"]
+run = "mkdir -p old-output new-output; echo run >> .runs"
+EOF
+assert "cd output-replacement && mise deps --only uv"
+assert "awk 'END { print NR }' output-replacement/.runs" "1"
+rm -rf output-replacement/old-output
+cat >output-replacement/mise.toml <<'EOF'
+[deps.uv]
+outputs = ["new-output"]
+run = "mkdir -p old-output new-output; echo run >> .runs"
+EOF
+assert "cd output-replacement && mise deps --only uv"
+assert "awk 'END { print NR }' output-replacement/.runs" "1"
+
+# Relative overrides resolve independently for every monorepo config root.
+mkdir -p monorepo/packages/a/inputs
+cat >monorepo/mise.toml <<'EOF'
+monorepo_root = true
+
+[monorepo]
+config_roots = ["packages/*"]
+EOF
+cat >monorepo/packages/a/pnpm-lock.yaml <<'EOF'
+lockfileVersion: '9.0'
+EOF
+echo initial >monorepo/packages/a/inputs/app.lock
+cat >monorepo/packages/a/mise.toml <<'EOF'
+[deps.pnpm]
+sources = ["inputs/*.lock"]
+outputs = ["isolated/node_modules"]
+run = "mkdir -p isolated/node_modules; echo run >> .runs"
+EOF
+
+assert_contains "cd monorepo && mise deps --monorepo --list" "packages/a/inputs/app.lock"
+assert_contains "cd monorepo && mise deps --monorepo --list" "packages/a/isolated/node_modules"
+assert "cd monorepo && mise deps --monorepo --only //packages/a:pnpm"
+assert "test -d monorepo/packages/a/isolated/node_modules"
+assert_fail "test -d monorepo/isolated/node_modules"
+assert "cd monorepo && mise deps --monorepo --only //packages/a:pnpm"
+assert "awk 'END { print NR }' monorepo/packages/a/.runs" "1"

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -4495,8 +4495,11 @@ run = 'echo "template"'
             provider.run.as_deref(),
             Some(format!("echo {config_root} $DEPS_SUFFIX").as_str())
         );
-        assert_eq!(provider.sources, [format!("{config_root}/input-expanded")]);
-        assert_eq!(provider.outputs, ["expanded/output"]);
+        assert_eq!(
+            provider.sources,
+            Some(vec![format!("{config_root}/input-expanded")])
+        );
+        assert_eq!(provider.outputs, Some(vec!["expanded/output".to_string()]));
         assert_eq!(provider.env["ROOT"], config_root);
         assert_eq!(provider.env["SUFFIX"], "expanded");
         assert_eq!(

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -763,8 +763,9 @@ impl DepsEngine {
                 }
             }
 
-            // Save content hashes and existing optional outputs for each
-            // successfully ran provider.
+            // Save content hashes and existing outputs for each successfully
+            // ran provider. Recording the expanded required outputs lets us
+            // detect when only some matches from an output glob are deleted.
             for step in &results {
                 if let DepsStepResult::Ran(id) = step
                     && let Some(provider) = providers.iter().find(|p| p.id() == id)
@@ -773,10 +774,11 @@ impl DepsEngine {
                     let sources = provider.sources();
                     if let Ok(hashes) = state::hash_sources(&sources, project_root) {
                         let seen: Vec<String> = provider
-                            .optional_outputs()
-                            .iter()
-                            .filter(|p| p.exists())
-                            .map(|p| state::relative_str(p, project_root))
+                            .outputs()
+                            .into_iter()
+                            .chain(provider.optional_outputs())
+                            .filter(|output| output.exists())
+                            .map(|output| state::relative_str(&output, project_root))
                             .collect();
                         let mut st = DepsState::load(project_root);
                         let provider_id = provider.base().id.as_str();
@@ -785,6 +787,7 @@ impl DepsEngine {
                         if let Some(command_hash) = command_hashes.get(id) {
                             st.set_command_hash(provider_id, command_hash.clone());
                         }
+                        st.set_output_rules(provider_id, provider.base().output_rules_hash());
                         if let Err(e) = st.save(project_root) {
                             warn!("failed to save deps state: {e}");
                         }
@@ -1083,14 +1086,33 @@ impl DepsEngine {
             }
         }
 
-        // Optional outputs are enforced only for paths that existed at the
-        // last successful run (recorded in state). This catches deletion
-        // (e.g. `rm -rf .venv` after `uv sync`) without forcing a re-run for
-        // providers whose canonical output is intentionally absent.
-        if let Some(seen) = st.get_seen_outputs(provider_id) {
-            for output in &optional_outputs {
-                let rel = state::relative_str(output, project_root);
-                if seen.iter().any(|p| p == &rel) && !output.exists() {
+        // Outputs that existed after the last successful run must continue to
+        // exist. This catches deletion of one match from a required output glob
+        // as well as deletion of an observed optional output (e.g. `.venv`).
+        let output_rules_match = st
+            .get_output_rules(provider_id)
+            .is_some_and(|rules| rules == &provider.base().output_rules_hash());
+        // State written before command hashing is migrated by the command-hash
+        // check below, so only report missing output rules once that state has
+        // already been migrated.
+        if st.get_output_rules(provider_id).is_none()
+            && st.get_command_hash(provider_id).is_some()
+            && st.get_seen_outputs(provider_id).is_some()
+            && (!outputs.is_empty() || !optional_outputs.is_empty())
+        {
+            return Ok(FreshnessResult::Stale(
+                "output tracking state changed".to_string(),
+            ));
+        }
+        if output_rules_match && let Some(seen) = st.get_seen_outputs(provider_id) {
+            for output in seen {
+                let output = PathBuf::from(output);
+                let output = if output.is_absolute() {
+                    output
+                } else {
+                    project_root.join(output)
+                };
+                if !output.exists() {
                     return Ok(FreshnessResult::OutputsMissing);
                 }
             }

--- a/src/deps/providers/aube.rs
+++ b/src/deps/providers/aube.rs
@@ -28,11 +28,13 @@ impl DepsProvider for AubeDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("aube-lock.yaml"), root.join("package.json")]
+        self.base
+            .sources(vec![root.join("aube-lock.yaml"), root.join("package.json")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join("node_modules")]
+        self.base
+            .outputs(vec![self.base.config_root().join("node_modules")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/bun.rs
+++ b/src/deps/providers/bun.rs
@@ -46,11 +46,12 @@ impl DepsProvider for BunDepsProvider {
             sources.push(lockfile);
         }
         sources.push(self.base.config_root().join("package.json"));
-        sources
+        self.base.sources(sources)
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join("node_modules")]
+        self.base
+            .outputs(vec![self.base.config_root().join("node_modules")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/bundler.rs
+++ b/src/deps/providers/bundler.rs
@@ -28,11 +28,12 @@ impl DepsProvider for BundlerDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("Gemfile.lock"), root.join("Gemfile")]
+        self.base
+            .sources(vec![root.join("Gemfile.lock"), root.join("Gemfile")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![]
+        self.base.outputs(vec![])
     }
 
     fn optional_outputs(&self) -> Vec<PathBuf> {
@@ -40,7 +41,8 @@ impl DepsProvider for BundlerDepsProvider {
         // only populates `vendor/bundle` when `--path vendor/bundle` is used.
         // Track it as optional so vendored projects detect deletion of
         // `vendor/bundle`, while non-vendored projects rely on source hashes.
-        vec![self.base.config_root().join("vendor/bundle")]
+        self.base
+            .optional_outputs(vec![self.base.config_root().join("vendor/bundle")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/composer.rs
+++ b/src/deps/providers/composer.rs
@@ -28,11 +28,13 @@ impl DepsProvider for ComposerDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("composer.lock"), root.join("composer.json")]
+        self.base
+            .sources(vec![root.join("composer.lock"), root.join("composer.json")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join("vendor")]
+        self.base
+            .outputs(vec![self.base.config_root().join("vendor")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/custom.rs
+++ b/src/deps/providers/custom.rs
@@ -1,10 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use eyre::Result;
-use glob::glob;
-
 use crate::deps::rule::DepsProviderConfig;
 use crate::deps::{DepsCommand, DepsProvider, DepsProviderApplicability};
+use eyre::Result;
 
 use super::ProviderBase;
 
@@ -20,36 +18,6 @@ impl CustomDepsProvider {
             base: ProviderBase::new(id, project_root, config),
         }
     }
-
-    /// Expand glob patterns in sources/outputs
-    fn expand_globs(&self, patterns: &[String]) -> Vec<PathBuf> {
-        let mut paths = vec![];
-
-        for pattern in patterns {
-            let base_dir = self.base.config_root();
-            let full_pattern = if PathBuf::from(pattern).is_relative() {
-                base_dir.join(pattern)
-            } else {
-                PathBuf::from(pattern)
-            };
-
-            // Check if it's a glob pattern
-            if pattern.contains('*') || pattern.contains('{') || pattern.contains('?') {
-                if let Ok(entries) = glob(full_pattern.to_string_lossy().as_ref()) {
-                    for entry in entries.flatten() {
-                        paths.push(entry);
-                    }
-                }
-            } else if full_pattern.exists() {
-                paths.push(full_pattern);
-            } else {
-                // Include even if doesn't exist (for outputs that may not exist yet)
-                paths.push(full_pattern);
-            }
-        }
-
-        paths
-    }
 }
 
 impl DepsProvider for CustomDepsProvider {
@@ -58,11 +26,11 @@ impl DepsProvider for CustomDepsProvider {
     }
 
     fn sources(&self) -> Vec<PathBuf> {
-        self.expand_globs(&self.base.config.sources)
+        self.base.sources(vec![])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        self.expand_globs(&self.base.config.outputs)
+        self.base.outputs(vec![])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/dart.rs
+++ b/src/deps/providers/dart.rs
@@ -37,7 +37,8 @@ impl DepsProvider for DartDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("pubspec.yaml"), root.join("pubspec.lock")]
+        self.base
+            .sources(vec![root.join("pubspec.yaml"), root.join("pubspec.lock")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
@@ -45,7 +46,7 @@ impl DepsProvider for DartDepsProvider {
         let pub_dir = root.join(".dart_tool/pub");
         let output = workspace_package_config(&pub_dir)
             .unwrap_or_else(|| root.join(".dart_tool/package_config.json"));
-        vec![output]
+        self.base.outputs(vec![output])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/deno.rs
+++ b/src/deps/providers/deno.rs
@@ -28,21 +28,22 @@ impl DepsProvider for DenoDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![
+        self.base.sources(vec![
             root.join("deno.lock"),
             root.join("deno.json"),
             root.join("deno.jsonc"),
             root.join("package.json"),
-        ]
+        ])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![]
+        self.base.outputs(vec![])
     }
 
     fn optional_outputs(&self) -> Vec<PathBuf> {
         // https://docs.deno.com/runtime/fundamentals/node/#node_modules
-        vec![self.base.config_root().join("node_modules")]
+        self.base
+            .optional_outputs(vec![self.base.config_root().join("node_modules")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/git_submodule.rs
+++ b/src/deps/providers/git_submodule.rs
@@ -68,11 +68,12 @@ impl DepsProvider for GitSubmoduleDepsProvider {
     }
 
     fn sources(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join(".gitmodules")]
+        self.base
+            .sources(vec![self.base.config_root().join(".gitmodules")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        self.submodule_paths()
+        self.base.outputs(self.submodule_paths())
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/go.rs
+++ b/src/deps/providers/go.rs
@@ -31,18 +31,20 @@ impl DepsProvider for GoDepsProvider {
         // Both go.mod and go.sum count as sources: go.mod declares the modules,
         // go.sum pins their checksums. A `go mod tidy` that updates only go.sum
         // should still trigger a re-run.
-        vec![root.join("go.mod"), root.join("go.sum")]
+        self.base
+            .sources(vec![root.join("go.mod"), root.join("go.sum")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![]
+        self.base.outputs(vec![])
     }
 
     fn optional_outputs(&self) -> Vec<PathBuf> {
         // Go downloads modules to GOPATH/pkg/mod by default. Track `vendor/` as
         // optional so vendored projects detect deletion without forcing a
         // re-run for non-vendored projects.
-        vec![self.base.config_root().join("vendor")]
+        self.base
+            .optional_outputs(vec![self.base.config_root().join("vendor")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/mod.rs
+++ b/src/deps/providers/mod.rs
@@ -32,7 +32,10 @@ pub use yarn::YarnDepsProvider;
 
 use std::path::{Path, PathBuf};
 
+use glob::glob;
+
 use crate::deps::rule::DepsProviderConfig;
+use crate::task::task_source_checker::expand_glob_braces;
 
 /// Shared base for all deps providers, holding the id, project root, and config.
 /// Provides common implementations for `id` and `is_auto`.
@@ -63,5 +66,273 @@ impl ProviderBase {
             Some(dir) => self.project_root.join(dir),
             None => self.project_root.clone(),
         }
+    }
+
+    pub fn sources(&self, default: Vec<PathBuf>) -> Vec<PathBuf> {
+        self.config
+            .sources
+            .as_deref()
+            .map(|patterns| self.resolve_path_patterns(patterns, false))
+            .unwrap_or(default)
+    }
+
+    pub fn outputs(&self, default: Vec<PathBuf>) -> Vec<PathBuf> {
+        self.config
+            .outputs
+            .as_deref()
+            .map(|patterns| self.resolve_path_patterns(patterns, true))
+            .unwrap_or(default)
+    }
+
+    pub fn optional_outputs(&self, default: Vec<PathBuf>) -> Vec<PathBuf> {
+        if self.config.outputs.is_some() {
+            vec![]
+        } else {
+            default
+        }
+    }
+
+    /// Returns a stable identity for the configured output rules without
+    /// expanding glob matches. This distinguishes omitted defaults, explicit
+    /// replacements, and an explicit empty list while keeping the identity
+    /// unchanged when files matching a glob are added or removed.
+    pub fn output_rules_hash(&self) -> String {
+        let rules = serde_json::to_string(&(&self.config.dir, &self.config.outputs))
+            .expect("deps output rules should serialize");
+        crate::hash::hash_blake3_to_str(&rules)
+    }
+
+    fn resolve_path_patterns(&self, patterns: &[String], require_glob_match: bool) -> Vec<PathBuf> {
+        let mut paths = vec![];
+
+        for pattern in patterns {
+            let expanded = match expand_glob_braces(pattern) {
+                Ok(expanded) => expanded,
+                Err(err) => {
+                    debug!("invalid deps path pattern {pattern:?}: {err}");
+                    vec![pattern.clone()]
+                }
+            };
+            for pattern in expanded {
+                let path = PathBuf::from(&pattern);
+                let full_pattern = if path.is_relative() {
+                    self.config_root().join(&pattern)
+                } else {
+                    path
+                };
+
+                if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
+                    if let Ok(entries) = glob(full_pattern.to_string_lossy().as_ref()) {
+                        let matches: Vec<_> = entries.flatten().collect();
+                        if matches.is_empty() && require_glob_match {
+                            // Preserve an unmatched required output pattern as
+                            // a non-existent path so freshness remains stale
+                            // until the provider produces at least one match.
+                            paths.push(full_pattern);
+                        } else {
+                            paths.extend(matches);
+                        }
+                    } else if require_glob_match {
+                        paths.push(full_pattern);
+                    }
+                } else {
+                    paths.push(full_pattern);
+                }
+            }
+        }
+
+        paths
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn path_overrides_distinguish_omitted_explicit_and_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let default_source = tmp.path().join("default.lock");
+        let default_output = tmp.path().join("default-output");
+        let optional_output = tmp.path().join("optional-output");
+
+        let base = ProviderBase::new("test", tmp.path(), DepsProviderConfig::default());
+        assert_eq!(
+            base.sources(vec![default_source.clone()]),
+            vec![default_source.clone()]
+        );
+        assert_eq!(
+            base.outputs(vec![default_output.clone()]),
+            vec![default_output.clone()]
+        );
+        assert_eq!(
+            base.optional_outputs(vec![optional_output.clone()]),
+            vec![optional_output]
+        );
+
+        let explicit = ProviderBase::new(
+            "test",
+            tmp.path(),
+            DepsProviderConfig {
+                sources: Some(vec!["custom.lock".into()]),
+                outputs: Some(vec!["custom-output".into()]),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            explicit.sources(vec![default_source]),
+            vec![tmp.path().join("custom.lock")]
+        );
+        assert_eq!(
+            explicit.outputs(vec![default_output]),
+            vec![tmp.path().join("custom-output")]
+        );
+        assert!(explicit.optional_outputs(vec![]).is_empty());
+
+        let empty = ProviderBase::new(
+            "test",
+            tmp.path(),
+            DepsProviderConfig {
+                sources: Some(vec![]),
+                outputs: Some(vec![]),
+                ..Default::default()
+            },
+        );
+        assert!(empty.sources(vec![tmp.path().join("ignored")]).is_empty());
+        assert!(empty.outputs(vec![tmp.path().join("ignored")]).is_empty());
+        assert!(
+            empty
+                .optional_outputs(vec![tmp.path().join("ignored")])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn path_overrides_resolve_from_dir_and_expand_globs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        let work = root.join("packages/app");
+        fs::create_dir_all(work.join("inputs")).unwrap();
+        fs::write(work.join("inputs/a.lock"), "a").unwrap();
+        fs::write(work.join("inputs/b.lock"), "b").unwrap();
+        fs::write(work.join("inputs/a.json"), "a").unwrap();
+        fs::write(work.join("inputs/b.json"), "b").unwrap();
+        let absolute = tmp.path().join("absolute-output");
+
+        let base = ProviderBase::new(
+            "test",
+            &root,
+            DepsProviderConfig {
+                dir: Some("packages/app".into()),
+                sources: Some(vec!["inputs/*.lock".into()]),
+                outputs: Some(vec![absolute.to_string_lossy().into_owned()]),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            base.sources(vec![]),
+            vec![work.join("inputs/a.lock"), work.join("inputs/b.lock")]
+        );
+        assert_eq!(base.outputs(vec![]), vec![absolute]);
+
+        let bracket_pattern = ProviderBase::new(
+            "test",
+            &root,
+            DepsProviderConfig {
+                dir: Some("packages/app".into()),
+                sources: Some(vec!["inputs/[ab].lock".into()]),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            bracket_pattern.sources(vec![]),
+            vec![work.join("inputs/a.lock"), work.join("inputs/b.lock")]
+        );
+
+        let brace_pattern = ProviderBase::new(
+            "test",
+            &root,
+            DepsProviderConfig {
+                dir: Some("packages/app".into()),
+                sources: Some(vec!["inputs/{a,b}.json".into()]),
+                outputs: Some(vec!["outputs/{app,vendor}.js".into()]),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            brace_pattern.sources(vec![]),
+            vec![work.join("inputs/a.json"), work.join("inputs/b.json")]
+        );
+        assert_eq!(
+            brace_pattern.outputs(vec![]),
+            vec![work.join("outputs/app.js"), work.join("outputs/vendor.js")]
+        );
+
+        let output_pattern = ProviderBase::new(
+            "test",
+            &root,
+            DepsProviderConfig {
+                dir: Some("packages/app".into()),
+                outputs: Some(vec!["outputs/*.js".into()]),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            output_pattern.outputs(vec![]),
+            vec![work.join("outputs/*.js")]
+        );
+        fs::create_dir_all(work.join("outputs")).unwrap();
+        fs::write(work.join("outputs/app.js"), "output").unwrap();
+        assert_eq!(
+            output_pattern.outputs(vec![]),
+            vec![work.join("outputs/app.js")]
+        );
+    }
+
+    #[test]
+    fn output_rules_hash_tracks_declared_rules_not_glob_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = DepsProviderConfig {
+            outputs: Some(vec!["dist/*.js".into()]),
+            ..Default::default()
+        };
+        let base = ProviderBase::new("test", tmp.path(), config.clone());
+        let hash = base.output_rules_hash();
+
+        fs::create_dir_all(tmp.path().join("dist")).unwrap();
+        fs::write(tmp.path().join("dist/app.js"), "output").unwrap();
+        assert_eq!(base.output_rules_hash(), hash);
+
+        let omitted = ProviderBase::new("test", tmp.path(), DepsProviderConfig::default());
+        let empty = ProviderBase::new(
+            "test",
+            tmp.path(),
+            DepsProviderConfig {
+                outputs: Some(vec![]),
+                ..Default::default()
+            },
+        );
+        let replacement = ProviderBase::new(
+            "test",
+            tmp.path(),
+            DepsProviderConfig {
+                outputs: Some(vec!["build/*.js".into()]),
+                ..Default::default()
+            },
+        );
+        let different_dir = ProviderBase::new(
+            "test",
+            tmp.path(),
+            DepsProviderConfig {
+                dir: Some("package".into()),
+                ..config
+            },
+        );
+
+        assert_ne!(omitted.output_rules_hash(), empty.output_rules_hash());
+        assert_ne!(hash, replacement.output_rules_hash());
+        assert_ne!(hash, different_dir.output_rules_hash());
     }
 }

--- a/src/deps/providers/npm.rs
+++ b/src/deps/providers/npm.rs
@@ -28,11 +28,15 @@ impl DepsProvider for NpmDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("package-lock.json"), root.join("package.json")]
+        self.base.sources(vec![
+            root.join("package-lock.json"),
+            root.join("package.json"),
+        ])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join("node_modules")]
+        self.base
+            .outputs(vec![self.base.config_root().join("node_modules")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/pip.rs
+++ b/src/deps/providers/pip.rs
@@ -27,11 +27,12 @@ impl DepsProvider for PipDepsProvider {
     }
 
     fn sources(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join("requirements.txt")]
+        self.base
+            .sources(vec![self.base.config_root().join("requirements.txt")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![]
+        self.base.outputs(vec![])
     }
 
     fn optional_outputs(&self) -> Vec<PathBuf> {
@@ -39,7 +40,8 @@ impl DepsProvider for PipDepsProvider {
         // create `.venv` itself. Track it as optional so projects that use a
         // local venv detect deletion, without forcing a re-run for projects
         // that don't.
-        vec![self.base.config_root().join(".venv")]
+        self.base
+            .optional_outputs(vec![self.base.config_root().join(".venv")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/pnpm.rs
+++ b/src/deps/providers/pnpm.rs
@@ -28,11 +28,13 @@ impl DepsProvider for PnpmDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("pnpm-lock.yaml"), root.join("package.json")]
+        self.base
+            .sources(vec![root.join("pnpm-lock.yaml"), root.join("package.json")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join("node_modules")]
+        self.base
+            .outputs(vec![self.base.config_root().join("node_modules")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/poetry.rs
+++ b/src/deps/providers/poetry.rs
@@ -28,18 +28,20 @@ impl DepsProvider for PoetryDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("poetry.lock"), root.join("pyproject.toml")]
+        self.base
+            .sources(vec![root.join("poetry.lock"), root.join("pyproject.toml")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![]
+        self.base.outputs(vec![])
     }
 
     fn optional_outputs(&self) -> Vec<PathBuf> {
         // Poetry only writes `.venv` in the project when `virtualenvs.in-project`
         // is enabled; otherwise the venv lives elsewhere. Track as optional so
         // in-project setups detect deletion without breaking the default mode.
-        vec![self.base.config_root().join(".venv")]
+        self.base
+            .optional_outputs(vec![self.base.config_root().join(".venv")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/uv.rs
+++ b/src/deps/providers/uv.rs
@@ -28,11 +28,12 @@ impl DepsProvider for UvDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("uv.lock"), root.join("pyproject.toml")]
+        self.base
+            .sources(vec![root.join("uv.lock"), root.join("pyproject.toml")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![]
+        self.base.outputs(vec![])
     }
 
     fn optional_outputs(&self) -> Vec<PathBuf> {
@@ -40,7 +41,8 @@ impl DepsProvider for UvDepsProvider {
         // `UV_PROJECT_ENVIRONMENT` can redirect it elsewhere. Track as optional
         // so the default case detects deletion while custom-env-path setups
         // still rely on source hashes.
-        vec![self.base.config_root().join(".venv")]
+        self.base
+            .optional_outputs(vec![self.base.config_root().join(".venv")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/providers/yarn.rs
+++ b/src/deps/providers/yarn.rs
@@ -28,11 +28,13 @@ impl DepsProvider for YarnDepsProvider {
 
     fn sources(&self) -> Vec<PathBuf> {
         let root = self.base.config_root();
-        vec![root.join("yarn.lock"), root.join("package.json")]
+        self.base
+            .sources(vec![root.join("yarn.lock"), root.join("package.json")])
     }
 
     fn outputs(&self) -> Vec<PathBuf> {
-        vec![self.base.config_root().join("node_modules")]
+        self.base
+            .outputs(vec![self.base.config_root().join("node_modules")])
     }
 
     fn install_command(&self) -> Result<DepsCommand> {

--- a/src/deps/rule.rs
+++ b/src/deps/rule.rs
@@ -49,11 +49,9 @@ pub struct DepsProviderConfig {
     /// Command to run when stale (required for custom, optional override for built-in)
     pub run: Option<String>,
     /// Files/patterns to check for changes (required for custom, auto-detected for built-in)
-    #[serde(default)]
-    pub sources: Vec<String>,
+    pub sources: Option<Vec<String>>,
     /// Files/directories that should be newer than sources (required for custom, auto-detected for built-in)
-    #[serde(default)]
-    pub outputs: Vec<String>,
+    pub outputs: Option<Vec<String>>,
     /// Environment variables to set
     #[serde(default)]
     pub env: BTreeMap<String, String>,
@@ -111,10 +109,10 @@ impl DepsProviderConfig {
         if let Some(run) = &self.run {
             validate("run", run)?;
         }
-        for (index, source) in self.sources.iter().enumerate() {
+        for (index, source) in self.sources.iter().flatten().enumerate() {
             validate(&format!("sources[{index}]"), source)?;
         }
-        for (index, output) in self.outputs.iter().enumerate() {
+        for (index, output) in self.outputs.iter().flatten().enumerate() {
             validate(&format!("outputs[{index}]"), output)?;
         }
         for (key, value) in &self.env {
@@ -142,10 +140,10 @@ impl DepsProviderConfig {
         if let Some(run) = &mut self.run {
             *run = render("run", run, false)?;
         }
-        for (index, source) in self.sources.iter_mut().enumerate() {
+        for (index, source) in self.sources.iter_mut().flatten().enumerate() {
             *source = render(&format!("sources[{index}]"), source, true)?;
         }
-        for (index, output) in self.outputs.iter_mut().enumerate() {
+        for (index, output) in self.outputs.iter_mut().flatten().enumerate() {
             *output = render(&format!("outputs[{index}]"), output, true)?;
         }
         if let Some(dir) = &mut self.dir {
@@ -252,8 +250,8 @@ mod tests {
         context.insert("env", &BTreeMap::<String, String>::new());
         let mut config = DepsProviderConfig {
             run: Some("run".into()),
-            sources: vec!["source".into()],
-            outputs: vec!["output".into()],
+            sources: Some(vec!["source".into()]),
+            outputs: Some(vec!["output".into()]),
             env: BTreeMap::from([("KEY".into(), "{{ env.EFFECTIVE }}".into())]),
             dir: Some("dir".into()),
             description: Some("description".into()),
@@ -276,8 +274,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.run.as_deref(), Some("rendered-run"));
-        assert_eq!(config.sources, ["rendered-source"]);
-        assert_eq!(config.outputs, ["rendered-output"]);
+        assert_eq!(config.sources, Some(vec!["rendered-source".to_string()]));
+        assert_eq!(config.outputs, Some(vec!["rendered-output".to_string()]));
         assert_eq!(config.env["KEY"], "{{ env.EFFECTIVE }}");
         assert_eq!(
             config
@@ -312,8 +310,8 @@ mod tests {
         context.insert("env", &BTreeMap::<String, String>::new());
         let config = DepsProviderConfig {
             run: Some("echo {{ env.EFFECTIVE }}".into()),
-            sources: vec!["{{ env.EFFECTIVE }}/source".into()],
-            outputs: vec!["{{ env.EFFECTIVE }}/output".into()],
+            sources: Some(vec!["{{ env.EFFECTIVE }}/source".into()]),
+            outputs: Some(vec!["{{ env.EFFECTIVE }}/output".into()]),
             env: BTreeMap::from([("KEY".into(), "{{ env.EFFECTIVE }}".into())]),
             dir: Some("{{ env.EFFECTIVE }}".into()),
             description: Some("{{ env.EFFECTIVE }} description".into()),
@@ -335,8 +333,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(rendered.run.as_deref(), Some("echo effective"));
-        assert_eq!(rendered.sources, ["effective/source"]);
-        assert_eq!(rendered.outputs, ["effective/output"]);
+        assert_eq!(rendered.sources, Some(vec!["effective/source".to_string()]));
+        assert_eq!(rendered.outputs, Some(vec!["effective/output".to_string()]));
         assert_eq!(rendered.env["KEY"], "effective");
         assert_eq!(rendered.dir.as_deref(), Some("effective"));
         assert_eq!(
@@ -345,5 +343,16 @@ mod tests {
         );
         assert_eq!(rendered.depends, ["effective"]);
         assert_eq!(rendered.timeout.as_deref(), Some("5s"));
+    }
+
+    #[test]
+    fn path_options_preserve_omitted_and_explicit_empty() {
+        let omitted: DepsConfig = toml::from_str("[npm]\n").unwrap();
+        assert_eq!(omitted.providers["npm"].sources, None);
+        assert_eq!(omitted.providers["npm"].outputs, None);
+
+        let empty: DepsConfig = toml::from_str("[npm]\nsources = []\noutputs = []\n").unwrap();
+        assert_eq!(empty.providers["npm"].sources, Some(vec![]));
+        assert_eq!(empty.providers["npm"].outputs, Some(vec![]));
     }
 }

--- a/src/deps/state.rs
+++ b/src/deps/state.rs
@@ -10,22 +10,27 @@ use crate::hash::{file_hash_blake3, hash_to_str};
 /// Persistent state for deps freshness checking.
 ///
 /// Stores blake3 content hashes of source files and effective commands keyed by
-/// provider ID, plus the set of optional output paths that existed at the last
-/// successful run.
+/// provider ID, plus the set of output paths that existed at the last successful
+/// run and the output-rule identity used to select them.
 /// Persisted to `$MISE_STATE_DIR/deps/<hash>.toml`, keyed by project root.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct DepsState {
     /// provider_id → (relative_path → blake3_hex)
     #[serde(default)]
     pub providers: BTreeMap<String, BTreeMap<String, String>>,
-    /// provider_id → list of optional output paths (relative to project root)
-    /// that existed after the last successful run. Used to detect when an
-    /// output that was previously present has been deleted.
+    /// provider_id → list of output paths (relative to project root) that
+    /// existed after the last successful run. Used to detect when an output
+    /// that was previously present has been deleted, including one match from
+    /// a required output glob.
     #[serde(default)]
     pub seen_outputs: BTreeMap<String, Vec<String>>,
     /// provider_id → blake3 hash of the effective command
     #[serde(default)]
     pub command_hashes: BTreeMap<String, String>,
+    /// provider_id → hash of the unexpanded configured output rules used
+    /// when `seen_outputs` was recorded.
+    #[serde(default)]
+    pub output_rule_hashes: BTreeMap<String, String>,
 }
 
 impl DepsState {
@@ -69,13 +74,13 @@ impl DepsState {
         self.providers.insert(provider_id.to_string(), hashes);
     }
 
-    /// Get optional outputs that existed at the last successful run, or None
-    /// if not previously recorded.
+    /// Get outputs that existed at the last successful run, or None if not
+    /// previously recorded.
     pub fn get_seen_outputs(&self, provider_id: &str) -> Option<&Vec<String>> {
         self.seen_outputs.get(provider_id)
     }
 
-    /// Record optional outputs that exist after a successful run.
+    /// Record outputs that exist after a successful run.
     pub fn set_seen_outputs(&mut self, provider_id: &str, outputs: Vec<String>) {
         self.seen_outputs.insert(provider_id.to_string(), outputs);
     }
@@ -88,6 +93,17 @@ impl DepsState {
     /// Record the effective command hash after a successful run.
     pub fn set_command_hash(&mut self, provider_id: &str, hash: String) {
         self.command_hashes.insert(provider_id.to_string(), hash);
+    }
+
+    /// Get the output-rule identity used to record a provider's seen outputs.
+    pub fn get_output_rules(&self, provider_id: &str) -> Option<&String> {
+        self.output_rule_hashes.get(provider_id)
+    }
+
+    /// Record the output-rule identity associated with a provider's outputs.
+    pub fn set_output_rules(&mut self, provider_id: &str, rules: String) {
+        self.output_rule_hashes
+            .insert(provider_id.to_string(), rules);
     }
 }
 
@@ -190,5 +206,19 @@ mod tests {
         assert!(!serialized.contains("run command"));
         let restored: DepsState = toml::from_str(&serialized).unwrap();
         assert_eq!(restored.get_command_hash("example"), Some("digest"));
+    }
+
+    #[test]
+    fn old_state_without_output_rule_hashes_remains_compatible() {
+        let state: DepsState = toml::from_str(
+            r#"
+[seen_outputs]
+npm = ["node_modules"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(state.get_seen_outputs("npm").unwrap(), &["node_modules"]);
+        assert!(state.get_output_rules("npm").is_none());
     }
 }


### PR DESCRIPTION
## Summary

- preserve whether deps provider `sources` and `outputs` were omitted or explicitly configured
- let built-in providers replace their default tracked paths, including disabling tracking with an empty array
- resolve built-in and custom path overrides through one config-root-aware implementation
- suppress built-in optional outputs whenever `outputs` is explicitly configured

## Motivation

Built-in deps providers accepted `sources` and `outputs` in the configuration schema, but their implementations always returned provider-specific defaults. This made custom virtualenv locations and isolated monorepo layouts impossible to track accurately.

The new behavior is a full replacement: omitted fields retain the built-in defaults, explicit arrays replace them, and `[]` intentionally disables that category of tracking. Applicability still uses each provider's canonical lockfile or manifest.

## Verification

- `mise exec -- cargo test --all-features deps::`
- `mise run test:e2e e2e/cli/test_deps_builtin_path_overrides e2e/cli/test_deps e2e/config/test_schema_deps_provider_arrays`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- Rustfmt, ShellCheck, shfmt, Prettier, and markdownlint checks for the changed files

The E2E coverage verifies pnpm-style isolated outputs, an explicit empty uv output list, and independent relative path resolution for monorepo config roots.

Addresses https://github.com/jdx/mise/discussions/8762

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable dependency source, required-output, and optional-output paths for built-in providers.
  * Supports relative and absolute paths, wildcard patterns, and explicitly empty lists.
  * Relative paths resolve from the configured project root.
  * Custom providers now use configured paths without automatic glob expansion.
  * Dependency checks detect missing outputs, track output changes, and rerun as needed.

* **Documentation**
  * Added configuration guidance and workspace examples.

* **Tests**
  * Added coverage for overrides, glob patterns, output suppression, freshness reruns, and missing-output recreation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->