### PR TITLE
registry: add dockerfmt

### DIFF
--- a/registry/dockerfmt.toml
+++ b/registry/dockerfmt.toml
@@ -1,0 +1,5 @@
+backends = ["aqua:reteps/dockerfmt"]
+bins = ["dockerfmt"]
+description = "An opinionated Dockerfile formatter"
+test = { cmd = "dockerfmt version", expected = "dockerfmt v{{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Follow up to #6017

Add `dockerfmt` to the registry using the preferred Aqua backend. `dockerfmt` is the only actively maintained standalone formatter I could find that focuses specifically on Dockerfiles. It is the spiritual successor to `dockfmt` and uses the BuildKit parser.