### PR TITLE
chore(deps): update aube to 1.39.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d1a6a6b2c833a6c81b44e51d3310cf59104c498f45e54a203133ca7c3c8fbb"
+checksum = "90c2d6661fa48702376c27e1fcf2bafc2eacc9aee6304f7a071c770a627ce397"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dab0ae089e0c6e47211a85592e7b39fd2d05c838cd51a56498e3225a01182a1"
+checksum = "f550d6a70f2488c51f4deb04be7e49a7b107a0986c43bc53db7107fa9aa050f2"
 dependencies = [
  "serde",
  "serde_json",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6388f0e3bfa7dfa5d0a6c48b4385dc1019832589dfcdcb155d030e9b41a164"
+checksum = "64644bba43b4008ff1fe734a62f8a860909637437a63f941b277c0e63a924f97"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833554cade0267488817f55bb2b4759f28a1bf531d07584b1c9af739ab3d3239"
+checksum = "b03ad3c037c7063cb52972fc6923919dac04c746eb2280d5476898c3871553eb"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -690,28 +690,25 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ece343eae75df129905ad9af19b6f100e5fbf733bbf0c745a95943963392474"
+checksum = "05dc65e27acbcc98ab070e4f7528782f0d8150187305229e23d46ef5df07d55b"
 dependencies = [
  "aube-codes",
  "aube-util",
  "miette",
  "serde",
  "serde_json",
- "serde_yaml",
  "sonic-rs",
  "thiserror 2.0.19",
  "yaml_serde",
- "yamlpatch",
- "yamlpath",
 ]
 
 [[package]]
 name = "aube-registry"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54d9f228eb52a28c3971c2b06d419335d2c44cdf2426579b06d70a64f05cc48a"
+checksum = "f98a739bf21cb23d16d536293be4bac0675d9a0e059c3d9278cf781db16866ce"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -736,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "018eef3bc8c4e18dca50e2505bcab069a1c44a38ddf3aaa7d6153b8644fe1cab"
+checksum = "7a092758e35ad7a739fdd2d5084d4aa43d5d21c5bcd258d72ff788a61ea94ca1"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -766,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71c8ef31cd884024d42c24ca47679dcff224090157b09a9aaa4e5a7c8dce3f0"
+checksum = "b5cdb0a765615410b6a5860c10d1ac61229d526d7d04d486790e314a617d2b9b"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -791,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209c75e6287985beb10008c8a301f9502602379752271beef5c4f2b03e8d6204"
+checksum = "1cfe6c4706ae73d80c2f147174604c2e1275fe9949480f6280ee1164d03027ca"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -811,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b4f0a637331dc40c9728797cf675ada1adb3e97ba8895523b949a95d55cb8f"
+checksum = "e97f6db64bd7ddadcdd9118f25fb83dc841435bbf0c2475130ccce4cfd56464e"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -825,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3089af6fdf3c1a76cc361bff0f51b9eff89cbf72b8d238239e81996f62ad3bac"
+checksum = "fecc989e9d366167f4f629178f2badd096963c52e0d43de2f1230a6d996e0b07"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -852,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001c6fafcdee4149823948f26ef9646483a566d46331f2d1e27459f3498cf922"
+checksum = "21d8d3586ad87de782560a2eb48c379002bd4e8e2029d8dc9f12ef1a2ca7200f"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -874,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.38.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7961d837ffc63183a1de84e324c60447abce20c206dbb222a61b0283465f38d2"
+checksum = "a0b239ed49eafd36a16b166e909f3ba79ae8fe358efbf2daf93e80abfb25a10b"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -6023,16 +6020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "line-index"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e27e0ed5a392a7f5ba0b3808a2afccff16c64933312c84b57618b49d1209bd2"
-dependencies = [
- "nohash-hasher",
- "text-size",
-]
-
-[[package]]
 name = "link-section"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6433,7 +6420,6 @@ dependencies = [
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
- "tree-sitter-iter",
  "ubi",
  "url",
  "urlencoding",
@@ -6699,12 +6685,6 @@ dependencies = [
  "thiserror 2.0.19",
  "winnow 0.7.15",
 ]
-
-[[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -9947,12 +9927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
-
-[[package]]
 name = "strip-ansi-escapes"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10007,17 +9981,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "subfeature"
-version = "1.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8789ac6b95c93b04102b7d30c297d7cb71b140139daaa4dc190cf5d1de0213b8"
-dependencies = [
- "memchr",
- "regex",
- "serde",
 ]
 
 [[package]]
@@ -10782,45 +10745,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tree-sitter"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
-dependencies = [
- "cc",
- "regex",
- "regex-syntax 0.8.11",
- "serde_json",
- "streaming-iterator",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-iter"
-version = "1.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbef0ee83b87916292355e78f4fdee268d719ececa729be8914882428ca86b0"
-dependencies = [
- "tree-sitter",
-]
-
-[[package]]
-name = "tree-sitter-language"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
-
-[[package]]
-name = "tree-sitter-yaml"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
-dependencies = [
- "cc",
- "tree-sitter-language",
 ]
 
 [[package]]
@@ -12084,36 +12008,6 @@ dependencies = [
  "libyaml-rs",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "yamlpatch"
-version = "1.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919764173d845c2b685a44ca9a028534ef1127bcf713edc6b69787430f18b030"
-dependencies = [
- "indexmap 2.14.0",
- "line-index",
- "serde_json",
- "subfeature",
- "thiserror 2.0.19",
- "yaml_serde",
- "yamlpath",
-]
-
-[[package]]
-name = "yamlpath"
-version = "1.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362068e6e34bf985c39ee42ee8d410fcc398fedbd5f9303602616db26f542b5"
-dependencies = [
- "line-index",
- "self_cell 1.3.0",
- "serde",
- "thiserror 2.0.19",
- "tree-sitter",
- "tree-sitter-iter",
- "tree-sitter-yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,8 +221,6 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 toml = { version = "1", features = ["parse", "preserve_order"] }
 toml_edit = { version = "0.25", features = ["parse"] }
-# 1.28.0 requires Rust 1.97, newer than mise's MSRV.
-tree-sitter-iter = "=1.27.0"
 ubi = { version = "0.10", default-features = false }
 url = "2"
 urlencoding = "2"
@@ -340,14 +338,7 @@ pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-x64{ ar
 pkg-url = "{ repo }/releases/download/v{ version }/mise-v{version}-linux-armv7{ archive-suffix }"
 
 [package.metadata.cargo-machete]
-ignored = [
-  "aws-lc-rs",
-  "built",
-  "cfg_aliases",
-  "openssl",
-  "phf_codegen",
-  "tree-sitter-iter",
-]
+ignored = ["aws-lc-rs", "built", "cfg_aliases", "openssl", "phf_codegen"]
 
 [package.metadata.release]
 pre-release-replacements = [


### PR DESCRIPTION
## Summary

- update all embedded Aube workspace crates from 1.38.1 to 1.39.0
- use Aube's optional workspace YAML preservation feature boundary
- remove mise's direct `tree-sitter-iter` compatibility pin and cargo-machete exception
- remove `yamlpath`, `yamlpatch`, and the tree-sitter parser stack from the resolved dependency graph

## Why

Aube 1.39.0 makes comment-preserving workspace YAML mutation optional. Mise embeds Aube with default features disabled, so it no longer needs the preservation-only dependency chain whose newer `tree-sitter-iter` releases require Rust 1.97.

## Validation

- `cargo check --locked`
- `cargo test --locked --bin mise aube`
- `cargo test --locked --bin mise task::workspace::node::tests`
- `mise run test:e2e e2e/backend/test_npm_aube`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump that drops unused optional YAML-preservation crates; no application logic changes and aube remains default-features-disabled.
> 
> **Overview**
> Bumps the embedded **aube** crates from **1.38.1** to **1.39.0**. With YAML comment preservation now optional and mise embedding aube with default features disabled, the preservation-only dependency chain is dropped from the lockfile.
> 
> Removes the direct `tree-sitter-iter` pin (and its cargo-machete exception) along with `yamlpath`, `yamlpatch`, and the tree-sitter parser stack that previously forced a Rust 1.97 MSRV conflict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6787012cef4c84962a5c3c45b6edcb3a393575f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused dependency and its associated package-management exception.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->