### PR TITLE
registry: add restate binaries (github:restatedev/restate)

### DIFF
--- a/registry/restate-server.toml
+++ b/registry/restate-server.toml
@@ -1,0 +1,10 @@
+bins = ["restate-server"]
+description = "Restate is a lightweight runtime to turn AI agents, workflows, and backend services into durable processes."
+test = { cmd = "restate-server --version", expected = "restate-server {{version}}" }
+version_order = "semver"
+
+[[backends]]
+full = "github:restatedev/restate"
+
+[backends.options]
+matching = "restate-server"

--- a/registry/restate.toml
+++ b/registry/restate.toml
@@ -1,0 +1,10 @@
+bins = ["restate"]
+description = "A command-line tool to inspect Restate services status, invocations, deployment, and much more."
+test = { cmd = "restate --version", expected = "restate-cli {{version}}" }
+version_order = "semver"
+
+[[backends]]
+full = "github:restatedev/restate"
+
+[backends.options]
+matching = "restate-cli"

--- a/registry/restatectl.toml
+++ b/registry/restatectl.toml
@@ -1,0 +1,10 @@
+bins = ["restatectl"]
+description = "A command-line tool for managing Restate clusters."
+test = { cmd = "restatectl --version", expected = "restatectl {{version}}" }
+version_order = "semver"
+
+[[backends]]
+full = "github:restatedev/restate"
+
+[backends.options]
+matching = "restatectl"


### PR DESCRIPTION
https://github.com/restatedev/restate

Restate is my preferred tool for backend development, but because each release contains three binaries, installing it with mise has always required me to modify my mise configuration, which motivated me to open this PR.

This adds registry shorthands for all three binaries published in each Restate release:

| Shorthand | Release asset |
| --- | --- |
| `restate` | `restate-cli` |
| `restate-server` | `restate-server` |
| `restatectl` | `restatectl` |


## Popularity

- **GitHub:** 4,285 stars and 194 forks — [restatedev/restate](https://github.com/restatedev/restate)
- **Releases:** 76 GitHub releases; latest `v1.7.3` on 2026-08-07
- **Maintenance:** last pushed on 2026-08-13
- **Ecosystem:** official installation methods also include Homebrew, npm, and Docker

## Backend choice

Tier 1 `github`: Restate is not currently available in the aqua registry, and its GitHub releases provide prebuilt binaries for Linux and macOS on both x64 and ARM64.

Each entry uses the `matching` option to select its corresponding asset from the shared release.

## Verification

Version listing works for all three asset filters:

```sh
$ mise ls-remote 'github:restatedev/restate[matching=restate-cli]' | tail -5
1.6.1
1.6.2
1.7.0
1.7.2
1.7.3

$ mise ls-remote 'github:restatedev/restate[matching=restate-server]' | tail -5
1.6.1
1.6.2
1.7.0
1.7.2
1.7.3

$ mise ls-remote 'github:restatedev/restate[matching=restatectl]' | tail -5
1.6.1
1.6.2
1.7.0
1.7.2
1.7.3
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry definitions for the Restate CLI, Restate server, and `restatectl`.
  * Added version detection and semantic version ordering for each tool.
  * Configured GitHub-based release discovery and backend matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->