### PR TITLE
fix(hooks): skip tool installation in preinstall tasks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -114,6 +114,11 @@ enter = ["echo 'entering project'", { task = "setup" }]
 
 Task hooks work with all hook types (`enter`, `leave`, `cd`, `preinstall`, `postinstall`).
 
+Task references used as `preinstall` hooks do not automatically install missing project- or
+task-level tools. This keeps the hook ahead of the installation it is preparing. Commands needed
+by a preinstall task must already be available from the system or an existing installation. Other
+task-backed hook types retain normal task tool installation behavior.
+
 ## Watch files hook
 
 While using `mise activate` you can have mise watch files for changes and execute a script or task when a file changes.

--- a/e2e/config/test_hooks_task_ref
+++ b/e2e/config/test_hooks_task_ref
@@ -10,17 +10,52 @@ dummy = 'latest'
 [tasks.setup]
 run = 'echo TASK-SETUP-RAN'
 
+[tasks.credentials]
+interactive = true
+run = '''
+echo CREDENTIAL-LINE-1
+if test -d "$MISE_DATA_DIR/installs/dummy"; then
+  echo TOOL-INSTALLED-BEFORE-PREINSTALL
+  exit 1
+fi
+echo PREINSTALL-BEFORE-TOOL
+printf 'Credential: '
+IFS= read -r credential
+echo "CREDENTIAL-INPUT:$credential"
+echo CREDENTIAL-LINE-2
+'''
+
+[tasks.after-install]
+run = 'dummy first second'
+
 [tasks.teardown]
 run = 'echo TASK-TEARDOWN-RAN'
 
 [hooks]
 enter = { task = "setup" }
 leave = { task = "teardown" }
-preinstall = { task = "setup" }
+preinstall = { task = "credentials" }
+postinstall = { task = "after-install" }
 EOF
 
-# Test preinstall hook with task reference
-assert_contains "mise i 2>&1" "TASK-SETUP-RAN"
+# The preinstall task preview shows the same --skip-tools invocation used at
+# runtime, but neither the task nor the tool installation is started.
+dry_run_output=$(mise i --dry-run 2>&1)
+assert_contains_text "$dry_run_output" "run --skip-tools credentials"
+assert_not_contains_text "$dry_run_output" "CREDENTIAL-LINE-1"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy'"
+
+# A task-backed preinstall hook must run before project tools are installed.
+# Interactive task stdio remains inherited by the nested mise process.
+install_output=$(printf 'secret-8800\n' | mise i 2>&1)
+assert_contains_text "$install_output" "CREDENTIAL-LINE-1"
+assert_contains_text "$install_output" "PREINSTALL-BEFORE-TOOL"
+assert_contains_text "$install_output" "CREDENTIAL-INPUT:secret-8800"
+assert_contains_text "$install_output" "CREDENTIAL-LINE-2"
+assert_not_contains_text "$install_output" "TOOL-INSTALLED-BEFORE-PREINSTALL"
+assert_contains_text "$install_output" "This is Dummy"
+assert_contains_text "$install_output" "second first"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy"
 
 eval "$(mise hook-env)"
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -519,13 +519,9 @@ async fn run_matched_hook(
 
 fn preview_matched_hook(root: &Path, hook: &Hook) -> Result<()> {
     let action = match &hook.action {
-        HookAction::Task { task_name } => shell_words::join([
-            "mise".to_string(),
-            "--cd".to_string(),
-            root.to_string_lossy().into_owned(),
-            "run".to_string(),
-            task_name.clone(),
-        ]),
+        HookAction::Task { task_name } => shell_words::join(
+            once("mise".to_string()).chain(task_hook_args(root, hook.hook, task_name)),
+        ),
         HookAction::CurrentShell { script, .. } => script.clone(),
         HookAction::Run { shell, .. } => {
             let Some(run) = hook.action.run_for_current_platform() else {
@@ -762,14 +758,24 @@ async fn execute_task(
     }
     env.insert("MISE_NO_HOOKS".to_string(), "1".to_string());
 
-    cmd(
-        mise_bin,
-        ["--cd", &root.to_string_lossy(), "run", task_name],
-    )
-    .stdout_to_stderr()
-    .full_env(env)
-    .run()?;
+    cmd(mise_bin, task_hook_args(root, hook.hook, task_name))
+        .stdout_to_stderr()
+        .full_env(env)
+        .run()?;
     Ok(())
+}
+
+fn task_hook_args(root: &Path, hook: Hooks, task_name: &str) -> Vec<String> {
+    let mut args = vec![
+        "--cd".to_string(),
+        root.to_string_lossy().into_owned(),
+        "run".to_string(),
+    ];
+    if hook == Hooks::Preinstall {
+        args.push("--skip-tools".to_string());
+    }
+    args.push(task_name.to_string());
+    args
 }
 
 #[cfg(test)]
@@ -780,6 +786,24 @@ mod tests {
     #[derive(Deserialize)]
     struct TestHook {
         hook: HookDef,
+    }
+
+    #[test]
+    fn preinstall_task_skips_tool_installation() {
+        assert_eq!(
+            task_hook_args(Path::new("project"), Hooks::Preinstall, "credentials"),
+            ["--cd", "project", "run", "--skip-tools", "credentials"]
+        );
+    }
+
+    #[test]
+    fn other_task_hooks_keep_normal_tool_handling() {
+        for hook in [Hooks::Enter, Hooks::Leave, Hooks::Cd, Hooks::Postinstall] {
+            assert_eq!(
+                task_hook_args(Path::new("project"), hook, "setup"),
+                ["--cd", "project", "run", "setup"]
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- run task-backed preinstall hooks with `mise run --skip-tools` so they complete before project or task tools are installed
- share task-hook argument construction between execution and dry-run previews
- document the preinstall tool-availability boundary and add ordering, interactive I/O, dry-run, and postinstall regression coverage

## Root cause

The outer install pipeline invoked the preinstall hook at the correct point, but a `{ task = "..." }` hook launched a nested `mise run`. That nested run performed its normal automatic tool installation before executing the task, so the nominal preinstall task observed the tools as already installed.

Only task-backed preinstall hooks now add `--skip-tools`. Enter, leave, cd, and postinstall task hooks retain normal task tool handling.

## Verification

- `mise exec -- cargo test --all-features hooks::tests` (12 passed)
- `mise run test:e2e e2e/config/test_hooks_task_ref`
- related hook E2E suite exercised through `e2e/config/test_hooks`
- macOS real-TTY credential prompt: input and multiline output preserved; hook completed before the outer tool install
- `mise exec -- cargo fmt --all -- --check`
- `mise exec -- cargo check --all-features`
- `mise exec -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- scoped ShellCheck, shfmt, and Markdown checks passed; the aggregate local `mise run lint` reached an unrelated actionlint repository-discovery limitation because this checkout uses Sapling without a `.git` directory

Addresses https://github.com/jdx/mise/discussions/8800

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task-backed preinstall hooks so they no longer automatically install missing project- or task-level tools.
  * Preserved standard tool installation for other task-backed hook types.
  * Improved hook preview and execution consistency.

* **Tests**
  * Added coverage for preinstall ordering, dry runs, interactive input inheritance, postinstall execution, and tool installation behavior.

* **Documentation**
  * Clarified tool installation behavior for task-backed preinstall hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->