### PR TITLE
fix(config): create the config directory before writing into it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6494,6 +6494,7 @@ dependencies = [
  "console",
  "nucleo-matcher",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml_edit 0.25.13+spec-1.1.0",
  "unicode-width 0.2.2",

--- a/crates/mise-interactive-config/Cargo.toml
+++ b/crates/mise-interactive-config/Cargo.toml
@@ -25,6 +25,9 @@ toml_edit = { version = "0.25", features = ["parse"] }
 unicode-width = "0.2" # Text width calculation for cursor positioning
 xx = { version = "2", default-features = false } # For display_path
 
+[dev-dependencies]
+tempfile = "3" # Scratch directories for the save tests
+
 [build-dependencies]
 serde_json = "1"
 

--- a/crates/mise-interactive-config/src/document.rs
+++ b/crates/mise-interactive-config/src/document.rs
@@ -409,8 +409,18 @@ impl TomlDocument {
         }
     }
 
-    /// Save the document to a file
+    /// Save the document to a file, creating its directory if it is not there yet.
+    ///
+    /// The editor is routinely pointed at a config that does not exist yet, and its directory
+    /// may not either — `mise generate config --global` on a fresh install is exactly that
+    /// case. Without this the save fails after the whole session's worth of edits, which is
+    /// the worst possible moment to find out.
+    ///
+    /// A bare relative name gives an empty parent, which `create_dir_all` treats as a no-op.
     pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
         std::fs::write(path, self.to_toml())
     }
 
@@ -729,5 +739,40 @@ node = "22"
             "Output should not contain quoted key: {}",
             output
         );
+    }
+
+    #[test]
+    fn test_save_creates_missing_directories() {
+        // `mise generate config --global` on a fresh install points here at
+        // ~/.config/mise/config.toml, and neither the file nor its directory exists yet.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mise").join("config.toml");
+        assert!(!path.parent().unwrap().exists());
+
+        TomlDocument::new().save(&path).unwrap();
+
+        assert!(path.is_file());
+    }
+
+    #[test]
+    fn test_save_still_writes_into_an_existing_directory() {
+        // Control for the case above: without it, that test would also pass if `save` had
+        // started creating a directory *at* `path` and writing nothing.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        TomlDocument::new().save(&path).unwrap();
+
+        assert!(path.is_file());
+    }
+
+    #[test]
+    fn test_a_bare_relative_name_has_an_empty_parent_that_is_safe_to_create() {
+        // What `save` relies on for `mise edit foo.toml`, pinned here rather than assumed:
+        // the parent is the empty path, and creating that is a no-op rather than an error.
+        // Asserted without touching the process's current directory, which the test harness
+        // shares across threads.
+        assert_eq!(Path::new("foo.toml").parent(), Some(Path::new("")));
+        std::fs::create_dir_all(Path::new("")).unwrap();
     }
 }

--- a/e2e/cli/test_edit_global
+++ b/e2e/cli/test_edit_global
@@ -27,3 +27,25 @@ node 22
 EOF
 assert_contains "mise edit preexisting.toml --tool-versions .tool-versions --dry-run 2>&1" 'go = "1.22"'
 assert_contains "mise edit preexisting.toml --tool-versions .tool-versions --dry-run 2>&1" 'node = "22"'
+
+# Everything above is --dry-run, so nothing here reached the write at all. The global config
+# lives at ~/.config/mise/config.toml and nothing creates that directory ahead of time, so on
+# a fresh install this reported "writing to ..." and then failed with a bare "no such file or
+# directory", leaving nothing behind.
+export MISE_GLOBAL_CONFIG_FILE="$PWD/fresh/mise/config.toml"
+assert_succeed "mise edit --global"
+# Asserting on the content, not just existence: a file that exists but is empty would mean
+# the directory got made and the write still went wrong.
+assert_contains "cat fresh/mise/config.toml" "mise config files are hierarchical"
+
+# Same for --tool-versions, which writes through a different branch.
+export MISE_GLOBAL_CONFIG_FILE="$PWD/fresh-tv/mise/config.toml"
+assert_succeed "mise edit --global --tool-versions .tool-versions"
+assert_contains "cat fresh-tv/mise/config.toml" 'node = "22"'
+
+# Control: with the directory already there both were always fine, so on their own the two
+# assertions above do not show that creating it is what changed.
+export MISE_GLOBAL_CONFIG_FILE="$PWD/existing/config.toml"
+mkdir -p existing
+assert_succeed "mise edit --global"
+assert_contains "cat existing/config.toml" "mise config files are hierarchical"

