### PR TITLE
fix(npm): render lifecycle logs through progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c2d6661fa48702376c27e1fcf2bafc2eacc9aee6304f7a071c770a627ce397"
+checksum = "ee1a6d61ee85662d22660bbf67663a00f3c0e8aaf77f5de7f1bbe06adf6d0313"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f550d6a70f2488c51f4deb04be7e49a7b107a0986c43bc53db7107fa9aa050f2"
+checksum = "d20c81d01a7b0f4178ec5f3cfe787fa7a289f801e3eba611263b77cbbad83de8"
 dependencies = [
  "serde",
  "serde_json",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64644bba43b4008ff1fe734a62f8a860909637437a63f941b277c0e63a924f97"
+checksum = "1ac7ae2ec5f5c2849bf9681f24dcc23712c0eed4415d2614c97b1012919af1a4"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03ad3c037c7063cb52972fc6923919dac04c746eb2280d5476898c3871553eb"
+checksum = "d65790305a14c71196a2904b47be60e41ce4439fe5c51ca9c93636e69fd04955"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05dc65e27acbcc98ab070e4f7528782f0d8150187305229e23d46ef5df07d55b"
+checksum = "718cfbee6b95620020176e9c6e1d99e115c577666ad0c401735d7d75ddb11695"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a092758e35ad7a739fdd2d5084d4aa43d5d21c5bcd258d72ff788a61ea94ca1"
+checksum = "b8a4d1a3a039de207eaea6f5688c10817a214fb9ceeac9f3872b82aa2b1ffeaa"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5cdb0a765615410b6a5860c10d1ac61229d526d7d04d486790e314a617d2b9b"
+checksum = "d7cb6591acafea6e9293a6a406a4af84d10a943914bf754b47897788249fbcf1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfe6c4706ae73d80c2f147174604c2e1275fe9949480f6280ee1164d03027ca"
+checksum = "fe54a641bc3be469fe874890d3bb91dcaab6fb8678323d200502302d970d1d3a"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97f6db64bd7ddadcdd9118f25fb83dc841435bbf0c2475130ccce4cfd56464e"
+checksum = "62f8feb289ab2a47c73cd2418c6b4cd1346a51cdc27027afe0e600fb197202b7"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecc989e9d366167f4f629178f2badd096963c52e0d43de2f1230a6d996e0b07"
+checksum = "e00b891cffa36f00b0df810fe9d930537e85ac09060e048fd455b94e7d904bd4"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8d3586ad87de782560a2eb48c379002bd4e8e2029d8dc9f12ef1a2ca7200f"
+checksum = "6021a3b376282be63c99ec3507e78a4598415ee58090b1534fab417782659f4f"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b239ed49eafd36a16b166e909f3ba79ae8fe358efbf2daf93e80abfb25a10b"
+checksum = "ea67f939ab347d9f23ad467a5f4ef4953b6e542375ff61974c1a245027b6a4c3"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1429,7 +1429,14 @@ fn apply_aube_event(event: aube::embed::InstallEvent, pr: &dyn SingleReport) {
         // Text aube would have written to stderr itself. Warnings are the
         // user's business; a fatal error also comes back as the returned
         // `Err`, so this is never the only place one surfaces.
-        InstallEvent::Output { level, message, .. } => match level {
+        InstallEvent::Output {
+            level,
+            code,
+            message,
+        } => match level {
+            InstallOutputLevel::Info if code.as_deref() == Some("AUBE_LIFECYCLE_SCRIPT_OUTPUT") => {
+                pr.println(message)
+            }
             InstallOutputLevel::Info => debug!("aube: {message}"),
             InstallOutputLevel::Warning | InstallOutputLevel::Error => warn!("{message}"),
         },
@@ -1564,6 +1571,15 @@ pub fn install_time_option_keys() -> Vec<String> {
 mod tests {
     use super::*;
     use crate::cli::args::{BackendArg, BackendResolution};
+
+    #[derive(Debug, Default)]
+    struct RecordingReport(std::sync::Mutex<Vec<String>>);
+
+    impl SingleReport for RecordingReport {
+        fn println(&self, message: String) {
+            self.0.lock().unwrap().push(message);
+        }
+    }
     use crate::toolset::{ToolRequest, ToolSource, ToolVersionOptions};
     use pretty_assertions::assert_eq;
 
@@ -2618,5 +2634,21 @@ mod tests {
         // Hyphen only inside build metadata (not legal semver, but be defensive)
         // — we treat it as stable since the version core has no pre-release.
         assert!(!is_semver_prerelease("1.0.0+build-5"));
+    }
+
+    #[test]
+    fn test_aube_lifecycle_output_prints_through_progress_report() {
+        let report = RecordingReport::default();
+
+        apply_aube_event(
+            aube::embed::InstallEvent::Output {
+                level: aube::embed::InstallOutputLevel::Info,
+                code: Some("AUBE_LIFECYCLE_SCRIPT_OUTPUT".to_string()),
+                message: "gyp info ok".to_string(),
+            },
+            &report,
+        );
+
+        assert_eq!(*report.0.lock().unwrap(), ["gyp info ok"]);
     }
 }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -2719,6 +2719,8 @@ mod tests {
         while let Ok(event) = rx.try_recv() {
             apply_aube_event(event, &report);
         }
-        assert_eq!(*report.0.lock().unwrap(), ["lifecycle-from-aube"]);
+        let messages = report.0.lock().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].trim_end(), "lifecycle-from-aube");
     }
 }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -2650,5 +2650,18 @@ mod tests {
         );
 
         assert_eq!(*report.0.lock().unwrap(), ["gyp info ok"]);
+
+        let report = RecordingReport::default();
+        for code in [None, Some("OTHER_AUBE_INFO".to_string())] {
+            apply_aube_event(
+                aube::embed::InstallEvent::Output {
+                    level: aube::embed::InstallOutputLevel::Info,
+                    code,
+                    message: "internal status".to_string(),
+                },
+                &report,
+            );
+            assert!(report.0.lock().unwrap().is_empty());
+        }
     }
 }

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -2664,4 +2664,61 @@ mod tests {
             assert!(report.0.lock().unwrap().is_empty());
         }
     }
