### PR TITLE
fix(toolset): accept a Windows tool path spelled with backslashes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,7 +418,11 @@ Both `mise.toml` and `.tool-versions` support "scopes" which modify the behavior
 - `prefix:<PREFIX>` - use the latest version that matches the prefix. Useful for Go since `1.20`
   would only match `1.20` exactly but `prefix:1.20` will match `1.20.1` and `1.20.2` etc.
 - `path:<PATH>` - use a custom compiled version at the given path. One use-case is to re-use
-  Homebrew tools (e.g.: `path:/opt/homebrew/opt/node@20`).
+  Homebrew tools (e.g.: `path:/opt/homebrew/opt/node@20`). On Windows both separators work and
+  mise stores the forward-slash form either way, but mind the TOML quoting: a backslash is an
+  escape inside a _basic_ (double-quoted) string, so write `{ path = 'C:\tools\node' }` as a
+  literal string, or double them as `"C:\\tools\\node"`. `"C:\tools\node"` is not rejected — TOML
+  reads `\t` as a tab — so the path silently becomes something else.
 - `sub-<PARTIAL_VERSION>:<ORIG_VERSION>` - resolves `ORIG_VERSION`, subtracts the numeric components
   in `PARTIAL_VERSION` from the corresponding resolved version components, then resolves the result
   as a version prefix. For example, `sub-2:lts` resolves `lts` and subtracts 2 from its major

