### PR TITLE
fix(tasks): stop telling Windows users to run chmod +x

### DIFF
--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -273,4 +273,45 @@ Write-Output ([Environment]::GetCommandLineArgs() -join " ")
             $output | Should -BeLike '*-NoProfile*'
         }
     }
+
+    Context 'a task file Windows cannot execute' {
+        BeforeAll {
+            $script:notExecDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+            New-Item -ItemType Directory -Path (Join-Path $script:notExecDir 'scripts') | Out-Null
+            # No shebang and no known extension, which is what `is_executable` looks at here --
+            # there is no permission bit involved on this platform.
+            Set-Content (Join-Path $script:notExecDir 'scripts\thing') 'echo hi' -NoNewline
+            @'
+[tasks.x]
+file = "scripts/thing"
+'@ | Out-File -FilePath (Join-Path $script:notExecDir 'mise.toml') -Encoding utf8NoBOM
+        }
+
+        It 'does not tell the user to run chmod' {
+            Push-Location $script:notExecDir
+            try {
+                $out = mise tasks validate 2>&1 | Out-String
+                $out | Should -BeLike '*not executable*'
+                # chmod does not exist here, and it is not the fix either: adding a shebang or a
+                # known extension is.
+                $out | Should -Not -BeLike '*chmod*'
+                $out | Should -BeLike '*shebang*'
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'says how to fix it when the task is run' {
+            Push-Location $script:notExecDir
+            try {
+                $out = mise run x 2>&1 | Out-String
+                $LASTEXITCODE | Should -Not -Be 0
+                $out | Should -BeLike '*not executable*'
+                $out | Should -BeLike '*shebang*'
+                $out | Should -Not -BeLike '*chmod*'
+            } finally {
+                Pop-Location
+            }
+        }
+    }
 }

--- a/e2e/tasks/test_task_validate
+++ b/e2e/tasks/test_task_validate
@@ -273,6 +273,10 @@ touch non-executable.sh
 assert_contains "mise tasks validate --errors-only 2>&1 || true" "error-task"
 assert_not_contains "mise tasks validate --errors-only 2>&1 || true" "warning-task"
 
+# The remedy is platform-specific -- Windows has no chmod and its `is_executable` does not look at
+# a permission bit -- so pin the unix wording here. e2e-win pins the other half.
+assert_contains "mise tasks validate 2>&1 || true" "chmod +x"
+
 # Test specific task validation
 cat <<EOF >mise.toml
 [tasks.good]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1376,11 +1376,23 @@ impl Run {
             && !file::is_executable(path)
         {
             let dp = crate::file::display_path(path);
+            // Only offer the fix where accepting it can change the answer. `make_executable` is a
+            // no-op on Windows, so the prompt would take a "yes" and then fail anyway; the same
+            // reasoning already keeps `make_task_executable` from running there.
+            if cfg!(windows) {
+                bail!(
+                    "`{dp}` is not executable. {}",
+                    file::make_executable_hint(path)
+                )
+            }
             let msg = format!("Script `{dp}` is not executable. Make it executable?");
             if ui::confirm(msg)? {
                 file::make_executable(path)?;
             } else {
-                bail!("`{dp}` is not executable")
+                bail!(
+                    "`{dp}` is not executable. {}",
+                    file::make_executable_hint(path)
+                )
             }
         }
         Ok(())

--- a/src/cli/tasks/validate.rs
+++ b/src/cli/tasks/validate.rs
@@ -449,7 +449,7 @@ impl TasksValidate {
                     severity: Severity::Warning,
                     category: "not-executable".to_string(),
                     message: format!("Task file is not executable: {}", file::display_path(file)),
-                    details: Some(format!("Run: chmod +x {}", file::display_path(file))),
+                    details: Some(file::make_executable_hint(file)),
                 });
             }
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -937,6 +937,28 @@ pub fn is_executable(path: &Path) -> bool {
     has_shebang(path)
 }
 
