### PR TITLE
feat(config): deprecate nixos all_compile default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,15 +225,16 @@ All commit messages and PR titles MUST follow conventional commit format:
 
 ## Deprecation Policy
 
-When deprecating a feature or backend:
+When deprecating a feature, backend, or implicit behavior:
 
-1. **Immediately**: Mark as deprecated in docs (add warning banner)
-2. **6 months later** (`warn_at`): Display deprecation warning in CLI using `deprecated_at!` macro from `src/output.rs`
-3. **12 months after warn** (`remove_at`): `debug_assert!` in `deprecated_at!` fires, signaling the code should be removed
+1. **Immediately**: Mark it as deprecated in docs (add a warning banner) and display a CLI warning using the `deprecated_at!` macro from `src/output.rs` (`warn_at` is the current version).
+2. **12 months after warn** (`remove_at`): `debug_assert!` in `deprecated_at!` fires, signaling the deprecated code or behavior should be removed.
+
+Delay the CLI warning for up to 6 months only when migration requires a new setting, syntax, or replacement that older supported mise versions would reject or fail to parse. This compatibility window lets users adopt a configuration that works across old and new clients before warnings begin. Do not delay warnings for a behavior change that requires no new configuration, or when the replacement already works in older clients.
 
 Use mise version format for dates (e.g., `deprecated_at!("2026.10.0", "2027.10.0", "id", "message")`).
 
-If the replacement has been available for a long time, the CLI warning can start immediately (set `warn_at` to the current version).
+If a compatibility window is required, removal remains 12 months after `warn_at`, not 12 months after the initial documentation notice.
 
 ## Important Implementation Notes
 

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -291,8 +291,11 @@ You can also import the package directly using
 `mise-flake.packages.${system}.mise`. It supports all default Nix
 systems.
 
