### PR TITLE
fix(upgrade): deprecate ambiguous -l shorthand

### DIFF
--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -23,7 +23,7 @@ If not specified, all tools in global and local configs will be shown
 
 Output in JSON format
 
-### `-l --bump`
+### `-b --bump`
 
 Compares against the latest versions available, not what matches the current config
 
@@ -52,6 +52,11 @@ Placeholder for future monorepo outdated checks; `mise outdated --monorepo` is n
 ### `--no-header`
 
 Don't show table header
+
+Deprecation:
+
+The `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.
+After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.
 
 Examples:
 

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -19,10 +19,6 @@ If not specified, all tools in global and local configs will be shown
 
 ## Flags
 
-### `-J --json`
-
-Output in JSON format
-
 ### `-b --bump`
 
 Compares against the latest versions available, not what matches the current config
@@ -31,6 +27,10 @@ For example, if you have `node = "20"` in your config by default `mise outdated`
 show other 20.x versions, not 21.x or 22.x versions.
 
 Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
+
+### `-J --json`
+
+Output in JSON format
 
 ### `--inactive`
 

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -34,7 +34,7 @@ Number of jobs to run in parallel
 Values below 1 are treated as 1
 [default: 4]
 
-### `-l --bump`
+### `-b --bump`
 
 Upgrades to the latest version available, bumping the version in mise.toml
 
@@ -104,6 +104,11 @@ for a single run.
 ### `--raw`
 
 Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
+
+Deprecation:
+
+The `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.
+After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.
 
 Examples:
 

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -24,16 +24,6 @@ If not specified, all current tools will be upgraded
 
 ## Flags
 
-### `-i --interactive`
-
-Display multiselect menu to choose which tools to upgrade
-
-### `-j --jobs <JOBS>`
-
-Number of jobs to run in parallel
-Values below 1 are treated as 1
-[default: 4]
-
 ### `-b --bump`
 
 Upgrades to the latest version available, bumping the version in mise.toml
@@ -43,6 +33,16 @@ this will install 22.1.0 and set `node = "22.1.0"` in your config.
 
 It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
 would change your config to `node = "22"`.
+
+### `-i --interactive`
+
+Display multiselect menu to choose which tools to upgrade
+
+### `-j --jobs <JOBS>`
+
+Number of jobs to run in parallel
+Values below 1 are treated as 1
+[default: 4]
 
 ### `-n --dry-run`
 

--- a/e2e/cli/test_outdated
+++ b/e2e/cli/test_outdated
@@ -19,6 +19,7 @@ assert_not_contains "mise ls --installed dummy" "1.1.0"
 assert "mise outdated dummy" "dummy  1  1.0.0  1.1.0 ~/workdir/.tool-versions"
 assert "mise outdated dummy --bump" "dummy  1  1.0.0  2  2.0.0 ~/workdir/.tool-versions"
 assert_contains "mise outdated dummy -l 2>&1" "deprecated [cli.outdated.bump-l]"
+assert_contains "mise outdated dummy -l 2>&1" "2.0.0"
 mise install dummy@1.1.0
 assert_contains "mise outdated dummy 2>&1" "Newer versions are available outside the configured version ranges"
 

--- a/e2e/cli/test_outdated
+++ b/e2e/cli/test_outdated
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+assert_contains "mise outdated --help" "-b, --bump"
+assert_not_contains "mise outdated --help" "-l, --bump"
+
 assert "mise outdated --json" "{}"
 assert "mise outdated" ""
 
@@ -15,6 +18,9 @@ assert_not_contains "mise ls --installed dummy" "1.1.0"
 
 assert "mise outdated dummy" "dummy  1  1.0.0  1.1.0 ~/workdir/.tool-versions"
 assert "mise outdated dummy --bump" "dummy  1  1.0.0  2  2.0.0 ~/workdir/.tool-versions"
+assert_contains "mise outdated dummy -l 2>&1" "deprecated [cli.outdated.bump-l]"
+mise install dummy@1.1.0
+assert_contains "mise outdated dummy 2>&1" "Newer versions are available outside the configured version ranges"
 
 # Test: --local should only show outdated tools from local config, not global
 cat <<EOF >mise.toml
@@ -46,4 +52,4 @@ mise uninstall dummy --all
 mise install dummy@1.0.0
 
 assert "mise outdated dummy --json | jq -r '.dummy.latest'" "1.1.0"
