### PR TITLE
registry: add native-sdk (github:vercel-labs/native)

### DIFF
--- a/registry/native-sdk.toml
+++ b/registry/native-sdk.toml
@@ -1,0 +1,28 @@
+description = "Toolkit for building native desktop apps"
+os = ["linux", "macos", "windows"]
+test = { cmd = "native-sdk --version", expected = "native {{version}}" }
+version_order = "semver"
+
+bins = ["native-sdk"]
+[[backends]]
+full = "github:vercel-labs/native"
+
+[backends.options]
+# Releases publish bare per-platform binaries rather than archives, and the glibc
+# and musl Linux builds share the `native-sdk-linux-` prefix, so the asset is named
+# explicitly instead of letting autodetection choose between them.
+asset_pattern = "native-sdk-{{ os(macos='darwin') }}-{{ arch() }}"
+bin = "native-sdk"
+# The repo also tags CEF bundles (e.g. cef-144.0.6+g5f7e671+chromium-144.0.7559.59)
+# in the same release stream; those are not the CLI, so list only `v`-prefixed tags.
+version_prefix = "v"
+
+# Windows assets use a `win32` infix and an `.exe` suffix, which the shared
+# asset_pattern above does not produce.
+[backends.options.platforms.windows-x64]
+asset_pattern = "native-sdk-win32-x64.exe"
+bin = "native-sdk.exe"
+
+[backends.options.platforms.windows-arm64]
+asset_pattern = "native-sdk-win32-arm64.exe"
+bin = "native-sdk.exe"

--- a/registry/native-sdk.toml
+++ b/registry/native-sdk.toml
@@ -8,17 +8,17 @@ bins = ["native-sdk"]
 full = "github:vercel-labs/native"
 
 [backends.options]
-# Releases publish bare per-platform binaries rather than archives, and the glibc
-# and musl Linux builds share the `native-sdk-linux-` prefix, so the asset is named
-# explicitly instead of letting autodetection choose between them.
-asset_pattern = "native-sdk-{{ os(macos='darwin') }}-{{ arch() }}"
+# Releases publish bare per-platform binaries rather than archives. Linux and macOS
+# are left to autodetection so that it can pick between the glibc
+# (native-sdk-linux-x64) and musl (native-sdk-linux-musl-x64) builds; a shared
+# asset_pattern would replace autodetection and pin every Linux host to glibc.
 bin = "native-sdk"
 # The repo also tags CEF bundles (e.g. cef-144.0.6+g5f7e671+chromium-144.0.7559.59)
 # in the same release stream; those are not the CLI, so list only `v`-prefixed tags.
 version_prefix = "v"
 
-# Windows assets use a `win32` infix and an `.exe` suffix, which the shared
-# asset_pattern above does not produce.
+# Windows assets use a `win32` infix rather than `windows`, so they are named
+# explicitly instead of relying on autodetection.
 [backends.options.platforms.windows-x64]
 asset_pattern = "native-sdk-win32-x64.exe"
 bin = "native-sdk.exe"


### PR DESCRIPTION
Adds a registry shorthand for [Native SDK](https://native-sdk.dev), Vercel Labs' toolkit for building native desktop apps, so `mise use native-sdk` works instead of the full `github:vercel-labs/native` spec.

## Popularity

- **GitHub:** 7,405 stars, 295 forks — [vercel-labs/native](https://github.com/vercel-labs/native)
- **npm:** 13,744 downloads in the last 30 days (`@native-sdk/cli`, the documented install path)
- **Releases:** 34 tagged releases, latest `v0.8.4` on 2026-08-10; last push 2026-08-12
- **License:** Apache-2.0, actively maintained (137 open issues, daily commits)

Stated up front so it can be weighed: the repo is young — created 2026-05-08. The star count and release cadence are the argument for inclusion; if "already widely used" implies a longer track record, that is a fair reason to pass on this.

## Backend choice

Tier 1 `github:`. The tool is not in the aqua registry — only `vercel-labs/agent-browser` exists under that org there — and it ships GitHub releases with prebuilt binaries for all six mainstream targets.

## Verification

Version listing works:

```
$ mise ls-remote 'github:vercel-labs/native[version_prefix=v]'
0.1.0 ... 0.8.4    # 34 versions
```

Install and the registry `test` command verified on macos-arm64, including checksum, GitHub artifact attestation, and SLSA provenance:

```
$ mise x github:vercel-labs/native@0.8.4 -- native-sdk --version
mise github:vercel-labs/native@0.8.4 [2/3] checksum native-sdk-darwin-arm64
mise github:vercel-labs/native@0.8.4 [2/3] verify GitHub artifact attestations
mise github:vercel-labs/native@0.8.4 [2/3] verify SLSA provenance
mise github:vercel-labs/native@0.8.4 ✓ installed
native 0.8.4 (commit a404ca1, automation protocol 0x096c8aa4730c11ec)
```

`taplo fmt --check` and `taplo check` (registry schema) both pass.

## Notes on the options

Three things in the entry are non-default and deliberate:

- **`version_prefix = "v"`** — the repo also tags CEF bundles in the same release stream (e.g. `cef-144.0.6+g5f7e671+chromium-144.0.7559.59`). Without the prefix filter that tag shows up in `ls-remote` output. `latest` resolves to `0.8.4` either way, but the listing is wrong.
- **Explicit `asset_pattern`** — releases publish bare per-platform binaries, not archives, and the glibc and musl Linux builds share the `native-sdk-linux-` prefix, so autodetection has an ambiguous candidate set on `linux-x64` / `linux-arm64`.
- **Per-platform Windows blocks** — Windows assets use a `win32` infix and an `.exe` suffix (`native-sdk-win32-x64.exe`), which the shared pattern does not produce. Followed the approach in `registry/claude.toml`, which handles the same `win32` naming, rather than templating a `windows=` remap into `os()` — there is no existing use of that kwarg in the registry and I had no Windows host to verify it on.

Only macos-arm64 was verified on real hardware; the other five targets are mapped against asset names confirmed present in the `v0.8.4` release, and CI covers the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native SDK registry support for Linux, macOS, and Windows.
  * Added automatic semantic version detection and ordering.
  * Added GitHub release sourcing with filtering for standard version tags.
  * Added platform-aware binary selection, including Linux and macOS autodetection and Windows x64 and ARM64 executables.
  * Added consistent binary naming across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->