### PR TITLE
fix(generate): honor absolute localized directories

### DIFF
--- a/e2e/generate/test_generate_bootstrap
+++ b/e2e/generate/test_generate_bootstrap
@@ -61,3 +61,11 @@ assert "MISE_VERSION=9999.1.2 ./bin/mise-plain hello" "version-stub hello"
 
 stub "$PWD/.mise/mise-9999.1.2" localized-version-stub
 assert "MISE_VERSION=v9999.1.2 ./bin/mise hello" "localized-version-stub hello"
+
+# Absolute localized directories must not be nested under the generated script's project root.
+# Shell metacharacters in the path must also stay literal in the generated script.
+absolute_localized_dir="$PWD/localized \$dir's cache"
+printf -v absolute_localized_dir_arg '%q' "$absolute_localized_dir"
+assert "mise generate bootstrap -l --localized-dir $absolute_localized_dir_arg -w ./bin/mise-absolute"
+stub "$absolute_localized_dir/mise-9999.1.2" absolute-localized-stub
+assert "MISE_VERSION=v9999.1.2 ./bin/mise-absolute hello" "absolute-localized-stub hello"

--- a/src/cli/generate/bootstrap.rs
+++ b/src/cli/generate/bootstrap.rs
@@ -66,12 +66,17 @@ impl Bootstrap {
         // script was generated with: `test -f "$MISE_INSTALL_PATH"` skips install.sh entirely, so
         // a fixed path would make a changed MISE_VERSION silently reuse the cached binary.
         let vars = if self.localize {
-            // TODO: this will only work right if it is in the base directory, not an absolute path or has a subdirectory
             let localized_dir = self.localized_dir.to_string_lossy();
+            let localized_dir = shell_words::quote(&localized_dir);
+            let localized_dir = if self.localized_dir.is_absolute() {
+                localized_dir.into_owned()
+            } else {
+                format!(r#""$project_dir"/{localized_dir}"#)
+            };
             format!(
                 r#"
 local project_dir=$( cd -- "$( dirname -- "${{BASH_SOURCE[0]}}" )" &> /dev/null && cd .. && pwd )
-local localized_dir="$project_dir/{localized_dir}"
+local localized_dir={localized_dir}
 export MISE_DATA_DIR="$localized_dir"
 export MISE_CONFIG_DIR="$localized_dir"
 export MISE_CACHE_DIR="$localized_dir/cache"


### PR DESCRIPTION
## Summary
- preserve absolute `--localized-dir` values instead of nesting them under the generated script's project root
- shell-quote localized paths so spaces and shell metacharacters remain literal
- cover the behavior with a no-download bootstrap regression

## Test plan
- `cargo build --locked`
- `cargo build --all-features`
- `mise run --skip-deps --skip-tools test:e2e e2e/generate/test_generate_bootstrap`
- `mise exec -- hk check src/cli/generate/bootstrap.rs e2e/generate/test_generate_bootstrap`
- `cargo fmt --all -- --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved absolute paths when configuring bootstrap localization directories.
  - Correctly resolved relative directories beneath the generated project directory.
  - Protected directory paths containing shell metacharacters from unintended interpretation.
  - Ensured generated bootstrap scripts use the configured localization stub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->