### PR TITLE
test(aqua): cover claude registry install

### DIFF
--- a/e2e/backend/test_registry_claude_slow
+++ b/e2e/backend/test_registry_claude_slow
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+export MISE_EXPERIMENTAL=1
+
+# Regression test for https://github.com/jdx/mise/discussions/11909.
+assert_contains \
+  "mise x claude@2.1.226 -- claude --version" \
+  "2.1.226 (Claude Code)"


### PR DESCRIPTION
## Summary

- add a slow e2e test that installs Claude Code through the `claude` registry shorthand
- verify the installed executable reports the pinned version
- cover the regression reported in discussion #11909

## Verification

- `mise run test:e2e e2e/backend/test_registry_claude_slow`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no production code, auth, or data-path changes.
> 
> **Overview**
> Adds a slow e2e regression test that installs Claude Code via the `claude` registry shorthand and checks that `claude --version` reports the pinned `2.1.226` build.
> 
> Covers the install failure reported in discussion #11909.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f22ebeadb009c0a27cec128564e956c879a7c13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression test verifying that the experimental configuration correctly installs and reports the expected Claude version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->