### PR TITLE
fix(cli): reject --global alongside a path instead of ignoring it

### DIFF
--- a/e2e/cli/test_edit_global
+++ b/e2e/cli/test_edit_global
@@ -1,17 +1,39 @@
 #!/usr/bin/env bash
 
 # `mise edit --global` writes to the global config file path.
+#
+# `mise generate config` shares this argument set -- it parses its own copy and hands it to
+# `Edit` -- so the one assertion about it below lives here, next to the rule it is checking,
+# rather than in e2e/generate.
 
 export MISE_GLOBAL_CONFIG_FILE="$PWD/global-config.toml"
 
 assert_contains "mise edit --global --dry-run 2>&1" "global-config.toml"
 assert_contains "mise edit -g -n 2>&1" "global-config.toml"
 
-# A positional path overrides --global regardless of argument order.
-assert_contains "mise edit --global custom.toml --dry-run 2>&1" "custom.toml"
-assert_not_contains "mise edit --global custom.toml --dry-run 2>&1" "global-config.toml"
-assert_contains "mise edit custom.toml --global --dry-run 2>&1" "custom.toml"
-assert_not_contains "mise edit custom.toml --global --dry-run 2>&1" "global-config.toml"
+# A positional path and --global are contradictory -- "edit the global config file, namely
+# ./custom.toml" has no meaning -- so the combination is rejected rather than resolved in the
+# positional's favour. Matched on a fragment rather than clap's whole message, which spells the
+# positional out in a way that is not worth pinning here.
+assert_fail_contains "mise edit --global custom.toml" "cannot be used with"
+assert_fail_contains "mise edit custom.toml --global" "cannot be used with"
+assert_fail_contains "mise generate config --global custom.toml" "cannot be used with"
+assert_fail_contains "mise generate config custom.toml --global" "cannot be used with"
+
+# The case from discussion #11046, and the reason rejecting beats warning: `mise config` has no
+# `edit` subcommand, so `mise edit config --global` is easy to type, and it used to take `config`
+# as the path, write a file by that name here, and report success while the global config went
+# untouched. Deliberately without --dry-run -- rejecting has to mean nothing is written.
+assert_fail_contains "mise edit config --global" "cannot be used with"
+assert_succeed "test ! -e config"
+assert_succeed "test ! -e custom.toml"
+# The other half of what was reported: the global config was not written either. Everything
+# above this point is a dry run or a rejection, so this file should not exist yet.
+assert_succeed "test ! -e global-config.toml"
+
+# Either on its own is unchanged.
+assert_contains "mise edit custom.toml --dry-run 2>&1" "custom.toml"
+assert_not_contains "mise edit custom.toml --dry-run 2>&1" "global-config.toml"
 
 # Without --global, the default config filename is used (regression guard).
 assert_contains "mise edit --dry-run 2>&1" "mise.toml"
@@ -27,6 +49,12 @@ node 22
 EOF
 assert_contains "mise edit preexisting.toml --tool-versions .tool-versions --dry-run 2>&1" 'go = "1.22"'
 assert_contains "mise edit preexisting.toml --tool-versions .tool-versions --dry-run 2>&1" 'node = "22"'