-assert "mise outdated dummy --bump --json | jq -r '.dummy.latest'" "2.0.0"
+assert "mise outdated dummy -b --json | jq -r '.dummy.latest'" "2.0.0"

--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+assert_contains "mise upgrade --help" "-b, --bump"
+assert_not_contains "mise upgrade --help" "-l, --bump"
+
 echo 'dummy 1' >.tool-versions
 mise install dummy@1.0.0
 
@@ -10,8 +13,10 @@ mise upgrade dummy
 
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_not_contains "mise ls --installed dummy" "1.0.0"
+assert_contains "mise upgrade dummy 2>&1" "Newer versions are available outside the configured version ranges"
+assert_contains "mise upgrade dummy -l --dry-run 2>&1" "deprecated [cli.upgrade.bump-l]"
 
-mise upgrade dummy --bump
+mise upgrade dummy -b
 assert_contains "mise ls --installed dummy" "2.0.0"
 assert_not_contains "mise ls --installed dummy" "1.1.0"
 rm .tool-versions

--- a/e2e/cli/test_upgrade
+++ b/e2e/cli/test_upgrade
@@ -15,6 +15,7 @@ assert_contains "mise ls --installed dummy" "1.1.0"
 assert_not_contains "mise ls --installed dummy" "1.0.0"
 assert_contains "mise upgrade dummy 2>&1" "Newer versions are available outside the configured version ranges"
 assert_contains "mise upgrade dummy -l --dry-run 2>&1" "deprecated [cli.upgrade.bump-l]"
+assert_contains "mise upgrade dummy -l --dry-run 2>&1" "Would install dummy@2.0.0"
 
 mise upgrade dummy -b
 assert_contains "mise ls --installed dummy" "2.0.0"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2905,16 +2905,19 @@ See `mise upgrade` to upgrade these versions.
 \fBOptions:\fR
 .PP
 .TP
-\fB\-J, \-\-json\fR
-Output in JSON format
-.TP
-\fB\-l, \-\-bump\fR
+\fB\-b, \-\-bump\fR
 Compares against the latest versions available, not what matches the current config
 
 For example, if you have `node = "20"` in your config by default `mise outdated` will only
 show other 20.x versions, not 21.x or 22.x versions.
 
 Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
+.TP
+\fB\-J, \-\-json\fR
+Output in JSON format
+.TP
+\fB\-l\fR
+Deprecated shorthand for \-\-bump
 .TP
 \fB\-\-inactive\fR
 Show outdated tools including installed\-but\-inactive tools not present in the current config
@@ -4711,6 +4714,15 @@ This will update mise.lock if it is enabled, see https://mise.jdx.dev/configurat
 \fBOptions:\fR
 .PP
 .TP
+\fB\-b, \-\-bump\fR
+Upgrades to the latest version available, bumping the version in mise.toml
+
+For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
+this will install 22.1.0 and set `node = "22.1.0"` in your config.
+
+It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
+would change your config to `node = "22"`.
+.TP
 \fB\-i, \-\-interactive\fR
 Display multiselect menu to choose which tools to upgrade
 .TP
@@ -4719,14 +4731,8 @@ Number of jobs to run in parallel
 Values below 1 are treated as 1
 [default: 4]
 .TP
-\fB\-l, \-\-bump\fR
-Upgrades to the latest version available, bumping the version in mise.toml
-
-For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
-this will install 22.1.0 and set `node = "22.1.0"` in your config.
-
-It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
-would change your config to `node = "22"`.
+\fB\-l\fR
+Deprecated shorthand for \-\-bump
 .TP
 \fB\-n, \-\-dry\-run\fR
 Just print what would be done, don't actually do it

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2678,6 +2678,11 @@ Shows outdated tool versions
 See `mise upgrade` to upgrade these versions.
 """#
     after_long_help #"""
+Deprecation:
+
+The `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.
+After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.
+
 Examples:
 
     $ mise outdated
@@ -2698,7 +2703,7 @@ Examples:
 
 """#
     flag "-J --json" help="Output in JSON format"
-    flag "-l --bump" help="Compares against the latest versions available, not what matches the current config" {
+    flag "-b --bump" help="Compares against the latest versions available, not what matches the current config" {
         long_help #"""
 Compares against the latest versions available, not what matches the current config
 
@@ -2708,6 +2713,7 @@ show other 20.x versions, not 21.x or 22.x versions.
 Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
 """#
     }
+    flag -l help="Deprecated shorthand for --bump" hide=#true
     flag --inactive help="Show outdated tools including installed-but-inactive tools not present in the current config" {
         long_help #"""
 Show outdated tools including installed-but-inactive tools not present in the current config
@@ -4561,6 +4567,11 @@ and bump the version in mise.toml.
 This will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
 """#
     after_long_help #"""
+Deprecation:
+
+The `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.
+After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.
+
 Examples:
 
     # Upgrades node to the latest version matching the range in mise.toml