+/// How to make `path` count as executable, phrased for the platform the user is on.
+///
+/// Lives beside [`is_executable`] because it has to track it: the two platforms answer that
+/// question by different rules, so the remedy differs too. `chmod +x` is not merely unavailable on
+/// Windows — it is the wrong instruction, since the Windows branch never looks at a permission bit.
+#[cfg(unix)]
+pub fn make_executable_hint(path: &Path) -> String {
+    format!("Run: chmod +x {}", display_path(path))
+}
+
+#[cfg(windows)]
+pub fn make_executable_hint(path: &Path) -> String {
+    format!(
+        "Add a shebang line to {}, or give it one of these extensions: {}",
+        display_path(path),
+        // Read from the setting rather than hardcoded: a user who has changed
+        // `windows_executable_extensions` would otherwise be told to use extensions mise will not
+        // accept from them.
+        Settings::get().windows_executable_extensions.join(", ")
+    )
+}
+
 #[cfg(windows)]
 pub fn has_known_executable_extension(path: &Path) -> bool {
     path.extension().map_or(
@@ -3728,5 +3750,26 @@ mod tests {
 
         assert!(!src.exists());
         assert_eq!(fs::read(dst.join("nested/bun")).unwrap(), b"hello");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn make_executable_hint_names_chmod_on_unix() {
+        let hint = make_executable_hint(Path::new("/proj/mise-tasks/build"));
+        assert!(hint.contains("chmod +x"), "{hint}");
+        assert!(hint.contains("build"), "{hint}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn make_executable_hint_does_not_name_chmod_on_windows() {
+        let hint = make_executable_hint(Path::new(r"C:\proj\mise-tasks\build"));
+        // The point of the change: `chmod` is not just unavailable here, it is the wrong fix --
+        // the Windows `is_executable` never looks at a permission bit.
+        assert!(!hint.contains("chmod"), "{hint}");
+        assert!(hint.contains("shebang"), "{hint}");
+        // and it must offer what that branch actually accepts
+        assert!(hint.contains("exe"), "{hint}");
+        assert!(hint.contains("build"), "{hint}");
     }
 }


### PR DESCRIPTION
mise tells Windows users to run `chmod +x`. Measured on `2026.8.4-DEBUG windows-x64`:

```console
$ cat mise.toml
[tasks.x]
file = "scripts/thing"        # no shebang, no extension

$ mise tasks validate
  ⚠ Task file is not executable: scripts/thing [not-executable]
      Run: chmod +x scripts/thing

$ mise run x
Error: `scripts/thing` is not executable
```

`chmod` is not merely unavailable there. It is **the wrong instruction**: the Windows
`is_executable` never looks at a permission bit —

```rust
#[cfg(windows)]
pub fn is_executable(path: &Path) -> bool {
    if !path.is_file() { return false; }
    if has_known_executable_extension(path) { return true; }
    has_shebang(path)
}
```

— so following it changes nothing. The second command gives no remedy at all. Interactively it
first asks *"Make it executable?"*, and `make_executable` is a no-op on Windows, so a "yes" is
taken and the run fails anyway.

## This is a gap in an existing decision, not a new one

Four places report this condition. **Three are already guarded**, which is what makes the
remaining two look like oversights rather than a policy question:

| | guard |
|---|---|
| `cli/tasks/ls.rs` | `!cfg!(windows)` ✓ |
| `task/task_list.rs` (the `bail!`) | `!cfg!(windows)` ✓ |
| `task/task_list.rs` (`make_task_executable`) | `if cfg!(windows) { return Ok(None) }` ✓ |
| `cli/tasks/validate.rs` | none |
| `cli/run.rs` | none |

## The change

A `make_executable_hint` beside `is_executable` in `src/file.rs`, because the remedy has to track
the rule — they are the same question asked twice, and splitting them is how the two drift:

```rust
#[cfg(unix)]
pub fn make_executable_hint(path: &Path) -> String {
    format!("Run: chmod +x {}", display_path(path))
}

#[cfg(windows)]
pub fn make_executable_hint(path: &Path) -> String {
    format!(
        "Add a shebang line to {}, or give it one of these extensions: {}",
        display_path(path),
        Settings::get().windows_executable_extensions.join(", ")
    )
}
```

The extensions come from the setting rather than a literal list. `windows_executable_extensions` is
user-configurable, and a hardcoded list would tell someone who has changed it to use extensions
mise will then refuse.

`validate.rs` uses it for the issue's `details`. `run.rs` uses it in the failure, and skips the
prompt on Windows — offering a fix that cannot apply is worse than not offering one, and this
matches what `make_task_executable` already does.

The `message` itself ("Task file is not executable") is accurate on both platforms and is
unchanged, as is the whole unix path.

## Tests

- **unit**, one per platform in `src/file.rs`: unix asserts `chmod +x`; Windows asserts the hint
  mentions a shebang, offers a real extension, and **does not contain `chmod`**.
- **e2e** — `test_task_validate` already builds a non-executable task file but never checked the
  message. Now pins `chmod +x` for unix.
- **e2e-win** — a new context in `task.Tests.ps1` covering both commands, asserting no `chmod` and
  that a shebang is suggested.

### Not run

`cargo fmt --all` only; the suites are CI's. The "before" transcript above is real, from a local
debug build. I have not built the fix — the "after" wording is what CI's `windows-e2e` checks.

## Not in this PR

Making Windows *discover* a shebang-less task file. That is a behaviour change; this is only about
what mise tells you when it does not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and execution errors for non-executable task files on Windows.
  * Windows guidance now recommends adding a shebang or recognized executable extension instead of suggesting `chmod`.
  * Unix errors continue to provide the appropriate `chmod +x` remediation.
  * Validation warnings now provide platform-specific instructions for making task files executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->