--- a/e2e/generate/test_generate_config
+++ b/e2e/generate/test_generate_config
@@ -14,3 +14,11 @@ EOF
 assert "mise generate config -n --tool-versions .tool-versions" '[tools]
 node = "22"
 python = ["3.9", "3.10", "3.11"]'
+
+# The command as reported in discussion #11046, without -n. Every assertion above is a
+# dry-run, so the write itself had no coverage: `mise generate config --global` is often the
+# first thing to touch ~/.config/mise on a fresh install, and it did not create that
+# directory before writing into it.
+export MISE_GLOBAL_CONFIG_FILE="$PWD/fresh/mise/config.toml"
+assert_succeed "mise generate config --global"
+assert_contains "cat fresh/mise/config.toml" "mise config files are hierarchical"

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -179,7 +179,7 @@ impl Edit {
                 miseprintln!("{doc}");
             } else {
                 info!("writing to {}", display_path(&path));
-                file::write(&path, doc)?;
+                write_config(&path, doc)?;
             }
         } else if self.should_run_interactive() {
             // Run interactive TOML editor
@@ -193,7 +193,7 @@ impl Edit {
                 miseprintln!("{doc}");
             } else {
                 info!("writing to {}", display_path(&path));
-                file::write(&path, doc)?;
+                write_config(&path, doc)?;
             }
         }
 
@@ -306,6 +306,23 @@ impl Edit {
             # go = "latest"
         "#}
     }
+}
+
+/// Write a generated config, creating its directory if it is not there yet.
+///
+/// `--global` resolves to `~/.config/mise/config.toml`, and nothing creates that directory
+/// ahead of time. Every other writer of that same file goes through `MiseToml::save`, which
+/// has always created the parent first — these two commands reached `file::write` directly, so
+/// on a fresh install, where `mise generate config --global` is the first thing to touch the
+/// path, they failed with a bare "no such file or directory" and wrote nothing.
+///
+/// A bare relative name (`mise edit foo.toml`) gives an empty parent, which `create_dir_all`
+/// treats as a no-op.
+fn write_config(path: &Path, doc: String) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        file::create_dir_all(parent)?;
+    }
+    file::write(path, doc)
 }
 
 // ============================================================================


