### PR TITLE
fix(config): stop a conf.d drop-in from becoming the write target

### DIFF
--- a/e2e/cli/test_global_config_confd
+++ b/e2e/cli/test_global_config_confd
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Writing to the global config must never land in a `conf.d` drop-in.
+# A config write must never land in a `conf.d` drop-in — global or local.
 #
-# `first_config_file` skips conf.d entries while choosing, but falls back to the
-# first candidate when nothing else qualifies — and `config_files_from_dir`
-# inserts conf.d entries first. A config dir holding only drop-ins therefore
-# handed one back as the write target.
+# `first_config_file` skips conf.d entries while choosing but has to fall back when
+# nothing else qualifies, and `config_files_from_dir` inserts conf.d entries first.
+# The fallback is therefore where a drop-in gets handed back as the write target.
 #
 # See: https://github.com/jdx/mise/discussions/5842
 
@@ -50,3 +49,17 @@ mise unuse -y dummy@system
 assert_not_contains "cat $HOME/.config/mise/config.toml" "dummy"
 assert_contains "cat $HOME/.config/mise/conf.d/10-drop-in.toml" "FROM_CONFD"
 assert_contains "mise env -s bash" "FROM_CONFD"
+
+# The rule is not specific to the global config dir. `.config/mise/conf.d/*.toml` is a
+# local config filename too, so a project directory holding only drop-ins reached the
+# same fallback through `config_file_in_dir`, and `mise use --path` wrote into it.
+mkdir -p localconfd/.config/mise/conf.d
+cat >localconfd/.config/mise/conf.d/10-drop-in.toml <<'TOML'
+[env]
+FROM_LOCAL_CONFD = "yes"
+TOML
+
+mise use --path localconfd dummy@system
+assert_contains "cat localconfd/mise.toml" "dummy"
+assert_not_contains "cat localconfd/.config/mise/conf.d/10-drop-in.toml" "dummy"
+assert_contains "cat localconfd/.config/mise/conf.d/10-drop-in.toml" "FROM_LOCAL_CONFD"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1721,12 +1721,21 @@ pub(crate) fn is_tool_versions_file(p: &Path) -> bool {
 /// it's the only option. This ensures commands like `mise use` write to mise.toml
 /// instead of mise.local.toml or .tool-versions when multiple configs exist.
 /// See: https://github.com/jdx/mise/discussions/6475
+///
+/// The two exclusions are not the same kind. `.tool-versions` is a *preference*: it is passed
+/// over while choosing and comes back once nothing else qualifies. A `conf.d` drop-in must not
+/// be written to at all, so it is excluded from the fallback as well, and this returns `None`
+/// instead — every caller turns that into a config of its own, which is the wanted outcome.
+///
+/// Carrying the drop-in exclusion in a filtered view rather than repeating it in each arm is
+/// what keeps the two apart: the preference needs a fallback, the exclusion must not have one,
+/// and a chain of `or_else` arms only holds that line for as long as every arm remembers to.
+/// See: <https://github.com/jdx/mise/discussions/5842>
 fn first_config_file(files: &IndexSet<PathBuf>) -> Option<&PathBuf> {
-    files
-        .iter()
-        .find(|p| !is_tool_versions_file(p) && !is_conf_d_file(p))
-        .or_else(|| files.iter().find(|p| is_tool_versions_file(p)))
-        .or_else(|| files.first())
+    let writable = || files.iter().filter(|p| !is_conf_d_file(p));
+    writable()
+        .find(|p| !is_tool_versions_file(p))
+        .or_else(|| writable().next())
 }
 
 fn is_conf_d_file(p: &Path) -> bool {
@@ -2296,11 +2305,6 @@ fn config_files_from_dir(dir: &Path) -> IndexSet<PathBuf> {
 pub fn global_config_path() -> PathBuf {
     let files = global_config_files();
     first_config_file(&files)
-        // Never write into a `conf.d` drop-in. `first_config_file` skips them
-        // while choosing, but falls back to `files.first()` when nothing else
-        // qualifies — and `config_files_from_dir` inserts conf.d entries first,
-        // so a config dir holding only drop-ins would hand one back here.
-        .filter(|p| !is_conf_d_file(p.as_path()))
         .cloned()
         .or_else(|| env::MISE_GLOBAL_CONFIG_FILE.clone())
         .unwrap_or_else(|| dirs::CONFIG.join("config.toml"))
@@ -5996,5 +6000,72 @@ vars = { target = "linux" }
         assert_eq!(tasks[0].name, "build");
         assert_eq!(tasks[0].description, "linux");
         Ok(())
+    }
+}
+
+/// Deliberately not inside the `#[cfg(unix)]` module above: `first_config_file` only inspects
+/// path components, so it behaves the same everywhere and is worth compiling on Windows too.
+#[cfg(test)]
+mod write_target_tests {
+    use super::*;
+
+    fn set(paths: &[&str]) -> IndexSet<PathBuf> {
+        paths.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn a_drop_in_never_wins_over_tool_versions() {
+        // `global_config_files` lists conf.d entries first and appends `~/.tool-versions`
+        // after them, so a fallback that does not skip drop-ins hands one back — and
+        // `global_config_path`, refusing it, creates a `config.toml` rather than writing to
+        // the `.tool-versions` sitting right there. That ordering is what makes this
+        // reachable, and nothing else in the file says so.
+        let files = set(&[
+            "/home/u/.config/mise/conf.d/10-drop-in.toml",
+            "/home/u/.tool-versions",
+        ]);
+        assert_eq!(
+            first_config_file(&files),
+            Some(&PathBuf::from("/home/u/.tool-versions"))
+        );
+    }
+
+    #[test]
+    fn nothing_but_drop_ins_means_no_write_target() {
+        // Every caller turns `None` into a config of its own, which is the wanted outcome:
+        // creating `config.toml` beats editing somebody's drop-in.
+        let files = set(&["/home/u/.config/mise/conf.d/10-drop-in.toml"]);
+        assert_eq!(first_config_file(&files), None);
+    }
+
+    #[test]
+    fn a_real_config_still_wins() {
+        let files = set(&[
+            "/home/u/.config/mise/conf.d/10-drop-in.toml",
+            "/home/u/.config/mise/config.toml",
+            "/home/u/.tool-versions",
+        ]);
+        assert_eq!(
+            first_config_file(&files),
+            Some(&PathBuf::from("/home/u/.config/mise/config.toml"))
+        );
+    }
+
+    #[test]
+    fn tool_versions_stays_deprioritised() {
+        // Control for the change above: `.tool-versions` is skipped *while choosing* and only
+        // returned when nothing else qualifies. Excluding drop-ins outright must not turn that
+        // preference into an exclusion as well.
+        let files = set(&["/proj/.tool-versions", "/proj/mise.toml"]);
+        assert_eq!(
+            first_config_file(&files),
+            Some(&PathBuf::from("/proj/mise.toml"))
+        );
+
+        let only = set(&["/proj/.tool-versions"]);
+        assert_eq!(
+            first_config_file(&only),
+            Some(&PathBuf::from("/proj/.tool-versions"))
+        );
     }
 }


### PR DESCRIPTION
Follow-up to the `first_config_file` change that landed in #11633. That fixed the reported
half; this closes the rest of it and folds the two overlapping guards into one rule.

## Where this stands

`first_config_file` picks the file `mise use` and friends write to. Two names must be treated
specially, and they are **not** the same kind of special:

- `.tool-versions` is a **preference** — passed over while choosing, but returned when nothing
  else qualifies. That is the point of the fallback.
- a `conf.d` drop-in must **not** be written to at all — it belongs to whatever put it there,
  and `mise config` does not present it as the write target.

The fallback is where the two collide, because `config_files_from_dir` lists conf.d entries
*first*. #11633 handled the collision by inserting an arm ahead of the fallback:

```rust
    .find(|p| !is_tool_versions_file(p) && !is_conf_d_file(p))
    .or_else(|| files.iter().find(|p| is_tool_versions_file(p)))   // added by #11633
    .or_else(|| files.first())                                     // can still be a drop-in
```

That reaches `~/.tool-versions` in the global case, which is what was broken. The final arm is
still unguarded though, so a candidate set that is *only* drop-ins still returns one.

`global_config_path` survives that because it re-filters the result afterwards. The two local
write-target resolvers do not:

- `config_file_in_dir` — `mise use --path <dir>`
- `nearest_local_config_file` — the same directory reached by walking up from the cwd

`.config/mise/conf.d/*.toml` is in `LOCAL_CONFIG_FILENAMES`, so this is a project directory,
not just `~/.config/mise`:

```console
$ ls -R proj
proj/.config/mise/conf.d/10-drop-in.toml       # nothing else

$ mise use --path proj dummy@1.0.0             # before: edits 10-drop-in.toml
                                               # after:  creates proj/mise.toml
```

## The change

Carry the drop-in exclusion in the candidate view instead of repeating it per arm, so it
applies to both passes by construction:

```rust
fn first_config_file(files: &IndexSet<PathBuf>) -> Option<&PathBuf> {
    let writable = || files.iter().filter(|p| !is_conf_d_file(p));
    writable()
        .find(|p| !is_tool_versions_file(p))
        .or_else(|| writable().next())
}
```

The preference keeps its fallback; the exclusion has none, and `None` comes back instead. Every
caller already handles `None` — default filename, keep walking up, or `MISE_GLOBAL_CONFIG_FILE`
— so no caller needed a new branch.

Two things fall out:

- #11633's middle arm is no longer needed. With drop-ins filtered out of the view, the fallback
  reaches `~/.tool-versions` on its own.
- `global_config_path`'s post-hoc `.filter(|p| !is_conf_d_file(...))` is no longer needed
  either, and is removed. It only existed to catch what the fallback could hand back.

## Measured

Three revisions on the same inputs, compiled standalone (`IndexSet` swapped for `Vec`; only
iteration order matters). `global` / `local` are what the respective callers do with the pick.

```
=== conf.d drop-in + ~/.tool-versions   (cli/test_global_config_confd) ===
  before    pick=conf.d/10-drop-in.toml   global=<creates config.toml>   local=conf.d/10-drop-in.toml
  #11633    pick=~/.tool-versions         global=~/.tool-versions        local=~/.tool-versions
  this PR   pick=~/.tool-versions         global=~/.tool-versions        local=~/.tool-versions

=== conf.d drop-in only ===
  before    pick=conf.d/10-drop-in.toml   global=<creates config.toml>   local=conf.d/10-drop-in.toml
  #11633    pick=conf.d/10-drop-in.toml   global=<creates config.toml>   local=conf.d/10-drop-in.toml   <-- left over
  this PR   pick=None                     global=<creates config.toml>   local=<creates mise.toml>

=== conf.d + config.toml + ~/.tool-versions ===
  all three pick=~/.config/mise/config.toml                                              <-- unchanged

=== local dir: .tool-versions listed before the conf.d glob ===
  all three pick=/proj/.tool-versions                                                    <-- unchanged

=== ~/.tool-versions first, mise.toml second ===
  all three pick=/proj/mise.toml                                                         <-- unchanged
```

The last three blocks are the controls: this has to be invisible wherever a real config exists,
and must not turn the `.tool-versions` preference into an exclusion.

## Tests

- **unit** — four cases on `first_config_file`, in a module that is deliberately **not**
  `#[cfg(unix)]`. The existing `mod tests` in this file is, and this function is pure path
  handling, so there is no reason for Windows not to run it.
- **e2e** — `cli/test_global_config_confd` keeps every existing assertion (those cover the
  global case and already pass on `main` since #11633) and gains the local `mise use --path`
  case above. Its header comment is widened, since the file is no longer only about the global
  config dir.

### Not run

`cargo fmt --all` and `cargo check --tests` locally; the suites are CI's. I did not run `mise`
itself end to end — the measurement above is of the selection function in isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration file selection so `conf.d` drop-ins are preserved rather than incorrectly selected as the primary configuration file.
  - Ensured `mise use --path` writes to the appropriate local configuration file without overwriting existing drop-in contents.
  - Added consistent `.tool-versions` fallback behavior when no standard configuration file is available.

- **Tests**
  - Expanded coverage for global and local drop-ins, configuration precedence, and cross-platform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
