### PR TITLE
chore(ci): avoid rate-limit helper bootstrap

### DIFF
--- a/.github/actions/mise-tools/action.yml
+++ b/.github/actions/mise-tools/action.yml
@@ -11,9 +11,9 @@ runs:
         path: |
           ~/.local/share/mise
           ~/.cache/mise
-    # The helper is itself installed from GitHub. Check the API directly first
-    # so a cold cache can wait instead of failing while bootstrapping the waiter.
-    - name: Wait before installing rate-limit helper
+    # Check the API directly instead of bootstrapping the rate-limit helper,
+    # since installing the helper itself requires GitHub API access.
+    - name: Wait for GitHub rate limit
       shell: bash
       run: |
         token=${MISE_GITHUB_TOKEN:-${GITHUB_API_TOKEN:-${GITHUB_TOKEN:-}}}
@@ -21,10 +21,14 @@ runs:
         if [ -n "$token" ]; then
           curl_args+=(-H "Authorization: Bearer ${token}")
         fi
-        rate_limit=$(curl "${curl_args[@]}" "https://api.github.com/rate_limit")
-        remaining=$(echo "$rate_limit" | jq -r '.resources.core.remaining // 0')
-        reset=$(echo "$rate_limit" | jq -r '.resources.core.reset // 0')
-        if [ "$remaining" -le 1 ]; then
+        rate_limit=$(curl --connect-timeout 10 --max-time 30 \
+          --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+          "${curl_args[@]}" "https://api.github.com/rate_limit" || true)
+        remaining=$(echo "$rate_limit" | jq -er '.resources.core.remaining' 2>/dev/null || true)
+        reset=$(echo "$rate_limit" | jq -er '.resources.core.reset' 2>/dev/null || true)
+        if ! [[ "$remaining" =~ ^[0-9]+$ && "$reset" =~ ^[0-9]+$ ]]; then
+          echo "::warning::Unable to check GitHub core rate limit; continuing without waiting"
+        elif [ "$remaining" -le 1 ]; then
           now=$(date +%s)
           wait_seconds=$((reset - now + 1))
           if [ "$wait_seconds" -gt 0 ]; then
@@ -32,7 +36,5 @@ runs:
             sleep "$wait_seconds"
           fi
         fi
-    - run: GITHUB_TOKEN="${MISE_GITHUB_TOKEN:-${GITHUB_API_TOKEN:-${GITHUB_TOKEN:-}}}" mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
-      shell: bash
     - run: mise install
       shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,30 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
         with:
           install_args: bun
-      - run: mise x wait-for-gh-rate-limit -- wait-for-gh-rate-limit
+      # Check the API directly instead of bootstrapping the rate-limit helper,
+      # since installing the helper itself requires GitHub API access.
+      - name: Wait for GitHub rate limit
+        run: |
+          token=${MISE_GITHUB_TOKEN:-${GITHUB_API_TOKEN:-${GITHUB_TOKEN:-}}}
+          curl_args=(-sf -H "User-Agent: mise-ci")
+          if [ -n "$token" ]; then
+            curl_args+=(-H "Authorization: Bearer ${token}")
+          fi
+          rate_limit=$(curl --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+            "${curl_args[@]}" "https://api.github.com/rate_limit" || true)
+          remaining=$(echo "$rate_limit" | jq -er '.resources.core.remaining' 2>/dev/null || true)
+          reset=$(echo "$rate_limit" | jq -er '.resources.core.reset' 2>/dev/null || true)
+          if ! [[ "$remaining" =~ ^[0-9]+$ && "$reset" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Unable to check GitHub core rate limit; continuing without waiting"
+          elif [ "$remaining" -le 1 ]; then
+            now=$(date +%s)
+            wait_seconds=$((reset - now + 1))
+            if [ "$wait_seconds" -gt 0 ]; then
+              echo "GitHub core rate limit exhausted; waiting ${wait_seconds}s"
+              sleep "$wait_seconds"
+            fi
+          fi
       - run: bun i
       - run: mise run docs:release
         env:


### PR DESCRIPTION
## Summary

- replace dynamic `wait-for-gh-rate-limit` bootstrapping in both the docs workflow and shared `mise-tools` action with direct GitHub core rate-limit waits
- retry transient API failures and continue with a workflow warning if the preflight cannot be completed
- wait until reset without installing another GitHub-hosted tool first
- keep the existing Bun setup, docs build, shared tool cache, and tool installation behavior unchanged

## Root cause

PR #11898 added a GitHub rate-limit preflight to the shared `mise-tools` action, but both that action and the docs workflow still installed `wait-for-gh-rate-limit` immediately afterward. When the selected installation token was exhausted, installing the helper attempted GitHub artifact attestation verification first and failed with a 403 before the helper could run.

The first docs run on this PR exposed the same cycle in the docs workflow. After removing that invocation, docs passed, while `unit-macos` reproduced the remaining copy inside the shared action. This change now uses the inline `/rate_limit` check as the waiter in both locations and removes the helper bootstrap entirely. The preflight is best-effort so a transient GitHub API or malformed response cannot prevent CI by itself.

## Verification

- `mise exec -- actionlint -config-file .github/actionlint.yaml .github/workflows/docs.yml`
- `mise x prettier -- prettier --check .github/workflows/docs.yml .github/actions/mise-tools/action.yml`
- the corrected docs workflow completed successfully on this PR
- the `unit-macos` job completed the updated shared `mise-tools` action successfully
- the GitHub zizmor run could not perform its online advisory audit because its TLS verifier returned `UnsupportedCertVersion`; it produced no finding against these files

Follow-up to #11898.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation and tooling workflows by checking GitHub API availability directly.
  * Added retry handling and validation for rate-limit information.
  * Workflows now wait when API capacity is nearly exhausted and continue with a warning if rate-limit data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->