### PR TITLE
chore(ci): keep SwiftPM source coverage mandatory

### DIFF
--- a/e2e/core/test_swift_slow
+++ b/e2e/core/test_swift_slow
@@ -13,13 +13,25 @@ assert_matches "mise x -- swift --version" 'Swift version 6\.'
 
 assert "mise x spm:nicklockwood/SwiftFormat@0.61.1 -- swiftformat --version" "0.61.1"
 
-# Source installs require a working SwiftPM. Swift's Ubuntu 24.04 binaries
-# cannot load SwiftPM on Ubuntu 26.04 because they require libxml2.so.2.
-if mise x -- swift package --version >/dev/null 2>&1; then
-  # A commit selector must be checked out as a Git revision rather than being
-  # converted into a release tag named `rev:<sha>`.
-  mkdir -p spm-revision/Sources/revision-tool
-  cat >spm-revision/Package.swift <<'EOF'
+# Swift's Ubuntu 24.04 binaries require libxml2.so.2, while Ubuntu 26.04 ships
+# the compatible library as libxml2.so.16. Keep SwiftPM mandatory by providing
+# the expected SONAME in the isolated test environment.
+if [[ $(uname -s) == Linux ]]; then
+  libxml2_path="$(find /usr/lib /lib -name 'libxml2.so.2' -print -quit 2>/dev/null)"
+  if [[ -z $libxml2_path ]]; then
+    libxml2_path="$(find /usr/lib /lib -name 'libxml2.so.16' -print -quit 2>/dev/null)"
+    [[ -n $libxml2_path ]]
+    mkdir -p swift-compat
+    ln -s "$libxml2_path" swift-compat/libxml2.so.2
+    export LD_LIBRARY_PATH="$PWD/swift-compat${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  fi
+fi
+assert_matches "mise x -- swift package --version" 'Swift Package Manager - Swift 6\.'
+
+# A commit selector must be checked out as a Git revision rather than being
+# converted into a release tag named `rev:<sha>`.
+mkdir -p spm-revision/Sources/revision-tool
+cat >spm-revision/Package.swift <<'EOF'
 // swift-tools-version: 5.9
 import PackageDescription
 
@@ -29,32 +41,29 @@ let package = Package(
     targets: [.executableTarget(name: "revision-tool")]
 )
 EOF
-  echo 'print("first commit")' >spm-revision/Sources/revision-tool/main.swift
-  git -C spm-revision init -q
-  git -C spm-revision add .
-  git -C spm-revision commit -qm "first"
-  first_revision="$(git -C spm-revision rev-parse HEAD)"
-  short_revision="${first_revision:0:12}"
-  echo 'print("second commit")' >spm-revision/Sources/revision-tool/main.swift
-  git -C spm-revision add .
-  git -C spm-revision commit -qm "second"
-  git_config="$PWD/spm-gitconfig"
-  git config --file "$git_config" \
-    url."file://$PWD/spm-revision".insteadOf \
-    "https://github.com/mise-test/spm-revision.git"
+echo 'print("first commit")' >spm-revision/Sources/revision-tool/main.swift
+git -C spm-revision init -q
+git -C spm-revision add .
+git -C spm-revision commit -qm "first"
+first_revision="$(git -C spm-revision rev-parse HEAD)"
+short_revision="${first_revision:0:12}"
+echo 'print("second commit")' >spm-revision/Sources/revision-tool/main.swift
+git -C spm-revision add .
+git -C spm-revision commit -qm "second"
+git_config="$PWD/spm-gitconfig"
+git config --file "$git_config" \
+  url."file://$PWD/spm-revision".insteadOf \
+  "https://github.com/mise-test/spm-revision.git"
 
-  assert \
-    "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise x spm:mise-test/spm-revision@rev:$first_revision -- revision-tool" \
-    "first commit"
-  assert \
-    "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise x spm:mise-test/spm-revision@ref:$short_revision -- revision-tool" \
-    "first commit"
-  assert_fail \
-    "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise install spm:mise-test/spm-revision@rev:deadbeef"
-  assert_fail "mise where spm:mise-test/spm-revision@rev:deadbeef"
-else
-  echo "SKIP: SwiftPM source tests require a compatible libxml2"
-fi
+assert \
+  "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise x spm:mise-test/spm-revision@rev:$first_revision -- revision-tool" \
+  "first commit"
+assert \
+  "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise x spm:mise-test/spm-revision@ref:$short_revision -- revision-tool" \
+  "first commit"
+assert_fail \
+  "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise install spm:mise-test/spm-revision@rev:deadbeef"
+assert_fail "mise where spm:mise-test/spm-revision@rev:deadbeef"
 
 # test package with resources (`templates list` command depends on resources being installed)
 #assert "mise x spm:SwiftGen/SwiftGen@6.6.2 --verbose -- swiftgen templates list --only colors" "colors:

--- a/e2e/core/test_swift_slow
+++ b/e2e/core/test_swift_slow
@@ -13,10 +13,13 @@ assert_matches "mise x -- swift --version" 'Swift version 6\.'
 
 assert "mise x spm:nicklockwood/SwiftFormat@0.61.1 -- swiftformat --version" "0.61.1"
 