-::: tip NixOS compiles from source by default
-For precompiled binaries, enable [nix-ld](https://github.com/Mic92/nix-ld) and disable [`all_compile`](/configuration/settings.html#all_compile).
+::: warning NixOS source-build default is deprecated
+NixOS currently compiles tools from source by default. This automatic behavior is deprecated:
+warnings begin in mise 2026.8.0, and the default will switch to precompiled binaries in mise
+2027.8.0. Enable [nix-ld](https://github.com/Mic92/nix-ld) before that change. To keep compiling
+from source, set [`all_compile = true`](/configuration/settings.html#all_compile) explicitly.
 :::
 
 ### yum (RHEL 8, CentOS Stream 8, Amazon Linux 2)

--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -293,9 +293,10 @@ systems.
 
 ::: warning NixOS source-build default is deprecated
 NixOS currently compiles tools from source by default. This automatic behavior is deprecated:
-warnings begin in mise 2026.8.0, and the default will switch to precompiled binaries in mise
-2027.8.0. Enable [nix-ld](https://github.com/Mic92/nix-ld) before that change. To keep compiling
-from source, set [`all_compile = true`](/configuration/settings.html#all_compile) explicitly.
+affected source installs warn beginning in mise 2026.8.0, and the default will switch to
+precompiled binaries in mise 2027.8.0. Enable [nix-ld](https://github.com/Mic92/nix-ld) before that
+change. To keep compiling from source, set
+[`all_compile = true`](/configuration/settings.html#all_compile) explicitly.
 :::
 
 ### yum (RHEL 8, CentOS Stream 8, Amazon Linux 2)

--- a/e2e/cli/test_settings_unset
+++ b/e2e/cli/test_settings_unset
@@ -5,6 +5,12 @@ assert "mise settings get python.compile" "true"
 mise settings unset python.compile
 assert_fail "mise settings get python.compile" "mise ERROR Setting [python.compile] is not set"
 
+# Optional settings with an effective default should report that default after unset.
+mise settings set all_compile true
+assert "mise settings get all_compile" "true"
+mise settings unset all_compile
+assert "mise settings get all_compile" "false"
+
 # regression: a parent key stored as an inline table must not panic on unset
 settings_config="$MISE_CONFIG_DIR/config.toml"
 printf '[settings]\npython = { compile = true }\n' >"$settings_config"

--- a/settings.toml
+++ b/settings.toml
@@ -61,7 +61,9 @@ type = "Bool"
 [all_compile]
 description = "do not use precompiled binaries for any tool"
 docs = """
-Default: false unless running NixOS or Alpine (let me know if others should be added)
+Default: false unless running Alpine. NixOS also defaults to true temporarily, but that automatic
+default is deprecated: warnings begin in mise 2026.8.0 and it will be removed in mise 2027.8.0.
+Afterward, NixOS users who require source builds must set `all_compile = true` explicitly.
 
 Do not use precompiled binaries for all languages. Useful if running on a Linux distribution
 like Alpine that does not use glibc and therefore likely won't be able to run precompiled binaries.

--- a/settings.toml
+++ b/settings.toml
@@ -74,6 +74,7 @@ not
 working with this config.
 """
 env = "MISE_ALL_COMPILE"
+optional = true
 type = "Bool"
 
 [always_keep_download]

--- a/settings.toml
+++ b/settings.toml
@@ -62,8 +62,9 @@ type = "Bool"
 description = "do not use precompiled binaries for any tool"
 docs = """
 Default: false unless running Alpine. NixOS also defaults to true temporarily, but that automatic
-default is deprecated: warnings begin in mise 2026.8.0 and it will be removed in mise 2027.8.0.
-Afterward, NixOS users who require source builds must set `all_compile = true` explicitly.
+default is deprecated: affected source installs warn beginning in mise 2026.8.0, and the default
+will be removed in mise 2027.8.0. Afterward, NixOS users who require source builds must set
+`all_compile = true` explicitly.
 
 Do not use precompiled binaries for all languages. Useful if running on a Linux distribution
 like Alpine that does not use glibc and therefore likely won't be able to run precompiled binaries.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,7 +3,7 @@ use eyre::{Context, Result, bail, eyre};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use path_absolutize::Absolutize;
-pub use settings::Settings;
+pub use settings::{CompilePurpose, Settings};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env::join_paths;
 use std::fmt::{Debug, Formatter};

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1108,7 +1108,11 @@ impl Settings {
 
     pub fn as_dict(&self) -> eyre::Result<toml::Table> {
         let s = toml::to_string(self)?;
-        let mut table = toml::from_str(&s)?;
+        let mut table: toml::Table = toml::from_str(&s)?;
+        table.insert(
+            "all_compile".to_string(),
+            toml::Value::Boolean(self.all_compile()),
+        );
         redact_settings_table(&mut table);
         Ok(table)
     }
@@ -1620,12 +1624,24 @@ mod tests {
         let mut settings = Settings::default();
         assert_eq!(settings.all_compile, None);
         assert!(!settings.all_compile());
+        assert_eq!(
+            settings.as_dict().unwrap().get("all_compile"),
+            Some(&toml::Value::Boolean(false))
+        );
 
         settings.all_compile = Some(true);
         assert!(settings.all_compile());
+        assert_eq!(
+            settings.as_dict().unwrap().get("all_compile"),
+            Some(&toml::Value::Boolean(true))
+        );
 
         settings.all_compile = Some(false);
         assert!(!settings.all_compile());
+        assert_eq!(
+            settings.as_dict().unwrap().get("all_compile"),
+            Some(&toml::Value::Boolean(false))
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -245,11 +245,26 @@ static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
 static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
+
+fn default_all_compile(linux_distro: Option<&str>) -> bool {
+    matches!(linux_distro, Some("alpine" | "nixos"))
+}
+
+fn warn_nixos_all_compile_default_deprecated() {
+    if env::LINUX_DISTRO.as_deref() == Some("nixos") {
+        deprecated_at!(
+            "2026.8.0",
+            "2027.8.0",
+            "nixos.all_compile_default",
+            "The automatic all_compile=true default on NixOS is deprecated. Enable nix-ld to use precompiled binaries, or configure all_compile=true explicitly to keep compiling tools from source."
+        );
+    }
+}
+
 static DEFAULT_SETTINGS: Lazy<SettingsPartial> = Lazy::new(|| {
     let mut s = SettingsPartial::empty();
     s.python.default_packages_file = Some(env::HOME.join(".default-python-packages"));
-    if let Some("alpine" | "nixos") = env::LINUX_DISTRO.as_ref().map(|s| s.as_str())
-        && !cfg!(test)
+    if !cfg!(test) && default_all_compile(env::LINUX_DISTRO.as_ref().map(|distro| distro.as_str()))
     {
         s.all_compile = Some(true);
     }
@@ -720,6 +735,7 @@ impl Settings {
 
     fn flush_deprecated_warnings_now() {
         DEPRECATED_WARNINGS_READY.store(true, Ordering::SeqCst);
+        warn_nixos_all_compile_default_deprecated();
         warn_deprecated_env_settings();
         let pending = {
             let mut pending = PENDING_DEPRECATED_SETTINGS.lock().unwrap();
@@ -1520,6 +1536,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_all_compile_is_limited_to_alpine_and_deprecated_nixos_behavior() {
+        assert!(default_all_compile(Some("alpine")));
+        assert!(default_all_compile(Some("nixos")));
+        assert!(!default_all_compile(Some("ubuntu")));
+        assert!(!default_all_compile(None));
+    }
 
     #[test]
     fn debug_settings_redact_remote_cache_token() {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -245,34 +245,38 @@ static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
 static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
-// TODO(2027.8.0): Remove these per-tool flags and warning hooks once the NixOS
+// TODO(2027.8.0): Remove the per-tool warning accessors once the NixOS
 // `all_compile` deprecation process is complete.
-static WARN_NIXOS_NODE_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
-static WARN_NIXOS_PYTHON_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
-static WARN_NIXOS_ERLANG_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
-#[cfg(not(windows))]
-static WARN_NIXOS_RUBY_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 
 fn default_all_compile(linux_distro: Option<&str>) -> bool {
     matches!(linux_distro, Some("alpine" | "nixos"))
 }
 
-fn should_warn_nixos_all_compile_default(
+fn compile_inherits_nixos_all_compile_default(
     linux_distro: Option<&str>,
     explicit_all_compile: Option<bool>,
-) -> bool {
-    linux_distro == Some("nixos") && explicit_all_compile.is_none()
-}
-
-fn compile_inherits_nixos_all_compile_default(
-    nixos_all_compile_is_implicit: bool,
     compile: Option<bool>,
 ) -> bool {
-    nixos_all_compile_is_implicit && compile.is_none()
+    linux_distro == Some("nixos") && explicit_all_compile.is_none() && compile.is_none()
 }
 
-fn warn_nixos_all_compile_default_deprecated(tool: &str, id: &'static str, inherited: &AtomicBool) {
-    if inherited.load(Ordering::Relaxed) {
+fn effective_compile_setting(all_compile: bool, compile: Option<bool>) -> Option<bool> {
+    compile.or_else(|| all_compile.then_some(true))
+}
+
+fn warn_nixos_all_compile_default_deprecated(
+    tool: &str,
+    id: &'static str,
+    all_compile: Option<bool>,
+    compile: Option<bool>,
+) {
+    if !cfg!(test)
+        && compile_inherits_nixos_all_compile_default(
+            env::LINUX_DISTRO.as_deref(),
+            all_compile,
+            compile,
+        )
+    {
         deprecated_at!(
             "2026.8.0",
             "2027.8.0",
@@ -620,31 +624,51 @@ impl Settings {
         })
     }
 
+    pub fn effective_node_compile(&self) -> Option<bool> {
+        effective_compile_setting(self.all_compile(), self.node.compile)
+    }
+
     pub fn node_compile(&self) -> Option<bool> {
         warn_nixos_all_compile_default_deprecated(
             "node",
             "nixos.node_all_compile_default",
-            &WARN_NIXOS_NODE_COMPILE_DEFAULT,
+            self.all_compile,
+            self.node.compile,
         );
-        self.node.compile
+        self.effective_node_compile()
+    }
+
+    pub fn effective_python_compile(&self) -> Option<bool> {
+        effective_compile_setting(self.all_compile(), self.python.compile)
     }
 
     pub fn python_compile(&self) -> Option<bool> {
         warn_nixos_all_compile_default_deprecated(
             "python",
             "nixos.python_all_compile_default",
-            &WARN_NIXOS_PYTHON_COMPILE_DEFAULT,
+            self.all_compile,
+            self.python.compile,
         );
-        self.python.compile
+        self.effective_python_compile()
+    }
+
+    pub fn effective_erlang_compile(&self) -> Option<bool> {
+        effective_compile_setting(self.all_compile(), self.erlang.compile)
     }
 
     pub fn erlang_compile(&self) -> Option<bool> {
         warn_nixos_all_compile_default_deprecated(
             "erlang",
             "nixos.erlang_all_compile_default",
-            &WARN_NIXOS_ERLANG_COMPILE_DEFAULT,
+            self.all_compile,
+            self.erlang.compile,
         );
-        self.erlang.compile
+        self.effective_erlang_compile()
+    }
+
+    #[cfg(not(windows))]
+    pub fn effective_ruby_compile(&self) -> Option<bool> {
+        effective_compile_setting(self.all_compile(), self.ruby.compile)
     }
 
     #[cfg(not(windows))]
@@ -652,9 +676,10 @@ impl Settings {
         warn_nixos_all_compile_default_deprecated(
             "ruby",
             "nixos.ruby_all_compile_default",
-            &WARN_NIXOS_RUBY_COMPILE_DEFAULT,
+            self.all_compile,
+            self.ruby.compile,
         );
-        self.ruby.compile
+        self.effective_ruby_compile()
     }
 
     pub fn try_get() -> Result<Arc<Self>> {
@@ -696,10 +721,6 @@ impl Settings {
         time!("try_get default_settings");
 
         settings = sb.load()?;
-        let nixos_all_compile_is_implicit = should_warn_nixos_all_compile_default(
-            env::LINUX_DISTRO.as_deref(),
-            settings.all_compile,
-        );
         time!("try_get load2");
         if !settings.legacy_version_file {
             settings.idiomatic_version_file = Some(false);
@@ -757,49 +778,6 @@ impl Settings {
         }
         if settings.ci {
             settings.yes = true;
-        }
-        WARN_NIXOS_NODE_COMPILE_DEFAULT.store(
-            compile_inherits_nixos_all_compile_default(
-                nixos_all_compile_is_implicit,
-                settings.node.compile,
-            ),
-            Ordering::Relaxed,
-        );
-        WARN_NIXOS_PYTHON_COMPILE_DEFAULT.store(
-            compile_inherits_nixos_all_compile_default(
-                nixos_all_compile_is_implicit,
-                settings.python.compile,
-            ),
-            Ordering::Relaxed,
-        );
-        WARN_NIXOS_ERLANG_COMPILE_DEFAULT.store(
-            compile_inherits_nixos_all_compile_default(
-                nixos_all_compile_is_implicit,
-                settings.erlang.compile,
-            ),
-            Ordering::Relaxed,
-        );
-        #[cfg(not(windows))]
-        WARN_NIXOS_RUBY_COMPILE_DEFAULT.store(
-            compile_inherits_nixos_all_compile_default(
-                nixos_all_compile_is_implicit,
-                settings.ruby.compile,
-            ),
-            Ordering::Relaxed,
-        );
-        if settings.all_compile() {
-            if settings.node.compile.is_none() {
-                settings.node.compile = Some(true);
-            }
-            if settings.python.compile.is_none() {
-                settings.python.compile = Some(true);
-            }
-            if settings.erlang.compile.is_none() {
-                settings.erlang.compile = Some(true);
-            }
-            if settings.ruby.compile.is_none() {
-                settings.ruby.compile = Some(true);
-            }
         }
         if settings.gpg_verify.is_some() {
             settings.node.gpg_verify = settings.node.gpg_verify.or(settings.gpg_verify);
@@ -1653,32 +1631,48 @@ mod tests {
     }
 
     #[test]
-    fn nixos_all_compile_default_warning_only_applies_to_implicit_value() {
-        assert!(should_warn_nixos_all_compile_default(Some("nixos"), None));
-        assert!(!should_warn_nixos_all_compile_default(
+    fn compile_warning_only_applies_to_implicit_nixos_values() {
+        assert!(compile_inherits_nixos_all_compile_default(
             Some("nixos"),
+            None,
+            None
+        ));
+        assert!(!compile_inherits_nixos_all_compile_default(
+            Some("nixos"),
+            Some(true),
+            None
+        ));
+        assert!(!compile_inherits_nixos_all_compile_default(
+            Some("nixos"),
+            Some(false),
+            None
+        ));
+        assert!(!compile_inherits_nixos_all_compile_default(
+            Some("nixos"),
+            None,
             Some(true)
         ));
-        assert!(!should_warn_nixos_all_compile_default(
+        assert!(!compile_inherits_nixos_all_compile_default(
             Some("nixos"),
+            None,
             Some(false)
         ));
-        assert!(!should_warn_nixos_all_compile_default(Some("alpine"), None));
-        assert!(!should_warn_nixos_all_compile_default(None, None));
+        assert!(!compile_inherits_nixos_all_compile_default(
+            Some("alpine"),
+            None,
+            None
+        ));
+        assert!(!compile_inherits_nixos_all_compile_default(
+            None, None, None
+        ));
     }
 
     #[test]
-    fn compile_warning_only_applies_to_unset_tool_compile_setting() {
-        assert!(compile_inherits_nixos_all_compile_default(true, None));
-        assert!(!compile_inherits_nixos_all_compile_default(
-            true,
-            Some(true)
-        ));
-        assert!(!compile_inherits_nixos_all_compile_default(
-            true,
-            Some(false)
-        ));
-        assert!(!compile_inherits_nixos_all_compile_default(false, None));
+    fn effective_compile_prefers_tool_setting_then_global_source_setting() {
+        assert_eq!(effective_compile_setting(true, None), Some(true));
+        assert_eq!(effective_compile_setting(false, None), None);
+        assert_eq!(effective_compile_setting(true, Some(true)), Some(true));
+        assert_eq!(effective_compile_setting(true, Some(false)), Some(false));
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -245,7 +245,10 @@ static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
 static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
-static WARN_NIXOS_ALL_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
+static WARN_NIXOS_NODE_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
+static WARN_NIXOS_PYTHON_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
+static WARN_NIXOS_ERLANG_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
+static WARN_NIXOS_RUBY_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 
 fn default_all_compile(linux_distro: Option<&str>) -> bool {
     matches!(linux_distro, Some("alpine" | "nixos"))
@@ -258,13 +261,20 @@ fn should_warn_nixos_all_compile_default(
     linux_distro == Some("nixos") && !all_compile_is_explicit
 }
 
-fn warn_nixos_all_compile_default_deprecated() {
-    if WARN_NIXOS_ALL_COMPILE_DEFAULT.load(Ordering::Relaxed) {
+fn compile_inherits_nixos_all_compile_default(
+    nixos_all_compile_is_implicit: bool,
+    compile: Option<bool>,
+) -> bool {
+    nixos_all_compile_is_implicit && compile.is_none()
+}
+
+fn warn_nixos_all_compile_default_deprecated(tool: &str, inherited: &AtomicBool) {
+    if inherited.load(Ordering::Relaxed) {
         deprecated_at!(
             "2026.8.0",
             "2027.8.0",
             "nixos.all_compile_default",
-            "The automatic all_compile=true default on NixOS is deprecated. Enable nix-ld to use precompiled binaries, or configure all_compile=true explicitly to keep compiling tools from source."
+            "The automatic all_compile=true default on NixOS caused {tool} to compile from source. Enable nix-ld to use precompiled binaries, or configure all_compile=true explicitly to keep compiling tools from source."
         );
     }
 }
@@ -603,6 +613,23 @@ impl Settings {
     pub fn get() -> Arc<Self> {
         Self::try_get().unwrap()
     }
+
+    pub fn warn_nixos_node_compile_default(&self) {
+        warn_nixos_all_compile_default_deprecated("node", &WARN_NIXOS_NODE_COMPILE_DEFAULT);
+    }
+
+    pub fn warn_nixos_python_compile_default(&self) {
+        warn_nixos_all_compile_default_deprecated("python", &WARN_NIXOS_PYTHON_COMPILE_DEFAULT);
+    }
+
+    pub fn warn_nixos_erlang_compile_default(&self) {
+        warn_nixos_all_compile_default_deprecated("erlang", &WARN_NIXOS_ERLANG_COMPILE_DEFAULT);
+    }
+
+    pub fn warn_nixos_ruby_compile_default(&self) {
+        warn_nixos_all_compile_default_deprecated("ruby", &WARN_NIXOS_RUBY_COMPILE_DEFAULT);
+    }
+
     pub fn try_get() -> Result<Arc<Self>> {
         if let Some(settings) = BASE_SETTINGS.read().unwrap().as_ref() {
             return Ok(settings.clone());
@@ -644,12 +671,9 @@ impl Settings {
         time!("try_get default_settings");
 
         settings = sb.load()?;
-        WARN_NIXOS_ALL_COMPILE_DEFAULT.store(
-            should_warn_nixos_all_compile_default(
-                env::LINUX_DISTRO.as_deref(),
-                all_compile_is_explicit,
-            ),
-            Ordering::Relaxed,
+        let nixos_all_compile_is_implicit = should_warn_nixos_all_compile_default(
+            env::LINUX_DISTRO.as_deref(),
+            all_compile_is_explicit,
         );
         time!("try_get load2");
         if !settings.legacy_version_file {
@@ -709,6 +733,34 @@ impl Settings {
         if settings.ci {
             settings.yes = true;
         }
+        WARN_NIXOS_NODE_COMPILE_DEFAULT.store(
+            compile_inherits_nixos_all_compile_default(
+                nixos_all_compile_is_implicit,
+                settings.node.compile,
+            ),
+            Ordering::Relaxed,
+        );
+        WARN_NIXOS_PYTHON_COMPILE_DEFAULT.store(
+            compile_inherits_nixos_all_compile_default(
+                nixos_all_compile_is_implicit,
+                settings.python.compile,
+            ),
+            Ordering::Relaxed,
+        );
+        WARN_NIXOS_ERLANG_COMPILE_DEFAULT.store(
+            compile_inherits_nixos_all_compile_default(
+                nixos_all_compile_is_implicit,
+                settings.erlang.compile,
+            ),
+            Ordering::Relaxed,
+        );
+        WARN_NIXOS_RUBY_COMPILE_DEFAULT.store(
+            compile_inherits_nixos_all_compile_default(
+                nixos_all_compile_is_implicit,
+                settings.ruby.compile,
+            ),
+            Ordering::Relaxed,
+        );
         if settings.all_compile {
             if settings.node.compile.is_none() {
                 settings.node.compile = Some(true);
@@ -752,7 +804,6 @@ impl Settings {
 
     fn flush_deprecated_warnings_now() {
         DEPRECATED_WARNINGS_READY.store(true, Ordering::SeqCst);
-        warn_nixos_all_compile_default_deprecated();
         warn_deprecated_env_settings();
         let pending = {
             let mut pending = PENDING_DEPRECATED_SETTINGS.lock().unwrap();
@@ -1571,6 +1622,20 @@ mod tests {
             false
         ));
         assert!(!should_warn_nixos_all_compile_default(None, false));
+    }
+
+    #[test]
+    fn compile_warning_only_applies_to_unset_tool_compile_setting() {
+        assert!(compile_inherits_nixos_all_compile_default(true, None));
+        assert!(!compile_inherits_nixos_all_compile_default(
+            true,
+            Some(true)
+        ));
+        assert!(!compile_inherits_nixos_all_compile_default(
+            true,
+            Some(false)
+        ));
+        assert!(!compile_inherits_nixos_all_compile_default(false, None));
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -245,13 +245,21 @@ static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
 static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
+static WARN_NIXOS_ALL_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 
 fn default_all_compile(linux_distro: Option<&str>) -> bool {
     matches!(linux_distro, Some("alpine" | "nixos"))
 }
 
+fn should_warn_nixos_all_compile_default(
+    linux_distro: Option<&str>,
+    all_compile_is_explicit: bool,
+) -> bool {
+    linux_distro == Some("nixos") && !all_compile_is_explicit
+}
+
 fn warn_nixos_all_compile_default_deprecated() {
-    if env::LINUX_DISTRO.as_deref() == Some("nixos") {
+    if WARN_NIXOS_ALL_COMPILE_DEFAULT.load(Ordering::Relaxed) {
         deprecated_at!(
             "2026.8.0",
             "2027.8.0",
@@ -620,13 +628,15 @@ impl Settings {
         }
 
         // Reload settings after current directory option processed
-        sb = Self::builder()
-            .preloaded(normalize_hidden_config_aliases(
-                CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
-            ))
-            .env();
+        let cli_settings = normalize_hidden_config_aliases(
+            CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
+        );
+        let mut all_compile_is_explicit =
+            cli_settings.all_compile.is_some() || env::var_os("MISE_ALL_COMPILE").is_some();
+        sb = Self::builder().preloaded(cli_settings).env();
         time!("try_get builder2+env");
         for file in Self::all_settings_files() {
+            all_compile_is_explicit |= file.all_compile.is_some();
             sb = sb.preloaded(file);
         }
         time!("try_get all_settings_files");
@@ -634,6 +644,13 @@ impl Settings {
         time!("try_get default_settings");
 
         settings = sb.load()?;
+        WARN_NIXOS_ALL_COMPILE_DEFAULT.store(
+            should_warn_nixos_all_compile_default(
+                env::LINUX_DISTRO.as_deref(),
+                all_compile_is_explicit,
+            ),
+            Ordering::Relaxed,
+        );
         time!("try_get load2");
         if !settings.legacy_version_file {
             settings.idiomatic_version_file = Some(false);
@@ -1543,6 +1560,17 @@ mod tests {
         assert!(default_all_compile(Some("nixos")));
         assert!(!default_all_compile(Some("ubuntu")));
         assert!(!default_all_compile(None));
+    }
+
+    #[test]
+    fn nixos_all_compile_default_warning_only_applies_to_implicit_value() {
+        assert!(should_warn_nixos_all_compile_default(Some("nixos"), false));
+        assert!(!should_warn_nixos_all_compile_default(Some("nixos"), true));
+        assert!(!should_warn_nixos_all_compile_default(
+            Some("alpine"),
+            false
+        ));
+        assert!(!should_warn_nixos_all_compile_default(None, false));
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -245,6 +245,8 @@ static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
 static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
+// TODO(2027.8.0): Remove these per-tool flags and simplify the NixOS
+// `all_compile` provenance tracking once the deprecation process is complete.
 static WARN_NIXOS_NODE_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 static WARN_NIXOS_PYTHON_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 static WARN_NIXOS_ERLANG_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -682,10 +682,11 @@ impl Settings {
         }
 
         // Reload settings after current directory option processed
-        let cli_settings = normalize_hidden_config_aliases(
-            CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
-        );
-        sb = Self::builder().preloaded(cli_settings).env();
+        sb = Self::builder()
+            .preloaded(normalize_hidden_config_aliases(
+                CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
+            ))
+            .env();
         time!("try_get builder2+env");
         for file in Self::all_settings_files() {
             sb = sb.preloaded(file);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -245,8 +245,8 @@ static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
 static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
-// TODO(2027.8.0): Remove these per-tool flags and simplify the NixOS
-// `all_compile` provenance tracking once the deprecation process is complete.
+// TODO(2027.8.0): Remove these per-tool flags and warning hooks once the NixOS
+// `all_compile` deprecation process is complete.
 static WARN_NIXOS_NODE_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 static WARN_NIXOS_PYTHON_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 static WARN_NIXOS_ERLANG_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
@@ -259,9 +259,9 @@ fn default_all_compile(linux_distro: Option<&str>) -> bool {
 
 fn should_warn_nixos_all_compile_default(
     linux_distro: Option<&str>,
-    all_compile_is_explicit: bool,
+    explicit_all_compile: Option<bool>,
 ) -> bool {
-    linux_distro == Some("nixos") && !all_compile_is_explicit
+    linux_distro == Some("nixos") && explicit_all_compile.is_none()
 }
 
 fn compile_inherits_nixos_all_compile_default(
@@ -678,12 +678,14 @@ impl Settings {
         let cli_settings = normalize_hidden_config_aliases(
             CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
         );
-        let mut all_compile_is_explicit =
-            cli_settings.all_compile.is_some() || env::var_os("MISE_ALL_COMPILE").is_some();
-        sb = Self::builder().preloaded(cli_settings).env();
+        let env_settings = SettingsPartial::from_env()?;
+        let mut explicit_all_compile = cli_settings.all_compile.or(env_settings.all_compile);
+        sb = Self::builder()
+            .preloaded(cli_settings)
+            .preloaded(env_settings);
         time!("try_get builder2+env");
         for file in Self::all_settings_files() {
-            all_compile_is_explicit |= file.all_compile.is_some();
+            explicit_all_compile = explicit_all_compile.or(file.all_compile);
             sb = sb.preloaded(file);
         }
         time!("try_get all_settings_files");
@@ -693,7 +695,7 @@ impl Settings {
         settings = sb.load()?;
         let nixos_all_compile_is_implicit = should_warn_nixos_all_compile_default(
             env::LINUX_DISTRO.as_deref(),
-            all_compile_is_explicit,
+            explicit_all_compile,
         );
         time!("try_get load2");
         if !settings.legacy_version_file {
@@ -1636,13 +1638,17 @@ mod tests {
 
     #[test]
     fn nixos_all_compile_default_warning_only_applies_to_implicit_value() {
-        assert!(should_warn_nixos_all_compile_default(Some("nixos"), false));
-        assert!(!should_warn_nixos_all_compile_default(Some("nixos"), true));
+        assert!(should_warn_nixos_all_compile_default(Some("nixos"), None));
         assert!(!should_warn_nixos_all_compile_default(
-            Some("alpine"),
-            false
+            Some("nixos"),
+            Some(true)
         ));
-        assert!(!should_warn_nixos_all_compile_default(None, false));
+        assert!(!should_warn_nixos_all_compile_default(
+            Some("nixos"),
+            Some(false)
+        ));
+        assert!(!should_warn_nixos_all_compile_default(Some("alpine"), None));
+        assert!(!should_warn_nixos_all_compile_default(None, None));
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -46,6 +46,12 @@ pub enum SettingsType {
     BoolOrString,
 }
 
+#[derive(Clone, Copy)]
+pub enum CompilePurpose {
+    Install,
+    Inspect,
+}
+
 pub struct SettingsMeta {
     // pub key: String,
     pub type_: SettingsType,
@@ -624,62 +630,54 @@ impl Settings {
         })
     }
 
-    pub fn effective_node_compile(&self) -> Option<bool> {
-        effective_compile_setting(self.all_compile(), self.node.compile)
+    fn compile_setting(
+        &self,
+        purpose: CompilePurpose,
+        tool: &str,
+        id: &'static str,
+        compile: Option<bool>,
+    ) -> Option<bool> {
+        if matches!(purpose, CompilePurpose::Install) {
+            warn_nixos_all_compile_default_deprecated(tool, id, self.all_compile, compile);
+        }
+        effective_compile_setting(self.all_compile(), compile)
     }
 
-    pub fn node_compile(&self) -> Option<bool> {
-        warn_nixos_all_compile_default_deprecated(
+    pub fn node_compile(&self, purpose: CompilePurpose) -> Option<bool> {
+        self.compile_setting(
+            purpose,
             "node",
             "nixos.node_all_compile_default",
-            self.all_compile,
             self.node.compile,
-        );
-        self.effective_node_compile()
+        )
     }
 
-    pub fn effective_python_compile(&self) -> Option<bool> {
-        effective_compile_setting(self.all_compile(), self.python.compile)
-    }
-
-    pub fn python_compile(&self) -> Option<bool> {
-        warn_nixos_all_compile_default_deprecated(
+    pub fn python_compile(&self, purpose: CompilePurpose) -> Option<bool> {
+        self.compile_setting(
+            purpose,
             "python",
             "nixos.python_all_compile_default",
-            self.all_compile,
             self.python.compile,
-        );
-        self.effective_python_compile()
+        )
     }
 
-    pub fn effective_erlang_compile(&self) -> Option<bool> {
-        effective_compile_setting(self.all_compile(), self.erlang.compile)
-    }
-
-    pub fn erlang_compile(&self) -> Option<bool> {
-        warn_nixos_all_compile_default_deprecated(
+    pub fn erlang_compile(&self, purpose: CompilePurpose) -> Option<bool> {
+        self.compile_setting(
+            purpose,
             "erlang",
             "nixos.erlang_all_compile_default",
-            self.all_compile,
             self.erlang.compile,
-        );
-        self.effective_erlang_compile()
+        )
     }
 
     #[cfg(not(windows))]
-    pub fn effective_ruby_compile(&self) -> Option<bool> {
-        effective_compile_setting(self.all_compile(), self.ruby.compile)
-    }
-
-    #[cfg(not(windows))]
-    pub fn ruby_compile(&self) -> Option<bool> {
-        warn_nixos_all_compile_default_deprecated(
+    pub fn ruby_compile(&self, purpose: CompilePurpose) -> Option<bool> {
+        self.compile_setting(
+            purpose,
             "ruby",
             "nixos.ruby_all_compile_default",
-            self.all_compile,
             self.ruby.compile,
-        );
-        self.effective_ruby_compile()
+        )
     }
 
     pub fn try_get() -> Result<Arc<Self>> {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -248,6 +248,7 @@ static DEPRECATED_WARNINGS_READY: AtomicBool = AtomicBool::new(false);
 static WARN_NIXOS_NODE_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 static WARN_NIXOS_PYTHON_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 static WARN_NIXOS_ERLANG_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
+#[cfg(not(windows))]
 static WARN_NIXOS_RUBY_COMPILE_DEFAULT: AtomicBool = AtomicBool::new(false);
 
 fn default_all_compile(linux_distro: Option<&str>) -> bool {
@@ -268,12 +269,12 @@ fn compile_inherits_nixos_all_compile_default(
     nixos_all_compile_is_implicit && compile.is_none()
 }
 
-fn warn_nixos_all_compile_default_deprecated(tool: &str, inherited: &AtomicBool) {
+fn warn_nixos_all_compile_default_deprecated(tool: &str, id: &'static str, inherited: &AtomicBool) {
     if inherited.load(Ordering::Relaxed) {
         deprecated_at!(
             "2026.8.0",
             "2027.8.0",
-            "nixos.all_compile_default",
+            id,
             "The automatic all_compile=true default on NixOS caused {tool} to compile from source. Enable nix-ld to use precompiled binaries, or configure all_compile=true explicitly to keep compiling tools from source."
         );
     }
@@ -615,19 +616,36 @@ impl Settings {
     }
 
     pub fn warn_nixos_node_compile_default(&self) {
-        warn_nixos_all_compile_default_deprecated("node", &WARN_NIXOS_NODE_COMPILE_DEFAULT);
+        warn_nixos_all_compile_default_deprecated(
+            "node",
+            "nixos.node_all_compile_default",
+            &WARN_NIXOS_NODE_COMPILE_DEFAULT,
+        );
     }
 
     pub fn warn_nixos_python_compile_default(&self) {
-        warn_nixos_all_compile_default_deprecated("python", &WARN_NIXOS_PYTHON_COMPILE_DEFAULT);
+        warn_nixos_all_compile_default_deprecated(
+            "python",
+            "nixos.python_all_compile_default",
+            &WARN_NIXOS_PYTHON_COMPILE_DEFAULT,
+        );
     }
 
     pub fn warn_nixos_erlang_compile_default(&self) {
-        warn_nixos_all_compile_default_deprecated("erlang", &WARN_NIXOS_ERLANG_COMPILE_DEFAULT);
+        warn_nixos_all_compile_default_deprecated(
+            "erlang",
+            "nixos.erlang_all_compile_default",
+            &WARN_NIXOS_ERLANG_COMPILE_DEFAULT,
+        );
     }
 
+    #[cfg(not(windows))]
     pub fn warn_nixos_ruby_compile_default(&self) {
-        warn_nixos_all_compile_default_deprecated("ruby", &WARN_NIXOS_RUBY_COMPILE_DEFAULT);
+        warn_nixos_all_compile_default_deprecated(
+            "ruby",
+            "nixos.ruby_all_compile_default",
+            &WARN_NIXOS_RUBY_COMPILE_DEFAULT,
+        );
     }
 
     pub fn try_get() -> Result<Arc<Self>> {
@@ -754,6 +772,7 @@ impl Settings {
             ),
             Ordering::Relaxed,
         );
+        #[cfg(not(windows))]
         WARN_NIXOS_RUBY_COMPILE_DEFAULT.store(
             compile_inherits_nixos_all_compile_default(
                 nixos_all_compile_is_implicit,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -285,10 +285,6 @@ fn warn_nixos_all_compile_default_deprecated(tool: &str, id: &'static str, inher
 static DEFAULT_SETTINGS: Lazy<SettingsPartial> = Lazy::new(|| {
     let mut s = SettingsPartial::empty();
     s.python.default_packages_file = Some(env::HOME.join(".default-python-packages"));
-    if !cfg!(test) && default_all_compile(env::LINUX_DISTRO.as_ref().map(|distro| distro.as_str()))
-    {
-        s.all_compile = Some(true);
-    }
     s
 });
 
@@ -617,37 +613,48 @@ impl Settings {
         Self::try_get().unwrap()
     }
 
-    pub fn warn_nixos_node_compile_default(&self) {
+    pub fn all_compile(&self) -> bool {
+        self.all_compile.unwrap_or_else(|| {
+            !cfg!(test)
+                && default_all_compile(env::LINUX_DISTRO.as_ref().map(|distro| distro.as_str()))
+        })
+    }
+
+    pub fn node_compile(&self) -> Option<bool> {
         warn_nixos_all_compile_default_deprecated(
             "node",
             "nixos.node_all_compile_default",
             &WARN_NIXOS_NODE_COMPILE_DEFAULT,
         );
+        self.node.compile
     }
 
-    pub fn warn_nixos_python_compile_default(&self) {
+    pub fn python_compile(&self) -> Option<bool> {
         warn_nixos_all_compile_default_deprecated(
             "python",
             "nixos.python_all_compile_default",
             &WARN_NIXOS_PYTHON_COMPILE_DEFAULT,
         );
+        self.python.compile
     }
 
-    pub fn warn_nixos_erlang_compile_default(&self) {
+    pub fn erlang_compile(&self) -> Option<bool> {
         warn_nixos_all_compile_default_deprecated(
             "erlang",
             "nixos.erlang_all_compile_default",
             &WARN_NIXOS_ERLANG_COMPILE_DEFAULT,
         );
+        self.erlang.compile
     }
 
     #[cfg(not(windows))]
-    pub fn warn_nixos_ruby_compile_default(&self) {
+    pub fn ruby_compile(&self) -> Option<bool> {
         warn_nixos_all_compile_default_deprecated(
             "ruby",
             "nixos.ruby_all_compile_default",
             &WARN_NIXOS_RUBY_COMPILE_DEFAULT,
         );
+        self.ruby.compile
     }
 
     pub fn try_get() -> Result<Arc<Self>> {
@@ -678,14 +685,9 @@ impl Settings {
         let cli_settings = normalize_hidden_config_aliases(
             CLI_SETTINGS.lock().unwrap().clone().unwrap_or_default(),
         );
-        let env_settings = SettingsPartial::from_env()?;
-        let mut explicit_all_compile = cli_settings.all_compile.or(env_settings.all_compile);
-        sb = Self::builder()
-            .preloaded(cli_settings)
-            .preloaded(env_settings);
+        sb = Self::builder().preloaded(cli_settings).env();
         time!("try_get builder2+env");
         for file in Self::all_settings_files() {
-            explicit_all_compile = explicit_all_compile.or(file.all_compile);
             sb = sb.preloaded(file);
         }
         time!("try_get all_settings_files");
@@ -695,7 +697,7 @@ impl Settings {
         settings = sb.load()?;
         let nixos_all_compile_is_implicit = should_warn_nixos_all_compile_default(
             env::LINUX_DISTRO.as_deref(),
-            explicit_all_compile,
+            settings.all_compile,
         );
         time!("try_get load2");
         if !settings.legacy_version_file {
@@ -784,7 +786,7 @@ impl Settings {
             ),
             Ordering::Relaxed,
         );
-        if settings.all_compile {
+        if settings.all_compile() {
             if settings.node.compile.is_none() {
                 settings.node.compile = Some(true);
             }
@@ -1634,6 +1636,19 @@ mod tests {
         assert!(default_all_compile(Some("nixos")));
         assert!(!default_all_compile(Some("ubuntu")));
         assert!(!default_all_compile(None));
+    }
+
+    #[test]
+    fn all_compile_preserves_unset_and_explicit_values() {
+        let mut settings = Settings::default();
+        assert_eq!(settings.all_compile, None);
+        assert!(!settings.all_compile());
+
+        settings.all_compile = Some(true);
+        assert!(settings.all_compile());
+
+        settings.all_compile = Some(false);
+        assert!(!settings.all_compile());
     }
 
     #[test]

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -615,12 +615,16 @@ impl Backend for ErlangPlugin {
 
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         let platform_key = self.get_platform_key();
+        let settings = Settings::get();
         if should_install_from_source(
             ctx.locked,
             &tv.lock_platforms,
             &platform_key,
-            Settings::get().erlang.compile,
+            settings.erlang.compile,
         ) {
+            if !ctx.locked {
+                settings.warn_nixos_erlang_compile_default();
+            }
             return self.install_via_kerl(ctx, tv).await;
         }
         if let Some(tv) = self.install_precompiled(ctx, tv.clone()).await? {

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -94,7 +94,7 @@ impl ErlangPlugin {
 
     fn precompiled_unavailable(&self, reason: impl Into<String>) -> Result<Option<ToolVersion>> {
         let reason = reason.into();
-        if Settings::get().erlang.compile == Some(false) {
+        if Settings::get().effective_erlang_compile() == Some(false) {
             bail!("precompiled erlang is not available: {reason}");
         }
         debug!("{reason}");
@@ -298,7 +298,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if !ctx.locked && Settings::get().erlang.compile == Some(true) {
+        if !ctx.locked && Settings::get().effective_erlang_compile() == Some(true) {
             return Ok(None);
         }
         let url = if let Some(url) = self.lockfile_url(ctx.locked, &tv) {
@@ -372,7 +372,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if !ctx.locked && Settings::get().erlang.compile == Some(true) {
+        if !ctx.locked && Settings::get().effective_erlang_compile() == Some(true) {
             return Ok(None);
         }
         let release_tag = Self::release_tag(&tv.version);
@@ -429,7 +429,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if !ctx.locked && Settings::get().erlang.compile == Some(true) {
+        if !ctx.locked && Settings::get().effective_erlang_compile() == Some(true) {
             return Ok(None);
         }
         let release_tag = Self::release_tag(&tv.version);
@@ -479,7 +479,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         _tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if !ctx.locked && Settings::get().erlang.compile == Some(true) {
+        if !ctx.locked && Settings::get().effective_erlang_compile() == Some(true) {
             Ok(None)
         } else {
             self.precompiled_unavailable("precompiled erlang is not supported on this platform")
@@ -571,7 +571,7 @@ impl Backend for ErlangPlugin {
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-        let versions = if Settings::get().erlang.compile == Some(false) {
+        let versions = if Settings::get().effective_erlang_compile() == Some(false) {
             github::list_releases("erlef/otp_builds")
                 .await?
                 .into_iter()
@@ -617,7 +617,7 @@ impl Backend for ErlangPlugin {
         let platform_key = self.get_platform_key();
         let settings = Settings::get();
         let erlang_compile = if ctx.locked {
-            settings.erlang.compile
+            settings.effective_erlang_compile()
         } else {
             settings.erlang_compile()
         };
@@ -643,7 +643,7 @@ impl Backend for ErlangPlugin {
         let mut opts = BTreeMap::new();
         let settings = Settings::get();
 
-        match settings.erlang.compile {
+        match settings.effective_erlang_compile() {
             Some(true) => {
                 opts.insert("compile".to_string(), "true".to_string());
             }
@@ -668,7 +668,7 @@ impl Backend for ErlangPlugin {
         tv: &ToolVersion,
         target: &PlatformTarget,
     ) -> Result<PlatformInfo> {
-        let compile = Settings::get().erlang.compile;
+        let compile = Settings::get().effective_erlang_compile();
         if compile == Some(true) {
             return self.resolve_source_lock_info(&tv.version).await;
         }

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -616,15 +616,17 @@ impl Backend for ErlangPlugin {
     async fn install_version_(&self, ctx: &InstallContext, tv: ToolVersion) -> Result<ToolVersion> {
         let platform_key = self.get_platform_key();
         let settings = Settings::get();
+        let erlang_compile = if ctx.locked {
+            settings.erlang.compile
+        } else {
+            settings.erlang_compile()
+        };
         if should_install_from_source(
             ctx.locked,
             &tv.lock_platforms,
             &platform_key,
-            settings.erlang.compile,
+            erlang_compile,
         ) {
-            if !ctx.locked {
-                settings.warn_nixos_erlang_compile_default();
-            }
             return self.install_via_kerl(ctx, tv).await;
         }
         if let Some(tv) = self.install_precompiled(ctx, tv.clone()).await? {

--- a/src/plugins/core/erlang.rs
+++ b/src/plugins/core/erlang.rs
@@ -9,7 +9,7 @@ use crate::backend::Backend;
 use crate::backend::VersionInfo;
 use crate::backend::platform_target::PlatformTarget;
 use crate::cli::args::BackendArg;
-use crate::config::{Config, Settings};
+use crate::config::{CompilePurpose, Config, Settings};
 #[cfg(unix)]
 use crate::file::ExtractOptions;
 use crate::file::display_path;
@@ -94,7 +94,7 @@ impl ErlangPlugin {
 
     fn precompiled_unavailable(&self, reason: impl Into<String>) -> Result<Option<ToolVersion>> {
         let reason = reason.into();
-        if Settings::get().effective_erlang_compile() == Some(false) {
+        if Settings::get().erlang_compile(CompilePurpose::Inspect) == Some(false) {
             bail!("precompiled erlang is not available: {reason}");
         }
         debug!("{reason}");
@@ -298,7 +298,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if !ctx.locked && Settings::get().effective_erlang_compile() == Some(true) {
+        if !ctx.locked && Settings::get().erlang_compile(CompilePurpose::Inspect) == Some(true) {
             return Ok(None);
         }
         let url = if let Some(url) = self.lockfile_url(ctx.locked, &tv) {
@@ -372,7 +372,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if !ctx.locked && Settings::get().effective_erlang_compile() == Some(true) {
+        if !ctx.locked && Settings::get().erlang_compile(CompilePurpose::Inspect) == Some(true) {
             return Ok(None);
         }
         let release_tag = Self::release_tag(&tv.version);
@@ -429,7 +429,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         mut tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if !ctx.locked && Settings::get().effective_erlang_compile() == Some(true) {
+        if !ctx.locked && Settings::get().erlang_compile(CompilePurpose::Inspect) == Some(true) {
             return Ok(None);
         }
         let release_tag = Self::release_tag(&tv.version);
@@ -479,7 +479,7 @@ impl ErlangPlugin {
         ctx: &InstallContext,
         _tv: ToolVersion,
     ) -> Result<Option<ToolVersion>> {
-        if !ctx.locked && Settings::get().effective_erlang_compile() == Some(true) {
+        if !ctx.locked && Settings::get().erlang_compile(CompilePurpose::Inspect) == Some(true) {
             Ok(None)
         } else {
             self.precompiled_unavailable("precompiled erlang is not supported on this platform")
@@ -571,7 +571,7 @@ impl Backend for ErlangPlugin {
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> Result<Vec<VersionInfo>> {
-        let versions = if Settings::get().effective_erlang_compile() == Some(false) {
+        let versions = if Settings::get().erlang_compile(CompilePurpose::Inspect) == Some(false) {
             github::list_releases("erlef/otp_builds")
                 .await?
                 .into_iter()
@@ -617,9 +617,9 @@ impl Backend for ErlangPlugin {
         let platform_key = self.get_platform_key();
         let settings = Settings::get();
         let erlang_compile = if ctx.locked {
-            settings.effective_erlang_compile()
+            settings.erlang_compile(CompilePurpose::Inspect)
         } else {
-            settings.erlang_compile()
+            settings.erlang_compile(CompilePurpose::Install)
         };
         if should_install_from_source(
             ctx.locked,
@@ -643,7 +643,7 @@ impl Backend for ErlangPlugin {
         let mut opts = BTreeMap::new();
         let settings = Settings::get();
 
-        match settings.effective_erlang_compile() {
+        match settings.erlang_compile(CompilePurpose::Inspect) {
             Some(true) => {
                 opts.insert("compile".to_string(), "true".to_string());
             }
@@ -668,7 +668,7 @@ impl Backend for ErlangPlugin {
         tv: &ToolVersion,
         target: &PlatformTarget,
     ) -> Result<PlatformInfo> {
-        let compile = Settings::get().effective_erlang_compile();
+        let compile = Settings::get().erlang_compile(CompilePurpose::Inspect);
         if compile == Some(true) {
             return self.resolve_source_lock_info(&tv.version).await;
         }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -7,7 +7,7 @@ use crate::cache::CacheManagerBuilder;
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
 use crate::config::settings::DEFAULT_NODE_MIRROR_URL;
-use crate::config::{Config, Settings};
+use crate::config::{CompilePurpose, Config, Settings};
 use crate::file::{ExtractOptions, ExtractionFormat};
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
@@ -138,7 +138,7 @@ impl NodePlugin {
                     bail!(
                         "precompiled node archive not found and locked mode requires the locked precompiled artifact"
                     )
-                } else if Settings::get().effective_node_compile() != Some(false) {
+                } else if Settings::get().node_compile(CompilePurpose::Inspect) != Some(false) {
                     if let Some(message) = node_flavor_not_found_message(opts) {
                         warn!("{message}");
                     }
@@ -717,9 +717,9 @@ impl Backend for NodePlugin {
         trace!("node build opts: {:#?}", opts);
         let platform_key = self.get_platform_key();
         let node_compile = if ctx.locked {
-            settings.effective_node_compile()
+            settings.node_compile(CompilePurpose::Inspect)
         } else {
-            settings.node_compile()
+            settings.node_compile(CompilePurpose::Install)
         };
         let compile_from_source =
             should_compile_from_source(ctx.locked, &tv.lock_platforms, &platform_key, node_compile);
@@ -891,7 +891,7 @@ impl Backend for NodePlugin {
             .join(&format!("v{version}/{filename}"))
             .map_err(|e| eyre::eyre!("Failed to construct Node.js download URL: {e}"))?;
 
-        let node_compile = settings.effective_node_compile();
+        let node_compile = settings.node_compile(CompilePurpose::Inspect);
         if node_compile == Some(true) && target.os_name() != "windows" {
             return self.resolve_source_lock_info(version).await;
         }

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -138,7 +138,7 @@ impl NodePlugin {
                     bail!(
                         "precompiled node archive not found and locked mode requires the locked precompiled artifact"
                     )
-                } else if Settings::get().node.compile != Some(false) {
+                } else if Settings::get().effective_node_compile() != Some(false) {
                     if let Some(message) = node_flavor_not_found_message(opts) {
                         warn!("{message}");
                     }
@@ -717,7 +717,7 @@ impl Backend for NodePlugin {
         trace!("node build opts: {:#?}", opts);
         let platform_key = self.get_platform_key();
         let node_compile = if ctx.locked {
-            settings.node.compile
+            settings.effective_node_compile()
         } else {
             settings.node_compile()
         };
@@ -891,7 +891,8 @@ impl Backend for NodePlugin {
             .join(&format!("v{version}/{filename}"))
             .map_err(|e| eyre::eyre!("Failed to construct Node.js download URL: {e}"))?;
 
-        if settings.node.compile == Some(true) && target.os_name() != "windows" {
+        let node_compile = settings.effective_node_compile();
+        if node_compile == Some(true) && target.os_name() != "windows" {
             return self.resolve_source_lock_info(version).await;
         }
 
@@ -901,7 +902,7 @@ impl Backend for NodePlugin {
         let checksum = match self.resolve_shasum(&mirror, version, &filename).await {
             Ok(Some(shasum)) => Some(shasum),
             Ok(None) => {
-                if settings.node.compile != Some(false) && target.os_name() != "windows" {
+                if node_compile != Some(false) && target.os_name() != "windows" {
                     return self.resolve_source_lock_info(version).await;
                 }
                 debug!(

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -716,19 +716,17 @@ impl Backend for NodePlugin {
         let opts = BuildOpts::new(ctx, &tv).await?;
         trace!("node build opts: {:#?}", opts);
         let platform_key = self.get_platform_key();
-        let compile_from_source = should_compile_from_source(
-            ctx.locked,
-            &tv.lock_platforms,
-            &platform_key,
-            settings.node.compile,
-        );
+        let node_compile = if ctx.locked {
+            settings.node.compile
+        } else {
+            settings.node_compile()
+        };
+        let compile_from_source =
+            should_compile_from_source(ctx.locked, &tv.lock_platforms, &platform_key, node_compile);
 
         if cfg!(windows) {
             self.install_windows(ctx, &mut tv, &opts).await?;
         } else if compile_from_source {
-            if !ctx.locked {
-                settings.warn_nixos_node_compile_default();
-            }
             self.install_compiling(ctx, &mut tv, &opts).await?;
         } else {
             self.install_precompiled(ctx, &mut tv, &opts).await?;

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -726,6 +726,9 @@ impl Backend for NodePlugin {
         if cfg!(windows) {
             self.install_windows(ctx, &mut tv, &opts).await?;
         } else if compile_from_source {
+            if !ctx.locked {
+                settings.warn_nixos_node_compile_default();
+            }
             self.install_compiling(ctx, &mut tv, &opts).await?;
         } else {
             self.install_precompiled(ctx, &mut tv, &opts).await?;

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -1070,11 +1070,10 @@ impl Backend for PythonPlugin {
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
         let settings = Settings::get();
-        if cfg!(windows) || settings.python.compile != Some(true) {
+        if cfg!(windows) || settings.python_compile() != Some(true) {
             validate_python_precompiled_settings(&settings)?;
             self.install_precompiled(ctx, &mut tv).await?;
         } else {
-            settings.warn_nixos_python_compile_default();
             self.install_compiled(ctx, &tv).await?;
         }
         self.test_python(&ctx.config, &tv, ctx.pr.as_ref()).await?;

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -484,7 +484,7 @@ impl PythonPlugin {
         // unix this function is still entered, but a `pypy*` version falls through to python-build
         // below and installs fine today — no reason to change that here.
         if tv.version.starts_with("pypy") {
-            if cfg!(windows) || Settings::get().python.compile == Some(false) {
+            if cfg!(windows) || Settings::get().effective_python_compile() == Some(false) {
                 return self.install_pypy(ctx, tv).await;
             }
             // With `compile` unset on unix this function is still entered, but python-build owns
@@ -511,7 +511,7 @@ impl PythonPlugin {
             let (tag, filename) = match precompile_info {
                 Some((_, tag, filename)) => (tag, filename),
                 None => {
-                    if cfg!(windows) || Settings::get().python.compile == Some(false) {
+                    if cfg!(windows) || Settings::get().effective_python_compile() == Some(false) {
                         if !cfg!(windows) {
                             hint!(
                                 "python_compile",
@@ -841,7 +841,8 @@ impl PythonPlugin {
     fn detect_precompiled_provenance(&self) -> Option<ProvenanceType> {
         // Provenance only applies to precompiled binaries, not compiled-from-source.
         // On Windows, precompiled is always used regardless of compile setting.
-        let uses_precompiled = cfg!(windows) || Settings::get().python.compile != Some(true);
+        let uses_precompiled =
+            cfg!(windows) || Settings::get().effective_python_compile() != Some(true);
         if !uses_precompiled || !Self::github_attestations_enabled() {
             return None;
         }
@@ -971,7 +972,7 @@ impl Backend for PythonPlugin {
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
-        if cfg!(windows) || Settings::get().python.compile == Some(false) {
+        if cfg!(windows) || Settings::get().effective_python_compile() == Some(false) {
             // python-build-standalone is CPython only, so pypy comes from its own index — and only
             // the releases that publish an archive for this platform, the way the CPython list is
             // already filtered. Offering the rest would list versions that cannot install: macOS
@@ -1138,7 +1139,9 @@ impl Backend for PythonPlugin {
                         self.ba().cache_path.join("remote_versions.msgpack.z"),
                     )
                     .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
-                    .with_cache_key((Settings::get().python.compile == Some(false)).to_string())
+                    .with_cache_key(
+                        (Settings::get().effective_python_compile() == Some(false)).to_string(),
+                    )
                     .build(),
                 ))
             })
@@ -1156,7 +1159,7 @@ impl Backend for PythonPlugin {
 
         // Only include compile option if true (non-default)
         let compile = if is_current_platform {
-            settings.python.compile.unwrap_or(false)
+            settings.effective_python_compile().unwrap_or(false)
         } else {
             false
         };

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -1074,6 +1074,7 @@ impl Backend for PythonPlugin {
             validate_python_precompiled_settings(&settings)?;
             self.install_precompiled(ctx, &mut tv).await?;
         } else {
+            settings.warn_nixos_python_compile_default();
             self.install_compiled(ctx, &tv).await?;
         }
         self.test_python(&ctx.config, &tv, ctx.pr.as_ref()).await?;

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -6,7 +6,7 @@ use crate::build_time::built_info;
 use crate::cache::{CacheManager, CacheManagerBuilder};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
-use crate::config::{Config, Settings};
+use crate::config::{CompilePurpose, Config, Settings};
 use crate::file::{ExtractOptions, ExtractionFormat, display_path};
 use crate::git::{CloneOptions, Git};
 use crate::http::{HTTP, HTTP_FETCH};
@@ -484,7 +484,9 @@ impl PythonPlugin {
         // unix this function is still entered, but a `pypy*` version falls through to python-build
         // below and installs fine today — no reason to change that here.
         if tv.version.starts_with("pypy") {
-            if cfg!(windows) || Settings::get().effective_python_compile() == Some(false) {
+            if cfg!(windows)
+                || Settings::get().python_compile(CompilePurpose::Inspect) == Some(false)
+            {
                 return self.install_pypy(ctx, tv).await;
             }
             // With `compile` unset on unix this function is still entered, but python-build owns
@@ -511,7 +513,9 @@ impl PythonPlugin {
             let (tag, filename) = match precompile_info {
                 Some((_, tag, filename)) => (tag, filename),
                 None => {
-                    if cfg!(windows) || Settings::get().effective_python_compile() == Some(false) {
+                    if cfg!(windows)
+                        || Settings::get().python_compile(CompilePurpose::Inspect) == Some(false)
+                    {
                         if !cfg!(windows) {
                             hint!(
                                 "python_compile",
@@ -842,7 +846,7 @@ impl PythonPlugin {
         // Provenance only applies to precompiled binaries, not compiled-from-source.
         // On Windows, precompiled is always used regardless of compile setting.
         let uses_precompiled =
-            cfg!(windows) || Settings::get().effective_python_compile() != Some(true);
+            cfg!(windows) || Settings::get().python_compile(CompilePurpose::Inspect) != Some(true);
         if !uses_precompiled || !Self::github_attestations_enabled() {
             return None;
         }
@@ -972,7 +976,7 @@ impl Backend for PythonPlugin {
     }
 
     async fn _list_remote_versions(&self, _config: &Arc<Config>) -> eyre::Result<Vec<VersionInfo>> {
-        if cfg!(windows) || Settings::get().effective_python_compile() == Some(false) {
+        if cfg!(windows) || Settings::get().python_compile(CompilePurpose::Inspect) == Some(false) {
             // python-build-standalone is CPython only, so pypy comes from its own index — and only
             // the releases that publish an archive for this platform, the way the CPython list is
             // already filtered. Offering the rest would list versions that cannot install: macOS
@@ -1071,7 +1075,7 @@ impl Backend for PythonPlugin {
         mut tv: ToolVersion,
     ) -> Result<ToolVersion> {
         let settings = Settings::get();
-        if cfg!(windows) || settings.python_compile() != Some(true) {
+        if cfg!(windows) || settings.python_compile(CompilePurpose::Install) != Some(true) {
             validate_python_precompiled_settings(&settings)?;
             self.install_precompiled(ctx, &mut tv).await?;
         } else {
@@ -1140,7 +1144,8 @@ impl Backend for PythonPlugin {
                     )
                     .with_fresh_duration(Settings::get().fetch_remote_versions_cache())
                     .with_cache_key(
-                        (Settings::get().effective_python_compile() == Some(false)).to_string(),
+                        (Settings::get().python_compile(CompilePurpose::Inspect) == Some(false))
+                            .to_string(),
                     )
                     .build(),
                 ))
@@ -1159,7 +1164,9 @@ impl Backend for PythonPlugin {
 
         // Only include compile option if true (non-default)
         let compile = if is_current_platform {
-            settings.effective_python_compile().unwrap_or(false)
+            settings
+                .python_compile(CompilePurpose::Inspect)
+                .unwrap_or(false)
         } else {
             false
         };

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -1102,7 +1102,7 @@ impl Backend for RubyPlugin {
         // No precompiled available, fall through to compile from source
 
         // Compile from source
-        Settings::get().warn_nixos_ruby_compile_default();
+        let _ = Settings::get().ruby_compile();
         if let Err(err) = self.update_build_tool(Some(ctx)).await {
             warn!("ruby build tool update error: {err:#}");
         }

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -438,7 +438,7 @@ impl RubyPlugin {
     /// Check if precompiled binaries should be tried.
     /// Precompiled binaries are the default unless source compilation is explicitly requested.
     fn should_try_precompiled(&self) -> bool {
-        Settings::get().ruby.compile != Some(true)
+        Settings::get().effective_ruby_compile() != Some(true)
     }
 
     /// Check if precompiled binaries are required, with no fallback to compiling.
@@ -446,7 +446,7 @@ impl RubyPlugin {
     /// to ruby-build, and remote version listings only offer versions that have a
     /// precompiled binary for this platform.
     fn precompiled_only(&self) -> bool {
-        Settings::get().ruby.compile == Some(false)
+        Settings::get().effective_ruby_compile() == Some(false)
     }
 
     /// Get platform identifier for precompiled binaries

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -12,7 +12,7 @@ use crate::backend::platform_target::PlatformTarget;
 use crate::backend::{Backend, VersionInfo, normalize_idiomatic_contents, strict_metadata};
 use crate::cli::args::BackendArg;
 use crate::cmd::CmdLineRunner;
-use crate::config::{Config, Settings};
+use crate::config::{CompilePurpose, Config, Settings};
 use crate::duration::DAILY;
 use crate::env::PATH_KEY;
 use crate::git::{CloneOptions, Git};
@@ -438,7 +438,7 @@ impl RubyPlugin {
     /// Check if precompiled binaries should be tried.
     /// Precompiled binaries are the default unless source compilation is explicitly requested.
     fn should_try_precompiled(&self) -> bool {
-        Settings::get().effective_ruby_compile() != Some(true)
+        Settings::get().ruby_compile(CompilePurpose::Inspect) != Some(true)
     }
 
     /// Check if precompiled binaries are required, with no fallback to compiling.
@@ -446,7 +446,7 @@ impl RubyPlugin {
     /// to ruby-build, and remote version listings only offer versions that have a
     /// precompiled binary for this platform.
     fn precompiled_only(&self) -> bool {
-        Settings::get().effective_ruby_compile() == Some(false)
+        Settings::get().ruby_compile(CompilePurpose::Inspect) == Some(false)
     }
 
     /// Get platform identifier for precompiled binaries
@@ -1102,7 +1102,7 @@ impl Backend for RubyPlugin {
         // No precompiled available, fall through to compile from source
 
         // Compile from source
-        let _ = Settings::get().ruby_compile();
+        let _ = Settings::get().ruby_compile(CompilePurpose::Install);
         if let Err(err) = self.update_build_tool(Some(ctx)).await {
             warn!("ruby build tool update error: {err:#}");
         }

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -1102,6 +1102,7 @@ impl Backend for RubyPlugin {
         // No precompiled available, fall through to compile from source
 
         // Compile from source
+        Settings::get().warn_nixos_ruby_compile_default();
         if let Err(err) = self.update_build_tool(Some(ctx)).await {
             warn!("ruby build tool update error: {err:#}");
         }

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -452,7 +452,7 @@ pub fn compute_settings_hash() -> String {
 
     // Add settings that affect env computation
     hasher.update(settings.experimental.to_string().as_bytes());
-    hasher.update(settings.all_compile.to_string().as_bytes());
+    hasher.update(settings.all_compile().to_string().as_bytes());
     // Safe mode drops project [env]/_.path directives, so a cache entry built
     // with a different `safe` value must not be reused.
     hasher.update(settings.safe.to_string().as_bytes());


### PR DESCRIPTION
## Summary

- deprecate the automatic `all_compile = true` default on NixOS
- warn immediately in mise 2026.8.0 and schedule removal for 2027.8.0
- keep Alpine's source-compilation default unchanged
- document the migration to `nix-ld` or an explicit `all_compile = true`
- clarify when deprecation warnings may be delayed for cross-version compatibility

## Why

The distro-wide NixOS default unexpectedly forces source builds for Node, Python, Erlang, and Ruby even when precompiled binaries work through `nix-ld`. This preserves the current behavior for a full deprecation window while giving users an immediate, actionable warning.

## Validation

- `cargo test --bin mise default_all_compile_is_limited_to_alpine_and_deprecated_nixos_behavior`
- scoped `hk run check --safe --format json` (cargo-check, cargo-fmt, taplo, markdownlint, prettier)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default install behavior timing and compile resolution for Node, Python, Erlang, and Ruby on NixOS across a deprecation window; incorrect warning or default logic could surprise users or flip binary vs source installs.
> 
> **Overview**
> **Deprecates the implicit `all_compile = true` behavior on NixOS** while keeping Alpine’s source-build default. Warnings start in **2026.8.0**; the automatic NixOS default is scheduled for removal in **2027.8.0**, with docs pointing users to **nix-ld** or an explicit `all_compile = true`.
> 
> `all_compile` is now **optional** and resolved lazily via `Settings::all_compile()` (distro-aware defaults) instead of being written into defaults at load time. The old load-time step that forced `node`/`python`/`erlang`/`ruby` `compile` to `true` when `all_compile` was set is **removed**; tool backends use new `*_compile(CompilePurpose)` helpers so global `all_compile` still implies compile-from-source, with **NixOS deprecation warnings only on actual installs** (`CompilePurpose::Install`), not lockfile/inspect paths.
> 
> `mise settings get` / `as_dict` now expose the **effective** `all_compile` value after unset (e2e asserts `false` when unset on non-Alpine). **AGENTS.md** updates the deprecation policy (immediate CLI warning by default, optional delay for cross-version config migration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b63e53439b02b885b5dd768c17627dda64c5599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tool-specific warnings for automatic source compilation on NixOS across Node, Python, Erlang, and Ruby.
  * Warnings begin in mise 2026.8.0, with precompiled binaries becoming the default in mise 2027.8.0.
  * Added guidance for enabling `nix-ld` or explicitly setting `all_compile = true`.

* **Documentation**
  * Clarified `all_compile` defaults across Alpine and NixOS.
  * Updated deprecation policy guidance, including immediate warnings, an optional migration window of up to six months, and removal 12 months after warnings begin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->