### PR TITLE
fix(aqua): apply explicit package type overrides

### DIFF
--- a/crates/aqua-registry/src/cache.rs
+++ b/crates/aqua-registry/src/cache.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-const COMPILED_REGISTRY_CACHE_VERSION: &str = "v7";
+const COMPILED_REGISTRY_CACHE_VERSION: &str = "v8";
 
 #[derive(Debug, Clone)]
 pub struct RegistryCache {

--- a/crates/aqua-registry/src/compiled.rs
+++ b/crates/aqua-registry/src/compiled.rs
@@ -236,6 +236,7 @@ fn fnv1a64(value: &str) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::AquaPackageType;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -319,6 +320,29 @@ packages:
         let package = registry.package("example/named-tool").unwrap();
 
         assert_eq!(package.name.as_deref(), Some("example/named-tool"));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn compiled_registry_preserves_omitted_and_explicit_package_types() {
+        let root = temp_cache_dir("compiled-aqua-registry-package-types");
+        let source = r#"
+packages:
+  - name: example/default-type
+  - name: example/explicit-type
+    type: github_release
+"#;
+
+        compile_registry(source, &root);
+        let registry = CompiledRegistry::load(&root).unwrap();
+        let default_type = registry.package("example/default-type").unwrap();
+        let explicit_type = registry.package("example/explicit-type").unwrap();
+
+        assert_eq!(default_type.r#type, None);
+        assert_eq!(default_type.package_type(), AquaPackageType::GithubRelease);
+        assert_eq!(explicit_type.r#type, Some(AquaPackageType::GithubRelease));
+        assert_eq!(explicit_type.package_type(), AquaPackageType::GithubRelease);
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -17,6 +17,7 @@ use versions::Versioning;
     RkyvDeserialize,
     RkyvSerialize,
     Default,
+    Copy,
     Clone,
     PartialEq,
     strum::Display,
@@ -38,7 +39,7 @@ pub enum AquaPackageType {
 ///
 /// rkyv archives parsed package data only. Runtime-only fields mirror serde's
 /// skipped behavior with `rkyv::with::Skip`.
-#[derive(Debug, Deserialize, Archive, RkyvDeserialize, RkyvSerialize, Clone)]
+#[derive(Debug, Default, Deserialize, Archive, RkyvDeserialize, RkyvSerialize, Clone)]
 #[rkyv(serialize_bounds(
     __S: rkyv::ser::Writer + rkyv::ser::Allocator,
     __S::Error: rkyv::rancor::Source,
@@ -52,7 +53,7 @@ pub enum AquaPackageType {
 ))]
 #[serde(default)]
 pub struct AquaPackage {
-    pub r#type: AquaPackageType,
+    pub r#type: Option<AquaPackageType>,
     pub repo_owner: String,
     pub repo_name: String,
     pub name: Option<String>,
@@ -371,49 +372,13 @@ fn yaml_scalar_to_string(value: serde_yaml::Value) -> Option<String> {
     }
 }
 
-impl Default for AquaPackage {
-    fn default() -> Self {
-        Self {
-            r#type: AquaPackageType::GithubRelease,
-            repo_owner: String::new(),
-            repo_name: String::new(),
-            name: None,
-            asset: String::new(),
-            url: String::new(),
-            description: None,
-            format: String::new(),
-            rosetta2: None,
-            windows_arm_emulation: None,
-            complete_windows_ext: None,
-            windows_ext: String::new(),
-            append_ext: None,
-            supported_envs: Vec::new(),
-            files: Vec::new(),
-            vars: Vec::new(),
-            replacements: HashMap::new(),
-            version_prefix: None,
-            version_filter: None,
-            version_filter_expr: None,
-            version_source: None,
-            cosign: None,
-            checksum: None,
-            slsa_provenance: None,
-            minisign: None,
-            github_artifact_attestations: None,
-            format_overrides: Vec::new(),
-            overrides: Vec::new(),
-            version_constraint: String::new(),
-            version_overrides: Vec::new(),
-            no_asset: None,
-            private: false,
-            error_message: None,
-            path: None,
-            var_values: HashMap::new(),
-        }
-    }
-}
-
 impl AquaPackage {
+    /// Return the package type, preserving aqua's default of `github_release`
+    /// when the field is omitted.
+    pub fn package_type(&self) -> AquaPackageType {
+        self.r#type.unwrap_or_default()
+    }
+
     /// Apply version-specific configurations and overrides
     pub fn with_version(self, versions: &[&str], os: &str, arch: &str) -> AquaPackage {
         self.with_version_runtime(versions, os, arch, AquaRuntime::default())
@@ -528,7 +493,7 @@ impl AquaPackage {
 
     pub fn windows_ext(&self) -> &str {
         if self.windows_ext.is_empty() {
-            match self.r#type {
+            match self.package_type() {
                 AquaPackageType::GithubArchive | AquaPackageType::GithubContent => ".sh",
                 _ => ".exe",
             }
@@ -541,7 +506,7 @@ impl AquaPackage {
         match self.complete_windows_ext {
             Some(complete) => complete,
             None => !matches!(
-                self.r#type,
+                self.package_type(),
                 AquaPackageType::GithubArchive | AquaPackageType::GithubContent
             ),
         }
@@ -597,7 +562,7 @@ impl AquaPackage {
 
     /// Get the format for this package and version
     pub fn format(&self, v: &str, os: &str, arch: &str) -> Result<&str> {
-        if self.r#type == AquaPackageType::GithubArchive {
+        if self.package_type() == AquaPackageType::GithubArchive {
             return Ok("tar.gz");
         }
         let format = if self.format.is_empty() {
@@ -1044,8 +1009,8 @@ impl AquaFile {
 }
 
 fn apply_override(mut orig: AquaPackage, avo: &AquaPackage) -> AquaPackage {
-    if avo.r#type != AquaPackageType::GithubRelease {
-        orig.r#type = avo.r#type.clone();
+    if let Some(r#type) = avo.r#type {
+        orig.r#type = Some(r#type);
     }
     if !avo.repo_owner.is_empty() {
         orig.repo_owner = avo.repo_owner.clone();
@@ -1275,7 +1240,7 @@ impl AquaChecksum {
         arch: &str,
     ) -> Result<HashMap<String, String>> {
         let mut ctx = pkg.template_context(&self.effective_replacements(pkg), v, os, arch);
-        if pkg.r#type == AquaPackageType::Http {
+        if pkg.package_type() == AquaPackageType::Http {
             ctx.insert("AssetURL".to_string(), pkg.url(v, os, arch)?);
         }
         Ok(ctx)
@@ -1588,6 +1553,104 @@ packages:
         .with_version(&["1.0.0"], "linux", "amd64");
 
         assert!(pkg.private);
+    }
+
+    #[test]
+    fn test_package_type_defaults_to_github_release_when_omitted() {
+        let pkg = first_registry_package("packages:\n  - name: example/tool\n");
+
+        assert_eq!(pkg.r#type, None);
+        assert_eq!(pkg.package_type(), AquaPackageType::GithubRelease);
+    }
+
+    #[test]
+    fn test_version_override_can_explicitly_select_github_release() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - type: http
+    repo_owner: anthropics
+    repo_name: claude-code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        type: github_release
+        asset: claude-{{.OS}}-{{.Arch}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+"#,
+        )
+        .with_version(&["2.1.226"], "linux", "amd64");
+
+        assert_eq!(pkg.r#type, Some(AquaPackageType::GithubRelease));
+        assert_eq!(pkg.package_type(), AquaPackageType::GithubRelease);
+        assert_eq!(pkg.format("2.1.226", "linux", "amd64").unwrap(), "tar.gz");
+        assert_eq!(
+            pkg.asset("2.1.226", "linux", "amd64").unwrap(),
+            "claude-linux-x64.tar.gz"
+        );
+    }
+
+    #[test]
+    fn test_omitted_version_override_type_preserves_http() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - type: http
+    url: https://example.com/tool
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        format: raw
+"#,
+        )
+        .with_version(&["1.0.0"], "linux", "amd64");
+
+        assert_eq!(pkg.r#type, Some(AquaPackageType::Http));
+        assert_eq!(pkg.package_type(), AquaPackageType::Http);
+    }
+
+    #[test]
+    fn test_version_override_can_select_http() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - type: github_release
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        type: http
+        url: https://example.com/tool
+"#,
+        )
+        .with_version(&["1.0.0"], "linux", "amd64");
+
+        assert_eq!(pkg.r#type, Some(AquaPackageType::Http));
+        assert_eq!(pkg.package_type(), AquaPackageType::Http);
+    }
+
+    #[test]
+    fn test_platform_override_can_explicitly_select_github_release() {
+        let pkg = first_registry_package(
+            r#"
+packages:
+  - type: http
+    url: https://example.com/tool
+    overrides:
+      - goos: linux
+        type: github_release
+        asset: tool-{{.OS}}-{{.Arch}}
+"#,
+        );
+
+        let linux = pkg.clone().with_version(&["1.0.0"], "linux", "amd64");
+        let darwin = pkg.with_version(&["1.0.0"], "darwin", "arm64");
+
+        assert_eq!(linux.r#type, Some(AquaPackageType::GithubRelease));
+        assert_eq!(linux.package_type(), AquaPackageType::GithubRelease);
+        assert_eq!(darwin.r#type, Some(AquaPackageType::Http));
+        assert_eq!(darwin.package_type(), AquaPackageType::Http);
     }
 
     #[test]
@@ -2365,7 +2428,7 @@ packages:
     #[test]
     fn test_github_content_does_not_complete_windows_ext_by_default() {
         let pkg = AquaPackage {
-            r#type: AquaPackageType::GithubContent,
+            r#type: Some(AquaPackageType::GithubContent),
             path: Some("install".to_string()),
             asset: "install".to_string(),
             format: "raw".to_string(),
@@ -2380,7 +2443,7 @@ packages:
     #[test]
     fn test_github_content_complete_windows_ext_defaults_to_sh() {
         let pkg = AquaPackage {
-            r#type: AquaPackageType::GithubContent,
+            r#type: Some(AquaPackageType::GithubContent),
             path: Some("install".to_string()),
             asset: "install".to_string(),
             format: "raw".to_string(),

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -189,11 +189,11 @@ impl Backend for AquaBackend {
         // Count checksum operation if explicitly configured OR if this is a GitHub release
         // (GitHub API may provide a digest even without explicit checksum config)
         if pkg.checksum.as_ref().is_some_and(|c| c.enabled())
-            || pkg.r#type == AquaPackageType::GithubRelease
+            || pkg.package_type() == AquaPackageType::GithubRelease
         {
             count += 1;
         }
-        if needs_extraction(format, &pkg.r#type) {
+        if needs_extraction(format, &pkg.package_type()) {
             count += 1;
         }
         count
@@ -494,7 +494,7 @@ impl Backend for AquaBackend {
         // Only validate for GithubRelease packages - other types use fixed URL formats
         // In locked mode, trust the lockfile URL without validation to avoid API calls
         let validated_url = if let Some(ref url) = existing_platform {
-            if ctx.locked || pkg.r#type != AquaPackageType::GithubRelease {
+            if ctx.locked || pkg.package_type() != AquaPackageType::GithubRelease {
                 existing_platform // Trust lockfile URL in locked mode or for non-release types
             } else {
                 let cached_filename = get_filename_from_url(url);
@@ -561,7 +561,7 @@ impl Backend for AquaBackend {
                 platform_key
             );
         } else {
-            let (url, url_api, v, digest) = if pkg.r#type == AquaPackageType::Http {
+            let (url, url_api, v, digest) = if pkg.package_type() == AquaPackageType::Http {
                 let (url, resolved_version) =
                     resolve_aqua_http_url(&pkg, &v, v_prefixed.as_deref(), os(), arch()).await?;
                 (url, None, resolved_version, None)
@@ -630,7 +630,7 @@ impl Backend for AquaBackend {
         self.verify(ctx, &mut tv, &pkg, &v, &filename).await?;
 
         // Advance to extraction operation if applicable
-        if needs_extraction(format, &pkg.r#type) {
+        if needs_extraction(format, &pkg.package_type()) {
             ctx.pr.next_operation();
         }
         self.install(ctx, &tv, &pkg, &v, &filename)?;
@@ -833,7 +833,7 @@ impl Backend for AquaBackend {
         }
 
         // Get URL and checksum for the target platform
-        let (url, url_api, checksum) = match pkg.r#type {
+        let (url, url_api, checksum) = match pkg.package_type() {
             AquaPackageType::GithubRelease => {
                 // Try v-prefixed version first (most aqua packages use v-prefixed tags),
                 // then fall back to the non-prefixed version.
@@ -1977,7 +1977,7 @@ impl AquaBackend {
         pkg: &AquaPackage,
         v: &str,
     ) -> Result<(String, Option<String>, bool, Option<String>)> {
-        match pkg.r#type {
+        match pkg.package_type() {
             AquaPackageType::GithubRelease => self
                 .github_release_url(pkg, v)
                 .await
@@ -2780,7 +2780,7 @@ impl AquaBackend {
             bail!("unsupported aqua package format: {format}");
         }
         let extraction_format = extraction_format.unwrap_or(ExtractionFormat::Raw);
-        if pkg.r#type == AquaPackageType::GithubArchive
+        if pkg.package_type() == AquaPackageType::GithubArchive
             && extraction_format == ExtractionFormat::Raw
         {
             // The aqua registry can omit format for GitHub-generated archive downloads.
@@ -2838,7 +2838,7 @@ impl AquaBackend {
         };
         let extraction_format = Self::effective_extraction_format(pkg, format)?;
         let mut make_executable = false;
-        if let AquaPackageType::GithubArchive = pkg.r#type {
+        if let AquaPackageType::GithubArchive = pkg.package_type() {
             file::extract_archive(
                 &tarball_path,
                 &install_path,
@@ -2846,7 +2846,7 @@ impl AquaBackend {
                 &extract_opts,
             )?;
             make_executable = true;
-        } else if let AquaPackageType::GithubContent = pkg.r#type {
+        } else if let AquaPackageType::GithubContent = pkg.package_type() {
             if let Some(parent) = first_bin_path.parent() {
                 file::create_dir_all(parent)?;
             }
@@ -3582,7 +3582,7 @@ mod tests {
     #[test]
     fn test_github_archive_omitted_format_defaults_to_targz() {
         let mut pkg = AquaPackage::default();
-        pkg.r#type = AquaPackageType::GithubArchive;
+        pkg.r#type = Some(AquaPackageType::GithubArchive);
 
         assert_eq!(
             AquaBackend::effective_extraction_format(&pkg, "").unwrap(),
@@ -3855,7 +3855,7 @@ packages:
     #[test]
     fn test_complete_windows_ext_can_default_to_sh() {
         let mut pkg = AquaPackage::default();
-        pkg.r#type = AquaPackageType::GithubContent;
+        pkg.r#type = Some(AquaPackageType::GithubContent);
         pkg.complete_windows_ext = Some(true);
 
         assert_eq!(
@@ -4539,7 +4539,7 @@ fn validate(pkg: &AquaPackage) -> Result<()> {
             pkg.supported_envs
         );
     }
-    match pkg.r#type {
+    match pkg.package_type() {
         AquaPackageType::Cargo => {
             bail!(
                 "package type `cargo` is not supported in the aqua backend. Use the cargo backend instead{}.",
@@ -4553,7 +4553,7 @@ fn validate(pkg: &AquaPackage) -> Result<()> {
         AquaPackageType::GoInstall | AquaPackageType::GoBuild => {
             bail!(
                 "package type `{}` is not supported in the aqua backend. Use the go backend instead{}.",
-                pkg.r#type,
+                pkg.package_type(),
                 pkg.path
                     .as_ref()
                     .map(|path| format!(": go:{path}"))


### PR DESCRIPTION
## Summary

- Preserve whether an Aqua package `type` was omitted or explicitly set.
- Apply explicit `github_release` values from version and platform overrides.
- Keep omitted top-level types defaulting to `github_release` at runtime.

## Root cause

[Aqua registry #58400](https://github.com/aquaproj/aqua-registry/pull/58400) changed newer Claude Code releases from the top-level `http` package definition to an explicit `github_release` version override. mise deserialized both an omitted type and an explicit `github_release` as the same default enum value, then deliberately skipped that value while merging overrides. As a result, PR #11898 retained the parent HTTP behavior and failed with:

```
Failed to install aqua:anthropics/claude-code@latest: builder error: relative URL without a base
```

## Changes

- Store Aqua package types as optional so inheritance and explicit overrides remain distinguishable.
- Route download, format, asset, validation, and version resolution decisions through one effective package-type accessor.
- Apply the same inheritance rule to version and platform overrides.
- Bump the compiled Aqua registry cache format from v7 to v8 so old archives are not reused.
- Add regression coverage for omitted and explicit types, both override forms, the reverse `github_release` to `http` transition, Claude Code-like assets, and compiled-cache round trips.

## Verification

- `mise exec -- cargo test -p aqua-registry` (128 passed)
- `mise exec -- cargo test --all-features --bin mise backend::aqua` (74 passed)
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- cargo fmt --all -- --check`
- Installed `claude@2.1.226` from the current Aqua registry in an isolated data directory and verified `claude --version` returned `2.1.226 (Claude Code)`.

`mise run lint` could not start locally because its hk wrapper requires a Git metadata directory while this working copy is Sapling-native; the underlying Rust formatting and Clippy checks above passed.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*