### PR TITLE
fix(config): apply ~/.config/mise/config.local.toml over config.toml

### DIFF
--- a/e2e/config/test_global_config_precedence
+++ b/e2e/config/test_global_config_precedence
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inside ~/.config/mise, config.local.toml overrides config.toml, which overrides
+# conf.d fragments. The ceiling keeps the config dir out of the cwd walk, so it is
+# only found as the global config group, together with ~/.tool-versions.
+export MISE_CEILING_PATHS="$HOME"
+
+mkdir -p "$MISE_CONFIG_DIR/conf.d"
+
+cat >"$MISE_CONFIG_DIR/conf.d/10-fragment.toml" <<EOF
+[settings]
+minimum_release_age_excludes = ["from-conf-d"]
+[env]
+GLOBAL_PRECEDENCE = "from-conf-d"
+EOF
+
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF
+[settings]
+minimum_release_age_excludes = ["from-config"]
+[env]
+GLOBAL_PRECEDENCE = "from-config"
+[tools]
+dummy = "2.0.0"
+EOF
+
+cat >"$MISE_CONFIG_DIR/config.local.toml" <<EOF
+[settings]
+minimum_release_age_excludes = ["from-local"]
+[env]
+GLOBAL_PRECEDENCE = "from-local"
+EOF
+
+echo "dummy 1.0.0" >"$HOME/.tool-versions"
+
+assert "mise env | grep GLOBAL_PRECEDENCE" "export GLOBAL_PRECEDENCE=from-local"
+assert "mise settings get minimum_release_age_excludes" '["from-local"]'
+# ~/.tool-versions joins the global group only under MISE_USE_TOML=0, and outranks
+# the config dir. Only the active version carries a source.
+assert "MISE_USE_TOML=0 mise ls dummy --json | jq -r '.[] | select(.source) | .source.path'" "$HOME/.tool-versions"
+
+rm "$MISE_CONFIG_DIR/config.local.toml"
+assert "mise env | grep GLOBAL_PRECEDENCE" "export GLOBAL_PRECEDENCE=from-config"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1823,8 +1823,9 @@ pub fn load_config_paths(config_filenames: &[String], include_ignored: bool) -> 
         })
         .collect::<Vec<_>>();
 
-    config_files.extend(global_config_files());
-    config_files.extend(system_config_files());
+    // rev: these groups are lowest-first, this list is highest-first
+    config_files.extend(global_config_files().into_iter().rev());
+    config_files.extend(system_config_files().into_iter().rev());
 
     config_files
         .into_iter()
@@ -2067,9 +2068,9 @@ pub async fn load_config_hierarchy_from_dir(
         })
         .collect::<Vec<_>>();
 
-    // Add global and system configs
-    config_files.extend(global_config_files());
-    config_files.extend(system_config_files());
+    // rev: these groups are lowest-first, this list is highest-first
+    config_files.extend(global_config_files().into_iter().rev());
+    config_files.extend(system_config_files().into_iter().rev());
 
     let paths = config_files
         .into_iter()
@@ -2209,13 +2210,12 @@ pub fn global_config_files() -> IndexSet<PathBuf> {
     if let Some(global_config_file) = &*env::MISE_GLOBAL_CONFIG_FILE {
         return vec![global_config_file.clone()].into_iter().collect();
     }
-    let mut config_files = IndexSet::new();
+    let mut config_files: IndexSet<PathBuf> = config_files_from_dir(&dirs::CONFIG);
     if !*env::MISE_USE_TOML {
         // only add ~/.tool-versions if MISE_CONFIG_FILE is not set
         // because that's how the user overrides the default
         config_files.insert(dirs::HOME.join(env::MISE_DEFAULT_TOOL_VERSIONS_FILENAME.as_str()));
     };
-    config_files.extend(config_files_from_dir(&dirs::CONFIG));
     *g = Some(config_files.clone());
     config_files
 }
@@ -2248,6 +2248,8 @@ static CONFIG_FILENAMES: Lazy<Vec<String>> = Lazy::new(|| {
     filenames
 });
 
+/// Config files in a global/system config dir, lowest precedence first: `conf.d`,
+/// then `config.toml`/`mise.toml`, then the `.local` variants.
 fn config_files_from_dir(dir: &Path) -> IndexSet<PathBuf> {
     let mut files = IndexSet::new();
     for p in file::ls(&dir.join("conf.d")).unwrap_or_default() {


### PR DESCRIPTION
## Why

Inside `~/.config/mise`, precedence ran backwards from what [the docs
describe](https://mise.jdx.dev/configuration.html): `config.toml` overrode
`config.local.toml`, and `conf.d/*.toml` overrode both. It applies to
`[settings]`, `[tools]`, and `[env]` alike, and list-valued settings are
replaced rather than merged, so the losing file's entries vanish entirely.

Only reproducible when `~/.config/mise` is outside the cwd walk, either with
`$HOME` in `ceiling_paths` or from a cwd outside `$HOME`. Otherwise the walk
finds those files through `LOCAL_CONFIG_FILENAMES`, which is ordered correctly,
and they win the `unique_by` dedupe.

## What changed

- Reverse the global and system groups where they join the path list in
  `load_config_paths` and `load_config_hierarchy_from_dir`. The list is
  highest-precedence-first, but `config_files_from_dir` builds those groups
  lowest-first, and both were appended unreversed.
- Move the `~/.tool-versions` insert to the end of `global_config_files` so its
  precedence relative to `~/.config/mise` is unchanged. That entry only joins the
  group under `MISE_USE_TOML=0`.
- Add `e2e/config/test_global_config_precedence`, which fails on `main` with
  `conf.d` winning. It covers `[env]` and `[settings]`, which resolve through
  separate merge paths, plus the `~/.tool-versions` position as a guard on the
  behaviour this preserves.

`global_config_path` is untouched, so `mise use -g` still writes to
`config.toml` rather than `config.local.toml`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.226.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration precedence so local settings override base settings, which override fragments.
  * Ensured global configuration files are applied in the correct order.
  * Improved discovery and source reporting for `.tool-versions` files when TOML configuration is disabled.

* **Documentation**
  * Clarified the precedence order for global and system configuration directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->