### PR TITLE
fix(task): resolve monorepo task names from subdirectories

### DIFF
--- a/docs/tasks/monorepo.md
+++ b/docs/tasks/monorepo.md
@@ -88,6 +88,11 @@ cd projects/frontend
 mise :build  # Runs the build task from frontend's config_root
 ```
 
+This works from any directory below a config_root, not just the config_root itself. The
+task name resolves to the nearest enclosing config_root, so `cd projects/frontend/src/components
+&& mise :build` also runs frontend's `build`. If no config_root encloses the current directory,
+the name resolves against the monorepo root.
+
 ::: tip Optional Colon Syntax
 The leading `:` is optional when running tasks from subdirectories or defining task dependencies. While both syntaxes work, **we encourage using the `:` prefix to be explicit** about monorepo task references.
 

--- a/e2e/tasks/test_task_monorepo_optional_colon
+++ b/e2e/tasks/test_task_monorepo_optional_colon
@@ -149,3 +149,40 @@ assert_contains "mise run //:init" "root init task executed"
 # Running from root directory with bare name should work the same
 assert_contains "mise run init" "root clean task executed"
 assert_contains "mise run init" "root init task executed"
+
+# Test 9: below a config root, names resolve up to the nearest enclosing one
+mkdir -p app/deep/deeper
+(
+  cd app/deep/deeper
+  assert_contains "mise run build" "build task executed"
+  assert_contains "mise run build" "setup task executed"
+  assert_contains "mise run :build" "build task executed"
+  assert_contains "mise run :build" "setup task executed"
+)
+
+# Test 10: absolute // forms are unaffected by a deep cwd
+(
+  cd app/deep/deeper
+  assert_contains "mise run //app:build" "build task executed"
+  assert_contains "mise run '//...:build'" "build task executed"
+)
+
+# Test 11: below no config root, names resolve to the monorepo root
+mkdir -p not-a-project/sub
+(
+  cd not-a-project/sub
+  assert_contains "mise run init" "root init task executed"
+  assert_contains "mise run :init" "root init task executed"
+)
+
+# Test 12: the nearest enclosing config root wins even when absent from config_roots
+mkdir -p services/nested/inner
+cat <<'EOF' >services/nested/mise.toml
+[tasks.nested-only]
+run = 'echo "nested-only task executed"'
+EOF
+(
+  cd services/nested/inner
+  assert_contains "mise run nested-only" "nested-only task executed"
+  assert_contains "mise run :nested-only" "nested-only task executed"
+)

--- a/e2e/tasks/test_task_monorepo_optional_colon
+++ b/e2e/tasks/test_task_monorepo_optional_colon
@@ -175,8 +175,13 @@ mkdir -p not-a-project/sub
   assert_contains "mise run :init" "root init task executed"
 )
 
-# Test 12: the nearest enclosing config root wins even when absent from config_roots
+# Test 12: the nearest enclosing config root wins over an ancestor defining the
+# same task, even when absent from config_roots
 mkdir -p services/nested/inner
+cat <<'EOF' >services/mise.toml
+[tasks.nested-only]
+run = 'echo "ancestor nested-only executed"'
+EOF
 cat <<'EOF' >services/nested/mise.toml
 [tasks.nested-only]
 run = 'echo "nested-only task executed"'
@@ -184,5 +189,7 @@ EOF
 (
   cd services/nested/inner
   assert_contains "mise run nested-only" "nested-only task executed"
+  assert_not_contains "mise run nested-only" "ancestor nested-only executed"
   assert_contains "mise run :nested-only" "nested-only task executed"
+  assert_not_contains "mise run :nested-only" "ancestor nested-only executed"
 )

--- a/e2e/tasks/test_task_shorthand_monorepo
+++ b/e2e/tasks/test_task_shorthand_monorepo
@@ -62,3 +62,19 @@ EOF
 assert_contains "mise '//deep/nested/dir:test'" "nested task"
 
 (cd deep/nested/dir && assert_contains "mise ':test'" "nested task")
+
+# Test 8: Bare and colon task names walk up to the nearest config root from deep directories
+mkdir -p project/deep/deeper
+(
+  cd project/deep/deeper
+  assert_contains "mise run build" "project build task"
+  assert_contains "mise run ':build'" "project build task"
+)
+
+# Test 9: A directory outside the configured projects resolves against the monorepo root
+mkdir -p unconfigured/deep
+(
+  cd unconfigured/deep
+  assert_contains "mise run build" "root build task"
+  assert_contains "mise run ':build'" "root build task"
+)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -625,7 +625,10 @@ impl Config {
     /// `None` matches any existing directory and is used for lockfile migration
     /// and routing. `Some(filenames)` requires a recognized config or idiomatic
     /// version file and is used for full monorepo union/task loading.
-    fn monorepo_config_root_dirs(&self, filenames: Option<&[String]>) -> Result<Vec<PathBuf>> {
+    pub(crate) fn monorepo_config_root_dirs(
+        &self,
+        filenames: Option<&[String]>,
+    ) -> Result<Vec<PathBuf>> {
         let monorepo_config = find_monorepo_config(&self.config_files)
             .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
         let monorepo_root = monorepo_config

--- a/src/task/task_load_context.rs
+++ b/src/task/task_load_context.rs
@@ -163,11 +163,11 @@ impl TaskLoadContext {
     }
 }
 
-/// Expands :task syntax to //path:task based on current directory relative to monorepo root
+/// Expands :task syntax to //path:task based on the current config root
 ///
 /// This function handles the special `:task` syntax that refers to tasks in the current
-/// config_root within a monorepo. It converts `:build` to either `//:build` (if at monorepo root)
-/// or `//project:build` (if in a subdirectory).
+/// config_root within a monorepo. It converts `:build` to either `//:build` (if the current
+/// config root is the monorepo root) or `//project:build` (if it is in a subdirectory).
 ///
 /// # Arguments
 /// * `task` - The task pattern to expand (e.g., ":build")
