### PR TITLE
test(windows): make the extensionless task test exercise the file it names

### DIFF
--- a/e2e-win/task.Tests.ps1
+++ b/e2e-win/task.Tests.ps1
@@ -3,8 +3,20 @@ Describe 'task' {
     BeforeAll {
         $originalPath = Get-Location
         Set-Location TestDrive:
+        # Saved before overwriting, restored in AfterAll: Pester runs every suite in one process,
+        # so removing an inherited value here would leave the next suite without it.
+        $script:originalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
         # Trust the TestDrive config path - use $TestDrive for physical path, not PSDrive path
         $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+
+        # Saved here, restored in AfterAll: the tests below set these and `BeforeEach` only clears
+        # them between tests in this file.
+        $script:originalShellEnv = @{}
+        foreach ($name in 'MISE_WINDOWS_EXECUTABLE_EXTENSIONS',
+            'MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS',
+            'MISE_USE_FILE_SHELL_FOR_EXECUTABLE_TASKS') {
+            $script:originalShellEnv[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+        }
 
         # Create mise.toml that includes tasks directory
         @'
@@ -21,11 +33,13 @@ includes = ["tasks"]
 echo mytask
 '@ | Out-File -FilePath "tasks\filetask.bat" -Encoding ascii -NoNewline
 
-        # Create filetask (no extension) for MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS test
+        # A task file with neither an extension nor a shebang. Deliberately *not* named
+        # `filetask`: that collapses to the same task name as `filetask.bat`, and the `.bat` is
+        # what runs, so nothing here would be exercised.
         @'
 @echo off
-echo mytask
-'@ | Out-File -FilePath "tasks\filetask" -Encoding ascii -NoNewline
+echo from-noext
+'@ | Out-File -FilePath "tasks\noexttask" -Encoding ascii -NoNewline
 
         # Create testtask.ps1 for pwsh test
         @'
@@ -35,7 +49,20 @@ Write-Output "windows"
 
     AfterAll {
         Set-Location $originalPath
-        Remove-Item -Path Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        if ($null -eq $script:originalTrusted) {
+            Remove-Item -Path Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:originalTrusted, 'Process')
+        }
+        # `BeforeEach` clears these for tests *inside* this Describe, but Pester runs every suite
+        # in one process, so whatever the last test left set would leak into the next suite.
+        foreach ($name in $script:originalShellEnv.Keys) {
+            if ($null -eq $script:originalShellEnv[$name]) {
+                Remove-Item -Path "Env:\$name" -ErrorAction SilentlyContinue
+            } else {
+                [Environment]::SetEnvironmentVariable($name, $script:originalShellEnv[$name], 'Process')
+            }
+        }
     }
 
     BeforeEach {
@@ -48,9 +75,25 @@ Write-Output "windows"
         mise run filetask.bat | Select -Last 1 | Should -Be 'mytask'
     }
 
-    It 'executes a task without extension' {
-        $env:MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS = "bat"
-        mise run filetask | Select -Last 1 | Should -Be 'mytask'
+    # `windows_executable_extensions` is what decides whether a file with no extension and no
+    # shebang is a task at all -- there is no permission bit here for `is_executable` to consult.
+    # Nothing else in this suite covers that boundary, and it is the reason the extensionless
+    # fixture above is invisible by default.
+    It 'does not discover an extensionless file task by default' {
+        $out = mise tasks ls | Out-String
+        # Both guards matter for the negative assertion below: it would also hold if the command
+        # had failed outright, or listed nothing at all.
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike '*filetask*'
+        $out | Should -Not -BeLike '*noexttask*'
+    }
+
+    It 'discovers an extensionless file task when the setting admits it' {
+        # The leading comma is the empty entry, which is what matches a file with no extension.
+        $env:MISE_WINDOWS_EXECUTABLE_EXTENSIONS = ",exe,bat,cmd"
+        $out = mise tasks ls | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike '*noexttask*'
     }
 
     It 'executes a shebang task with bash' {


### PR DESCRIPTION
`It 'executes a task without extension'` is green but never touches the file it names. Found while
checking a review comment on #11923 that assumed this test covered a working path.

## The collision

`BeforeAll` writes two fixtures whose task names collapse to the same thing:

```
tasks\filetask.bat      @echo off / echo mytask
tasks\filetask          @echo off / echo mytask     <- no extension, the intended subject
```

Giving them different bodies shows which one runs:

```console
$ cat tasks/filetask.bat  ->  echo FROM-BAT
$ cat tasks/filetask      ->  echo FROM-EXTENSIONLESS

$ MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS=bat mise tasks ls
filetask                       # one task, not two

$ MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS=bat mise run filetask
FROM-BAT                       # exit=0
```

The `.bat` supplies the task. Rename the extensionless fixture and the original assertion fails
immediately:

```console
$ MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS=bat mise run noexttask
Error: no task noexttask found
```

There is a second defect behind the first. The working example in this same file,
`It 'executes a task in pwsh'`, sets all three of `windows_executable_extensions`,
`windows_default_file_shell_args` and `use_file_shell_for_executable_tasks`. The broken test sets
one, and its value — `"bat"` — is not a shell.

## Why this is not fixed by "make it run the extensionless file"

The behaviour the name claims is not reachable with in-box Windows tooling. Every combination
measured on `2026.8.4-DEBUG windows-x64`:

| configuration | result |
|---|---|
| default | `mise tasks ls` empty — `is_executable` wants an extension or a shebang |
| `MISE_WINDOWS_EXECUTABLE_EXTENSIONS=""` or `",exe"` | **discovered** |
| + run it | `os error 193` — exec'd directly |
| + `MISE_USE_FILE_SHELL_FOR_EXECUTABLE_TASKS=1`, shell `cmd /c` | cmd: "not recognized as an internal or external command" |
| shell `pwsh.exe -File` / `powershell.exe -File` | refused: "does not have a '.ps1' extension" |
| shell `cscript //nologo //E:vbscript` | "Can't find script engine" — VBScript is gone on Windows 11 |

Only a POSIX shell can execute an extensionless script, and that is not in-box. **mise already has
the mechanism for extensionless files: the shebang** — covered by
`It 'executes a shebang task with bash'` two tests below.

So the fix belongs in the test, not in mise.

## The change

Test-only, one file.

1. Rename the extensionless fixture to `noexttask` so it stops shadowing, and give it a
   distinguishable body.
2. Replace the false claim with the rule that actually governs it — `windows_executable_extensions`
   is the discovery boundary. Deterministic, no external shell, `mise tasks ls` only:

```powershell
It 'does not discover an extensionless file task by default' {
    $out = mise tasks ls | Out-String
    # Both guards matter for the negative assertion below: it would also hold if the command
    # had failed outright, or listed nothing at all.
    $LASTEXITCODE | Should -Be 0
    $out | Should -BeLike '*filetask*'
    $out | Should -Not -BeLike '*noexttask*'
}

It 'discovers an extensionless file task when the setting admits it' {
    # The leading comma is the empty entry, which is what matches a file with no extension.
    $env:MISE_WINDOWS_EXECUTABLE_EXTENSIONS = ",exe,bat,cmd"
    $out = mise tasks ls | Out-String
    $LASTEXITCODE | Should -Be 0
    $out | Should -BeLike '*noexttask*'
}
```

The exit-code check and the `filetask` positive control came out of review, and they are the
point: a bare `Should -Not -BeLike` is exactly the assertion this PR exists to fix. It would pass
if `mise tasks ls` crashed, and it would pass if the fixture had never been written — the same
class of green-but-empty test as the one being replaced.

3. Save and restore the three shell settings in `BeforeAll`/`AfterAll`. `BeforeEach` clears them
   between tests *inside* this `Describe`, but Pester runs every suite in one process, so whatever
   the last test left set leaked into the next file. Also from review.

Both discovery assertions verified locally against a real `mise tasks ls`: `filetask` alone by
default, `filetask` and `noexttask` with the setting.

## Coverage does not drop

The removed assertion had nothing behind it, and its neighbours already cover the paths that work:

| path | test |
|---|---|
| `.bat` file task | `It 'executes a task'` |
| execution through the file shell | `It 'executes a task in pwsh'` (sets all three settings) |
| extensionless **with a shebang** | `It 'executes a shebang task with bash'` |

What is added is the discovery boundary, which nothing covered.

## Not done

No bash-based test of "extensionless through a POSIX file shell". It would be the literal reading
of the old name, but it depends on which `bash.exe` the runner resolves — on the machine this was
measured on that is `C:\WINDOWS\system32\bash.exe`, the WSL launcher, not Git Bash. I am not
building a test on a dependency I cannot inspect.

I also did not run the Pester suite: Windows tests cannot run in a Linux container, so `windows-e2e`
is the only place that exercises it.

## Conflicts

#11923 adds a context to this same file. Whichever lands second should merge them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows task discovery behavior for tasks without file extensions.
  * Extensionless tasks are now excluded by default and can be enabled through executable extension settings.

* **Tests**
  * Added Windows coverage to verify extensionless task discovery and environment settings are preserved between tests.
  * Replaced a duplicate fixture with a dedicated extensionless task fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
