### PR TITLE
fix(config): allow typing j/k to filter in mise edit's tool picker

### DIFF
--- a/crates/mise-interactive-config/src/editor/handlers.rs
+++ b/crates/mise-interactive-config/src/editor/handlers.rs
@@ -262,11 +262,11 @@ impl InteractiveConfig {
                         self.mode = Mode::Navigate;
                     }
                 }
-                Key::ArrowUp | Key::Char('k') => {
+                Key::ArrowUp => {
                     picker.move_up();
                     self.mode = Mode::Picker(kind, Box::new(picker));
                 }
-                Key::ArrowDown | Key::Char('j') => {
+                Key::ArrowDown => {
                     picker.move_down();
                     self.mode = Mode::Picker(kind, Box::new(picker));
                 }


### PR DESCRIPTION
## Summary
- `mise edit`'s interactive TOML editor (`crates/mise-interactive-config`) has a `Picker` mode used for fuzzy-searching lists (tool, backend, setting, hook, etc.). Its key handler bound `Key::Char('k')`/`Key::Char('j')` as aliases for `ArrowUp`/`ArrowDown` *before* the `Key::Char(c) => picker.type_char(c)` catch-all, so those two letters could never reach the filter's text input — e.g. typing "kube" while picking a tool would eat the `k` as a move-up and leave the rest unfiltered.
- Unlike the `demand`-crate-based pickers used elsewhere in mise (`mise use`, `mise search -i`, task list), there's no filter/browse mode distinction here and no escape hatch (no `/`-to-filter toggle) — `j`/`k` were simply unreachable as filter text, unconditionally.
- Audited every other key handler in the crate (`Navigate`, `Edit`, `NewKey`, `RenameKey`, `BackendToolName`, `VersionSelect`, `BooleanSelect`) — this `Picker` mode is the only place where a movement-key alias sits ahead of a free-text catch-all. The others are either pure command modes with no text entry (`Navigate`) or already put the catch-all last with no letter-shortcut collisions.

## Fix
Drop the `j`/`k` char aliases from the `Picker` handler. Arrow keys already provide movement, and this widget is filter-first, so plain letters (including `j`/`k`) should always reach the filter.

## Test plan
- [x] `cargo test` in `crates/mise-interactive-config` — 37 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` in `crates/mise-interactive-config` — clean
- [x] Manual check: `mise edit`, open the tool picker, type a tool name containing `j`/`k` (e.g. "kubectl")

*AI-assisted — Tool: Claude Code; model: claude-sonnet-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated picker navigation so vertical movement responds only to the Up and Down arrow keys.
  * Other picker interactions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->