+
+# --tool-versions is a flag, not the positional, so it still combines with --global. Worth
+# pinning: it is the one way to reach the global config with another file named on the command
+# line, and the rule above is easy to over-apply to it.
+assert_contains "mise edit --global --tool-versions .tool-versions --dry-run 2>&1" "global-config.toml"
+assert_contains "mise edit --global --tool-versions .tool-versions --dry-run 2>&1" 'node = "22"'
 
 # Everything above is --dry-run, so nothing here reached the write at all. The global config
 # lives at ~/.config/mise/config.toml and nothing creates that directory ahead of time, so on

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -124,7 +124,12 @@ impl BackendProvider for MiseBackendProvider {
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Edit {
     /// Edit the global config file (~/.config/mise/config.toml)
-    #[clap(long, short = 'g')]
+    // Rejected alongside a path rather than resolved in its favour: "edit the global config
+    // file, namely ./custom.toml" has no meaning, and resolving it silently is how
+    // `mise edit config --global` came to write a file called `config` into the current
+    // directory and report success. `mise bootstrap dotfiles add` states the same collision the
+    // same way, with `conflicts_with_all` between its own `--global` and `--path`.
+    #[clap(long, short = 'g', conflicts_with = "path")]
     global: bool,
     /// Show what would be generated without writing to file
     #[clap(long, short = 'n')]

--- a/src/cli/generate/config.rs
+++ b/src/cli/generate/config.rs
@@ -10,7 +10,9 @@ use crate::cli::edit::Edit;
 #[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Config {
     /// Generate the global config file (~/.config/mise/config.toml)
-    #[clap(long, short = 'g')]
+    // Declared here as well as on `Edit`: this command parses its own arguments before handing
+    // them over, so the conflict does not carry across on its own.
+    #[clap(long, short = 'g', conflicts_with = "path")]
     global: bool,
     /// Show what would be generated without writing to file
     #[clap(long, short = 'n')]


### PR DESCRIPTION
The second half of [#11046](https://github.com/jdx/mise/discussions/11046). #11934 was the first
half and has since merged — `mise generate config --global` now creates the directory it writes
into — so this is what remains of that report.

Closes #11046.

**This changes behaviour that #9953 pinned on purpose.** That is the part worth your judgement,
and the case for it is below.

## The problem

The reporter ran `mise edit config --global`, was told it had saved, and found the global config
untouched. Measured on **2026.8.2**:

```console
$ mise edit config --global
mise writing to config
exit=0

$ ls
cfg  config          # a file called `config`, in the current directory
```

`config` is taken as the positional `[PATH]` and `--global` is discarded without a word. It is an
easy thing to type: `mise config` has `get`, `ls` and `set`, but no `edit`, so `mise edit config`
looks like the way to reach it.

## The change

```rust
#[clap(long, short = 'g', conflicts_with = "path")]
global: bool,
```

on `Edit` and on `generate config`, which parses its own copy of these arguments before handing
them to `Edit`.

```console
$ mise edit config --global
error: the argument '--global' cannot be used with '[PATH]'

Usage: mise edit [OPTIONS] [PATH]
```

Nothing is written. That is the reason for rejecting rather than warning: a warning explains the
surprise but still leaves `./config` behind, which is half the thing being reported.

`--tool-versions` is a flag rather than the positional, so `mise edit --global --tool-versions
.tool-versions` still works. There is a test for that, since the rule above is easy to over-apply
to it.

## Why change something that was deliberate

`e2e/cli/test_edit_global` pins the current resolution — *"A positional path overrides --global
regardless of argument order"* — added by #9953 along with the flag itself. Its stated reason:

> Positional `path` overrides `--global`, matching the existing flag-override pattern.

**There is no such pattern to match.** Measured, both orders:

```console
$ mise use -g --path other.toml --dry-run node@22   ->  would update other.toml
$ mise use --path other.toml -g --dry-run node@22   ->  would update <global config>

$ mise edit -g custom.toml --dry-run                ->  would write to custom.toml
$ mise edit custom.toml -g --dry-run                ->  would write to custom.toml
```

`use` (and `unuse`, and `set`) declare mutual `overrides_with_all`, so the **later** argument wins
and the answer depends on order. `edit` had the positional win regardless of order. Those are
different rules, and `edit`/`generate config` were in fact the only `--global` in the CLI with no
relationship declared at all:

| command | declaration | behaviour |
|---|---|---|
| `use`, `unuse`, `set` | mutual `overrides_with_all` | later argument wins |
| `bootstrap dotfiles add` | `conflicts_with_all` | error |
| `edit`, `generate config` | none | positional wins, silently |

`mise bootstrap dotfiles add` states this exact collision — its own `--global` against its own
`--path` — as `conflicts_with_all`, which is what this follows.

[#9942](https://github.com/jdx/mise/discussions/9942), the request `--global` came from, does not
mention the combination.

**No documented example combines them.** `docs/cli/edit.md` and `docs/cli/generate/config.md` show
`-g` on its own and a path on its own; the `AFTER_LONG_HELP` examples in both files do the same.
So nothing that is written down anywhere stops working.

### If you would rather warn

It is a small change — drop `conflicts_with` and `warn!` when both are set. I did not take it
because the stray `./config` would still be created, and that is what the reporter actually saw.
Happy to switch if you disagree; the e2e assertions are the only other thing that would move.

## Tests

`e2e/cli/test_edit_global`, replacing the four assertions that pinned the old resolution:

- both orders rejected, for `mise edit` and for `mise generate config` — the latter carries its
  own `conflicts_with` on its own `clap::Args`. Matched on `cannot be used with` rather than
  clap's whole message, which spells the positional out in a way not worth pinning
- **nothing written when rejected**, deliberately without `--dry-run`: no `config`, no
  `custom.toml`, and no `global-config.toml` either. That last one is the other half of the
  report — "it says saved, but the global config is missing" — and these assertions together are
  what distinguishes this from warning, so they matter more than the failure itself
- the reported invocation, `mise edit config --global`, verbatim
- regression guards: `-g` alone, a path alone, and `--global --tool-versions` together

No docs regeneration: `conflicts_with` is not rendered into the usage spec. `bootstrap dotfiles
add` has declared `conflicts_with_all` for a while and `mise.usage.kdl` carries only
`flag "-g --global" help="Write to the global config"` for it, with `docs/cli/.../add.md` the
same. The doc comments here are unchanged, so `render` has nothing to do.

### Not run

`cargo fmt --all` only; no local build, so I have not seen this binary produce the error. The
wording the test matches was read out of clap rather than observed:
`clap_builder-4.6.5/src/error/format.rs:163` renders `ArgumentConflict` as
`the argument '<arg>' cannot be used with`, and the style markers wrap the argument name rather
than the phrase, so the fragment stays contiguous with or without colour. `MISE_FRIENDLY_ERROR=1`,
which the e2e failure helper sets, does not reach it — `clap_error` calls `err.print()` and exits
with clap's own code, while the friendly-error path handles `eyre::Report`.

## Conflicts

Resolved. #11934 also edited `e2e/cli/test_edit_global`, adding coverage for the write path, and
has since merged; this branch is rebased onto it and the two sets of assertions are merged in the
file.

They turned out to be complementary rather than duplicate, so both are kept: the guard added here
is `--global --tool-versions --dry-run`, which pins that the new rejection rule is not over-applied
to a flag that is not the positional, while #11934's is the same combination *without* `--dry-run`,
which pins that it actually writes. One checks parsing, the other checks the write.

Ordering matters in that file and was checked rather than assumed: `assert_succeed "test ! -e
global-config.toml"` claims nothing has been written yet, so it has to stay above the first real
write, which it does.

## Not in this PR

Adding an `edit` subcommand under `mise config`. It is why `mise edit config` is easy to type, but
a new subcommand is a separate decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented combining the global configuration option with a specific file path in `mise edit` and `mise generate config`.
  * Added clear validation for conflicting options, avoiding unintended file creation.
  * Preserved compatibility between global configuration and the `--tool-versions` option, including merging tool data into the global configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
