### PR TITLE
fix(toolset): reject cmd.exe metacharacters in a Windows tool path

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -422,7 +422,9 @@ Both `mise.toml` and `.tool-versions` support "scopes" which modify the behavior
   mise stores the forward-slash form either way, but mind the TOML quoting: a backslash is an
   escape inside a _basic_ (double-quoted) string, so write `{ path = 'C:\tools\node' }` as a
   literal string, or double them as `"C:\\tools\\node"`. `"C:\tools\node"` is not rejected — TOML
-  reads `\t` as a tab — so the path silently becomes something else.
+  reads `\t` as a tab — so the path silently becomes something else. A path containing a `cmd.exe`
+  metacharacter (`& | < > ^ %`) is rejected there, since the path is passed to tool plugins that
+  build shell commands with it; `%` in particular is not a literal.
 - `sub-<PARTIAL_VERSION>:<ORIG_VERSION>` - resolves `ORIG_VERSION`, subtracts the numeric components
   in `PARTIAL_VERSION` from the corresponding resolved version components, then resolves the result
   as a version prefix. For example, `sub-2:lts` resolves `lts` and subtracts 2 from its major

--- a/e2e-win/tool_path_metacharacters.Tests.ps1
+++ b/e2e-win/tool_path_metacharacters.Tests.ps1
@@ -1,0 +1,88 @@
+Describe 'tool-path-metacharacters' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
+
+        # Saved and restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next file without it.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        Set-Location $script:TestRoot
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    # `path:` values are checked against a denylist because the resolved path reaches vfox plugin
+    # hooks that build shell commands with it. The list was written for a POSIX shell; on Windows
+    # the shell is cmd.exe, and these are its metacharacters. `%` is the one that matters most:
+    # cmd expands `%NAME%` even inside double quotes, so a value like this does not stay literal.
+    #
+    # Each case is written out rather than shared through a helper: Pester runs an `It` body in
+    # its own scope and does not carry a function defined in the `Describe` into it.
+    It 'rejects a tool path containing a percent sign' {
+        @"
+[tools]
+node = { path = 'C:/%USERPROFILE%/tool' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*invalid tool path*'
+    }
+
+    It 'rejects a tool path containing an ampersand' {
+        @"
+[tools]
+node = { path = 'C:/a&b/tool' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*invalid tool path*'
+    }
+
+    It 'rejects a tool path containing a caret' {
+        @"
+[tools]
+node = { path = 'C:/a^b/tool' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*invalid tool path*'
+    }
+
+    It 'rejects a tool path containing a pipe' {
+        @"
+[tools]
+node = { path = 'C:/a|b/tool' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -BeLike '*invalid tool path*'
+    }
+
+    It 'still accepts an ordinary Windows path' {
+        # The control: only the metacharacters are rejected, not forward-slash paths in general.
+        New-Item -ItemType Directory -Path (Join-Path $script:TestRoot "Program Files\tool") -Force | Out-Null
+        $ok = ($script:TestRoot -replace '\\', '/') + '/Program Files/tool'
+        @"
+[tools]
+node = { path = '$ok' }
+"@ | Out-File (Join-Path $script:TestRoot "mise.toml")
+
+        $out = mise ls --current 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike '*Program Files/tool*'
+    }
+}

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -523,7 +523,9 @@ fn validate_ref_string(s: &str) -> Result<()> {
 ///
 /// The list is written for a POSIX shell, which is why `\` is on it. On Windows `\` is a path
 /// separator instead, so it is rewritten by [`windows_path_separators`] before it gets here rather
-/// than being allowed through — see that function.
+/// than being allowed through — see that function. The shell those hooks run through there is
+/// `cmd.exe`, whose metacharacters are a different set, so a few more are rejected on Windows —
+/// see [`is_forbidden_path_char`].
 fn validate_path_string(s: &str) -> Result<()> {
     if s.is_empty() {
         return Ok(());
@@ -531,7 +533,7 @@ fn validate_path_string(s: &str) -> Result<()> {
     if let Some(c) = s.chars().find(|c| {
         // Allow newlines/tabs/etc. in paths is still bad — keep control-char
         // and quote/expansion rejection, but allow `/` since paths need it.
-        is_forbidden_version_char(*c)
+        is_forbidden_path_char(*c)
     }) {
         // The only `\` that survives the rewrite is an extended-length or device prefix, so say
         // what is actually wrong instead of naming a character the user cannot avoid.
@@ -581,6 +583,30 @@ fn is_forbidden_version_char(c: char) -> bool {
         return true;
     }
     matches!(c, '"' | '\'' | '`' | '\\' | '$')
+}
+
+/// The `path:` denylist: the shared version list, plus `cmd.exe`'s metacharacters on Windows.
+///
+/// The version list covers a POSIX shell. On Windows the resolved path reaches vfox hooks that
+/// build `cmd.exe` command lines with it, so cmd's metacharacters are as dangerous here as the
+/// POSIX ones already are — this mirrors that rejection on the platform where cmd is the shell.
+/// `%` is the sharpest: cmd expands `%NAME%` even inside double quotes, so a hook that quotes its
+/// interpolation correctly still cannot contain it.
+///
+/// Only the `path:` arm uses this. Version strings keep the POSIX-only list, because `^` is a real
+/// npm-style range prefix (`^1.2.3`) that must not become a hard error.
+fn is_forbidden_path_char(c: char) -> bool {
+    is_forbidden_version_char(c) || is_forbidden_cmd_char(c)
+}
+
+#[cfg(windows)]
+fn is_forbidden_cmd_char(c: char) -> bool {
+    matches!(c, '&' | '|' | '<' | '>' | '^' | '%')
+}
+
+#[cfg(not(windows))]
+fn is_forbidden_cmd_char(_c: char) -> bool {
+    false
 }
 
 /// Resolve a `path:` tool version request value against the config file's directory.
@@ -929,6 +955,40 @@ mod tests {
         // shell escape there, so none of the rewriting reaches this platform.
         assert_eq!(super::windows_path_separators(r"/tmp/\rm"), r"/tmp/\rm");
         assert!(accept_tool_path(r"/tmp/\rm").is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_validate_path_string_rejects_cmd_metacharacters() {
+        use super::validate_path_string;
+        // These pass a POSIX shell but are cmd.exe metacharacters, and the resolved path reaches
+        // vfox hooks that build cmd command lines with it. `%` is the one that survives quoting.
+        for p in [
+            "C:/a&b/tool",
+            "C:/%USERPROFILE%/tool",
+            "C:/a^b/tool",
+            "C:/a|b/tool",
+            "C:/a<b/tool",
+            "C:/a>b/tool",
+        ] {
+            assert!(
+                validate_path_string(p).is_err(),
+                "expected Windows path {p:?} to be rejected"
+            );
+        }
+        // An ordinary Windows path is still fine.
+        assert!(validate_path_string("C:/Program Files/tool").is_ok());
+    }
+
+    #[test]
+    fn test_version_string_keeps_the_posix_only_list() {
+        // The cmd-metacharacter rejection is `path:`-only. Versions keep the POSIX list, or `^1.2.3`
+        // — a real npm-style range — would become a hard error. `&` is not a version metacharacter
+        // there, so this stays accepted on every platform.
+        assert!(validate_version_string("^1.2.3").is_ok());
+        assert!(validate_version_string("1.0&x").is_ok());
+        // The POSIX shell characters are still rejected, unchanged.
+        assert!(validate_version_string("1.0$(id)").is_err());
     }
 
     #[test]


### PR DESCRIPTION
The denylist that `path:` values are checked against is written for a POSIX shell. On Windows the
shell is `cmd.exe`, and its metacharacters pass straight through.

## Background

[#9814](https://github.com/jdx/mise/pull/9814) added `validate_path_string` because a `path:` value
resolves into `ctx.rootPath` for path-mode tools, which vfox plugin hooks interpolate into shell
commands. It rejects `$`, backtick, quotes and `\` — the characters that break a POSIX shell.

Those are not cmd's metacharacters. Measured on **2026.8.2 windows-x64** — every one of these is
accepted today:

```
path = "C:/a&b/tool"            accepted     ( & separates commands )
path = "C:/%USERPROFILE%/tool"  accepted     ( %NAME% expands )
path = "C:/a^b/tool"            accepted     ( ^ escapes )
path = "C:/a|b/tool"            accepted     ( | pipes )
path = "C:/a$b/tool"            REJECTED     <- the POSIX control, the only one that fires
```

**`%` is the one that matters most.** cmd expands `%NAME%` *even inside double quotes*, so a hook
that quotes its interpolation correctly still cannot contain it. The effect is that the path a
plugin ends up operating on is an environment variable's value rather than the string that was
written — I confirmed the expansion takes effect when a path-mode tool is set up, so this is not
theoretical. The others (`& | < > ^`) are cmd's command-separator / redirect / escape set, the
same class `$` is on the POSIX side.

## The change

On Windows, `path:` also rejects `& | < > ^ %`. This is #9814's rejection, mirrored onto the
platform where cmd is the shell — not a new kind of check.

```rust
fn is_forbidden_path_char(c: char) -> bool {
    is_forbidden_version_char(c) || is_forbidden_cmd_char(c)
}

#[cfg(windows)]
fn is_forbidden_cmd_char(c: char) -> bool {
    matches!(c, '&' | '|' | '<' | '>' | '^' | '%')
}
```

Scoped deliberately:

- **Windows only.** `#[cfg(windows)]`; nothing changes off Windows.
- **`path:` only, not versions.** `^1.2.3` is a real npm-style range, so `^` must not become a hard
  error in a version. The version denylist is untouched; only the new `path:`-specific
  `is_forbidden_path_char` adds the cmd set.

## Nothing that worked before is rejected now

- `%` — `resolve_path` only ever expanded `~/`, never `%VAR%`, so a `%` in a `path:` was already
  non-functional. Rejecting it removes nothing that worked.
- `< > |` — already invalid in a Windows filename, so a path containing them failed downstream in
  directory creation with a bare OS error. Rejecting at validation just turns that into a clear
  message.
- `& ^` — legal in a Windows path but very rare; rejecting is the hardening.

### `( )` are deliberately not on the list

They are cmd metacharacters in the sense that a `)` can close a `( … )` block early, but they are
not an injection vector, which is the bar the rest of this list meets. Measured, with `&` as the
control:

```console
> cmd /c "chmod +x C:\a&echo AMP-INJECTED"
AMP-INJECTED                                                 <- injected

> cmd /c "chmod +x C:\a(echo PAREN-INJECTED)b"
'chmod' is not recognized as an internal or external command <- nothing injected
```

The breakage case is real but needs a hook that both wraps the interpolation in a `( … )` block
*and* leaves the path unquoted; double-quoting contains it, and the bundled hooks that build a
Windows command line double-quote. Against that, `C:\Program Files (x86)\…` is one of the two
standard program directories on 64-bit Windows and exactly the kind of path `path:` exists to
point at — rejecting it would be a certain, common breakage traded for a hypothetical one.

## Tests

`path:` had **no** Windows coverage before this.

- **unit** — `#[cfg(windows)]`: each of `&`, `%`, `^`, `|`, `<`, `>` in a path is rejected, and an
  ordinary `C:/Program Files/tool` still passes. All-platform: a version keeps accepting `^1.2.3`
  and `1.0&x` (the cmd set is path-only) while the POSIX `$(id)` stays rejected — the control that
  this widened the path list without touching versions. The module is not `#[cfg(unix)]`, so CI
  runs the Windows cases.
- **e2e-win (new)** — `tool_path_metacharacters.Tests.ps1`: `%`, `&`, `^`, `|` paths make
  `mise ls --current` fail with `invalid tool path`, plus an ordinary path as the control.

`docs/configuration.md`'s `path:` entry gains a sentence. It is hand-written, so nothing is
regenerated.

### Not run

`cargo fmt --all` and an isolated `rustc` probe of the denylist; no full local build. The
measurements above are of a released binary. CI, and `windows-e2e` in particular, is what exercises
the change.

## Overlap with #11937

Resolved — #11937 has merged and this branch is rebased onto it. The two changes compose as
expected: separators are rewritten first, then the value is validated against the POSIX+cmd set.
Merging them by hand kept both sides of three conflicts rather than picking one, since the TOML
quoting note and the cmd metacharacter note are about different things, and both files' tests are
still present.

Originally written as:

[#11937](https://github.com/jdx/mise/pull/11937) also edits `validate_path_string` — it rewrites
`\` to `/` *before* validation so native Windows paths are accepted. This adds rejections *inside*
validation. They compose in that order (rewrite separators, then validate against the POSIX+cmd
set) and the hunks are adjacent but distinct; whichever lands second should rebase. The two
Windows path e2e files have different names on purpose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path validation by rejecting shell metacharacters that could cause execution issues.
  * Preserved support for valid version specifications, including npm-style caret ranges.
  * Confirmed that standard Windows paths continue to work as expected.
  * Added coverage for invalid Windows paths containing `%`, `&`, `^`, or `|`.

* **Documentation**
  * Expanded configuration guidance with Windows-specific path validation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

