### PR TITLE
fix(install): write manifests atomically

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -346,6 +346,108 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()>
     trace!("write {}", display_path(path));
     fs::write(path, contents).wrap_err_with(|| format!("failed write: {}", display_path(path)))
 }
+
+/// Writes a complete replacement beside `path`, then atomically renames it into place.
+///
+/// New files use ordinary write permissions subject to the process umask. Replacements preserve
+/// the destination's existing Unix permissions.
+pub fn write_atomic<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
+    let path = path.as_ref();
+    trace!("write_atomic {}", display_path(path));
+    let target = atomic_write_target(path)?;
+    let path = target.as_path();
+    let parent = path
+        .parent()
+        .ok_or_else(|| eyre::eyre!("path has no parent: {}", display_path(path)))?;
+    let prefix = format!(
+        ".{}.",
+        path.file_name().unwrap_or_default().to_string_lossy()
+    );
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(&prefix);
+
+    #[cfg(unix)]
+    let existing_permissions = match fs::metadata(path) {
+        Ok(metadata) => Some(metadata.permissions()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => return Err(err.into()),
+    };
+
+    #[cfg(unix)]
+    if existing_permissions.is_none() {
+        builder.permissions(fs::Permissions::from_mode(0o666));
+    }
+
+    let mut temporary = builder.tempfile_in(parent)?;
+
+    #[cfg(unix)]
+    if let Some(permissions) = existing_permissions {
+        temporary.as_file().set_permissions(permissions)?;
+    }
+
+    temporary.write_all(contents.as_ref())?;
+
+    temporary.as_file_mut().sync_all()?;
+    persist_atomic(temporary, path)
+        .wrap_err_with(|| format!("failed atomic write: {}", display_path(path)))?;
+    sync_dir(parent)?;
+    Ok(())
+}
+
+fn atomic_write_target(path: &Path) -> Result<PathBuf> {
+    const MAX_SYMLINKS: usize = 40;
+
+    let mut target = path.to_path_buf();
+    for followed in 0..=MAX_SYMLINKS {
+        if !target.is_symlink() {
+            return Ok(desymlink_path(&target));
+        }
+        if followed == MAX_SYMLINKS {
+            break;
+        }
+        let link = fs::read_link(&target)
+            .wrap_err_with(|| format!("failed to read symlink: {}", display_path(&target)))?;
+        target = if link.is_absolute() {
+            link
+        } else {
+            target.parent().unwrap_or_else(|| Path::new("")).join(link)
+        };
+    }
+
+    bail!(
+        "too many symlinks while resolving atomic write target: {}",
+        display_path(path)
+    )
+}
+
+fn persist_atomic(mut temporary: tempfile::NamedTempFile, path: &Path) -> Result<()> {
+    const RETRIES: u32 = 20;
+
+    for attempt in 0..=RETRIES {
+        match temporary.persist(path) {
+            Ok(_) => return Ok(()),
+            Err(err) if should_retry_atomic_persist(&err.error) && attempt < RETRIES => {
+                temporary = err.file;
+                std::thread::sleep(Duration::from_millis(5 * u64::from(attempt + 1)));
+            }
+            Err(err) => return Err(err.error.into()),
+        }
+    }
+
+    unreachable!("atomic persist retry loop should always return");
+}
+
+#[cfg(windows)]
+fn should_retry_atomic_persist(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::PermissionDenied
+        || matches!(err.raw_os_error(), Some(5) | Some(32))
+}
+
+#[cfg(not(windows))]
+fn should_retry_atomic_persist(_err: &std::io::Error) -> bool {
+    false
+}
+
 pub async fn write_async<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
     let path = path.as_ref();
     trace!("write {}", display_path(path));
