### PR TITLE
registry: add ryl

### DIFF
--- a/registry/ryl.toml
+++ b/registry/ryl.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:owenlamont/ryl"]
+bins = ["ryl"]
+description = "Fast YAML linter written in Rust"
+test = { cmd = "ryl --version", expected = "ryl {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Add `ryl` to the registry using the preferred Aqua backend. `ryl` is already available as a built-in YAML linter in [jdx/hk](https://github.com/jdx/hk/blob/main/pkl/builtins/ryl.pkl), which uses the same `aqua:owenlamont/ryl` package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry metadata for the `aqua:owenlamont/ryl` backend, including its executable details, description, version check, and semantic version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->