### PR TITLE
fix(semver): stop calling a mangled value a semver range

### DIFF
--- a/e2e/config/test_semver_range_warning
+++ b/e2e/config/test_semver_range_warning
@@ -8,3 +8,16 @@ EOF
 
 assert_contains "mise ls 2>&1" 'semver range "^20.0.0" is not supported for node (source: ~/workdir/mise.toml); use a concrete version or version prefix'
 assert_contains "mise ls 2>&1" 'semver range "^3.1.0" is not supported for npm:prettier (source: ~/workdir/mise.toml); use a concrete version or version prefix'
+
+# A value mangled before it got here is not a range. TOML reads `\t` as a tab and `\n` as a
+# newline inside a basic string, and `split_whitespace` counts those as separators, so this used
+# to be reported as a semver range -- pointing at versions when the path is what is wrong.
+cat <<'EOF' >mise.toml
+[tools]
+node = { path = "C:\tools\node" }
+EOF
+
+# `mise ls` exits non-zero here, so these use the failure helpers rather than the ones above,
+# which treat a non-zero status as the test failing.
+assert_fail_contains "mise ls" 'invalid tool path'
+assert "mise ls 2>&1 | grep -c 'semver range' || true" "0"

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -74,6 +74,14 @@ pub fn is_npm_semver_range_query(query: &str) -> bool {
     if query.is_empty() || query.eq_ignore_ascii_case("latest") {
         return false;
     }
+    // A real npm range never contains a control character, but `split_whitespace` below counts
+    // tabs and newlines as separators, so a string that was mangled before it got here looks like
+    // a multi-part range. TOML reading `\t` as a tab in `path = "C:\tools\node"` is how that
+    // happens in practice. Calling such a value a semver range points the reader at versions when
+    // the problem is the value itself; the validation that follows already names the real cause.
+    if query.chars().any(|c| c.is_control()) {
+        return false;
+    }
     if query == "*" || query.eq_ignore_ascii_case("x") {
         return true;
     }
@@ -118,8 +126,8 @@ pub fn semver_is_at_least(version: &str, minimum: &str) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::{
-        chunkify_version, npm_semver_range_filter, semver_cmp, semver_is_at_least,
-        semver_is_older_than, semver_triplet, split_version_prefix,
+        chunkify_version, is_npm_semver_range_query, npm_semver_range_filter, semver_cmp,
+        semver_is_at_least, semver_is_older_than, semver_triplet, split_version_prefix,
     };
     use std::cmp::Ordering;
 
@@ -239,6 +247,45 @@ mod tests {
             npm_semver_range_filter(&["1.0.0".to_string()], "1.0.0"),
             None
         );
+    }
+
+    #[test]
+    fn test_npm_semver_range_query_ignores_mangled_values() {
+        // A value broken before it reached here is not a range. TOML reads `\t` in
+        // `path = "C:\tools\node"` as a tab and `\n` as a newline, which `split_whitespace`
+        // counts as separators -- so it used to be reported as a multi-part semver range, with
+        // no mention of the path that was actually wrong.
+        assert!(!is_npm_semver_range_query("path:C:\tools\node"));
+        assert!(!is_npm_semver_range_query("1.0\t2.0"));
+        assert!(!is_npm_semver_range_query("1.0\n2.0"));
+    }
+
+    #[test]
+    fn test_npm_semver_range_query_still_detects_real_ranges() {
+        // The control for the test above: skipping control characters must not stop any range
+        // from being detected. None of these contain one.
+        for q in [
+            "^1.2.3",
+            ">=1.0 <2.0",
+            "1.x",
+            "*",
+            "1.2 - 1.5",
+            "1.0 || 2.0",
+        ] {
+            assert!(is_npm_semver_range_query(q), "expected {q:?} to be a range");
+        }
+        // Ordinary values stay non-ranges, including a well-formed `path:`.
+        for q in [
+            "1.0.0",
+            "latest",
+            "path:C:/tools/node",
+            "path:/opt/homebrew/opt/node@20",
+        ] {
+            assert!(
+                !is_npm_semver_range_query(q),
+                "expected {q:?} not to be a range"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
A tool version that was mangled before it reached mise gets reported as an unsupported semver
range, which sends the reader looking at versions when the value itself is what is wrong.

## The problem

Measured on **2026.8.2 windows-x64**, with `node = { path = "C:\tools\node" }` in `mise.toml`:

```console
$ mise ls
mise WARN  semver range "path:C:<TAB>ools<LF>ode" is not supported for node (source: …/mise.toml);
           use a concrete version or version prefix
mise ERROR invalid version for node in …/mise.toml
mise ERROR invalid tool path "C:\tools\node": contains forbidden character '\t'
```

**The error is already right.** The warning above it is not, and it is what a reader sees first —
so the advice they act on is "use a concrete version", which has nothing to do with the problem.

TOML reads `\t` as a tab and `\n` as a newline inside a *basic* (double-quoted) string, so the
value arrives here with control characters embedded. That is easy to write by accident on Windows;
#11937 documents the quoting side of it.

## Why it is detected as a range

`is_npm_semver_range_query` ends with:

```rust
if query.split_whitespace().count() > 1 {
    return true;
}
```

`split_whitespace` counts tabs and newlines as separators, so `path:C:<TAB>ools<LF>ode` looks like
a multi-part range. Confirmed with a standalone `rustc` probe of the predicate:

```
"path:C:\tools\node"     is_range=true   has_control=true    <- the false positive
"path:C:/tools/node"     is_range=false  has_control=false
"^1.2.3"                 is_range=true   has_control=false
">=1.0 <2.0"             is_range=true   has_control=false
"1.x"                    is_range=true   has_control=false
"*"                      is_range=true   has_control=false
```

**A real npm range never contains a control character.** That is what makes the two cases
separable rather than a judgement call.

## The change

One early return in the predicate:

```rust
if query.chars().any(|c| c.is_control()) {
    return false;
}
```

Fixed in `is_npm_semver_range_query` rather than at the call site in `tool_request.rs`, because
the predicate answers "is this npm range syntax?" and returning `true` for a string with control
characters in it is wrong by that contract — any other caller would inherit the same mistake.

### What does not change

- Range detection for `^1.2.3`, `>=1.0 <2.0`, `1.x`, `*`, `1.2 - 1.5`, `1.0 || 2.0` — none contain
  a control character.
- The value is still rejected. `validate_version_string` and `validate_path_string` both reject
  characters below `0x20`, so suppressing the warning does not let anything through; it just stops
  the misleading line from preceding the accurate one.
- The `invalid tool path …: contains forbidden character '\t'` error is untouched.

## Tests

- **unit** — added to `src/semver.rs`'s existing test module: tab/newline values are not ranges
  (including the `path:C:\tools\node` case), with a **control** asserting the six range forms above
  are still detected and that ordinary values — `1.0.0`, `latest`, and a well-formed
  `path:C:/tools/node` — stay non-ranges. Without that control this could pass by disabling range
  detection entirely.
- **e2e** — `e2e/config/test_semver_range_warning` already covered the warning firing for real
  ranges; it now also covers a mangled value producing `invalid tool path` and **no** `semver
  range` line. `mise ls` exits non-zero for that config, so those two assertions use the failure
  helpers rather than `assert_contains`, which treats a non-zero status as the test failing.

### Not run

`cargo fmt --all` and a standalone `rustc` probe of the predicate covering every assertion the new
unit tests make (0 failures); no full local build. The transcript above is from a released binary
reproducing the bug. CI is what exercises the fix.

Found while working on #11937, and split out of it as a separate concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of semantic version range queries.
  * Windows-style paths with escaped whitespace are no longer incorrectly interpreted as version ranges.
  * Values containing control characters are correctly rejected as semantic version ranges.
  * Valid semantic version range formats continue to be recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->