@@ -2122,6 +2224,108 @@ mod tests {
         // `fs::hard_link` refuses an existing destination, so this exercises the copy arm.
         hard_link_or_copy(&from, &to).unwrap();
         assert_eq!(fs::read(&to).unwrap(), b"new");
+    }
+
+    #[test]
+    fn write_atomic_replaces_existing_contents_without_temp_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.toml");
+        write_atomic(&path, "old").unwrap();
+
+        write_atomic(&path, "new").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "new");
+        assert_eq!(fs::read_dir(tmp.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_preserves_existing_permissions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("state.toml");
+        write_atomic(&path, "old").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+
+        write_atomic(&path, "new").unwrap();
+
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_updates_symlink_target_without_replacing_link() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target.toml");
+        let link = tmp.path().join("state.toml");
+        fs::write(&target, "old").unwrap();
+        symlink(&target, &link).unwrap();
+
+        write_atomic(&link, "new").unwrap();
+
+        assert!(link.is_symlink());
+        assert_eq!(fs::read_to_string(target).unwrap(), "new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_creates_dangling_relative_symlink_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target.toml");
+        let link = tmp.path().join("state.toml");
+        symlink("target.toml", &link).unwrap();
+
+        write_atomic(&link, "new").unwrap();
+
+        assert!(link.is_symlink());
+        assert_eq!(fs::read_to_string(target).unwrap(), "new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_preserves_dangling_symlink_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target.toml");
+        let middle = tmp.path().join("middle.toml");
+        let link = tmp.path().join("state.toml");
+        symlink("target.toml", &middle).unwrap();
+        symlink("middle.toml", &link).unwrap();
+
+        write_atomic(&link, "new").unwrap();
+
+        assert!(link.is_symlink());
+        assert!(middle.is_symlink());
+        assert_eq!(fs::read_to_string(target).unwrap(), "new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_accepts_forty_symlinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target.toml");
+        for index in 0..40 {
+            let link = tmp.path().join(format!("link-{index}.toml"));
+            let next = if index == 39 {
+                "target.toml".to_string()
+            } else {
+                format!("link-{}.toml", index + 1)
+            };
+            symlink(next, link).unwrap();
+        }
+
+        write_atomic(tmp.path().join("link-0.toml"), "new").unwrap();
+
+        assert_eq!(fs::read_to_string(target).unwrap(), "new");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn atomic_persist_retries_windows_sharing_violations() {
+        assert!(should_retry_atomic_persist(
+            &std::io::Error::from_raw_os_error(32)
+        ));
     }
 
     fn utf16le(s: &str) -> Vec<u8> {

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -102,7 +102,7 @@ fn write_manifest(manifest: &Manifest) -> Result<()> {
 
 fn write_manifest_to(path: &Path, manifest: &Manifest) -> Result<()> {
     let body = toml::to_string_pretty(manifest)?;
-    file::write(path, body.trim())?;
+    file::write_atomic(path, body.trim())?;
     Ok(())
 }
 
@@ -111,6 +111,7 @@ fn read_tool_manifest_from(path: &Path) -> Option<ManifestTool> {
         return None;
     }
     match file::read_to_string(path) {
+        std::result::Result::Ok(body) if body.trim().is_empty() => None,
         std::result::Result::Ok(body) => match toml::from_str(&body) {
             std::result::Result::Ok(m) => Some(m),
             Err(err) => {
@@ -127,7 +128,7 @@ fn read_tool_manifest_from(path: &Path) -> Option<ManifestTool> {
 
 fn write_tool_manifest_to(path: &Path, tool: &ManifestTool) -> Result<()> {
     let body = toml::to_string_pretty(tool)?;
-    file::write(path, body.trim())?;
+    file::write_atomic(path, body.trim())?;
     Ok(())
 }
 
@@ -693,12 +694,23 @@ pub fn reset() {
 
 #[cfg(test)]
 mod tests {
-    use super::{lock_tool_version, normalize_version_for_sort, tool_version_lock};
+    use super::{
+        lock_tool_version, normalize_version_for_sort, read_tool_manifest_from, tool_version_lock,
+    };
     use itertools::Itertools;
     use std::collections::BTreeMap;
     use std::sync::mpsc;
     use std::time::Duration;
     use versions::Versioning;
+
+    #[test]
+    fn empty_tool_manifest_is_ignored() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join(".mise.backend.toml");
+        std::fs::write(&path, "").unwrap();
+
+        assert!(read_tool_manifest_from(&path).is_none());
+    }
 
     #[test]
     fn tool_version_locks_serialize_logical_versions() {


### PR DESCRIPTION
## Summary
- add a reusable `file::write_atomic` helper that writes beside the destination and atomically replaces it
- preserve existing Unix permissions, respect the user's umask for new files, fsync contents/metadata and the parent directory, and retry transient Windows access-denied and sharing-violation failures
- apply restrictive or preserved permissions before writing temporary-file contents
- follow existing, dangling, and chained destination symlinks so atomic updates preserve links and replace or create their ultimate targets, including the 40-link boundary
- use the helper for consolidated and per-tool install manifests
- treat empty per-tool manifests left by interrupted older writes as absent
- add regression coverage for atomic replacement, temporary-file cleanup, permissions, direct/chained/dangling symlinks, boundary handling, Windows retries, and empty sidecars

## Root cause
Install manifests used `std::fs::write`, which truncates an existing destination before writing its replacement. An interrupted or failed write could therefore leave a zero-byte `.mise.backend.toml`; concurrent mise processes could also observe the file during the truncate/write window. Deserializing that empty TOML document then reported a missing required `short` field.

## User impact
Interrupted manifest updates can no longer corrupt an existing manifest. Users who already have a zero-byte per-tool sidecar will silently fall back to the consolidated manifest instead of receiving repeated parse warnings. Symlinked manifests continue updating their ultimate targets, including creating missing targets through dangling link chains, instead of having any link replaced.

The atomic-write primitive is available for other ordinary file replacements. Callers with additional policy—fixed secret-file modes, ownership changes, or specialized dangling-symlink behavior—retain their specialized implementations.

## Validation
- `cargo test --locked --bin mise 'file::tests::write_atomic'`
- `cargo test --locked --bin mise toolset::install_state`
- `hk run check --safe --format json --files0-from -` scoped to the changed Rust files
- `mise run test:e2e e2e/backend/test_install_manifest`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core install-state persistence and new filesystem semantics (symlinks, permissions, fsync); scope is limited to manifest writes with solid test coverage.
> 
> **Overview**
> Install manifests were updated with plain `fs::write`, which could truncate files mid-write and leave zero-byte `.mise.backend.toml` sidecars that failed TOML parsing.
> 
> This PR adds **`file::write_atomic`**: write to a temp file in the same directory, fsync, rename into place, sync the parent directory, preserve Unix permissions (or umask for new files), follow symlink chains to the real target without replacing links, and retry transient Windows sharing errors on persist.
> 
> **Install state** now uses `write_atomic` for `.mise-installs.toml` and per-tool `.mise.backend.toml`. **Empty** per-tool manifest files are treated as missing so leftover zero-byte files from older interrupted writes fall back to the consolidated manifest instead of parse warnings.
> 
> Regression tests cover atomic replacement, permissions, symlink cases, and Windows retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 838066c4f6073c80da9b67526510e5d89e5c4149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->