### PR TITLE
registry: use aqua for pandoc

### DIFF
--- a/registry/pandoc.toml
+++ b/registry/pandoc.toml
@@ -1,4 +1,5 @@
-backends = ["github:jgm/pandoc", "asdf:Fbrisset/asdf-pandoc"]
+backends = ["aqua:jgm/pandoc", "github:jgm/pandoc", "asdf:Fbrisset/asdf-pandoc"]
 bins = ["pandoc", "pandoc-lua", "pandoc-server"]
 description = "Universal markup converter"
+test = { cmd = "pandoc --version", expected = "pandoc {{version}}" }
 version_order = "source"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing and managing Pandoc through the registry.

* **Tests**
  * Added version verification to confirm the installed Pandoc version matches the configured version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->