### PR TITLE
registry: add mailpit (aqua:axllent/mailpit)

### DIFF
--- a/registry/mailpit.toml
+++ b/registry/mailpit.toml
@@ -1,0 +1,3 @@
+backends = ["aqua:axllent/mailpit"]
+description = "An email and SMTP testing tool with API for developers"
+test = { cmd = "mailpit version | grep 'mailpit v' | awk '{print $2}'", expected = "v{{version}}" }

--- a/registry/mailpit.toml
+++ b/registry/mailpit.toml
@@ -1,3 +1,4 @@
 backends = ["aqua:axllent/mailpit"]
 description = "An email and SMTP testing tool with API for developers"
 test = { cmd = "mailpit version | grep 'mailpit v' | awk '{print $2}'", expected = "v{{version}}" }
+version_order = "semver"


### PR DESCRIPTION
https://github.com/axllent/mailpit - 10.1k stars - email sink (maintained replacement for mailhog)

See https://github.com/jdx/mise/discussions/11955 for context on why `grep` and `awk` are required for the test command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mailpit to the available tool registry.
  * Included Mailpit metadata, Aqua backend support, and version verification.
  * Mailpit versions are now ordered semantically for reliable version selection and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->