### PR TITLE
fix(ruby): support ruby-build cli options

### DIFF
--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -213,6 +213,26 @@ mise ls-remote ruby
 [handful of settings](https://github.com/rbenv/ruby-build?tab=readme-ov-file#custom-build-configuration),
 in additional to that mise has a few extra settings:
 
+To pass options to `ruby-build` itself, use `ruby.ruby_build_cli_opts`. For example, `--keep`
+preserves the source tree after installation; set `RUBY_BUILD_BUILD_PATH` to choose where it is
+kept:
+
+```toml
+[settings.ruby]
+ruby_build_cli_opts = "--keep"
+
+[env]
+RUBY_BUILD_BUILD_PATH = "{{ config_root }}/.ruby-build"
+```
+
+Configure arguments such as `--enable-yjit` belong in `ruby.ruby_build_opts`. mise passes those
+after ruby-build's `--` separator:
+
+```toml
+[settings.ruby]
+ruby_build_opts = "--enable-yjit"
+```
+
 <script setup>
 import Settings from '/components/settings.vue';
 </script>

--- a/e2e/core/test_ruby_build_cli_opts
+++ b/e2e/core/test_ruby_build_cli_opts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+RUBY_BUILD_REPO="$PWD/ruby-build"
+RUBY_BUILD_ARGS_FILE="$PWD/ruby-build-args"
+
+mkdir -p "$RUBY_BUILD_REPO/bin"
+
+cat >"$RUBY_BUILD_REPO/install.sh" <<'SH'
+#!/bin/sh
+set -eu
+mkdir -p "$PREFIX/bin"
+cp bin/ruby-build "$PREFIX/bin/ruby-build"
+chmod +x "$PREFIX/bin/ruby-build"
+SH
+
+cat >"$RUBY_BUILD_REPO/bin/ruby-build" <<'SH'
+#!/bin/sh
+set -eu
+
+case "${1:-}" in
+--version)
+  echo "ruby-build 99999999"
+  exit 0
+  ;;
+--definitions)
+  echo "3.3.0"
+  exit 0
+  ;;
+esac
+
+printf '%s\n' "$@" >"$RUBY_BUILD_ARGS_FILE"
+
+install_path=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "3.3.0" ]; then
+    shift
+    install_path="$1"
+    break
+  fi
+  shift
+done
+
+[ -n "$install_path" ]
+mkdir -p "$install_path/bin"
+cat >"$install_path/bin/ruby" <<'RUBY'
+#!/bin/sh
+echo "ruby 3.3.0"
+RUBY
+chmod +x "$install_path/bin/ruby"
+SH
+
+git -C "$RUBY_BUILD_REPO" init
+git -C "$RUBY_BUILD_REPO" add .
+git -C "$RUBY_BUILD_REPO" -c user.name=mise -c user.email=mise@example.com commit -m init
+
+cat >mise.toml <<EOF
+[settings.ruby]
+compile = true
+ruby_build_repo = "file://$RUBY_BUILD_REPO"
+ruby_build_cli_opts = "--keep -4"
+ruby_build_opts = "--enable-yjit"
+
+[tools]
+ruby = "3.3.0"
+
+[env]
+RUBY_BUILD_ARGS_FILE = "$RUBY_BUILD_ARGS_FILE"
+EOF
+
+mise install
+
+RUBY_INSTALL_PATH="$(mise where ruby@3.3.0)"
+assert "sed -n '1p' '$RUBY_BUILD_ARGS_FILE'" "--keep"
+assert "sed -n '2p' '$RUBY_BUILD_ARGS_FILE'" "-4"
+assert "sed -n '3p' '$RUBY_BUILD_ARGS_FILE'" "3.3.0"
+assert "sed -n '4p' '$RUBY_BUILD_ARGS_FILE'" "$RUBY_INSTALL_PATH"
+assert "sed -n '5p' '$RUBY_BUILD_ARGS_FILE'" "--"
+assert "sed -n '6p' '$RUBY_BUILD_ARGS_FILE'" "--enable-yjit"
+assert "mise exec -- ruby --version" "ruby 3.3.0"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1580,8 +1580,12 @@
               "description": "URL template or GitHub repo for precompiled Ruby binaries.",
               "type": "string"
             },
