### PR TITLE
fix(http): retry send failures that never produced a response (HTTP/2 REFUSED_STREAM)

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -1819,6 +1819,17 @@ pub(crate) fn is_transient(err: &Report) -> bool {
         if reqwest_err.is_timeout() || reqwest_err.is_connect() || reqwest_err.is_body() {
             return true;
         }
+        // Send failures that never produced a response: the connection was
+        // established but the request did not complete, so no application logic
+        // ran and a retry is safe. This covers HTTP/2 stream errors such as
+        // REFUSED_STREAM (which RFC 9113 §8.7 defines as "the request was not
+        // processed", i.e. safely retryable) and connections closed before the
+        // response started. These are not is_connect(), because connecting
+        // succeeded, and they carry no status, so without this they fall through
+        // and fail on the first attempt regardless of `http_retries`.
+        if reqwest_err.is_request() && reqwest_err.status().is_none() {
+            return true;
+        }
         // Status errors: 5xx server errors plus 408 (Request Timeout) and
         // 429 (Too Many Requests). Other 4xx are deterministic — don't retry.
         if let Some(status) = reqwest_err.status() {
@@ -2765,6 +2776,26 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let formatted = format_response_body(&body);
         assert_eq!(formatted.strip_suffix("\n<truncated>").unwrap().len(), 4096);
         assert!(formatted.ends_with("\n<truncated>"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_retry_rescues_send_failure_with_no_response() {
+        // A connection that is accepted and then closed without a response fails
+        // with a reqwest "request" error: connecting succeeded, so it is not
+        // is_connect(), and no response arrived, so there is no status. HTTP/2
+        // REFUSED_STREAM lands in the same class. Before these were classified as
+        // transient, such failures exited on the first attempt even with retries
+        // enabled.
+        let _guard = set_test_http_retries(1);
+        let (port, count) = spawn_canned_server(vec!["", ok_response()]).await;
+        let url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+
+        let resp = client.get_async(url).await.unwrap();
+
+        assert!(resp.status().is_success());
+        // Two connections: the aborted one, then the retry that succeeded.
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Follows up #11954.

An HTTP/2 `REFUSED_STREAM` fails on the first attempt even with `http_retries` at 3. It reaches `is_transient()` as a reqwest `Request` error that matches no existing arm: `is_connect()` is false (the connection succeeded, the stream was refused), it is not a timeout or body error, and `status()` is `None`. So it falls through to `false` and never retries.

RFC 9113 §8.7 defines `REFUSED_STREAM` as the request not having been processed, which makes it one of the safest things to retry — mise's own message even says "before processing any application logic". CDNs emit it as backpressure under concurrency, so it hits exactly when a retry would help. On our CI it caused 120 failed runs in 4 days, all rescuable by one retry.

```rust
if reqwest_err.is_request() && reqwest_err.status().is_none() {
    return true;
}
```

I used `is_request()` rather than inspecting h2 reason codes since `h2` isn't a direct dependency. Gating on `status().is_none()` keeps anything that produced a real response on the existing path, mirroring `is_connection_error()`. Happy to narrow it to an h2-specific check if you prefer.

The test uses the existing `spawn_canned_server` with an empty response, so the socket is accepted then closed with nothing written — same class of error.

**Caveat:** I have no Rust toolchain on this machine, so this is uncompiled and I could not confirm the test fails without the fix. Please let CI judge it. If reqwest classifies a closed-before-response connection as `is_body()` instead, the test would pass without the patch and needs tightening — happy to follow up either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic recovery from temporary connection failures.
  * Requests can now retry safely when a connection closes before returning a response, including certain HTTP/2 stream failures.
  * Added coverage to verify successful recovery after an initial connection failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->