### PR TITLE
chore(ci): verify actual aws sdk msrv compatibility

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,12 +10,6 @@
   },
   "packageRules": [
     {
-      "description": "AWS SDK requires Rust 1.94.1; keep updates disabled while the project MSRV is 1.93.",
-      "matchPackageNames": ["aws-config", "aws-sdk-*"],
-      "matchManagers": ["cargo"],
-      "enabled": false
-    },
-    {
       "description": "copr image is rebuilt from source on Dockerfile changes; pinning a digest would cause stale image regressions.",
       "matchPackageNames": ["ghcr.io/jdx/mise"],
       "matchCurrentValue": "copr",

--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -253,6 +253,8 @@ jobs:
           	cargo clean || true
           EOF
 
+          # CI verifies that the locked dependencies actually compile with mise's MSRV.
+          sed -i '/cargo build --profile/ s/$/ --ignore-rust-version/' debian/rules
           chmod +x debian/rules
 
           cat > debian/copyright << EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,9 +271,11 @@ jobs:
             env:
               HK_SKIP_STEPS: cargo-check
           # MSRV uses a separate target directory so its older compiler cannot
-          # invalidate stable's build artifacts.
+          # invalidate stable's build artifacts. Some AWS crates declare a newer
+          # rust-version than their code requires; rustc still rejects genuinely
+          # incompatible syntax and APIs when the metadata check is ignored.
           - name: Verify MSRV
-            run: cargo msrv verify
+            run: cargo msrv verify -- cargo check --ignore-rust-version
             env:
               CARGO_TARGET_DIR: target/msrv
           - name: Run Clippy

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -255,8 +255,8 @@ export AWS_LC_SYS_PREBUILT_NASM=1
 %endif
 %endif
 
-# Build with specified profile
-cargo build --profile __BUILD_PROFILE__ --frozen --bin mise
+# CI verifies that the locked dependencies actually compile with mise's MSRV.
+cargo build --profile __BUILD_PROFILE__ --frozen --bin mise --ignore-rust-version
 
 %install
 mkdir -p %{buildroot}%{_bindir}


### PR DESCRIPTION
## Summary

- verify mise's declared MSRV with `cargo check --ignore-rust-version`, allowing the compiler rather than AWS SDK metadata to determine compatibility
- use the same metadata override for COPR and Ubuntu PPA builds
- re-enable Renovate updates for `aws-config` and `aws-sdk-*`

## Why

The AWS SDK currently declares Rust 1.94.1 across its crates even though the locked dependency graph compiles successfully with mise's Rust 1.93 MSRV. The dedicated MSRV job still derives its toolchain from `package.rust-version`, so genuinely incompatible mise or dependency syntax and APIs continue to fail.

Normal development and release builds remain strict; the override is limited to MSRV verification and the Rust 1.93 package builders.

## Validation

- `cargo msrv verify -- cargo check --ignore-rust-version`
- `cargo +1.93 build --frozen --bin mise --ignore-rust-version`
- `mise run lint-fix`
- `actionlint .github/workflows/test.yml .github/workflows/ppa-publish.yml`
- `bash -n packaging/copr/build-copr.sh`
- `jq empty .github/renovate.json`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release packaging builds (COPR/PPA) and re-enables AWS SDK dependency updates; a bad update could still compile under --ignore-rust-version while claiming a higher MSRV.
> 
> **Overview**
> Allows mise to keep its **1.93 MSRV** while AWS SDK crates declare a newer `rust-version`, by checking real compiler compatibility instead of crate metadata.
> 
> **MSRV CI** now runs `cargo msrv verify -- cargo check --ignore-rust-version`, so rustc still rejects incompatible syntax/APIs but ignores overly strict AWS crate metadata.
> 
> The same `--ignore-rust-version` override is applied to **COPR** and **Ubuntu PPA** package builds. Renovate updates for `aws-config` / `aws-sdk-*` are re-enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d6169ee4bc15bb1a6a96183b0d9add18595b8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package builds when dependencies declare a newer Rust version than the project’s supported compiler.
  * Updated validation and packaging workflows to maintain compatibility with the project’s minimum supported Rust version.

* **Chores**
  * Dependency update automation can now track AWS SDK updates without being blocked by the previous Rust-version restriction.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->