### PR TITLE
feat(config): add config-root-scoped locked tool policy

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,8 +82,8 @@ Different configuration sections merge in different ways:
 # Result: node@20, python@3.11, go@1.21
 ```
 
-**Tool policy** (`[tool_config]`): Applies only to tools declared by the same
-config file; it is not merged into invocation-wide settings
+**Tool policy** (`[tool_config]`): Applies only to tools declared by configs
+sharing the same config root; it is not merged into invocation-wide settings
 
 ```toml
 [tool_config]
@@ -196,10 +196,12 @@ Examples:
 node = { version = "22", postinstall = "corepack enable" }
 ```
 
-### `[tool_config]` - Config-scoped tool policy
+### `[tool_config]` - Config-root-scoped tool policy
 
-`[tool_config]` applies policy to the tools declared by the same config file.
-It does not affect tools inherited from global, system, or parent configs.
+`[tool_config]` applies policy to tools declared by configs sharing the same
+config root. For example, policy in `mise.local.toml` also applies to tools in
+`mise.toml` beside it. It does not affect tools inherited from global, system,
+or parent config roots.
 
 ```toml
 [tool_config]
@@ -209,8 +211,8 @@ locked = true
 node = "24"
 ```
 
-Currently, `locked` is the only supported policy. It requires this config's
-tools to resolve and install from its lockfile. See [mise.lock](/dev-tools/mise-lock.html#strict-lockfile-mode).
+Currently, `locked` is the only supported policy. It requires this config
+root's tools to resolve and install from their lockfiles. See [mise.lock](/dev-tools/mise-lock.html#strict-lockfile-mode).
 
 ### `[env]` - Arbitrary Environment Variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,14 @@ Different configuration sections merge in different ways:
 # Result: node@20, python@3.11, go@1.21
 ```
 
+**Tool policy** (`[tool_config]`): Applies only to tools declared by the same
+config file; it is not merged into invocation-wide settings
+
+```toml
+[tool_config]
+locked = true
+```
+
 **Environment Variables** (`[env]`): Additive with overrides
 
 ```toml
@@ -187,6 +195,22 @@ Examples:
 [tools]
 node = { version = "22", postinstall = "corepack enable" }
 ```
