### PR TITLE
test(windows): restore MISE_TRUSTED_CONFIG_PATHS after the trust suite

### DIFF
--- a/e2e-win/trusted_config_paths.Tests.ps1
+++ b/e2e-win/trusted_config_paths.Tests.ps1
@@ -1,6 +1,10 @@
 Describe 'MISE_TRUSTED_CONFIG_PATHS' {
     BeforeAll {
         $script:OriginalDir = Get-Location
+        # Saved here, restored in AfterAll: Pester runs every suite in one process, so removing an
+        # inherited value would leave the next suite without it. The tests below set this var and
+        # AfterEach clears it between them.
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
         $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
         New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
 
@@ -24,7 +28,11 @@ PROJECT = "b"
     AfterAll {
         Set-Location $script:OriginalDir
         Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
-        Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
     }
 
     AfterEach {


### PR DESCRIPTION
`e2e-win/trusted_config_paths.Tests.ps1`'s `AfterAll` removed `MISE_TRUSTED_CONFIG_PATHS`
outright. Pester runs every suite in one process, so if the process had inherited a value, it was
gone for whatever suite ran next.

Saved in `BeforeAll`, restored in `AfterAll` — removed only when there was nothing to restore:

```powershell
$script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
…
if ($null -eq $script:OriginalTrusted) {
    Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
} else {
    [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
}
```

`AfterEach` is unchanged: it clears the var between this suite's own tests, each of which sets it
explicitly. Only the cross-suite leak needed fixing.

This is the same pattern the new suites in #11937 use. The one other file with the same clear-only
`AfterAll` is `task.Tests.ps1`, fixed alongside its other changes in #11924 — the two were split so
each lands with the file it belongs to.

Test-only, one file. Windows Pester tests do not run in a Linux container, so `windows-e2e` is
what exercises it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test cleanup by preserving and restoring the `MISE_TRUSTED_CONFIG_PATHS` environment setting, preventing test runs from affecting subsequent processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->