### PR TITLE
chore(ci): install cmake for snapcraft builds

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -49,6 +49,7 @@ parts:
     rust-channel: stable
 
     build-packages:
+      - cmake
       - libssl-dev
     build-attributes:
       - enable-patchelf


### PR DESCRIPTION
## Summary

- install `cmake` in the Snapcraft build environment
- allow `libz-ng-sys` to compile for amd64 and arm64 Snap packages

## Context

Snap publishing has failed since v2026.7.12 because `libz-ng-sys` invokes CMake, but the Snapcraft build environment does not include the `cmake` executable. This leaves the stable Snap at v2026.7.11, as reported in [discussion #11967](https://github.com/jdx/mise/discussions/11967).

## Validation

- `mise run lint-fix`
- `hk` safe check (schema, formatting, shell, workflow, Markdown, and `cargo check`)

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to the Snap build environment; no runtime or application logic changes.
> 
> **Overview**
> Adds **`cmake`** to the Snapcraft `mise` part **`build-packages`** so the Rust build can compile **`libz-ng-sys`** (which runs CMake at build time).
> 
> This aligns Snap packaging with other Linux release paths that already list CMake and should unblock **amd64** and **arm64** Snap publishes that have failed since v2026.7.12.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b3418e8c6b32fd64392a0e1386294beb6d322c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CMake as a build dependency for the application package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->