--- a/e2e-win/tool_path.Tests.ps1
+++ b/e2e-win/tool_path.Tests.ps1
@@ -1,0 +1,120 @@
+Describe 'tool-path' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+
+        # A directory to point `path:` at. Nothing is installed into it -- `path:` means "the
+        # tool is already here", so parsing and resolving the value is the whole of it, and
+        # parsing is where this used to fail.
+        $script:ToolDir = Join-Path $script:TestRoot "tools\bin"
+        New-Item -ItemType Directory -Path $script:ToolDir | Out-Null
+
+        # `mise ls` reports the resolved path with forward slashes, so this is what the native
+        # spelling below has to come back as.
+        $script:Forward = $script:ToolDir -replace '\\', '/'
+
+        # Saved rather than just cleared afterwards: Pester runs every suite in one process, so
+        # removing an inherited value would leave the next file without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'accepts a tool path spelled the way Windows spells it' {
+        # Backslashes are what Explorer shows and what `pwd` prints, so this is the spelling a
+        # Windows user actually has. It used to be rejected outright:
+        #   invalid tool path "C:\\...": contains forbidden character '\'
+        #
+        # Written as a TOML literal string, which is what takes backslashes as-is. In a basic
+        # string they are escapes -- see the doubled form below.
+        @"
+[tools]
+node = { path = '$($script:ToolDir)' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        # Asserting the resolved value, not just that the command survived: the separators are
+        # rewritten rather than allowed through, and this is where that shows.
+        $out | Should -BeLike "*path:$($script:Forward)*"
+    }
+
+    It 'accepts the same path written as a TOML basic string' {
+        # The other spelling that actually delivers backslashes to mise, and the one the docs
+        # offer as an alternative: doubled inside a double-quoted string. `"C:\tools\node"` is a
+        # third thing entirely -- TOML reads `\t` as a tab and the path silently becomes
+        # something else -- which is why the docs say which two to use.
+        $doubled = $script:ToolDir -replace '\\', '\\'
+        @"
+[tools]
+node = { path = "$doubled" }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike "*path:$($script:Forward)*"
+    }
+
+    It 'accepts the same path written with forward slashes' {
+        # The workaround people were given while the above was broken. It has to keep working.
+        @"
+[tools]
+node = { path = '$($script:Forward)' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike "*path:$($script:Forward)*"
+    }
+
+    It 'still rejects a path containing a quote' {
+        # The control for the two above. Only the separator is rewritten; the rest of the list
+        # that `path:` values are checked against is untouched, and a quote is on it because the
+        # resolved path reaches plugin hooks that build shell commands with it.
+        @"
+[tools]
+node = { path = 'C:/a"b' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*invalid tool path*'
+    }
+
+    # `\\?\` and `\\.\` are the one place Windows does not accept `/`, so they are the branch that
+    # is deliberately *not* rewritten. Both assert the message rather than only the failure: it is
+    # the one that branch produces, so a change that started rewriting them would surface here as
+    # the generic "forbidden character" wording instead of as a passing test.
+    It 'still rejects an extended-length path, and says why' {
+        @"
+[tools]
+node = { path = '\\?\C:\Users\foo' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*extended-length and device paths*'
+    }
+
+    It 'still rejects a device path, and says why' {
+        @"
+[tools]
+node = { path = '\\.\COM1' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*extended-length and device paths*'
+    }
+}

--- a/e2e/config/test_tool_path_validation
+++ b/e2e/config/test_tool_path_validation
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# A `path:` value is resolved into `ctx.rootPath` for path-mode tools, which plugin hooks build
+# shell commands with, so it is checked against a list of shell-quote-breaking characters (#9814).
+#
+# On Windows `\` is the path separator rather than a shell escape, so it is rewritten to `/` before
+# that check. Here it is a shell escape and a legal character in a filename, so it stays rejected.
+# This is the end-to-end guard that the rewrite did not leak off Windows.
+
+mkdir -p tools/bin
+
+cat >mise.toml <<'EOF'
+[tools]
+node = { path = '/tmp/\rm' }
+EOF
+assert_fail_contains "mise ls --current" "invalid tool path"
+
+cat >mise.toml <<'EOF'
+[tools]
+node = { path = '/tmp/$(id)' }
+EOF
+assert_fail_contains "mise ls --current" "invalid tool path"
+
+# The control: an ordinary path resolves, so the assertions above are about the character and not
+# about `path:` being broken in this sandbox.
+cat >mise.toml <<'EOF'
+[tools]
+node = { path = "./tools/bin" }
+EOF
+assert_contains "mise ls --current" "tools/bin"

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -107,8 +107,9 @@ impl ToolRequest {
                 }
             }
             Some(("path", p)) => {
-                validate_path_string(p)?;
-                let path = resolve_path(p, &source);
+                let p = windows_path_separators(p);
+                validate_path_string(&p)?;
+                let path = resolve_path(&p, &source);
                 Self::Path {
                     path,
                     options: backend.opts(),
@@ -519,6 +520,10 @@ fn validate_ref_string(s: &str) -> Result<()> {
 /// entry in a project config cannot inject shell syntax. Path traversal is
 /// intentionally not rejected here because `path:../tools/foo` is a normal
 /// relative-path use case.
+///
+/// The list is written for a POSIX shell, which is why `\` is on it. On Windows `\` is a path
+/// separator instead, so it is rewritten by [`windows_path_separators`] before it gets here rather
+/// than being allowed through — see that function.
 fn validate_path_string(s: &str) -> Result<()> {
     if s.is_empty() {
         return Ok(());
@@ -528,9 +533,47 @@ fn validate_path_string(s: &str) -> Result<()> {
         // and quote/expansion rejection, but allow `/` since paths need it.
         is_forbidden_version_char(*c)
     }) {
+        // The only `\` that survives the rewrite is an extended-length or device prefix, so say
+        // what is actually wrong instead of naming a character the user cannot avoid.
+        #[cfg(windows)]
+        if c == '\\' {
+            bail!(
+                "invalid tool path {s:?}: extended-length and device paths (\\\\?\\, \\\\.\\) are not supported"
+            );
+        }
         bail!("invalid tool path {s:?}: contains forbidden character {c:?}");
     }
     Ok(())
+}
+
+/// Rewrite `\` to `/` in a `path:` value on Windows.
+///
+/// `\` is the path separator there, not a shell metacharacter, so [`validate_path_string`] used to
+/// reject every native path — anything copied out of Explorer or printed by `pwd`. Win32 accepts
+/// `/` wherever it accepts `\`, so rewriting is what makes those usable *without* letting a `\`
+/// reach a vfox hook's `ctx.rootPath`, which is the thing the list exists to prevent (#9814). The
+/// alternative — dropping `\` from the list on Windows — would have weakened that.
+///
+/// Extended-length and device prefixes (`\\?\`, `\\.\`) are left alone. Those are the one place
+/// Windows does not accept `/`, so rewriting would hand back a path that looks right and does not
+/// resolve; they keep being rejected, as they are today.
+#[cfg(windows)]
+fn windows_path_separators(s: &str) -> std::borrow::Cow<'_, str> {
+    if s.starts_with(r"\\?\") || s.starts_with(r"\\.\") {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    if s.contains('\\') {
+        std::borrow::Cow::Owned(s.replace('\\', "/"))
+    } else {
+        std::borrow::Cow::Borrowed(s)
+    }
+}
+
+/// No-op off Windows: `\` is a legal character in a unix filename, so rewriting it would change
+/// which file is meant, and there it really is a shell escape — it stays rejected.
+#[cfg(not(windows))]
+fn windows_path_separators(s: &str) -> std::borrow::Cow<'_, str> {
+    std::borrow::Cow::Borrowed(s)
 }
 
 fn is_forbidden_version_char(c: char) -> bool {
@@ -783,6 +826,8 @@ mod tests {
 
     #[test]
     fn test_validate_path_string() {
+        // `validate_path_string` in isolation. On Windows the `path:` arm rewrites separators
+        // first, so a `\` in a real config does not reach here — that pair is covered below.
         use super::validate_path_string;
         // valid paths
         for p in [
@@ -813,6 +858,77 @@ mod tests {
                 "expected path {p:?} to be rejected"
             );
         }
+    }
+
+    /// Rewrite then validate, in the order the `path:` arm does it.
+    fn accept_tool_path(p: &str) -> Result<String, eyre::Report> {
+        let p = super::windows_path_separators(p);
+        super::validate_path_string(&p)?;
+        Ok(p.into_owned())
+    }
+
+    #[test]
+    fn test_tool_path_rewrite_does_not_widen_the_rest() {
+        // The control for the two platform-specific tests below: quote and expansion characters
+        // stay rejected everywhere, and a path with no separator to rewrite comes back untouched.
+        assert_eq!(
+            accept_tool_path("/home/user/tools/foo").unwrap(),
+            "/home/user/tools/foo"
+        );
+        assert_eq!(accept_tool_path("C:/Users/foo").unwrap(), "C:/Users/foo");
+        for p in [
+            "/tmp/$HOME",
+            "/tmp/`id`",
+            "/tmp/$(id)",
+            "/tmp/'rm",
+            "/tmp/\"rm",
+            "/tmp/\nrm",
+        ] {
+            assert!(
+                accept_tool_path(p).is_err(),
+                "expected path {p:?} to be rejected"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_native_windows_tool_path_is_accepted() {
+        // The reported case: a path spelled the way Windows spells it. Rewritten rather than
+        // allowed through, so no `\` reaches a plugin hook's `ctx.rootPath`.
+        for (input, expected) in [
+            (r"C:\Users\foo\bin", "C:/Users/foo/bin"),
+            (r"~\.local\bin", "~/.local/bin"),
+            (r"..\tools\foo", "../tools/foo"),
+            (r"C:\Program Files\tool", "C:/Program Files/tool"),
+        ] {
+            assert_eq!(accept_tool_path(input).unwrap(), expected, "{input:?}");
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_extended_length_tool_path_is_left_alone_and_rejected() {
+        // `\\?\` and `\\.\` are the one place Windows does not accept `/`, so rewriting them
+        // would produce a path that looks right and does not resolve. They stay rejected, as
+        // they are on every version before this change.
+        for input in [r"\\?\C:\Users\foo", r"\\.\COM1"] {
+            assert_eq!(
+                super::windows_path_separators(input),
+                input,
+                "{input:?} should not be rewritten"
+            );
+            assert!(accept_tool_path(input).is_err(), "{input:?}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_backslash_is_still_rejected_on_unix() {
+        // The control for the Windows tests: `\` is a legal character in a unix filename and a
+        // shell escape there, so none of the rewriting reaches this platform.
+        assert_eq!(super::windows_path_separators(r"/tmp/\rm"), r"/tmp/\rm");
+        assert!(accept_tool_path(r"/tmp/\rm").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes [#11192](https://github.com/jdx/mise/discussions/11192).

`tool.<name>.path` rejects every path spelled the way Windows spells it.

## The problem

Measured on **2026.8.2 windows-x64**, same directory each time:

```console
path = 'C:\Users\Jam\…\tools\bin'   ->  mise ERROR invalid version for node in …\mise.toml
                                        mise ERROR invalid tool path "C:\\Users\\…": contains
                                                   forbidden character '\'
                                        exit=1

path = 'C:/Users/Jam/…/tools/bin'   ->  exit=0, node  path:C:/Users/Jam/…/tools/bin

path = '~/.local/bin'               ->  exit=0
```

So the only spelling that works is the one nothing on Windows produces — Explorer, `pwd`, and
tab-completion all give backslashes. The error says a character is forbidden, not that slashes get
through, so there is nothing to act on.

The existing unit test puts `"C:/Users/foo"` on the accepted side. `C:\Users\foo` is on neither
side: the standard Windows spelling was never decided, it just fell through to the reject arm.

### Correcting the analysis on the thread

There is a comment on #11192 saying validation runs *after* `~` expansion, so any `path:` using `~`
is unusable. That is not true of current main — `validate_path_string` runs on the raw string
(`tool_request.rs:110`) and `resolve_path` expands afterwards, which is why the third line above
passes. The reporter was on 2026.7.11; the order changed since.

## Why the character is on the list

[#9814](https://github.com/jdx/mise/pull/9814) — *"security: reject shell metacharacters in version
strings and CI inputs"* — added it. A `path:` value resolves into `ctx.rootPath` for path-mode
tools, and vfox plugin hooks interpolate that into shell commands, so the fix killed that RCE class
at the Rust boundary rather than in each Lua plugin. `\` is on the list because it is an escape in
a POSIX shell.

That reasoning holds. It just does not describe Windows, where `\` is the path separator.

## The change

**Rewrite `\` to `/` before validating, on Windows only.** Not "allow `\` there".

Win32 accepts `/` wherever it accepts `\`, so the meaning of the path is unchanged — and **no
backslash reaches `ctx.rootPath`**, so the property #9814 established is kept exactly rather than
weakened. Dropping `\` from the list on Windows would have been the smaller diff and the worse
answer.

```rust
Some(("path", p)) => {
    let p = windows_path_separators(p);
    validate_path_string(&p)?;
    let path = resolve_path(&p, &source);
```

Unix is untouched: the function is a borrow-through no-op there, because `\` is a legal character
in a filename — rewriting would change which file is meant — and it really is a shell escape.

`resolve_path` needed nothing: `~/` matching and `is_absolute()` both work on the rewritten form
(`C:/Users/foo` is absolute).

One code path covers both spellings of the config: `uv = { path = "…" }` is folded into the string
`path:…` in `mise_toml.rs` before it reaches `ToolRequest::new`.

### `\\?\` and `\\.\` are deliberately not rewritten

Extended-length and device prefixes are the one place Windows does **not** accept `/`, so rewriting
would hand back a path that looks right and does not resolve — silently. They are left alone, which
means they keep being rejected exactly as they are today; nothing regresses and nothing new
silently breaks. The error for them now says what is actually wrong instead of naming a character
the user cannot avoid.

I have not verified against a real `\\?\` path that forward slashes break it — that is from
Microsoft's documentation. **The design does not depend on the claim**: not rewriting is the
conservative branch either way.

### Not widened here

The list is POSIX-shaped in the other direction too: `&` and `%` are cmd's real metacharacters and
`path:` accepts both today. Flagging it rather than fixing it — that is a separate question about
what the list should be on Windows, and this PR is about a spelling that has no alternative.

## Tests

**`path:` had no e2e coverage at all**, on either platform. There were only unit tests for the
validator.

- **unit** — the rewrite-then-validate pair in the order the `path:` arm runs it. Windows: the
  native spellings are accepted and come back reduced (`C:\Users\foo\bin` → `C:/Users/foo/bin`,
  and `C:\Program Files\tool`, and `~\.local\bin`); `\\?\C:\…` and `\\.\COM1` are unchanged and
  still rejected. Unix: `/tmp/\rm` is unchanged and still rejected — the control for "the rewrite
  did not leak off Windows". Every platform: quotes, backtick and `$` still rejected, which is the
  control for "the rewrite did not widen anything but the separator". These live in the file's
  existing test module, which is not `#[cfg(unix)]`, so CI runs them on Windows too.
- **e2e-win (new)** — `tool_path.Tests.ps1`. Writes a native `C:\…` path into `mise.toml` and
  asserts `mise ls --current` succeeds **and reports the rewritten path**, so it checks the
  resolved value rather than only that the command survived. Both TOML spellings that deliver a
  backslash — a literal string and a doubled basic string — plus the forward-slash spelling, which
  has to keep working, and a quote in the path, which has to keep failing. `\\?\C:\Users\foo` and
  `\\.\COM1` assert **the message**, not just the failure: only the no-rewrite branch produces
  `extended-length and device paths …`, so a change that started normalising them would fall
  through to the generic `contains forbidden character` arm — still a failure and still non-zero,
  which a test checking only those two things would accept.
- **e2e (new, unix)** — `config/test_tool_path_validation`: `\` and `$(id)` still rejected, with an
  ordinary path as the control so the two rejections are about the character rather than about
  `path:` being broken in the sandbox.

### The TOML quoting matters, and review caught that I had skipped it

`docs/configuration.md`'s `path:` entry showed only a Homebrew example, so it gains the Windows
case. The first version of that sentence said `path:C:\tools\node` works without saying which TOML
quoting actually delivers that string, which is a trap. Measured:

```console
node = { path = "C:\tools\node" }     ->  mise WARN  semver range "path:C:<TAB>ools<LF>ode" is not
                                                     supported for node …          exit=1
node = { path = "C:\Users\foo" }      ->  Error loading settings file: TOML parse error
                                          (\U is TOML's unicode escape)
node = { path = 'C:\tools\node' }     ->  reaches mise intact
node = { path = "C:\\tools\\node" }   ->  reaches mise intact
```

The first is the bad one: **not an error**. TOML reads `\t` as a tab, the value silently becomes
something else, and what the user sees is a complaint about a *semver range* with no mention of a
path. The docs now name the two spellings that work and say what the third does. The e2e-win suite
covers both of them rather than only the literal-string form the test happened to use.

`docs/configuration.md` is hand-written, so nothing is regenerated.

Not touched: the `semver range …` wording that the mangled string produces. mise is reporting
accurately on a string TOML already broke; how unparseable tool versions are reported is a separate
question.

### Not run

`cargo fmt --all` only; no local build. The three measurements at the top are of a released binary
reproducing the bug, not of the fix — CI is what exercises it, and `windows-e2e` is the job that
matters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Windows `path:` tool requests now support backslash and forward-slash separators with consistent normalization.
  - Unsafe paths, including quotes, carriage returns, command substitution, and unsupported Windows prefixes, remain rejected.
  - Unix behavior is unchanged, including rejection of backslash separators.

- **Documentation**
  - Clarified Windows path separators, normalization, and TOML escaping, including tab interpretation.

- **Tests**
  - Added cross-platform end-to-end coverage for valid and invalid tool paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