+
+### `[tool_config]` - Config-scoped tool policy
+
+`[tool_config]` applies policy to the tools declared by the same config file.
+It does not affect tools inherited from global, system, or parent configs.
+
+```toml
+[tool_config]
+locked = true
+
+[tools]
+node = "24"
+```
+
+Currently, `locked` is the only supported policy. It requires this config's
+tools to resolve and install from its lockfile. See [mise.lock](/dev-tools/mise-lock.html#strict-lockfile-mode).
 
 ### `[env]` - Arbitrary Environment Variables
 

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -186,7 +186,7 @@ MISE_LOCKED=1 mise install
 All mise settings are global in scope. Setting `locked = true` in a project's `mise.toml` applies to **all** tool resolution, including tools from your global `~/.config/mise/config.toml`. If you see warnings about global tools missing from the lockfile, run `mise lock -g` to generate a global lockfile.
 :::
 
-To enforce strict mode only for tools declared by one config file, use
+To enforce strict mode only for tools declared by one config root, use
 `tool_config.locked` instead of the invocation-wide setting:
 
 ```toml
@@ -197,8 +197,9 @@ locked = true
 node = "24"
 ```
 
-This policy belongs to the containing config: the tools above must be present in
-that config's lockfile, while tools inherited from global or parent configs keep
+This policy belongs to the containing config root: tools declared by `mise.toml`,
+`mise.local.toml`, and other configs sharing that root must be present in their
+respective lockfiles. Tools inherited from global or parent config roots keep
 their own policy. `--locked`, `MISE_LOCKED=1`, and `[settings] locked = true`
 continue to apply to the entire active toolset.
 

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -186,6 +186,22 @@ MISE_LOCKED=1 mise install
 All mise settings are global in scope. Setting `locked = true` in a project's `mise.toml` applies to **all** tool resolution, including tools from your global `~/.config/mise/config.toml`. If you see warnings about global tools missing from the lockfile, run `mise lock -g` to generate a global lockfile.
 :::
 
+To enforce strict mode only for tools declared by one config file, use
+`tool_config.locked` instead of the invocation-wide setting:
+
+```toml
+[tool_config]
+locked = true
+
+[tools]
+node = "24"
+```
+
+This policy belongs to the containing config: the tools above must be present in
+that config's lockfile, while tools inherited from global or parent configs keep
+their own policy. `--locked`, `MISE_LOCKED=1`, and `[settings] locked = true`
+continue to apply to the entire active toolset.
+
 When enabled, `mise install` will fail if a tool doesn't have a URL for the current platform in the lockfile. To fix this, first populate the lockfile with URLs:
 
 ```sh

--- a/e2e/lockfile/test_lockfile_tool_config_locked
+++ b/e2e/lockfile/test_lockfile_tool_config_locked
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Config-scoped locked policy applies only to tools declared by that config.
+# Config-root-scoped locked policy applies only to tools declared at that root.
 export MISE_LOCKFILE=1
 detect_platform
 PLATFORM="$MISE_PLATFORM"
@@ -11,11 +11,14 @@ dummy = "latest"
 EOF
 
 cat <<'EOF' >mise.toml
-[tool_config]
-locked = true
-
 [tools]
 tiny = "1"
+EOF
+
+# Policy in a sibling config applies to tools from the same config root.
+cat <<'EOF' >mise.local.toml
+[tool_config]
+locked = true
 EOF
 
 # The project tool must be locked, but the unrelated global tool must not be
@@ -36,4 +39,5 @@ assert_fail_contains "mise install --dry-run 2>&1" "disable locked mode"
 
 # Invocation-wide locked mode retains its existing behavior for global tools.
 rm mise.toml
+rm mise.local.toml
 assert_fail_contains "MISE_LOCKED=1 mise install --dry-run 2>&1" "dummy@latest is not in the lockfile"

--- a/e2e/lockfile/test_lockfile_tool_config_locked
+++ b/e2e/lockfile/test_lockfile_tool_config_locked
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Config-scoped locked policy applies only to tools declared by that config.
+export MISE_LOCKFILE=1
+detect_platform
+PLATFORM="$MISE_PLATFORM"
+
+cat <<'EOF' >"$MISE_CONFIG_DIR/config.toml"
+[tools]
+dummy = "latest"
+EOF
+
+cat <<'EOF' >mise.toml
+[tool_config]
+locked = true
+
+[tools]
+tiny = "1"
+EOF
+
+# The project tool must be locked, but the unrelated global tool must not be
+# required in the global lockfile.
+cat <<EOF >mise.lock
+[[tools.tiny]]
+version = "1.0.0"
+backend = "vfox:tiny"
+"platforms.$PLATFORM" = { url = "https://example.com/tiny-1.0.0.tar.gz" }
+EOF
+
+assert_contains "mise install --dry-run 2>&1" "tiny@1.0.0"
+assert_contains "mise install --dry-run 2>&1" "dummy@2.0.0"
+
+rm mise.lock
+assert_fail_contains "mise install --dry-run 2>&1" "No lockfile URL found for tiny@1"
+assert_fail_contains "mise install --dry-run 2>&1" "disable locked mode"
+
+# Invocation-wide locked mode retains its existing behavior for global tools.
+rm mise.toml
+assert_fail_contains "MISE_LOCKED=1 mise install --dry-run 2>&1" "dummy@latest is not in the lockfile"

--- a/e2e/lockfile/test_lockfile_tool_config_locked
+++ b/e2e/lockfile/test_lockfile_tool_config_locked
@@ -41,3 +41,23 @@ assert_fail_contains "mise install --dry-run 2>&1" "disable locked mode"
 rm mise.toml
 rm mise.local.toml
 assert_fail_contains "MISE_LOCKED=1 mise install --dry-run 2>&1" "dummy@latest is not in the lockfile"
+
+# A local config directly in $HOME has the same path-valued config_root as the
+# global config by default, but they remain distinct policy scopes.
+cat <<'EOF' >"$HOME/mise.toml"
+[tool_config]
+locked = true
+
+[tools]
+tiny = "1"
+EOF
+
+cat <<EOF >"$HOME/mise.lock"
+[[tools.tiny]]
+version = "1.0.0"
+backend = "vfox:tiny"
+"platforms.$PLATFORM" = { url = "https://example.com/tiny-1.0.0.tar.gz" }
+EOF
+
+assert_contains "mise -C \"$HOME\" install --dry-run 2>&1" "tiny@1.0.0"
+assert_contains "mise -C \"$HOME\" install --dry-run 2>&1" "dummy@2.0.0"

--- a/e2e/lockfile/test_lockfile_tool_config_locked
+++ b/e2e/lockfile/test_lockfile_tool_config_locked
@@ -4,6 +4,7 @@
 export MISE_LOCKFILE=1
 detect_platform
 PLATFORM="$MISE_PLATFORM"
+mise plugin install tiny
 
 cat <<'EOF' >"$MISE_CONFIG_DIR/config.toml"
 [tools]
@@ -34,8 +35,8 @@ assert_contains "mise install --dry-run 2>&1" "tiny@1.0.0"
 assert_contains "mise install --dry-run 2>&1" "dummy@2.0.0"
 
 rm mise.lock
-assert_fail_contains "mise install --dry-run 2>&1" "No lockfile URL found for tiny@1"
-assert_fail_contains "mise install --dry-run 2>&1" "disable locked mode"
+assert_fail_contains "mise install --dry-run 2>&1" "tiny@1 is not in the lockfile"
+assert_fail_contains "mise install --dry-run 2>&1" "tool_config.locked"
 
 # Invocation-wide locked mode retains its existing behavior for global tools.
 rm mise.toml

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2480,13 +2480,13 @@
       }
     },
     "tool_config": {
-      "description": "policy for tools declared by the containing config file",
+      "description": "policy for tools declared by configs sharing the containing config root",
       "type": "object",
       "unevaluatedProperties": false,
       "properties": {
         "locked": {
           "default": false,
-          "description": "require tools declared by this config to resolve and install from its lockfile",
+          "description": "require tools declared by this config root to resolve and install from their lockfiles",
           "type": "boolean"
         }
       }
@@ -4667,7 +4667,7 @@
       "$ref": "#/$defs/task_config"
     },
     "tool_config": {
-      "description": "policy for tools declared by this config file",
+      "description": "policy for tools declared by this config root",
       "$ref": "#/$defs/tool_config"
     },
     "tasks": {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2479,6 +2479,18 @@
         }
       }
     },
+    "tool_config": {
+      "description": "policy for tools declared by the containing config file",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "locked": {
+          "default": false,
+          "description": "require tools declared by this config to resolve and install from its lockfile",
+          "type": "boolean"
+        }
+      }
+    },
     "monorepo_root": {
       "description": "Marks this config as a monorepo root, enabling target path syntax for tasks. When enabled, tasks can be referenced with paths like //projects/frontend:build",
       "type": "boolean"
@@ -4653,6 +4665,10 @@
     "task_config": {
       "description": "configuration for task execution and management",
       "$ref": "#/$defs/task_config"
+    },
+    "tool_config": {
+      "description": "policy for tools declared by this config file",
+      "$ref": "#/$defs/tool_config"
     },
     "tasks": {
       "additionalProperties": {

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -20,7 +20,7 @@ use versions::Versioning;
 use crate::backend::unalias_backend;
 use crate::cli::args::BackendArg;
 use crate::config::config_file::{
-    ConfigFile, TaskConfig, config_trust_root, is_ignored, trust, trust_check,
+    ConfigFile, TaskConfig, ToolConfig, config_trust_root, is_ignored, trust, trust_check,
 };
 use crate::config::config_file::{config_root, toml::deserialize_arr};
 use crate::config::env_directive::{
@@ -395,6 +395,8 @@ pub struct MiseToml {
     redactions: Redactions,
     #[serde(default)]
     task_config: TaskConfig,
+    #[serde(default)]
+    tool_config: ToolConfig,
     #[serde(default)]
     tasks: Tasks,
     #[serde(default)]
@@ -1587,6 +1589,10 @@ impl ConfigFile for MiseToml {
         &self.task_config
     }
 
+    fn tool_config(&self) -> &ToolConfig {
+        &self.tool_config
+    }
+
     fn task_config_includes(&self) -> eyre::Result<Option<Vec<String>>> {
         self.task_config
             .includes
@@ -1838,6 +1844,7 @@ impl Clone for MiseToml {
             tasks: self.tasks.clone(),
             task_templates: self.task_templates.clone(),
             task_config: self.task_config.clone(),
+            tool_config: self.tool_config.clone(),
             settings: self.settings.clone(),
             watch_files: self.watch_files.clone(),
             deps: self.deps.clone(),

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -815,10 +815,10 @@ pub struct TaskConfig {
     pub input_groups: IndexMap<String, Vec<String>>,
 }
 
-/// Policy applied only to tools declared by the config file containing it.
+/// Policy applied to tools declared by configs sharing this config's root.
 ///
-/// Unlike `[settings]`, this is intentionally config-owned rather than an
-/// invocation-wide merged value.
+/// Unlike `[settings]`, this is intentionally config-root-owned rather than
+/// an invocation-wide merged value.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ToolConfig {

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -116,6 +116,11 @@ pub trait ConfigFile: Debug + Send + Sync {
         &DEFAULT_TASK_CONFIG
     }
 
+    fn tool_config(&self) -> &ToolConfig {
+        static DEFAULT_TOOL_CONFIG: Lazy<ToolConfig> = Lazy::new(ToolConfig::default);
+        &DEFAULT_TOOL_CONFIG
+    }
+
     fn task_config_includes(&self) -> eyre::Result<Option<Vec<String>>> {
         Ok(self.task_config().includes.clone())
     }
@@ -808,6 +813,16 @@ pub struct TaskConfig {
     pub global_pass_through_env: Vec<String>,
     pub global_inputs: Vec<String>,
     pub input_groups: IndexMap<String, Vec<String>>,
+}
+
+/// Policy applied only to tools declared by the config file containing it.
+///
+/// Unlike `[settings]`, this is intentionally config-owned rather than an
+/// invocation-wide merged value.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ToolConfig {
+    pub locked: bool,
 }
 
 /// Deliberately not `#[cfg(unix)]` like the module below: the bug these cover is

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -111,16 +111,19 @@ pub fn is_loaded() -> bool {
 }
 
 impl Config {
-    /// Whether the config that owns this tool request opted it into strict
+    /// Whether the config root that owns this tool request opted it into strict
     /// lockfile enforcement. Non-config sources remain governed only by the
     /// invocation-wide `locked` setting/flag.
     pub fn tool_config_locked(&self, source: &ToolSource) -> bool {
         let ToolSource::MiseToml(path) = source else {
             return false;
         };
+        let Some(root) = self.config_files.get(path).map(|cf| cf.config_root()) else {
+            return false;
+        };
         self.config_files
-            .get(path)
-            .is_some_and(|cf| cf.tool_config().locked)
+            .values()
+            .any(|cf| cf.config_root() == root && cf.tool_config().locked)
     }
 
     pub async fn get() -> Result<Arc<Self>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -121,9 +121,15 @@ impl Config {
         let Some(root) = self.config_files.get(path).map(|cf| cf.config_root()) else {
             return false;
         };
-        self.config_files
-            .values()
-            .any(|cf| cf.config_root() == root && cf.tool_config().locked)
+        // The global config root defaults to $HOME, which can also be the
+        // config_root of a local config stored directly in $HOME. Keep those
+        // conceptual roots separate even when their path values coincide.
+        let is_global = is_global_config(path);
+        self.config_files.values().any(|cf| {
+            is_global_config(cf.get_path()) == is_global
+                && cf.config_root() == root
+                && cf.tool_config().locked
+        })
     }
 
     pub async fn get() -> Result<Arc<Self>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,7 +39,7 @@ use crate::tera::{contains_template_syntax, get_empty_tera, render_str, take_ter
 use crate::toolset::env_cache::{CachedNonToolEnv, compute_settings_hash, get_file_mtime};
 use crate::toolset::{
     ResolvedToolOptions, ToolOptionSource, ToolOptions, ToolRequestSet, ToolRequestSetBuilder,
-    ToolVersion, ToolVersionOptions, Toolset, install_state,
+    ToolSource, ToolVersion, ToolVersionOptions, Toolset, install_state,
 };
 use crate::ui::style;
 use crate::{backend, dirs, env, file, lockfile, registry, runtime_symlinks, shims, timeout};
@@ -111,6 +111,18 @@ pub fn is_loaded() -> bool {
 }
 
 impl Config {
+    /// Whether the config that owns this tool request opted it into strict
+    /// lockfile enforcement. Non-config sources remain governed only by the
+    /// invocation-wide `locked` setting/flag.
+    pub fn tool_config_locked(&self, source: &ToolSource) -> bool {
+        let ToolSource::MiseToml(path) = source else {
+            return false;
+        };
+        self.config_files
+            .get(path)
+            .is_some_and(|cf| cf.tool_config().locked)
+    }
+
     pub async fn get() -> Result<Arc<Self>> {
         if let Some(config) = &*_CONFIG.read().unwrap() {
             return Ok(config.clone());

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -366,14 +366,20 @@ impl ToolVersion {
             return Ok(Self::from_lockfile(request.clone(), lt));
         }
         let settings = Settings::get();
-        if settings.locked
+        let tool_config_locked = config.tool_config_locked(request.source());
+        if (settings.locked || tool_config_locked)
             && opts.use_locked_version
             && settings.lockfile_enabled()
             && !has_linked_version(request.ba())
             && request.source().path().is_some()
         {
+            let hint = if tool_config_locked && !settings.locked {
+                "Run `mise lock` to update the lockfile, or disable `tool_config.locked`"
+            } else {
+                "Run `mise install` without --locked to update the lockfile"
+            };
             bail!(
-                "{}@{} is not in the lockfile\nhint: Run `mise install` without --locked to update the lockfile",
+                "{}@{} is not in the lockfile\nhint: {hint}",
                 request.ba().short,
                 request.version()
             );

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -566,7 +566,7 @@ impl Toolset {
             pr: mpr.add_with_options(&tv.style(), opts.dry_run),
             force: opts.force,
             dry_run: opts.dry_run,
-            locked: opts.locked,
+            locked: opts.locked || config.tool_config_locked(tr.source()),
             before_date,
         };
 


### PR DESCRIPTION
## Summary

- add a `[tool_config]` section for policy owned by one config root
- support `[tool_config] locked = true` for tools declared by configs sharing that root
- keep `[settings] locked`, `--locked`, and `MISE_LOCKED` invocation-wide
- document and test the boundary with sibling project configs plus an unrelated global config root

## Status: design probe

This is intentionally a concrete design probe, not a settled decision to add the feature. I’m going to review the abstraction and tradeoffs myself as a human before deciding whether this belongs in mise. I’m not yet sure the additional configuration surface is justified, and this PR may be closed after that review.

The important boundary is that `[settings]` remains merged invocation-wide state. This proposal does not make settings project-local; it introduces a separate tool policy scoped to a `config_root`. A policy declared in `mise.local.toml`, for example, also governs tools declared by sibling `mise.toml`, but not tools inherited from a global or parent config root.

Context: #8663

## Tests

- `mise run test:e2e e2e/lockfile/test_lockfile_tool_config_locked e2e/lockfile/test_lockfile_locked_mode`
- `mise run render:schema`
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile enforcement during tool resolution and install, but behavior is additive and scoped; global locked mode is unchanged.
> 
> **Overview**
> Introduces **`[tool_config]`** as config-root-owned policy (not merged like `[settings]`). **`[tool_config] locked = true`** requires tools declared by configs sharing that root—including siblings like `mise.toml` + `mise.local.toml`—to resolve and install from their lockfiles, without forcing global or parent-root tools into the same strict mode.
> 
> **`Config::tool_config_locked`** drives this at runtime: resolution and install treat **`settings.locked` / `--locked` / `MISE_LOCKED`** as invocation-wide, while **`tool_config.locked`** applies only to matching `MiseToml` tool sources; global vs home-local roots stay separate when paths coincide. Missing lockfile errors get a **`tool_config.locked`**-specific hint.
> 
> Docs, JSON schema, and e2e coverage document and exercise the boundary vs global locked mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f87c173ca2243ea510256deb31f20c12d3f7836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enforce lockfile-based tool installation for tools declared in a specific configuration file.
  * Added schema support and validation for the new `tool_config.locked` setting.
  * Lockfile errors now provide context-specific guidance for resolving missing entries.

* **Documentation**
  * Documented configuration-scoped lockfile enforcement and how it interacts with global settings and invocation flags.

* **Tests**
  * Added end-to-end coverage for configuration-scoped and global locked-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->