@@ -4599,7 +4610,7 @@ Values below 1 are treated as 1
 """# {
         arg <JOBS>
     }
-    flag "-l --bump" help="Upgrades to the latest version available, bumping the version in mise.toml" {
+    flag "-b --bump" help="Upgrades to the latest version available, bumping the version in mise.toml" {
         long_help #"""
 Upgrades to the latest version available, bumping the version in mise.toml
 
@@ -4610,6 +4621,7 @@ It keeps the same precision as what was there before, so if you instead had `nod
 would change your config to `node = "22"`.
 """#
     }
+    flag -l help="Deprecated shorthand for --bump" hide=#true
     flag "-n --dry-run" help="Just print what would be done, don't actually do it"
     flag "-x --exclude" help=#"""
 Tool(s) to exclude from upgrading

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2702,7 +2702,6 @@ Examples:
     node    20         20.0.0   20.1.0
 
 """#
-    flag "-J --json" help="Output in JSON format"
     flag "-b --bump" help="Compares against the latest versions available, not what matches the current config" {
         long_help #"""
 Compares against the latest versions available, not what matches the current config
@@ -2713,6 +2712,7 @@ show other 20.x versions, not 21.x or 22.x versions.
 Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
 """#
     }
+    flag "-J --json" help="Output in JSON format"
     flag -l help="Deprecated shorthand for --bump" hide=#true
     flag --inactive help="Show outdated tools including installed-but-inactive tools not present in the current config" {
         long_help #"""
@@ -4602,14 +4602,6 @@ Examples:
     $ mise upgrade --local
 
 """#
-    flag "-i --interactive" help="Display multiselect menu to choose which tools to upgrade"
-    flag "-j --jobs" help=#"""
-Number of jobs to run in parallel
-Values below 1 are treated as 1
-[default: 4]
-"""# {
-        arg <JOBS>
-    }
     flag "-b --bump" help="Upgrades to the latest version available, bumping the version in mise.toml" {
         long_help #"""
 Upgrades to the latest version available, bumping the version in mise.toml
@@ -4620,6 +4612,14 @@ this will install 22.1.0 and set `node = "22.1.0"` in your config.
 It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
 would change your config to `node = "22"`.
 """#
+    }
+    flag "-i --interactive" help="Display multiselect menu to choose which tools to upgrade"
+    flag "-j --jobs" help=#"""
+Number of jobs to run in parallel
+Values below 1 are treated as 1
+[default: 4]
+"""# {
+        arg <JOBS>
     }
     flag -l help="Deprecated shorthand for --bump" hide=#true
     flag "-n --dry-run" help="Just print what would be done, don't actually do it"

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -22,10 +22,6 @@ pub struct Outdated {
     #[clap(value_name = "TOOL@VERSION", verbatim_doc_comment)]
     pub tool: Vec<ToolArg>,
 
-    /// Output in JSON format
-    #[clap(short = 'J', long, verbatim_doc_comment)]
-    pub json: bool,
-
     /// Compares against the latest versions available, not what matches the current config
     ///
     /// For example, if you have `node = "20"` in your config by default `mise outdated` will only
@@ -34,6 +30,10 @@ pub struct Outdated {
     /// Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
     #[clap(long, short = 'b', verbatim_doc_comment)]
     pub bump: bool,
+
+    /// Output in JSON format
+    #[clap(short = 'J', long, verbatim_doc_comment)]
+    pub json: bool,
 
     /// Deprecated shorthand for --bump
     #[clap(short = 'l', hide = true)]

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -32,8 +32,12 @@ pub struct Outdated {
     /// show other 20.x versions, not 21.x or 22.x versions.
     ///
     /// Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
-    #[clap(long, short = 'l', verbatim_doc_comment)]
+    #[clap(long, short = 'b', verbatim_doc_comment)]
     pub bump: bool,
+
+    /// Deprecated shorthand for --bump
+    #[clap(short = 'l', hide = true)]
+    pub legacy_bump: bool,
 
     /// Show outdated tools including installed-but-inactive tools not present in the current config
     ///
@@ -58,7 +62,16 @@ pub struct Outdated {
 }
 
 impl Outdated {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
+        if self.legacy_bump {
+            deprecated_at!(
+                "2026.8.5",
+                "2027.8.5",
+                "cli.outdated.bump-l",
+                "`mise outdated -l` is deprecated. Use `mise outdated -b` or `mise outdated --bump` instead. After removal, `-l` will become shorthand for `--local`."
+            );
+            self.bump = true;
+        }
         if self.monorepo {
             unimplemented!("mise outdated --monorepo is not implemented yet");
         }
@@ -90,26 +103,39 @@ impl Outdated {
                 },
             )
             .await;
-        self.display(outdated).await?;
+        let bump_available = if !self.json && !self.bump && outdated.is_empty() {
+            ts.list_outdated_versions(
+                &config,
+                true,
+                &ResolveOptions {
+                    inactive: self.inactive,
+                    ..Default::default()
+                },
+            )
+            .await
+            .iter()
+            .any(|o| o.bump.is_some())
+        } else {
+            false
+        };
+        self.display(outdated, bump_available)?;
         Ok(())
     }
 
-    async fn display(&self, outdated: Vec<OutdatedInfo>) -> Result<()> {
+    fn display(&self, outdated: Vec<OutdatedInfo>, bump_available: bool) -> Result<()> {
         match self.json {
             true => self.display_json(outdated)?,
-            false => self.display_table(outdated)?,
+            false => self.display_table(outdated, bump_available)?,
         }
         Ok(())
     }
 
-    fn display_table(&self, outdated: Vec<OutdatedInfo>) -> Result<()> {
+    fn display_table(&self, outdated: Vec<OutdatedInfo>, bump_available: bool) -> Result<()> {
         if outdated.is_empty() {
             info!("All tools are up to date");
-            if !self.bump {
-                hint!(
-                    "outdated_bump",
-                    r#"By default, `mise outdated` only shows versions that match your config. Use `mise outdated --bump` to see all new versions."#,
-                    ""
+            if bump_available {
+                info!(
+                    "Newer versions are available outside the configured version ranges. Use `mise outdated --bump` to view them."
                 );
             }
             return Ok(());
@@ -134,7 +160,12 @@ impl Outdated {
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(
-    r#"<bold><underline>Examples:</underline></bold>
+    r#"<bold><underline>Deprecation:</underline></bold>
+
+The `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.
+After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.
+
+<bold><underline>Examples:</underline></bold>
 
     $ <bold>mise outdated</bold>
     Plugin  Requested  Current  Latest

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -60,8 +60,12 @@ pub struct Upgrade {
     ///
     /// It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
     /// would change your config to `node = "22"`.
-    #[clap(long, short = 'l', verbatim_doc_comment)]
+    #[clap(long, short = 'b', verbatim_doc_comment)]
     bump: bool,
+
+    /// Deprecated shorthand for --bump
+    #[clap(short = 'l', hide = true)]
+    legacy_bump: bool,
 
     /// Just print what would be done, don't actually do it
     #[clap(long, short = 'n', verbatim_doc_comment)]
@@ -145,7 +149,16 @@ impl Upgrade {
         }
     }
 
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
+        if self.legacy_bump {
+            deprecated_at!(
+                "2026.8.5",
+                "2027.8.5",
+                "cli.upgrade.bump-l",
+                "`mise upgrade -l` is deprecated. Use `mise upgrade -b` or `mise upgrade --bump` instead. After removal, `-l` will become shorthand for `--local`."
+            );
+            self.bump = true;
+        }
         if self.monorepo {
             unimplemented!("mise upgrade --monorepo is not implemented yet");
         }
