### PR TITLE
fix(cli): accept both pwsh and powershell in activate and completion

### DIFF
--- a/docs/cli/activate.md
+++ b/docs/cli/activate.md
@@ -41,6 +41,7 @@ Shell type to generate the script for
 - `xonsh`
 - `zsh`
 - `pwsh`
+- `powershell`
 
 ## Flags
 

--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -18,6 +18,7 @@ Shell type to generate completions for
 - `bash`
 - `fish`
 - `powershell`
+- `pwsh`
 - `zsh`
 
 ## Flags

--- a/docs/cli/env.md
+++ b/docs/cli/env.md
@@ -40,6 +40,7 @@ Shell type to generate environment variables for
 - `xonsh`
 - `zsh`
 - `pwsh`
+- `powershell`
 
 ### `--json-extended`
 

--- a/e2e/cli/test_shell_name_aliases
+++ b/e2e/cli/test_shell_name_aliases
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# `mise activate` and `mise completion` name PowerShell differently -- `pwsh` and `powershell` --
+# because their accepted values come from two different enums. Setup runs the two commands one
+# after the other, so whichever name a user learns first used to be rejected by the other.
+#
+# Both names are accepted by both commands now. Nothing here is Windows-specific: the argument
+# parsing is the same everywhere, which is why this lives in the unix e2e.
+#
+# The aliases are not hidden: `mise usage` renders them, so both names are listed as choices in
+# `mise.usage.kdl` and the generated CLI docs. That is checked by the `render` lint, not here.
+
+assert_succeed "mise activate pwsh"
+assert_succeed "mise activate powershell"
+
+assert_succeed "mise completion powershell"
+assert_succeed "mise completion pwsh"
+
+# Accepted has to mean equivalent, not merely "exits 0".
+assert "diff <(mise activate pwsh) <(mise activate powershell) && echo same" "same"
+assert "diff <(mise completion powershell) <(mise completion pwsh) && echo same" "same"

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -125,7 +125,7 @@ Examples:
     flag "-q --quiet" help="Suppress non-error messages"
     flag "-s --shell" help="Shell type to generate the script for" hide=#true {
         arg <SHELL> {
-            choices bash elvish fish nu xonsh zsh pwsh
+            choices bash elvish fish nu xonsh zsh pwsh powershell
         }
     }
     flag --no-hook-env help="Do not automatically call hook-env" {
@@ -151,7 +151,7 @@ See https://mise.jdx.dev/dev-tools/shims.html#shims-vs-path for more information
     }
     flag --status help="Show \"mise: <TOOL>@<VERSION>\" message when changing directories" hide=#true
     arg "[SHELL_TYPE]" help="Shell type to generate the script for" required=#false {
-        choices bash elvish fish nu xonsh zsh pwsh
+        choices bash elvish fish nu xonsh zsh pwsh powershell
     }
 }
 cmd tool-alias help="Manage tool version aliases." effect=read {
@@ -996,7 +996,7 @@ Examples:
 """#
     flag "-s --shell" help="Shell type to generate completions for" hide=#true {
         arg <SHELL_TYPE> {
-            choices bash fish powershell zsh
+            choices bash fish powershell pwsh zsh
         }
     }
     flag --include-bash-completion-lib help="Include the bash completion library in the bash completion script" {
@@ -1022,7 +1022,7 @@ https://usage.jdx.dev
 """#
     }
     arg "[SHELL]" help="Shell type to generate completions for" required=#false {