+            "ruby_build_cli_opts": {
+              "description": "CLI options passed directly to ruby-build before the version and install prefix.",
+              "type": "string"
+            },
             "ruby_build_opts": {
-              "description": "Options to pass to ruby-build.",
+              "description": "Configure arguments passed through ruby-build after `--`.",
               "type": "string"
             },
             "ruby_build_repo": {

--- a/settings.toml
+++ b/settings.toml
@@ -2344,8 +2344,14 @@ precompiled_url = "https://my-mirror.example.com/ruby-{version}.{platform}.tar.g
 env = "MISE_RUBY_PRECOMPILED_URL"
 type = "String"
 
+[ruby.ruby_build_cli_opts]
+description = "CLI options passed directly to ruby-build before the version and install prefix."
+env = "MISE_RUBY_BUILD_CLI_OPTS"
+optional = true
+type = "String"
+
 [ruby.ruby_build_opts]
-description = "Options to pass to ruby-build."
+description = "Configure arguments passed through ruby-build after `--`."
 env = "MISE_RUBY_BUILD_OPTS"
 optional = true
 type = "String"

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -319,6 +319,9 @@ impl RubyPlugin {
         if settings.ruby.apply_patches.is_some() {
             args.push("--patch".into());
         }
+        if let Some(opts) = &settings.ruby.ruby_build_cli_opts {
+            args.extend(shell_words::split(opts)?);
+        }
         args.push(tv.version.clone());
         args.push(tv.install_path().to_string_lossy().to_string());
         if let Some(opts) = &settings.ruby.ruby_build_opts {
@@ -1161,6 +1164,9 @@ impl Backend for RubyPlugin {
                 ruby.ruby_install_repo.clone(),
             );
         } else {
+            if let Some(ruby_build_cli_opts) = ruby.ruby_build_cli_opts.clone() {
+                opts.insert("ruby_build_cli_opts".to_string(), ruby_build_cli_opts);
+            }
             if let Some(ruby_build_opts) = ruby.ruby_build_opts.clone() {
                 opts.insert("ruby_build_opts".to_string(), ruby_build_opts);
             }
@@ -1328,6 +1334,17 @@ mod tests {
             |settings| settings.ruby.compile = compile,
             |backend| backend.precompiled_only(),
         )
+    }
+
+    fn ruby_build_args(
+        configure_settings: impl FnOnce(&mut SettingsPartial),
+    ) -> Result<Vec<String>> {
+        with_ruby_settings(configure_settings, |backend| {
+            let request =
+                ToolRequest::new(backend.ba().clone(), "3.3.0", ToolSource::Unknown).unwrap();
+            let tv = ToolVersion::new(request, "3.3.0".to_string());
+            backend.install_args_ruby_build(&tv)
+        })
     }
 
     fn ruby_precompiled_cache_context(
@@ -1657,6 +1674,7 @@ mod tests {
     fn test_ruby_lockfile_options_include_source_build_inputs() {
         let opts = resolve_ruby_lockfile_options(|settings| {
             settings.ruby.compile = Some(true);
+            settings.ruby.ruby_build_cli_opts = Some("--keep".to_string());
             settings.ruby.ruby_build_opts = Some("--enable-yjit".to_string());
             settings.ruby.apply_patches = Some("https://example.com/ruby.patch".to_string());
         });
@@ -1673,10 +1691,47 @@ mod tests {
                     "ruby_build_repo".to_string(),
                     DEFAULT_RUBY_BUILD_REPO.to_string(),
                 ),
+                ("ruby_build_cli_opts".to_string(), "--keep".to_string()),
                 ("ruby_build_opts".to_string(), "--enable-yjit".to_string()),
                 ("ruby_install".to_string(), "false".to_string()),
             ])
         );
+    }
+
+    #[test]
+    fn test_ruby_build_cli_and_configure_option_order() {
+        let args = ruby_build_args(|settings| {
+            settings.ruby.apply_patches = Some("https://example.com/ruby.patch".to_string());
+            settings.ruby.ruby_build_cli_opts =
+                Some("--keep --definitions='/path with spaces'".to_string());
+            settings.ruby.ruby_build_opts =
+                Some("--enable-yjit --with-openssl-dir='/opt with spaces'".to_string());
+        })
+        .unwrap();
+
+        assert_eq!(
+            args[0..4],
+            [
+                "--patch",
+                "--keep",
+                "--definitions=/path with spaces",
+                "3.3.0"
+            ]
+        );
+        assert!(Path::new(&args[4]).ends_with("installs/ruby/3.3.0"));
+        assert_eq!(
+            args[5..],
+            ["--", "--enable-yjit", "--with-openssl-dir=/opt with spaces"]
+        );
+    }
+
+    #[test]
+    fn test_ruby_build_cli_opts_reject_invalid_shell_words() {
+        let result = ruby_build_args(|settings| {
+            settings.ruby.ruby_build_cli_opts = Some("--keep '".to_string());
+        });
+
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `ruby.ruby_build_cli_opts` / `MISE_RUBY_BUILD_CLI_OPTS` for options consumed by ruby-build itself
- preserve `ruby.ruby_build_opts` as configure arguments passed after the `--` separator
- include the new source-build input in lockfile options and document a stable `--keep` setup

## Problem

ruby-build distinguishes its own CLI options from configure arguments by position. mise previously exposed only `ruby_build_opts`, which PR #2609 intentionally placed after `--` for compatibility with options such as `--enable-yjit`. As a result, ruby-build CLI options such as `--keep` could not be expressed: they were forwarded to configure instead.

## Solution

Source builds now construct arguments as:

```text
ruby-build <mise options> <ruby_build_cli_opts> <version> <prefix> -- <ruby_build_opts>
```

Both option strings use the existing shell-word parser, so quoted values remain intact and malformed quoting fails before ruby-build starts. The new setting participates in source-build lockfile identity. ruby-install, Windows, and successful precompiled installs remain unchanged; a precompiled fallback to ruby-build uses the new option.

## Example

```toml
[settings.ruby]
ruby_build_cli_opts = "--keep"
ruby_build_opts = "--enable-yjit"

[env]
RUBY_BUILD_BUILD_PATH = "{{ config_root }}/.ruby-build"
```

## Verification

- `mise run render`
- `mise exec -- cargo test --all-features plugins::core::ruby::tests` (22 passed)
- `mise run test:e2e e2e/core/test_ruby_build_cli_opts`
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- shfmt -d e2e/core/test_ruby_build_cli_opts`
- `mise exec -- shellcheck e2e/core/test_ruby_build_cli_opts`
- `mise exec -- prettier --check docs/lang/ruby.md schema/mise.json`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run docs:build`

Addresses https://github.com/jdx/mise/discussions/6639

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ruby.ruby_build_cli_opts` for passing options directly to `ruby-build`.
  * Clarified `ruby.ruby_build_opts` for passing configure arguments, such as enabling YJIT.
  * Ruby build options now support correct ordering and shell-style argument parsing.

* **Documentation**
  * Added Ruby configuration guidance and examples for customizing source trees and build options.

* **Bug Fixes**
  * Improved handling and validation of Ruby build option syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->