### PR TITLE
chore: release 2026.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,123 @@
 # Changelog
 
+## [2026.8.6](https://github.com/jdx/mise/compare/v2026.8.5..v2026.8.6) - 2026-08-14
+
+### 🚀 Features
+
+- **(brew)** support structured cask symlinks by @jdx in [#11962](https://github.com/jdx/mise/pull/11962)
+- **(brew)** support generic cask artifacts by @jdx in [#11963](https://github.com/jdx/mise/pull/11963)
+- **(brew)** support cask copy and installer steps by @jdx in [#11964](https://github.com/jdx/mise/pull/11964)
+- **(config)** add config-root-scoped locked tool policy by @jdx in [#11940](https://github.com/jdx/mise/pull/11940)
+- **(config)** deprecate nixos all_compile default by @jdx in [#11956](https://github.com/jdx/mise/pull/11956)
+- **(deps)** support templates in provider configs by @Marukome0743 in [#11886](https://github.com/jdx/mise/pull/11886)
+- **(dotfiles)** add inline whole-file content by @jdx in [#11983](https://github.com/jdx/mise/pull/11983)
+- **(http)** resume interrupted downloads by @Marukome0743 in [#11866](https://github.com/jdx/mise/pull/11866)
+- **(task)** add --all to run picker by @jdx in [#11920](https://github.com/jdx/mise/pull/11920)
+- **(task)** add task.cache.audit_report for the full audit report by @stevenpollack in [#11997](https://github.com/jdx/mise/pull/11997)
+
+### 🐛 Bug Fixes
+
+- **(aqua)** error instead of returning a wrong checksum on filename mismatch by @jakedgy in [#11973](https://github.com/jdx/mise/pull/11973)
+- **(bootstrap)** avoid sudo for user-writable files by @jdx in [#11984](https://github.com/jdx/mise/pull/11984)
+- **(bootstrap)** allow Windows bootstrap without system files by @jdx in [#12003](https://github.com/jdx/mise/pull/12003)
+- **(cli)** accept both pwsh and powershell in activate and completion by @JamBalaya56562 in [#11928](https://github.com/jdx/mise/pull/11928)
+- **(cli)** reject --global alongside a path instead of ignoring it by @JamBalaya56562 in [#11935](https://github.com/jdx/mise/pull/11935)
+- **(conda)** preserve cross-platform lock data by @jdx in [#11946](https://github.com/jdx/mise/pull/11946)
+- **(conda)** honor url replacements by @Marukome0743 in [#11930](https://github.com/jdx/mise/pull/11930)
+- **(config)** allow typing j/k to filter in mise edit's tool picker by @jakedgy in [#11969](https://github.com/jdx/mise/pull/11969)
+- **(config)** create the config directory before writing into it by @JamBalaya56562 in [#11934](https://github.com/jdx/mise/pull/11934)
+- **(config)** stop a conf.d drop-in from becoming the write target by @JamBalaya56562 in [#11917](https://github.com/jdx/mise/pull/11917)
+- **(dotfiles)** treat an unmanaged file as a conflict on Windows too by @JamBalaya56562 in [#11981](https://github.com/jdx/mise/pull/11981)
+- **(dotfiles)** give the test helper the field FileRequest now requires by @JamBalaya56562 in [#11989](https://github.com/jdx/mise/pull/11989)
+- **(exec)** allow symlinked resolv.conf in sandbox by @jdx in [#11958](https://github.com/jdx/mise/pull/11958)
+- **(generate)** honor absolute localized directories by @NgoQuocViet2001 in [#11975](https://github.com/jdx/mise/pull/11975)
+- **(hooks)** skip tool installation in preinstall tasks by @Marukome0743 in [#11927](https://github.com/jdx/mise/pull/11927)
+- **(http)** retry send failures that never produced a response (HTTP/2 REFUSED_STREAM) by @mariadeluna-tomtom in [#11961](https://github.com/jdx/mise/pull/11961)
+- **(http)** honor system install destinations by @Marukome0743 in [#11851](https://github.com/jdx/mise/pull/11851)
+- **(install)** write manifests atomically by @jdx in [#11957](https://github.com/jdx/mise/pull/11957)
+- **(lock)** include task-specific tools by @Marukome0743 in [#11976](https://github.com/jdx/mise/pull/11976)
+- **(npm)** render lifecycle logs through progress by @jdx in [#11939](https://github.com/jdx/mise/pull/11939)
+- **(oci)** strip the tag from name:tag@digest references by @fire-ant in [#11979](https://github.com/jdx/mise/pull/11979)
+- **(pipx)** discover wheel-only package versions by @jdx in [#11959](https://github.com/jdx/mise/pull/11959)
+- **(ruby)** support ruby-build cli options by @Marukome0743 in [#11918](https://github.com/jdx/mise/pull/11918)
+- **(rust)** resolve nightly to dated toolchains by @Marukome0743 in [#11980](https://github.com/jdx/mise/pull/11980)
+- **(semver)** stop calling a mangled value a semver range by @JamBalaya56562 in [#11949](https://github.com/jdx/mise/pull/11949)
+- **(shell)** resolve a shell named by a Windows path by @JamBalaya56562 in [#11950](https://github.com/jdx/mise/pull/11950)
+- **(shims)** stop treating a full-path argv[0] as a shim name by @JamBalaya56562 in [#11982](https://github.com/jdx/mise/pull/11982)
+- **(task)** normalize variadic usage env values by @Marukome0743 in [#11881](https://github.com/jdx/mise/pull/11881)
+- **(task)** resolve monorepo task names from subdirectories by @pikeas in [#11941](https://github.com/jdx/mise/pull/11941)
+- **(task)** mask archive modes in remote cache nodes by @stevenpollack in [#11877](https://github.com/jdx/mise/pull/11877)
+- **(task)** avoid zsh process substitution hangs by @Marukome0743 in [#11904](https://github.com/jdx/mise/pull/11904)
+- **(task)** bound buffered command output by @Marukome0743 in [#11922](https://github.com/jdx/mise/pull/11922)
+- **(task)** normalize task cwd for source freshness by @jdx in [#11987](https://github.com/jdx/mise/pull/11987)
+- **(tasks)** stop telling Windows users to run chmod +x by @JamBalaya56562 in [#11923](https://github.com/jdx/mise/pull/11923)
+- **(toolset)** accept a Windows tool path spelled with backslashes by @JamBalaya56562 in [#11937](https://github.com/jdx/mise/pull/11937)
+- **(toolset)** reject cmd.exe metacharacters in a Windows tool path by @JamBalaya56562 in [#11947](https://github.com/jdx/mise/pull/11947)
+- **(upgrade)** deprecate ambiguous -l shorthand by @jdx in [#11945](https://github.com/jdx/mise/pull/11945)
+
+### 🚜 Refactor
+
+- **(backend)** add request-aware version selection by @risu729 in [#11551](https://github.com/jdx/mise/pull/11551)
+
+### ⚡ Performance
+
+- **(cache)** accelerate artifact materialization by @jdx in [#11932](https://github.com/jdx/mise/pull/11932)
+
+### 🧪 Testing
+
+- **(aqua)** cover claude registry install by @jdx in [#11925](https://github.com/jdx/mise/pull/11925)
+- **(aqua)** install latest claude release by @jdx in [#11931](https://github.com/jdx/mise/pull/11931)
+- **(windows)** restore MISE_TRUSTED_CONFIG_PATHS after the trust suite by @JamBalaya56562 in [#11948](https://github.com/jdx/mise/pull/11948)
+- **(windows)** drop teardown Pester already does by @JamBalaya56562 in [#11985](https://github.com/jdx/mise/pull/11985)
+- **(windows)** make the extensionless task test exercise the file it names by @JamBalaya56562 in [#11924](https://github.com/jdx/mise/pull/11924)
+
+### 📦️ Dependency Updates
+
+- invalidate state when commands change by @Marukome0743 in [#11849](https://github.com/jdx/mise/pull/11849)
+- bump msrv to 1.93 by @jdx in [#11916](https://github.com/jdx/mise/pull/11916)
+- update aube to 1.39.0 by @jdx in [#11933](https://github.com/jdx/mise/pull/11933)
+- update rust crate aube-registry to v1.40.0 by @renovate[bot] in [#11972](https://github.com/jdx/mise/pull/11972)
+- honor source and output overrides by @Marukome0743 in [#11896](https://github.com/jdx/mise/pull/11896)
+
+### 📦 Registry
+
+- add native-sdk ([github:vercel-labs/native](https://github.com/vercel-labs/native)) by @phall1 in [#11942](https://github.com/jdx/mise/pull/11942)
+- add restate binaries ([github:restatedev/restate](https://github.com/restatedev/restate)) by @Bing-su in [#11953](https://github.com/jdx/mise/pull/11953)
+- add mailpit ([aqua:axllent/mailpit](https://github.com/axllent/mailpit)) by @joealden in [#11960](https://github.com/jdx/mise/pull/11960)
+
+### Chore
+
+- **(ci)** avoid rate-limit helper bootstrap by @Marukome0743 in [#11914](https://github.com/jdx/mise/pull/11914)
+- **(ci)** verify actual aws sdk msrv compatibility by @jdx in [#11926](https://github.com/jdx/mise/pull/11926)
+- **(ci)** install cmake for snapcraft builds by @jdx in [#11974](https://github.com/jdx/mise/pull/11974)
+- integrate hk agent workflow by @jdx in [#11936](https://github.com/jdx/mise/pull/11936)
+
+### New Contributors
+
+- @stevenpollack made their first contribution in [#11997](https://github.com/jdx/mise/pull/11997)
+- @mariadeluna-tomtom made their first contribution in [#11961](https://github.com/jdx/mise/pull/11961)
+- @pikeas made their first contribution in [#11941](https://github.com/jdx/mise/pull/11941)
+- @phall1 made their first contribution in [#11942](https://github.com/jdx/mise/pull/11942)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (3)
+
+- [`OpenRouterLabs/ori-releases`](https://github.com/OpenRouterLabs/ori-releases)
+- [`mekedron/wolt-cli`](https://github.com/mekedron/wolt-cli)
+- [`mikevalstar/okq`](https://github.com/mikevalstar/okq)
+
+#### Updated Packages (8)
+
+- [`apstndb/execspansql`](https://github.com/apstndb/execspansql)
+- [`apstndb/spannerplanviz/rendertree`](https://github.com/apstndb/spannerplanviz)
+- [`concourse/concourse/fly`](https://github.com/concourse/concourse)
+- [`jgm/pandoc`](https://github.com/jgm/pandoc)
+- [`kunobi-ninja/kunobi`](https://github.com/kunobi-ninja/kunobi)
+- [`masutaka/github-nippou`](https://github.com/masutaka/github-nippou)
+- [`modem-dev/hunk`](https://github.com/modem-dev/hunk)
+- [`stefanprodan/timoni`](https://github.com/stefanprodan/timoni)
+
 ## [2026.8.5](https://github.com/jdx/mise/compare/v2026.8.4..v2026.8.5) - 2026-08-12
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6294,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.8.5"
+version = "2026.8.6"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.8.5"
+version = "2026.8.6"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ ~/.local/bin/mise --version
  / / / / / / (__  )  __/_____/  __/ / / /_____/ /_/ / / /_/ / /__/  __/
 /_/ /_/ /_/_/____/\___/      \___/_/ /_/     / .___/_/\__,_/\___/\___/
                                             /_/                 by @jdx
-2026.8.5 macos-arm64 (2026-08-12)
+2026.8.6 macos-arm64 (2026-08-14)
 ```
 
 Hook mise into your shell (pick the right one for your shell):

--- a/completions/_mise
+++ b/completions/_mise
@@ -26,7 +26,7 @@ _mise() {
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
   [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_5.spec"
+  local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_6.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage >| "$spec_file"

--- a/completions/mise.bash
+++ b/completions/mise.bash
@@ -11,7 +11,7 @@ _mise() {
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
     [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
-    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_5.spec"
+    local spec_file="$spec_dir/usage__usage_spec_mise_2026_8_6.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
         mise usage >| "$spec_file"

--- a/completions/mise.fish
+++ b/completions/mise.fish
@@ -9,7 +9,7 @@ if ! type -P usage &> /dev/null
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
 test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
-set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_5.spec"
+set -l spec_file "$spec_dir/usage__usage_spec_mise_2026_8_6.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mise_*.spec' -type f -mtime +30 -delete 2>/dev/null
     mise usage | string collect > "$spec_file"

--- a/completions/mise.ps1
+++ b/completions/mise.ps1
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName 'mise' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_5.kdl"
+    $specFile = Join-Path $tmpDir "usage__usage_spec_mise_2026_8_6.kdl"
 
     if (-not (Test-Path $specFile)) {
     mise usage | Out-File -FilePath $specFile -Encoding utf8

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.8.5";
+  version = "2026.8.6";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "32.3k",
+      stars: "32.4k",
     };
   },
 };

--- a/mise.lock
+++ b/mise.lock
@@ -312,6 +312,10 @@ checksum = "sha256:7e23929588aaf5daff1e93bfc4addca7ccf55195444e84552b6588c9d8646
 url = "https://github.com/mitsuhiko/insta/releases/download/1.48.0/cargo-insta-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/mitsuhiko/insta/releases/assets/444757862"
 
+[[tools."cargo:flamegraph"]]
+version = "0.6.14"
+backend = "cargo:flamegraph"
+
 [[tools.communique]]
 version = "1.2.4"
 backend = "github:jdx/communique"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.8.5
+Version: 2026.8.6
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.8.5"
+version: "2026.8.6"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "7be5f3b7e1330b6fba326c456d7d1f151e3408e8"
+  "tag": "3faad1446762bb8f5dd43303956a98af22b33c61"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -6333,6 +6333,29 @@ packages:
         format: raw
         complete_windows_ext: false
   - type: github_release
+    repo_owner: OpenRouterLabs
+    repo_name: ori-releases
+    description: Ori CLI release repo
+    version_prefix: cli-
+    files:
+      - name: ori
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["cli-0.0.0-02e9757", "cli-0.0.0-1b829d5", "cli-0.0.0-1c71b5b", "cli-0.0.0-1f610f5", "cli-0.0.0-2f0a249", "cli-0.0.0-34641b1", "cli-0.0.0-3d9c01d", "cli-0.0.0-47f0103", "cli-0.0.0-50b0d25", "cli-0.0.0-5302a93", "cli-0.0.0-592965f", "cli-0.0.0-944fc7a", "cli-0.0.0-9645986", "cli-0.0.0-b5fd984", "cli-0.0.0-b98cd74", "cli-0.0.0-cebea8b", "cli-0.0.0-d68ced1", "cli-0.0.0-d9bbd76", "cli-0.0.0-e701796", "cli-0.0.0-faa36d3"]
+        no_asset: true
+      - version_constraint: "true"
+        asset: ori-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: Orange-OpenSource
     repo_name: hurl
     description: Hurl, run and test HTTP requests with plain text
@@ -14523,14 +14546,12 @@ packages:
     repo_owner: apstndb
     repo_name: execspansql
     description: Yet another gcloud spanner databases execute-sql replacement for better composability
-    version_source: github_tag
   - name: apstndb/spannerplanviz/rendertree
     type: go_install
     repo_owner: apstndb
     repo_name: spannerplanviz
     path: github.com/apstndb/spannerplanviz/cmd/rendertree
     description: This tool render YAML or JSON representation of Cloud Spanner query plan as ascii format
-    version_source: github_tag
   - type: github_release
     repo_owner: aptly-dev
     repo_name: aptly
@@ -28658,8 +28679,10 @@ packages:
       - darwin
       - amd64
     rosetta2: true
-    # TODO checksum: support sha1
-    # https://github.com/aquaproj/aqua/issues/1216
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha1"
+      algorithm: sha1
     files:
       - name: fly
   - name: connectrpc/connect-go/protoc-gen-connect-go
@@ -53317,17 +53340,17 @@ packages:
         windows_arm_emulation: true
         replacements:
           darwin: macOS
+        files:
+          - name: pandoc
+            src: "pandoc-{{.Version}}/bin/pandoc"
+          - name: pandoc-lua
+            src: "pandoc-{{.Version}}/bin/pandoc-lua"
+          - name: pandoc-server
+            src: "pandoc-{{.Version}}/bin/pandoc-server"
         overrides:
-          - goos: linux
-            files:
-              - name: pandoc
-                src: "pandoc-{{.Version}}/bin/pandoc"
           - goos: darwin
             format: zip
             asset: pandoc-{{.Version}}-{{.OS}}.{{.Format}}
-            files:
-              - name: pandoc
-                src: "pandoc-{{.Version}}/bin/pandoc"
           - goos: windows
             format: zip
             files:
@@ -53348,6 +53371,10 @@ packages:
             files:
               - name: pandoc
                 src: "pandoc-{{.Version}}/bin/pandoc"
+              - name: pandoc-lua
+                src: "pandoc-{{.Version}}/bin/pandoc-lua"
+              - name: pandoc-server
+                src: "pandoc-{{.Version}}/bin/pandoc-server"
             replacements:
               amd64: amd64
           - goos: darwin
@@ -53355,6 +53382,10 @@ packages:
             files:
               - name: pandoc
                 src: "pandoc-{{.Version}}-{{.Arch}}/bin/pandoc"
+              - name: pandoc-lua
+                src: "pandoc-{{.Version}}-{{.Arch}}/bin/pandoc-lua"
+              - name: pandoc-server
+                src: "pandoc-{{.Version}}-{{.Arch}}/bin/pandoc-server"
           - goos: windows
             files:
               - name: pandoc
@@ -61254,7 +61285,6 @@ packages:
       - name: kunobi-ninja/kunobi-releases
     description: Kubernetes IDE for managing clusters, resources, and workloads
     link: https://kunobi.ninja
-    version_source: github_tag
     url: https://r2.kunobi.ninja/v{{.Version}}/Kunobi_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     format: tar.gz
     replacements:
@@ -64142,6 +64172,14 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: Version == "v4.3.0"
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: github-nippou_{{.Version}}_checksums.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
@@ -64150,6 +64188,8 @@ packages:
           type: github_release
           asset: github-nippou_{{.Version}}_checksums.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: masutaka/github-nippou/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: mathew-fleisch
     repo_name: bashbot
@@ -64725,6 +64765,25 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+  - type: github_release
+    repo_owner: mekedron
+    repo_name: wolt-cli
+    description: "Free & Open Source CLI for Wolt: discover venues, inspect menus and options, manage carts, and preview checkout from the terminal"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: wolt
+          - name: wolt-mcp
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: mercari
     repo_name: hcledit
@@ -65766,6 +65825,29 @@ packages:
               - https://github.com/mikefarah/yq/.github/workflows/release.yml@refs/tags/{{.Version}}
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+  - type: github_release
+    repo_owner: mikevalstar
+    repo_name: okq
+    description: Fast, deterministic CLI to search and navigate Open Knowledge Format (OKF), or Obsidian style doc bundles — for humans and AI agents. Find by frontmatter, traverse the link graph, surface orphans/deadlinks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: okq-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: okq-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: miku
     repo_name: zek
@@ -66810,6 +66892,17 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("<= 0.12.0-beta.1")
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: hunk
+            src: "{{.AssetWithoutExt}}/hunk"
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -66821,6 +66914,7 @@ packages:
         supported_envs:
           - linux
           - darwin
+          - windows/amd64
   - type: github_release
     repo_owner: momaek
     repo_name: authy
@@ -87950,6 +88044,23 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+      - version_constraint: semver("<= 0.29.0")
+        asset: timoni_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          type: github_release
+          asset: timoni_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        slsa_provenance:
+          type: github_release
+          asset: timoni_{{trimV .Version}}_provenance.intoto.jsonl
       - version_constraint: "true"
         asset: timoni_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -87967,6 +88078,8 @@ packages:
         slsa_provenance:
           type: github_release
           asset: timoni_{{trimV .Version}}_provenance.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: stefanprodan/timoni/\.github/workflows/release\.yaml
   - type: github_release
     repo_owner: stepchowfun
     repo_name: docuum


### PR DESCRIPTION
### 🚀 Features

- **(brew)** support structured cask symlinks by @jdx in [#11962](https://github.com/jdx/mise/pull/11962)
- **(brew)** support generic cask artifacts by @jdx in [#11963](https://github.com/jdx/mise/pull/11963)
- **(brew)** support cask copy and installer steps by @jdx in [#11964](https://github.com/jdx/mise/pull/11964)
- **(config)** add config-root-scoped locked tool policy by @jdx in [#11940](https://github.com/jdx/mise/pull/11940)
- **(config)** deprecate nixos all_compile default by @jdx in [#11956](https://github.com/jdx/mise/pull/11956)
- **(deps)** support templates in provider configs by @Marukome0743 in [#11886](https://github.com/jdx/mise/pull/11886)
- **(dotfiles)** add inline whole-file content by @jdx in [#11983](https://github.com/jdx/mise/pull/11983)
- **(http)** resume interrupted downloads by @Marukome0743 in [#11866](https://github.com/jdx/mise/pull/11866)
- **(task)** add --all to run picker by @jdx in [#11920](https://github.com/jdx/mise/pull/11920)
- **(task)** add task.cache.audit_report for the full audit report by @stevenpollack in [#11997](https://github.com/jdx/mise/pull/11997)

### 🐛 Bug Fixes

- **(aqua)** error instead of returning a wrong checksum on filename mismatch by @jakedgy in [#11973](https://github.com/jdx/mise/pull/11973)
- **(bootstrap)** avoid sudo for user-writable files by @jdx in [#11984](https://github.com/jdx/mise/pull/11984)
- **(bootstrap)** allow Windows bootstrap without system files by @jdx in [#12003](https://github.com/jdx/mise/pull/12003)
- **(cli)** accept both pwsh and powershell in activate and completion by @JamBalaya56562 in [#11928](https://github.com/jdx/mise/pull/11928)
- **(cli)** reject --global alongside a path instead of ignoring it by @JamBalaya56562 in [#11935](https://github.com/jdx/mise/pull/11935)
- **(conda)** preserve cross-platform lock data by @jdx in [#11946](https://github.com/jdx/mise/pull/11946)
- **(conda)** honor url replacements by @Marukome0743 in [#11930](https://github.com/jdx/mise/pull/11930)
- **(config)** allow typing j/k to filter in mise edit's tool picker by @jakedgy in [#11969](https://github.com/jdx/mise/pull/11969)
- **(config)** create the config directory before writing into it by @JamBalaya56562 in [#11934](https://github.com/jdx/mise/pull/11934)
- **(config)** stop a conf.d drop-in from becoming the write target by @JamBalaya56562 in [#11917](https://github.com/jdx/mise/pull/11917)
- **(dotfiles)** treat an unmanaged file as a conflict on Windows too by @JamBalaya56562 in [#11981](https://github.com/jdx/mise/pull/11981)
- **(dotfiles)** give the test helper the field FileRequest now requires by @JamBalaya56562 in [#11989](https://github.com/jdx/mise/pull/11989)
- **(exec)** allow symlinked resolv.conf in sandbox by @jdx in [#11958](https://github.com/jdx/mise/pull/11958)
- **(generate)** honor absolute localized directories by @NgoQuocViet2001 in [#11975](https://github.com/jdx/mise/pull/11975)
- **(hooks)** skip tool installation in preinstall tasks by @Marukome0743 in [#11927](https://github.com/jdx/mise/pull/11927)
- **(http)** retry send failures that never produced a response (HTTP/2 REFUSED_STREAM) by @mariadeluna-tomtom in [#11961](https://github.com/jdx/mise/pull/11961)
- **(http)** honor system install destinations by @Marukome0743 in [#11851](https://github.com/jdx/mise/pull/11851)
- **(install)** write manifests atomically by @jdx in [#11957](https://github.com/jdx/mise/pull/11957)
- **(lock)** include task-specific tools by @Marukome0743 in [#11976](https://github.com/jdx/mise/pull/11976)
- **(npm)** render lifecycle logs through progress by @jdx in [#11939](https://github.com/jdx/mise/pull/11939)
- **(oci)** strip the tag from name:tag@digest references by @fire-ant in [#11979](https://github.com/jdx/mise/pull/11979)
- **(pipx)** discover wheel-only package versions by @jdx in [#11959](https://github.com/jdx/mise/pull/11959)
- **(ruby)** support ruby-build cli options by @Marukome0743 in [#11918](https://github.com/jdx/mise/pull/11918)
- **(rust)** resolve nightly to dated toolchains by @Marukome0743 in [#11980](https://github.com/jdx/mise/pull/11980)
- **(semver)** stop calling a mangled value a semver range by @JamBalaya56562 in [#11949](https://github.com/jdx/mise/pull/11949)
- **(shell)** resolve a shell named by a Windows path by @JamBalaya56562 in [#11950](https://github.com/jdx/mise/pull/11950)
- **(shims)** stop treating a full-path argv[0] as a shim name by @JamBalaya56562 in [#11982](https://github.com/jdx/mise/pull/11982)
- **(task)** normalize variadic usage env values by @Marukome0743 in [#11881](https://github.com/jdx/mise/pull/11881)
- **(task)** resolve monorepo task names from subdirectories by @pikeas in [#11941](https://github.com/jdx/mise/pull/11941)
- **(task)** mask archive modes in remote cache nodes by @stevenpollack in [#11877](https://github.com/jdx/mise/pull/11877)
- **(task)** avoid zsh process substitution hangs by @Marukome0743 in [#11904](https://github.com/jdx/mise/pull/11904)
- **(task)** bound buffered command output by @Marukome0743 in [#11922](https://github.com/jdx/mise/pull/11922)
- **(task)** normalize task cwd for source freshness by @jdx in [#11987](https://github.com/jdx/mise/pull/11987)
- **(tasks)** stop telling Windows users to run chmod +x by @JamBalaya56562 in [#11923](https://github.com/jdx/mise/pull/11923)
- **(toolset)** accept a Windows tool path spelled with backslashes by @JamBalaya56562 in [#11937](https://github.com/jdx/mise/pull/11937)
- **(toolset)** reject cmd.exe metacharacters in a Windows tool path by @JamBalaya56562 in [#11947](https://github.com/jdx/mise/pull/11947)
- **(upgrade)** deprecate ambiguous -l shorthand by @jdx in [#11945](https://github.com/jdx/mise/pull/11945)

### 🚜 Refactor

- **(backend)** add request-aware version selection by @risu729 in [#11551](https://github.com/jdx/mise/pull/11551)

### ⚡ Performance

- **(cache)** accelerate artifact materialization by @jdx in [#11932](https://github.com/jdx/mise/pull/11932)

### 🧪 Testing

- **(aqua)** cover claude registry install by @jdx in [#11925](https://github.com/jdx/mise/pull/11925)
- **(aqua)** install latest claude release by @jdx in [#11931](https://github.com/jdx/mise/pull/11931)
- **(windows)** restore MISE_TRUSTED_CONFIG_PATHS after the trust suite by @JamBalaya56562 in [#11948](https://github.com/jdx/mise/pull/11948)
- **(windows)** drop teardown Pester already does by @JamBalaya56562 in [#11985](https://github.com/jdx/mise/pull/11985)
- **(windows)** make the extensionless task test exercise the file it names by @JamBalaya56562 in [#11924](https://github.com/jdx/mise/pull/11924)

### 📦️ Dependency Updates

- invalidate state when commands change by @Marukome0743 in [#11849](https://github.com/jdx/mise/pull/11849)
- bump msrv to 1.93 by @jdx in [#11916](https://github.com/jdx/mise/pull/11916)
- update aube to 1.39.0 by @jdx in [#11933](https://github.com/jdx/mise/pull/11933)
- update rust crate aube-registry to v1.40.0 by @renovate[bot] in [#11972](https://github.com/jdx/mise/pull/11972)
- honor source and output overrides by @Marukome0743 in [#11896](https://github.com/jdx/mise/pull/11896)

### 📦 Registry

- add native-sdk ([github:vercel-labs/native](https://github.com/vercel-labs/native)) by @phall1 in [#11942](https://github.com/jdx/mise/pull/11942)
- add restate binaries ([github:restatedev/restate](https://github.com/restatedev/restate)) by @Bing-su in [#11953](https://github.com/jdx/mise/pull/11953)
- add mailpit ([aqua:axllent/mailpit](https://github.com/axllent/mailpit)) by @joealden in [#11960](https://github.com/jdx/mise/pull/11960)

### Chore

- **(ci)** avoid rate-limit helper bootstrap by @Marukome0743 in [#11914](https://github.com/jdx/mise/pull/11914)
- **(ci)** verify actual aws sdk msrv compatibility by @jdx in [#11926](https://github.com/jdx/mise/pull/11926)
- **(ci)** install cmake for snapcraft builds by @jdx in [#11974](https://github.com/jdx/mise/pull/11974)
- integrate hk agent workflow by @jdx in [#11936](https://github.com/jdx/mise/pull/11936)

### New Contributors

- @stevenpollack made their first contribution in [#11997](https://github.com/jdx/mise/pull/11997)
- @mariadeluna-tomtom made their first contribution in [#11961](https://github.com/jdx/mise/pull/11961)
- @pikeas made their first contribution in [#11941](https://github.com/jdx/mise/pull/11941)
- @phall1 made their first contribution in [#11942](https://github.com/jdx/mise/pull/11942)

## 📦 Aqua Registry Updates

### New Packages (3)

- [`OpenRouterLabs/ori-releases`](https://github.com/OpenRouterLabs/ori-releases)
- [`mekedron/wolt-cli`](https://github.com/mekedron/wolt-cli)
- [`mikevalstar/okq`](https://github.com/mikevalstar/okq)

### Updated Packages (8)

- [`apstndb/execspansql`](https://github.com/apstndb/execspansql)
- [`apstndb/spannerplanviz/rendertree`](https://github.com/apstndb/spannerplanviz)
- [`concourse/concourse/fly`](https://github.com/concourse/concourse)
- [`jgm/pandoc`](https://github.com/jgm/pandoc)
- [`kunobi-ninja/kunobi`](https://github.com/kunobi-ninja/kunobi)
- [`masutaka/github-nippou`](https://github.com/masutaka/github-nippou)
- [`modem-dev/hunk`](https://github.com/modem-dev/hunk)
- [`stefanprodan/timoni`](https://github.com/stefanprodan/timoni)