-        choices bash fish powershell zsh
+        choices bash fish powershell pwsh zsh
     }
 }
 cmd config help="Manage config files" effect=read {
@@ -1383,7 +1383,7 @@ Examples:
     flag "-J --json" help="Output in JSON format"
     flag "-s --shell" help="Shell type to generate environment variables for" {
         arg <SHELL> {
-            choices bash elvish fish nu xonsh zsh pwsh
+            choices bash elvish fish nu xonsh zsh pwsh powershell
         }
     }
     flag --json-extended help="Output in JSON format with additional information (source, tool)"
@@ -1877,7 +1877,7 @@ cmd hook-env hide=#true help="[internal] called by activate hook to update env v
     flag "-q --quiet" help="Hide warnings such as when a tool is not installed"
     flag "-s --shell" help="Shell type to generate script for" {
         arg <SHELL> {
-            choices bash elvish fish nu xonsh zsh pwsh
+            choices bash elvish fish nu xonsh zsh pwsh powershell
         }
     }
     flag --reason help="Reason for calling hook-env (e.g., \"precmd\", \"chpwd\")" hide=#true {
@@ -1890,7 +1890,7 @@ cmd hook-env hide=#true help="[internal] called by activate hook to update env v
 cmd hook-not-found hide=#true help="[internal] called by shell when a command is not found" effect=write {
     flag "-s --shell" help="Shell type to generate script for" {
         arg <SHELL> {
-            choices bash elvish fish nu xonsh zsh pwsh
+            choices bash elvish fish nu xonsh zsh pwsh powershell
         }
     }
     arg <BIN> help="Attempted bin to run"

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -118,6 +118,46 @@ impl ValueEnum for Shell {
         &[Self::Bash, Self::Fish, Self::Powershell, Self::Zsh]
     }
     fn to_possible_value(&self) -> Option<PossibleValue> {
-        Some(PossibleValue::new(self.to_string()))
+        let value = PossibleValue::new(self.to_string());
+        Some(match self {
+            // `mise activate` names this shell `pwsh`, and the two commands are run one after the
+            // other during setup, so whichever name a user learns first is rejected by the other.
+            // The names differ only because the two lists come from different places, not because
+            // they mean different shells.
+            //
+            // `mise usage` renders aliases, so this shows up in the generated CLI docs as a
+            // choice alongside `powershell` rather than being hidden.
+            Self::Powershell => value.alias("pwsh"),
+            _ => value,
+        })
+    }
+}
+
+#[cfg(test)]
+mod shell_name_tests {
+    use super::*;
+
+    #[test]
+    fn pwsh_is_accepted_as_powershell() {
+        assert!(matches!(
+            <Shell as ValueEnum>::from_str("pwsh", true),
+            Ok(Shell::Powershell)
+        ));
+        assert!(matches!(
+            <Shell as ValueEnum>::from_str("powershell", true),
+            Ok(Shell::Powershell)
+        ));
+    }
+
+    #[test]
+    fn the_primary_names_are_unchanged() {
+        // Only the *names* -- the alias is rendered into the CLI docs, so asserting it absent
+        // here would state something false. This pins that adding it renamed nothing.
+        let listed: Vec<String> = Shell::value_variants()
+            .iter()
+            .filter_map(|v| v.to_possible_value())
+            .map(|pv| pv.get_name().to_string())
+            .collect();
+        assert_eq!(listed, ["bash", "fish", "powershell", "zsh"]);
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -21,6 +21,16 @@ pub enum ShellType {
     Nu,
     Xonsh,
     Zsh,
+    // `powershell` is an alias, not a second shell. mise picks PowerShell 7 features at *runtime*
+    // -- the emitted script checks `$PSVersionTable.PSVersion` and drops the chpwd hook below 7 --
+    // so the name never carried the 5.1-vs-7 distinction, and `mise completion` already spells the
+    // same shell `powershell`.
+    //
+    // It is not hidden, whatever `alias` suggests: `mise usage` renders aliases into
+    // `mise.usage.kdl` and from there into the CLI docs, so both names are listed there.
+    //
+    // Deliberately not a doc comment: the derive turns those into the value's help text.
+    #[value(alias = "powershell")]
     Pwsh,
 }
 
@@ -61,7 +71,8 @@ impl FromStr for ShellType {
         // spells the separator `\`, and `MISE_SHELL` falls back to `SHELL`, which is `COMSPEC`
         // there -- always a full path. So every native path failed to resolve.
         let s = s.rsplit_once(['/', '\\']).map(|(_, s)| s).unwrap_or(&s);
-        // `pwsh.exe` / `bash.exe` is how Windows names them.
+        // `pwsh.exe` / `powershell.exe` is how Windows names them, and nothing between here and
+        // `MISE_SHELL` strips that. Applied to every shell: `bash.exe` has the same problem.
         let s = s.strip_suffix(".exe").unwrap_or(s);
         match s {
             "bash" | "sh" => Ok(Self::Bash),
@@ -70,7 +81,9 @@ impl FromStr for ShellType {
             "nu" => Ok(Self::Nu),
             "xonsh" => Ok(Self::Xonsh),
             "zsh" => Ok(Self::Zsh),
-            "pwsh" => Ok(Self::Pwsh),
+            // Both names, for the same reason `sh` maps to bash above: this parses a shell the
+            // user is already in, and `powershell.exe` is what Windows PowerShell reports.
+            "pwsh" | "powershell" => Ok(Self::Pwsh),
             _ => Err(format!("unsupported shell type: {s}")),
         }
     }
@@ -154,7 +167,8 @@ pub fn get_shell(shell: Option<ShellType>) -> Option<Box<dyn Shell>> {
 /// paths were not being parsed.
 #[cfg(test)]
 mod tests {
-    use super::ShellType;
+    use super::*;
+    use clap::ValueEnum;
     use std::str::FromStr;
 
     #[test]
@@ -167,7 +181,12 @@ mod tests {
             (r"C:\Program Files\Git\bin\PWSH.EXE", ShellType::Pwsh),
             ("pwsh.exe", ShellType::Pwsh),
         ] {
-            assert_eq!(ShellType::from_str(input), Ok(expected), "{input:?}");
+            // Qualified because `ValueEnum` is in scope here and also defines `from_str`.
+            assert_eq!(
+                <ShellType as FromStr>::from_str(input),
+                Ok(expected),
+                "{input:?}"
+            );
         }
     }
 
@@ -182,7 +201,11 @@ mod tests {
             ("pwsh", ShellType::Pwsh),
             ("fish", ShellType::Fish),
         ] {
-            assert_eq!(ShellType::from_str(input), Ok(expected), "{input:?}");
+            assert_eq!(
+                <ShellType as FromStr>::from_str(input),
+                Ok(expected),
+                "{input:?}"
+            );
         }
     }
 
@@ -193,10 +216,64 @@ mod tests {
         // is that the message names `cmd` instead of repeating the whole path back.
         for input in [r"C:\WINDOWS\system32\cmd.exe", "cmd.exe"] {
             assert_eq!(
-                ShellType::from_str(input),
+                <ShellType as FromStr>::from_str(input),
                 Err("unsupported shell type: cmd".to_string()),
                 "{input:?}"
             );
         }
+    }
+
+    #[test]
+    fn powershell_is_accepted_as_pwsh() {
+        // Two paths reach this enum: clap for `mise activate <SHELL>`, and FromStr for detecting
+        // the shell the user is already in. Both have to take the alias or the fix is half done.
+        // Qualified because both traits in scope define `from_str`.
+        assert_eq!(
+            <ShellType as FromStr>::from_str("powershell"),
+            Ok(ShellType::Pwsh),
+            "FromStr"
+        );
+        assert_eq!(
+            <ShellType as ValueEnum>::from_str("powershell", true),
+            Ok(ShellType::Pwsh),
+            "clap"
+        );
+        assert_eq!(
+            <ShellType as ValueEnum>::from_str("pwsh", true),
+            Ok(ShellType::Pwsh)
+        );
+    }
+
+    #[test]
+    fn the_exe_suffix_is_stripped() {
+        // `MISE_SHELL` is parsed straight through `FromStr` with nothing removing the suffix
+        // first, so a Windows shell name has to be matched with it.
+        for name in ["powershell.exe", "pwsh.exe", "PowerShell.exe"] {
+            assert_eq!(
+                <ShellType as FromStr>::from_str(name),
+                Ok(ShellType::Pwsh),
+                "{name}"
+            );
+        }
+        assert_eq!(
+            <ShellType as FromStr>::from_str("bash.exe"),
+            Ok(ShellType::Bash)
+        );
+    }
+
+    #[test]
+    fn the_primary_names_are_unchanged() {
+        // Only the *names*. The alias is deliberately not asserted absent here: `mise usage`
+        // renders aliases into `mise.usage.kdl` and the CLI docs, so "hidden" would be false.
+        // What this pins is that adding an alias did not rename or reorder an existing value.
+        let listed: Vec<String> = ShellType::value_variants()
+            .iter()
+            .filter_map(|v| v.to_possible_value())
+            .map(|pv| pv.get_name().to_string())
+            .collect();
+        assert_eq!(
+            listed,
+            ["bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"]
+        );
     }
 }


### PR DESCRIPTION
The same shell has two names, and the two commands you run back to back during setup accept
opposite ones:

```console
$ mise activate   pwsh        -> ok
$ mise activate   powershell  -> error: invalid value 'powershell' for '[SHELL_TYPE]'

$ mise completion pwsh        -> error: invalid value 'pwsh' for '[SHELL]'
$ mise completion powershell  -> ok
```

`bash`, `zsh` and `fish` are spelled the same in both, so this only ever bites Windows users.

## It is not a PowerShell 7 vs 5.1 distinction

That was my first suspicion — `pwsh` and `powershell` really are different programs — so I checked
before touching anything. mise makes that distinction **at runtime, not by the name**:

```powershell
# src/shell/pwsh.rs, inside the script `mise activate pwsh` emits
function __enable_mise_chpwd {
    if ($PSVersionTable.PSVersion.Major -lt 7) {
        Write-Warning "mise: chpwd functionality requires PowerShell version 7 or higher. ..."
        return
    }
```

Measured on Windows PowerShell 5.1.26100.9168:

```console
# the pwsh activate script, sourced in 5.1
WARNING: mise: chpwd functionality requires PowerShell version 7 or higher. ...
2026.8.4-DEBUG windows-x64        # mise ran, exit 0 -- only chpwd is dropped

# the powershell completion script, sourced in both
pwsh 7  -> loaded ok
5.1     -> loaded ok
```

`windows_powershell_no_profile` says the same thing in its description: "PowerShell
(`pwsh`/`powershell`) shells that mise spawns". One family, one behaviour, version handled inside.

The names differ only because the accepted values come from two places:

| command | source |
|---|---|
| `activate` | mise's own `ShellType` (`clap::ValueEnum` derive) |
| `completion` | a separate `Shell` enum in `completion.rs` with a hand-written `ValueEnum` |

## The change

Each accepts the other's name:

```rust
// src/shell/mod.rs
#[value(alias = "powershell")]
Pwsh,

// src/cli/completion.rs
Self::Powershell => value.alias("pwsh"),
```

**These are not hidden, despite what clap calls them.** I expected `alias` to keep the second name
out of the generated reference and wrote the first version of this PR on that assumption. `mise
usage` renders aliases, so both names now appear as choices in `mise.usage.kdl`, `docs/cli/activate.md`,
`docs/cli/completion.md` and `docs/cli/env.md`. Those regenerated files are part of this diff. It
reads correctly — both names do work — it is simply not the "accepted but unadvertised" behaviour
the attribute name suggests.

`mise env`, `hook-env` and `hook-not-found` take the same shell argument and pick the alias up for
free.

## Shell detection

The hand-written `FromStr` on `ShellType` takes `powershell` too. That path parses the shell the
user is *already in*, and it also now strips a `.exe` suffix:

```rust
"pwsh" | "powershell" => Ok(Self::Pwsh),
```

`powershell.exe` — which is how Windows PowerShell reports itself — used to fall through to the
error arm.

**This section has shrunk since the description was first written.** It originally also added the
`.exe` strip, and called out as deliberately-not-fixed that the separator split was `/`-only, so a
full Windows path like `C:\…\pwsh.exe` would not reduce. Both of those have since landed on `main`
via #11950, so after rebasing they are no longer part of this diff — what remains here is the
`powershell` name itself. A native Windows path now resolves, which it did not when this was
opened.

## Tests

- **unit** — each alias parses through the path clap actually uses; `.exe` stripping is covered for
  PowerShell *and* bash; and the rendered list of **primary names** is unchanged, which pins that
  adding an alias renamed nothing. That last test deliberately does not assert the alias is absent
  — that would be false, as above.

  `src/cli/completion.rs` gets a new test module. `src/shell/mod.rs` no longer does: #11950 added
  one there in the meantime, so rebasing merged these tests into it rather than adding a second
  module. The calls are written `<ShellType as FromStr>::from_str(…)` because `clap::ValueEnum` is
  in scope in that module and also defines `from_str` — unqualified calls do not compile there.
- **e2e** — `mise activate` and `mise completion` had **no** argument coverage at all. New
  `e2e/cli/test_shell_name_aliases` runs all four combinations and asserts the two names produce
  **identical output**, since "accepted" has to mean "equivalent" rather than "exits 0".

### Not run

`cargo fmt --all` only; no local build. The regenerated docs were produced by applying the exact
diff the `render` lint printed rather than by running `mise run render` locally, so that job
re-verifies them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for both `pwsh` and `powershell` shell names across activation, completions, environment commands, and shell hooks.
  * Both names produce equivalent PowerShell output.
  * Windows executable names ending in `.exe` are recognized.

* **Documentation**
  * Updated CLI documentation and generated usage guidance to list the supported shell names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