### PR DESCRIPTION
From [#11046](https://github.com/jdx/mise/discussions/11046). Not `Closes` — that report contains a
second, unrelated thing (see "Not in this PR").

`mise generate config --global` and `mise edit --global` write to
`~/.config/mise/config.toml` without creating the directory first.

## The problem

Measured on **2026.8.2 windows-x64**, with `XDG_CONFIG_HOME` pointed at a directory that does not
exist yet:

```console
$ mise generate config --global
mise writing to ...\absent\mise\config.toml
mise ERROR failed write: ...\absent\mise\config.toml
mise ERROR 指定されたパスが見つかりません。 (os error 3)
exit=1
```

It says *writing to*, then fails, and nothing is left behind. The reporter hit the same thing
through the interactive editor, where it lands after a whole session's worth of edits.

## It is not Windows-specific

It is reported as a Windows bug and it is not one. Same steps, `jdxcode/mise:latest`
(**2026.8.3 linux-x64**):

```console
$ XDG_CONFIG_HOME=/tmp/absent mise generate config --global
mise writing to /tmp/absent/mise/config.toml
mise ERROR failed write: /tmp/absent/mise/config.toml
mise ERROR No such file or directory (os error 2)
exit=1
```

Control, both platforms: create the directory first and the same command exits 0 and writes.

**What decides whether you see it is which command you run first.** Every other writer of the
global config goes through `MiseToml::save`, which has always done `create_dir_all(parent)` before
`file::write`. Measured, directory absent in each case:

| command | result |
|---|---|
| `mise settings set experimental true` | exit 0, **directory created** |
| `mise use -g node@22` | exit 0, **directory created** |
| `mise generate config --global` | exit 1, nothing created |
| `mise edit --global` | exit 1, nothing created |

So a machine where `mise use -g` or `mise settings set` ran at any point never reproduces this
again. It is reachable on a fresh install, where `generate config` or `edit` is the first thing to
touch the path — which is exactly what a new user does, and why it arrived from a Windows user who
had just run `winget install`.

## The change

Three writes, none of which created the parent:

| | |
|---|---|
| `src/cli/edit.rs` (default template) | the path measured above |
| `src/cli/edit.rs` (`--tool-versions`) | same branch, different source |
| `crates/mise-interactive-config/src/document.rs` | the interactive save — **the reported one** |

`mise generate config` is a thin delegation to `Edit::run`, so the two `edit.rs` sites cover both
commands; `editor/actions.rs` delegates to `TomlDocument::save`, so the crate needs one site.

The shape is `MiseToml::save`'s, unchanged, so it reads as the same thing:

```rust
if let Some(parent) = path.parent() {
    create_dir_all(parent)?;
}
```

A bare relative name — `mise edit foo.toml` — gives `Some("")` for the parent. That is a no-op
rather than an error, which I checked rather than assumed:

```
create_dir_all("")            -> Ok(())
Path::new("config").parent()  -> Some("")   is_empty -> true
```

There is a unit test pinning both halves of that, since the code depends on it and `std` does not
document it.

### Not making `file::write` do this

It has on the order of a hundred callers. Creating directories there would mean a mistyped path
quietly builds a tree instead of failing, which is a much larger behaviour change than the bug
being fixed.

## Tests

**The existing e2e for both commands was entirely `--dry-run`.** Every assertion in
`e2e/cli/test_edit_global` and `e2e/generate/test_generate_config` used `--dry-run` or `-n`, so
the write path had no coverage at all — which is how this survived.

- **e2e** — both files gain the write: `--global` pointed under a directory that does not exist,
  then the file's *contents* asserted rather than its existence, since a file that exists but is
  empty would mean the directory got made and the write still went wrong. `test_edit_global` also
  covers the `--tool-versions` branch and carries a control with the directory already present,
  because on their own the new assertions do not show that creating it is what changed. These run
  on unix, which also demonstrates the point above.
- **unit** — `TomlDocument::save` creates missing parents, with a control for the
  directory-already-there case, plus the empty-parent assumption. This is the only way to reach
  the interactive path: it needs a TTY, so e2e cannot drive it.

`tempfile` is added as a dev-dependency of `mise-interactive-config` for the scratch directory
(`crates/mise-cache-core` already depends on it, and it is already in the lockfile — the
`Cargo.lock` diff is one line).

### Not run

`cargo fmt --all` and the `rustc` probe quoted above. I have not built this; the measurements are
of released binaries reproducing the bug, not of the fix. CI is what exercises the fix.

## Not in this PR

The second half of #11046: `mise edit config --global` reports `saved to config` and leaves the
global config untouched. That one is not a bug in the sense the first is — `config` is taken as
the positional `[PATH]`, and `e2e/cli/test_edit_global` pins that precedence deliberately
("A positional path overrides --global regardless of argument order"). What remains is a UX
question — `mise config` has no `edit` subcommand, so `mise edit config` is an easy thing to type,
and `--global` is then discarded silently. `mise use` resolves the same collision the other way
(`overrides_with_all = &["path", "env"]` on `global`). Worth settling, but as its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Global configuration files can now be created successfully when their parent directories do not yet exist.
  * `mise edit --global` and global configuration generation now work with fresh paths.
  * Existing configuration-writing behavior remains unchanged for established directories.

* **Tests**
  * Added coverage for nested directories, relative paths, tool-version configurations, and generated global configuration content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->