-# A commit selector must be checked out as a Git revision rather than being
-# converted into a release tag named `rev:<sha>`.
-mkdir -p spm-revision/Sources/revision-tool
-cat >spm-revision/Package.swift <<'EOF'
+# Source installs require a working SwiftPM. Swift's Ubuntu 24.04 binaries
+# cannot load SwiftPM on Ubuntu 26.04 because they require libxml2.so.2.
+if mise x -- swift package --version >/dev/null 2>&1; then
+  # A commit selector must be checked out as a Git revision rather than being
+  # converted into a release tag named `rev:<sha>`.
+  mkdir -p spm-revision/Sources/revision-tool
+  cat >spm-revision/Package.swift <<'EOF'
 // swift-tools-version: 5.9
 import PackageDescription
 
@@ -26,29 +29,32 @@ let package = Package(
     targets: [.executableTarget(name: "revision-tool")]
 )
 EOF
-echo 'print("first commit")' >spm-revision/Sources/revision-tool/main.swift
-git -C spm-revision init -q
-git -C spm-revision add .
-git -C spm-revision commit -qm "first"
-first_revision="$(git -C spm-revision rev-parse HEAD)"
-short_revision="${first_revision:0:12}"
-echo 'print("second commit")' >spm-revision/Sources/revision-tool/main.swift
-git -C spm-revision add .
-git -C spm-revision commit -qm "second"
-git_config="$PWD/spm-gitconfig"
-git config --file "$git_config" \
-  url."file://$PWD/spm-revision".insteadOf \
-  "https://github.com/mise-test/spm-revision.git"
+  echo 'print("first commit")' >spm-revision/Sources/revision-tool/main.swift
+  git -C spm-revision init -q
+  git -C spm-revision add .
+  git -C spm-revision commit -qm "first"
+  first_revision="$(git -C spm-revision rev-parse HEAD)"
+  short_revision="${first_revision:0:12}"
+  echo 'print("second commit")' >spm-revision/Sources/revision-tool/main.swift
+  git -C spm-revision add .
+  git -C spm-revision commit -qm "second"
+  git_config="$PWD/spm-gitconfig"
+  git config --file "$git_config" \
+    url."file://$PWD/spm-revision".insteadOf \
+    "https://github.com/mise-test/spm-revision.git"
 
-assert \
-  "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise x spm:mise-test/spm-revision@rev:$first_revision -- revision-tool" \
-  "first commit"
-assert \
-  "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise x spm:mise-test/spm-revision@ref:$short_revision -- revision-tool" \
-  "first commit"
-assert_fail \
-  "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise install spm:mise-test/spm-revision@rev:deadbeef"
-assert_fail "mise where spm:mise-test/spm-revision@rev:deadbeef"
+  assert \
+    "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise x spm:mise-test/spm-revision@rev:$first_revision -- revision-tool" \
+    "first commit"
+  assert \
+    "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise x spm:mise-test/spm-revision@ref:$short_revision -- revision-tool" \
+    "first commit"
+  assert_fail \
+    "GIT_CONFIG_GLOBAL=$git_config MISE_GIX=0 mise install spm:mise-test/spm-revision@rev:deadbeef"
+  assert_fail "mise where spm:mise-test/spm-revision@rev:deadbeef"
+else
+  echo "SKIP: SwiftPM source tests require a compatible libxml2"
+fi
 
 # test package with resources (`templates list` command depends on resources being installed)
 #assert "mise x spm:SwiftGen/SwiftGen@6.6.2 --verbose -- swiftgen templates list --only colors" "colors:


### PR DESCRIPTION
## Summary
- keep SwiftPM source-install coverage mandatory instead of skipping on probe failures
- provide Ubuntu 26.04's `libxml2.so.16` under the SONAME expected by Swift's Ubuntu 24.04 toolchain inside the isolated test directory
- assert that SwiftPM starts before exercising full, abbreviated, and invalid revision selectors

## Root cause

The Ubuntu 26.04 E2E runner installs Swift's Ubuntu 24.04 toolchain. Its `swift-package` binary requires `libxml2.so.2`, while Ubuntu 26.04 provides the compatible library as `libxml2.so.16`.

The initial fix skipped the revision assertions whenever the SwiftPM probe failed. Review correctly identified that this could hide unrelated regressions, so SwiftPM is now a hard prerequisite and every source-install assertion runs unconditionally.

## Validation
- focused E2E passed inside the published `ghcr.io/jdx/mise:e2e` Ubuntu 26.04 container
- `mise run test:e2e e2e/core/test_swift_slow` passed on Ubuntu 24.04
- `mise run lint-fix`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI workaround with no production code or security-sensitive changes.
> 
> **Overview**
> Fixes Swift e2e failures on Ubuntu 26.04 by bridging the `libxml2.so.2` / `libxml2.so.16` SONAME mismatch so SwiftPM can still load.
> 
> On Linux, if `libxml2.so.2` is missing, the test now symlinks `libxml2.so.16` into a local `swift-compat` dir, adds it to `LD_LIBRARY_PATH`, and asserts `swift package --version` succeeds before the source-install coverage runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a1df27bd2954bca41b4b4ea53ccb0712d92e66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Swift package test reliability on Linux by supporting multiple available `libxml2` versions.
  * Added a compatibility fallback for environments where the expected library version is unavailable.
  * Added validation that Swift Package Manager is installed and accessible before running related tests.
  * Provides clearer handling when required Swift tooling cannot be run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->