### PR TITLE
fix(http): ensure extracted archives have executable permissions

### DIFF
--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -544,6 +544,10 @@ impl HttpBackend {
 
         file::extract_archive(file_path, dest, cache_plan.file_info.format, &extract_opts)?;
 
+        // Fix execute permissions for archives (especially ZIPs) that don't
+        // preserve Unix execute bits. See https://github.com/jdx/mise/issues/11135
+        file::ensure_executable_bits(dest)?;
+
         // Handle rename_exe option for archives
         if let Some(rename_value) = lookup_value_with_fallback(opts.raw(), "rename_exe") {
             // When bin_path is not explicitly set, auto-detect bin/ subdirectory to match

--- a/src/file.rs
+++ b/src/file.rs
@@ -967,7 +967,9 @@ pub fn ensure_executable_bits(dir: &Path) -> Result<()> {
     for entry in WalkDir::new(dir) {
         let entry = entry.wrap_err("walking directory during ensure_executable_bits")?;
         let path = entry.path();
-        if !path.is_file() {
+        // Use file_type() (lstat-based) instead of path.is_file() (stat-based)
+        // to avoid following symlinks that could escape the extraction directory.
+        if !entry.file_type().is_file() {
             continue;
         }
         // Skip files that already have execute permission
@@ -2168,6 +2170,37 @@ mod tests {
         );
         // Plain text files should remain non-executable
         assert!(!is_executable(&readme), "README should not be executable");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_executable_bits_does_not_follow_symlinks() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Create an ELF binary *outside* the scan directory with restrictive perms.
+        let outside = tmp.path().join("outside-elf");
+        fs::write(&outside, b"\x7fELF\x02\x01\x01\x00fake binary").unwrap();
+        fs::set_permissions(&outside, fs::Permissions::from_mode(0o600)).unwrap();
+
+        // Create a symlink *inside* the scan directory pointing to it.
+        let scan_dir = tmp.path().join("scan");
+        fs::create_dir_all(&scan_dir).unwrap();
+        let link = scan_dir.join("evil-link");
+        symlink(&outside, &link).unwrap();
+
+        ensure_executable_bits(&scan_dir).unwrap();
+
+        // The target's permissions must NOT have been changed.
+        let mode = fs::metadata(&outside)
+            .unwrap()
+            .permissions()
+            .mode();
+        assert!(
+            mode & 0o111 == 0,
+            "symlink target should not have gained execute bits, got {:o}",
+            mode
+        );
     }
 
     #[test]

--- a/src/file.rs
+++ b/src/file.rs
@@ -941,6 +941,52 @@ pub fn make_executable<P: AsRef<Path>>(_path: P) -> Result<()> {
     Ok(())
 }
 
+/// Check if a file looks like a native executable or script based on its content.
+/// Returns true for ELF binaries and scripts starting with a shebang (`#!`).
+#[cfg(unix)]
+fn looks_like_executable(path: &Path) -> bool {
+    let mut buf = [0u8; 4];
+    let n = match File::open(path).and_then(|mut f| f.read(&mut buf)) {
+        Ok(n) => n,
+        Err(_) => return false,
+    };
+    // ELF magic: \x7fELF
+    n >= 4 && &buf[..4] == b"\x7fELF" ||
+    // Shebang: #!
+    n >= 2 && &buf[..2] == b"#!"
+}
+
+/// Walk a directory and ensure files that look like executables (ELF binaries
+/// or scripts with shebangs) have execute permission.
+///
+/// Some archives—particularly ZIPs created on Windows or CI—don't store Unix
+/// execute bits. After extraction, binaries end up mode `0644` and fail with
+/// "permission denied" when invoked.
+#[cfg(unix)]
+pub fn ensure_executable_bits(dir: &Path) -> Result<()> {
+    for entry in WalkDir::new(dir) {
+        let entry = entry.wrap_err("walking directory during ensure_executable_bits")?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        // Skip files that already have execute permission
+        if is_executable(path) {
+            continue;
+        }
+        if looks_like_executable(path) {
+            debug!("fixing execute permission: {}", display_path(path));
+            make_executable(path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn ensure_executable_bits(_dir: &Path) -> Result<()> {
+    Ok(())
+}
+
 #[cfg(unix)]
 pub async fn make_executable_async<P: AsRef<Path>>(path: P) -> Result<()> {
     trace!("chmod +x {}", display_path(&path));
@@ -2090,6 +2136,38 @@ mod tests {
         assert_eq!(executable_mode(0o755), 0o755);
         // group/other write bits are preserved
         assert_eq!(executable_mode(0o660), 0o775);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_executable_bits_fixes_archive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Simulate a binary that lost its execute bit (like from a ZIP that
+        // doesn't store Unix permissions).
+        let elf = tmp.path().join("myapp");
+        fs::write(&elf, b"\x7fELF\x02\x01\x01\x00fake binary").unwrap();
+        fs::set_permissions(&elf, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let script = tmp.path().join("myscript");
+        fs::write(&script, b"#!/bin/sh\necho hi").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let readme = tmp.path().join("README.md");
+        fs::write(&readme, b"# My App\n").unwrap();
+        fs::set_permissions(&readme, fs::Permissions::from_mode(0o644)).unwrap();
+
+        ensure_executable_bits(tmp.path()).unwrap();
+
+        // ELF and shebang files should now have execute bits
+        assert!(is_executable(&elf), "ELF binary should be executable after fix");
+        assert!(
+            is_executable(&script),
+            "script with shebang should be executable after fix"
+        );
+        // Plain text files should remain non-executable
+        assert!(!is_executable(&readme), "README should not be executable");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When the HTTP backend installs a tool from a ZIP archive, extracted binaries may lack the Unix execute bit. This happens because some ZIP archives—particularly those created on Windows or CI pipelines—don't store Unix permission bits in the archive's `external_attr` field.

**Example:** CodeRabbit CLI distributes a `coderabbit-linux-x64.zip` containing a single ELF binary with mode `0o644` stored in the ZIP. After `mise install http:coderabbit@latest`, the binary is installed to `~/.local/share/mise/installs/http-coderabbit/latest/coderabbit` but cannot be executed:

```
$ command -v coderabbit
/root/.local/share/mise/installs/http-coderabbit/latest/coderabbit

$ ls -l $(command -v coderabbit)
-rw-r--r-- 1 root root 104143168 Aug 12 20:00 ...coderabbit

$ coderabbit --version
bash: coderabbit: Permission denied
```

## Root Cause

The HTTP backend has three extraction paths, but **only the first two call `make_executable()`**:

| Path | Function | Calls `make_executable`? |
|---|---|---|
| Raw binary download | `extract_raw_file()` | ✅ |
| Compressed single binary (`.gz`, `.xz`) | `extract_compressed_binary()` | ✅ |
| **Archive (ZIP, tar)** | **`extract_archive()`** | **❌** |

For tarballs this is usually not a problem because the tar format natively preserves Unix permissions. ZIP archives, however, depend entirely on the archive creator setting the correct permission bits — and many don't.

PR #11135 previously fixed `make_executable` for the raw-file path (ensuring read bits accompany execute bits), but the archive path was never covered.

## Fix

Add `ensure_executable_bits()` in `src/file.rs` — a function that walks an extracted directory and calls `make_executable()` on any file that **looks like an executable** based on its content:

- **ELF magic bytes** (`\x7fELF`) — covers native binaries (Linux/BSD)
- **Shebang** (`#!`) — covers scripts (shell, Python, etc.)

Files that already have execute permission are skipped (no-op for well-formed tarballs). Non-executable files (READMEs, configs, libraries) are left untouched.

The function is called in `extract_archive()` right after `file::extract_archive()` returns, before `rename_exe` handling.

## Test

Added `test_ensure_executable_bits_fixes_archive_permissions` which:
1. Creates files with `0o644` permissions: a fake ELF binary, a shebang script, and a README
2. Calls `ensure_executable_bits()`
3. Asserts the ELF and script are now executable, and the README is not

```
test file::tests::test_ensure_executable_bits_fixes_archive_permissions ... ok
```

## Scope

- `src/file.rs`: +45 lines (`looks_like_executable`, `ensure_executable_bits`, test)
- `src/backend/http.rs`: +4 lines (one function call)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored executable permissions for extracted command-line tools and scripts.
  * Improved archive extraction reliability on Unix systems.
  * Left ordinary text files unchanged and handled unreadable files safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->