### PR TITLE
fix(exec): allow symlinked resolv.conf in sandbox

### DIFF
--- a/src/sandbox/landlock.rs
+++ b/src/sandbox/landlock.rs
@@ -22,6 +22,13 @@ const SYSTEM_READ_PATHS: &[&str] = &[
     "/home/linuxbrew",
 ];
 
+/// System files that may resolve outside [`SYSTEM_READ_PATHS`].
+///
+/// Landlock rules apply to the resolved file hierarchy. On many Linux systems,
+/// /etc/resolv.conf points into /run, which must not be made broadly readable
+/// because it can contain runtime secrets.
+const SYSTEM_READ_FILES: &[&str] = &["/etc/resolv.conf"];
+
 fn add_read_rule(
     ruleset: landlock::RulesetCreated,
     path: &str,
@@ -90,6 +97,9 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<()> {
         for path in SYSTEM_READ_PATHS {
             ruleset = add_read_rule(ruleset, path, read_access)?;
         }
+        for path in SYSTEM_READ_FILES {
+            ruleset = add_read_rule(ruleset, path, read_access)?;
+        }
         ruleset = add_read_rule(ruleset, "/tmp", full_access)?;
         ruleset = add_read_rule(ruleset, "/dev", full_access)?;
         let installs_dir: &std::path::Path = &crate::dirs::INSTALLS;
@@ -106,6 +116,9 @@ pub fn apply_landlock(config: &SandboxConfig) -> Result<()> {
     } else if deny_read {
         // Only reads restricted — only handle read access so writes are unaffected
         for path in SYSTEM_READ_PATHS {
+            ruleset = add_read_rule(ruleset, path, read_access)?;
+        }
+        for path in SYSTEM_READ_FILES {
             ruleset = add_read_rule(ruleset, path, read_access)?;
         }
         // /tmp and /dev need read access (not in SYSTEM_READ_PATHS, handled separately)


### PR DESCRIPTION
## Summary

- add `/etc/resolv.conf` as an exact Linux Landlock read rule
- allow symlinked resolver configuration without exposing all of `/run`
- apply the rule to both read-only and read/write sandbox modes

## Root cause

The sandbox allows `/etc`, but Landlock evaluates the resolved file hierarchy. On systems where `/etc/resolv.conf` points into `/run`, the `/etc` directory rule does not authorize the symlink target, so DNS clients receive `EACCES`.

Registering the file itself causes Landlock to anchor the rule to its resolved target while keeping other runtime files and secrets under `/run` inaccessible.

Fixes the behavior reported in https://github.com/jdx/mise/discussions/11951.

## Validation

- `mise run format`
- `cargo test --locked --bin mise sandbox::`
- `mise run build`
- direct Linux Landlock fixture covering an external symlink target under both `--deny-read` and `--deny-all`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted sandbox allowlist change with documented security rationale; only affects Linux Landlock read-restriction paths.
> 
> **Overview**
> Fixes **DNS failures** (`EACCES` reading resolver config) in restricted Linux sandboxes when `/etc/resolv.conf` is a symlink into `/run`.
> 
> Landlock authorizes the **resolved** path, so the existing `/etc` directory rule does not cover the target. The change introduces `SYSTEM_READ_FILES` (starting with `/etc/resolv.conf`) and registers an explicit read rule in both **read-restricted** modes (`deny_read && deny_write` and `deny_read` only), so the symlink target is allowed without making all of `/run` readable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607a376e87792e9e720c7d172312bf01b088c835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandboxed network access by allowing required DNS configuration files to be read.
  * Applied the fix consistently in both read-only and read/write sandbox modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->