### PR TITLE
fix(shell): resolve a shell named by a Windows path

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -57,7 +57,12 @@ impl FromStr for ShellType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.to_lowercase();
-        let s = s.rsplit_once('/').map(|(_, s)| s).unwrap_or(&s);
+        // Take the last path component. Splitting on `/` alone only ever worked on unix: Windows
+        // spells the separator `\`, and `MISE_SHELL` falls back to `SHELL`, which is `COMSPEC`
+        // there -- always a full path. So every native path failed to resolve.
+        let s = s.rsplit_once(['/', '\\']).map(|(_, s)| s).unwrap_or(&s);
+        // `pwsh.exe` / `bash.exe` is how Windows names them.
+        let s = s.strip_suffix(".exe").unwrap_or(s);
         match s {
             "bash" | "sh" => Ok(Self::Bash),
             "elvish" => Ok(Self::Elvish),
@@ -143,4 +148,55 @@ pub fn build_deactivation_script(shell: &dyn Shell) -> String {
 
 pub fn get_shell(shell: Option<ShellType>) -> Option<Box<dyn Shell>> {
     shell.or(*env::MISE_SHELL).map(|st| st.as_shell())
+}
+
+/// Deliberately not `#[cfg(unix)]`: this is string handling, and Windows is the platform whose
+/// paths were not being parsed.
+#[cfg(test)]
+mod tests {
+    use super::ShellType;
+    use std::str::FromStr;
+
+    #[test]
+    fn a_windows_path_resolves_to_its_shell() {
+        // `MISE_SHELL`/`SHELL` hold a full path on Windows, and `\` is the separator there.
+        for (input, expected) in [
+            (r"C:\Program Files\PowerShell\7\pwsh.exe", ShellType::Pwsh),
+            (r"C:\msys64\usr\bin\bash.exe", ShellType::Bash),
+            // The value is lowercased before the split, so casing does not matter.
+            (r"C:\Program Files\Git\bin\PWSH.EXE", ShellType::Pwsh),
+            ("pwsh.exe", ShellType::Pwsh),
+        ] {
+            assert_eq!(ShellType::from_str(input), Ok(expected), "{input:?}");
+        }
+    }
+
+    #[test]
+    fn unix_paths_and_bare_names_are_unchanged() {
+        // The regression guard: `/` splitting already worked, and nothing here may change.
+        for (input, expected) in [
+            ("/usr/bin/bash", ShellType::Bash),
+            ("/bin/zsh", ShellType::Zsh),
+            ("bash", ShellType::Bash),
+            ("sh", ShellType::Bash),
+            ("pwsh", ShellType::Pwsh),
+            ("fish", ShellType::Fish),
+        ] {
+            assert_eq!(ShellType::from_str(input), Ok(expected), "{input:?}");
+        }
+    }
+
+    #[test]
+    fn an_unsupported_shell_still_fails_but_names_itself() {
+        // mise has no `cmd` activate script, so this stays an error -- the control for reading
+        // the change as "more shells are supported" rather than "paths now resolve". What is new
+        // is that the message names `cmd` instead of repeating the whole path back.
+        for input in [r"C:\WINDOWS\system32\cmd.exe", "cmd.exe"] {
+            assert_eq!(
+                ShellType::from_str(input),
+                Err("unsupported shell type: cmd".to_string()),
+                "{input:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
`ShellType::from_str` reduces a full path to its last component by splitting on `/`. That is the
unix separator. On Windows the separator is `\`, so a shell named by a native path never resolved —
and a native path is the normal case there.

## Why it is the normal case on Windows

`MISE_SHELL` falls back to `SHELL` (`src/env.rs`), and `SHELL` on Windows is `COMSPEC`, which is
always a full path. Measured, `mise doctor` with `MISE_SHELL` unset on **2026.8.2 windows-x64**:

```console
$ mise doctor
shell:
  (unknown)

$ MISE_SHELL=pwsh mise doctor      # the control
shell:
  pwsh
  PowerShell 7.6.4
```

That `(unknown)` also appears in the `mise doctor` output pasted in discussion #11192.

Splitting, measured against the current code:

```
C:\Program Files\PowerShell\7\pwsh.exe  ->  Err("unsupported shell type: c:\program files\...")
C:\msys64\usr\bin\bash.exe              ->  Err(...)
C:\WINDOWS\system32\cmd.exe             ->  Err(...)
/usr/bin/bash                           ->  Ok(Bash)     <- unix already benefits from the split
/bin/zsh                                ->  Ok(Zsh)
bash                                    ->  Ok(Bash)
```

So unix gets the last-component behaviour and Windows does not.

## The change

```rust
let s = s.rsplit_once(['/', '\\']).map(|(_, s)| s).unwrap_or(&s);
let s = s.strip_suffix(".exe").unwrap_or(s);
```

The `.exe` strip is part of the same fix rather than an extra: splitting alone turns
`C:\…\pwsh.exe` into `pwsh.exe`, which still does not match. Both lines are needed for the symptom
to go away.

## What this does *not* do

**`cmd.exe` stays an error.** There is no `ShellType::Cmd` and mise has no cmd activate script, so
`C:\WINDOWS\system32\cmd.exe` still fails — it just fails saying `unsupported shell type: cmd`
instead of repeating the whole path back. Concretely: on a machine where `COMSPEC` is `cmd.exe` and
`MISE_SHELL` is unset, `mise doctor` still prints `(unknown)`. What is fixed is every *supported*
shell named by a path — `pwsh.exe`, `bash.exe` and the rest — and an error message that names what
is unsupported.

## Tests

`src/shell/mod.rs` had no test module; this adds one, not `#[cfg(unix)]`, since it is string
handling and Windows is the platform it exists for.

- Windows paths resolve: `C:\Program Files\PowerShell\7\pwsh.exe` → `Pwsh`,
  `C:\msys64\usr\bin\bash.exe` → `Bash`, a mixed-case `PWSH.EXE` (the value is lowercased first),
  and a bare `pwsh.exe`.
- **Regression guard**: `/usr/bin/bash`, `/bin/zsh` and the bare names `bash`, `sh`, `pwsh`, `fish`
  are unchanged.
- **Control**: `cmd.exe` and its full path are still `Err`, with the message asserted as
  `unsupported shell type: cmd`. Without this the change could be read as "more shells are
  supported" rather than "paths now resolve".

### Not run

`cargo fmt --all` and a standalone `rustc` probe covering all twelve cases the tests assert (0
mismatches); no full local build. The `mise doctor` transcript is from a released binary. CI is
what exercises the change.

## Overlap with #11928

[#11928](https://github.com/jdx/mise/pull/11928) contains these same two lines, added there while
teaching `activate`/`completion` to accept both `pwsh` and `powershell`. This PR is independent of
it and branches from main, so whichever lands second should rebase — the hunk is the same few
lines of `from_str`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell detection for Windows-style paths.
  * Windows executable names ending in `.exe` are now recognized correctly.
  * Unsupported shell errors now display the normalized shell name.
  * Existing Unix path and bare-name detection remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->