@@ -215,9 +215,16 @@ pub fn expand_colon_task_syntax(
     // We're in a monorepo context
     let monorepo_root = monorepo_root.unwrap();
 
-    // Determine the current directory relative to monorepo root
+    // Task names are keyed to the defining config's directory, so scope to
+    // Config::project_root (nearest config root above cwd), not cwd itself;
+    // fall back to cwd when it lies outside the selected monorepo.
     if let Some(cwd) = &*crate::dirs::CWD {
-        if let Some(scope) = monorepo_scope(&monorepo_root, cwd) {
+        let scope_dir = config
+            .project_root
+            .as_deref()
+            .filter(|root| root.starts_with(&monorepo_root) && cwd.starts_with(root))
+            .unwrap_or(cwd);
+        if let Some(scope) = monorepo_scope(&monorepo_root, scope_dir) {
             // For bare task names, only expand if we're actually in the monorepo
             // For colon patterns, always expand (and error if outside monorepo)
 

--- a/src/task/task_load_context.rs
+++ b/src/task/task_load_context.rs
@@ -1,5 +1,5 @@
 use eyre::bail;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Return the absolute `//path` scope for a directory within a monorepo.
 pub(crate) fn monorepo_scope(monorepo_root: &Path, dir: &Path) -> Option<String> {
@@ -215,15 +215,24 @@ pub fn expand_colon_task_syntax(
     // We're in a monorepo context
     let monorepo_root = monorepo_root.unwrap();
 
-    // Task names are keyed to the defining config's directory, so scope to
-    // Config::project_root (nearest config root above cwd), not cwd itself;
-    // fall back to cwd when it lies outside the selected monorepo.
+    // Task names are keyed to project roots: the directories of configs in
+    // scope plus declared [monorepo].config_roots, which may hold only file
+    // tasks and no config. Scope to the nearest such root above cwd, not cwd
+    // itself; the monorepo root bounds the walk and counts as a root.
     if let Some(cwd) = &*crate::dirs::CWD {
-        let scope_dir = config
-            .project_root
-            .as_deref()
-            .filter(|root| root.starts_with(&monorepo_root) && cwd.starts_with(root))
-            .unwrap_or(cwd);
+        let scope_dir: &Path = if cwd.starts_with(&monorepo_root) {
+            let roots: Vec<PathBuf> = config
+                .config_files
+                .values()
+                .filter_map(|cf| cf.project_root())
+                .chain(config.monorepo_config_root_dirs(None).unwrap_or_default())
+                .collect();
+            cwd.ancestors()
+                .find(|a| *a == monorepo_root || roots.iter().any(|r| r == a))
+                .unwrap_or(cwd)
+        } else {
+            cwd
+        };
         if let Some(scope) = monorepo_scope(&monorepo_root, scope_dir) {
             // For bare task names, only expand if we're actually in the monorepo
             // For colon patterns, always expand (and error if outside monorepo)


### PR DESCRIPTION
### Problem

In monorepo mode, running a task by its bare or `:`-prefixed name only works when the cwd is *exactly* a config root. From any directory below one it fails:

```console
$ cd mono/proj/deep/deeper
$ mise run hello-mono
Error: no task //proj/deep/deeper:hello-mono found
      Did you mean one of these?
        - //proj:hello-mono
```

This contradicts non-monorepo mode (which has always walked up to the nearest mise.toml), monorepo config/env discovery (which walks up correctly — `mise env` in the same directory shows the project's `[env]`), and the docs ("The leading `:` is optional when running tasks from subdirectories"). Absolute forms (`//proj:task`, `//.../proj:task`, `//...:task`) already work from any depth.

### Root cause

`expand_colon_task_syntax` (`src/task/task_load_context.rs`) converted the cwd to a task-path prefix verbatim via `monorepo_scope(&monorepo_root, cwd)` — a pure `strip_prefix`, no upward walk. The loader names tasks on a different basis: `load_local_tasks_with_context` walks `all_dirs()` upward from the cwd and prefixes each config's tasks with the *defining directory's* scope. The two only agree when the cwd is itself the defining directory — the one case that worked. The error message is self-diagnosing: mise had already loaded `//proj:hello-mono` while asking for `//proj/deep/deeper:hello-mono`.

### Fix

Scope bare and `:`-prefixed names to the nearest *project root* at or above the cwd, instead of to the cwd itself:

```rust
let scope_dir: &Path = if cwd.starts_with(&monorepo_root) {
    let roots: Vec<PathBuf> = config
        .config_files
        .values()
        .filter_map(|cf| cf.project_root())
        .chain(config.monorepo_config_root_dirs(None).unwrap_or_default())
        .collect();
    cwd.ancestors()
        .find(|a| *a == monorepo_root || roots.iter().any(|r| r == a))
        .unwrap_or(cwd)
} else {
    cwd
};
```

A "project root" here is the union of two sources, and both are load-bearing:

- **Directories of configs in scope** (nearest-first ConfigMap, the same upward walk the loader uses to name tasks). Needed because a `mise.toml` in a subdirectory *not* listed in `[monorepo].config_roots` still gets its own namespace from the loader (`//proj/nested:nested-task`) — a name typed in `proj/nested/inner` must resolve to `//proj/nested`, not the outer project.
- **Declared `[monorepo].config_roots`** (resolved via `monorepo_config_root_dirs(None)`, which matches any existing directory). Needed because a declared project may contain only file tasks (`mise-tasks/`) and no config file at all — the loader still names its tasks `//projects/frontend:build` (covered by `e2e/tasks/test_task_non_executable_error`).

The walk is bounded by the monorepo root, which counts as a root itself, and a cwd outside the monorepo is left as-is, preserving every existing error path.

### Alternatives considered

- **Reuse `Config::project_root` alone**: one line, and correct for every config-file case — but it misses declared config roots that hold only file tasks (caught by `test_task_non_executable_error` in CI).
- **Expand `[monorepo].config_roots` alone**: wrong in the other direction — unlisted nested configs resolve to the outer project, which lacks the task.
- **Retry the matcher with successively shorter path prefixes**: changes matching semantics globally; would let `//a/b:t` silently resolve to `//a:t`, weakening the absolute forms, which must stay exact.
- **Reset the cwd to the config root before expansion**: cwd is load-bearing elsewhere (`{{cwd}}`, relative script paths); far wider blast radius.

### Risk and compatibility

- Only `expand_colon_task_syntax` changed; all its callers (`mise run`, bare shorthand, `tasks info`, `tasks deps`, `cache task`) gain the same resolution consistently.
- `depends` (incl. `./...`) is structurally unaffected: dependency patterns resolve via `resolve_task_pattern` from the declaring task's *name*, never the cwd. Its e2e coverage passes.
- Absolute `//` forms return early before this code; non-monorepo mode returns early on `monorepo_root.is_none()`.
- Cwd exactly at a config root or the monorepo root: `project_root == cwd`, so the scope is byte-identical to before (verified — identical task names and cwds in all control cases).
- One intentional change beyond the bug: a cwd inside the monorepo but below no config root previously expanded to a guaranteed-miss literal name; it now resolves to the monorepo root's `//` scope. An error case starts working; no previously-working command changes meaning.

### Tests

- `e2e/tasks/test_task_shorthand_monorepo`: deep-subdir bare + `:name`; a directory outside all configured projects resolving to root tasks.
- `e2e/tasks/test_task_monorepo_optional_colon`: deep-subdir bare + `:name` including dependency execution; absolute `//app:build` and `//...:build` from a deep cwd; a monorepo-root subdir below no config root; nearest-root-wins for an *unlisted* nested config, including precedence over an ancestor config defining the same task name. These fail on the pre-fix binary (at the first new assertion, with `no task //app/deep/deeper:build found`), so they are regression tests rather than tautologies.
- The file-task-only declared-root case is covered by the existing `e2e/tasks/test_task_non_executable_error`, which runs `:build` from a project that has `mise-tasks/` but no config file.
- Docs: `docs/tasks/monorepo.md` now states `:task` works from any directory below a config_root and resolves to the nearest enclosing one.

Verified additionally: 13-case repro matrix (classic-mode control, config-root/monorepo-root controls, deep-cwd cases, absolute forms from deep cwd, below-no-config-root, unlisted-nested-config) — all pass; `cargo clippy --locked --bin mise -- -D warnings` clean; `cargo fmt --check` clean; targeted monorepo e2e suite incl. the `./...` depends-scoping tests passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