+
+    #[tokio::test]
+    async fn test_embedded_aube_emits_lifecycle_output_for_progress_report() {
+        crate::backend::aube_host::init();
+
+        let workspace = tempfile::tempdir().unwrap();
+        let app = workspace.path().join("packages/app");
+        let library = workspace.path().join("packages/library");
+        std::fs::create_dir_all(&app).unwrap();
+        std::fs::create_dir_all(&library).unwrap();
+        std::fs::write(
+            workspace.path().join("package.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "private": true,
+                "scripts": {
+                    "pnpm:devPreinstall": "echo lifecycle-from-aube"
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            workspace.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - packages/*\n",
+        )
+        .unwrap();
+        std::fs::write(app.join("package.json"), "{\"name\":\"app\"}\n").unwrap();
+        std::fs::write(
+            library.join("package.json"),
+            "{\"name\":\"library\",\"version\":\"1.0.0\"}\n",
+        )
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        aube::embed::add_with_overrides(
+            &app,
+            &["library@workspace:*".to_string()],
+            aube::embed::AddToProjectOptions {
+                offline: true,
+                control: aube::embed::InstallControl::events(Arc::new(AubeProgressReporter { tx })),
+                ..Default::default()
+            },
+            aube::embed::EmbedderInstallOverrides {
+                use_global_virtual_store: Some(false),
+                cache_dir: Some(workspace.path().join("cache")),
+                store_dir: Some(workspace.path().join("store")),
+            },
+        )
+        .await
+        .unwrap();
+
+        let report = RecordingReport::default();
+        while let Ok(event) = rx.try_recv() {
+            apply_aube_event(event, &report);
+        }
+        assert_eq!(*report.0.lock().unwrap(), ["lifecycle-from-aube"]);
+    }
 }


### PR DESCRIPTION
## Summary
- recognize lifecycle output events emitted by embedded aube
- print lifecycle lines through mise’s `SingleReport`, so clx safely redraws concurrent progress jobs
- keep non-lifecycle informational events at debug level and preserve warning/error handling

## Dependency
- updates the embedded aube workspace crates to 1.40.0, which captures lifecycle stdout/stderr and tags those `InstallEvent::Output` events
- this replaces the previous approach that paused the global progress renderer for the entire lifecycle phase

## Tests
- `cargo check --locked`
- `cargo test --locked --bin mise aube`
- `cargo test --locked --bin mise task::workspace::node::tests`
- `mise run test:e2e e2e/backend/test_npm_aube`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lifecycle-script output is now displayed through the installation progress reporting experience.
  * Informational lifecycle messages that do not require user attention remain out of the primary progress display, reducing unnecessary noise.
  * Installation progress now presents relevant lifecycle events more consistently while lifecycle scripts run.

* **Tests**
  * Added coverage to verify relevant lifecycle output is shown and unrelated informational messages remain hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to npm embedded-aube install UX and a dependency bump; no changes to auth, locking, or install resolution logic.
> 
> **Overview**
> Bumps embedded **aube** workspace crates from **1.39.0** to **1.40.0**, which tag lifecycle script stdout/stderr as `InstallEvent::Output` with code `AUBE_LIFECYCLE_SCRIPT_OUTPUT`.
> 
> In `apply_aube_event`, those info events are printed via **`SingleReport::println`** so mise’s progress layer (clx) can redraw safely alongside active install jobs. Other informational aube output stays at **debug**; warnings and errors are unchanged.
> 
> Adds unit/integration tests that assert lifecycle lines reach the progress report and that non-lifecycle info is not printed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bcf9de0dabb7449d06fc1d180509c67fc6068a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->