@@ -199,11 +212,20 @@ impl Upgrade {
         if outdated.is_empty() {
             info!("All tools are up to date");
             if !self.bump {
-                hint!(
-                    "outdated_bump",
-                    r#"By default, `mise upgrade` only upgrades versions that match your config. Use `mise upgrade --bump` to upgrade all new versions."#,
-                    ""
-                );
+                let bump_outdated = ts
+                    .list_outdated_versions_filtered(
+                        &config,
+                        true,
+                        &opts,
+                        filter_tools,
+                        exclude_tools,
+                    )
+                    .await;
+                if bump_outdated.iter().any(|o| o.bump.is_some()) {
+                    info!(
+                        "Newer versions are available outside the configured version ranges. Use `mise upgrade --bump` to upgrade them."
+                    );
+                }
             }
         } else {
             self.upgrade(&mut config, outdated, before_date).await?;
@@ -914,7 +936,12 @@ fn release_is_eligible_at(created_at: Timestamp, now: Timestamp, age: &Span) -> 
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(
-    r#"<bold><underline>Examples:</underline></bold>
+    r#"<bold><underline>Deprecation:</underline></bold>
+
+The `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.
+After removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.
+
+<bold><underline>Examples:</underline></bold>
 
     # Upgrades node to the latest version matching the range in mise.toml
     $ <bold>mise upgrade node</bold>

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -43,16 +43,6 @@ pub struct Upgrade {
     #[clap(value_name = "INSTALLED_TOOL@VERSION", verbatim_doc_comment)]
     tool: Vec<ToolArg>,
 
-    /// Display multiselect menu to choose which tools to upgrade
-    #[clap(long, short, verbatim_doc_comment, conflicts_with = "tool")]
-    interactive: bool,
-
-    /// Number of jobs to run in parallel
-    /// Values below 1 are treated as 1
-    /// [default: 4]
-    #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
-    jobs: Option<usize>,
-
     /// Upgrades to the latest version available, bumping the version in mise.toml
     ///
     /// For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
@@ -62,6 +52,16 @@ pub struct Upgrade {
     /// would change your config to `node = "22"`.
     #[clap(long, short = 'b', verbatim_doc_comment)]
     bump: bool,
+
+    /// Display multiselect menu to choose which tools to upgrade
+    #[clap(long, short, verbatim_doc_comment, conflicts_with = "tool")]
+    interactive: bool,
+
+    /// Number of jobs to run in parallel
+    /// Values below 1 are treated as 1
+    /// [default: 4]
+    #[clap(long, short, env = "MISE_JOBS", verbatim_doc_comment)]
+    jobs: Option<usize>,
 
     /// Deprecated shorthand for --bump
     #[clap(short = 'l', hide = true)]


### PR DESCRIPTION
## Summary

- add `-b` as the visible shorthand for `--bump` on `mise upgrade` and `mise outdated`
- hide and deprecate the legacy `-l` bump shorthand until mise 2027.8.5, after which it can be reassigned to `--local`
- when configured ranges are current but a real `--bump` candidate exists, explain that newer versions are available outside those ranges
- update generated CLI documentation and focused E2E coverage

## Motivation

`-l` was originally chosen to mean “latest,” even though its long-form flag is `--bump`. That is surprising and prevents the natural `-l` shorthand for the existing `--local` option. It also contributed to misleading “All tools are up to date” output for exact pins.

## Validation

- `mise run lint-fix`
- `cargo check --all-features --locked`
- `mise run test:e2e e2e/cli/test_outdated e2e/cli/test_upgrade`
- `mise run render:usage`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible CLI deprecation with tests and docs; behavior change is limited to flag shorthands and clearer “up to date” messaging.
> 
> **Overview**
> **`mise outdated` and `mise upgrade`** now expose **`-b`** as the primary shorthand for **`--bump`**. The old **`-l`** bump shorthand is **hidden from help**, still accepted with a **`deprecated_at!`** warning (removal planned **2027.8.5**), and documented so **`-l`** can later mean **`--local`**.
> 
> When tools are current within configured version ranges but a **`--bump`**-style upgrade would be available, both commands print an **info** line pointing users to **`--bump`** instead of the previous generic hint.
> 
> Generated CLI docs (`docs/cli`, `man`, `mise.usage.kdl`) and **e2e** tests cover help text, `-b`/`-l` behavior, and the new message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e69a911b1b9352df72668ed49a5313d144d7dddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated `outdated` and `upgrade` commands to use `-b` as the shorthand for `--bump`.
  * Continued temporary support for `-l` with deprecation warnings; it will later be reassigned to `--local`.
  * Improved reporting when newer versions exist outside configured version ranges.
* **Documentation**
  * Updated command references and help text with the new flag and deprecation timeline.
* **Tests**
  * Added coverage for shorthand usage, legacy option warnings, and out-of-range version reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->