### PR TITLE
fix(upgrade): allow typing to filter tools in interactive upgrade picker

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -639,6 +639,7 @@ impl Upgrade {
         let theme = crate::ui::theme::get_theme();
         let mut ms = demand::MultiSelect::new("mise upgrade")
             .description("Select tools to upgrade")
+            .filtering(true)
             .filterable(true)
             .theme(&theme);
         for out in outdated {


### PR DESCRIPTION
## Summary
- `mise upgrade`'s interactive multiselect (`get_interactive_tool_set` in `src/cli/upgrade.rs`) built its `demand::MultiSelect` with `.filterable(true)` but not `.filtering(true)`.
- Without `.filtering(true)`, the widget starts in browse mode: `j`/`k`/`h`/`l` are bound to movement and any other typed character is swallowed until `/` is pressed to enter filter mode. So typing e.g. `kube` to narrow the list does nothing visible — no filter box appears, the cursor doesn't move, and the letters vanish.
- The other three interactive pickers in the codebase (`mise use`, `mise search -i`, the task list picker) all already set `.filtering(true)` and work correctly — `mise upgrade` was the only outlier. Verified there are no other `Select`/`MultiSelect` construction sites in the repo, and `mise install` has no interactive picker at all.

## Fix
One-line addition of `.filtering(true)` to match the other three call sites.

## Test plan
- [x] Built a standalone repro against the exact `demand` v2.0.5 builder call used here and drove it over a real pty with `expect`, confirming: before the fix, typing `kube` did nothing; after adding `.filtering(true)`, it correctly narrows/highlights matches (`kubectl`, `kube-linter`, `kubent`).
- [ ] Manual check: `mise upgrade -i` (or `cargo run -- upgrade -i`) with several outdated tools, type to filter.

*AI-assisted — Tool: Claude Code; model: claude-sonnet-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added filtering support to the interactive upgrade selection menu, making it easier to find and choose upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->